### PR TITLE
Ensure chronos jobs have docker credentials to pull from the private registry

### DIFF
--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -339,6 +339,7 @@ class ChronosJobConfig(InstanceConfig):
                 'type': 'DOCKER',
                 'volumes': docker_volumes
             },
+            'uris': ['file:///root/.dockercfg', ],
             'environmentVariables': self.get_env(),
             'mem': self.get_mem(),
             'cpus': self.get_cpus(),

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -602,6 +602,7 @@ class TestChronosTools:
                 'image': fake_docker_url,
                 'type': 'DOCKER',
             },
+            'uris': ['file:///root/.dockercfg', ],
             'shell': True,
         }
         with mock.patch('monitoring_tools.get_team', return_value=fake_owner):
@@ -789,6 +790,7 @@ class TestChronosTools:
                     'image': "fake_registry/paasta-test_service-penguin",
                     'type': 'DOCKER'
                 },
+                'uris': ['file:///root/.dockercfg', ],
                 'mem': 1024.4,
                 'owner': fake_owner,
                 'shell': True,
@@ -842,6 +844,7 @@ class TestChronosTools:
                     'image': "fake_registry/fake_image",
                     'type': 'DOCKER'
                 },
+                'uris': ['file:///root/.dockercfg', ],
                 'mem': 1024.4,
                 'owner': fake_owner,
                 'shell': True,
@@ -895,6 +898,7 @@ class TestChronosTools:
                     'image': "fake_registry/fake_image",
                     'type': 'DOCKER'
                 },
+                'uris': ['file:///root/.dockercfg', ],
                 'mem': 1024.4,
                 'owner': fake_owner,
                 'shell': True,
@@ -964,6 +968,7 @@ class TestChronosTools:
                     'image': "fake_registry/fake_image",
                     'type': 'DOCKER'
                 },
+                'uris': ['file:///root/.dockercfg', ],
                 'mem': 1024.4,
                 'owner': fake_owner,
                 'shell': True,


### PR DESCRIPTION
We do this in marathon, we should also do it in chronos.

The last we spoke with mesosphere this was the state of the art on dealing with private registries. (other than making your own docker wrapper)
