### PR TITLE
Fix chronos bouncing to properly delete chronos jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 dist/
 .tox
+.pip/
 *.py?
 .*.sw?
 paasta_tools.egg-info/

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,6 +1,32 @@
 Contributing
 ============
 
+Running The Tests
+-----------------
+
+Unit Tests
+^^^^^^^^^^
+
+Python 2.7 and tox are required for running the unit tests. You can simply run
+``make test`` or ``tox`` to execute them.
+
+This will build a virtualenv with the required python packages, then run the tests
+writen in the ``tests`` directory
+
+Integration Tests
+^^^^^^^^^^^^^^^^^
+
+Python 2.7, tox, and Docker are required to run the integration test suite.
+You can run ``make itest`` to execute them.
+
+Syste Package Building / itests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+PaaSTA is distributed as a debian package. This package can be built and tested
+with ``make itest_trusty``. These tests make assertions about the
+packaging implementation.
+
+
 Making new versions
 -------------------
 * Make a branch. WRITE TESTS FIRST (TDD)! Add features.

--- a/paasta_itests/setup_chronos_job.feature
+++ b/paasta_itests/setup_chronos_job.feature
@@ -31,3 +31,14 @@ Feature: setup_chronos_job can create and bounce jobs
       And the old job has no running tasks
       And the new job is enabled in chronos
       And the new job has running tasks
+
+  Scenario: jobs will be cleaned up by the "graceful" bounce
+    Given a working paasta cluster
+      And I have yelpsoa-configs for the service "test-service" with enabled chronos instance "test-instance"
+      And I have a deployments.json for the service "test-service" with enabled chronos instance "test-instance"
+     When we create a chronos job dict from the configs for instance "test-instance" of service "test-service"
+      And we load the configs for instance "test-instance" of service "test-service" into a ChronosJobConfig
+      And 10 old jobs are left over from previous bounces
+      And we run setup_chronos_job
+     Then there should be 1 enabled jobs
+      And there should be 5 disabled jobs

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -577,8 +577,8 @@ def disable_job(client, job):
 
 
 def delete_job(client, job):
-    log.debug("Deleting job: %s" % job)
-    client.delete(job)
+    log.debug("Deleting job: %s" % job["name"])
+    client.delete(job["name"])
 
 
 def create_job(client, job):

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import datetime
 import mock
 from pytest import raises
@@ -1069,10 +1070,12 @@ class TestChronosTools:
         fake_client.update.assert_called_once_with({"disabled": True})
 
     def test_delete_job(self):
+        fake_job_to_delete = copy.deepcopy(self.fake_config_dict)
+        fake_job_to_delete["name"] = 'fake_job'
         fake_client_class = mock.Mock(spec='chronos.ChronosClient')
         fake_client = fake_client_class(servers=[])
-        chronos_tools.delete_job(job=self.fake_config_dict, client=fake_client)
-        fake_client.delete.assert_called_once_with(self.fake_config_dict)
+        chronos_tools.delete_job(job=fake_job_to_delete, client=fake_client)
+        fake_client.delete.assert_called_once_with('fake_job')
 
     def test_create_job(self):
         fake_client_class = mock.Mock(spec='chronos.ChronosClient')


### PR DESCRIPTION
The chronos bounce code wasn't properly deleting jobs, and it wasn't under itest.
