### PR TITLE
Make tab completions work in zsh

### DIFF
--- a/paasta_tools/paasta_cli/paasta_tabcomplete.sh
+++ b/paasta_tools/paasta_cli/paasta_tabcomplete.sh
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [[ -n ${ZSH_VERSION-} ]]; then
+	autoload -U +X bashcompinit && bashcompinit
+fi
+
 # This magic eval enables tab-completion for the "paasta" command
 # http://argcomplete.readthedocs.org/en/latest/index.html#synopsis
 # This comes from the paasta-tools system package

--- a/yelp_package/dockerfiles/lucid/Dockerfile
+++ b/yelp_package/dockerfiles/lucid/Dockerfile
@@ -18,7 +18,7 @@ MAINTAINER Kyle Anderson <kwa@yelp.com>
 # Make sure we get a package suitable for building this package correctly.
 # Per dnephin we need https://github.com/spotify/dh-virtualenv/pull/20
 # Which at this time is in this package
-RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools python-dev debhelper dh-virtualenv=0.6-yelp2 python-yaml python-pytest pyflakes python2.7 python2.7-dev help2man
+RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools python-dev debhelper dh-virtualenv=0.6-yelp2 python-yaml python-pytest pyflakes python2.7 python2.7-dev help2man zsh
 
 ENV HOME /work
 ENV PWD /work

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools \
   python-dev debhelper python-yaml python-pytest pyflakes \
-  help2man
+  help2man zsh
 
 # Older versions of dh-virtualenv are buggy and don't.. work
 RUN curl http://ppa.launchpad.net/dh-virtualenv/daily/ubuntu/pool/main/d/dh-virtualenv/dh-virtualenv_0.10-0~80~ubuntu14.04.1_all.deb --output dh-virtualenv_0.10-0~80~ubuntu14.04.1_all.deb && \

--- a/yelp_package/itest/tab_complete.sh
+++ b/yelp_package/itest/tab_complete.sh
@@ -48,6 +48,13 @@ else
     tab_complete_fail "$pre_typed" "$actual" "$expected"
 fi
 
+# Test tab completion in zsh
+zsh_actual=$(zsh -c "COMP_LINE='paasta $pre_typed' COMP_POINT=99 _ARGCOMPLETE=1 paasta 8>&1 9>/dev/null")
+if [[ $expected == $zsh_actual ]]; then
+    tab_complete_pass "$pre_typed"
+else
+    tab_complete_fail "$pre_typed" "$zsh_actual" "$expected"
+fi
 
 # laziness test
 #


### PR DESCRIPTION
This solution is based on a [Pull Request](https://github.com/creationix/nvm/pull/200/files#diff-93a91fe1c49ea5c2f5a4208187212f02) by [croach])(https://github.com/croach) for the [nvm](https://github.com/creationix/nvm) project. I tested it with `make itest_lucid` and `make itest_trusty`. It using the same completions that bash uses, so they should always be in sync.
