### PR TITLE
Install tox in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
   - "2.7"
-install: "pip install -r requirements.txt"
+install:
+  - pip install --use-mirrors tox
 script: make test


### PR DESCRIPTION
We need to install tox in travis for `make test` to work.