### PR TITLE
Make setup_chronos_job handle the situation where the docker image isn't available

### DIFF
--- a/paasta_tools/setup_chronos_job.py
+++ b/paasta_tools/setup_chronos_job.py
@@ -55,6 +55,7 @@ from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import NoDeploymentsAvailable
+from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import SPACER
 
 
@@ -195,8 +196,9 @@ def main():
             cluster=cluster,
             soa_dir=soa_dir,
         )
-    except NoDeploymentsAvailable:
-        error_msg = "No deployments found for %s in cluster %s" % (args.service_instance, cluster)
+    except (NoDeploymentsAvailable, NoDockerImageError):
+        error_msg = "No deployment found for %s in cluster %s. Has Jenkins run for it?" % (
+            args.service_instance, cluster)
         send_event(
             service=service,
             instance=None,


### PR DESCRIPTION
I don't really like how this code is structured, if anyone has better opinions on what we *should* be doing, I can redo it.

We currently catch all exceptional cases in main. This is another case that can happen, and without catching the exception we will crash. But of course it isn't "that" exceptional.

In marathon we kinda split it up, some exceptions are caught in main, some are caught closer to where the actual function is invoked.