### PR TITLE
Mrtyler instance filter

### DIFF
--- a/paasta_tools/paasta_cli/cmds/status.py
+++ b/paasta_tools/paasta_cli/cmds/status.py
@@ -146,19 +146,17 @@ def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployme
 
         # Case: service deployed to cluster.instance
         if namespace in actual_deployments:
-            unformatted_instance = instance
-            instance = PaastaColors.blue(instance)
+            formatted_instance = PaastaColors.blue(instance)
             version = actual_deployments[namespace][:8]
             # TODO: Perform sanity checks once per cluster instead of for each namespace
-            status = execute_paasta_serviceinit_on_remote_master('status', cluster, service, unformatted_instance,
-                                                                 verbose=verbose)
+            status = execute_paasta_serviceinit_on_remote_master('status', cluster, service, instance, verbose=verbose)
         # Case: service NOT deployed to cluster.instance
         else:
-            instance = PaastaColors.red(instance)
+            formatted_instance = PaastaColors.red(instance)
             version = 'None'
             status = None
 
-        print '  instance: %s' % instance
+        print '  instance: %s' % formatted_instance
         print '    Git sha:    %s' % version
         if status is not None:
             for line in status.rstrip().split('\n'):

--- a/paasta_tools/paasta_cli/cmds/status.py
+++ b/paasta_tools/paasta_cli/cmds/status.py
@@ -171,16 +171,15 @@ def report_bogus_filters(filters, items, item_type):
     """Warns the user if the filter used is not even in the deployed
     list. Helps pick up typos"""
     return_string = ""
-    if filters is not None:
-        bogus_filters = []
-        for filt in filters:
-            if filt not in items:
-                bogus_filters.append(filt)
-        if len(bogus_filters) > 0:
-            return_string = (
-                "\n"
-                "Warning: This service does not have any %s matching these filters:\n%s"
-            ) % (item_type, ",".join(bogus_filters))
+    bogus_filters = []
+    for filt in filters:
+        if filt not in items:
+            bogus_filters.append(filt)
+    if len(bogus_filters) > 0:
+        return_string = (
+            "\n"
+            "Warning: This service does not have any %s matching these names:\n%s"
+        ) % (item_type, ",".join(bogus_filters))
     return return_string
 
 
@@ -190,7 +189,7 @@ def report_status(service, deploy_pipeline, actual_deployments, cluster_filter, 
 
     deployed_clusters = list_deployed_clusters(deploy_pipeline, actual_deployments)
     for cluster in deployed_clusters:
-        if cluster_filter is None or cluster in cluster_filter:
+        if not cluster_filter or cluster in cluster_filter:
             report_status_for_cluster(
                 service=service,
                 cluster=cluster,
@@ -212,11 +211,11 @@ def paasta_status(args):
     if args.clusters is not None:
         cluster_filter = args.clusters.split(",")
     else:
-        cluster_filter = None
+        cluster_filter = []
     if args.instances is not None:
         instance_filter = args.instances.split(",")
     else:
-        instance_filter = None
+        instance_filter = []
 
     if actual_deployments:
         deploy_pipeline = list(get_planned_deployments(deploy_info))

--- a/paasta_tools/paasta_cli/cmds/status.py
+++ b/paasta_tools/paasta_cli/cmds/status.py
@@ -164,24 +164,23 @@ def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployme
             for line in status.rstrip().split('\n'):
                 print '    %s' % line
 
-    print report_bogus_filters(instance_filter, seen_instances)
+    print report_bogus_filters(instance_filter, seen_instances, 'instance')
 
 
-def report_bogus_filters(cluster_filters, deployed_clusters):
+def report_bogus_filters(filters, items, item_type):
     """Warns the user if the filter used is not even in the deployed
     list. Helps pick up typos"""
     return_string = ""
-    if cluster_filters is not None:
-        bogus_clusters = []
-        for c in cluster_filters:
-            if c not in deployed_clusters:
-                bogus_clusters.append(c)
-        if len(bogus_clusters) > 0:
+    if filters is not None:
+        bogus_filters = []
+        for filt in filters:
+            if filt not in items:
+                bogus_filters.append(filt)
+        if len(bogus_filters) > 0:
             return_string = (
                 "\n"
-                "Warning: The following clusters in the filter look bogus, this service\n"
-                "is not deployed to the following cluster(s):\n%s"
-            ) % ",".join(bogus_clusters)
+                "Warning: This service does not have any %s matching these filters:\n%s"
+            ) % (item_type, ",".join(bogus_filters))
     return return_string
 
 
@@ -201,7 +200,7 @@ def report_status(service, deploy_pipeline, actual_deployments, cluster_filter, 
                 verbose=verbose,
             )
 
-    print report_bogus_filters(cluster_filter, deployed_clusters)
+    print report_bogus_filters(cluster_filter, deployed_clusters, 'cluster')
 
 
 def paasta_status(args):

--- a/paasta_tools/paasta_cli/cmds/status.py
+++ b/paasta_tools/paasta_cli/cmds/status.py
@@ -130,7 +130,7 @@ def get_actual_deployments(service):
     return actual_deployments
 
 
-def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployments, verbose=False):
+def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployments, instance_filter, verbose=False):
     """With a given service and cluster, prints the status of the instances
     in that cluster"""
     # Get cluster.instance in the order in which they appear in deploy.yaml

--- a/paasta_tools/paasta_cli/cmds/status.py
+++ b/paasta_tools/paasta_cli/cmds/status.py
@@ -55,6 +55,11 @@ def add_subparser(subparsers):
         help="A comma-separated list of clusters to view. Defaults to view all clusters.\n"
              "For example: --clusters norcal-prod,nova-prod"
     ).completer = lazy_choices_completer(list_clusters)
+    status_parser.add_argument(
+        '-i', '--instances',
+        help="A comma-separated list of instances to view. Defaults to view all instances.\n"
+             "For example: --instances canary,main"
+    )  # No completer because we need to know service first and we can't until some other stuff has happened
     status_parser.set_defaults(command=paasta_status)
 
 
@@ -200,9 +205,20 @@ def paasta_status(args):
         cluster_filter = args.clusters.split(",")
     else:
         cluster_filter = None
+    if args.instances is not None:
+        instance_filter = args.instances.split(",")
+    else:
+        instance_filter = None
 
     if actual_deployments:
         deploy_pipeline = list(get_planned_deployments(deploy_info))
-        report_status(service, deploy_pipeline, actual_deployments, cluster_filter, args.verbose)
+        report_status(
+            service=service,
+            deploy_pipeline=deploy_pipeline,
+            actual_deployments=actual_deployments,
+            cluster_filter=cluster_filter,
+            instance_filter=instance_filter,
+            verbose=args.verbose,
+        )
     else:
         print missing_deployments_message(service)

--- a/paasta_tools/paasta_cli/cmds/status.py
+++ b/paasta_tools/paasta_cli/cmds/status.py
@@ -183,14 +183,21 @@ def report_bogus_filters(cluster_filter, deployed_clusters):
     return return_string
 
 
-def report_status(service, deploy_pipeline, actual_deployments, cluster_filter, verbose=False):
+def report_status(service, deploy_pipeline, actual_deployments, cluster_filter, instance_filter, verbose=False):
     pipeline_url = get_pipeline_url(service)
     print "Pipeline: %s" % pipeline_url
 
     deployed_clusters = list_deployed_clusters(deploy_pipeline, actual_deployments)
     for cluster in deployed_clusters:
         if cluster_filter is None or cluster in cluster_filter:
-            report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployments, verbose)
+            report_status_for_cluster(
+                service=service,
+                cluster=cluster,
+                deploy_pipeline=deploy_pipeline,
+                actual_deployments=actual_deployments,
+                instance_filter=instance_filter,
+                verbose=verbose,
+            )
 
     print report_bogus_filters(cluster_filter, deployed_clusters)
 

--- a/paasta_tools/paasta_cli/cmds/status.py
+++ b/paasta_tools/paasta_cli/cmds/status.py
@@ -164,22 +164,23 @@ def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployme
             for line in status.rstrip().split('\n'):
                 print '    %s' % line
 
-    print report_bogus_whitelists(instance_whitelist, seen_instances, 'instance')
+    print report_invalid_whitelist_values(instance_whitelist, seen_instances, 'instance')
 
 
-def report_bogus_whitelists(whitelists, items, item_type):
-    """Warns the user if the whitelist used is not even in the deployed
-    list. Helps pick up typos"""
+def report_invalid_whitelist_values(whitelist, items, item_type):
+    """Warns the user if there are entries in ``whitelist`` which don't
+    correspond to any item in ``items``. Helps highlight typos.
+    """
     return_string = ""
-    bogus_whitelists = []
-    for whitelist in whitelists:
-        if whitelist not in items:
-            bogus_whitelists.append(whitelist)
-    if len(bogus_whitelists) > 0:
+    bogus_entries = []
+    for entry in whitelist:
+        if entry not in items:
+            bogus_entries.append(entry)
+    if len(bogus_entries) > 0:
         return_string = (
             "\n"
             "Warning: This service does not have any %s matching these names:\n%s"
-        ) % (item_type, ",".join(bogus_whitelists))
+        ) % (item_type, ",".join(bogus_entries))
     return return_string
 
 
@@ -199,7 +200,7 @@ def report_status(service, deploy_pipeline, actual_deployments, cluster_whitelis
                 verbose=verbose,
             )
 
-    print report_bogus_whitelists(cluster_whitelist, deployed_clusters, 'cluster')
+    print report_invalid_whitelist_values(cluster_whitelist, deployed_clusters, 'cluster')
 
 
 def paasta_status(args):

--- a/paasta_tools/paasta_cli/cmds/status.py
+++ b/paasta_tools/paasta_cli/cmds/status.py
@@ -167,13 +167,13 @@ def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployme
     print report_bogus_filters(instance_filter, seen_instances)
 
 
-def report_bogus_filters(cluster_filter, deployed_clusters):
+def report_bogus_filters(cluster_filters, deployed_clusters):
     """Warns the user if the filter used is not even in the deployed
     list. Helps pick up typos"""
     return_string = ""
-    if cluster_filter is not None:
+    if cluster_filters is not None:
         bogus_clusters = []
-        for c in cluster_filter:
+        for c in cluster_filters:
             if c not in deployed_clusters:
                 bogus_clusters.append(c)
         if len(bogus_clusters) > 0:

--- a/paasta_tools/paasta_cli/cmds/status.py
+++ b/paasta_tools/paasta_cli/cmds/status.py
@@ -136,8 +136,10 @@ def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployme
     # Get cluster.instance in the order in which they appear in deploy.yaml
     print
     print "cluster: %s" % cluster
+    seen_instances = []
     for namespace in deploy_pipeline:
         cluster_in_pipeline, instance = namespace.split('.')
+        seen_instances.append(instance)
 
         if cluster_in_pipeline != cluster:
             continue
@@ -161,6 +163,8 @@ def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployme
         if status is not None:
             for line in status.rstrip().split('\n'):
                 print '    %s' % line
+
+    print report_bogus_filters(instance_filter, seen_instances)
 
 
 def report_bogus_filters(cluster_filter, deployed_clusters):

--- a/paasta_tools/paasta_cli/cmds/status.py
+++ b/paasta_tools/paasta_cli/cmds/status.py
@@ -140,8 +140,8 @@ def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployme
         cluster_in_pipeline, instance = namespace.split('.')
 
         if cluster_in_pipeline != cluster:
-            # This function only prints things that are relevant to cluster
-            # We skip anything not in this cluster
+            continue
+        if instance_filter and instance not in instance_filter:
             continue
 
         # Case: service deployed to cluster.instance

--- a/tests/paasta_cli/test_cmds_status.py
+++ b/tests/paasta_cli/test_cmds_status.py
@@ -72,9 +72,11 @@ def test_status_arg_service_not_found(mock_stdout, mock_guess_service_name,
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_for_cluster_displays_deployed_service(
     mock_stdout,
+    mock_report_bogus_filters,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     # paasta_status with no args displays deploy info - vanilla case
@@ -110,9 +112,11 @@ def test_report_status_for_cluster_displays_deployed_service(
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_serviceinit_on_remote_master(
     mock_stdout,
+    mock_report_bogus_filters,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     # paasta_status with no args displays deploy info - vanilla case
@@ -142,9 +146,11 @@ def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_s
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_for_cluster_instance_sorts_in_deploy_order(
     mock_stdout,
+    mock_report_bogus_filters,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     # paasta_status with no args displays deploy info
@@ -189,9 +195,11 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_print_cluster_status_missing_deploys_in_red(
     mock_stdout,
+    mock_report_bogus_filters,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     # paasta_status displays missing deploys in red
@@ -233,9 +241,11 @@ def test_print_cluster_status_missing_deploys_in_red(
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
     mock_stdout,
+    mock_report_bogus_filters,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     service = 'fake_service'
@@ -267,9 +277,11 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_for_cluster_obeys_instance_filter(
     mock_stdout,
+    mock_report_bogus_filters,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     service = 'fake_service'
@@ -293,9 +305,11 @@ def test_report_status_for_cluster_obeys_instance_filter(
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_calls_report_bogus_filters(
     mock_stdout,
+    mock_report_bogus_filters,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     service = 'fake_service'
@@ -303,15 +317,14 @@ def test_report_status_calls_report_bogus_filters(
     actual_deployments = {}
     instance_filter = None
 
-    with patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True) as mock_report_bogus_filters:
-        status.report_status_for_cluster(
-            service=service,
-            cluster='cluster',
-            deploy_pipeline=planned_deployments,
-            actual_deployments=actual_deployments,
-            instance_filter=instance_filter,
-        )
-        mock_report_bogus_filters.assert_called_once_with(instance_filter, ['instance1', 'instance2'])
+    status.report_status_for_cluster(
+        service=service,
+        cluster='cluster',
+        deploy_pipeline=planned_deployments,
+        actual_deployments=actual_deployments,
+        instance_filter=instance_filter,
+    )
+    mock_report_bogus_filters.assert_called_once_with(instance_filter, ['instance1', 'instance2'])
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.figure_out_service_name', autospec=True)

--- a/tests/paasta_cli/test_cmds_status.py
+++ b/tests/paasta_cli/test_cmds_status.py
@@ -436,14 +436,14 @@ def test_status_calls_sergeants(
         service=service,
         deploy_pipeline=planned_deployments,
         actual_deployments=actual_deployments,
-        cluster_filter=None,
-        instance_filter=None,
+        cluster_filter=[],
+        instance_filter=[],
         verbose=False,
     )
 
 
 def test_report_bogus_filters_no_filters():
-    filters = None
+    filters = []
     items = ['cluster1', 'cluster2', 'cluster3']
     item_type = 'thingy'
     actual = report_bogus_filters(filters, items, item_type)

--- a/tests/paasta_cli/test_cmds_status.py
+++ b/tests/paasta_cli/test_cmds_status.py
@@ -23,7 +23,7 @@ from paasta_tools.paasta_cli.utils import \
     NoSuchService, PaastaColors, PaastaCheckMessages
 from paasta_tools.paasta_cli.cmds.status import paasta_status, \
     missing_deployments_message
-from paasta_tools.paasta_cli.cmds.status import report_bogus_whitelists
+from paasta_tools.paasta_cli.cmds.status import report_invalid_whitelist_values
 from paasta_tools.paasta_cli.cmds.status import report_status
 from paasta_tools.paasta_cli.cmds import status
 
@@ -72,11 +72,11 @@ def test_status_arg_service_not_found(mock_stdout, mock_guess_service_name,
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_invalid_whitelist_values', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_for_cluster_displays_deployed_service(
     mock_stdout,
-    mock_report_bogus_whitelists,
+    mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     # paasta_status with no args displays deploy info - vanilla case
@@ -112,11 +112,11 @@ def test_report_status_for_cluster_displays_deployed_service(
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_invalid_whitelist_values', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_serviceinit_on_remote_master(
     mock_stdout,
-    mock_report_bogus_whitelists,
+    mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     # paasta_status with no args displays deploy info - vanilla case
@@ -146,11 +146,11 @@ def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_s
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_invalid_whitelist_values', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_for_cluster_instance_sorts_in_deploy_order(
     mock_stdout,
-    mock_report_bogus_whitelists,
+    mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     # paasta_status with no args displays deploy info
@@ -195,11 +195,11 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_invalid_whitelist_values', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_print_cluster_status_missing_deploys_in_red(
     mock_stdout,
-    mock_report_bogus_whitelists,
+    mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     # paasta_status displays missing deploys in red
@@ -241,11 +241,11 @@ def test_print_cluster_status_missing_deploys_in_red(
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_invalid_whitelist_values', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
     mock_stdout,
-    mock_report_bogus_whitelists,
+    mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     service = 'fake_service'
@@ -277,11 +277,11 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_invalid_whitelist_values', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_for_cluster_obeys_instance_whitelist(
     mock_stdout,
-    mock_report_bogus_whitelists,
+    mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     service = 'fake_service'
@@ -305,11 +305,11 @@ def test_report_status_for_cluster_obeys_instance_whitelist(
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_invalid_whitelist_values', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
-def test_report_status_calls_report_bogus_whitelists(
+def test_report_status_calls_report_invalid_whitelist_values(
     mock_stdout,
-    mock_report_bogus_whitelists,
+    mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     service = 'fake_service'
@@ -324,7 +324,11 @@ def test_report_status_calls_report_bogus_whitelists(
         actual_deployments=actual_deployments,
         instance_whitelist=instance_whitelist,
     )
-    mock_report_bogus_whitelists.assert_called_once_with(instance_whitelist, ['instance1', 'instance2'], 'instance')
+    mock_report_invalid_whitelist_values.assert_called_once_with(
+        instance_whitelist,
+        ['instance1', 'instance2'],
+        'instance',
+    )
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.figure_out_service_name', autospec=True)
@@ -442,30 +446,30 @@ def test_status_calls_sergeants(
     )
 
 
-def test_report_bogus_whitelists_no_whitelists():
-    whitelists = []
+def test_report_invalid_whitelist_values_no_whitelists():
+    whitelist = []
     items = ['cluster1', 'cluster2', 'cluster3']
     item_type = 'thingy'
-    actual = report_bogus_whitelists(whitelists, items, item_type)
+    actual = report_invalid_whitelist_values(whitelist, items, item_type)
     assert actual == ''
 
 
-def test_report_bogus_whitelists_with_whitelists():
-    whitelists = ['bogus1', 'cluster1']
+def test_report_invalid_whitelist_values_with_whitelists():
+    whitelist = ['bogus1', 'cluster1']
     items = ['cluster1', 'cluster2', 'cluster3']
     item_type = 'thingy'
-    actual = report_bogus_whitelists(whitelists, items, item_type)
+    actual = report_invalid_whitelist_values(whitelist, items, item_type)
     assert 'Warning' in actual
     assert item_type in actual
     assert 'bogus1' in actual
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.report_status_for_cluster', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_invalid_whitelist_values', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_obeys_cluster_whitelist(
     mock_stdout,
-    mock_report_bogus_whitelists,
+    mock_report_invalid_whitelist_values,
     mock_report_status_for_cluster,
 ):
     service = 'fake_service'
@@ -480,7 +484,7 @@ def test_report_status_obeys_cluster_whitelist(
         cluster_whitelist=cluster_whitelist,
         instance_whitelist=instance_whitelist,
     )
-    mock_report_bogus_whitelists.assert_called_once_with(
+    mock_report_invalid_whitelist_values.assert_called_once_with(
         cluster_whitelist, ['cluster1', 'cluster2', 'cluster3'], 'cluster')
     mock_report_status_for_cluster.assert_called_once_with(
         service=service,
@@ -493,11 +497,11 @@ def test_report_status_obeys_cluster_whitelist(
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.report_status_for_cluster', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_invalid_whitelist_values', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_handle_none_whitelist(
     mock_stdout,
-    mock_report_bogus_whitelists,
+    mock_report_invalid_whitelist_values,
     mock_report_status_for_cluster,
 ):
     service = 'fake_service'

--- a/tests/paasta_cli/test_cmds_status.py
+++ b/tests/paasta_cli/test_cmds_status.py
@@ -28,7 +28,7 @@ from paasta_tools.paasta_cli.cmds.status import report_status
 from paasta_tools.paasta_cli.cmds import status
 
 
-@patch('paasta_tools.paasta_cli.utils.validate_service_name')
+@patch('paasta_tools.paasta_cli.utils.validate_service_name', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_figure_out_service_name_not_found(mock_stdout,
                                            mock_validate_service_name):
@@ -48,8 +48,8 @@ def test_figure_out_service_name_not_found(mock_stdout,
     assert output == expected_output
 
 
-@patch('paasta_tools.paasta_cli.utils.validate_service_name')
-@patch('paasta_tools.paasta_cli.utils.guess_service_name')
+@patch('paasta_tools.paasta_cli.utils.validate_service_name', autospec=True)
+@patch('paasta_tools.paasta_cli.utils.guess_service_name', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_status_arg_service_not_found(mock_stdout, mock_guess_service_name,
                                       mock_validate_service_name):
@@ -71,7 +71,7 @@ def test_status_arg_service_not_found(mock_stdout, mock_guess_service_name,
     assert output == expected_output
 
 
-@patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master')
+@patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_for_cluster_displays_deployed_service(
     mock_stdout,
@@ -109,7 +109,7 @@ def test_report_status_for_cluster_displays_deployed_service(
     assert expected_output in output
 
 
-@patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master')
+@patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_serviceinit_on_remote_master(
     mock_stdout,
@@ -141,7 +141,7 @@ def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_s
     assert expected_output in output
 
 
-@patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master')
+@patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_for_cluster_instance_sorts_in_deploy_order(
     mock_stdout,
@@ -188,7 +188,7 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
     assert expected_output in output
 
 
-@patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master')
+@patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_print_cluster_status_missing_deploys_in_red(
     mock_stdout,
@@ -266,9 +266,9 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
     assert expected_output in output
 
 
-@patch('paasta_tools.paasta_cli.cmds.status.figure_out_service_name')
-@patch('paasta_tools.paasta_cli.cmds.status.get_deploy_info')
-@patch('paasta_tools.paasta_cli.cmds.status.get_actual_deployments')
+@patch('paasta_tools.paasta_cli.cmds.status.figure_out_service_name', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.get_deploy_info', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.get_actual_deployments', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_status_pending_pipeline_build_message(
         mock_stdout, mock_get_actual_deployments, mock_get_deploy_info,
@@ -332,11 +332,11 @@ def test_get_deploy_info_does_not_exist(mock_stdout, mock_read_deploy, mock_join
     assert output == expected_output
 
 
-@patch('paasta_tools.paasta_cli.cmds.status.figure_out_service_name')
-@patch('paasta_tools.paasta_cli.cmds.status.get_deploy_info')
-@patch('paasta_tools.paasta_cli.cmds.status.get_actual_deployments')
-@patch('paasta_tools.paasta_cli.cmds.status.get_planned_deployments')
-@patch('paasta_tools.paasta_cli.cmds.status.report_status')
+@patch('paasta_tools.paasta_cli.cmds.status.figure_out_service_name', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.get_deploy_info', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.get_actual_deployments', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.get_planned_deployments', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_status', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_status_calls_sergeants(
     mock_stdout,
@@ -395,8 +395,8 @@ def test_report_bogus_filters_with_filter():
     assert 'Warning' in actual
 
 
-@patch('paasta_tools.paasta_cli.cmds.status.report_status_for_cluster')
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters')
+@patch('paasta_tools.paasta_cli.cmds.status.report_status_for_cluster', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_obeys_cluster_filter(
     mock_stdout,
@@ -427,8 +427,8 @@ def test_report_status_obeys_cluster_filter(
     )
 
 
-@patch('paasta_tools.paasta_cli.cmds.status.report_status_for_cluster')
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters')
+@patch('paasta_tools.paasta_cli.cmds.status.report_status_for_cluster', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_handle_none_filter(
     mock_stdout,

--- a/tests/paasta_cli/test_cmds_status.py
+++ b/tests/paasta_cli/test_cmds_status.py
@@ -83,6 +83,7 @@ def test_report_status_for_cluster_displays_deployed_service(
     actual_deployments = {
         'cluster.instance': 'sha'
     }
+    instance_filter = None
     fake_status = 'status: SOMETHING FAKE'
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_status
     expected_output = (
@@ -98,7 +99,12 @@ def test_report_status_for_cluster_displays_deployed_service(
     )
 
     status.report_status_for_cluster(
-        service, 'cluster', planned_deployments, actual_deployments)
+        service=service,
+        cluster='cluster',
+        deploy_pipeline=planned_deployments,
+        actual_deployments=actual_deployments,
+        instance_filter=instance_filter,
+    )
     output = mock_stdout.getvalue()
     assert expected_output in output
 
@@ -115,6 +121,7 @@ def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_s
     actual_deployments = {
         'cluster.instance': 'this_is_a_sha'
     }
+    instance_filter = None
     fake_status = 'status: SOMETHING FAKE\nand then something fake\non another line!\n\n\n'
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_status
     expected_output = (
@@ -124,7 +131,12 @@ def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_s
     )
 
     status.report_status_for_cluster(
-        service, 'cluster', planned_deployments, actual_deployments)
+        service=service,
+        cluster='cluster',
+        deploy_pipeline=planned_deployments,
+        actual_deployments=actual_deployments,
+        instance_filter=instance_filter,
+    )
     output = mock_stdout.getvalue()
     assert expected_output in output
 
@@ -145,6 +157,7 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
         'a_cluster.a_instance': '533976a9',
         'a_cluster.b_instance': '533976a9',
     }
+    instance_filter = None
     fake_status = 'status: SOMETHING FAKE'
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_status
     expected_output = (
@@ -165,7 +178,12 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
     )
 
     status.report_status_for_cluster(
-        service, 'a_cluster', planned_deployments, actual_deployments)
+        service=service,
+        cluster='a_cluster',
+        deploy_pipeline=planned_deployments,
+        actual_deployments=actual_deployments,
+        instance_filter=instance_filter,
+    )
     output = mock_stdout.getvalue()
     assert expected_output in output
 
@@ -185,6 +203,7 @@ def test_print_cluster_status_missing_deploys_in_red(
     actual_deployments = {
         'a_cluster.a_instance': '533976a981679d586bed1cfb534fdba4b4e2c815',
     }
+    instance_filter = None
     fake_status = 'status: SOMETHING FAKE'
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_status
     expected_output = (
@@ -203,7 +222,12 @@ def test_print_cluster_status_missing_deploys_in_red(
     )
 
     status.report_status_for_cluster(
-        service, 'a_cluster', planned_deployments, actual_deployments)
+        service=service,
+        cluster='a_cluster',
+        deploy_pipeline=planned_deployments,
+        actual_deployments=actual_deployments,
+        instance_filter=instance_filter,
+    )
     output = mock_stdout.getvalue()
     assert expected_output in output
 
@@ -222,12 +246,18 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
     actual_deployments = {
         'a_cluster.a_instance': 'this_is_a_sha',
     }
+    instance_filter = None
     fake_output = "Marathon: 5 instances"
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_output
     expected_output = "    %s\n" % fake_output
 
     status.report_status_for_cluster(
-        service, 'a_cluster', planned_deployments, actual_deployments)
+        service=service,
+        cluster='a_cluster',
+        deploy_pipeline=planned_deployments,
+        actual_deployments=actual_deployments,
+        instance_filter=instance_filter,
+    )
     assert mock_execute_paasta_serviceinit_on_remote_master.call_count == 1
     mock_execute_paasta_serviceinit_on_remote_master.assert_any_call(
         'status', 'a_cluster', service, 'a_instance', verbose=False)

--- a/tests/paasta_cli/test_cmds_status.py
+++ b/tests/paasta_cli/test_cmds_status.py
@@ -23,7 +23,7 @@ from paasta_tools.paasta_cli.utils import \
     NoSuchService, PaastaColors, PaastaCheckMessages
 from paasta_tools.paasta_cli.cmds.status import paasta_status, \
     missing_deployments_message
-from paasta_tools.paasta_cli.cmds.status import report_bogus_filters
+from paasta_tools.paasta_cli.cmds.status import report_bogus_whitelists
 from paasta_tools.paasta_cli.cmds.status import report_status
 from paasta_tools.paasta_cli.cmds import status
 
@@ -72,11 +72,11 @@ def test_status_arg_service_not_found(mock_stdout, mock_guess_service_name,
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_for_cluster_displays_deployed_service(
     mock_stdout,
-    mock_report_bogus_filters,
+    mock_report_bogus_whitelists,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     # paasta_status with no args displays deploy info - vanilla case
@@ -85,7 +85,7 @@ def test_report_status_for_cluster_displays_deployed_service(
     actual_deployments = {
         'cluster.instance': 'sha'
     }
-    instance_filter = []
+    instance_whitelist = []
     fake_status = 'status: SOMETHING FAKE'
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_status
     expected_output = (
@@ -105,18 +105,18 @@ def test_report_status_for_cluster_displays_deployed_service(
         cluster='cluster',
         deploy_pipeline=planned_deployments,
         actual_deployments=actual_deployments,
-        instance_filter=instance_filter,
+        instance_whitelist=instance_whitelist,
     )
     output = mock_stdout.getvalue()
     assert expected_output in output
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_serviceinit_on_remote_master(
     mock_stdout,
-    mock_report_bogus_filters,
+    mock_report_bogus_whitelists,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     # paasta_status with no args displays deploy info - vanilla case
@@ -125,7 +125,7 @@ def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_s
     actual_deployments = {
         'cluster.instance': 'this_is_a_sha'
     }
-    instance_filter = []
+    instance_whitelist = []
     fake_status = 'status: SOMETHING FAKE\nand then something fake\non another line!\n\n\n'
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_status
     expected_output = (
@@ -139,18 +139,18 @@ def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_s
         cluster='cluster',
         deploy_pipeline=planned_deployments,
         actual_deployments=actual_deployments,
-        instance_filter=instance_filter,
+        instance_whitelist=instance_whitelist,
     )
     output = mock_stdout.getvalue()
     assert expected_output in output
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_report_status_for_cluster_instance_sorts_in_deploy_order(
     mock_stdout,
-    mock_report_bogus_filters,
+    mock_report_bogus_whitelists,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     # paasta_status with no args displays deploy info
@@ -163,7 +163,7 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
         'a_cluster.a_instance': '533976a9',
         'a_cluster.b_instance': '533976a9',
     }
-    instance_filter = []
+    instance_whitelist = []
     fake_status = 'status: SOMETHING FAKE'
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_status
     expected_output = (
@@ -188,18 +188,18 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
         cluster='a_cluster',
         deploy_pipeline=planned_deployments,
         actual_deployments=actual_deployments,
-        instance_filter=instance_filter,
+        instance_whitelist=instance_whitelist,
     )
     output = mock_stdout.getvalue()
     assert expected_output in output
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_print_cluster_status_missing_deploys_in_red(
     mock_stdout,
-    mock_report_bogus_filters,
+    mock_report_bogus_whitelists,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     # paasta_status displays missing deploys in red
@@ -211,7 +211,7 @@ def test_print_cluster_status_missing_deploys_in_red(
     actual_deployments = {
         'a_cluster.a_instance': '533976a981679d586bed1cfb534fdba4b4e2c815',
     }
-    instance_filter = []
+    instance_whitelist = []
     fake_status = 'status: SOMETHING FAKE'
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_status
     expected_output = (
@@ -234,18 +234,18 @@ def test_print_cluster_status_missing_deploys_in_red(
         cluster='a_cluster',
         deploy_pipeline=planned_deployments,
         actual_deployments=actual_deployments,
-        instance_filter=instance_filter,
+        instance_whitelist=instance_whitelist,
     )
     output = mock_stdout.getvalue()
     assert expected_output in output
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
 def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
     mock_stdout,
-    mock_report_bogus_filters,
+    mock_report_bogus_whitelists,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     service = 'fake_service'
@@ -256,7 +256,7 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
     actual_deployments = {
         'a_cluster.a_instance': 'this_is_a_sha',
     }
-    instance_filter = []
+    instance_whitelist = []
     fake_output = "Marathon: 5 instances"
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_output
     expected_output = "    %s\n" % fake_output
@@ -266,7 +266,7 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
         cluster='a_cluster',
         deploy_pipeline=planned_deployments,
         actual_deployments=actual_deployments,
-        instance_filter=instance_filter,
+        instance_whitelist=instance_whitelist,
     )
     assert mock_execute_paasta_serviceinit_on_remote_master.call_count == 1
     mock_execute_paasta_serviceinit_on_remote_master.assert_any_call(
@@ -277,11 +277,11 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
-def test_report_status_for_cluster_obeys_instance_filter(
+def test_report_status_for_cluster_obeys_instance_whitelist(
     mock_stdout,
-    mock_report_bogus_filters,
+    mock_report_bogus_whitelists,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     service = 'fake_service'
@@ -290,14 +290,14 @@ def test_report_status_for_cluster_obeys_instance_filter(
         'cluster.instance1': 'sha',
         'cluster.instance2': 'sha',
     }
-    instance_filter = ['instance1']
+    instance_whitelist = ['instance1']
 
     status.report_status_for_cluster(
         service=service,
         cluster='cluster',
         deploy_pipeline=planned_deployments,
         actual_deployments=actual_deployments,
-        instance_filter=instance_filter,
+        instance_whitelist=instance_whitelist,
     )
     output = mock_stdout.getvalue()
     assert 'instance1' in output
@@ -305,26 +305,26 @@ def test_report_status_for_cluster_obeys_instance_filter(
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
-def test_report_status_calls_report_bogus_filters(
+def test_report_status_calls_report_bogus_whitelists(
     mock_stdout,
-    mock_report_bogus_filters,
+    mock_report_bogus_whitelists,
     mock_execute_paasta_serviceinit_on_remote_master,
 ):
     service = 'fake_service'
     planned_deployments = ['cluster.instance1', 'cluster.instance2']
     actual_deployments = {}
-    instance_filter = []
+    instance_whitelist = []
 
     status.report_status_for_cluster(
         service=service,
         cluster='cluster',
         deploy_pipeline=planned_deployments,
         actual_deployments=actual_deployments,
-        instance_filter=instance_filter,
+        instance_whitelist=instance_whitelist,
     )
-    mock_report_bogus_filters.assert_called_once_with(instance_filter, ['instance1', 'instance2'], 'instance')
+    mock_report_bogus_whitelists.assert_called_once_with(instance_whitelist, ['instance1', 'instance2'], 'instance')
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.figure_out_service_name', autospec=True)
@@ -436,88 +436,88 @@ def test_status_calls_sergeants(
         service=service,
         deploy_pipeline=planned_deployments,
         actual_deployments=actual_deployments,
-        cluster_filter=[],
-        instance_filter=[],
+        cluster_whitelist=[],
+        instance_whitelist=[],
         verbose=False,
     )
 
 
-def test_report_bogus_filters_no_filters():
-    filters = []
+def test_report_bogus_whitelists_no_whitelists():
+    whitelists = []
     items = ['cluster1', 'cluster2', 'cluster3']
     item_type = 'thingy'
-    actual = report_bogus_filters(filters, items, item_type)
+    actual = report_bogus_whitelists(whitelists, items, item_type)
     assert actual == ''
 
 
-def test_report_bogus_filters_with_filters():
-    filters = ['bogus1', 'cluster1']
+def test_report_bogus_whitelists_with_whitelists():
+    whitelists = ['bogus1', 'cluster1']
     items = ['cluster1', 'cluster2', 'cluster3']
     item_type = 'thingy'
-    actual = report_bogus_filters(filters, items, item_type)
+    actual = report_bogus_whitelists(whitelists, items, item_type)
     assert 'Warning' in actual
     assert item_type in actual
     assert 'bogus1' in actual
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.report_status_for_cluster', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
-def test_report_status_obeys_cluster_filter(
+def test_report_status_obeys_cluster_whitelist(
     mock_stdout,
-    mock_report_bogus_filters,
+    mock_report_bogus_whitelists,
     mock_report_status_for_cluster,
 ):
     service = 'fake_service'
-    cluster_filter = ['cluster1']
-    instance_filter = []
+    cluster_whitelist = ['cluster1']
+    instance_whitelist = []
     deploy_pipeline = actual_deployments = [
         'cluster1.main', 'cluster2.main', 'cluster3.main']
     report_status(
         service=service,
         deploy_pipeline=deploy_pipeline,
         actual_deployments=actual_deployments,
-        cluster_filter=cluster_filter,
-        instance_filter=instance_filter,
+        cluster_whitelist=cluster_whitelist,
+        instance_whitelist=instance_whitelist,
     )
-    mock_report_bogus_filters.assert_called_once_with(
-        cluster_filter, ['cluster1', 'cluster2', 'cluster3'], 'cluster')
+    mock_report_bogus_whitelists.assert_called_once_with(
+        cluster_whitelist, ['cluster1', 'cluster2', 'cluster3'], 'cluster')
     mock_report_status_for_cluster.assert_called_once_with(
         service=service,
         cluster='cluster1',
         deploy_pipeline=deploy_pipeline,
         actual_deployments=actual_deployments,
-        instance_filter=instance_filter,
+        instance_whitelist=instance_whitelist,
         verbose=False
     )
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.report_status_for_cluster', autospec=True)
-@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.status.report_bogus_whitelists', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
-def test_report_status_handle_none_filter(
+def test_report_status_handle_none_whitelist(
     mock_stdout,
-    mock_report_bogus_filters,
+    mock_report_bogus_whitelists,
     mock_report_status_for_cluster,
 ):
     service = 'fake_service'
-    cluster_filter = []
-    instance_filter = []
+    cluster_whitelist = []
+    instance_whitelist = []
     deploy_pipeline = actual_deployments = [
         'cluster1.main', 'cluster2.main', 'cluster3.main']
     report_status(
         service=service,
         deploy_pipeline=deploy_pipeline,
         actual_deployments=actual_deployments,
-        cluster_filter=cluster_filter,
-        instance_filter=instance_filter,
+        cluster_whitelist=cluster_whitelist,
+        instance_whitelist=instance_whitelist,
     )
     mock_report_status_for_cluster.assert_any_call(
         service=service,
         cluster='cluster1',
         deploy_pipeline=deploy_pipeline,
         actual_deployments=actual_deployments,
-        instance_filter=instance_filter,
+        instance_whitelist=instance_whitelist,
         verbose=False
     )
     mock_report_status_for_cluster.assert_any_call(
@@ -525,7 +525,7 @@ def test_report_status_handle_none_filter(
         cluster='cluster2',
         deploy_pipeline=deploy_pipeline,
         actual_deployments=actual_deployments,
-        instance_filter=instance_filter,
+        instance_whitelist=instance_whitelist,
         verbose=False
     )
     mock_report_status_for_cluster.assert_any_call(
@@ -533,6 +533,6 @@ def test_report_status_handle_none_filter(
         cluster='cluster3',
         deploy_pipeline=deploy_pipeline,
         actual_deployments=actual_deployments,
-        instance_filter=instance_filter,
+        instance_whitelist=instance_whitelist,
         verbose=False
     )

--- a/tests/paasta_cli/test_cmds_status.py
+++ b/tests/paasta_cli/test_cmds_status.py
@@ -85,7 +85,7 @@ def test_report_status_for_cluster_displays_deployed_service(
     actual_deployments = {
         'cluster.instance': 'sha'
     }
-    instance_filter = None
+    instance_filter = []
     fake_status = 'status: SOMETHING FAKE'
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_status
     expected_output = (
@@ -125,7 +125,7 @@ def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_s
     actual_deployments = {
         'cluster.instance': 'this_is_a_sha'
     }
-    instance_filter = None
+    instance_filter = []
     fake_status = 'status: SOMETHING FAKE\nand then something fake\non another line!\n\n\n'
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_status
     expected_output = (
@@ -163,7 +163,7 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
         'a_cluster.a_instance': '533976a9',
         'a_cluster.b_instance': '533976a9',
     }
-    instance_filter = None
+    instance_filter = []
     fake_status = 'status: SOMETHING FAKE'
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_status
     expected_output = (
@@ -211,7 +211,7 @@ def test_print_cluster_status_missing_deploys_in_red(
     actual_deployments = {
         'a_cluster.a_instance': '533976a981679d586bed1cfb534fdba4b4e2c815',
     }
-    instance_filter = None
+    instance_filter = []
     fake_status = 'status: SOMETHING FAKE'
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_status
     expected_output = (
@@ -256,7 +256,7 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
     actual_deployments = {
         'a_cluster.a_instance': 'this_is_a_sha',
     }
-    instance_filter = None
+    instance_filter = []
     fake_output = "Marathon: 5 instances"
     mock_execute_paasta_serviceinit_on_remote_master.return_value = fake_output
     expected_output = "    %s\n" % fake_output
@@ -315,7 +315,7 @@ def test_report_status_calls_report_bogus_filters(
     service = 'fake_service'
     planned_deployments = ['cluster.instance1', 'cluster.instance2']
     actual_deployments = {}
-    instance_filter = None
+    instance_filter = []
 
     status.report_status_for_cluster(
         service=service,
@@ -470,7 +470,7 @@ def test_report_status_obeys_cluster_filter(
 ):
     service = 'fake_service'
     cluster_filter = ['cluster1']
-    instance_filter = None
+    instance_filter = []
     deploy_pipeline = actual_deployments = [
         'cluster1.main', 'cluster2.main', 'cluster3.main']
     report_status(
@@ -501,8 +501,8 @@ def test_report_status_handle_none_filter(
     mock_report_status_for_cluster,
 ):
     service = 'fake_service'
-    cluster_filter = None
-    instance_filter = None
+    cluster_filter = []
+    instance_filter = []
     deploy_pipeline = actual_deployments = [
         'cluster1.main', 'cluster2.main', 'cluster3.main']
     report_status(

--- a/tests/paasta_cli/test_cmds_status.py
+++ b/tests/paasta_cli/test_cmds_status.py
@@ -443,8 +443,9 @@ def test_status_calls_sergeants(
 
 
 def test_report_bogus_filters_nofilter():
+    filters = None
     deployed_clusters = ['cluster1', 'cluster2', 'cluster3']
-    actual = report_bogus_filters(None, deployed_clusters)
+    actual = report_bogus_filters(filters, deployed_clusters)
     assert actual == ''
 
 

--- a/tests/paasta_cli/test_cmds_status.py
+++ b/tests/paasta_cli/test_cmds_status.py
@@ -266,6 +266,32 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
     assert expected_output in output
 
 
+@patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
+@patch('sys.stdout', new_callable=StringIO)
+def test_report_status_for_cluster_obeys_instance_filter(
+    mock_stdout,
+    mock_execute_paasta_serviceinit_on_remote_master,
+):
+    service = 'fake_service'
+    planned_deployments = ['cluster.instance1', 'cluster.instance2']
+    actual_deployments = {
+        'cluster.instance1': 'sha',
+        'cluster.instance2': 'sha',
+    }
+    instance_filter = ['instance1']
+
+    status.report_status_for_cluster(
+        service=service,
+        cluster='cluster',
+        deploy_pipeline=planned_deployments,
+        actual_deployments=actual_deployments,
+        instance_filter=instance_filter,
+    )
+    output = mock_stdout.getvalue()
+    assert 'instance1' in output
+    assert 'instance2' not in output
+
+
 @patch('paasta_tools.paasta_cli.cmds.status.figure_out_service_name', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.status.get_deploy_info', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.status.get_actual_deployments', autospec=True)

--- a/tests/paasta_cli/test_cmds_status.py
+++ b/tests/paasta_cli/test_cmds_status.py
@@ -368,21 +368,33 @@ def test_report_bogus_filters_with_filter():
 @patch('paasta_tools.paasta_cli.cmds.status.report_status_for_cluster')
 @patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters')
 @patch('sys.stdout', new_callable=StringIO)
-def test_report_status_obeys_filter(
+def test_report_status_obeys_cluster_filter(
     mock_stdout,
     mock_report_bogus_filters,
     mock_report_status_for_cluster,
 ):
     service = 'fake_service'
     cluster_filter = ['cluster1']
+    instance_filter = None
     deploy_pipeline = actual_deployments = [
         'cluster1.main', 'cluster2.main', 'cluster3.main']
     report_status(
-        service, deploy_pipeline, actual_deployments, cluster_filter)
+        service=service,
+        deploy_pipeline=deploy_pipeline,
+        actual_deployments=actual_deployments,
+        cluster_filter=cluster_filter,
+        instance_filter=instance_filter,
+    )
     mock_report_bogus_filters.assert_called_once_with(
         cluster_filter, ['cluster1', 'cluster2', 'cluster3'])
-    mock_report_status_for_cluster.assert_called_once_with(service, 'cluster1', deploy_pipeline,
-                                                           actual_deployments, False)
+    mock_report_status_for_cluster.assert_called_once_with(
+        service=service,
+        cluster='cluster1',
+        deploy_pipeline=deploy_pipeline,
+        actual_deployments=actual_deployments,
+        instance_filter=instance_filter,
+        verbose=False
+    )
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.report_status_for_cluster')
@@ -395,13 +407,37 @@ def test_report_status_handle_none_filter(
 ):
     service = 'fake_service'
     cluster_filter = None
+    instance_filter = None
     deploy_pipeline = actual_deployments = [
         'cluster1.main', 'cluster2.main', 'cluster3.main']
     report_status(
-        service, deploy_pipeline, actual_deployments, cluster_filter)
+        service=service,
+        deploy_pipeline=deploy_pipeline,
+        actual_deployments=actual_deployments,
+        cluster_filter=cluster_filter,
+        instance_filter=instance_filter,
+    )
     mock_report_status_for_cluster.assert_any_call(
-        service, 'cluster1', deploy_pipeline, actual_deployments, False)
+        service=service,
+        cluster='cluster1',
+        deploy_pipeline=deploy_pipeline,
+        actual_deployments=actual_deployments,
+        instance_filter=instance_filter,
+        verbose=False
+    )
     mock_report_status_for_cluster.assert_any_call(
-        service, 'cluster2', deploy_pipeline, actual_deployments, False)
+        service=service,
+        cluster='cluster2',
+        deploy_pipeline=deploy_pipeline,
+        actual_deployments=actual_deployments,
+        instance_filter=instance_filter,
+        verbose=False
+    )
     mock_report_status_for_cluster.assert_any_call(
-        service, 'cluster3', deploy_pipeline, actual_deployments, False)
+        service=service,
+        cluster='cluster3',
+        deploy_pipeline=deploy_pipeline,
+        actual_deployments=actual_deployments,
+        instance_filter=instance_filter,
+        verbose=False
+    )

--- a/tests/paasta_cli/test_cmds_status.py
+++ b/tests/paasta_cli/test_cmds_status.py
@@ -292,6 +292,28 @@ def test_report_status_for_cluster_obeys_instance_filter(
     assert 'instance2' not in output
 
 
+@patch('paasta_tools.paasta_cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
+@patch('sys.stdout', new_callable=StringIO)
+def test_report_status_calls_report_bogus_filters(
+    mock_stdout,
+    mock_execute_paasta_serviceinit_on_remote_master,
+):
+    service = 'fake_service'
+    planned_deployments = ['cluster.instance1', 'cluster.instance2']
+    actual_deployments = {}
+    instance_filter = None
+
+    with patch('paasta_tools.paasta_cli.cmds.status.report_bogus_filters', autospec=True) as mock_report_bogus_filters:
+        status.report_status_for_cluster(
+            service=service,
+            cluster='cluster',
+            deploy_pipeline=planned_deployments,
+            actual_deployments=actual_deployments,
+            instance_filter=instance_filter,
+        )
+        mock_report_bogus_filters.assert_called_once_with(instance_filter, ['instance1', 'instance2'])
+
+
 @patch('paasta_tools.paasta_cli.cmds.status.figure_out_service_name', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.status.get_deploy_info', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.status.get_actual_deployments', autospec=True)

--- a/tests/paasta_cli/test_cmds_status.py
+++ b/tests/paasta_cli/test_cmds_status.py
@@ -442,14 +442,14 @@ def test_status_calls_sergeants(
     )
 
 
-def test_report_bogus_filters_nofilter():
+def test_report_bogus_filters_no_filters():
     filters = None
     deployed_clusters = ['cluster1', 'cluster2', 'cluster3']
     actual = report_bogus_filters(filters, deployed_clusters)
     assert actual == ''
 
 
-def test_report_bogus_filters_with_filter():
+def test_report_bogus_filters_with_filters():
     filters = ['bogus1', 'cluster1']
     deployed_clusters = ['cluster1', 'cluster2', 'cluster3']
     actual = report_bogus_filters(filters, deployed_clusters)

--- a/tests/paasta_cli/test_cmds_status.py
+++ b/tests/paasta_cli/test_cmds_status.py
@@ -324,7 +324,7 @@ def test_report_status_calls_report_bogus_filters(
         actual_deployments=actual_deployments,
         instance_filter=instance_filter,
     )
-    mock_report_bogus_filters.assert_called_once_with(instance_filter, ['instance1', 'instance2'])
+    mock_report_bogus_filters.assert_called_once_with(instance_filter, ['instance1', 'instance2'], 'instance')
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.figure_out_service_name', autospec=True)
@@ -444,17 +444,20 @@ def test_status_calls_sergeants(
 
 def test_report_bogus_filters_no_filters():
     filters = None
-    deployed_clusters = ['cluster1', 'cluster2', 'cluster3']
-    actual = report_bogus_filters(filters, deployed_clusters)
+    items = ['cluster1', 'cluster2', 'cluster3']
+    item_type = 'thingy'
+    actual = report_bogus_filters(filters, items, item_type)
     assert actual == ''
 
 
 def test_report_bogus_filters_with_filters():
     filters = ['bogus1', 'cluster1']
-    deployed_clusters = ['cluster1', 'cluster2', 'cluster3']
-    actual = report_bogus_filters(filters, deployed_clusters)
-    assert 'bogus1' in actual
+    items = ['cluster1', 'cluster2', 'cluster3']
+    item_type = 'thingy'
+    actual = report_bogus_filters(filters, items, item_type)
     assert 'Warning' in actual
+    assert item_type in actual
+    assert 'bogus1' in actual
 
 
 @patch('paasta_tools.paasta_cli.cmds.status.report_status_for_cluster', autospec=True)
@@ -478,7 +481,7 @@ def test_report_status_obeys_cluster_filter(
         instance_filter=instance_filter,
     )
     mock_report_bogus_filters.assert_called_once_with(
-        cluster_filter, ['cluster1', 'cluster2', 'cluster3'])
+        cluster_filter, ['cluster1', 'cluster2', 'cluster3'], 'cluster')
     mock_report_status_for_cluster.assert_called_once_with(
         service=service,
         cluster='cluster1',

--- a/tests/paasta_cli/test_cmds_status.py
+++ b/tests/paasta_cli/test_cmds_status.py
@@ -334,6 +334,7 @@ def test_status_calls_sergeants(
     args = MagicMock()
     args.service = service
     args.clusters = None
+    args.instances = None
     args.verbose = False
     paasta_status(args)
 
@@ -341,7 +342,13 @@ def test_status_calls_sergeants(
     mock_get_actual_deployments.assert_called_once_with(service)
     mock_get_deploy_info.assert_called_once_with(service)
     mock_report_status.assert_called_once_with(
-        service, planned_deployments, actual_deployments, None, False)
+        service=service,
+        deploy_pipeline=planned_deployments,
+        actual_deployments=actual_deployments,
+        cluster_filter=None,
+        instance_filter=None,
+        verbose=False,
+    )
 
 
 def test_report_bogus_filters_nofilter():


### PR DESCRIPTION
I wanted to try out some stuff with a new instance of the reminder service, but that service has a ton of instances so doing paasta status is slow and painful. Now we can filter instances like we can filter clusters:

```
(py)troscoe@dev2-devc:~/paasta_tools (mrtyler_instance_filter) $ ./paasta_tools/paasta_cli/paasta_cli.py status -s paasta_canary -c norcal-devc,qwer -i sensu_canary,asdf
Pipeline: https://jenkins.yelpcorp.com/view/services-paasta_canary

cluster: norcal-devc
  instance: sensu_canary
    Git sha:    b8517e76
    Config:     configbb7d0b2a
      Status:   Enabled, Started
      Last:     OK (2015-11-13T16:40, a minute ago)
      Schedule: R/2015-11-14T00:50:00.000Z/PT10M Epsilon: PT60S
      Command:  sensu-scheduled-canary.sh
      Mesos:    Not running

Warning: This service does not have any instance matching these filters:
asdf

Warning: This service does not have any cluster matching these filters:
qwer
```
