### PR TITLE
upgrade marathon and chronos-python

### DIFF
--- a/paasta_itests/paasta_metastatus.feature
+++ b/paasta_itests/paasta_metastatus.feature
@@ -14,7 +14,7 @@ Feature: paasta_metastatus describes the state of the paasta cluster
   Scenario: High memory usage
     Given a working paasta cluster
      When an app with id "memtest" using high memory is launched
-      And a task belonging to the app with id "memtest" is in the task list
+      And a task belonging to the app with id "/memtest" is in the task list
      Then paasta_metastatus exits with return code "2" and output "CRITICAL: Less than 10% memory available."
 
   # paasta_metastatus defines 'high' cpu usage as > 90% of the total cluster
@@ -29,7 +29,7 @@ Feature: paasta_metastatus describes the state of the paasta cluster
   Scenario: High cpu usage
     Given a working paasta cluster
      When an app with id "cputest" using high cpu is launched
-      And a task belonging to the app with id "cputest" is in the task list
+      And a task belonging to the app with id "/cputest" is in the task list
      Then paasta_metastatus exits with return code "2" and output "CRITICAL: Less than 10% CPUs available."
 
   Scenario: With a launched chronos job

--- a/paasta_itests/paasta_metastatus.feature
+++ b/paasta_itests/paasta_metastatus.feature
@@ -14,7 +14,7 @@ Feature: paasta_metastatus describes the state of the paasta cluster
   Scenario: High memory usage
     Given a working paasta cluster
      When an app with id "memtest" using high memory is launched
-      And a task belonging to the app with id "/memtest" is in the task list
+      And a task belonging to the app with id "memtest" is in the task list
      Then paasta_metastatus exits with return code "2" and output "CRITICAL: Less than 10% memory available."
 
   # paasta_metastatus defines 'high' cpu usage as > 90% of the total cluster
@@ -29,7 +29,7 @@ Feature: paasta_metastatus describes the state of the paasta cluster
   Scenario: High cpu usage
     Given a working paasta cluster
      When an app with id "cputest" using high cpu is launched
-      And a task belonging to the app with id "/cputest" is in the task list
+      And a task belonging to the app with id "cputest" is in the task list
      Then paasta_metastatus exits with return code "2" and output "CRITICAL: Less than 10% CPUs available."
 
   Scenario: With a launched chronos job

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -778,12 +778,15 @@ def app_has_tasks(client, app_id, expected_tasks, exact_matches_only=False):
     Raises a marathon.NotFoundError when no app with matching id is found.
 
     :param client: the marathon client
-    :param app_id: the app_id to which the tasks should belong
+    :param app_id: the app_id to which the tasks should belong. The app_id has a / prepended
+    to it in the case it does not start with one.
     :param expected_tasks: the number of tasks to check for
     :param exact_matches_only: a boolean indicating whether we require exactly expected_tasks to be running
     :returns: a boolean indicating whether there are atleast expected_tasks tasks with
         an app id matching app_id
     """
+    if not app_id.startswith("/"):
+        app_id = "/%s" % app_id
     try:
         tasks = client.list_tasks(app_id=app_id)
     except NotFoundError:

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -778,15 +778,14 @@ def app_has_tasks(client, app_id, expected_tasks, exact_matches_only=False):
     Raises a marathon.NotFoundError when no app with matching id is found.
 
     :param client: the marathon client
-    :param app_id: the app_id to which the tasks should belong. The app_id has a / prepended
-    to it in the case it does not start with one.
+    :param app_id: the app_id to which the tasks should belong. The leading / that marathon appends to
+    app_ids is added here.
     :param expected_tasks: the number of tasks to check for
     :param exact_matches_only: a boolean indicating whether we require exactly expected_tasks to be running
     :returns: a boolean indicating whether there are atleast expected_tasks tasks with
         an app id matching app_id
     """
-    if not app_id.startswith("/"):
-        app_id = "/%s" % app_id
+    app_id = "/%s" % app_id
     try:
         tasks = client.list_tasks(app_id=app_id)
     except NotFoundError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ argparse==1.2.1
 backports.ssl-match-hostname==3.4.0.2
 blessings==1.6
 boto==2.38.0
--e git://github.com/asher/chronos-python.git@64dacd198d730e78dfb83bc8050623089c6e4751#egg=chronos-python
+chronos-python==0.34.0
 docker-py==1.2.3
 dulwich==0.10.0
 future==0.14.3
@@ -17,7 +17,7 @@ importlib==1.0.3
 isodate==0.5.1
 kazoo==2.2
 lockfile==0.9.1
--e git://github.com/yelp/marathon-python.git@e7e2116159528c45afdbb8b01c03fbd0333e0108#egg=marathon
+marathon==0.7.3
 mccabe==0.3.1
 mesos.cli==0.1.3
 mesos.interface==0.22.1.2

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'argcomplete >= 0.8.1',
         # argparse is pinned to 1.2.1 since it comes in the core python2.7 libs and pip can't seem to override it
         'argparse == 1.2.1',
-        'chronos-python == 0.33.0',
+        'chronos-python == 0.34.0',
         # Don't update this unless you have confirmed the client works with the Docker version deployed on PaaSTA servers
         'docker-py == 1.2.3',
         'dulwich == 0.10.0',
@@ -41,7 +41,7 @@ setup(
         'httplib2 >= 0.9, <= 1.0',
         'isodate >= 0.5.0',
         'kazoo >= 2.0.0',
-        'marathon >= 0.7.1',
+        'marathon >= 0.7.3',
         'mesos.cli == 0.1.3',
         'ordereddict >= 1.1',
         'path.py >= 8.1',

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1042,6 +1042,13 @@ class TestMarathonTools:
         assert marathon_tools.app_has_tasks(fake_client, 'fake_app', 4) is False
         assert marathon_tools.app_has_tasks(fake_client, 'fake_app', 4, exact_matches_only=True) is False
 
+    @patch('marathon_tools.MarathonClient.list_tasks')
+    def test_add_leading_slash(self, patch_list_tasks):
+        fake_client = mock.Mock()
+        fake_client.list_tasks = patch_list_tasks
+        marathon_tools.app_has_tasks(fake_client, 'fake_app', 4)
+        assert patch_list_tasks.called_with('/fake_app')
+
     def test_get_code_sha_from_dockerurl(self):
         fake_docker_url = 'docker-paasta.yelpcorp.com:443/services-cieye:paasta-93340779404579'
         actual = marathon_tools.get_code_sha_from_dockerurl(fake_docker_url)


### PR DESCRIPTION
- Use versions of chronos-python and marathon from pypi
- Fix a test broken by the new version of marathon