### PR TITLE
fail gracefully if you try and run paasta logs without scribe existing

### DIFF
--- a/paasta_tools/paasta_cli/cmds/logs.py
+++ b/paasta_tools/paasta_cli/cmds/logs.py
@@ -26,6 +26,7 @@ import re
 import sys
 
 import isodate
+
 try:
     from scribereader import scribereader
     from scribereader.scribereader import StreamTailerSetupError
@@ -509,6 +510,12 @@ def tail_paasta_logs(service, levels, components, clusters, raw_mode=False):
 def paasta_logs(args):
     """Print the logs for as Paasta service.
     :param args: argparse.Namespace obj created from sys.args by paasta_cli"""
+    if 'scribereader' not in vars():
+        sys.exit(
+            "Unfortunately, `paasta logs` is unavailable without Scribe."
+            " We're working to support alternative logging backends in PaaSTA:"
+            " follow https://github.com/Yelp/paasta/issues/64 for updates."
+        )
     service = figure_out_service_name(args)
 
     if args.clusters is None:


### PR DESCRIPTION
I'd like a better way of doing this - logic for dealing with missing scribereader is sprawled into a few places now. If anyone has a better suggestion, I'm open to discussion.