### PR TITLE
execute docker pull before running container

### DIFF
--- a/general_itests/paasta_execute_docker_command.feature
+++ b/general_itests/paasta_execute_docker_command.feature
@@ -2,19 +2,19 @@ Feature: paasta_execute_docker_command can find and run commands inside a docker
 
   Scenario: paasta_execute_docker_command can run a trivial command
    Given Docker is available
-     And a running docker container with task id foo
+    And a running docker container with task id foo and image ubuntu:trusty
     When we paasta_execute_docker_command a command with exit code 0 in container with task id foo
     Then the exit code is 0
 
   Scenario: paasta_execute_docker_command exits when it cannot find the container
    Given Docker is available
-     And a running docker container with task id foo
+    And a running docker container with task id foo and image ubuntu:trusty
     When we paasta_execute_docker_command a command with exit code 0 in container with task id bar
     Then the exit code is 1
 
   Scenario: paasta_execute_docker_command reuses exec instances
    Given Docker is available
-     And a running docker container with task id foo
+    And a running docker container with task id foo and image ubuntu:trusty
     When we paasta_execute_docker_command a command with exit code 0 in container with task id foo
      And we paasta_execute_docker_command a command with exit code 0 in container with task id foo
     Then the docker container has at most 1 exec instances

--- a/general_itests/steps/paasta_execute_docker_command.py
+++ b/general_itests/steps/paasta_execute_docker_command.py
@@ -38,6 +38,7 @@ def create_docker_container(context, task_id):
         context.docker_client.remove_container(container_name, force=True)
     except APIError:
         pass
+    context.docker_client.pull('ubuntu:trusty')
     container = context.docker_client.create_container(
         name=container_name,
         image='ubuntu:trusty',

--- a/general_itests/steps/paasta_execute_docker_command.py
+++ b/general_itests/steps/paasta_execute_docker_command.py
@@ -31,17 +31,17 @@ def docker_is_available(context):
     context.docker_client = docker_client
 
 
-@given(u'a running docker container with task id {task_id}')
-def create_docker_container(context, task_id):
+@given(u'a running docker container with task id {task_id} and image {image_name}')
+def create_docker_container(context, task_id, image_name):
     container_name = 'paasta-itest-execute-in-containers'
     try:
         context.docker_client.remove_container(container_name, force=True)
     except APIError:
         pass
-    context.docker_client.pull('ubuntu:trusty')
+    context.docker_client.pull(image_name)
     container = context.docker_client.create_container(
         name=container_name,
-        image='ubuntu:trusty',
+        image=image_name,
         command='/bin/sleep infinity',
         environment={'MESOS_TASK_ID': task_id},
     )


### PR DESCRIPTION
We found an edge case where this failed because the image didn't already exist on the host travis was running the tests on - dockerpy doesn't pull an image if it doesn't already exist, so this addresses that.