### PR TITLE
Use dulwich for mark for deployment

### DIFF
--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -181,7 +181,7 @@ def write_soa_dir_chronos_deployments(context, service, disabled, instance):
     with open(os.path.join(context.soa_dir, service, 'deployments.json'), 'w') as dp:
         dp.write(json.dumps({
             'v1': {
-                '%s:%s' % (service, utils.get_default_branch(context.cluster, instance)): {
+                '%s:%s' % (service, utils.get_paasta_branch(context.cluster, instance)): {
                     'docker_image': 'test-image-foobar%d' % context.tag_version,
                     'desired_state': desired_state,
                 }

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -31,7 +31,7 @@ from paasta_tools.utils import compose_job_id as utils_compose_job_id
 from paasta_tools.utils import decompose_job_id as utils_decompose_job_id
 from paasta_tools.utils import get_code_sha_from_dockerurl
 from paasta_tools.utils import get_config_hash
-from paasta_tools.utils import get_default_branch
+from paasta_tools.utils import get_paasta_branch
 from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import InvalidJobNameError
@@ -146,7 +146,7 @@ def load_chronos_job_config(service, instance, cluster, load_deployments=True, s
     branch_dict = {}
     if load_deployments:
         deployments_json = load_deployments_json(service, soa_dir=soa_dir)
-        branch = get_default_branch(cluster, instance)
+        branch = get_paasta_branch(cluster=cluster, instance=instance)
         branch_dict = deployments_json.get_branch_dict(service, branch)
     return ChronosJobConfig(service, instance, service_chronos_jobs[instance], branch_dict)
 

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -48,7 +48,7 @@ import service_configuration_lib
 
 from paasta_tools import remote_git
 from paasta_tools.utils import atomic_file_write
-from paasta_tools.utils import get_default_branch
+from paasta_tools.utils import get_paasta_branch
 from paasta_tools.utils import get_git_url
 
 
@@ -93,7 +93,7 @@ def get_branches_from_config_file(file_dir, filename):
                 # cluster may contain dashes (and frequently does) so
                 # reassemble the cluster after stripping the chronos/marathon prefix
                 cluster = '-'.join(filename.split('-')[1:]).split('.')[0]
-                target_branch = get_default_branch(cluster, instance)
+                target_branch = get_paasta_branch(cluster, instance)
             except IndexError:
                 pass
         if target_branch:

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -37,7 +37,7 @@ from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import get_code_sha_from_dockerurl
 from paasta_tools.utils import get_config_hash
-from paasta_tools.utils import get_default_branch
+from paasta_tools.utils import get_paasta_branch
 from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import InstanceConfig
@@ -146,7 +146,7 @@ def load_marathon_service_config(service, instance, cluster, load_deployments=Tr
     branch_dict = {}
     if load_deployments:
         deployments_json = load_deployments_json(service, soa_dir=soa_dir)
-        branch = general_config.get('branch', get_default_branch(cluster, instance))
+        branch = general_config.get('branch', get_paasta_branch(cluster, instance))
         branch_dict = deployments_json.get_branch_dict(service, branch)
 
     return MarathonServiceConfig(

--- a/paasta_tools/paasta_cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/paasta_cli/cmds/mark_for_deployment.py
@@ -22,7 +22,8 @@ import sys
 from paasta_tools.paasta_cli.utils import get_jenkins_build_output_url
 from paasta_tools.paasta_cli.utils import validate_service_name
 from paasta_tools.utils import _log
-from paasta_tools.utils import _run
+from paasta_tools.utils import get_paasta_branch
+from paasta_tools import remote_git
 
 
 def add_subparser(subparsers):

--- a/paasta_tools/paasta_cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/paasta_cli/cmds/mark_for_deployment.py
@@ -19,7 +19,6 @@ deployment to a cluster.instance.
 
 import sys
 
-from paasta_tools.paasta_cli.utils import get_jenkins_build_output_url
 from paasta_tools.paasta_cli.utils import validate_service_name
 from paasta_tools.utils import _log
 from paasta_tools.utils import get_paasta_branch
@@ -54,57 +53,23 @@ def add_subparser(subparsers):
     list_parser.set_defaults(command=paasta_mark_for_deployment)
 
 
-def build_command(
-    upstream_git_url,
-    upstream_git_commit,
-    cluster,
-    instance,
-):
-    """upstream_git_url is the Git URL where the service lives (e.g.
-    git@git.yelpcorp.com:services/foo)
-
-    instancename is where you want to deploy. E.g. cluster1.canary indicates
-    a Mesos cluster (cluster1) and an instance within that cluster (canary)
-    """
-    cmd = 'git push -f %s %s:refs/heads/paasta-%s.%s' % (
-        upstream_git_url,
-        upstream_git_commit,
-        cluster,
-        instance,
-    )
-    return cmd
-
-
-def get_loglines(returncode, cmd, output, commit, cluster, instance):
-    loglines = []
-    if returncode != 0:
-        loglines.append('ERROR: Failed to mark %s for deployment in %s.%s.' % (commit, cluster, instance))
-        loglines.append("Ran: '%s'" % cmd)
-        loglines.append("Output: %s" % output)
-        output_url = get_jenkins_build_output_url()
-        if output_url:
-            loglines.append('See Jenkins output at %s' % output)
-    else:
-        loglines.append('Marked %s in %s.%s for deployment.' % (commit, cluster, instance))
-    return loglines
-
-
 def mark_for_deployment(git_url, cluster, instance, service, commit):
     """Mark a docker image for deployment"""
-    cmd = build_command(git_url, commit, cluster=cluster, instance=instance)
-    # Clusterinstance should be in cluster.instance format
-    returncode, output = _run(
-        cmd,
-        timeout=30,
+    remote_branch = get_paasta_branch(cluster=cluster, instance=instance)
+    ref_mutator = remote_git.make_force_push_mutate_refs_func(
+        target_branches=[remote_branch],
+        sha=commit,
     )
-    loglines = get_loglines(
-        returncode=returncode,
-        cmd=cmd,
-        output=output,
-        commit=commit,
-        cluster=cluster,
-        instance=instance
-    )
+    try:
+        remote_git.create_remote_refs(git_url=git_url, ref_mutator=ref_mutator, force=True)
+        loglines = ["Marked %s in for deployment on %s in the %s cluster" % (commit, instance, cluster)]
+        return_code = 0
+    except Exception as e:
+        loglines = ["Failed to mark %s in for deployment on %s in the %s cluster!" % (commit, instance, cluster)]
+        for line in str(e).split('\n'):
+            loglines.append(line)
+        return_code = 1
+
     for logline in loglines:
         _log(
             service=service,
@@ -114,7 +79,7 @@ def mark_for_deployment(git_url, cluster, instance, service, commit):
             cluster=cluster,
             instance=instance,
         )
-    return returncode
+    return return_code
 
 
 def paasta_mark_for_deployment(args):

--- a/paasta_tools/paasta_cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/paasta_cli/cmds/mark_for_deployment.py
@@ -62,13 +62,14 @@ def mark_for_deployment(git_url, cluster, instance, service, commit):
     )
     try:
         remote_git.create_remote_refs(git_url=git_url, ref_mutator=ref_mutator, force=True)
-        loglines = ["Marked %s in for deployment on %s in the %s cluster" % (commit, instance, cluster)]
-        return_code = 0
     except Exception as e:
         loglines = ["Failed to mark %s in for deployment on %s in the %s cluster!" % (commit, instance, cluster)]
         for line in str(e).split('\n'):
             loglines.append(line)
         return_code = 1
+    else:
+        loglines = ["Marked %s in for deployment on %s in the %s cluster" % (commit, instance, cluster)]
+        return_code = 0
 
     for logline in loglines:
         _log(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -953,7 +953,7 @@ class DeploymentsJson(dict):
         return self.get(full_branch, {})
 
 
-def get_default_branch(cluster, instance):
+def get_paasta_branch(cluster, instance):
     return 'paasta-%s.%s' % (cluster, instance)
 
 

--- a/tests/test_remote_git.py
+++ b/tests/test_remote_git.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import mock
+
 from paasta_tools import remote_git
 
 
@@ -41,3 +43,59 @@ def test_make_determine_wants_func():
     actual = determine_wants(refs)
     expected = dict(refs.items() + [('foo', 'bar')])
     assert actual == expected
+
+
+def test_make_force_push_mutate_refs_func_overwrites_shas():
+    target_branches = ['targeta', 'targetb']
+    newsha = 'newsha'
+    input_refs = {
+        'refs/heads/foo': '12345',
+        'refs/heads/targeta': '12345',
+        'refs/heads/targetb': '12345',
+        'refs/heads/ignored': '12345',
+        'refs/tags/blah': '12345',
+    }
+    expected = {
+        'refs/heads/foo': '12345',
+        'refs/heads/targeta': newsha,
+        'refs/heads/targetb': newsha,
+        'refs/heads/ignored': '12345',
+        'refs/tags/blah': '12345',
+    }
+
+    mutate_refs_func = remote_git.make_force_push_mutate_refs_func(
+        target_branches=target_branches,
+        sha=newsha,
+    )
+    actual = mutate_refs_func(input_refs)
+    assert actual == expected
+
+
+@mock.patch('dulwich.client', autospec=True)
+@mock.patch('paasta_tools.remote_git._make_determine_wants_func', autospec=True)
+def test_create_remote_refs_is_safe_by_default(mock_make_determine_wants_func, mock_dulwich_client):
+    git_url = 'fake_git_url'
+    ref_mutator = lambda x: x
+    fake_git_client = mock.Mock()
+    mock_dulwich_client.get_transport_and_path.return_value = fake_git_client, 'fake_path'
+    remote_git.create_remote_refs(
+        git_url=git_url,
+        ref_mutator=ref_mutator,
+    )
+    fake_git_client.send_pack.assert_called_once_with(
+        'fake_path', mock_make_determine_wants_func.return_value, mock.ANY)
+
+
+@mock.patch('dulwich.client', autospec=True)
+def test_create_remote_refs_allows_force_and_uses_the_provided_mutator(mock_dulwich_client):
+    git_url = 'fake_git_url'
+    ref_mutator = lambda x: x
+    fake_git_client = mock.Mock()
+    mock_dulwich_client.get_transport_and_path.return_value = fake_git_client, 'fake_path'
+    remote_git.create_remote_refs(
+        git_url=git_url,
+        ref_mutator=ref_mutator,
+        force=True,
+    )
+    fake_git_client.send_pack.assert_called_once_with(
+        'fake_path', ref_mutator, mock.ANY)


### PR DESCRIPTION
This converts mark-for-deployment to use dulwich so you don't need a local checkout.
This will be necessary for non-jenkins use cases and will be handy for the "rollback" command.

Some extra code was necissary in the `remote_git` module to support this. I would like @EvanKrall to look extra carefully at that, it was my first time using dulwich.

Manual testing:
```
kwa@dev13-devc:~/Projects/devops (master) $ git branch -a -v
  remotes/origin/paasta-nova-devc.demo                1aaf828 devops demo 2

(py)kwa@dev13-devc:~/Projects/paasta (use_dulwich_for_mark_for_deployment) $ ./paasta_tools/paasta_cli/paasta_cli.py mark-for-deployment -u git@git.yelpcorp.com:services/devops -c 700bda5e32aae2345af581af29494ef095bd9666 -l nova-devc.demo -s devops
Marked 700bda5e32aae2345af581af29494ef095bd9666 in for deployment on demo in the nova-devc cluster

kwa@dev13-devc:~/Projects/devops (master) $ git branch -a -v  | grep nova-devc
  remotes/origin/paasta-nova-devc.demo                700bda5 Revert "Failing test to test email notifications"
```