### PR TITLE
Mrtyler rejigger status

### DIFF
--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -79,11 +79,8 @@ def get_short_task_id(task_id):
 
 
 def _format_config_hash(job):
-    config_hash = PaastaColors.red("UNKNOWN")
-    job_id = job.get("name", None)
-    if job_id:
-        (_, __, ___, config_hash) = chronos_tools.decompose_job_id(job_id)
-    return config_hash
+    job_id = job.get("name", PaastaColors.red("UNKNOWN"))
+    return job_id
 
 
 def _format_disabled_status(job):

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -155,14 +155,11 @@ def _format_mesos_status(job, running_tasks):
     return mesos_status
 
 
-def format_chronos_job_status(job, desired_state, running_tasks, verbose):
+def format_chronos_job_status(job, running_tasks, verbose):
     """Given a job, returns a pretty-printed human readable output regarding
     the status of the job.
 
     :param job: dictionary of the job status
-    :param desired_state: a pretty-formatted string representing the
-                          job's started/stopped state as set with paasta emergency-[stop|start], e.g.
-                          the result of ``get_desired_state_human()``
     :param running_tasks: a list of Mesos tasks associated with ``job``, e.g. the
                           result of ``mesos_tools.get_running_tasks_from_active_frameworks()``.
 
@@ -178,14 +175,13 @@ def format_chronos_job_status(job, desired_state, running_tasks, verbose):
         mesos_status = "%s\n%s" % (mesos_status, mesos_status_verbose)
     return (
         "Config:     %(config_hash)s\n"
-        "  Status:   %(disabled_state)s, %(desired_state)s\n"
+        "  Status:   %(disabled_state)s\n"
         "  Last:     %(last_result)s (%(formatted_time)s)\n"
         "  Schedule: %(schedule)s\n"
         "  Command:  %(command)s\n"
         "  Mesos:    %(mesos_status)s" % {
             "config_hash": config_hash,
             "disabled_state": disabled_state,
-            "desired_state": desired_state,
             "last_result": last_result,
             "formatted_time": formatted_time,
             "schedule": schedule,
@@ -208,9 +204,10 @@ def status_chronos_jobs(jobs, job_config, verbose):
     else:
         output = []
         desired_state = job_config.get_desired_state_human()
+        output.append("Desired:    %s" % desired_state)
         for job in jobs:
             running_tasks = get_running_tasks_from_active_frameworks(job["name"])
-            output.append(format_chronos_job_status(job, desired_state, running_tasks, verbose))
+            output.append(format_chronos_job_status(job, running_tasks, verbose))
         return "\n".join(output)
 
 

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -86,9 +86,9 @@ def _format_config_hash(job):
 def _format_disabled_status(job):
     status = PaastaColors.red("UNKNOWN")
     if job.get("disabled", False):
-        status = PaastaColors.red("Disabled")
+        status = PaastaColors.grey("Not scheduled")
     else:
-        status = PaastaColors.green("Enabled")
+        status = PaastaColors.green("Scheduled")
     return status
 
 

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -101,12 +101,7 @@ def test_format_chronos_job_name_exists():
     running_tasks = []
     verbose = False
     actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
-    # Includes only the 'tag' portion of the name, not the service and instance
-    # (as these are unnecessary and would just add clutter).
-    assert 'my_service' not in actual
-    assert 'my_instance' not in actual
-    assert 'gityourmom' not in actual
-    assert 'configyourdad' in actual
+    assert example_job['name'] in actual
 
 
 def test_format_chronos_job_name_does_not_exist():

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -97,19 +97,17 @@ def test_format_chronos_job_name_exists():
     example_job = {
         'name': 'my_service my_instance gityourmom configyourdad',
     }
-    desired_state = ''
     running_tasks = []
     verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     assert example_job['name'] in actual
 
 
 def test_format_chronos_job_name_does_not_exist():
     example_job = {}
-    desired_state = ''
     running_tasks = []
     verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     assert PaastaColors.red('UNKNOWN') in actual
 
 
@@ -117,10 +115,9 @@ def test_format_chronos_job_status_disabled():
     example_job = {
         'disabled': True,
     }
-    desired_state = ''
     running_tasks = []
     verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     assert PaastaColors.red('Disabled') in actual
 
 
@@ -128,20 +125,10 @@ def test_format_chronos_job_status_enabled():
     example_job = {
         'disabled': False,
     }
-    desired_state = ''
     running_tasks = []
     verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     assert PaastaColors.green('Enabled') in actual
-
-
-def test_format_chronos_job_status_desired_state_passed_through():
-    example_job = {}
-    desired_state = 'stopped (or started)'
-    running_tasks = []
-    verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
-    assert desired_state in actual
 
 
 def test_format_chronos_job_status_no_last_run():
@@ -149,10 +136,9 @@ def test_format_chronos_job_status_no_last_run():
         'lastError': '',
         'lastSuccess': '',
     }
-    desired_state = ''
     running_tasks = []
     verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     assert PaastaColors.yellow('New') in actual
     assert '(never)' in actual
 
@@ -162,10 +148,9 @@ def test_format_chronos_job_status_failure_no_success():
         'lastError': '2015-04-20T23:20:00.420Z',
         'lastSuccess': '',
     }
-    desired_state = ''
     running_tasks = []
     verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     assert PaastaColors.red('Failed') in actual
     assert '(2015-04-20T23:20' in actual
     assert 'ago)' in actual
@@ -176,10 +161,9 @@ def test_format_chronos_job_status_success_no_failure():
         'lastError': '',
         'lastSuccess': '2015-04-20T23:20:00.420Z',
     }
-    desired_state = ''
     running_tasks = []
     verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     assert PaastaColors.green('OK') in actual
     assert '(2015-04-20' in actual
     assert 'ago)' in actual
@@ -190,10 +174,9 @@ def test_format_chronos_job_status_failure_and_then_success():
         'lastError': '2015-04-20T23:20:00.420Z',
         'lastSuccess': '2015-04-21T23:20:00.420Z',
     }
-    desired_state = ''
     running_tasks = []
     verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     assert PaastaColors.green('OK') in actual
     assert '(2015-04-21' in actual
     assert 'ago)' in actual
@@ -204,10 +187,9 @@ def test_format_chronos_job_status_success_and_then_failure():
         'lastError': '2015-04-21T23:20:00.420Z',
         'lastSuccess': '2015-04-20T23:20:00.420Z',
     }
-    desired_state = ''
     running_tasks = []
     verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     assert PaastaColors.red('Failed') in actual
     assert '(2015-04-21' in actual
     assert 'ago)' in actual
@@ -218,10 +200,9 @@ def test_format_chronos_job_schedule():
         'schedule': 'R/2015-04-20T23:20:00+00:00/PT60M',
         'epsilon': 'PT42S',
     }
-    desired_state = ''
     running_tasks = []
     verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     assert example_job['schedule'] in actual
     assert example_job['epsilon'] in actual
 
@@ -230,37 +211,33 @@ def test_format_chronos_job_command():
     example_job = {
         'command': 'do the hokey pokey',
     }
-    desired_state = ''
     running_tasks = []
     verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     assert example_job['command'] in actual
 
 
 def test_format_chronos_job_zero_mesos_tasks():
     example_job = {}
-    desired_state = ''
     running_tasks = []
     verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     assert PaastaColors.grey('Not running') in actual
 
 
 def test_format_chronos_job_one_mesos_task():
     example_job = {}
-    desired_state = ''
     running_tasks = ['slay the nemean lion']
     verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     assert PaastaColors.yellow('Running') in actual
 
 
 def test_format_chronos_job_two_mesos_tasks():
     example_job = {}
-    desired_state = ''
     running_tasks = ['slay the nemean lion', 'slay the lernaean hydra']
     verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     assert 'Critical' in actual
 
 
@@ -268,7 +245,6 @@ def test_format_chronos_job_mesos_verbose():
     example_job = {
         'name': 'my_service my_instance gityourmom configyourdad',
     }
-    desired_state = ''
     running_tasks = ['slay the nemean lion']
     verbose = True
     with mock.patch(
@@ -276,7 +252,7 @@ def test_format_chronos_job_mesos_verbose():
         autospec=True,
         return_value='status_mesos_tasks_verbose output',
     ) as mock_status_mesos_tasks_verbose:
-        actual = chronos_serviceinit.format_chronos_job_status(example_job, desired_state, running_tasks, verbose)
+        actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
     mock_status_mesos_tasks_verbose.assert_called_once_with(example_job['name'], chronos_serviceinit.get_short_task_id)
     assert 'status_mesos_tasks_verbose output' in actual
 
@@ -303,7 +279,7 @@ def test_status_chronos_jobs_is_deployed():
             complete_job_config,
             verbose,
         )
-        assert actual == 'job_status_output'
+        assert '\njob_status_output' in actual
 
 
 def test_status_chronos_jobs_is_not_deployed():
@@ -348,12 +324,13 @@ def test_status_chronos_jobs_get_desired_state_human():
             return_value=[],
         ),
     ):
-        chronos_serviceinit.status_chronos_jobs(
+        actual = chronos_serviceinit.status_chronos_jobs(
             jobs,
             complete_job_config,
             verbose,
         )
-        assert complete_job_config.get_desired_state_human.call_count == 1
+        assert 'Desired:' in actual
+        assert repr(complete_job_config.get_desired_state_human.return_value) in actual
 
 
 def test_status_chronos_jobs_multiple_jobs():
@@ -381,7 +358,7 @@ def test_status_chronos_jobs_multiple_jobs():
             complete_job_config,
             verbose,
         )
-        assert actual == 'job_status_output\njob_status_output'
+        assert '\njob_status_output\njob_status_output' in actual
 
 
 def test_status_chronos_jobs_get_running_tasks():

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -118,7 +118,7 @@ def test_format_chronos_job_status_disabled():
     running_tasks = []
     verbose = False
     actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
-    assert PaastaColors.red('Disabled') in actual
+    assert PaastaColors.grey('Not scheduled') in actual
 
 
 def test_format_chronos_job_status_enabled():
@@ -128,7 +128,7 @@ def test_format_chronos_job_status_enabled():
     running_tasks = []
     verbose = False
     actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
-    assert PaastaColors.green('Enabled') in actual
+    assert PaastaColors.green('Scheduled') in actual
 
 
 def test_format_chronos_job_status_no_last_run():


### PR DESCRIPTION
This addresses some concerns brought up by carroux way back in review:115197:
- paasta level "started/stopped" (i.e. the result of "paasta stop/start") is only accurate at the instance level. It is wrong and misleading to display it for each config
- "enabled/disabled" is not very clear

After some thinking and some consultation with mfield, here's what I did:
- paasta level "started/stopped" is reported only at the top level (parallel with git sha), and no longer as part of individual configs
- Change "enabled/disabled" to "scheduled/not scheduled"
-- mfield noticed that there are sort of three states here: enabled, disabled because the whole service is disabled, disabled because this is an old version that we're keeping around for history. We couldn't think of a great way to communicate those three states and differentiating between the latter two would require additional refactoring, so I just went with "scheduled/not scheduled".

Screenshot:
![5850345041297408](https://cloud.githubusercontent.com/assets/1369918/11290072/e15a5cfa-8ee7-11e5-984a-4cc185e489b6.png)