### PR TITLE
active_only=True doesn't work with chronos. Let's try it with False.

### DIFF
--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -100,7 +100,7 @@ def get_current_tasks(job_id):
     :param job_id: the job id of the tasks.
     :return tasks: a list of mesos.cli.Task.
     """
-    return master.CURRENT.tasks(fltr=job_id, active_only=True)
+    return master.CURRENT.tasks(fltr=job_id, active_only=False)
 
 
 def filter_running_tasks(tasks):


### PR DESCRIPTION
I noticed this was broken in #paasta at 2015-10-14 22:25.

```
<troscoe> robj: tell me what you know about mesos master.CURRENT.tasks(active_only=True)
<troscoe> (Pdb) len([task['id'] for task in master.CURRENT.tasks(fltr=u'paasta_canary sensu_canary git2af124f2 config34fce6d7', active_only=True)])
<troscoe> 0
<troscoe> (Pdb) len([task['id'] for task in master.CURRENT.tasks(fltr=u'paasta_canary sensu_canary git2af124f2 config34fce6d7', active_only=False)])
<troscoe> 1000
<troscoe> this is why chronos status can only show currently running jobs :(
<troscoe> currently running mesos tasks*
<troscoe> contrast with
<troscoe> (Pdb) len([task['id'] for task in master.CURRENT.tasks(fltr='paasta--canary.main.git2af124f2.confige3ef71dd', active_only=True)])5
<troscoe> (Pdb) len([task['id'] for task in master.CURRENT.tasks(fltr='paasta--canary.main.git2af124f2.confige3ef71dd', active_only=False)])
<troscoe> 28
<troscoe> active_only is hardcoded True in the relevant mesos_tools code:
<troscoe> return master.CURRENT.tasks(fltr=job_id, active_only=True)
<troscoe> the mesos-cli code indicates that active_only refers to "frameworks"
<troscoe> and i'm pretty sure this was a real thing you ran into and that's why you hardcoded active_only=True
<troscoe> but obv i am puzzled about chronos's behavior
<troscoe> robj: so: halp
<troscoe> the hardcoding happened in f690c3fe934f30495584ff9933a046537f196369
```

After further discussion, we agreed that it had simply been broken without anyone noticing. Flipping to active_only=False appears to do the right thing for both marathon and chronos jobs. I still fear that there is some weirdness lurking here that caused robj to flip it to True in the first place, but True definitely never displays old mesos tasks so I guess we'll push this and see how it goes.