### PR TITLE
Make local-run default to use bash if set to be interactive

### DIFF
--- a/paasta_tools/paasta_cli/cmds/local_run.py
+++ b/paasta_tools/paasta_cli/cmds/local_run.py
@@ -258,12 +258,11 @@ def add_subparser(subparsers):
     )
     list_parser.add_argument(
         '-C', '--cmd',
-        help=(
-            'Run Docker container with particular command, '
-            'for instance bash'
-        ),
+        help=('Run Docker container with particular command, '
+              'for example: "bash". By default will use the command or args specified by the '
+              'soa-configs or what was specified in the Dockefile'),
         required=False,
-        default='',
+        default=None,
     )
     list_parser.add_argument(
         '-i', '--instance',
@@ -280,7 +279,8 @@ def add_subparser(subparsers):
     )
     list_parser.add_argument(
         '-I', '--interactive',
-        help='Run container in interactive mode',
+        help=('Run container in interactive mode. If interactive is set the default command will be "bash" '
+              'unless otherwise set by the "--cmd" flag'),
         action='store_true',
         required=False,
         default=False,
@@ -301,7 +301,6 @@ def add_subparser(subparsers):
         required=False,
         default=False,
     )
-
     list_parser.set_defaults(command=paasta_local_run)
 
 
@@ -550,7 +549,9 @@ def configure_and_run_docker_container(docker_client, docker_hash, service, args
     for volume in system_paasta_config.get_volumes() + extra_volumes:
         volumes.append('%s:%s:%s' % (volume['hostPath'], volume['containerPath'], volume['mode'].lower()))
 
-    if args.cmd:
+    if args.interactive is True and args.cmd is None:
+        command = 'bash'
+    elif args.cmd:
         command = shlex.split(args.cmd)
     else:
         command_from_config = instance_config.get_cmd()

--- a/tests/paasta_cli/test_cmds_local_run.py
+++ b/tests/paasta_cli/test_cmds_local_run.py
@@ -349,6 +349,43 @@ def test_configure_and_run_command_uses_cmd_from_config(
     )
 
 
+@mock.patch('paasta_tools.paasta_cli.cmds.local_run.run_docker_container', autospec=True)
+@mock.patch('paasta_tools.paasta_cli.cmds.local_run.load_system_paasta_config', autospec=True)
+@mock.patch('paasta_tools.paasta_cli.cmds.local_run.get_instance_config', autospec=True)
+def test_configure_and_run_uses_bash_by_default_when_interactive(
+    mock_get_instance_config,
+    mock_load_system_paasta_config,
+    mock_run_docker_container,
+):
+    mock_load_system_paasta_config.return_value = SystemPaastaConfig(
+        {'cluster': 'fake_cluster', 'volumes': []}, '/fake_dir/')
+    mock_docker_client = mock.MagicMock(spec_set=docker.Client)
+    fake_service = 'fake_service'
+    docker_hash = '8' * 40
+    args = mock.MagicMock()
+    args.cmd = None
+    args.service = fake_service
+    args.healthcheck = False
+    args.healthcheck_only = False
+    args.instance = 'fake_instance'
+    args.interactive = True
+    args.cluster = 'fake_cluster'
+
+    configure_and_run_docker_container(mock_docker_client, docker_hash, fake_service, args) is None
+    mock_run_docker_container.assert_called_once_with(
+        docker_client=mock_docker_client,
+        service=fake_service,
+        instance=args.instance,
+        docker_hash=docker_hash,
+        volumes=[],
+        interactive=args.interactive,
+        command='bash',
+        healthcheck=args.healthcheck,
+        healthcheck_only=args.healthcheck_only,
+        instance_config=mock_get_instance_config.return_value
+    )
+
+
 @mock.patch('paasta_tools.paasta_cli.cmds.local_run.validate_environment', autospec=True)
 @mock.patch('paasta_tools.paasta_cli.cmds.local_run.figure_out_service_name', autospec=True)
 @mock.patch('paasta_tools.paasta_cli.cmds.local_run.configure_and_run_docker_container', autospec=True)


### PR DESCRIPTION
I this a small step towards ad-hoc "batches", I think a large portion will of the use cases will want to just get an interactive shell, so this makes it a little bit easier as you will be able to just say "-I"