### PR TITLE
update dh-virtualenv location

### DIFF
--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 FROM ubuntu:trusty
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 88ADA4A042F8DD13 && \
+    echo 'deb http://ppa.launchpad.net/dh-virtualenv/daily/ubuntu trusty main\ndeb-src http://ppa.launchpad.net/dh-virtualenv/daily/ubuntu trusty main' >> /etc/apt/sources.list
+
 RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools \
   python-dev debhelper python-yaml python-pytest pyflakes \
-  git help2man zsh
-
-# Older versions of dh-virtualenv are buggy and don't.. work
-RUN curl http://ppa.launchpad.net/dh-virtualenv/daily/ubuntu/pool/main/d/dh-virtualenv/dh-virtualenv_0.10-0~80~ubuntu14.04.1_all.deb --output dh-virtualenv_0.10-0~80~ubuntu14.04.1_all.deb && \
-  dpkg -i dh-virtualenv_0.10-0~80~ubuntu14.04.1_all.deb && rm dh-virtualenv_0.10-0~80~ubuntu14.04.1_all.deb
+  git help2man zsh dh-virtualenv
 
 ENV HOME /work
 ENV PWD /work


### PR DESCRIPTION
the link to dh-virtualenv was 404ing (I guess they removed the old version when they released 0.10-0~81) and causing Jenkins + Travis to fail. This fixes that (Travis should pass tests now?).