### PR TITLE
Added paasta_rollback command

### DIFF
--- a/paasta_tools/paasta_cli/cmds/rollback.py
+++ b/paasta_tools/paasta_cli/cmds/rollback.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# Copyright 2015 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mechanism to rollback to a previous deployed version.
+"""
+import sys
+
+from paasta_tools.utils import get_git_url
+from paasta_tools.paasta_cli.utils import figure_out_service_name
+from paasta_tools.paasta_cli.utils import lazy_choices_completer
+from paasta_tools.paasta_cli.utils import list_services
+from paasta_tools.paasta_cli.utils import list_instances
+from paasta_tools.paasta_cli.cmds.mark_for_deployment import mark_for_deployment
+from paasta_tools.utils import list_clusters
+
+
+def add_subparser(subparsers):
+    list_parser = subparsers.add_parser(
+        'rollback',
+        description='Rollback a docker image to a previous deploy',
+        help='Rollback a docker image to a previous deploy')
+
+    list_parser.add_argument('-k', '--commit',
+                             help='Git sha to mark for rollback',
+                             required=True,
+                             )
+    list_parser.add_argument('-i', '--instance',
+                             help='Mark the instance we want to roll back (e.g. '
+                             'canary, .main)',
+                             required=True,
+                             ).completer = lazy_choices_completer(list_instances)
+    list_parser.add_argument('-c', '--cluster',
+                             help='Mark the cluster we want to rollback (e.g. '
+                             'cluster1, cluster2)',
+                             required=True,
+                             ).completer = lazy_choices_completer(list_clusters)
+    list_parser.add_argument('-s', '--service',
+                             help='Name of service you wish to rollback'
+                             ).completer = lazy_choices_completer(list_services)
+
+    list_parser.set_defaults(command=paasta_rollback)
+
+
+def paasta_rollback(args):
+    """Call mark_for_deployment with rollback parameters"""
+    service = figure_out_service_name(args)
+    cluster = args.cluster
+    instance = args.instance
+    git_url = get_git_url(service)
+    commit = args.commit
+
+    if cluster in list_clusters(service):
+        returncode = mark_for_deployment(
+            git_url=git_url,
+            cluster=cluster,
+            instance=instance,
+            service=service,
+            commit=commit
+        )
+    else:
+        print "ERROR: The service %s is not deployed into cluster %s.\n" % (service, cluster)
+        returncode = 1
+
+    sys.exit(returncode)

--- a/tests/paasta_cli/test_cmds_rollback.py
+++ b/tests/paasta_cli/test_cmds_rollback.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# Copyright 2015 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mock import patch
+from paasta_tools.paasta_cli.cmds.rollback import paasta_rollback
+
+
+class fake_args:
+    cluster = 'cluster1'
+    instance = 'instance1'
+    service = 'test_service'
+    git_url = 'git://git.repo'
+    commit = '123456'
+
+
+@patch('paasta_tools.paasta_cli.cmds.rollback.figure_out_service_name', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.list_clusters', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.get_git_url', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.mark_for_deployment', autospec=True)
+@patch('sys.exit', autospec=True)
+def test_paasta_rollback_mark_for_deployment_invocation(
+    mock_exit,
+    mock_mark_for_deployment,
+    mock_get_git_url,
+    mock_list_clusters,
+    mock_figure_out_service_name,
+):
+
+    mock_get_git_url.return_value = 'git://git.repo'
+    mock_figure_out_service_name.return_value = 'test_service'
+    mock_list_clusters.return_value = ['cluster1', 'cluster2']
+
+    paasta_rollback(fake_args)
+
+    mock_mark_for_deployment.assert_called_once_with(
+        git_url=mock_get_git_url.return_value,
+        cluster=fake_args.cluster,
+        instance=fake_args.instance,
+        service=mock_figure_out_service_name.return_value,
+        commit=fake_args.commit
+    )
+
+
+@patch('paasta_tools.paasta_cli.cmds.rollback.figure_out_service_name', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.list_clusters', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.get_git_url', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.mark_for_deployment', autospec=True)
+@patch('sys.exit', autospec=True)
+def test_paasta_rollback_mark_for_deployment_wrong_cluster(
+    mock_exit,
+    mock_mark_for_deployment,
+    mock_get_git_url,
+    mock_list_clusters,
+    mock_figure_out_service_name,
+):
+
+    mock_get_git_url.return_value = 'git://git.repo'
+    mock_figure_out_service_name.return_value = 'test_service'
+    mock_list_clusters.return_value = ['cluster0', 'cluster2']
+
+    paasta_rollback(fake_args)
+
+    mock_exit.assert_called_once_with(1)

--- a/tests/paasta_cli/test_cmds_rollback.py
+++ b/tests/paasta_cli/test_cmds_rollback.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pytest import raises
 from mock import patch, Mock
 from paasta_tools.paasta_cli.cmds.rollback import paasta_rollback
 
@@ -21,9 +22,7 @@ from paasta_tools.paasta_cli.cmds.rollback import paasta_rollback
 @patch('paasta_tools.paasta_cli.cmds.rollback.list_clusters', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.get_git_url', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.mark_for_deployment', autospec=True)
-@patch('sys.exit', autospec=True)
 def test_paasta_rollback_mark_for_deployment_invocation(
-    mock_exit,
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_list_clusters,
@@ -33,16 +32,16 @@ def test_paasta_rollback_mark_for_deployment_invocation(
     fake_args = Mock(
         cluster='cluster1',
         instance='instance1',
-        service='test_service',
-        git_url='git://git.repo',
         commit='123456'
     )
 
-    mock_get_git_url.return_value = fake_args.git_url
-    mock_figure_out_service_name.return_value = fake_args.service
+    mock_get_git_url.return_value = 'git://git.repo'
+    mock_figure_out_service_name.return_value = 'fakeservice'
     mock_list_clusters.return_value = ['cluster1', 'cluster2']
 
-    paasta_rollback(fake_args)
+    with raises(SystemExit) as sys_exit:
+        paasta_rollback(fake_args)
+        assert sys_exit.value_code == 0
 
     mock_mark_for_deployment.assert_called_once_with(
         git_url=mock_get_git_url.return_value,
@@ -57,9 +56,7 @@ def test_paasta_rollback_mark_for_deployment_invocation(
 @patch('paasta_tools.paasta_cli.cmds.rollback.list_clusters', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.get_git_url', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.mark_for_deployment', autospec=True)
-@patch('sys.exit', autospec=True)
 def test_paasta_rollback_mark_for_deployment_wrong_cluster(
-    mock_exit,
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_list_clusters,
@@ -69,15 +66,13 @@ def test_paasta_rollback_mark_for_deployment_wrong_cluster(
     fake_args = Mock(
         cluster='cluster1',
         instance='instance1',
-        service='test_service',
-        git_url='git://git.repo',
         commit='123456'
     )
 
-    mock_get_git_url.return_value = fake_args.git_url
-    mock_figure_out_service_name.return_value = fake_args.service
+    mock_get_git_url.return_value = 'git://git.repo'
+    mock_figure_out_service_name.return_value = 'fakeservice'
     mock_list_clusters.return_value = ['cluster0', 'cluster2']
 
-    paasta_rollback(fake_args)
-
-    mock_exit.assert_called_once_with(1)
+    with raises(SystemExit) as sys_exit:
+        paasta_rollback(fake_args)
+        assert sys_exit.value_code == 1

--- a/tests/paasta_cli/test_cmds_rollback.py
+++ b/tests/paasta_cli/test_cmds_rollback.py
@@ -13,16 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import patch
+from mock import patch, Mock
 from paasta_tools.paasta_cli.cmds.rollback import paasta_rollback
-
-
-class fake_args:
-    cluster = 'cluster1'
-    instance = 'instance1'
-    service = 'test_service'
-    git_url = 'git://git.repo'
-    commit = '123456'
 
 
 @patch('paasta_tools.paasta_cli.cmds.rollback.figure_out_service_name', autospec=True)
@@ -38,8 +30,16 @@ def test_paasta_rollback_mark_for_deployment_invocation(
     mock_figure_out_service_name,
 ):
 
-    mock_get_git_url.return_value = 'git://git.repo'
-    mock_figure_out_service_name.return_value = 'test_service'
+    fake_args = Mock(
+        cluster='cluster1',
+        instance='instance1',
+        service='test_service',
+        git_url='git://git.repo',
+        commit='123456'
+    )
+
+    mock_get_git_url.return_value = fake_args.git_url
+    mock_figure_out_service_name.return_value = fake_args.service
     mock_list_clusters.return_value = ['cluster1', 'cluster2']
 
     paasta_rollback(fake_args)
@@ -66,8 +66,16 @@ def test_paasta_rollback_mark_for_deployment_wrong_cluster(
     mock_figure_out_service_name,
 ):
 
-    mock_get_git_url.return_value = 'git://git.repo'
-    mock_figure_out_service_name.return_value = 'test_service'
+    fake_args = Mock(
+        cluster='cluster1',
+        instance='instance1',
+        service='test_service',
+        git_url='git://git.repo',
+        commit='123456'
+    )
+
+    mock_get_git_url.return_value = fake_args.git_url
+    mock_figure_out_service_name.return_value = fake_args.service
     mock_list_clusters.return_value = ['cluster0', 'cluster2']
 
     paasta_rollback(fake_args)


### PR DESCRIPTION
paasta_rollback is meant to be a more user friendly cli option for mark_for_deployment. There is some room for improvements, still (so work in progress).

Example usage:
`paasta_rollback -c %cluster% -i %instance% -s %example_service% -k %commit_sha%`
