### PR TITLE
Bump scribereader requirement

### DIFF
--- a/yelp_package/extra_requirements.txt
+++ b/yelp_package/extra_requirements.txt
@@ -1,1 +1,1 @@
-scribereader==0.1.25
+scribereader==0.1.30


### PR DESCRIPTION
This makes `paasta logs` work for more environments internally