### PR TITLE
Minor fixups to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # Copyright 2015 Yelp Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# -*- coding: utf-8 -*-
 
 from setuptools import setup, find_packages
 
@@ -26,8 +26,7 @@ setup(
     author         = 'Kyle Anderson',
     author_email   = 'kwa@yelp.com',
     description    = 'Tools for Yelps SOA infrastructure',
-    packages       = find_packages(exclude=["tests", "scripts"]),
-    setup_requires = ['setuptools'],
+    packages       = find_packages(exclude=("tests*", "scripts*")),
     include_package_data=True,
     install_requires = [
         'argcomplete >= 0.8.1',


### PR DESCRIPTION
- use `/usr/bin/env python` over `/usr/bin/python`
- coding pragma must be in the first 2 lines (shebang must be first, so => second!)
- exclude should have a star to avoid adding sub-packages
- setup_requires setuptools is silly given setuptools is imported at the top of the file