### PR TITLE
Only allow the itest_% Makefile target to run at Yelp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Set ENV to 'YELP' if FQDN ends in '.yelpcorp.com'
+# Otherwise, set ENV to the FQDN
+ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
+	ENV := YELP
+else
+	ENV := $(shell hostname -f)
+endif
+
 .PHONY: all docs test itest
 
 docs:
@@ -28,7 +36,11 @@ itest: test
 itest_%:
 	# See the makefile in yelp_package/Makefile for packaging stuff
 	# Note: For now, these builds only work inside Yelp's environment.
-	make -C yelp_package $@
+	@if [ "$(ENV)" = "YELP" ]; then \
+		make -C yelp_package $@; \
+	else \
+		echo "This Makefile target currently will NOT work outside of Yelp's Environment."; \
+	fi
 
 # Steps to release
 # 1. Bump version in yelp_package/Makefile

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@
 # Set ENV to 'YELP' if FQDN ends in '.yelpcorp.com'
 # Otherwise, set ENV to the FQDN
 ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
-	ENV := YELP
+	PAASTA_ENV ?= YELP
 else
-	ENV := $(shell hostname -f)
+	PAASTA_ENV ?= $(shell hostname -f)
 endif
 
 .PHONY: all docs test itest
@@ -36,7 +36,7 @@ itest: test
 itest_%:
 	# See the makefile in yelp_package/Makefile for packaging stuff
 	# Note: For now, these builds only work inside Yelp's environment.
-	@if [ "$(ENV)" = "YELP" ]; then \
+	@if [ "$(PAASTA_ENV)" = "YELP" ]; then \
 		make -C yelp_package $@; \
 	else \
 		echo "This Makefile target currently will NOT work outside of Yelp's Environment."; \


### PR DESCRIPTION
This target will currently fail outside of Yelp. Use the machine's
FQDN to determine if it is a Yelp box. If it is, run the target.
If it is not, simply display a warning.

This should hopefully help avoid confusion as to why the target fails to work.