### PR TITLE
remove hardcoded docker registry location

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -732,7 +732,8 @@ def build_docker_image_name(upstream_job_name):
     service's path in git. E.g. For git.yelpcorp.com:services/foo the
     upstream_job_name is services-foo.
     """
-    name = 'docker-paasta.yelpcorp.com:443/services-%s' % upstream_job_name
+    docker_registry_url = load_system_paasta_config().get_docker_registry()
+    name = '%s/services-%s' % (docker_registry_url, upstream_job_name)
     return name
 
 

--- a/tests/paasta_cli/test_cmds_itest.py
+++ b/tests/paasta_cli/test_cmds_itest.py
@@ -23,13 +23,16 @@ from paasta_tools.paasta_cli.cmds.itest import paasta_itest
 @patch('sys.exit')
 @patch('paasta_tools.paasta_cli.cmds.itest._log', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.itest.check_docker_image', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.itest.build_docker_tag', autospec=True)
 def test_itest_run_fail(
+    mock_build_docker_tag,
     mock_docker_image,
     mock_log,
     mock_exit,
     mock_run,
     mock_validate_service_name,
 ):
+    mock_build_docker_tag.return_value = 'fake-registry/services-foo:paasta-bar'
     mock_docker_image.return_value = True
     mock_run.return_value = (1, 'fake_output')
     args = MagicMock()
@@ -42,13 +45,16 @@ def test_itest_run_fail(
 @patch('sys.exit')
 @patch('paasta_tools.paasta_cli.cmds.itest._log', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.itest.check_docker_image', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.itest.build_docker_tag', autospec=True)
 def test_itest_success(
+    mock_build_docker_tag,
     mock_docker_image,
     mock_log,
     mock_exit,
     mock_run,
     mock_validate_service_name,
 ):
+    mock_build_docker_tag.return_value = 'fake-registry/services-foo:paasta-bar'
     mock_docker_image.return_value = True
     mock_run.return_value = (0, 'Yeeehaaa')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -408,18 +408,21 @@ def test_decompose_job_id_with_hashes():
     assert actual == expected
 
 
-def test_build_docker_tag():
-    upstream_job_name = 'fake_upstream_job_name'
-    upstream_git_commit = 'fake_upstream_git_commit'
-    expected = 'docker-paasta.yelpcorp.com:443/services-%s:paasta-%s' % (
-        upstream_job_name,
+@mock.patch('utils.build_docker_image_name')
+def test_build_docker_tag(mock_build_docker_image_name):
+    upstream_job_name = 'foo'
+    upstream_git_commit = 'bar'
+    mock_build_docker_image_name.return_value = 'fake-registry/services-foo'
+    expected = 'fake-registry/services-foo:paasta-%s' % (
         upstream_git_commit,
     )
     actual = utils.build_docker_tag(upstream_job_name, upstream_git_commit)
     assert actual == expected
 
 
-def test_check_docker_image_false():
+@mock.patch('utils.build_docker_image_name')
+def test_check_docker_image_false(mock_build_docker_image_name):
+    mock_build_docker_image_name.return_value = 'fake-registry/services-foo'
     fake_app = 'fake_app'
     fake_commit = 'fake_commit'
     docker_tag = utils.build_docker_tag(fake_app, fake_commit)
@@ -436,9 +439,11 @@ def test_check_docker_image_false():
         assert utils.check_docker_image('test_service', 'tag2') is False
 
 
-def test_check_docker_image_true():
+@mock.patch('utils.build_docker_image_name')
+def test_check_docker_image_true(mock_build_docker_image_name):
     fake_app = 'fake_app'
     fake_commit = 'fake_commit'
+    mock_build_docker_image_name.return_value = 'fake-registry/services-foo'
     docker_tag = utils.build_docker_tag(fake_app, fake_commit)
     with mock.patch('docker.Client') as mock_docker:
         docker_client = mock_docker.return_value


### PR DESCRIPTION
I made an unhelpful comment on another review of 'we should remove this'. So here it is.