### PR TITLE
Paasta rollback now accepts none, one or a list of instances.

### DIFF
--- a/paasta_tools/paasta_cli/cmds/rollback.py
+++ b/paasta_tools/paasta_cli/cmds/rollback.py
@@ -24,6 +24,7 @@ from paasta_tools.paasta_cli.utils import list_services
 from paasta_tools.paasta_cli.utils import list_instances
 from paasta_tools.paasta_cli.cmds.mark_for_deployment import mark_for_deployment
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import list_all_instances_for_service
 
 
 def add_subparser(subparsers):
@@ -37,9 +38,9 @@ def add_subparser(subparsers):
                              required=True,
                              )
     list_parser.add_argument('-i', '--instance',
-                             help='Mark the instance we want to roll back (e.g. '
-                             'canary, .main)',
-                             required=True,
+                             help='Mark the instance[s] we want to roll back (e.g. '
+                             'canary, main)',
+                             required=False,
                              ).completer = lazy_choices_completer(list_instances)
     list_parser.add_argument('-c', '--cluster',
                              help='Mark the cluster we want to rollback (e.g. '
@@ -53,22 +54,47 @@ def add_subparser(subparsers):
     list_parser.set_defaults(command=paasta_rollback)
 
 
+def validate_given_instances(service, args_instances):
+    """Trying to find which instances are actually valid for the given service"""
+    service_instances = list_all_instances_for_service(service)
+    invalid_instances = None
+
+    if not args_instances:
+        valid_instances = service_instances
+    else:
+        args_instances = args_instances.split(",")
+        valid_instances = set(args_instances).intersection(service_instances)
+        invalid_instances = set(args_instances).difference(service_instances)
+
+    return valid_instances, invalid_instances
+
+
 def paasta_rollback(args):
     """Call mark_for_deployment with rollback parameters"""
     service = figure_out_service_name(args)
     cluster = args.cluster
-    instance = args.instance
     git_url = get_git_url(service)
     commit = args.commit
 
     if cluster in list_clusters(service):
-        returncode = mark_for_deployment(
-            git_url=git_url,
-            cluster=cluster,
-            instance=instance,
-            service=service,
-            commit=commit
-        )
+        instances, invalid = validate_given_instances(service, args.instance)
+
+        if invalid:
+            print "WARNING: These instances are not valid and will not be deployed: %s.\n" % (",").join(invalid)
+
+        if instances:
+            for instance in instances:
+                print "Deploying %s to %s.%s.\n" % (service, cluster, instance)
+                returncode = mark_for_deployment(
+                    git_url=git_url,
+                    cluster=cluster,
+                    instance=instance,
+                    service=service,
+                    commit=commit
+                )
+        else:
+            print "ERROR: No valid instances specified for %s.\n" % (service)
+            returncode = 1
     else:
         print "ERROR: The service %s is not deployed into cluster %s.\n" % (service, cluster)
         returncode = 1

--- a/paasta_tools/paasta_cli/cmds/rollback.py
+++ b/paasta_tools/paasta_cli/cmds/rollback.py
@@ -59,7 +59,13 @@ def add_subparser(subparsers):
 
 
 def validate_given_instances(service_instances, args_instances):
-    """Trying to find which instances are actually valid for the given service"""
+    """Given two lists of instances, return the intersection and difference between them.
+
+    :param service_instances: instances actually belonging to a service
+    :param args_instances: the desired instances
+    :returns: a tuple with (common, difference) indicating instances common in both
+    lists and those only in args_instances
+    """
     if len(args_instances) is 0:
         valid_instances = set(service_instances)
         invalid_instances = set([])
@@ -71,7 +77,11 @@ def validate_given_instances(service_instances, args_instances):
 
 
 def paasta_rollback(args):
-    """Call mark_for_deployment with rollback parameters"""
+    """Call mark_for_deployment with rollback parameters
+    :param args: contains all the arguments passed onto the script: service,
+    cluster, instance and sha. These arguments will be verified and passed onto
+    mark_for_deployment.
+    """
     service = figure_out_service_name(args)
     cluster = args.cluster
     git_url = get_git_url(service)

--- a/tests/paasta_cli/test_cmds_rollback.py
+++ b/tests/paasta_cli/test_cmds_rollback.py
@@ -14,19 +14,22 @@
 # limitations under the License.
 
 from pytest import raises
-from mock import patch, Mock
+from mock import patch, call, Mock
 from paasta_tools.paasta_cli.cmds.rollback import paasta_rollback
+from paasta_tools.paasta_cli.cmds.rollback import validate_given_instances
 
 
+@patch('paasta_tools.paasta_cli.cmds.rollback.validate_given_instances', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.figure_out_service_name', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.list_clusters', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.get_git_url', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.mark_for_deployment', autospec=True)
-def test_paasta_rollback_mark_for_deployment_invocation(
+def test_paasta_rollback_mark_for_deployment_simple_invocation(
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_list_clusters,
     mock_figure_out_service_name,
+    mock_validate_given_instances,
 ):
 
     fake_args = Mock(
@@ -38,6 +41,7 @@ def test_paasta_rollback_mark_for_deployment_invocation(
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
     mock_list_clusters.return_value = ['cluster1', 'cluster2']
+    mock_validate_given_instances.return_value = [['instance1'], []]
 
     with raises(SystemExit) as sys_exit:
         paasta_rollback(fake_args)
@@ -51,7 +55,10 @@ def test_paasta_rollback_mark_for_deployment_invocation(
         commit=fake_args.commit
     )
 
+    assert mock_mark_for_deployment.call_count == 1
 
+
+@patch('paasta_tools.paasta_cli.cmds.rollback.validate_given_instances', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.figure_out_service_name', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.list_clusters', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.get_git_url', autospec=True)
@@ -61,6 +68,7 @@ def test_paasta_rollback_mark_for_deployment_wrong_cluster(
     mock_get_git_url,
     mock_list_clusters,
     mock_figure_out_service_name,
+    mock_validate_given_instances,
 ):
 
     fake_args = Mock(
@@ -72,7 +80,178 @@ def test_paasta_rollback_mark_for_deployment_wrong_cluster(
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
     mock_list_clusters.return_value = ['cluster0', 'cluster2']
+    mock_validate_given_instances.return_value = [['instance1'], []]
 
     with raises(SystemExit) as sys_exit:
         paasta_rollback(fake_args)
         assert sys_exit.value_code == 1
+
+    assert mock_mark_for_deployment.call_count == 0
+
+
+@patch('paasta_tools.paasta_cli.cmds.rollback.validate_given_instances', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.figure_out_service_name', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.list_clusters', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.get_git_url', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.mark_for_deployment', autospec=True)
+def test_paasta_rollback_mark_for_deployment_no_instance_arg(
+    mock_mark_for_deployment,
+    mock_get_git_url,
+    mock_list_clusters,
+    mock_figure_out_service_name,
+    mock_validate_given_instances,
+):
+
+    fake_args = Mock(
+        cluster='cluster1',
+        commit='123456',
+        instance=None
+    )
+
+    mock_get_git_url.return_value = 'git://git.repo'
+    mock_figure_out_service_name.return_value = 'fakeservice'
+    mock_list_clusters.return_value = ['cluster1', 'cluster2']
+    mock_validate_given_instances.return_value = [['instance1', 'instance2'], []]
+
+    with raises(SystemExit) as sys_exit:
+        paasta_rollback(fake_args)
+        assert sys_exit.value_code == 0
+
+    expected = [
+        call(
+            git_url=mock_get_git_url.return_value,
+            cluster=fake_args.cluster,
+            service=mock_figure_out_service_name.return_value,
+            commit=fake_args.commit,
+            instance='instance1'
+        ),
+        call(
+            git_url=mock_get_git_url.return_value,
+            cluster=fake_args.cluster,
+            service=mock_figure_out_service_name.return_value,
+            commit=fake_args.commit,
+            instance='instance2'
+        ),
+    ]
+
+    assert expected == mock_mark_for_deployment.mock_calls
+    assert mock_mark_for_deployment.call_count == 2
+
+
+@patch('paasta_tools.paasta_cli.cmds.rollback.validate_given_instances', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.figure_out_service_name', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.list_clusters', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.get_git_url', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.mark_for_deployment', autospec=True)
+def test_paasta_rollback_mark_for_deployment_wrong_instance_args(
+    mock_mark_for_deployment,
+    mock_get_git_url,
+    mock_list_clusters,
+    mock_figure_out_service_name,
+    mock_validate_given_instances,
+):
+
+    fake_args = Mock(
+        cluster='cluster1',
+        commit='123456',
+        instance='instance0,not_an_instance'
+    )
+
+    mock_get_git_url.return_value = 'git://git.repo'
+    mock_figure_out_service_name.return_value = 'fakeservice'
+    mock_list_clusters.return_value = ['cluster1', 'cluster2']
+    mock_validate_given_instances.return_value = [[], ['instance0', 'not_an_instance']]
+
+    with raises(SystemExit) as sys_exit:
+        paasta_rollback(fake_args)
+        assert sys_exit.value_code == 1
+
+    assert mock_mark_for_deployment.call_count == 0
+
+
+@patch('paasta_tools.paasta_cli.cmds.rollback.validate_given_instances', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.figure_out_service_name', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.list_clusters', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.get_git_url', autospec=True)
+@patch('paasta_tools.paasta_cli.cmds.rollback.mark_for_deployment', autospec=True)
+def test_paasta_rollback_mark_for_deployment_multiple_instance_args(
+    mock_mark_for_deployment,
+    mock_get_git_url,
+    mock_list_clusters,
+    mock_figure_out_service_name,
+    mock_validate_given_instances,
+):
+
+    fake_args = Mock(
+        cluster='cluster1',
+        instance='instance1,instance2',
+        commit='123456'
+    )
+
+    mock_get_git_url.return_value = 'git://git.repo'
+    mock_figure_out_service_name.return_value = 'fakeservice'
+    mock_list_clusters.return_value = ['cluster1', 'cluster2']
+    mock_validate_given_instances.return_value = [['instance1', 'instance2'], []]
+
+    with raises(SystemExit) as sys_exit:
+        paasta_rollback(fake_args)
+        assert sys_exit.value_code == 0
+
+    expected = [
+        call(
+            git_url=mock_get_git_url.return_value,
+            cluster=fake_args.cluster,
+            service=mock_figure_out_service_name.return_value,
+            commit=fake_args.commit,
+            instance='instance1'
+        ),
+        call(
+            git_url=mock_get_git_url.return_value,
+            cluster=fake_args.cluster,
+            service=mock_figure_out_service_name.return_value,
+            commit=fake_args.commit,
+            instance='instance2'
+        ),
+    ]
+
+    mock_mark_for_deployment.assert_has_calls(expected, any_order=True)
+    assert mock_mark_for_deployment.call_count == 2
+
+
+@patch('paasta_tools.paasta_cli.cmds.rollback.list_all_instances_for_service', autospec=True)
+def test_validate_given_instances_wrong_arg(
+    mock_list_all_instances_for_service,
+):
+    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2']
+    given_instances = 'instance0,not_an_instance'
+
+    actual_valid, actual_invalid = validate_given_instances('test_service', given_instances)
+
+    assert actual_valid == set([])
+    assert actual_invalid == set(['instance0', 'not_an_instance'])
+
+
+@patch('paasta_tools.paasta_cli.cmds.rollback.list_all_instances_for_service', autospec=True)
+def test_validate_given_instances_single_arg(
+    mock_list_all_instances_for_service,
+):
+    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2']
+    given_instances = 'instance1'
+
+    actual_valid, actual_invalid = validate_given_instances('test_service', given_instances)
+
+    assert actual_valid == set(['instance1'])
+    assert actual_invalid == set([])
+
+
+@patch('paasta_tools.paasta_cli.cmds.rollback.list_all_instances_for_service', autospec=True)
+def test_validate_given_instances_multiple_args(
+    mock_list_all_instances_for_service,
+):
+    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2', 'instance3']
+    given_instances = 'instance1,instance2'
+
+    actual_valid, actual_invalid = validate_given_instances('test_service', given_instances)
+
+    assert actual_valid == set(['instance1', 'instance2'])
+    assert actual_invalid == set([])

--- a/tests/paasta_cli/test_cmds_rollback.py
+++ b/tests/paasta_cli/test_cmds_rollback.py
@@ -19,6 +19,7 @@ from paasta_tools.paasta_cli.cmds.rollback import paasta_rollback
 from paasta_tools.paasta_cli.cmds.rollback import validate_given_instances
 
 
+@patch('paasta_tools.paasta_cli.cmds.rollback.list_all_instances_for_service', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.validate_given_instances', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.figure_out_service_name', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.list_clusters', autospec=True)
@@ -30,17 +31,19 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
     mock_list_clusters,
     mock_figure_out_service_name,
     mock_validate_given_instances,
+    mock_list_all_instances_for_service,
 ):
 
     fake_args = Mock(
         cluster='cluster1',
-        instance='instance1',
+        instances='instance1',
         commit='123456'
     )
 
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
     mock_list_clusters.return_value = ['cluster1', 'cluster2']
+    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2']
     mock_validate_given_instances.return_value = [['instance1'], []]
 
     with raises(SystemExit) as sys_exit:
@@ -50,7 +53,7 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
     mock_mark_for_deployment.assert_called_once_with(
         git_url=mock_get_git_url.return_value,
         cluster=fake_args.cluster,
-        instance=fake_args.instance,
+        instance=fake_args.instances,
         service=mock_figure_out_service_name.return_value,
         commit=fake_args.commit
     )
@@ -58,6 +61,7 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
     assert mock_mark_for_deployment.call_count == 1
 
 
+@patch('paasta_tools.paasta_cli.cmds.rollback.list_all_instances_for_service', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.validate_given_instances', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.figure_out_service_name', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.list_clusters', autospec=True)
@@ -69,17 +73,19 @@ def test_paasta_rollback_mark_for_deployment_wrong_cluster(
     mock_list_clusters,
     mock_figure_out_service_name,
     mock_validate_given_instances,
+    mock_list_all_instances_for_service,
 ):
 
     fake_args = Mock(
         cluster='cluster1',
-        instance='instance1',
+        instances='instance1',
         commit='123456'
     )
 
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
     mock_list_clusters.return_value = ['cluster0', 'cluster2']
+    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2']
     mock_validate_given_instances.return_value = [['instance1'], []]
 
     with raises(SystemExit) as sys_exit:
@@ -89,6 +95,7 @@ def test_paasta_rollback_mark_for_deployment_wrong_cluster(
     assert mock_mark_for_deployment.call_count == 0
 
 
+@patch('paasta_tools.paasta_cli.cmds.rollback.list_all_instances_for_service', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.validate_given_instances', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.figure_out_service_name', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.list_clusters', autospec=True)
@@ -100,17 +107,19 @@ def test_paasta_rollback_mark_for_deployment_no_instance_arg(
     mock_list_clusters,
     mock_figure_out_service_name,
     mock_validate_given_instances,
+    mock_list_all_instances_for_service,
 ):
 
     fake_args = Mock(
         cluster='cluster1',
         commit='123456',
-        instance=None
+        instances='',
     )
 
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
     mock_list_clusters.return_value = ['cluster1', 'cluster2']
+    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2']
     mock_validate_given_instances.return_value = [['instance1', 'instance2'], []]
 
     with raises(SystemExit) as sys_exit:
@@ -138,6 +147,7 @@ def test_paasta_rollback_mark_for_deployment_no_instance_arg(
     assert mock_mark_for_deployment.call_count == 2
 
 
+@patch('paasta_tools.paasta_cli.cmds.rollback.list_all_instances_for_service', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.validate_given_instances', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.figure_out_service_name', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.list_clusters', autospec=True)
@@ -149,17 +159,19 @@ def test_paasta_rollback_mark_for_deployment_wrong_instance_args(
     mock_list_clusters,
     mock_figure_out_service_name,
     mock_validate_given_instances,
+    mock_list_all_instances_for_service,
 ):
 
     fake_args = Mock(
         cluster='cluster1',
         commit='123456',
-        instance='instance0,not_an_instance'
+        instances='instance0,not_an_instance'
     )
 
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
     mock_list_clusters.return_value = ['cluster1', 'cluster2']
+    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2']
     mock_validate_given_instances.return_value = [[], ['instance0', 'not_an_instance']]
 
     with raises(SystemExit) as sys_exit:
@@ -169,6 +181,7 @@ def test_paasta_rollback_mark_for_deployment_wrong_instance_args(
     assert mock_mark_for_deployment.call_count == 0
 
 
+@patch('paasta_tools.paasta_cli.cmds.rollback.list_all_instances_for_service', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.validate_given_instances', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.figure_out_service_name', autospec=True)
 @patch('paasta_tools.paasta_cli.cmds.rollback.list_clusters', autospec=True)
@@ -180,17 +193,19 @@ def test_paasta_rollback_mark_for_deployment_multiple_instance_args(
     mock_list_clusters,
     mock_figure_out_service_name,
     mock_validate_given_instances,
+    mock_list_all_instances_for_service,
 ):
 
     fake_args = Mock(
         cluster='cluster1',
-        instance='instance1,instance2',
+        instances='instance1,instance2',
         commit='123456'
     )
 
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
     mock_list_clusters.return_value = ['cluster1', 'cluster2']
+    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2', 'instance3']
     mock_validate_given_instances.return_value = [['instance1', 'instance2'], []]
 
     with raises(SystemExit) as sys_exit:
@@ -218,40 +233,66 @@ def test_paasta_rollback_mark_for_deployment_multiple_instance_args(
     assert mock_mark_for_deployment.call_count == 2
 
 
-@patch('paasta_tools.paasta_cli.cmds.rollback.list_all_instances_for_service', autospec=True)
-def test_validate_given_instances_wrong_arg(
-    mock_list_all_instances_for_service,
-):
-    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2']
-    given_instances = 'instance0,not_an_instance'
+def test_validate_given_instances_no_arg():
+    service_instances = ['instance1', 'instance2']
+    given_instances = []
 
-    actual_valid, actual_invalid = validate_given_instances('test_service', given_instances)
+    expected_valid = set(['instance1', 'instance2'])
+    expected_invalid = set([])
 
-    assert actual_valid == set([])
-    assert actual_invalid == set(['instance0', 'not_an_instance'])
+    actual_valid, actual_invalid = validate_given_instances(service_instances, given_instances)
 
-
-@patch('paasta_tools.paasta_cli.cmds.rollback.list_all_instances_for_service', autospec=True)
-def test_validate_given_instances_single_arg(
-    mock_list_all_instances_for_service,
-):
-    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2']
-    given_instances = 'instance1'
-
-    actual_valid, actual_invalid = validate_given_instances('test_service', given_instances)
-
-    assert actual_valid == set(['instance1'])
-    assert actual_invalid == set([])
+    assert actual_valid == expected_valid
+    assert actual_invalid == expected_invalid
 
 
-@patch('paasta_tools.paasta_cli.cmds.rollback.list_all_instances_for_service', autospec=True)
-def test_validate_given_instances_multiple_args(
-    mock_list_all_instances_for_service,
-):
-    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2', 'instance3']
-    given_instances = 'instance1,instance2'
+def test_validate_given_instances_wrong_arg():
+    service_instances = ['instance1', 'instance2']
+    given_instances = ['instance0', 'not_an_instance']
 
-    actual_valid, actual_invalid = validate_given_instances('test_service', given_instances)
+    expected_valid = set([])
+    expected_invalid = set(['instance0', 'not_an_instance'])
 
-    assert actual_valid == set(['instance1', 'instance2'])
-    assert actual_invalid == set([])
+    actual_valid, actual_invalid = validate_given_instances(service_instances, given_instances)
+
+    assert actual_valid == expected_valid
+    assert actual_invalid == expected_invalid
+
+
+def test_validate_given_instances_single_arg():
+    service_instances = ['instance1', 'instance2']
+    given_instances = ['instance1']
+
+    expected_valid = set(['instance1'])
+    expected_invalid = set([])
+
+    actual_valid, actual_invalid = validate_given_instances(service_instances, given_instances)
+
+    assert actual_valid == expected_valid
+    assert actual_invalid == expected_invalid
+
+
+def test_validate_given_instances_multiple_args():
+    service_instances = ['instance1', 'instance2', 'instance3']
+    given_instances = ['instance1', 'instance2']
+
+    expected_valid = set(['instance1', 'instance2'])
+    expected_invalid = set([])
+
+    actual_valid, actual_invalid = validate_given_instances(service_instances, given_instances)
+
+    assert actual_valid == expected_valid
+    assert actual_invalid == expected_invalid
+
+
+def test_validate_given_instances_duplicate_args():
+    service_instances = ['instance1', 'instance2', 'instance3']
+    given_instances = ['instance1', 'instance1']
+
+    expected_valid = set(['instance1'])
+    expected_invalid = set([])
+
+    actual_valid, actual_invalid = validate_given_instances(service_instances, given_instances)
+
+    assert actual_valid == expected_valid
+    assert actual_invalid == expected_invalid


### PR DESCRIPTION
Paasta rollback now accepts none, one or a list of instances. If any are wrong it will give a warning and carry on with the valid ones.

Added a bunch of tests to verify the behaviour on each case.