### PR TITLE
Bump max_consecutive_failures to 30 (5 minutes)

### DIFF
--- a/docs/source/workflow.rst
+++ b/docs/source/workflow.rst
@@ -101,10 +101,12 @@ unhealthy tasks from continuously filling up disks and logs -- the more times
 that your service has failed to start, the longer Mesos will wait before
 trying to start it again.
 
-Mesos *will* healthcheck the task based on the same healthcheck that Smartstack
-uses, in order to prune unhealthy tasks. This pruning is less agressive than
-smartstack's checking, so a dead task will go DOWN in smartstack before it is
-reaped by Mesos.
+Mesos *will* healthcheck the task based on the same healthcheck that SmartStack
+uses, in order to prune unhealthy tasks. This pruning is less aggressive than
+SmartStack's checking, so a dead task will go DOWN in SmartStack before it is
+reaped by Marathon. By default the healthchecks occur every 10 seconds, and a service
+must fail 30 times before that task is pruned and a new one is launched in its place.
+This means a task had 5 minutes by default to properly respond to its healthchecks.
 
 Time Zones In Docker Containers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -406,7 +406,7 @@ class MarathonServiceConfig(InstanceConfig):
         return self.config_dict.get('healthcheck_timeout_seconds', 10)
 
     def get_healthcheck_max_consecutive_failures(self):
-        return self.config_dict.get('healthcheck_max_consecutive_failures', 6)
+        return self.config_dict.get('healthcheck_max_consecutive_failures', 30)
 
     def get_nerve_namespace(self):
         return self.config_dict.get('nerve_ns', self.instance)

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1415,7 +1415,7 @@ class TestMarathonServiceConfig(object):
                 "intervalSeconds": 10,
                 "portIndex": 0,
                 "timeoutSeconds": 10,
-                "maxConsecutiveFailures": 6
+                "maxConsecutiveFailures": 30
             },
         ]
         actual = fake_marathon_service_config.get_healthchecks(fake_service_namespace_config)
@@ -1431,7 +1431,7 @@ class TestMarathonServiceConfig(object):
                 "intervalSeconds": 10,
                 "portIndex": 0,
                 "timeoutSeconds": 10,
-                "maxConsecutiveFailures": 6
+                "maxConsecutiveFailures": 30
             },
         ]
         actual = fake_marathon_service_config.get_healthchecks(fake_service_namespace_config)
@@ -1450,7 +1450,7 @@ class TestMarathonServiceConfig(object):
                 "gracePeriodSeconds": 60,
                 "intervalSeconds": 10,
                 "timeoutSeconds": 10,
-                "maxConsecutiveFailures": 6
+                "maxConsecutiveFailures": 30
             },
         ]
         actual = fake_marathon_service_config.get_healthchecks(fake_service_namespace_config)
@@ -1470,7 +1470,7 @@ class TestMarathonServiceConfig(object):
                 "gracePeriodSeconds": 60,
                 "intervalSeconds": 10,
                 "timeoutSeconds": 10,
-                "maxConsecutiveFailures": 6
+                "maxConsecutiveFailures": 30
             },
         ]
         actual = fake_marathon_service_config.get_healthchecks(fake_service_namespace_config)
@@ -1490,7 +1490,7 @@ class TestMarathonServiceConfig(object):
                 "gracePeriodSeconds": 60,
                 "intervalSeconds": 10,
                 "timeoutSeconds": 10,
-                "maxConsecutiveFailures": 6
+                "maxConsecutiveFailures": 30
             },
         ]
         actual = fake_marathon_service_config.get_healthchecks(fake_service_namespace_config)
@@ -1515,7 +1515,7 @@ class TestMarathonServiceConfig(object):
                 "gracePeriodSeconds": 60,
                 "intervalSeconds": 10,
                 "timeoutSeconds": fake_timeout,
-                "maxConsecutiveFailures": 6
+                "maxConsecutiveFailures": 30
             },
         ]
         actual = fake_marathon_service_config.get_healthchecks(fake_service_namespace_config)
@@ -1685,7 +1685,7 @@ def test_create_complete_config_with_smartstack():
                     'timeoutSeconds': 10,
                     'intervalSeconds': 10,
                     'gracePeriodSeconds': 60,
-                    'maxConsecutiveFailures': 6,
+                    'maxConsecutiveFailures': 30,
                     'path': '/status',
                 }
             ],


### PR DESCRIPTION
After our recent outage, I think 1 minute is too aggressive. This bumps it to 5 minutes. This reduces our overall churn rate and gives more breathing room to the distributed system to recover from network issues.