### PR TITLE
Make local-run stream the docker-pull with /dev/null as stdin

### DIFF
--- a/paasta_tools/paasta_cli/cmds/local_run.py
+++ b/paasta_tools/paasta_cli/cmds/local_run.py
@@ -364,14 +364,11 @@ def docker_pull_image(docker_url):
     bindings due to the docker auth/registry transition. Once we are past Docker 1.6
     we can use better credential management, but for now this function assumes the
     user running the command has already been authorized for the registry"""
-    sys.stderr.write("Please wait while the image (%s) is pulled..." % docker_url)
-    ret, output = _run('docker pull %s' % docker_url)
+    sys.stderr.write("Please wait while the image (%s) is pulled...\n" % docker_url)
+    ret, output = _run('docker pull %s' % docker_url, stream=True)
     if ret != 0:
-        sys.stderr.write("\nPull failed:\n")
-        sys.stderr.write(output)
+        sys.stderr.write("\nPull failed. Are you authorized to run docker commands?")
         sys.exit(ret)
-    else:
-        sys.stderr.write(" Done.\n")
 
 
 def get_container_id(docker_client, container_name):

--- a/paasta_tools/paasta_cli/cmds/local_run.py
+++ b/paasta_tools/paasta_cli/cmds/local_run.py
@@ -365,7 +365,8 @@ def docker_pull_image(docker_url):
     we can use better credential management, but for now this function assumes the
     user running the command has already been authorized for the registry"""
     sys.stderr.write("Please wait while the image (%s) is pulled...\n" % docker_url)
-    ret, output = _run('docker pull %s' % docker_url, stream=True)
+    DEVNULL = open(os.devnull, 'wb')
+    ret, output = _run('docker pull %s' % docker_url, stream=True, stdin=DEVNULL)
     if ret != 0:
         sys.stderr.write("\nPull failed. Are you authorized to run docker commands?")
         sys.exit(ret)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -586,7 +586,7 @@ class SystemPaastaConfig(dict):
             raise PaastaNotConfiguredError('Could not find scribe_map in configuration directory: %s' % self.directory)
 
 
-def _run(command, env=os.environ, timeout=None, log=False, **kwargs):
+def _run(command, env=os.environ, timeout=None, log=False, stream=False, **kwargs):
     """Given a command, run it. Return a tuple of the return code and any
     output.
 
@@ -608,13 +608,16 @@ def _run(command, env=os.environ, timeout=None, log=False, **kwargs):
         instance = kwargs.get('instance', ANY_INSTANCE)
         loglevel = kwargs.get('loglevel', DEFAULT_LOGLEVEL)
     try:
-        process = Popen(shlex.split(command), stdout=PIPE, stderr=STDOUT, env=env)
+        DEVNULL = open(os.devnull, 'wb')
+        process = Popen(shlex.split(command), stdout=PIPE, stderr=STDOUT, stdin=DEVNULL, env=env)
         process.name = command
         # start the timer if we specified a timeout
         if timeout:
             proctimer = threading.Timer(timeout, _timeout, (process,))
             proctimer.start()
         for line in iter(process.stdout.readline, ''):
+            if stream:
+                print(line.rstrip('\n'))
             if log:
                 _log(
                     service=service,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -586,7 +586,7 @@ class SystemPaastaConfig(dict):
             raise PaastaNotConfiguredError('Could not find scribe_map in configuration directory: %s' % self.directory)
 
 
-def _run(command, env=os.environ, timeout=None, log=False, stream=False, **kwargs):
+def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=None, **kwargs):
     """Given a command, run it. Return a tuple of the return code and any
     output.
 
@@ -608,8 +608,7 @@ def _run(command, env=os.environ, timeout=None, log=False, stream=False, **kwarg
         instance = kwargs.get('instance', ANY_INSTANCE)
         loglevel = kwargs.get('loglevel', DEFAULT_LOGLEVEL)
     try:
-        DEVNULL = open(os.devnull, 'wb')
-        process = Popen(shlex.split(command), stdout=PIPE, stderr=STDOUT, stdin=DEVNULL, env=env)
+        process = Popen(shlex.split(command), stdout=PIPE, stderr=STDOUT, stdin=stdin, env=env)
         process.name = command
         # start the timer if we specified a timeout
         if timeout:

--- a/tests/paasta_cli/test_cmds_local_run.py
+++ b/tests/paasta_cli/test_cmds_local_run.py
@@ -1029,7 +1029,7 @@ def test_get_instance_config_unknown(
 @mock.patch('paasta_tools.paasta_cli.cmds.local_run._run', autospec=True, return_value=(0, 'fake _run output'))
 def test_pull_image_runs_docker_pull(mock_run):
     docker_pull_image('fake_image')
-    mock_run.assert_called_once_with('docker pull fake_image', stream=True)
+    mock_run.assert_called_once_with('docker pull fake_image', stream=True, stdin=mock.ANY)
 
 
 @mock.patch('paasta_tools.paasta_cli.cmds.local_run._run', autospec=True, return_value=(42, 'fake _run output'))
@@ -1037,4 +1037,4 @@ def test_pull_docker_image_exists_with_failure(mock_run):
     with raises(SystemExit) as excinfo:
         docker_pull_image('fake_image')
     assert excinfo.value.code == 42
-    mock_run.assert_called_once_with('docker pull fake_image', stream=True)
+    mock_run.assert_called_once_with('docker pull fake_image', stream=True, stdin=mock.ANY)

--- a/tests/paasta_cli/test_cmds_local_run.py
+++ b/tests/paasta_cli/test_cmds_local_run.py
@@ -1029,7 +1029,7 @@ def test_get_instance_config_unknown(
 @mock.patch('paasta_tools.paasta_cli.cmds.local_run._run', autospec=True, return_value=(0, 'fake _run output'))
 def test_pull_image_runs_docker_pull(mock_run):
     docker_pull_image('fake_image')
-    mock_run.assert_called_once_with('docker pull fake_image')
+    mock_run.assert_called_once_with('docker pull fake_image', stream=True)
 
 
 @mock.patch('paasta_tools.paasta_cli.cmds.local_run._run', autospec=True, return_value=(42, 'fake _run output'))
@@ -1037,4 +1037,4 @@ def test_pull_docker_image_exists_with_failure(mock_run):
     with raises(SystemExit) as excinfo:
         docker_pull_image('fake_image')
     assert excinfo.value.code == 42
-    mock_run.assert_called_once_with('docker pull fake_image')
+    mock_run.assert_called_once_with('docker pull fake_image', stream=True)


### PR DESCRIPTION
This is to improve the new adhoc batch stuff.

Without devnull as stdin, it just hangs expecting you to type in a username+password. I'm going to make the call that we never want to do this in paasta?

Also I added a small flag to allow streaming the output, so you *see* the pull so you get better feedback as it is being pulled. (instead of waiting with no output)