### PR TITLE
Remove docker-dev.yelpcorp.com check

### DIFF
--- a/paasta_tools/paasta_cli/cmds/check.py
+++ b/paasta_tools/paasta_cli/cmds/check.py
@@ -83,30 +83,12 @@ def deploy_has_performance_check(service):
         return False
 
 
-def docker_file_reads_from_yelpcorp(path):
-    """Ensure Dockerfile is valid.
-
-    :param path : path to a Dockerfile
-    :return : A boolean that is True if the Dockerfile reads from yelpcorp"""
-
-    docker_dev_re = re.compile('FROM\s+docker-dev.yelpcorp.com.*')
-    for line in read_dockerfile_lines(path):
-        if docker_dev_re.match(line):
-            return True
-    return False
-
-
 def docker_check():
     """Check whether Dockerfile exists in service directory, and is valid.
     Prints suitable message depending on outcome"""
     docker_file_path = is_file_in_dir('Dockerfile', os.getcwd())
     if docker_file_path:
         print PaastaCheckMessages.DOCKERFILE_FOUND
-
-        if docker_file_reads_from_yelpcorp(docker_file_path):
-            print PaastaCheckMessages.DOCKERFILE_YELPCORP
-        else:
-            print PaastaCheckMessages.DOCKERFILE_NOT_YELPCORP
     else:
         print PaastaCheckMessages.DOCKERFILE_MISSING
 

--- a/tests/paasta_cli/test_cmds_check.py
+++ b/tests/paasta_cli/test_cmds_check.py
@@ -21,7 +21,6 @@ from paasta_tools.paasta_cli.cmds.check import deploy_check
 from paasta_tools.paasta_cli.cmds.check import deploy_has_performance_check
 from paasta_tools.paasta_cli.cmds.check import deploy_has_security_check
 from paasta_tools.paasta_cli.cmds.check import docker_check
-from paasta_tools.paasta_cli.cmds.check import docker_file_reads_from_yelpcorp
 from paasta_tools.paasta_cli.cmds.check import get_marathon_steps
 from paasta_tools.paasta_cli.cmds.check import makefile_check
 from paasta_tools.paasta_cli.cmds.check import makefile_has_a_tab
@@ -142,58 +141,31 @@ def test_check_deploy_check_fail(mock_stdout, mock_is_file_in_dir):
 
 
 @patch('paasta_tools.paasta_cli.cmds.check.is_file_in_dir')
-@patch('paasta_tools.paasta_cli.cmds.check.'
-       'docker_file_reads_from_yelpcorp')
 @patch('sys.stdout', new_callable=StringIO)
-def test_check_docker_check_pass(
-        mock_stdout, mock_docker_file_reads_from_yelpcorp,
-        mock_is_file_in_dir):
-    # Dockerfile exists and is valid
-
+def test_check_docker_exists_and_is_valid(
+    mock_stdout,
+    mock_is_file_in_dir,
+):
     mock_is_file_in_dir.return_value = "/fake/path"
-    mock_docker_file_reads_from_yelpcorp.return_value = True
 
     docker_check()
     output = mock_stdout.getvalue()
 
     assert PaastaCheckMessages.DOCKERFILE_FOUND in output
-    assert PaastaCheckMessages.DOCKERFILE_YELPCORP in output
 
 
 @patch('paasta_tools.paasta_cli.cmds.check.is_file_in_dir')
-@patch('paasta_tools.paasta_cli.cmds.check.'
-       'docker_file_reads_from_yelpcorp')
-@patch('sys.stdout', new_callable=StringIO)
-def test_check_docker_check_doesnt_read_yelpcorp(
-        mock_stdout, mock_docker_file_reads_from_yelpcorp,
-        mock_is_file_in_dir):
-
-    mock_is_file_in_dir.return_value = "/fake/path"
-    mock_docker_file_reads_from_yelpcorp.return_value = False
-
-    docker_check()
-    output = mock_stdout.getvalue()
-
-    assert PaastaCheckMessages.DOCKERFILE_FOUND in output
-    assert PaastaCheckMessages.DOCKERFILE_NOT_YELPCORP in output
-
-
-@patch('paasta_tools.paasta_cli.cmds.check.is_file_in_dir')
-@patch('paasta_tools.paasta_cli.cmds.check.'
-       'docker_file_reads_from_yelpcorp')
 @patch('sys.stdout', new_callable=StringIO)
 def test_check_docker_check_file_not_found(
-        mock_stdout, mock_docker_file_reads_from_yelpcorp,
-        mock_is_file_in_dir):
-
+    mock_stdout,
+    mock_is_file_in_dir
+):
     mock_is_file_in_dir.return_value = False
-    mock_docker_file_reads_from_yelpcorp.return_value = False
 
     docker_check()
     output = mock_stdout.getvalue()
 
     assert PaastaCheckMessages.DOCKERFILE_MISSING in output
-    assert PaastaCheckMessages.DOCKERFILE_NOT_YELPCORP not in output
 
 
 @patch('paasta_tools.paasta_cli.cmds.check.is_file_in_dir')
@@ -616,28 +588,6 @@ def test_marathon_deployments_marathon_but_not_deploy(
     actual = marathon_deployments_check('fake_service')
     assert actual is False
     assert 'BOGUS' in mock_stdout.getvalue()
-
-
-@patch('paasta_tools.paasta_cli.cmds.check.read_dockerfile_lines', autospec=True)
-def test_docker_file_reads_from_yelpcorp_sad(
-    mock_read_dockerfile_lines,
-):
-    mock_read_dockerfile_lines.return_value = [
-        '# some comment',
-        'FROM BAD',
-    ]
-    assert docker_file_reads_from_yelpcorp("unused") is False
-
-
-@patch('paasta_tools.paasta_cli.cmds.check.read_dockerfile_lines', autospec=True)
-def test_docker_file_reads_from_yelpcorp_happy(
-    mock_read_dockerfile_lines,
-):
-    mock_read_dockerfile_lines.return_value = [
-        '# some comment',
-        'FROM docker-dev.yelpcorp.com/trusty_yelp',
-    ]
-    assert docker_file_reads_from_yelpcorp("unused") is True
 
 
 def test_makefile_check():


### PR DESCRIPTION
I think we need to just remove this check. Obviously it has no value outside of yelp, and I don't really want to add the complexity of imposing some sort of custom rule framework.

We should still encourage our local users to use our base images of course.