### PR TITLE
Fix InvalidJobNameError in marathon_services_running_here

### DIFF
--- a/paasta_itests/marathon.feature
+++ b/paasta_itests/marathon.feature
@@ -5,4 +5,11 @@ Feature: paasta_tools can create marathon apps
      When we create a trivial marathon app
      Then we should see it running in marathon
 
+  Scenario: get_marathon_services_running_here_for_nerve works
+    Given a working paasta cluster
+     When we create a trivial marathon app
+     Then we should see it running in marathon
+     When the task has started
+     Then it should show up in marathon_services_running_here
+
 # vim: set ts=2 sw=2

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -644,6 +644,11 @@ def get_all_namespaces(soa_dir=DEFAULT_SOA_DIR):
     return namespace_list
 
 
+def get_app_id_and_task_uuid_from_executor_id(executor_id):
+    """Parse the marathon executor ID and return the (app id, task uuid)"""
+    return executor_id.rsplit('.', 1)
+
+
 def marathon_services_running_here():
     """See what marathon services are being run by a mesos-slave on this host.
     :returns: A list of triples of (service, instance, port)"""
@@ -653,7 +658,8 @@ def marathon_services_running_here():
                  if u'TASK_RUNNING' in [t[u'state'] for t in ex.get('tasks', [])]]
     srv_list = []
     for executor in executors:
-        (srv_name, srv_instance, _, __) = deformat_job_id(executor['id'])
+        app_id, task_uuid = get_app_id_and_task_uuid_from_executor_id(executor['id'])
+        (srv_name, srv_instance, _, __) = deformat_job_id(app_id)
         srv_port = int(re.findall('[0-9]+', executor['resources']['ports'])[0])
         srv_list.append((srv_name, srv_instance, srv_port))
     return srv_list

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -485,11 +485,11 @@ class TestMarathonTools:
 
     @mock.patch('marathon_tools.get_local_slave_state', autospec=True)
     def test_marathon_services_running_here(self, mock_get_local_slave_state):
-        id_1 = 'klingon.ships.detected.249qwiomelht4jioewglkemr'
-        id_2 = 'fire.photon.torpedos.jtgriemot5yhtwe94'
-        id_3 = 'dota.axe.cleave.482u9jyoi4wed'
-        id_4 = 'mesos.deployment.is.hard'
-        id_5 = 'how.to.fake.data'
+        id_1 = 'klingon.ships.detected.249qwiomelht4jioewglkemr.someuuid'
+        id_2 = 'fire.photon.torpedos.jtgriemot5yhtwe94.someuuid'
+        id_3 = 'dota.axe.cleave.482u9jyoi4wed.someuuid'
+        id_4 = 'mesos.deployment.is.hard.someuuid'
+        id_5 = 'how.to.fake.data.someuuid'
         ports_1 = '[111-111]'
         ports_2 = '[222-222]'
         ports_3 = '[333-333]'


### PR DESCRIPTION
configure_nerve built against newer paasta_tools was getting an error: 

```
Traceback (most recent call last):
  File "/usr/bin/configure_nerve", line 9, in <module>
    load_entry_point('nerve-tools==0.8.27', 'console_scripts', 'configure_nerve')()
  File "/usr/share/python/nerve-tools/lib/python2.7/site-packages/nerve_tools/configure_nerve.py", line 195, in main
    new_config = generate_configuration(get_services_running_here_for_nerve(), opts.heartbeat_path)
  File "/usr/share/python/nerve-tools/lib/python2.7/site-packages/paasta_tools/marathon_tools.py", line 743, in get_services_running_here_for_nerve
    return get_marathon_services_running_here_for_nerve(cluster, soa_dir) + \
  File "/usr/share/python/nerve-tools/lib/python2.7/site-packages/paasta_tools/marathon_tools.py", line 673, in get_marathon_services_running_here_for_nerve
    marathon_services = marathon_services_running_here()
  File "/usr/share/python/nerve-tools/lib/python2.7/site-packages/paasta_tools/marathon_tools.py", line 656, in marathon_services_running_here
    (srv_name, srv_instance, _, __) = deformat_job_id(executor['id'])
  File "/usr/share/python/nerve-tools/lib/python2.7/site-packages/paasta_tools/marathon_tools.py", line 577, in deformat_job_id
    return decompose_job_id(job_id)
  File "/usr/share/python/nerve-tools/lib/python2.7/site-packages/paasta_tools/utils.py", line 723, in decompose_job_id
    raise InvalidJobNameError('invalid job id %s' % job_id)
paasta_tools.utils.InvalidJobNameError: invalid job id example_service.mesosstage_main.gitfb0c7ac5.configa27f4485.25d25b29-9df1-11e5-a639-2a9e4587c827
```

This should fix that, once we push this and bump the version of paasta_tools that nerve-tools deps.