### PR TITLE
Fix some sys.stderr.writes that don't have their newlines

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -356,7 +356,7 @@ def docker_pull_image(docker_url):
     DEVNULL = open(os.devnull, 'wb')
     ret, output = _run('docker pull %s' % docker_url, stream=True, stdin=DEVNULL)
     if ret != 0:
-        sys.stderr.write("\nPull failed. Are you authorized to run docker commands?")
+        sys.stderr.write("\nPull failed. Are you authorized to run docker commands?\n")
         sys.exit(ret)
 
 

--- a/paasta_tools/cli/fsm/questions.py
+++ b/paasta_tools/cli/fsm/questions.py
@@ -105,7 +105,7 @@ def get_monitoring_stanza(auto, team):
             print ", ".join(sorted(all_teams))
             team = ask("Team responsible for this service?")
     if not all_teams:
-        sys.stderr.write("Warning: No sensu teams are defined on disk, cannot perform validation on this team name")
+        sys.stderr.write("Warning: No sensu teams are defined on disk, cannot perform validation on this team name\n")
     elif team not in all_teams:
         print "I Don't See Your Team '%s' In The List Of Valid Teams:" % team
         sys.exit(", ".join(sorted(all_teams)))


### PR DESCRIPTION
Fixed the one I cared about, found another with:

```bash
git grep 'sys.stderr.write' | grep -v '\n["'"'"']' | grep ')'
```