### PR TITLE
Improve the human readable state of services depending on their type

### DIFF
--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -94,7 +94,7 @@ def chronos_status_returns_healthy(context):
     print  # sacrificial line for behave to eat instead of our output
 
     assert exit_code == 0
-    assert "Stopped" in output
+    assert "Disabled" in output
     assert "New" in output
 
 

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -37,6 +37,7 @@ from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import PATH_TO_SYSTEM_PAASTA_CONFIG_DIR
 from paasta_tools.utils import timeout
 
@@ -393,6 +394,15 @@ class ChronosJobConfig(InstanceConfig):
     def get_healthcheck_mode(self, _):
         # Healthchecks are not supported yet in chronos
         return None
+
+    def get_desired_state_human(self):
+        desired_state = self.get_desired_state()
+        if desired_state == 'start':
+            return PaastaColors.bold('Scheduled')
+        elif desired_state == 'stop':
+            return PaastaColors.red('Disabled')
+        else:
+            return PaastaColors.red('Unknown (desired_state: %s)' % desired_state)
 
 
 # TODO just use utils.get_service_instance_list(cluster, instance_type='chronos', soa_dir)

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -400,7 +400,7 @@ class ChronosJobConfig(InstanceConfig):
         if desired_state == 'start':
             return PaastaColors.bold('Scheduled')
         elif desired_state == 'stop':
-            return PaastaColors.red('Disabled')
+            return PaastaColors.bold('Disabled')
         else:
             return PaastaColors.red('Unknown (desired_state: %s)' % desired_state)
 

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -45,6 +45,7 @@ from paasta_tools.utils import InvalidInstanceConfig
 from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import NoConfigurationForServiceError
+from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import PATH_TO_SYSTEM_PAASTA_CONFIG_DIR
 from paasta_tools.utils import timeout
@@ -429,6 +430,17 @@ class MarathonServiceConfig(InstanceConfig):
         if service_namespace_config.is_in_smartstack():
             default = {'check_haproxy': True}
         return self.config_dict.get('bounce_health_params', default)
+
+    def get_desired_state_human(self):
+        desired_state = self.get_desired_state()
+        if desired_state == 'start' and self.get_instances() != 0:
+            return PaastaColors.bold('Started')
+        elif desired_state == 'start' and self.get_instances() == 0:
+            return PaastaColors.bold('Stopped')
+        elif desired_state == 'stop':
+            return PaastaColors.red('Stopped')
+        else:
+            return PaastaColors.red('Unknown (desired_state: %s)' % desired_state)
 
 
 def load_service_namespace_config(service, namespace, soa_dir=DEFAULT_SOA_DIR):

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -156,15 +156,6 @@ class InstanceConfig(dict):
         branch from a generated deployments.json file."""
         return self.branch_dict.get('desired_state', 'start')
 
-    def get_desired_state_human(self):
-        desired_state = self.get_desired_state()
-        if desired_state == 'start':
-            return PaastaColors.bold('Started')
-        elif desired_state == 'stop':
-            return PaastaColors.red('Stopped')
-        else:
-            return PaastaColors.red('Unknown (desired_state: %s)' % desired_state)
-
     def get_force_bounce(self):
         """Get the force_bounce token for a given service branch from a generated
         deployments.json file. This is a token that, when changed, indicates that

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -558,6 +558,14 @@ class TestChronosTools:
         # assert okay is False
         # assert msg == 'The specified time zone "+0200" does not conform to the tz database format.'
 
+    def test_get_desired_state_human_when_stopped(self):
+        fake_conf = chronos_tools.ChronosJobConfig('', '', {}, {'desired_state': 'stop'})
+        assert 'Disabled' in fake_conf.get_desired_state_human()
+
+    def test_get_desired_state_human_with_started(self):
+        fake_conf = chronos_tools.ChronosJobConfig('', '', {}, {'desired_state': 'start'})
+        assert 'Scheduled' in fake_conf.get_desired_state_human()
+
     def test_check_param_with_check(self):
         with contextlib.nested(
             mock.patch('chronos_tools.ChronosJobConfig.check_cpus', autospec=True),

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1547,6 +1547,20 @@ class TestMarathonServiceConfig(object):
             "service", "instance", {'instances': 0}, {})
         assert marathon_config.get_backoff_seconds() == 1
 
+    def test_get_desired_state_human(self):
+        fake_conf = marathon_tools.MarathonServiceConfig('service', 'instance', {}, {'desired_state': 'stop'})
+        assert 'Stopped' in fake_conf.get_desired_state_human()
+
+    def test_get_desired_state_human_started_with_instances(self):
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            'service', 'instance', {'instances': 42}, {'desired_state': 'start'})
+        assert 'Started' in fake_conf.get_desired_state_human()
+
+    def test_get_desired_state_human_with_0_instances(self):
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            'service', 'instance', {'instances': 0}, {'desired_state': 'start'})
+        assert 'Stopped' in fake_conf.get_desired_state_human()
+
 
 class TestServiceNamespaceConfig(object):
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -763,10 +763,6 @@ class TestInstanceConfig:
         fake_conf = utils.InstanceConfig({}, {'desired_state': 'stop'})
         assert fake_conf.get_desired_state() == 'stop'
 
-    def test_get_desired_state_human(self):
-        fake_conf = utils.InstanceConfig({}, {'desired_state': 'stop'})
-        assert 'Stopped' in fake_conf.get_desired_state_human()
-
     def test_monitoring_blacklist_default(self):
         fake_conf = utils.InstanceConfig({}, {})
         assert fake_conf.get_monitoring_blacklist() == []


### PR DESCRIPTION
This was a feature request from @gchin.

In the beginning when we only had marathon, this logic made sense. Now I think it can be better if it the human readable output was more "aware" of what kind of job it is, which influences what it means to be "stopped or started".

At the same time, a service with 0 instances is considered "stopped" when you run paasta stop, so we we improve this message and just say "stopped", even if you didn't literally use the paasta stop command?