### PR TITLE
Paasta validate itests

### DIFF
--- a/general_itests/fake_soa_configs_validate/fake_invalid_service/chronos-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_invalid_service/chronos-test-cluster.yaml
@@ -1,0 +1,4 @@
+---
+chronos_job:
+  cpus: .1
+  mem: 100

--- a/general_itests/fake_soa_configs_validate/fake_invalid_service/marathon-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_invalid_service/marathon-test-cluster.yaml
@@ -1,0 +1,7 @@
+---
+main:
+    cpus: .1
+    mem: 100
+    instances: 1
+    env:
+      FOO: BAR

--- a/general_itests/fake_soa_configs_validate/fake_valid_service/chronos-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_valid_service/chronos-test-cluster.yaml
@@ -1,0 +1,5 @@
+---
+chronos_job:
+  cpus: .1
+  mem: 100
+  schedule: 'R/2015-08-14T10:00:00+00:00/PT10M'

--- a/general_itests/fake_soa_configs_validate/fake_valid_service/marathon-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_valid_service/marathon-test-cluster.yaml
@@ -1,0 +1,7 @@
+---
+main:
+    cpus: .1
+    mem: 100
+    instances: 1
+    env:
+      FOO: BAR

--- a/general_itests/steps/validate_steps.py
+++ b/general_itests/steps/validate_steps.py
@@ -1,0 +1,52 @@
+# Copyright 2015 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from behave import given, when, then
+
+from paasta_tools.cli.utils import x_mark
+from paasta_tools.utils import _run
+
+
+@given(u'a "{service_type}" service')
+@given(u'an "{service_type}" service')
+def given_service(context, service_type):
+    context.service = 'fake_%s_service' % service_type
+    context.soa_dir = 'fake_soa_configs_validate'
+
+
+@when(u'we run paasta validate')
+def run_paasta_validate(context):
+    validate_cmd = ("cli.py validate "
+                    "--yelpsoa-config-root %s "
+                    "--service %s " % (context.soa_dir, context.service))
+    context.validate_return_code, context.validate_output = _run(command=validate_cmd)
+    context.validate_output = context.validate_output.decode('utf-8')
+
+
+@then(u'it should have a return code of "{code:d}"')
+def see_expected_return_code(context, code):
+    print context.validate_output
+    print context.validate_return_code
+    print
+    assert context.validate_return_code == code
+
+
+@then(u'everything should pass')
+def validate_status_all_pass(context):
+    assert not context.validate_output or x_mark().decode('utf-8') not in context.validate_output
+
+
+@then(u'something should fail')
+def validate_status_something_fail(context):
+    assert x_mark().decode('utf-8') in context.validate_output

--- a/general_itests/validate.feature
+++ b/general_itests/validate.feature
@@ -1,0 +1,13 @@
+Feature: paasta validate can be used
+
+  Scenario: Running paasta validate against a valid service
+    Given a "valid" service
+    When we run paasta validate
+    Then it should have a return code of "0"
+     And everything should pass
+
+  Scenario: Running paasta validate against an invalid service
+    Given an "invalid" service
+    When we run paasta validate
+    Then it should have a return code of "1"
+     And something should fail

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -18,16 +18,21 @@ import os
 import pkgutil
 import yaml
 
+from collections import OrderedDict
 from glob import glob
 from jsonschema import Draft4Validator
 from jsonschema import FormatChecker
 from jsonschema import ValidationError
+
+from paasta_tools.chronos_tools import load_chronos_job_config
 from paasta_tools.cli.utils import failure
 from paasta_tools.cli.utils import get_file_contents
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import PaastaColors
 from paasta_tools.cli.utils import success
+from paasta_tools.utils import list_all_instances_for_service
+from paasta_tools.utils import list_clusters
 
 
 SCHEMA_VALID = success("Successfully validated schema")
@@ -48,6 +53,17 @@ UNKNOWN_SERVICE = "Unable to determine service to validate.\n" \
                   "Please supply the %s name you wish to " \
                   "validate with the %s option." \
                   % (PaastaColors.cyan('SERVICE'), PaastaColors.cyan('-s'))
+
+
+def invalid_chronos_instance(cluster, instance, output):
+    return failure(
+        'chronos-%s.yaml has an invalid instance: %s.\n  %s\n  '
+        'More info:' % (cluster, instance, output),
+        "http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html#chronos-clustername-yaml")
+
+
+def valid_chronos_instance(cluster, instance):
+    return success('chronos-%s.yaml has a valid instance: %s.' % (cluster, instance))
 
 
 def get_schema(file_type):
@@ -93,7 +109,7 @@ def validate_schema(file_path, file_type):
         print '%s: %s' % (SCHEMA_INVALID, file_path)
         print '  Validation Message: %s' % e.message
     else:
-        print '%s: %s' % (SCHEMA_VALID, file_path)
+        print '%s: %s' % (SCHEMA_VALID, basename)
 
 
 def validate_all_schemas(service_path):
@@ -149,6 +165,31 @@ def get_service_path(service, soa_dir):
             return None
 
 
+def path_to_soa_dir_service(service_path):
+    soa_dir = os.path.dirname(service_path)
+    service = os.path.basename(service_path)
+
+    return soa_dir, service
+
+
+def validate_chronos(service_path):
+    soa_dir, service = path_to_soa_dir_service(service_path)
+    instance_type = 'chronos'
+
+    for cluster in list_clusters(service, soa_dir, instance_type):
+        for instance in list_all_instances_for_service(service, instance_type, soa_dir):
+            cjc = load_chronos_job_config(service, instance, cluster, False, soa_dir)
+            (checks_passed, check_msgs) = cjc.validate()
+
+            # Remove duplicate check_msgs
+            unique_check_msgs = list(OrderedDict.fromkeys(check_msgs))
+
+            if not checks_passed:
+                print invalid_chronos_instance(cluster, instance, "\n  ".join(unique_check_msgs))
+            else:
+                print valid_chronos_instance(cluster, instance)
+
+
 def paasta_validate(args):
     """Analyze the service in the PWD to determine if conf files are all valid
 
@@ -163,3 +204,4 @@ def paasta_validate(args):
         return 1
 
     validate_all_schemas(service_path)
+    validate_chronos(service_path)

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -16,6 +16,7 @@
 import json
 import os
 import pkgutil
+import sys
 import yaml
 
 from collections import OrderedDict
@@ -96,7 +97,7 @@ def validate_schema(file_path, file_type):
         config_file = get_file_contents(file_path)
     except IOError:
         print '%s: %s' % (FAILED_READING_FILE, file_path)
-        return
+        return 1
     if extension == '.yaml':
         config_file_object = yaml.load(config_file)
     elif extension == '.json':
@@ -108,8 +109,10 @@ def validate_schema(file_path, file_type):
     except ValidationError as e:
         print '%s: %s' % (SCHEMA_INVALID, file_path)
         print '  Validation Message: %s' % e.message
+        return 1
     else:
         print '%s: %s' % (SCHEMA_VALID, basename)
+        return 0
 
 
 def validate_all_schemas(service_path):
@@ -125,9 +128,13 @@ def validate_all_schemas(service_path):
         if os.path.islink(file_name):
             continue
         basename = os.path.basename(file_name)
+        returncode = 0
         for file_type in ['chronos', 'marathon']:
             if basename.startswith(file_type):
-                validate_schema(file_name, file_type)
+                tmp_returncode = validate_schema(file_name, file_type)
+                if tmp_returncode != 0:
+                    returncode = tmp_returncode
+        return returncode
 
 
 def add_subparser(subparsers):
@@ -156,13 +163,22 @@ def get_service_path(service, soa_dir):
     :param args: argparse.Namespace obj created from sys.args by cli
     """
     if service:
-        return os.path.join(soa_dir, service)
+        service_path = os.path.join(soa_dir, service)
     else:
         if soa_dir == os.getcwd():
-            return os.getcwd()
+            service_path = os.getcwd()
         else:
             print UNKNOWN_SERVICE
             return None
+    if not os.path.isdir(service_path):
+        print failure("%s is not a directory" % service_path,
+                      "http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html")
+        return None
+    if not glob(os.path.join(service_path, "*.yaml")):
+        print failure("%s does not contain any .yaml files" % service_path,
+                      "http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html")
+        return None
+    return service_path
 
 
 def path_to_soa_dir_service(service_path):
@@ -176,6 +192,7 @@ def validate_chronos(service_path):
     soa_dir, service = path_to_soa_dir_service(service_path)
     instance_type = 'chronos'
 
+    returncode = 0
     for cluster in list_clusters(service, soa_dir, instance_type):
         for instance in list_all_instances_for_service(service, instance_type, soa_dir):
             cjc = load_chronos_job_config(service, instance, cluster, False, soa_dir)
@@ -186,8 +203,10 @@ def validate_chronos(service_path):
 
             if not checks_passed:
                 print invalid_chronos_instance(cluster, instance, "\n  ".join(unique_check_msgs))
+                returncode = 1
             else:
                 print valid_chronos_instance(cluster, instance)
+    return returncode
 
 
 def paasta_validate(args):
@@ -201,7 +220,13 @@ def paasta_validate(args):
     service_path = get_service_path(service, soa_dir)
 
     if service_path is None:
-        return 1
+        sys.exit(1)
 
-    validate_all_schemas(service_path)
-    validate_chronos(service_path)
+    returncode = 0
+    tmp_returncode = validate_all_schemas(service_path)
+    if tmp_returncode != 0:
+        returncode = tmp_returncode
+    tmp_returncode = validate_chronos(service_path)
+    if tmp_returncode != 0:
+        returncode = tmp_returncode
+    sys.exit(returncode)

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -305,7 +305,7 @@ def guess_instance(service, cluster, args):
     else:
         try:
             instances = list_all_instances_for_service(
-                service=service, cluster=cluster, instance_type=None, soa_dir=args.yelpsoa_config_root)
+                service=service, instance_type=None, soa_dir=args.yelpsoa_config_root)
             if 'main' in instances:
                 instance = 'main'
             else:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -804,7 +804,7 @@ def get_default_cluster_for_service(service):
     return cluster
 
 
-def list_clusters(service=None, soa_dir=DEFAULT_SOA_DIR):
+def list_clusters(service=None, soa_dir=DEFAULT_SOA_DIR, instance_type=None):
     """Returns a sorted list of clusters a service is configured to deploy to,
     or all clusters if ``service`` is not specified.
 
@@ -818,14 +818,21 @@ def list_clusters(service=None, soa_dir=DEFAULT_SOA_DIR):
         service = '*'
     srv_path = os.path.join(soa_dir, service)
 
+    if instance_type == 'marathon' or instance_type == 'chronos':
+        instance_types = instance_type
+    else:
+        instance_types = 'marathon|chronos'
+
+    search_re = r'/.*/(' + instance_types + r')-([0-9a-z-]*).yaml$'
+
     for yaml_file in glob.glob('%s/*.yaml' % srv_path):
-        cluster_re_match = re.search('/.*/(marathon|chronos)-([0-9a-z-]*).yaml$', yaml_file)
+        cluster_re_match = re.search(search_re, yaml_file)
         if cluster_re_match is not None:
             clusters.add(cluster_re_match.group(2))
     return sorted(clusters)
 
 
-def list_all_instances_for_service(service, cluster=None, instance_type=None, soa_dir=DEFAULT_SOA_DIR):
+def list_all_instances_for_service(service, instance_type=None, soa_dir=DEFAULT_SOA_DIR):
     instances = set()
     for cluster in list_clusters(service, soa_dir=soa_dir):
         for service_instance in get_service_instance_list(service, cluster, instance_type, soa_dir=soa_dir):

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -18,8 +18,12 @@ import os
 from mock import patch
 from StringIO import StringIO
 
+from paasta_tools.chronos_tools import ChronosJobConfig
 from paasta_tools.cli.cmds.validate import get_schema
 from paasta_tools.cli.cmds.validate import get_service_path
+from paasta_tools.cli.cmds.validate import invalid_chronos_instance
+from paasta_tools.cli.cmds.validate import valid_chronos_instance
+from paasta_tools.cli.cmds.validate import validate_chronos
 from paasta_tools.cli.cmds.validate import validate_schema
 from paasta_tools.cli.cmds.validate import paasta_validate
 from paasta_tools.cli.cmds.validate import SCHEMA_VALID
@@ -28,9 +32,11 @@ from paasta_tools.cli.cmds.validate import UNKNOWN_SERVICE
 
 
 @patch('paasta_tools.cli.cmds.validate.validate_all_schemas')
+@patch('paasta_tools.cli.cmds.validate.validate_chronos')
 @patch('paasta_tools.cli.cmds.validate.get_service_path')
 def test_paasta_validate_calls_everything(
     mock_get_service_path,
+    mock_validate_chronos,
     mock_validate_all_schemas
 ):
     # Ensure each check in 'paasta_validate' is called
@@ -44,6 +50,7 @@ def test_paasta_validate_calls_everything(
     paasta_validate(args)
 
     assert mock_validate_all_schemas.called
+    assert mock_validate_chronos.called
 
 
 @patch('sys.stdout', new_callable=StringIO)
@@ -197,3 +204,155 @@ def test_chronos_validate_schema_keys_outside_instance_blocks_bad(
     output = mock_stdout.getvalue()
 
     assert SCHEMA_INVALID in output
+
+
+@patch('paasta_tools.cli.cmds.validate.list_clusters')
+@patch('paasta_tools.cli.cmds.validate.list_all_instances_for_service')
+@patch('paasta_tools.cli.cmds.validate.load_chronos_job_config')
+@patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service')
+@patch('sys.stdout', new_callable=StringIO)
+def test_validate_chronos_missing_schedule(
+    mock_stdout,
+    mock_path_to_soa_dir_service,
+    mock_load_chronos_job_config,
+    mock_list_all_instances_for_service,
+    mock_list_clusters
+):
+    fake_service = 'test-service'
+    fake_instance = 'fake-instance'
+    fake_job_name = 'test'
+    fake_cluster = 'penguin'
+    fake_monitoring_info = {'fake_monitoring_info': 'fake_monitoring_value'}
+    fake_config_dict = {
+        'bounce_method': 'graceful',
+        'cmd': '/bin/sleep 40',
+        'epsilon': 'PT30M',
+        'retries': 5,
+        'cpus': 5.5,
+        'mem': 1024.4,
+        'disabled': True,
+        'schedule_time_zone': 'Zulu',
+        'monitoring': fake_monitoring_info,
+    }
+    fake_branch_dict = {
+        'desired_state': 'start',
+        'docker_image': 'paasta-%s-%s' % (fake_service, fake_cluster),
+    }
+    fake_chronos_job_config = ChronosJobConfig(fake_service,
+                                               fake_job_name,
+                                               fake_config_dict,
+                                               fake_branch_dict)
+
+    mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'fake_service')
+    mock_list_clusters.return_value = [fake_cluster]
+    mock_list_all_instances_for_service.return_value = [fake_instance]
+    mock_load_chronos_job_config.return_value = fake_chronos_job_config
+
+    validate_chronos('fake_service_path')
+
+    output = mock_stdout.getvalue()
+
+    expected_output = 'You must specify a "schedule" in your configuration'
+    assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
+
+
+@patch('paasta_tools.cli.cmds.validate.list_clusters')
+@patch('paasta_tools.cli.cmds.validate.list_all_instances_for_service')
+@patch('paasta_tools.cli.cmds.validate.load_chronos_job_config')
+@patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service')
+@patch('sys.stdout', new_callable=StringIO)
+def test_validate_chronos_invalid_instance(
+    mock_stdout,
+    mock_path_to_soa_dir_service,
+    mock_load_chronos_job_config,
+    mock_list_all_instances_for_service,
+    mock_list_clusters
+):
+    fake_service = 'test-service'
+    fake_instance = 'fake-instance'
+    fake_job_name = 'test'
+    fake_cluster = 'penguin'
+    fake_monitoring_info = {'fake_monitoring_info': 'fake_monitoring_value'}
+    fake_config_dict = {
+        'bounce_method': 'graceful',
+        'cmd': '/bin/sleep 40',
+        'epsilon': 'PT30M',
+        'retries': 5,
+        'cpus': 5.5,
+        'mem': 1024.4,
+        'disabled': True,
+        'schedule': 'P1DT09:00:00',
+        'schedule_time_zone': 'Zulu',
+        'monitoring': fake_monitoring_info,
+    }
+    fake_branch_dict = {
+        'desired_state': 'start',
+        'docker_image': 'paasta-%s-%s' % (fake_service, fake_cluster),
+    }
+    fake_chronos_job_config = ChronosJobConfig(fake_service,
+                                               fake_job_name,
+                                               fake_config_dict,
+                                               fake_branch_dict)
+
+    mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'fake_service')
+    mock_list_clusters.return_value = [fake_cluster]
+    mock_list_all_instances_for_service.return_value = [fake_instance]
+    mock_load_chronos_job_config.return_value = fake_chronos_job_config
+
+    validate_chronos('fake_service_path')
+
+    output = mock_stdout.getvalue()
+
+    expected_output = 'The specified schedule "%s" is invalid' % \
+        fake_config_dict['schedule']
+    assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
+
+
+@patch('paasta_tools.cli.cmds.validate.list_clusters')
+@patch('paasta_tools.cli.cmds.validate.list_all_instances_for_service')
+@patch('paasta_tools.cli.cmds.validate.load_chronos_job_config')
+@patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service')
+@patch('sys.stdout', new_callable=StringIO)
+def test_validate_chronos_valid_instance(
+    mock_stdout,
+    mock_path_to_soa_dir_service,
+    mock_load_chronos_job_config,
+    mock_list_all_instances_for_service,
+    mock_list_clusters
+):
+    fake_service = 'test-service'
+    fake_instance = 'fake-instance'
+    fake_job_name = 'test'
+    fake_cluster = 'penguin'
+    fake_monitoring_info = {'fake_monitoring_info': 'fake_monitoring_value'}
+    fake_config_dict = {
+        'bounce_method': 'graceful',
+        'cmd': '/bin/sleep 40',
+        'epsilon': 'PT30M',
+        'retries': 5,
+        'cpus': 5.5,
+        'mem': 1024.4,
+        'disabled': True,
+        'schedule': 'R/2015-03-25T19:36:35Z/PT5M',
+        'schedule_time_zone': 'Zulu',
+        'monitoring': fake_monitoring_info,
+    }
+    fake_branch_dict = {
+        'desired_state': 'start',
+        'docker_image': 'paasta-%s-%s' % (fake_service, fake_cluster),
+    }
+    fake_chronos_job_config = ChronosJobConfig(fake_service,
+                                               fake_job_name,
+                                               fake_config_dict,
+                                               fake_branch_dict)
+
+    mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'fake_service')
+    mock_list_clusters.return_value = [fake_cluster]
+    mock_list_all_instances_for_service.return_value = [fake_instance]
+    mock_load_chronos_job_config.return_value = fake_chronos_job_config
+
+    validate_chronos('fake_service_path')
+
+    output = mock_stdout.getvalue()
+
+    assert valid_chronos_instance(fake_cluster, fake_instance) in output

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -75,7 +75,15 @@ def test_validate_unknown_service():
     assert paasta_validate(args) == 1
 
 
-def test_get_service_path_cwd():
+@patch('paasta_tools.cli.cmds.validate.os.path.isdir')
+@patch('paasta_tools.cli.cmds.validate.glob')
+def test_get_service_path_cwd(
+    mock_glob,
+    mock_isdir
+):
+    mock_isdir.return_value = True
+    mock_glob.return_value = ['something.yaml']
+
     service = None
     soa_dir = os.getcwd()
 
@@ -84,7 +92,15 @@ def test_get_service_path_cwd():
     assert service_path == os.getcwd()
 
 
-def test_get_service_path_soa_dir():
+@patch('paasta_tools.cli.cmds.validate.os.path.isdir')
+@patch('paasta_tools.cli.cmds.validate.glob')
+def test_get_service_path_soa_dir(
+    mock_glob,
+    mock_isdir
+):
+    mock_isdir.return_value = True
+    mock_glob.return_value = ['something.yaml']
+
     service = 'some_service'
     soa_dir = 'some/path'
 
@@ -134,7 +150,7 @@ main_http:
 """
     mock_get_file_contents.return_value = marathon_content
 
-    validate_schema('unused_service_path.yaml', 'marathon')
+    assert validate_schema('unused_service_path.yaml', 'marathon') == 0
 
     output = mock_stdout.getvalue()
 
@@ -155,7 +171,7 @@ def test_marathon_validate_schema_keys_outside_instance_blocks_bad(
     "page": false
 }
 """
-    validate_schema('unused_service_path.json', 'marathon')
+    assert validate_schema('unused_service_path.json', 'marathon') == 1
 
     output = mock_stdout.getvalue()
 
@@ -178,7 +194,7 @@ def test_chronos_validate_schema_list_hashes_good(
     }
 }
 """
-    validate_schema('unused_service_path.json', 'chronos')
+    assert validate_schema('unused_service_path.json', 'chronos') == 0
 
     output = mock_stdout.getvalue()
 
@@ -199,7 +215,7 @@ def test_chronos_validate_schema_keys_outside_instance_blocks_bad(
     "page": false
 }
 """
-    validate_schema('unused_service_path.json', 'chronos')
+    assert validate_schema('unused_service_path.json', 'chronos') == 1
 
     output = mock_stdout.getvalue()
 
@@ -248,7 +264,7 @@ def test_validate_chronos_missing_schedule(
     mock_list_all_instances_for_service.return_value = [fake_instance]
     mock_load_chronos_job_config.return_value = fake_chronos_job_config
 
-    validate_chronos('fake_service_path')
+    assert validate_chronos('fake_service_path') == 1
 
     output = mock_stdout.getvalue()
 
@@ -299,7 +315,7 @@ def test_validate_chronos_invalid_instance(
     mock_list_all_instances_for_service.return_value = [fake_instance]
     mock_load_chronos_job_config.return_value = fake_chronos_job_config
 
-    validate_chronos('fake_service_path')
+    assert validate_chronos('fake_service_path') == 1
 
     output = mock_stdout.getvalue()
 
@@ -351,7 +367,7 @@ def test_validate_chronos_valid_instance(
     mock_list_all_instances_for_service.return_value = [fake_instance]
     mock_load_chronos_job_config.return_value = fake_chronos_job_config
 
-    validate_chronos('fake_service_path')
+    assert validate_chronos('fake_service_path') == 0
 
     output = mock_stdout.getvalue()
 


### PR DESCRIPTION
Add some simple integration tests for `paasta validate`. I also updated `paasta validate` to return 1 if it finds anything invalid and 0 if everything is valid. More of the functionality is tested with unit tests already. This builds on my paasta-validate-chronos branch.