### PR TITLE
First support for creating dependent jobs - Fixes #140, #141, #146

### DIFF
--- a/paasta_itests/chronos.feature
+++ b/paasta_itests/chronos.feature
@@ -1,9 +1,0 @@
-Feature: paasta_tools can interact with chronos
-
-  Scenario: Trivial chronos jobs can be deployed
-    Given a working paasta cluster
-     When we create a trivial chronos job
-      And we wait for the chronos job to appear in the job list
-     Then we should be able to see it when we list jobs
-
-# vim: set ts=2 sw=2

--- a/paasta_itests/cleanup_chronos_jobs.feature
+++ b/paasta_itests/cleanup_chronos_jobs.feature
@@ -2,9 +2,9 @@ Feature: cleanup_chronos_jobs removes chronos jobs no longer in the config
 
  Scenario: Cleanup chronos jobs removes jobs
    Given a working paasta cluster
-     And I have yelpsoa-configs for the service "myservice" with disabled scheduled chronos instance "UNUSED"
-    When I launch 3 configured jobs for the service "myservice" with scheduled chronos instance "UNUSED" and differing tags
-     And I launch 1 unconfigured jobs for the service "oldservice" with scheduled chronos instance "foo" and differing tags
+      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+    When I launch 3 configured jobs for the service "testservice" with scheduled chronos instance "testinstance" and differing tags
+     And I launch 1 unconfigured jobs for the service "oldservice" with scheduled chronos instance "othertestinstance" and differing tags
      And I launch 3 non-paasta jobs
     Then cleanup_chronos_jobs exits with return code "0" and the correct output
      And the non chronos jobs are still in the job list

--- a/paasta_itests/cleanup_chronos_jobs.feature
+++ b/paasta_itests/cleanup_chronos_jobs.feature
@@ -2,9 +2,9 @@ Feature: cleanup_chronos_jobs removes chronos jobs no longer in the config
 
  Scenario: Cleanup chronos jobs removes jobs
    Given a working paasta cluster
-     And I have yelpsoa-configs for the service "myservice" with disabled chronos instance "UNUSED"
-    When I launch 3 configured jobs for the service "myservice" with chronos instance "UNUSED" and differing tags
-     And I launch 1 unconfigured jobs for the service "oldservice" with chronos instance "foo" and differing tags
+     And I have yelpsoa-configs for the service "myservice" with disabled scheduled chronos instance "UNUSED"
+    When I launch 3 configured jobs for the service "myservice" with scheduled chronos instance "UNUSED" and differing tags
+     And I launch 1 unconfigured jobs for the service "oldservice" with scheduled chronos instance "foo" and differing tags
      And I launch 3 non-paasta jobs
     Then cleanup_chronos_jobs exits with return code "0" and the correct output
      And the non chronos jobs are still in the job list

--- a/paasta_itests/environment.py
+++ b/paasta_itests/environment.py
@@ -64,6 +64,8 @@ def _clean_up_chronos_jobs(context):
                 print "after_scenario: Job %s is present in chronos. Deleting." % job['name']
                 context.chronos_client.delete(job['name'])
             time.sleep(1)
+    if hasattr(context, 'jobs'):
+        context.jobs = {}
 
 
 def _clean_up_mesos_cli_config(context):

--- a/paasta_itests/paasta_metastatus.feature
+++ b/paasta_itests/paasta_metastatus.feature
@@ -35,8 +35,8 @@ Feature: paasta_metastatus describes the state of the paasta cluster
   Scenario: With a launched chronos job
     Given a working paasta cluster
      When we create a trivial marathon app
-      And we create a trivial chronos job
-      And we wait for the chronos job to appear in the job list
+      And we create a trivial chronos job called "testjob"
+      And we wait for the chronos job stored as "testjob" to appear in the job list
      Then paasta_metastatus exits with return code "0" and output "Enabled chronos jobs: 1"
 
 #  Scenario: Mesos master unreachable

--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -3,7 +3,7 @@ Feature: paasta_serviceinit
   Scenario: marathon_serviceinit can run status
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
-      And I have a deployments.json for the service "test-service" with enabled instance "main"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main"
       And we wait for it to be deployed
      Then marathon_serviceinit status_marathon_job should return "Healthy" for "test-service.main"
@@ -11,79 +11,81 @@ Feature: paasta_serviceinit
   Scenario: marathon_serviceinit can restart tasks
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
-      And I have a deployments.json for the service "test-service" with enabled instance "main"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main"
       And we wait for it to be deployed
      Then marathon_serviceinit restart should get new task_ids for "test-service.main"
 
   Scenario: paasta_serviceinit can run status on chronos jobs
     Given a working paasta cluster
-      And I have yelpsoa-configs for the service "test-service" with disabled scheduled chronos instance "job"
-      And I have a deployments.json for the service "test-service" with disabled instance "job"
-     When we create a chronos job dict from the configs for instance "job" of service "test-service"
-      And we send the job to chronos
-      And we wait for the chronos job to appear in the job list
-     Then paasta_serviceinit status exits with return code 0 and the correct output
+      And we have yelpsoa-configs for the service "testservice" with disabled scheduled chronos instance "testinstance"
+      And we have a deployments.json for the service "testservice" with disabled instance "testinstance"
+     When we run setup_chronos_job for service_instance "testservice.testinstance"
+      And we store the name of the job for the service testservice and instance testinstance as myjob
+      And we wait for the chronos job stored as "myjob" to appear in the job list
+     Then paasta_serviceinit status for the service_instance "testservice.testinstance" exits with return code 0 and the correct output
 
   Scenario: paasta_serviceinit can run status --verbose on chronos jobs
     Given a working paasta cluster
-      And I have yelpsoa-configs for the service "test-service" with disabled scheduled chronos instance "job"
-      And I have a deployments.json for the service "test-service" with disabled instance "job"
-     When we create a chronos job dict from the configs for instance "job" of service "test-service"
-      And we send the job to chronos
-      And we wait for the chronos job to appear in the job list
-     Then paasta_serviceinit status --verbose exits with return code 0 and the correct output
+      And we have yelpsoa-configs for the service "testservice" with disabled scheduled chronos instance "testinstance"
+      And we have a deployments.json for the service "testservice" with disabled instance "testinstance"
+     When we run setup_chronos_job for service_instance "testservice.testinstance"
+      And we store the name of the job for the service testservice and instance testinstance as myjob
+      And we wait for the chronos job stored as "myjob" to appear in the job list
+     Then paasta_serviceinit status --verbose for the service_instance "testservice.testinstance" exits with return code 0 and the correct output
 
   Scenario: paasta_serviceinit can run emergency-stop on an enabled chronos job
     Given a working paasta cluster
-      And I have yelpsoa-configs for the service "test-service" with enabled scheduled chronos instance "job"
-      And I have a deployments.json for the service "test-service" with enabled instance "job"
-     When we create a chronos job dict from the configs for instance "job" of service "test-service"
-      And we send the job to chronos
-      And we wait for the chronos job to appear in the job list
-      And we paasta_serviceinit emergency-stop the chronos job
-     Then the job is disabled in chronos
+      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+      And we have a deployments.json for the service "testservice" with enabled instance "testinstance"
+     When we run setup_chronos_job for service_instance "testservice.testinstance"
+      And we store the name of the job for the service testservice and instance testinstance as myjob
+      And we wait for the chronos job stored as "myjob" to appear in the job list
+      And we paasta_serviceinit emergency-stop the service_instance "testservice.testinstance"
+     Then the job stored as "myjob" is disabled in chronos
       And the job has no running tasks
 
   Scenario: paasta_serviceinit can run emergency-start on an enabled chronos job
     Given a working paasta cluster
-      And I have yelpsoa-configs for the service "test-service" with enabled scheduled chronos instance "job"
-      And I have a deployments.json for the service "test-service" with enabled instance "job"
-     When we create a chronos job dict from the configs for instance "job" of service "test-service"
-      And we paasta_serviceinit emergency-start the chronos job
-      And we wait for the chronos job to appear in the job list
-     Then the job is enabled in chronos
+      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+      And we have a deployments.json for the service "testservice" with enabled instance "testinstance"
+     When we run setup_chronos_job for service_instance "testservice.testinstance"
+      And we store the name of the job for the service testservice and instance testinstance as myjob
+      And we wait for the chronos job stored as "myjob" to appear in the job list
+      And we paasta_serviceinit emergency-start the service_instance "testservice.testinstance"
+     Then the job stored as "myjob" is enabled in chronos
       And the job has running tasks
 
   Scenario: paasta_serviceinit can run emergency-start on a disabled chronos job
     Given a working paasta cluster
-      And I have yelpsoa-configs for the service "test-service" with disabled scheduled chronos instance "job"
-      And I have a deployments.json for the service "test-service" with disabled instance "job"
-     When we create a chronos job dict from the configs for instance "job" of service "test-service"
-      And we paasta_serviceinit emergency-start the chronos job
-      And we wait for the chronos job to appear in the job list
-     Then the job is disabled in chronos
+      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+      And we have a deployments.json for the service "testservice" with enabled instance "testinstance"
+     When we run setup_chronos_job for service_instance "testservice.testinstance"
+      And we store the name of the job for the service testservice and instance testinstance as myjob
+      And we wait for the chronos job stored as "myjob" to appear in the job list
+      And we paasta_serviceinit emergency-start the service_instance "testservice.testinstance"
+     Then the job stored as "myjob" is enabled in chronos
       And the job has no running tasks
 
   Scenario: paasta_serviceinit can run emergency-restart on an enabled chronos job
     Given a working paasta cluster
-      And I have yelpsoa-configs for the service "test-service" with enabled scheduled chronos instance "job"
-      And I have a deployments.json for the service "test-service" with enabled instance "job"
-     When we create a chronos job dict from the configs for instance "job" of service "test-service"
-      And we send the job to chronos
-      And we wait for the chronos job to appear in the job list
-      And we update the tag for the service "test-service" with enabled scheduled chronos instance "job"
-      And we create a chronos job dict from the configs for instance "job" of service "test-service"
-      And we paasta_serviceinit emergency-restart the chronos job
-     Then the old job is disabled in chronos
+      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+      And we have a deployments.json for the service "testservice" with enabled instance "testinstance"
+     When we run setup_chronos_job for service_instance "testservice.testinstance"
+      And we store the name of the job for the service testservice and instance testinstance as myjob
+      And we wait for the chronos job stored as "myjob" to appear in the job list
+     When we set the "cmd" field of the chronos config for service "testservice" and instance "testinstance" to "sleep 60m"
+      And we paasta_serviceinit emergency-start the service_instance "testservice.testinstance"
+      And we store the name of the job for the service testservice and instance testinstance as mynewjob
+     Then the job stored as "myjob" is enabled in chronos
+      And the job stored as "mynewjob" is enabled in chronos
       And the old job has no running tasks
-      And the new job is enabled in chronos
       And the new job has running tasks
 
   Scenario: paasta_serviceinit can run emergency-stop on a marathon app
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
-      And I have a deployments.json for the service "test-service" with enabled instance "main"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main"
       And we wait for it to be deployed
       And we run paasta serviceinit "stop" on "test-service.main"
@@ -93,7 +95,7 @@ Feature: paasta_serviceinit
   Scenario: paasta_serviceinit can run emergency-stop on a marathon app via appid
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
-      And I have a deployments.json for the service "test-service" with enabled instance "main"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main"
       And we wait for it to be deployed
       And we run paasta serviceinit --appid "stop" on "test-service.main"
@@ -103,7 +105,7 @@ Feature: paasta_serviceinit
   Scenario: paasta_serviceinit can run emergency-scale on a marathon app
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
-      And I have a deployments.json for the service "test-service" with enabled instance "main"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main"
       And we wait for it to be deployed
       And we run paasta serviceinit scale --delta "1" on "test-service.main"

--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -18,7 +18,7 @@ Feature: paasta_serviceinit
 
   Scenario: paasta_serviceinit can run status on chronos jobs
     Given a working paasta cluster
-      And I have yelpsoa-configs for the service "test-service" with disabled chronos instance "job"
+      And I have yelpsoa-configs for the service "test-service" with disabled scheduled chronos instance "job"
       And I have a deployments.json for the service "test-service" with disabled instance "job"
      When we create a chronos job dict from the configs for instance "job" of service "test-service"
       And we send the job to chronos
@@ -27,7 +27,7 @@ Feature: paasta_serviceinit
 
   Scenario: paasta_serviceinit can run status --verbose on chronos jobs
     Given a working paasta cluster
-      And I have yelpsoa-configs for the service "test-service" with disabled chronos instance "job"
+      And I have yelpsoa-configs for the service "test-service" with disabled scheduled chronos instance "job"
       And I have a deployments.json for the service "test-service" with disabled instance "job"
      When we create a chronos job dict from the configs for instance "job" of service "test-service"
       And we send the job to chronos
@@ -36,7 +36,7 @@ Feature: paasta_serviceinit
 
   Scenario: paasta_serviceinit can run emergency-stop on an enabled chronos job
     Given a working paasta cluster
-      And I have yelpsoa-configs for the service "test-service" with enabled chronos instance "job"
+      And I have yelpsoa-configs for the service "test-service" with enabled scheduled chronos instance "job"
       And I have a deployments.json for the service "test-service" with enabled instance "job"
      When we create a chronos job dict from the configs for instance "job" of service "test-service"
       And we send the job to chronos
@@ -47,7 +47,7 @@ Feature: paasta_serviceinit
 
   Scenario: paasta_serviceinit can run emergency-start on an enabled chronos job
     Given a working paasta cluster
-      And I have yelpsoa-configs for the service "test-service" with enabled chronos instance "job"
+      And I have yelpsoa-configs for the service "test-service" with enabled scheduled chronos instance "job"
       And I have a deployments.json for the service "test-service" with enabled instance "job"
      When we create a chronos job dict from the configs for instance "job" of service "test-service"
       And we paasta_serviceinit emergency-start the chronos job
@@ -57,7 +57,7 @@ Feature: paasta_serviceinit
 
   Scenario: paasta_serviceinit can run emergency-start on a disabled chronos job
     Given a working paasta cluster
-      And I have yelpsoa-configs for the service "test-service" with disabled chronos instance "job"
+      And I have yelpsoa-configs for the service "test-service" with disabled scheduled chronos instance "job"
       And I have a deployments.json for the service "test-service" with disabled instance "job"
      When we create a chronos job dict from the configs for instance "job" of service "test-service"
       And we paasta_serviceinit emergency-start the chronos job
@@ -67,12 +67,12 @@ Feature: paasta_serviceinit
 
   Scenario: paasta_serviceinit can run emergency-restart on an enabled chronos job
     Given a working paasta cluster
-      And I have yelpsoa-configs for the service "test-service" with enabled chronos instance "job"
+      And I have yelpsoa-configs for the service "test-service" with enabled scheduled chronos instance "job"
       And I have a deployments.json for the service "test-service" with enabled instance "job"
      When we create a chronos job dict from the configs for instance "job" of service "test-service"
       And we send the job to chronos
       And we wait for the chronos job to appear in the job list
-      And we update the tag for the service "test-service" with enabled chronos instance "job"
+      And we update the tag for the service "test-service" with enabled scheduled chronos instance "job"
       And we create a chronos job dict from the configs for instance "job" of service "test-service"
       And we paasta_serviceinit emergency-restart the chronos job
      Then the old job is disabled in chronos

--- a/paasta_itests/setup_chronos_job.feature
+++ b/paasta_itests/setup_chronos_job.feature
@@ -2,8 +2,10 @@ Feature: setup_chronos_job can create and bounce jobs
 
   Scenario: complete jobs can be deployed
     Given a working paasta cluster
-     When we create a complete chronos job
-     Then we should see it in the list of jobs
+      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+      And we have a deployments.json for the service "testservice" with enabled chronos instance "testinstance"
+     When we run setup_chronos_job for service_instance "testservice.testinstance"
+     Then we should see a job for the service "testservice" and instance "testinstance" in the job list
 
   Scenario: jobs can be bounced using the "graceful" method
     Given a working paasta cluster

--- a/paasta_itests/setup_chronos_job.feature
+++ b/paasta_itests/setup_chronos_job.feature
@@ -9,38 +9,34 @@ Feature: setup_chronos_job can create and bounce jobs
 
   Scenario: jobs can be bounced using the "graceful" method
     Given a working paasta cluster
-      And I have yelpsoa-configs for the service "test-service" with enabled chronos instance "test-instance"
-      And I have a deployments.json for the service "test-service" with enabled chronos instance "test-instance"
-     When we load the configs for instance "test-instance" of service "test-service" into a ChronosJobConfig
-      And we set the bounce_method of the ChronosJobConfig to "graceful"
-      And we create a chronos job dict from the configs for instance "test-instance" of service "test-service"
-      And we run setup_chronos_job
-      And we manually start the job
-     Then the job is enabled in chronos
-      And the job has running tasks
+      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+      And we have a deployments.json for the service "testservice" with enabled chronos instance "testinstance"
+     When we set the "bounce" field of the chronos config for service "testservice" and instance "testinstance" to "graceful"
+      And we run setup_chronos_job for service_instance "testservice.testinstance"
+      And we store the name of the job for the service testservice and instance testinstance as myfirstjob
+     Then the field "disabled" for the job stored as "myfirstjob" is set to "False"
 
-     When we update the tag for the service "test-service" with enabled chronos instance "test-instance"
-      And we create a chronos job dict from the configs for instance "test-instance" of service "test-service"
-      And we run setup_chronos_job
-     Then the old job is disabled in chronos
-      And the old job has running tasks
-      And the new job is enabled in chronos
+     When we set the "cmd" field of the chronos config for service "testservice" and instance "testinstance" to "sleep 60m"
+      And we run setup_chronos_job for service_instance "testservice.testinstance"
+      And we store the name of the job for the service testservice and instance testinstance as mysecondjob
+     Then the field "disabled" for the job stored as "myfirstjob" is set to "True"
+      And the field "disabled" for the job stored as "mysecondjob" is set to "False"
 
-     When we update the tag for the service "test-service" with enabled chronos instance "test-instance"
-      And we create a chronos job dict from the configs for instance "test-instance" of service "test-service"
-      And we run setup_chronos_job
-     Then the old job is disabled in chronos
-      And the old job has no running tasks
-      And the new job is enabled in chronos
-      And the new job has running tasks
+     When we set the "cmd" field of the chronos config for service "testservice" and instance "testinstance" to "echo hello && sleep 60m"
+      And we run setup_chronos_job for service_instance "testservice.testinstance"
+      And we store the name of the job for the service testservice and instance testinstance as mythirdjob
+     Then the field "disabled" for the job stored as "mysecondjob" is set to "True"
+      And the field "disabled" for the job stored as "mythirdjob" is set to "False"
 
   Scenario: jobs will be cleaned up by the "graceful" bounce
     Given a working paasta cluster
-      And I have yelpsoa-configs for the service "test-service" with enabled chronos instance "test-instance"
-      And I have a deployments.json for the service "test-service" with enabled chronos instance "test-instance"
-     When we create a chronos job dict from the configs for instance "test-instance" of service "test-service"
-      And we load the configs for instance "test-instance" of service "test-service" into a ChronosJobConfig
-      And 10 old jobs are left over from previous bounces
-      And we run setup_chronos_job
-     Then there should be 1 enabled jobs
-      And there should be 5 disabled jobs
+      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+      And we have a deployments.json for the service "testservice" with enabled chronos instance "testinstance"
+     When we set the "bounce" field of the chronos config for service "testservice" and instance "testinstance" to "graceful"
+      And we run setup_chronos_job for service_instance "testservice.testinstance"
+      And we store the name of the job for the service testservice and instance testinstance as myjob
+     When we create 10 disabled jobs that look like the job stored as "myjob"
+     When we set the "cmd" field of the chronos config for service "testservice" and instance "testinstance" to "sleep 60m"
+      And we run setup_chronos_job for service_instance "testservice.testinstance"
+     Then there should be 1 enabled jobs for the service "testservice" and instance "testinstance"
+      And there should be 5 disabled jobs for the service "testservice" and instance "testinstance"

--- a/paasta_itests/setup_chronos_job.feature
+++ b/paasta_itests/setup_chronos_job.feature
@@ -40,3 +40,15 @@ Feature: setup_chronos_job can create and bounce jobs
       And we run setup_chronos_job for service_instance "testservice.testinstance"
      Then there should be 1 enabled jobs for the service "testservice" and instance "testinstance"
       And there should be 5 disabled jobs for the service "testservice" and instance "testinstance"
+
+  Scenario: dependent jobs can be launched
+    Given a working paasta cluster
+      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+      And we have a deployments.json for the service "testservice" with enabled chronos instance "testinstance"
+     When we run setup_chronos_job for service_instance "testservice.testinstance"
+      And we store the name of the job for the service testservice and instance testinstance as myjob
+
+    Given we have yelpsoa-configs for the service "testservice" with enabled dependent chronos instance "dependentjob" and parent "testservice.testjob"
+      And we have a deployments.json for the service "testservice" with enabled chronos instance "dependentjob"
+     When we run setup_chronos_job for service_instance "testservice.dependentjob"
+     Then there should be 1 enabled jobs for the service "testservice" and instance "dependentjob"

--- a/paasta_itests/setup_chronos_job.feature
+++ b/paasta_itests/setup_chronos_job.feature
@@ -48,7 +48,7 @@ Feature: setup_chronos_job can create and bounce jobs
      When we run setup_chronos_job for service_instance "testservice.testinstance"
       And we store the name of the job for the service testservice and instance testinstance as myjob
 
-    Given we have yelpsoa-configs for the service "testservice" with enabled dependent chronos instance "dependentjob" and parent "testservice.testjob"
+    Given we have yelpsoa-configs for the service "testservice" with enabled dependent chronos instance "dependentjob" and parent "testservice.testinstance"
       And we have a deployments.json for the service "testservice" with enabled chronos instance "dependentjob"
      When we run setup_chronos_job for service_instance "testservice.dependentjob"
      Then there should be 1 enabled jobs for the service "testservice" and instance "dependentjob"

--- a/paasta_itests/steps/chronos_steps.py
+++ b/paasta_itests/steps/chronos_steps.py
@@ -32,9 +32,10 @@ def create_trivial_chronos_job(context, job_name):
     context.chronos_client.add(job_config)
     context.chronos_job_name = job_config['name']
 
+
 @when(u'we store the name of the job for the service {service} and instance {instance} as {job_name}')
 def create_chronos_job_config_object_from_configs(context, service, instance, job_name):
-    job_config =  chronos_tools.create_complete_config(
+    job_config = chronos_tools.create_complete_config(
         service=service,
         job_name=instance,
         soa_dir=context.soa_dir,
@@ -92,6 +93,7 @@ def chronos_check_job_state(context, field, job_name, value):
     assert len(jobs) == 1
     # we cast to a string so you can correctly assert that a value is True/False
     assert str(jobs[0][field]) == value
+
 
 @then(u'the job stored as "{job_name}" is {disabled} in chronos')
 def job_is_disabled(context, job_name, disabled):

--- a/paasta_itests/steps/chronos_steps.py
+++ b/paasta_itests/steps/chronos_steps.py
@@ -43,7 +43,6 @@ def create_chronos_job_config_object_from_configs(context, service, instance, jo
     # s_c_l caches reads from the fs and doesn't offer a way to ignore the cache, so doesn't return
     # the most recent version on the file. I *hate* this, but need to move on.
     chronos_tools.service_configuration_lib._yaml_cache = {}
-    logging.info("storing job_config name %s as job_name %s" % (job_config['name'], job_name))
     context.jobs[job_name] = job_config
 
 

--- a/paasta_itests/steps/chronos_steps.py
+++ b/paasta_itests/steps/chronos_steps.py
@@ -58,11 +58,6 @@ def chronos_job_is_ready(context):
     chronos_tools.wait_for_job(context.chronos_client, context.chronos_job_name)
 
 
-@when(u'we manually start the job')
-def chronos_manually_run_job(context):
-    context.chronos_client.run(context.chronos_job_name)
-
-
 @then(u"we {should_or_not} be able to see it when we list jobs")
 def list_chronos_jobs_has_job(context, should_or_not):
     jobs = context.chronos_client.list()

--- a/paasta_itests/steps/cleanup_chronos_job_steps.py
+++ b/paasta_itests/steps/cleanup_chronos_job_steps.py
@@ -21,7 +21,8 @@ from paasta_tools.utils import _run
 from paasta_tools.chronos_tools import compose_job_id
 
 
-@when('I launch {num_jobs} {state} jobs for the service "{service}" with scheduled chronos instance "{job}" and differing tags')
+@when(('I launch {num_jobs} {state} jobs for the service "{service}"'
+      'with scheduled chronos instance "{job}" and differing tags'))
 def launch_jobs(context, num_jobs, state, service, job):
     client = context.chronos_client
     jobs = [{

--- a/paasta_itests/steps/cleanup_chronos_job_steps.py
+++ b/paasta_itests/steps/cleanup_chronos_job_steps.py
@@ -21,7 +21,7 @@ from paasta_tools.utils import _run
 from paasta_tools.chronos_tools import compose_job_id
 
 
-@when('I launch {num_jobs} {state} jobs for the service "{service}" with chronos instance "{job}" and differing tags')
+@when('I launch {num_jobs} {state} jobs for the service "{service}" with scheduled chronos instance "{job}" and differing tags')
 def launch_jobs(context, num_jobs, state, service, job):
     client = context.chronos_client
     jobs = [{

--- a/paasta_itests/steps/cleanup_chronos_job_steps.py
+++ b/paasta_itests/steps/cleanup_chronos_job_steps.py
@@ -22,7 +22,7 @@ from paasta_tools.chronos_tools import compose_job_id
 
 
 @when(('I launch {num_jobs} {state} jobs for the service "{service}"'
-      'with scheduled chronos instance "{job}" and differing tags'))
+      ' with scheduled chronos instance "{job}" and differing tags'))
 def launch_jobs(context, num_jobs, state, service, job):
     client = context.chronos_client
     jobs = [{

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -85,9 +85,9 @@ def marathon_restart_gets_new_task_ids(context, job_id):
     assert old_tasks != new_tasks
 
 
-@then(u"paasta_serviceinit status exits with return code 0 and the correct output")
-def chronos_status_returns_healthy(context):
-    cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s test-service.job status' % context.soa_dir
+@then(u'paasta_serviceinit status for the service_instance "{service_instance}" exits with return code 0 and the correct output')
+def chronos_status_returns_healthy(context, service_instance):
+    cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s %s status' % (context.soa_dir, service_instance)
     print 'Running cmd %s' % cmd
     (exit_code, output) = _run(cmd)
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
@@ -98,9 +98,9 @@ def chronos_status_returns_healthy(context):
     assert "New" in output
 
 
-@then(u"paasta_serviceinit status --verbose exits with return code 0 and the correct output")
-def chronos_status_verbose_returns_healthy(context):
-    cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s test-service.job status --verbose' % context.soa_dir
+@then(u'paasta_serviceinit status --verbose for the service_instance "{service_instance}" exits with return code 0 and the correct output')
+def chronos_status_verbose_returns_healthy(context, service_instance):
+    cmd = "../paasta_tools/paasta_serviceinit.py --soa-dir %s %s status --verbose" % (context.soa_dir, service_instance)
     print 'Running cmd %s' % cmd
     (exit_code, output) = _run(cmd)
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
@@ -110,9 +110,9 @@ def chronos_status_verbose_returns_healthy(context):
     assert "Running Tasks:" in output
 
 
-@when(u"we paasta_serviceinit emergency-stop the chronos job")
-def chronos_emergency_stop_job(context):
-    cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s test-service.job stop' % context.soa_dir
+@when(u'we paasta_serviceinit emergency-stop the service_instance "{service_instance}"')
+def chronos_emergency_stop_job(context, service_instance):
+    cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s %s stop' % (context.soa_dir, service_instance)
     print 'Running cmd %s' % cmd
     (exit_code, output) = _run(cmd)
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
@@ -121,9 +121,9 @@ def chronos_emergency_stop_job(context):
     assert exit_code == 0
 
 
-@when(u"we paasta_serviceinit emergency-start the chronos job")
-def chronos_emergency_start_job(context):
-    cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s test-service.job start' % context.soa_dir
+@when(u'we paasta_serviceinit emergency-start the service_instance "{service_instance}"')
+def chronos_emergency_start_job(context, service_instance):
+    cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s %s start' % (context.soa_dir, service_instance)
     print 'Running cmd %s' % cmd
     (exit_code, output) = _run(cmd)
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -86,7 +86,7 @@ def marathon_restart_gets_new_task_ids(context, job_id):
 
 
 @then((u'paasta_serviceinit status for the service_instance "{service_instance}"'
-      'exits with return code 0 and the correct output'))
+      ' exits with return code 0 and the correct output'))
 def chronos_status_returns_healthy(context, service_instance):
     cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s %s status' % (context.soa_dir, service_instance)
     print 'Running cmd %s' % cmd
@@ -100,7 +100,7 @@ def chronos_status_returns_healthy(context, service_instance):
 
 
 @then((u'paasta_serviceinit status --verbose for the service_instance "{service_instance}"'
-      'exits with return code 0 and the correct output'))
+      ' exits with return code 0 and the correct output'))
 def chronos_status_verbose_returns_healthy(context, service_instance):
     cmd = "../paasta_tools/paasta_serviceinit.py --soa-dir %s %s status --verbose" % (context.soa_dir, service_instance)
     print 'Running cmd %s' % cmd

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -85,7 +85,8 @@ def marathon_restart_gets_new_task_ids(context, job_id):
     assert old_tasks != new_tasks
 
 
-@then(u'paasta_serviceinit status for the service_instance "{service_instance}" exits with return code 0 and the correct output')
+@then((u'paasta_serviceinit status for the service_instance "{service_instance}"'
+      'exits with return code 0 and the correct output'))
 def chronos_status_returns_healthy(context, service_instance):
     cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s %s status' % (context.soa_dir, service_instance)
     print 'Running cmd %s' % cmd
@@ -98,7 +99,8 @@ def chronos_status_returns_healthy(context, service_instance):
     assert "New" in output
 
 
-@then(u'paasta_serviceinit status --verbose for the service_instance "{service_instance}" exits with return code 0 and the correct output')
+@then((u'paasta_serviceinit status --verbose for the service_instance "{service_instance}"'
+      'exits with return code 0 and the correct output'))
 def chronos_status_verbose_returns_healthy(context, service_instance):
     cmd = "../paasta_tools/paasta_serviceinit.py --soa-dir %s %s status --verbose" % (context.soa_dir, service_instance)
     print 'Running cmd %s' % cmd

--- a/paasta_itests/steps/setup_chronos_job_steps.py
+++ b/paasta_itests/steps/setup_chronos_job_steps.py
@@ -50,6 +50,7 @@ def old_jobs_leftover(context, job_count, job_name):
         job_definition['name'] = modified_name
         job_definition['disabled'] = True
         context.chronos_client.add(job_definition)
+
 @then(u'there should be {job_count} {disabled} jobs for the service "{service}" and instance "{instance}"')
 def should_be_disabled_jobs(context, disabled, job_count, service, instance):
     is_disabled = True if disabled == "disabled" else False

--- a/paasta_itests/steps/setup_chronos_job_steps.py
+++ b/paasta_itests/steps/setup_chronos_job_steps.py
@@ -35,11 +35,7 @@ def job_exists(context, service, instance):
 @when(u'we run setup_chronos_job for service_instance "{service_instance}"')
 def run_setup_chronos_job(context, service_instance):
     cmd = "../paasta_tools/setup_chronos_job.py %s -d %s" % (service_instance, context.soa_dir)
-    logging.info("Running cmd")
-    logging.info(cmd)
     exit_code, output = _run(cmd)
-    logging.info(exit_code)
-    logging.info(output)
     context.exit_code, context.output = exit_code, output
 
 
@@ -54,7 +50,6 @@ def old_jobs_leftover(context, job_count, job_name):
         job_definition['name'] = modified_name
         job_definition['disabled'] = True
         context.chronos_client.add(job_definition)
-    logging.info(len(context.chronos_client.list()))
 @then(u'there should be {job_count} {disabled} jobs for the service "{service}" and instance "{instance}"')
 def should_be_disabled_jobs(context, disabled, job_count, service, instance):
     is_disabled = True if disabled == "disabled" else False
@@ -64,9 +59,5 @@ def should_be_disabled_jobs(context, disabled, job_count, service, instance):
         client=context.chronos_client,
         include_disabled=True,
     )
-    logging.info("all jobs")
-    logging.info(len(all_jobs))
     filtered_jobs = [job for job in all_jobs if job["disabled"] is is_disabled]
-    logging.info("%s jobs" % disabled)
-    logging.info(len(filtered_jobs))
     assert len(filtered_jobs) == int(job_count)

--- a/paasta_itests/steps/setup_chronos_job_steps.py
+++ b/paasta_itests/steps/setup_chronos_job_steps.py
@@ -18,7 +18,6 @@ import sys
 from behave import when, then
 
 sys.path.append('../')
-from paasta_tools import setup_chronos_job
 from paasta_tools import chronos_tools
 from paasta_tools.utils import _run
 
@@ -32,6 +31,7 @@ def job_exists(context, service, instance):
     )
     assert len(matching_jobs) == 1
 
+
 @when(u'we run setup_chronos_job for service_instance "{service_instance}"')
 def run_setup_chronos_job(context, service_instance):
     cmd = "../paasta_tools/setup_chronos_job.py %s -d %s" % (service_instance, context.soa_dir)
@@ -39,10 +39,8 @@ def run_setup_chronos_job(context, service_instance):
     context.exit_code, context.output = exit_code, output
 
 
-
 @when(u'we create {job_count:d} disabled jobs that look like the job stored as "{job_name}"')
 def old_jobs_leftover(context, job_count, job_name):
-    fake_jobs = []
     for i in xrange(job_count):
         job_definition = copy.deepcopy(context.jobs[job_name])
         # modify the name by replacing the last character in the config hash
@@ -50,6 +48,7 @@ def old_jobs_leftover(context, job_count, job_name):
         job_definition['name'] = modified_name
         job_definition['disabled'] = True
         context.chronos_client.add(job_definition)
+
 
 @then(u'there should be {job_count} {disabled} jobs for the service "{service}" and instance "{instance}"')
 def should_be_disabled_jobs(context, disabled, job_count, service, instance):

--- a/paasta_itests/steps/setup_chronos_job_steps.py
+++ b/paasta_itests/steps/setup_chronos_job_steps.py
@@ -69,7 +69,6 @@ def create_complete_job(context):
     return_tuple = setup_chronos_job.setup_job(
         fake_service_name,
         fake_instance_name,
-        fake_service_job_config,
         fake_service_config,
         context.chronos_client,
         "fake_cluster",
@@ -82,7 +81,6 @@ def setup_the_chronos_job(context):
     exit_code, output = setup_chronos_job.setup_job(
         service=fake_service_name,
         instance=fake_instance_name,
-        chronos_job_config=context.chronos_job_config_obj,
         complete_job_config=context.chronos_job_config,
         client=context.chronos_client,
         cluster=context.cluster

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -187,7 +187,7 @@ def write_soa_dir_marathon_job(context, job_id):
     context.soa_dir = soa_dir
 
 
-@given(u'I have a deployments.json for the service "{service}" with {disabled} instance "{instance}"')
+@given(u'we have a deployments.json for the service "{service}" with {disabled} instance "{instance}"')
 def write_soa_dir_chronos_deployments(context, service, disabled, instance):
     if disabled == 'disabled':
         desired_state = 'stop'

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -113,6 +113,7 @@ def working_paasta_cluster(context):
     if not hasattr(context, 'chronos_client'):
         context.chronos_config = setup_chronos_config()
         context.chronos_client = setup_chronos_client()
+        context.jobs = {}
     else:
         print 'Chronos connection already established'
 

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -155,7 +155,7 @@ def write_soa_dir_chronos_instance(context, service, disabled, instance):
 
 
 @given((u'we have yelpsoa-configs for the service "{service}" with {disabled} dependent chronos instance'
-       '"{instance}" and parent "{parent}"'))
+       ' "{instance}" and parent "{parent}"'))
 def write_soa_dir_dependent_chronos_instance(context, service, disabled, instance, parent):
     soa_dir = mkdtemp()
     desired_disabled = (disabled == 'disabled')
@@ -210,7 +210,7 @@ def write_soa_dir_chronos_deployments(context, service, disabled, instance):
 
 
 @when((u'we set the "{field}" field of the {framework} config for service "{service}"'
-       'and instance "{instance}" to "{value}"'))
+       ' and instance "{instance}" to "{value}"'))
 def modify_configs(context, field, framework, service, instance, value):
     soa_dir = context.soa_dir
     with open(os.path.join(soa_dir, service, "%s-%s.yaml" % (framework, context.cluster)), 'r+') as f:

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -162,7 +162,7 @@ def write_soa_dir_dependent_chronos_instance(context, service, disabled, instanc
     with open(os.path.join(soa_dir, service, 'chronos-%s.yaml' % context.cluster), 'w') as f:
         f.write(yaml.safe_dump({
             instance: {
-                'parent':  parent,
+                'parents':  parent,
                 'cmd': 'echo "Taking a nap..." && sleep 1m && echo "Nap time over, back to work"',
                 'monitoring': {'team': 'fake_team'},
                 'disabled': desired_disabled,

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -16,7 +16,7 @@ import os
 from tempfile import NamedTemporaryFile
 from tempfile import mkdtemp
 
-from behave import given
+from behave import given, when
 import chronos
 import json
 import yaml
@@ -205,3 +205,13 @@ def write_soa_dir_chronos_deployments(context, service, disabled, instance):
                 }
             }
         }))
+
+@when(u'we set the "{field}" field of the {framework} config for service "{service}" and instance "{instance}" to "{value}"')
+def modify_configs(context, field, framework, service, instance, value):
+    soa_dir = context.soa_dir
+    with open(os.path.join(soa_dir, service, "%s-%s.yaml" % (framework, context.cluster)), 'r+') as f:
+        data = yaml.load(f.read())
+        data[instance][field] = value
+        f.seek(0)
+        f.write(yaml.safe_dump(data))
+        f.truncate()

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -136,17 +136,34 @@ def working_paasta_cluster(context):
     }, 'volumes.json')
 
 
-@given(u'I have yelpsoa-configs for the service "{service}" with {disabled} chronos instance "{instance}"')
+@given(u'we have yelpsoa-configs for the service "{service}" with {disabled} scheduled chronos instance "{instance}"')
 def write_soa_dir_chronos_instance(context, service, disabled, instance):
     soa_dir = mkdtemp()
     desired_disabled = (disabled == 'disabled')
     if not os.path.exists(os.path.join(soa_dir, service)):
         os.makedirs(os.path.join(soa_dir, service))
     with open(os.path.join(soa_dir, service, 'chronos-%s.yaml' % context.cluster), 'w') as f:
-        f.write(yaml.dump({
-            "%s" % instance: {
+        f.write(yaml.safe_dump({
+            instance: {
                 'schedule': 'R/2000-01-01T16:20:00Z/PT60S',
-                'command': 'echo "Taking a nap..." && sleep 1m && echo "Nap time over, back to work"',
+                'cmd': 'echo "Taking a nap..." && sleep 1m && echo "Nap time over, back to work"',
+                'monitoring': {'team': 'fake_team'},
+                'disabled': desired_disabled,
+            }
+        }))
+    context.soa_dir = soa_dir
+
+@given(u'we have yelpsoa-configs for the service "{service}" with {disabled} dependent chronos instance "{instance}" and parent "{parent}"')
+def write_soa_dir_dependent_chronos_instance(context, service, disabled, instance, parent):
+    soa_dir = mkdtemp()
+    desired_disabled = (disabled == 'disabled')
+    if not os.path.exists(os.path.join(soa_dir, service)):
+        os.makedirs(os.path.join(soa_dir, service))
+    with open(os.path.join(soa_dir, service, 'chronos-%s.yaml' % context.cluster), 'w') as f:
+        f.write(yaml.safe_dump({
+            instance: {
+                'parent':  parent,
+                'cmd': 'echo "Taking a nap..." && sleep 1m && echo "Nap time over, back to work"',
                 'monitoring': {'team': 'fake_team'},
                 'disabled': desired_disabled,
             }

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -153,7 +153,9 @@ def write_soa_dir_chronos_instance(context, service, disabled, instance):
         }))
     context.soa_dir = soa_dir
 
-@given(u'we have yelpsoa-configs for the service "{service}" with {disabled} dependent chronos instance "{instance}" and parent "{parent}"')
+
+@given((u'we have yelpsoa-configs for the service "{service}" with {disabled} dependent chronos instance'
+       '"{instance}" and parent "{parent}"'))
 def write_soa_dir_dependent_chronos_instance(context, service, disabled, instance, parent):
     soa_dir = mkdtemp()
     desired_disabled = (disabled == 'disabled')
@@ -206,7 +208,9 @@ def write_soa_dir_chronos_deployments(context, service, disabled, instance):
             }
         }))
 
-@when(u'we set the "{field}" field of the {framework} config for service "{service}" and instance "{instance}" to "{value}"')
+
+@when((u'we set the "{field}" field of the {framework} config for service "{service}"'
+       'and instance "{instance}" to "{value}"'))
 def modify_configs(context, field, framework, service, instance, value):
     soa_dir = context.soa_dir
     with open(os.path.join(soa_dir, service, "%s-%s.yaml" % (framework, context.cluster)), 'r+') as f:

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -162,7 +162,7 @@ def write_soa_dir_dependent_chronos_instance(context, service, disabled, instanc
     with open(os.path.join(soa_dir, service, 'chronos-%s.yaml' % context.cluster), 'w') as f:
         f.write(yaml.safe_dump({
             instance: {
-                'parents':  parent,
+                'parents': [parent],
                 'cmd': 'echo "Taking a nap..." && sleep 1m && echo "Nap time over, back to work"',
                 'monitoring': {'team': 'fake_team'},
                 'disabled': desired_disabled,

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -33,6 +33,7 @@ from paasta_tools.utils import get_code_sha_from_dockerurl
 from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_paasta_branch
 from paasta_tools.utils import get_docker_url
+from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import load_deployments_json
@@ -399,24 +400,15 @@ class ChronosJobConfig(InstanceConfig):
         return None
 
 
-# TODO just use utils.get_service_instance_list(cluster, instance_type='chronos', soa_dir)
 def list_job_names(service, cluster=None, soa_dir=DEFAULT_SOA_DIR):
-    """Enumerate the Chronos jobs defined for a service as a list of tuples.
+    """A chronos-specific wrapper around utils.get_service_instance_list.
 
     :param name: The service name
     :param cluster: The cluster to read the configuration for
     :param soa_dir: The SOA config directory to read from
-    :returns: A list of tuples of (name, job) for each job defined for the service name"""
-    job_list = []
-    if not cluster:
-        cluster = load_system_paasta_config().get_cluster()
-    chronos_conf_file = "chronos-%s" % cluster
-    log.info("Enumerating all jobs from config file: %s/*/%s.yaml" % (soa_dir, chronos_conf_file))
-
-    for job in read_chronos_jobs_for_service(service, cluster, soa_dir=soa_dir):
-        job_list.append((service, job))
-    log.debug("Enumerated the following jobs: %s" % job_list)
-    return job_list
+    :returns: A list of tuples of (name, job) for each job defined for the service name
+    """
+    return get_service_instance_list(service, cluster, 'chronos', soa_dir)
 
 
 # TODO just use utils.get_services_for_cluster(cluster, instance_type='chronos', soa_dir)

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -656,7 +656,7 @@ def parse_time_variables(input_string, parse_time=None):
 
 def check_parent_format(parent):
     """ A predicate defining if the parent field string is formatted correctly """
-    return len(parent.split(".")) is 2
+    return len(parent.split(".")) == 2
 
 
 def disable_job(client, job):

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -69,6 +69,7 @@ class LastRunState:
 class ChronosNotConfigured(Exception):
     pass
 
+
 class InvalidParentError(Exception):
     pass
 

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -699,5 +699,5 @@ def find_matching_parent_jobs(job_names):
         # job to use as the parent
         ordered = sort_jobs(matching_jobs)
         if len(ordered) > 0:
-            formatted.append(ordered[0])
+            formatted.append(ordered[0]['name'])
     return formatted

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -260,7 +260,10 @@ class ChronosJobConfig(InstanceConfig):
     def check_parents(self):
         parents = self.get_parents()
         if parents is not None:
-            return False, 'Parents are not yet supported'
+            results = [(parent, check_parent_format(parent)) for parent in parents]
+            badly_formatted = [res[0] for res in results if res[1] is False]
+            if len(badly_formatted) > 0:
+                return  False, 'The job name(s) %s is not formatted correctly: expected service.instance' % ", ".join(badly_formatted)
         return True, ''
 
     # a valid 'repeat_string' is 'R' or 'Rn', where n is a positive integer representing the number of times to repeat
@@ -645,6 +648,10 @@ def parse_time_variables(input_string, parse_time=None):
     job_context.job_run.run_time = parse_time
     # The job_context object works like a normal dictionary for string replacement
     return input_string % job_context
+
+def check_parent_format(parent):
+    """ A predicate defining if the parent field string is formatted correctly """
+    return len(parent.split(".")) is 2
 
 
 def disable_job(client, job):

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -385,7 +385,8 @@ class ChronosJobConfig(InstanceConfig):
         if self.get_schedule() is not None:
             complete_config['schedule'] = self.get_schedule()
         else:
-            complete_config['parents'] = self.get_parents()
+            full_parent_ids = find_matching_parent_jobs(self.get_parents())
+            complete_config['parents'] = full_parent_ids
         return complete_config
 
     # 'docker job' requirements: https://mesos.github.io/chronos/docs/api.html#adding-a-docker-job

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -263,7 +263,8 @@ class ChronosJobConfig(InstanceConfig):
             results = [(parent, check_parent_format(parent)) for parent in parents]
             badly_formatted = [res[0] for res in results if res[1] is False]
             if len(badly_formatted) > 0:
-                return  False, 'The job name(s) %s is not formatted correctly: expected service.instance' % ", ".join(badly_formatted)
+                return False, ('The job name(s) %s is not formatted correctly: expected service.instance'
+                               % ", ".join(badly_formatted))
         return True, ''
 
     # a valid 'repeat_string' is 'R' or 'Rn', where n is a positive integer representing the number of times to repeat
@@ -378,11 +379,13 @@ class ChronosJobConfig(InstanceConfig):
             'async': False,  # we don't support async jobs
             'disabled': self.get_disabled(),
             'owner': self.get_owner(),
-            'parents': None if self.get_parents() is None else find_matching_parent_jobs(self.get_parents()),
-            'schedule': self.get_schedule(),
             'scheduleTimeZone': self.get_schedule_time_zone(),
             'shell': self.get_shell(),
         }
+        if self.get_schedule() is not None:
+            complete_config['schedule'] = self.get_schedule()
+        else:
+            complete_config['parents'] = self.get_parents()
         return complete_config
 
     # 'docker job' requirements: https://mesos.github.io/chronos/docs/api.html#adding-a-docker-job
@@ -649,6 +652,7 @@ def parse_time_variables(input_string, parse_time=None):
     job_context.job_run.run_time = parse_time
     # The job_context object works like a normal dictionary for string replacement
     return input_string % job_context
+
 
 def check_parent_format(parent):
     """ A predicate defining if the parent field string is formatted correctly """

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -309,8 +309,6 @@ class ChronosJobConfig(InstanceConfig):
             if not self._check_schedule_repeat_helper(repeat):
                 msgs.append('The specified repeat "%s" in schedule "%s" '
                             'does not conform to the ISO 8601 format.' % (repeat, schedule))
-        else:
-            msgs.append('You must specify a "schedule" in your configuration')
 
         return len(msgs) == 0, '\n'.join(msgs)
 

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -389,7 +389,7 @@ class ChronosJobConfig(InstanceConfig):
         if self.get_schedule() is not None:
             complete_config['schedule'] = self.get_schedule()
         else:
-            matching_parent_pairs = [(parent, find_matching_parent_jobs(parent)) for parent in self.get_parents()]
+            matching_parent_pairs = [(parent, find_matching_parent_job(parent)) for parent in self.get_parents()]
             for parent_pair in matching_parent_pairs:
                 if parent_pair[1] is None:
                     raise InvalidParentError("%s has no matching jobs in Chronos" % parent_pair[0])
@@ -683,7 +683,7 @@ def create_job(client, job):
     client.add(job)
 
 
-def find_matching_parent_jobs(job_name):
+def find_matching_parent_job(job_name):
     """ Given a service.instance, convert it to a 'real' job name,
     where the 'real' job name is the id of the most recent job
     matching that service and instance.

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -128,6 +128,10 @@ class InvalidChronosConfigError(Exception):
     pass
 
 
+class UnknownChronosJobError(Exception):
+    pass
+
+
 def read_chronos_jobs_for_service(service, cluster, soa_dir=DEFAULT_SOA_DIR):
     chronos_conf_file = 'chronos-%s' % cluster
     log.info("Reading Chronos configuration file: %s/%s/chronos-%s.yaml" % (soa_dir, service, cluster))
@@ -142,7 +146,7 @@ def read_chronos_jobs_for_service(service, cluster, soa_dir=DEFAULT_SOA_DIR):
 def load_chronos_job_config(service, instance, cluster, load_deployments=True, soa_dir=DEFAULT_SOA_DIR):
     service_chronos_jobs = read_chronos_jobs_for_service(service, cluster, soa_dir=soa_dir)
     if instance not in service_chronos_jobs:
-        raise InvalidChronosConfigError('No job named "%s" in config file chronos-%s.yaml' % (instance, cluster))
+        raise UnknownChronosJobError('No job named "%s" in config file chronos-%s.yaml' % (instance, cluster))
     branch_dict = {}
     if load_deployments:
         deployments_json = load_deployments_json(service, soa_dir=soa_dir)

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -34,6 +34,7 @@ from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_paasta_branch
 from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_service_instance_list
+from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import load_deployments_json
@@ -411,21 +412,13 @@ def list_job_names(service, cluster=None, soa_dir=DEFAULT_SOA_DIR):
     return get_service_instance_list(service, cluster, 'chronos', soa_dir)
 
 
-# TODO just use utils.get_services_for_cluster(cluster, instance_type='chronos', soa_dir)
 def get_chronos_jobs_for_cluster(cluster=None, soa_dir=DEFAULT_SOA_DIR):
-    """Retrieve all Chronos jobs defined to run on a cluster.
+    """A chronos-specific wrapper around utils.get_services_for_cluster
 
     :param cluster: The cluster to read the configuration for
     :param soa_dir: The SOA config directory to read from
     :returns: A list of tuples of (service, job_name)"""
-    if not cluster:
-        cluster = load_system_paasta_config().get_cluster()
-    rootdir = os.path.abspath(soa_dir)
-    log.info("Retrieving all Chronos job names from %s for cluster %s" % (rootdir, cluster))
-    job_list = []
-    for service in os.listdir(rootdir):
-        job_list.extend(list_job_names(service, cluster, soa_dir))
-    return job_list
+    return get_services_for_cluster(cluster, 'chronos', soa_dir)
 
 
 def create_complete_config(service, job_name, soa_dir=DEFAULT_SOA_DIR):

--- a/paasta_tools/setup_chronos_job.py
+++ b/paasta_tools/setup_chronos_job.py
@@ -150,6 +150,7 @@ def setup_job(service, instance, complete_job_config, client, cluster):
         service=service,
         instance=instance,
         client=client,
+        include_disabled=True,
     ))
     old_jobs = [job for job in all_existing_jobs if job["name"] != job_id]
     enabled_old_jobs = [job for job in old_jobs if not job["disabled"]]

--- a/paasta_tools/setup_chronos_job.py
+++ b/paasta_tools/setup_chronos_job.py
@@ -141,7 +141,7 @@ def bounce_chronos_job(
     return (0, "All chronos bouncing tasks finished.")
 
 
-def setup_job(service, instance, chronos_job_config, complete_job_config, client, cluster):
+def setup_job(service, instance, complete_job_config, client, cluster):
     job_id = complete_job_config['name']
     # Sort this initial list since other lists of jobs will come from it (with
     # their orders preserved by list comprehensions) and since we'll care about
@@ -190,10 +190,9 @@ def main():
     cluster = load_system_paasta_config().get_cluster()
 
     try:
-        chronos_job_config = chronos_tools.load_chronos_job_config(
+        complete_job_config = chronos_tools.create_complete_config(
             service=service,
-            instance=instance,
-            cluster=cluster,
+            job_name=instance,
             soa_dir=soa_dir,
         )
     except (NoDeploymentsAvailable, NoDockerImageError):
@@ -222,16 +221,10 @@ def main():
         log.error(error_msg)
         sys.exit(0)
 
-    complete_job_config = chronos_tools.create_complete_config(
-        service=service,
-        job_name=instance,
-        soa_dir=soa_dir,
-    )
     status, output = setup_job(
         service=service,
         instance=instance,
         cluster=cluster,
-        chronos_job_config=chronos_job_config,
         complete_job_config=complete_job_config,
         client=client,
     )

--- a/paasta_tools/setup_chronos_job.py
+++ b/paasta_tools/setup_chronos_job.py
@@ -207,13 +207,11 @@ def main():
             output=error_msg,
         )
         log.error(error_msg)
-        # exit 0 because the event was sent to the right team and this is not an issue with Paasta itself
         sys.exit(0)
-    except chronos_tools.InvalidChronosConfigError as e:
+    except chronos_tools.UnknownChronosJobError as e:
         error_msg = (
             "Could not read chronos configuration file for %s in cluster %s\n" % (args.service_instance, cluster) +
             "Error was: %s" % str(e))
-        log.error(error_msg)
         send_event(
             service=service,
             instance=instance,
@@ -221,7 +219,7 @@ def main():
             status=pysensu_yelp.Status.CRITICAL,
             output=error_msg,
         )
-        # exit 0 because the event was sent to the right team and this is not an issue with Paasta itself
+        log.error(error_msg)
         sys.exit(0)
 
     complete_job_config = chronos_tools.create_complete_config(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -836,7 +836,7 @@ def list_all_instances_for_service(service, cluster=None, instance_type=None, so
 def get_service_instance_list(service, cluster=None, instance_type=None, soa_dir=DEFAULT_SOA_DIR):
     """Enumerate the instances defined for a service as a list of tuples.
 
-    :param name: The service name
+    :param service: The service name
     :param cluster: The cluster to read the configuration for
     :param instance_type: The type of instances to examine: 'marathon', 'chronos', or None (default) for both
     :param soa_dir: The SOA config directory to read from

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -833,7 +833,7 @@ def list_all_instances_for_service(service, cluster=None, instance_type=None, so
     return instances
 
 
-def get_service_instance_list(name, cluster=None, instance_type=None, soa_dir=DEFAULT_SOA_DIR):
+def get_service_instance_list(service, cluster=None, instance_type=None, soa_dir=DEFAULT_SOA_DIR):
     """Enumerate the instances defined for a service as a list of tuples.
 
     :param name: The service name
@@ -854,12 +854,12 @@ def get_service_instance_list(name, cluster=None, instance_type=None, soa_dir=DE
         conf_file = "%s-%s" % (srv_instance_type, cluster)
         log.info("Enumerating all instances for config file: %s/*/%s.yaml" % (soa_dir, conf_file))
         instances = service_configuration_lib.read_extra_service_information(
-            name,
+            service,
             conf_file,
             soa_dir=soa_dir
         )
         for instance in instances:
-            instance_list.append((name, instance))
+            instance_list.append((service, instance))
 
     log.debug("Enumerated the following instances: %s", instance_list)
     return instance_list

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -688,27 +688,9 @@ class TestChronosTools:
             assert sorted(expected) == sorted(actual)
 
     def test_get_chronos_jobs_for_cluster(self):
-        cluster = 'mainframe_42'
-        soa_dir = 'my_computer'
-        jobs = [['boop', 'beep'], ['bop']]
-        expected = ['beep', 'bop', 'boop']
-        with contextlib.nested(
-            mock.patch('os.path.abspath', autospec=True, return_value='windows_explorer'),
-            mock.patch('os.listdir', autospec=True, return_value=['dir1', 'dir2']),
-            mock.patch('chronos_tools.list_job_names',
-                       side_effect=lambda a, b, c: jobs.pop())
-        ) as (
-            abspath_patch,
-            listdir_patch,
-            list_jobs_patch,
-        ):
-            actual = chronos_tools.get_chronos_jobs_for_cluster(cluster, soa_dir)
-            assert sorted(expected) == sorted(actual)
-            abspath_patch.assert_called_once_with(soa_dir)
-            listdir_patch.assert_called_once_with('windows_explorer')
-            list_jobs_patch.assert_any_call('dir1', cluster, soa_dir)
-            list_jobs_patch.assert_any_call('dir2', cluster, soa_dir)
-            assert list_jobs_patch.call_count == 2
+        with mock.patch('chronos_tools.get_services_for_cluster', autospec=True, return_value=[]) as get_services_for_cluster_patch:
+            assert chronos_tools.get_chronos_jobs_for_cluster('mycluster', soa_dir='my_soa_dir') == []
+            get_services_for_cluster_patch.assert_called_once_with('mycluster', 'chronos', 'my_soa_dir')
 
     def test_lookup_chronos_jobs_with_service_and_instance(self):
         fake_client = mock.Mock()

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -688,7 +688,10 @@ class TestChronosTools:
             assert sorted(expected) == sorted(actual)
 
     def test_get_chronos_jobs_for_cluster(self):
-        with mock.patch('chronos_tools.get_services_for_cluster', autospec=True, return_value=[]) as get_services_for_cluster_patch:
+        with mock.patch('chronos_tools.get_services_for_cluster',
+                        autospec=True,
+                        return_value=[],
+                        ) as get_services_for_cluster_patch:
             assert chronos_tools.get_chronos_jobs_for_cluster('mycluster', soa_dir='my_soa_dir') == []
             get_services_for_cluster_patch.assert_called_once_with('mycluster', 'chronos', 'my_soa_dir')
 

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -646,31 +646,6 @@ class TestChronosTools:
             invalid_config.format_chronos_job_dict('', [])
         assert 'The specified schedule "%s" is invalid' % fake_schedule in exc.value
 
-    def test_format_chronos_job_dict_incomplete(self):
-        fake_service = 'test_service'
-        fake_job_name = 'test_job'
-        incomplete_config = chronos_tools.ChronosJobConfig(
-            fake_service,
-            fake_job_name,
-            {},
-            {}
-        )
-        with raises(chronos_tools.InvalidChronosConfigError) as exc:
-            incomplete_config.format_chronos_job_dict('', [])
-        assert 'You must specify a "schedule" in your configuration' in exc.value
-
-    def test_validate(self):
-        fake_service = 'test_service'
-        fake_job_name = 'test_job'
-        incomplete_config = chronos_tools.ChronosJobConfig(
-            fake_service,
-            fake_job_name,
-            {},
-            {}
-        )
-        valid, error_msgs = incomplete_config.validate()
-        assert 'You must specify a "schedule" in your configuration' in error_msgs
-        assert not valid
 
     def test_list_job_names(self):
         fake_name = 'vegetables'

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1334,3 +1334,18 @@ class TestChronosTools:
         mock_load_chronos_config.return_value = {}
         matching = chronos_tools.find_matching_parent_jobs(['service.instance', 'service.instance2'])
         assert len(matching) == 2
+
+    @mock.patch('chronos_tools.lookup_chronos_jobs', autospec=True)
+    @mock.patch('chronos_tools.get_chronos_client', autospec=True)
+    @mock.patch('chronos_tools.load_chronos_config', autospec=True)
+    def test_find_matching_parent_jobs_returns_names(
+        self,
+        mock_load_chronos_config,
+        mock_get_chronos_client,
+        mock_lookup_chronos_jobs,
+    ):
+        mock_matching_jobs = [{'name': 'service.myinstance.gitabc.config1'}]
+        mock_lookup_chronos_jobs.return_value = mock_matching_jobs
+        mock_load_chronos_config.return_value = {}
+        matching = chronos_tools.find_matching_parent_jobs(['service.myinstance'])
+        assert matching == ['service.myinstance.gitabc.config1']

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -382,23 +382,26 @@ class TestChronosTools:
         assert msg == ''
 
     def test_check_parents_all_ok(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {'parents': ['service1.instance1', 'service1.instance2']}, {})
+        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance',
+                                                   {'parents': ['service1.instance1', 'service1.instance2']}, {})
         okay, msg = fake_conf.check_parents()
         assert okay is True
         assert msg == ''
 
     def test_check_parents_one_bad(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {'parents': ['service1.instance1', 'service1-instance1']}, {})
+        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance',
+                                                   {'parents': ['service1.instance1', 'service1-instance1']}, {})
         okay, msg = fake_conf.check_parents()
         assert okay is False
         assert msg == 'The job name(s) service1-instance1 is not formatted correctly: expected service.instance'
 
     def test_check_parents_all_bad(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {'parents': ['service1-instance1', 'service1-instance2']}, {})
+        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance',
+                                                   {'parents': ['service1-instance1', 'service1-instance2']}, {})
         okay, msg = fake_conf.check_parents()
         assert okay is False
-        assert msg == 'The job name(s) service1-instance1, service1-instance2 is not formatted correctly: expected service.instance'
-
+        assert msg == ('The job name(s) service1-instance1, service1-instance2'
+                       ' is not formatted correctly: expected service.instance')
 
     def test_check_bounce_method_valid(self):
         okay, msg = self.fake_chronos_job_config.check_bounce_method()
@@ -664,7 +667,6 @@ class TestChronosTools:
         with raises(chronos_tools.InvalidChronosConfigError) as exc:
             invalid_config.format_chronos_job_dict('', [])
         assert 'The specified schedule "%s" is invalid' % fake_schedule in exc.value
-
 
     def test_list_job_names(self):
         fake_name = 'vegetables'

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1311,20 +1311,20 @@ class TestChronosTools:
     @mock.patch('chronos_tools.lookup_chronos_jobs', autospect=True)
     @mock.patch('chronos_tools.get_chronos_client', autospect=True)
     @mock.patch('chronos_tools.load_chronos_config', autospect=True)
-    def test_find_matching_parent_jobs_none_matching(
+    def test_find_matching_parent_job_none_matching(
         self,
         mock_lookup_chronos_jobs,
         mock_get_chronos_client,
         mock_load_chronos_config,
     ):
         mock_lookup_chronos_jobs.return_value = []
-        matching = chronos_tools.find_matching_parent_jobs('service.instance')
+        matching = chronos_tools.find_matching_parent_job('service.instance')
         assert matching is None
 
     @mock.patch('chronos_tools.lookup_chronos_jobs', autospec=True)
     @mock.patch('chronos_tools.get_chronos_client', autospec=True)
     @mock.patch('chronos_tools.load_chronos_config', autospec=True)
-    def test_find_matching_parent_jobs_returns_names(
+    def test_find_matching_parent_job_returns_names(
         self,
         mock_load_chronos_config,
         mock_get_chronos_client, mock_lookup_chronos_jobs,
@@ -1332,5 +1332,5 @@ class TestChronosTools:
         mock_matching_jobs = [{'name': 'service.myinstance.gitabc.config1'}]
         mock_lookup_chronos_jobs.return_value = mock_matching_jobs
         mock_load_chronos_config.return_value = {}
-        matching = chronos_tools.find_matching_parent_jobs('service.myinstance')
+        matching = chronos_tools.find_matching_parent_job('service.myinstance')
         assert matching == 'service.myinstance.gitabc.config1'

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -226,26 +226,21 @@ class TestChronosTools:
             assert dict(actual) == dict(self.fake_chronos_job_config)
 
     def test_load_chronos_job_config_unknown_job(self):
-        fake_soa_dir = '/tmp/'
-        fake_job_name = 'polar bear'
         with contextlib.nested(
-            mock.patch('chronos_tools.load_deployments_json', autospec=True,),
             mock.patch('chronos_tools.read_chronos_jobs_for_service', autospec=True),
         ) as (
-            mock_load_deployments_json,
             mock_read_chronos_jobs_for_service,
         ):
-            mock_load_deployments_json.return_value.get_branch_dict.return_value = self.fake_branch_dict
-            mock_read_chronos_jobs_for_service.return_value = self.fake_config_file
-            with raises(chronos_tools.InvalidChronosConfigError) as exc:
-                chronos_tools.load_chronos_job_config(service=self.fake_service,
-                                                      instance=fake_job_name,
-                                                      cluster=self.fake_cluster,
-                                                      soa_dir=fake_soa_dir)
-            mock_read_chronos_jobs_for_service.assert_called_once_with(self.fake_service,
-                                                                       self.fake_cluster,
-                                                                       soa_dir=fake_soa_dir)
-            assert str(exc.value) == 'No job named "polar bear" in config file chronos-penguin.yaml'
+            mock_read_chronos_jobs_for_service.return_value = []
+            with raises(chronos_tools.UnknownChronosJobError) as exc:
+                chronos_tools.load_chronos_job_config(service='fake_service',
+                                                      instance='fake_job',
+                                                      cluster='fake_cluster',
+                                                      soa_dir='fake_dir')
+            mock_read_chronos_jobs_for_service.assert_called_once_with('fake_service',
+                                                                       'fake_cluster',
+                                                                       soa_dir='fake_dir')
+            assert str(exc.value) == 'No job named "fake_job" in config file chronos-fake_cluster.yaml'
 
     def test_get_bounce_method_in_config(self):
         expected = self.fake_config_dict['bounce_method']

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1318,22 +1318,8 @@ class TestChronosTools:
         mock_load_chronos_config,
     ):
         mock_lookup_chronos_jobs.return_value = []
-        matching = chronos_tools.find_matching_parent_jobs(['service.instance'])
-        assert len(matching) == 0
-
-    @mock.patch('chronos_tools.lookup_chronos_jobs', autospec=True)
-    @mock.patch('chronos_tools.get_chronos_client', autospec=True)
-    @mock.patch('chronos_tools.load_chronos_config', autospec=True)
-    def test_find_matching_parent_jobs_correct_number(
-        self,
-        mock_load_chronos_config,
-        mock_get_chronos_client,
-        mock_lookup_chronos_jobs,
-    ):
-        mock_lookup_chronos_jobs.return_value = [{'name': 'service.instance'}, {'name': 'service.instance2'}]
-        mock_load_chronos_config.return_value = {}
-        matching = chronos_tools.find_matching_parent_jobs(['service.instance', 'service.instance2'])
-        assert len(matching) == 2
+        matching = chronos_tools.find_matching_parent_jobs('service.instance')
+        assert matching is None
 
     @mock.patch('chronos_tools.lookup_chronos_jobs', autospec=True)
     @mock.patch('chronos_tools.get_chronos_client', autospec=True)
@@ -1341,11 +1327,10 @@ class TestChronosTools:
     def test_find_matching_parent_jobs_returns_names(
         self,
         mock_load_chronos_config,
-        mock_get_chronos_client,
-        mock_lookup_chronos_jobs,
+        mock_get_chronos_client, mock_lookup_chronos_jobs,
     ):
         mock_matching_jobs = [{'name': 'service.myinstance.gitabc.config1'}]
         mock_lookup_chronos_jobs.return_value = mock_matching_jobs
         mock_load_chronos_config.return_value = {}
-        matching = chronos_tools.find_matching_parent_jobs(['service.myinstance'])
-        assert matching == ['service.myinstance.gitabc.config1']
+        matching = chronos_tools.find_matching_parent_jobs('service.myinstance')
+        assert matching == 'service.myinstance.gitabc.config1'

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1305,3 +1305,30 @@ class TestChronosTools:
 
     def test_check_format_job_ok(self):
         assert chronos_tools.check_parent_format("foo.bar") is True
+
+    @mock.patch('chronos_tools.lookup_chronos_jobs', autospect=True)
+    @mock.patch('chronos_tools.get_chronos_client', autospect=True)
+    @mock.patch('chronos_tools.load_chronos_config', autospect=True)
+    def test_find_matching_parent_jobs_none_matching(
+        self,
+        mock_lookup_chronos_jobs,
+        mock_get_chronos_client,
+        mock_load_chronos_config,
+    ):
+        mock_lookup_chronos_jobs.return_value = []
+        matching = chronos_tools.find_matching_parent_jobs(['service.instance'])
+        assert len(matching) == 0
+
+    @mock.patch('chronos_tools.lookup_chronos_jobs', autospec=True)
+    @mock.patch('chronos_tools.get_chronos_client', autospec=True)
+    @mock.patch('chronos_tools.load_chronos_config', autospec=True)
+    def test_find_matching_parent_jobs_correct_number(
+        self,
+        mock_load_chronos_config,
+        mock_get_chronos_client,
+        mock_lookup_chronos_jobs,
+    ):
+        mock_lookup_chronos_jobs.return_value = [{'name': 'service.instance'}, {'name': 'service.instance2'}]
+        mock_load_chronos_config.return_value = {}
+        matching = chronos_tools.find_matching_parent_jobs(['service.instance', 'service.instance2'])
+        assert len(matching) == 2

--- a/tests/test_setup_chronos_job.py
+++ b/tests/test_setup_chronos_job.py
@@ -172,7 +172,7 @@ class TestSetupChronosJob:
             mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        return_value=self.fake_chronos_job_config,
                        autospec=True,
-                       side_effect=chronos_tools.InvalidChronosConfigError('test bad configuration')),
+                       side_effect=chronos_tools.UnknownChronosJobError('test bad configuration')),
             mock.patch('setup_chronos_job.setup_job',
                        return_value=(0, 'it_is_finished'),
                        autospec=True),

--- a/tests/test_setup_chronos_job.py
+++ b/tests/test_setup_chronos_job.py
@@ -77,9 +77,6 @@ class TestSetupChronosJob:
             mock.patch('paasta_tools.chronos_tools.get_chronos_client',
                        return_value=self.fake_client,
                        autospec=True),
-            mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
-                       return_value=self.fake_chronos_job_config,
-                       autospec=True),
             mock.patch('paasta_tools.chronos_tools.create_complete_config',
                        return_value=fake_complete_job_config,
                        autospec=True),
@@ -93,7 +90,6 @@ class TestSetupChronosJob:
             parse_args_patch,
             load_chronos_config_patch,
             get_client_patch,
-            load_chronos_job_config_patch,
             create_complete_config_patch,
             setup_job_patch,
             send_event_patch,
@@ -105,16 +101,9 @@ class TestSetupChronosJob:
 
             parse_args_patch.assert_called_once_with()
             get_client_patch.assert_called_once_with(load_chronos_config_patch.return_value)
-            load_chronos_job_config_patch.assert_called_once_with(
-                service=self.fake_service,
-                instance=self.fake_instance,
-                cluster=self.fake_cluster,
-                soa_dir=self.fake_args.soa_dir,
-            )
             setup_job_patch.assert_called_once_with(
                 service=self.fake_service,
                 instance=self.fake_instance,
-                chronos_job_config=self.fake_chronos_job_config,
                 complete_job_config=fake_complete_job_config,
                 client=self.fake_client,
                 cluster=self.fake_cluster,
@@ -137,8 +126,8 @@ class TestSetupChronosJob:
             mock.patch('paasta_tools.chronos_tools.get_chronos_client',
                        return_value=self.fake_client,
                        autospec=True),
-            mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
-                       return_value=self.fake_chronos_job_config,
+            mock.patch('paasta_tools.chronos_tools.create_complete_config',
+                       return_value={},
                        autospec=True,
                        side_effect=NoDeploymentsAvailable),
             mock.patch('setup_chronos_job.setup_job',
@@ -169,8 +158,7 @@ class TestSetupChronosJob:
             mock.patch('paasta_tools.chronos_tools.get_chronos_client',
                        return_value=self.fake_client,
                        autospec=True),
-            mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
-                       return_value=self.fake_chronos_job_config,
+            mock.patch('paasta_tools.chronos_tools.create_complete_config',
                        autospec=True,
                        side_effect=chronos_tools.UnknownChronosJobError('test bad configuration')),
             mock.patch('setup_chronos_job.setup_job',
@@ -232,7 +220,6 @@ class TestSetupChronosJob:
             actual = setup_chronos_job.setup_job(
                 service=self.fake_service,
                 instance=self.fake_instance,
-                chronos_job_config=self.fake_chronos_job_config,
                 complete_job_config=complete_config,
                 client=self.fake_client,
                 cluster=self.fake_cluster,
@@ -279,7 +266,6 @@ class TestSetupChronosJob:
             actual = setup_chronos_job.setup_job(
                 service=self.fake_service,
                 instance=self.fake_instance,
-                chronos_job_config=self.fake_chronos_job_config,
                 complete_job_config=complete_config,
                 client=self.fake_client,
                 cluster=self.fake_cluster,
@@ -327,7 +313,6 @@ class TestSetupChronosJob:
             actual = setup_chronos_job.setup_job(
                 service=self.fake_service,
                 instance=self.fake_instance,
-                chronos_job_config=self.fake_chronos_job_config,
                 complete_job_config=complete_config,
                 client=self.fake_client,
                 cluster=self.fake_cluster,


### PR DESCRIPTION
This is a first pass at adding support for dependent jobs: a user can now add a 'parents' key to the yelpsoa-configs for their job and have a dependent job created.

A user specifies the parent for a dependent job in the format `service.instance`. This value is an array, and must be specified as so in the soa config.

When the job object is formatted into the JSON to be POSTed to Chronos, the 'service.instance' is translated into the 'full' job name by finding the most recent job associated with that service instance.

Caveats:

- The 'parent' job must already be launched in chronos before the dependent job is launched #147
- Validation for a matching job is done at launch time, rather than at 'validate' time.
- parents is an array, and setting the ``parent`` value as a string rather than array will blow up

There is probably more, but these are the ones I can think of immediately.

I've also done some refactoring of the integration tests for chronos as part of this. The key reasons for this were:

- We can now operate on multiple jobs at the same time using the new `jobs` field I added to the context. Before ``context.chronos_job`` was the only key available, which makes it more difficult when I need to operate on multiple jobs at the same time.
- The integration tests for ``setup_chronos_job`` were operating on ChronosJobConfig objects, and the chronos client rather than going through the full workflow the user would go through. I've modified this, so now the features more closely follow the users pattern. E.G 'I have yelpsoa-configs, I run setup_chronos_job, I modify the yelpsoa-configs, I run setup_chronos_job' rather than 'I have a chronosjobconfig, I run setup_chronos_job.setup_job(myconfig), I edit a field in the config etc. I think this is a good thing - the only caveat here is there are exceptions in the itest output from errors connecting to Sensu. Hopefully I can fix that by adding something that acts like a sensu server to listen a discard messages.

I found a bug (#146) as a result of doing this, so I think it was worthwhile. The fix for #146 is also in this PR.