### PR TITLE
remove assumptions from paasta validate tests

### DIFF
--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -19,7 +19,6 @@ from mock import patch
 from pytest import raises
 from StringIO import StringIO
 
-from paasta_tools.chronos_tools import ChronosJobConfig
 from paasta_tools.cli.cmds.validate import get_schema
 from paasta_tools.cli.cmds.validate import get_service_path
 from paasta_tools.cli.cmds.validate import invalid_chronos_instance
@@ -233,100 +232,29 @@ def test_chronos_validate_schema_keys_outside_instance_blocks_bad(
 @patch('paasta_tools.cli.cmds.validate.load_chronos_job_config')
 @patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service')
 @patch('sys.stdout', new_callable=StringIO)
-def test_validate_chronos_missing_schedule(
+def test_failing_chronos_job_validate(
     mock_stdout,
     mock_path_to_soa_dir_service,
     mock_load_chronos_job_config,
     mock_list_all_instances_for_service,
     mock_list_clusters
 ):
-    fake_service = 'test-service'
     fake_instance = 'fake-instance'
-    fake_job_name = 'test'
     fake_cluster = 'penguin'
-    fake_monitoring_info = {'fake_monitoring_info': 'fake_monitoring_value'}
-    fake_config_dict = {
-        'bounce_method': 'graceful',
-        'cmd': '/bin/sleep 40',
-        'epsilon': 'PT30M',
-        'retries': 5,
-        'cpus': 5.5,
-        'mem': 1024.4,
-        'disabled': True,
-        'schedule_time_zone': 'Zulu',
-        'monitoring': fake_monitoring_info,
-    }
-    fake_branch_dict = {
-        'desired_state': 'start',
-        'docker_image': 'paasta-%s-%s' % (fake_service, fake_cluster),
-    }
-    fake_chronos_job_config = ChronosJobConfig(fake_service,
-                                               fake_job_name,
-                                               fake_config_dict,
-                                               fake_branch_dict)
+
+    mock_chronos_job = mock.Mock(autospec=True)
+    mock_chronos_job.validate.return_value = (False, ['something is wrong with the config'])
 
     mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'fake_service')
     mock_list_clusters.return_value = [fake_cluster]
     mock_list_all_instances_for_service.return_value = [fake_instance]
-    mock_load_chronos_job_config.return_value = fake_chronos_job_config
+    mock_load_chronos_job_config.return_value = mock_chronos_job
 
     assert validate_chronos('fake_service_path') == 1
 
     output = mock_stdout.getvalue()
 
-    expected_output = 'You must specify a "schedule" in your configuration'
-    assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
-
-
-@patch('paasta_tools.cli.cmds.validate.list_clusters')
-@patch('paasta_tools.cli.cmds.validate.list_all_instances_for_service')
-@patch('paasta_tools.cli.cmds.validate.load_chronos_job_config')
-@patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service')
-@patch('sys.stdout', new_callable=StringIO)
-def test_validate_chronos_invalid_instance(
-    mock_stdout,
-    mock_path_to_soa_dir_service,
-    mock_load_chronos_job_config,
-    mock_list_all_instances_for_service,
-    mock_list_clusters
-):
-    fake_service = 'test-service'
-    fake_instance = 'fake-instance'
-    fake_job_name = 'test'
-    fake_cluster = 'penguin'
-    fake_monitoring_info = {'fake_monitoring_info': 'fake_monitoring_value'}
-    fake_config_dict = {
-        'bounce_method': 'graceful',
-        'cmd': '/bin/sleep 40',
-        'epsilon': 'PT30M',
-        'retries': 5,
-        'cpus': 5.5,
-        'mem': 1024.4,
-        'disabled': True,
-        'schedule': 'P1DT09:00:00',
-        'schedule_time_zone': 'Zulu',
-        'monitoring': fake_monitoring_info,
-    }
-    fake_branch_dict = {
-        'desired_state': 'start',
-        'docker_image': 'paasta-%s-%s' % (fake_service, fake_cluster),
-    }
-    fake_chronos_job_config = ChronosJobConfig(fake_service,
-                                               fake_job_name,
-                                               fake_config_dict,
-                                               fake_branch_dict)
-
-    mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'fake_service')
-    mock_list_clusters.return_value = [fake_cluster]
-    mock_list_all_instances_for_service.return_value = [fake_instance]
-    mock_load_chronos_job_config.return_value = fake_chronos_job_config
-
-    assert validate_chronos('fake_service_path') == 1
-
-    output = mock_stdout.getvalue()
-
-    expected_output = 'The specified schedule "%s" is invalid' % \
-        fake_config_dict['schedule']
+    expected_output = 'something is wrong with the config'
     assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
 
 
@@ -342,36 +270,16 @@ def test_validate_chronos_valid_instance(
     mock_list_all_instances_for_service,
     mock_list_clusters
 ):
-    fake_service = 'test-service'
     fake_instance = 'fake-instance'
-    fake_job_name = 'test'
     fake_cluster = 'penguin'
-    fake_monitoring_info = {'fake_monitoring_info': 'fake_monitoring_value'}
-    fake_config_dict = {
-        'bounce_method': 'graceful',
-        'cmd': '/bin/sleep 40',
-        'epsilon': 'PT30M',
-        'retries': 5,
-        'cpus': 5.5,
-        'mem': 1024.4,
-        'disabled': True,
-        'schedule': 'R/2015-03-25T19:36:35Z/PT5M',
-        'schedule_time_zone': 'Zulu',
-        'monitoring': fake_monitoring_info,
-    }
-    fake_branch_dict = {
-        'desired_state': 'start',
-        'docker_image': 'paasta-%s-%s' % (fake_service, fake_cluster),
-    }
-    fake_chronos_job_config = ChronosJobConfig(fake_service,
-                                               fake_job_name,
-                                               fake_config_dict,
-                                               fake_branch_dict)
+
+    mock_chronos_job = mock.Mock(autospec=True)
+    mock_chronos_job.validate.return_value = (True, [])
 
     mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'fake_service')
     mock_list_clusters.return_value = [fake_cluster]
     mock_list_all_instances_for_service.return_value = [fake_instance]
-    mock_load_chronos_job_config.return_value = fake_chronos_job_config
+    mock_load_chronos_job_config.return_value = mock_chronos_job
 
     assert validate_chronos('fake_service_path') == 0
 


### PR DESCRIPTION
as it stands, we rely on assumptions on the behaviour of ChronosJobConfig.validate for the paasta validate unit tests. This removes those assumptions using Mocks so that we don't have to update these unit tests every time the behaviour of ChronosJobConfig.validate changes.