### PR TITLE
Added an extra verbosity level to paasta_metastatus

### DIFF
--- a/paasta_itests/docker-compose.yml
+++ b/paasta_itests/docker-compose.yml
@@ -19,6 +19,7 @@ mesosslave:
   environment:
     -CLUSTER: testcluster
   command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512"'
+  hostname: mesosslave.test_hostname
 
 marathon:
   build: ../yelp_package/dockerfiles/itest/marathon/

--- a/paasta_itests/itest_utils.py
+++ b/paasta_itests/itest_utils.py
@@ -17,19 +17,8 @@ import os
 import time
 
 import requests
-from compose.cli import command
 
 from paasta_tools.utils import timeout
-
-
-def get_docker_compose_id_from_name(container_name):
-    cmd = command.Command()
-    project = cmd.get_project(cmd.get_config_path())
-    containers = project.containers(service_names=container_name)
-    if containers is []:
-        raise Exception("Could not find a container with that name")
-    else:
-        return containers[0].id
 
 
 def get_service_connection_string(service):

--- a/paasta_itests/itest_utils.py
+++ b/paasta_itests/itest_utils.py
@@ -17,8 +17,19 @@ import os
 import time
 
 import requests
+from compose.cli import command
 
 from paasta_tools.utils import timeout
+
+
+def get_docker_compose_id_from_name(container_name):
+    cmd = command.Command()
+    project = cmd.get_project(cmd.get_config_path())
+    containers = project.containers(service_names=container_name)
+    if containers is []:
+        raise Exception("Could not find a container with that name")
+    else:
+        return containers[0].id
 
 
 def get_service_connection_string(service):

--- a/paasta_itests/paasta_metastatus.feature
+++ b/paasta_itests/paasta_metastatus.feature
@@ -15,7 +15,7 @@ Feature: paasta_metastatus describes the state of the paasta cluster
     Given a working paasta cluster
      When an app with id "memtest" using high memory is launched
       And a task belonging to the app with id "memtest" is in the task list
-     Then paasta_metastatus exits with return code "2" and output "CRITICAL: Less than 10% memory available."
+     Then paasta_metastatus -v exits with return code "2" and output "CRITICAL: Less than 10% memory available."
 
   # paasta_metastatus defines 'high' cpu usage as > 90% of the total cluster
   # capacity. in docker-compose.yml, we set cpus at 10 for the 1 mesos slave in use;
@@ -30,18 +30,22 @@ Feature: paasta_metastatus describes the state of the paasta cluster
     Given a working paasta cluster
      When an app with id "cputest" using high cpu is launched
       And a task belonging to the app with id "cputest" is in the task list
-     Then paasta_metastatus exits with return code "2" and output "CRITICAL: Less than 10% CPUs available."
+     Then paasta_metastatus -v exits with return code "2" and output "CRITICAL: Less than 10% CPUs available."
 
   Scenario: With a launched chronos job
     Given a working paasta cluster
      When we create a trivial marathon app
       And we create a trivial chronos job called "testjob"
       And we wait for the chronos job stored as "testjob" to appear in the job list
-     Then paasta_metastatus exits with return code "0" and output "Enabled chronos jobs: 1"
+     Then paasta_metastatus -v exits with return code "0" and output "Enabled chronos jobs: 1"
 
 #  Scenario: Mesos master unreachable
 #    Given a working paasta cluster
 #     When all masters are unavailable
 #     Then metastatus returns 2
 
+  Scenario:
+    Given a working paasta cluster
+     When we create a trivial marathon app
+     Then paasta_metastatus -vv exits with return code "0" and outputs the slave's hostname
 # vim: set ts=2 sw=2

--- a/paasta_itests/paasta_metastatus.feature
+++ b/paasta_itests/paasta_metastatus.feature
@@ -48,4 +48,5 @@ Feature: paasta_metastatus describes the state of the paasta cluster
     Given a working paasta cluster
      When we create a trivial marathon app
      Then paasta_metastatus -vv exits with return code "0" and outputs the slave's hostname
+
 # vim: set ts=2 sw=2

--- a/paasta_itests/steps/paasta_metastatus_steps.py
+++ b/paasta_itests/steps/paasta_metastatus_steps.py
@@ -20,7 +20,6 @@ from behave import when, then
 sys.path.append('../')
 from paasta_tools.utils import _run
 from paasta_tools.utils import remove_ansi_escape_sequences
-from paasta_itests.itest_utils import get_docker_compose_id_from_name
 from paasta_tools import marathon_tools
 from marathon import MarathonApp
 
@@ -84,5 +83,5 @@ def check_metastatus_contains_hostname(context, flags, expected_return_code):
         context,
         flags,
         expected_return_code,
-        get_docker_compose_id_from_name('mesosslave')
+        'mesosslave.test_hostname',
     )

--- a/paasta_itests/steps/paasta_metastatus_steps.py
+++ b/paasta_itests/steps/paasta_metastatus_steps.py
@@ -57,12 +57,12 @@ def marathon_task_is_ready(context, app_id):
     marathon_tools.wait_for_app_to_launch_tasks(context.marathon_client, app_id, 1)
 
 
-@then(u'paasta_metastatus {flags} exits with return code "{expected_return_code}" and output "{expected_output}"')
-def check_metastatus_return_code(context, flags, expected_return_code, expected_output):
+@then(u'paasta_metastatus{flags} exits with return code "{expected_return_code}" and output "{expected_output}"')
+def check_metastatus_return_code_with_flags(context, flags, expected_return_code, expected_output):
     # We don't want to invoke the "paasta metastatus" wrapper because by
     # default it will check every cluster. This is also the way sensu invokes
     # this check.
-    cmd = '../paasta_tools/paasta_metastatus.py %s' % flags
+    cmd = '../paasta_tools/paasta_metastatus.py%s' % flags
     env = dict(os.environ)
     env['MESOS_CLI_CONFIG'] = context.mesos_cli_config_filename
     print 'Running cmd %s with MESOS_CLI_CONFIG=%s' % (cmd, env['MESOS_CLI_CONFIG'])
@@ -77,11 +77,21 @@ def check_metastatus_return_code(context, flags, expected_return_code, expected_
     assert expected_output in escaped_output
 
 
-@then(u'paasta_metastatus {flags} exits with return code "{expected_return_code}" and outputs the slave\'s hostname')
-def check_metastatus_contains_hostname(context, flags, expected_return_code):
-    check_metastatus_return_code(
-        context,
-        flags,
-        expected_return_code,
-        'mesosslave.test_hostname',
+@then(u'paasta_metastatus exits with return code "{expected_return_code}" and output "{expected_output}"')
+def check_metastatus_return_code_no_flags(context, expected_return_code, expected_output):
+    check_metastatus_return_code_with_flags(
+        context=context,
+        flags='',
+        expected_return_code=expected_return_code,
+        expected_output=expected_output,
+    )
+
+
+@then(u'paasta_metastatus -vv exits with return code "{expected_return_code}" and outputs the slave\'s hostname')
+def check_metastatus_contains_hostname(context, expected_return_code):
+    check_metastatus_return_code_with_flags(
+        context=context,
+        flags=' -vv',
+        expected_return_code=expected_return_code,
+        expected_output='mesosslave.test_hostname',
     )

--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -41,7 +41,7 @@ def add_subparser(subparsers):
         action='count',
         dest="verbose",
         default=0,
-        help="Print out more output regarding the state of the cluster",
+        help="Print out more output regarding the state of the cluster. Multiple v options increase verbosity. Maximum is 2.",
     )
     clusters_help = (
         'A comma separated list of clusters to view. Defaults to view all clusters. '

--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -38,9 +38,9 @@ def add_subparser(subparsers):
     )
     status_parser.add_argument(
         '-v', '--verbose',
-        action='store_true',
+        action='count',
         dest="verbose",
-        default=False,
+        default=0,
         help="Print out more output regarding the state of the cluster",
     )
     clusters_help = (
@@ -54,7 +54,7 @@ def add_subparser(subparsers):
     status_parser.set_defaults(command=paasta_metastatus)
 
 
-def print_cluster_status(cluster, verbose=False):
+def print_cluster_status(cluster, verbose=0):
     """With a given cluster and verboseness, returns the status of the cluster
     output is printed directly to provide dashbaords even if the cluster is unavailable"""
     print "Cluster: %s" % cluster

--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -41,7 +41,8 @@ def add_subparser(subparsers):
         action='count',
         dest="verbose",
         default=0,
-        help="Print out more output regarding the state of the cluster. Multiple v options increase verbosity. Maximum is 2.",
+        help="""Print out more output regarding the state of the cluster.
+        Multiple v options increase verbosity. Maximum is 2.""",
     )
     clusters_help = (
         'A comma separated list of clusters to view. Defaults to view all clusters. '

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -513,8 +513,8 @@ def execute_paasta_serviceinit_on_remote_master(subcommand, cluster, service, in
 
 
 def run_paasta_metastatus(master, verbose=0):
-    if verbose is not 0:
-        verbose_flag = " -" + 'v'*verbose
+    if verbose > 0:
+        verbose_flag = " -%s" % 'v'*verbose
         timeout = 120
     else:
         verbose_flag = ''

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -512,9 +512,9 @@ def execute_paasta_serviceinit_on_remote_master(subcommand, cluster, service, in
     return run_paasta_serviceinit(subcommand, master, service, instancename, cluster, **kwargs)
 
 
-def run_paasta_metastatus(master, verbose=False):
-    if verbose:
-        verbose_flag = " -v"
+def run_paasta_metastatus(master, verbose=0):
+    if verbose is not 0:
+        verbose_flag = " -" + 'v'*verbose
         timeout = 120
     else:
         verbose_flag = ''
@@ -527,7 +527,7 @@ def run_paasta_metastatus(master, verbose=False):
     return output
 
 
-def execute_paasta_metastatus_on_remote_master(cluster, verbose=False):
+def execute_paasta_metastatus_on_remote_master(cluster, verbose=0):
     """Returns a string containing an error message if an error occurred.
     Otherwise returns the output of run_paasta_metastatus().
     """

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -174,8 +174,8 @@ def get_mesos_status():
     metrics_results = run_healthchecks_with_param(metrics, [
         assert_cpu_health,
         assert_memory_health,
-        assert_slave_health,
-        assert_tasks_running])
+        aassert_tasks_running,
+        assert_slave_health])
 
     return cluster_results + metrics_results
 
@@ -300,7 +300,7 @@ def print_extra_mesos_data():
                 if resource_type in ['cpus', 'disk', 'mem']:
                     resource_dict[resource_type] -= value
 
-    for slave in slaves.values():
+    for slave in sorted(slaves.values()):
         print '%45s %8.2f %9.2f' % (slave['hostname'], slave['free_resources']['cpus'], slave['free_resources']['mem'])
 
 
@@ -346,6 +346,8 @@ def main():
     chronos_summary = generate_summary_for_check("Chronos", chronos_ok)
 
     print_results_for_healthchecks(mesos_summary, mesos_ok, mesos_results, args.verbose)
+    if args.verbose >= 2:
+        print_extra_mesos_data()
     print_results_for_healthchecks(marathon_summary, marathon_ok, marathon_results, args.verbose)
     print_results_for_healthchecks(chronos_summary, chronos_ok, chronos_results, args.verbose)
 

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -300,12 +300,8 @@ def print_extra_mesos_data():
                 if resource_type in ['cpus', 'disk', 'mem']:
                     resource_dict[resource_type] -= value
 
-<<<<<<< HEAD
     for slave in sorted(slaves.values()):
-=======
-    for slave in slaves.values():
->>>>>>> faa8d51a8dd8a90a4742a38ed261c69b5be63d8f
-        print '%45s %8.2f %9.2f' % (slave['hostname'], slave['free_resources']['cpus'], slave['free_resources']['mem'])
+        print '%40s %8.2f %9.2f' % (slave['hostname'], slave['free_resources']['cpus'], slave['free_resources']['mem'])
 
 
 def main():
@@ -354,9 +350,6 @@ def main():
         print_extra_mesos_data()
     print_results_for_healthchecks(marathon_summary, marathon_ok, marathon_results, args.verbose)
     print_results_for_healthchecks(chronos_summary, chronos_ok, chronos_results, args.verbose)
-
-    if args.verbose >= 2:
-        print_extra_mesos_data()
 
     if not all([mesos_ok, marathon_ok, chronos_ok]):
         sys.exit(2)

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -174,7 +174,7 @@ def get_mesos_status():
     metrics_results = run_healthchecks_with_param(metrics, [
         assert_cpu_health,
         assert_memory_health,
-        aassert_tasks_running,
+        assert_tasks_running,
         assert_slave_health])
 
     return cluster_results + metrics_results

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -179,7 +179,7 @@ def assert_quorum_size(state):
 
 
 def assert_extra_slave_data(mesos_state):
-    header_string = '%12s %36s %9s' % ('Hostname', 'CPU free', 'RAM free')
+    header_string = '%10s %36s %9s' % ('Hostname', 'CPU free', 'RAM free')
     slave_outputs = ['%40s %8.2f %9.2f' % (
         slave['hostname'],
         slave['free_resources']['cpus'],

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -300,7 +300,11 @@ def print_extra_mesos_data():
                 if resource_type in ['cpus', 'disk', 'mem']:
                     resource_dict[resource_type] -= value
 
+<<<<<<< HEAD
     for slave in sorted(slaves.values()):
+=======
+    for slave in slaves.values():
+>>>>>>> faa8d51a8dd8a90a4742a38ed261c69b5be63d8f
         print '%45s %8.2f %9.2f' % (slave['hostname'], slave['free_resources']['cpus'], slave['free_resources']['mem'])
 
 

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -300,6 +300,8 @@ def print_extra_mesos_data():
                 if resource_type in ['cpus', 'disk', 'mem']:
                     resource_dict[resource_type] -= value
 
+    print '%40s %8s %9s' % ('Hostname', 'CPU free', 'RAM free')
+
     for slave in sorted(slaves.values()):
         print '%40s %8.2f %9.2f' % (slave['hostname'], slave['free_resources']['cpus'], slave['free_resources']['mem'])
 

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -300,7 +300,7 @@ def print_extra_mesos_data():
                 if resource_type in ['cpus', 'disk', 'mem']:
                     resource_dict[resource_type] -= value
 
-    print '%40s %8s %9s' % ('Hostname', 'CPU free', 'RAM free')
+    print '%12s %36s %9s' % ('Hostname', 'CPU free', 'RAM free')
 
     for slave in sorted(slaves.values()):
         print '%40s %8.2f %9.2f' % (slave['hostname'], slave['free_resources']['cpus'], slave['free_resources']['mem'])

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -265,7 +265,7 @@ def test_get_mesos_status(
     expected_masters_quorum_output = \
         "quorum: masters: 5 configured quorum: 3 "
 
-    results = paasta_metastatus.get_mesos_status(mesos_state)
+    results = paasta_metastatus.get_mesos_status(mesos_state, verbosity=0)
 
     assert mock_get_mesos_stats.called_once()
     assert (expected_masters_quorum_output, True) in results


### PR DESCRIPTION
Uses Krall's mesos slave analysis script to display free CPU and RAM on each host. Called by using paasta metastatus -vv (or --verbose --verbose).