### PR TITLE
Extend schemas

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -123,17 +123,17 @@ def validate_all_schemas(service_path):
 
     path = os.path.join(service_path, '*.yaml')
 
+    returncode = 0
     for file_name in glob(path):
         if os.path.islink(file_name):
             continue
         basename = os.path.basename(file_name)
-        returncode = 0
         for file_type in ['chronos', 'marathon']:
             if basename.startswith(file_type):
                 tmp_returncode = validate_schema(file_name, file_type)
                 if tmp_returncode != 0:
                     returncode = tmp_returncode
-        return returncode
+    return returncode
 
 
 def add_subparser(subparsers):

--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -5,7 +5,69 @@
     "minProperties": 1,
     "additionalProperties": {
         "type": "object",
-        "properties": {},
-        "additionalProperties": true
+        "additionalProperties": false,
+        "minProperties": 1,
+        "properties": {
+            "schedule": {
+                "type": "string"
+            },
+            "cmd": {
+                "type": "string"
+            },
+            "args": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "epsilon": {
+                "type": "string"
+            },
+            "retries": {
+                "type": "integer",
+                "default": 2
+            },
+            "disabled": {
+                "type": "boolean",
+                "default": false
+            },
+            "cpus": {
+                "type": "number",
+                "minimum": 0,
+                "exclusiveMinimum": true,
+                "default": 0.25
+            },
+            "mem": {
+                "type": "number",
+                "minimum": 0,
+                "exclusiveMinimum": true,
+                "default": 1024
+            },
+            "bounce_method": {
+                "enum": [ "graceful" ],
+                "default": "graceful"
+            },
+            "monitoring": {
+                "type": "object"
+            },
+            "env": {
+                "type": "object"
+            },
+            "extra_volumes": {
+                "type": "array",
+                "items": {
+                    "type": "object"
+                },
+                "uniqueItems": true
+            },
+            "constraints": {
+                "type": "array",
+                "items": {
+                    "type": "array"
+                },
+                "uniqueItems": true
+            }
+        },
+        "required": ["schedule"]
     }
 }

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -23,7 +23,7 @@
             "instances": {
                 "type": "integer",
                 "minimum": 0,
-                "exclusiveMinimum": true
+                "exclusiveMinimum": false
             },
             "nerve_ns": {
                 "type": "string"
@@ -40,6 +40,15 @@
                     },
                     "min_task_uptime": {
                         "type": "number"
+                    }
+                }
+            },
+            "bounce_health_params": {
+                "type": "object",
+                "properties": {
+                    "check_haproxy": {
+                        "type": "boolean",
+                        "default": true
                     }
                 }
             },

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -5,7 +5,109 @@
     "minProperties": 1,
     "additionalProperties": {
         "type": "object",
-        "properties": {},
-        "additionalProperties": true
+        "additionalProperties": false,
+        "minProperties": 1,
+        "properties": {
+            "cpus": {
+                "type": "number",
+                "minimum": 0,
+                "exclusiveMinimum": true,
+                "default": 0.25
+            },
+            "mem": {
+                "type": "number",
+                "minimum": 0,
+                "exclusiveMinimum": true,
+                "default": 1024
+            },
+            "instances": {
+                "type": "integer",
+                "minimum": 0,
+                "exclusiveMinimum": true
+            },
+            "nerve_ns": {
+                "type": "string"
+            },
+            "bounce_method": {
+                "type": "string"
+            },
+            "bounce_method_params": {
+                "type": "object",
+                "properties": {
+                    "check_haproxy": {
+                        "type": "boolean",
+                        "default": true
+                    },
+                    "min_task_uptime": {
+                        "type": "number"
+                    }
+                }
+            },
+            "drain_method": {
+                "enum": [ "noop", "hacheck", "test" ],
+                "default": "noop"
+            },
+            "drain_method_params": {
+                "type": "object"
+            },
+            "constraints": {
+                "type": "array",
+                "items": {
+                    "type": "array"
+                },
+                "uniqueItems": true
+            },
+            "cmd": {
+                "type": "string"
+            },
+            "args": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "env": {
+                "type": "object"
+            },
+            "extra_volumes": {
+                "type": "array",
+                "items": {
+                    "type": "object"
+                },
+                "uniqueItems": true
+            },
+            "monitoring": {
+                "type": "object"
+            },
+            "deploy_blacklist": {
+                "type": "array"
+            },
+            "monitoring_blacklist": {
+                "type": "array"
+            },
+            "healthcheck_mode": {
+                "enum": [ "cmd", "tcp", "http" ]
+            },
+            "healthcheck_cmd": {
+                "type": "string",
+                "default": "/bin/true"
+            },
+            "healthcheck_grace_period_seconds": {
+                "type": "number",
+                "default": 60
+            },
+            "healthcheck_interval_seconds": {
+                "type": "number",
+                "default": 10
+            },
+            "healthcheck_timeout_seconds": {
+                "type": "number",
+                "default": 10
+            },
+            "healthcheck_max_consecutive_failures": {
+                "type": "integer",
+                "default": 6
+            }
+        }
     }
 }

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -185,6 +185,26 @@ def test_marathon_validate_schema_keys_outside_instance_blocks_bad(
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents')
 @patch('sys.stdout', new_callable=StringIO)
+def test_marathon_validate_invalid_key_bad(
+    mock_stdout,
+    mock_get_file_contents
+):
+    mock_get_file_contents.return_value = """
+{
+    "main": {
+        "fake_key": 5
+    }
+}
+"""
+    assert validate_schema('unused_service_path.json', 'marathon') == 1
+
+    output = mock_stdout.getvalue()
+
+    assert SCHEMA_INVALID in output
+
+
+@patch('paasta_tools.cli.cmds.validate.get_file_contents')
+@patch('sys.stdout', new_callable=StringIO)
 def test_chronos_validate_schema_list_hashes_good(
     mock_stdout,
     mock_get_file_contents


### PR DESCRIPTION
This change attempts to bring out schemas (used for validation) in line with http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html . I manually tested it against all of our existing yelpsoa configs with no unexpected results. While doing this, I discovered a small bug with the validate command that prevented it from validating all yaml files (and I fixed it).

Closes #129 