### PR TITLE
Make deploy_chronos_services shuffle

### DIFF
--- a/paasta_tools/deploy_chronos_jobs
+++ b/paasta_tools/deploy_chronos_jobs
@@ -1,4 +1,4 @@
 #!/bin/bash
 if am_i_mesos_leader >/dev/null; then
-  list_chronos_jobs | shuf | xargs -n 1 -r -P 5 setup_chronos_job
+  list_chronos_jobs | tr ' ' '\n' | shuf | xargs -n 1 -r -P 5 setup_chronos_job
 fi

--- a/paasta_tools/deploy_chronos_jobs
+++ b/paasta_tools/deploy_chronos_jobs
@@ -1,4 +1,4 @@
 #!/bin/bash
 if am_i_mesos_leader >/dev/null; then
-  list_chronos_jobs | tr ' ' '\n' | shuf | xargs -n 1 -r -P 5 setup_chronos_job
+  list_chronos_jobs | shuf | xargs -n 1 -r -P 5 setup_chronos_job
 fi

--- a/paasta_tools/list_chronos_jobs.py
+++ b/paasta_tools/list_chronos_jobs.py
@@ -18,7 +18,7 @@
 Enumerates all Chronos jobs for services in the SOA directory that
 are for the current cluster (defined by the Chronos configuration file).
 
-Outputs (to stdout) a space-separated list of service.job_name
+Outputs (to stdout) a list of service.job_name (one per line)
 for each job found in chronos-<CLUSTER>.yaml for every folder
 in the SOA Configuration directory.
 
@@ -51,7 +51,7 @@ def main():
     jobs = chronos_tools.get_chronos_jobs_for_cluster(cluster=args.cluster, soa_dir=args.soa_dir)
     # TODO use compose_job_id instead of constructing string once INTERNAL_SPACER deprecated
     composed = ['%s%s%s' % (name, chronos_tools.INTERNAL_SPACER, job) for name, job in jobs]
-    print ' '.join(composed)
+    print '\n'.join(composed)
     sys.exit(0)
 
 

--- a/paasta_tools/list_marathon_service_instances.py
+++ b/paasta_tools/list_marathon_service_instances.py
@@ -18,7 +18,7 @@
 Enumerates all marathon instances for services in the soa directory that
 are for the current cluster (defined by the marathon configuration file).
 
-Outputs (to stdout) a space separated list of service.instance
+Outputs (to stdout) a list of service.instance (one per line)
 for each instance found in marathon-<CLUSTER>.yaml for every folder
 in the SOA Configuration directory.
 
@@ -53,7 +53,7 @@ def main():
     composed = []
     for name, instance in instances:
         composed.append(compose_job_id(name, instance))
-    print ' '.join(composed)
+    print '\n'.join(composed)
     sys.exit(0)
 
 


### PR DESCRIPTION
The shuf command shuffles lines, but list_chronos_jobs outputs 1
space-delimited line. This fixes #154