### PR TITLE
Make paasta check call validate (Closes #128)

### DIFF
--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -21,6 +21,7 @@ import urllib2
 from service_configuration_lib import DEFAULT_SOA_DIR
 from service_configuration_lib import read_service_configuration
 
+from paasta_tools.cli.cmds.validate import paasta_validate
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_file_contents
 from paasta_tools.cli.utils import is_file_in_dir
@@ -349,6 +350,7 @@ def paasta_check(args):
     deployments_check(service, soa_dir)
     sensu_check(service, service_path)
     smartstack_check(service, service_path)
+    paasta_validate(None, service_path)
 
 
 def read_dockerfile_lines(path):

--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -21,7 +21,6 @@ import urllib2
 from service_configuration_lib import DEFAULT_SOA_DIR
 from service_configuration_lib import read_service_configuration
 
-from paasta_tools.cli.cmds.validate import paasta_validate
 from paasta_tools.cli.cmds.validate import paasta_validate_soa_configs
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_file_contents

--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -22,6 +22,7 @@ from service_configuration_lib import DEFAULT_SOA_DIR
 from service_configuration_lib import read_service_configuration
 
 from paasta_tools.cli.cmds.validate import paasta_validate
+from paasta_tools.cli.cmds.validate import paasta_validate_soa_configs
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_file_contents
 from paasta_tools.cli.utils import is_file_in_dir
@@ -350,7 +351,7 @@ def paasta_check(args):
     deployments_check(service, soa_dir)
     sensu_check(service, service_path)
     smartstack_check(service, service_path)
-    paasta_validate(None, service_path)
+    paasta_validate_soa_configs(service_path)
 
 
 def read_dockerfile_lines(path):

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -208,14 +208,17 @@ def validate_chronos(service_path):
     return returncode
 
 
-def paasta_validate(args):
+def paasta_validate(args, service_path=None):
     """Analyze the service in the PWD to determine if conf files are all valid
 
     :param args: argparse.Namespace obj created from sys.args by cli
     """
 
-    service = args.service
-    soa_dir = args.yelpsoa_config_root
+    if service_path:
+        soa_dir, service = path_to_soa_dir_service(service_path)
+    else:
+        service = args.service
+        soa_dir = args.yelpsoa_config_root
     service_path = get_service_path(service, soa_dir)
 
     if service_path is None:

--- a/tests/cli/test_cmds_check.py
+++ b/tests/cli/test_cmds_check.py
@@ -53,7 +53,9 @@ from paasta_tools.cli.utils import PaastaCheckMessages
 @patch('paasta_tools.cli.cmds.check.deployments_check')
 @patch('paasta_tools.cli.cmds.check.sensu_check')
 @patch('paasta_tools.cli.cmds.check.smartstack_check')
+@patch('paasta_tools.cli.cmds.check.paasta_validate')
 def test_check_paasta_check_calls_everything(
+        mock_paasta_validate,
         mock_smartstart_check,
         mock_sensu_check,
         mock_deployments_check,
@@ -88,6 +90,7 @@ def test_check_paasta_check_calls_everything(
     assert mock_yaml_check.called
     assert mock_sensu_check.called
     assert mock_smartstart_check.called
+    assert mock_paasta_validate.called
 
     service_path = os.path.join(args.yelpsoa_config_root,
                                 mock_figure_out_service_name.return_value)

--- a/tests/cli/test_cmds_check.py
+++ b/tests/cli/test_cmds_check.py
@@ -53,9 +53,9 @@ from paasta_tools.cli.utils import PaastaCheckMessages
 @patch('paasta_tools.cli.cmds.check.deployments_check')
 @patch('paasta_tools.cli.cmds.check.sensu_check')
 @patch('paasta_tools.cli.cmds.check.smartstack_check')
-@patch('paasta_tools.cli.cmds.check.paasta_validate')
+@patch('paasta_tools.cli.cmds.check.paasta_validate_soa_configs')
 def test_check_paasta_check_calls_everything(
-        mock_paasta_validate,
+        mock_paasta_validate_soa_configs,
         mock_smartstart_check,
         mock_sensu_check,
         mock_deployments_check,
@@ -90,7 +90,7 @@ def test_check_paasta_check_calls_everything(
     assert mock_yaml_check.called
     assert mock_sensu_check.called
     assert mock_smartstart_check.called
-    assert mock_paasta_validate.called
+    assert mock_paasta_validate_soa_configs.called
 
     service_path = os.path.join(args.yelpsoa_config_root,
                                 mock_figure_out_service_name.return_value)

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -79,6 +79,15 @@ def test_validate_unknown_service():
     assert excinfo.value.code == 1
 
 
+def test_validate_unknown_service_service_path():
+    service_path = 'unused/path'
+
+    with raises(SystemExit) as excinfo:
+        paasta_validate(None, service_path=service_path)
+
+    assert excinfo.value.code == 1
+
+
 @patch('paasta_tools.cli.cmds.validate.os.path.isdir')
 @patch('paasta_tools.cli.cmds.validate.glob')
 def test_get_service_path_cwd(

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -44,10 +44,10 @@ def test_paasta_validate_calls_everything(
 ):
     # Ensure each check in 'paasta_validate' is called
 
-    mock_check_service_path.return_value = 0
+    mock_check_service_path.return_value = True
     mock_get_service_path.return_value = 'unused_path'
-    mock_validate_all_schemas.return_value = 0
-    mock_validate_chronos.return_value = 0
+    mock_validate_all_schemas.return_value = True
+    mock_validate_chronos.return_value = True
 
     args = mock.MagicMock()
     args.service = None
@@ -87,7 +87,7 @@ def test_validate_unknown_service():
 def test_validate_unknown_service_service_path():
     service_path = 'unused/path'
 
-    assert paasta_validate_soa_configs(service_path) == 1
+    assert not paasta_validate_soa_configs(service_path)
 
 
 @patch('paasta_tools.cli.cmds.validate.os.path.isdir')
@@ -165,7 +165,7 @@ main_http:
 """
     mock_get_file_contents.return_value = marathon_content
 
-    assert validate_schema('unused_service_path.yaml', 'marathon') == 0
+    assert validate_schema('unused_service_path.yaml', 'marathon')
 
     output = mock_stdout.getvalue()
 
@@ -186,7 +186,7 @@ def test_marathon_validate_schema_keys_outside_instance_blocks_bad(
     "page": false
 }
 """
-    assert validate_schema('unused_service_path.json', 'marathon') == 1
+    assert not validate_schema('unused_service_path.json', 'marathon')
 
     output = mock_stdout.getvalue()
 
@@ -206,7 +206,7 @@ def test_marathon_validate_invalid_key_bad(
     }
 }
 """
-    assert validate_schema('unused_service_path.json', 'marathon') == 1
+    assert not validate_schema('unused_service_path.json', 'marathon')
 
     output = mock_stdout.getvalue()
 
@@ -229,7 +229,7 @@ def test_chronos_validate_schema_list_hashes_good(
     }
 }
 """
-    assert validate_schema('unused_service_path.json', 'chronos') == 0
+    assert validate_schema('unused_service_path.json', 'chronos')
 
     output = mock_stdout.getvalue()
 
@@ -250,7 +250,7 @@ def test_chronos_validate_schema_keys_outside_instance_blocks_bad(
     "page": false
 }
 """
-    assert validate_schema('unused_service_path.json', 'chronos') == 1
+    assert not validate_schema('unused_service_path.json', 'chronos')
 
     output = mock_stdout.getvalue()
 
@@ -280,7 +280,7 @@ def test_failing_chronos_job_validate(
     mock_list_all_instances_for_service.return_value = [fake_instance]
     mock_load_chronos_job_config.return_value = mock_chronos_job
 
-    assert validate_chronos('fake_service_path') == 1
+    assert not validate_chronos('fake_service_path')
 
     output = mock_stdout.getvalue()
 
@@ -311,7 +311,7 @@ def test_validate_chronos_valid_instance(
     mock_list_all_instances_for_service.return_value = [fake_instance]
     mock_load_chronos_job_config.return_value = mock_chronos_job
 
-    assert validate_chronos('fake_service_path') == 0
+    assert validate_chronos('fake_service_path')
 
     output = mock_stdout.getvalue()
 
@@ -323,7 +323,7 @@ def test_check_service_path_none(
     mock_stdout
 ):
     service_path = None
-    assert check_service_path(service_path) == 1
+    assert not check_service_path(service_path)
 
     output = mock_stdout.getvalue()
     assert "%s is not a directory" % service_path in output
@@ -337,7 +337,7 @@ def test_check_service_path_empty(
 ):
     mock_isdir.return_value = True
     service_path = 'fake/path'
-    assert check_service_path(service_path) == 1
+    assert not check_service_path(service_path)
 
     output = mock_stdout.getvalue()
     assert "%s does not contain any .yaml files" % service_path in output
@@ -352,4 +352,4 @@ def test_check_service_path_good(
     mock_isdir.return_value = True
     mock_glob.return_value = True
     service_path = 'fake/path'
-    assert check_service_path(service_path) == 0
+    assert check_service_path(service_path)

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -18,8 +18,8 @@ import mock
 from mock import patch
 from pytest import raises
 
-from paasta_tools.cli.cmds.validate import get_schema
 from paasta_tools.cli.cmds.validate import check_service_path
+from paasta_tools.cli.cmds.validate import get_schema
 from paasta_tools.cli.cmds.validate import get_service_path
 from paasta_tools.cli.cmds.validate import invalid_chronos_instance
 from paasta_tools.cli.cmds.validate import paasta_validate


### PR DESCRIPTION
This will allow `paasta check` to notify users of additional errors with their service. It will catch things such as invalid yelpsoa config syntax (based on the jsonschemas) and invalid chronos schedules.

Closes #128 