### PR TITLE
Consider chronos*.yaml for deploy checks (Closes: #110)

### DIFF
--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -162,9 +162,12 @@ class PaastaCheckMessages:
 
     MARATHON_YAML_FOUND = success("Found marathon.yaml file.")
 
-    MARATHON_YAML_MISSING = failure(
-        "No marathon.yaml exists, so your service cannot be deployed.\n  "
-        "Push a marathon-[superregion].yaml and run `paasta generate-pipeline`.\n  "
+    CHRONOS_YAML_FOUND = success("Found chronos.yaml file.")
+
+    YAML_MISSING = failure(
+        "No marathon.yaml or chronos.yaml exists, so your service cannot be deployed.\n  "
+        "Push a marathon-[superregion].yaml or chronos-[superregion].yaml "
+        "and run `paasta generate-pipeline`.\n  "
         "More info:", "http://y/yelpsoa-configs")
 
     MAKEFILE_FOUND = success("A Makefile is present")


### PR DESCRIPTION
This will avoid `paasta check` message such as:

```
✗ There are some instance(s) in deploy.yaml that are not referenced
  by any marathon instance:
  cluster-name.batch-name, cluster-name2.batch-name
  You should probably delete these deploy.yaml entries if they are unused.
```

when there is a chronos-*.yaml file referencing the instance.

This change also will not show:

```
✗ No marathon.yaml exists, so your service cannot be deployed.
  Push a marathon-[superregion].yaml and run `paasta generate-pipeline`.
  More info: http://y/yelpsoa-configs
```

if a chronos.yaml file exists (and will show a more accurate message if neither yaml file exists).

Closes #110 