### PR TITLE
Allow users to set accepted_resource_roles in marathon yamls.

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -312,6 +312,11 @@ class MarathonServiceConfig(InstanceConfig):
             'cmd': self.get_cmd(),
             'args': self.get_args(),
         }
+
+        accepted_resource_roles = self.get_accepted_resource_roles()
+        if accepted_resource_roles is not None:
+            complete_config['accepted_resource_roles'] = accepted_resource_roles
+
         log.debug("Complete configuration for instance is: %s", complete_config)
         return complete_config
 
@@ -429,6 +434,9 @@ class MarathonServiceConfig(InstanceConfig):
         if service_namespace_config.is_in_smartstack():
             default = {'check_haproxy': True}
         return self.config_dict.get('bounce_health_params', default)
+
+    def get_accepted_resource_roles(self):
+        return self.config_dict.get('accepted_resource_roles', None)
 
 
 def load_service_namespace_config(service, namespace, soa_dir=DEFAULT_SOA_DIR):

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -820,6 +820,7 @@ class TestMarathonTools:
             'health_checks': fake_healthchecks,
             'backoff_factor': 2,
             'backoff_seconds': mock.ANY,
+            'accepted_resource_roles': ['ads'],
         }
         config = marathon_tools.MarathonServiceConfig(
             'can_you_dig_it',
@@ -835,6 +836,7 @@ class TestMarathonTools:
                 'healthcheck_interval_seconds':  10,
                 'healthcheck_timeout_seconds':  10,
                 'healthcheck_max_consecutive_failures': 3,
+                'accepted_resource_roles': ['ads'],
             },
             {'desired_state': 'start'}
         )
@@ -1579,6 +1581,16 @@ class TestMarathonServiceConfig(object):
         marathon_config = marathon_tools.MarathonServiceConfig(
             "service", "instance", {'instances': 0}, {})
         assert marathon_config.get_backoff_seconds() == 1
+
+    def test_get_accepted_resource_roles_default(self):
+        marathon_config = marathon_tools.MarathonServiceConfig(
+            "service", "instance", {}, {})
+        assert marathon_config.get_accepted_resource_roles() is None
+
+    def test_get_accepted_resource_roles(self):
+        marathon_config = marathon_tools.MarathonServiceConfig(
+            "service", "instance", {"accepted_resource_roles": ["ads"]}, {})
+        assert marathon_config.get_accepted_resource_roles() == ["ads"]
 
 
 class TestServiceNamespaceConfig(object):


### PR DESCRIPTION
internal ticket PAASTA-2455.

This passes the `accepted_resource_roles` parameter through marathon.yaml into the marathon config, allowing for apps to be deployed to dedicated hardware.
