### PR TITLE
made InstanceConfig take service, cluster and instance as args

### DIFF
--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -73,9 +73,12 @@ def step_impl_when(context):
                    return_value=context.test_git_repo_dir),
         mock.patch('paasta_tools.generate_deployments_for_service.parse_args',
                    autospec=True, return_value=fake_args),
+        mock.patch('paasta_tools.generate_deployments_for_service.get_branches_for_service', autospec=True,
+                   return_value=['paasta-test_cluster.test_instance']),
     ) as (
         mock_get_git_url,
         mock_parse_args,
+        mock_get_branches_for_service,
     ):
         generate_deployments_for_service.main()
 

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -23,13 +23,15 @@ from paasta_tools import setup_marathon_job
 from paasta_tools import marathon_tools
 
 fake_service_name = 'fake_complete_service'
+fake_cluster_name = 'fake_cluster'
 fake_instance_name = 'fake_instance'
 fake_appid = 'fake--complete--service.fake--instance.gitdeadbeef.configdeadbeef2'
 fake_service_marathon_config = marathon_tools.MarathonServiceConfig(
-    fake_service_name,
-    fake_instance_name,
-    {},
-    {'docker_image': 'test-image'},
+    service=fake_service_name,
+    cluster=fake_cluster_name,
+    instance=fake_instance_name,
+    config_dict={},
+    branch_dict={'docker_image': 'test-image'},
 )
 fake_service_config = {
     'id': fake_appid,

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -159,21 +159,29 @@ def load_chronos_job_config(service, instance, cluster, load_deployments=True, s
         deployments_json = load_deployments_json(service, soa_dir=soa_dir)
         branch = get_paasta_branch(cluster=cluster, instance=instance)
         branch_dict = deployments_json.get_branch_dict(service, branch)
-    return ChronosJobConfig(service, instance, service_chronos_jobs[instance], branch_dict)
+    return ChronosJobConfig(
+        service=service,
+        cluster=cluster,
+        instance=instance,
+        config_dict=service_chronos_jobs[instance],
+        branch_dict=branch_dict,
+    )
 
 
 class ChronosJobConfig(InstanceConfig):
 
-    def __init__(self, service, job_name, config_dict, branch_dict):
-        super(ChronosJobConfig, self).__init__(config_dict, branch_dict)
-        self.service = service
-        self.job_name = job_name
-        self.config_dict = config_dict
-        self.branch_dict = branch_dict
+    def __init__(self, service, instance, cluster, config_dict, branch_dict):
+        super(ChronosJobConfig, self).__init__(
+            cluster=cluster,
+            instance=instance,
+            service=service,
+            config_dict=config_dict,
+            branch_dict=branch_dict,
+        )
 
     def __eq__(self, other):
         return ((self.service == other.service)
-                and (self.job_name == other.job_name)
+                and (self.get_job_name() == other.get_job_name())
                 and (self.config_dict == other.config_dict)
                 and (self.branch_dict == other.branch_dict))
 
@@ -181,7 +189,7 @@ class ChronosJobConfig(InstanceConfig):
         return self.service
 
     def get_job_name(self):
-        return self.job_name
+        return self.instance
 
     def get_cmd(self):
         original_cmd = super(ChronosJobConfig, self).get_cmd()

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -151,10 +151,11 @@ def load_marathon_service_config(service, instance, cluster, load_deployments=Tr
         branch_dict = deployments_json.get_branch_dict(service, branch)
 
     return MarathonServiceConfig(
-        service,
-        instance,
-        general_config,
-        branch_dict,
+        service=service,
+        cluster=cluster,
+        instance=instance,
+        config_dict=general_config,
+        branch_dict=branch_dict,
     )
 
 
@@ -164,16 +165,19 @@ class InvalidMarathonConfig(Exception):
 
 class MarathonServiceConfig(InstanceConfig):
 
-    def __init__(self, service, instance, config_dict, branch_dict):
-        super(MarathonServiceConfig, self).__init__(config_dict, branch_dict)
-        self.service = service
-        self.instance = instance
-        self.config_dict = config_dict
-        self.branch_dict = branch_dict
+    def __init__(self, service, cluster, instance, config_dict, branch_dict):
+        super(MarathonServiceConfig, self).__init__(
+            cluster=cluster,
+            instance=instance,
+            service=service,
+            config_dict=config_dict,
+            branch_dict=branch_dict,
+        )
 
     def __repr__(self):
-        return "MarathonServiceConfig(%r, %r, %r, %r)" % (
+        return "MarathonServiceConfig(%r, %r, %r, %r, %r)" % (
             self.service,
+            self.cluster,
             self.instance,
             self.config_dict,
             self.branch_dict

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -84,6 +84,9 @@ class InstanceConfig(dict):
     def get_service(self):
         return self.service
 
+    def get_deploy_group(self):
+        return self.config_dict.get('deploy_group', '.'.join((self.get_cluster(), self.get_instance())))
+
     def get_mem(self):
         """Gets the memory required from the service's configuration.
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -68,9 +68,21 @@ class InvalidInstanceConfig(Exception):
 
 class InstanceConfig(dict):
 
-    def __init__(self, config_dict, branch_dict):
+    def __init__(self, cluster, instance, service, config_dict, branch_dict):
         self.config_dict = config_dict
         self.branch_dict = branch_dict
+        self.cluster = cluster
+        self.instance = instance
+        self.service = service
+
+    def get_cluster(self):
+        return self.cluster
+
+    def get_instance(self):
+        return self.instance
+
+    def get_service(self):
+        return self.service
 
     def get_mem(self):
         """Gets the memory required from the service's configuration.

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -822,9 +822,15 @@ def test_simulate_healthcheck_on_service_disabled(mock_sleep):
 @mock.patch('paasta_tools.cli.cmds.local_run.run_healthcheck_on_container', autospec=True)
 def test_simulate_healthcheck_on_service_enabled_success(mock_run_healthcheck_on_container, mock_sleep):
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)
-    mock_service_manifest = MarathonServiceConfig('fake_name', 'fake_instance', {
-        'healthcheck_grace_period_seconds': 0,
-    }, {})
+    mock_service_manifest = MarathonServiceConfig(
+        service='fake_name',
+        cluster='fake_cluster',
+        instance='fake_instance',
+        config_dict={
+            'healthcheck_grace_period_seconds': 0,
+        },
+        branch_dict={},
+    )
     fake_container_id = 'fake_container_id'
     fake_mode = 'http'
     fake_url = 'http://fake_host/fake_status_path'
@@ -837,9 +843,15 @@ def test_simulate_healthcheck_on_service_enabled_success(mock_run_healthcheck_on
 @mock.patch('paasta_tools.cli.cmds.local_run.run_healthcheck_on_container', autospec=True)
 def test_simulate_healthcheck_on_service_enabled_failure(mock_run_healthcheck_on_container, mock_sleep):
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)
-    mock_service_manifest = MarathonServiceConfig('fake_name', 'fake_instance', {
-        'healthcheck_grace_period_seconds': 0,
-    }, {})
+    mock_service_manifest = MarathonServiceConfig(
+        service='fake_name',
+        cluster='fake_cluster',
+        instance='fake_instance',
+        config_dict={
+            'healthcheck_grace_period_seconds': 0,
+        },
+        branch_dict={},
+    )
     mock_service_manifest
 
     fake_container_id = 'fake_container_id'
@@ -855,9 +867,15 @@ def test_simulate_healthcheck_on_service_enabled_failure(mock_run_healthcheck_on
             autospec=True, side_effect=[False, False, False, False, True])
 def test_simulate_healthcheck_on_service_enabled_partial_failure(mock_run_healthcheck_on_container, mock_sleep):
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)
-    mock_service_manifest = MarathonServiceConfig('fake_name', 'fake_instance', {
-        'healthcheck_grace_period_seconds': 0,
-    }, {})
+    mock_service_manifest = MarathonServiceConfig(
+        service='fake_name',
+        cluster='fake_cluster',
+        instance='fake_instance',
+        config_dict={
+            'healthcheck_grace_period_seconds': 0,
+        },
+        branch_dict={},
+    )
 
     fake_container_id = 'fake_container_id'
     fake_mode = 'http'
@@ -881,9 +899,15 @@ def test_simulate_healthcheck_on_service_enabled_during_grace_period(
     # prevent grace period from ending
     mock_time.side_effect = [0, 0]
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)
-    mock_service_manifest = MarathonServiceConfig('fake_name', 'fake_instance', {
-        'healthcheck_grace_period_seconds': 1,
-    }, {})
+    mock_service_manifest = MarathonServiceConfig(
+        service='fake_name',
+        cluster='fake_cluster',
+        instance='fake_instance',
+        config_dict={
+            'healthcheck_grace_period_seconds': 1,
+        },
+        branch_dict={},
+    )
 
     fake_container_id = 'fake_container_id'
     fake_mode = 'http'
@@ -907,10 +931,16 @@ def test_simulate_healthcheck_on_service_enabled_honors_grace_period(
     # change time to make sure we are sufficiently past grace period
     mock_time.side_effect = [0, 2]
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)
-    mock_service_manifest = MarathonServiceConfig('fake_name', 'fake_instance', {
-        # only one healthcheck will be performed silently
-        'healthcheck_grace_period_seconds': 1,
-    }, {})
+    mock_service_manifest = MarathonServiceConfig(
+        service='fake_name',
+        cluster='fake_cluster',
+        instance='fake_instance',
+        config_dict={
+            # only one healthcheck will be performed silently
+            'healthcheck_grace_period_seconds': 1,
+        },
+        branch_dict={},
+    )
 
     fake_container_id = 'fake_container_id'
     fake_mode = 'http'

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -46,10 +46,12 @@ class TestChronosTools:
         'desired_state': 'start',
         'docker_image': 'paasta-%s-%s' % (fake_service, fake_cluster),
     }
-    fake_chronos_job_config = chronos_tools.ChronosJobConfig(fake_service,
-                                                             fake_job_name,
-                                                             fake_config_dict,
-                                                             fake_branch_dict)
+    fake_chronos_job_config = chronos_tools.ChronosJobConfig(service=fake_service,
+                                                             cluster=fake_cluster,
+                                                             instance=fake_job_name,
+                                                             config_dict=fake_config_dict,
+                                                             branch_dict=fake_branch_dict,
+                                                             )
 
     fake_invalid_config_dict = {
         'bounce_method': 'crossover',
@@ -62,10 +64,12 @@ class TestChronosTools:
         'schedule': 'forever/now/5 min',
         'schedule_time_zone': '+0200',
     }
-    fake_invalid_chronos_job_config = chronos_tools.ChronosJobConfig(fake_service,
-                                                                     fake_job_name,
-                                                                     fake_invalid_config_dict,
-                                                                     fake_branch_dict)
+    fake_invalid_chronos_job_config = chronos_tools.ChronosJobConfig(service=fake_service,
+                                                                     cluster=fake_cluster,
+                                                                     instance=fake_job_name,
+                                                                     config_dict=fake_invalid_config_dict,
+                                                                     branch_dict=fake_branch_dict,
+                                                                     )
     fake_config_file = {
         fake_job_name: fake_config_dict,
         'bad_job': fake_invalid_config_dict,
@@ -248,7 +252,13 @@ class TestChronosTools:
         assert actual == expected
 
     def test_get_bounce_method_default(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         actual = fake_conf.get_bounce_method()
         assert actual == 'graceful'
 
@@ -258,13 +268,27 @@ class TestChronosTools:
         assert actual == expected
 
     def test_get_epsilon_default(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         actual = fake_conf.get_epsilon()
         assert actual == 'PT60S'
 
     def test_get_epsilon(self):
         fake_epsilon = 'fake_epsilon'
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {'epsilon': fake_epsilon}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={
+                'epsilon': fake_epsilon,
+            },
+            branch_dict={},
+        )
         actual = fake_conf.get_epsilon()
         assert actual == fake_epsilon
 
@@ -297,7 +321,12 @@ class TestChronosTools:
             'chronos_tools.parse_time_variables', autospec=True, return_value=expected
                 ) as mock_parse_time_variables:
             fake_chronos_job_config = chronos_tools.ChronosJobConfig(
-                'fake_service', 'fake_job', fake_config_dict, {})
+                service='fake_service',
+                cluster='fake_cluster',
+                instance='fake_job',
+                config_dict=fake_config_dict,
+                branch_dict={},
+            )
             actual = fake_chronos_job_config.get_cmd()
             mock_parse_time_variables.assert_called_once_with(fake_cmd)
         assert actual == expected
@@ -310,12 +339,24 @@ class TestChronosTools:
             assert actual == fake_owner
 
     def test_get_shell_without_args_specified(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {'args': ['a', 'b']}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'args': ['a', 'b']},
+            branch_dict={},
+        )
         actual = fake_conf.get_shell()
         assert actual is False
 
     def test_get_shell_when_args_present(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_shell() is True
 
     def test_get_env(self):
@@ -324,80 +365,160 @@ class TestChronosTools:
             {"name": "foo", "value": "bar"},
             {"name": "biz", "value": "baz"},
         ]
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {'env': input_env}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'env': input_env},
+            branch_dict={},
+        )
         assert sorted(fake_conf.get_env()) == sorted(expected_env)
 
     def test_get_constraints(self):
         fake_constraints = 'fake_constraints'
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {'constraints': fake_constraints}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'constraints': fake_constraints},
+            branch_dict={},
+        )
         actual = fake_conf.get_constraints()
         assert actual == fake_constraints
 
     def test_get_retries_default(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         actual = fake_conf.get_retries()
         assert actual == 2
 
     def test_get_retries(self):
         fake_retries = 'fake_retries'
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {'retries': fake_retries}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'retries': fake_retries},
+            branch_dict={},
+        )
         actual = fake_conf.get_retries()
         assert actual == fake_retries
 
     def test_get_disabled_default(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         actual = fake_conf.get_disabled()
         assert not actual
 
     def test_get_disabled(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {'disabled': True}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'disabled': True},
+            branch_dict={},
+        )
         actual = fake_conf.get_disabled()
         assert actual
 
     def test_get_schedule(self):
         fake_schedule = 'fake_schedule'
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {'schedule': fake_schedule}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'schedule': fake_schedule},
+            branch_dict={},
+        )
         actual = fake_conf.get_schedule()
         assert actual == fake_schedule
 
     def test_get_schedule_time_zone(self):
         fake_schedule_time_zone = 'fake_schedule_time_zone'
         fake_conf = chronos_tools.ChronosJobConfig(
-            'fake_name', 'fake_instance', {'schedule_time_zone': fake_schedule_time_zone}, {})
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'schedule_time_zone': fake_schedule_time_zone},
+            branch_dict={},
+        )
         actual = fake_conf.get_schedule_time_zone()
         assert actual == fake_schedule_time_zone
 
     def test_get_parents_ok(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {'parents': None}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'parents': None},
+            branch_dict={},
+        )
         assert fake_conf.get_parents() is None
 
     def test_get_parents_bad(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {'parents': ['my-parent']}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'parents': ['my-parent']},
+            branch_dict={},
+        )
         assert fake_conf.get_parents() == ['my-parent']
 
     def test_check_parents_none(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance', {'parents': None}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'parents': None},
+            branch_dict={},
+        )
         okay, msg = fake_conf.check_parents()
         assert okay is True
         assert msg == ''
 
     def test_check_parents_all_ok(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance',
-                                                   {'parents': ['service1.instance1', 'service1.instance2']}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'parents': ['service1.instance1', 'service1.instance2']},
+            branch_dict={},
+        )
         okay, msg = fake_conf.check_parents()
         assert okay is True
         assert msg == ''
 
     def test_check_parents_one_bad(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance',
-                                                   {'parents': ['service1.instance1', 'service1-instance1']}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'parents': ['service1.instance1', 'service1-instance1']},
+            branch_dict={},
+        )
         okay, msg = fake_conf.check_parents()
         assert okay is False
         assert msg == 'The job name(s) service1-instance1 is not formatted correctly: expected service.instance'
 
     def test_check_parents_all_bad(self):
-        fake_conf = chronos_tools.ChronosJobConfig('fake_name', 'fake_instance',
-                                                   {'parents': ['service1-instance1', 'service1-instance2']}, {})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'parents': ['service1-instance1', 'service1-instance2']},
+            branch_dict={},
+        )
         okay, msg = fake_conf.check_parents()
         assert okay is False
         assert msg == ('The job name(s) service1-instance1, service1-instance2'
@@ -483,7 +604,13 @@ class TestChronosTools:
 
     def test_check_schedule_invalid_empty_start_time(self):
         fake_schedule = 'R10//PT70S'
-        chronos_config = chronos_tools.ChronosJobConfig('', '', {'schedule': fake_schedule}, {})
+        chronos_config = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'schedule': fake_schedule},
+            branch_dict={},
+        )
         okay, msg = chronos_config.check_schedule()
         assert okay is False
         assert msg == 'The specified schedule "%s" does not contain a start time' % fake_schedule
@@ -491,7 +618,13 @@ class TestChronosTools:
     def test_check_schedule_invalid_start_time_no_t_designator(self):
         fake_start_time = 'now'
         fake_schedule = 'R10/%s/PT70S' % fake_start_time
-        chronos_config = chronos_tools.ChronosJobConfig('', '', {'schedule': fake_schedule}, {})
+        chronos_config = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'schedule': fake_schedule},
+            branch_dict={},
+        )
         fake_isodate_exception = 'ISO 8601 time designator \'T\' missing. Unable to parse datetime string \'now\''
         okay, msg = chronos_config.check_schedule()
         assert okay is False
@@ -501,7 +634,13 @@ class TestChronosTools:
     def test_check_schedule_invalid_start_time_bad_date(self):
         fake_start_time = 'todayT19:20:30Z'
         fake_schedule = 'R10/%s/PT70S' % fake_start_time
-        chronos_config = chronos_tools.ChronosJobConfig('', '', {'schedule': fake_schedule}, {})
+        chronos_config = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'schedule': fake_schedule},
+            branch_dict={},
+        )
         fake_isodate_exception = 'Unrecognised ISO 8601 date format: \'today\''
         okay, msg = chronos_config.check_schedule()
         assert okay is False
@@ -511,7 +650,13 @@ class TestChronosTools:
     def test_check_schedule_invalid_start_time_bad_time(self):
         fake_start_time = '1994-02-18Tmorning'
         fake_schedule = 'R10/%s/PT70S' % fake_start_time
-        chronos_config = chronos_tools.ChronosJobConfig('', '', {'schedule': fake_schedule}, {})
+        chronos_config = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'schedule': fake_schedule},
+            branch_dict={},
+        )
         fake_isodate_exception = 'Unrecognised ISO 8601 time format: \'morning\''
         okay, msg = chronos_config.check_schedule()
         assert okay is False
@@ -520,7 +665,13 @@ class TestChronosTools:
 
     def test_check_schedule_invalid_empty_interval(self):
         fake_schedule = 'R10/2015-03-25T19:36:35Z/'
-        chronos_config = chronos_tools.ChronosJobConfig('', '', {'schedule': fake_schedule}, {})
+        chronos_config = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'schedule': fake_schedule},
+            branch_dict={},
+        )
         okay, msg = chronos_config.check_schedule()
         assert okay is False
         assert msg == ('The specified interval "" in schedule "%s" does not conform to the ISO 8601 format.'
@@ -528,7 +679,13 @@ class TestChronosTools:
 
     def test_check_schedule_invalid_interval(self):
         fake_schedule = 'R10/2015-03-25T19:36:35Z/Mondays'
-        chronos_config = chronos_tools.ChronosJobConfig('', '', {'schedule': fake_schedule}, {})
+        chronos_config = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'schedule': fake_schedule},
+            branch_dict={},
+        )
         okay, msg = chronos_config.check_schedule()
         assert okay is False
         assert msg == ('The specified interval "Mondays" in schedule "%s" does not conform to the ISO 8601 format.'
@@ -536,14 +693,26 @@ class TestChronosTools:
 
     def test_check_schedule_low_interval(self):
         fake_schedule = 'R10/2015-03-25T19:36:35Z/PT10S'
-        chronos_config = chronos_tools.ChronosJobConfig('', '', {'schedule': fake_schedule}, {})
+        chronos_config = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'schedule': fake_schedule},
+            branch_dict={},
+        )
         okay, msg = chronos_config.check_schedule()
         assert okay is False
         assert msg == 'Unsupported interval "PT10S": jobs must be run at an interval of > 60 seconds'
 
     def test_check_schedule_invalid_empty_repeat(self):
         fake_schedule = '/2015-03-25T19:36:35Z/PT70S'
-        chronos_config = chronos_tools.ChronosJobConfig('', '', {'schedule': fake_schedule}, {})
+        chronos_config = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'schedule': fake_schedule},
+            branch_dict={},
+        )
         okay, msg = chronos_config.check_schedule()
         assert okay is False
         assert msg == ('The specified repeat "" in schedule "%s" does not conform to the ISO 8601 format.'
@@ -551,7 +720,13 @@ class TestChronosTools:
 
     def test_check_schedule_invalid_repeat(self):
         fake_schedule = 'forever/2015-03-25T19:36:35Z/PT70S'
-        chronos_config = chronos_tools.ChronosJobConfig('', '', {'schedule': fake_schedule}, {})
+        chronos_config = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'schedule': fake_schedule},
+            branch_dict={},
+        )
         okay, msg = chronos_config.check_schedule()
         assert okay is False
         assert msg == ('The specified repeat "forever" in schedule "%s" does not conform to the ISO 8601 format.'
@@ -563,7 +738,13 @@ class TestChronosTools:
         assert msg == ''
 
     def test_check_schedule_time_zone_valid_empty(self):
-        chronos_config = chronos_tools.ChronosJobConfig('', '', {'schedule_time_zone': ''}, {})
+        chronos_config = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'schedule_time_zone': ''},
+            branch_dict={},
+        )
         okay, msg = chronos_config.check_schedule_time_zone()
         assert okay is True
         assert msg == ''
@@ -576,11 +757,23 @@ class TestChronosTools:
         # assert msg == 'The specified time zone "+0200" does not conform to the tz database format.'
 
     def test_get_desired_state_human_when_stopped(self):
-        fake_conf = chronos_tools.ChronosJobConfig('', '', {}, {'desired_state': 'stop'})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={},
+            branch_dict={'desired_state': 'stop'},
+        )
         assert 'Disabled' in fake_conf.get_desired_state_human()
 
     def test_get_desired_state_human_with_started(self):
-        fake_conf = chronos_tools.ChronosJobConfig('', '', {}, {'desired_state': 'start'})
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={},
+            branch_dict={'desired_state': 'start'},
+        )
         assert 'Scheduled' in fake_conf.get_desired_state_human()
 
     def test_check_param_with_check(self):
@@ -619,14 +812,15 @@ class TestChronosTools:
         fake_docker_volumes = ['fake_docker_volume']
 
         chronos_job_config = chronos_tools.ChronosJobConfig(
-            fake_service,
-            fake_job_name,
-            {
+            service=fake_service,
+            cluster='',
+            instance=fake_job_name,
+            config_dict={
                 'cmd': fake_command,
                 'schedule': fake_schedule,
                 'epsilon': 'PT60S',
             },
-            {}
+            branch_dict={},
         )
         expected = {
             'name': fake_job_name,
@@ -663,14 +857,15 @@ class TestChronosTools:
         fake_command = 'echo foo >> /tmp/test_service_log'
         fake_schedule = 'fake_bad_schedule'
         invalid_config = chronos_tools.ChronosJobConfig(
-            fake_service,
-            fake_job_name,
-            {
+            service=fake_service,
+            cluster='',
+            instance=fake_job_name,
+            config_dict={
                 'cmd': fake_command,
                 'schedule': fake_schedule,
                 'epsilon': 'PT60S',
             },
-            {}
+            branch_dict={},
         )
         with raises(chronos_tools.InvalidChronosConfigError) as exc:
             invalid_config.format_chronos_job_dict('', [])
@@ -994,13 +1189,14 @@ class TestChronosTools:
     def test_create_complete_config_desired_state_start(self):
         fake_owner = 'test_team'
         fake_chronos_job_config = chronos_tools.ChronosJobConfig(
-            self.fake_service,
-            self.fake_job_name,
-            self.fake_config_dict,
-            {
+            service=self.fake_service,
+            cluster='',
+            instance=self.fake_job_name,
+            config_dict=self.fake_config_dict,
+            branch_dict={
                 'desired_state': 'start',
                 'docker_image': 'fake_image'
-            }
+            },
         )
         with contextlib.nested(
             mock.patch('chronos_tools.load_system_paasta_config', autospec=True),
@@ -1048,13 +1244,14 @@ class TestChronosTools:
     def test_create_complete_config_desired_state_stop(self):
         fake_owner = 'test@test.com'
         fake_chronos_job_config = chronos_tools.ChronosJobConfig(
-            self.fake_service,
-            self.fake_job_name,
-            self.fake_config_dict,
-            {
+            service=self.fake_service,
+            cluster='',
+            instance=self.fake_job_name,
+            config_dict=self.fake_config_dict,
+            branch_dict={
                 'desired_state': 'stop',
                 'docker_image': 'fake_image'
-            }
+            },
         )
         with contextlib.nested(
             mock.patch('chronos_tools.load_system_paasta_config', autospec=True),
@@ -1118,13 +1315,14 @@ class TestChronosTools:
         fake_instance_config = self.fake_config_dict
         fake_instance_config['extra_volumes'] = fake_extra_volumes
         fake_chronos_job_config = chronos_tools.ChronosJobConfig(
-            self.fake_service,
-            self.fake_job_name,
-            fake_instance_config,
-            {
+            service=self.fake_service,
+            cluster='',
+            instance=self.fake_job_name,
+            config_dict=fake_instance_config,
+            branch_dict={
                 'desired_state': 'stop',
                 'docker_image': 'fake_image'
-            }
+            },
         )
         with contextlib.nested(
             mock.patch('chronos_tools.load_system_paasta_config', autospec=True),

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -30,19 +30,20 @@ from paasta_tools.utils import PaastaColors
 
 
 fake_marathon_job_config = marathon_tools.MarathonServiceConfig(
-    'servicename',
-    'instancename',
-    {
+    service='servicename',
+    cluster='clustername',
+    instance='instancename',
+    config_dict={
         'instances': 3,
         'cpus': 1,
         'mem': 100,
         'nerve_ns': 'fake_nerve_ns',
     },
-    {
+    branch_dict={
         'docker_image': 'test_docker:1.0',
         'desired_state': 'start',
         'force_bounce': None,
-    }
+    },
 )
 
 
@@ -86,10 +87,11 @@ def test_get_bouncing_status():
     ):
         mock_get_matching_appids.return_value = ['a', 'b']
         mock_config = marathon_tools.MarathonServiceConfig(
-            'fake_service',
-            'fake_instance',
-            {'bounce_method': 'fake_bounce'},
-            {},
+            service='fake_service',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'bounce_method': 'fake_bounce'},
+            branch_dict={},
         )
         actual = marathon_serviceinit.get_bouncing_status('fake_service', 'fake_instance', 'unused', mock_config)
         assert 'fake_bounce' in actual

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -28,19 +28,20 @@ from utils import SystemPaastaConfig
 class TestMarathonTools:
 
     fake_marathon_app_config = marathon_tools.MarathonServiceConfig(
-        'servicename',
-        'instancename',
-        {
+        service='servicename',
+        cluster='clustername',
+        instance='instancename',
+        config_dict={
             'instances': 3,
             'cpus': 1,
             'mem': 100,
             'nerve_ns': 'fake_nerve_ns',
         },
-        {
+        branch_dict={
             'docker_image': 'test_docker:1.0',
             'desired_state': 'start',
             'force_bounce': None,
-        }
+        },
     )
     fake_srv_config = {
         'data': {},
@@ -131,13 +132,14 @@ class TestMarathonTools:
         config_copy = self.fake_marathon_app_config.config_dict.copy()
 
         expected = marathon_tools.MarathonServiceConfig(
-            fake_name,
-            fake_instance,
-            dict(
+            service=fake_name,
+            cluster='',
+            instance=fake_instance,
+            config_dict=dict(
                 self.fake_srv_config.items() +
                 self.fake_marathon_app_config.config_dict.items()
             ),
-            {},
+            branch_dict={},
         )
 
         with contextlib.nested(
@@ -208,13 +210,14 @@ class TestMarathonTools:
             load_deployments_json_patch,
         ):
             expected = marathon_tools.MarathonServiceConfig(
-                fake_name,
-                fake_instance,
-                dict(
+                service=fake_name,
+                cluster='',
+                instance=fake_instance,
+                config_dict=dict(
                     self.fake_srv_config.items() +
                     self.fake_marathon_app_config.config_dict.items()
                 ),
-                fake_branch_dict,
+                branch_dict=fake_branch_dict,
             )
             actual = marathon_tools.load_marathon_service_config(
                 fake_name,
@@ -823,9 +826,10 @@ class TestMarathonTools:
             'accepted_resource_roles': ['ads'],
         }
         config = marathon_tools.MarathonServiceConfig(
-            'can_you_dig_it',
-            'yes_i_can',
-            {
+            service='can_you_dig_it',
+            cluster='',
+            instance='yes_i_can',
+            config_dict={
                 'env': fake_env,
                 'mem': fake_mem,
                 'cpus': fake_cpus,
@@ -838,7 +842,7 @@ class TestMarathonTools:
                 'healthcheck_max_consecutive_failures': 3,
                 'accepted_resource_roles': ['ads'],
             },
-            {'desired_state': 'start'}
+            branch_dict={'desired_state': 'start'}
         )
 
         with mock.patch('marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True) as get_slaves_patch:
@@ -852,102 +856,184 @@ class TestMarathonTools:
 
     def test_instances_is_zero_when_desired_state_is_stop(self):
         fake_conf = marathon_tools.MarathonServiceConfig(
-            'fake_name',
-            'fake_instance',
-            {'instances': 10},
-            {'desired_state': 'stop'},
+            service='fake_name',
+            cluster='',
+            instance='fake_instance',
+            config_dict={'instances': 10},
+            branch_dict={'desired_state': 'stop'},
         )
         assert fake_conf.get_instances() == 0
 
     def test_get_bounce_method_in_config(self):
-        fake_conf = marathon_tools.MarathonServiceConfig('fake_name', 'fake_instance', {'bounce_method': 'aaargh'}, {})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='',
+            instance='fake_instance',
+            config_dict={'bounce_method': 'aaargh'},
+            branch_dict={})
         assert fake_conf.get_bounce_method() == 'aaargh'
 
     def test_get_bounce_method_default(self):
-        fake_conf = marathon_tools.MarathonServiceConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_bounce_method() == 'crossover'
 
     def test_get_bounce_health_params_in_config(self):
         fake_param = 'fake_param'
         fake_conf = marathon_tools.MarathonServiceConfig(
-            'fake_name', 'fake_instance', {'bounce_health_params': fake_param}, {})
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'bounce_health_params': fake_param},
+            branch_dict={},
+        )
         assert fake_conf.get_bounce_health_params(mock.Mock()) == fake_param
 
     def test_get_bounce_health_params_default_when_not_in_smartstack(self):
         fake_service_namespace_config = mock.Mock(is_in_smartstack=mock.Mock(return_value=False))
-        fake_conf = marathon_tools.MarathonServiceConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_bounce_health_params(fake_service_namespace_config) == {}
 
     def test_get_bounce_health_params_default_when_in_smartstack(self):
         fake_service_namespace_config = mock.Mock(is_in_smartstack=mock.Mock(return_value=True))
-        fake_conf = marathon_tools.MarathonServiceConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_bounce_health_params(fake_service_namespace_config) == {'check_haproxy': True}
 
     def test_get_drain_method_in_config(self):
         fake_param = 'fake_param'
         fake_conf = marathon_tools.MarathonServiceConfig(
-            'fake_name', 'fake_instance', {'drain_method': fake_param}, {})
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'drain_method': fake_param},
+            branch_dict={},
+        )
         assert fake_conf.get_drain_method(mock.Mock()) == fake_param
 
     def test_get_drain_method_default_when_not_in_smartstack(self):
         fake_service_namespace_config = mock.Mock(is_in_smartstack=mock.Mock(return_value=False))
-        fake_conf = marathon_tools.MarathonServiceConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_drain_method(fake_service_namespace_config) == 'noop'
 
     def test_get_drain_method_default_when_in_smartstack(self):
         fake_service_namespace_config = mock.Mock(is_in_smartstack=mock.Mock(return_value=True))
-        fake_conf = marathon_tools.MarathonServiceConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_drain_method(fake_service_namespace_config) == 'hacheck'
 
     def test_get_drain_method_params_in_config(self):
         fake_param = 'fake_param'
         fake_conf = marathon_tools.MarathonServiceConfig(
-            'fake_name', 'fake_instance', {'drain_method_params': fake_param}, {})
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'drain_method_params': fake_param},
+            branch_dict={},
+        )
         assert fake_conf.get_drain_method_params(mock.Mock()) == fake_param
 
     def test_get_drain_method_params_default_when_not_in_smartstack(self):
         fake_service_namespace_config = mock.Mock(is_in_smartstack=mock.Mock(return_value=False))
-        fake_conf = marathon_tools.MarathonServiceConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_drain_method_params(fake_service_namespace_config) == {}
 
     def test_get_drain_method_params_default_when_in_smartstack(self):
         fake_service_namespace_config = mock.Mock(is_in_smartstack=mock.Mock(return_value=True))
-        fake_conf = marathon_tools.MarathonServiceConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_drain_method_params(fake_service_namespace_config) == {'delay': 30}
 
     def test_get_instances_in_config(self):
         fake_conf = marathon_tools.MarathonServiceConfig(
-            'fake_name',
-            'fake_instance',
-            {'instances': -10},
-            {'desired_state': 'start'},
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'instances': -10},
+            branch_dict={'desired_state': 'start'},
         )
         assert fake_conf.get_instances() == -10
 
     def test_get_instances_default(self):
-        fake_conf = marathon_tools.MarathonServiceConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_instances() == 1
 
     def test_get_instances_respects_false(self):
         fake_conf = marathon_tools.MarathonServiceConfig(
-            'fake_name',
-            'fake_instance',
-            {'instances': False},
-            {'desired_state': 'start'},
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'instances': False},
+            branch_dict={'desired_state': 'start'},
         )
         assert fake_conf.get_instances() == 0
 
     def test_get_constraints_in_config(self):
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
-        fake_conf = marathon_tools.MarathonServiceConfig('fake_name', 'fake_instance', {'constraints': 'so_many_walls'},
-                                                         {})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'constraints': 'so_many_walls'},
+            branch_dict={},
+        )
         with mock.patch('marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True) as get_slaves_patch:
             assert fake_conf.get_constraints(fake_service_namespace_config) == 'so_many_walls'
             assert get_slaves_patch.call_count == 0
 
     def test_get_constraints_default(self):
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
-        fake_conf = marathon_tools.MarathonServiceConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         with mock.patch('marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True) as get_slaves_patch:
             get_slaves_patch.return_value = {'fake_region': {}}
             assert fake_conf.get_constraints(fake_service_namespace_config) == [["region", "GROUP_BY", "1"]]
@@ -958,7 +1044,13 @@ class TestMarathonTools:
             'healthcheck_uri': '/status',
             'discover': 'habitat',
         })
-        fake_conf = marathon_tools.MarathonServiceConfig('fake_name', 'fake_instance', {}, {})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
         with mock.patch('marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True) as get_slaves_patch:
             get_slaves_patch.return_value = {'fake_region': {}, 'fake_other_region': {}}
             assert fake_conf.get_constraints(fake_service_namespace_config) == [["habitat", "GROUP_BY", "2"]]
@@ -967,8 +1059,13 @@ class TestMarathonTools:
     def test_get_constraints_respects_deploy_blacklist(self):
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
         fake_deploy_blacklist = [["region", "fake_blacklisted_region"]]
-        fake_conf = marathon_tools.MarathonServiceConfig('fake_name', 'fake_instance',
-                                                         {'deploy_blacklist': fake_deploy_blacklist}, {})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'deploy_blacklist': fake_deploy_blacklist},
+            branch_dict={},
+        )
         expected_constraints = [["region", "GROUP_BY", "1"], ["region", "UNLIKE", "fake_blacklisted_region"]]
         with mock.patch('marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True) as get_slaves_patch:
             get_slaves_patch.return_value = {'fake_region': {}}
@@ -976,7 +1073,13 @@ class TestMarathonTools:
             get_slaves_patch.assert_called_once_with(attribute='region', blacklist=fake_deploy_blacklist)
 
     def test_instance_config_getters_in_config(self):
-        fake_conf = marathon_tools.MarathonServiceConfig('fake_name', 'fake_instance', {'monitoring': 'test'}, {})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'monitoring': 'test'},
+            branch_dict={},
+        )
         assert fake_conf.get_monitoring() == 'test'
 
     def test_get_marathon_client(self):
@@ -1076,33 +1179,36 @@ class TestMarathonTools:
         }, '/fake/dir/')
 
         fake_service_config_1 = marathon_tools.MarathonServiceConfig(
-            fake_name,
-            fake_instance,
-            self.fake_marathon_app_config.config_dict,
-            {
+            service=fake_name,
+            cluster='fake_cluster',
+            instance=fake_instance,
+            config_dict=self.fake_marathon_app_config.config_dict,
+            branch_dict={
                 'desired_state': 'start',
                 'force_bounce': '88888',
-            }
+            },
         )
 
         fake_service_config_2 = marathon_tools.MarathonServiceConfig(
-            fake_name,
-            fake_instance,
-            self.fake_marathon_app_config.config_dict,
-            {
+            service=fake_name,
+            cluster='fake_cluster',
+            instance=fake_instance,
+            config_dict=self.fake_marathon_app_config.config_dict,
+            branch_dict={
                 'desired_state': 'start',
                 'force_bounce': '99999',
-            }
+            },
         )
 
         fake_service_config_3 = marathon_tools.MarathonServiceConfig(
-            fake_name,
-            fake_instance,
-            self.fake_marathon_app_config.config_dict,
-            {
+            service=fake_name,
+            cluster='fake_cluster',
+            instance=fake_instance,
+            config_dict=self.fake_marathon_app_config.config_dict,
+            branch_dict={
                 'desired_state': 'stop',
                 'force_bounce': '99999',
-            }
+            },
         )
 
         with contextlib.nested(
@@ -1151,6 +1257,7 @@ class TestMarathonTools:
         fake_instances = [(service, 'blue'), (service, 'green')]
         fake_srv_config = marathon_tools.MarathonServiceConfig(
             service=service,
+            cluster='fake_cluster',
             instance='blue',
             config_dict={'nerve_ns': 'rojo', 'instances': 11},
             branch_dict={},
@@ -1160,7 +1267,13 @@ class TestMarathonTools:
             if inst == 'blue':
                 return fake_srv_config
             else:
-                return marathon_tools.MarathonServiceConfig(service, 'green', {'nerve_ns': 'amarillo'}, {})
+                return marathon_tools.MarathonServiceConfig(
+                    service=service,
+                    cluster='fake_cluster',
+                    instance='green',
+                    config_dict={'nerve_ns': 'amarillo'},
+                    branch_dict={},
+                )
 
         with contextlib.nested(
             mock.patch('marathon_tools.get_service_instance_list',
@@ -1208,20 +1321,22 @@ class TestMarathonTools:
 
     def test_get_healthcheck_cmd_happy(self):
         fake_conf = marathon_tools.MarathonServiceConfig(
-            'fake_name',
-            'fake_instance',
-            {'healthcheck_cmd': 'test_cmd'},
-            {},
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'healthcheck_cmd': 'test_cmd'},
+            branch_dict={},
         )
         actual = fake_conf.get_healthcheck_cmd()
         assert actual == 'test_cmd'
 
     def test_get_healthcheck_cmd_raises_when_unset(self):
         fake_conf = marathon_tools.MarathonServiceConfig(
-            'fake_name',
-            'fake_instance',
-            {},
-            {},
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
         )
         with raises(marathon_tools.InvalidInstanceConfig) as exc:
             fake_conf.get_healthcheck_cmd()
@@ -1234,7 +1349,13 @@ class TestMarathonTools:
         fake_random_port = 666
 
         fake_path = '/fake_path'
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(fake_service, fake_namespace, {}, {})
+        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
+            service=fake_service,
+            cluster='fake_cluster',
+            instance=fake_namespace,
+            config_dict={},
+            branch_dict={},
+        )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig({
             'mode': 'http',
             'healthcheck_uri': fake_path,
@@ -1263,7 +1384,13 @@ class TestMarathonTools:
         fake_hostname = 'fake_hostname'
         fake_random_port = 666
 
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(fake_service, fake_namespace, {}, {})
+        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
+            service=fake_service,
+            cluster='fake_cluster',
+            instance=fake_namespace,
+            config_dict={},
+            branch_dict={},
+        )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig({
             'mode': 'tcp',
         })
@@ -1291,10 +1418,16 @@ class TestMarathonTools:
         fake_hostname = 'fake_hostname'
         fake_random_port = 666
         fake_cmd = '/bin/fake_command'
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(fake_service, fake_namespace, {
-            'healthcheck_mode': 'cmd',
-            'healthcheck_cmd': fake_cmd
-        }, {})
+        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
+            service=fake_service,
+            cluster='fake_cluster',
+            instance=fake_namespace,
+            config_dict={
+                'healthcheck_mode': 'cmd',
+                'healthcheck_cmd': fake_cmd
+            },
+            branch_dict={},
+        )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig({})
         with contextlib.nested(
             mock.patch('marathon_tools.load_marathon_service_config',
@@ -1319,9 +1452,15 @@ class TestMarathonTools:
         fake_namespace = 'fake_namespace'
         fake_hostname = 'fake_hostname'
         fake_random_port = 666
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(fake_service, fake_namespace, {
-            'healthcheck_mode': None,
-        }, {})
+        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
+            service=fake_service,
+            cluster='fake_cluster',
+            instance=fake_namespace,
+            config_dict={
+                'healthcheck_mode': None,
+            },
+            branch_dict={},
+        )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig({})
         with contextlib.nested(
             mock.patch('marathon_tools.load_marathon_service_config',
@@ -1347,9 +1486,15 @@ class TestMarathonTools:
         fake_hostname = 'fake_hostname'
         fake_random_port = 666
         fake_soadir = '/fake/soadir'
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(fake_service, fake_namespace, {
-            'healthcheck_mode': None,
-        }, {})
+        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
+            service=fake_service,
+            cluster='fake_cluster',
+            instance=fake_namespace,
+            config_dict={
+                'healthcheck_mode': None,
+            },
+            branch_dict={},
+        )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig({})
         with contextlib.nested(
             mock.patch('marathon_tools.load_marathon_service_config',
@@ -1374,42 +1519,73 @@ class TestMarathonTools:
 class TestMarathonServiceConfig(object):
 
     def test_repr(self):
-        actual = repr(marathon_tools.MarathonServiceConfig('foo', 'bar', {'baz': 'baz'}, {'bubble': 'gum'}))
-        expected = """MarathonServiceConfig('foo', 'bar', {'baz': 'baz'}, {'bubble': 'gum'})"""
+        actual = repr(marathon_tools.MarathonServiceConfig('foo', 'bar', '', {'baz': 'baz'}, {'bubble': 'gum'}))
+        expected = """MarathonServiceConfig('foo', 'bar', '', {'baz': 'baz'}, {'bubble': 'gum'})"""
         assert actual == expected
 
     def test_get_healthcheck_mode_default(self):
         namespace_config = marathon_tools.ServiceNamespaceConfig({})
-        marathon_config = marathon_tools.MarathonServiceConfig("service", "instance", {}, {})
+        marathon_config = marathon_tools.MarathonServiceConfig(
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={},
+            branch_dict={},
+        )
         assert marathon_config.get_healthcheck_mode(namespace_config) is None
 
     def test_get_healthcheck_mode_default_from_namespace_config(self):
         namespace_config = marathon_tools.ServiceNamespaceConfig({'proxy_port': 1234})
-        marathon_config = marathon_tools.MarathonServiceConfig("service", "instance", {}, {})
+        marathon_config = marathon_tools.MarathonServiceConfig(
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={},
+            branch_dict={},
+        )
         assert marathon_config.get_healthcheck_mode(namespace_config) == 'http'
 
     def test_get_healthcheck_mode_valid(self):
         namespace_config = marathon_tools.ServiceNamespaceConfig({})
-        marathon_config = marathon_tools.MarathonServiceConfig("service", "instance", {'healthcheck_mode': 'tcp'}, {})
+        marathon_config = marathon_tools.MarathonServiceConfig(
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={'healthcheck_mode': 'tcp'},
+            branch_dict={},
+        )
         assert marathon_config.get_healthcheck_mode(namespace_config) == 'tcp'
 
     def test_get_healthcheck_mode_invalid(self):
         namespace_config = marathon_tools.ServiceNamespaceConfig({})
-        marathon_config = marathon_tools.MarathonServiceConfig("service", "instance", {'healthcheck_mode': 'udp'}, {})
+        marathon_config = marathon_tools.MarathonServiceConfig(
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={'healthcheck_mode': 'udp'},
+            branch_dict={},
+        )
         with raises(marathon_tools.InvalidMarathonHealthcheckMode):
             marathon_config.get_healthcheck_mode(namespace_config)
 
     def test_get_healthcheck_mode_explicit_none(self):
         namespace_config = marathon_tools.ServiceNamespaceConfig({})
-        marathon_config = marathon_tools.MarathonServiceConfig("service", "instance", {'healthcheck_mode': None}, {})
+        marathon_config = marathon_tools.MarathonServiceConfig(
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={'healthcheck_mode': None},
+            branch_dict={},
+        )
         assert marathon_config.get_healthcheck_mode(namespace_config) is None
 
     def test_get_healthchecks_http_overrides(self):
         fake_path = '/mycoolstatus'
         fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-            "service",
-            "instance",
-            {
+            service='service',
+            instance='instance',
+            cluster='cluster',
+            config_dict={
                 "healthcheck_mode": "http",  # Actually the default here, but I want to be specific.
                 "healthcheck_uri": fake_path,
                 "healthcheck_grace_period_seconds": 70,
@@ -1417,7 +1593,7 @@ class TestMarathonServiceConfig(object):
                 "healthcheck_timeout_seconds": 13,
                 "healthcheck_max_consecutive_failures": 7,
             },
-            {},
+            branch_dict={},
         )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig({
             'mode': 'http',
@@ -1440,7 +1616,13 @@ class TestMarathonServiceConfig(object):
         assert actual == expected
 
     def test_get_healthchecks_http_defaults(self):
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig("service", "instance", {}, {})
+        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={},
+            branch_dict={},
+        )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig({'mode': 'http'})
         expected = [
             {
@@ -1457,7 +1639,13 @@ class TestMarathonServiceConfig(object):
         assert actual == expected
 
     def test_get_healthchecks_tcp(self):
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig("service", "instance", {}, {})
+        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={},
+            branch_dict={},
+        )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig({'mode': 'tcp'})
         expected = [
             {
@@ -1475,7 +1663,12 @@ class TestMarathonServiceConfig(object):
     def test_get_healthchecks_cmd(self):
         fake_command = '/fake_cmd'
         fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-            "service", "instance", {'healthcheck_mode': 'cmd', 'healthcheck_cmd': fake_command}, {})
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={'healthcheck_mode': 'cmd', 'healthcheck_cmd': fake_command},
+            branch_dict={},
+        )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
         expected_cmd = "paasta_execute_docker_command --mesos-id \"$MESOS_TASK_ID\" --cmd /fake_cmd --timeout '10'"
         expected = [
@@ -1494,7 +1687,12 @@ class TestMarathonServiceConfig(object):
     def test_get_healthchecks_cmd_quotes(self):
         fake_command = '/bin/fake_command with spaces'
         fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-            "service", "instance", {'healthcheck_mode': 'cmd', 'healthcheck_cmd': fake_command}, {})
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={'healthcheck_mode': 'cmd', 'healthcheck_cmd': fake_command},
+            branch_dict={},
+        )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
         expected_cmd = "paasta_execute_docker_command " \
             "--mesos-id \"$MESOS_TASK_ID\" --cmd '%s' --timeout '10'" % fake_command
@@ -1514,7 +1712,12 @@ class TestMarathonServiceConfig(object):
     def test_get_healthchecks_cmd_overrides(self):
         fake_command = '/bin/fake_command'
         fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-            "service", "instance", {'healthcheck_mode': 'cmd', 'healthcheck_cmd': fake_command}, {})
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={'healthcheck_mode': 'cmd', 'healthcheck_cmd': fake_command},
+            branch_dict={},
+        )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
         expected_cmd = "paasta_execute_docker_command " \
             "--mesos-id \"$MESOS_TASK_ID\" --cmd %s --timeout '10'" % fake_command
@@ -1535,10 +1738,14 @@ class TestMarathonServiceConfig(object):
         fake_command = '/bin/fake_command'
         fake_timeout = 4
         fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-            "service",
-            "instance",
-            {'healthcheck_mode': 'cmd', 'healthcheck_timeout_seconds': fake_timeout, 'healthcheck_cmd': fake_command},
-            {}
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={
+                'healthcheck_mode': 'cmd',
+                'healthcheck_timeout_seconds': fake_timeout,
+                'healthcheck_cmd': fake_command},
+            branch_dict={},
         )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
         expected_cmd = "paasta_execute_docker_command " \
@@ -1557,29 +1764,56 @@ class TestMarathonServiceConfig(object):
         assert actual == expected
 
     def test_get_healthchecks_empty(self):
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig("service", "instance", {}, {})
+        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={},
+            branch_dict={},
+        )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig({})
         assert fake_marathon_service_config.get_healthchecks(fake_service_namespace_config) == []
 
     def test_get_healthchecks_invalid_mode(self):
-        marathon_config = marathon_tools.MarathonServiceConfig("service", "instance", {'healthcheck_mode': 'none'}, {})
+        marathon_config = marathon_tools.MarathonServiceConfig(
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={'healthcheck_mode': 'none'},
+            branch_dict={},
+        )
         namespace_config = marathon_tools.ServiceNamespaceConfig({})
         with raises(marathon_tools.InvalidMarathonHealthcheckMode):
             marathon_config.get_healthchecks(namespace_config)
 
     def test_get_backoff_seconds_scales_up(self):
         marathon_config = marathon_tools.MarathonServiceConfig(
-            "service", "instance", {'instances': 100}, {})
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={'instances': 100},
+            branch_dict={},
+        )
         assert marathon_config.get_backoff_seconds() == 0.1
 
     def test_get_backoff_seconds_scales_down(self):
         marathon_config = marathon_tools.MarathonServiceConfig(
-            "service", "instance", {'instances': 1}, {})
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={'instances': 1},
+            branch_dict={},
+        )
         assert marathon_config.get_backoff_seconds() == 10
 
     def test_get_backoff_doesnt_devide_by_zero(self):
         marathon_config = marathon_tools.MarathonServiceConfig(
-            "service", "instance", {'instances': 0}, {})
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={'instances': 0},
+            branch_dict={},
+        )
         assert marathon_config.get_backoff_seconds() == 1
 
     def test_get_accepted_resource_roles_default(self):
@@ -1593,17 +1827,33 @@ class TestMarathonServiceConfig(object):
         assert marathon_config.get_accepted_resource_roles() == ["ads"]
 
     def test_get_desired_state_human(self):
-        fake_conf = marathon_tools.MarathonServiceConfig('service', 'instance', {}, {'desired_state': 'stop'})
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={},
+            branch_dict={'desired_state': 'stop'},
+        )
         assert 'Stopped' in fake_conf.get_desired_state_human()
 
     def test_get_desired_state_human_started_with_instances(self):
         fake_conf = marathon_tools.MarathonServiceConfig(
-            'service', 'instance', {'instances': 42}, {'desired_state': 'start'})
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={'instances': 42},
+            branch_dict={'desired_state': 'start'},
+        )
         assert 'Started' in fake_conf.get_desired_state_human()
 
     def test_get_desired_state_human_with_0_instances(self):
         fake_conf = marathon_tools.MarathonServiceConfig(
-            'service', 'instance', {'instances': 0}, {'desired_state': 'start'})
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={'instances': 0},
+            branch_dict={'desired_state': 'start'},
+        )
         assert 'Stopped' in fake_conf.get_desired_state_human()
 
 
@@ -1643,10 +1893,11 @@ def test_create_complete_config_no_smartstack():
     fake_job_id = "service.instance.some.hash"
     fake_marathon_config = marathon_tools.MarathonConfig({}, 'fake_file.json')
     fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-        service,
-        instance,
-        {},
-        {'docker_image': 'abcdef'},
+        service=service,
+        cluster='cluster',
+        instance=instance,
+        config_dict={},
+        branch_dict={'docker_image': 'abcdef'},
     )
     fake_system_paasta_config = SystemPaastaConfig({
         'volumes': [],
@@ -1706,10 +1957,11 @@ def test_create_complete_config_with_smartstack():
     fake_job_id = "service.instance.some.hash"
     fake_marathon_config = marathon_tools.MarathonConfig({}, 'fake_file.json')
     fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-        service,
-        instance,
-        {},
-        {'docker_image': 'abcdef'},
+        service=service,
+        cluster='cluster',
+        instance=instance,
+        config_dict={},
+        branch_dict={'docker_image': 'abcdef'},
     )
     fake_system_paasta_config = SystemPaastaConfig({
         'volumes': [],
@@ -1793,10 +2045,11 @@ def test_create_complete_config_utilizes_extra_volumes():
     ]
     fake_marathon_config = marathon_tools.MarathonConfig({}, 'fake_file.json')
     fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-        service_name,
-        instance_name,
-        {'extra_volumes': fake_extra_volumes},
-        {'docker_image': 'abcdef'},
+        service=service_name,
+        cluster='cluster',
+        instance=instance_name,
+        config_dict={'extra_volumes': fake_extra_volumes},
+        branch_dict={'docker_image': 'abcdef'},
     )
     fake_system_paasta_config = SystemPaastaConfig({
         'volumes': fake_system_volumes,

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1818,12 +1818,22 @@ class TestMarathonServiceConfig(object):
 
     def test_get_accepted_resource_roles_default(self):
         marathon_config = marathon_tools.MarathonServiceConfig(
-            "service", "instance", {}, {})
+            service='service',
+            instance='instance',
+            cluster='cluster',
+            config_dict={},
+            branch_dict={},
+        )
         assert marathon_config.get_accepted_resource_roles() is None
 
     def test_get_accepted_resource_roles(self):
         marathon_config = marathon_tools.MarathonServiceConfig(
-            "service", "instance", {"accepted_resource_roles": ["ads"]}, {})
+            service='service',
+            instance='instance',
+            cluster='cluster',
+            config_dict={"accepted_resource_roles": ["ads"]},
+            branch_dict={},
+        )
         assert marathon_config.get_accepted_resource_roles() == ["ads"]
 
     def test_get_desired_state_human(self):

--- a/tests/test_monitoring_tools.py
+++ b/tests/test_monitoring_tools.py
@@ -31,31 +31,39 @@ class TestMonitoring_Tools:
         'page': general_page
     }
 
-    empty_service_config = marathon_tools.MarathonServiceConfig('myservicename', 'myinstance', {}, {})
+    empty_service_config = marathon_tools.MarathonServiceConfig(
+        service='myservicename',
+        cluster='mycluster',
+        instance='myinstance',
+        config_dict={},
+        branch_dict={},
+    )
     job_page = False
     fake_marathon_job_config = marathon_tools.MarathonServiceConfig(
-        'myservicename',
-        'myinstance',
-        {
+        service='myservicename',
+        cluster='myclustername',
+        instance='myinstance',
+        config_dict={
             'team': 'job_test_team',
             'runbook': 'y/job_test_runbook',
             'tip': 'job_test_tip',
             'notification_email': 'job_test_notification_email',
             'page': job_page
         },
-        {},
+        branch_dict={},
     )
     fake_chronos_job_config = chronos_tools.ChronosJobConfig(
-        'myservicename',
-        'myinstance',
-        {
+        service='myservicename',
+        cluster='myclustername',
+        instance='myinstance',
+        config_dict={
             'team': 'job_test_team',
             'runbook': 'y/job_test_runbook',
             'tip': 'job_test_tip',
             'notification_email': 'job_test_notification_email',
             'page': job_page
         },
-        {},
+        branch_dict={},
     )
     empty_job_config = {}
     monitor_page = True

--- a/tests/test_setup_chronos_job.py
+++ b/tests/test_setup_chronos_job.py
@@ -53,10 +53,12 @@ class TestSetupChronosJob:
     fake_branch_dict = {
         'docker_image': 'paasta-%s-%s' % (fake_service, fake_cluster),
     }
-    fake_chronos_job_config = chronos_tools.ChronosJobConfig(fake_service,
-                                                             fake_instance,
-                                                             fake_config_dict,
-                                                             fake_branch_dict)
+    fake_chronos_job_config = chronos_tools.ChronosJobConfig(service=fake_service,
+                                                             cluster=fake_cluster,
+                                                             instance=fake_instance,
+                                                             config_dict=fake_config_dict,
+                                                             branch_dict=fake_branch_dict,
+                                                             )
 
     fake_docker_registry = 'remote_registry.com'
     fake_args = mock.MagicMock(

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -35,9 +35,10 @@ class TestSetupMarathonJob:
     fake_docker_image = 'test_docker:1.0'
     fake_cluster = 'fake_test_cluster'
     fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-        'servicename',
-        'instancename',
-        {
+        service='servicename',
+        cluster='clustername',
+        instance='instancename',
+        config_dict={
             'instances': 3,
             'cpus': 1,
             'mem': 100,
@@ -45,7 +46,7 @@ class TestSetupMarathonJob:
             'nerve_ns': 'aaaaugh',
             'bounce_method': 'brutal'
         },
-        {},
+        branch_dict={},
     )
     fake_docker_registry = 'remote_registry.com'
     fake_marathon_config = marathon_tools.MarathonConfig({

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -699,90 +699,216 @@ class TestInstanceConfig:
 
     def test_get_monitoring(self):
         fake_info = 'fake_info'
-        assert utils.InstanceConfig({'monitoring': fake_info}, {}).get_monitoring() == fake_info
+        assert utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'monitoring': fake_info},
+            branch_dict={},
+        ).get_monitoring() == fake_info
 
     def test_get_cpus_in_config(self):
-        fake_conf = utils.InstanceConfig({'cpus': -5}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'cpus': -5},
+            branch_dict={},
+        )
         assert fake_conf.get_cpus() == -5
 
     def test_get_cpus_in_config_float(self):
-        fake_conf = utils.InstanceConfig({'cpus': .66}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'cpus': .66},
+            branch_dict={},
+        )
         assert fake_conf.get_cpus() == .66
 
     def test_get_cpus_default(self):
-        fake_conf = utils.InstanceConfig({}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_cpus() == .25
 
     def test_get_mem_in_config(self):
-        fake_conf = utils.InstanceConfig({'mem': -999}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            instance='',
+            cluster='',
+            config_dict={'mem': -999},
+            branch_dict={},
+        )
         assert fake_conf.get_mem() == -999
 
     def test_get_mem_default(self):
-        fake_conf = utils.InstanceConfig({}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            instance='',
+            cluster='',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_mem() == 1024
 
     def test_get_cmd_default(self):
-        fake_conf = utils.InstanceConfig({}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_cmd() is None
 
     def test_get_cmd_in_config(self):
-        fake_conf = utils.InstanceConfig({'cmd': 'FAKECMD'}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'cmd': 'FAKECMD'},
+            branch_dict={},
+        )
         assert fake_conf.get_cmd() == 'FAKECMD'
 
     def test_get_env_default(self):
-        fake_conf = utils.InstanceConfig({}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_env() == {}
 
     def test_get_env_with_config(self):
-        fake_conf = utils.InstanceConfig({'env': {'SPECIAL_ENV': 'TRUE'}}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'env': {'SPECIAL_ENV': 'TRUE'}},
+            branch_dict={},
+        )
         assert fake_conf.get_env() == {'SPECIAL_ENV': 'TRUE'}
 
     def test_get_args_default_no_cmd(self):
-        fake_conf = utils.InstanceConfig({}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_args() == []
 
     def test_get_args_default_with_cmd(self):
-        fake_conf = utils.InstanceConfig({'cmd': 'FAKECMD'}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'cmd': 'FAKECMD'},
+            branch_dict={},
+        )
         assert fake_conf.get_args() is None
 
     def test_get_args_in_config(self):
-        fake_conf = utils.InstanceConfig({'args': ['arg1', 'arg2']}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'args': ['arg1', 'arg2']},
+            branch_dict={},
+        )
         assert fake_conf.get_args() == ['arg1', 'arg2']
 
     def test_get_args_in_config_with_cmd(self):
-        fake_conf = utils.InstanceConfig({'args': ['A'], 'cmd': 'C'}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'args': ['A'], 'cmd': 'C'},
+            branch_dict={},
+        )
         fake_conf.get_cmd()
         with raises(utils.InvalidInstanceConfig):
             fake_conf.get_args()
 
     def test_get_force_bounce(self):
-        fake_conf = utils.InstanceConfig({}, {'force_bounce': 'blurp'})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={},
+            branch_dict={'force_bounce': 'blurp'},
+        )
         assert fake_conf.get_force_bounce() == 'blurp'
 
     def test_get_desired_state(self):
-        fake_conf = utils.InstanceConfig({}, {'desired_state': 'stop'})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={},
+            branch_dict={'desired_state': 'stop'},
+        )
         assert fake_conf.get_desired_state() == 'stop'
 
     def test_monitoring_blacklist_default(self):
-        fake_conf = utils.InstanceConfig({}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_monitoring_blacklist() == []
 
     def test_monitoring_blacklist_defaults_to_deploy_blacklist(self):
         fake_deploy_blacklist = [["region", "fake_region"]]
-        fake_conf = utils.InstanceConfig({'deploy_blacklist': fake_deploy_blacklist}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'deploy_blacklist': fake_deploy_blacklist},
+            branch_dict={},
+        )
         assert fake_conf.get_monitoring_blacklist() == fake_deploy_blacklist
 
     def test_deploy_blacklist_default(self):
-        fake_conf = utils.InstanceConfig({}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_deploy_blacklist() == []
 
     def test_deploy_blacklist_reads_blacklist(self):
         fake_deploy_blacklist = [["region", "fake_region"]]
-        fake_conf = utils.InstanceConfig({'deploy_blacklist': fake_deploy_blacklist}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'deploy_blacklist': fake_deploy_blacklist},
+            branch_dict={},
+        )
         assert fake_conf.get_deploy_blacklist() == fake_deploy_blacklist
 
     def test_extra_volumes_default(self):
-        fake_conf = utils.InstanceConfig({}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={},
+            branch_dict={},
+        )
         assert fake_conf.get_extra_volumes() == []
 
     def test_extra_volumes_normal(self):
@@ -793,7 +919,13 @@ class TestInstanceConfig:
                 "mode": "RO"
             },
         ]
-        fake_conf = utils.InstanceConfig({'extra_volumes': fake_extra_volumes}, {})
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'extra_volumes': fake_extra_volumes},
+            branch_dict={},
+        )
         assert fake_conf.get_extra_volumes() == fake_extra_volumes
 
 


### PR DESCRIPTION
InstanceConfig and it's children MesosServiceConfig and ChronosJobConfig now directly store service name, cluster and instance. This should enable some cleaner code in the future.