### PR TITLE
Remove PYTHONPATH hax when running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,14 @@
 language: python
-python:
-  - '2.7'
 env:
-  - TOX_ENV=docs
-  - TOX_ENV=general_itests
-  - TOX_ENV=paasta_itests
+  - TOXENV=py27
+  - TOXENV=docs
+  - TOXENV=general_itests
+  - TOXENV=paasta_itests
 sudo: required
 services:
   - docker
-install:
-  - pip install coveralls
-  - pip install tox
-before_script:
-  - tox -e py
-script:
-  - tox -e $TOX_ENV
+install: pip install coveralls tox
+script: tox
 after_success:
   - coveralls
 deploy:

--- a/general_itests/steps/paasta_execute_docker_command.py
+++ b/general_itests/steps/paasta_execute_docker_command.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
 from behave import given, when, then
 from docker import Client
 from docker.errors import APIError
 
-sys.path.append('../')
 from paasta_tools.utils import _run
 from paasta_tools.utils import get_docker_host
 

--- a/paasta_itests/steps/cleanup_chronos_job_steps.py
+++ b/paasta_itests/steps/cleanup_chronos_job_steps.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import json
 from behave import when, then
 
-sys.path.append('../')
 from paasta_tools.utils import _run
 from paasta_tools.chronos_tools import compose_job_id
 

--- a/paasta_itests/steps/marathon_steps.py
+++ b/paasta_itests/steps/marathon_steps.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import time
 
 from behave import when, then
 import mock
 
-sys.path.append('../')
 import paasta_tools
 
 APP_ID = 'test--marathon--app.instance.git01234567.configabcdef01'

--- a/paasta_itests/steps/mesos_steps.py
+++ b/paasta_itests/steps/mesos_steps.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
 import contextlib
 import mock
 from behave import when, then
@@ -21,7 +19,6 @@ import mesos.cli.master
 
 from itest_utils import get_service_connection_string
 
-sys.path.append('../')
 from paasta_tools import check_mesos_resource_utilization
 
 

--- a/paasta_itests/steps/paasta_metastatus_steps.py
+++ b/paasta_itests/steps/paasta_metastatus_steps.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 import os
-import sys
 
 from behave import when, then
 
-sys.path.append('../')
 from paasta_tools.utils import _run
 from paasta_tools.utils import remove_ansi_escape_sequences
 from paasta_tools import marathon_tools

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import time
 
 from behave import when, then
 import mock
 
-sys.path.append('../')
 import paasta_tools
 from paasta_tools import marathon_serviceinit
 from paasta_tools import marathon_tools

--- a/paasta_itests/steps/setup_chronos_job_steps.py
+++ b/paasta_itests/steps/setup_chronos_job_steps.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 import copy
-import sys
 
 from behave import when, then
 
-sys.path.append('../')
 from paasta_tools import chronos_tools
 from paasta_tools.utils import _run
 

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 
 import contextlib
-import sys
 
 from behave import when, then
 import mock
 
-sys.path.append('../')
 from paasta_tools import setup_marathon_job
 from paasta_tools import marathon_tools
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+pep8==1.5.7
+flake8==2.5.0
+pytest==2.7.3
+pytest-cov==2.2.0
+mock==1.0.1
+

--- a/tests/test_bounce_lib.py
+++ b/tests/test_bounce_lib.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import bounce_lib
 import contextlib
 import datetime
 import mock
 import marathon
 
+from paasta_tools import bounce_lib
 from paasta_tools.smartstack_tools import DEFAULT_SYNAPSE_PORT
 
 
@@ -29,7 +29,7 @@ class TestBounceLib:
         lock_file = '/var/lock/%s.lock' % lock_name
         fake_fd = mock.MagicMock(spec=file)
         with contextlib.nested(
-            mock.patch('bounce_lib.open', create=True, return_value=fake_fd),
+            mock.patch('paasta_tools.bounce_lib.open', create=True, return_value=fake_fd),
             mock.patch('fcntl.lockf'),
             mock.patch('os.remove')
         ) as (
@@ -50,9 +50,9 @@ class TestBounceLib:
         fake_zk = mock.MagicMock(Lock=mock.Mock(return_value=fake_lock))
         fake_zk_hosts = 'awjti42ior'
         with contextlib.nested(
-            mock.patch('bounce_lib.KazooClient', return_value=fake_zk, autospec=True),
+            mock.patch('paasta_tools.bounce_lib.KazooClient', return_value=fake_zk, autospec=True),
             mock.patch(
-                'bounce_lib.load_system_paasta_config',
+                'paasta_tools.bounce_lib.load_system_paasta_config',
                 return_value=mock.Mock(
                     get_zk_hosts=lambda: fake_zk_hosts
                 ),
@@ -78,8 +78,8 @@ class TestBounceLib:
         fake_client = marathon_client_mock
         fake_config = {'id': 'fake_creation'}
         with contextlib.nested(
-            mock.patch('bounce_lib.create_app_lock', spec=contextlib.contextmanager),
-            mock.patch('bounce_lib.wait_for_create'),
+            mock.patch('paasta_tools.bounce_lib.create_app_lock', spec=contextlib.contextmanager),
+            mock.patch('paasta_tools.bounce_lib.wait_for_create'),
         ) as (
             lock_patch,
             wait_patch,
@@ -96,8 +96,8 @@ class TestBounceLib:
         fake_client = mock.Mock(delete_app=mock.Mock())
         fake_id = 'fake_deletion'
         with contextlib.nested(
-            mock.patch('bounce_lib.create_app_lock', spec=contextlib.contextmanager),
-            mock.patch('bounce_lib.wait_for_delete'),
+            mock.patch('paasta_tools.bounce_lib.create_app_lock', spec=contextlib.contextmanager),
+            mock.patch('paasta_tools.bounce_lib.wait_for_delete'),
             mock.patch('time.sleep')
         ) as (
             lock_patch,
@@ -114,7 +114,7 @@ class TestBounceLib:
     def test_kill_old_ids(self):
         old_ids = ['mmm.whatcha.say', 'that.you', 'only.meant.well']
         fake_client = mock.MagicMock()
-        with mock.patch('bounce_lib.delete_marathon_app') as delete_patch:
+        with mock.patch('paasta_tools.bounce_lib.delete_marathon_app') as delete_patch:
             bounce_lib.kill_old_ids(old_ids, fake_client)
             for old_id in old_ids:
                 delete_patch.assert_any_call(old_id, fake_client)
@@ -125,7 +125,7 @@ class TestBounceLib:
         fake_client = mock.Mock(spec='paasta_tools.setup_marathon_job.MarathonClient')
         fake_is_app_running_values = [False, False, True]
         with contextlib.nested(
-            mock.patch('marathon_tools.is_app_id_running'),
+            mock.patch('paasta_tools.marathon_tools.is_app_id_running'),
             mock.patch('time.sleep'),
         ) as (
             is_app_id_running_patch,
@@ -141,7 +141,7 @@ class TestBounceLib:
         fake_client = mock.Mock(spec='paasta_tools.setup_marathon_job.MarathonClient')
         fake_is_app_running_values = [True]
         with contextlib.nested(
-            mock.patch('marathon_tools.is_app_id_running'),
+            mock.patch('paasta_tools.marathon_tools.is_app_id_running'),
             mock.patch('time.sleep'),
         ) as (
             is_app_id_running_patch,
@@ -157,7 +157,7 @@ class TestBounceLib:
         fake_client = mock.Mock(spec='paasta_tools.setup_marathon_job.MarathonClient')
         fake_is_app_running_values = [True, True, False]
         with contextlib.nested(
-            mock.patch('marathon_tools.is_app_id_running'),
+            mock.patch('paasta_tools.marathon_tools.is_app_id_running'),
             mock.patch('time.sleep'),
         ) as (
             is_app_id_running_patch,
@@ -173,7 +173,7 @@ class TestBounceLib:
         fake_client = mock.Mock(spec='paasta_tools.setup_marathon_job.MarathonClient')
         fake_is_app_running_values = [False]
         with contextlib.nested(
-            mock.patch('marathon_tools.is_app_id_running'),
+            mock.patch('paasta_tools.marathon_tools.is_app_id_running'),
             mock.patch('time.sleep'),
         ) as (
             is_app_id_running_patch,
@@ -260,8 +260,8 @@ class TestBounceLib:
         tasks = [mock.Mock(health_check_results=[mock.Mock(alive=True)]) for i in xrange(5)]
         fake_app = mock.Mock(tasks=tasks, health_checks=[])
         with contextlib.nested(
-            mock.patch('bounce_lib.get_registered_marathon_tasks', return_value=tasks[2:], autospec=True),
-            mock.patch('mesos_tools.get_mesos_slaves_grouped_by_attribute',
+            mock.patch('paasta_tools.bounce_lib.get_registered_marathon_tasks', return_value=tasks[2:], autospec=True),
+            mock.patch('paasta_tools.mesos_tools.get_mesos_slaves_grouped_by_attribute',
                        return_value={'fake_region': ['fake_host']}, autospec=True),
         ) as (
             _,
@@ -275,8 +275,8 @@ class TestBounceLib:
         tasks = [mock.Mock(health_check_results=[mock.Mock(alive=False)]) for i in xrange(5)]
         fake_app = mock.Mock(tasks=tasks, health_checks=[])
         with contextlib.nested(
-            mock.patch('bounce_lib.get_registered_marathon_tasks', return_value=tasks[2:], autospec=True),
-            mock.patch('mesos_tools.get_mesos_slaves_grouped_by_attribute',
+            mock.patch('paasta_tools.bounce_lib.get_registered_marathon_tasks', return_value=tasks[2:], autospec=True),
+            mock.patch('paasta_tools.mesos_tools.get_mesos_slaves_grouped_by_attribute',
                        return_value={'fake_region': ['fake_host']}, autospec=True),
         ) as (
             _,
@@ -290,8 +290,11 @@ class TestBounceLib:
         tasks = [mock.Mock(health_check_results=[mock.Mock(alive=True)]) for i in xrange(5)]
         fake_app = mock.Mock(tasks=tasks, health_checks=[])
         with contextlib.nested(
-            mock.patch('bounce_lib.get_registered_marathon_tasks', side_effect=[tasks[2:3], tasks[3:]], autospec=True),
-            mock.patch('mesos_tools.get_mesos_slaves_grouped_by_attribute', autospec=True),
+            mock.patch(
+                'paasta_tools.bounce_lib.get_registered_marathon_tasks',
+                side_effect=[tasks[2:3], tasks[3:]], autospec=True,
+            ),
+            mock.patch('paasta_tools.mesos_tools.get_mesos_slaves_grouped_by_attribute', autospec=True),
         ) as (
             get_registered_marathon_tasks_patch,
             get_mesos_slaves_grouped_by_attribute_patch,

--- a/tests/test_check_chronos_jobs.py
+++ b/tests/test_check_chronos_jobs.py
@@ -7,8 +7,8 @@ from mock import Mock
 from pytest import raises
 
 
-@patch('check_chronos_jobs.chronos_tools.load_chronos_job_config')
-@patch('check_chronos_jobs.monitoring_tools.get_runbook')
+@patch('paasta_tools.check_chronos_jobs.chronos_tools.load_chronos_job_config')
+@patch('paasta_tools.check_chronos_jobs.monitoring_tools.get_runbook')
 def test_compose_monitoring_overrides_for_service(mock_get_runbook, mock_load_chronos_job_config):
     mymock = Mock()
     mymock.get_monitoring.return_value = {}
@@ -31,7 +31,7 @@ def test_compose_check_name_for_job():
     assert check_chronos_jobs.compose_check_name_for_job('myservice', 'myinstance') == expected_check
 
 
-@patch('check_chronos_jobs.monitoring_tools.send_event')
+@patch('paasta_tools.check_chronos_jobs.monitoring_tools.send_event')
 def test_send_event_to_sensu(mock_send_event):
     check_chronos_jobs.send_event_to_sensu(
         service='myservice',
@@ -51,7 +51,7 @@ def test_send_event_to_sensu(mock_send_event):
     )
 
 
-@patch('check_chronos_jobs.chronos_tools.get_status_last_run')
+@patch('paasta_tools.check_chronos_jobs.chronos_tools.get_status_last_run')
 def test_last_run_state_for_jobs(mock_status_last_run):
     mock_status_last_run.side_effect = [
         ('faketimestamp', chronos_tools.LastRunState.Success),
@@ -85,9 +85,9 @@ def test_sensu_event_for_last_run_state_invalid():
         check_chronos_jobs.sensu_event_for_last_run_state(100)
 
 
-@patch('check_chronos_jobs.chronos_tools.lookup_chronos_jobs', autospec=True)
-@patch('check_chronos_jobs.chronos_tools.filter_enabled_jobs', autospec=True)
-@patch('check_chronos_jobs.chronos_tools.get_status_last_run', autospec=True)
+@patch('paasta_tools.check_chronos_jobs.chronos_tools.lookup_chronos_jobs', autospec=True)
+@patch('paasta_tools.check_chronos_jobs.chronos_tools.filter_enabled_jobs', autospec=True)
+@patch('paasta_tools.check_chronos_jobs.chronos_tools.get_status_last_run', autospec=True)
 def test_build_service_job_mapping(mock_last_run_state, mock_filter_enabled_jobs, mock_lookup_chronos_jobs):
     # iter() is a workaround
     # (http://lists.idyll.org/pipermail/testing-in-python/2013-April/005527.html)

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -19,10 +19,10 @@ import pysensu_yelp
 
 from datetime import datetime, timedelta
 
-import check_marathon_services_replication
+from paasta_tools import check_marathon_services_replication
 from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.smartstack_tools import DEFAULT_SYNAPSE_PORT
-from utils import compose_job_id
+from paasta_tools.utils import compose_job_id
 
 check_marathon_services_replication.log = mock.Mock()
 
@@ -39,7 +39,7 @@ def test_send_event_users_monitoring_tools_send_event_properly():
     expected_check_name = 'check_marathon_services_replication.%s' % compose_job_id(fake_service_name, fake_namespace)
     with contextlib.nested(
         mock.patch("paasta_tools.monitoring_tools.send_event", autospec=True),
-        mock.patch('check_marathon_services_replication.load_system_paasta_config', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.load_system_paasta_config', autospec=True),
         mock.patch("paasta_tools.check_marathon_services_replication._log", autospec=True),
         mock.patch("paasta_tools.marathon_tools.load_marathon_service_config", autospec=True),
     ) as (
@@ -83,7 +83,7 @@ def test_send_event_users_monitoring_tools_send_event_respects_alert_after():
     expected_check_name = 'check_marathon_services_replication.%s' % compose_job_id(fake_service_name, fake_namespace)
     with contextlib.nested(
         mock.patch("paasta_tools.monitoring_tools.send_event", autospec=True),
-        mock.patch('check_marathon_services_replication.load_system_paasta_config', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.load_system_paasta_config', autospec=True),
         mock.patch("paasta_tools.check_marathon_services_replication._log", autospec=True),
         mock.patch("paasta_tools.marathon_tools.load_marathon_service_config", autospec=True),
     ) as (
@@ -125,10 +125,10 @@ def test_check_smartstack_replication_for_instance_ok_when_expecting_zero():
     soa_dir = 'test_dir'
     crit = 90
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.send_event', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
         mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                    autospec=True, return_value=instance),
-        mock.patch('check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
@@ -158,10 +158,10 @@ def test_check_smartstack_replication_for_instance_crit_when_absent():
     soa_dir = 'test_dir'
     crit = 90
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.send_event', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
         mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                    autospec=True, return_value=instance),
-        mock.patch('check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
@@ -193,10 +193,10 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication():
     soa_dir = 'test_dir'
     crit = 90
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.send_event', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
         mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                    autospec=True, return_value=instance),
-        mock.patch('check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
@@ -228,10 +228,10 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication():
     soa_dir = 'test_dir'
     crit = 90
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.send_event', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
         mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                    autospec=True, return_value=instance),
-        mock.patch('check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
@@ -263,10 +263,10 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication():
     soa_dir = 'test_dir'
     crit = 90
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.send_event', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
         mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                    autospec=True, return_value=instance),
-        mock.patch('check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
@@ -299,11 +299,11 @@ def test_check_smartstack_replication_for_instance_ignores_things_under_a_differ
     soa_dir = 'test_dir'
     crit = 90
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.send_event_if_under_replication', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.send_event_if_under_replication', autospec=True),
         mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                    autospec=True, return_value=namespace),
-        mock.patch('check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
-        mock.patch('marathon_tools.load_marathon_service_config', autospec=True)
+        mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
+        mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event_if_under_replication,
         mock_read_namespace_for_service_instance,
@@ -328,10 +328,10 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication_mu
     soa_dir = 'test_dir'
     crit = 90
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.send_event', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
         mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                    autospec=True, return_value=instance),
-        mock.patch('check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
@@ -363,10 +363,10 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication_mul
     soa_dir = 'test_dir'
     crit = 90
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.send_event', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
         mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                    autospec=True, return_value=instance),
-        mock.patch('check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
@@ -398,10 +398,10 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication_mu
     soa_dir = 'test_dir'
     crit = 90
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.send_event', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
         mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                    autospec=True, return_value=instance),
-        mock.patch('check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
@@ -433,10 +433,10 @@ def test_check_smartstack_replication_for_instance_crit_when_missing_replication
     soa_dir = 'test_dir'
     crit = 90
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.send_event', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
         mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                    autospec=True, return_value=instance),
-        mock.patch('check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
@@ -468,10 +468,10 @@ def test_check_smartstack_replication_for_instance_crit_when_no_smartstack_info(
     soa_dir = 'test_dir'
     crit = 90
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.send_event', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
         mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                    autospec=True, return_value=instance),
-        mock.patch('check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
@@ -503,7 +503,7 @@ def test_check_service_replication_for_normal_smartstack():
                    autospec=True, return_value=666),
         mock.patch('paasta_tools.marathon_tools.get_expected_instance_count_for_namespace',
                    autospec=True, return_value=100),
-        mock.patch('check_marathon_services_replication.check_smartstack_replication_for_instance',
+        mock.patch('paasta_tools.check_marathon_services_replication.check_smartstack_replication_for_instance',
                    autospec=True),
     ) as (
         mock_get_proxy_port_for_instance,
@@ -531,7 +531,7 @@ def test_check_service_replication_for_non_smartstack():
         mock.patch('paasta_tools.marathon_tools.get_proxy_port_for_instance', autospec=True, return_value=None),
         mock.patch('paasta_tools.marathon_tools.get_expected_instance_count_for_namespace',
                    autospec=True, return_value=100),
-        mock.patch('check_marathon_services_replication.check_healthy_marathon_tasks_for_service_instance',
+        mock.patch('paasta_tools.check_marathon_services_replication.check_healthy_marathon_tasks_for_service_instance',
                    autospec=True),
     ) as (
         mock_get_proxy_port_for_instance,
@@ -593,8 +593,8 @@ def test_get_healthy_marathon_instances_for_short_app_id_considers_new_tasks_not
     assert actual == 3
 
 
-@mock.patch('check_marathon_services_replication.send_event_if_under_replication')
-@mock.patch('check_marathon_services_replication.get_healthy_marathon_instances_for_short_app_id')
+@mock.patch('paasta_tools.check_marathon_services_replication.send_event_if_under_replication')
+@mock.patch('paasta_tools.check_marathon_services_replication.get_healthy_marathon_instances_for_short_app_id')
 def test_check_healthy_marathon_tasks_for_service_instance(mock_healthy_instances,
                                                            mock_send_event_if_under_replication):
     service = 'service'
@@ -651,7 +651,7 @@ def test_send_event_if_under_replication_handles_0_expected():
     available = 0
     soa_dir = '/dne'
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.send_event', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
     ) as (
         mock_send_event,
     ):
@@ -675,7 +675,7 @@ def test_send_event_if_under_replication_good():
     available = 100
     soa_dir = '/dne'
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.send_event', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
     ) as (
         mock_send_event,
     ):
@@ -699,7 +699,7 @@ def test_send_event_if_under_replication_critical():
     available = 89
     soa_dir = '/dne'
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.send_event', autospec=True),
+        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
     ) as (
         mock_send_event,
     ):
@@ -761,15 +761,15 @@ def test_main():
     services = [('a', 'main'), ('b', 'main'), ('c', 'main')]
     args = mock.Mock(soa_dir=soa_dir, crit=crit, verbose=False)
     with contextlib.nested(
-        mock.patch('check_marathon_services_replication.parse_args',
+        mock.patch('paasta_tools.check_marathon_services_replication.parse_args',
                    return_value=args, autospec=True),
-        mock.patch('check_marathon_services_replication.get_services_for_cluster',
+        mock.patch('paasta_tools.check_marathon_services_replication.get_services_for_cluster',
                    return_value=services, autospec=True),
-        mock.patch('check_marathon_services_replication.check_service_replication',
+        mock.patch('paasta_tools.check_marathon_services_replication.check_service_replication',
                    autospec=True),
-        mock.patch('check_marathon_services_replication.load_system_paasta_config',
+        mock.patch('paasta_tools.check_marathon_services_replication.load_system_paasta_config',
                    autospec=True),
-        mock.patch('check_marathon_services_replication.marathon_tools.load_marathon_config')
+        mock.patch('paasta_tools.check_marathon_services_replication.marathon_tools.load_marathon_config')
     ) as (
         mock_parse_args,
         mock_get_services_for_cluster,

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -17,7 +17,7 @@
 import contextlib
 import mock
 
-import chronos_serviceinit
+from paasta_tools import chronos_serviceinit
 from paasta_tools.utils import PaastaColors
 
 
@@ -29,7 +29,7 @@ def test_start_chronos_job():
     old_schedule = 'R/2015-03-25T19:36:35Z/PT5M'
     job_config = {'beep': 'boop', 'disabled': False, 'schedule': old_schedule}
     with contextlib.nested(
-        mock.patch('chronos_serviceinit.chronos_tools.chronos.ChronosClient', autospec=True),
+        mock.patch('paasta_tools.chronos_serviceinit.chronos_tools.chronos.ChronosClient', autospec=True),
     ) as (
         mock_client,
     ):
@@ -52,7 +52,7 @@ def test_start_chronos_job_does_not_run_disabled_job():
     old_schedule = 'R/2015-03-25T19:36:35Z/PT5M'
     job_config = {'beep': 'boop', 'disabled': True, 'schedule': old_schedule}
     with contextlib.nested(
-        mock.patch('chronos_serviceinit.chronos_tools.chronos.ChronosClient', autospec=True),
+        mock.patch('paasta_tools.chronos_serviceinit.chronos_tools.chronos.ChronosClient', autospec=True),
     ) as (
         mock_client,
     ):
@@ -75,7 +75,7 @@ def test_stop_chronos_job():
                      {'name': 'job_v2', 'disabled': False},
                      {'name': 'job_v3', 'disabled': True}]
     with contextlib.nested(
-        mock.patch('chronos_serviceinit.chronos_tools.chronos.ChronosClient', autospec=True),
+        mock.patch('paasta_tools.chronos_serviceinit.chronos_tools.chronos.ChronosClient', autospec=True),
     ) as (
         mock_client,
     ):
@@ -248,7 +248,7 @@ def test_format_chronos_job_mesos_verbose():
     running_tasks = ['slay the nemean lion']
     verbose = True
     with mock.patch(
-        'chronos_serviceinit.status_mesos_tasks_verbose',
+        'paasta_tools.chronos_serviceinit.status_mesos_tasks_verbose',
         autospec=True,
         return_value='status_mesos_tasks_verbose output',
     ) as mock_status_mesos_tasks_verbose:
@@ -264,12 +264,12 @@ def test_status_chronos_jobs_is_deployed():
     verbose = False
     with contextlib.nested(
         mock.patch(
-            'chronos_serviceinit.format_chronos_job_status',
+            'paasta_tools.chronos_serviceinit.format_chronos_job_status',
             autospec=True,
             return_value='job_status_output',
         ),
         mock.patch(
-            'chronos_serviceinit.get_running_tasks_from_active_frameworks',
+            'paasta_tools.chronos_serviceinit.get_running_tasks_from_active_frameworks',
             autospec=True,
             return_value=[],
         ),
@@ -289,12 +289,12 @@ def test_status_chronos_jobs_is_not_deployed():
     verbose = False
     with contextlib.nested(
         mock.patch(
-            'chronos_serviceinit.format_chronos_job_status',
+            'paasta_tools.chronos_serviceinit.format_chronos_job_status',
             autospec=True,
             return_value='job_status_output',
         ),
         mock.patch(
-            'chronos_serviceinit.get_running_tasks_from_active_frameworks',
+            'paasta_tools.chronos_serviceinit.get_running_tasks_from_active_frameworks',
             autospec=True,
             return_value=[],
         ),
@@ -314,12 +314,12 @@ def test_status_chronos_jobs_get_desired_state_human():
     verbose = False
     with contextlib.nested(
         mock.patch(
-            'chronos_serviceinit.format_chronos_job_status',
+            'paasta_tools.chronos_serviceinit.format_chronos_job_status',
             autospec=True,
             return_value='job_status_output',
         ),
         mock.patch(
-            'chronos_serviceinit.get_running_tasks_from_active_frameworks',
+            'paasta_tools.chronos_serviceinit.get_running_tasks_from_active_frameworks',
             autospec=True,
             return_value=[],
         ),
@@ -343,12 +343,12 @@ def test_status_chronos_jobs_multiple_jobs():
     verbose = False
     with contextlib.nested(
         mock.patch(
-            'chronos_serviceinit.format_chronos_job_status',
+            'paasta_tools.chronos_serviceinit.format_chronos_job_status',
             autospec=True,
             return_value='job_status_output',
         ),
         mock.patch(
-            'chronos_serviceinit.get_running_tasks_from_active_frameworks',
+            'paasta_tools.chronos_serviceinit.get_running_tasks_from_active_frameworks',
             autospec=True,
             return_value=[],
         ),
@@ -368,12 +368,12 @@ def test_status_chronos_jobs_get_running_tasks():
     verbose = False
     with contextlib.nested(
         mock.patch(
-            'chronos_serviceinit.format_chronos_job_status',
+            'paasta_tools.chronos_serviceinit.format_chronos_job_status',
             autospec=True,
             return_value='job_status_output',
         ),
         mock.patch(
-            'chronos_serviceinit.get_running_tasks_from_active_frameworks',
+            'paasta_tools.chronos_serviceinit.get_running_tasks_from_active_frameworks',
             autospec=True,
             return_value=[],
         ),

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -17,10 +17,10 @@ import copy
 import datetime
 
 import mock
+from mock import Mock
 from pytest import raises
 
-import chronos_tools
-from mock import Mock
+from paasta_tools import chronos_tools
 
 
 class TestChronosTools:
@@ -114,7 +114,7 @@ class TestChronosTools:
         expected = {'foo': 'bar'}
         file_mock = mock.MagicMock(spec=file)
         with contextlib.nested(
-            mock.patch('chronos_tools.open', create=True, return_value=file_mock),
+            mock.patch('paasta_tools.chronos_tools.open', create=True, return_value=file_mock),
             mock.patch('json.load', autospec=True, return_value=expected)
         ) as (
             open_file_patch,
@@ -127,7 +127,7 @@ class TestChronosTools:
     def test_load_chronos_config_bad(self):
         fake_path = '/dne'
         with contextlib.nested(
-            mock.patch('chronos_tools.open', create=True, side_effect=IOError(2, 'a', 'b')),
+            mock.patch('paasta_tools.chronos_tools.open', create=True, side_effect=IOError(2, 'a', 'b')),
         ) as (
             open_patch,
         ):
@@ -171,7 +171,7 @@ class TestChronosTools:
         fake_soa_dir = '/tmp/'
         expected_chronos_conf_file = 'chronos-penguin'
         with contextlib.nested(
-            mock.patch('chronos_tools.load_deployments_json', autospec=True,),
+            mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True,),
             mock.patch('service_configuration_lib.read_extra_service_information', autospec=True),
         ) as (
             mock_load_deployments_json,
@@ -190,8 +190,8 @@ class TestChronosTools:
     def test_load_chronos_job_config(self):
         fake_soa_dir = '/tmp/'
         with contextlib.nested(
-            mock.patch('chronos_tools.load_deployments_json', autospec=True,),
-            mock.patch('chronos_tools.read_chronos_jobs_for_service', autospec=True),
+            mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True,),
+            mock.patch('paasta_tools.chronos_tools.read_chronos_jobs_for_service', autospec=True),
         ) as (
             mock_load_deployments_json,
             mock_read_chronos_jobs_for_service,
@@ -211,8 +211,8 @@ class TestChronosTools:
     def test_load_chronos_job_config_can_ignore_deployments(self):
         fake_soa_dir = '/tmp/'
         with contextlib.nested(
-            mock.patch('chronos_tools.load_deployments_json', autospec=True,),
-            mock.patch('chronos_tools.read_chronos_jobs_for_service', autospec=True),
+            mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True,),
+            mock.patch('paasta_tools.chronos_tools.read_chronos_jobs_for_service', autospec=True),
         ) as (
             mock_load_deployments_json,
             mock_read_chronos_jobs_for_service,
@@ -231,7 +231,7 @@ class TestChronosTools:
 
     def test_load_chronos_job_config_unknown_job(self):
         with contextlib.nested(
-            mock.patch('chronos_tools.read_chronos_jobs_for_service', autospec=True),
+            mock.patch('paasta_tools.chronos_tools.read_chronos_jobs_for_service', autospec=True),
         ) as (
             mock_read_chronos_jobs_for_service,
         ):
@@ -318,7 +318,7 @@ class TestChronosTools:
         }
         expected = 'parsed_time'
         with mock.patch(
-            'chronos_tools.parse_time_variables', autospec=True, return_value=expected
+            'paasta_tools.chronos_tools.parse_time_variables', autospec=True, return_value=expected
                 ) as mock_parse_time_variables:
             fake_chronos_job_config = chronos_tools.ChronosJobConfig(
                 service='fake_service',
@@ -333,7 +333,7 @@ class TestChronosTools:
 
     def test_get_owner(self):
         fake_owner = 'fake_team'
-        with mock.patch('monitoring_tools.get_team', autospec=True) as mock_get_team:
+        with mock.patch('paasta_tools.monitoring_tools.get_team', autospec=True) as mock_get_team:
             mock_get_team.return_value = fake_owner
             actual = self.fake_chronos_job_config.get_owner()
             assert actual == fake_owner
@@ -778,7 +778,7 @@ class TestChronosTools:
 
     def test_check_param_with_check(self):
         with contextlib.nested(
-            mock.patch('chronos_tools.ChronosJobConfig.check_cpus', autospec=True),
+            mock.patch('paasta_tools.chronos_tools.ChronosJobConfig.check_cpus', autospec=True),
         ) as (
             mock_check_cpus,
         ):
@@ -847,7 +847,7 @@ class TestChronosTools:
             'uris': ['file:///root/.dockercfg', ],
             'shell': True,
         }
-        with mock.patch('monitoring_tools.get_team', return_value=fake_owner):
+        with mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner):
             actual = chronos_job_config.format_chronos_job_dict(fake_docker_url, fake_docker_volumes)
             assert actual == expected
 
@@ -887,7 +887,7 @@ class TestChronosTools:
             assert sorted(expected) == sorted(actual)
 
     def test_get_chronos_jobs_for_cluster(self):
-        with mock.patch('chronos_tools.get_services_for_cluster',
+        with mock.patch('paasta_tools.chronos_tools.get_services_for_cluster',
                         autospec=True,
                         return_value=[],
                         ) as get_services_for_cluster_patch:
@@ -898,7 +898,7 @@ class TestChronosTools:
         fake_client = mock.Mock()
         fake_service = 'fake_service'
         fake_instance = 'fake_instance'
-        with mock.patch('chronos_tools.filter_chronos_jobs', autospec=True) as mock_filter_chronos_jobs:
+        with mock.patch('paasta_tools.chronos_tools.filter_chronos_jobs', autospec=True) as mock_filter_chronos_jobs:
             chronos_tools.lookup_chronos_jobs(
                 client=fake_client,
                 service=fake_service,
@@ -1144,12 +1144,12 @@ class TestChronosTools:
     def test_create_complete_config(self):
         fake_owner = 'test_team'
         with contextlib.nested(
-            mock.patch('chronos_tools.load_system_paasta_config', autospec=True),
-            mock.patch('chronos_tools.load_chronos_job_config',
+            mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        autospec=True, return_value=self.fake_chronos_job_config),
-            mock.patch('chronos_tools.get_code_sha_from_dockerurl', autospec=True, return_value="sha"),
-            mock.patch('chronos_tools.get_config_hash', autospec=True, return_value="hash"),
-            mock.patch('monitoring_tools.get_team', return_value=fake_owner)
+            mock.patch('paasta_tools.chronos_tools.get_code_sha_from_dockerurl', autospec=True, return_value="sha"),
+            mock.patch('paasta_tools.chronos_tools.get_config_hash', autospec=True, return_value="hash"),
+            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner)
         ) as (
             load_system_paasta_config_patch,
             load_chronos_job_config_patch,
@@ -1199,12 +1199,12 @@ class TestChronosTools:
             },
         )
         with contextlib.nested(
-            mock.patch('chronos_tools.load_system_paasta_config', autospec=True),
-            mock.patch('chronos_tools.load_chronos_job_config',
+            mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        autospec=True, return_value=fake_chronos_job_config),
-            mock.patch('chronos_tools.get_code_sha_from_dockerurl', autospec=True, return_value="sha"),
-            mock.patch('chronos_tools.get_config_hash', autospec=True, return_value="hash"),
-            mock.patch('monitoring_tools.get_team', return_value=fake_owner)
+            mock.patch('paasta_tools.chronos_tools.get_code_sha_from_dockerurl', autospec=True, return_value="sha"),
+            mock.patch('paasta_tools.chronos_tools.get_config_hash', autospec=True, return_value="hash"),
+            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner)
         ) as (
             load_system_paasta_config_patch,
             load_chronos_job_config_patch,
@@ -1254,12 +1254,12 @@ class TestChronosTools:
             },
         )
         with contextlib.nested(
-            mock.patch('chronos_tools.load_system_paasta_config', autospec=True),
-            mock.patch('chronos_tools.load_chronos_job_config',
+            mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        autospec=True, return_value=fake_chronos_job_config),
-            mock.patch('chronos_tools.get_code_sha_from_dockerurl', autospec=True, return_value="sha"),
-            mock.patch('chronos_tools.get_config_hash', autospec=True, return_value="hash"),
-            mock.patch('monitoring_tools.get_team', return_value=fake_owner)
+            mock.patch('paasta_tools.chronos_tools.get_code_sha_from_dockerurl', autospec=True, return_value="sha"),
+            mock.patch('paasta_tools.chronos_tools.get_config_hash', autospec=True, return_value="hash"),
+            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner)
         ) as (
             load_system_paasta_config_patch,
             load_chronos_job_config_patch,
@@ -1325,12 +1325,12 @@ class TestChronosTools:
             },
         )
         with contextlib.nested(
-            mock.patch('chronos_tools.load_system_paasta_config', autospec=True),
-            mock.patch('chronos_tools.load_chronos_job_config',
+            mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        autospec=True, return_value=fake_chronos_job_config),
-            mock.patch('chronos_tools.get_code_sha_from_dockerurl', autospec=True, return_value="sha"),
-            mock.patch('chronos_tools.get_config_hash', autospec=True, return_value="hash"),
-            mock.patch('monitoring_tools.get_team', return_value=fake_owner)
+            mock.patch('paasta_tools.chronos_tools.get_code_sha_from_dockerurl', autospec=True, return_value="sha"),
+            mock.patch('paasta_tools.chronos_tools.get_config_hash', autospec=True, return_value="hash"),
+            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner)
         ) as (
             load_system_paasta_config_patch,
             load_chronos_job_config_patch,
@@ -1514,9 +1514,9 @@ class TestChronosTools:
     def test_check_format_job_ok(self):
         assert chronos_tools.check_parent_format("foo.bar") is True
 
-    @mock.patch('chronos_tools.lookup_chronos_jobs', autospect=True)
-    @mock.patch('chronos_tools.get_chronos_client', autospect=True)
-    @mock.patch('chronos_tools.load_chronos_config', autospect=True)
+    @mock.patch('paasta_tools.chronos_tools.lookup_chronos_jobs', autospect=True)
+    @mock.patch('paasta_tools.chronos_tools.get_chronos_client', autospect=True)
+    @mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospect=True)
     def test_find_matching_parent_job_none_matching(
         self,
         mock_lookup_chronos_jobs,
@@ -1527,9 +1527,9 @@ class TestChronosTools:
         matching = chronos_tools.find_matching_parent_job('service.instance')
         assert matching is None
 
-    @mock.patch('chronos_tools.lookup_chronos_jobs', autospec=True)
-    @mock.patch('chronos_tools.get_chronos_client', autospec=True)
-    @mock.patch('chronos_tools.load_chronos_config', autospec=True)
+    @mock.patch('paasta_tools.chronos_tools.lookup_chronos_jobs', autospec=True)
+    @mock.patch('paasta_tools.chronos_tools.get_chronos_client', autospec=True)
+    @mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospec=True)
     def test_find_matching_parent_job_returns_names(
         self,
         mock_load_chronos_config,

--- a/tests/test_cleanup_marathon_jobs.py
+++ b/tests/test_cleanup_marathon_jobs.py
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cleanup_marathon_jobs
 import mock
 import contextlib
 
 from pytest import raises
 
+from paasta_tools import cleanup_marathon_jobs
 from paasta_tools import marathon_tools
 
 
@@ -38,8 +38,8 @@ class TestCleanupMarathonJobs:
         soa_dir = 'paasta_maaaachine'
         fake_args = mock.Mock(verbose=False, soa_dir=soa_dir)
         with contextlib.nested(
-            mock.patch('cleanup_marathon_jobs.parse_args', return_value=fake_args),
-            mock.patch('cleanup_marathon_jobs.cleanup_apps')
+            mock.patch('paasta_tools.cleanup_marathon_jobs.parse_args', return_value=fake_args),
+            mock.patch('paasta_tools.cleanup_marathon_jobs.cleanup_apps')
         ) as (
             args_patch,
             cleanup_patch
@@ -55,14 +55,14 @@ class TestCleanupMarathonJobs:
                         mock.Mock(id='not-here.oh.no.weirdo')]
         self.fake_marathon_client.list_apps = mock.Mock(return_value=fake_app_ids)
         with contextlib.nested(
-            mock.patch('cleanup_marathon_jobs.get_services_for_cluster',
+            mock.patch('paasta_tools.cleanup_marathon_jobs.get_services_for_cluster',
                        return_value=expected_apps, autospec=True),
             mock.patch('paasta_tools.marathon_tools.load_marathon_config',
                        autospec=True,
                        return_value=self.fake_marathon_config),
             mock.patch('paasta_tools.marathon_tools.get_marathon_client', autospec=True,
                        return_value=self.fake_marathon_client),
-            mock.patch('cleanup_marathon_jobs.delete_app', autospec=True),
+            mock.patch('paasta_tools.cleanup_marathon_jobs.delete_app', autospec=True),
         ) as (
             get_services_for_cluster_patch,
             config_patch,
@@ -83,14 +83,14 @@ class TestCleanupMarathonJobs:
         fake_app_ids = [mock.Mock(id='non_conforming_app')]
         self.fake_marathon_client.list_apps = mock.Mock(return_value=fake_app_ids)
         with contextlib.nested(
-            mock.patch('cleanup_marathon_jobs.get_services_for_cluster',
+            mock.patch('paasta_tools.cleanup_marathon_jobs.get_services_for_cluster',
                        return_value=expected_apps, autospec=True),
             mock.patch('paasta_tools.marathon_tools.load_marathon_config',
                        autospec=True,
                        return_value=self.fake_marathon_config),
             mock.patch('paasta_tools.marathon_tools.get_marathon_client', autospec=True,
                        return_value=self.fake_marathon_client),
-            mock.patch('cleanup_marathon_jobs.delete_app', autospec=True),
+            mock.patch('paasta_tools.cleanup_marathon_jobs.delete_app', autospec=True),
         ) as (
             get_services_for_cluster_patch,
             config_patch,
@@ -104,10 +104,10 @@ class TestCleanupMarathonJobs:
         app_id = 'example--service.main.git93340779.configddb38a65'
         client = self.fake_marathon_client
         with contextlib.nested(
-            mock.patch('cleanup_marathon_jobs.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.cleanup_marathon_jobs.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.bounce_lib.bounce_lock_zookeeper', autospec=True),
             mock.patch('paasta_tools.bounce_lib.delete_marathon_app', autospec=True),
-            mock.patch('cleanup_marathon_jobs._log', autospec=True),
+            mock.patch('paasta_tools.cleanup_marathon_jobs._log', autospec=True),
         ) as (
             mock_load_system_paasta_config,
             mock_bounce_lock_zookeeper,
@@ -136,10 +136,10 @@ class TestCleanupMarathonJobs:
         client = self.fake_marathon_client
 
         with contextlib.nested(
-            mock.patch('cleanup_marathon_jobs.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.cleanup_marathon_jobs.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.bounce_lib.bounce_lock_zookeeper', autospec=True),
             mock.patch('paasta_tools.bounce_lib.delete_marathon_app', side_effect=ValueError('foo')),
-            mock.patch('cleanup_marathon_jobs._log', autospec=True),
+            mock.patch('paasta_tools.cleanup_marathon_jobs._log', autospec=True),
         ) as (
             mock_load_system_paasta_config,
             mock_bounce_lock_zookeeper,

--- a/tests/test_drain_lib.py
+++ b/tests/test_drain_lib.py
@@ -19,7 +19,7 @@ from paasta_tools import drain_lib
 
 def test_register_drain_method():
 
-    with mock.patch('drain_lib._drain_methods'):
+    with mock.patch.dict(drain_lib._drain_methods):
         @drain_lib.register_drain_method('FAKEDRAINMETHOD')
         class FakeDrainMethod(drain_lib.DrainMethod):
             pass

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import generate_deployments_for_service
 import mock
 import contextlib
+from paasta_tools import generate_deployments_for_service
 from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.chronos_tools import ChronosJobConfig
 
@@ -26,13 +26,13 @@ def test_get_branches_for_service():
     expected = set(['red', 'green', 'blue', 'orange', 'white', 'black', 'cluster_a.chronos_job',
                     'cluster_b.chronos_job', 'cluster_c.chronos_job'])
     with contextlib.nested(
-        mock.patch('generate_deployments_for_service.list_clusters',
+        mock.patch('paasta_tools.generate_deployments_for_service.list_clusters',
                    return_value=['cluster_a', 'cluster_b', 'cluster_c']),
-        mock.patch('generate_deployments_for_service.get_service_instance_list',
+        mock.patch('paasta_tools.generate_deployments_for_service.get_service_instance_list',
                    side_effect=lambda service, cluster, instance_type:
                        [('', 'main_example'), ('', 'canary_example')] if instance_type == 'marathon'
                        else [('', 'chronos_job')]),
-        mock.patch('generate_deployments_for_service.load_marathon_service_config',
+        mock.patch('paasta_tools.generate_deployments_for_service.load_marathon_service_config',
                    side_effect=lambda service, instance, cluster, soa_dir: MarathonServiceConfig(
                        service=service,
                        cluster=cluster,
@@ -40,7 +40,7 @@ def test_get_branches_for_service():
                        config_dict={'deploy_group': fake_branches.pop()},
                        branch_dict={},
                    )),
-        mock.patch('generate_deployments_for_service.load_chronos_job_config',
+        mock.patch('paasta_tools.generate_deployments_for_service.load_chronos_job_config',
                    side_effect=lambda service, instance, cluster, soa_dir: ChronosJobConfig(
                        service=service,
                        cluster=cluster,
@@ -89,7 +89,7 @@ def test_get_branch_mappings():
         },
     }
     with contextlib.nested(
-        mock.patch('generate_deployments_for_service.get_branches_for_service',
+        mock.patch('paasta_tools.generate_deployments_for_service.get_branches_for_service',
                    return_value=fake_branches),
         mock.patch('paasta_tools.remote_git.list_remote_refs',
                    return_value=fake_remote_refs),
@@ -117,20 +117,20 @@ def test_main():
     fake_soa_dir = '/etc/true/null'
     file_mock = mock.MagicMock(spec=file)
     with contextlib.nested(
-        mock.patch('generate_deployments_for_service.parse_args',
+        mock.patch('paasta_tools.generate_deployments_for_service.parse_args',
                    return_value=mock.Mock(verbose=False, soa_dir=fake_soa_dir, service='fake_service'),
                    autospec=True),
         mock.patch('os.path.abspath', return_value='ABSOLUTE', autospec=True),
         mock.patch(
-            'generate_deployments_for_service.get_branch_mappings',
+            'paasta_tools.generate_deployments_for_service.get_branch_mappings',
             return_value={'MAP': {'docker_image': 'PINGS', 'desired_state': 'start'}},
             autospec=True,
         ),
         mock.patch('os.path.join', return_value='JOIN', autospec=True),
-        mock.patch('generate_deployments_for_service.open', create=True, return_value=file_mock),
+        mock.patch('paasta_tools.generate_deployments_for_service.open', create=True, return_value=file_mock),
         mock.patch('json.dump', autospec=True),
         mock.patch('json.load', return_value={'OLD_MAP': 'PINGS'}, autospec=True),
-        mock.patch('generate_deployments_for_service.atomic_file_write', autospec=True),
+        mock.patch('paasta_tools.generate_deployments_for_service.atomic_file_write', autospec=True),
     ) as (
         parse_patch,
         abspath_patch,

--- a/tests/test_generate_services_yaml.py
+++ b/tests/test_generate_services_yaml.py
@@ -14,7 +14,7 @@
 
 import mock
 
-import generate_services_yaml
+from paasta_tools import generate_services_yaml
 
 
 MOCK_NAMESPACES = [
@@ -35,7 +35,7 @@ def test_generate_configuration():
         }
     }
 
-    with mock.patch('generate_services_yaml.get_all_namespaces',
+    with mock.patch('paasta_tools.generate_services_yaml.get_all_namespaces',
                     return_value=MOCK_NAMESPACES):
         actual = generate_services_yaml.generate_configuration()
 

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -19,10 +19,10 @@ import mock
 from mock import patch
 from pytest import raises
 
-import marathon_tools
-from utils import compose_job_id
-from utils import DeploymentsJson
-from utils import SystemPaastaConfig
+from paasta_tools import marathon_tools
+from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import DeploymentsJson
+from paasta_tools.utils import SystemPaastaConfig
 
 
 class TestMarathonTools:
@@ -82,7 +82,7 @@ class TestMarathonTools:
         fake_cluster = 'amnesia'
         fake_dir = '/nail/home/sanfran'
         with contextlib.nested(
-            mock.patch('marathon_tools.load_deployments_json', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.load_deployments_json', autospec=True),
             mock.patch('service_configuration_lib.read_service_configuration', autospec=True),
             mock.patch('service_configuration_lib.read_extra_service_information', autospec=True),
         ) as (
@@ -107,7 +107,7 @@ class TestMarathonTools:
         fake_cluster = 'amnesia'
         fake_dir = '/nail/home/sanfran'
         with contextlib.nested(
-            mock.patch('marathon_tools.load_deployments_json', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.load_deployments_json', autospec=True),
             mock.patch('service_configuration_lib.read_service_configuration', autospec=True),
             mock.patch('service_configuration_lib.read_extra_service_information', autospec=True),
         ) as (
@@ -200,7 +200,7 @@ class TestMarathonTools:
                 return_value={fake_instance: config_copy},
             ),
             mock.patch(
-                'marathon_tools.load_deployments_json',
+                'paasta_tools.marathon_tools.load_deployments_json',
                 autospec=True,
                 return_value=deployments_json_mock,
             ),
@@ -241,7 +241,7 @@ class TestMarathonTools:
         expected = {'foo': 'bar'}
         file_mock = mock.MagicMock(spec=file)
         with contextlib.nested(
-            mock.patch('marathon_tools.open', create=True, return_value=file_mock),
+            mock.patch('paasta_tools.marathon_tools.open', create=True, return_value=file_mock),
             mock.patch('json.load', autospec=True, return_value=expected)
         ) as (
             open_file_patch,
@@ -254,7 +254,7 @@ class TestMarathonTools:
     def test_load_marathon_config_path_dne(self):
         fake_path = '/var/dir_of_fake'
         with contextlib.nested(
-            mock.patch('marathon_tools.open', create=True, side_effect=IOError(2, 'a', 'b')),
+            mock.patch('paasta_tools.marathon_tools.open', create=True, side_effect=IOError(2, 'a', 'b')),
         ) as (
             open_patch,
         ):
@@ -291,7 +291,7 @@ class TestMarathonTools:
         with contextlib.nested(
             mock.patch('os.path.abspath', autospec=True, return_value='oxygen'),
             mock.patch('os.listdir', autospec=True, return_value=['rid1', 'rid2']),
-            mock.patch('marathon_tools.get_all_namespaces_for_service',
+            mock.patch('paasta_tools.marathon_tools.get_all_namespaces_for_service',
                        autospec=True,
                        side_effect=lambda a, b: namespaces.pop())
         ) as (
@@ -316,9 +316,9 @@ class TestMarathonTools:
         fake_port = 1234567890
         fake_nerve = marathon_tools.ServiceNamespaceConfig({'proxy_port': fake_port})
         with contextlib.nested(
-            mock.patch('marathon_tools.read_namespace_for_service_instance',
+            mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                        autospec=True, return_value=namespace),
-            mock.patch('marathon_tools.load_service_namespace_config',
+            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
                        autospec=True, return_value=fake_nerve)
         ) as (
             read_ns_patch,
@@ -337,9 +337,9 @@ class TestMarathonTools:
         namespace = 'thirsty_mock'
         expected = None
         with contextlib.nested(
-            mock.patch('marathon_tools.read_namespace_for_service_instance',
+            mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                        autospec=True, return_value=namespace),
-            mock.patch('marathon_tools.load_service_namespace_config',
+            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
                        autospec=True, return_value={})
         ) as (
             read_ns_patch,
@@ -486,7 +486,7 @@ class TestMarathonTools:
         assert actual == instance
         read_info_patch.assert_called_once_with(name, 'marathon-%s' % cluster, soa_dir)
 
-    @mock.patch('marathon_tools.get_local_slave_state', autospec=True)
+    @mock.patch('paasta_tools.marathon_tools.get_local_slave_state', autospec=True)
     def test_marathon_services_running_here(self, mock_get_local_slave_state):
         id_1 = 'klingon.ships.detected.249qwiomelht4jioewglkemr.someuuid'
         id_2 = 'fire.photon.torpedos.jtgriemot5yhtwe94.someuuid'
@@ -548,13 +548,13 @@ class TestMarathonTools:
         expected = [('no_test.uno', {'clock': 0, 'port': 1111, 'proxy_port': 6666}),
                     ('no_docstrings.dos', {'binary': 1, 'port': 2222, 'proxy_port': 6666})]
         with contextlib.nested(
-            mock.patch('marathon_tools.marathon_services_running_here',
+            mock.patch('paasta_tools.marathon_tools.marathon_services_running_here',
                        autospec=True,
                        return_value=fake_marathon_services),
-            mock.patch('marathon_tools.read_namespace_for_service_instance',
+            mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                        autospec=True,
                        side_effect=lambda a, b, c, d: namespaces.pop()),
-            mock.patch('marathon_tools.load_service_namespace_config',
+            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
                        autospec=True,
                        side_effect=lambda a, b, c: nerve_dicts.pop()),
         ) as (
@@ -582,13 +582,13 @@ class TestMarathonTools:
                        marathon_tools.ServiceNamespaceConfig({'clock': 0, 'proxy_port': 6666})]
         expected = [('no_test.uno', {'clock': 0, 'port': 1111, 'proxy_port': 6666})]
         with contextlib.nested(
-            mock.patch('marathon_tools.marathon_services_running_here',
+            mock.patch('paasta_tools.marathon_tools.marathon_services_running_here',
                        autospec=True,
                        return_value=fake_marathon_services),
-            mock.patch('marathon_tools.read_namespace_for_service_instance',
+            mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
                        autospec=True,
                        side_effect=lambda a, b, c, d: namespaces.pop()),
-            mock.patch('marathon_tools.load_service_namespace_config',
+            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
                        autospec=True,
                        side_effect=lambda a, b, c: nerve_dicts.pop()),
         ) as (
@@ -611,11 +611,11 @@ class TestMarathonTools:
         soa_dir = 'the_sound_of_music'
         with contextlib.nested(
             mock.patch(
-                'marathon_tools.load_system_paasta_config',
+                'paasta_tools.marathon_tools.load_system_paasta_config',
                 autospec=True,
             ),
             mock.patch(
-                'marathon_tools.marathon_services_running_here',
+                'paasta_tools.marathon_tools.marathon_services_running_here',
                 autospec=True,
                 return_value=[],
             ),
@@ -633,11 +633,11 @@ class TestMarathonTools:
         soa_dir = 'the_sound_of_music'
         with contextlib.nested(
             mock.patch(
-                'marathon_tools.load_system_paasta_config',
+                'paasta_tools.marathon_tools.load_system_paasta_config',
                 autospec=True,
             ),
             mock.patch(
-                'marathon_tools.marathon_services_running_here',
+                'paasta_tools.marathon_tools.marathon_services_running_here',
                 autospec=True,
                 return_value=[],
             ),
@@ -655,11 +655,11 @@ class TestMarathonTools:
         soa_dir = 'the_sound_of_music'
         with contextlib.nested(
             mock.patch(
-                'marathon_tools.load_system_paasta_config',
+                'paasta_tools.marathon_tools.load_system_paasta_config',
                 autospec=True,
             ),
             mock.patch(
-                'marathon_tools.marathon_services_running_here',
+                'paasta_tools.marathon_tools.marathon_services_running_here',
                 autospec=True,
                 return_value=[],
             ),
@@ -674,7 +674,7 @@ class TestMarathonTools:
     def test_get_classic_service_information_for_nerve(self):
         with contextlib.nested(
             mock.patch('service_configuration_lib.read_port', return_value=101),
-            mock.patch('marathon_tools.load_service_namespace_config', autospec=True,
+            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True,
                        return_value={'ten': 10}),
         ) as (
             read_port_patch,
@@ -716,17 +716,17 @@ class TestMarathonTools:
     def test_get_classic_services_running_here_for_nerve(self):
         with contextlib.nested(
             mock.patch(
-                'marathon_tools.get_classic_services_that_run_here',
+                'paasta_tools.marathon_tools.get_classic_services_that_run_here',
                 autospec=True,
                 side_effect=lambda: ['a', 'b', 'c']
             ),
             mock.patch(
-                'marathon_tools.get_all_namespaces_for_service',
+                'paasta_tools.marathon_tools.get_all_namespaces_for_service',
                 autospec=True,
                 side_effect=lambda x, y, full_name: [('foo', {})]
             ),
             mock.patch(
-                'marathon_tools._namespaced_get_classic_service_information_for_nerve',
+                'paasta_tools.marathon_tools._namespaced_get_classic_service_information_for_nerve',
                 autospec=True,
                 side_effect=lambda x, y, _: (compose_job_id(x, y), {})
             ),
@@ -742,10 +742,10 @@ class TestMarathonTools:
         fake_classic_services = [('walk', 'on'), ('his', 'feet')]
         expected = fake_marathon_services + fake_classic_services
         with contextlib.nested(
-            mock.patch('marathon_tools.get_marathon_services_running_here_for_nerve',
+            mock.patch('paasta_tools.marathon_tools.get_marathon_services_running_here_for_nerve',
                        autospec=True,
                        return_value=fake_marathon_services),
-            mock.patch('marathon_tools.get_classic_services_running_here_for_nerve',
+            mock.patch('paasta_tools.marathon_tools.get_classic_services_running_here_for_nerve',
                        autospec=True,
                        return_value=fake_classic_services),
         ) as (
@@ -845,7 +845,10 @@ class TestMarathonTools:
             branch_dict={'desired_state': 'start'}
         )
 
-        with mock.patch('marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True) as get_slaves_patch:
+        with mock.patch(
+            'paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
+            autospec=True,
+        ) as get_slaves_patch:
             get_slaves_patch.return_value = {'fake_region': {}}
             actual = config.format_marathon_app_dict(fake_id, fake_url, fake_volumes,
                                                      fake_service_namespace_config)
@@ -1021,7 +1024,10 @@ class TestMarathonTools:
             config_dict={'constraints': 'so_many_walls'},
             branch_dict={},
         )
-        with mock.patch('marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True) as get_slaves_patch:
+        with mock.patch(
+            'paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
+            autospec=True,
+        ) as get_slaves_patch:
             assert fake_conf.get_constraints(fake_service_namespace_config) == 'so_many_walls'
             assert get_slaves_patch.call_count == 0
 
@@ -1034,7 +1040,10 @@ class TestMarathonTools:
             config_dict={},
             branch_dict={},
         )
-        with mock.patch('marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True) as get_slaves_patch:
+        with mock.patch(
+            'paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
+            autospec=True,
+        ) as get_slaves_patch:
             get_slaves_patch.return_value = {'fake_region': {}}
             assert fake_conf.get_constraints(fake_service_namespace_config) == [["region", "GROUP_BY", "1"]]
 
@@ -1051,7 +1060,10 @@ class TestMarathonTools:
             config_dict={},
             branch_dict={},
         )
-        with mock.patch('marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True) as get_slaves_patch:
+        with mock.patch(
+            'paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
+            autospec=True,
+        ) as get_slaves_patch:
             get_slaves_patch.return_value = {'fake_region': {}, 'fake_other_region': {}}
             assert fake_conf.get_constraints(fake_service_namespace_config) == [["habitat", "GROUP_BY", "2"]]
             get_slaves_patch.assert_called_once_with(attribute='habitat', blacklist=[])
@@ -1067,7 +1079,10 @@ class TestMarathonTools:
             branch_dict={},
         )
         expected_constraints = [["region", "GROUP_BY", "1"], ["region", "UNLIKE", "fake_blacklisted_region"]]
-        with mock.patch('marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True) as get_slaves_patch:
+        with mock.patch(
+            'paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
+            autospec=True,
+        ) as get_slaves_patch:
             get_slaves_patch.return_value = {'fake_region': {}}
             assert fake_conf.get_constraints(fake_service_namespace_config) == expected_constraints
             get_slaves_patch.assert_called_once_with(attribute='region', blacklist=fake_deploy_blacklist)
@@ -1086,7 +1101,7 @@ class TestMarathonTools:
         fake_url = "nothing_for_me_to_do_but_dance"
         fake_user = "the_boogie"
         fake_passwd = "is_for_real"
-        with mock.patch('marathon_tools.MarathonClient', autospec=True) as client_patch:
+        with mock.patch('paasta_tools.marathon_tools.MarathonClient', autospec=True) as client_patch:
             marathon_tools.get_marathon_client(fake_url, fake_user, fake_passwd)
             client_patch.assert_called_once_with(fake_url, fake_user, fake_passwd, timeout=30)
 
@@ -1104,7 +1119,7 @@ class TestMarathonTools:
         fake_all_marathon_app_ids = ['fake_app1', 'fake_app2']
         fake_client = mock.Mock()
         with mock.patch(
-            'marathon_tools.list_all_marathon_app_ids',
+            'paasta_tools.marathon_tools.list_all_marathon_app_ids',
             autospec=True,
             return_value=fake_all_marathon_app_ids,
         ) as list_all_marathon_app_ids_patch:
@@ -1116,14 +1131,14 @@ class TestMarathonTools:
         fake_all_marathon_app_ids = ['fake_app1', 'fake_app2']
         fake_client = mock.Mock()
         with mock.patch(
-            'marathon_tools.list_all_marathon_app_ids',
+            'paasta_tools.marathon_tools.list_all_marathon_app_ids',
             autospec=True,
             return_value=fake_all_marathon_app_ids,
         ) as list_all_marathon_app_ids_patch:
             assert marathon_tools.is_app_id_running(fake_id, fake_client) is False
             list_all_marathon_app_ids_patch.assert_called_once_with(fake_client)
 
-    @patch('marathon_tools.MarathonClient.list_tasks')
+    @patch('paasta_tools.marathon_tools.MarathonClient.list_tasks')
     def test_app_has_tasks_exact(self, patch_list_tasks):
         fake_client = mock.Mock()
         fake_client.list_tasks = patch_list_tasks
@@ -1131,7 +1146,7 @@ class TestMarathonTools:
         assert marathon_tools.app_has_tasks(fake_client, 'fake_app', 3) is True
         assert marathon_tools.app_has_tasks(fake_client, 'fake_app', 3, exact_matches_only=True) is True
 
-    @patch('marathon_tools.MarathonClient.list_tasks')
+    @patch('paasta_tools.marathon_tools.MarathonClient.list_tasks')
     def test_app_has_tasks_less(self, patch_list_tasks):
         fake_client = mock.Mock()
         fake_client.list_tasks = patch_list_tasks
@@ -1139,7 +1154,7 @@ class TestMarathonTools:
         assert marathon_tools.app_has_tasks(fake_client, 'fake_app', 2) is True
         assert marathon_tools.app_has_tasks(fake_client, 'fake_app', 2, exact_matches_only=True) is False
 
-    @patch('marathon_tools.MarathonClient.list_tasks')
+    @patch('paasta_tools.marathon_tools.MarathonClient.list_tasks')
     def test_app_has_tasks_more(self, patch_list_tasks):
         fake_client = mock.Mock()
         fake_client.list_tasks = patch_list_tasks
@@ -1147,7 +1162,7 @@ class TestMarathonTools:
         assert marathon_tools.app_has_tasks(fake_client, 'fake_app', 4) is False
         assert marathon_tools.app_has_tasks(fake_client, 'fake_app', 4, exact_matches_only=True) is False
 
-    @patch('marathon_tools.MarathonClient.list_tasks')
+    @patch('paasta_tools.marathon_tools.MarathonClient.list_tasks')
     def test_add_leading_slash(self, patch_list_tasks):
         fake_client = mock.Mock()
         fake_client.list_tasks = patch_list_tasks
@@ -1212,13 +1227,13 @@ class TestMarathonTools:
         )
 
         with contextlib.nested(
-            mock.patch('marathon_tools.load_system_paasta_config',
+            mock.patch('paasta_tools.marathon_tools.load_system_paasta_config',
                        autospec=True, return_value=fake_system_paasta_config),
-            mock.patch('marathon_tools.load_marathon_service_config', autospec=True),
-            mock.patch('marathon_tools.get_docker_url', autospec=True, return_value=fake_url),
-            mock.patch('marathon_tools.load_service_namespace_config', autospec=True,
+            mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.get_docker_url', autospec=True, return_value=fake_url),
+            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True,
                        return_value=self.fake_service_namespace_config),
-            mock.patch('marathon_tools.get_mesos_slaves_grouped_by_attribute',
+            mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
                        autospec=True, return_value={'fake_region': {}})
         ) as (
             load_system_paasta_config_patch,
@@ -1276,10 +1291,10 @@ class TestMarathonTools:
                 )
 
         with contextlib.nested(
-            mock.patch('marathon_tools.get_service_instance_list',
+            mock.patch('paasta_tools.marathon_tools.get_service_instance_list',
                        autospec=True,
                        return_value=fake_instances),
-            mock.patch('marathon_tools.load_marathon_service_config',
+            mock.patch('paasta_tools.marathon_tools.load_marathon_service_config',
                        autospec=True,
                        side_effect=config_helper),
         ) as (
@@ -1361,10 +1376,10 @@ class TestMarathonTools:
             'healthcheck_uri': fake_path,
         })
         with contextlib.nested(
-            mock.patch('marathon_tools.load_marathon_service_config',
+            mock.patch('paasta_tools.marathon_tools.load_marathon_service_config',
                        autospec=True,
                        return_value=fake_marathon_service_config),
-            mock.patch('marathon_tools.load_service_namespace_config',
+            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
                        autospec=True,
                        return_value=fake_service_namespace_config),
             mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
@@ -1395,10 +1410,10 @@ class TestMarathonTools:
             'mode': 'tcp',
         })
         with contextlib.nested(
-            mock.patch('marathon_tools.load_marathon_service_config',
+            mock.patch('paasta_tools.marathon_tools.load_marathon_service_config',
                        autospec=True,
                        return_value=fake_marathon_service_config),
-            mock.patch('marathon_tools.load_service_namespace_config',
+            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
                        autospec=True,
                        return_value=fake_service_namespace_config),
             mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
@@ -1430,10 +1445,10 @@ class TestMarathonTools:
         )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig({})
         with contextlib.nested(
-            mock.patch('marathon_tools.load_marathon_service_config',
+            mock.patch('paasta_tools.marathon_tools.load_marathon_service_config',
                        autospec=True,
                        return_value=fake_marathon_service_config),
-            mock.patch('marathon_tools.load_service_namespace_config',
+            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
                        autospec=True,
                        return_value=fake_service_namespace_config),
             mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
@@ -1463,10 +1478,10 @@ class TestMarathonTools:
         )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig({})
         with contextlib.nested(
-            mock.patch('marathon_tools.load_marathon_service_config',
+            mock.patch('paasta_tools.marathon_tools.load_marathon_service_config',
                        autospec=True,
                        return_value=fake_marathon_service_config),
-            mock.patch('marathon_tools.load_service_namespace_config',
+            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
                        autospec=True,
                        return_value=fake_service_namespace_config),
             mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
@@ -1497,10 +1512,10 @@ class TestMarathonTools:
         )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig({})
         with contextlib.nested(
-            mock.patch('marathon_tools.load_marathon_service_config',
+            mock.patch('paasta_tools.marathon_tools.load_marathon_service_config',
                        autospec=True,
                        return_value=fake_marathon_service_config),
-            mock.patch('marathon_tools.load_service_namespace_config',
+            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
                        autospec=True,
                        return_value=fake_service_namespace_config),
             mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
@@ -1917,11 +1932,17 @@ def test_create_complete_config_no_smartstack():
     fake_cluster = "clustername"
 
     with contextlib.nested(
-        mock.patch('marathon_tools.load_marathon_service_config', return_value=fake_marathon_service_config),
-        mock.patch('marathon_tools.load_service_namespace_config', return_value=fake_service_namespace_config),
-        mock.patch('marathon_tools.format_job_id', return_value=fake_job_id),
-        mock.patch('marathon_tools.load_system_paasta_config', return_value=fake_system_paasta_config),
-        mock.patch('marathon_tools.get_mesos_slaves_grouped_by_attribute',
+        mock.patch(
+            'paasta_tools.marathon_tools.load_marathon_service_config',
+            return_value=fake_marathon_service_config,
+        ),
+        mock.patch(
+            'paasta_tools.marathon_tools.load_service_namespace_config',
+            return_value=fake_service_namespace_config,
+        ),
+        mock.patch('paasta_tools.marathon_tools.format_job_id', return_value=fake_job_id),
+        mock.patch('paasta_tools.marathon_tools.load_system_paasta_config', return_value=fake_system_paasta_config),
+        mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
                    autospec=True, return_value={'fake_region': {}})
     ) as (
         mock_load_marathon_service_config,
@@ -1981,11 +2002,17 @@ def test_create_complete_config_with_smartstack():
     fake_cluster = "clustername"
 
     with contextlib.nested(
-        mock.patch('marathon_tools.load_marathon_service_config', return_value=fake_marathon_service_config),
-        mock.patch('marathon_tools.load_service_namespace_config', return_value=fake_service_namespace_config),
-        mock.patch('marathon_tools.format_job_id', return_value=fake_job_id),
-        mock.patch('marathon_tools.load_system_paasta_config', return_value=fake_system_paasta_config),
-        mock.patch('marathon_tools.get_mesos_slaves_grouped_by_attribute',
+        mock.patch(
+            'paasta_tools.marathon_tools.load_marathon_service_config',
+            return_value=fake_marathon_service_config,
+        ),
+        mock.patch(
+            'paasta_tools.marathon_tools.load_service_namespace_config',
+            return_value=fake_service_namespace_config,
+        ),
+        mock.patch('paasta_tools.marathon_tools.format_job_id', return_value=fake_job_id),
+        mock.patch('paasta_tools.marathon_tools.load_system_paasta_config', return_value=fake_system_paasta_config),
+        mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
                    autospec=True, return_value={'fake_region': {}})
     ) as (
         mock_load_marathon_service_config,
@@ -2069,11 +2096,17 @@ def test_create_complete_config_utilizes_extra_volumes():
     fake_cluster = "clustername"
 
     with contextlib.nested(
-        mock.patch('marathon_tools.load_marathon_service_config', return_value=fake_marathon_service_config),
-        mock.patch('marathon_tools.load_service_namespace_config', return_value=fake_service_namespace_config),
-        mock.patch('marathon_tools.format_job_id', return_value=fake_job_id),
-        mock.patch('marathon_tools.load_system_paasta_config', return_value=fake_system_paasta_config),
-        mock.patch('marathon_tools.get_mesos_slaves_grouped_by_attribute',
+        mock.patch(
+            'paasta_tools.marathon_tools.load_marathon_service_config',
+            return_value=fake_marathon_service_config,
+        ),
+        mock.patch(
+            'paasta_tools.marathon_tools.load_service_namespace_config',
+            return_value=fake_service_namespace_config,
+        ),
+        mock.patch('paasta_tools.marathon_tools.format_job_id', return_value=fake_job_id),
+        mock.patch('paasta_tools.marathon_tools.load_system_paasta_config', return_value=fake_system_paasta_config),
+        mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
                    autospec=True, return_value={'fake_region': {}})
     ) as (
         mock_load_marathon_service_config,

--- a/tests/test_monitoring_tools.py
+++ b/tests/test_monitoring_tools.py
@@ -15,9 +15,9 @@
 import contextlib
 import mock
 
-import chronos_tools
-import marathon_tools
-import monitoring_tools
+from paasta_tools import chronos_tools
+from paasta_tools import marathon_tools
+from paasta_tools import monitoring_tools
 
 
 class TestMonitoring_Tools:
@@ -82,73 +82,97 @@ class TestMonitoring_Tools:
     soa_dir = '/fake/soa/dir'
 
     def test_get_team(self):
-        with mock.patch('monitoring_tools.__get_monitoring_config_value') as get_monitoring_config_value_patch:
+        with mock.patch(
+            'paasta_tools.monitoring_tools.__get_monitoring_config_value',
+        ) as get_monitoring_config_value_patch:
             monitoring_tools.get_team(self.overrides, self.service, self.soa_dir)
             get_monitoring_config_value_patch.assert_called_once_with('team', self.overrides, self.service,
                                                                       self.soa_dir)
 
     def test_get_runbook(self):
-        with mock.patch('monitoring_tools.__get_monitoring_config_value') as get_monitoring_config_value_patch:
+        with mock.patch(
+            'paasta_tools.monitoring_tools.__get_monitoring_config_value',
+        ) as get_monitoring_config_value_patch:
             monitoring_tools.get_runbook(self.overrides, self.service, self.soa_dir)
             get_monitoring_config_value_patch.assert_called_once_with('runbook', self.overrides, self.service,
                                                                       self.soa_dir)
 
     def test_get_tip(self):
-        with mock.patch('monitoring_tools.__get_monitoring_config_value') as get_monitoring_config_value_patch:
+        with mock.patch(
+            'paasta_tools.monitoring_tools.__get_monitoring_config_value',
+        ) as get_monitoring_config_value_patch:
             monitoring_tools.get_tip(self.overrides, self.service, self.soa_dir)
             get_monitoring_config_value_patch.assert_called_once_with('tip', self.overrides, self.service,
                                                                       self.soa_dir)
 
     def test_get_notification_email(self):
-        with mock.patch('monitoring_tools.__get_monitoring_config_value') as get_monitoring_config_value_patch:
+        with mock.patch(
+            'paasta_tools.monitoring_tools.__get_monitoring_config_value',
+        ) as get_monitoring_config_value_patch:
             monitoring_tools.get_notification_email(self.overrides, self.service, self.soa_dir)
             get_monitoring_config_value_patch.assert_called_once_with('notification_email', self.overrides,
                                                                       self.service, self.soa_dir)
 
     def test_get_page(self):
-        with mock.patch('monitoring_tools.__get_monitoring_config_value') as get_monitoring_config_value_patch:
+        with mock.patch(
+            'paasta_tools.monitoring_tools.__get_monitoring_config_value',
+        ) as get_monitoring_config_value_patch:
             monitoring_tools.get_page(self.overrides, self.service, self.soa_dir)
             get_monitoring_config_value_patch.assert_called_once_with('page', self.overrides, self.service,
                                                                       self.soa_dir)
 
     def test_get_alert_after(self):
-        with mock.patch('monitoring_tools.__get_monitoring_config_value') as get_monitoring_config_value_patch:
+        with mock.patch(
+            'paasta_tools.monitoring_tools.__get_monitoring_config_value',
+        ) as get_monitoring_config_value_patch:
             monitoring_tools.get_alert_after(self.overrides, self.service, self.soa_dir)
             get_monitoring_config_value_patch.assert_called_once_with('alert_after', self.overrides, self.service,
                                                                       self.soa_dir)
 
     def test_get_realert_every(self):
-        with mock.patch('monitoring_tools.__get_monitoring_config_value') as get_monitoring_config_value_patch:
+        with mock.patch(
+            'paasta_tools.monitoring_tools.__get_monitoring_config_value',
+        ) as get_monitoring_config_value_patch:
             monitoring_tools.get_realert_every(self.overrides, self.service, self.soa_dir)
             get_monitoring_config_value_patch.assert_called_once_with('realert_every', self.overrides,
                                                                       self.service, self.soa_dir)
 
     def test_get_check_every(self):
-        with mock.patch('monitoring_tools.__get_monitoring_config_value') as get_monitoring_config_value_patch:
+        with mock.patch(
+            'paasta_tools.monitoring_tools.__get_monitoring_config_value',
+        ) as get_monitoring_config_value_patch:
             monitoring_tools.get_check_every(self.overrides, self.service, self.soa_dir)
             get_monitoring_config_value_patch.assert_called_once_with('check_every', self.overrides, self.service,
                                                                       self.soa_dir)
 
     def test_get_irc_channels(self):
-        with mock.patch('monitoring_tools.__get_monitoring_config_value') as get_monitoring_config_value_patch:
+        with mock.patch(
+            'paasta_tools.monitoring_tools.__get_monitoring_config_value',
+        ) as get_monitoring_config_value_patch:
             monitoring_tools.get_irc_channels(self.overrides, self.service, self.soa_dir)
             get_monitoring_config_value_patch.assert_called_once_with('irc_channels', self.overrides, self.service,
                                                                       self.soa_dir)
 
     def test_get_dependencies(self):
-        with mock.patch('monitoring_tools.__get_monitoring_config_value') as get_monitoring_config_value_patch:
+        with mock.patch(
+            'paasta_tools.monitoring_tools.__get_monitoring_config_value',
+        ) as get_monitoring_config_value_patch:
             monitoring_tools.get_dependencies(self.overrides, self.service, self.soa_dir)
             get_monitoring_config_value_patch.assert_called_once_with('dependencies', self.overrides, self.service,
                                                                       self.soa_dir)
 
     def test_get_ticket(self):
-        with mock.patch('monitoring_tools.__get_monitoring_config_value') as get_monitoring_config_value_patch:
+        with mock.patch(
+            'paasta_tools.monitoring_tools.__get_monitoring_config_value',
+        ) as get_monitoring_config_value_patch:
             monitoring_tools.get_ticket(self.overrides, self.service, self.soa_dir)
             get_monitoring_config_value_patch.assert_called_once_with('ticket', self.overrides, self.service,
                                                                       self.soa_dir)
 
     def test_get_project(self):
-        with mock.patch('monitoring_tools.__get_monitoring_config_value') as get_monitoring_config_value_patch:
+        with mock.patch(
+            'paasta_tools.monitoring_tools.__get_monitoring_config_value',
+        ) as get_monitoring_config_value_patch:
             monitoring_tools.get_project(self.overrides, self.service, self.soa_dir)
             get_monitoring_config_value_patch.assert_called_once_with('project', self.overrides, self.service,
                                                                       self.soa_dir)
@@ -158,9 +182,9 @@ class TestMonitoring_Tools:
         with contextlib.nested(
             mock.patch('service_configuration_lib.read_service_configuration', autospec=True,
                        return_value=self.fake_general_service_config),
-            mock.patch('monitoring_tools.read_monitoring_config',
+            mock.patch('paasta_tools.monitoring_tools.read_monitoring_config',
                        autospec=True, return_value=self.fake_monitor_config),
-            mock.patch('monitoring_tools.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.monitoring_tools.load_system_paasta_config', autospec=True),
         ) as (
             service_configuration_lib_patch,
             read_monitoring_patch,
@@ -177,9 +201,9 @@ class TestMonitoring_Tools:
         with contextlib.nested(
             mock.patch('service_configuration_lib.read_service_configuration', autospec=True,
                        return_value=self.fake_general_service_config),
-            mock.patch('monitoring_tools.read_monitoring_config',
+            mock.patch('paasta_tools.monitoring_tools.read_monitoring_config',
                        autospec=True, return_value=self.empty_monitor_config),
-            mock.patch('monitoring_tools.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.monitoring_tools.load_system_paasta_config', autospec=True),
         ) as (
             service_configuration_lib_patch,
             read_monitoring_patch,
@@ -196,9 +220,9 @@ class TestMonitoring_Tools:
         with contextlib.nested(
             mock.patch('service_configuration_lib.read_service_configuration', autospec=True,
                        return_value=self.empty_job_config),
-            mock.patch('monitoring_tools.read_monitoring_config',
+            mock.patch('paasta_tools.monitoring_tools.read_monitoring_config',
                        autospec=True, return_value=self.empty_monitor_config),
-            mock.patch('monitoring_tools.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.monitoring_tools.load_system_paasta_config', autospec=True),
         ) as (
             service_configuration_lib_patch,
             read_monitoring_patch,
@@ -213,7 +237,7 @@ class TestMonitoring_Tools:
     def test_get_team_email_address_uses_override_if_specified(self):
         fake_email = 'fake_email'
         with contextlib.nested(
-            mock.patch('monitoring_tools.__get_monitoring_config_value', autospec=True),
+            mock.patch('paasta_tools.monitoring_tools.__get_monitoring_config_value', autospec=True),
         ) as (
             mock_get_monitoring_config_value,
         ):
@@ -224,7 +248,7 @@ class TestMonitoring_Tools:
     def test_get_team_email_address_uses_instance_config_if_specified(self):
         expected = 'fake_email'
         with contextlib.nested(
-            mock.patch('monitoring_tools.__get_monitoring_config_value', autospec=True),
+            mock.patch('paasta_tools.monitoring_tools.__get_monitoring_config_value', autospec=True),
         ) as (
             mock_get_monitoring_config_value,
         ):
@@ -235,9 +259,9 @@ class TestMonitoring_Tools:
     def test_get_team_email_address_uses_team_data_as_last_resort(self):
         expected = 'team_data_email'
         with contextlib.nested(
-            mock.patch('monitoring_tools.__get_monitoring_config_value', autospec=True),
-            mock.patch('monitoring_tools.get_sensu_team_data', autospec=True),
-            mock.patch('monitoring_tools.get_team', autospec=True),
+            mock.patch('paasta_tools.monitoring_tools.__get_monitoring_config_value', autospec=True),
+            mock.patch('paasta_tools.monitoring_tools.get_sensu_team_data', autospec=True),
+            mock.patch('paasta_tools.monitoring_tools.get_team', autospec=True),
         ) as (
             mock_get_monitoring_config_value,
             mock_get_sensu_team_data,
@@ -253,9 +277,9 @@ class TestMonitoring_Tools:
 
     def test_get_team_email_address_returns_none_if_not_available(self):
         with contextlib.nested(
-            mock.patch('monitoring_tools.__get_monitoring_config_value', autospec=True),
-            mock.patch('monitoring_tools.get_sensu_team_data', autospec=True),
-            mock.patch('monitoring_tools.get_team', autospec=True),
+            mock.patch('paasta_tools.monitoring_tools.__get_monitoring_config_value', autospec=True),
+            mock.patch('paasta_tools.monitoring_tools.get_sensu_team_data', autospec=True),
+            mock.patch('paasta_tools.monitoring_tools.get_team', autospec=True),
         ) as (
             mock_get_monitoring_config_value,
             mock_get_sensu_team_data,
@@ -296,42 +320,42 @@ class TestMonitoring_Tools:
         }
         with contextlib.nested(
             mock.patch(
-                "monitoring_tools.get_team",
+                "paasta_tools.monitoring_tools.get_team",
                 return_value=fake_team,
                 autospec=True,
             ),
             mock.patch(
-                "monitoring_tools.get_tip",
+                "paasta_tools.monitoring_tools.get_tip",
                 return_value=fake_tip,
                 autospec=True,
             ),
             mock.patch(
-                "monitoring_tools.get_notification_email",
+                "paasta_tools.monitoring_tools.get_notification_email",
                 return_value=fake_notification_email,
                 autospec=True,
             ),
             mock.patch(
-                "monitoring_tools.get_irc_channels",
+                "paasta_tools.monitoring_tools.get_irc_channels",
                 return_value=fake_irc,
                 autospec=True,
             ),
             mock.patch(
-                "monitoring_tools.get_ticket",
+                "paasta_tools.monitoring_tools.get_ticket",
                 return_value=False,
                 autospec=True,
             ),
             mock.patch(
-                "monitoring_tools.get_project",
+                "paasta_tools.monitoring_tools.get_project",
                 return_value=None,
                 autospec=True,
             ),
             mock.patch(
-                "monitoring_tools.get_page",
+                "paasta_tools.monitoring_tools.get_page",
                 return_value=True,
                 autospec=True,
             ),
             mock.patch("pysensu_yelp.send_event", autospec=True),
-            mock.patch('monitoring_tools.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.monitoring_tools.load_system_paasta_config', autospec=True),
         ) as (
             get_team_patch,
             get_tip_patch,

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -20,7 +20,7 @@ from mock import patch
 from httplib2 import ServerNotFoundError
 from pytest import raises
 
-from chronos_tools import ChronosNotConfigured
+from paasta_tools.chronos_tools import ChronosNotConfigured
 from paasta_tools import paasta_metastatus
 from paasta_tools.utils import PaastaColors
 from paasta_tools.marathon_tools import MarathonConfig

--- a/tests/test_setup_chronos_job.py
+++ b/tests/test_setup_chronos_job.py
@@ -20,7 +20,7 @@ import mock
 from pysensu_yelp import Status
 from pytest import raises
 
-import setup_chronos_job
+from paasta_tools import setup_chronos_job
 from paasta_tools import chronos_tools
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import compose_job_id
@@ -72,7 +72,7 @@ class TestSetupChronosJob:
         expected_output = 'it_is_finished'
         fake_complete_job_config = {'foo': 'bar'}
         with contextlib.nested(
-            mock.patch('setup_chronos_job.parse_args',
+            mock.patch('paasta_tools.setup_chronos_job.parse_args',
                        return_value=self.fake_args,
                        autospec=True),
             mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospec=True),
@@ -82,11 +82,11 @@ class TestSetupChronosJob:
             mock.patch('paasta_tools.chronos_tools.create_complete_config',
                        return_value=fake_complete_job_config,
                        autospec=True),
-            mock.patch('setup_chronos_job.setup_job',
+            mock.patch('paasta_tools.setup_chronos_job.setup_job',
                        return_value=(expected_status, expected_output),
                        autospec=True),
-            mock.patch('setup_chronos_job.send_event', autospec=True),
-            mock.patch('setup_chronos_job.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.setup_chronos_job.send_event', autospec=True),
+            mock.patch('paasta_tools.setup_chronos_job.load_system_paasta_config', autospec=True),
             mock.patch('sys.exit', autospec=True),
         ) as (
             parse_args_patch,
@@ -121,7 +121,7 @@ class TestSetupChronosJob:
 
     def test_main_no_deployments(self):
         with contextlib.nested(
-            mock.patch('setup_chronos_job.parse_args',
+            mock.patch('paasta_tools.setup_chronos_job.parse_args',
                        return_value=self.fake_args,
                        autospec=True),
             mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospec=True),
@@ -132,11 +132,11 @@ class TestSetupChronosJob:
                        return_value={},
                        autospec=True,
                        side_effect=NoDeploymentsAvailable),
-            mock.patch('setup_chronos_job.setup_job',
+            mock.patch('paasta_tools.setup_chronos_job.setup_job',
                        return_value=(0, 'it_is_finished'),
                        autospec=True),
-            mock.patch('setup_chronos_job.load_system_paasta_config', autospec=True),
-            mock.patch('setup_chronos_job.send_event', autospec=True),
+            mock.patch('paasta_tools.setup_chronos_job.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.setup_chronos_job.send_event', autospec=True),
         ) as (
             parse_args_patch,
             load_chronos_config_patch,
@@ -153,7 +153,7 @@ class TestSetupChronosJob:
 
     def test_main_bad_chronos_job_config_notifies_user(self):
         with contextlib.nested(
-            mock.patch('setup_chronos_job.parse_args',
+            mock.patch('paasta_tools.setup_chronos_job.parse_args',
                        return_value=self.fake_args,
                        autospec=True),
             mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospec=True),
@@ -163,11 +163,11 @@ class TestSetupChronosJob:
             mock.patch('paasta_tools.chronos_tools.create_complete_config',
                        autospec=True,
                        side_effect=chronos_tools.UnknownChronosJobError('test bad configuration')),
-            mock.patch('setup_chronos_job.setup_job',
+            mock.patch('paasta_tools.setup_chronos_job.setup_job',
                        return_value=(0, 'it_is_finished'),
                        autospec=True),
-            mock.patch('setup_chronos_job.load_system_paasta_config', autospec=True),
-            mock.patch('setup_chronos_job.send_event', autospec=True),
+            mock.patch('paasta_tools.setup_chronos_job.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.setup_chronos_job.send_event', autospec=True),
         ) as (
             parse_args_patch,
             load_chronos_config_patch,
@@ -196,7 +196,7 @@ class TestSetupChronosJob:
     def test_setup_job_new_app_with_no_previous_jobs(self):
         fake_existing_jobs = []
         with contextlib.nested(
-            mock.patch('setup_chronos_job.bounce_chronos_job', autospec=True, return_value=(0, 'ok')),
+            mock.patch('paasta_tools.setup_chronos_job.bounce_chronos_job', autospec=True, return_value=(0, 'ok')),
             mock.patch('paasta_tools.chronos_tools.lookup_chronos_jobs',
                        autospec=True),
             mock.patch('paasta_tools.chronos_tools.sort_jobs',
@@ -243,7 +243,7 @@ class TestSetupChronosJob:
             'disabled': False,
         }
         with contextlib.nested(
-            mock.patch('setup_chronos_job.bounce_chronos_job', autospec=True, return_value=(0, 'ok')),
+            mock.patch('paasta_tools.setup_chronos_job.bounce_chronos_job', autospec=True, return_value=(0, 'ok')),
             mock.patch('paasta_tools.chronos_tools.lookup_chronos_jobs',
                        autospec=True),
             mock.patch('paasta_tools.chronos_tools.sort_jobs',
@@ -287,7 +287,7 @@ class TestSetupChronosJob:
     def test_setup_job_does_nothing_with_only_existing_app(self):
         fake_existing_job = self.fake_config_dict
         with contextlib.nested(
-            mock.patch('setup_chronos_job.bounce_chronos_job', autospec=True, return_value=(0, 'ok')),
+            mock.patch('paasta_tools.setup_chronos_job.bounce_chronos_job', autospec=True, return_value=(0, 'ok')),
             mock.patch('paasta_tools.chronos_tools.lookup_chronos_jobs',
                        autospec=True),
             mock.patch('paasta_tools.chronos_tools.sort_jobs',
@@ -339,7 +339,7 @@ class TestSetupChronosJob:
         with contextlib.nested(
             mock.patch("paasta_tools.monitoring_tools.send_event", autospec=True),
             mock.patch("paasta_tools.chronos_tools.load_chronos_job_config", autospec=True),
-            mock.patch("setup_chronos_job.load_system_paasta_config", autospec=True),
+            mock.patch("paasta_tools.setup_chronos_job.load_system_paasta_config", autospec=True),
         ) as (
             mock_send_event,
             mock_load_chronos_job_config,
@@ -375,7 +375,7 @@ class TestSetupChronosJob:
         fake_jobs_to_delete = [{'name': 'job_to_delete'}]
         fake_job_to_create = {'name': 'job_to_create'}
         with contextlib.nested(
-            mock.patch("setup_chronos_job._log", autospec=True),
+            mock.patch("paasta_tools.setup_chronos_job._log", autospec=True),
             mock.patch("paasta_tools.chronos_tools.disable_job", autospec=True),
             mock.patch("paasta_tools.chronos_tools.delete_job", autospec=True),
             mock.patch("paasta_tools.chronos_tools.create_job", autospec=True),
@@ -419,7 +419,7 @@ class TestSetupChronosJob:
         fake_jobs_to_delete = []
         fake_job_to_create = []
         with contextlib.nested(
-            mock.patch("setup_chronos_job._log", autospec=True),
+            mock.patch("paasta_tools.setup_chronos_job._log", autospec=True),
             mock.patch("paasta_tools.chronos_tools.disable_job", autospec=True),
             mock.patch("paasta_tools.chronos_tools.delete_job", autospec=True),
             mock.patch("paasta_tools.chronos_tools.create_job", autospec=True),

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -27,7 +27,7 @@ from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import NoDockerImageError
-import setup_marathon_job
+from paasta_tools import setup_marathon_job
 
 
 class TestSetupMarathonJob:
@@ -67,12 +67,12 @@ class TestSetupMarathonJob:
         fake_client = mock.MagicMock()
         with contextlib.nested(
             mock.patch(
-                'setup_marathon_job.parse_args',
+                'paasta_tools.setup_marathon_job.parse_args',
                 return_value=self.fake_args,
                 autospec=True,
             ),
             mock.patch(
-                'setup_marathon_job.get_main_marathon_config',
+                'paasta_tools.setup_marathon_job.get_main_marathon_config',
                 return_value=self.fake_marathon_config,
                 autospec=True,
             ),
@@ -87,12 +87,12 @@ class TestSetupMarathonJob:
                 autospec=True,
             ),
             mock.patch(
-                'setup_marathon_job.setup_service',
+                'paasta_tools.setup_marathon_job.setup_service',
                 return_value=(0, 'it_is_finished'),
                 autospec=True,
             ),
-            mock.patch('setup_marathon_job.load_system_paasta_config', autospec=True),
-            mock.patch('setup_marathon_job.send_event', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.send_event', autospec=True),
             mock.patch('sys.exit', autospec=True),
         ) as (
             parse_args_patch,
@@ -133,12 +133,12 @@ class TestSetupMarathonJob:
         fake_client = mock.MagicMock()
         with contextlib.nested(
             mock.patch(
-                'setup_marathon_job.parse_args',
+                'paasta_tools.setup_marathon_job.parse_args',
                 return_value=self.fake_args,
                 autospec=True,
             ),
             mock.patch(
-                'setup_marathon_job.get_main_marathon_config',
+                'paasta_tools.setup_marathon_job.get_main_marathon_config',
                 return_value=self.fake_marathon_config,
                 autospec=True,
             ),
@@ -153,12 +153,12 @@ class TestSetupMarathonJob:
                 autospec=True,
             ),
             mock.patch(
-                'setup_marathon_job.setup_service',
+                'paasta_tools.setup_marathon_job.setup_service',
                 return_value=(1, 'NEVER'),
                 autospec=True,
             ),
-            mock.patch('setup_marathon_job.load_system_paasta_config', autospec=True),
-            mock.patch('setup_marathon_job.send_event', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.send_event', autospec=True),
             mock.patch('sys.exit', autospec=True),
         ) as (
             parse_args_patch,
@@ -197,12 +197,12 @@ class TestSetupMarathonJob:
         fake_client = mock.MagicMock()
         with contextlib.nested(
             mock.patch(
-                'setup_marathon_job.parse_args',
+                'paasta_tools.setup_marathon_job.parse_args',
                 return_value=self.fake_args,
                 autospec=True,
             ),
             mock.patch(
-                'setup_marathon_job.get_main_marathon_config',
+                'paasta_tools.setup_marathon_job.get_main_marathon_config',
                 return_value=self.fake_marathon_config,
                 autospec=True,
             ),
@@ -217,12 +217,12 @@ class TestSetupMarathonJob:
                 autospec=True,
             ),
             mock.patch(
-                'setup_marathon_job.setup_service',
+                'paasta_tools.setup_marathon_job.setup_service',
                 return_value=(1, 'NEVER'),
                 autospec=True,
             ),
-            mock.patch('setup_marathon_job.load_system_paasta_config', autospec=True),
-            mock.patch('setup_marathon_job.send_event', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.send_event', autospec=True),
         ) as (
             parse_args_patch,
             get_main_conf_patch,
@@ -267,7 +267,7 @@ class TestSetupMarathonJob:
         with contextlib.nested(
             mock.patch("paasta_tools.monitoring_tools.send_event", autospec=True),
             mock.patch("paasta_tools.marathon_tools.load_marathon_service_config", autospec=True),
-            mock.patch("setup_marathon_job.load_system_paasta_config", autospec=True),
+            mock.patch("paasta_tools.setup_marathon_job.load_system_paasta_config", autospec=True),
         ) as (
             send_event_patch,
             load_marathon_service_config_patch,
@@ -363,9 +363,9 @@ class TestSetupMarathonJob:
         expected_drain_task_count = len(fake_bounce_func_return['tasks_to_drain'])
 
         with contextlib.nested(
-            mock.patch('setup_marathon_job._log', autospec=True),
-            mock.patch('setup_marathon_job.bounce_lib.create_marathon_app', autospec=True),
-            mock.patch('setup_marathon_job.bounce_lib.kill_old_ids', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.bounce_lib.create_marathon_app', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.bounce_lib.kill_old_ids', autospec=True),
         ) as (mock_log, mock_create_marathon_app, mock_kill_old_ids):
             setup_marathon_job.do_bounce(
                 bounce_func=fake_bounce_func,
@@ -426,9 +426,9 @@ class TestSetupMarathonJob:
         expected_drain_task_count = len(fake_bounce_func_return['tasks_to_drain'])
 
         with contextlib.nested(
-            mock.patch('setup_marathon_job._log', autospec=True),
-            mock.patch('setup_marathon_job.bounce_lib.create_marathon_app', autospec=True),
-            mock.patch('setup_marathon_job.bounce_lib.kill_old_ids', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.bounce_lib.create_marathon_app', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.bounce_lib.kill_old_ids', autospec=True),
         ) as (mock_log, mock_create_marathon_app, mock_kill_old_ids):
             setup_marathon_job.do_bounce(
                 bounce_func=fake_bounce_func,
@@ -487,9 +487,9 @@ class TestSetupMarathonJob:
         expected_drain_task_count = len(fake_bounce_func_return['tasks_to_drain'])
 
         with contextlib.nested(
-            mock.patch('setup_marathon_job._log', autospec=True),
-            mock.patch('setup_marathon_job.bounce_lib.create_marathon_app', autospec=True),
-            mock.patch('setup_marathon_job.bounce_lib.kill_old_ids', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.bounce_lib.create_marathon_app', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.bounce_lib.kill_old_ids', autospec=True),
         ) as (mock_log, mock_create_marathon_app, mock_kill_old_ids):
             setup_marathon_job.do_bounce(
                 bounce_func=fake_bounce_func,
@@ -547,9 +547,9 @@ class TestSetupMarathonJob:
         expected_new_task_count = fake_config["instances"] - len(fake_happy_new_tasks)
 
         with contextlib.nested(
-            mock.patch('setup_marathon_job._log', autospec=True),
-            mock.patch('setup_marathon_job.bounce_lib.create_marathon_app', autospec=True),
-            mock.patch('setup_marathon_job.bounce_lib.kill_old_ids', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.bounce_lib.create_marathon_app', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.bounce_lib.kill_old_ids', autospec=True),
         ) as (mock_log, mock_create_marathon_app, mock_kill_old_ids):
             setup_marathon_job.do_bounce(
                 bounce_func=fake_bounce_func,
@@ -610,10 +610,10 @@ class TestSetupMarathonJob:
         )
 
         with contextlib.nested(
-            mock.patch('setup_marathon_job._log', autospec=True),
-            mock.patch('setup_marathon_job.bounce_lib.create_marathon_app', autospec=True),
-            mock.patch('setup_marathon_job.bounce_lib.kill_old_ids', autospec=True),
-            mock.patch('setup_marathon_job.send_sensu_bounce_keepalive', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.bounce_lib.create_marathon_app', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.bounce_lib.kill_old_ids', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.send_sensu_bounce_keepalive', autospec=True),
         ) as (
             mock_log,
             mock_create_marathon_app,
@@ -672,7 +672,7 @@ class TestSetupMarathonJob:
                 autospec=True,
             ),
             mock.patch(
-                'setup_marathon_job.deploy_service',
+                'paasta_tools.setup_marathon_job.deploy_service',
                 autospec=True,
             ),
         ) as (
@@ -717,7 +717,7 @@ class TestSetupMarathonJob:
                 autospec=True,
             ),
             mock.patch(
-                'setup_marathon_job.deploy_service',
+                'paasta_tools.setup_marathon_job.deploy_service',
                 return_value=(111, 'Never'),
                 autospec=True,
             ),
@@ -795,7 +795,7 @@ class TestSetupMarathonJob:
         fake_name = 'test_service'
         fake_instance = 'test_instance'
         with mock.patch(
-            'setup_marathon_job.marathon_tools.create_complete_config',
+            'paasta_tools.setup_marathon_job.marathon_tools.create_complete_config',
             side_effect=NoDockerImageError,
         ):
             status, output = setup_marathon_job.setup_service(
@@ -825,8 +825,8 @@ class TestSetupMarathonJob:
         expected = (1, errormsg)
 
         with contextlib.nested(
-            mock.patch('setup_marathon_job._log', autospec=True),
-            mock.patch('setup_marathon_job.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
             mock.patch(
                 'paasta_tools.drain_lib._drain_methods',
                 new={'exists1': mock.Mock(), 'exists2': mock.Mock()},
@@ -865,8 +865,8 @@ class TestSetupMarathonJob:
         expected = (1, errormsg)
 
         with contextlib.nested(
-            mock.patch('setup_marathon_job._log', autospec=True),
-            mock.patch('setup_marathon_job.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
         ) as (mock_log, mock_load_system_paasta_config):
             mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value='fake_cluster')
             actual = setup_marathon_job.deploy_service(
@@ -934,8 +934,8 @@ class TestSetupMarathonJob:
             ),
             mock.patch('paasta_tools.bounce_lib.kill_old_ids', autospec=True),
             mock.patch('paasta_tools.bounce_lib.create_marathon_app', autospec=True),
-            mock.patch('setup_marathon_job._log', autospec=True),
-            mock.patch('setup_marathon_job.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.drain_lib.get_drain_method', return_value=fake_drain_method),
         ) as (_, _, _, kill_old_ids_patch, create_marathon_app_patch, mock_log, mock_load_system_paasta_config, _):
             mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value='fake_cluster')
@@ -1025,8 +1025,8 @@ class TestSetupMarathonJob:
                 autospec=True,
                 side_effect=lambda x, _, __, **kwargs: x,
             ),
-            mock.patch('setup_marathon_job._log', autospec=True),
-            mock.patch('setup_marathon_job.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
         ) as (_, _, _, _, mock_load_system_paasta_config):
             mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value='fake_cluster')
             result = setup_marathon_job.deploy_service(
@@ -1056,9 +1056,9 @@ class TestSetupMarathonJob:
         fake_config = {'id': fake_id, 'instances': 2}
 
         with contextlib.nested(
-            mock.patch('setup_marathon_job._log', autospec=True),
-            mock.patch('setup_marathon_job.bounce_lib.get_bounce_method_func', side_effect=IOError('foo')),
-            mock.patch('setup_marathon_job.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.bounce_lib.get_bounce_method_func', side_effect=IOError('foo')),
+            mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
         ) as (mock_log, mock_bounce, mock_load_system_paasta_config):
             mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value='fake_cluster')
             with raises(IOError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,7 @@ import tempfile
 import json
 import mock
 
-import utils
+from paasta_tools import utils
 from pytest import raises
 
 
@@ -62,7 +62,7 @@ def test_format_log_line():
         'component': fake_component,
         'message': input_line,
     }, sort_keys=True)
-    with mock.patch('utils._now', autospec=True) as mock_now:
+    with mock.patch('paasta_tools.utils._now', autospec=True) as mock_now:
         mock_now.return_value = fake_now
         actual = utils.format_log_line(fake_level, fake_cluster, fake_instance, fake_component, input_line)
         assert actual == expected
@@ -119,8 +119,8 @@ def test_get_readable_files_in_glob_ignores_unreadable():
         mock.patch('glob.glob', autospec=True, return_value=['/fake/b.json', '/fake/a.json', '/fake/c.json']),
         mock.patch('os.path.isfile', autospec=True, return_value=True),
         mock.patch('os.access', autospec=True, side_effect=[True, False, True]),
-        mock.patch('utils.open', create=True, return_value=file_mock),
-        mock.patch('utils.json.load', autospec=True, return_value=fake_file_contents)
+        mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock),
+        mock.patch('paasta_tools.utils.json.load', autospec=True, return_value=fake_file_contents)
     ):
         assert utils.get_readable_files_in_glob(fake_dir) == expected
 
@@ -134,8 +134,8 @@ def test_get_readable_files_in_glob_is_lexicographic():
         mock.patch('glob.glob', autospec=True, return_value=['/fake/b.json', '/fake/a.json']),
         mock.patch('os.path.isfile', autospec=True, return_value=True),
         mock.patch('os.access', autospec=True, return_value=True),
-        mock.patch('utils.open', create=True, return_value=file_mock),
-        mock.patch('utils.json.load', autospec=True, return_value=fake_file_contents)
+        mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock),
+        mock.patch('paasta_tools.utils.json.load', autospec=True, return_value=fake_file_contents)
     ):
         assert utils.get_readable_files_in_glob(fake_dir) == expected
 
@@ -147,10 +147,10 @@ def test_load_system_paasta_config():
     with contextlib.nested(
         mock.patch('os.path.isdir', return_value=True),
         mock.patch('os.access', return_value=True),
-        mock.patch('utils.open', create=True, return_value=file_mock),
-        mock.patch('utils.get_readable_files_in_glob', autospec=True,
+        mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock),
+        mock.patch('paasta_tools.utils.get_readable_files_in_glob', autospec=True,
                    return_value=['/some/fake/dir/some_file.json']),
-        mock.patch('utils.json.load', autospec=True, return_value=json_load_return_value)
+        mock.patch('paasta_tools.utils.json.load', autospec=True, return_value=json_load_return_value)
     ) as (
         os_is_dir_patch,
         os_access_patch,
@@ -202,8 +202,8 @@ def test_load_system_paasta_config_file_dne():
     with contextlib.nested(
         mock.patch('os.path.isdir', return_value=True),
         mock.patch('os.access', return_value=True),
-        mock.patch('utils.open', create=True, side_effect=IOError(2, 'a', 'b')),
-        mock.patch('utils.get_readable_files_in_glob', autospec=True, return_value=[fake_path]),
+        mock.patch('paasta_tools.utils.open', create=True, side_effect=IOError(2, 'a', 'b')),
+        mock.patch('paasta_tools.utils.get_readable_files_in_glob', autospec=True, return_value=[fake_path]),
     ) as (
         isdir_patch,
         access_patch,
@@ -223,10 +223,10 @@ def test_load_system_paasta_config_merge_lexographically():
     with contextlib.nested(
         mock.patch('os.path.isdir', return_value=True),
         mock.patch('os.access', return_value=True),
-        mock.patch('utils.open', create=True, return_value=file_mock),
-        mock.patch('utils.get_readable_files_in_glob', autospec=True,
+        mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock),
+        mock.patch('paasta_tools.utils.get_readable_files_in_glob', autospec=True,
                    return_value=['a', 'b']),
-        mock.patch('utils.json.load', autospec=True, side_effect=[fake_file_a, fake_file_b])
+        mock.patch('paasta_tools.utils.json.load', autospec=True, side_effect=[fake_file_a, fake_file_b])
     ) as (
         os_is_dir_patch,
         os_access_patch,
@@ -408,7 +408,7 @@ def test_decompose_job_id_with_hashes():
     assert actual == expected
 
 
-@mock.patch('utils.build_docker_image_name')
+@mock.patch('paasta_tools.utils.build_docker_image_name')
 def test_build_docker_tag(mock_build_docker_image_name):
     upstream_job_name = 'foo'
     upstream_git_commit = 'bar'
@@ -420,7 +420,7 @@ def test_build_docker_tag(mock_build_docker_image_name):
     assert actual == expected
 
 
-@mock.patch('utils.build_docker_image_name')
+@mock.patch('paasta_tools.utils.build_docker_image_name')
 def test_check_docker_image_false(mock_build_docker_image_name):
     mock_build_docker_image_name.return_value = 'fake-registry/services-foo'
     fake_app = 'fake_app'
@@ -439,7 +439,7 @@ def test_check_docker_image_false(mock_build_docker_image_name):
         assert utils.check_docker_image('test_service', 'tag2') is False
 
 
-@mock.patch('utils.build_docker_image_name')
+@mock.patch('paasta_tools.utils.build_docker_image_name')
 def test_check_docker_image_true(mock_build_docker_image_name):
     fake_app = 'fake_app'
     fake_commit = 'fake_commit'
@@ -468,8 +468,8 @@ def test_get_default_cluster_for_service():
     fake_service = 'fake_service'
     fake_clusters = ['fake_cluster-1', 'fake_cluster-2']
     with contextlib.nested(
-        mock.patch('utils.list_clusters', autospec=True, return_value=fake_clusters),
-        mock.patch('utils.load_system_paasta_config', autospec=True),
+        mock.patch('paasta_tools.utils.list_clusters', autospec=True, return_value=fake_clusters),
+        mock.patch('paasta_tools.utils.load_system_paasta_config', autospec=True),
     ) as (
         mock_list_clusters,
         mock_load_system_paasta_config,
@@ -482,8 +482,8 @@ def test_get_default_cluster_for_service():
 def test_get_default_cluster_for_service_empty_deploy_config():
     fake_service = 'fake_service'
     with contextlib.nested(
-        mock.patch('utils.list_clusters', autospec=True, return_value=[]),
-        mock.patch('utils.load_system_paasta_config', autospec=True),
+        mock.patch('paasta_tools.utils.list_clusters', autospec=True, return_value=[]),
+        mock.patch('paasta_tools.utils.load_system_paasta_config', autospec=True),
     ) as (
         mock_list_clusters,
         mock_load_system_paasta_config,
@@ -556,8 +556,8 @@ def test_list_all_instances_for_service():
     mock_instances = [(service, 'instance1'), (service, 'instance2')]
     expected = set(['instance1', 'instance2'])
     with contextlib.nested(
-        mock.patch('utils.list_clusters', autospec=True),
-        mock.patch('utils.get_service_instance_list', autospec=True),
+        mock.patch('paasta_tools.utils.list_clusters', autospec=True),
+        mock.patch('paasta_tools.utils.get_service_instance_list', autospec=True),
     ) as (
         mock_list_clusters,
         mock_service_instance_list,
@@ -581,7 +581,7 @@ def test_get_service_instance_list():
     expected = [(fake_name, fake_instance_1), (fake_name, fake_instance_1),
                 (fake_name, fake_instance_2), (fake_name, fake_instance_2)]
     with contextlib.nested(
-        mock.patch('utils.service_configuration_lib.read_extra_service_information', autospec=True,
+        mock.patch('paasta_tools.utils.service_configuration_lib.read_extra_service_information', autospec=True,
                    return_value=fake_job_config),
     ) as (
         read_extra_info_patch,
@@ -601,7 +601,7 @@ def test_get_services_for_cluster():
     with contextlib.nested(
         mock.patch('os.path.abspath', autospec=True, return_value='chex_mix'),
         mock.patch('os.listdir', autospec=True, return_value=['dir1', 'dir2']),
-        mock.patch('utils.get_service_instance_list',
+        mock.patch('paasta_tools.utils.get_service_instance_list',
                    side_effect=lambda a, b, c, d: instances.pop()),
     ) as (
         abspath_patch,
@@ -653,9 +653,9 @@ def test_DeploymentsJson_read():
         },
     }
     with contextlib.nested(
-        mock.patch('utils.open', create=True, return_value=file_mock),
+        mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock),
         mock.patch('json.load', autospec=True, return_value=fake_json),
-        mock.patch('utils.os.path.isfile', autospec=True, return_value=True),
+        mock.patch('paasta_tools.utils.os.path.isfile', autospec=True, return_value=True),
     ) as (
         open_patch,
         json_patch,
@@ -683,8 +683,8 @@ def test_run_cancels_timer_thread_on_keyboard_interrupt():
     mock_process = mock.Mock()
     mock_timer_object = mock.Mock()
     with contextlib.nested(
-        mock.patch('utils.Popen', autospec=True, return_value=mock_process),
-        mock.patch('utils.threading.Timer', autospec=True, return_value=mock_timer_object),
+        mock.patch('paasta_tools.utils.Popen', autospec=True, return_value=mock_process),
+        mock.patch('paasta_tools.utils.threading.Timer', autospec=True, return_value=mock_timer_object),
     ) as (
         mock_popen,
         mock_timer
@@ -968,7 +968,7 @@ def test_validate_service_instance_valid_marathon():
     fake_cluster = 'fake_cluster'
     fake_soa_dir = 'fake_soa_dir'
     with contextlib.nested(
-        mock.patch('utils.get_services_for_cluster',
+        mock.patch('paasta_tools.utils.get_services_for_cluster',
                    autospec=True,
                    side_effect=[mock_marathon_services, mock_chronos_services]),
     ) as (
@@ -995,7 +995,7 @@ def test_validate_service_instance_valid_chronos():
     fake_cluster = 'fake_cluster'
     fake_soa_dir = 'fake_soa_dir'
     with contextlib.nested(
-        mock.patch('utils.get_services_for_cluster',
+        mock.patch('paasta_tools.utils.get_services_for_cluster',
                    autospec=True,
                    side_effect=[mock_marathon_services, mock_chronos_services]),
     ) as (
@@ -1022,7 +1022,7 @@ def test_validate_service_instance_invalid():
     fake_cluster = 'fake_cluster'
     fake_soa_dir = 'fake_soa_dir'
     with contextlib.nested(
-        mock.patch('utils.get_services_for_cluster',
+        mock.patch('paasta_tools.utils.get_services_for_cluster',
                    autospec=True,
                    side_effect=[mock_marathon_services, mock_chronos_services]),
         mock.patch('sys.exit'),

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 skipsdist=True
-usedevelop=True
-basepython = python2.7
-envlist = py
+envlist = py27
 indexserver =
     default = https://pypi.python.org/simple
     private = https://pypi.yelpcorp.com/simple
@@ -11,26 +9,15 @@ indexserver =
 max-line-length = 120
 
 [testenv]
-usedevelop=True
-basepython = python2.7
-install_command = pip install --upgrade {opts} {packages}
-deps = -rrequirements.txt
-
-[testenv:py]
-basepython = python2.7
 setenv=
-    PYTHONPATH = ./paasta_tools
     TZ = UTC
 deps =
-    {[testenv]deps}
-    pep8==1.5.7
-    flake8==2.5.0
-    pytest==2.7.3
-    pytest-cov==2.2.0
-    mock==1.0.1
+    --requirement={toxinidir}/requirements.txt
+    --requirement={toxinidir}/requirements-dev.txt
+    --editable={toxinidir}
 commands =
     flake8 paasta_tools tests general_itests paasta_itests
-    py.test --cov-config .coveragerc --cov=paasta_tools --cov-report=term-missing --cov-report=html -s {posargs:tests}
+    python -m pytest --cov-config .coveragerc --cov=paasta_tools --cov-report=term-missing --cov-report=html -s {posargs:tests}
 
 [testenv:docs]
 deps =
@@ -43,13 +30,11 @@ commands =
     sphinx-build -b html -d docs/build/doctrees docs/source docs/build/html
 
 [testenv:manpages]
-# This tox invocation is called by dh-virtualenv inside a container
-# and needs the full path so it can work regardless of the current directory
 deps =
     :private:scribereader==0.1.30
     :private:yelp-cgeom==1.3.1
     :private:yelp-logging==1.0.37
-    -r/work/requirements.txt
+    --requirement={toxinidir}/requirements.txt
 install_command= pip install --allow-external scribereader {opts} {packages}
 commands = ./build-manpages.sh
 
@@ -75,24 +60,19 @@ commands =
 
 [testenv:paasta_itests_inside_container]
 envdir=/tmp/
-skipsdist=True
-recreate=True
 setenv =
     DOCKER_COMPOSE_PROJECT_NAME = paastatools_inside_container
 changedir=paasta_itests/
 deps =
+    {[testenv]deps}
     behave==1.2.4
-    mock==1.0.1
-    -r/work/requirements.txt
 commands =
-    behave {posargs}
+    python -m behave {posargs}
 
 [testenv:general_itests]
-skipsdist=True
 changedir=general_itests/
 deps =
     {[testenv]deps}
     behave==1.2.4
-    mock==1.0.1
 commands =
-    behave {posargs}
+    python -m behave {posargs}


### PR DESCRIPTION
This probably requires some explaining (and may not be entirely complete).

Currently tox sets `PYTHONPATH=paasta_tools/` which is entirely unrealistic in a real running situation, writing code which depends on this will pass under test but fail miserably when run in an integration scenario.

I also had to change `py.test` to `python -m pytest`.  The former puts the bin/ directory on the pythonpath.

I removed the line in tox and then fixed all the things that broke because of it.
