### PR TITLE
fixed paasta_metastatus -vv when there are no mesos slaves

### DIFF
--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -66,7 +66,7 @@ def get_extra_mesos_slave_data(mesos_state):
     slaves = dict((slave['id'], {
         'free_resources': slave['resources'],
         'hostname': slave['hostname'],
-    }) for slave in mesos_state.get('slaves', []))
+    }) for slave in mesos_state['slaves'])
 
     for framework in mesos_state.get('frameworks', []):
         for task in framework.get('tasks', []):
@@ -189,10 +189,10 @@ def assert_extra_slave_data(mesos_state):
                 '%.2f' % slave['free_resources']['cpus'],
                 '%.2f' % slave['free_resources']['mem'],
             ))
-        output = '\n'.join(('    %s' % row for row in format_table(rows)))[2:]
+        result = ('\n'.join(('    %s' % row for row in format_table(rows)))[2:], True)
     else:
-        output = '  No mesos slaves on this cluster'
-    return (output, True)
+        result = ('  No mesos slaves registered on this cluster!', False)
+    return result
 
 
 def get_mesos_status(mesos_state, verbosity):

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -413,6 +413,13 @@ def test_main_no_chronos_config():
         assert excinfo.value.code == 0
 
 
+def test_assert_extra_slave_data_no_slaves():
+    fake_mesos_state = {'slaves': [], 'frameworks': [], 'tasks': []}
+    expected = 'No mesos slaves on this cluster'
+    actual = paasta_metastatus.assert_extra_slave_data(fake_mesos_state)[0]
+    assert expected == actual.strip()
+
+
 def test_status_for_results():
     assert paasta_metastatus.status_for_results([('message', True), ('message', False)]) == [True, False]
 

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -415,7 +415,7 @@ def test_main_no_chronos_config():
 
 def test_assert_extra_slave_data_no_slaves():
     fake_mesos_state = {'slaves': [], 'frameworks': [], 'tasks': []}
-    expected = 'No mesos slaves on this cluster'
+    expected = 'No mesos slaves registered on this cluster!'
     actual = paasta_metastatus.assert_extra_slave_data(fake_mesos_state)[0]
     assert expected == actual.strip()
 


### PR DESCRIPTION
Running paasta metastatus -vv on a cluster with no mesos slaves will no longer throw an exception (hopefully)

This also takes into account running paasta metastatus on a mesos setup with no frameworks, or no tasks in a framework.