### PR TITLE
Force python2.7 in other tox environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands =
     python -m pytest --cov-config .coveragerc --cov=paasta_tools --cov-report=term-missing --cov-report=html -s {posargs:tests}
 
 [testenv:docs]
+basepython = python2.7
 deps =
     {[testenv]deps}
     sphinx
@@ -30,6 +31,7 @@ commands =
     sphinx-build -b html -d docs/build/doctrees docs/source docs/build/html
 
 [testenv:manpages]
+basepython = python2.7
 deps =
     :private:scribereader==0.1.30
     :private:yelp-cgeom==1.3.1
@@ -39,6 +41,7 @@ install_command= pip install --allow-external scribereader {opts} {packages}
 commands = ./build-manpages.sh
 
 [testenv:paasta_itests]
+basepython = python2.7
 changedir=paasta_itests/
 deps =
     docker-compose==1.3.0
@@ -59,6 +62,7 @@ commands =
     docker-compose rm --force
 
 [testenv:paasta_itests_inside_container]
+basepython = python2.7
 envdir=/tmp/
 setenv =
     DOCKER_COMPOSE_PROJECT_NAME = paastatools_inside_container
@@ -70,6 +74,7 @@ commands =
     python -m behave {posargs}
 
 [testenv:general_itests]
+basepython = python2.7
 changedir=general_itests/
 deps =
     {[testenv]deps}


### PR DESCRIPTION
This will use py27 on machines that have `python` that is not python2.7 (such as lucid)

I didn't notice this when changing this since I was developing on trusty (and travis uses precise)