### PR TITLE
Enabled deploy_groups

### DIFF
--- a/docs/source/installation/getting_started.rst
+++ b/docs/source/installation/getting_started.rst
@@ -180,7 +180,7 @@ This may be something as simple as a bash script::
   sha=$(git rev-parse HEAD)
   paasta itest --service $service --commit $sha
   paasta push-to-registry --service $service --commit $sha
-  paasta mark-for-deployment --git-url $(git config --get remote.origin.url) --commit $sha --clusterinstance prod.main --service $service
+  paasta mark-for-deployment --git-url $(git config --get remote.origin.url) --commit $sha --deploy_group prod.main --service $service
 
 PaaSTA can integrate with any existing orchestration tool that can execute
 commands like this.

--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -29,7 +29,6 @@ from dulwich.repo import Repo
 
 from paasta_tools import generate_deployments_for_service
 from paasta_tools import marathon_tools
-from paasta_tools.utils import InstanceConfig
 
 
 @given(u'a test git repo is setup with commits')

--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -29,6 +29,7 @@ from dulwich.repo import Repo
 
 from paasta_tools import generate_deployments_for_service
 from paasta_tools import marathon_tools
+from paasta_tools.utils import InstanceConfig
 
 
 @given(u'a test git repo is setup with commits')

--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -19,6 +19,10 @@ import re
 import urllib2
 
 from paasta_tools.cli.cmds.validate import paasta_validate_soa_configs
+from service_configuration_lib import DEFAULT_SOA_DIR
+from service_configuration_lib import read_service_configuration
+
+from paasta_tools.chronos_tools import load_chronos_job_config
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_file_contents
 from paasta_tools.cli.utils import is_file_in_dir
@@ -30,6 +34,7 @@ from paasta_tools.cli.utils import success
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.cli.utils import x_mark
 from paasta_tools.marathon_tools import get_all_namespaces_for_service
+from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.monitoring_tools import get_team
 from paasta_tools.utils import _run
 from paasta_tools.utils import DEPLOY_PIPELINE_NON_DEPLOY_STEPS
@@ -37,11 +42,6 @@ from paasta_tools.utils import get_git_url
 from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import PaastaColors
-from paasta_tools.utils import _run
-from service_configuration_lib import DEFAULT_SOA_DIR
-from service_configuration_lib import read_service_configuration
-from paasta_tools.marathon_tools import load_marathon_service_config
-from paasta_tools.chronos_tools import load_chronos_job_config
 
 
 def get_pipeline_config(service, soa_dir):

--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -223,6 +223,7 @@ def get_chronos_steps(service, soa_dir):
                 instance=instance,
                 cluster=cluster,
                 soa_dir=soa_dir,
+                load_deployments=False,
             )
             steps.append(config.get_deploy_group())
     return steps
@@ -243,6 +244,7 @@ def get_marathon_steps(service, soa_dir):
                 instance=instance,
                 cluster=cluster,
                 soa_dir=soa_dir,
+                load_deployments=False,
             )
             steps.append(config.get_deploy_group())
     return steps

--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -18,11 +18,11 @@ import os
 import re
 import urllib2
 
-from paasta_tools.cli.cmds.validate import paasta_validate_soa_configs
 from service_configuration_lib import DEFAULT_SOA_DIR
 from service_configuration_lib import read_service_configuration
 
 from paasta_tools.chronos_tools import load_chronos_job_config
+from paasta_tools.cli.cmds.validate import paasta_validate_soa_configs
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_file_contents
 from paasta_tools.cli.utils import is_file_in_dir

--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -212,9 +212,12 @@ def get_chronos_steps(service, soa_dir):
     with what deploy.yaml has for linting."""
     steps = []
     for cluster in list_clusters(service, soa_dir):
-        for _, instance in get_service_instance_list(service=service, cluster=cluster,
-                                                     instance_type='chronos',
-                                                     soa_dir=soa_dir):
+        for _, instance in get_service_instance_list(
+                service=service,
+                cluster=cluster,
+                instance_type='chronos',
+                soa_dir=soa_dir,
+        ):
             config = load_chronos_job_config(
                 service=service,
                 instance=instance,

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -20,7 +20,8 @@ import sys
 from paasta_tools import remote_git
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.utils import _log
-from paasta_tools.utils import get_paasta_branch
+from paasta_tools.utils import get_paasta_branch_from_identifier
+from paasta_tools import remote_git
 
 
 def add_subparser(subparsers):
@@ -48,8 +49,8 @@ def add_subparser(subparsers):
         required=True,
     )
     list_parser.add_argument(
-        '-l', '--clusterinstance',
-        help='Mark the service ready for deployment in this clusterinstance (e.g. '
+        '-l', '--deploy_group',
+        help='Mark the service ready for deployment in this deploy group (e.g. '
              'cluster1.canary, cluster2.main)',
         required=True,
     )
@@ -63,9 +64,9 @@ def add_subparser(subparsers):
     list_parser.set_defaults(command=paasta_mark_for_deployment)
 
 
-def mark_for_deployment(git_url, cluster, instance, service, commit):
+def mark_for_deployment(git_url, deploy_group, service, commit):
     """Mark a docker image for deployment"""
-    remote_branch = get_paasta_branch(cluster=cluster, instance=instance)
+    remote_branch = get_paasta_branch_from_identifier(identifier=deploy_group)
     ref_mutator = remote_git.make_force_push_mutate_refs_func(
         target_branches=[remote_branch],
         sha=commit,
@@ -73,12 +74,12 @@ def mark_for_deployment(git_url, cluster, instance, service, commit):
     try:
         remote_git.create_remote_refs(git_url=git_url, ref_mutator=ref_mutator, force=True)
     except Exception as e:
-        loglines = ["Failed to mark %s in for deployment on %s in the %s cluster!" % (commit, instance, cluster)]
+        loglines = ["Failed to mark %s in for deployment in deploy group %s!" % (commit, deploy_group)]
         for line in str(e).split('\n'):
             loglines.append(line)
         return_code = 1
     else:
-        loglines = ["Marked %s in for deployment on %s in the %s cluster" % (commit, instance, cluster)]
+        loglines = ["Marked %s in for deployment in deploy group %s" % (commit, deploy_group)]
         return_code = 0
 
     for logline in loglines:
@@ -87,23 +88,20 @@ def mark_for_deployment(git_url, cluster, instance, service, commit):
             line=logline,
             component='deploy',
             level='event',
-            cluster=cluster,
-            instance=instance,
         )
     return return_code
 
 
 def paasta_mark_for_deployment(args):
     """Wrapping mark_for_deployment"""
-    cluster, instance = args.clusterinstance.split('.')
+    deploy_group = args.deploy_group
     service = args.service
     if service and service.startswith('services-'):
         service = service.split('services-', 1)[1]
     validate_service_name(service)
     returncode = mark_for_deployment(
         git_url=args.git_url,
-        cluster=cluster,
-        instance=instance,
+        deploy_group=deploy_group,
         service=service,
         commit=args.commit
     )

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -20,7 +20,7 @@ import sys
 from paasta_tools import remote_git
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.utils import _log
-from paasta_tools.utils import get_paasta_branch_from_identifier
+from paasta_tools.utils import get_paasta_branch_from_deploy_group
 
 
 def add_subparser(subparsers):
@@ -66,7 +66,7 @@ def add_subparser(subparsers):
 
 def mark_for_deployment(git_url, deploy_group, service, commit):
     """Mark a docker image for deployment"""
-    remote_branch = get_paasta_branch_from_identifier(identifier=deploy_group)
+    remote_branch = get_paasta_branch_from_deploy_group(identifier=deploy_group)
     ref_mutator = remote_git.make_force_push_mutate_refs_func(
         target_branches=[remote_branch],
         sha=commit,

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -49,7 +49,7 @@ def add_subparser(subparsers):
         required=True,
     )
     list_parser.add_argument(
-        '-l', '--deploy_group',
+        '-l', '--deploy_group', '--clusterinstance',
         help='Mark the service ready for deployment in this deploy group (e.g. '
              'cluster1.canary, cluster2.main)',
         required=True,

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -21,7 +21,6 @@ from paasta_tools import remote_git
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.utils import _log
 from paasta_tools.utils import get_paasta_branch_from_identifier
-from paasta_tools import remote_git
 
 
 def add_subparser(subparsers):

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -50,7 +50,8 @@ def add_subparser(subparsers):
     list_parser.add_argument(
         '-l', '--deploy_group', '--clusterinstance',
         help='Mark the service ready for deployment in this deploy group (e.g. '
-             'cluster1.canary, cluster2.main)',
+             'cluster1.canary, cluster2.main). --clusterinstance is depricated and '
+             'should be replaced with --deploy_group',
         required=True,
     )
     list_parser.add_argument(

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -14,17 +14,15 @@
 # limitations under the License.
 import sys
 
+from service_configuration_lib import DEFAULT_SOA_DIR
+
 from paasta_tools.cli.cmds.mark_for_deployment import mark_for_deployment
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import list_services
-from paasta_tools.utils import get_git_url
-from paasta_tools.utils import list_all_instances_for_service
-from paasta_tools.utils import list_clusters
-from paasta_tools.utils import PaastaColors
 from paasta_tools.generate_deployments_for_service import get_instance_config_for_service
-from service_configuration_lib import DEFAULT_SOA_DIR
+from paasta_tools.utils import get_git_url
+from paasta_tools.utils import PaastaColors
 
 
 def add_subparser(subparsers):

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -87,8 +87,7 @@ def paasta_rollback(args):
     service = figure_out_service_name(args)
     git_url = get_git_url(service)
     commit = args.commit
-    # filter deploy_groups.split by the bool function to remove empty string literals
-    given_deploy_groups = filter(bool, args.deploy_groups.split(","))
+    given_deploy_groups = [deploy_group for deploy_group in args.deploy_groups.split(",") if deploy_group]
 
     service_deploy_groups = set(config.get_deploy_group() for config in get_instance_config_for_service(
         soa_dir=DEFAULT_SOA_DIR,

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -87,6 +87,7 @@ def paasta_rollback(args):
     service = figure_out_service_name(args)
     git_url = get_git_url(service)
     commit = args.commit
+    # filter deploy_groups.split by the bool function to remove empty string literals
     given_deploy_groups = filter(bool, args.deploy_groups.split(","))
 
     service_deploy_groups = set(config.get_deploy_group() for config in get_instance_config_for_service(
@@ -97,7 +98,7 @@ def paasta_rollback(args):
     if len(invalid) > 0:
         print PaastaColors.yellow("These deploy groups are not valid and will be skipped: %s.\n" % (",").join(invalid))
 
-    if len(deploy_groups) is 0:
+    if len(deploy_groups) == 0:
         print PaastaColors.red("ERROR: No valid deploy groups specified for %s.\n" % (service))
         returncode = 1
 

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -33,7 +33,7 @@ def get_branches(service):
     remote_refs = remote_git.list_remote_refs(utils.get_git_url(service))
 
     for branch in paasta_control_branches:
-        if 'refs/heads/%s' % branch in remote_refs:
+        if 'refs/heads/paasta-%s' % branch in remote_refs:
             yield branch
 
 

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -18,11 +18,11 @@ import sys
 
 from paasta_tools import remote_git
 from paasta_tools import utils
-from paasta_tools.generate_deployments_for_service import get_instance_config_for_service
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import list_services
+from paasta_tools.generate_deployments_for_service import get_instance_config_for_service
 
 
 SOA_DIR = '/nail/etc/services'

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -18,21 +18,21 @@ import sys
 
 from paasta_tools import remote_git
 from paasta_tools import utils
+from paasta_tools.generate_deployments_for_service import get_instance_config_for_service
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import list_services
-from paasta_tools.generate_deployments_for_service import get_branches_for_service
 
 
 SOA_DIR = '/nail/etc/services'
 
 
 def get_branches(service):
-    paasta_branches = set(get_branches_for_service(SOA_DIR, service))
+    paasta_control_branches = set((config.get_branch() for config in get_instance_config_for_service(SOA_DIR, service)))
     remote_refs = remote_git.list_remote_refs(utils.get_git_url(service))
 
-    for branch in paasta_branches:
+    for branch in paasta_control_branches:
         if 'refs/heads/%s' % branch in remote_refs:
             yield branch
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -12,8 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import sys
+
+from service_configuration_lib import read_deploy
 
 from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
@@ -24,11 +25,9 @@ from paasta_tools.cli.utils import PaastaCheckMessages
 from paasta_tools.cli.utils import x_mark
 from paasta_tools.marathon_tools import DEFAULT_SOA_DIR
 from paasta_tools.marathon_tools import load_deployments_json
-from paasta_tools.utils import DEPLOY_PIPELINE_NON_DEPLOY_STEPS
+from paasta_tools.utils import get_soa_cluster_deploy_files
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import PaastaColors
-from paasta_tools.utils import get_soa_cluster_deploy_files
-from service_configuration_lib import read_deploy
 
 
 def add_subparser(subparsers):

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -76,14 +76,12 @@ def get_instance_config_for_service(soa_dir, service):
         service=service,
         soa_dir=soa_dir,
     ):
-        print cluster
         for _, instance in get_service_instance_list(
             service=service,
             cluster=cluster,
             instance_type='marathon',
             soa_dir=soa_dir,
         ):
-            print instance
             yield load_marathon_service_config(
                 service=service,
                 instance=instance,
@@ -144,7 +142,7 @@ def get_deploy_group_mappings(soa_dir, service, old_mappings):
         deploy_ref_name = 'refs/heads/paasta-%s' % deploy_group
         if deploy_ref_name in remote_refs:
             commit_sha = remote_refs[deploy_ref_name]
-            deploy_group_branch_alias = '%s:%s' % (service, deploy_group)
+            deploy_group_branch_alias = '%s:paasta-%s' % (service, deploy_group)
             docker_image = build_docker_image_name(service, commit_sha)
             log.info('Mapping deploy_group %s to docker image %s', deploy_group_branch_alias, docker_image)
             mapping = mappings.setdefault(deploy_group_branch_alias, {})

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -235,7 +235,7 @@ def main():
             old_mappings = get_deploy_group_mappings_from_deployments_dict(old_deployments_dict)
     except (IOError, ValueError):
         old_mappings = {}
-    mappings = get_branch_mappings(
+    mappings = get_deploy_group_mappings(
         soa_dir=soa_dir,
         service=service,
         old_mappings=old_mappings,

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -142,10 +142,11 @@ def get_deploy_group_mappings(soa_dir, service, old_mappings):
         deploy_ref_name = 'refs/heads/paasta-%s' % deploy_group
         if deploy_ref_name in remote_refs:
             commit_sha = remote_refs[deploy_ref_name]
+            control_branch_alias = '%s:paasta-%s' % (service, control_branch)
             deploy_group_branch_alias = '%s:paasta-%s' % (service, deploy_group)
             docker_image = build_docker_image_name(service, commit_sha)
             log.info('Mapping deploy_group %s to docker image %s', deploy_group_branch_alias, docker_image)
-            mapping = mappings.setdefault(deploy_group_branch_alias, {})
+            mapping = mappings.setdefault(control_branch_alias, {})
             mapping['docker_image'] = docker_image
 
             desired_state, force_bounce = get_desired_state(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -84,7 +84,7 @@ class InstanceConfig(dict):
         return self.service
 
     def get_branch(self):
-        return 'paasta-%s' % SPACER.join((self.get_cluster(), self.get_instance()))
+        return SPACER.join((self.get_cluster(), self.get_instance()))
 
     def get_deploy_group(self):
         return self.config_dict.get('deploy_group', self.get_branch())
@@ -815,7 +815,7 @@ def get_default_cluster_for_service(service):
 def get_soa_cluster_deploy_files(service=None, soa_dir=DEFAULT_SOA_DIR, instance_type=None):
     if service is None:
         service = '*'
-    service_path = os.path.join(DEFAULT_SOA_DIR, service)
+    service_path = os.path.join(soa_dir, service)
 
     if instance_type == 'marathon' or instance_type == 'chronos':
         instance_types = instance_type

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -984,12 +984,12 @@ class DeploymentsJson(dict):
         return self.get(full_branch, {})
 
 
-def get_paasta_branch_from_identifier(identifier):
+def get_paasta_branch_from_deploy_group(identifier):
     return 'paasta-%s' % (identifier)
 
 
 def get_paasta_branch(cluster, instance):
-    return get_paasta_branch_from_identifier('%s.%s' % (cluster, instance))
+    return get_paasta_branch_from_deploy_group('%s.%s' % (cluster, instance))
 
 
 class NoDockerImageError(Exception):

--- a/tests/cli/test_cmds_check.py
+++ b/tests/cli/test_cmds_check.py
@@ -37,6 +37,7 @@ from paasta_tools.cli.cmds.check import service_dir_check
 from paasta_tools.cli.cmds.check import smartstack_check
 from paasta_tools.cli.cmds.check import yaml_check
 from paasta_tools.cli.utils import PaastaCheckMessages
+from paasta_tools.marathon_tools import MarathonServiceConfig
 
 
 @patch('paasta_tools.cli.cmds.check.git_repo_check')
@@ -518,14 +519,23 @@ def test_deploy_has_performance_check_true(mock_pipeline_config, mock_stdout):
     assert actual is True
 
 
+@patch('paasta_tools.cli.cmds.check.load_marathon_service_config')
 @patch('paasta_tools.cli.cmds.check.list_clusters')
 @patch('paasta_tools.cli.cmds.check.get_service_instance_list')
 def test_get_marathon_steps(
     mock_get_service_instance_list,
     mock_list_clusters,
+    mock_load_marathon_service_config,
 ):
     mock_list_clusters.return_value = ['cluster1']
     mock_get_service_instance_list.return_value = [('unused', 'instance1'), ('unused', 'instance2')]
+    mock_load_marathon_service_config.side_effect = lambda service, instance, cluster, soa_dir: MarathonServiceConfig(
+        service=service,
+        instance=instance,
+        cluster=cluster,
+        config_dict={},
+        branch_dict={},
+    )
     expected = ['cluster1.instance1', 'cluster1.instance2']
     actual = get_marathon_steps(service='unused', soa_dir='/fake/path')
     assert actual == expected

--- a/tests/cli/test_cmds_check.py
+++ b/tests/cli/test_cmds_check.py
@@ -529,13 +529,14 @@ def test_get_marathon_steps(
 ):
     mock_list_clusters.return_value = ['cluster1']
     mock_get_service_instance_list.return_value = [('unused', 'instance1'), ('unused', 'instance2')]
-    mock_load_marathon_service_config.side_effect = lambda service, instance, cluster, soa_dir: MarathonServiceConfig(
-        service=service,
-        instance=instance,
-        cluster=cluster,
-        config_dict={},
-        branch_dict={},
-    )
+    mock_load_marathon_service_config.side_effect = \
+        lambda service, instance, cluster, soa_dir, load_deployments: MarathonServiceConfig(
+            service=service,
+            instance=instance,
+            cluster=cluster,
+            config_dict={},
+            branch_dict={},
+        )
     expected = ['cluster1.instance1', 'cluster1.instance2']
     actual = get_marathon_steps(service='unused', soa_dir='/fake/path')
     assert actual == expected

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -19,7 +19,7 @@ from paasta_tools.cli.cmds import mark_for_deployment
 
 
 class fake_args:
-    clusterinstance = 'cluster.instance'
+    deploy_group = 'test_deploy_group'
     service = 'test_service'
     git_url = 'git://false.repo/services/test_services'
     commit = 'fake-hash'
@@ -36,8 +36,7 @@ def test_paasta_mark_for_deployment_acts_like_main(
         mark_for_deployment.paasta_mark_for_deployment(fake_args)
     mock_mark_for_deployment.assert_called_once_with(
         service='test_service',
-        instance='instance',
-        cluster='cluster',
+        deploy_group='test_deploy_group',
         commit='fake-hash',
         git_url='git://false.repo/services/test_services',
     )
@@ -50,8 +49,7 @@ def test_paasta_mark_for_deployment_acts_like_main(
 def test_mark_for_deployment_happy(mock_create_remote_refs):
     actual = mark_for_deployment.mark_for_deployment(
         git_url='fake_git_url',
-        cluster='fake_cluster',
-        instance='fake_instance',
+        deploy_group='fake_deploy_group',
         service='fake_service',
         commit='fake_commit',
     )
@@ -68,8 +66,7 @@ def test_mark_for_deployment_sad(mock_create_remote_refs):
     mock_create_remote_refs.side_effect = Exception('something bad')
     actual = mark_for_deployment.mark_for_deployment(
         git_url='fake_git_url',
-        cluster='fake_cluster',
-        instance='fake_instance',
+        deploy_group='fake_deploy_group',
         service='fake_service',
         commit='fake_commit',
     )

--- a/tests/cli/test_cmds_rollback.py
+++ b/tests/cli/test_cmds_rollback.py
@@ -18,35 +18,36 @@ from mock import patch
 from pytest import raises
 
 from paasta_tools.cli.cmds.rollback import paasta_rollback
-from paasta_tools.cli.cmds.rollback import validate_given_instances
+from paasta_tools.cli.cmds.rollback import validate_given_deploy_groups
+from paasta_tools.marathon_tools import MarathonServiceConfig
 
 
-@patch('paasta_tools.cli.cmds.rollback.list_all_instances_for_service', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.validate_given_instances', autospec=True)
+@patch('paasta_tools.cli.cmds.rollback.get_instance_config_for_service', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.figure_out_service_name', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.list_clusters', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.get_git_url', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.mark_for_deployment', autospec=True)
 def test_paasta_rollback_mark_for_deployment_simple_invocation(
     mock_mark_for_deployment,
     mock_get_git_url,
-    mock_list_clusters,
     mock_figure_out_service_name,
-    mock_validate_given_instances,
-    mock_list_all_instances_for_service,
+    mock_get_instance_config,
 ):
 
     fake_args = Mock(
-        cluster='cluster1',
-        instances='instance1',
+        deploy_groups='fake_deploy_groups',
         commit='123456'
     )
 
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
-    mock_list_clusters.return_value = ['cluster1', 'cluster2']
-    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2']
-    mock_validate_given_instances.return_value = [['instance1'], []]
+
+    mock_get_instance_config.return_value = [MarathonServiceConfig(
+        service='',
+        cluster='',
+        instance='',
+        branch_dict={},
+        config_dict={'deploy_group': 'fake_deploy_groups'},
+    )]
 
     with raises(SystemExit) as sys_exit:
         paasta_rollback(fake_args)
@@ -54,8 +55,7 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
 
     mock_mark_for_deployment.assert_called_once_with(
         git_url=mock_get_git_url.return_value,
-        cluster=fake_args.cluster,
-        instance=fake_args.instances,
+        deploy_group=fake_args.deploy_groups,
         service=mock_figure_out_service_name.return_value,
         commit=fake_args.commit
     )
@@ -63,66 +63,41 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
     assert mock_mark_for_deployment.call_count == 1
 
 
-@patch('paasta_tools.cli.cmds.rollback.list_all_instances_for_service', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.validate_given_instances', autospec=True)
+@patch('paasta_tools.cli.cmds.rollback.get_instance_config_for_service', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.figure_out_service_name', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.list_clusters', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.get_git_url', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.mark_for_deployment', autospec=True)
-def test_paasta_rollback_mark_for_deployment_wrong_cluster(
+def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
     mock_mark_for_deployment,
     mock_get_git_url,
-    mock_list_clusters,
     mock_figure_out_service_name,
-    mock_validate_given_instances,
-    mock_list_all_instances_for_service,
+    mock_get_instance_config,
 ):
 
     fake_args = Mock(
-        cluster='cluster1',
-        instances='instance1',
-        commit='123456'
-    )
-
-    mock_get_git_url.return_value = 'git://git.repo'
-    mock_figure_out_service_name.return_value = 'fakeservice'
-    mock_list_clusters.return_value = ['cluster0', 'cluster2']
-    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2']
-    mock_validate_given_instances.return_value = [['instance1'], []]
-
-    with raises(SystemExit) as sys_exit:
-        paasta_rollback(fake_args)
-        assert sys_exit.value_code == 1
-
-    assert mock_mark_for_deployment.call_count == 0
-
-
-@patch('paasta_tools.cli.cmds.rollback.list_all_instances_for_service', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.validate_given_instances', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.figure_out_service_name', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.list_clusters', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.get_git_url', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.mark_for_deployment', autospec=True)
-def test_paasta_rollback_mark_for_deployment_no_instance_arg(
-    mock_mark_for_deployment,
-    mock_get_git_url,
-    mock_list_clusters,
-    mock_figure_out_service_name,
-    mock_validate_given_instances,
-    mock_list_all_instances_for_service,
-):
-
-    fake_args = Mock(
-        cluster='cluster1',
         commit='123456',
-        instances='',
+        deploy_groups='',
     )
 
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
-    mock_list_clusters.return_value = ['cluster1', 'cluster2']
-    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2']
-    mock_validate_given_instances.return_value = [['instance1', 'instance2'], []]
+
+    mock_get_instance_config.return_value = [
+        MarathonServiceConfig(
+            service=mock_figure_out_service_name.return_value,
+            cluster='',
+            instance='',
+            config_dict={'deploy_group': 'fake_deploy_group'},
+            branch_dict={},
+        ),
+        MarathonServiceConfig(
+            service=mock_figure_out_service_name.return_value,
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        ),
+    ]
 
     with raises(SystemExit) as sys_exit:
         paasta_rollback(fake_args)
@@ -131,50 +106,51 @@ def test_paasta_rollback_mark_for_deployment_no_instance_arg(
     expected = [
         call(
             git_url=mock_get_git_url.return_value,
-            cluster=fake_args.cluster,
             service=mock_figure_out_service_name.return_value,
             commit=fake_args.commit,
-            instance='instance1'
+            deploy_group='fake_cluster.fake_instance',
         ),
         call(
             git_url=mock_get_git_url.return_value,
-            cluster=fake_args.cluster,
             service=mock_figure_out_service_name.return_value,
             commit=fake_args.commit,
-            instance='instance2'
+            deploy_group='fake_deploy_group',
         ),
     ]
 
-    assert expected == mock_mark_for_deployment.mock_calls
+    assert all([x in expected for x in mock_mark_for_deployment.mock_calls])
+    assert len(expected) == len(mock_mark_for_deployment.mock_calls)
     assert mock_mark_for_deployment.call_count == 2
 
 
-@patch('paasta_tools.cli.cmds.rollback.list_all_instances_for_service', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.validate_given_instances', autospec=True)
+@patch('paasta_tools.cli.cmds.rollback.get_instance_config_for_service', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.figure_out_service_name', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.list_clusters', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.get_git_url', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.mark_for_deployment', autospec=True)
-def test_paasta_rollback_mark_for_deployment_wrong_instance_args(
+def test_paasta_rollback_mark_for_deployment_wrong_deploy_group_args(
     mock_mark_for_deployment,
     mock_get_git_url,
-    mock_list_clusters,
     mock_figure_out_service_name,
-    mock_validate_given_instances,
-    mock_list_all_instances_for_service,
+    mock_get_instance_config_for_service,
 ):
 
     fake_args = Mock(
-        cluster='cluster1',
         commit='123456',
-        instances='instance0,not_an_instance'
+        deploy_groups='test_group,fake_deploy.group',
     )
 
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
-    mock_list_clusters.return_value = ['cluster1', 'cluster2']
-    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2']
-    mock_validate_given_instances.return_value = [[], ['instance0', 'not_an_instance']]
+
+    mock_get_instance_config_for_service.return_value = [
+        MarathonServiceConfig(
+            instance='some_other_instance',
+            cluster='some_other_cluster',
+            service=mock_figure_out_service_name.return_value,
+            config_dict={},
+            branch_dict={},
+        ),
+    ]
 
     with raises(SystemExit) as sys_exit:
         paasta_rollback(fake_args)
@@ -183,32 +159,41 @@ def test_paasta_rollback_mark_for_deployment_wrong_instance_args(
     assert mock_mark_for_deployment.call_count == 0
 
 
-@patch('paasta_tools.cli.cmds.rollback.list_all_instances_for_service', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.validate_given_instances', autospec=True)
+@patch('paasta_tools.cli.cmds.rollback.get_instance_config_for_service', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.figure_out_service_name', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.list_clusters', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.get_git_url', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.mark_for_deployment', autospec=True)
 def test_paasta_rollback_mark_for_deployment_multiple_instance_args(
     mock_mark_for_deployment,
     mock_get_git_url,
-    mock_list_clusters,
     mock_figure_out_service_name,
-    mock_validate_given_instances,
-    mock_list_all_instances_for_service,
+    mock_get_instance_config_for_service,
 ):
 
     fake_args = Mock(
-        cluster='cluster1',
-        instances='instance1,instance2',
-        commit='123456'
+        deploy_groups='cluster.instance1,cluster.instance2',
+        commit='123456',
     )
 
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
-    mock_list_clusters.return_value = ['cluster1', 'cluster2']
-    mock_list_all_instances_for_service.return_value = ['instance1', 'instance2', 'instance3']
-    mock_validate_given_instances.return_value = [['instance1', 'instance2'], []]
+
+    mock_get_instance_config_for_service.return_value = [
+        MarathonServiceConfig(
+            instance='instance1',
+            cluster='cluster',
+            service=mock_figure_out_service_name.return_value,
+            config_dict={},
+            branch_dict={},
+        ),
+        MarathonServiceConfig(
+            instance='instance2',
+            cluster='cluster',
+            service=mock_figure_out_service_name.return_value,
+            config_dict={},
+            branch_dict={},
+        ),
+    ]
 
     with raises(SystemExit) as sys_exit:
         paasta_rollback(fake_args)
@@ -217,17 +202,15 @@ def test_paasta_rollback_mark_for_deployment_multiple_instance_args(
     expected = [
         call(
             git_url=mock_get_git_url.return_value,
-            cluster=fake_args.cluster,
             service=mock_figure_out_service_name.return_value,
             commit=fake_args.commit,
-            instance='instance1'
+            deploy_group='cluster.instance1',
         ),
         call(
             git_url=mock_get_git_url.return_value,
-            cluster=fake_args.cluster,
             service=mock_figure_out_service_name.return_value,
             commit=fake_args.commit,
-            instance='instance2'
+            deploy_group='cluster.instance2',
         ),
     ]
 
@@ -235,66 +218,66 @@ def test_paasta_rollback_mark_for_deployment_multiple_instance_args(
     assert mock_mark_for_deployment.call_count == 2
 
 
-def test_validate_given_instances_no_arg():
-    service_instances = ['instance1', 'instance2']
-    given_instances = []
+def test_validate_given_deploy_groups_no_arg():
+    service_deploy_groups = ['deploy_group1', 'deploy_group2']
+    given_deploy_groups = []
 
-    expected_valid = set(['instance1', 'instance2'])
+    expected_valid = set(['deploy_group1', 'deploy_group2'])
     expected_invalid = set([])
 
-    actual_valid, actual_invalid = validate_given_instances(service_instances, given_instances)
+    actual_valid, actual_invalid = validate_given_deploy_groups(service_deploy_groups, given_deploy_groups)
 
     assert actual_valid == expected_valid
     assert actual_invalid == expected_invalid
 
 
-def test_validate_given_instances_wrong_arg():
-    service_instances = ['instance1', 'instance2']
-    given_instances = ['instance0', 'not_an_instance']
+def test_validate_given_deploy_groups_wrong_arg():
+    service_deploy_groups = ['deploy_group1', 'deploy_group2']
+    given_deploy_groups = ['deploy_group0', 'not_an_deploy_group']
 
     expected_valid = set([])
-    expected_invalid = set(['instance0', 'not_an_instance'])
+    expected_invalid = set(['deploy_group0', 'not_an_deploy_group'])
 
-    actual_valid, actual_invalid = validate_given_instances(service_instances, given_instances)
-
-    assert actual_valid == expected_valid
-    assert actual_invalid == expected_invalid
-
-
-def test_validate_given_instances_single_arg():
-    service_instances = ['instance1', 'instance2']
-    given_instances = ['instance1']
-
-    expected_valid = set(['instance1'])
-    expected_invalid = set([])
-
-    actual_valid, actual_invalid = validate_given_instances(service_instances, given_instances)
+    actual_valid, actual_invalid = validate_given_deploy_groups(service_deploy_groups, given_deploy_groups)
 
     assert actual_valid == expected_valid
     assert actual_invalid == expected_invalid
 
 
-def test_validate_given_instances_multiple_args():
-    service_instances = ['instance1', 'instance2', 'instance3']
-    given_instances = ['instance1', 'instance2']
+def test_validate_given_deploy_groups_single_arg():
+    service_deploy_groups = ['deploy_group1', 'deploy_group2']
+    given_deploy_groups = ['deploy_group1']
 
-    expected_valid = set(['instance1', 'instance2'])
+    expected_valid = set(['deploy_group1'])
     expected_invalid = set([])
 
-    actual_valid, actual_invalid = validate_given_instances(service_instances, given_instances)
+    actual_valid, actual_invalid = validate_given_deploy_groups(service_deploy_groups, given_deploy_groups)
 
     assert actual_valid == expected_valid
     assert actual_invalid == expected_invalid
 
 
-def test_validate_given_instances_duplicate_args():
-    service_instances = ['instance1', 'instance2', 'instance3']
-    given_instances = ['instance1', 'instance1']
+def test_validate_given_deploy_groups_multiple_args():
+    service_deploy_groups = ['deploy_group1', 'deploy_group2', 'deploy_group3']
+    given_deploy_groups = ['deploy_group1', 'deploy_group2']
 
-    expected_valid = set(['instance1'])
+    expected_valid = set(['deploy_group1', 'deploy_group2'])
     expected_invalid = set([])
 
-    actual_valid, actual_invalid = validate_given_instances(service_instances, given_instances)
+    actual_valid, actual_invalid = validate_given_deploy_groups(service_deploy_groups, given_deploy_groups)
+
+    assert actual_valid == expected_valid
+    assert actual_invalid == expected_invalid
+
+
+def test_validate_given_deploy_groups_duplicate_args():
+    service_deploy_groups = ['deploy_group1', 'deploy_group2', 'deploy_group3']
+    given_deploy_groups = ['deploy_group1', 'deploy_group1']
+
+    expected_valid = set(['deploy_group1'])
+    expected_invalid = set([])
+
+    actual_valid, actual_invalid = validate_given_deploy_groups(service_deploy_groups, given_deploy_groups)
 
     assert actual_valid == expected_valid
     assert actual_invalid == expected_invalid

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -376,19 +376,17 @@ def test_get_actual_deployments(mock_get_deployments,):
     assert expected == actual
 
 
-@patch('paasta_tools.cli.cmds.status.join', autospec=True)
 @patch('paasta_tools.cli.cmds.status.read_deploy', autospec=True)
-def test_get_deploy_info_exists(mock_read_deploy, mock_join):
+def test_get_deploy_info_exists(mock_read_deploy):
     expected = 'fake deploy yaml'
     mock_read_deploy.return_value = expected
     actual = status.get_deploy_info('fake_service')
     assert expected == actual
 
 
-@patch('paasta_tools.cli.cmds.status.join', autospec=True)
 @patch('paasta_tools.cli.cmds.status.read_deploy', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
-def test_get_deploy_info_does_not_exist(mock_stdout, mock_read_deploy, mock_join):
+def test_get_deploy_info_does_not_exist(mock_stdout, mock_read_deploy):
     mock_read_deploy.return_value = False
     expected_output = '%s\n' % PaastaCheckMessages.DEPLOY_YAML_MISSING
     with raises(SystemExit) as sys_exit:

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -399,7 +399,6 @@ def test_get_deploy_info_does_not_exist(mock_stdout, mock_read_deploy, mock_join
 
 
 @patch('paasta_tools.cli.cmds.status.figure_out_service_name', autospec=True)
-@patch('paasta_tools.cli.cmds.status.get_deploy_info', autospec=True)
 @patch('paasta_tools.cli.cmds.status.get_actual_deployments', autospec=True)
 @patch('paasta_tools.cli.cmds.status.get_planned_deployments', autospec=True)
 @patch('paasta_tools.cli.cmds.status.report_status', autospec=True)
@@ -409,17 +408,13 @@ def test_status_calls_sergeants(
     mock_report_status,
     mock_get_planned_deployments,
     mock_get_actual_deployments,
-    mock_get_deploy_info,
     mock_figure_out_service_name,
 ):
     service = 'fake_service'
     mock_figure_out_service_name.return_value = service
 
-    pipeline = [{'instancename': 'cluster.instance'}]
-    deploy_info = {'pipeline': pipeline}
     planned_deployments = [
         'cluster1.instance1', 'cluster1.instance2', 'cluster2.instance1']
-    mock_get_deploy_info.return_value = deploy_info
     mock_get_planned_deployments.return_value = planned_deployments
 
     actual_deployments = {
@@ -436,7 +431,6 @@ def test_status_calls_sergeants(
 
     mock_figure_out_service_name.assert_called_once_with(args)
     mock_get_actual_deployments.assert_called_once_with(service)
-    mock_get_deploy_info.assert_called_once_with(service)
     mock_report_status.assert_called_once_with(
         service=service,
         deploy_pipeline=planned_deployments,

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -311,7 +311,7 @@ def test_validate_chronos_valid_instance(
     mock_list_all_instances_for_service.return_value = [fake_instance]
     mock_load_chronos_job_config.return_value = mock_chronos_job
 
-    assert validate_chronos('fake_service_path')
+    assert validate_chronos('fake_service_path') == 0
 
     output = mock_stdout.getvalue()
 

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -311,7 +311,7 @@ def test_validate_chronos_valid_instance(
     mock_list_all_instances_for_service.return_value = [fake_instance]
     mock_load_chronos_job_config.return_value = mock_chronos_job
 
-    assert validate_chronos('fake_service_path') == 0
+    assert validate_chronos('fake_service_path')
 
     output = mock_stdout.getvalue()
 

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -16,61 +16,33 @@ import contextlib
 import mock
 
 from paasta_tools import generate_deployments_for_service
-from paasta_tools.chronos_tools import ChronosJobConfig
 from paasta_tools.marathon_tools import MarathonServiceConfig
 
 
-def test_get_branches_for_service():
-    fake_dir = '/mail/var/tea'
-    fake_srv = 'boba'
-    fake_branches = ['red', 'green', 'blue', 'orange', 'white', 'black']
-    expected = ['red', 'green', 'blue', 'orange', 'white', 'black', 'cluster_a.chronos_job',
-                'cluster_b.chronos_job', 'cluster_c.chronos_job']
-    with contextlib.nested(
-        mock.patch('paasta_tools.generate_deployments_for_service.list_clusters',
-                   return_value=['cluster_a', 'cluster_b', 'cluster_c']),
-        mock.patch('paasta_tools.generate_deployments_for_service.get_service_instance_list',
-                   side_effect=lambda service, cluster, instance_type, soa_dir:
-                       [('', 'main_example'), ('', 'canary_example')] if instance_type == 'marathon'
-                       else [('', 'chronos_job')]),
-        mock.patch('paasta_tools.generate_deployments_for_service.load_marathon_service_config',
-                   side_effect=lambda service, instance, cluster, soa_dir, load_deployments: MarathonServiceConfig(
-                       service=service,
-                       cluster=cluster,
-                       instance=instance,
-                       config_dict={'deploy_group': fake_branches.pop()},
-                       branch_dict={},
-                   )),
-        mock.patch('paasta_tools.generate_deployments_for_service.load_chronos_job_config',
-                   side_effect=lambda service, instance, cluster, soa_dir, load_deployments: ChronosJobConfig(
-                       service=service,
-                       cluster=cluster,
-                       instance=instance,
-                       config_dict={},
-                       branch_dict={},
-                   )),
-    ) as (
-        list_clusters_patch,
-        get_service_instance_list_patch,
-        load_marathon_config_patch,
-        load_chronos_config_patch,
-    ):
-        actual = generate_deployments_for_service.get_branches_for_service(fake_dir, fake_srv)
-        assert set(['paasta-%s' % branch for branch in expected]) == actual
-        # three clusters each having a canary and main marathon instance equals six instances total
-        assert load_marathon_config_patch.call_count == 6
-        # three clusters each having one chronos job equals six instances total
-        assert load_chronos_config_patch.call_count == 3
-
-
-def test_get_branch_mappings():
+def test_get_deploy_group_mappings():
     fake_service = 'fake_service'
     fake_soa_dir = '/no/yes/maybe'
-    fake_branches = ['try_me', 'no_thanks']
+
+    fake_service_configs = [
+        MarathonServiceConfig(
+            service=fake_service,
+            cluster='clusterA',
+            instance='main',
+            branch_dict={},
+            config_dict={'deploy_group': 'no_thanks'},
+        ),
+        MarathonServiceConfig(
+            service=fake_service,
+            cluster='clusterB',
+            instance='main',
+            branch_dict={},
+            config_dict={'deploy_group': 'try_me'},
+        ),
+    ]
 
     fake_remote_refs = {
         'refs/heads/try_me': '123456',
-        'refs/tags/paasta-try_me-123-stop': '123456',
+        'refs/tags/paasta-clusterB.main-123-stop': '123456',
         'refs/heads/okay': 'ijowarg',
         'refs/heads/no_thanks': '789009',
         'refs/heads/nah': 'j8yiomwer',
@@ -90,24 +62,19 @@ def test_get_branch_mappings():
         },
     }
     with contextlib.nested(
-        mock.patch('paasta_tools.generate_deployments_for_service.get_branches_for_service',
-                   return_value=fake_branches),
+        mock.patch('paasta_tools.generate_deployments_for_service.get_instance_config_for_service',
+                   return_value=fake_service_configs),
         mock.patch('paasta_tools.remote_git.list_remote_refs',
                    return_value=fake_remote_refs),
     ) as (
-        get_branches_patch,
+        get_instance_config_for_service_patch,
         list_remote_refs_patch,
     ):
-        actual = generate_deployments_for_service.get_branch_mappings(fake_soa_dir, fake_service, fake_old_mappings)
-        print actual
-        print expected
-        assert expected == actual
-        get_branches_patch.assert_any_call(
-            soa_dir=fake_soa_dir,
-            service=fake_service,
-        )
-        assert get_branches_patch.call_count == 1
+        actual = generate_deployments_for_service.get_deploy_group_mappings(fake_soa_dir,
+                                                                            fake_service, fake_old_mappings)
+        get_instance_config_for_service_patch.assert_called_once_with(soa_dir=fake_soa_dir, service=fake_service)
         assert list_remote_refs_patch.call_count == 1
+        assert expected == actual
 
 
 def test_get_service_from_docker_image():
@@ -126,7 +93,7 @@ def test_main():
                    autospec=True),
         mock.patch('os.path.abspath', return_value='ABSOLUTE', autospec=True),
         mock.patch(
-            'paasta_tools.generate_deployments_for_service.get_branch_mappings',
+            'paasta_tools.generate_deployments_for_service.get_deploy_group_mappings',
             return_value={'MAP': {'docker_image': 'PINGS', 'desired_state': 'start'}},
             autospec=True,
         ),
@@ -184,6 +151,6 @@ def test_get_deployments_dict():
         },
     }
 
-    assert generate_deployments_for_service.get_deployments_dict_from_branch_mappings(branch_mappings) == {
+    assert generate_deployments_for_service.get_deployments_dict_from_deploy_group_mappings(branch_mappings) == {
         'v1': branch_mappings,
     }

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -50,12 +50,12 @@ def test_get_deploy_group_mappings():
 
     fake_old_mappings = ['']
     expected = {
-        'fake_service:paasta-no_thanks': {
+        'fake_service:paasta-clusterA.main': {
             'docker_image': 'services-fake_service:paasta-789009',
             'desired_state': 'start',
             'force_bounce': None,
         },
-        'fake_service:paasta-try_me': {
+        'fake_service:paasta-clusterB.main': {
             'docker_image': 'services-fake_service:paasta-123456',
             'desired_state': 'stop',
             'force_bounce': '123',

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -41,11 +41,11 @@ def test_get_deploy_group_mappings():
     ]
 
     fake_remote_refs = {
-        'refs/heads/try_me': '123456',
+        'refs/heads/paasta-try_me': '123456',
         'refs/tags/paasta-clusterB.main-123-stop': '123456',
-        'refs/heads/okay': 'ijowarg',
-        'refs/heads/no_thanks': '789009',
-        'refs/heads/nah': 'j8yiomwer',
+        'refs/heads/paasta-okay': 'ijowarg',
+        'refs/heads/paasta-no_thanks': '789009',
+        'refs/heads/paasta-nah': 'j8yiomwer',
     }
 
     fake_old_mappings = ['']

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -50,12 +50,12 @@ def test_get_deploy_group_mappings():
 
     fake_old_mappings = ['']
     expected = {
-        'fake_service:no_thanks': {
+        'fake_service:paasta-no_thanks': {
             'docker_image': 'services-fake_service:paasta-789009',
             'desired_state': 'start',
             'force_bounce': None,
         },
-        'fake_service:try_me': {
+        'fake_service:paasta-try_me': {
             'docker_image': 'services-fake_service:paasta-123456',
             'desired_state': 'stop',
             'force_bounce': '123',


### PR DESCRIPTION
Placing multiple instances in a deploy group makes it so they are all deployed with the same docker container and are deployed at the same time (as specified in deploy.yaml). However, they can be controlled independently by flagging deploy_state and force_bounce in git refs.