### PR TITLE
Catch the 'bean not found' error. Fixes #172

### DIFF
--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -243,7 +243,7 @@ def do_bounce(
         if drain_method.is_safe_to_kill(task):
             killed_tasks.add(task)
             log_bounce_action(line='%s bounce killing drained task %s' % (bounce_method, task.id))
-            client.kill_task(task.app_id, task.id, scale=True)
+            marathon_tools.kill_task(client=client, app_id=task.app_id, task_id=task.id, scale=True)
 
     apps_to_kill = []
     for app in old_app_live_tasks.keys():

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -14,6 +14,7 @@
 import contextlib
 
 import mock
+from marathon import MarathonHttpError
 from marathon.models import MarathonApp
 from mock import patch
 from pytest import raises
@@ -687,7 +688,7 @@ class TestMarathonTools:
             mock.patch(
                 'service_configuration_lib.services_that_run_here',
                 autospec=True,
-                return_value={'d', 'c'}
+                return_value={'d', 'c'},
             ),
             mock.patch(
                 'os.listdir',
@@ -2143,3 +2144,24 @@ def test_create_complete_config_utilizes_extra_volumes():
 
         # Assert that the complete config can be inserted into the MarathonApp model
         assert MarathonApp(**actual)
+
+
+def test_kill_tasks_passes_through():
+    fake_client = mock.Mock()
+    marathon_tools.kill_task(client=fake_client, app_id='app_id', task_id='task_id', scale=True)
+    fake_client.kill_task.assert_called_once_with(scale=True, task_id='task_id', app_id='app_id')
+
+
+def test_kill_tasks_passes_catches_fewer_than_error():
+    fake_client = mock.Mock()
+    bad_fake_response = mock.Mock()
+    bad_fake_response.status_code = 422
+    bad_fake_response.json.return_value = {
+        "message": "Bean is not valid",
+        "errors": [{"attribute": "instances", "error": "must be greater than or equal to 0"}],
+    }
+    fake_client.kill_task = mock.Mock()
+    fake_client.kill_task.side_effect = MarathonHttpError(response=bad_fake_response)
+    actual = marathon_tools.kill_task(client=fake_client, app_id='app_id', task_id='task_id', scale=True)
+    fake_client.kill_task.assert_called_once_with(scale=True, task_id='task_id', app_id='app_id')
+    assert actual == []

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -966,8 +966,8 @@ class TestSetupMarathonJob:
             fake_drain_method.drain.assert_any_call(old_task_to_drain)
 
             assert fake_client.kill_task.call_count == 2
-            fake_client.kill_task.assert_any_call(old_app_id, old_task_is_draining.id, scale=True)
-            fake_client.kill_task.assert_any_call(old_app_id, old_task_to_drain.id, scale=True)
+            fake_client.kill_task.assert_any_call(app_id=old_app_id, task_id=old_task_is_draining.id, scale=True)
+            fake_client.kill_task.assert_any_call(app_id=old_app_id, task_id=old_task_to_drain.id, scale=True)
 
             create_marathon_app_patch.assert_called_once_with(fake_config['id'], fake_config, fake_client)
             assert kill_old_ids_patch.call_count == 0


### PR DESCRIPTION
I investigated *why* this happens, I do believe it is the race between killing a task in a previous test and reading it in the next. Here is some correlated logs:

```
  Scenario: The crossover bounce works
    Given a working paasta cluster
      And a new healthy app to be deployed
      And an old app to be destroyed

     When there are 2 old healthy tasks
      And deploy_service with bounce strategy "crossover" and drain method "noop" is initiated
crossover bounce creating new app with app_id bounce.test1.newapp.confighash
     Then the new app should be running
      And the old app should be running


     When there are 1 new healthy tasks
      And deploy_service with bounce strategy "crossover" and drain method "noop" is initiated
crossover bounce draining 1 old tasks with app_id /bounce.test1.oldapp.confighash
crossover bounce killing drained task bounce.test1.oldapp.confighash.a77520b5-bf9d-11e5-8713-0242ac11001c
     Then the old app should be running
      And the old app should be configured to have 1 instances

     When there are 2 new healthy tasks
      And deploy_service with bounce strategy "crossover" and drain method "noop" is initiated
crossover bounce draining 2 old tasks with app_id /bounce.test1.oldapp.confighash
crossover bounce killing drained task bounce.test1.oldapp.confighash.a77547c6-bf9d-11e5-8713-0242ac11001c
crossover bounce killing drained task bounce.test1.oldapp.confighash.a77520b5-bf9d-11e5-8713-0242ac11001c
      And we wait a bit for the old app to disappear
     Then the old app should be gone
```

So yea, killing a task that is already dead.

I thought we might fight this by adding a sleep, but I don't want to add a sleep :(
So swallowing this error I think is the next best thing, and let the the bounce system itself work around it eventually. (as it has been already, just spewing errors)