### PR TITLE
Added more debug for manpage building

### DIFF
--- a/build-manpages.sh
+++ b/build-manpages.sh
@@ -19,14 +19,20 @@
 mkdir -p /nail/etc/services
 
 mkdir -p docs/man/
-. .tox/manpages/bin/activate
 
+set -e
+source .tox/manpages/bin/activate
+
+set -vx
 VERSION=`./paasta_tools/cli/cli.py --version 2>&1 | cut -f 2 -d ' '`
+./paasta_tools/cli/cli.py --version 2>&1 | cut -f 2 -d ' '
+./paasta_tools/cli/cli.py --version
 
 function build_man() {
     COMMAND=$1
-    echo "paasta $COMMAND --help"
-    help2man --name=$COMMAND --version-string=$VERSION "./paasta_tools/cli/cli.py $COMMAND" > docs/man/paasta-$COMMAND.1
+    set -vx
+    help2man --name="$COMMAND" --version-string="$VERSION" "./paasta_tools/cli/cli.py $COMMAND" > docs/man/paasta-$COMMAND.1
+    set +vx
 }
 
 for FILE in paasta_tools/cli/cmds/*.py


### PR DESCRIPTION
Since "the great tox.ini" refactor, our (package) itests no longer work. They get stuck on building manpages.

Granted the manpage building is kinda strange, I don't understand why it no longer works.

Here is some debug:
```
$:~/Projects/paasta (master) $ tox -r -e manpages
manpages create: /nail/home/kwa/Projects/paasta/.tox/manpages
manpages installdeps: :private:scribereader==0.1.30, :private:yelp-cgeom==1.3.1, :private:yelp-logging==1.0.37, --requirement=/nail/home/kwa/Projects/paasta/requirements.txt
manpages runtests: PYTHONHASHSEED='2474917905'
manpages runtests: commands[0] | ./build-manpages.sh
VERSION=`./paasta_tools/cli/cli.py --version 2>&1 | cut -f 2 -d ' '`
./paasta_tools/cli/cli.py --version 2>&1 | cut -f 2 -d ' '
++ ./paasta_tools/cli/cli.py --version
++ cut -f 2 -d ' '
+ VERSION='(most


No'
./paasta_tools/cli/cli.py --version 2>&1 | cut -f 2 -d ' '
+ ./paasta_tools/cli/cli.py --version
+ cut -f 2 -d ' '
(most


No
./paasta_tools/cli/cli.py --version
+ ./paasta_tools/cli/cli.py --version
Traceback (most recent call last):
  File "./paasta_tools/cli/cli.py", line 22, in <module>
    from paasta_tools.cli import cmds
ImportError: No module named paasta_tools.cli
ERROR: InvocationError: '/nail/home/kwa/Projects/paasta/build-manpages.sh'
_________________________________________________________________________________ summary __________________________________________________________________________________
ERROR:   manpages: commands failed
```

But what I don't understand is *why* it can't import that stuff. In the normal `py27` env it works fine:
```
(py27)kwa@dev13-devc:~/Projects/paasta (fix_manpages) $ ./paasta_tools/cli//cli.py  --version
paasta-tools 0.16.16
```

@asottile can you ... give me a hint at what this might be? We have all the `__init__`s in place. It has to be some sort of difference between the manpages tox env and everything else, but I don't see it.
