### PR TITLE
Make tox faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 env:
   - TOXENV=py27
+  - TOXENV=coverage
   - TOXENV=docs
   - TOXENV=general_itests
   - TOXENV=paasta_itests

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1374,7 +1374,9 @@ class TestChronosTools:
         # only provide the right response on the third attempt
         client.list = Mock(side_effect=[[], [], [{'name': 'foo'}]])
 
-        assert chronos_tools.wait_for_job(client, 'foo')
+        with mock.patch('paasta_tools.chronos_tools.sleep') as mock_sleep:
+            assert chronos_tools.wait_for_job(client, 'foo')
+            assert mock_sleep.call_count == 2
 
     def test_parse_time_variables_parses_shortdate(self):
         input_time = datetime.datetime(2012, 3, 14)

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,20 @@ deps =
     --requirement={toxinidir}/requirements-dev.txt
     --editable={toxinidir}
 commands =
-    pre-commit install -f --install-hooks
-    pre-commit run --all-files
+    py.test -s {posargs:tests}
+
+
+[testenv:coverage]
+setenv=
+    TZ = UTC
+basepython = python2.7
+deps =
+    --requirement={toxinidir}/requirements.txt
+    --requirement={toxinidir}/requirements-dev.txt
+    --editable={toxinidir}
+commands =
     python -m pytest --cov-config .coveragerc --cov=paasta_tools --cov-report=term-missing --cov-report=html -s {posargs:tests}
+
 
 [testenv:docs]
 basepython = python2.7
@@ -78,6 +89,8 @@ deps =
     {[testenv]deps}
     behave==1.2.4
 commands =
+    pre-commit install -f --install-hooks
+    pre-commit run --all-files
     python -m behave {posargs}
 
 [flake8]


### PR DESCRIPTION
Make local runs of tox faster by moving pre-commit to testenv:general_itest, moving coverage into its own testenv, and speeding up a unit test that was taking 1 second.