### PR TITLE
Mark for deployment tags

### DIFF
--- a/general_itests/deployments_json.feature
+++ b/general_itests/deployments_json.feature
@@ -5,3 +5,8 @@ Feature: Per-Service Deployments.json can be written and read back
 	When paasta stop is run against the repo
 	 And we generate deployments.json for that service
         Then that deployments.json can be read back correctly
+
+    Scenario: mark-for-deployments
+	Given a test git repo is setup with commits
+	 When paasta mark-for-deployments is run against the repo
+	 Then the repository should be correctly tagged

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -22,7 +22,7 @@ from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.utils import _log
 from paasta_tools.utils import format_tag
 from paasta_tools.utils import get_paasta_branch_from_deploy_group
-from paasta_tools.utils import get_paasta_tag
+from paasta_tools.utils import get_paasta_tag_from_deploy_group
 
 
 def add_subparser(subparsers):
@@ -69,7 +69,7 @@ def add_subparser(subparsers):
 def mark_for_deployment(git_url, deploy_group, service, commit):
     """Mark a docker image for deployment"""
     remote_branch = 'refs/heads/%s' % get_paasta_branch_from_deploy_group(identifier=deploy_group)
-    tag = get_paasta_tag(cluster=cluster, instance=instance, desired_state='deploy')
+    tag = get_paasta_tag_from_deploy_group(identifier=deploy_group, desired_state='deploy')
     remote_tag = format_tag(tag)
     ref_mutator = remote_git.make_force_push_mutate_refs_func(
         targets=[remote_branch, remote_tag],

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -21,6 +21,7 @@ from paasta_tools import remote_git
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.utils import _log
 from paasta_tools.utils import get_paasta_branch_from_deploy_group
+from paasta_tools.utils import get_paasta_tag
 
 
 def add_subparser(subparsers):
@@ -39,7 +40,7 @@ def add_subparser(subparsers):
     )
     list_parser.add_argument(
         '-u', '--git-url',
-        help='Git url for service -- where magic mark-for-deployment branches are pushed',
+        help='Git url for service -- where magic mark-for-deployment branches/tags are pushed',
         required=True,
     )
     list_parser.add_argument(
@@ -66,9 +67,10 @@ def add_subparser(subparsers):
 
 def mark_for_deployment(git_url, deploy_group, service, commit):
     """Mark a docker image for deployment"""
-    remote_branch = get_paasta_branch_from_deploy_group(identifier=deploy_group)
+    remote_branch = 'refs/heads/%s' % get_paasta_branch_from_deploy_group(identifier=deploy_group)
+    remote_tag = 'refs/tags/%s' % get_paasta_tag(cluster=cluster, instance=instance)
     ref_mutator = remote_git.make_force_push_mutate_refs_func(
-        target_branches=[remote_branch],
+        targets=[remote_branch, remote_tag],
         sha=commit,
     )
     try:

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -20,6 +20,7 @@ import sys
 from paasta_tools import remote_git
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.utils import _log
+from paasta_tools.utils import format_tag
 from paasta_tools.utils import get_paasta_branch_from_deploy_group
 from paasta_tools.utils import get_paasta_tag
 
@@ -68,7 +69,8 @@ def add_subparser(subparsers):
 def mark_for_deployment(git_url, deploy_group, service, commit):
     """Mark a docker image for deployment"""
     remote_branch = 'refs/heads/%s' % get_paasta_branch_from_deploy_group(identifier=deploy_group)
-    remote_tag = 'refs/tags/%s' % get_paasta_tag(cluster=cluster, instance=instance)
+    tag = get_paasta_tag(cluster=cluster, instance=instance, desired_state='deploy')
+    remote_tag = format_tag(tag)
     ref_mutator = remote_git.make_force_push_mutate_refs_func(
         targets=[remote_branch, remote_tag],
         sha=commit,

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -78,12 +78,6 @@ def add_subparser(subparsers):
         status_parser.set_defaults(command=cmd_func)
 
 
-def format_timestamp(dt=None):
-    if dt is None:
-        dt = datetime.datetime.utcnow()
-    return dt.strftime('%Y%m%dT%H%M%S')
-
-
 def format_tag(branch, force_bounce, desired_state):
     return 'refs/tags/%s-%s-%s' % (branch, force_bounce, desired_state)
 
@@ -148,7 +142,7 @@ def paasta_start_or_stop(args, desired_state):
         print "Has it been deployed there yet?"
         sys.exit(1)
 
-    force_bounce = format_timestamp(datetime.datetime.utcnow())
+    force_bounce = utils.format_timestamp(datetime.datetime.utcnow())
     branches = [branch]
     issue_state_change_for_branches(service, instance, cluster, branches, force_bounce,
                                     desired_state)

--- a/paasta_tools/remote_git.py
+++ b/paasta_tools/remote_git.py
@@ -66,16 +66,16 @@ def list_remote_refs(git_url):
         raise LSRemoteException("Unable to fetch remote refs: %s" % e)
 
 
-def make_force_push_mutate_refs_func(target_branches, sha):
+def make_force_push_mutate_refs_func(targets, sha):
     """Create a 'force push' function that will inform send_pack that we want
-    to mark a certain list of target branches to point to a particular
+    to mark a certain list of target branches/tags to point to a particular
     git_sha.
 
-    :param target_branches: List of branches to point at the input sha
-    :param sha: The git sha to point the branches at
+    :param targets: List of branches/tags to point at the input sha
+    :param sha: The git sha to point the branches/tags at
     :returns: A function to do the ref manipulation that a dulwich client can use"""
     def mutate_refs(refs):
-        for branch in target_branches:
-            refs['refs/heads/%s' % branch] = sha
+        for target in targets:
+            refs[target] = sha
         return refs
     return mutate_refs

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -992,8 +992,19 @@ def get_paasta_branch(cluster, instance):
     return get_paasta_branch_from_deploy_group('%s.%s' % (cluster, instance))
 
 
-def get_paasta_tag(cluster, instance):
-    return get_paasta_branch(cluster, instance)
+def format_timestamp(dt=None):
+    if dt is None:
+        dt = datetime.datetime.utcnow()
+    return dt.strftime('%Ya%m%dT%H%M%S')
+
+
+def get_paasta_tag(cluster, instance, desired_state):
+    timestamp = format_timestamp(datetime.datetime.utcnow())
+    return 'paasta-%s.%s-%s-%s' % (cluster, instance, timestamp, desired_state)
+
+
+def format_tag(tag):
+    return 'refs/tags/%s' % tag
 
 
 class NoDockerImageError(Exception):

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -998,6 +998,11 @@ def format_timestamp(dt=None):
     return dt.strftime('%Y%m%dT%H%M%S')
 
 
+def get_paasta_tag_from_deploy_group(identifier, desired_state):
+    timestamp = format_timestamp(datetime.datetime.utcnow())
+    return 'paasta-%s-%s-%s' % (identifier, timestamp, desired_state)
+
+
 def get_paasta_tag(cluster, instance, desired_state):
     timestamp = format_timestamp(datetime.datetime.utcnow())
     return 'paasta-%s.%s-%s-%s' % (cluster, instance, timestamp, desired_state)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -992,6 +992,10 @@ def get_paasta_branch(cluster, instance):
     return get_paasta_branch_from_deploy_group('%s.%s' % (cluster, instance))
 
 
+def get_paasta_tag(cluster, instance):
+    return get_paasta_branch(cluster, instance)
+
+
 class NoDockerImageError(Exception):
     pass
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -995,7 +995,7 @@ def get_paasta_branch(cluster, instance):
 def format_timestamp(dt=None):
     if dt is None:
         dt = datetime.datetime.utcnow()
-    return dt.strftime('%Ya%m%dT%H%M%S')
+    return dt.strftime('%Y%m%dT%H%M%S')
 
 
 def get_paasta_tag(cluster, instance, desired_state):

--- a/tests/test_remote_git.py
+++ b/tests/test_remote_git.py
@@ -45,25 +45,25 @@ def test_make_determine_wants_func():
 
 
 def test_make_force_push_mutate_refs_func_overwrites_shas():
-    target_branches = ['targeta', 'targetb']
+    targets = ['refs/heads/targeta', 'refs/tags/targetb']
     newsha = 'newsha'
     input_refs = {
         'refs/heads/foo': '12345',
         'refs/heads/targeta': '12345',
-        'refs/heads/targetb': '12345',
+        'refs/tags/targetb': '12345',
         'refs/heads/ignored': '12345',
         'refs/tags/blah': '12345',
     }
     expected = {
         'refs/heads/foo': '12345',
         'refs/heads/targeta': newsha,
-        'refs/heads/targetb': newsha,
+        'refs/tags/targetb': newsha,
         'refs/heads/ignored': '12345',
         'refs/tags/blah': '12345',
     }
 
     mutate_refs_func = remote_git.make_force_push_mutate_refs_func(
-        target_branches=target_branches,
+        targets=targets,
         sha=newsha,
     )
     actual = mutate_refs_func(input_refs)


### PR DESCRIPTION
In an effort to migrate us from branches to tags, this first pull request updates `mark_for_deployment` to tag as well as create a branch. Since branches are still being created like normal and no other code has been updated to switch from branches to tags, this should be a safe change.

The change to CHAGNELOG.md was to make the pre-commit hook happy.