### PR TITLE
made cleanup_chronos_jobs send OK on sensu

### DIFF
--- a/paasta_tools/check_chronos_jobs.py
+++ b/paasta_tools/check_chronos_jobs.py
@@ -14,7 +14,7 @@ import service_configuration_lib
 from paasta_tools import chronos_tools
 from paasta_tools import monitoring_tools
 from paasta_tools import utils
-from paasta_tools.chronos_tools import send_event_to_sensu
+from paasta_tools.chronos_tools import compose_check_name_for_service_instance
 
 
 def parse_args():
@@ -39,6 +39,19 @@ def compose_monitoring_overrides_for_service(cluster, service, instance, soa_dir
     monitoring_overrides['check_every'] = '1m'
     monitoring_overrides['runbook'] = monitoring_tools.get_runbook(monitoring_overrides, service, soa_dir=soa_dir)
     return monitoring_overrides
+
+
+def send_event(service, instance, monitoring_overrides, soa_dir, status_code, message):
+    check_name = compose_check_name_for_service_instance('check_chronos_jobs', service, instance)
+
+    monitoring_tools.send_event(
+        service=service,
+        check_name=check_name,
+        overrides=monitoring_overrides,
+        status=status_code,
+        output=message,
+        soa_dir=soa_dir,
+    )
 
 
 def compose_check_name_for_job(service, instance):
@@ -148,7 +161,7 @@ def main(args):
             instance=instance,
             soa_dir=args.soa_dir
         )
-        send_event_to_sensu(
+        send_event(
             service=service,
             instance=instance,
             monitoring_overrides=monitoring_overrides,

--- a/paasta_tools/check_chronos_jobs.py
+++ b/paasta_tools/check_chronos_jobs.py
@@ -14,6 +14,7 @@ import service_configuration_lib
 from paasta_tools import chronos_tools
 from paasta_tools import monitoring_tools
 from paasta_tools import utils
+from paasta_tools.chronos_tools import send_event_to_sensu
 
 
 def parse_args():
@@ -43,19 +44,6 @@ def compose_monitoring_overrides_for_service(cluster, service, instance, soa_dir
 def compose_check_name_for_job(service, instance):
     """Compose a sensu check name for a given job"""
     return 'check-chronos-jobs.%s%s%s' % (service, utils.SPACER, instance)
-
-
-def send_event_to_sensu(service, instance, monitoring_overrides, soa_dir, status_code, message):
-    check_name = compose_check_name_for_job(service, instance)
-
-    monitoring_tools.send_event(
-        service=service,
-        check_name=check_name,
-        overrides=monitoring_overrides,
-        status=status_code,
-        output=message,
-        soa_dir=soa_dir,
-    )
 
 
 def last_run_state_for_jobs(jobs):

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -715,19 +715,6 @@ def find_matching_parent_job(job_name):
         return None
 
 
-def compose_check_name_for_job(service, instance):
+def compose_check_name_for_service_instance(check_name, service, instance):
     """Compose a sensu check name for a given job"""
-    return 'check-chronos-jobs.%s%s%s' % (service, INTERNAL_SPACER, instance)
-
-
-def send_event_to_sensu(service, instance, monitoring_overrides, soa_dir, status_code, message):
-    check_name = compose_check_name_for_job(service, instance)
-
-    monitoring_tools.send_event(
-        service=service,
-        check_name=check_name,
-        overrides=monitoring_overrides,
-        status=status_code,
-        output=message,
-        soa_dir=soa_dir,
-    )
+    return '%s.%s%s%s' % (check_name, service, INTERNAL_SPACER, instance)

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -713,3 +713,21 @@ def find_matching_parent_job(job_name):
         return sorted_jobs[0]['name']
     else:
         return None
+
+
+def compose_check_name_for_job(service, instance):
+    """Compose a sensu check name for a given job"""
+    return 'check-chronos-jobs.%s%s%s' % (service, INTERNAL_SPACER, instance)
+
+
+def send_event_to_sensu(service, instance, monitoring_overrides, soa_dir, status_code, message):
+    check_name = compose_check_name_for_job(service, instance)
+
+    monitoring_tools.send_event(
+        service=service,
+        check_name=check_name,
+        overrides=monitoring_overrides,
+        status=status_code,
+        output=message,
+        soa_dir=soa_dir,
+    )

--- a/paasta_tools/cleanup_chronos_jobs.py
+++ b/paasta_tools/cleanup_chronos_jobs.py
@@ -32,7 +32,7 @@ import pysensu_yelp
 import service_configuration_lib
 
 from paasta_tools import chronos_tools
-from paasta_tools.chronos_tools import send_event_to_sensu
+from paasta_tools.check_chronos_jobs import send_event
 from paasta_tools.utils import InvalidJobNameError
 
 
@@ -136,7 +136,7 @@ def main():
         else:
             job_successes.append(response)
             (service, instance, _, __) = chronos_tools.decompose_job_id(response[0])
-            send_event_to_sensu(
+            send_event(
                 service=service,
                 instance=instance,
                 monitoring_overrides={},

--- a/paasta_tools/cleanup_chronos_jobs.py
+++ b/paasta_tools/cleanup_chronos_jobs.py
@@ -32,7 +32,7 @@ import pysensu_yelp
 import service_configuration_lib
 
 from paasta_tools import chronos_tools
-from paasta_tools.check_chronos_jobs import send_event_to_sensu
+from paasta_tools.chronos_tools import send_event_to_sensu
 from paasta_tools.utils import InvalidJobNameError
 
 

--- a/paasta_tools/cleanup_chronos_jobs.py
+++ b/paasta_tools/cleanup_chronos_jobs.py
@@ -28,9 +28,11 @@ Any tasks associated with that job are also deleted.
 import argparse
 import sys
 
+import pysensu_yelp
 import service_configuration_lib
 
 from paasta_tools import chronos_tools
+from paasta_tools.check_chronos_jobs import send_event_to_sensu
 from paasta_tools.utils import InvalidJobNameError
 
 
@@ -103,6 +105,7 @@ def filter_paasta_jobs(jobs):
 def main():
 
     args = parse_args()
+    soa_dir = args.soa_dir
 
     config = chronos_tools.load_chronos_config()
     client = chronos_tools.get_chronos_client(config)
@@ -132,6 +135,15 @@ def main():
             job_failures.append(response)
         else:
             job_successes.append(response)
+            (service, instance, _, __) = chronos_tools.decompose_job_id(response[0])
+            send_event_to_sensu(
+                service=service,
+                instance=instance,
+                monitoring_overrides={},
+                soa_dir=soa_dir,
+                status_code=pysensu_yelp.Status.OK,
+                message="This instance was removed and is no longer supposed to be scheduled.",
+            )
 
     if len(to_delete) == 0:
         print 'No Chronos Jobs to remove'

--- a/tests/test_check_chronos_jobs.py
+++ b/tests/test_check_chronos_jobs.py
@@ -29,12 +29,12 @@ def test_compose_monitoring_overrides_for_service(mock_get_runbook, mock_load_ch
 
 def test_compose_check_name_for_job():
     expected_check = 'check-chronos-jobs.myservice.myinstance'
-    assert check_chronos_jobs.compose_check_name_for_job('myservice', 'myinstance') == expected_check
+    assert chronos_tools.compose_check_name_for_job('myservice', 'myinstance') == expected_check
 
 
-@patch('paasta_tools.check_chronos_jobs.monitoring_tools.send_event')
+@patch('paasta_tools.chronos_tools.monitoring_tools.send_event')
 def test_send_event_to_sensu(mock_send_event):
-    check_chronos_jobs.send_event_to_sensu(
+    chronos_tools.send_event_to_sensu(
         service='myservice',
         instance='myinstance',
         monitoring_overrides={},

--- a/tests/test_check_chronos_jobs.py
+++ b/tests/test_check_chronos_jobs.py
@@ -29,12 +29,13 @@ def test_compose_monitoring_overrides_for_service(mock_get_runbook, mock_load_ch
 
 def test_compose_check_name_for_job():
     expected_check = 'check-chronos-jobs.myservice.myinstance'
-    assert chronos_tools.compose_check_name_for_job('myservice', 'myinstance') == expected_check
+    assert chronos_tools.compose_check_name_for_service_instance('check-chronos-jobs',
+                                                                 'myservice', 'myinstance') == expected_check
 
 
 @patch('paasta_tools.chronos_tools.monitoring_tools.send_event')
 def test_send_event_to_sensu(mock_send_event):
-    chronos_tools.send_event_to_sensu(
+    check_chronos_jobs.send_event(
         service='myservice',
         instance='myinstance',
         monitoring_overrides={},


### PR DESCRIPTION
When instances are removed from a `chronos-*.yaml` `cleanup_chronos_jobs` now sends an OK status to sensu.