### PR TITLE
Remove tags chronos jobs

### DIFF
--- a/paasta_itests/cleanup_chronos_jobs.feature
+++ b/paasta_itests/cleanup_chronos_jobs.feature
@@ -2,11 +2,11 @@ Feature: cleanup_chronos_jobs removes chronos jobs no longer in the config
 
  Scenario: Cleanup chronos jobs removes jobs
    Given a working paasta cluster
-      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
-    When I launch 3 configured jobs for the service "testservice" with scheduled chronos instance "testinstance" and differing tags
-     And I launch 1 unconfigured jobs for the service "oldservice" with scheduled chronos instance "othertestinstance" and differing tags
+     And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+    When I launch 1 configured jobs for the service "testservice" with scheduled chronos instance "testinstance"
+     And I launch 1 unconfigured jobs for the service "oldservice" with scheduled chronos instance "othertestinstance"
      And I launch 3 non-paasta jobs
     Then cleanup_chronos_jobs exits with return code "0" and the correct output
-     And the non chronos jobs are still in the job list
+     And the non-paasta jobs are still in the job list
      And the configured chronos jobs are in the job list
      And the unconfigured chronos jobs are not in the job list

--- a/paasta_itests/setup_chronos_job.feature
+++ b/paasta_itests/setup_chronos_job.feature
@@ -18,28 +18,8 @@ Feature: setup_chronos_job can create and bounce jobs
 
      When we set the "cmd" field of the chronos config for service "testservice" and instance "testinstance" to "sleep 60m"
       And we run setup_chronos_job for service_instance "testservice.testinstance"
-      And we store the name of the job for the service testservice and instance testinstance as mysecondjob
-     Then the field "disabled" for the job stored as "myfirstjob" is set to "True"
-      And the field "disabled" for the job stored as "mysecondjob" is set to "False"
-
-     When we set the "cmd" field of the chronos config for service "testservice" and instance "testinstance" to "echo hello && sleep 60m"
-      And we run setup_chronos_job for service_instance "testservice.testinstance"
-      And we store the name of the job for the service testservice and instance testinstance as mythirdjob
-     Then the field "disabled" for the job stored as "mysecondjob" is set to "True"
-      And the field "disabled" for the job stored as "mythirdjob" is set to "False"
-
-  Scenario: jobs will be cleaned up by the "graceful" bounce
-    Given a working paasta cluster
-      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
-      And we have a deployments.json for the service "testservice" with enabled chronos instance "testinstance"
-     When we set the "bounce" field of the chronos config for service "testservice" and instance "testinstance" to "graceful"
-      And we run setup_chronos_job for service_instance "testservice.testinstance"
-      And we store the name of the job for the service testservice and instance testinstance as myjob
-     When we create 10 disabled jobs that look like the job stored as "myjob"
-     When we set the "cmd" field of the chronos config for service "testservice" and instance "testinstance" to "sleep 60m"
-      And we run setup_chronos_job for service_instance "testservice.testinstance"
-     Then there should be 1 enabled jobs for the service "testservice" and instance "testinstance"
-      And there should be 5 disabled jobs for the service "testservice" and instance "testinstance"
+      And we store the name of the job for the service testservice and instance testinstance as mynewjob
+     Then the field "command" for the job stored as "mynewjob" is set to "sleep 60m"
 
   Scenario: dependent jobs can be launched
     Given a working paasta cluster

--- a/paasta_itests/steps/chronos_steps.py
+++ b/paasta_itests/steps/chronos_steps.py
@@ -81,12 +81,10 @@ def chronos_check_running_tasks(context, old_or_new_job, has_or_not):
 @then(u'the field "{field}" for the job stored as "{job_name}" is set to "{value}"')
 def chronos_check_job_state(context, field, job_name, value):
     job_id = context.jobs[job_name]['name']
-    (service, instance, git_hash, config_hash) = chronos_tools.decompose_job_id(job_id)
+    service, instance = chronos_tools.decompose_job_id(job_id)
     jobs = chronos_tools.lookup_chronos_jobs(
         service=service,
         instance=instance,
-        git_hash=git_hash,
-        config_hash=config_hash,
         client=context.chronos_client,
         include_disabled=True
     )

--- a/paasta_itests/steps/cleanup_chronos_job_steps.py
+++ b/paasta_itests/steps/cleanup_chronos_job_steps.py
@@ -21,14 +21,14 @@ from paasta_tools.utils import _run
 
 
 @when(('I launch {num_jobs} {state} jobs for the service "{service}"'
-       ' with scheduled chronos instance "{job}" and differing tags'))
+       ' with scheduled chronos instance "{job}"'))
 def launch_jobs(context, num_jobs, state, service, job):
     client = context.chronos_client
     jobs = [{
         'async': False,
         'command': 'echo 1',
         'epsilon': 'PT15M',
-        'name': compose_job_id(service, job, 'githash', 'config%d' % x),
+        'name': compose_job_id(service, job),
         'owner': 'paasta',
         'disabled': True,
         'schedule': 'R/2014-01-01T00:00:00Z/PT60M',
@@ -90,7 +90,7 @@ def check_cleanup_chronos_jobs_output(context, expected_return_code):
         assert '  %s' % job in output
 
 
-@then('the non chronos jobs are still in the job list')
+@then('the non-paasta jobs are still in the job list')
 def check_non_paasta_jobs(context):
     jobs = context.chronos_client.list()
     running_job_names = [job['name'] for job in jobs]

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -247,18 +247,9 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir):
         # Setting up transparent cache for http API calls
         requests_cache.install_cache("paasta_serviceinit", backend="memory")
         # Verbose mode shows previous versions.
-        if verbose:
-            git_hash = None
-            config_hash = None
-        # Non-verbose shows only the version specified via
-        # create_complete_config.
-        else:
-            (_, __, git_hash, config_hash) = chronos_tools.decompose_job_id(job_id)
         matching_jobs = chronos_tools.lookup_chronos_jobs(
             service=service,
             instance=instance,
-            git_hash=git_hash,
-            config_hash=config_hash,
             client=client,
             include_disabled=True,
         )

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -27,6 +27,7 @@ import service_configuration_lib
 from tron import command_context
 
 from paasta_tools.utils import decompose_job_id as utils_decompose_job_id
+from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_paasta_branch
 from paasta_tools.utils import get_service_instance_list
@@ -467,6 +468,10 @@ def create_complete_config(service, job_name, soa_dir=DEFAULT_SOA_DIR):
 
     complete_config['name'] = compose_job_id(service, job_name)
     desired_state = chronos_job_config.get_desired_state()
+
+    # we use the undocumented description field to store a hash of the chronos config.
+    # this makes it trivial to compare configs and know when to bounce.
+    complete_config['description'] = get_config_hash(complete_config)
 
     # If the job was previously stopped, we should stop the new job as well
     # NOTE this clobbers the 'disabled' param specified in the config file!

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -26,10 +26,7 @@ import monitoring_tools
 import service_configuration_lib
 from tron import command_context
 
-from paasta_tools.utils import compose_job_id as utils_compose_job_id
 from paasta_tools.utils import decompose_job_id as utils_decompose_job_id
-from paasta_tools.utils import get_code_sha_from_dockerurl
-from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_paasta_branch
 from paasta_tools.utils import get_service_instance_list
@@ -120,14 +117,15 @@ def get_chronos_client(config):
                            password=config.get_password())
 
 
-def compose_job_id(service, instance, git_hash=None, config_hash=None):
-    """Thin wrapper around generic compose_job_id to use our local SPACER."""
-    return utils_compose_job_id(service, instance, git_hash, config_hash, spacer=SPACER)
+def compose_job_id(service, instance):
+    """In chronos, a job is just service{SPACER}instance """
+    return "%s%s%s" % (service, SPACER, instance)
 
 
 def decompose_job_id(job_id):
     """Thin wrapper around generic decompose_job_id to use our local SPACER."""
-    return utils_decompose_job_id(job_id, spacer=SPACER)
+    service, job, _, __ = utils_decompose_job_id(job_id, spacer=SPACER)
+    return (service, job)
 
 
 class InvalidChronosConfigError(Exception):
@@ -466,13 +464,8 @@ def create_complete_config(service, job_name, soa_dir=DEFAULT_SOA_DIR):
         docker_url,
         docker_volumes,
     )
-    code_sha = get_code_sha_from_dockerurl(docker_url)
-    config_hash = get_config_hash(complete_config)
 
-    # Chronos clears the history for a job whenever it is updated, so we use a new job name for each revision
-    # so that we can keep history of old job revisions rather than just the latest version
-    full_id = compose_job_id(service, job_name, code_sha, config_hash)
-    complete_config['name'] = full_id
+    complete_config['name'] = compose_job_id(service, job_name)
     desired_state = chronos_job_config.get_desired_state()
 
     # If the job was previously stopped, we should stop the new job as well
@@ -585,14 +578,12 @@ def sort_jobs(jobs):
     )
 
 
-def lookup_chronos_jobs(client, service=None, instance=None, git_hash=None, config_hash=None, include_disabled=False):
+def lookup_chronos_jobs(client, service=None, instance=None, include_disabled=False):
     """Discovers Chronos jobs and filters them with ``filter_chronos_jobs()``.
 
     :param client: Chronos client object
     :param service: passed on to ``filter_chronos_jobs()``
     :param instance: passed on to ``filter_chronos_jobs()``
-    :param git_hash: passed on to ``filter_chronos_jobs()``
-    :param config_hash: passed on to ``filter_chronos_jobs()``
     :param include_disabled: passed on to ``filter_chronos_jobs()``
     :returns: list of job dicts discovered by ``client`` and filtered by
     ``filter_chronos_jobs()`` using the other parameters
@@ -602,22 +593,16 @@ def lookup_chronos_jobs(client, service=None, instance=None, git_hash=None, conf
         jobs=jobs,
         service=service,
         instance=instance,
-        git_hash=git_hash,
-        config_hash=config_hash,
         include_disabled=include_disabled,
     )
 
 
-def filter_chronos_jobs(jobs, service, instance, git_hash, config_hash, include_disabled):
+def filter_chronos_jobs(jobs, service, instance, include_disabled):
     """Filters a list of Chronos jobs based on several criteria.
 
     :param jobs: a list of jobs, as calculated in ``lookup_chronos_jobs()``
     :param service: service we're looking for. If None, don't filter based on this key.
     :param instance: instance we're looking for. If None, don't filter based on this key.
-    :param git_hash: git_hash we're looking for. If None, don't filter based on
-    this key.
-    :param config_hash: config_hash we're looking for. If None, don't filter
-    based on this key.
     :param include_disabled: boolean indicating if disabled jobs should be
     included in the returned list
     :returns: list of job dicts whose name matches the arguments (if any)
@@ -626,14 +611,12 @@ def filter_chronos_jobs(jobs, service, instance, git_hash, config_hash, include_
     matching_jobs = []
     for job in jobs:
         try:
-            (job_service, job_instance, job_git_hash, job_config_hash) = decompose_job_id(job['name'])
+            job_service, job_instance = decompose_job_id(job['name'])
         except InvalidJobNameError:
             continue
         if (
             (service is None or job_service == service) and
-            (instance is None or job_instance == instance) and
-            (git_hash is None or job_git_hash == git_hash) and
-            (config_hash is None or job_config_hash == config_hash)
+            (instance is None or job_instance == instance)
         ):
             if job['disabled'] and not include_disabled:
                 continue
@@ -700,6 +683,11 @@ def delete_job(client, job):
 def create_job(client, job):
     log.debug("Creating job: %s" % job)
     client.add(job)
+
+
+def update_job(client, job):
+    log.debug("Updating job: %s" % job)
+    client.update(job)
 
 
 def find_matching_parent_job(job_name):

--- a/paasta_tools/setup_chronos_job.py
+++ b/paasta_tools/setup_chronos_job.py
@@ -141,7 +141,8 @@ def setup_job(service, instance, complete_job_config, client, cluster):
 
     job_to_update = None
     if len(all_existing_jobs) > 0:
-        if all_existing_jobs[0] != complete_job_config:
+        # we store the md5 sum of the config in the description field.
+        if all_existing_jobs[0]['description'] != complete_job_config['description']:
             job_to_update = complete_job_config
     else:
         job_to_update = complete_job_config

--- a/paasta_tools/setup_chronos_job.py
+++ b/paasta_tools/setup_chronos_job.py
@@ -96,7 +96,7 @@ def send_event(service, instance, soa_dir, status, output):
     # we need to set the ``check_every`` to the frequency of our cron job, which
     # is 10s.
     monitoring_overrides['check_every'] = '10s'
-    # Most deploy_chrono_jobs failures are transient and represent issues
+    # Most deploy_chronos_jobs failures are transient and represent issues
     # that will probably be fixed eventually, so we set an alert_after
     # to suppress extra noise
     monitoring_overrides['alert_after'] = '10m'
@@ -115,58 +115,42 @@ def bounce_chronos_job(
     service,
     instance,
     cluster,
-    jobs_to_disable,
-    jobs_to_delete,
-    job_to_create,
+    job_to_update,
     client
 ):
-    if any([jobs_to_disable, jobs_to_delete, job_to_create]):
-        log_line = "Chronos bouncing. Jobs to disable: %s, jobs to delete: %s, job_to_create: %s" % (
-            jobs_to_disable, jobs_to_delete, job_to_create)
+    if job_to_update:
+        log_line = 'Job to update: %s' % job_to_update
         _log(service=service, instance=instance, component='deploy',
              cluster=cluster, level='debug', line=log_line)
-    else:
-        log.debug("Not doing any chronos bounce action for %s" % chronos_tools.compose_job_id(
-            service, instance))
-    for job in jobs_to_disable:
-        chronos_tools.disable_job(client=client, job=job)
-    for job in jobs_to_delete:
-        chronos_tools.delete_job(client=client, job=job)
-    if job_to_create:
-        chronos_tools.create_job(client=client, job=job_to_create)
-        log_line = 'Created new Chronos job: %s' % job_to_create['name']
+        chronos_tools.update_job(client=client, job=job_to_update)
+        log_line = 'Updated Chronos job: %s' % job_to_update['name']
         _log(service=service, instance=instance, component='deploy',
              cluster=cluster, level='event', line=log_line)
+
     return (0, "All chronos bouncing tasks finished.")
 
 
 def setup_job(service, instance, complete_job_config, client, cluster):
-    job_id = complete_job_config['name']
-    # Sort this initial list since other lists of jobs will come from it (with
-    # their orders preserved by list comprehensions) and since we'll care about
-    # ordering by recency when we go calculate jobs_to_delete.
-    all_existing_jobs = chronos_tools.sort_jobs(chronos_tools.lookup_chronos_jobs(
+    # There should only ever be *one* job for a given service_instance
+    all_existing_jobs = chronos_tools.lookup_chronos_jobs(
         service=service,
         instance=instance,
         client=client,
         include_disabled=True,
-    ))
-    old_jobs = [job for job in all_existing_jobs if job["name"] != job_id]
-    enabled_old_jobs = [job for job in old_jobs if not job["disabled"]]
+    )
 
-    if all_existing_jobs == old_jobs:
-        job_to_create = complete_job_config
+    job_to_update = None
+    if len(all_existing_jobs) > 0:
+        if all_existing_jobs[0] != complete_job_config:
+            job_to_update = complete_job_config
     else:
-        job_to_create = None
+        job_to_update = complete_job_config
 
-    number_of_old_jobs_to_keep = 5
     return bounce_chronos_job(
         service=service,
         instance=instance,
         cluster=cluster,
-        jobs_to_disable=enabled_old_jobs,
-        jobs_to_delete=old_jobs[number_of_old_jobs_to_keep:],
-        job_to_create=job_to_create,
+        job_to_update=job_to_update,
         client=client,
     )
 
@@ -180,7 +164,9 @@ def main():
     else:
         log.setLevel(logging.WARNING)
     try:
-        service, instance, _, __ = decompose_job_id(args.service_instance)
+        service, instance, _, __ = decompose_job_id(args.service_instance, spacer=chronos_tools.INTERNAL_SPACER)
+        print 'service, instance'
+        print service, instance
     except InvalidJobNameError:
         log.error("Invalid service instance '%s' specified. Format is service%sinstance."
                   % (args.service_instance, SPACER))

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -45,12 +45,14 @@ class TestChronosTools:
         'desired_state': 'start',
         'docker_image': 'paasta-%s-%s' % (fake_service, fake_cluster),
     }
-    fake_chronos_job_config = chronos_tools.ChronosJobConfig(service=fake_service,
-                                                             cluster=fake_cluster,
-                                                             instance=fake_job_name,
-                                                             config_dict=fake_config_dict,
-                                                             branch_dict=fake_branch_dict,
-                                                             )
+
+    fake_chronos_job_config = chronos_tools.ChronosJobConfig(
+        service=fake_service,
+        cluster=fake_cluster,
+        instance=fake_job_name,
+        config_dict=fake_config_dict,
+        branch_dict=fake_branch_dict,
+    )
 
     fake_invalid_config_dict = {
         'bounce_method': 'crossover',
@@ -145,26 +147,13 @@ class TestChronosTools:
             chronos_tools.get_chronos_client(fake_config)
             assert mock_connect.call_count == 1
 
-    def test_compose_job_id_without_hashes(self):
+    def test_compose_job_id(self):
         actual = chronos_tools.compose_job_id('service', 'instance')
         assert actual == 'service instance'
 
-    def test_compose_job_id_with_hashes(self):
-        actual = chronos_tools.compose_job_id(
-            'service',
-            'instance',
-            'gityourmom',
-            'configyourdad',
-        )
-        assert actual == 'service instance gityourmom configyourdad'
-
     def test_decompose_job_id_without_hashes(self):
         actual = chronos_tools.decompose_job_id('service instance')
-        assert actual == ('service', 'instance', None, None)
-
-    def test_decompose_job_id_with_hashes(self):
-        actual = chronos_tools.decompose_job_id('service instance gityourmom configyourdad')
-        assert actual == ('service', 'instance', 'gityourmom', 'configyourdad')
+        assert actual == ('service', 'instance')
 
     def test_read_chronos_jobs_for_service(self):
         fake_soa_dir = '/tmp/'
@@ -907,48 +896,22 @@ class TestChronosTools:
                 jobs=fake_client.list.return_value,
                 service=fake_service,
                 instance=fake_instance,
-                git_hash=None,
-                config_hash=None,
                 include_disabled=False,
             )
 
     def test_filter_chronos_jobs_with_no_filters(self):
-        fake_service = 'fake_service'
-        fake_instance = 'fake_instance'
         fake_jobs = [
             {
                 'name': chronos_tools.compose_job_id(
-                    fake_service,
-                    fake_instance,
-                    'git1111',
-                    'config1111',
+                    'fake_service',
+                    'fake_instance',
                 ),
                 'disabled': False,
             },
             {
                 'name': chronos_tools.compose_job_id(
-                    fake_service,
-                    fake_instance,
-                    'git2222',
-                    'config2222',
-                ),
-                'disabled': False,
-            },
-            {
-                'name': chronos_tools.compose_job_id(
-                    fake_service,
-                    fake_instance,
-                    'gitdisabled',
-                    'configdisabled',
-                ),
-                'disabled': True,
-            },
-            {
-                'name': chronos_tools.compose_job_id(
-                    'some_other_service',
-                    'some_other_instance',
-                    'gitother',
-                    'configother',
+                    'other_fake_service',
+                    'other_fake_instance',
                 ),
                 'disabled': False,
             },
@@ -958,8 +921,6 @@ class TestChronosTools:
             jobs=fake_jobs,
             service=None,
             instance=None,
-            git_hash=None,
-            config_hash=None,
             include_disabled=True,
         )
         assert sorted(actual) == sorted(expected)
@@ -970,48 +931,24 @@ class TestChronosTools:
         fake_jobs = [
             {
                 'name': chronos_tools.compose_job_id(
-                    fake_service,
-                    fake_instance,
-                    'git1111',
-                    'config1111',
+                    'fake_service',
+                    'fake_instance',
                 ),
                 'disabled': False,
             },
             {
                 'name': chronos_tools.compose_job_id(
-                    fake_service,
-                    fake_instance,
-                    'git2222',
-                    'config2222',
-                ),
-                'disabled': False,
-            },
-            {
-                'name': chronos_tools.compose_job_id(
-                    fake_service,
-                    fake_instance,
-                    'gitdisabled',
-                    'configdisabled',
-                ),
-                'disabled': True,
-            },
-            {
-                'name': chronos_tools.compose_job_id(
-                    'some_other_service',
-                    'some_other_instance',
-                    'git3333',
-                    'config3333',
+                    'other_fake_service',
+                    'other_fake_instance',
                 ),
                 'disabled': False,
             },
         ]
-        expected = [fake_jobs[0], fake_jobs[1]]
+        expected = [fake_jobs[0]]
         actual = chronos_tools.filter_chronos_jobs(
             jobs=fake_jobs,
             service=fake_service,
             instance=fake_instance,
-            git_hash=None,
-            config_hash=None,
             include_disabled=False,
         )
         assert sorted(actual) == sorted(expected)
@@ -1024,8 +961,6 @@ class TestChronosTools:
                 'name': chronos_tools.compose_job_id(
                     fake_service,
                     fake_instance,
-                    'git1111',
-                    'config1111',
                 ),
                 'disabled': False,
             },
@@ -1033,8 +968,6 @@ class TestChronosTools:
                 'name': chronos_tools.compose_job_id(
                     fake_service,
                     fake_instance,
-                    'git2222',
-                    'config2222',
                 ),
                 'disabled': False,
             },
@@ -1042,8 +975,6 @@ class TestChronosTools:
                 'name': chronos_tools.compose_job_id(
                     fake_service,
                     fake_instance,
-                    'gitdisabled',
-                    'configdisabled',
                 ),
                 'disabled': True,
             },
@@ -1051,8 +982,6 @@ class TestChronosTools:
                 'name': chronos_tools.compose_job_id(
                     'some_other_service',
                     'some_other_instance',
-                    'git3333',
-                    'config3333',
                 ),
                 'disabled': False,
             },
@@ -1062,63 +991,7 @@ class TestChronosTools:
             jobs=fake_jobs,
             service=fake_service,
             instance=fake_instance,
-            git_hash=None,
-            config_hash=None,
             include_disabled=True,
-        )
-        assert sorted(actual) == sorted(expected)
-
-    def test_filter_chronos_jobs_with_everything_specified(self):
-        fake_service = 'fake_service'
-        fake_instance = 'fake_instance'
-        fake_git_hash = 'fake_git_hash'
-        fake_config_hash = 'fake_config_hash'
-        fake_jobs = [
-            {
-                'name': chronos_tools.compose_job_id(
-                    fake_service,
-                    fake_instance,
-                    fake_git_hash,
-                    fake_config_hash,
-                ),
-                'disabled': False,
-            },
-            {
-                'name': chronos_tools.compose_job_id(
-                    fake_service,
-                    fake_instance,
-                    'git2222',
-                    'config2222',
-                ),
-                'disabled': False,
-            },
-            {
-                'name': chronos_tools.compose_job_id(
-                    fake_service,
-                    fake_instance,
-                    'gitdisabled',
-                    'configdisabled',
-                ),
-                'disabled': True,
-            },
-            {
-                'name': chronos_tools.compose_job_id(
-                    'some_other_service',
-                    'some_other_instance',
-                    'git3333',
-                    'config3333',
-                ),
-                'disabled': False,
-            },
-        ]
-        expected = [fake_jobs[0]]
-        actual = chronos_tools.filter_chronos_jobs(
-            jobs=fake_jobs,
-            service=fake_service,
-            instance=fake_instance,
-            git_hash=fake_git_hash,
-            config_hash=fake_config_hash,
-            include_disabled=False,
         )
         assert sorted(actual) == sorted(expected)
 
@@ -1133,8 +1006,6 @@ class TestChronosTools:
             jobs=fake_jobs,
             service='whatever',
             instance='whatever',
-            git_hash='whatever',
-            config_hash='whatever',
             include_disabled=False,
         )
         # The main thing here is that InvalidJobNameError is not raised.
@@ -1146,14 +1017,10 @@ class TestChronosTools:
             mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        autospec=True, return_value=self.fake_chronos_job_config),
-            mock.patch('paasta_tools.chronos_tools.get_code_sha_from_dockerurl', autospec=True, return_value="sha"),
-            mock.patch('paasta_tools.chronos_tools.get_config_hash', autospec=True, return_value="hash"),
             mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner)
         ) as (
             load_system_paasta_config_patch,
             load_chronos_job_config_patch,
-            code_sha_patch,
-            config_hash_patch,
             mock_get_team,
         ):
             load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=[])
@@ -1169,7 +1036,7 @@ class TestChronosTools:
                 'environmentVariables': [],
                 'retries': 5,
                 'disabled': False,
-                'name': 'fake-service fake-job sha hash',
+                'name': 'fake-service fake-job',
                 'command': '/bin/sleep 40',
                 'epsilon': 'PT30M',
                 'container': {
@@ -1201,14 +1068,10 @@ class TestChronosTools:
             mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        autospec=True, return_value=fake_chronos_job_config),
-            mock.patch('paasta_tools.chronos_tools.get_code_sha_from_dockerurl', autospec=True, return_value="sha"),
-            mock.patch('paasta_tools.chronos_tools.get_config_hash', autospec=True, return_value="hash"),
             mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner)
         ) as (
             load_system_paasta_config_patch,
             load_chronos_job_config_patch,
-            code_sha_patch,
-            config_hash_patch,
             mock_get_team,
         ):
             load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=[])
@@ -1224,7 +1087,7 @@ class TestChronosTools:
                 'environmentVariables': [],
                 'retries': 5,
                 'disabled': False,
-                'name': 'fake_service fake_job sha hash',
+                'name': 'fake_service fake_job',
                 'command': '/bin/sleep 40',
                 'epsilon': 'PT30M',
                 'container': {
@@ -1256,14 +1119,10 @@ class TestChronosTools:
             mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        autospec=True, return_value=fake_chronos_job_config),
-            mock.patch('paasta_tools.chronos_tools.get_code_sha_from_dockerurl', autospec=True, return_value="sha"),
-            mock.patch('paasta_tools.chronos_tools.get_config_hash', autospec=True, return_value="hash"),
             mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner)
         ) as (
             load_system_paasta_config_patch,
             load_chronos_job_config_patch,
-            code_sha_patch,
-            config_hash_patch,
             mock_get_team,
         ):
             load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=[])
@@ -1279,7 +1138,7 @@ class TestChronosTools:
                 'environmentVariables': [],
                 'retries': 5,
                 'disabled': True,
-                'name': 'fake_service fake_job sha hash',
+                'name': 'fake_service fake_job',
                 'command': '/bin/sleep 40',
                 'epsilon': 'PT30M',
                 'container': {
@@ -1327,14 +1186,10 @@ class TestChronosTools:
             mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        autospec=True, return_value=fake_chronos_job_config),
-            mock.patch('paasta_tools.chronos_tools.get_code_sha_from_dockerurl', autospec=True, return_value="sha"),
-            mock.patch('paasta_tools.chronos_tools.get_config_hash', autospec=True, return_value="hash"),
             mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner)
         ) as (
             load_system_paasta_config_patch,
             load_chronos_job_config_patch,
-            code_sha_patch,
-            config_hash_patch,
             mock_get_team,
         ):
             load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=fake_system_volumes)
@@ -1350,7 +1205,7 @@ class TestChronosTools:
                 'environmentVariables': [],
                 'retries': 5,
                 'disabled': True,
-                'name': 'fake_service fake_job sha hash',
+                'name': 'fake_service fake_job',
                 'command': '/bin/sleep 40',
                 'epsilon': 'PT30M',
                 'container': {
@@ -1505,6 +1360,12 @@ class TestChronosTools:
         fake_client = fake_client_class(servers=[])
         chronos_tools.create_job(job=self.fake_config_dict, client=fake_client)
         fake_client.add.assert_called_once_with(self.fake_config_dict)
+
+    def test_update_job(self):
+        fake_client_class = mock.Mock(spec='chronos.ChronosClient')
+        fake_client = fake_client_class(servers=[])
+        chronos_tools.update_job(job=self.fake_config_dict, client=fake_client)
+        fake_client.update.assert_called_once_with(self.fake_config_dict)
 
     def test_check_format_job_short(self):
         assert chronos_tools.check_parent_format("foo") is False

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -835,7 +835,9 @@ class TestChronosTools:
             'uris': ['file:///root/.dockercfg', ],
             'shell': True,
         }
-        with mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner):
+        with contextlib.nested(
+            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner, autospec=True),
+        ):
             actual = chronos_job_config.format_chronos_job_dict(fake_docker_url, fake_docker_volumes)
             assert actual == expected
 
@@ -1013,21 +1015,25 @@ class TestChronosTools:
 
     def test_create_complete_config(self):
         fake_owner = 'test_team'
+        fake_config_hash = 'fake_config_hash'
         with contextlib.nested(
             mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        autospec=True, return_value=self.fake_chronos_job_config),
-            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner)
+            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner),
+            mock.patch('paasta_tools.chronos_tools.get_config_hash', return_value=fake_config_hash),
         ) as (
             load_system_paasta_config_patch,
             load_chronos_job_config_patch,
             mock_get_team,
+            mock_get_config_hash,
         ):
             load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=[])
             load_system_paasta_config_patch.return_value.get_docker_registry = mock.Mock(return_value='fake_registry')
             actual = chronos_tools.create_complete_config('fake-service', 'fake-job')
             expected = {
                 'arguments': None,
+                'description': fake_config_hash,
                 'constraints': None,
                 'schedule': 'R/2015-03-25T19:36:35Z/PT5M',
                 'async': False,
@@ -1064,21 +1070,25 @@ class TestChronosTools:
                 'docker_image': 'fake_image'
             },
         )
+        fake_config_hash = 'fake_config_hash'
         with contextlib.nested(
             mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        autospec=True, return_value=fake_chronos_job_config),
-            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner)
+            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner),
+            mock.patch('paasta_tools.chronos_tools.get_config_hash', return_value=fake_config_hash),
         ) as (
             load_system_paasta_config_patch,
             load_chronos_job_config_patch,
             mock_get_team,
+            mock_fake_config_hash,
         ):
             load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=[])
             load_system_paasta_config_patch.return_value.get_docker_registry = mock.Mock(return_value='fake_registry')
             actual = chronos_tools.create_complete_config('fake_service', 'fake_job')
             expected = {
                 'arguments': None,
+                'description': fake_config_hash,
                 'constraints': None,
                 'schedule': 'R/2015-03-25T19:36:35Z/PT5M',
                 'async': False,
@@ -1115,21 +1125,25 @@ class TestChronosTools:
                 'docker_image': 'fake_image'
             },
         )
+        fake_config_hash = 'fake_config_hash'
         with contextlib.nested(
             mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        autospec=True, return_value=fake_chronos_job_config),
-            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner)
+            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner),
+            mock.patch('paasta_tools.chronos_tools.get_config_hash', return_value=fake_config_hash),
         ) as (
             load_system_paasta_config_patch,
             load_chronos_job_config_patch,
             mock_get_team,
+            mock_fake_config_hash,
         ):
             load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=[])
             load_system_paasta_config_patch.return_value.get_docker_registry = mock.Mock(return_value='fake_registry')
             actual = chronos_tools.create_complete_config('fake_service', 'fake_job')
             expected = {
                 'arguments': None,
+                'description': fake_config_hash,
                 'constraints': None,
                 'schedule': 'R/2015-03-25T19:36:35Z/PT5M',
                 'async': False,
@@ -1182,20 +1196,24 @@ class TestChronosTools:
                 'docker_image': 'fake_image'
             },
         )
+        fake_config_hash = 'fake_config_hash'
         with contextlib.nested(
             mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        autospec=True, return_value=fake_chronos_job_config),
-            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner)
+            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner),
+            mock.patch('paasta_tools.chronos_tools.get_config_hash', return_value=fake_config_hash),
         ) as (
             load_system_paasta_config_patch,
             load_chronos_job_config_patch,
             mock_get_team,
+            mock_get_config_hash,
         ):
             load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=fake_system_volumes)
             load_system_paasta_config_patch.return_value.get_docker_registry = mock.Mock(return_value='fake_registry')
             actual = chronos_tools.create_complete_config('fake_service', 'fake_job')
             expected = {
+                'description': fake_config_hash,
                 'arguments': None,
                 'constraints': None,
                 'schedule': 'R/2015-03-25T19:36:35Z/PT5M',

--- a/tests/test_setup_chronos_job.py
+++ b/tests/test_setup_chronos_job.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import contextlib
+import copy
 
 import mock
 from pysensu_yelp import Status
@@ -51,12 +52,13 @@ class TestSetupChronosJob:
     fake_branch_dict = {
         'docker_image': 'paasta-%s-%s' % (fake_service, fake_cluster),
     }
-    fake_chronos_job_config = chronos_tools.ChronosJobConfig(service=fake_service,
-                                                             cluster=fake_cluster,
-                                                             instance=fake_instance,
-                                                             config_dict=fake_config_dict,
-                                                             branch_dict=fake_branch_dict,
-                                                             )
+    fake_chronos_job_config = chronos_tools.ChronosJobConfig(
+        service=fake_service,
+        cluster=fake_cluster,
+        instance=fake_instance,
+        config_dict=fake_config_dict,
+        branch_dict=fake_branch_dict,
+    )
 
     fake_docker_registry = 'remote_registry.com'
     fake_args = mock.MagicMock(
@@ -228,9 +230,7 @@ class TestSetupChronosJob:
                 service=self.fake_service,
                 instance=self.fake_instance,
                 cluster=self.fake_cluster,
-                jobs_to_delete=[],
-                jobs_to_disable=[],
-                job_to_create=complete_config,
+                job_to_update=complete_config,
                 client=self.fake_client,
             )
             assert actual == mock_bounce_chronos_job.return_value
@@ -274,39 +274,29 @@ class TestSetupChronosJob:
                 service=self.fake_service,
                 instance=self.fake_instance,
                 cluster=self.fake_cluster,
-                jobs_to_delete=[],
-                jobs_to_disable=[fake_existing_job],
-                job_to_create=complete_config,
+                job_to_update=complete_config,
                 client=self.fake_client,
             )
             assert mock_lookup_chronos_jobs.called
             assert actual == mock_bounce_chronos_job.return_value
 
     def test_setup_job_does_nothing_with_only_existing_app(self):
-        fake_existing_job = self.fake_config_dict
+        fake_existing_job = copy.deepcopy(self.fake_config_dict)
         with contextlib.nested(
             mock.patch('paasta_tools.setup_chronos_job.bounce_chronos_job', autospec=True, return_value=(0, 'ok')),
             mock.patch('paasta_tools.chronos_tools.lookup_chronos_jobs',
-                       autospec=True),
-            mock.patch('paasta_tools.chronos_tools.sort_jobs',
-                       autospec=True,
-                       return_value=[fake_existing_job]),
+                       autospec=True, return_value=[fake_existing_job]),
             mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        autospec=True, return_value=self.fake_chronos_job_config),
         ) as (
             mock_bounce_chronos_job,
             mock_lookup_chronos_jobs,
-            mock_sort_jobs,
             load_system_paasta_config_patch,
             load_chronos_job_config_patch,
         ):
             load_system_paasta_config_patch.return_value.get_cluster.return_value = self.fake_cluster
-            complete_config = chronos_tools.create_complete_config(
-                service=self.fake_service,
-                job_name=self.fake_instance,
-                soa_dir=self.fake_args.soa_dir
-            )
+            complete_config = copy.deepcopy(self.fake_config_dict)
             # Force the complete_config's name to match the return value of
             # lookup_chronos_jobs to simulate that they have the same name
             complete_config["name"] = fake_existing_job["name"]
@@ -321,9 +311,7 @@ class TestSetupChronosJob:
                 service=self.fake_service,
                 instance=self.fake_instance,
                 cluster=self.fake_cluster,
-                jobs_to_delete=[],
-                jobs_to_disable=[],
-                job_to_create=None,
+                job_to_update=None,
                 client=self.fake_client,
             )
             assert mock_lookup_chronos_jobs.called
@@ -369,27 +357,19 @@ class TestSetupChronosJob:
             )
 
     def test_bounce_chronos_job_takes_actions(self):
-        fake_jobs_to_disable = [{'name': 'job_to_disable'}]
-        fake_jobs_to_delete = [{'name': 'job_to_delete'}]
-        fake_job_to_create = {'name': 'job_to_create'}
+        fake_job_to_update = {'name': 'job_to_update'}
         with contextlib.nested(
             mock.patch("paasta_tools.setup_chronos_job._log", autospec=True),
-            mock.patch("paasta_tools.chronos_tools.disable_job", autospec=True),
-            mock.patch("paasta_tools.chronos_tools.delete_job", autospec=True),
-            mock.patch("paasta_tools.chronos_tools.create_job", autospec=True),
+            mock.patch("paasta_tools.chronos_tools.update_job", autospec=True),
         ) as (
             mock_log,
-            mock_disable_job,
-            mock_delete_job,
-            mock_create_job,
+            mock_update_job,
         ):
             setup_chronos_job.bounce_chronos_job(
                 service=self.fake_service,
                 instance=self.fake_instance,
                 cluster=self.fake_cluster,
-                jobs_to_disable=fake_jobs_to_disable,
-                jobs_to_delete=fake_jobs_to_delete,
-                job_to_create=fake_job_to_create,
+                job_to_update=fake_job_to_update,
                 client=self.fake_client,
             )
             mock_log.assert_any_call(
@@ -401,42 +381,29 @@ class TestSetupChronosJob:
                 service=self.fake_service,
             )
             mock_log.assert_any_call(
-                line="Created new Chronos job: job_to_create",
+                line="Updated Chronos job: job_to_update",
                 level='event',
                 instance=self.fake_instance,
                 cluster=self.fake_cluster,
                 component='deploy',
                 service=self.fake_service,
             )
-            mock_disable_job.assert_called_once_with(job=fake_jobs_to_disable[0], client=self.fake_client)
-            mock_delete_job.assert_called_once_with(job=fake_jobs_to_delete[0], client=self.fake_client)
-            mock_create_job.assert_called_once_with(job=fake_job_to_create, client=self.fake_client)
+            mock_update_job.assert_called_once_with(job=fake_job_to_update, client=self.fake_client)
 
     def test_bounce_chronos_job_doesnt_log_when_nothing_to_do(self):
-        fake_jobs_to_disable = []
-        fake_jobs_to_delete = []
-        fake_job_to_create = []
         with contextlib.nested(
             mock.patch("paasta_tools.setup_chronos_job._log", autospec=True),
-            mock.patch("paasta_tools.chronos_tools.disable_job", autospec=True),
-            mock.patch("paasta_tools.chronos_tools.delete_job", autospec=True),
-            mock.patch("paasta_tools.chronos_tools.create_job", autospec=True),
+            mock.patch("paasta_tools.chronos_tools.update_job", autospec=True),
         ) as (
             mock_log,
-            mock_disable_job,
-            mock_delete_job,
-            mock_create_job,
+            mock_update_job,
         ):
             setup_chronos_job.bounce_chronos_job(
                 service=self.fake_service,
                 instance=self.fake_instance,
                 cluster=self.fake_cluster,
-                jobs_to_disable=fake_jobs_to_disable,
-                jobs_to_delete=fake_jobs_to_delete,
-                job_to_create=fake_job_to_create,
+                job_to_update=None,
                 client=self.fake_client,
             )
             assert not mock_log.called
-            assert not mock_disable_job.called
-            assert not mock_delete_job.called
-            assert not mock_create_job.called
+            assert not mock_update_job.called


### PR DESCRIPTION
This reverts the revert + adds the config sha to the 'description' field of the chronos job so that jobs are only bounced when necessary.