### PR TITLE
Add healthcheck_mode to service config

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -394,9 +394,12 @@ Healthchecks
 
 You can control your healthchecks with the following keys.
 
+ * ``healthcheck_mode``: specifies the mode for the healthcheck (``http`` or
+   ``tcp``). Defaults to the ``mode`` of the service.
+
  * ``healthcheck_uri``: string specifying the URI which SmartStack should use to
-   healthcheck the service. Defaults to ``/status``. This is ignored for TCP
-   services.
+   healthcheck the service. Defaults to ``/status``. This is ignored if
+   ``healthcheck_mode`` is ``tcp``.
 
  * ``healthcheck_port``: an alternative port to use for healthchecking your
    service. This is not required; it defaults to the port your service instance

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -461,6 +461,7 @@ def load_service_namespace_config(service, namespace, soa_dir=DEFAULT_SOA_DIR):
     Retrevies the following keys:
 
     - proxy_port: the proxy port defined for the given namespace
+    - healthcheck_mode: the mode for the healthcheck (http or tcp)
     - healthcheck_port: An alternate port to use for health checking
     - healthcheck_uri: URI target for healthchecking
     - healthcheck_timeout_s: healthcheck timeout in seconds
@@ -495,6 +496,7 @@ def load_service_namespace_config(service, namespace, soa_dir=DEFAULT_SOA_DIR):
     # and there's other things that appear in the smartstack section in
     # several cases.
     key_whitelist = set([
+        'healthcheck_mode',
         'healthcheck_uri',
         'healthcheck_port',
         'healthcheck_timeout_s',

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -355,6 +355,7 @@ class TestMarathonTools:
         namespace = 'ecapseman'
         soa_dir = 'rid_aos'
         mode = 'http'
+        fake_healthcheck_mode = 'http'
         fake_uri = 'energy'
         fake_timeout = -10103
         fake_port = 777
@@ -362,6 +363,7 @@ class TestMarathonTools:
         fake_discover = 'myhabitat'
         fake_advertise = ['red', 'blue']
         fake_info = {
+            'healthcheck_mode': fake_healthcheck_mode,
             'healthcheck_uri': fake_uri,
             'healthcheck_timeout_s': fake_timeout,
             'proxy_port': fake_port,
@@ -396,6 +398,7 @@ class TestMarathonTools:
             },
         }
         expected = {
+            'healthcheck_mode': fake_healthcheck_mode,
             'healthcheck_uri': fake_uri,
             'healthcheck_timeout_s': fake_timeout,
             'proxy_port': fake_port,


### PR DESCRIPTION
The healthcheck_mode option was added to nerve-tools, but it is not actually loaded from the config file since the 'healthcheck_mode' key is not in the whitelist.