### PR TITLE
skip dependent jobs if they are created before their parent

### DIFF
--- a/paasta_itests/setup_chronos_job.feature
+++ b/paasta_itests/setup_chronos_job.feature
@@ -52,3 +52,10 @@ Feature: setup_chronos_job can create and bounce jobs
       And we have a deployments.json for the service "testservice" with enabled chronos instance "dependentjob"
      When we run setup_chronos_job for service_instance "testservice.dependentjob"
      Then there should be 1 enabled jobs for the service "testservice" and instance "dependentjob"
+
+  Scenario: dependent jobs created before their parent are skipped
+    Given a working paasta cluster
+      And we have yelpsoa-configs for the service "testservice" with enabled dependent chronos instance "dependentjob" and parent "testservice.testinstance"
+      And we have a deployments.json for the service "testservice" with enabled chronos instance "dependentjob"
+     When we run setup_chronos_job for service_instance "testservice.dependentjob"
+     Then setup_chronos_job exits with return code "0" and the output contains "Parent job could not be found"

--- a/paasta_itests/steps/setup_chronos_job_steps.py
+++ b/paasta_itests/steps/setup_chronos_job_steps.py
@@ -59,3 +59,10 @@ def should_be_disabled_jobs(context, disabled, job_count, service, instance):
     )
     filtered_jobs = [job for job in all_jobs if job["disabled"] is is_disabled]
     assert len(filtered_jobs) == int(job_count)
+
+
+@then(u'setup_chronos_job exits with return code "{expected_return_code}"'
+      u' and the output contains "{expected_output_substring}"')
+def check_setup_chronos_job_output(context, expected_return_code, expected_output_substring):
+    assert int(expected_return_code) == context.exit_code
+    assert expected_output_substring in context.output

--- a/paasta_tools/setup_chronos_job.py
+++ b/paasta_tools/setup_chronos_job.py
@@ -220,6 +220,9 @@ def main():
         )
         log.error(error_msg)
         sys.exit(0)
+    except chronos_tools.InvalidParentError:
+        log.warn("Skipping %s.%s: Parent job could not be found" % (service, instance))
+        sys.exit(0)
 
     status, output = setup_job(
         service=service,


### PR DESCRIPTION
Address #147 by catching `InvalidParentError` in `setup_chronos_job` and returning a 0 exit code.
Alternatively, we could add logic to `list_chronos_jobs` to shuffle the jobs while maintaining parent-dependent relationships. That's not currently possible because the `xargs -P 5` in 
 [deploy_chronos_jobs](https://github.com/Yelp/paasta/blob/42ae5c252fd80e08dea2885e09b3c11949748311/paasta_tools/deploy_chronos_jobs#L3)) is likely to de-serialize the jobs again.