### PR TITLE
Show details of parents in output of ``paasta status``

### DIFF
--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -158,7 +158,7 @@ def _format_parents_verbose(job):
     parent_statuses = [(parent, _format_last_result(job)) for parent in parent_jobs]
     formatted_lines = [("\n"
                         "    - %(job_name)s\n"
-                        "      Last Run: %(status)s (%(last_run)s)\n" % {
+                        "      Last Run: %(status)s (%(last_run)s)" % {
                             "job_name": parent['name'],
                             "last_run": status_parent[1],
                             "status": status_parent[0],

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -202,7 +202,7 @@ def _get_schedule_field_for_job_type(job_type):
     elif job_type == chronos_tools.JobType.Scheduled:
         return 'Schedule'
     else:
-        return 'Unknown'
+        raise ValueError("Expected a valid JobType")
 
 
 def _format_command(job):

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -131,7 +131,10 @@ def _format_last_result(job):
 
 
 def _format_schedule(job):
-    schedule = job.get("schedule", PaastaColors.red("UNKNOWN"))
+    if job.get('parents') is not None:
+        schedule = PaastaColors.yellow("None (Dependent Job). Run with -v to see parent details.")
+    else:
+        schedule = job.get("schedule", PaastaColors.red("UNKNOWN"))
     epsilon = job.get("epsilon", PaastaColors.red("UNKNOWN"))
     formatted_schedule = "%s Epsilon: %s" % (schedule, epsilon)
     return formatted_schedule
@@ -189,8 +192,11 @@ def format_chronos_job_status(job, running_tasks, verbose):
     config_hash = _format_config_hash(job)
     disabled_state = _format_disabled_status(job)
     (last_result, formatted_time) = _format_last_result(job)
+
     schedule = _format_schedule(job)
     parents = _format_parents(job)
+
+
     command = _format_command(job)
     mesos_status = _format_mesos_status(job, running_tasks)
     if verbose:

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -141,8 +141,7 @@ def _format_schedule(job):
 
 
 def _format_parents_summary(parents):
-    num_parents = len(parents)
-    return "%d. Add --verbose for more information." % num_parents
+    return " %s" % ",".join(parents)
 
 
 def _format_parents_verbose(job):
@@ -170,6 +169,18 @@ def none_formatter():
     return "None"
 
 
+def get_schedule_formatter(job_type, verbose):
+    """ Given a job type and a verbosity level, return
+    a function suitable for formatting details of the job's
+    schedule. In the case of a Dependent Job, the fn will
+    format the parents of the job, and a schedule in the case
+    of a Scheduled Job"""
+    if job_type == chronos_tools.JobType.Dependent:
+        return _get_parent_formatter(verbose)
+    else:
+        return _format_schedule
+
+
 def _get_parent_formatter(verbose):
     """ Returns a formatting function dependent on
     desired verbosity.
@@ -183,6 +194,15 @@ def _get_parent_formatter(verbose):
         else:
             return _format_parents_summary(parents)
     return dispatch_formatter
+
+
+def _get_schedule_field_for_job_type(job_type):
+    if job_type == chronos_tools.JobType.Dependent:
+        return 'Parents'
+    elif job_type == chronos_tools.JobType.Scheduled:
+        return 'Schedule'
+    else:
+        return 'Unknown'
 
 
 def _format_command(job):
@@ -215,10 +235,10 @@ def format_chronos_job_status(job, running_tasks, verbose):
     disabled_state = _format_disabled_status(job)
     (last_result, formatted_time) = _format_last_result(job)
 
-    schedule = _format_schedule(job)
-
-    parent_format_fn = _get_parent_formatter(verbose)
-    parent_string = parent_format_fn(job)
+    job_type = chronos_tools.get_job_type(job)
+    schedule_type = _get_schedule_field_for_job_type(job_type)
+    schedule_formatter = get_schedule_formatter(job_type, verbose)
+    schedule_value = schedule_formatter(job)
 
     command = _format_command(job)
     mesos_status = _format_mesos_status(job, running_tasks)
@@ -229,16 +249,15 @@ def format_chronos_job_status(job, running_tasks, verbose):
         "Config:     %(config_hash)s\n"
         "  Status:   %(disabled_state)s\n"
         "  Last:     %(last_result)s (%(formatted_time)s)\n"
-        "  Schedule: %(schedule)s\n"
-        "  Parents:  %(parents)s\n"
+        "  %(schedule_type)s: %(schedule_value)s\n"
         "  Command:  %(command)s\n"
         "  Mesos:    %(mesos_status)s" % {
             "config_hash": config_hash,
+            "schedule_type": schedule_type,
             "disabled_state": disabled_state,
             "last_result": last_result,
             "formatted_time": formatted_time,
-            "parents": parent_string,
-            "schedule": schedule,
+            "schedule_value": schedule_value,
             "command": command,
             "mesos_status": mesos_status,
         }

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -64,6 +64,11 @@ class LastRunState:
     Success, Fail, NotRun = range(0, 3)
 
 
+class JobType:
+    """ An enum to represent job types """
+    Dependent, Scheduled = range(0, 2)
+
+
 class ChronosNotConfigured(Exception):
     pass
 
@@ -563,6 +568,16 @@ def get_status_last_run(job):
             return (last_success, LastRunState.Success)
         else:
             return (last_failure, LastRunState.Fail)
+
+
+def get_job_type(job):
+    """ Given a job, return a chronos_tools.JobType """
+    if job.get('schedule') is not None:
+        return JobType.Scheduled
+    elif job.get('parents') is not None:
+        return JobType.Dependent
+    else:
+        raise ValueError('Expected either schedule field or parents field')
 
 
 def sort_jobs(jobs):

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -241,7 +241,12 @@ def test_format_chronos_job_two_mesos_tasks():
     assert 'Critical' in actual
 
 
-def test_format_parents():
+def test_format_parents_summary():
+    parents = ['service instance', 'service otherinstance']
+    assert chronos_serviceinit._format_parents_summary(parents) == '2. Add --verbose for more information.'
+
+
+def test_format_parents_verbose():
     example_job = {
         'name': 'myexamplejob',
         'parents': ['testservice testinstance']
@@ -261,10 +266,9 @@ def test_format_parents():
             return_value=example_status
         ),
     ):
-        actual = chronos_serviceinit._format_parents(example_job)
+        actual = chronos_serviceinit._format_parents_verbose(example_job)
         assert "testservice testinstance" in actual
         assert "  Last Run: %s (2007-04-05T14:30, 8 years ago)" % PaastaColors.green("OK") in actual
-        assert "OK" in actual
 
 
 def test_format_schedule_dependent_job():
@@ -273,7 +277,7 @@ def test_format_schedule_dependent_job():
         'parents': ['testservice testinstance']
     }
     actual = chronos_serviceinit._format_schedule(example_job)
-    assert "None (Dependent Job). Run with -v to see parent details." in actual
+    assert "None (Dependent Job)." in actual
     assert "Epsilon: myepsilon" in actual
 
 

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -96,6 +96,7 @@ def test_get_short_task_id():
 def test_format_chronos_job_name_exists():
     example_job = {
         'name': 'my_service my_instance gityourmom configyourdad',
+        'schedule': 'foo'
     }
     running_tasks = []
     verbose = False
@@ -104,7 +105,9 @@ def test_format_chronos_job_name_exists():
 
 
 def test_format_chronos_job_name_does_not_exist():
-    example_job = {}
+    example_job = {
+        'schedule': 'foo'
+    }
     running_tasks = []
     verbose = False
     actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
@@ -114,6 +117,7 @@ def test_format_chronos_job_name_does_not_exist():
 def test_format_chronos_job_status_disabled():
     example_job = {
         'disabled': True,
+        'schedule': 'foo'
     }
     running_tasks = []
     verbose = False
@@ -124,6 +128,7 @@ def test_format_chronos_job_status_disabled():
 def test_format_chronos_job_status_enabled():
     example_job = {
         'disabled': False,
+        'schedule': 'foo'
     }
     running_tasks = []
     verbose = False
@@ -135,6 +140,7 @@ def test_format_chronos_job_status_no_last_run():
     example_job = {
         'lastError': '',
         'lastSuccess': '',
+        'schedule': 'foo'
     }
     running_tasks = []
     verbose = False
@@ -147,6 +153,7 @@ def test_format_chronos_job_status_failure_no_success():
     example_job = {
         'lastError': '2015-04-20T23:20:00.420Z',
         'lastSuccess': '',
+        'schedule': 'foo'
     }
     running_tasks = []
     verbose = False
@@ -160,6 +167,7 @@ def test_format_chronos_job_status_success_no_failure():
     example_job = {
         'lastError': '',
         'lastSuccess': '2015-04-20T23:20:00.420Z',
+        'schedule': 'foo'
     }
     running_tasks = []
     verbose = False
@@ -173,6 +181,7 @@ def test_format_chronos_job_status_failure_and_then_success():
     example_job = {
         'lastError': '2015-04-20T23:20:00.420Z',
         'lastSuccess': '2015-04-21T23:20:00.420Z',
+        'schedule': 'foo'
     }
     running_tasks = []
     verbose = False
@@ -186,6 +195,7 @@ def test_format_chronos_job_status_success_and_then_failure():
     example_job = {
         'lastError': '2015-04-21T23:20:00.420Z',
         'lastSuccess': '2015-04-20T23:20:00.420Z',
+        'schedule': 'foo'
     }
     running_tasks = []
     verbose = False
@@ -199,6 +209,7 @@ def test_format_chronos_job_schedule():
     example_job = {
         'schedule': 'R/2015-04-20T23:20:00+00:00/PT60M',
         'epsilon': 'PT42S',
+        'schedule': 'foo'
     }
     running_tasks = []
     verbose = False
@@ -210,6 +221,7 @@ def test_format_chronos_job_schedule():
 def test_format_chronos_job_command():
     example_job = {
         'command': 'do the hokey pokey',
+        'schedule': 'foo'
     }
     running_tasks = []
     verbose = False
@@ -218,7 +230,7 @@ def test_format_chronos_job_command():
 
 
 def test_format_chronos_job_zero_mesos_tasks():
-    example_job = {}
+    example_job = {'schedule': 'foo'}
     running_tasks = []
     verbose = False
     actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
@@ -226,7 +238,7 @@ def test_format_chronos_job_zero_mesos_tasks():
 
 
 def test_format_chronos_job_one_mesos_task():
-    example_job = {}
+    example_job = {'schedule': 'foo'}
     running_tasks = ['slay the nemean lion']
     verbose = False
     actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
@@ -234,7 +246,7 @@ def test_format_chronos_job_one_mesos_task():
 
 
 def test_format_chronos_job_two_mesos_tasks():
-    example_job = {}
+    example_job = {'schedule': 'foo'}
     running_tasks = ['slay the nemean lion', 'slay the lernaean hydra']
     verbose = False
     actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
@@ -243,7 +255,7 @@ def test_format_chronos_job_two_mesos_tasks():
 
 def test_format_parents_summary():
     parents = ['service instance', 'service otherinstance']
-    assert chronos_serviceinit._format_parents_summary(parents) == '2. Add --verbose for more information.'
+    assert chronos_serviceinit._format_parents_summary(parents) == ' service instance,service otherinstance'
 
 
 def test_format_parents_verbose():
@@ -284,6 +296,7 @@ def test_format_schedule_dependent_job():
 def test_format_chronos_job_mesos_verbose():
     example_job = {
         'name': 'my_service my_instance gityourmom configyourdad',
+        'schedule': 'foo',
     }
     running_tasks = ['slay the nemean lion']
     verbose = True

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -15,6 +15,7 @@
 import contextlib
 
 import mock
+import pytest
 
 from paasta_tools import chronos_serviceinit
 from paasta_tools import chronos_tools
@@ -437,3 +438,16 @@ def test_status_chronos_jobs_get_running_tasks():
             verbose,
         )
         assert mock_get_running_tasks.call_count == 1
+
+
+def test_get_schedule_for_job_type_scheduled():
+    assert chronos_serviceinit._get_schedule_field_for_job_type(chronos_tools.JobType.Scheduled) == "Schedule"
+
+
+def test_get_schedule_for_job_type_dependent():
+    assert chronos_serviceinit._get_schedule_field_for_job_type(chronos_tools.JobType.Dependent) == "Parents"
+
+
+def test_get_schedule_for_job_type_invalid():
+    with pytest.raises(ValueError):
+        assert chronos_serviceinit._get_schedule_field_for_job_type(3)

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -267,6 +267,16 @@ def test_format_parents():
         assert "OK" in actual
 
 
+def test_format_schedule_dependent_job():
+    example_job = {
+        'epsilon': 'myepsilon',
+        'parents': ['testservice testinstance']
+    }
+    actual = chronos_serviceinit._format_schedule(example_job)
+    assert "None (Dependent Job). Run with -v to see parent details." in actual
+    assert "Epsilon: myepsilon" in actual
+
+
 def test_format_chronos_job_mesos_verbose():
     example_job = {
         'name': 'my_service my_instance gityourmom configyourdad',

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1404,19 +1404,19 @@ class TestChronosTools:
         mock_load_chronos_config,
     ):
         mock_lookup_chronos_jobs.return_value = []
-        matching = chronos_tools.find_matching_parent_job('service.instance')
+        matching = chronos_tools.get_job_for_service_instance('service', 'instance')
         assert matching is None
 
     @mock.patch('paasta_tools.chronos_tools.lookup_chronos_jobs', autospec=True)
     @mock.patch('paasta_tools.chronos_tools.get_chronos_client', autospec=True)
     @mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospec=True)
-    def test_find_matching_parent_job_returns_names(
+    def test_find_matching_parent_job(
         self,
         mock_load_chronos_config,
         mock_get_chronos_client, mock_lookup_chronos_jobs,
     ):
-        mock_matching_jobs = [{'name': 'service.myinstance.gitabc.config1'}]
+        mock_matching_jobs = [{'name': 'service instance'}]
         mock_lookup_chronos_jobs.return_value = mock_matching_jobs
         mock_load_chronos_config.return_value = {}
-        matching = chronos_tools.find_matching_parent_job('service.myinstance')
-        assert matching == 'service.myinstance.gitabc.config1'
+        matching = chronos_tools.get_job_for_service_instance('service', 'instance')
+        assert matching == mock_matching_jobs[0]


### PR DESCRIPTION
<img width="902" alt="screen shot 2016-01-28 at 16 17 39" src="https://cloud.githubusercontent.com/assets/1389671/12650428/b91d65d2-c5da-11e5-851a-93353453882d.png">

This is slightly wasteful, in that we're doing the lookups for the parent jobs multiple times. I'm ok with that for now, but probably a case where we can optimize if we get to the point where it's impacting on performance.

Closes #96