### PR TITLE
made cleanup_chronos_jobs remove all non-paasta jobs

### DIFF
--- a/paasta_itests/cleanup_chronos_jobs.feature
+++ b/paasta_itests/cleanup_chronos_jobs.feature
@@ -7,6 +7,6 @@ Feature: cleanup_chronos_jobs removes chronos jobs no longer in the config
      And I launch 1 unconfigured jobs for the service "oldservice" with scheduled chronos instance "othertestinstance"
      And I launch 3 non-paasta jobs
     Then cleanup_chronos_jobs exits with return code "0" and the correct output
-     And the non-paasta jobs are still in the job list
+     And the non-paasta jobs are not in the job list
      And the configured chronos jobs are in the job list
      And the unconfigured chronos jobs are not in the job list

--- a/paasta_itests/steps/cleanup_chronos_job_steps.py
+++ b/paasta_itests/steps/cleanup_chronos_job_steps.py
@@ -90,11 +90,11 @@ def check_cleanup_chronos_jobs_output(context, expected_return_code):
         assert '  %s' % job in output
 
 
-@then('the non-paasta jobs are still in the job list')
+@then('the non-paasta jobs are not in the job list')
 def check_non_paasta_jobs(context):
     jobs = context.chronos_client.list()
     running_job_names = [job['name'] for job in jobs]
-    assert all([job_name in running_job_names for job_name in context.non_paasta_jobs])
+    assert not any([job_name in running_job_names for job_name in context.non_paasta_jobs])
 
 
 @then('the {state} chronos jobs are not in the job list')

--- a/tests/test_cleanup_chronos_jobs.py
+++ b/tests/test_cleanup_chronos_jobs.py
@@ -36,19 +36,6 @@ def test_cleanup_jobs():
     assert isinstance(result[2][1], Exception)
 
 
-def test_jobs_to_delete():
-    configured_jobs = [('service1', 'job1'), ('service1', 'job2')]
-    deployed_jobs = [('service1', 'job1', 'config'), ('service1', 'job2', 'config')]
-    assert cleanup_chronos_jobs.jobs_to_delete(configured_jobs, deployed_jobs) == []
-
-
-def test_jobs_to_delete_unknown_job():
-    configured_jobs = [('service1', 'job1'), ('service1', 'job2'), ('service1', 'job3')]
-    deployed_jobs = [('service1', 'job1', 'config'), ('service1', 'job2', 'config'),
-                     ('service1', 'job3', 'config'), ('service1', 'job5', 'config')]
-    assert cleanup_chronos_jobs.jobs_to_delete(configured_jobs, deployed_jobs) == [('service1', 'job5', 'config')]
-
-
 def test_format_list_output():
     assert cleanup_chronos_jobs.format_list_output("Successfully Removed:", ['foo', 'bar', 'baz']) \
         == "Successfully Removed:\n  foo\n  bar\n  baz"


### PR DESCRIPTION
This should make deploying robj's change easier and also prevent random chronos jobs from mixing in with paasta jobs in the future.

This also makes `cleanup_chronos_jobs` behave more like `cleanup_marathon_jobs`.