### PR TITLE
Use acutal running tasks for marathon_services_running_here_works itest

### DIFF
--- a/paasta_itests/steps/marathon_steps.py
+++ b/paasta_itests/steps/marathon_steps.py
@@ -46,8 +46,7 @@ def list_marathon_apps_has_trivial_app(context):
 def marathon_services_running_here_works(context):
     with mock.patch('paasta_tools.mesos_tools.socket.getfqdn', return_value='mesosslave'):
         discovered = paasta_tools.marathon_tools.marathon_services_running_here()
-        print get_local_slave_state()
-        assert len(discovered) == 1, repr(discovered)
+        assert len(discovered) == 1, (repr(discovered), get_local_slave_state())
         assert discovered == [(u'test_marathon_app', u'instance', mock.ANY)], repr(discovered)
 
 
@@ -55,8 +54,8 @@ def marathon_services_running_here_works(context):
 def when_the_task_has_started(context):
     # 120 * 0.5 = 60 seconds
     for _ in xrange(120):
-        app = context.marathon_client.get_app(APP_ID, embed_tasks=True)
-        happy_count = len(app.tasks)
+        app = context.marathon_client.get_app(APP_ID)
+        happy_count = app.tasks_running
         if happy_count >= 1:
             return
         time.sleep(0.5)

--- a/paasta_tools/cleanup_chronos_jobs.py
+++ b/paasta_tools/cleanup_chronos_jobs.py
@@ -136,7 +136,7 @@ def main():
         else:
             job_successes.append(response)
             try:
-                (service, instance, _, __) = chronos_tools.decompose_job_id(response[0])
+                (service, instance) = chronos_tools.decompose_job_id(response[0])
                 send_event(
                     service=service,
                     instance=instance,

--- a/paasta_tools/cleanup_chronos_jobs.py
+++ b/paasta_tools/cleanup_chronos_jobs.py
@@ -135,15 +135,20 @@ def main():
             job_failures.append(response)
         else:
             job_successes.append(response)
-            (service, instance, _, __) = chronos_tools.decompose_job_id(response[0])
-            send_event(
-                service=service,
-                instance=instance,
-                monitoring_overrides={},
-                soa_dir=soa_dir,
-                status_code=pysensu_yelp.Status.OK,
-                message="This instance was removed and is no longer supposed to be scheduled.",
-            )
+            try:
+                (service, instance, _, __) = chronos_tools.decompose_job_id(response[0])
+                send_event(
+                    service=service,
+                    instance=instance,
+                    monitoring_overrides={},
+                    soa_dir=soa_dir,
+                    status_code=pysensu_yelp.Status.OK,
+                    message="This instance was removed and is no longer supposed to be scheduled.",
+                )
+            except InvalidJobNameError:
+                # If we deleted some bogus job with a bogus jobid that could not be parsed,
+                # Just move on, no need to send any kind of paasta event.
+                pass
 
     if len(to_delete) == 0:
         print 'No Chronos Jobs to remove'


### PR DESCRIPTION
Primary: @EvanKrall 

Seems so obvious amirite?

I've kept the get_local_slave_state but only if the assertion fails, I need it to debug why this didn't work.