### PR TITLE
added support for old bugged refs/tags

### DIFF
--- a/general_itests/deployments_json.feature
+++ b/general_itests/deployments_json.feature
@@ -1,6 +1,7 @@
 Feature: Per-Service Deployments.json can be written and read back
 
     Scenario: Per-Service Deployments.json can be written and read back
-        Given a test git repo is setup with commits
-        When we generate deployments.json for that service
+       Given a test git repo is setup with commits
+	When paasta stop is run against the repo
+	 And we generate deployments.json for that service
         Then that deployments.json can be read back correctly

--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -15,6 +15,7 @@ import contextlib
 import os
 import shutil
 import tempfile
+from datetime import datetime
 from time import time
 
 import mock
@@ -29,6 +30,8 @@ from dulwich.repo import Repo
 
 from paasta_tools import generate_deployments_for_service
 from paasta_tools import marathon_tools
+from paasta_tools.cli.cmds.start_stop_restart import format_timestamp
+from paasta_tools.cli.cmds.start_stop_restart import paasta_stop
 
 
 @given(u'a test git repo is setup with commits')
@@ -55,6 +58,30 @@ def step_impl_given(context):
 
     context.test_git_repo.refs['refs/heads/paasta-test_cluster.test_instance'] = commit.id
     context.expected_commit = commit.id
+
+
+@when(u'paasta stop is run against the repo')
+def step_paasta_start_given(context):
+    fake_args = mock.MagicMock(
+        cluster='test_cluster',
+        instance='test_instance',
+        soa_dir='fake_soa_configs',
+        service='fake_deployments_json_service',
+    )
+    context.force_bounce_timestamp = format_timestamp(datetime.utcnow())
+    with contextlib.nested(
+        mock.patch('paasta_tools.cli.cmds.start_stop_restart.utils.get_git_url', autospec=True,
+                   return_value=context.test_git_repo_dir),
+        mock.patch('paasta_tools.cli.cmds.start_stop_restart.format_timestamp', autospec=True,
+                   return_value=context.force_bounce_timestamp),
+    ) as (
+        mock_get_git_url,
+        mock_get_timestamp,
+    ):
+        try:
+            paasta_stop(fake_args)
+        except SystemExit:
+            pass
 
 
 @when(u'we generate deployments.json for that service')
@@ -86,8 +113,8 @@ def step_impl_then(context):
     deployments = marathon_tools.load_deployments_json('fake_deployments_json_service', soa_dir='fake_soa_configs')
     expected_deployments = {
         'fake_deployments_json_service:paasta-test_cluster.test_instance': {
-            'force_bounce': None,
-            'desired_state': 'start',
+            'force_bounce': context.force_bounce_timestamp,
+            'desired_state': 'stop',
             'docker_image': 'services-fake_deployments_json_service:paasta-%s' % context.expected_commit
         }
     }

--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -61,7 +61,7 @@ def step_impl_given(context):
 
 
 @when(u'paasta stop is run against the repo')
-def step_paasta_start_given(context):
+def step_paasta_stop_when(context):
     fake_args = mock.MagicMock(
         cluster='test_cluster',
         instance='test_instance',

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -137,10 +137,10 @@ def paasta_start_or_stop(args, desired_state):
     instance = args.instance
     cluster = args.cluster
     soa_dir = args.soa_dir
-    service = figure_out_service_name(args, soa_dir)
+    service = figure_out_service_name(args=args, soa_dir=soa_dir)
 
     branch = "paasta-%s.%s" % (cluster, instance)
-    all_branches = list(get_branches(service, soa_dir))
+    all_branches = list(get_branches(service=service, soa_dir=soa_dir))
 
     if branch not in all_branches:
         print "No branches found for %s in %s." % \

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -16,6 +16,8 @@ import datetime
 import socket
 import sys
 
+from service_configuration_lib import DEFAULT_SOA_DIR
+
 from paasta_tools import remote_git
 from paasta_tools import utils
 from paasta_tools.cli.utils import figure_out_service_name
@@ -25,15 +27,13 @@ from paasta_tools.cli.utils import list_services
 from paasta_tools.generate_deployments_for_service import get_instance_config_for_service
 
 
-SOA_DIR = '/nail/etc/services'
-
-
-def get_branches(service):
-    paasta_control_branches = set((config.get_branch() for config in get_instance_config_for_service(SOA_DIR, service)))
+def get_branches(service, soa_dir):
+    paasta_control_branches = set(('paasta-%s' % config.get_branch()
+                                   for config in get_instance_config_for_service(soa_dir, service)))
     remote_refs = remote_git.list_remote_refs(utils.get_git_url(service))
 
     for branch in paasta_control_branches:
-        if 'refs/heads/paasta-%s' % branch in remote_refs:
+        if 'refs/heads/%s' % branch in remote_refs:
             yield branch
 
 
@@ -68,6 +68,13 @@ def add_subparser(subparsers):
             help='The PaaSTA cluster that has the service you want to %s. Like norcal-prod' % lower,
             required=True,
         ).completer = lazy_choices_completer(utils.list_clusters)
+        status_parser.add_argument(
+            '-d', '--soa-dir',
+            dest="soa_dir",
+            metavar="SOA_DIR",
+            default=DEFAULT_SOA_DIR,
+            help="define a different soa config directory",
+        )
         status_parser.set_defaults(command=cmd_func)
 
 
@@ -78,7 +85,7 @@ def format_timestamp(dt=None):
 
 
 def format_tag(branch, force_bounce, desired_state):
-    return 'refs/tags/paasta-%s-%s-%s' % (branch, force_bounce, desired_state)
+    return 'refs/tags/%s-%s-%s' % (branch, force_bounce, desired_state)
 
 
 def make_mutate_refs_func(branches, force_bounce, desired_state):
@@ -127,12 +134,13 @@ def issue_state_change_for_branches(service, instance, cluster, branches, force_
 
 def paasta_start_or_stop(args, desired_state):
     """Requests a change of state to start or stop given branches of a service."""
-    service = figure_out_service_name(args)
     instance = args.instance
     cluster = args.cluster
+    soa_dir = args.soa_dir
+    service = figure_out_service_name(args, soa_dir)
 
     branch = "paasta-%s.%s" % (cluster, instance)
-    all_branches = list(get_branches(service))
+    all_branches = list(get_branches(service, soa_dir))
 
     if branch not in all_branches:
         print "No branches found for %s in %s." % \

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -180,7 +180,9 @@ def get_desired_state(service, branch, remote_refs, deploy_group):
     an arbitrary value (which may be None) that will change when a restart is
     desired.
     """
-    tag_pattern = r'^refs/tags/paasta-%s-(?P<force_bounce>[^-]+)-(?P<state>.*)$' % branch
+    # (?:paasta-){1,2} supports a previous mistake where some tags would be called
+    # paasta-paasta-cluster.instance
+    tag_pattern = r'^refs/tags/(?:paasta-){1,2}%s-(?P<force_bounce>[^-]+)-(?P<state>.*)$' % branch
 
     states = []
     head_sha = remote_refs['refs/heads/paasta-%s' % deploy_group]

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -19,7 +19,7 @@ from paasta_tools.cli.cmds import start_stop_restart
 
 
 def test_format_tag():
-    expected = 'refs/tags/paasta-BRANCHNAME-TIMESTAMP-stop'
+    expected = 'refs/tags/BRANCHNAME-TIMESTAMP-stop'
     actual = start_stop_restart.format_tag(
         branch='BRANCHNAME',
         force_bounce='TIMESTAMP',
@@ -72,8 +72,8 @@ def test_make_mutate_refs_func():
 
     expected = dict(old_refs)
     expected.update({
-        'refs/tags/paasta-a-FORCEBOUNCE-stop': 'hash_for_a',
-        'refs/tags/paasta-b-FORCEBOUNCE-stop': 'hash_for_b',
+        'refs/tags/a-FORCEBOUNCE-stop': 'hash_for_a',
+        'refs/tags/b-FORCEBOUNCE-stop': 'hash_for_b',
     })
 
     actual = mutate_refs(old_refs)


### PR DESCRIPTION
Bugged == of the format 'paasta-paasta-cluster.instance'.

Also added an itest that makes sure generate deployments works properly with force_bounce and state tags.