### PR TITLE
made paasta start/stop deploy-group aware

### DIFF
--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -125,7 +125,7 @@ def paasta_start_or_stop(args, desired_state):
     service = figure_out_service_name(args=args, soa_dir=soa_dir)
 
     service_config = get_instance_config(
-        service - service,
+        service=service,
         cluster=cluster,
         instance=instance,
         soa_dir=soa_dir,

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -20,12 +20,11 @@ from service_configuration_lib import DEFAULT_SOA_DIR
 
 from paasta_tools import remote_git
 from paasta_tools import utils
-from paasta_tools.chronos_tools import load_chronos_job_config
 from paasta_tools.cli.utils import figure_out_service_name
+from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import list_services
-from paasta_tools.marathon_tools import load_marathon_service_config
 
 
 def add_subparser(subparsers):
@@ -125,33 +124,13 @@ def paasta_start_or_stop(args, desired_state):
     soa_dir = args.soa_dir
     service = figure_out_service_name(args=args, soa_dir=soa_dir)
 
-    instance_type = utils.validate_service_instance(
-        service=service,
-        instance=instance,
+    service_config = get_instance_config(
+        service - service,
         cluster=cluster,
+        instance=instance,
         soa_dir=soa_dir,
+        load_deployments=False,
     )
-
-    if instance_type == 'marathon':
-        service_config = load_marathon_service_config(
-            service=service,
-            instance=instance,
-            cluster=cluster,
-            soa_dir=soa_dir,
-            load_deployments=False,
-        )
-    elif instance_type == 'chronos':
-        service_config = load_chronos_job_config(
-            service=service,
-            instance=instance,
-            cluster=cluster,
-            soa_dir=soa_dir,
-            load_deployments=False,
-        )
-    else:
-        print "A service config other than type 'marathon' or 'chronos' was loaded!"
-        print "'%s' is not currently supported by paasta %s" % (instance_type, desired_state)
-        sys.exit(3)
 
     remote_refs = remote_git.list_remote_refs(utils.get_git_url(service))
 

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -139,6 +139,7 @@ def get_deploy_group_mappings(soa_dir, service, old_mappings):
     remote_refs = remote_git.list_remote_refs(git_url)
 
     for control_branch, deploy_group in deploy_group_branch_mappings.items():
+        print control_branch, deploy_group
         deploy_ref_name = 'refs/heads/paasta-%s' % deploy_group
         if deploy_ref_name in remote_refs:
             commit_sha = remote_refs[deploy_ref_name]

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -139,7 +139,6 @@ def get_deploy_group_mappings(soa_dir, service, old_mappings):
     remote_refs = remote_git.list_remote_refs(git_url)
 
     for control_branch, deploy_group in deploy_group_branch_mappings.items():
-        print control_branch, deploy_group
         deploy_ref_name = 'refs/heads/paasta-%s' % deploy_group
         if deploy_ref_name in remote_refs:
             commit_sha = remote_refs[deploy_ref_name]

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -23,7 +23,6 @@ from paasta_tools.cli.cmds.local_run import docker_pull_image
 from paasta_tools.cli.cmds.local_run import get_container_id
 from paasta_tools.cli.cmds.local_run import get_container_name
 from paasta_tools.cli.cmds.local_run import get_docker_run_cmd
-from paasta_tools.cli.cmds.local_run import get_instance_config
 from paasta_tools.cli.cmds.local_run import LostContainerException
 from paasta_tools.cli.cmds.local_run import paasta_local_run
 from paasta_tools.cli.cmds.local_run import perform_cmd_healthcheck
@@ -978,59 +977,6 @@ def test_simulate_healthcheck_on_service_enabled_honors_grace_period(
         mock_service_manifest, mock_docker_client, fake_container_id, fake_mode, fake_url, True)
     assert mock_sleep.call_count == 0
     assert mock_run_healthcheck_on_container.call_count == 2
-
-
-@mock.patch('paasta_tools.cli.cmds.local_run.validate_service_instance', autospec=True)
-@mock.patch('paasta_tools.cli.cmds.local_run.load_marathon_service_config', autospec=True)
-def test_get_instance_config_marathon(
-    mock_load_marathon_service_config,
-    mock_validate_service_instance,
-):
-    mock_validate_service_instance.return_value = 'marathon'
-    mock_load_marathon_service_config.return_value = 'fake_service_config'
-    actual = get_instance_config(
-        service='fake_service',
-        instance='fake_instance',
-        cluster='fake_cluster',
-        soa_dir='fake_soa_dir',
-    )
-    assert mock_validate_service_instance.call_count == 1
-    assert mock_load_marathon_service_config.call_count == 1
-    assert actual == 'fake_service_config'
-
-
-@mock.patch('paasta_tools.cli.cmds.local_run.validate_service_instance', autospec=True)
-@mock.patch('paasta_tools.cli.cmds.local_run.load_chronos_job_config', autospec=True)
-def test_get_instance_Config_chronos(
-    mock_load_chronos_job_config,
-    mock_validate_service_instance,
-):
-    mock_validate_service_instance.return_value = 'chronos'
-    mock_load_chronos_job_config.return_value = 'fake_service_config'
-    actual = get_instance_config(
-        service='fake_service',
-        instance='fake_instance',
-        cluster='fake_cluster',
-        soa_dir='fake_soa_dir',
-    )
-    assert mock_validate_service_instance.call_count == 1
-    assert mock_load_chronos_job_config.call_count == 1
-    assert actual == 'fake_service_config'
-
-
-@mock.patch('paasta_tools.cli.cmds.local_run.validate_service_instance', autospec=True)
-def test_get_instance_config_unknown(
-    mock_validate_service_instance,
-):
-    with raises(NotImplementedError):
-        mock_validate_service_instance.return_value = 'some bogus unsupported framework'
-        get_instance_config(
-            service='fake_service',
-            instance='fake_instance',
-            cluster='fake_cluster',
-            soa_dir='fake_soa_dir',
-        )
-        assert mock_validate_service_instance.call_count == 1
 
 
 @mock.patch('paasta_tools.cli.cmds.local_run._run', autospec=True, return_value=(0, 'fake _run output'))

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -477,3 +477,56 @@ def test_modules_in_pkg():
     assert '__init__' not in ret
     assert 'cook_image' in ret
     assert 'list_clusters' in ret
+
+
+@mock.patch('paasta_tools.cli.utils.validate_service_instance', autospec=True)
+@mock.patch('paasta_tools.cli.utils.load_marathon_service_config', autospec=True)
+def test_get_instance_config_marathon(
+    mock_load_marathon_service_config,
+    mock_validate_service_instance,
+):
+    mock_validate_service_instance.return_value = 'marathon'
+    mock_load_marathon_service_config.return_value = 'fake_service_config'
+    actual = utils.get_instance_config(
+        service='fake_service',
+        instance='fake_instance',
+        cluster='fake_cluster',
+        soa_dir='fake_soa_dir',
+    )
+    assert mock_validate_service_instance.call_count == 1
+    assert mock_load_marathon_service_config.call_count == 1
+    assert actual == 'fake_service_config'
+
+
+@mock.patch('paasta_tools.cli.utils.validate_service_instance', autospec=True)
+@mock.patch('paasta_tools.cli.utils.load_chronos_job_config', autospec=True)
+def test_get_instance_Config_chronos(
+    mock_load_chronos_job_config,
+    mock_validate_service_instance,
+):
+    mock_validate_service_instance.return_value = 'chronos'
+    mock_load_chronos_job_config.return_value = 'fake_service_config'
+    actual = utils.get_instance_config(
+        service='fake_service',
+        instance='fake_instance',
+        cluster='fake_cluster',
+        soa_dir='fake_soa_dir',
+    )
+    assert mock_validate_service_instance.call_count == 1
+    assert mock_load_chronos_job_config.call_count == 1
+    assert actual == 'fake_service_config'
+
+
+@mock.patch('paasta_tools.cli.utils.validate_service_instance', autospec=True)
+def test_get_instance_config_unknown(
+    mock_validate_service_instance,
+):
+    with raises(NotImplementedError):
+        mock_validate_service_instance.return_value = 'some bogus unsupported framework'
+        utils.get_instance_config(
+            service='fake_service',
+            instance='fake_instance',
+            cluster='fake_cluster',
+            soa_dir='fake_soa_dir',
+        )
+        assert mock_validate_service_instance.call_count == 1


### PR DESCRIPTION
This fixes a bug where paasta start and stop wouldn't work on tasks using deploy groups.