### PR TITLE
added deploy_group to valid schemas for paasta check

### DIFF
--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -27,6 +27,9 @@
                 "type": "integer",
                 "default": 2
             },
+	    "deploy_group": {
+	        "type": "string"
+	    },
             "disabled": {
                 "type": "boolean",
                 "default": false

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -52,6 +52,9 @@
                     }
                 }
             },
+	    "deploy_group": {
+		"type": "string"
+	    },
             "drain_method": {
                 "enum": [ "noop", "hacheck", "test" ],
                 "default": "noop"


### PR DESCRIPTION
Config files that use deploy groups will no longer fail paasta check.