### PR TITLE
Gracefully handle killing a marathon task that is already dead. PAASTA-1219

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -971,5 +971,8 @@ def kill_task(client, app_id, task_id, scale):
         if e.error_message == 'Bean is not valid' and e.status_code == 422:
             log.debug("Probably tried to kill a task id that didn't exist. Continuing.")
             return []
+        elif 'does not exist' in e.error_message and e.status_code == 404:
+            log.debug("Probably tried to kill a task id that was already dead. Continuing.")
+            return []
         else:
             raise

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -2165,3 +2165,18 @@ def test_kill_tasks_passes_catches_fewer_than_error():
     actual = marathon_tools.kill_task(client=fake_client, app_id='app_id', task_id='task_id', scale=True)
     fake_client.kill_task.assert_called_once_with(scale=True, task_id='task_id', app_id='app_id')
     assert actual == []
+
+
+def test_kill_tasks_passes_catches_already_dead_task():
+    fake_client = mock.Mock()
+    bad_fake_response = mock.Mock()
+    bad_fake_response.status_code = 404
+    bad_fake_response.json.return_value = {
+        "message": "Task 'foo' does not exist",
+        "errors": [],
+    }
+    fake_client.kill_task.side_effect = MarathonHttpError(response=bad_fake_response)
+
+    actual = marathon_tools.kill_task(client=fake_client, app_id='app_id', task_id='task_id', scale=True)
+    fake_client.kill_task.assert_called_once_with(scale=True, task_id='task_id', app_id='app_id')
+    assert actual == []


### PR DESCRIPTION
This has become pretty easy now that we are wrapping kill_task.