### PR TITLE
Fix regression from https://github.com/Yelp/paasta/pull/179 where we …

### DIFF
--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -250,10 +250,11 @@ def do_bounce(
 
     apps_to_kill = []
     for app in old_app_live_happy_tasks.keys():
-        live_tasks = old_app_live_happy_tasks[app]
+        live_happy_tasks = old_app_live_happy_tasks[app]
+        live_unhappy_tasks = old_app_live_unhappy_tasks[app]
         draining_tasks = old_app_draining_tasks[app]
 
-        if 0 == len((live_tasks | draining_tasks) - killed_tasks):
+        if 0 == len((live_happy_tasks | live_unhappy_tasks | draining_tasks) - killed_tasks):
             apps_to_kill.append(app)
 
     if apps_to_kill:


### PR DESCRIPTION
…would kill apps with unhealthy tasks before letting them drain properly.

Since we were ignoring `old_app_live_unhappy_tasks` in calculating `apps_to_kill`, we would kill apps if all of their tasks were unhappy, even though we just started draining those tasks.

This patch makes it so we wait until the tasks are properly drained before killing them.