### PR TITLE
Upgrade mesos to 0.23.1-0.2.61.ubuntu1404

### DIFF
--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
-RUN apt-get update && apt-get -y install mesos=0.22.1-1.0.ubuntu1404
+RUN apt-get update && apt-get -y install mesos=0.23.1-0.2.61.ubuntu1404
 
 RUN apt-get -y install chronos=2.4.0-0.1.20151007110204.ubuntu1404
 # Chronos will look in here for zk config, so we blow away the bogus defaults

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
-RUN apt-get update && apt-get -y install mesos=0.22.1-1.0.ubuntu1404
+RUN apt-get update && apt-get -y install mesos=0.23.1-0.2.61.ubuntu1404
 
 # Install Java 8 PPA
 RUN apt-get install -y software-properties-common

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -15,4 +15,4 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
-RUN apt-get update && apt-get -y install mesos=0.22.1-1.0.ubuntu1404
+RUN apt-get update && apt-get -y install mesos=0.23.1-0.2.61.ubuntu1404


### PR DESCRIPTION
Following http://paasta.readthedocs.org/en/latest/upgrading_mesos.html . This is step 1 to bump the version of Mesos that is installed in the integration tests.