### PR TITLE
Use full GPG fingerprints

### DIFF
--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
 RUN apt-get update && apt-get -y install mesos=0.23.1-0.2.61.ubuntu1404
 
 RUN apt-get -y install chronos=2.4.0-0.1.20151007110204.ubuntu1404

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
 RUN apt-get update && apt-get -y install mesos=0.23.1-0.2.61.ubuntu1404
 
 # Install Java 8 PPA

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -14,5 +14,5 @@
 
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
 RUN apt-get update && apt-get -y install mesos=0.23.1-0.2.61.ubuntu1404

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM ubuntu:trusty
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 88ADA4A042F8DD13 && \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 2F6464D3394993A19970736C88ADA4A042F8DD13 && \
     echo 'deb http://ppa.launchpad.net/dh-virtualenv/daily/ubuntu trusty main\ndeb-src http://ppa.launchpad.net/dh-virtualenv/daily/ubuntu trusty main' >> /etc/apt/sources.list
 
 RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools \


### PR DESCRIPTION
Use the full GPG fingerprint rather than just the short id. This avoids
accidentally adding the wrong key per
http://www.asheesh.org/note/debian/short-key-ids-are-bad-news.html
Closes #212