### PR TITLE
allow a string or array value for the 'parents' key of a dependent job

### DIFF
--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -176,6 +176,7 @@ class ChronosJobConfig(InstanceConfig):
             config_dict=config_dict,
             branch_dict=branch_dict,
         )
+        self.__normalize()
 
     def __eq__(self, other):
         return (
@@ -184,6 +185,13 @@ class ChronosJobConfig(InstanceConfig):
             (self.config_dict == other.config_dict) and
             (self.branch_dict == other.branch_dict)
         )
+
+    def __normalize(self):
+        """When the config supports alternative syntaxes, convert them
+        to a normal form."""
+        parents = self.get_parents()
+        if parents is not None and not isinstance(parents, list):
+            self.config_dict['parents'] = [parents]
 
     def get_service(self):
         return self.service

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -176,22 +176,6 @@ class ChronosJobConfig(InstanceConfig):
             config_dict=config_dict,
             branch_dict=branch_dict,
         )
-        self.__normalize()
-
-    def __eq__(self, other):
-        return (
-            (self.service == other.service) and
-            (self.get_job_name() == other.get_job_name()) and
-            (self.config_dict == other.config_dict) and
-            (self.branch_dict == other.branch_dict)
-        )
-
-    def __normalize(self):
-        """When the config supports alternative syntaxes, convert them
-        to a normal form."""
-        parents = self.get_parents()
-        if parents is not None and not isinstance(parents, list):
-            self.config_dict['parents'] = [parents]
 
     def get_service(self):
         return self.service
@@ -253,7 +237,11 @@ class ChronosJobConfig(InstanceConfig):
         return self.config_dict.get('schedule_time_zone')
 
     def get_parents(self):
-        return self.config_dict.get('parents', None)
+        parents = self.config_dict.get('parents', None)
+        if parents is not None and not isinstance(parents, list):
+            return [parents]
+        else:
+            return parents
 
     def get_shell(self):
         """Per https://mesos.github.io/chronos/docs/api.html, ``shell`` defaults

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -487,6 +487,19 @@ class TestChronosTools:
         assert okay is True
         assert msg == ''
 
+    # 'parents' doesn't need to be an array, it can also be a string
+    def test_check_parents_scalar_to_array(self):
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'parents': 'service1.instance1'},
+            branch_dict={},
+        )
+        okay, msg = fake_conf.check_parents()
+        assert okay is True
+        assert msg == ''
+
     def test_check_parents_one_bad(self):
         fake_conf = chronos_tools.ChronosJobConfig(
             service='fake_name',


### PR DESCRIPTION
Allow `parents` jobs to be passed in the config as an array or a string, see #149.
Note that the `parents` key isn't currently schema-validated (will be fixed in #217).

Closes #149