### PR TITLE
Stopped printing dashboards with metastatus

### DIFF
--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -14,9 +14,7 @@
 # limitations under the License.
 from paasta_tools.cli.utils import execute_paasta_metastatus_on_remote_master
 from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.smartstack_tools import DEFAULT_SYNAPSE_PORT
 from paasta_tools.utils import list_clusters
-from paasta_tools.utils import PaastaColors
 
 
 def add_subparser(subparsers):
@@ -55,10 +53,8 @@ def add_subparser(subparsers):
 
 
 def print_cluster_status(cluster, verbose=0):
-    """With a given cluster and verboseness, returns the status of the cluster
-    output is printed directly to provide dashbaords even if the cluster is unavailable"""
+    """With a given cluster and verboseness, returns the status of the cluster"""
     print "Cluster: %s" % cluster
-    print get_cluster_dashboards(cluster)
     print execute_paasta_metastatus_on_remote_master(cluster, verbose)
     print ""
 
@@ -69,23 +65,6 @@ def figure_out_clusters_to_inspect(args, all_clusters):
     else:
         clusters_to_inspect = all_clusters
     return clusters_to_inspect
-
-
-def get_cluster_dashboards(cluster):
-    """Returns the direct dashboards for humans to use for a given cluster"""
-    output = []
-    output.append("Warning: Dashboards in prod are not directly reachable. "
-                  "See http://y/paasta-troubleshooting for instructions. (search for 'prod dashboards')")
-    output.append("User Dashboards (Read Only):")
-    output.append("  Mesos:    %s" % PaastaColors.cyan("http://mesos.paasta-%s.yelp/" % cluster))
-    output.append("  Marathon: %s" % PaastaColors.cyan("http://marathon.paasta-%s.yelp/" % cluster))
-    output.append("  Chronos:  %s" % PaastaColors.cyan("http://chronos.paasta-%s.yelp/" % cluster))
-    output.append("  Synapse:  %s" % PaastaColors.cyan("http://paasta-%s.yelp:%s/" % (cluster, DEFAULT_SYNAPSE_PORT)))
-    output.append("Admin Dashboards (Read/write, requires secrets):")
-    output.append("  Mesos:    %s" % PaastaColors.cyan("http://paasta-%s.yelp:5050/" % cluster))
-    output.append("  Marathon: %s" % PaastaColors.cyan("http://paasta-%s.yelp:5052/" % cluster))
-    output.append("  Chronos:  %s" % PaastaColors.cyan("http://paasta-%s.yelp:5053/" % cluster))
-    return '\n'.join(output)
 
 
 def paasta_metastatus(args):

--- a/tests/cli/test_cmds_metastatus.py
+++ b/tests/cli/test_cmds_metastatus.py
@@ -16,7 +16,6 @@ from StringIO import StringIO
 import mock
 
 from paasta_tools.cli.cmds import metastatus
-from paasta_tools.smartstack_tools import DEFAULT_SYNAPSE_PORT
 
 
 @mock.patch('sys.stdout', new_callable=StringIO)
@@ -39,14 +38,3 @@ def test_figure_out_clusters_to_inspect_respects_the_user():
     fake_args.clusters = 'a,b,c'
     fake_all_clusters = ['a', 'b', 'c', 'd']
     assert ['a', 'b', 'c'] == metastatus.figure_out_clusters_to_inspect(fake_args, fake_all_clusters)
-
-
-def test_get_cluster_dashboards():
-    output_text = metastatus.get_cluster_dashboards('fake-cluster')
-    assert 'http://paasta-fake-cluster.yelp:5050' in output_text
-    assert 'http://paasta-fake-cluster.yelp:5052' in output_text
-    assert 'http://paasta-fake-cluster.yelp:5053' in output_text
-    assert 'http://paasta-fake-cluster.yelp:%s' % DEFAULT_SYNAPSE_PORT in output_text
-    assert 'http://chronos.paasta-fake-cluster.yelp/' in output_text
-    assert 'http://mesos.paasta-fake-cluster.yelp/' in output_text
-    assert 'http://marathon.paasta-fake-cluster.yelp/' in output_text


### PR DESCRIPTION
I think we are ready to stop doing this. The whole prod dashboards thing is misleading anyway, people are typing in ldap creds for the marathon RW dashboards, and it is all yelpy.