### PR TITLE
Use json.dumps to get more consistent hash keys

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1044,7 +1044,7 @@ def get_config_hash(config, force_bounce=None):
     :returns: A MD5 hash of str(config)
     """
     hasher = hashlib.md5()
-    hasher.update(str(config) + (force_bounce or ''))
+    hasher.update(json.dumps(config, sort_keys=True) + (force_bounce or ''))
     return "config%s" % hasher.hexdigest()[:8]
 
 


### PR DESCRIPTION
I don't know how we got along without this so far. The PAASTA_ stuff just exaggerated it?