### PR TITLE
Update chronos json schema #217

### DIFF
--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -72,15 +72,11 @@
             },
             "parents": {
                 "oneOf": [
-                    {
-                        "type": "string",
-                        "pattern": "^[a-zA-Z0-9_]+\\.[a-zA-Z0-9_]+$"
-                    },
+                    { "$ref": "#/definitions/jobName" },
                     {
                         "type": "array",
                         "items": {
-                            "type": "string",
-                            "pattern": "^[a-zA-Z0-9_]+\\.[a-zA-Z0-9_]+$"
+                            "$ref": "#/definitions/jobName"
                         },
                         "uniqueItems": true
                     }
@@ -95,7 +91,7 @@
     "definitions": {
         "jobName": {
             "type": "string",
-            "pattern": "blah"
+            "pattern": "^[a-zA-Z0-9_]+\\.[a-zA-Z0-9_]+$"
         }
     }
 }

--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -69,8 +69,33 @@
                     "type": "array"
                 },
                 "uniqueItems": true
+            },
+            "parents": {
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9_]+\\.[a-zA-Z0-9_]+$"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_]+\\.[a-zA-Z0-9_]+$"
+                        },
+                        "uniqueItems": true
+                    }
+                ]
             }
         },
-        "required": ["schedule"]
+        "oneOf": [
+            {"required": ["schedule"]},
+            {"required": ["parents"]}
+        ]
+    },
+    "definitions": {
+        "jobName": {
+            "type": "string",
+            "pattern": "blah"
+        }
     }
 }


### PR DESCRIPTION
Should fix #217.

I wasn't sure what's allowed as a job name, so I used "`^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$`".

`parents` array:

```
mesosstage_robj_child:
  parents:
    - example_service.mesosstage_robj_parent
  cmd: 'echo "I am a batch"'
  monitoring:
    team: noop
  deploy_group: dev-stage.everything

(py27)gcioffi@dev9-devc:~/git/paasta (update_chronos_json_schema-issue-217) $ paasta_tools/cli/cli.py check -y ~/git/yelpsoa-configs -s example_service | grep schema.*chronos
✓ Successfully validated schema: chronos-mesosstage.yaml
```

`parents` string:

```
mesosstage_robj_child:
  parents: example_service.mesosstage_robj_parent
  cmd: 'echo "I am a batch"'
  monitoring:
    team: noop
  deploy_group: dev-stage.everything

(py27)gcioffi@dev9-devc:~/git/paasta (update_chronos_json_schema-issue-217) $ paasta_tools/cli/cli.py check -y ~/git/yelpsoa-configs -s example_service | grep schema.*chronos
✓ Successfully validated schema: chronos-mesosstage.yaml
```

Neither `parents` nor `schedule`:

```
mesosstage_robj_child:
  cmd: 'echo "I am a batch"'
  monitoring:
    team: noop
  deploy_group: dev-stage.everything

(py27)gcioffi@dev9-devc:~/git/paasta (update_chronos_json_schema-issue-217) $ paasta_tools/cli/cli.py check -y ~/git/yelpsoa-configs -s example_service | grep schema.*chronos
✗ Failed to validate schema. More info: http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html: /nail/home/gcioffi/git/yelpsoa-configs/example_service/chronos-mesosstage.yaml
  Validation Message: {'deploy_group': 'dev-stage.everything', 'cmd': 'echo "I am a batch"', 'monitoring': {'team': 'noop'}} is not valid under any of the given schemas
```

Both `parents` and `schedule`:

```
mesosstage_robj_child:
  schedule: 'R/2015-08-14T10:00:00+00:00/PT60M'
  parents:
    - example_service.mesosstage_robj_parent
  cmd: 'echo "I am a batch"'
  monitoring:
    team: noop
  deploy_group: dev-stage.everything

(py27)gcioffi@dev9-devc:~/git/paasta (update_chronos_json_schema-issue-217) $ paasta_tools/cli/cli.py check -y ~/git/yelpsoa-configs -s example_service | grep -A1 schema.*chronos
✗ Failed to validate schema. More info: http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html: /nail/home/gcioffi/git/yelpsoa-configs/example_service/chronos-mesosstage.yaml
  Validation Message: {'deploy_group': 'dev-stage.everything', 'cmd': 'echo "I am a batch"', 'monitoring': {'team': 'noop'}, 'schedule': 'R/2015-08-14T10:00:00+00:00/PT60M', 'parents': ['example_service.mesosstage_robj_parent']} is valid under each of {u'required': [u'parents']}, {u'required': [u'schedule']}
```

Parent name not in the `service.instance` form:

```
mesosstage_robj_child:
  parents:
    - example_service_mesosstage_robj_parent
  cmd: 'echo "I am a batch"'
  monitoring:
    team: noop
  deploy_group: dev-stage.everything

(py27)gcioffi@dev9-devc:~/git/paasta (update_chronos_json_schema-issue-217) $ paasta_tools/cli/cli.py check -y ~/git/yelpsoa-configs -s example_service | grep -A1 schema.*chronos
✗ Failed to validate schema. More info: http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html: /nail/home/gcioffi/git/yelpsoa-configs/example_service/chronos-mesosstage.yaml
  Validation Message: ['example_service_mesosstage_robj_parent'] is not valid under any of the given schemas
```
