### PR TITLE
Added generate-pipeline warning

### DIFF
--- a/paasta_tools/cli/cmds/generate_pipeline.py
+++ b/paasta_tools/cli/cmds/generate_pipeline.py
@@ -80,6 +80,20 @@ def get_git_repo_for_fab_repo(service):
     return repo
 
 
+def print_warning():
+    print "Warning: paasta generate-pipeline is a Yelp-specific tool and will"
+    print "not work outside Yelp."
+    print ""
+    print "paasta generate-pipeline is designed only to give a starting jenkings"
+    print "configuration that can be customzied later"
+    print ""
+    print "Warning: running this tool on an existing pipeline will remove any"
+    print "hand-made customizations and will leave behind orphaned jenkins jobs"
+    print "that need to be manually cleaned up."
+    print ""
+    raw_input("Press any key to continue or cntrl-c to cancel")
+
+
 def generate_pipeline(service):
     email_address = get_team_email_address(service=service)
     repo = get_git_repo_for_fab_repo(service)
@@ -95,6 +109,7 @@ def generate_pipeline(service):
         'fab_repo setup_jenkins:services/%s,'
         'profile=paasta_boilerplate,owner=%s,repo=%s' % (service, owner, repo),
     ]
+    print_warning()
     for cmd in cmds:
         print "INFO: Executing %s" % cmd
         returncode, output = _run(cmd, timeout=90)

--- a/tests/cli/test_cmds_generate_pipeline.py
+++ b/tests/cli/test_cmds_generate_pipeline.py
@@ -49,7 +49,9 @@ def test_paasta_generate_pipeline_service_not_found(
 
 @patch('paasta_tools.cli.cmds.generate_pipeline.get_team_email_address', autospec=True)
 @patch('paasta_tools.cli.cmds.generate_pipeline._run', autospec=True)
+@patch('paasta_tools.cli.cmds.generate_pipeline.print_warning', autospec=True)
 def test_generate_pipeline_run_fails(
+        mock_print_warning,
         mock_run,
         mock_get_team_email_address,
 ):
@@ -62,7 +64,9 @@ def test_generate_pipeline_run_fails(
 
 @patch('paasta_tools.cli.cmds.generate_pipeline.get_team_email_address', autospec=True)
 @patch('paasta_tools.cli.cmds.generate_pipeline._run', autospec=True)
+@patch('paasta_tools.cli.cmds.generate_pipeline.print_warning', autospec=True)
 def test_generate_pipeline_success(
+        mock_print_warning,
         mock_run,
         mock_get_team_email_address,
 ):
@@ -74,7 +78,9 @@ def test_generate_pipeline_success(
 @patch('paasta_tools.cli.cmds.generate_pipeline._run', autospec=True)
 @patch('paasta_tools.cli.cmds.generate_pipeline.get_team_email_address', autospec=True)
 @patch('paasta_tools.cli.cmds.generate_pipeline.get_git_repo_for_fab_repo', autospec=True)
+@patch('paasta_tools.cli.cmds.generate_pipeline.print_warning', autospec=True)
 def test_generate_pipeline_calls_the_right_commands_and_owner(
+        mock_print_warning,
         mock_get_git_repo_for_fab_repo,
         mock_get_team_email_address,
         mock_run,
@@ -96,7 +102,9 @@ def test_generate_pipeline_calls_the_right_commands_and_owner(
 @patch('paasta_tools.cli.cmds.generate_pipeline.get_team_email_address', autospec=True)
 @patch('paasta_tools.cli.cmds.generate_pipeline.get_team', autospec=True)
 @patch('paasta_tools.cli.cmds.generate_pipeline.get_git_repo_for_fab_repo', autospec=True)
+@patch('paasta_tools.cli.cmds.generate_pipeline.print_warning', autospec=True)
 def test_generate_pipeline_uses_team_name_as_fallback_for_owner(
+        mock_print_warning,
         mock_get_git_repo_for_fab_repo,
         mock_get_team,
         mock_get_team_email_address,


### PR DESCRIPTION
There is lots of expectations and confusion about what this tool does, and we have had a couple of times where people have run it, not-knowing that it overwrites customization.

I would like to add this warning to make that more explicit.