### PR TITLE
Add a new itest to assert new services have a desired_state of start

### DIFF
--- a/general_itests/deployments_json.feature
+++ b/general_itests/deployments_json.feature
@@ -5,3 +5,8 @@ Feature: Per-Service Deployments.json can be written and read back
 	When paasta stop is run against the repo
 	 And we generate deployments.json for that service
         Then that deployments.json can be read back correctly
+
+    Scenario: New services have a desired_state of "start"
+	Given a test git repo is setup with commits
+	 When we generate deployments.json for that service
+	Then that deployments.json has a desired_state of "start"

--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -125,9 +125,9 @@ def step_impl_then(context):
     assert expected_deployments == deployments, "actual: %s\nexpected:%s" % (deployments, expected_deployments)
 
 
-@then(u'that deployments.json has a desired_state of "{state}"')
-def step_impl_then_desired_state(context, state):
+@then(u'that deployments.json has a desired_state of "{expected_state}"')
+def step_impl_then_desired_state(context, expected_state):
     deployments = load_deployments_json('fake_deployments_json_service', soa_dir='fake_soa_configs')
     latest = sorted(deployments.iteritems(), key=lambda(key, value): value['force_bounce'], reverse=True)[0][1]
     desired_state = latest['desired_state']
-    assert desired_state == state
+    assert desired_state == expected_state


### PR DESCRIPTION
This new itest should avoid us adding code that modifies deployments.json in such a way that new services no longer have a desired_state of 'start'. This should help avoid incidents like #223 from happening again.