### PR TITLE
paasta status - show the value of schedule_time_zone (PAASTA-2389)

### DIFF
--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -138,8 +138,8 @@ def _format_schedule(job):
     epsilon = job.get("epsilon", PaastaColors.red("UNKNOWN"))
     schedule_time_zone = job.get("scheduleTimeZone", "null")
     if schedule_time_zone == "null":  # This is what Chronos returns.
-        schedule_time_zone = PaastaColors.grey("unspecified")
-    formatted_schedule = "%s Epsilon: %s TZ: %s" % (schedule, epsilon, schedule_time_zone)
+        schedule_time_zone = "UTC"
+    formatted_schedule = "%s (%s) Epsilon: %s" % (schedule, schedule_time_zone, epsilon)
     return formatted_schedule
 
 

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -136,7 +136,10 @@ def _format_schedule(job):
     else:
         schedule = job.get("schedule", PaastaColors.red("UNKNOWN"))
     epsilon = job.get("epsilon", PaastaColors.red("UNKNOWN"))
-    formatted_schedule = "%s Epsilon: %s" % (schedule, epsilon)
+    schedule_time_zone = job.get("scheduleTimeZone", "null")
+    if schedule_time_zone == "null":  # This is what Chronos returns.
+        schedule_time_zone = PaastaColors.grey("unspecified")
+    formatted_schedule = "%s Epsilon: %s TZ: %s" % (schedule, epsilon, schedule_time_zone)
     return formatted_schedule
 
 

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -294,6 +294,22 @@ def test_format_schedule_dependent_job():
     assert "Epsilon: myepsilon" in actual
 
 
+def test_format_schedule_null_scheduletimezone():
+    example_job = {
+        'scheduleTimeZone': 'null'  # This is what Chronos returns.
+    }
+    actual = chronos_serviceinit._format_schedule(example_job)
+    assert "(UTC) Epsilon" in actual  # In the output, we default to UTC (Chronos should do the same)
+
+
+def test_format_schedule_scheduletimezone():
+    example_job = {
+        'scheduleTimeZone': 'Zulu'
+    }
+    actual = chronos_serviceinit._format_schedule(example_job)
+    assert "(Zulu) Epsilon" in actual
+
+
 def test_format_chronos_job_mesos_verbose():
     example_job = {
         'name': 'my_service my_instance gityourmom configyourdad',


### PR DESCRIPTION
When no TZ is specified:
![screen shot 2016-02-05 at 5 34 53 pm](https://cloud.githubusercontent.com/assets/615907/12854307/e90cfb98-cc30-11e5-9a34-24c547e2818b.png)

PST:
![screen shot 2016-02-05 at 5 35 28 pm](https://cloud.githubusercontent.com/assets/615907/12854310/eff4d3d6-cc30-11e5-9ed1-c66550f0295e.png)
