### PR TITLE
reduced kill_orphaned_docker_containers runtime

### DIFF
--- a/paasta_tools/contrib/kill_orphaned_docker_containers.py
+++ b/paasta_tools/contrib/kill_orphaned_docker_containers.py
@@ -24,7 +24,7 @@ def get_running_task_ids_from_mesos_slave():
     frameworks = state.get('frameworks')
     executors = [ex for fw in frameworks for ex in fw.get('executors', [])
                  if u'TASK_RUNNING' in [t[u'state'] for t in ex.get('tasks', [])]]
-    return [e["id"] for e in executors]
+    return set([e["id"] for e in executors])
 
 
 def get_running_mesos_docker_containers(client):


### PR DESCRIPTION
reduced runtime  by casting running container list to a set

We check for the membership of every running docker container id against the list of running containers that are in mesos. Since checking membership in a list is an O(n) operation, this runs in quadratic time. Changing to a set reduces the runtime to linear since sets have constant-time lookup.