### PR TITLE
re-ordered default deploy order in fsm

### DIFF
--- a/general_itests/steps/fsm_wizard_steps.py
+++ b/general_itests/steps/fsm_wizard_steps.py
@@ -76,6 +76,34 @@ def step_impl_when_fsm_auto(context):
                     'norcal-prod': 'PROD',
                     'nova-prod': 'PROD'
                 },
+                'fsm_deploy_pipeline': [
+                    {
+                        "instancename": "itest",
+                    },
+                    {
+                        "instancename": "security-check",
+                    },
+                    {
+                        "instancename": "push-to-registry",
+                    },
+                    {
+                        "instancename": "performance-check",
+                    },
+                    {
+                        "instancename": "stage.everything",
+                        "trigger_next_step_manually": True,
+                    },
+                    {
+                        "instancename": "prod.canary",
+                        "trigger_next_step_manually": True,
+                    },
+                    {
+                        "instancename": "prod.non_canary",
+                    },
+                    {
+                        "instancename": "dev.everything",
+                    },
+                ],
             },
             directory=context.fake_yelpsoa_configs,
         )

--- a/paasta_tools/cli/cmds/fsm.py
+++ b/paasta_tools/cli/cmds/fsm.py
@@ -19,7 +19,6 @@ from os.path import join
 from service_configuration_lib import DEFAULT_SOA_DIR
 
 from paasta_tools.cli.fsm.questions import _yamlize
-from paasta_tools.cli.fsm.questions import get_deploy_stanza
 from paasta_tools.cli.fsm.questions import get_marathon_stanza
 from paasta_tools.cli.fsm.questions import get_monitoring_stanza
 from paasta_tools.cli.fsm.questions import get_service_stanza
@@ -104,13 +103,17 @@ def validate_args(args):
 
 
 def get_paasta_config(yelpsoa_config_root, srvname, auto, port, team, description, external_link):
+    paasta_config = load_system_paasta_config()
+
     srvname = get_srvname(srvname, auto)
     smartstack_stanza = get_smartstack_stanza(yelpsoa_config_root, auto, port)
     monitoring_stanza = get_monitoring_stanza(auto, team)
-    deploy_stanza = get_deploy_stanza()
     marathon_stanza = get_marathon_stanza()
+    deploy_stanza = paasta_config.get_fsm_deploy_pipeline(),
     service_stanza = get_service_stanza(description, external_link, auto)
-    return (srvname, service_stanza, smartstack_stanza, monitoring_stanza, deploy_stanza, marathon_stanza, team)
+    cluster_stanza = paasta_config.get_fsm_cluster_map()
+    return (srvname, service_stanza, smartstack_stanza, monitoring_stanza,
+            deploy_stanza, marathon_stanza, cluster_stanza, team)
 
 
 def write_paasta_config(
@@ -135,7 +138,8 @@ def write_paasta_config(
 
 def paasta_fsm(args):
     validate_args(args)
-    (srvname, service_stanza, smartstack_stanza, monitoring_stanza, deploy_stanza, marathon_stanza, team) = (
+    (srvname, service_stanza, smartstack_stanza, monitoring_stanza,
+     deploy_stanza, marathon_stanza, cluster_stanza, team) = (
         get_paasta_config(
             args.yelpsoa_config_root,
             args.srvname,
@@ -154,7 +158,7 @@ def paasta_fsm(args):
         monitoring_stanza,
         deploy_stanza,
         marathon_stanza,
-        load_system_paasta_config().get_fsm_cluster_map(),
+        cluster_stanza,
     )
     print PaastaColors.yellow("               _  _(o)_(o)_  _")
     print PaastaColors.red("             ._\`:_ F S M _:' \_,")

--- a/paasta_tools/cli/fsm/questions.py
+++ b/paasta_tools/cli/fsm/questions.py
@@ -112,22 +112,6 @@ def get_monitoring_stanza(auto, team):
     return stanza
 
 
-def get_deploy_stanza():
-    """Produce a deploy.yaml a la http://y/cep319"""
-    stanza = {}
-    stanza["pipeline"] = [
-        {"instancename": "itest", },
-        {"instancename": "security-check", },
-        {"instancename": "push-to-registry", },
-        {"instancename": "performance-check", },
-        {"instancename": "dev.everything", },
-        {"instancename": "stage.everything", "trigger_next_step_manually": True, },
-        {"instancename": "prod.canary", "trigger_next_step_manually": True, },
-        {"instancename": "prod.non_canary", },
-    ]
-    return stanza
-
-
 def get_marathon_stanza():
     """Produce a ``marathon-*.yaml`` a la
     `the docs <yelpsoa_configs.html#marathon-clustername-yaml>`_

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -640,6 +640,13 @@ class SystemPaastaConfig(dict):
             raise PaastaNotConfiguredError(
                 'Could not find dashboard_links in configuration directory: %s' % self.directory)
 
+    def get_fsm_deploy_pipeline(self):
+        try:
+            return self['fsm_deploy_pipeline']
+        except KeyError:
+            raise PaastaNotConfiguredError(
+                'Could not find fsm_deploy_pipeline in configuration directory: %s' % self.directory)
+
 
 def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=None, **kwargs):
     """Given a command, run it. Return a tuple of the return code and any

--- a/tests/cli/fsm/fsm_test.py
+++ b/tests/cli/fsm/fsm_test.py
@@ -78,11 +78,11 @@ class TestGetPaastaConfig:
             yield mock_get_monitoring_stanza
 
     @yield_fixture
-    def mock_get_deploy_stanza(self):
+    def mock_get_paasta_config(self):
         with (
-            mock.patch("paasta_tools.cli.cmds.fsm.get_deploy_stanza", autospec=True)
-        ) as mock_get_deploy_stanza:
-            yield mock_get_deploy_stanza
+            mock.patch("paasta_tools.cli.cmds.fsm.load_system_paasta_config", autospec=True)
+        ) as mock_get_paasta_config:
+            yield mock_get_paasta_config
 
     def test_everything_specified(
         self,
@@ -91,7 +91,7 @@ class TestGetPaastaConfig:
         mock_get_smartstack_stanza,
         mock_get_marathon_stanza,
         mock_get_monitoring_stanza,
-        mock_get_deploy_stanza
+        mock_get_paasta_config,
     ):
         """A sort of happy path test because we don't care about the logic in
         the individual get_* methods, just that all of them get called as
@@ -111,7 +111,7 @@ class TestGetPaastaConfig:
         mock_get_smartstack_stanza.assert_called_once_with(yelpsoa_config_root, auto, port)
         mock_get_marathon_stanza.assert_called_once_with()
         mock_get_monitoring_stanza.assert_called_once_with(auto, team)
-        mock_get_deploy_stanza.assert_called_once_with()
+        mock_get_paasta_config.assert_called_once_with()
 
 
 class TestWritePaastaConfig:
@@ -132,6 +132,9 @@ class TestWritePaastaConfig:
                     'norcal-devc': 'DEV',
                     'norcal-prod': 'PROD',
                     'nova-prod': 'PROD'
+                },
+                'fsm_deploy_pipeline': {
+                    'otto': 'dude',
                 },
             },
             directory='/fake/dir',
@@ -154,7 +157,7 @@ class TestWritePaastaConfig:
             service_stanza,
             smartstack_stanza,
             monitoring_stanza,
-            deploy_stanza,
+            test_paasta_config.get_fsm_deploy_pipeline(),
             marathon_stanza,
             test_paasta_config.get_fsm_cluster_map(),
         )

--- a/tests/cli/fsm/questions_test.py
+++ b/tests/cli/fsm/questions_test.py
@@ -198,34 +198,6 @@ class TestGetMonitoringStanzaTestCase(TestQuestions):
         assert ("team", mock_ask.return_value) in actual.items()
 
 
-class TestGetDeployStanzaTestCase(TestQuestions):
-    def test(self, mock_ask):
-        actual = fsm.get_deploy_stanza()
-        assert "pipeline" in actual.keys()
-        actual["pipeline"] = actual["pipeline"]
-
-        for expected_entry in (
-            {"instancename": "itest"},
-            {"instancename": "security-check"},
-            {"instancename": "performance-check"},
-            {
-                "instancename": "dev.everything",
-            },
-            {
-                "instancename": "stage.everything",
-                "trigger_next_step_manually": True,
-            },
-            {
-                "instancename": "prod.canary",
-                "trigger_next_step_manually": True,
-            },
-            {
-                "instancename": "prod.non_canary",
-            },
-        ):
-            assert expected_entry in actual["pipeline"]
-
-
 class TestGetMarathonStanzaTestCase(TestQuestions):
     def test(self, mock_ask):
         for _, stanza in fsm.get_marathon_stanza():


### PR DESCRIPTION
This changes the default deploy order to stage -> prod canary -> prod non-canary & dev

@EvanKrall @asottile you can argue for or against this here