### PR TITLE
validate dependent jobs' parents - issue 148

### DIFF
--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -415,7 +415,7 @@ class ChronosJobConfig(InstanceConfig):
         # Use InstanceConfig to validate shared config keys like cpus and mem
         error_msgs.extend(super(ChronosJobConfig, self).validate())
 
-        for param in ['epsilon', 'retries', 'cpus', 'mem', 'disk', 'schedule', 'scheduleTimeZone']:
+        for param in ['epsilon', 'retries', 'cpus', 'mem', 'disk', 'schedule', 'scheduleTimeZone', 'parents']:
             check_passed, check_msg = self.check(param)
             if not check_passed:
                 error_msgs.append(check_msg)

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -203,7 +203,7 @@ def validate_chronos(service_path):
 
     returncode = True
     for cluster in list_clusters(service, soa_dir, instance_type):
-        services_in_cluster = get_services_for_cluster(cluster=cluster, instance_type='chronos')
+        services_in_cluster = get_services_for_cluster(cluster=cluster, instance_type='chronos', soa_dir=soa_dir)
         valid_services = set([name + '.' + instance for name, instance in services_in_cluster])
         for instance in list_all_instances_for_service(
                 service=service, clusters=[cluster], instance_type=instance_type,

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -16,7 +16,6 @@ import json
 import os
 import pkgutil
 import sys
-from collections import OrderedDict
 from glob import glob
 
 import yaml
@@ -24,6 +23,7 @@ from jsonschema import Draft4Validator
 from jsonschema import FormatChecker
 from jsonschema import ValidationError
 
+from paasta_tools.chronos_tools import check_parent_format
 from paasta_tools.chronos_tools import load_chronos_job_config
 from paasta_tools.cli.utils import failure
 from paasta_tools.cli.utils import get_file_contents
@@ -31,6 +31,7 @@ from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import PaastaColors
 from paasta_tools.cli.utils import success
+from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import list_all_instances_for_service
 from paasta_tools.utils import list_clusters
 
@@ -199,35 +200,36 @@ def validate_chronos(service_path):
     """Check that any chronos configurations are valid"""
     soa_dir, service = path_to_soa_dir_service(service_path)
     instance_type = 'chronos'
-    cjcs = OrderedDict()
 
     returncode = True
     for cluster in list_clusters(service, soa_dir, instance_type):
+        services_in_cluster = get_services_for_cluster(cluster=cluster, instance_type='chronos')
+        valid_services = set([name + '.' + instance for name, instance in services_in_cluster])
         for instance in list_all_instances_for_service(
                 service=service, clusters=[cluster], instance_type=instance_type,
                 soa_dir=soa_dir):
             cjc = load_chronos_job_config(service, instance, cluster, False, soa_dir)
-            cjcs[service + '.' + cjc.get_job_name()] = cjc
+            parents = cjc.get_parents() or []
+            checks_passed, check_msgs = cjc.validate()
 
-    for cjc in cjcs.values():
-        cluster = cjc.get_cluster()
-        instance = cjc.get_instance()
-        checks_passed, check_msgs = cjc.validate()
+            for parent in parents:
+                if not check_parent_format(parent):
+                    continue
+                if service + '.' + instance == parent:
+                    checks_passed = False
+                    check_msgs.append("Job %s can not depend on itself" % parent)
+                elif parent not in valid_services:
+                    checks_passed = False
+                    check_msgs.append("Parent job %s could not be found" % parent)
 
-        parents = cjc.get_parents() or []
-        for parent in parents:
-            if parent not in cjcs:
-                checks_passed = False
-                check_msgs.append("Parent job %s could not be found" % parent)
+            # Remove duplicate check_msgs
+            unique_check_msgs = list(set(check_msgs))
 
-        # Remove duplicate check_msgs
-        unique_check_msgs = list(set(check_msgs))
-
-        if not checks_passed:
-            print invalid_chronos_instance(cluster, instance, "\n  ".join(unique_check_msgs))
-            returncode = False
-        else:
-            print valid_chronos_instance(cluster, instance)
+            if not checks_passed:
+                print invalid_chronos_instance(cluster, instance, "\n  ".join(unique_check_msgs))
+                returncode = False
+            else:
+                print valid_chronos_instance(cluster, instance)
     return returncode
 
 

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -217,7 +217,7 @@ def validate_chronos(service_path):
                     continue
                 if service + '.' + instance == parent:
                     checks_passed = False
-                    check_msgs.append("Job %s can not depend on itself" % parent)
+                    check_msgs.append("Job %s cannot depend on itself" % parent)
                 elif parent not in valid_services:
                     checks_passed = False
                     check_msgs.append("Parent job %s could not be found" % parent)

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -323,7 +323,7 @@ def test_failing_chronos_job_self_dependent(
 
     output = mock_stdout.getvalue()
 
-    expected_output = 'Job fake-service.fake-instance can not depend on itself'
+    expected_output = 'Job fake-service.fake-instance cannot depend on itself'
     assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
 
 

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -275,6 +275,10 @@ def test_failing_chronos_job_validate(
     fake_cluster = 'penguin'
 
     mock_chronos_job = mock.Mock(autospec=True)
+    mock_chronos_job.get_job_name.return_value = fake_instance
+    mock_chronos_job.get_cluster.return_value = fake_cluster
+    mock_chronos_job.get_instance.return_value = fake_instance
+    mock_chronos_job.get_parents.return_value = None
     mock_chronos_job.validate.return_value = (False, ['something is wrong with the config'])
 
     mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'fake_service')
@@ -295,6 +299,41 @@ def test_failing_chronos_job_validate(
 @patch('paasta_tools.cli.cmds.validate.load_chronos_job_config')
 @patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service')
 @patch('sys.stdout', new_callable=StringIO)
+def test_failing_chronos_job_validate_missing_parents(
+    mock_stdout,
+    mock_path_to_soa_dir_service,
+    mock_load_chronos_job_config,
+    mock_list_all_instances_for_service,
+    mock_list_clusters
+):
+    fake_instance = 'fake-instance'
+    fake_cluster = 'penguin'
+
+    mock_chronos_job = mock.Mock(autospec=True)
+    mock_chronos_job.get_job_name.return_value = fake_instance
+    mock_chronos_job.get_cluster.return_value = fake_cluster
+    mock_chronos_job.get_instance.return_value = fake_instance
+    mock_chronos_job.get_parents.return_value = ['parent_1']
+    mock_chronos_job.validate.return_value = (True, [])
+
+    mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'fake_service')
+    mock_list_clusters.return_value = [fake_cluster]
+    mock_list_all_instances_for_service.return_value = [fake_instance]
+    mock_load_chronos_job_config.return_value = mock_chronos_job
+
+    assert not validate_chronos('fake_service_path')
+
+    output = mock_stdout.getvalue()
+
+    expected_output = 'Parent job parent_1 could not be found'
+    assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
+
+
+@patch('paasta_tools.cli.cmds.validate.list_clusters')
+@patch('paasta_tools.cli.cmds.validate.list_all_instances_for_service')
+@patch('paasta_tools.cli.cmds.validate.load_chronos_job_config')
+@patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service')
+@patch('sys.stdout', new_callable=StringIO)
 def test_validate_chronos_valid_instance(
     mock_stdout,
     mock_path_to_soa_dir_service,
@@ -306,6 +345,10 @@ def test_validate_chronos_valid_instance(
     fake_cluster = 'penguin'
 
     mock_chronos_job = mock.Mock(autospec=True)
+    mock_chronos_job.get_job_name.return_value = fake_instance
+    mock_chronos_job.get_cluster.return_value = fake_cluster
+    mock_chronos_job.get_instance.return_value = fake_instance
+    mock_chronos_job.get_parents.return_value = None
     mock_chronos_job.validate.return_value = (True, [])
 
     mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'fake_service')

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -18,6 +18,7 @@ import mock
 from mock import patch
 from pytest import raises
 
+import paasta_tools.chronos_tools
 from paasta_tools.cli.cmds.validate import check_service_path
 from paasta_tools.cli.cmds.validate import get_schema
 from paasta_tools.cli.cmds.validate import get_service_path
@@ -312,9 +313,10 @@ def test_failing_chronos_job_self_dependent(
     fake_service = 'fake-service'
     fake_instance = 'fake-instance'
     fake_cluster = 'penguin'
+    chronos_spacer = paasta_tools.chronos_tools.INTERNAL_SPACER
 
     mock_chronos_job = mock.Mock(autospec=True)
-    mock_chronos_job.get_parents.return_value = [fake_service + '.' + fake_instance]
+    mock_chronos_job.get_parents.return_value = ["%s%s%s" % (fake_service, chronos_spacer, fake_instance)]
     mock_chronos_job.validate.return_value = (True, [])
 
     mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', fake_service)
@@ -348,9 +350,10 @@ def test_failing_chronos_job_missing_parent(
     fake_service = 'fake-service'
     fake_instance = 'fake-instance'
     fake_cluster = 'penguin'
+    chronos_spacer = paasta_tools.chronos_tools.INTERNAL_SPACER
 
     mock_chronos_job = mock.Mock(autospec=True)
-    mock_chronos_job.get_parents.return_value = [fake_service + '.' + 'parent-1']
+    mock_chronos_job.get_parents.return_value = ["%s%s%s" % (fake_service, chronos_spacer, 'parent-1')]
     mock_chronos_job.validate.return_value = (True, [])
 
     mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', fake_service)

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -259,6 +259,7 @@ def test_chronos_validate_schema_keys_outside_instance_blocks_bad(
     assert SCHEMA_INVALID in output
 
 
+@patch('paasta_tools.cli.cmds.validate.get_services_for_cluster')
 @patch('paasta_tools.cli.cmds.validate.list_clusters')
 @patch('paasta_tools.cli.cmds.validate.list_all_instances_for_service')
 @patch('paasta_tools.cli.cmds.validate.load_chronos_job_config')
@@ -269,8 +270,10 @@ def test_failing_chronos_job_validate(
     mock_path_to_soa_dir_service,
     mock_load_chronos_job_config,
     mock_list_all_instances_for_service,
-    mock_list_clusters
+    mock_list_clusters,
+    mock_get_services_for_cluster
 ):
+    fake_service = 'fake-service'
     fake_instance = 'fake-instance'
     fake_cluster = 'penguin'
 
@@ -278,9 +281,10 @@ def test_failing_chronos_job_validate(
     mock_chronos_job.get_parents.return_value = None
     mock_chronos_job.validate.return_value = (False, ['something is wrong with the config'])
 
-    mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'fake_service')
+    mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', fake_service)
     mock_list_clusters.return_value = [fake_cluster]
     mock_list_all_instances_for_service.return_value = [fake_instance]
+    mock_get_services_for_cluster.return_value = [(fake_service, fake_instance)]
     mock_load_chronos_job_config.return_value = mock_chronos_job
 
     assert not validate_chronos('fake_service_path')
@@ -363,6 +367,7 @@ def test_failing_chronos_job_missing_parent(
     assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
 
 
+@patch('paasta_tools.cli.cmds.validate.get_services_for_cluster')
 @patch('paasta_tools.cli.cmds.validate.list_clusters')
 @patch('paasta_tools.cli.cmds.validate.list_all_instances_for_service')
 @patch('paasta_tools.cli.cmds.validate.load_chronos_job_config')
@@ -373,8 +378,10 @@ def test_validate_chronos_valid_instance(
     mock_path_to_soa_dir_service,
     mock_load_chronos_job_config,
     mock_list_all_instances_for_service,
-    mock_list_clusters
+    mock_list_clusters,
+    mock_get_services_for_cluster
 ):
+    fake_service = 'fake-service'
     fake_instance = 'fake-instance'
     fake_cluster = 'penguin'
 
@@ -382,9 +389,10 @@ def test_validate_chronos_valid_instance(
     mock_chronos_job.get_parents.return_value = None
     mock_chronos_job.validate.return_value = (True, [])
 
-    mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'fake_service')
+    mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', fake_service)
     mock_list_clusters.return_value = [fake_cluster]
     mock_list_all_instances_for_service.return_value = [fake_instance]
+    mock_get_services_for_cluster.return_value = [(fake_service, fake_instance)]
     mock_load_chronos_job_config.return_value = mock_chronos_job
 
     assert validate_chronos('fake_service_path')


### PR DESCRIPTION
This should fix #148 .

Catches two types of config errors:
- Parents whose name is invalid (!= `service_name.instance_name`). Similar to what the JSON schema also enforces.
- Parents that are referenced in a dependent job, but are not actually configured.

Note that the second validation won't let a "`ServiceA` child" depend on a "`ServiceB` parent". That's the best we can do without parsing the entire `yelpsoa-configs` tree.

In my opinion `paasta_tools/cli/cmds/validate.py`, in order to validate the Chronos config, needs to know too many details about `ChronosJobConfig`. If need be, I'm happy to move as much of that logic into `paasta_tools/chronos_tools.py` as possible, so that the latter is in charge of the validation and the former just prints out the outcome.

![screen shot 2016-02-10 at 6 08 14 pm](https://cloud.githubusercontent.com/assets/615907/12956804/b8a560e0-d021-11e5-88d5-f073925dc520.png)

