### PR TITLE
made metastatus read from /etc/paasta to get dashboards

### DIFF
--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -16,6 +16,7 @@ from paasta_tools.cli.utils import execute_paasta_metastatus_on_remote_master
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import PaastaNotConfiguredError
 
 
 def add_subparser(subparsers):
@@ -72,12 +73,16 @@ def figure_out_clusters_to_inspect(args, all_clusters):
 
 def get_cluster_dashboards(cluster):
     """Returns the direct dashboards for humans to use for a given cluster"""
-    dashboards = load_system_paasta_config().get_dashboard_links()[cluster]
-    spacing = max((len(label) for label in dashboards.keys())) + 1
     SPACER = ' '
-    output = []
-    for label, url in dashboards.items():
-        output.append('%s:%s%s' % (label, SPACER * (spacing - len(label)), url))
+    try:
+        dashboards = load_system_paasta_config().get_dashboard_links()[cluster]
+    except PaastaNotConfiguredError:
+        output = ['No dashboards configured for %s!' % cluster]
+    else:
+        output = ['Dashboards:']
+        spacing = max((len(label) for label in dashboards.keys())) + 1
+        for label, url in dashboards.items():
+            output.append('  %s:%s%s' % (label, SPACER * (spacing - len(label)), url))
     return '\n'.join(output)
 
 

--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -14,9 +14,8 @@
 # limitations under the License.
 from paasta_tools.cli.utils import execute_paasta_metastatus_on_remote_master
 from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.smartstack_tools import DEFAULT_SYNAPSE_PORT
 from paasta_tools.utils import list_clusters
-from paasta_tools.utils import PaastaColors
+from paasta_tools.utils import load_system_paasta_config
 
 
 def add_subparser(subparsers):
@@ -73,18 +72,12 @@ def figure_out_clusters_to_inspect(args, all_clusters):
 
 def get_cluster_dashboards(cluster):
     """Returns the direct dashboards for humans to use for a given cluster"""
+    dashboards = load_system_paasta_config().get_dashboard_links()[cluster]
+    spacing = max((len(label) for label in dashboards.keys())) + 1
+    SPACER = ' '
     output = []
-    output.append("Warning: Dashboards in prod are not directly reachable. "
-                  "See http://y/paasta-troubleshooting for instructions. (search for 'prod dashboards')")
-    output.append("User Dashboards (Read Only):")
-    output.append("  Mesos:    %s" % PaastaColors.cyan("http://mesos.paasta-%s.yelp/" % cluster))
-    output.append("  Marathon: %s" % PaastaColors.cyan("http://marathon.paasta-%s.yelp/" % cluster))
-    output.append("  Chronos:  %s" % PaastaColors.cyan("http://chronos.paasta-%s.yelp/" % cluster))
-    output.append("  Synapse:  %s" % PaastaColors.cyan("http://paasta-%s.yelp:%s/" % (cluster, DEFAULT_SYNAPSE_PORT)))
-    output.append("Admin Dashboards (Read/write, requires secrets):")
-    output.append("  Mesos:    %s" % PaastaColors.cyan("http://paasta-%s.yelp:5050/" % cluster))
-    output.append("  Marathon: %s" % PaastaColors.cyan("http://paasta-%s.yelp:5052/" % cluster))
-    output.append("  Chronos:  %s" % PaastaColors.cyan("http://paasta-%s.yelp:5053/" % cluster))
+    for label, url in dashboards.items():
+        output.append('%s:%s%s' % (label, SPACER * (spacing - len(label)), url))
     return '\n'.join(output)
 
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -633,6 +633,13 @@ class SystemPaastaConfig(dict):
             raise PaastaNotConfiguredError(
                 'Could not find fsm_cluster_map in configuration directory: %s' % self.directory)
 
+    def get_dashboard_links(self):
+        try:
+            return self['dashboard_links']
+        except KeyError:
+            raise PaastaNotConfiguredError(
+                'Could not find dashboard_links in configuration directory: %s' % self.directory)
+
 
 def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=None, **kwargs):
     """Given a command, run it. Return a tuple of the return code and any


### PR DESCRIPTION
Sample output:
```
matts@dev2-devc:~/paasta (master) $ python paasta_tools/cli/cli.py metastatus -c nova-prod
Cluster: nova-prod
Note:              Viewing raw dashboards in prod requires an extra proxy. See https://docs.google.com/document/d/1OXEcmSubOG8T0RHFETh3GM98AF0MXj-1vQL6x8xLJO0/edit#heading=h.anrifrwk9e2r
Chronos RO:        http://chronos-nova-prod.yelpcorp.com (LDAP Login)
Mesos:             http://mesos.paasta-nova-prod.yelp (Requires Prod Proxy, see note at the end)
To run metastatus: paasta metastatus -c nova-prod (requires prod access)
Smartstack:        http://paasta-nova-prod.yelp:3212  (Requires Prod Proxy, see note at the end)
Signalfx:          https://app.signalfx.com/#/dashboard/CYJklh9AYAo?sources%5B%5D=superregion:nova-prod
Marathon RO:       http://marathon-nova-prod.yelpcorp.com (LDAP Login)
Mesos Status: OK
Marathon Status: OK
Chronos Status: OK
```