### PR TITLE
Update paasta check sensu_check and smartstack_check to pass soa_dir

### DIFF
--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -302,7 +302,7 @@ def pipeline_check(service):
         print PaastaCheckMessages.PIPELINE_MISSING
 
 
-def sensu_check(service, service_path):
+def sensu_check(service, service_path, soa_dir):
     """Check whether monitoring.yaml exists in service directory,
     and that the team name is declared.
 
@@ -310,7 +310,7 @@ def sensu_check(service, service_path):
     :param service_path: path to loction of monitoring.yaml file"""
     if is_file_in_dir('monitoring.yaml', service_path):
         print PaastaCheckMessages.SENSU_MONITORING_FOUND
-        team = get_team(service=service, overrides={})
+        team = get_team(service=service, overrides={}, soa_dir=soa_dir)
         if team is None:
             print PaastaCheckMessages.SENSU_TEAM_MISSING
         else:
@@ -330,7 +330,7 @@ def service_dir_check(service, soa_dir):
         print PaastaCheckMessages.service_dir_missing(service, soa_dir)
 
 
-def smartstack_check(service, service_path):
+def smartstack_check(service, service_path, soa_dir):
     """Check whether smartstack.yaml exists in service directory, and the proxy
     ports are declared.  Print appropriate message depending on outcome.
 
@@ -338,9 +338,11 @@ def smartstack_check(service, service_path):
     :param service_path: path to loction of smartstack.yaml file"""
     if is_file_in_dir('smartstack.yaml', service_path):
         print PaastaCheckMessages.SMARTSTACK_YAML_FOUND
-        instances = get_all_namespaces_for_service(service)
+        instances = get_all_namespaces_for_service(service=service, soa_dir=soa_dir)
         if len(instances) > 0:
-            for namespace, config in get_all_namespaces_for_service(service, full_name=False):
+            for namespace, config in get_all_namespaces_for_service(service=service,
+                                                                    soa_dir=soa_dir,
+                                                                    full_name=False):
                 if 'proxy_port' in config:
                     print PaastaCheckMessages.smartstack_port_found(
                         namespace, config.get('proxy_port'))
@@ -367,8 +369,8 @@ def paasta_check(args):
     makefile_check()
     yaml_check(service_path)
     deployments_check(service, soa_dir)
-    sensu_check(service, service_path)
-    smartstack_check(service, service_path)
+    sensu_check(service, service_path, soa_dir)
+    smartstack_check(service, service_path, soa_dir)
     paasta_validate_soa_configs(service_path)
 
 

--- a/tests/cli/test_cmds_check.py
+++ b/tests/cli/test_cmds_check.py
@@ -224,11 +224,12 @@ def test_check_sensu_check_pass(mock_stdout, mock_get_team,
     expected_output = "%s\n%s\n" % (PaastaCheckMessages.SENSU_MONITORING_FOUND,
                                     PaastaCheckMessages.sensu_team_found(team))
 
-    sensu_check('fake_service', 'path')
+    sensu_check(service='fake_service', service_path='path', soa_dir='path')
     output = mock_stdout.getvalue()
 
     assert output == expected_output
-    mock_get_team.assert_called_once_with(service='fake_service', overrides={})
+    mock_get_team.assert_called_once_with(service='fake_service', overrides={},
+                                          soa_dir='path')
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir')
@@ -243,7 +244,7 @@ def test_check_sensu_team_missing(mock_stdout, mock_get_team,
     expected_output = "%s\n%s\n" % (PaastaCheckMessages.SENSU_MONITORING_FOUND,
                                     PaastaCheckMessages.SENSU_TEAM_MISSING)
 
-    sensu_check('fake_service', 'path')
+    sensu_check(service='fake_service', service_path='path', soa_dir='path')
     output = mock_stdout.getvalue()
 
     assert output == expected_output
@@ -257,7 +258,7 @@ def test_check_sensu_check_fail(mock_stdout, mock_is_file_in_dir):
     mock_is_file_in_dir.return_value = False
     expected_output = "%s\n" % PaastaCheckMessages.SENSU_MONITORING_MISSING
 
-    sensu_check('fake_service', 'path')
+    sensu_check(service='fake_service', service_path='path', soa_dir='path')
     output = mock_stdout.getvalue()
 
     assert output == expected_output
@@ -287,7 +288,7 @@ def test_check_smartstack_check_pass(mock_stdout, mock_is_file_in_dir,
                          PaastaCheckMessages.smartstack_port_found(
                              instance, port))
 
-    smartstack_check('fake_service', 'path')
+    smartstack_check(service='fake_service', service_path='path', soa_dir='path')
     output = mock_stdout.getvalue()
 
     assert output == expected_output
@@ -313,7 +314,7 @@ def test_check_smartstack_check_missing_port(
                       % (PaastaCheckMessages.SMARTSTACK_YAML_FOUND,
                          PaastaCheckMessages.SMARTSTACK_PORT_MISSING)
 
-    smartstack_check('fake_service', 'path')
+    smartstack_check(service='fake_service', service_path='path', soa_dir='path')
     output = mock_stdout.getvalue()
 
     assert output == expected_output
@@ -334,7 +335,7 @@ def test_check_smartstack_check_missing_instance(
                       % (PaastaCheckMessages.SMARTSTACK_YAML_FOUND,
                          PaastaCheckMessages.SMARTSTACK_PORT_MISSING)
 
-    smartstack_check('fake_service', 'path')
+    smartstack_check(service='fake_service', service_path='path', soa_dir='path')
     output = mock_stdout.getvalue()
 
     assert output == expected_output
@@ -346,7 +347,7 @@ def test_check_smartstack_check_is_ok_when_no_smartstack(mock_stdout, mock_is_fi
 
     mock_is_file_in_dir.return_value = False
     expected_output = ""
-    smartstack_check('fake_service', 'path')
+    smartstack_check(service='fake_service', service_path='path', soa_dir='path')
     output = mock_stdout.getvalue()
 
     assert output == expected_output


### PR DESCRIPTION
It was pointed out that when `paasta check` tests for a team and proxy_port, it displays a failure when a custom soa_dir is specified. This PR properly passes the soa_dir argument to fix that issue.