### PR TITLE
Ignore command healthchecks when judging how happy tasks are

### DIFF
--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -96,7 +96,7 @@ def when_there_are_num_which_tasks(context, num, which, state):
                 return
         time.sleep(0.5)
     raise Exception("timed out waiting for %d %s tasks on %s; there are %d" %
-                    (context.max_tasks, state, app_id, app.tasks))
+                    (context.max_tasks, state, app_id, len(app.tasks)))
 
 
 @when(u'deploy_service with bounce strategy "{bounce_method}" and drain method "{drain_method}" is initiated')

--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -257,7 +257,9 @@ def get_happy_tasks(app, service, nerve_ns, min_task_uptime=None, check_haproxy=
                 continue
 
         # if there are healthchecks defined for the app but none have executed yet, then task is unhappy
-        if len(app.health_checks) > 0 and len(task.health_check_results) == 0:
+        # Except for command healchecks. Marathon currently is not reporting them back via the API
+        non_command_healthchecks = [hc for hc in app.health_checks if hc.protocol != 'COMMAND']
+        if len(non_command_healthchecks) > 0 and len(task.health_check_results) == 0:
             continue
 
         # if there are health check results, check if at least one healthcheck is passing

--- a/tests/test_bounce_lib.py
+++ b/tests/test_bounce_lib.py
@@ -198,8 +198,14 @@ class TestBounceLib:
     def test_get_happy_tasks_when_running_with_healthchecks_defined(self):
         """All running tasks with no health check results are unhealthy if the app defines healthchecks"""
         tasks = [mock.Mock(health_check_results=[]) for _ in xrange(5)]
-        fake_app = mock.Mock(tasks=tasks, health_checks=["fake_healthcheck_definition"])
+        fake_app = mock.Mock(tasks=tasks, health_checks=[mock.Mock(protocol="HTTP")])
         assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace') == []
+
+    def test_get_happy_tasks_when_running_with_command_healthchecks_defined_are_ignored(self):
+        """All running tasks with no health check results are unhealthy if the app defines healthchecks"""
+        tasks = [mock.Mock(health_check_results=[]) for _ in xrange(5)]
+        fake_app = mock.Mock(tasks=tasks, health_checks=[mock.Mock(protocol="COMMAND")])
+        assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace') == tasks
 
     def test_get_happy_tasks_when_all_healthy(self):
         """All tasks with only passing healthchecks should be happy"""


### PR DESCRIPTION
Primary: @EvanKrall 

I am not super stoked about this one, but I can confirm that the command healthcheck results are just not available to marathon to use. Maybe because they happen on the mesos slave? (but we still see them in the marathon logs? idk.

Closes internal ticket PAASTA-3110.