### PR TITLE
No longer use paasta_execute_in_container for command healthchecks.

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -20,7 +20,6 @@ make the PaaSTA stack work.
 import json
 import logging
 import os
-import pipes
 import re
 import socket
 from time import sleep
@@ -395,14 +394,10 @@ class MarathonServiceConfig(InstanceConfig):
                 },
             ]
         elif mode == 'cmd':
-            command = pipes.quote(self.get_healthcheck_cmd())
-            hc_command = "paasta_execute_docker_command " \
-                "--mesos-id \"$MESOS_TASK_ID\" --cmd %s --timeout '%s'" % (command, timeoutseconds)
-
             healthchecks = [
                 {
                     "protocol": "COMMAND",
-                    "command": {"value": hc_command},
+                    "command": {"value": self.get_healthcheck_cmd()},
                     "gracePeriodSeconds": graceperiodseconds,
                     "intervalSeconds": intervalseconds,
                     "timeoutSeconds": timeoutseconds,

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1730,61 +1730,10 @@ class TestMarathonServiceConfig(object):
             branch_dict={},
         )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
-        expected_cmd = "paasta_execute_docker_command --mesos-id \"$MESOS_TASK_ID\" --cmd /fake_cmd --timeout '10'"
         expected = [
             {
                 "protocol": "COMMAND",
-                "command": {"value": expected_cmd},
-                "gracePeriodSeconds": 60,
-                "intervalSeconds": 10,
-                "timeoutSeconds": 10,
-                "maxConsecutiveFailures": 30
-            },
-        ]
-        actual = fake_marathon_service_config.get_healthchecks(fake_service_namespace_config)
-        assert actual == expected
-
-    def test_get_healthchecks_cmd_quotes(self):
-        fake_command = '/bin/fake_command with spaces'
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-            service='service',
-            cluster='cluster',
-            instance='instance',
-            config_dict={'healthcheck_mode': 'cmd', 'healthcheck_cmd': fake_command},
-            branch_dict={},
-        )
-        fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
-        expected_cmd = "paasta_execute_docker_command " \
-            "--mesos-id \"$MESOS_TASK_ID\" --cmd '%s' --timeout '10'" % fake_command
-        expected = [
-            {
-                "protocol": "COMMAND",
-                "command": {"value": expected_cmd},
-                "gracePeriodSeconds": 60,
-                "intervalSeconds": 10,
-                "timeoutSeconds": 10,
-                "maxConsecutiveFailures": 30
-            },
-        ]
-        actual = fake_marathon_service_config.get_healthchecks(fake_service_namespace_config)
-        assert actual == expected
-
-    def test_get_healthchecks_cmd_overrides(self):
-        fake_command = '/bin/fake_command'
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-            service='service',
-            cluster='cluster',
-            instance='instance',
-            config_dict={'healthcheck_mode': 'cmd', 'healthcheck_cmd': fake_command},
-            branch_dict={},
-        )
-        fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
-        expected_cmd = "paasta_execute_docker_command " \
-            "--mesos-id \"$MESOS_TASK_ID\" --cmd %s --timeout '10'" % fake_command
-        expected = [
-            {
-                "protocol": "COMMAND",
-                "command": {"value": expected_cmd},
+                "command": {"value": fake_command},
                 "gracePeriodSeconds": 60,
                 "intervalSeconds": 10,
                 "timeoutSeconds": 10,
@@ -1808,12 +1757,10 @@ class TestMarathonServiceConfig(object):
             branch_dict={},
         )
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
-        expected_cmd = "paasta_execute_docker_command " \
-            "--mesos-id \"$MESOS_TASK_ID\" --cmd %s --timeout '%s'" % (fake_command, fake_timeout)
         expected = [
             {
                 "protocol": "COMMAND",
-                "command": {"value": expected_cmd},
+                "command": {"value": fake_command},
                 "gracePeriodSeconds": 60,
                 "intervalSeconds": 10,
                 "timeoutSeconds": fake_timeout,


### PR DESCRIPTION
Apparently mesos 0.23 and up execute the command healthchecks *in* the container, so we no longer need our wrapper script. (see also https://github.com/mesosphere/marathon/issues/2140)