### PR TITLE
made setup_chronos_jobs handle non-existant jobs

### DIFF
--- a/paasta_tools/setup_chronos_job.py
+++ b/paasta_tools/setup_chronos_job.py
@@ -86,12 +86,15 @@ def send_event(service, instance, soa_dir, status, output):
     :param output: The output to emit for this event
     """
     cluster = load_system_paasta_config().get_cluster()
-    monitoring_overrides = chronos_tools.load_chronos_job_config(
-        service=service,
-        instance=instance,
-        cluster=cluster,
-        soa_dir=soa_dir,
-    ).get_monitoring()
+    try:
+        monitoring_overrides = chronos_tools.load_chronos_job_config(
+            service=service,
+            instance=instance,
+            cluster=cluster,
+            soa_dir=soa_dir,
+        ).get_monitoring()
+    except chronos_tools.UnknownChronosJobError:
+        monitoring_overrides = {}
     # In order to let sensu know how often to expect this check to fire,
     # we need to set the ``check_every`` to the frequency of our cron job, which
     # is 10s.
@@ -187,7 +190,7 @@ def main():
             args.service_instance, cluster)
         send_event(
             service=service,
-            instance=None,
+            instance=instance,
             soa_dir=soa_dir,
             status=pysensu_yelp.Status.CRITICAL,
             output=error_msg,


### PR DESCRIPTION
Fixes this trace:

```
Traceback (most recent call last):
  File "/usr/bin/setup_chronos_job", line 234, in <module>
    main()
  File "/usr/bin/setup_chronos_job", line 193, in main
    output=error_msg,
  File "/usr/bin/setup_chronos_job", line 93, in send_event
    soa_dir=soa_dir,
  File "/usr/share/python/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/chronos_tools.py", line 159, in load_chronos_job_config
    raise UnknownChronosJobError('No job named "%s" in config file chronos-%s.yaml' % (instance, cluster))
paasta_tools.chronos_tools.UnknownChronosJobError: No job named "None" in config file chronos-norcal-prod.yaml
```