### PR TITLE
made bounce kill apps only when they have instances == 0

### DIFF
--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -250,15 +250,10 @@ def do_bounce(
             log_bounce_action(line='%s bounce killing drained task %s' % (bounce_method, task.id))
             marathon_tools.kill_task(client=client, app_id=task.app_id, task_id=task.id, scale=True)
 
-    apps_to_kill = []
-    for app in old_app_live_happy_tasks.keys():
-        live_happy_tasks = old_app_live_happy_tasks[app]
-        live_unhappy_tasks = old_app_live_unhappy_tasks[app]
-        draining_tasks = old_app_draining_tasks[app]
+    apps = set(old_app_live_happy_tasks.keys()) | set(old_app_live_unhappy_tasks.keys()) \
+        | set(old_app_draining_tasks.keys())
 
-        if 0 == len((live_happy_tasks | live_unhappy_tasks | draining_tasks) - killed_tasks):
-            apps_to_kill.append(app)
-
+    apps_to_kill = [app for app in apps if client.get_app(app).instances == 0]
     if apps_to_kill:
         log_bounce_action(
             line='%s bounce removing old unused apps with app_ids: %s' %

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -549,16 +549,18 @@ class TestSetupMarathonJob:
         fake_bounce_method = 'fake_bounce_method'
         fake_drain_method = mock.Mock()
         fake_marathon_jobid = 'fake.marathon.jobid'
-        fake_client = mock.create_autospec(
-            marathon.MarathonClient
-        )
+        fake_client = mock.Mock(get_app=mock.Mock(return_value=mock.Mock(instances=0)))
         expected_new_task_count = fake_config["instances"] - len(fake_happy_new_tasks)
 
         with contextlib.nested(
             mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.bounce_lib.create_marathon_app', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.bounce_lib.kill_old_ids', autospec=True),
-        ) as (mock_log, mock_create_marathon_app, mock_kill_old_ids):
+        ) as (
+            mock_log,
+            mock_create_marathon_app,
+            mock_kill_old_ids,
+        ):
             setup_marathon_job.do_bounce(
                 bounce_func=fake_bounce_func,
                 drain_method=fake_drain_method,


### PR DESCRIPTION
@solarkennedy @EvanKrall right now scaling tasks down kills them since `do_bounce` doesn't know about the other healthy tasks we want to keep up. This fixes that.

This blocks testing scaling & unpinning paasta-tools so I'd like this looked over ASAP please.