### PR TITLE
Pass --env_vars_prefix to marathon and remove local_run workaround

### DIFF
--- a/docs/source/workflow.rst
+++ b/docs/source/workflow.rst
@@ -86,8 +86,6 @@ configuration for the running image:
   ``PAASTA_`` environment variables will also be injected, see the `related docs <yelpsoa_configs.html#marathon-clustername-yaml>`_
   for more information.
 
-  * **WARNING**: A PORT variable is provided to the docker image, but it represents the EXTERNAL port, not the internal one. The internal service MUST listen on 8888, so this PORT variable confuses some service stacks that are listening for this variable. Such services MUST overwrite this environment variable to function. (``PORT=8888 ./uwisgi.py```)
-
 * ``--publish``: Mesos picks a random port on the host that maps to and exposes
   port 8888 inside the container. This random port is announced to Smartstack
   so that it can be used for load balancing.

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -100,14 +100,6 @@ instance MAY have:
     * ``PAASTA_INSTANCE``: The instance name
     * ``PAASTA_CLUSTER``: The cluster name
 
-    * **WARNING**: A PORT variable is provided to the docker image, but it
-      represents the EXTERNAL port, not the internal one. The internal service
-      MUST listen on 8888, so this PORT variable confuses some service stacks
-      that are listening for this variable. Such services MUST overwrite this
-      environment variable to function. (``PORT=8888 ./uwsgi.py```) We tried
-      to work around this, see `PAASTA-267
-      <https://jira.yelpcorp.com/browse/PAASTA-267>`_.
-
   * ``extra_volumes``: An array of dictionaries specifying extra bind-mounts
     inside the container. Can be used to expose filesystem resources available
     on the host into the running container. Common use cases might be to share

--- a/paasta_itests/docker-compose.yml
+++ b/paasta_itests/docker-compose.yml
@@ -29,7 +29,7 @@ marathon:
     - zookeeper
   environment:
     -CLUSTER: testcluster
-  command: 'marathon --zk zk://zookeeper:2181/marathon --master zk://zookeeper:2181/mesos-testcluster --no-logger'
+  command: 'marathon --zk zk://zookeeper:2181/marathon --master zk://zookeeper:2181/mesos-testcluster --no-logger --env_vars_prefix MARATHON_'
 
 paastatools:
   build: ../yelp_package/dockerfiles/trusty/

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -51,8 +51,6 @@ from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import Timeout
 from paasta_tools.utils import TimeoutError
 
-BAD_PORT_WARNING = 'This_service_is_listening_on_the_PORT_variable__You_must_use_8888__see_y/paasta_deploy'
-
 
 def pick_random_port():
     """Bind to an ephemeral port, force it into the TIME_WAIT state, and
@@ -374,10 +372,6 @@ def get_docker_run_cmd(memory, random_port, container_name, volumes, env, intera
     for k, v in env.iteritems():
         cmd.append('--env=\"%s=%s\"' % (k, v))
     cmd.append('--env=HOST=%s' % hostname)
-    # We inject an invalid port as the PORT variable, as marathon injects the externally
-    # assigned port like this. That allows this test run to catch services that might
-    # be using this variable in surprising ways. See PAASTA-267 for more context.
-    cmd.append('--env=PORT=%s' % BAD_PORT_WARNING)
     cmd.append('--env=MESOS_SANDBOX=/mnt/mesos/sandbox')
     cmd.append('--memory=%dm' % memory)
     cmd.append('--publish=%d:%d' % (random_port, CONTAINER_PORT))

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -444,7 +444,6 @@ def test_get_docker_run_cmd_interactive_false():
     actual = get_docker_run_cmd(memory, random_port, container_name, volumes,
                                 env, interactive, docker_hash, command, hostname)
 
-    assert any(['--env=PORT=' in arg for arg in actual])
     assert '--memory=%dm' % memory in actual
     assert any(['--publish=%s' % random_port in arg for arg in actual])
     assert '--name=%s' % container_name in actual


### PR DESCRIPTION
Pass the `--env_vars_prefix` argument to Marathon. By using this argument, we can avoid having it hog the `PORT` environment variable.

I'm removing the warnings in the docs. The contract still notes the requirement to use port 8888. I have also removed the hack in `local_run` to explicitly set the `PORT` environment variable to match production.

Fixes #152 