### PR TITLE
Add extra_constraints and pool to schemas for paasta validate

### DIFF
--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -76,6 +76,16 @@
                 },
                 "uniqueItems": true
             },
+            "extra_constraints": {
+                "type": "array",
+                "items": {
+                    "type": "array"
+                },
+                "uniqueItems": true
+            },
+            "pool": {
+                "type": "string"
+            },
             "parents": {
                 "oneOf": [
                     { "$ref": "#/definitions/jobName" },

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -75,6 +75,16 @@
                 },
                 "uniqueItems": true
             },
+            "extra_constraints": {
+                "type": "array",
+                "items": {
+                    "type": "array"
+                },
+                "uniqueItems": true
+            },
+            "pool": {
+                "type": "string"
+            },
             "cmd": {
                 "type": "string"
             },


### PR DESCRIPTION
Currently, `paasta validate` complains about marathon/chronos configs that contain these keys. This change fixes that so they show up as valid.

I am also wondering if it is worth adding some more logic around the constraints to make `paasta validate` aware of invalid constraints.