### PR TITLE
Set MARATHON_PORT env variable in local-run

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -371,6 +371,7 @@ def get_docker_run_cmd(memory, random_port, container_name, volumes, env, intera
     cmd = ['docker', 'run']
     for k, v in env.iteritems():
         cmd.append('--env=\"%s=%s\"' % (k, v))
+    cmd.append('--env=MARATHON_PORT=%s' % random_port)
     cmd.append('--env=HOST=%s' % hostname)
     cmd.append('--env=MESOS_SANDBOX=/mnt/mesos/sandbox')
     cmd.append('--memory=%dm' % memory)

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -444,6 +444,7 @@ def test_get_docker_run_cmd_interactive_false():
     actual = get_docker_run_cmd(memory, random_port, container_name, volumes,
                                 env, interactive, docker_hash, command, hostname)
 
+    assert any(['--env=MARATHON_PORT=%s' % random_port in arg for arg in actual])
     assert '--memory=%dm' % memory in actual
     assert any(['--publish=%s' % random_port in arg for arg in actual])
     assert '--name=%s' % container_name in actual


### PR DESCRIPTION
We now use Marathon's `--env_vars_prefix` option. This change makes sure that services run with `local-run` have `MARATHON_PORT` set similarly to how it would be set once deployed.