### PR TITLE
Update docs to note Marathon env_var_prefix

### DIFF
--- a/docs/source/workflow.rst
+++ b/docs/source/workflow.rst
@@ -84,7 +84,10 @@ configuration for the running image:
 
 * ``--env``: Any environment variables specified in the ``env`` section will be here. Additional
   ``PAASTA_`` environment variables will also be injected, see the `related docs <yelpsoa_configs.html#marathon-clustername-yaml>`_
-  for more information.
+  for more information. Marathon and Mesos will also set up some
+  `environment variables <https://mesosphere.github.io/marathon/docs/task-environment-vars.html>`_.
+  They will all be prefixed with ``MARATHON_`` or ``MESOS_`` to avoid conflicting with environment
+  variables set by your service.
 
 * ``--publish``: Mesos picks a random port on the host that maps to and exposes
   port 8888 inside the container. This random port is announced to Smartstack

--- a/docs/source/workflow.rst
+++ b/docs/source/workflow.rst
@@ -83,11 +83,8 @@ configuration for the running image:
 * ``--net``: PaaSTA uses bridge mode to enable random port allocation.
 
 * ``--env``: Any environment variables specified in the ``env`` section will be here. Additional
-  ``PAASTA_`` environment variables will also be injected, see the `related docs <yelpsoa_configs.html#marathon-clustername-yaml>`_
-  for more information. Marathon and Mesos will also set up some
-  `environment variables <https://mesosphere.github.io/marathon/docs/task-environment-vars.html>`_.
-  They will all be prefixed with ``MARATHON_`` or ``MESOS_`` to avoid conflicting with environment
-  variables set by your service.
+  ``PAASTA_``, ``MARATHON_``, and ``MESOS_`` environment variables will also be injected, see the
+  `related docs <yelpsoa_configs.html#env>`_ for more information.
 
 * ``--publish``: Mesos picks a random port on the host that maps to and exposes
   port 8888 inside the container. This random port is announced to Smartstack

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -111,6 +111,8 @@ instance MAY have:
     Parsing the Marathon config file will fail if both args and cmd are
     specified [#note]_.
 
+  .. _env:
+
   * ``env``: A dictionary of environment variables that will be made available
     to the container. PaaSTA additionally will inject the following variables:
 
@@ -118,9 +120,9 @@ instance MAY have:
     * ``PAASTA_INSTANCE``: The instance name
     * ``PAASTA_CLUSTER``: The cluster name
 
-    Marathon adds a ``MARATHON_`` prefix to environment variables it sets up to
-    avoid conflicting with variables created by your service. It will *not* add
-    a prefix to variables specified in this dictionary.
+    Additionally, there are ``MARATHON_`` prefixed variables available. See the
+    `docs <https://mesosphere.github.io/marathon/docs/task-environment-vars.html>`_
+    for more information about these variables.
 
   * ``extra_volumes``: An array of dictionaries specifying extra bind-mounts
     inside the container. Can be used to expose filesystem resources available

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -118,6 +118,10 @@ instance MAY have:
     * ``PAASTA_INSTANCE``: The instance name
     * ``PAASTA_CLUSTER``: The cluster name
 
+    Marathon adds a ``MARATHON_`` prefix to environment variables it sets up to
+    avoid conflicting with variables created by your service. It will *not* add
+    a prefix to variables specified in this dictionary.
+
   * ``extra_volumes``: An array of dictionaries specifying extra bind-mounts
     inside the container. Can be used to expose filesystem resources available
     on the host into the running container. Common use cases might be to share


### PR DESCRIPTION
Mention that Marathon adds environment variables that are prefixed with `MARATHON_` and that it won't touch user-specified env variables.