### PR TITLE
Order tasks in verbose paasta status

### DIFF
--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -146,8 +146,6 @@ def get_running_tasks_from_active_frameworks(job_id):
 def get_non_running_tasks_from_active_frameworks(job_id):
     active_framework_tasks = get_current_tasks(job_id)
     not_running_tasks = filter_not_running_tasks(active_framework_tasks)
-    # Order the tasks by timestamp
-    not_running_tasks.sort(key=lambda task: get_first_status_timestamp(task))
     return not_running_tasks
 
 
@@ -334,7 +332,11 @@ def status_mesos_tasks_verbose(job_id, get_short_task_id, tail_stdstreams=False)
         output.append(tasks_table_running[0])  # header
         output.extend(zip_tasks_verbose_output(tasks_table_running[1:], tasks_stdstreams_running))
 
-    non_running_tasks = list(reversed(get_non_running_tasks_from_active_frameworks(job_id)[-10:]))
+    non_running_tasks = get_non_running_tasks_from_active_frameworks(job_id)
+    # Order the tasks by timestamp
+    non_running_tasks.sort(key=lambda task: get_first_status_timestamp(task))
+    non_running_tasks_ordered = list(reversed(non_running_tasks[-10:]))
+
     output.append(PaastaColors.grey("  Non-Running Tasks"))
     rows_non_running = [[
         PaastaColors.grey("Mesos Task ID"),
@@ -342,7 +344,7 @@ def status_mesos_tasks_verbose(job_id, get_short_task_id, tail_stdstreams=False)
         PaastaColors.grey("Deployed at what localtime"),
         PaastaColors.grey("Status"),
     ]]
-    for task in non_running_tasks:
+    for task in non_running_tasks_ordered:
         rows_non_running.append(format_non_running_mesos_task_row(task, get_short_task_id))
     tasks_table_non_running = ["    %s" % row for row in format_table(rows_non_running)]
     if not tail_stdstreams:

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -146,6 +146,8 @@ def get_running_tasks_from_active_frameworks(job_id):
 def get_non_running_tasks_from_active_frameworks(job_id):
     active_framework_tasks = get_current_tasks(job_id)
     not_running_tasks = filter_not_running_tasks(active_framework_tasks)
+    # Order the tasks by timestamp
+    not_running_tasks.sort(key=lambda task: get_first_status_timestamp(task))
     return not_running_tasks
 
 

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -46,6 +46,40 @@ def test_filter_not_running_tasks():
     assert not_running[0]['id'] == 2
 
 
+def test_get_non_running_tasks_from_active_frameworks():
+    with mock.patch('paasta_tools.mesos_tools.get_current_tasks', autospec=True) as get_current_tasks_patch:
+        get_current_tasks_patch.return_value = [
+            {
+                'statuses': [{'timestamp': '1457109986'}],
+                'state': 'NOT_RUNNING',
+            },
+            {
+                'statuses': [{'timestamp': '1457110226'}],
+                'state': 'NOT_RUNNING',
+            },
+            {
+                'statuses': [{'timestamp': '1457110106'}],
+                'state': 'NOT_RUNNING',
+            },
+        ]
+        expected = [
+            {
+                'statuses': [{'timestamp': '1457109986'}],
+                'state': 'NOT_RUNNING',
+            },
+            {
+                'statuses': [{'timestamp': '1457110106'}],
+                'state': 'NOT_RUNNING',
+            },
+            {
+                'statuses': [{'timestamp': '1457110226'}],
+                'state': 'NOT_RUNNING',
+            },
+        ]
+
+        assert mesos_tools.get_non_running_tasks_from_active_frameworks(123) == expected
+
+
 @mark.parametrize('test_case', [
     [False, 0],
     [True, 2]

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -46,43 +46,9 @@ def test_filter_not_running_tasks():
     assert not_running[0]['id'] == 2
 
 
-def test_get_non_running_tasks_from_active_frameworks():
-    with mock.patch('paasta_tools.mesos_tools.get_current_tasks', autospec=True) as get_current_tasks_patch:
-        get_current_tasks_patch.return_value = [
-            {
-                'statuses': [{'timestamp': '1457109986'}],
-                'state': 'NOT_RUNNING',
-            },
-            {
-                'statuses': [{'timestamp': '1457110226'}],
-                'state': 'NOT_RUNNING',
-            },
-            {
-                'statuses': [{'timestamp': '1457110106'}],
-                'state': 'NOT_RUNNING',
-            },
-        ]
-        expected = [
-            {
-                'statuses': [{'timestamp': '1457109986'}],
-                'state': 'NOT_RUNNING',
-            },
-            {
-                'statuses': [{'timestamp': '1457110106'}],
-                'state': 'NOT_RUNNING',
-            },
-            {
-                'statuses': [{'timestamp': '1457110226'}],
-                'state': 'NOT_RUNNING',
-            },
-        ]
-
-        assert mesos_tools.get_non_running_tasks_from_active_frameworks(123) == expected
-
-
 @mark.parametrize('test_case', [
     [False, 0],
-    [True, 2]
+    [True, 4]
 ])
 def test_status_mesos_tasks_verbose(test_case):
     tail_stdstreams, expected_format_tail_call_count = test_case
@@ -100,7 +66,20 @@ def test_status_mesos_tasks_verbose(test_case):
         format_stdstreams_tail_for_task_patch,
     ):
         get_running_mesos_tasks_patch.return_value = ['doing a lap']
-        get_non_running_mesos_tasks_patch.return_value = ['eating a burrito']
+        get_non_running_mesos_tasks_patch.return_value = [
+            {
+                'statuses': [{'timestamp': '1457109986'}],
+                'state': 'NOT_RUNNING',
+            },
+            {
+                'statuses': [{'timestamp': '1457110226'}],
+                'state': 'NOT_RUNNING',
+            },
+            {
+                'statuses': [{'timestamp': '1457110106'}],
+                'state': 'NOT_RUNNING',
+            },
+        ]
         format_running_mesos_task_row_patch.return_value = ['id', 'host', 'mem', 'cpu', 'disk', 'time']
         format_non_running_mesos_task_row_patch.return_value = ['id', 'host', 'time', 'state']
         format_stdstreams_tail_for_task_patch.return_value = ['tail']
@@ -113,7 +92,7 @@ def test_status_mesos_tasks_verbose(test_case):
         assert 'Running Tasks' in actual
         assert 'Non-Running Tasks' in actual
         format_running_mesos_task_row_patch.assert_called_once_with('doing a lap', get_short_task_id)
-        format_non_running_mesos_task_row_patch.assert_called_once_with('eating a burrito', get_short_task_id)
+        assert format_non_running_mesos_task_row_patch.call_count == 3
         assert format_stdstreams_tail_for_task_patch.call_count == expected_format_tail_call_count
 
 


### PR DESCRIPTION
`paasta status -v` returns the list of Non-Running Tasks in a random
order. Also it only shows the last 10, so you might see old runs but not
the more recent ones.

This change orders the not_running_tasks list by start time. Since
they're reversed in status_mesos_tasks_verbose they'll be printed from
the latest one to the oldest one.

AFAICT this script is run directly on the mesos master, so I wasn't able to really try it.