### PR TITLE
Revert "Upgrade mesos.cli for mesos 0.24.1 upgrade"

### DIFF
--- a/paasta_itests/itest_utils.py
+++ b/paasta_itests/itest_utils.py
@@ -61,7 +61,6 @@ def setup_mesos_cli_config(config_file, cluster):
         "default": {
             "master": "zk://%s/mesos-%s" % (zookeeper_service, cluster),
             "log_file": "None",
-            "response_timeout": 5,
         }
     }
     print 'Generating mesos.cli config file: %s' % config_file

--- a/paasta_itests/steps/mesos_steps.py
+++ b/paasta_itests/steps/mesos_steps.py
@@ -26,8 +26,7 @@ from paasta_tools import check_mesos_resource_utilization
 def check_mesos_utilization(context, percent):
     config = {
         "master": "%s" % get_service_connection_string('mesosmaster'),
-        "scheme": "http",
-        "response_timeout": 5,
+        "scheme": "http"
     }
 
     with contextlib.nested(

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -81,7 +81,6 @@ def _generate_mesos_cli_config(zk_host_and_port):
             'master': zk_host_and_port,
             'log_level': 'warning',
             'log_file': 'None',
-            'response_timeout': 5,
         }
     }
     return config

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -322,7 +322,7 @@ def get_number_of_mesos_masters(zk_config):
     zk = KazooClient(hosts=zk_config['hosts'], read_only=True)
     zk.start()
     root_entries = zk.get_children(zk_config['path'])
-    result = [info for info in root_entries if info.startswith('json.info_') or info.startswith('info_')]
+    result = [info for info in root_entries if info.startswith('info_')]
     zk.stop()
     return len(result)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ kazoo==2.2
 lockfile==0.9.1
 marathon==0.7.6
 mccabe==0.3.1
-mesos.cli==0.1.5
+mesos.cli==0.1.3
 mesos.interface==0.23.1
 ordereddict==1.1
 path.py==8.1

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'jsonschema',
         'kazoo >= 2.0.0',
         'marathon >= 0.7.5',
-        'mesos.cli == 0.1.5',
+        'mesos.cli == 0.1.3',
         'ordereddict >= 1.1',
         'path.py >= 8.1',
         'pysensu-yelp >= 0.2.2',

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -187,7 +187,7 @@ def test_get_number_of_mesos_masters(
     fake_zk_config = {'hosts': '1.1.1.1', 'path': 'fake_path'}
 
     zk = mock_kazoo.return_value
-    zk.get_children.return_value = ['log_11', 'state', 'json.info_1', 'info_2']
+    zk.get_children.return_value = ['log_11', 'state', 'info_1', 'info_2']
     assert mesos_tools.get_number_of_mesos_masters(fake_zk_config) == 2
 
 

--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install mesos=0.24.1-0.2.35.ubuntu1404
+RUN apt-get update && apt-get -y install mesos=0.23.1-0.2.61.ubuntu1404
 
 RUN apt-get -y install chronos=2.4.0-0.1.20151007110204.ubuntu1404
 # Chronos will look in here for zk config, so we blow away the bogus defaults

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install mesos=0.24.1-0.2.35.ubuntu1404
+RUN apt-get update && apt-get -y install mesos=0.23.1-0.2.61.ubuntu1404
 
 # Install Java 8 PPA
 RUN apt-get install -y software-properties-common

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -15,4 +15,4 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install mesos=0.24.1-0.2.35.ubuntu1404
+RUN apt-get update && apt-get -y install mesos=0.23.1-0.2.61.ubuntu1404


### PR DESCRIPTION
This reverts commit 28ebb20a109d7539989d1cbc639acdd25b540f61.

Conflicts:
	paasta_tools/mesos_tools.py
	tests/test_mesos_tools.py