### PR TITLE
Added 'framework' to the ServiceConfig objects

### DIFF
--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -181,6 +181,7 @@ class ChronosJobConfig(InstanceConfig):
             config_dict=config_dict,
             branch_dict=branch_dict,
         )
+        self.framework = 'chronos'
 
     def get_service(self):
         return self.service

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -174,6 +174,7 @@ class MarathonServiceConfig(InstanceConfig):
             config_dict=config_dict,
             branch_dict=branch_dict,
         )
+        self.framework = 'marathon'
 
     def __repr__(self):
         return "MarathonServiceConfig(%r, %r, %r, %r, %r)" % (

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -73,6 +73,7 @@ class InstanceConfig(dict):
         self.cluster = cluster
         self.instance = instance
         self.service = service
+        self.framework = None
         config_interpolation_keys = ('deploy_group',)
         interpolation_facts = self.__get_interpolation_facts()
         for key in config_interpolation_keys:
@@ -94,6 +95,9 @@ class InstanceConfig(dict):
 
     def get_service(self):
         return self.service
+
+    def get_framework(self):
+        return self.framework
 
     def get_branch(self):
         return SPACER.join((self.get_cluster(), self.get_instance()))

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -196,6 +196,7 @@ class TestChronosTools:
                                                                        self.fake_cluster,
                                                                        soa_dir=fake_soa_dir)
             assert actual == self.fake_chronos_job_config
+            assert actual.get_framework() == 'chronos'
 
     def test_load_chronos_job_config_can_ignore_deployments(self):
         fake_soa_dir = '/tmp/'

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -92,15 +92,16 @@ class TestMarathonTools:
             mock_read_extra_service_information,
         ):
             mock_read_extra_service_information.return_value = {fake_instance: {}}
-            marathon_tools.load_marathon_service_config(
-                fake_name,
-                fake_instance,
-                fake_cluster,
+            actual = marathon_tools.load_marathon_service_config(
+                service=fake_name,
+                instance=fake_instance,
+                cluster=fake_cluster,
                 soa_dir=fake_dir,
             )
             assert mock_read_service_configuration.call_count == 1
             assert mock_read_extra_service_information.call_count == 1
             mock_load_deployments_json.assert_called_once_with(fake_name, soa_dir=fake_dir)
+            assert actual.get_framework() == 'marathon'
 
     def test_load_marathon_service_config_bails_with_no_config(self):
         fake_name = 'jazz'


### PR DESCRIPTION
Right now we end up loading a config object and then storing how we ended up loading it (marathon vs chronos)

There are a couple places in our code where it would be easier for us to "just asked" the config object what framework it is for, so we can adjust say, or local-run behavior or the message we print for help in paasta stop, etc.