### PR TITLE
Allow paasta to use docker http api

### DIFF
--- a/general_itests/environment.py
+++ b/general_itests/environment.py
@@ -13,16 +13,13 @@
 # limitations under the License.
 import shutil
 
-from docker import Client
-
-from paasta_tools.utils import get_docker_host
+from paasta_tools.utils import get_docker_client
 
 
 def after_scenario(context, scenario):
     if getattr(context, "tmpdir", None):
         shutil.rmtree(context.tmpdir)
     if getattr(context, "running_container_id", None):
-        base_docker_url = get_docker_host()
-        docker_client = Client(base_url=base_docker_url)
+        docker_client = get_docker_client()
         docker_client.stop(container=context.running_container_id)
         docker_client.remove_container(container=context.running_container_id)

--- a/general_itests/steps/paasta_execute_docker_command.py
+++ b/general_itests/steps/paasta_execute_docker_command.py
@@ -14,17 +14,15 @@
 from behave import given
 from behave import then
 from behave import when
-from docker import Client
 from docker.errors import APIError
 
 from paasta_tools.utils import _run
-from paasta_tools.utils import get_docker_host
+from paasta_tools.utils import get_docker_client
 
 
 @given(u'Docker is available')
 def docker_is_available(context):
-    base_docker_url = get_docker_host()
-    docker_client = Client(base_url=base_docker_url)
+    docker_client = get_docker_client()
     assert docker_client.ping()
     context.docker_client = docker_client
 

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -24,7 +24,6 @@ from urlparse import urlparse
 
 import requests
 import service_configuration_lib
-from docker import Client
 from docker import errors
 
 from paasta_tools.cli.cmds.check import makefile_responds_to
@@ -40,7 +39,7 @@ from paasta_tools.marathon_tools import CONTAINER_PORT
 from paasta_tools.marathon_tools import get_healthcheck_for_instance
 from paasta_tools.paasta_execute_docker_command import execute_in_container
 from paasta_tools.utils import _run
-from paasta_tools.utils import get_docker_host
+from paasta_tools.utils import get_docker_client
 from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_username
 from paasta_tools.utils import list_clusters
@@ -659,8 +658,7 @@ def paasta_local_run(args):
     service = figure_out_service_name(args, soa_dir=args.yelpsoa_config_root)
     cluster = guess_cluster(service=service, args=args)
     instance = guess_instance(service=service, cluster=cluster, args=args)
-    base_docker_url = get_docker_host()
-    docker_client = Client(base_url=base_docker_url)
+    docker_client = get_docker_client()
 
     if build:
         default_tag = 'paasta-local-run-%s-%s' % (service, get_username())

--- a/paasta_tools/contrib/kill_orphaned_docker_containers.py
+++ b/paasta_tools/contrib/kill_orphaned_docker_containers.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 import argparse
 
-from docker import Client
-
 from paasta_tools import mesos_tools
-from paasta_tools.utils import get_docker_host
+from paasta_tools.utils import get_docker_client
 
 
 def parse_args():
@@ -30,11 +28,6 @@ def get_running_task_ids_from_mesos_slave():
 def get_running_mesos_docker_containers(client):
     running_containers = client.containers()
     return [container for container in running_containers if "mesos-" in container["Names"][0]]
-
-
-def get_docker_client():
-    base_docker_url = get_docker_host()
-    return Client(base_url=base_docker_url)
 
 
 def main():

--- a/paasta_tools/paasta_execute_docker_command.py
+++ b/paasta_tools/paasta_execute_docker_command.py
@@ -30,10 +30,8 @@ import signal
 import sys
 from contextlib import contextmanager
 
-from docker import Client
-
 from paasta_tools.mesos_tools import get_container_id_for_mesos_id
-from paasta_tools.utils import get_docker_host
+from paasta_tools.utils import get_docker_client
 
 
 def parse_args():
@@ -84,8 +82,7 @@ def main():
             "The Mesos task id you supplied seems to be an empty string! Please provide a valid task id.\n")
         sys.exit(2)
 
-    base_docker_url = get_docker_host()
-    docker_client = Client(base_url=base_docker_url)
+    docker_client = get_docker_client()
 
     container_id = get_container_id_for_mesos_id(docker_client, args.mesos_id)
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -38,6 +38,9 @@ import dateutil.tz
 import docker
 import service_configuration_lib
 import yaml
+from docker import Client
+from docker.utils import kwargs_from_env
+
 
 # DO NOT CHANGE SPACER, UNLESS YOU'RE PREPARED TO CHANGE ALL INSTANCES
 # OF IT IN OTHER LIBRARIES (i.e. service_configuration_lib).
@@ -982,6 +985,14 @@ def parse_yaml_file(yaml_file):
 
 def get_docker_host():
     return os.environ.get('DOCKER_HOST', 'unix://var/run/docker.sock')
+
+
+def get_docker_client():
+    client_opts = kwargs_from_env(assert_hostname=False)
+    if 'base_url' in client_opts:
+        return Client(**client_opts)
+    else:
+        return Client(base_url=get_docker_host(), **client_opts)
 
 
 class TimeoutError(Exception):

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -370,7 +370,7 @@ def test_configure_and_run_pulls_image_when_asked(
 
 @mock.patch('paasta_tools.cli.cmds.local_run.figure_out_service_name', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.configure_and_run_docker_container', autospec=True)
-@mock.patch('paasta_tools.cli.cmds.local_run.Client', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.local_run.get_docker_client', spec_set=docker.Client)
 @mock.patch('paasta_tools.cli.cmds.cook_image.validate_service_name', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.cook_image.makefile_responds_to', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.cook_image._run', autospec=True)

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ commands = ./build-manpages.sh
 [testenv:paasta_itests]
 basepython = python2.7
 changedir=paasta_itests/
+passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
 deps =
     docker-compose==1.3.0
 commands =
@@ -85,6 +86,7 @@ commands =
 [testenv:general_itests]
 basepython = python2.7
 changedir=general_itests/
+passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
 deps =
     {[testenv]deps}
     behave==1.2.4


### PR DESCRIPTION
Fixes #287 and also enables us to use TLS in the future to secure Docker's api