### PR TITLE
Add stdout/err tail snippet to paasta status -vv (PAASTA-3268)

### DIFF
--- a/general_itests/steps/paasta_execute_docker_command.py
+++ b/general_itests/steps/paasta_execute_docker_command.py
@@ -51,7 +51,7 @@ def create_docker_container(context, task_id, image_name):
 def run_command_in_container(context, code, task_id):
     cmd = '../paasta_tools/paasta_execute_docker_command.py -i %s -c "exit %s"' % (task_id, code)
     print 'Running cmd %s' % cmd
-    (exit_code, output) = _run(cmd)
+    exit_code, output = _run(cmd)
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
     context.return_code = exit_code
 

--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -34,6 +34,14 @@ Feature: paasta_serviceinit
       And we wait for the chronos job stored as "myjob" to appear in the job list
      Then paasta_serviceinit status --verbose for the service_instance "testservice.testinstance" exits with return code 0 and the correct output
 
+  Scenario: paasta_serviceinit can run status -vv to tail a mesos task stdout/stderr
+    Given a working paasta cluster
+      And I have yelpsoa-configs for the marathon job "test-service.main"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
+     When we run the marathon app "test-service.main"
+      And we wait for it to be deployed
+     Then paasta_serviceinit status -vv for the service_instance "test-service.main" exits with return code 0 and the correct output
+
   Scenario: paasta_serviceinit can run emergency-stop on an enabled chronos job
     Given a working paasta cluster
       And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"

--- a/paasta_itests/steps/cleanup_chronos_job_steps.py
+++ b/paasta_itests/steps/cleanup_chronos_job_steps.py
@@ -79,7 +79,7 @@ def launch_non_paasta_jobs(context, num_jobs):
 def check_cleanup_chronos_jobs_output(context, expected_return_code):
     cmd = '../paasta_tools/cleanup_chronos_jobs.py --soa-dir %s' % context.soa_dir
     print cmd
-    (exit_code, output) = _run(cmd)
+    exit_code, output = _run(cmd)
     print context.unconfigured_job_names
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
 

--- a/paasta_itests/steps/paasta_metastatus_steps.py
+++ b/paasta_itests/steps/paasta_metastatus_steps.py
@@ -69,7 +69,7 @@ def check_metastatus_return_code_with_flags(context, flags, expected_return_code
     env = dict(os.environ)
     env['MESOS_CLI_CONFIG'] = context.mesos_cli_config_filename
     print 'Running cmd %s with MESOS_CLI_CONFIG=%s' % (cmd, env['MESOS_CLI_CONFIG'])
-    (exit_code, output) = _run(cmd, env=env)
+    exit_code, output = _run(cmd, env=env)
 
     # we don't care about the colouring here, so remove any ansi escape sequences
     escaped_output = remove_ansi_escape_sequences(output)

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -110,6 +110,22 @@ def chronos_status_verbose_returns_healthy(context, service_instance):
     assert "Running Tasks:" in output
 
 
+@then((u'paasta_serviceinit status -vv for the service_instance "{service_instance}"'
+       ' exits with return code 0 and the correct output'))
+def paasta_serviceinit_tail_stdstreams(context, service_instance):
+    cmd = "../paasta_tools/paasta_serviceinit.py --soa-dir %s %s status -vv" % (context.soa_dir, service_instance)
+    print 'Running cmd %s' % cmd
+    (exit_code, output) = _run(cmd)
+    print 'Got exitcode %s with output:\n%s' % (exit_code, output)
+    print  # sacrificial line for behave to eat instead of our output
+
+    assert exit_code == 0
+    # The container we run doesn't really have a stdout/stderr. The message below
+    # comes from mesos.cli, proving that paasta_serviceinit tried to read stdout/sdterr,
+    # caught the Exception and presented the right information to the user.
+    assert "No such task has the requested file or directory" in output
+
+
 @when(u'we paasta_serviceinit emergency-stop the service_instance "{service_instance}"')
 def chronos_emergency_stop_job(context, service_instance):
     cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s %s stop' % (context.soa_dir, service_instance)

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -88,7 +88,7 @@ def marathon_restart_gets_new_task_ids(context, job_id):
 def chronos_status_returns_healthy(context, service_instance):
     cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s %s status' % (context.soa_dir, service_instance)
     print 'Running cmd %s' % cmd
-    (exit_code, output) = _run(cmd)
+    exit_code, output = _run(cmd)
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
     print  # sacrificial line for behave to eat instead of our output
 
@@ -102,7 +102,7 @@ def chronos_status_returns_healthy(context, service_instance):
 def chronos_status_verbose_returns_healthy(context, service_instance):
     cmd = "../paasta_tools/paasta_serviceinit.py --soa-dir %s %s status --verbose" % (context.soa_dir, service_instance)
     print 'Running cmd %s' % cmd
-    (exit_code, output) = _run(cmd)
+    exit_code, output = _run(cmd)
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
     print  # sacrificial line for behave to eat instead of our output
 
@@ -115,7 +115,7 @@ def chronos_status_verbose_returns_healthy(context, service_instance):
 def paasta_serviceinit_tail_stdstreams(context, service_instance):
     cmd = "../paasta_tools/paasta_serviceinit.py --soa-dir %s %s status -vv" % (context.soa_dir, service_instance)
     print 'Running cmd %s' % cmd
-    (exit_code, output) = _run(cmd)
+    exit_code, output = _run(cmd)
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
     print  # sacrificial line for behave to eat instead of our output
 
@@ -130,7 +130,7 @@ def paasta_serviceinit_tail_stdstreams(context, service_instance):
 def chronos_emergency_stop_job(context, service_instance):
     cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s %s stop' % (context.soa_dir, service_instance)
     print 'Running cmd %s' % cmd
-    (exit_code, output) = _run(cmd)
+    exit_code, output = _run(cmd)
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
     print  # sacrificial line for behave to eat instead of our output
 
@@ -141,7 +141,7 @@ def chronos_emergency_stop_job(context, service_instance):
 def chronos_emergency_start_job(context, service_instance):
     cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s %s start' % (context.soa_dir, service_instance)
     print 'Running cmd %s' % cmd
-    (exit_code, output) = _run(cmd)
+    exit_code, output = _run(cmd)
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
     print  # sacrificial line for behave to eat instead of our output
 
@@ -152,7 +152,7 @@ def chronos_emergency_start_job(context, service_instance):
 def chronos_emergency_restart_job(context):
     cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s test-service.job restart' % context.soa_dir
     print 'Running cmd %s' % cmd
-    (exit_code, output) = _run(cmd)
+    exit_code, output = _run(cmd)
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
     print  # sacrificial line for behave to eat instead of our output
 
@@ -163,7 +163,7 @@ def chronos_emergency_restart_job(context):
 def paasta_serviceinit_command(context, command, job_id):
     cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s %s %s' % (context.soa_dir, job_id, command)
     print 'Running cmd %s' % cmd
-    (exit_code, output) = _run(cmd)
+    exit_code, output = _run(cmd)
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
     print  # sacrificial line for behave to eat instead of our output
 
@@ -177,7 +177,7 @@ def paasta_serviceinit_command_appid(context, command, job_id):
     cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s --appid %s %s %s' \
           % (context.soa_dir, app_id, job_id, command)
     print 'Running cmd %s' % cmd
-    (exit_code, output) = _run(cmd)
+    exit_code, output = _run(cmd)
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
     print  # sacrificial line for behave to eat instead of our output
 
@@ -189,7 +189,7 @@ def paasta_serviceinit_command_scale(context, delta, job_id):
     cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s %s scale --delta %s' \
           % (context.soa_dir, job_id, delta)
     print 'Running cmd %s' % cmd
-    (exit_code, output) = _run(cmd)
+    exit_code, output = _run(cmd)
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
     print  # sacrificial line for behave to eat instead of our output
 

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -225,7 +225,7 @@ def _format_mesos_status(job, running_tasks):
     return mesos_status
 
 
-def format_chronos_job_status(job, running_tasks, verbose):
+def format_chronos_job_status(job, running_tasks, verbose=0):
     """Given a job, returns a pretty-printed human readable output regarding
     the status of the job.
 

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -232,7 +232,7 @@ def format_chronos_job_status(job, running_tasks, verbose):
     :param job: dictionary of the job status
     :param running_tasks: a list of Mesos tasks associated with ``job``, e.g. the
                           result of ``mesos_tools.get_running_tasks_from_active_frameworks()``.
-
+    :param verbose: int verbosity level
     """
     config_hash = _format_config_hash(job)
     disabled_state = _format_disabled_status(job)
@@ -245,8 +245,9 @@ def format_chronos_job_status(job, running_tasks, verbose):
 
     command = _format_command(job)
     mesos_status = _format_mesos_status(job, running_tasks)
-    if verbose:
-        mesos_status_verbose = status_mesos_tasks_verbose(job["name"], get_short_task_id)
+    if verbose > 0:
+        tail_stdstreams = verbose > 1
+        mesos_status_verbose = status_mesos_tasks_verbose(job["name"], get_short_task_id, tail_stdstreams)
         mesos_status = "%s\n%s" % (mesos_status, mesos_status_verbose)
     return (
         "Config:     %(config_hash)s\n"
@@ -274,6 +275,7 @@ def status_chronos_jobs(jobs, job_config, verbose):
         client
     :param job_config: dict containing configuration about these jobs as
         provided by chronos_tools.load_chronos_job_config().
+    :param verbose: int verbosity level
     """
     if jobs == []:
         return "%s: chronos job is not set up yet" % PaastaColors.yellow("Warning")
@@ -345,7 +347,7 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir):
             cluster=cluster,
             soa_dir=soa_dir,
         )
-        print status_chronos_jobs(sorted_matching_jobs, job_config, verbose > 0)
+        print status_chronos_jobs(sorted_matching_jobs, job_config, verbose)
     else:
         # The command parser shouldn't have let us get this far...
         raise NotImplementedError("Command %s is not implemented!" % command)

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -288,6 +288,14 @@ def status_chronos_jobs(jobs, job_config, verbose):
 
 
 def perform_command(command, service, instance, cluster, verbose, soa_dir):
+    """Performs a start/stop/restart/status on an instance
+    :param command: String of start, stop, restart, status or scale
+    :param service: service name
+    :param instance: instance name, like "main" or "canary"
+    :param cluster: cluster name
+    :param verbose: int verbosity level
+    :returns: A unix-style return code
+    """
     chronos_config = chronos_tools.load_chronos_config()
     client = chronos_tools.get_chronos_client(chronos_config)
     complete_job_config = chronos_tools.create_complete_config(service, instance, soa_dir=soa_dir)
@@ -337,7 +345,7 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir):
             cluster=cluster,
             soa_dir=soa_dir,
         )
-        print status_chronos_jobs(sorted_matching_jobs, job_config, verbose)
+        print status_chronos_jobs(sorted_matching_jobs, job_config, verbose > 0)
     else:
         # The command parser shouldn't have let us get this far...
         raise NotImplementedError("Command %s is not implemented!" % command)

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -46,9 +46,9 @@ def add_subparser(subparsers):
     )
     status_parser.add_argument(
         '-v', '--verbose',
-        action='store_true',
+        action='count',
         dest="verbose",
-        default=False,
+        default=0,
         help="Print out more output regarding the state of the service")
     status_parser.add_argument(
         '-s', '--service',
@@ -119,7 +119,7 @@ def get_actual_deployments(service):
     return actual_deployments
 
 
-def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployments, instance_whitelist, verbose=False):
+def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployments, instance_whitelist, verbose=0):
     """With a given service and cluster, prints the status of the instances
     in that cluster"""
     print
@@ -172,7 +172,7 @@ def report_invalid_whitelist_values(whitelist, items, item_type):
     return return_string
 
 
-def report_status(service, deploy_pipeline, actual_deployments, cluster_whitelist, instance_whitelist, verbose=False):
+def report_status(service, deploy_pipeline, actual_deployments, cluster_whitelist, instance_whitelist, verbose=0):
     pipeline_url = get_pipeline_url(service)
     print "Pipeline: %s" % pipeline_url
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -49,7 +49,8 @@ def add_subparser(subparsers):
         action='count',
         dest="verbose",
         default=0,
-        help="Print out more output regarding the state of the service")
+        help="Print out more output regarding the state of the service. "
+             "A second -v will also print the stdout/stderr tail.")
     status_parser.add_argument(
         '-s', '--service',
         help='The name of the service you wish to inspect'

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -475,8 +475,8 @@ def check_ssh_and_sudo_on_master(master, timeout=10):
 
 def run_paasta_serviceinit(subcommand, master, service, instancename, cluster, **kwargs):
     """Run 'paasta_serviceinit <subcommand>'. Return the output from running it."""
-    if 'verbose' in kwargs and kwargs['verbose']:
-        verbose_flag = "-v "
+    if 'verbose' in kwargs and kwargs['verbose'] > 0:
+        verbose_flag = '-v ' * kwargs['verbose']
         timeout = 240
     else:
         verbose_flag = ''

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -324,7 +324,7 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir, app_i
     :param service: service name
     :param instance: instance name, like "main" or "canary"
     :param cluster: cluster name
-    :param verbose: bool if the output should be verbose or not
+    :param verbose: int verbosity level
     :returns: A unix-style return code
     """
     marathon_config = marathon_tools.load_marathon_config()
@@ -357,10 +357,10 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir, app_i
         print status_desired_state(service, instance, client, job_config)
         print status_marathon_job(service, instance, app_id, normal_instance_count, client)
         tasks, out = status_marathon_job_verbose(service, instance, client)
-        if verbose:
+        if verbose > 0:
             print out
         print status_mesos_tasks(service, instance, normal_instance_count)
-        if verbose:
+        if verbose > 0:
             print status_mesos_tasks_verbose(app_id, get_short_task_id)
         if proxy_port is not None:
             print status_smartstack_backends(
@@ -371,7 +371,7 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir, app_i
                 tasks=tasks,
                 expected_count=normal_smartstack_count,
                 soa_dir=soa_dir,
-                verbose=verbose,
+                verbose=verbose > 0,
             )
     elif command == 'scale':
         scale_marathon_job(service, instance, app_id, delta, client, cluster)

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -361,7 +361,8 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir, app_i
             print out
         print status_mesos_tasks(service, instance, normal_instance_count)
         if verbose > 0:
-            print status_mesos_tasks_verbose(app_id, get_short_task_id)
+            tail_stdstreams = verbose > 1
+            print status_mesos_tasks_verbose(app_id, get_short_task_id, tail_stdstreams)
         if proxy_port is not None:
             print status_smartstack_backends(
                 service=service,

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -291,7 +291,8 @@ def zip_tasks_verbose_output(table, stdstreams):
     :param table: a formatted list of tasks
     :param stdstreams: for each task, a list of lines from stdout/stderr tail
     """
-    assert len(table) == len(stdstreams)
+    if len(table) != len(stdstreams):
+        raise ValueError('Can only zip same-length lists')
     output = []
     for i in xrange(len(table)):
         output.append(table[i])

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -256,16 +256,16 @@ def format_stdstreams_tail_for_task(task, get_short_task_id, nlines=10):
     error_message = PaastaColors.red("      couldn't read stdout/stderr for %s (%s)")
     output = []
     try:
-        fobjs = list(mesos.cli.cluster.files(flist=['stdout', 'stderr'], fltr=task['id']))
-        fobjs.sort(key=lambda fobj: fobj[0].path, reverse=True)
+        fobjs = list(mesos.cli.cluster.files(lambda x: x, flist=['stdout', 'stderr'], fltr=task['id']))
+        fobjs.sort(key=lambda fobj: fobj.path, reverse=True)
         if not fobjs:
             output.append(PaastaColors.blue("      no stdout/stderrr for %s" % get_short_task_id(task['id'])))
             return output
         for fobj in fobjs:
-            output.append(PaastaColors.blue("      %s tail for %s" % (fobj[0].path, get_short_task_id(task['id']))))
+            output.append(PaastaColors.blue("      %s tail for %s" % (fobj.path, get_short_task_id(task['id']))))
             # read nlines, starting from EOF
             # mesos.cli is smart and can efficiently read a file backwards
-            reversed_file = reversed(fobj[0])
+            reversed_file = reversed(fobj)
             tail = []
             for _ in xrange(nlines):
                 line = next(reversed_file, None)
@@ -275,7 +275,7 @@ def format_stdstreams_tail_for_task(task, get_short_task_id, nlines=10):
             # reverse the tail, so that EOF is at the bottom again
             if tail:
                 output.extend(tail[::-1])
-            output.append(PaastaColors.blue("      %s EOF" % fobj[0].path))
+            output.append(PaastaColors.blue("      %s EOF" % fobj.path))
     except (MasterNotAvailableException,
             SlaveNotAvailableException,
             TaskNotFoundException,

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -256,26 +256,26 @@ def format_stdstreams_tail_for_task(task, get_short_task_id, nlines=10):
     error_message = PaastaColors.red("      couldn't read stdout/stderr for %s (%s)")
     output = []
     try:
-        for stream in ['stdout', 'stderr']:
-            fobjs = mesos.cli.cluster.files(flist=[stream], fltr=task['id'])
-            if not fobjs:
-                output.append(PaastaColors.blue("      no stdout/stderrr for %s" % get_short_task_id(task['id'])))
-                return output
-            for fobj in fobjs:
-                output.append(PaastaColors.blue("      %s tail for %s" % (fobj[0].path, get_short_task_id(task['id']))))
-                # read nlines, starting from EOF
-                # mesos.cli is smart and can efficiently read a file backwards
-                reversed_file = reversed(fobj[0])
-                tail = []
-                for _ in xrange(nlines):
-                    line = next(reversed_file, None)
-                    if line is None:
-                        break
-                    tail.append(line)
-                # reverse the tail, so that EOF is at the bottom again
-                if tail:
-                    output.extend(tail[::-1])
-                output.append(PaastaColors.blue("      %s EOF" % fobj[0].path))
+        fobjs = list(mesos.cli.cluster.files(flist=['stdout', 'stderr'], fltr=task['id']))
+        fobjs.sort(key=lambda fobj: fobj[0].path, reverse=True)
+        if not fobjs:
+            output.append(PaastaColors.blue("      no stdout/stderrr for %s" % get_short_task_id(task['id'])))
+            return output
+        for fobj in fobjs:
+            output.append(PaastaColors.blue("      %s tail for %s" % (fobj[0].path, get_short_task_id(task['id']))))
+            # read nlines, starting from EOF
+            # mesos.cli is smart and can efficiently read a file backwards
+            reversed_file = reversed(fobj[0])
+            tail = []
+            for _ in xrange(nlines):
+                line = next(reversed_file, None)
+                if line is None:
+                    break
+                tail.append(line)
+            # reverse the tail, so that EOF is at the bottom again
+            if tail:
+                output.extend(tail[::-1])
+            output.append(PaastaColors.blue("      %s EOF" % fobj[0].path))
     except (MasterNotAvailableException,
             SlaveNotAvailableException,
             TaskNotFoundException,

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -40,7 +40,8 @@ def parse_args():
         description='Runs start/stop/restart/status/scale on a PaaSTA service in a given cluster.',
     )
     parser.add_argument('-v', '--verbose', action='count', dest="verbose", default=0,
-                        help="Print out more output regarding the state of the service")
+                        help="Print out more output regarding the state of the service. "
+                             "Multiple -v options increase verbosity. Maximum is 2.")
     parser.add_argument('-D', '--debug', action='store_true', dest="debug", default=False,
                         help="Output debug logs regarding files, connections, etc")
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -39,7 +39,7 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description='Runs start/stop/restart/status/scale on a PaaSTA service in a given cluster.',
     )
-    parser.add_argument('-v', '--verbose', action='store_true', dest="verbose", default=False,
+    parser.add_argument('-v', '--verbose', action='count', dest="verbose", default=0,
                         help="Print out more output regarding the state of the service")
     parser.add_argument('-D', '--debug', action='store_true', dest="debug", default=False,
                         help="Output debug logs regarding files, connections, etc")
@@ -88,7 +88,7 @@ def main():
             service=service,
             instance=instance,
             cluster=cluster,
-            verbose=args.verbose,
+            verbose=args.verbose > 0,
             soa_dir=args.soa_dir,
         )
         sys.exit(return_code)

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -89,7 +89,7 @@ def main():
             service=service,
             instance=instance,
             cluster=cluster,
-            verbose=args.verbose > 0,
+            verbose=args.verbose,
             soa_dir=args.soa_dir,
         )
         sys.exit(return_code)

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -16,6 +16,7 @@ from StringIO import StringIO
 from mock import MagicMock
 from mock import Mock
 from mock import patch
+from pytest import mark
 from pytest import raises
 
 from paasta_tools import utils
@@ -241,6 +242,7 @@ def test_print_cluster_status_missing_deploys_in_red(
     assert expected_output in output
 
 
+@mark.parametrize('verbosity_level', [0, 2])
 @patch('paasta_tools.cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
 @patch('paasta_tools.cli.cmds.status.report_invalid_whitelist_values', autospec=True)
 @patch('sys.stdout', new_callable=StringIO)
@@ -248,6 +250,7 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
     mock_stdout,
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
+    verbosity_level,
 ):
     service = 'fake_service'
     planned_deployments = [
@@ -268,10 +271,11 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
         deploy_pipeline=planned_deployments,
         actual_deployments=actual_deployments,
         instance_whitelist=instance_whitelist,
+        verbose=verbosity_level,
     )
     assert mock_execute_paasta_serviceinit_on_remote_master.call_count == 1
     mock_execute_paasta_serviceinit_on_remote_master.assert_any_call(
-        'status', 'a_cluster', service, 'a_instance', verbose=False)
+        'status', 'a_cluster', service, 'a_instance', verbose=verbosity_level)
 
     output = mock_stdout.getvalue()
     assert expected_output in output
@@ -435,7 +439,7 @@ def test_status_calls_sergeants(
         actual_deployments=actual_deployments,
         cluster_whitelist=[],
         instance_whitelist=[],
-        verbose=False,
+        verbose=0,
     )
 
 
@@ -485,7 +489,7 @@ def test_report_status_obeys_cluster_whitelist(
         deploy_pipeline=deploy_pipeline,
         actual_deployments=actual_deployments,
         instance_whitelist=instance_whitelist,
-        verbose=False
+        verbose=0
     )
 
 
@@ -515,7 +519,7 @@ def test_report_status_handle_none_whitelist(
         deploy_pipeline=deploy_pipeline,
         actual_deployments=actual_deployments,
         instance_whitelist=instance_whitelist,
-        verbose=False
+        verbose=0
     )
     mock_report_status_for_cluster.assert_any_call(
         service=service,
@@ -523,7 +527,7 @@ def test_report_status_handle_none_whitelist(
         deploy_pipeline=deploy_pipeline,
         actual_deployments=actual_deployments,
         instance_whitelist=instance_whitelist,
-        verbose=False
+        verbose=0
     )
     mock_report_status_for_cluster.assert_any_call(
         service=service,
@@ -531,5 +535,5 @@ def test_report_status_handle_none_whitelist(
         deploy_pipeline=deploy_pipeline,
         actual_deployments=actual_deployments,
         instance_whitelist=instance_whitelist,
-        verbose=False
+        verbose=0
     )

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -159,7 +159,24 @@ def test_run_paasta_serviceinit_status_verbose(mock_run):
         'fake_service',
         'fake_instance',
         'fake_cluster',
-        verbose=True,
+        verbose=1,
+    )
+    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY)
+    assert actual == mock_run.return_value[1]
+
+
+@patch('paasta_tools.cli.utils._run', autospec=True)
+def test_run_paasta_serviceinit_status_verbose_multi(mock_run):
+    mock_run.return_value = ('unused', 'fake_output')
+    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit -v -v -v -v fake_service.fake_instance status '
+
+    actual = utils.run_paasta_serviceinit(
+        'status',
+        'fake_master',
+        'fake_service',
+        'fake_instance',
+        'fake_cluster',
+        verbose=4,
     )
     mock_run.assert_called_once_with(expected_command, timeout=mock.ANY)
     assert actual == mock_run.return_value[1]
@@ -226,7 +243,7 @@ def test_run_paasta_serviceinit_scaling(mock_run):
         'fake_service',
         'fake_instance',
         'fake_cluster',
-        verbose=True,
+        verbose=1,
         delta=1,
     )
     mock_run.assert_called_once_with(expected_command, timeout=mock.ANY)

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -310,20 +310,22 @@ def test_format_schedule_scheduletimezone():
     assert "(Zulu) Epsilon" in actual
 
 
-def test_format_chronos_job_mesos_verbose():
+@pytest.mark.parametrize('verbosity_level', [1, 2])
+def test_format_chronos_job_mesos_verbose(verbosity_level):
     example_job = {
         'name': 'my_service my_instance gityourmom configyourdad',
         'schedule': 'foo',
     }
     running_tasks = ['slay the nemean lion']
-    verbose = True
+    tail_stdstreams = verbosity_level > 1
     with mock.patch(
         'paasta_tools.chronos_serviceinit.status_mesos_tasks_verbose',
         autospec=True,
         return_value='status_mesos_tasks_verbose output',
     ) as mock_status_mesos_tasks_verbose:
-        actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
-    mock_status_mesos_tasks_verbose.assert_called_once_with(example_job['name'], chronos_serviceinit.get_short_task_id)
+        actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbosity_level)
+    mock_status_mesos_tasks_verbose.assert_called_once_with(example_job['name'],
+                                                            chronos_serviceinit.get_short_task_id, tail_stdstreams)
     assert 'status_mesos_tasks_verbose output' in actual
 
 

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -477,9 +477,8 @@ def test_zip_tasks_verbose_output(test_case):
 ])
 def test_format_stdstreams_tail_for_task(test_case):
     def gen_mesos_cli_fobj(file_path, file_lines):
-        """mesos.cli.cluster.files (0.1.3 - newer versions differ),
-        returns a list of tuples like:
-          (mesos.cli.mesos_file.File, Bool)
+        """mesos.cli.cluster.files (0.1.5),
+        returns a list of mesos.cli.mesos_file.File
         `File` is an iterator-like object.
         """
         fake_iter = mock.MagicMock()
@@ -487,13 +486,13 @@ def test_format_stdstreams_tail_for_task(test_case):
         fobj = mock.create_autospec(mesos.cli.mesos_file.File)
         fobj.path = file_path
         fobj.__reversed__ = fake_iter
-        return (fobj, False)
+        return fobj
 
     def get_short_task_id(task_id):
         return task_id
 
     def gen_mock_cluster_files(file1, file2, raise_what):
-        def retfunc(**kwargs):
+        def retfunc(*args, **kwargs):
             # If we're asked to raise a particular exception we do so.
             # .message is set to the exception class name.
             if raise_what:

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -450,7 +450,7 @@ def test_zip_tasks_verbose_output(test_case):
     raised = False
     try:
         result = mesos_tools.zip_tasks_verbose_output(table, stdstreams)
-    except AssertionError:
+    except ValueError:
         raised = True
 
     assert raised == should_raise


### PR DESCRIPTION
`paasta status -vv` displays, for each Mesos task in the output (Marathon, Chronos, running and non-running) 10 lines from the tail of both `stdout` and `stderr`.

Happy path. `stdout`/`stderr` are purposely not indented (if they were, long lines wrapping would arguably make the output more confusing).
<img width="1195" alt="screen shot 2016-03-06 at 10 46 16 pm" src="https://cloud.githubusercontent.com/assets/615907/13558466/29dcc30e-e3fd-11e5-94cd-a67e40283d45.png">

Exceptions come from `mesos.cli`, they are trapped and displayed (`paasta status` still returns zero in that case).
<img width="1270" alt="screen shot 2016-03-06 at 10 54 15 pm" src="https://cloud.githubusercontent.com/assets/615907/13558473/3b29a064-e3fd-11e5-8314-29177ebcca05.png">
