### PR TITLE
ensure disabled flag is considered when computing config hash for chr…

### DIFF
--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -473,16 +473,16 @@ def create_complete_config(service, job_name, soa_dir=DEFAULT_SOA_DIR):
     complete_config['name'] = compose_job_id(service, job_name)
     desired_state = chronos_job_config.get_desired_state()
 
-    # we use the undocumented description field to store a hash of the chronos config.
-    # this makes it trivial to compare configs and know when to bounce.
-    complete_config['description'] = get_config_hash(complete_config)
-
     # If the job was previously stopped, we should stop the new job as well
     # NOTE this clobbers the 'disabled' param specified in the config file!
     if desired_state == 'start':
         complete_config['disabled'] = False
     elif desired_state == 'stop':
         complete_config['disabled'] = True
+
+    # we use the undocumented description field to store a hash of the chronos config.
+    # this makes it trivial to compare configs and know when to bounce.
+    complete_config['description'] = get_config_hash(complete_config)
 
     log.debug("Complete configuration for instance is: %s" % complete_config)
     return complete_config


### PR DESCRIPTION
…onos job

we *should* be considering the disabled field when deciding if a job should be enabled, otherwise ``paasta stop`` doesn't work. This fixes #283 