### PR TITLE
fixed the default autoscaling config args

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -227,7 +227,7 @@ class MarathonServiceConfig(InstanceConfig):
         default_params = {
             'method': 'default',
         }
-        return self.config_dict.get('autoscaling', default_params)
+        return dict(default_params, **self.config_dict.get('autoscaling', {}))
 
     def get_backoff_seconds(self):
         """backoff_seconds represents a penalization factor for relaunching failing tasks.


### PR DESCRIPTION
`self.config_dict.get('autoscaling', default_params)` doesn't work if `'autoscaling'` is only a partial dict -- e.g. there are two default params and `'autoscaling'` only contains one of them.