### PR TITLE
Print metastatus free resources alongside total resource capacity

### DIFF
--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import copy
 import sys
 from collections import Counter
 from collections import defaultdict
@@ -106,7 +107,7 @@ def get_extra_mesos_attribute_data(mesos_state):
             slave_attribute_mapping[slave['id']] = slave_attribute_name
             filtered_resources = filter_mesos_state_metrics(slave['resources'])
             resource_free_dict[slave_attribute_name].update(filtered_resources)
-            resource_availability_dict[slave_attribute_name] = filtered_resources
+        resource_availability_dict = copy.deepcopy(resource_free_dict)
         for framework in mesos_state.get('frameworks', []):
             for task in framework.get('tasks', []):
                 task_resources = task['resources']
@@ -260,6 +261,7 @@ def assert_extra_attribute_data(mesos_state):
             rows.append((attribute.capitalize(), 'CPU (free/total)', 'RAM (free/total)', 'Disk (free/total)'))
             for attribute_location, resources_remaining in resource_free_dict.items():
                 resources_available = resource_availability_dict[attribute_location]
+
                 rows.append((
                     attribute_location,
                     '%.2f/%.2f' % (resources_remaining['cpus'], resources_available['cpus']),

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -98,18 +98,21 @@ def get_extra_mesos_attribute_data(mesos_state):
     attributes = set().union(*(slave['attributes'].keys() for slave in mesos_state['slaves']))
 
     for attribute in attributes:
-        resource_dict = defaultdict(Counter)
+        resource_free_dict = defaultdict(Counter)
+        resource_availability_dict = dict()
         slave_attribute_mapping = {}
         for slave in mesos_state['slaves']:
             slave_attribute_name = slave['attributes'].get(attribute, 'UNDEFINED')
             slave_attribute_mapping[slave['id']] = slave_attribute_name
-            resource_dict[slave_attribute_name].update(filter_mesos_state_metrics(slave['resources']))
+            filtered_resources = filter_mesos_state_metrics(slave['resources'])
+            resource_free_dict[slave_attribute_name].update(filtered_resources)
+            resource_availability_dict[slave_attribute_name] = filtered_resources
         for framework in mesos_state.get('frameworks', []):
             for task in framework.get('tasks', []):
                 task_resources = task['resources']
                 attribute_value = slave_attribute_mapping[task['slave_id']]
-                resource_dict[attribute_value].subtract(filter_mesos_state_metrics(task_resources))
-        yield (attribute, resource_dict)
+                resource_free_dict[attribute_value].subtract(filter_mesos_state_metrics(task_resources))
+        yield (attribute, {"free": resource_free_dict, "availability": resource_availability_dict})
 
 
 def quorum_ok(masters, quorum):
@@ -251,14 +254,17 @@ def assert_extra_attribute_data(mesos_state):
     extra_attribute_data = list(get_extra_mesos_attribute_data(mesos_state))
     rows = []
     for attribute, resource_dict in extra_attribute_data:
-        if len(resource_dict.keys()) >= 2:  # filter out attributes that apply to every slave in the cluster
-            rows.append((attribute.capitalize(), 'CPU free', 'RAM free', 'Disk free'))
-            for attribute_location, resources_remaining in resource_dict.items():
+        resource_free_dict = resource_dict["free"]
+        resource_availability_dict = resource_dict["availability"]
+        if len(resource_free_dict.keys()) >= 2:  # filter out attributes that apply to every slave in the cluster
+            rows.append((attribute.capitalize(), 'CPU (free/total)', 'RAM (free/total)', 'Disk (free/total)'))
+            for attribute_location, resources_remaining in resource_free_dict.items():
+                resources_available = resource_availability_dict[attribute_location]
                 rows.append((
                     attribute_location,
-                    '%.2f' % resources_remaining['cpus'],
-                    '%.2f' % resources_remaining['mem'],
-                    '%.2f' % resources_remaining['disk'],
+                    '%.2f/%.2f' % (resources_remaining['cpus'], resources_available['cpus']),
+                    '%.2f/%.2f' % (resources_remaining['mem'], resources_available['mem']),
+                    '%.2f/%.2f' % (resources_remaining['disk'], resources_available['disk'])
                 ))
     if len(rows) == 0:
         result = ("  No slave attributes that apply to more than one slave were detected.", True)

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -584,8 +584,8 @@ def test_get_mesos_habitat_data():
                 'id': 'test-slave',
                 'hostname': 'test.somewhere.www',
                 'resources': {
-                    'cpus': 50,
-                    'disk': 200,
+                    'cpus': 75,
+                    'disk': 250,
                     'mem': 1000,
                 },
                 'attributes': {
@@ -598,7 +598,19 @@ def test_get_mesos_habitat_data():
                 'resources': {
                     'cpus': 50,
                     'disk': 200,
-                    'mem': 1000,
+                    'mem': 750,
+                },
+                'attributes': {
+                    'habitat': 'test-habitat-2',
+                },
+            },
+            {
+                'id': 'test-slave3',
+                'hostname': 'test3.somewhere.www',
+                'resources': {
+                    'cpus': 22,
+                    'disk': 201,
+                    'mem': 920,
                 },
                 'attributes': {
                     'habitat': 'test-habitat-2',

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -641,31 +641,32 @@ def test_get_mesos_habitat_data():
                 'free':
                 {
                     'test-habitat': {
-                        'cpus': 0,
-                        'disk': 100,
+                        'cpus': 25,
+                        'disk': 150,
                         'mem': 1000,
                     },
                     'test-habitat-2': {
-                        'cpus': 50,
-                        'disk': 200,
-                        'mem': 1000,
+                        'cpus': 72,
+                        'disk': 401,
+                        'mem': 1670,
                     },
                 },
                 'availability':
                     {
                     'test-habitat': {
-                        'cpus': 50,
-                        'disk': 200,
+                        'cpus': 75,
+                        'disk': 250,
                         'mem': 1000,
                     },
                     'test-habitat-2': {
-                        'cpus': 50,
-                        'disk': 200,
-                        'mem': 1000,
+                        'cpus': 72,
+                        'disk': 401,
+                        'mem': 1670,
                     },
                 }
             }
         ),
     )
     extra_mesos_habitat_data = paasta_metastatus.get_extra_mesos_attribute_data(mesos_state)
+
     assert (tuple(extra_mesos_habitat_data) == expected_free_resources)

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -626,16 +626,32 @@ def test_get_mesos_habitat_data():
         (
             'habitat',
             {
-                'test-habitat': {
-                    'cpus': 0,
-                    'disk': 100,
-                    'mem': 1000,
+                'free':
+                {
+                    'test-habitat': {
+                        'cpus': 0,
+                        'disk': 100,
+                        'mem': 1000,
+                    },
+                    'test-habitat-2': {
+                        'cpus': 50,
+                        'disk': 200,
+                        'mem': 1000,
+                    },
                 },
-                'test-habitat-2': {
-                    'cpus': 50,
-                    'disk': 200,
-                    'mem': 1000,
-                },
+                'availability':
+                    {
+                    'test-habitat': {
+                        'cpus': 50,
+                        'disk': 200,
+                        'mem': 1000,
+                    },
+                    'test-habitat-2': {
+                        'cpus': 50,
+                        'disk': 200,
+                        'mem': 1000,
+                    },
+                }
             }
         ),
     )


### PR DESCRIPTION
Add more detail to the output of paasta_metastatus. When used with the current Mesos test data, output at the moment looks like: 
```
  Habitat         CPU free  RAM free  Disk free
    test-habitat-2  50.00     1000.00   200.00
    test-habitat    0.00      1000.00   100.00
```

With this change it looks like: 
```
  Habitat         CPU (free/total)  RAM (free/total)  Disk (free/total)
    test-habitat-2  50.00/50.00       1000.00/1000.00   200.00/200.00
    test-habitat    0.00/50.00        1000.00/1000.00   100.00/200.00
```