### PR TITLE
Use authentication with mesos in itests

### DIFF
--- a/paasta_itests/docker-compose.yml
+++ b/paasta_itests/docker-compose.yml
@@ -8,7 +8,7 @@ mesosmaster:
     - 5050
   links:
     - zookeeper
-  command: 'mesos-master --zk=zk://zookeeper:2181/mesos-testcluster --registry=in_memory --quorum=1'
+  command: 'mesos-master --zk=zk://zookeeper:2181/mesos-testcluster --registry=in_memory --quorum=1 --authenticate --authenticate_slaves --credentials=/etc/mesos-secrets'
 
 mesosslave:
   build: ../yelp_package/dockerfiles/itest/mesos/
@@ -18,7 +18,7 @@ mesosslave:
     - zookeeper
   environment:
     -CLUSTER: testcluster
-  command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100"'
+  command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret'
   hostname: mesosslave.test_hostname
 
 marathon:
@@ -29,7 +29,7 @@ marathon:
     - zookeeper
   environment:
     -CLUSTER: testcluster
-  command: 'marathon --zk zk://zookeeper:2181/marathon --master zk://zookeeper:2181/mesos-testcluster --no-logger --env_vars_prefix MARATHON_'
+  command: 'marathon --zk zk://zookeeper:2181/marathon --master zk://zookeeper:2181/mesos-testcluster --no-logger --env_vars_prefix MARATHON_ --mesos_authentication_principal marathon --mesos_authentication_secret_file /etc/marathon_framework_secret'
 
 paastatools:
   build: ../yelp_package/dockerfiles/trusty/

--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install mesos=0.24.1-0.2.35.ubuntu1404
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.23.1-0.2.61.ubuntu1404
 
 RUN apt-get -y install chronos=2.4.0-0.1.20151007110204.ubuntu1404
 # Chronos will look in here for zk config, so we blow away the bogus defaults
@@ -25,6 +25,9 @@ RUN echo 8081 > /etc/chronos/conf/http_port
 RUN echo 'zk://zookeeper:2181/mesos-testcluster' > /etc/chronos/conf/master
 RUN echo 'zookeeper:2181' > /etc/chronos/conf/zk_hosts
 RUN echo '/chronos' > /etc/chronos/conf/zk_path
+RUN echo -n 'chronos' > /etc/chronos/conf/mesos_authentication_principal
+RUN echo -n 'secret3' > /etc/chronos_framework_secret
+RUN echo -n '/etc/chronos_framework_secret' > /etc/chronos/conf/mesos_authentication_secret_file
 
 CMD rsyslogd ; (/usr/bin/chronos &) ; tail -f /var/log/syslog
 

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install mesos=0.24.1-0.2.35.ubuntu1404
+RUN apt-get update && apt-get -y install mesos=0.23.1-0.2.61.ubuntu1404
 
 # Install Java 8 PPA
 RUN apt-get install -y software-properties-common
@@ -24,6 +24,8 @@ RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set
 RUN echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections
 RUN apt-get update && apt-get -y install lsb-release oracle-java8-installer
 
-RUN apt-get -y install marathon=0.11.1-1.0.432.ubuntu1404
+RUN apt-get -y install libsasl2-modules marathon=0.11.1-1.0.432.ubuntu1404
+
+RUN echo -n "secret2" > /etc/marathon_framework_secret
 
 EXPOSE 8080

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -15,4 +15,25 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install mesos=0.24.1-0.2.35.ubuntu1404
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.23.1-0.2.61.ubuntu1404
+RUN echo -n '{\n\
+  "credentials": [\n\
+    {\n\
+      "principal": "slave",\n\
+      "secret": "secret1"\n\
+    },\n\
+    {\n\
+      "principal": "marathon",\n\
+      "secret": "secret2"\n\
+    },\n\
+    {\n\
+      "principal": "chronos",\n\
+      "secret": "secret3"\n\
+    }\n\
+  ]\n\
+}' > /etc/mesos-secrets
+RUN echo -n '{\n\
+  "principal": "slave",\n\
+  "secret": "secret1"\n\
+}' > /etc/mesos-slave-secret
+RUN chmod 600 /etc/mesos-secrets


### PR DESCRIPTION
This change updates mesos/marathon/chronos to use [authentication](http://mesos.apache.org/documentation/latest/authentication/) to communicate. This more closely matches production, and it should allow us to spot issues (such as those caused by the mesos 0.24.1 upgrade) faster.

This PR also changes the itests to use mesos 0.23.1 again for the time being.