### PR TITLE
Mesos 0.24.1 Passes Tests!

### DIFF
--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.23.1-0.2.61.ubuntu1404
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.24.1-0.2.35.ubuntu1404
 
 RUN apt-get -y install chronos=2.4.0-0.1.20151007110204.ubuntu1404
 # Chronos will look in here for zk config, so we blow away the bogus defaults

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install mesos=0.23.1-0.2.61.ubuntu1404
+RUN apt-get update && apt-get -y install mesos=0.24.1-0.2.35.ubuntu1404
 
 # Install Java 8 PPA
 RUN apt-get install -y software-properties-common

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -16,24 +16,6 @@ FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
 RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.24.1-0.2.35.ubuntu1404
-RUN echo -n '{\n\
-  "credentials": [\n\
-    {\n\
-      "principal": "slave",\n\
-      "secret": "secret1"\n\
-    },\n\
-    {\n\
-      "principal": "marathon",\n\
-      "secret": "secret2"\n\
-    },\n\
-    {\n\
-      "principal": "chronos",\n\
-      "secret": "secret3"\n\
-    }\n\
-  ]\n\
-}' > /etc/mesos-secrets
-RUN echo -n '{\n\
-  "principal": "slave",\n\
-  "secret": "secret1"\n\
-}' > /etc/mesos-slave-secret
+RUN echo -n 'slave secret1\nmarathon secret2\nchronos secret3' > /etc/mesos-secrets
+RUN echo -n 'slave secret1' > /etc/mesos-slave-secret
 RUN chmod 600 /etc/mesos-secrets

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.23.1-0.2.61.ubuntu1404
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.24.1-0.2.35.ubuntu1404
 RUN echo -n '{\n\
   "credentials": [\n\
     {\n\


### PR DESCRIPTION
I finally managed to get mesos 0.24.1 to pass the tests and have marathon properly authenticate. We were getting bitten by https://issues.apache.org/jira/browse/MESOS-3560

This issue is fixed in 0.26.0 via a breaking change.