### PR TITLE
Upgrade to mesos 0.25.0

### DIFF
--- a/paasta_itests/docker-compose.yml
+++ b/paasta_itests/docker-compose.yml
@@ -18,7 +18,7 @@ mesosslave:
     - zookeeper
   environment:
     -CLUSTER: testcluster
-  command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret'
+  command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret --launcher=posix'
   hostname: mesosslave.test_hostname
 
 marathon:

--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.24.1-0.2.35.ubuntu1404
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.25.0-0.2.70.ubuntu1404
 
 RUN apt-get -y install chronos=2.4.0-0.1.20151007110204.ubuntu1404
 # Chronos will look in here for zk config, so we blow away the bogus defaults

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install mesos=0.24.1-0.2.35.ubuntu1404
+RUN apt-get update && apt-get -y install mesos=0.25.0-0.2.70.ubuntu1404
 
 # Install Java 8 PPA
 RUN apt-get install -y software-properties-common

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.24.1-0.2.35.ubuntu1404
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.25.0-0.2.70.ubuntu1404
 RUN echo -n 'slave secret1\nmarathon secret2\nchronos secret3' > /etc/mesos-secrets
 RUN echo -n 'slave secret1' > /etc/mesos-slave-secret
 RUN chmod 600 /etc/mesos-secrets


### PR DESCRIPTION
Now that I think I've sorted out all of the issues with mesos 0.24.1, it is time to upgrade to 0.25.0. I encountered one [issue](https://www.mail-archive.com/user@mesos.apache.org/msg04937.html) with this upgrade which I fixed (I will make a similar change within Puppet).

I will obviously hold off on merging this change until we are sure we have 0.24.1 working everywhere.