### PR TITLE
Use tags rather than branches for deployments

### DIFF
--- a/general_itests/deployments_json.feature
+++ b/general_itests/deployments_json.feature
@@ -2,7 +2,8 @@ Feature: Per-Service Deployments.json can be written and read back
 
     Scenario: Per-Service Deployments.json can be written and read back
        Given a test git repo is setup with commits
-	When paasta stop is run against the repo
+	When paasta mark-for-deployments is run against the repo
+	 And paasta stop is run against the repo
 	 And we generate deployments.json for that service
         Then that deployments.json can be read back correctly
 
@@ -16,9 +17,4 @@ Feature: Per-Service Deployments.json can be written and read back
 	Given a test git repo is setup with commits
 	 When paasta mark-for-deployments is run against the repo
 	 Then the repository should be correctly tagged
-
-    Scenario: generate deployments has deploy tags
-	Given a test git repo is setup with commits
-	 When paasta mark-for-deployments is run against the repo
-	  And we generate deployments.json for that service
-	Then that deployments.json can be read back correctly
+	  And the repository should not have old style branches

--- a/general_itests/deployments_json.feature
+++ b/general_itests/deployments_json.feature
@@ -16,3 +16,9 @@ Feature: Per-Service Deployments.json can be written and read back
 	Given a test git repo is setup with commits
 	 When paasta mark-for-deployments is run against the repo
 	 Then the repository should be correctly tagged
+
+    Scenario: generate deployments has deploy tags
+	Given a test git repo is setup with commits
+	 When paasta mark-for-deployments is run against the repo
+	  And we generate deployments.json for that service
+	Then that deployments.json can be read back correctly

--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -32,6 +32,7 @@ from paasta_tools.cli.cmds.mark_for_deployment import paasta_mark_for_deployment
 from paasta_tools.cli.cmds.start_stop_restart import paasta_stop
 from paasta_tools.utils import format_tag
 from paasta_tools.utils import format_timestamp
+from paasta_tools.utils import get_paasta_branch_from_deploy_group
 from paasta_tools.utils import get_paasta_tag_from_deploy_group
 from paasta_tools.utils import load_deployments_json
 
@@ -58,7 +59,7 @@ def step_impl_given(context):
     object_store.add_object(tree)
     object_store.add_object(commit)
 
-    context.test_git_repo.refs['refs/heads/paasta-test_cluster.test_instance'] = commit.id
+    context.test_git_repo.refs['refs/heads/master'] = commit.id
     context.expected_commit = commit.id
 
 
@@ -172,3 +173,10 @@ def step_impl_then_correctly_tagged(context):
     expected_formatted_tag = format_tag(expected_tag)
     assert expected_formatted_tag in context.test_git_repo.refs
     assert context.test_git_repo.refs[expected_formatted_tag] == context.expected_commit
+
+
+@then(u'the repository should not have old style branches')
+def step_impl_then_no_old_style_branches(context):
+    old_style_branch = get_paasta_branch_from_deploy_group(identifier='test_cluster.test_instance')
+    formatted_old_style_branch = 'refs/heads/%s' % old_style_branch
+    assert formatted_old_style_branch not in context.test_git_repo.refs

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -19,7 +19,6 @@ from paasta_tools import remote_git
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.utils import _log
 from paasta_tools.utils import format_tag
-from paasta_tools.utils import get_paasta_branch_from_deploy_group
 from paasta_tools.utils import get_paasta_tag_from_deploy_group
 
 
@@ -39,7 +38,7 @@ def add_subparser(subparsers):
     )
     list_parser.add_argument(
         '-u', '--git-url',
-        help='Git url for service -- where magic mark-for-deployment branches/tags are pushed',
+        help='Git url for service -- where magic mark-for-deployment tags are pushed',
         required=True,
     )
     list_parser.add_argument(
@@ -66,11 +65,10 @@ def add_subparser(subparsers):
 
 def mark_for_deployment(git_url, deploy_group, service, commit):
     """Mark a docker image for deployment"""
-    remote_branch = 'refs/heads/%s' % get_paasta_branch_from_deploy_group(identifier=deploy_group)
     tag = get_paasta_tag_from_deploy_group(identifier=deploy_group, desired_state='deploy')
     remote_tag = format_tag(tag)
     ref_mutator = remote_git.make_force_push_mutate_refs_func(
-        targets=[remote_branch, remote_tag],
+        targets=[remote_tag],
         sha=commit,
     )
     try:

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -163,6 +163,6 @@ def test_start_or_stop_bad_refs(mock_list_remote_refs, mock_get_instance_config,
         branch_dict={},
     )
     mock_list_remote_refs.return_value = {
-        "refs/heads/paasta-deliberatelyinvalidref": "70f7245ccf039d778c7e527af04eac00d261d783"}
+        "refs/tags/paasta-deliberatelyinvalidref-20160304T053919-deploy": "70f7245ccf039d778c7e527af04eac00d261d783"}
     assert start_stop_restart.paasta_start_or_stop(args, 'restart') == 1
     assert "No branches found for" in mock_stdout.getvalue()

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -76,10 +76,10 @@ def test_make_mutate_refs_func():
     )
 
     old_refs = {
-        'refs/heads/paasta-a': 'hash_for_a',
-        'refs/heads/paasta-b': 'hash_for_b',
-        'refs/heads/paasta-c': 'hash_for_c',
-        'refs/heads/paasta-d': 'hash_for_d',
+        'refs/tags/paasta-a-20160308T053933-deploy': 'hash_for_a',
+        'refs/tags/paasta-b-20160308T053933-deploy': 'hash_for_b',
+        'refs/tags/paasta-c-20160308T053933-deploy': 'hash_for_c',
+        'refs/tags/paasta-d-20160308T053933-deploy': 'hash_for_d',
     }
 
     expected = dict(old_refs)

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -41,11 +41,11 @@ def test_get_deploy_group_mappings():
     ]
 
     fake_remote_refs = {
-        'refs/heads/paasta-try_me': '123456',
+        'refs/tags/paasta-try_me-20160308T053933-deploy': '123456',
         'refs/tags/paasta-clusterB.main-123-stop': '123456',
-        'refs/heads/paasta-okay': 'ijowarg',
-        'refs/heads/paasta-no_thanks': '789009',
-        'refs/heads/paasta-nah': 'j8yiomwer',
+        'refs/tags/paasta-okay-20160308T053933-deploy': 'ijowarg',
+        'refs/tags/paasta-no_thanks-20160308T053933-deploy': '789009',
+        'refs/tags/paasta-nah-20160308T053933-deploy': 'j8yiomwer',
     }
 
     fake_old_mappings = ['']
@@ -166,8 +166,8 @@ def test_get_desired_state_understands_tags():
         'refs/tags/paasta-cluster.instance-20160202T233805-start': 'BE68473F98F619F26FD7824B8F56F9A7ABAEB860',
         'refs/tags/paasta-cluster2.someinstance-20160202T233805-start': 'D6B9A0F86DC54A132FBB7747460F53F48C9AEEAD',
         'refs/tags/paasta-cluster2.someinstance-20160205T182601-stop': '9085FD67ED1BB5FADAFA7F2AFAF8DEDEE7342711',
-        'refs/heads/paasta-cluster.instance': '4EF01B5A574B519AB546309E89F72972A33B6B75',
-        'refs/heads/paasta-cluster2.someinstance': '9085FD67ED1BB5FADAFA7F2AFAF8DEDEE7342711',
+        'refs/tags/paasta-cluster.instance-20160308T053933-deploy': '4EF01B5A574B519AB546309E89F72972A33B6B75',
+        'refs/tags/paasta-cluster2.someinstance-20160308T053933-deploy': '9085FD67ED1BB5FADAFA7F2AFAF8DEDEE7342711',
     }
     branch = 'cluster2.someinstance'
     deploy_group = branch


### PR DESCRIPTION
This change migrates us from using branches to using tags for deployments. Ever since #252 was merged, we have been creating -deploy tags in addition to the git branches. With this change, we will now actually use those tags and stop creating branches.