### PR TITLE
Allow 'paasta re.start -c' to use a list of clusters

### DIFF
--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -89,7 +89,8 @@ def step_paasta_mark_for_deployments_when(context):
 @when(u'paasta stop is run against the repo')
 def step_paasta_stop_when(context):
     fake_args = mock.MagicMock(
-        clusters='test_cluster',
+        cluster='test_cluster',
+        clusters=None,
         instance='test_instance',
         soa_dir='fake_soa_configs',
         service='fake_deployments_json_service',

--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -89,7 +89,7 @@ def step_paasta_mark_for_deployments_when(context):
 @when(u'paasta stop is run against the repo')
 def step_paasta_stop_when(context):
     fake_args = mock.MagicMock(
-        cluster='test_cluster',
+        clusters='test_cluster',
         instance='test_instance',
         soa_dir='fake_soa_configs',
         service='fake_deployments_json_service',

--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -89,8 +89,7 @@ def step_paasta_mark_for_deployments_when(context):
 @when(u'paasta stop is run against the repo')
 def step_paasta_stop_when(context):
     fake_args = mock.MagicMock(
-        cluster='test_cluster',
-        clusters=None,
+        clusters='test_cluster',
         instance='test_instance',
         soa_dir='fake_soa_configs',
         service='fake_deployments_json_service',

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -202,11 +202,14 @@ def paasta_start_or_stop(args, desired_state):
                 desired_state=desired_state,
             )
 
+    return_val = 0
     if invalid_deploy_groups:
         print "No branches found for %s in %s." % \
             (", ".join(invalid_deploy_groups), remote_refs)
-        print "Has it been deployed there yet?"
-        return 1
+        print "Has %s been deployed there yet?" % service
+        return_val = 1
+
+    return return_val
 
 
 def paasta_start(args):

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -95,8 +95,9 @@ def make_mutate_refs_func(service_config, force_bounce, desired_state):
 def log_event(service_config, desired_state):
     user = utils.get_username()
     host = socket.getfqdn()
-    line = "Issued request to change state of %s to '%s' by %s@%s" % (
-        service_config.get_instance(), desired_state, user, host)
+    line = "Issued request to change state of %s (an instance of %s) to '%s' by %s@%s" % (
+        service_config.get_instance(), service_config.get_service(),
+        desired_state, user, host)
     utils._log(
         service=service_config.get_service(),
         level='event',

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -65,7 +65,7 @@ def add_subparser(subparsers):
             '--cluster',
             choices=list_clusters(),
             help="A single cluster to view.\n"
-            " Deprecated! For example: --cluster norcal-prod. Will supersede any use of --clusters."
+            " Deprecated! For example: --cluster norcal-prod. Will override any use of --clusters."
         ).completer = lazy_choices_completer(list_clusters)
 
         status_parser.add_argument(

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -156,34 +156,34 @@ def paasta_start_or_stop(args, desired_state):
     else:
         clusters = list_clusters(service)
 
+    service_config = get_instance_config(
+        service=service,
+        cluster=clusters[0],
+        instance=instance,
+        soa_dir=soa_dir,
+        load_deployments=False,
+    )
+
+    try:
+        remote_refs = remote_git.list_remote_refs(utils.get_git_url(service))
+    except remote_git.LSRemoteException as e:
+        msg = (
+            "Error talking to the git server: %s\n"
+            "This PaaSTA command requires access to the git server to operate.\n"
+            "The git server may be down or not reachable from here.\n"
+            "Try again from somewhere where the git server can be reached, "
+            "like your developer environment."
+        ) % str(e)
+        print msg
+        return 1
+
+    if 'refs/heads/paasta-%s' % service_config.get_deploy_group() not in remote_refs:
+        print "No branches found for %s in %s." % \
+            (service_config.get_deploy_group(), remote_refs)
+        print "Has it been deployed there yet?"
+        return 1
+
     for cluster in clusters:
-        service_config = get_instance_config(
-            service=service,
-            cluster=cluster,
-            instance=instance,
-            soa_dir=soa_dir,
-            load_deployments=False,
-        )
-
-        try:
-            remote_refs = remote_git.list_remote_refs(utils.get_git_url(service))
-        except remote_git.LSRemoteException as e:
-            msg = (
-                "Error talking to the git server: %s\n"
-                "This PaaSTA command requires access to the git server to operate.\n"
-                "The git server may be down or not reachable from here.\n"
-                "Try again from somewhere where the git server can be reached, "
-                "like your developer environment."
-            ) % str(e)
-            print msg
-            return 1
-
-        if 'refs/heads/paasta-%s' % service_config.get_deploy_group() not in remote_refs:
-            print "No branches found for %s in %s." % \
-                (service_config.get_deploy_group(), remote_refs)
-            print "Has it been deployed there yet?"
-            return 1
-
         force_bounce = utils.format_timestamp(datetime.datetime.utcnow())
         issue_state_change_for_service(
             service_config=service_config,

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import datetime
 import socket
-import sys
 
 from service_configuration_lib import DEFAULT_SOA_DIR
 
@@ -61,12 +60,6 @@ def add_subparser(subparsers):
             choices=list_clusters(),
             help="A comma-separated list of clusters to view. Defaults to view all clusters.\n"
             "For example: --clusters norcal-prod,nova-prod"
-        ).completer = lazy_choices_completer(list_clusters)
-        status_parser.add_argument(
-            '--cluster',
-            choices=list_clusters(),
-            help="A single cluster to view.\n"
-            " Deprecated! For example: --cluster norcal-prod."
         ).completer = lazy_choices_completer(list_clusters)
 
         status_parser.add_argument(
@@ -160,19 +153,10 @@ def paasta_start_or_stop(args, desired_state):
     soa_dir = args.soa_dir
     service = figure_out_service_name(args=args, soa_dir=soa_dir)
 
-    if args.clusters and args.cluster:
-        print "--cluster and --clusters cannot be used at the same time"
-        return 1
-
     if args.clusters is not None:
         clusters = args.clusters.split(",")
     else:
         clusters = list_clusters(service)
-
-    if args.cluster is not None:
-        sys.stderr.write(("Warning - the use of --cluster is deprecated and will be removed in "
-                          "favour of --clusters in future versions."))
-        clusters = [args.cluster]
 
     try:
         remote_refs = remote_git.list_remote_refs(utils.get_git_url(service))

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -184,6 +184,14 @@ def paasta_start_or_stop(args, desired_state):
         return 1
 
     for cluster in clusters:
+        service_config = get_instance_config(
+            service=service,
+            cluster=cluster,
+            instance=instance,
+            soa_dir=soa_dir,
+            load_deployments=False,
+        )
+
         force_bounce = utils.format_timestamp(datetime.datetime.utcnow())
         issue_state_change_for_service(
             service_config=service_config,

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import datetime
 import socket
+import sys
 
 from service_configuration_lib import DEFAULT_SOA_DIR
 
@@ -65,7 +66,7 @@ def add_subparser(subparsers):
             '--cluster',
             choices=list_clusters(),
             help="A single cluster to view.\n"
-            " Deprecated! For example: --cluster norcal-prod. Will override any use of --clusters."
+            " Deprecated! For example: --cluster norcal-prod."
         ).completer = lazy_choices_completer(list_clusters)
 
         status_parser.add_argument(
@@ -159,14 +160,18 @@ def paasta_start_or_stop(args, desired_state):
     soa_dir = args.soa_dir
     service = figure_out_service_name(args=args, soa_dir=soa_dir)
 
+    if args.clusters and args.cluster:
+        print "--cluster and --clusters cannot be used at the same time"
+        return 1
+
     if args.clusters is not None:
         clusters = args.clusters.split(",")
     else:
         clusters = list_clusters(service)
 
     if args.cluster is not None:
-        print ("Warning - the use of --cluster is deprecated and will be removed in "
-               "favour of --clusters in future versions.")
+        sys.stderr.write(("Warning - the use of --cluster is deprecated and will be removed in "
+                          "favour of --clusters in future versions."))
         clusters = [args.cluster]
 
     try:

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -133,7 +133,6 @@ def test_stop_or_start_handle_ls_remote_failures(
     mock_stdout,
 ):
     args = mock.Mock()
-    args.cluster = None
     args.clusters = 'cluster1'
     mock_get_git_url.return_value = 'fake_git_url'
     mock_figure_out_service_name.return_value = 'fake_service'
@@ -153,7 +152,6 @@ def test_start_or_stop_bad_refs(mock_list_remote_refs, mock_get_instance_config,
 
     args = mock.Mock()
     # To suppress any messages due to Mock making everything truthy
-    args.cluster = None
     args.clusters = 'fake_cluster1,fake_cluster2'
 
     mock_figure_out_service_name.return_value = 'fake_service'

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -141,3 +141,25 @@ def test_stop_or_start_handle_ls_remote_failures(
 
     assert start_stop_restart.paasta_start_or_stop(args, 'restart') == 1
     assert "may be down" in mock_stdout.getvalue()
+
+
+@mock.patch('sys.stdout', new_callable=StringIO)
+@mock.patch('paasta_tools.cli.cmds.start_stop_restart.figure_out_service_name', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.start_stop_restart.get_instance_config', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.start_stop_restart.remote_git.list_remote_refs', autospec=True)
+def test_start_or_stop_bad_refs(mock_list_remote_refs, mock_get_instance_config,
+                                mock_figure_out_service_name, mock_stdout):
+
+    args = mock.Mock()
+
+    mock_figure_out_service_name.return_value = 'fake_service'
+    mock_get_instance_config.return_value = MarathonServiceConfig(
+        cluster='fake_cluster',
+        instance='fake_instance',
+        service='fake_service',
+        config_dict={},
+        branch_dict={},
+    )
+    mock_list_remote_refs.return_value = ["refs/heads/paasta-deliberatelyinvalidref"]
+    assert start_stop_restart.paasta_start_or_stop(args, 'restart') == 1
+    assert "No branches found for" in mock_stdout.getvalue()

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -133,6 +133,7 @@ def test_stop_or_start_handle_ls_remote_failures(
     mock_stdout,
 ):
     args = mock.Mock()
+    args.cluster = None
     args.clusters = 'cluster1'
     mock_get_git_url.return_value = 'fake_git_url'
     mock_figure_out_service_name.return_value = 'fake_service'
@@ -151,10 +152,13 @@ def test_start_or_stop_bad_refs(mock_list_remote_refs, mock_get_instance_config,
                                 mock_figure_out_service_name, mock_stdout):
 
     args = mock.Mock()
+    # To suppress any messages due to Mock making everything truthy
+    args.cluster = None
+    args.clusters = 'fake_cluster1,fake_cluster2'
 
     mock_figure_out_service_name.return_value = 'fake_service'
     mock_get_instance_config.return_value = MarathonServiceConfig(
-        cluster='fake_cluster',
+        cluster='fake_cluster1',
         instance='fake_instance',
         service='fake_service',
         config_dict={},

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -132,6 +132,7 @@ def test_stop_or_start_handls_ls_remote_failures(
     mock_stdout,
 ):
     args = mock.Mock()
+    args.clusters = 'cluster1,cluster2'
     mock_get_git_url.return_value = 'fake_git_url'
     mock_figure_out_service_name.return_value = 'fake_service'
     mock_get_instance_config.return_value = None

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -115,7 +115,8 @@ def test_log_event():
             level='event',
             component='deploy',
             cluster='fake_cluster',
-            line="Issued request to change state of fake_instance to 'stopped' by fake_user@fake_fqdn"
+            line=("Issued request to change state of fake_instance (an instance of "
+                  "fake_service) to 'stopped' by fake_user@fake_fqdn")
         )
 
 
@@ -124,7 +125,7 @@ def test_log_event():
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.figure_out_service_name', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.get_instance_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.utils.get_git_url', autospec=True)
-def test_stop_or_start_handls_ls_remote_failures(
+def test_stop_or_start_handle_ls_remote_failures(
     mock_get_git_url,
     mock_get_instance_config,
     mock_figure_out_service_name,
@@ -132,7 +133,7 @@ def test_stop_or_start_handls_ls_remote_failures(
     mock_stdout,
 ):
     args = mock.Mock()
-    args.clusters = 'cluster1,cluster2'
+    args.clusters = 'cluster1'
     mock_get_git_url.return_value = 'fake_git_url'
     mock_figure_out_service_name.return_value = 'fake_service'
     mock_get_instance_config.return_value = None


### PR DESCRIPTION
Currently paasta restart -c accepts only one cluster. There has been an internal request to allow -c to use a list of clusters. 

There is some inconsistency around how this is currently implemented, with emergency_scale, emergency_restart, emergency_stop, emergency_start, restart and local_run using ```--cluster```, and logs, status and metastatus supporting ```--clusters```. 