### PR TITLE
Upgrade mesos.interface to 0.24.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ lockfile==0.9.1
 marathon==0.7.6
 mccabe==0.3.1
 mesos.cli==0.1.5
-mesos.interface==0.23.1
+mesos.interface==0.24.1
 ordereddict==1.1
 path.py==8.1
 ply==3.4


### PR DESCRIPTION
Mesos has been upgraded to 0.24.1 everywhere. The final step to finish this upgrade is to bump the version of `mesos.interface` in `requirements.txt` to 0.24.1