### PR TITLE
stopped per-instance configs from nuking global defaults

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -34,6 +34,7 @@ from paasta_tools.mesos_tools import get_local_slave_state
 from paasta_tools.mesos_tools import get_mesos_slaves_grouped_by_attribute
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import decompose_job_id
+from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import deploy_blacklist_to_constraints
 from paasta_tools.utils import get_code_sha_from_dockerurl
 from paasta_tools.utils import get_config_hash
@@ -142,7 +143,9 @@ def load_marathon_service_config(service, instance, cluster, load_deployments=Tr
             "%s not found in config file %s/%s/%s.yaml." % (instance, soa_dir, service, marathon_conf_file)
         )
 
-    general_config.update(instance_configs[instance])
+    base_instance_config = instance_configs[instance]
+    deep_merge_dictionaries(source=general_config, destination=base_instance_config)
+    general_config = base_instance_config
 
     branch_dict = {}
     if load_deployments:

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -234,7 +234,7 @@ class MarathonServiceConfig(InstanceConfig):
         default_params = {
             'method': 'default',
         }
-        return dict(default_params, **self.config_dict.get('autoscaling', {}))
+        return deep_merge_dictionaries(source=self.config_dict.get('autoscaling', {}), destination=default_params)
 
     def get_backoff_seconds(self):
         """backoff_seconds represents a penalization factor for relaunching failing tasks.

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -143,9 +143,7 @@ def load_marathon_service_config(service, instance, cluster, load_deployments=Tr
             "%s not found in config file %s/%s/%s.yaml." % (instance, soa_dir, service, marathon_conf_file)
         )
 
-    base_instance_config = instance_configs[instance]
-    deep_merge_dictionaries(source=general_config, destination=base_instance_config)
-    general_config = base_instance_config
+    general_config = deep_merge_dictionaries(source=general_config, destination=instance_configs[instance])
 
     branch_dict = {}
     if load_deployments:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1345,7 +1345,7 @@ def format_table(rows, min_spacing=2):
 
 def deep_merge_dictionaries(source, destination):
     """
-    Merges two dicitonaries.
+    Merges two dictionaries.
     """
     result = copy.deepcopy(destination)
     stack = [(source, result)]

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -14,6 +14,7 @@
 from __future__ import print_function
 
 import contextlib
+import copy
 import datetime
 import errno
 import fcntl
@@ -1344,12 +1345,12 @@ def format_table(rows, min_spacing=2):
 
 def deep_merge_dictionaries(source, destination):
     """
-    Recursively merges two dicitonaries.
+    Merges two dicitonaries.
     """
+    result = copy.deepcopy(destination)
     for key, value in source.items():
-        child = destination.setdefault(key, {})
+        child = result.setdefault(key, {})
         if isinstance(value, dict) and isinstance(child, dict):
-            deep_merge_dictionaries(value, child)
-        else:
-            destination[key] = value
-    return destination
+            value = deep_merge_dictionaries(value, child)
+        result[key] = value
+    return result

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1347,8 +1347,8 @@ def deep_merge_dictionaries(source, destination):
     Recursively merges two dicitonaries.
     """
     for key, value in source.items():
-        if isinstance(value, dict):
-            child = destination.setdefault(key, {})
+        child = destination.setdefault(key, {})
+        if isinstance(value, dict) and isinstance(child, dict):
             deep_merge_dictionaries(value, child)
         else:
             destination[key] = value

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1348,9 +1348,13 @@ def deep_merge_dictionaries(source, destination):
     Merges two dicitonaries.
     """
     result = copy.deepcopy(destination)
-    for key, value in source.items():
-        child = result.setdefault(key, {})
-        if isinstance(value, dict) and isinstance(child, dict):
-            value = deep_merge_dictionaries(value, child)
-        result[key] = value
+    stack = [(source, result)]
+    while stack:
+        source_dict, result_dict = stack.pop()
+        for key, value in source_dict.items():
+            child = result_dict.setdefault(key, {})
+            if isinstance(value, dict) and isinstance(child, dict):
+                stack.append((value, child))
+            else:
+                result_dict[key] = value
     return result

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1340,3 +1340,16 @@ def format_table(rows, min_spacing=2):
             expanded_rows.append(expanded_row)
 
     return [(' ' * min_spacing).join(r) for r in expanded_rows]
+
+
+def deep_merge_dictionaries(source, destination):
+    """
+    Recursively merges two dicitonaries.
+    """
+    for key, value in source.items():
+        if isinstance(value, dict):
+            child = destination.setdefault(key, {})
+            deep_merge_dictionaries(value, child)
+        else:
+            destination[key] = value
+    return destination

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1334,5 +1334,4 @@ def test_deep_merge_dictionaries():
         'overwriting_key': 'value',
         'overwriting_dict': {'test': 'value'},
     }
-    utils.deep_merge_dictionaries(source, destination)
-    assert destination == expected
+    assert utils.deep_merge_dictionaries(source, destination) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1291,3 +1291,42 @@ class TestFileLogWriter:
 
             mock_FileIO.assert_called_once_with("/dev/null", mode=fw.mode, closefd=True)
             fake_file.write.assert_called_once_with("%s\n" % fake_line)
+
+
+def test_deep_merge_dictionaries():
+    source = {
+        'common_key': 'value',
+        'common_dict': {
+            'subkey1': 1,
+            'subkey2': 2,
+            'subkey3': 3,
+        },
+        'just_in_source': 'value',
+        'just_in_source_dict': {'key': 'value'},
+    }
+    destination = {
+        'common_key': 'overwritten_value',
+        'common_dict': {
+            'subkey1': 'overwritten_value',
+            'subkey4': 4,
+            'subkey5': 5,
+        },
+        'just_in_dest': 'value',
+        'just_in_dest_dict': {'key': 'value'},
+    }
+    expected = {
+        'common_key': 'value',
+        'common_dict': {
+            'subkey1': 1,
+            'subkey2': 2,
+            'subkey3': 3,
+            'subkey4': 4,
+            'subkey5': 5,
+        },
+        'just_in_source': 'value',
+        'just_in_source_dict': {'key': 'value'},
+        'just_in_dest': 'value',
+        'just_in_dest_dict': {'key': 'value'},
+    }
+    utils.deep_merge_dictionaries(source, destination)
+    assert destination == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1303,6 +1303,8 @@ def test_deep_merge_dictionaries():
         },
         'just_in_source': 'value',
         'just_in_source_dict': {'key': 'value'},
+        'overwriting_key': 'value',
+        'overwriting_dict': {'test': 'value'},
     }
     destination = {
         'common_key': 'overwritten_value',
@@ -1313,6 +1315,8 @@ def test_deep_merge_dictionaries():
         },
         'just_in_dest': 'value',
         'just_in_dest_dict': {'key': 'value'},
+        'overwriting_key': {'overwritten-key', 'overwritten-value'},
+        'overwriting_dict': 'overwritten-value',
     }
     expected = {
         'common_key': 'value',
@@ -1327,6 +1331,8 @@ def test_deep_merge_dictionaries():
         'just_in_source_dict': {'key': 'value'},
         'just_in_dest': 'value',
         'just_in_dest_dict': {'key': 'value'},
+        'overwriting_key': 'value',
+        'overwriting_dict': {'test': 'value'},
     }
     utils.deep_merge_dictionaries(source, destination)
     assert destination == expected


### PR DESCRIPTION
Fixed a bug where your entire `monitoring.yaml` config changes would be blown away if an instance had any monitoring configs. Probably applies to non-monitoring config files as well.