### PR TITLE
fixed paasta fsm creating invalid deploy.yaml

### DIFF
--- a/paasta_tools/cli/cmds/fsm.py
+++ b/paasta_tools/cli/cmds/fsm.py
@@ -109,7 +109,7 @@ def get_paasta_config(yelpsoa_config_root, srvname, auto, port, team, descriptio
     smartstack_stanza = get_smartstack_stanza(yelpsoa_config_root, auto, port)
     monitoring_stanza = get_monitoring_stanza(auto, team)
     marathon_stanza = get_marathon_stanza()
-    deploy_stanza = paasta_config.get_fsm_deploy_pipeline(),
+    deploy_stanza = paasta_config.get_fsm_deploy_pipeline()
     service_stanza = get_service_stanza(description, external_link, auto)
     cluster_stanza = paasta_config.get_fsm_cluster_map()
     return (srvname, service_stanza, smartstack_stanza, monitoring_stanza,


### PR DESCRIPTION
TL;DR a comma at the end of a line causes a statement to be interpreted as a 1-tuple

Before:
```
---
- pipeline:
  - instancename: itest
  - instancename: security-check
  - instancename: push-to-registry
  - instancename: performance-check
  - instancename: stage.everything
    trigger_next_step_manually: true
  - instancename: prod.canary
    trigger_next_step_manually: true
  - instancename: prod.non_canary
  - instancename: dev.everything
```

After:
```
---
pipeline:
- instancename: itest
- instancename: security-check
- instancename: push-to-registry
- instancename: performance-check
- instancename: stage.everything
  trigger_next_step_manually: true
- instancename: prod.canary
  trigger_next_step_manually: true
- instancename: prod.non_canary
- instancename: dev.everything
```