### PR TITLE
Make -vv output consistent with -vvv output, humanize figures

### DIFF
--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -46,7 +46,7 @@ def parse_args():
     )
     parser.add_argument('-v', '--verbose', action='count', dest="verbose", default=0,
                         help="Print out more output regarding the state of the cluster")
-    parser.add_argument('-h', '--humanize', action='store_true', dest="humanize", default=False,
+    parser.add_argument('-H', '--humanize', action='store_true', dest="humanize", default=False,
                         help="Print human-readable sizes")
     return parser.parse_args()
 

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -95,9 +95,7 @@ def get_extra_mesos_slave_data(mesos_state):
     for framework in mesos_state.get('frameworks', []):
         for task in framework.get('tasks', []):
             mesos_metrics = filter_mesos_state_metrics(task['resources'])
-            for resource, count in mesos_metrics.iteritems():
-                slaves[task['slave_id']]['free_resources'][resource] = slaves[
-                    task['slave_id']]['total_resources'][resource] - count
+            slaves[task['slave_id']]['free_resources'].subtract(mesos_metrics)
 
     return sorted(slaves.values())
 
@@ -278,7 +276,8 @@ def assert_extra_attribute_data(mesos_state, humanize_output=False):
         resource_availability_dict = resource_dict["availability"]
         if len(resource_free_dict.keys()) >= 2:  # filter out attributes that apply to every slave in the cluster
             rows.append((attribute.capitalize(), 'CPU (free/total)', 'RAM (free/total)', 'Disk (free/total)'))
-            for attribute_location, resources_remaining in resource_free_dict.items():
+            for attribute_location in sorted(resource_free_dict.keys()):
+                resources_remaining = resource_free_dict[attribute_location]
                 resources_available = resource_availability_dict[attribute_location]
 
                 if humanize_output:

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -722,8 +722,8 @@ def test_get_mesos_habitat_data_humanized():
     test.somewhere.www   25.00/75.00       20.0M/100.0M      150.0M/250.0M
     test2.somewhere.www  500.00/500.00     750.0M/750.0M     200.0M/200.0M"""
     expected_attribute_humanize_output = """  Habitat                 CPU (free/total)  RAM (free/total)  Disk (free/total)
-    somenametest-habitat-2  500.00/500.00     750.0M/750.0M     200.0M/200.0M
-    somenametest-habitat    25.00/75.00       20.0M/100.0M      150.0M/250.0M"""
+    somenametest-habitat    25.00/75.00       20.0M/100.0M      150.0M/250.0M
+    somenametest-habitat-2  500.00/500.00     750.0M/750.0M     200.0M/200.0M"""
 
     extra_slave_data = paasta_metastatus.assert_extra_slave_data(mesos_state,
                                                                  humanize_output=True)
@@ -785,8 +785,8 @@ def test_get_mesos_habitat_data_nonhumanized():
     test.somewhere.www   25.00/75.00       20.00/100.00      150.00/250.00
     test2.somewhere.www  500.00/500.00     750.00/750.00     200.00/200.00"""
     expected_attribute_output = """  Habitat                 CPU (free/total)  RAM (free/total)  Disk (free/total)
-    somenametest-habitat-2  500.00/500.00     750.00/750.00     200.00/200.00
-    somenametest-habitat    25.00/75.00       20.00/100.00      150.00/250.00"""
+    somenametest-habitat    25.00/75.00       20.00/100.00      150.00/250.00
+    somenametest-habitat-2  500.00/500.00     750.00/750.00     200.00/200.00"""
 
     extra_slave_data = paasta_metastatus.assert_extra_slave_data(mesos_state, humanize_output=False)
     extra_attribute_data = paasta_metastatus.assert_extra_attribute_data(mesos_state, humanize_output=False)

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -670,3 +670,126 @@ def test_get_mesos_habitat_data():
     extra_mesos_habitat_data = paasta_metastatus.get_extra_mesos_attribute_data(mesos_state)
 
     assert (tuple(extra_mesos_habitat_data) == expected_free_resources)
+
+
+def test_get_mesos_habitat_data_humanized():
+    mesos_state = {
+        'slaves': [
+            {
+                'id': 'somenametest-slave',
+                'hostname': 'test.somewhere.www',
+                'resources': {
+                    'cpus': 75,
+                    'disk': 250,
+                    'mem': 100,
+                },
+                'attributes': {
+                    'habitat': 'somenametest-habitat',
+                },
+            },
+            {
+                'id': 'somenametest-slave2',
+                'hostname': 'test2.somewhere.www',
+                'resources': {
+                    'cpus': 500,
+                    'disk': 200,
+                    'mem': 750,
+                },
+                'attributes': {
+                    'habitat': 'somenametest-habitat-2',
+                },
+            },
+        ],
+
+        'frameworks': [
+            {
+                'tasks': [
+                    {
+                        'slave_id': 'somenametest-slave',
+                        'resources': {
+                            'cpus': 50,
+                            'disk': 100,
+                            'mem': 80,
+                            'something-bogus': 25,
+                        },
+                    },
+                ],
+            },
+        ],
+        'cluster': 'fake_cluster',
+    }
+    expected_slave_humanize_output = """  Hostname             CPU (free/total)  RAM (free/total)  Disk (free/total)
+    test.somewhere.www   25.00/75.00       20.0M/100.0M      150.0M/250.0M
+    test2.somewhere.www  500.00/500.00     750.0M/750.0M     200.0M/200.0M"""
+    expected_attribute_humanize_output = """  Habitat                 CPU (free/total)  RAM (free/total)  Disk (free/total)
+    somenametest-habitat-2  500.00/500.00     750.0M/750.0M     200.0M/200.0M
+    somenametest-habitat    25.00/75.00       20.0M/100.0M      150.0M/250.0M"""
+
+    extra_slave_data = paasta_metastatus.assert_extra_slave_data(mesos_state,
+                                                                 humanize_output=True)
+    extra_attribute_data = paasta_metastatus.assert_extra_attribute_data(mesos_state,
+                                                                         humanize_output=True)
+
+    assert extra_slave_data[0] == expected_slave_humanize_output
+    assert extra_attribute_data[0] == expected_attribute_humanize_output
+
+
+def test_get_mesos_habitat_data_nonhumanized():
+    mesos_state = {
+        'slaves': [
+            {
+                'id': 'somenametest-slave',
+                'hostname': 'test.somewhere.www',
+                'resources': {
+                    'cpus': 75,
+                    'disk': 250,
+                    'mem': 100,
+                },
+                'attributes': {
+                    'habitat': 'somenametest-habitat',
+                },
+            },
+            {
+                'id': 'somenametest-slave2',
+                'hostname': 'test2.somewhere.www',
+                'resources': {
+                    'cpus': 500,
+                    'disk': 200,
+                    'mem': 750,
+                },
+                'attributes': {
+                    'habitat': 'somenametest-habitat-2',
+                },
+            },
+        ],
+
+        'frameworks': [
+            {
+                'tasks': [
+                    {
+                        'slave_id': 'somenametest-slave',
+                        'resources': {
+                            'cpus': 50,
+                            'disk': 100,
+                            'mem': 80,
+                            'something-bogus': 25,
+                        },
+                    },
+                ],
+            },
+        ],
+        'cluster': 'fake_cluster',
+    }
+
+    expected_slave_output = """  Hostname             CPU (free/total)  RAM (free/total)  Disk (free/total)
+    test.somewhere.www   25.00/75.00       20.00/100.00      150.00/250.00
+    test2.somewhere.www  500.00/500.00     750.00/750.00     200.00/200.00"""
+    expected_attribute_output = """  Habitat                 CPU (free/total)  RAM (free/total)  Disk (free/total)
+    somenametest-habitat-2  500.00/500.00     750.00/750.00     200.00/200.00
+    somenametest-habitat    25.00/75.00       20.00/100.00      150.00/250.00"""
+
+    extra_slave_data = paasta_metastatus.assert_extra_slave_data(mesos_state, humanize_output=False)
+    extra_attribute_data = paasta_metastatus.assert_extra_attribute_data(mesos_state, humanize_output=False)
+
+    assert extra_slave_data[0] == expected_slave_output
+    assert extra_attribute_data[0] == expected_attribute_output


### PR DESCRIPTION
Currently the outputs of ```paasta metastatus -vv``` and ```paasta metastatus -vvv``` are quite inconsistent. 
```paasta metastatus -vv``` will return: 
```
  Hostname             CPU free  RAM free  Disk free
    test3.somewhere.www  22.00     920.00    200.00
    test.somewhere.www   25.00     0.00      150.00
    test2.somewhere.www  500.00    750.00    200.00
```
While ```paasta metastatus -vvv``` will return: 
```
  Habitat                 CPU (free/total)  RAM (free/total)  Disk (free/total)
    somenametest-habitat-2  522.00/522.00     1670.00/1670.00   400.00/400.00
    somenametest-habitat    25.00/75.00       0.00/100.00       150.00/250.00
```

This PR brings the two output formats somewhat into cohesion and also uses ```humanize``` to make the outputs a little more friendly to users: 

```paasta metastatus -vv```:
```
  Hostname             CPU (free/total)  RAM (free/total)  Disk (free/total)
    test3.somewhere.www  22.00/22.00       920.0M/920.0M     200.0M/200.0M
    test.somewhere.www   25.00/75.00       0B/100.0M         150.0M/250.0M
    test2.somewhere.www  500.00/500.00     750.0M/750.0M     200.0M/200.0M
```
```paasta metastatus -vvv```:
```
  Habitat                 CPU (free/total)  RAM (free/total)  Disk (free/total)
    somenametest-habitat-2  522.00/522.00     1.6G/1.6G         400.0M/400.0M
    somenametest-habitat    25.00/75.00       0B/100.0M         150.0M/250.0M
```