### PR TITLE
added schedule_time_zone to chronos schema

### DIFF
--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -30,6 +30,9 @@
 	    "deploy_group": {
 	        "type": "string"
 	    },
+	    "schedule_time_zone": {
+	    	"type": "string"
+	    },
             "disabled": {
                 "type": "boolean",
                 "default": false


### PR DESCRIPTION
A couple of services were failing `paasta validate` because of this.

Fixes #338 