### PR TITLE
fixed _run throwing an error when popen failed with a timeout

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -859,9 +859,10 @@ def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=N
         if timeout:
             proctimer.cancel()
         raise
-    # Stop the timer
-    if timeout:
-        proctimer.cancel()
+    else:
+        # Stop the timer
+        if timeout:
+            proctimer.cancel()
     if returncode == -9:
         output.append("Command '%s' timed out (longer than %ss)" % (command, timeout))
     return returncode, '\n'.join(output)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -755,6 +755,14 @@ def test_run_cancels_timer_thread_on_keyboard_interrupt():
         assert mock_timer_object.cancel.call_count == 1
 
 
+def test_run_returns_when_popen_fails():
+    fake_exception = OSError(1234, 'fake error')
+    with mock.patch('paasta_tools.utils.Popen', autospec=True, side_effect=fake_exception):
+        return_code, output = utils._run('nonexistant command', timeout=10)
+    assert return_code == 1234
+    assert 'fake error' in output
+
+
 class TestInstanceConfig:
 
     def test_get_monitoring(self):


### PR DESCRIPTION
Fixes #60 

The test added in this commit fails without this change with error `UnboundLocalError: local variable 'proctimer' referenced before assignment`