### PR TITLE
made metastatus print sane errors if mesos states it has 0 resources

### DIFF
--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -135,7 +135,11 @@ def percent_used(total, used):
 
 def assert_cpu_health(metrics, threshold=10):
     total, used, available = get_mesos_cpu_status(metrics)
-    perc_used = percent_used(total, used)
+    try:
+        perc_used = percent_used(total, used)
+    except ZeroDivisionError:
+        return (PaastaColors.red("Error reading total available cpu from mesos!"), False)
+
     if check_threshold(perc_used, threshold):
         return ("CPUs: %.2f / %d in use (%s)"
                 % (used, total, PaastaColors.green("%.2f%%" % perc_used)),
@@ -150,7 +154,10 @@ def assert_cpu_health(metrics, threshold=10):
 def assert_memory_health(metrics, threshold=10):
     total = metrics['master/mem_total'] / float(1024)
     used = metrics['master/mem_used'] / float(1024)
-    perc_used = percent_used(total, used)
+    try:
+        perc_used = percent_used(total, used)
+    except ZeroDivisionError:
+        return (PaastaColors.red("Error reading total available memory from mesos!"), False)
 
     if check_threshold(perc_used, threshold):
         return ("Memory: %0.2f / %0.2fGB in use (%s)"
@@ -166,7 +173,10 @@ def assert_memory_health(metrics, threshold=10):
 def assert_disk_health(metrics, threshold=10):
     total = metrics['master/disk_total'] / float(1024)
     used = metrics['master/disk_used'] / float(1024)
-    perc_used = percent_used(total, used)
+    try:
+        perc_used = percent_used(total, used)
+    except ZeroDivisionError:
+        return (PaastaColors.red("Error reading total available disk from mesos!"), False)
 
     if check_threshold(perc_used, threshold):
         return ("Disk: %0.2f / %0.2fGB in use (%s)"

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -105,6 +105,36 @@ def test_failing_disk_health():
     assert PaastaColors.red("CRITICAL: Less than 10% disk available. (Currently using 97.66%)") in failure_output
 
 
+def assert_cpu_health_mesos_reports_zero():
+    mesos_metrics = {
+        'master/cpus_total': 0,
+        'master/cpus_used': 1,
+    }
+    failure_output, failure_health = paasta_metastatus.assert_cpu_health(mesos_metrics)
+    assert failure_output == "Error reading total available cpu from mesos!"
+    assert failure_health is False
+
+
+def assert_memory_health_mesos_reports_zero():
+    mesos_metrics = {
+        'master/mem_total': 0,
+        'master/mem_used': 1,
+    }
+    failure_output, failure_health = paasta_metastatus.assert_memory_health(mesos_metrics)
+    assert failure_output == "Error reading total available memory from mesos!"
+    assert failure_health is False
+
+
+def assert_disk_health_mesos_reports_zero():
+    mesos_metrics = {
+        'master/disk_total': 0,
+        'master/disk_used': 1,
+    }
+    failure_output, failure_health = paasta_metastatus.assert_disk_health(mesos_metrics)
+    assert failure_output == "Error reading total available disk from mesos!"
+    assert failure_health is False
+
+
 def test_assert_no_duplicate_frameworks():
     state = {
         'frameworks': [


### PR DESCRIPTION
Fixes #348 

Should these healthchecks return False when Mesos says it has 0 available cpu/mem/disk?