### PR TITLE
Ensure cleanup jobs understands tmp jobs

### DIFF
--- a/paasta_itests/cleanup_chronos_jobs.feature
+++ b/paasta_itests/cleanup_chronos_jobs.feature
@@ -10,3 +10,13 @@ Feature: cleanup_chronos_jobs removes chronos jobs no longer in the config
      And the non-paasta jobs are not in the job list
      And the configured chronos jobs are in the job list
      And the unconfigured chronos jobs are not in the job list
+
+ Scenario: Cleanup chronos jobs ignores temporary jobs
+   Given a working paasta cluster
+     And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+     And we have a deployments.json for the service "testservice" with enabled instance "testinstance"
+    When we run chronos_rerun for service_instance testservice testinstance
+     And we store the name of the job for the service testservice and instance testinstance as myjob
+     And we run cleanup_chronos_jobs
+    Then we should get exit code 0
+     And we should see a job for the service "testservice" and instance "testinstance" in the job list

--- a/paasta_itests/cleanup_chronos_jobs.feature
+++ b/paasta_itests/cleanup_chronos_jobs.feature
@@ -20,3 +20,4 @@ Feature: cleanup_chronos_jobs removes chronos jobs no longer in the config
      And we run cleanup_chronos_jobs
     Then we should get exit code 0
      And we should see a job for the service "testservice" and instance "testinstance" in the job list
+     And there exists a job named "tmp testservice testinstance" in chronos

--- a/paasta_itests/cleanup_chronos_jobs.feature
+++ b/paasta_itests/cleanup_chronos_jobs.feature
@@ -20,4 +20,4 @@ Feature: cleanup_chronos_jobs removes chronos jobs no longer in the config
      And we run cleanup_chronos_jobs
     Then we should get exit code 0
      And we should see a job for the service "testservice" and instance "testinstance" in the job list
-     And there exists a job named "tmp testservice testinstance" in chronos
+     And there is a temporary job for the service testservice and instance testinstance

--- a/paasta_itests/steps/chronos_steps.py
+++ b/paasta_itests/steps/chronos_steps.py
@@ -100,3 +100,9 @@ def job_is_disabled(context, job_name, disabled):
     all_jobs = context.chronos_client.list()
     filtered_jobs = [job for job in all_jobs if job["name"] == full_job_name]
     assert filtered_jobs[0]["disabled"] is is_disabled
+
+
+@then('there exists a job named "{job_name}" in chronos')
+def job_exists(context, job_name):
+    all_jobs = context.chronos_client.list()
+    assert any([job['name'] == job_name for job in all_jobs])

--- a/paasta_itests/steps/cleanup_chronos_job_steps.py
+++ b/paasta_itests/steps/cleanup_chronos_job_steps.py
@@ -86,7 +86,6 @@ def check_cleanup_chronos_jobs_output(context, expected_return_code):
     assert "Successfully Removed Tasks (if any were running) for:" in output
     assert "Successfully Removed Jobs:" in output
     for job in context.unconfigured_job_names:
-        print job
         assert '  %s' % job in output
 
 

--- a/paasta_itests/steps/cleanup_chronos_job_steps.py
+++ b/paasta_itests/steps/cleanup_chronos_job_steps.py
@@ -78,7 +78,6 @@ def launch_non_paasta_jobs(context, num_jobs):
 @then(u'cleanup_chronos_jobs exits with return code "{expected_return_code}" and the correct output')
 def check_cleanup_chronos_jobs_output(context, expected_return_code):
     cmd = '../paasta_tools/cleanup_chronos_jobs.py --soa-dir %s' % context.soa_dir
-    print cmd
     exit_code, output = _run(cmd)
     print context.unconfigured_job_names
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
@@ -87,7 +86,15 @@ def check_cleanup_chronos_jobs_output(context, expected_return_code):
     assert "Successfully Removed Tasks (if any were running) for:" in output
     assert "Successfully Removed Jobs:" in output
     for job in context.unconfigured_job_names:
+        print job
         assert '  %s' % job in output
+
+
+@when(u'we run cleanup_chronos_jobs')
+def run_cleanup_chronos_jobs(context):
+    cmd = '../paasta_tools/cleanup_chronos_jobs.py --soa-dir %s' % context.soa_dir
+    context.exit_code, context.output = _run(cmd)
+    print context.output
 
 
 @then('the non-paasta jobs are not in the job list')

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -739,3 +739,20 @@ def get_job_for_service_instance(service, instance, include_disabled=True):
 def compose_check_name_for_service_instance(check_name, service, instance):
     """Compose a sensu check name for a given job"""
     return '%s.%s%s%s' % (check_name, service, INTERNAL_SPACER, instance)
+
+
+def get_temporary_jobs_for_service_instance(client, service, instance):
+    """ Given a service and instance, find any temporary jobs
+    for that job, as created by chronos_rerun.
+    """
+    temporary_jobs = []
+    all_jobs = lookup_chronos_jobs(
+        client=client,
+        service=service,
+        instance=instance,
+        include_disabled=True,
+    )
+    for job in all_jobs:
+        if job['name'].startswith(TMP_JOB_IDENTIFIER):
+            temporary_jobs.append(job)
+    return temporary_jobs

--- a/paasta_tools/cleanup_chronos_jobs.py
+++ b/paasta_tools/cleanup_chronos_jobs.py
@@ -129,7 +129,6 @@ def filter_expired_tmp_jobs(client, job_names):
         )
         for job in temporary_jobs:
             last_run_time, last_run_state = chronos_tools.get_status_last_run(job)
-            print last_run_time, last_run_state
             if last_run_state != chronos_tools.LastRunState.NotRun:
                 if (datetime.datetime.utcnow() - last_run_time) > datetime.timedelta(days=1):
                     expired.append(job_name)

--- a/paasta_tools/cleanup_chronos_jobs.py
+++ b/paasta_tools/cleanup_chronos_jobs.py
@@ -145,15 +145,14 @@ def main():
 
     running_jobs = set(deployed_job_names(client))
 
-    expected_service_jobs = [chronos_tools.compose_job_id(*job) for job in
-                             chronos_tools.get_chronos_jobs_for_cluster(soa_dir=args.soa_dir)]
+    expected_service_jobs = set([chronos_tools.compose_job_id(*job) for job in
+                                 chronos_tools.get_chronos_jobs_for_cluster(soa_dir=args.soa_dir)])
 
-    all_tmp_jobs = filter_tmp_jobs(filter_paasta_jobs(running_jobs))
-    expired_tmp_jobs = filter_expired_tmp_jobs(client, all_tmp_jobs)
+    all_tmp_jobs = set(filter_tmp_jobs(filter_paasta_jobs(running_jobs)))
+    expired_tmp_jobs = set(filter_expired_tmp_jobs(client, all_tmp_jobs))
+    valid_tmp_jobs = all_tmp_jobs - expired_tmp_jobs
 
-    valid_tmp_jobs = [job for job in all_tmp_jobs if job not in expired_tmp_jobs]
-
-    to_delete = [job for job in running_jobs if job not in expected_service_jobs and job not in valid_tmp_jobs]
+    to_delete = running_jobs - expected_service_jobs - valid_tmp_jobs
 
     task_responses = cleanup_tasks(client, to_delete)
     task_successes = []

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -25,6 +25,7 @@ from jsonschema import ValidationError
 import paasta_tools.chronos_tools
 from paasta_tools.chronos_tools import check_parent_format
 from paasta_tools.chronos_tools import load_chronos_job_config
+from paasta_tools.chronos_tools import TMP_JOB_IDENTIFIER
 from paasta_tools.cli.utils import failure
 from paasta_tools.cli.utils import get_file_contents
 from paasta_tools.cli.utils import lazy_choices_completer
@@ -203,6 +204,11 @@ def validate_chronos(service_path):
     chronos_spacer = paasta_tools.chronos_tools.INTERNAL_SPACER
 
     returncode = True
+
+    if service == TMP_JOB_IDENTIFIER:
+        print ("Services using scheduled tasks cannot be named %s, as it clashes with the"
+               " identifier used for temporary jobs" % TMP_JOB_IDENTIFIER)
+        return False
     for cluster in list_clusters(service, soa_dir, instance_type):
         services_in_cluster = get_services_for_cluster(cluster=cluster, instance_type='chronos', soa_dir=soa_dir)
         valid_services = set(["%s%s%s" % (name, chronos_spacer, instance) for name, instance in services_in_cluster])

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -205,7 +205,7 @@ def validate_chronos(service_path):
 
     returncode = True
 
-    if service == TMP_JOB_IDENTIFIER:
+    if service.startswith(TMP_JOB_IDENTIFIER):
         print ("Services using scheduled tasks cannot be named %s, as it clashes with the"
                " identifier used for temporary jobs" % TMP_JOB_IDENTIFIER)
         return False

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -400,6 +400,20 @@ def test_validate_chronos_valid_instance(
     assert valid_chronos_instance(fake_cluster, fake_instance) in output
 
 
+@patch("paasta_tools.chronos_tools.TMP_JOB_IDENTIFIER", 'tmp')
+@patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service')
+@patch('sys.stdout', new_callable=StringIO)
+def test_validate_chronos_tmp_job(
+    mock_stdout,
+    mock_path_to_soa_dir_service,
+):
+    mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'tmp')
+    assert validate_chronos('fake_path/tmp') is False
+    assert ("Services using scheduled tasks cannot be named tmp, as it clashes"
+            " with the identifier used for temporary jobs") in \
+        mock_stdout.getvalue()
+
+
 @patch('sys.stdout', new_callable=StringIO)
 def test_check_service_path_none(
     mock_stdout


### PR DESCRIPTION
closes #324 

This makes ``cleanup_chronos_jobs`` aware of temporary jobs. It will only clean any temporary jobs up when:

- the job has completed (either successfully or unsuccessfully)
- the job completed > 24 hours ago.

By keeping the job around for 24 hours, the job will continue to be visible to users via ``paasta status`` once the run has completed (so service authors can inspect the job to find the current status)