### PR TITLE
Pin kazoo to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ humanize==0.5.1
 importlib==1.0.3
 isodate==0.5.1
 jsonschema==2.5.1
-kazoo==2.2
+kazoo==2.0.0
 lockfile==0.9.1
 marathon==0.7.6
 mccabe==0.3.1


### PR DESCRIPTION
This related to #353 

This change downgrades us from kazoo 2.2 to 2.0.0 to work around a limitation in the unsupported mesos.cli. Once we fork/patch mesos.cli or swtich to dcos-cli, we can upgrade kazoo again.