### PR TITLE
fixed a bug where smartstack.yaml was overriding marathon.yaml

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -143,7 +143,7 @@ def load_marathon_service_config(service, instance, cluster, load_deployments=Tr
             "%s not found in config file %s/%s/%s.yaml." % (instance, soa_dir, service, marathon_conf_file)
         )
 
-    general_config = deep_merge_dictionaries(source=general_config, destination=instance_configs[instance])
+    general_config = deep_merge_dictionaries(source=instance_configs[instance], destination=general_config)
 
     branch_dict = {}
     if load_deployments:

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -85,10 +85,12 @@ class TestMarathonTools:
             mock.patch('paasta_tools.marathon_tools.load_deployments_json', autospec=True),
             mock.patch('service_configuration_lib.read_service_configuration', autospec=True),
             mock.patch('service_configuration_lib.read_extra_service_information', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.deep_merge_dictionaries', autospec=True),
         ) as (
             mock_load_deployments_json,
             mock_read_service_configuration,
             mock_read_extra_service_information,
+            _,
         ):
             mock_read_extra_service_information.return_value = {fake_instance: {}}
             marathon_tools.load_marathon_service_config(


### PR DESCRIPTION
I had this swapped when I added `deep_merge_dictionaries`.

I'd like this to be pushed out quickly because atm @gstarnberger is getting spammed with alerts.