### PR TITLE
Fix bintray upload

### DIFF
--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -69,7 +69,7 @@ package_trusty: build_trusty_docker
 itest_trusty: package_trusty bintray.json
 	$(DOCKER_RUN_TRUSTY) /work/yelp_package/itest/ubuntu.sh paasta-tools_$(ACTUAL_PACKAGE_VERSION)_amd64.deb
 
-DATE := $(shell date +'%Y-%m-%d' -d `dpkg-parsechangelog -l../debian/changelog | sed -n 's/^Date: //p'`)
+DATE := $(shell date +'%Y-%m-%d' -d "`dpkg-parsechangelog -l../debian/changelog | sed -n 's/^Date: //p'`")
 PAASTAVERSION := $(shell dpkg-parsechangelog -l../debian/changelog | sed -n 's/^Version: //p')
 bintray.json: bintray.json.in ../debian/changelog
 	sed -e 's/@DATE@/$(DATE)/g' -e 's/@PAASTAVERSION@/$(PAASTAVERSION)/g' $< > $@

--- a/yelp_package/bintray.json.in
+++ b/yelp_package/bintray.json.in
@@ -27,7 +27,7 @@
 
     "files":
         [
-        {"includePattern": "dist/(paasta-tools.*\.deb)", "uploadPattern": "$1", "matrixParams": { "deb_distribution": "trusty", "deb_component": "main", "deb_architecture": "amd64"} }
+        {"includePattern": "dist/(.*.deb)", "uploadPattern": "$1", "matrixParams": { "deb_distribution": "trusty", "deb_component": "main", "deb_architecture": "amd64"} }
         ],
     "publish": true
 }

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools \
   python-dev debhelper python-yaml python-pytest pyflakes \
   git help2man zsh wget
 
-RUN wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_0.11-1_all.deb && dpkg -i dh-virtualenv_0.11-1_all.deb && apt-get -f install
+RUN cd `mktemp -d` && wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_0.11-1_all.deb && dpkg -i dh-virtualenv_0.11-1_all.deb && apt-get -f install
 
 ENV HOME /work
 ENV PWD /work


### PR DESCRIPTION
This fixes a few issues: For some reason, travis(dpl) didn't like my includePattern; it didn't try uploading anything. I've changed the pattern to be more generous, so I've made it so we don't drop dh-virtualenv*.deb into dist/ when running itest_trusty.

I also noticed I wasn't properly setting the date in bintray.json, so I fixed that.