### PR TITLE
made local run create a fresh deployments.json

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -45,7 +45,6 @@ from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_username
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import load_system_paasta_config
-from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
@@ -588,26 +587,16 @@ def configure_and_run_docker_container(docker_client, docker_hash, service, inst
     soa_dir = args.yelpsoa_config_root
 
     volumes = list()
-    try:
-        instance_config = get_instance_config(
-            service=service,
-            instance=instance,
-            cluster=cluster,
-            load_deployments=pull_image,
-            soa_dir=soa_dir,
-        )
-    except NoDeploymentsAvailable:
-        sys.stdout.write(PaastaColors.yellow("Could not find deployment information for %s in %s.\n"
-                                             "local-run will attempt to generate it now.\n" % (
-                                                 service, soa_dir)))
+    if pull_image:
         generate_deployments_for_service(service, soa_dir)
-        instance_config = get_instance_config(
-            service=service,
-            instance=instance,
-            cluster=cluster,
-            load_deployments=pull_image,
-            soa_dir=soa_dir,
-        )
+
+    instance_config = get_instance_config(
+        service=service,
+        instance=instance,
+        cluster=cluster,
+        load_deployments=pull_image,
+        soa_dir=soa_dir,
+    )
 
     if pull_image:
         docker_url = get_docker_url(

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -35,6 +35,7 @@ from paasta_tools.cli.utils import guess_instance
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import list_services
+from paasta_tools.generate_deployments_for_service import generate_deployments_for_service
 from paasta_tools.marathon_tools import CONTAINER_PORT
 from paasta_tools.marathon_tools import get_healthcheck_for_instance
 from paasta_tools.paasta_execute_docker_command import execute_in_container
@@ -44,6 +45,7 @@ from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_username
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
@@ -583,14 +585,29 @@ def configure_and_run_docker_container(docker_client, docker_hash, service, inst
         ))
         system_paasta_config = SystemPaastaConfig({"volumes": []}, '/etc/paasta')
 
+    soa_dir = args.yelpsoa_config_root
+
     volumes = list()
-    instance_config = get_instance_config(
-        service=service,
-        instance=instance,
-        cluster=cluster,
-        load_deployments=pull_image,
-        soa_dir=args.yelpsoa_config_root,
-    )
+    try:
+        instance_config = get_instance_config(
+            service=service,
+            instance=instance,
+            cluster=cluster,
+            load_deployments=pull_image,
+            soa_dir=soa_dir,
+        )
+    except NoDeploymentsAvailable:
+        sys.stdout.write(PaastaColors.yellow("Could not find deployment information for %s in %s.\n"
+                                             "local-run will attempt to generate it now.\n" % (
+                                                 service, soa_dir)))
+        generate_deployments_for_service(service, soa_dir)
+        instance_config = get_instance_config(
+            service=service,
+            instance=instance,
+            cluster=cluster,
+            load_deployments=pull_image,
+            soa_dir=soa_dir,
+        )
 
     if pull_image:
         docker_url = get_docker_url(

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -611,9 +611,9 @@ def configure_and_run_docker_container(docker_client, docker_hash, service, inst
                 system_paasta_config.get_docker_registry(), instance_config.get_docker_image())
         except NoDockerImageError:
             sys.stderr.write(PaastaColors.red(
-                "Error: The deploy group %s for the service %s has not been marked for deployment.\n"
-                "To use paasta local-run with `--pull`, make sure you've pushed a docker image and "
-                "run paasta mark-for-deployment.\n" % (instance_config.get_deploy_group(), service)))
+                "Error: No sha has been marked for deployment for the %s deploy group.\n"
+                "Please ensure this service has either run through a jenkins pipeline "
+                "or paasta mark-for-deployment has been run for %s" % (instance_config.get_deploy_group(), service)))
             return
         docker_hash = docker_url
         docker_pull_image(docker_url)

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -599,9 +599,11 @@ def configure_and_run_docker_container(docker_client, docker_hash, service, inst
         )
     except NoDeploymentsAvailable:
         sys.stderr.write(PaastaColors.red(
-            "Error: No deployments.json found in %s/%s.\n"
-            "You can generate this by running paasta generate_deployments_for_service.\n" % (
-                soa_dir, service)))
+            "Error: No deployments.json found in %(soa_dir)s/%(service)s.\n"
+            "You can generate this by running:\n"
+            "generate_deployments_for_service -d %(soa_dir)s -s %(service)s\n" % {
+                'soa_dir': soa_dir, 'service': service}))
+        return
 
     if pull_image:
         try:

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -245,14 +245,7 @@ def get_deploy_group_mappings_from_deployments_dict(deployments_dict):
         return deploy_group_mappings
 
 
-def main():
-    args = parse_args()
-    soa_dir = os.path.abspath(args.soa_dir)
-    service = args.service
-    if args.verbose:
-        log.setLevel(logging.DEBUG)
-    else:
-        log.setLevel(logging.WARNING)
+def generate_deployments_for_service(service, soa_dir):
     try:
         with open(os.path.join(soa_dir, service, TARGET_FILE), 'r') as f:
             old_deployments_dict = json.load(f)
@@ -269,6 +262,18 @@ def main():
 
     with atomic_file_write(os.path.join(soa_dir, service, TARGET_FILE)) as f:
         json.dump(deployments_dict, f)
+
+
+def main():
+    args = parse_args()
+    soa_dir = os.path.abspath(args.soa_dir)
+    service = args.service
+    if args.verbose:
+        log.setLevel(logging.DEBUG)
+    else:
+        log.setLevel(logging.WARNING)
+
+    generate_deployments_for_service(service=service, soa_dir=soa_dir)
 
 
 if __name__ == "__main__":

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -223,7 +223,6 @@ def test_get_container_name(mock_get_username, mock_randint):
     assert actual == expected
 
 
-@mock.patch('paasta_tools.cli.cmds.local_run.generate_deployments_for_service', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.socket.getfqdn', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.load_system_paasta_config', autospec=True)
@@ -233,7 +232,6 @@ def test_configure_and_run_command_uses_cmd_from_config(
     mock_load_system_paasta_config,
     mock_run_docker_container,
     mock_socket_getfqdn,
-    mock_generate_deployments_for_service,
 ):
     mock_load_system_paasta_config.return_value = SystemPaastaConfig(
         {'cluster': 'fake_cluster', 'volumes': []}, '/fake_dir/')
@@ -275,7 +273,6 @@ def test_configure_and_run_command_uses_cmd_from_config(
     )
 
 
-@mock.patch('paasta_tools.cli.cmds.local_run.generate_deployments_for_service', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.socket.getfqdn', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.load_system_paasta_config', autospec=True)
@@ -285,7 +282,6 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
     mock_load_system_paasta_config,
     mock_run_docker_container,
     mock_socket_getfqdn,
-    mock_generate_deployments_for_service,
 ):
     mock_load_system_paasta_config.return_value = SystemPaastaConfig(
         {'cluster': 'fake_cluster', 'volumes': []}, '/fake_dir/')
@@ -326,7 +322,6 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
     )
 
 
-@mock.patch('paasta_tools.cli.cmds.local_run.generate_deployments_for_service', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.socket.getfqdn', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.docker_pull_image', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True)
@@ -338,7 +333,6 @@ def test_configure_and_run_pulls_image_when_asked(
     mock_run_docker_container,
     mock_docker_pull_image,
     mock_socket_getfqdn,
-    mock_generate_deployments_for_service,
 ):
     mock_load_system_paasta_config.return_value = SystemPaastaConfig(
         {'cluster': 'fake_cluster', 'volumes': [], 'docker_registry': 'fake_registry'}, '/fake_dir/')

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -223,6 +223,7 @@ def test_get_container_name(mock_get_username, mock_randint):
     assert actual == expected
 
 
+@mock.patch('paasta_tools.cli.cmds.local_run.generate_deployments_for_service', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.socket.getfqdn', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.load_system_paasta_config', autospec=True)
@@ -232,6 +233,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
     mock_load_system_paasta_config,
     mock_run_docker_container,
     mock_socket_getfqdn,
+    mock_generate_deployments_for_service,
 ):
     mock_load_system_paasta_config.return_value = SystemPaastaConfig(
         {'cluster': 'fake_cluster', 'volumes': []}, '/fake_dir/')
@@ -273,6 +275,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
     )
 
 
+@mock.patch('paasta_tools.cli.cmds.local_run.generate_deployments_for_service', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.socket.getfqdn', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.load_system_paasta_config', autospec=True)
@@ -282,6 +285,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
     mock_load_system_paasta_config,
     mock_run_docker_container,
     mock_socket_getfqdn,
+    mock_generate_deployments_for_service,
 ):
     mock_load_system_paasta_config.return_value = SystemPaastaConfig(
         {'cluster': 'fake_cluster', 'volumes': []}, '/fake_dir/')
@@ -322,6 +326,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
     )
 
 
+@mock.patch('paasta_tools.cli.cmds.local_run.generate_deployments_for_service', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.socket.getfqdn', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.docker_pull_image', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True)
@@ -333,6 +338,7 @@ def test_configure_and_run_pulls_image_when_asked(
     mock_run_docker_container,
     mock_docker_pull_image,
     mock_socket_getfqdn,
+    mock_generate_deployments_for_service,
 ):
     mock_load_system_paasta_config.return_value = SystemPaastaConfig(
         {'cluster': 'fake_cluster', 'volumes': [], 'docker_registry': 'fake_registry'}, '/fake_dir/')


### PR DESCRIPTION
Before:

```
matts@dev2-devc:~/paasta (master) $ sudo python paasta_tools/cli/cli.py local-run -s example_service -c mesosstage -i mesosstage_main -p -y /nail/home/matts/yelpsoa-configs/
Traceback (most recent call last):
  File "paasta_tools/cli/cli.py", line 99, in <module>
    main()
  File "paasta_tools/cli/cli.py", line 95, in main
    return_code = args.command(args)
  File "/nail/home/matts/paasta/paasta_tools/cli/cmds/local_run.py", line 681, in paasta_local_run
    pull_image=pull_image,
  File "/nail/home/matts/paasta/paasta_tools/cli/cmds/local_run.py", line 592, in configure_and_run_docker_container
    soa_dir=args.yelpsoa_config_root,
  File "/nail/home/matts/paasta/paasta_tools/cli/utils.py", line 618, in get_instance_config
    soa_dir=soa_dir
  File "/nail/home/matts/paasta/paasta_tools/marathon_tools.py", line 150, in load_marathon_service_config
    deployments_json = load_deployments_json(service, soa_dir=soa_dir)
  File "/nail/home/matts/paasta/paasta_tools/utils.py", line 1192, in load_deployments_json
    raise NoDeploymentsAvailable
paasta_tools.utils.NoDeploymentsAvailable
```

After:

```
matts@dev2-devc:~/paasta (local_run_generate_deployments) $ sudo python paasta_tools/cli/cli.py local-run -s example_service -c mesosstage -i mesosstage_main -p -y /nail/home/matts/yelpsoa-configs/
Could not find deployment information for example_service in /nail/home/matts/yelpsoa-configs/.
local-run will attempt to generate it now.
Please wait while the image (docker-paasta.yelpcorp.com:443/services-example_service:paasta-3eaa22dff8a4963716c4903ff02054917d22a460) is pulled...
```