### PR TITLE
Use behave-pytest for pytest-style asserts

### DIFF
--- a/general_itests/environment.py
+++ b/general_itests/environment.py
@@ -13,7 +13,13 @@
 # limitations under the License.
 import shutil
 
+from behave_pytest.hook import install_pytest_asserts
+
 from paasta_tools.utils import get_docker_client
+
+
+def before_all(context):
+    install_pytest_asserts()
 
 
 def after_scenario(context, scenario):

--- a/paasta_itests/environment.py
+++ b/paasta_itests/environment.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import time
 
+from behave_pytest.hook import install_pytest_asserts
 from itest_utils import cleanup_file
 from itest_utils import get_service_connection_string
 from itest_utils import setup_mesos_cli_config
@@ -26,6 +27,7 @@ from paasta_tools import marathon_tools
 
 
 def before_all(context):
+    install_pytest_asserts()
     context.cluster = "testcluster"
     context.mesos_cli_config = os.path.join(os.getcwd(), 'mesos-cli.json')
     wait_for_marathon()

--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,7 @@ changedir=paasta_itests/
 deps =
     {[testenv]deps}
     behave==1.2.4
+    behave-pytest==0.1.1
 commands =
     python -m behave {posargs}
 
@@ -89,6 +90,7 @@ passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
 deps =
     {[testenv]deps}
     behave==1.2.4
+    behave-pytest==0.1.1
 commands =
     pre-commit install -f --install-hooks
     pre-commit run --all-files


### PR DESCRIPTION
This switches us to use https://github.com/ribozz/behave-pytest , which will provide us with some more information when an assertion fails (actual and expected values). Some of the output will look a bit off (due to how we have color/formatting in our output), but it should still help with debugging test failures.