### PR TITLE
Only deploy to pypi on py27 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ deploy:
       secure: r9zzkDhFF/aMhId26nVuyk91t0uMLFd80ZWIXpOdGL36AvOKTj90l2Usb9ipxJeIBdiccQ5rFtX7r2RnFC9Q3cP83A0c5p1jacpb7OyNRVDaYqr/+iDVp83SQKF9l2PnKyIXeLpIbVi6x7s0L+gJ7Ex+6ck0X9V1MA1zFtFxOyhGRAPxjPhywLAIsWd7RdclD/Bg79YtZ9pZGg0QK0hm9S3RZL+e2kdM+9rNpfhmyI6Bcf6ZBMoJtsCWWRRg8JgI/StfrXs1VpJfjWmy+XApsOWTWWfjdLO3IpuDhQrAfrCwM8n7AHv8MCfxt8yPlRKA4OEg2TGOm7U+VSIubV64hgFdSt7fazYh+uttUxGE8cz8Jt/rRCYmrYmWPzm7MIoFOwBfrK7QEQDxSN9gWUbL3eWgPGQMVZC06hb0pdLog/8piNrC5DBwywlPy24ChVlt+0UMA8rzIepwX1//Bcc4a9lIxbLFg8P/1JtS7Tkfag9p2Y1Z943GU1JAHhPLktdxMxFlZ4qTfaaxz7fYU+Kr/47noNLWKtnNejVEgy4bYAR9NxDET/vnpeJ7MacefYL0zvXBWO6MCbVDCUbM8fQWrZUAjeFzMCk8kXgA1qkkQ0Lm/7ACbUUECiZ1qclZh2du6Cvt6xRsBJXDXjzYwm2ECKGS8GQ4pJ6h3DypdHgHrMM=
     on:
       tags: true
+      condition: $TOXENV == py27
       repo: Yelp/paasta
   - provider: bintray
     file: "yelp_package/bintray.json"


### PR DESCRIPTION
This prevents pypi deployments from messing with dist/ on the itest_trusty build.

In testing my original bintray uploading branch, the pypi deployment wasn't running (since it only runs on tags), so my testing worked just fine. Once I merged, however, the uploads stopped working. It appears that the pypi development does something to the dist/ directory (cleans it out?), so if the pypi and bintray deployers both run on the same build, bintray won't work.

This should also prevent us from uploading the same package to pypi 6 times in one go.