### PR TITLE
Upgrade to marathon 0.13.1 in itests

### DIFF
--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -49,7 +49,7 @@ def given_a_new_app_to_be_deployed(context, state):
         'id': 'bounce.test1.newapp.confighash',
         'cmd': '/bin/sleep 300',
         'instances': 2,
-        'backoff_seconds': 0.1,
+        'backoff_seconds': 1,
         'backoff_factor': 1,
         'health_checks': [
             {
@@ -68,7 +68,7 @@ def given_an_old_app_to_be_destroyed(context):
         'id': old_app_name,
         'cmd': '/bin/sleep 300',
         'instances': 2,
-        'backoff_seconds': 0.1,
+        'backoff_seconds': 1,
         'backoff_factor': 1,
     }
     with contextlib.nested(

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -18,6 +18,7 @@ import mock
 from behave import then
 from behave import when
 from itest_utils import get_service_connection_string
+from marathon.exceptions import MarathonHttpError
 
 from paasta_tools import marathon_tools
 from paasta_tools import setup_marathon_job
@@ -47,7 +48,7 @@ def run_setup_marathon_job(context):
         )
         try:
             setup_marathon_job.main()
-        except SystemExit:
+        except (SystemExit, MarathonHttpError):
             pass
 
 

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -53,6 +53,7 @@ from paasta_tools import bounce_lib
 from paasta_tools import drain_lib
 from paasta_tools import marathon_tools
 from paasta_tools import monitoring_tools
+from paasta_tools.marathon_tools import kill_given_tasks
 from paasta_tools.utils import _log
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import decompose_job_id
@@ -249,7 +250,7 @@ def do_bounce(
             tasks_to_kill.add(task)
             log_bounce_action(line='%s bounce killing drained task %s' % (bounce_method, task.id))
 
-    client.kill_given_tasks(task_ids=[task.id for task in tasks_to_kill], scale=True)
+    kill_given_tasks(client=client, task_ids=[task.id for task in tasks_to_kill], scale=True)
 
     apps_to_kill = []
     for app in old_app_live_happy_tasks.keys():

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ isodate==0.5.1
 jsonschema==2.5.1
 kazoo==2.2
 lockfile==0.9.1
-marathon==0.7.6
+marathon==0.7.7
 mccabe==0.3.1
 mesos.cli==0.1.5
 mesos.interface==0.25.0

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'isodate >= 0.5.0',
         'jsonschema',
         'kazoo >= 2.0.0',
-        'marathon >= 0.7.5',
+        'marathon >= 0.7.7',
         'mesos.cli == 0.1.5',
         'ordereddict >= 1.1',
         'path.py >= 8.1',

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1818,7 +1818,7 @@ class TestMarathonServiceConfig(object):
             config_dict={'instances': 100},
             branch_dict={},
         )
-        assert marathon_config.get_backoff_seconds() == 0.1
+        assert marathon_config.get_backoff_seconds() == 1
 
     def test_get_backoff_seconds_scales_down(self):
         marathon_config = marathon_tools.MarathonServiceConfig(

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -24,7 +24,7 @@ RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set
 RUN echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections
 RUN apt-get update && apt-get -y install lsb-release oracle-java8-installer
 
-RUN apt-get -y install libsasl2-modules marathon=0.13.0-1.0.456.ubuntu1404
+RUN apt-get -y install libsasl2-modules marathon=0.13.1-1.0.456.ubuntu1404
 
 RUN echo -n "secret2" > /etc/marathon_framework_secret
 

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -24,7 +24,7 @@ RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set
 RUN echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections
 RUN apt-get update && apt-get -y install lsb-release oracle-java8-installer
 
-RUN apt-get -y install libsasl2-modules marathon=0.11.1-1.0.432.ubuntu1404
+RUN apt-get -y install libsasl2-modules marathon=0.13.0-1.0.456.ubuntu1404
 
 RUN echo -n "secret2" > /etc/marathon_framework_secret
 


### PR DESCRIPTION
Apparently, our old version of marathon is trying to access newly renamed mesos endpoints. This issue (among other things) should be fixed by upgrading.