### PR TITLE
Make the marathon cleanup script resolve all related sensu events.

### DIFF
--- a/paasta_tools/cleanup_marathon_jobs.py
+++ b/paasta_tools/cleanup_marathon_jobs.py
@@ -70,11 +70,25 @@ def delete_app(app_id, client, soa_dir):
         short_app_id = marathon_tools.compose_job_id(service, instance)
         with bounce_lib.bounce_lock_zookeeper(short_app_id):
             bounce_lib.delete_marathon_app(app_id, client)
-        # resolve any check marathon replication alerts
-        check_name = 'check_marathon_services_replication.%s' % short_app_id
         send_event(
             service=service,
-            check_name=check_name,
+            check_name='check_marathon_services_replication.%s' % short_app_id,
+            soa_dir=soa_dir,
+            status=pysensu_yelp.Status.OK,
+            overrides={},
+            output="This instance was removed and is no longer running",
+        )
+        send_event(
+            service=service,
+            check_name='setup_marathon_job.%s' % short_app_id,
+            soa_dir=soa_dir,
+            status=pysensu_yelp.Status.OK,
+            overrides={},
+            output="This instance was removed and is no longer running",
+        )
+        send_event(
+            service=service,
+            check_name='paasta_bounce_progress.%s' % short_app_id,
             soa_dir=soa_dir,
             status=pysensu_yelp.Status.OK,
             overrides={},

--- a/tests/test_cleanup_marathon_jobs.py
+++ b/tests/test_cleanup_marathon_jobs.py
@@ -135,6 +135,7 @@ class TestCleanupMarathonJobs:
                 cluster='fake_cluster',
                 line=expected_log_line,
             )
+            assert mock_send_sensu_event.call_count == 3
 
     def test_delete_app_throws_exception(self):
         app_id = 'example--service.main.git93340779.configddb38a65'


### PR DESCRIPTION
Right now there are potentially 3 sensu alerts that could be thrown on a marathon service, this cleanup resolves them all.