### PR TITLE
parse the datetime string from lastruntime in chronos jobs

### DIFF
--- a/paasta_tools/cleanup_chronos_jobs.py
+++ b/paasta_tools/cleanup_chronos_jobs.py
@@ -131,7 +131,9 @@ def filter_expired_tmp_jobs(client, job_names):
         for job in temporary_jobs:
             last_run_time, last_run_state = chronos_tools.get_status_last_run(job)
             if last_run_state != chronos_tools.LastRunState.NotRun:
-                if (datetime.datetime.utcnow() - dateutil.parser.parse(last_run_time)) > datetime.timedelta(days=1):
+                if ((datetime.datetime.now(dateutil.tz.tzutc()) -
+                     dateutil.parser.parse(last_run_time)) >
+                        datetime.timedelta(days=1)):
                     expired.append(job_name)
     return expired
 

--- a/paasta_tools/cleanup_chronos_jobs.py
+++ b/paasta_tools/cleanup_chronos_jobs.py
@@ -29,6 +29,7 @@ import argparse
 import datetime
 import sys
 
+import dateutil.parser
 import pysensu_yelp
 import service_configuration_lib
 
@@ -130,7 +131,7 @@ def filter_expired_tmp_jobs(client, job_names):
         for job in temporary_jobs:
             last_run_time, last_run_state = chronos_tools.get_status_last_run(job)
             if last_run_state != chronos_tools.LastRunState.NotRun:
-                if (datetime.datetime.utcnow() - last_run_time) > datetime.timedelta(days=1):
+                if (datetime.datetime.utcnow() - dateutil.parser.parse(last_run_time)) > datetime.timedelta(days=1):
                     expired.append(job_name)
     return expired
 

--- a/tests/test_cleanup_chronos_jobs.py
+++ b/tests/test_cleanup_chronos_jobs.py
@@ -55,9 +55,9 @@ def test_filter_expired_tmp_jobs(mock_get_temporary_jobs):
     one_hour_ago = datetime.datetime.now() - datetime.timedelta(hours=1)
     mock_get_temporary_jobs.side_effect = [
                                           [{'name': 'tmp foo bar',
-                                            'lastSuccess': two_days_ago}],
+                                            'lastSuccess': two_days_ago.isoformat()}],
                                           [{'name': 'tmp anotherservice anotherinstance',
-                                            'lastSuccess': one_hour_ago}]]
+                                            'lastSuccess': one_hour_ago.isoformat()}]]
     actual = cleanup_chronos_jobs.filter_expired_tmp_jobs(mock.Mock(), ['foo bar', 'anotherservice anotherinstance'])
     assert actual == ['foo bar']
 


### PR DESCRIPTION
closes #388 

There was a missing cast of string -> datetime, causing the comparison of time to fail.