### PR TITLE
Make is_app_id_running tolerate leading slashes

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -891,7 +891,7 @@ def is_app_id_running(app_id, client):
     :param client: A MarathonClient object"""
 
     all_app_ids = list_all_marathon_app_ids(client)
-    return app_id in all_app_ids
+    return app_id.lstrip('/') in all_app_ids
 
 
 def app_has_tasks(client, app_id, expected_tasks, exact_matches_only=False):

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1213,6 +1213,18 @@ class TestMarathonTools:
             assert marathon_tools.is_app_id_running(fake_id, fake_client) is False
             list_all_marathon_app_ids_patch.assert_called_once_with(fake_client)
 
+    def test_is_app_id_running_handles_leading_slashes(self):
+        fake_id = '/fake_app1'
+        fake_all_marathon_app_ids = ['fake_app1', 'fake_app2']
+        fake_client = mock.Mock()
+        with mock.patch(
+            'paasta_tools.marathon_tools.list_all_marathon_app_ids',
+            autospec=True,
+            return_value=fake_all_marathon_app_ids,
+        ) as list_all_marathon_app_ids_patch:
+            assert marathon_tools.is_app_id_running(fake_id, fake_client) is True
+            list_all_marathon_app_ids_patch.assert_called_once_with(fake_client)
+
     @patch('paasta_tools.marathon_tools.MarathonClient.list_tasks')
     def test_app_has_tasks_exact(self, patch_list_tasks):
         fake_client = mock.Mock()


### PR DESCRIPTION
This function needs to tolerate the situation where we could potentially give it an appid without a leading slash (like from a generated appid or a user provided one) or from the API which might return leading slashes. (the api is not consistent when it provides a leading slash or not.)