### PR TITLE
Use json for mesos authentication

### DIFF
--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -16,6 +16,6 @@ FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
 RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.28.0-2.0.16.ubuntu1404
-RUN echo -n 'slave secret1\nmarathon secret2\nchronos secret3' > /etc/mesos-secrets
-RUN echo -n 'slave secret1' > /etc/mesos-slave-secret
+ADD mesos-secrets /etc/mesos-secrets
+ADD mesos-slave-secret /etc/mesos-slave-secret
 RUN chmod 600 /etc/mesos-secrets

--- a/yelp_package/dockerfiles/itest/mesos/mesos-secrets
+++ b/yelp_package/dockerfiles/itest/mesos/mesos-secrets
@@ -1,0 +1,16 @@
+{
+  "credentials": [
+    {
+      "principal": "slave",
+      "secret": "secret1"
+    },
+    {
+      "principal": "marathon",
+      "secret": "secret2"
+    },
+    {
+      "principal": "chronos",
+      "secret": "secret3"
+    }
+  ]
+}

--- a/yelp_package/dockerfiles/itest/mesos/mesos-slave-secret
+++ b/yelp_package/dockerfiles/itest/mesos/mesos-slave-secret
@@ -1,0 +1,4 @@
+{
+  "principal": "slave",
+  "secret": "secret1"
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MESOS-2281 deprecates using plain text credentials for authentication in Mesos 0.29.0. The bug that forced us to move off of json credentials has been fixed. This PR switches us back to using json.