### PR TITLE
Bump mesos.interface to 0.28.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ lockfile==0.9.1
 marathon==0.7.7
 mccabe==0.3.1
 mesos.cli==0.1.5
-mesos.interface==0.25.0
+mesos.interface==0.28.0
 ordereddict==1.1
 path.py==8.1
 ply==3.4


### PR DESCRIPTION
We've upgraded to mesos 0.28.0. This bumps up mesos.interface in requirements.txt.