### PR TITLE
Revert "Merge branch 'dont-require-start-time'"

### DIFF
--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -304,7 +304,9 @@ class ChronosJobConfig(InstanceConfig):
                 return False, 'The specified schedule "%s" is invalid' % schedule
 
             # an empty start time is not valid ISO8601 but Chronos accepts it: '' == current time
-            if not start_time == '':
+            if start_time == '':
+                msgs.append('The specified schedule "%s" does not contain a start time' % schedule)
+            else:
                 # Check if start time contains time zone information
                 try:
                     dt = isodate.parse_datetime(start_time)

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -647,7 +647,7 @@ class TestChronosTools:
         assert okay is True
         assert msg == ''
 
-    def test_check_schedule_valid_empty_start_time(self):
+    def test_check_schedule_invalid_empty_start_time(self):
         fake_schedule = 'R10//PT70S'
         chronos_config = chronos_tools.ChronosJobConfig(
             service='',
@@ -657,8 +657,8 @@ class TestChronosTools:
             branch_dict={},
         )
         okay, msg = chronos_config.check_schedule()
-        assert okay is True
-        assert msg == ''
+        assert okay is False
+        assert msg == 'The specified schedule "%s" does not contain a start time' % fake_schedule
 
     def test_check_schedule_invalid_start_time_no_t_designator(self):
         fake_start_time = 'now'


### PR DESCRIPTION
This reverts commit c8eaa31533407ff3400776b1abf1c611e192515d, reversing
changes made to c0733d2541c6a4d963ba6a344f42ab2e12fbd876.

This was done for good reason, as documented in our soa-configs:

>  Although Chronos supports an empty start time to indicate that the job should start immediately, we do not allow this. In a situation such as restarting Chronos, all jobs with empty start times would start simultaneously, causing serious performance degradation and ignoring the fact that the job may have just run.