### PR TITLE
create a frontend paasta rerun command

### DIFF
--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -740,7 +740,7 @@ def uses_time_variables(chronos_job):
     """
     current_command = chronos_job.get_cmd()
     interpolated_command = parse_time_variables(current_command, datetime.datetime.utcnow())
-    return not current_command == interpolated_command
+    return current_command != interpolated_command
 
 
 def check_parent_format(parent):

--- a/paasta_tools/cli/cmds/rerun.py
+++ b/paasta_tools/cli/cmds/rerun.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+# Copyright 2015 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import datetime
+
+from paasta_tools.cli.cmds.status import get_actual_deployments
+from paasta_tools.cli.cmds.status import get_planned_deployments
+from paasta_tools.cli.cmds.status import list_deployed_clusters
+from paasta_tools.cli.utils import execute_chronos_rerun_on_remote_master
+from paasta_tools.cli.utils import figure_out_service_name
+from paasta_tools.cli.utils import lazy_choices_completer
+from paasta_tools.cli.utils import list_instances
+from paasta_tools.cli.utils import list_services
+from paasta_tools.utils import list_clusters
+from paasta_tools.utils import PaastaColors
+from paasta_tools.utils import SPACER
+
+
+EXECUTION_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+
+def type_execution_date(value):
+    try:
+        parsed = datetime.datetime.strptime(value, EXECUTION_DATE_FORMAT)
+    except ValueError:
+        raise argparse.ArgumentTypeError('must be in the format "%s"' % EXECUTION_DATE_FORMAT)
+    return parsed
+
+
+def add_subparser(subparsers):
+    rerun_parser = subparsers.add_parser(
+        'rerun',
+        help="Re-run a scheduled PaaSTA job",
+        description=(
+            "'paasta rerun' creates a copy of the specified PaaSTA scheduled job and executes it immediately. "
+            "Parent-dependent relationships are ignored: 'pasta rerun' only executes individual jobs."
+        ),
+        epilog=(
+            "Note: This command requires SSH and sudo privileges on the remote PaaSTA "
+            "masters."
+        ),
+    )
+    rerun_parser.add_argument(
+        '-v', '--verbose',
+        action='count',
+        dest="verbose",
+        default=0,
+        help="Print out more output regarding the operation."
+    )
+    rerun_parser.add_argument(
+        '-s', '--service',
+        help='The name of the service you wish to operate on.',
+        required=True,
+    ).completer = lazy_choices_completer(list_services)
+    rerun_parser.add_argument(
+        '-i', '--instance',
+        help='Name of the scheduled job (instance) that you want to rerun.',
+        required=True,
+    ).completer = lazy_choices_completer(list_instances)
+    rerun_parser.add_argument(
+        '-c', '--clusters',
+        help="A comma-separated list of clusters to rerun the job on. Defaults to rerun on all clusters.\n"
+             "For example: --clusters norcal-prod,nova-prod"
+    ).completer = lazy_choices_completer(list_clusters)
+    rerun_parser.add_argument(
+        '-d', '--execution_date',
+        help="The date the job should be rerun for. Expected in the format %%Y-%%m-%%dT%%H:%%M:%%S .",
+        required=True,
+        type=type_execution_date
+    )
+    rerun_parser.set_defaults(command=paasta_rerun)
+
+
+def _get_cluster_instance(cluster_dot_instance_list):
+    """given a list of cluster.instance, returns
+    a nested dict of ['cluster']['instance'] = True"""
+    cluster_instance_dict = {}
+    for namespace in cluster_dot_instance_list:
+        cluster_in_pipeline, instance = namespace.split(SPACER, 1)
+        instance_dict = cluster_instance_dict.get(cluster_in_pipeline, {})
+        instance_dict[instance] = True
+        cluster_instance_dict[cluster_in_pipeline] = instance_dict
+    return cluster_instance_dict
+
+
+def paasta_rerun(args):
+    """Reruns a Chronos job.
+    :param args: argparse.Namespace obj created from sys.args by cli"""
+    service = figure_out_service_name(args)  # exit with an error if the service doesn't exist
+    execution_date = args.execution_date.strftime(EXECUTION_DATE_FORMAT)
+
+    all_clusters = list_clusters()
+    actual_deployments = get_actual_deployments(service)  # cluster.instance: sha
+    if actual_deployments:
+        deploy_pipeline = list(get_planned_deployments(service))  # cluster.instance
+        deployed_clusters = list_deployed_clusters(deploy_pipeline, actual_deployments)
+        deployed_cluster_instance = _get_cluster_instance(actual_deployments.keys())
+
+    if args.clusters is not None:
+        clusters = args.clusters.split(",")
+    else:
+        clusters = deployed_clusters
+
+    for cluster in clusters:
+        print "cluster: %s" % cluster
+
+        if cluster not in all_clusters:
+            print "  Warning: \"%s\" does not look like a valid cluster..." % cluster
+            continue
+        if cluster not in deployed_clusters:
+            print "  Warning: service \"%s\" has not been deployed to \"%s\" yet..." % (service, cluster)
+            continue
+        if not deployed_cluster_instance[cluster].get(args.instance, False):
+            print ("  Warning: instance \"%s\" is either invalid "
+                   "or has not been deployed to \"%s\" yet..." % (args.instance, cluster))
+            continue
+
+        rc, output = execute_chronos_rerun_on_remote_master(service,
+                                                            args.instance,
+                                                            cluster,
+                                                            verbose=args.verbose,
+                                                            execution_date=execution_date)
+        if rc == 0:
+            print PaastaColors.green('  success')
+        else:
+            print PaastaColors.red('  error')
+            print output

--- a/paasta_tools/cli/cmds/rerun.py
+++ b/paasta_tools/cli/cmds/rerun.py
@@ -91,7 +91,7 @@ def paasta_rerun(args):
     :param args: argparse.Namespace obj created from sys.args by cli"""
     service = figure_out_service_name(args)  # exit with an error if the service doesn't exist
     if args.execution_date:
-        execution_date = args.execution_date.strftime(chronos_tools.EXECUTION_DATE_FORMAT)
+        execution_date = args.execution_date
     else:
         execution_date = None
 
@@ -134,11 +134,13 @@ def paasta_rerun(args):
         if execution_date is None:
             execution_date = _get_default_execution_date()
 
-        rc, output = execute_chronos_rerun_on_remote_master(service,
-                                                            args.instance,
-                                                            cluster,
-                                                            verbose=args.verbose,
-                                                            execution_date=execution_date)
+        rc, output = execute_chronos_rerun_on_remote_master(
+            service=service,
+            instancename=args.instance,
+            cluster=cluster,
+            verbose=args.verbose,
+            execution_date=execution_date.strftime(chronos_tools.EXECUTION_DATE_FORMAT)
+        )
         if rc == 0:
             print PaastaColors.green('  successfully created job')
         else:

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -548,6 +548,34 @@ def execute_paasta_metastatus_on_remote_master(cluster, verbose=0):
     return run_paasta_metastatus(master, verbose)
 
 
+def run_chronos_rerun(master, service, instancename, **kwargs):
+    timeout = 60
+    verbose_flags = '-v ' * kwargs['verbose']
+    command = 'ssh -A -n %s \'sudo chronos_rerun %s"%s %s" "%s"\'' % (
+        master,
+        verbose_flags,
+        service,
+        instancename,
+        kwargs['execution_date'],
+    )
+    return _run(command, timeout=timeout)
+
+
+def execute_chronos_rerun_on_remote_master(service, instancename, cluster, **kwargs):
+    """Returns a string containing an error message if an error occurred.
+    Otherwise returns the output of run_chronos_rerun().
+    """
+    masters, output = calculate_remote_masters(cluster)
+    if masters == []:
+        return 'ERROR: %s' % output
+    master, output = find_connectable_master(masters)
+    if not master:
+        return (
+            'ERROR: could not find connectable master in cluster %s\nOutput: %s' % (cluster, output)
+        )
+    return run_chronos_rerun(master, service, instancename, **kwargs)
+
+
 def lazy_choices_completer(list_func):
     def inner(prefix, **kwargs):
         options = list_func(**kwargs)

--- a/tests/cli/test_cmds_rerun.py
+++ b/tests/cli/test_cmds_rerun.py
@@ -1,0 +1,146 @@
+# Copyright 2015 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import contextlib
+import datetime
+from StringIO import StringIO
+
+from mock import MagicMock
+from mock import patch
+from pytest import mark
+
+from paasta_tools.cli.cmds.rerun import add_subparser
+from paasta_tools.cli.cmds.rerun import EXECUTION_DATE_FORMAT
+from paasta_tools.cli.cmds.rerun import paasta_rerun
+
+
+_list_clusters = ['cluster1', 'cluster2']
+_actual_deployments = {'cluster1.instance1': 'this_is_a_sha'}
+_planned_deployments = ['cluster1.instance1', 'cluster1.instance2', 'cluster2.instance1']
+
+
+@mark.parametrize('test_case', [
+    [
+        ['a_service', 'instance1', 'cluster1', '2016-04-08T02:37:27'],
+        'a_service',
+        _list_clusters, _actual_deployments, _planned_deployments,
+        'success',
+    ],
+    [
+        ['a_service', 'instance1', 'cluster1,cluster2', '2016-04-08T02:37:27'],
+        'a_service',
+        _list_clusters, _actual_deployments, _planned_deployments,
+        'success',
+    ],
+    [
+        ['a_service', 'instance1', None, '2016-04-08T02:37:27'],
+        'a_service',
+        _list_clusters, _actual_deployments, _planned_deployments,
+        'cluster: cluster1',  # success
+    ],
+    [
+        ['a_service', 'instance1', 'cluster3', '2016-04-08T02:37:27'],
+        'a_service',
+        _list_clusters, _actual_deployments, _planned_deployments,
+        '"cluster3" does not look like a valid cluster',
+    ],
+    [
+        ['a_service', 'instance1', 'cluster2', '2016-04-08T02:37:27'],
+        'a_service',
+        _list_clusters, _actual_deployments, _planned_deployments,
+        'service "a_service" has not been deployed to "cluster2" yet',
+    ],
+    [
+        ['a_service', 'instanceX', 'cluster1', '2016-04-08T02:37:27'],
+        'a_service',
+        _list_clusters, _actual_deployments, _planned_deployments,
+        'instance "instanceX" is either invalid',
+    ],
+    [
+        ['a_service', 'instance2', 'cluster1', '2016-04-08T02:37:27'],
+        'a_service',
+        _list_clusters, _actual_deployments, _planned_deployments,
+        ' or has not been deployed to "cluster1" yet',
+    ]
+])
+def test_rerun_validations(test_case):
+    with contextlib.nested(
+        patch('sys.stdout', new_callable=StringIO),
+        patch('paasta_tools.cli.cmds.rerun.figure_out_service_name', autospec=True),
+        patch('paasta_tools.cli.cmds.rerun.list_clusters', autospec=True),
+        patch('paasta_tools.cli.cmds.rerun.get_actual_deployments', autospec=True),
+        patch('paasta_tools.cli.cmds.rerun.get_planned_deployments', autospec=True),
+        patch('paasta_tools.cli.cmds.rerun.execute_chronos_rerun_on_remote_master', autospec=True),
+    ) as (
+        mock_stdout,
+        mock_figure_out_service_name,
+        mock_list_clusters,
+        mock_get_actual_deployments,
+        mock_get_planned_deployments,
+        mock_execute_rerun_remote,
+    ):
+
+        (rerun_args,
+         mock_figure_out_service_name.return_value,
+         mock_list_clusters.return_value,
+         mock_get_actual_deployments.return_value,
+         mock_get_planned_deployments.return_value,
+         expected_output) = test_case
+
+        mock_execute_rerun_remote.return_value = (0, '')
+
+        args = MagicMock()
+        args.service = rerun_args[0]
+        args.instance = rerun_args[1]
+        args.clusters = rerun_args[2]
+        args.execution_date = datetime.datetime.strptime(rerun_args[3], EXECUTION_DATE_FORMAT)
+        args.verbose = 0
+
+        paasta_rerun(args)
+
+        output = mock_stdout.getvalue()
+        assert expected_output in output
+
+
+@mark.parametrize('test_case', [
+    [['rerun'], True],
+    [['rerun', '-s', 'a_service'], True],
+    [['rerun', '-s', 'a_service', '-i', 'an_instance'], True],
+    [['rerun', '-s', 'a_service', '-i', 'an_instance', '-d', '2016-04-08T02:37:27'], False],
+    [['rerun', '-s', 'a_service', '-i', 'an_instance', '-d', 'not_a_date'], True],
+    [['rerun', '-v', '-v', '-s', 'a_service', '-i', 'an_instance', '-d', '2016-04-08T02:37:27'], False],
+])
+def test_rerun_argparse(test_case):
+    argv, should_exit = test_case
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    add_subparser(subparsers)
+
+    exited = False
+    rc = None
+    args = None
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as sys_exit:
+        exited = True
+        rc = sys_exit.code
+
+    assert exited == should_exit
+    if should_exit:
+        assert rc == 2
+
+    if args:
+        if args.verbose:
+            assert args.verbose == 2  # '-v' yields a verbosity level...
+        assert isinstance(args.execution_date, datetime.datetime)

--- a/tests/cli/test_cmds_rerun.py
+++ b/tests/cli/test_cmds_rerun.py
@@ -119,7 +119,8 @@ def test_rerun_validations(test_case):
          expected_output) = test_case
 
         mock_load_chronos_job_config.return_value = {}
-        mock_get_default_execution_date.return_value = 'default_date'
+        default_date = datetime.datetime(2002, 2, 2, 2, 2, 2, 2)
+        mock_get_default_execution_date.return_value = default_date
         mock_execute_rerun_remote.return_value = (0, '')
 
         args = MagicMock()
@@ -137,7 +138,8 @@ def test_rerun_validations(test_case):
         # No --execution_date argument, but that's ok: the job doesn't use time vars interpolation.
         # Check if the backend rerun command was called with the default date.
         if args.execution_date is None and not mock_uses_time_variables.return_value:
-            assert mock_execute_rerun_remote.call_args[1]['execution_date'] == 'default_date'
+            assert mock_execute_rerun_remote.call_args[1]['execution_date'] \
+                == default_date.strftime(EXECUTION_DATE_FORMAT)
 
         # The job does use time vars interpolation. Make sure the User supplied date was used.
         if args.execution_date is not None and mock_uses_time_variables.return_value:

--- a/tests/cli/test_cmds_rerun.py
+++ b/tests/cli/test_cmds_rerun.py
@@ -20,11 +20,12 @@ from mock import MagicMock
 from mock import patch
 from pytest import mark
 
+from paasta_tools.chronos_tools import EXECUTION_DATE_FORMAT
 from paasta_tools.cli.cmds.rerun import add_subparser
-from paasta_tools.cli.cmds.rerun import EXECUTION_DATE_FORMAT
 from paasta_tools.cli.cmds.rerun import paasta_rerun
 
 
+_user_supplied_execution_date = '2016-04-08T02:37:27'
 _list_clusters = ['cluster1', 'cluster2']
 _actual_deployments = {'cluster1.instance1': 'this_is_a_sha'}
 _planned_deployments = ['cluster1.instance1', 'cluster1.instance2', 'cluster2.instance1']
@@ -32,45 +33,57 @@ _planned_deployments = ['cluster1.instance1', 'cluster1.instance2', 'cluster2.in
 
 @mark.parametrize('test_case', [
     [
-        ['a_service', 'instance1', 'cluster1', '2016-04-08T02:37:27'],
+        ['a_service', 'instance1', 'cluster1', _user_supplied_execution_date],
         'a_service',
-        _list_clusters, _actual_deployments, _planned_deployments,
-        'success',
+        _list_clusters, _actual_deployments, _planned_deployments, False,
+        'successfully created job',
     ],
     [
-        ['a_service', 'instance1', 'cluster1,cluster2', '2016-04-08T02:37:27'],
+        ['a_service', 'instance1', 'cluster1', None],
         'a_service',
-        _list_clusters, _actual_deployments, _planned_deployments,
-        'success',
+        _list_clusters, _actual_deployments, _planned_deployments, False,
+        'successfully created job',
     ],
     [
-        ['a_service', 'instance1', None, '2016-04-08T02:37:27'],
+        ['a_service', 'instance1', 'cluster1', None],
         'a_service',
-        _list_clusters, _actual_deployments, _planned_deployments,
+        _list_clusters, _actual_deployments, _planned_deployments, True,
+        'please supply a `--execution_date` argument',  # job uses time variables interpolation
+    ],
+    [
+        ['a_service', 'instance1', 'cluster1,cluster2', _user_supplied_execution_date],
+        'a_service',
+        _list_clusters, _actual_deployments, _planned_deployments, False,
+        'successfully created job',
+    ],
+    [
+        ['a_service', 'instance1', None, _user_supplied_execution_date],
+        'a_service',
+        _list_clusters, _actual_deployments, _planned_deployments, False,
         'cluster: cluster1',  # success
     ],
     [
-        ['a_service', 'instance1', 'cluster3', '2016-04-08T02:37:27'],
+        ['a_service', 'instance1', 'cluster3', _user_supplied_execution_date],
         'a_service',
-        _list_clusters, _actual_deployments, _planned_deployments,
+        _list_clusters, _actual_deployments, _planned_deployments, False,
         '"cluster3" does not look like a valid cluster',
     ],
     [
-        ['a_service', 'instance1', 'cluster2', '2016-04-08T02:37:27'],
+        ['a_service', 'instance1', 'cluster2', _user_supplied_execution_date],
         'a_service',
-        _list_clusters, _actual_deployments, _planned_deployments,
+        _list_clusters, _actual_deployments, _planned_deployments, False,
         'service "a_service" has not been deployed to "cluster2" yet',
     ],
     [
-        ['a_service', 'instanceX', 'cluster1', '2016-04-08T02:37:27'],
+        ['a_service', 'instanceX', 'cluster1', _user_supplied_execution_date],
         'a_service',
-        _list_clusters, _actual_deployments, _planned_deployments,
+        _list_clusters, _actual_deployments, _planned_deployments, False,
         'instance "instanceX" is either invalid',
     ],
     [
-        ['a_service', 'instance2', 'cluster1', '2016-04-08T02:37:27'],
+        ['a_service', 'instance2', 'cluster1', _user_supplied_execution_date],
         'a_service',
-        _list_clusters, _actual_deployments, _planned_deployments,
+        _list_clusters, _actual_deployments, _planned_deployments, False,
         ' or has not been deployed to "cluster1" yet',
     ]
 ])
@@ -82,6 +95,9 @@ def test_rerun_validations(test_case):
         patch('paasta_tools.cli.cmds.rerun.get_actual_deployments', autospec=True),
         patch('paasta_tools.cli.cmds.rerun.get_planned_deployments', autospec=True),
         patch('paasta_tools.cli.cmds.rerun.execute_chronos_rerun_on_remote_master', autospec=True),
+        patch('paasta_tools.cli.cmds.rerun.chronos_tools.load_chronos_job_config', autospec=True),
+        patch('paasta_tools.cli.cmds.rerun.chronos_tools.uses_time_variables', autospec=True),
+        patch('paasta_tools.cli.cmds.rerun._get_default_execution_date', autospec=True),
     ) as (
         mock_stdout,
         mock_figure_out_service_name,
@@ -89,6 +105,9 @@ def test_rerun_validations(test_case):
         mock_get_actual_deployments,
         mock_get_planned_deployments,
         mock_execute_rerun_remote,
+        mock_load_chronos_job_config,
+        mock_uses_time_variables,
+        mock_get_default_execution_date,
     ):
 
         (rerun_args,
@@ -96,18 +115,33 @@ def test_rerun_validations(test_case):
          mock_list_clusters.return_value,
          mock_get_actual_deployments.return_value,
          mock_get_planned_deployments.return_value,
+         mock_uses_time_variables.return_value,
          expected_output) = test_case
 
+        mock_load_chronos_job_config.return_value = {}
+        mock_get_default_execution_date.return_value = 'default_date'
         mock_execute_rerun_remote.return_value = (0, '')
 
         args = MagicMock()
         args.service = rerun_args[0]
         args.instance = rerun_args[1]
         args.clusters = rerun_args[2]
-        args.execution_date = datetime.datetime.strptime(rerun_args[3], EXECUTION_DATE_FORMAT)
+        if rerun_args[3]:
+            args.execution_date = datetime.datetime.strptime(rerun_args[3], EXECUTION_DATE_FORMAT)
+        else:
+            args.execution_date = None
         args.verbose = 0
 
         paasta_rerun(args)
+
+        # No --execution_date argument, but that's ok: the job doesn't use time vars interpolation.
+        # Check if the backend rerun command was called with the default date.
+        if args.execution_date is None and not mock_uses_time_variables.return_value:
+            assert mock_execute_rerun_remote.call_args[1]['execution_date'] == 'default_date'
+
+        # The job does use time vars interpolation. Make sure the User supplied date was used.
+        if args.execution_date is not None and mock_uses_time_variables.return_value:
+            assert mock_execute_rerun_remote.call_args[1]['execution_date'] == _user_supplied_execution_date
 
         output = mock_stdout.getvalue()
         assert expected_output in output
@@ -116,10 +150,10 @@ def test_rerun_validations(test_case):
 @mark.parametrize('test_case', [
     [['rerun'], True],
     [['rerun', '-s', 'a_service'], True],
-    [['rerun', '-s', 'a_service', '-i', 'an_instance'], True],
-    [['rerun', '-s', 'a_service', '-i', 'an_instance', '-d', '2016-04-08T02:37:27'], False],
+    [['rerun', '-s', 'a_service', '-i', 'an_instance'], False],
+    [['rerun', '-s', 'a_service', '-i', 'an_instance', '-d', _user_supplied_execution_date], False],
     [['rerun', '-s', 'a_service', '-i', 'an_instance', '-d', 'not_a_date'], True],
-    [['rerun', '-v', '-v', '-s', 'a_service', '-i', 'an_instance', '-d', '2016-04-08T02:37:27'], False],
+    [['rerun', '-v', '-v', '-s', 'a_service', '-i', 'an_instance', '-d', _user_supplied_execution_date], False],
 ])
 def test_rerun_argparse(test_case):
     argv, should_exit = test_case
@@ -143,4 +177,5 @@ def test_rerun_argparse(test_case):
     if args:
         if args.verbose:
             assert args.verbose == 2  # '-v' yields a verbosity level...
-        assert isinstance(args.execution_date, datetime.datetime)
+        if args.execution_date:
+            assert isinstance(args.execution_date, datetime.datetime)

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -547,3 +547,20 @@ def test_get_instance_config_unknown(
             soa_dir='fake_soa_dir',
         )
         assert mock_validate_service_instance.call_count == 1
+
+
+@patch('paasta_tools.cli.utils._run', autospec=True)
+def test_run_chronos_rerun(mock_run):
+    mock_run.return_value = (0, 'fake_output')
+    expected_command = ('ssh -A -n fake_master \'sudo chronos_rerun -v -v "a_service an_instance" '
+                        '"2016-04-08T02:37:27"\'')
+
+    actual = utils.run_chronos_rerun(
+        'fake_master',
+        'a_service',
+        'an_instance',
+        verbose=2,
+        execution_date='2016-04-08T02:37:27'
+    )
+    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY)
+    assert actual == mock_run.return_value

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -647,7 +647,7 @@ class TestChronosTools:
         assert okay is True
         assert msg == ''
 
-    def test_check_schedule_valid_empty_start_time(self):
+    def test_check_schedule_invalid_empty_start_time(self):
         fake_schedule = 'R10//PT70S'
         chronos_config = chronos_tools.ChronosJobConfig(
             service='',
@@ -657,8 +657,8 @@ class TestChronosTools:
             branch_dict={},
         )
         okay, msg = chronos_config.check_schedule()
-        assert okay is True
-        assert msg == ''
+        assert okay is False
+        assert msg == 'The specified schedule "%s" does not contain a start time' % fake_schedule
 
     def test_check_schedule_invalid_start_time_no_t_designator(self):
         fake_start_time = 'now'
@@ -889,6 +889,7 @@ class TestChronosTools:
                 'volumes': fake_docker_volumes,
                 'image': fake_docker_url,
                 'type': 'DOCKER',
+                'parameters': {'memory-swap': '1024m'}
             },
             'uris': ['file:///root/.dockercfg', ],
             'shell': True,
@@ -1140,7 +1141,8 @@ class TestChronosTools:
                     'network': 'BRIDGE',
                     'volumes': [],
                     'image': "fake_registry/paasta-test-service-penguin",
-                    'type': 'DOCKER'
+                    'type': 'DOCKER',
+                    'parameters': {'memory-swap': '1024.4m'}
                 },
                 'uris': ['file:///root/.dockercfg', ],
                 'mem': 1024.4,
@@ -1231,7 +1233,8 @@ class TestChronosTools:
                     'network': 'BRIDGE',
                     'volumes': [],
                     'image': "fake_registry/fake_image",
-                    'type': 'DOCKER'
+                    'type': 'DOCKER',
+                    'parameters': {'memory-swap': '1024.4m'}
                 },
                 'uris': ['file:///root/.dockercfg', ],
                 'mem': 1024.4,
@@ -1289,7 +1292,8 @@ class TestChronosTools:
                     'network': 'BRIDGE',
                     'volumes': [],
                     'image': "fake_registry/fake_image",
-                    'type': 'DOCKER'
+                    'type': 'DOCKER',
+                    'parameters': {'memory-swap': '1024.4m'}
                 },
                 'uris': ['file:///root/.dockercfg', ],
                 'mem': 1024.4,
@@ -1363,7 +1367,8 @@ class TestChronosTools:
                     'network': 'BRIDGE',
                     'volumes': fake_system_volumes + fake_extra_volumes,
                     'image': "fake_registry/fake_image",
-                    'type': 'DOCKER'
+                    'type': 'DOCKER',
+                    'parameters': {'memory-swap': '1024.4m'}
                 },
                 'uris': ['file:///root/.dockercfg', ],
                 'mem': 1024.4,
@@ -1560,6 +1565,22 @@ class TestChronosTools:
         assert chronos_tools.determine_disabled_state('stop', False) is True
         assert chronos_tools.determine_disabled_state('start', True) is True
         assert chronos_tools.determine_disabled_state('stop', True) is True
+
+    def test_filter_non_temporary_jobs(self):
+        fake_jobs = [
+            {
+                'name': 'tmp-2016-04-09T064121354622 example_service mesosstage_robjreruntest'
+            },
+            {
+                'name': 'example_service mesosstage_robjreruntest'
+            }
+        ]
+        expected = [
+            {
+                'name': 'example_service mesosstage_robjreruntest'
+            }
+        ]
+        assert chronos_tools.filter_non_temporary_chronos_jobs(fake_jobs) == expected
 
     def test_uses_time_variables_false(self):
         fake_chronos_job_config = copy.deepcopy(self.fake_chronos_job_config)

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1560,3 +1560,13 @@ class TestChronosTools:
         assert chronos_tools.determine_disabled_state('stop', False) is True
         assert chronos_tools.determine_disabled_state('start', True) is True
         assert chronos_tools.determine_disabled_state('stop', True) is True
+
+    def test_uses_time_variables_false(self):
+        fake_chronos_job_config = copy.deepcopy(self.fake_chronos_job_config)
+        fake_chronos_job_config.config_dict['cmd'] = '/usr/bin/printf hello'
+        assert not chronos_tools.uses_time_variables(fake_chronos_job_config)
+
+    def test_uses_time_variables_true(self):
+        fake_chronos_job_config = copy.deepcopy(self.fake_chronos_job_config)
+        fake_chronos_job_config.config_dict['cmd'] = '/usr/bin/printf %(shortdate)s'
+        assert chronos_tools.uses_time_variables(fake_chronos_job_config)


### PR DESCRIPTION
Closes #323.

A `paasta rerun` command allows Users to re-run Chronos jobs.

![screen shot 2016-04-08 at 3 36 23 pm](https://cloud.githubusercontent.com/assets/615907/14387492/971a8df8-fda1-11e5-9d07-a26ce549096d.png)