### PR TITLE
added healthcheck output to marathon status

### DIFF
--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -138,7 +138,7 @@ def get_verbose_status_of_marathon_app(app):
     output.append("    App created: %s (%s)" % (str(create_datetime), humanize.naturaltime(create_datetime)))
     output.append("    Tasks:")
 
-    rows = [("Mesos Task ID", "Host deployed to", "Deployed at what localtime", "Health checks")]
+    rows = [("Mesos Task ID", "Host deployed to", "Deployed at what localtime", "Health")]
     for task in app.tasks:
         local_deployed_datetime = datetime_from_utc_to_local(task.staged_at)
         if task.host is not None:
@@ -148,11 +148,11 @@ def get_verbose_status_of_marathon_app(app):
         health_check_results = [health_check.alive for health_check in task.health_check_results
                                 if health_check.alive is not None]
         if not health_check_results:
-            health_check_status = PaastaColors.grey("UNKNOWN")
+            health_check_status = PaastaColors.grey("N/A")
         elif all(health_check_results):
-            health_check_status = PaastaColors.green("PASSING")
+            health_check_status = PaastaColors.green("Healthy")
         else:
-            health_check_status = PaastaColors.red("FAILING")
+            health_check_status = PaastaColors.red("Unhealthy")
 
         rows.append((
             get_short_task_id(task.id),

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -138,20 +138,30 @@ def get_verbose_status_of_marathon_app(app):
     output.append("    App created: %s (%s)" % (str(create_datetime), humanize.naturaltime(create_datetime)))
     output.append("    Tasks:")
 
-    rows = [("Mesos Task ID", "Host deployed to", "Deployed at what localtime")]
+    rows = [("Mesos Task ID", "Host deployed to", "Deployed at what localtime", "Health checks")]
     for task in app.tasks:
         local_deployed_datetime = datetime_from_utc_to_local(task.staged_at)
         if task.host is not None:
             hostname = "%s:%s" % (task.host.split(".")[0], task.ports[0])
         else:
             hostname = "Unknown"
+        health_check_results = [health_check.alive for health_check in task.health_check_results
+                                if health_check.alive is not None]
+        if not health_check_results:
+            health = PaastaColors.grey("UNKNOWN")
+        elif all(health_check_results):
+            health = PaastaColors.green("PASSING")
+        else:
+            health = PaastaColors.red("FAILING")
+
         rows.append((
             get_short_task_id(task.id),
             hostname,
             '%s (%s)' % (
                 local_deployed_datetime.strftime("%Y-%m-%dT%H:%M"),
                 humanize.naturaltime(local_deployed_datetime),
-            )
+            ),
+            health,
         ))
     output.append('\n'.join(["      %s" % line for line in format_table(rows)]))
     if len(app.tasks) == 0:

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -148,11 +148,11 @@ def get_verbose_status_of_marathon_app(app):
         health_check_results = [health_check.alive for health_check in task.health_check_results
                                 if health_check.alive is not None]
         if not health_check_results:
-            health = PaastaColors.grey("UNKNOWN")
+            health_check_status = PaastaColors.grey("UNKNOWN")
         elif all(health_check_results):
-            health = PaastaColors.green("PASSING")
+            health_check_status = PaastaColors.green("PASSING")
         else:
-            health = PaastaColors.red("FAILING")
+            health_check_status = PaastaColors.red("FAILING")
 
         rows.append((
             get_short_task_id(task.id),
@@ -161,7 +161,7 @@ def get_verbose_status_of_marathon_app(app):
                 local_deployed_datetime.strftime("%Y-%m-%dT%H:%M"),
                 humanize.naturaltime(local_deployed_datetime),
             ),
-            health,
+            health_check_status,
         ))
     output.append('\n'.join(["      %s" % line for line in format_table(rows)]))
     if len(app.tasks) == 0:

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -177,6 +177,7 @@ def test_get_verbose_status_of_marathon_app():
     fake_task.host = 'fake_deployed_host'
     fake_task.ports = [6666]
     fake_task.staged_at = datetime.datetime.fromtimestamp(0)
+    fake_task.health_check_results = []
     fake_app.tasks = [fake_task]
     tasks, out = marathon_serviceinit.get_verbose_status_of_marathon_app(fake_app)
     assert 'fake_task_id' in out
@@ -196,12 +197,14 @@ def test_get_verbose_status_of_marathon_app_column_alignment():
     fake_task1.host = 'fake_deployed_host'
     fake_task1.ports = [6666]
     fake_task1.staged_at = datetime.datetime.fromtimestamp(0)
+    fake_task1.health_check_results = []
 
     fake_task2 = mock.create_autospec(marathon.models.app.MarathonTask)
     fake_task2.id = 'fake_task2_id'
     fake_task2.host = 'fake_deployed_host_with_a_really_long_name'
     fake_task2.ports = [6666]
     fake_task2.staged_at = datetime.datetime.fromtimestamp(0)
+    fake_task2.health_check_results = []
 
     fake_app.tasks = [fake_task1, fake_task2]
     tasks, out = marathon_serviceinit.get_verbose_status_of_marathon_app(fake_app)


### PR DESCRIPTION
Sample output
```
>>> from paasta_tools.marathon_serviceinit import perform_command
>>> perform_command('status', 'paasta_canary', 'mesosstage_main', 'mesosstage', 1, '/nail/etc/services')
State:      Running - Desired state: Started
Marathon:   Healthy - up with (5/5) instances. Status: Running.
  Marathon app ID: /paasta--canary.mesosstage--main.gitc19f9731.configdbd127ab
    App created: 2016-04-05 12:42:35.199000 (5 days ago)
    Tasks:
      Mesos Task ID                         Host deployed to           Deployed at what localtime         Health checks
      a57cc3df-0011-11e6-b964-0242a1bf1f9a  mesos2-uswest1cdevc:31194  2016-04-11T11:17 (16 minutes ago)  PASSING
      7bf354da-0010-11e6-a226-0242e21a17e4  mesos1-uswest1cdevc:31583  2016-04-11T11:09 (24 minutes ago)  PASSING
      b7f576c4-0011-11e6-b964-0242a1bf1f9a  mesos2-uswest1cdevc:31947  2016-04-11T11:17 (15 minutes ago)  PASSING
      9e42a30a-0011-11e6-b964-0242a1bf1f9a  mesos3-uswest1cdevc:31260  2016-04-11T11:17 (16 minutes ago)  PASSING
      9e42ca1c-0011-11e6-b964-0242a1bf1f9a  mesos2-uswest1cdevc:31959  2016-04-11T11:17 (16 minutes ago)  PASSING
Mesos:      Healthy - (5/5) tasks in the TASK_RUNNING state.
  Running Tasks:
    Mesos Task ID                         Host deployed to     Ram      CPU   Deployed at what localtime
    a57cc3df-0011-11e6-b964-0242a1bf1f9a  mesos2-uswest1cdevc  0/532MB  0.3%  2016-04-11T11:17 (16 minutes ago)
    9e42ca1c-0011-11e6-b964-0242a1bf1f9a  mesos2-uswest1cdevc  0/532MB  0.3%  2016-04-11T11:17 (16 minutes ago)
    9e42a30a-0011-11e6-b964-0242a1bf1f9a  mesos3-uswest1cdevc  0/532MB  0.4%  2016-04-11T11:17 (16 minutes ago)
    b7f576c4-0011-11e6-b964-0242a1bf1f9a  mesos2-uswest1cdevc  0/532MB  0.4%  2016-04-11T11:17 (15 minutes ago)
    7bf354da-0010-11e6-a226-0242e21a17e4  mesos1-uswest1cdevc  0/532MB  0.3%  2016-04-11T11:10 (23 minutes ago)
  Non-Running Tasks
    Mesos Task ID                         Host deployed to  Deployed at what localtime         Status
    a57c4eae-0011-11e6-b964-0242a1bf1f9a  Unknown           2016-04-11T11:17 (16 minutes ago)  TASK_FAILED
    abcc0f81-0011-11e6-b964-0242a1bf1f9a  Unknown           2016-04-11T11:17 (15 minutes ago)  TASK_FAILED
    b7639196-fffe-11e5-b964-0242a1bf1f9a  Unknown           2016-04-11T09:01 (2 hours ago)     TASK_FINISHED
    ae98d7ee-fff9-11e5-b964-0242a1bf1f9a  Unknown           2016-04-11T08:25 (3 hours ago)     TASK_FINISHED
    ae979f6d-fff9-11e5-b964-0242a1bf1f9a  Unknown           2016-04-11T08:25 (3 hours ago)     TASK_FAILED
    844ba08b-fff4-11e5-b964-0242a1bf1f9a  Unknown           2016-04-11T07:48 (3 hours ago)     TASK_FAILED
Smartstack:
  Haproxy Service Name: paasta_canary.mesosstage_main
  Backends:
      Name                             LastCheck        LastChange      Status
    uswest1-devc - Healthy - in haproxy with (5/5) total backends UP in this namespace.
      mesos2-uswest1cdevc:31194        L7OK/200 in 1ms  13 minutes ago  UP
      mesos1-uswest1cdevc:31583        L7OK/200 in 1ms  13 minutes ago  UP
      mesos2-uswest1cdevc:31947        L7OK/200 in 5ms  13 minutes ago  UP
      mesos3-uswest1cdevc:31260        L7OK/200 in 1ms  13 minutes ago  UP
      mesos2-uswest1cdevc:31959        L7OK/200 in 7ms  13 minutes ago  UP
      10-40-25-82-uswest1cdevc:31685   INI/ in ms       13 minutes ago  MAINT
      10-40-25-82-uswest1cdevc:31182   INI/ in ms       13 minutes ago  MAINT
      10-40-25-209-uswest1cdevc:31239  INI/ in ms       13 minutes ago  MAINT
      10-40-25-209-uswest1cdevc:31081  INI/ in ms       13 minutes ago  MAINT
```