### PR TITLE
ignore temporary jobs when checking chronos jobs

### DIFF
--- a/paasta_tools/check_chronos_jobs.py
+++ b/paasta_tools/check_chronos_jobs.py
@@ -101,7 +101,8 @@ def build_service_job_mapping(client, configured_jobs):
             instance=job[1],
             client=client,
         )
-        with_states = last_run_state_for_jobs(matching_jobs)
+        filtered = chronos_tools.filter_non_temporary_chronos_jobs(matching_jobs)
+        with_states = last_run_state_for_jobs(filtered)
         service_job_mapping[job] = with_states
     return service_job_mapping
 

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -651,6 +651,18 @@ def lookup_chronos_jobs(client, service=None, instance=None, include_disabled=Fa
     )
 
 
+def filter_non_temporary_chronos_jobs(jobs):
+    """
+    Given a list of Chronos jobs, as pulled from the API, remove those
+    which are defined as 'temporary' jobs.
+
+    :param jobs: a list of chronos jobs
+    :returns: a list of chronos jobs containing the same jobs as those provided
+    by the ``jobs`` parameter, but with temporary jobs removed.
+    """
+    return [job for job in jobs if not job['name'].startswith(TMP_JOB_IDENTIFIER)]
+
+
 def filter_chronos_jobs(jobs, service, instance, include_disabled):
     """Filters a list of Chronos jobs based on several criteria.
 

--- a/tests/test_check_chronos_jobs.py
+++ b/tests/test_check_chronos_jobs.py
@@ -107,7 +107,18 @@ def test_build_service_job_mapping(mock_last_run_state, mock_filter_enabled_jobs
     # iter() is a workaround
     # (http://lists.idyll.org/pipermail/testing-in-python/2013-April/005527.html)
     # for a bug in mock (http://bugs.python.org/issue17826)
-    mock_lookup_chronos_jobs.side_effect = iter([[{}, {}, {}] for x in range(0, 3)])
+    fake_jobs = [[
+        {
+            'name': 'foo'
+        },
+        {
+            'name': 'foo'
+        },
+        {
+            'name': 'foo'
+        }
+    ] for x in range(0, 3)]
+    mock_lookup_chronos_jobs.side_effect = iter(fake_jobs)
     mock_filter_enabled_jobs.side_effect = iter([[{}, {}, {}] for x in range(0, 3)])
     mock_last_run_state.side_effect = iter([
         ('faketimestamp', chronos_tools.LastRunState.Success),
@@ -119,9 +130,9 @@ def test_build_service_job_mapping(mock_last_run_state, mock_filter_enabled_jobs
     fake_client = Mock(list=Mock(return_value=[('service1', 'main'), ('service2', 'main'), ('service3', 'main')]))
 
     expected_job_states = [
-        ({}, chronos_tools.LastRunState.Success),
-        ({}, chronos_tools.LastRunState.Fail),
-        ({}, chronos_tools.LastRunState.NotRun),
+        ({'name': 'foo'}, chronos_tools.LastRunState.Success),
+        ({'name': 'foo'}, chronos_tools.LastRunState.Fail),
+        ({'name': 'foo'}, chronos_tools.LastRunState.NotRun),
     ]
 
     expected = {

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1560,3 +1560,19 @@ class TestChronosTools:
         assert chronos_tools.determine_disabled_state('stop', False) is True
         assert chronos_tools.determine_disabled_state('start', True) is True
         assert chronos_tools.determine_disabled_state('stop', True) is True
+
+    def test_filter_non_temporary_jobs(self):
+        fake_jobs = [
+            {
+                'name': 'tmp-2016-04-09T064121354622 example_service mesosstage_robjreruntest'
+            },
+            {
+                'name': 'example_service mesosstage_robjreruntest'
+            }
+        ]
+        expected = [
+            {
+                'name': 'example_service mesosstage_robjreruntest'
+            }
+        ]
+        assert chronos_tools.filter_non_temporary_chronos_jobs(fake_jobs) == expected


### PR DESCRIPTION
closes #421 

The issue was a bit more of an edge case than I realised - it occurred to me that this wasn't consistent, and we weren't always being told about > 1 job existing when we had Chronos rerun jobs around.

What I found was:

- we filter **enabled** jobs when looking for chronos jobs belonging to a service_instance in ``check_chronos_jobs``
- when running ``chronos_rerun`` we launch a job with ``disabled: False``. If ``disabled: True``, then Chronos refuses to run the job at all. Instead, we control the 'run once' functionality using the repeat value in the schedule field (``R1/start-time/interval``)
- Chronos **disables** the job once the job has been run, and adjusts the schedule to have ``R0``
- As a result, the extra job only triggers the issue of > 1 job showing up for a service_isntance in ``check_chronos_jobs`` if ``check_chronos_jobs`` is run whilst the rerun job is still running.