### PR TITLE
removed portMapping from non-bridge nets

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -373,13 +373,6 @@ class MarathonServiceConfig(InstanceConfig):
                 'docker': {
                     'image': docker_url,
                     'network': net,
-                    'portMappings': [
-                        {
-                            'containerPort': CONTAINER_PORT,
-                            'hostPort': 0,
-                            'protocol': 'tcp',
-                        },
-                    ],
                     "parameters": [
                         {"key": "memory-swap", "value": "%sm" % str(self.get_mem())},
                     ]


### PR DESCRIPTION
I fixed this a while ago but it looks like it got re-included in a merge. Specifying `portMappings` with `--net=host` causes launching the docker container to fail.

The TF2 server will not go to space today ):