### PR TITLE
Use marathon 1.1.1 in itest and upgrade marathon-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ isodate==0.5.1
 jsonschema==2.5.1
 kazoo==2.2
 lockfile==0.9.1
-marathon==0.7.7
+marathon==0.7.8
 mccabe==0.3.1
 mesos.cli==0.1.5
 mesos.interface==0.28.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ isodate==0.5.1
 jsonschema==2.5.1
 kazoo==2.2
 lockfile==0.9.1
-marathon==0.8.0
+marathon==0.8.1
 mccabe==0.3.1
 mesos.cli==0.1.5
 mesos.interface==0.28.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ isodate==0.5.1
 jsonschema==2.5.1
 kazoo==2.2
 lockfile==0.9.1
-marathon==0.7.8
+marathon==0.8.0
 mccabe==0.3.1
 mesos.cli==0.1.5
 mesos.interface==0.28.0

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'isodate >= 0.5.0',
         'jsonschema',
         'kazoo >= 2.0.0',
-        'marathon >= 0.7.7',
+        'marathon >= 0.7.8',
         'mesos.cli == 0.1.5',
         'ordereddict >= 1.1',
         'path.py >= 8.1',

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'isodate >= 0.5.0',
         'jsonschema',
         'kazoo >= 2.0.0',
-        'marathon >= 0.8.0',
+        'marathon >= 0.8.1',
         'mesos.cli == 0.1.5',
         'ordereddict >= 1.1',
         'path.py >= 8.1',

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'isodate >= 0.5.0',
         'jsonschema',
         'kazoo >= 2.0.0',
-        'marathon >= 0.7.8',
+        'marathon >= 0.8.0',
         'mesos.cli == 0.1.5',
         'ordereddict >= 1.1',
         'path.py >= 8.1',

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -25,7 +25,7 @@ RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set
 RUN echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections
 RUN apt-get update && apt-get -y install lsb-release oracle-java8-installer
 
-RUN apt-get -y install libsasl2-modules marathon=0.15.3-1.0.463.ubuntu1404
+RUN apt-get -y install libsasl2-modules marathon=1.1.1-1.0.472.ubuntu1404
 
 RUN echo -n "secret2" > /etc/marathon_framework_secret
 


### PR DESCRIPTION
Marathon 1.1.1 has been released. Let's upgrade to it.

This will fail in Travis until @solarkennedy's [PR](https://github.com/thefactory/marathon-python/pull/92) is merged and a new version of marathon-python is released.