### PR TITLE
Don't alert teams if a service hasn't been deployed yet

### DIFF
--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -232,7 +232,7 @@ def check_service_replication(client, service, instance, cluster, soa_dir):
     try:
         expected_count = marathon_tools.get_expected_instance_count_for_namespace(service, instance, soa_dir=soa_dir)
     except NoDeploymentsAvailable:
-        log.info('deployments.json missing for %s. Skipping replication monitoring.' % job_id)
+        log.debug('deployments.json missing for %s. Skipping replication monitoring.' % job_id)
         return
     if expected_count is None:
         return

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -577,17 +577,13 @@ def main():
             soa_dir=soa_dir,
         )
     except NoDeploymentsAvailable:
-        error_msg = "No deployments found for %s in cluster %s" % (args.service_instance,
-                                                                   load_system_paasta_config().get_cluster())
-        log.error(error_msg)
-        send_event(service, instance, soa_dir, pysensu_yelp.Status.CRITICAL, error_msg)
-        # exit 0 because the event was sent to the right team and this is not an issue with Paasta itself
+        log.debug("No deployments found for %s in cluster %s. Skipping." % (args.service_instance,
+                                                                            load_system_paasta_config().get_cluster()))
         sys.exit(0)
     except NoConfigurationForServiceError:
         error_msg = "Could not read marathon configuration file for %s in cluster %s" % \
             (args.service_instance, load_system_paasta_config().get_cluster())
         log.error(error_msg)
-        send_event(service, instance, soa_dir, pysensu_yelp.Status.CRITICAL, error_msg)
         sys.exit(1)
 
     try:


### PR DESCRIPTION
I'm not really so sure we have to alert/page all the peoples just because something hasn't been deployed yet. These lines have mostly caused a bunch of pages to people who don't need to be paged for this.

Pretty much nobody cares when they are setting up a new service, so I think it would be better if we just "move along" as if it wasn't a big deal and exit 0.