### PR TITLE
always round --memory-swap param up to closest mb

### DIFF
--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -391,9 +391,9 @@ class ChronosJobConfig(InstanceConfig):
                 'network': net,
                 'type': 'DOCKER',
                 'volumes': docker_volumes,
-                'parameters': {
-                    'memory-swap': "%sm" % self.get_mem(),
-                }
+                'parameters': [
+                    {"key": "memory-swap", "value": self.get_mem_swap()},
+                ]
             },
             'uris': [dockerfile_location, ],
             'environmentVariables': self.get_env(),

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -374,7 +374,7 @@ class MarathonServiceConfig(InstanceConfig):
                     'image': docker_url,
                     'network': net,
                     "parameters": [
-                        {"key": "memory-swap", "value": "%sm" % str(self.get_mem())},
+                        {"key": "memory-swap", "value": self.get_mem_swap()},
                     ]
                 },
                 'type': 'DOCKER',

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -24,6 +24,7 @@ import importlib
 import io
 import json
 import logging
+import math
 import os
 import pwd
 import re
@@ -117,6 +118,16 @@ class InstanceConfig(dict):
         :returns: The amount of memory specified by the config, 1024 if not specified"""
         mem = self.config_dict.get('mem', 1024)
         return mem
+
+    def get_mem_swap(self):
+        """Gets the memory-swap value. This value is passed to the docker
+        container to ensure that the total memory limit (memory + swap) is the
+        same value as the 'mem' key in soa-configs. Note - this value *has* to
+        be >= to the mem key, so we always round up to the closest MB.
+        """
+        mem = self.get_mem()
+        mem_swap = int(math.ceil(mem))
+        return "%sm" % mem_swap
 
     def get_cpus(self):
         """Gets the number of cpus required from the service's configuration.

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -889,7 +889,7 @@ class TestChronosTools:
                 'volumes': fake_docker_volumes,
                 'image': fake_docker_url,
                 'type': 'DOCKER',
-                'parameters': {'memory-swap': '1024m'}
+                'parameters': [{"key": "memory-swap", "value": "1024m"}],
             },
             'uris': ['file:///root/.dockercfg', ],
             'shell': True,
@@ -1142,7 +1142,7 @@ class TestChronosTools:
                     'volumes': [],
                     'image': "fake_registry/paasta-test-service-penguin",
                     'type': 'DOCKER',
-                    'parameters': {'memory-swap': '1024.4m'}
+                    'parameters': [{"key": "memory-swap", "value": "1025m"}],
                 },
                 'uris': ['file:///root/.dockercfg', ],
                 'mem': 1024.4,
@@ -1234,7 +1234,7 @@ class TestChronosTools:
                     'volumes': [],
                     'image': "fake_registry/fake_image",
                     'type': 'DOCKER',
-                    'parameters': {'memory-swap': '1024.4m'}
+                    'parameters': [{"key": "memory-swap", "value": "1025m"}],
                 },
                 'uris': ['file:///root/.dockercfg', ],
                 'mem': 1024.4,
@@ -1293,7 +1293,7 @@ class TestChronosTools:
                     'volumes': [],
                     'image': "fake_registry/fake_image",
                     'type': 'DOCKER',
-                    'parameters': {'memory-swap': '1024.4m'}
+                    'parameters': [{"key": "memory-swap", "value": "1025m"}],
                 },
                 'uris': ['file:///root/.dockercfg', ],
                 'mem': 1024.4,
@@ -1368,7 +1368,7 @@ class TestChronosTools:
                     'volumes': fake_system_volumes + fake_extra_volumes,
                     'image': "fake_registry/fake_image",
                     'type': 'DOCKER',
-                    'parameters': {'memory-swap': '1024.4m'}
+                    'parameters': [{"key": "memory-swap", "value": "1025m"}],
                 },
                 'uris': ['file:///root/.dockercfg', ],
                 'mem': 1024.4,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -854,6 +854,30 @@ class TestInstanceConfig:
         )
         assert fake_conf.get_mem() == 1024
 
+    def test_get_mem_swap_int(self):
+        fake_conf = utils.InstanceConfig(
+            service='',
+            instance='',
+            cluster='',
+            config_dict={
+                'mem': 50
+            },
+            branch_dict={},
+        )
+        assert fake_conf.get_mem_swap() == "50m"
+
+    def test_get_mem_swap_float_rounds_up(self):
+        fake_conf = utils.InstanceConfig(
+            service='',
+            instance='',
+            cluster='',
+            config_dict={
+                'mem': 50.4
+            },
+            branch_dict={},
+        )
+        assert fake_conf.get_mem_swap() == "51m"
+
     def test_get_disk_in_config(self):
         fake_conf = utils.InstanceConfig(
             service='',


### PR DESCRIPTION
the value of the arg for ``--memory-swap`` is required to be >= the
``mem`` param passed to docker - it also doesn't accept float values,
so we round whatever value is set in the mem field up to the closest MB. 
The only reason we haven't been bitten by this is because none of our 
soa-configs specify a float value for mem, but having tested it, it definitely causes apps 
to fail.