### PR TITLE
Make DOCKER_TAG check less strict

### DIFF
--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -139,7 +139,7 @@ def makefile_has_a_tab(makefile_path):
 
 def makefile_has_docker_tag(makefile_path):
     contents = get_file_contents(makefile_path)
-    return re.search(r"^DOCKER_TAG\s*\?=", contents, re.MULTILINE) is not None
+    return re.search(r"DOCKER_TAG\s*\?=", contents, re.MULTILINE) is not None
 
 
 def makefile_check():


### PR DESCRIPTION
it's also valid to have "export DOCKER_TAG ?= ...", etc.

Fixes #439 