### PR TITLE
fixed error running paasta metastatus

### DIFF
--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -101,7 +101,7 @@ def paasta_metastatus(args):
     clusters_to_inspect = figure_out_clusters_to_inspect(args, all_clusters)
     for cluster in clusters_to_inspect:
         if cluster in all_clusters:
-            print_cluster_status(cluster, args.verbose, soa_dir)
+            print_cluster_status(cluster, args.verbose)
         else:
             print "Cluster %s doesn't look like a valid cluster?" % args.clusters
             print "Try using tab completion to help complete the cluster name"


### PR DESCRIPTION
```
matts@dev2-devc:~$ paasta metastatus -c norcal-prod -vvv
Traceback (most recent call last):
  File "/usr/bin/paasta", line 120, in <module>
    main()
  File "/usr/bin/paasta", line 116, in main
    return_code = args.command(args)
  File "/usr/share/python/paasta-tools/lib/python2.7/site-packages/paasta_tools/cli/cmds/metastatus.py", line 104, in paasta_metastatus
    print_cluster_status(cluster, args.verbose, soa_dir)
TypeError: print_cluster_status() takes at most 2 arguments (3 given)
```