### PR TITLE
interpolate datestrings when using local-run with a chronos job

### DIFF
--- a/paasta_tools/cli/cmds/cook_image.py
+++ b/paasta_tools/cli/cmds/cook_image.py
@@ -77,6 +77,7 @@ def paasta_cook_image(args, service=None, soa_dir=None):
             service=service,
             loglevel='debug'
         )
+        print output
         if returncode != 0:
             _log(
                 service=service,

--- a/paasta_tools/cli/cmds/cook_image.py
+++ b/paasta_tools/cli/cmds/cook_image.py
@@ -77,7 +77,6 @@ def paasta_cook_image(args, service=None, soa_dir=None):
             service=service,
             loglevel='debug'
         )
-        print output
         if returncode != 0:
             _log(
                 service=service,

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -598,7 +598,7 @@ def command_function_for_framework(framework):
     elif framework == 'marathon':
         return format_marathon_command
     else:
-        raise ValueError("Invalid Frmework")
+        raise ValueError("Invalid Framework")
 
 
 def configure_and_run_docker_container(docker_client, docker_hash, service, instance, cluster, args, pull_image=False):

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
 import math
 import os
 import pipes
@@ -27,6 +28,7 @@ import requests
 import service_configuration_lib
 from docker import errors
 
+from paasta_tools.chronos_tools import parse_time_variables
 from paasta_tools.cli.cmds.check import makefile_responds_to
 from paasta_tools.cli.cmds.cook_image import paasta_cook_image
 from paasta_tools.cli.utils import figure_out_service_name
@@ -52,6 +54,7 @@ from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import Timeout
 from paasta_tools.utils import TimeoutError
+from paasta_tools.utils import validate_service_instance
 
 
 def pick_random_port():
@@ -578,6 +581,26 @@ def run_docker_container(
     sys.exit(returncode)
 
 
+def command_function_for_framework(framework):
+    """
+    Given a framework, return a function that appropriately formats
+    the command to be run.
+    """
+    def format_marathon_command(cmd):
+        return cmd
+
+    def format_chronos_command(cmd):
+        interpolated_command = parse_time_variables(cmd, datetime.datetime.now())
+        return interpolated_command
+
+    if framework == 'chronos':
+        return format_chronos_command
+    elif framework == 'marathon':
+        return format_marathon_command
+    else:
+        raise ValueError("Invalid Frmework")
+
+
 def configure_and_run_docker_container(docker_client, docker_hash, service, instance, cluster, args, pull_image=False):
     """
     Run Docker container by image hash with args set in command line.
@@ -596,6 +619,8 @@ def configure_and_run_docker_container(docker_client, docker_hash, service, inst
     soa_dir = args.yelpsoa_config_root
 
     volumes = list()
+
+    instance_type = validate_service_instance(service, instance, cluster, soa_dir)
 
     try:
         instance_config = get_instance_config(
@@ -641,7 +666,8 @@ def configure_and_run_docker_container(docker_client, docker_hash, service, inst
     else:
         command_from_config = instance_config.get_cmd()
         if command_from_config:
-            command = shlex.split(command_from_config)
+            command_modifier = command_function_for_framework(instance_type)
+            command = shlex.split(command_modifier(command_from_config))
         else:
             command = instance_config.get_args()
 

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -227,12 +227,15 @@ def test_get_container_name(mock_get_username, mock_randint):
 @mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.load_system_paasta_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.get_instance_config', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.local_run.validate_service_instance', autospec=True)
 def test_configure_and_run_command_uses_cmd_from_config(
+    mock_validate_service_instance,
     mock_get_instance_config,
     mock_load_system_paasta_config,
     mock_run_docker_container,
     mock_socket_getfqdn,
 ):
+    mock_validate_service_instance.return_value = 'marathon'
     mock_load_system_paasta_config.return_value = SystemPaastaConfig(
         {'cluster': 'fake_cluster', 'volumes': []}, '/fake_dir/')
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)
@@ -249,7 +252,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
     args.healthcheck_only = False
     args.interactive = False
 
-    configure_and_run_docker_container(
+    assert configure_and_run_docker_container(
         docker_client=mock_docker_client,
         docker_hash=docker_hash,
         service=fake_service,
@@ -277,12 +280,15 @@ def test_configure_and_run_command_uses_cmd_from_config(
 @mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.load_system_paasta_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.get_instance_config', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.local_run.validate_service_instance', autospec=True)
 def test_configure_and_run_uses_bash_by_default_when_interactive(
+    mock_validate_service_instance,
     mock_get_instance_config,
     mock_load_system_paasta_config,
     mock_run_docker_container,
     mock_socket_getfqdn,
 ):
+    mock_validate_service_instance.return_value = 'marathon'
     mock_load_system_paasta_config.return_value = SystemPaastaConfig(
         {'cluster': 'fake_cluster', 'volumes': []}, '/fake_dir/')
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)
@@ -327,13 +333,16 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
 @mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.load_system_paasta_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.get_instance_config', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.local_run.validate_service_instance', autospec=True)
 def test_configure_and_run_pulls_image_when_asked(
+    mock_validate_service_instance,
     mock_get_instance_config,
     mock_load_system_paasta_config,
     mock_run_docker_container,
     mock_docker_pull_image,
     mock_socket_getfqdn,
 ):
+    mock_validate_service_instance.return_value = 'marathon'
     mock_load_system_paasta_config.return_value = SystemPaastaConfig(
         {'cluster': 'fake_cluster', 'volumes': [], 'docker_registry': 'fake_registry'}, '/fake_dir/')
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)


### PR DESCRIPTION
closes internal ticket PAASTA-4142 - paasta local-run doesn't interpolate tron-style datestrings when running chronos jobs.