### PR TITLE
only register classic instances in main namespace

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -853,9 +853,10 @@ def _namespaced_get_classic_service_information_for_nerve(name, namespace, soa_d
 def get_classic_services_running_here_for_nerve(soa_dir):
     classic_services = []
     for name in get_classic_services_that_run_here():
-        for namespace in get_all_namespaces_for_service(name, soa_dir, full_name=False):
+        namespaces = get_all_namespaces_for_service(name, soa_dir, full_name=False)
+        if 'main' in [namespace[0] for namespace in namespaces]:
             classic_services.append(_namespaced_get_classic_service_information_for_nerve(
-                name, namespace[0], soa_dir))
+                name, 'main', soa_dir))
     return classic_services
 
 

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -728,7 +728,7 @@ class TestMarathonTools:
             mock.patch(
                 'paasta_tools.marathon_tools.get_all_namespaces_for_service',
                 autospec=True,
-                side_effect=lambda x, y, full_name: [('foo', {})]
+                side_effect=lambda x, y, full_name: [('main', {}), ('canary', {})]
             ),
             mock.patch(
                 'paasta_tools.marathon_tools._namespaced_get_classic_service_information_for_nerve',
@@ -737,7 +737,7 @@ class TestMarathonTools:
             ),
         ):
             assert marathon_tools.get_classic_services_running_here_for_nerve('baz') == [
-                ('a.foo', {}), ('b.foo', {}), ('c.foo', {}),
+                ('a.main', {}), ('b.main', {}), ('c.main', {}),
             ]
 
     def test_get_services_running_here_for_nerve(self):


### PR DESCRIPTION
closes internal ticket https://jira.yelpcorp.com/browse/PAASTA-4157

I wonder if this is a bit too yelp-y having 'main' hardcoded?

Before:

```
>>> filter(lambda x : x[0].startswith('biz_app'), marathon_tools.get_services_running_here_for_nerve())
[('biz_app.main', {'extra_advertise': [('region:uswest1-stagef', 'region:uswest2-stagef'), ('region:uswest1-stageg', 'region:uswest2-stageg'), ('ecosystem:testopia', 'ecosystem:testopia'), ('region:dc6-prod', 'region:useast1-prod'), ('ecosystem:devc', 'ecosystem:devc'), ('ecosystem:stageb', 'ecosystem:stageb')], 'healthcheck_timeout_s': 6, 'timeout_server_ms': 60000, 'proxy_port': 20093, 'mode': 'http', 'port': 13849}), ('biz_app.canary', {'port': 13849, 'discover': 'superregion', 'healthcheck_timeout_s': 6, 'proxy_port': 20101, 'mode': 'http', 'advertise': ['superregion'], 'timeout_server_ms': 60000})]
```

After:
```
>>> from paasta_tools import marathon_tools
>>> filter(lambda x : x[0].startswith('biz_app'), marathon_tools.get_services_running_here_for_nerve())
[('biz_app.main', {'extra_advertise': [('region:uswest1-stagef', 'region:uswest2-stagef'), ('region:uswest1-stageg', 'region:uswest2-stageg'), ('ecosystem:testopia', 'ecosystem:testopia'), ('region:dc6-prod', 'region:useast1-prod'), ('ecosystem:devc', 'ecosystem:devc'), ('ecosystem:stageb', 'ecosystem:stageb')], 'healthcheck_timeout_s': 6, 'timeout_server_ms': 60000, 'proxy_port': 20093, 'mode': 'http', 'port': 13849})]
```