### PR TITLE
made the default metrics provider mesos_cpu

### DIFF
--- a/docs/source/autoscaling.rst
+++ b/docs/source/autoscaling.rst
@@ -12,7 +12,7 @@ Enabling autoscaling
 
 In order to use autoscaling, edit your ``marathon-*.yaml`` files in your soa configs and add a ``min_instances`` and a ``max_instances`` attribute and remove the ``instances`` attribute from each instance you want to autoscale. When using autoscaling, the ``min_instances`` and ``max_instances`` attributes become the minimum and maximum (inclusive) number of marathon tasks paasta will create for your job. If autoscaling information for your service is not available in Zookeeper (e.g. you've just created your service) PaaSTA will default to creating ``min_instances`` instances. Autoscaling only considers marathon tasks that have passing health checks. This is so new tasks that have higher-than-average load when starting up are ignored until their first health check passes. PaaSTA will not autoscale a service without any health checks, though these services can be autoscaled using the ``bespoke`` decision policy.
 
-Autoscaling parameters are stored in an ``autoscaling`` attribute of your instances as a dictionary. Within the ``autoscaling`` attribute, setting a ``metrics_provider`` will allow you to specify a method that determines the utilization of your service. If a metrics provider isn't provided, the ``"mesos_cpu_ram"`` metrics provider will be used. Within the ``autoscaling`` attribute, setting a ``decision_policy`` will allow you to specify the logic that determines when to autoscale your service. If a decision policy isn't provided, the ``"pid"`` decision policy will be used. Specifying a ``setpoint`` allows you to specify a target utilization for your service. The default ``setpoint`` is 0.8 (80%). Decision policies and metrics providers have their own optional keyword arguments that may be placed into the ``autoscaling`` dictionary as well.
+Autoscaling parameters are stored in an ``autoscaling`` attribute of your instances as a dictionary. Within the ``autoscaling`` attribute, setting a ``metrics_provider`` will allow you to specify a method that determines the utilization of your service. If a metrics provider isn't provided, the ``"mesos_cpu"`` metrics provider will be used. Within the ``autoscaling`` attribute, setting a ``decision_policy`` will allow you to specify the logic that determines when to autoscale your service. If a decision policy isn't provided, the ``"pid"`` decision policy will be used. Specifying a ``setpoint`` allows you to specify a target utilization for your service. The default ``setpoint`` is 0.8 (80%). Decision policies and metrics providers have their own optional keyword arguments that may be placed into the ``autoscaling`` dictionary as well.
 
 Let's look at sample marathon config file:
 
@@ -26,10 +26,10 @@ Let's look at sample marathon config file:
      max_instances: 50
      autoscaling:
        decision_policy: pid
-       metrics_provider: mesos_cpu_ram
+       metrics_provider: mesos_cpu
        setpoint: 0.5
 
-This makes the instance ``main`` autoscale using the ``pid`` decision policy and the ``mesos_cpu_ram`` metrics provider. PaaSTA will aim to keep this service's utilization at 50%.
+This makes the instance ``main`` autoscale using the ``pid`` decision policy and the ``mesos_cpu`` metrics provider. PaaSTA will aim to keep this service's utilization at 50%.
 
 Autoscaling components
 ----------------------
@@ -39,8 +39,8 @@ Metrics providers
 
 The currently available metrics providers are:
 
-:mesos_cpu_ram:
-  The default autoscaling method if none is provided. Tries to use cpu and ram usage to predict when to autoscale.
+:mesos_cpu:
+  The default autoscaling method if none is provided. Tries to use cpu usage to predict when to autoscale.
 :http:
   Makes a request on a HTTP endpoint on your service. Expects a JSON-formatted dictionary with a ``'utilization'`` field containing a number between 0 and 1.
 

--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -188,8 +188,8 @@ def http_metrics_provider(marathon_service_config, marathon_tasks, mesos_tasks, 
     return sum(utilization) / len(utilization)
 
 
-@register_autoscaling_component('mesos_cpu_ram', METRICS_PROVIDER_KEY)
-def mesos_cpu_ram_metrics_provider(marathon_service_config, marathon_tasks, mesos_tasks, **kwargs):
+@register_autoscaling_component('mesos_cpu', METRICS_PROVIDER_KEY)
+def mesos_cpu_metrics_provider(marathon_service_config, marathon_tasks, mesos_tasks, **kwargs):
     """
     Gets the average utilization of a service across all of its tasks, where the utilization of
     a task is the maximum value between its cpu and ram utilization.
@@ -230,13 +230,6 @@ def mesos_cpu_ram_metrics_provider(marathon_service_config, marathon_tasks, meso
         last_cpu_seconds, task_id = datum.split(':')
         if task_id in mesos_cpu_data:
             utilization[task_id] = (mesos_cpu_data[task_id] - float(last_cpu_seconds)) / time_delta
-
-    for task_id, stats in mesos_tasks.items():
-        if stats.get('mem_limit_bytes', 0) != 0:
-            utilization[task_id] = max(
-                utilization.get(task_id, 0),
-                float(stats.get('mem_rss_bytes', 0)) / stats.get('mem_limit_bytes', 0),
-            )
 
     if not utilization:
         raise MetricsProviderNoDataError("Couldn't get any cpu or ram data from Mesos")

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -230,7 +230,7 @@ class MarathonServiceConfig(InstanceConfig):
 
     def get_autoscaling_params(self):
         default_params = {
-            'metrics_provider': 'mesos_cpu_ram',
+            'metrics_provider': 'mesos_cpu',
             'decision_policy': 'pid',
             'setpoint': 0.8,
         }

--- a/tests/test_autoscaling_lib.py
+++ b/tests/test_autoscaling_lib.py
@@ -144,7 +144,7 @@ def test_compose_autoscaling_zookeeper_root():
 
 def test_get_autoscaling_metrics_provider():
     assert autoscaling_lib.get_autoscaling_metrics_provider(
-        'mesos_cpu_ram') == autoscaling_lib.mesos_cpu_ram_metrics_provider
+        'mesos_cpu') == autoscaling_lib.mesos_cpu_metrics_provider
 
 
 def test_get_autoscaling_decision_policy():
@@ -249,49 +249,12 @@ def test_mesos_cpu_metrics_provider():
         _,
     ):
         mock_datetime.now.return_value = current_time
-        assert autoscaling_lib.mesos_cpu_ram_metrics_provider(
+        assert autoscaling_lib.mesos_cpu_metrics_provider(
             fake_marathon_service_config, fake_marathon_tasks, (fake_mesos_task,)) == 0.8
         mock_zk_client.return_value.set.assert_has_calls([
             mock.call('/autoscaling/fake-service/fake-instance/cpu_last_time', current_time.strftime('%s')),
             mock.call('/autoscaling/fake-service/fake-instance/cpu_data', '480.0:fake-service.fake-instance'),
         ], any_order=True)
-
-
-def test_mesos_ram_metrics_provider():
-    fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-        service='fake-service',
-        instance='fake-instance',
-        cluster='fake-cluster',
-        config_dict={},
-        branch_dict={},
-    )
-    fake_mesos_task = mock.MagicMock(
-        stats={
-            'mem_rss_bytes': 800,
-            'mem_limit_bytes': 1000,
-            'cpus_limit': 1.1,
-        },
-    )
-    fake_mesos_task.__getitem__.return_value = 'fake-service.fake-instance'
-
-    fake_marathon_tasks = [mock.Mock(id='fake-service.fake-instance')]
-
-    current_time = datetime.now()
-
-    with contextlib.nested(
-            mock.patch('paasta_tools.utils.KazooClient', autospec=True,
-                       return_value=mock.Mock(get=mock.Mock(side_effect=NoNodeError))),
-            mock.patch('paasta_tools.autoscaling_lib.datetime', autospec=True),
-            mock.patch('paasta_tools.utils.load_system_paasta_config', autospec=True,
-                       return_value=mock.Mock(get_zk_hosts=mock.Mock())),
-    ) as (
-        mock_zk_client,
-        mock_datetime,
-        _,
-    ):
-        mock_datetime.now.return_value = current_time
-        assert autoscaling_lib.mesos_cpu_ram_metrics_provider(
-            fake_marathon_service_config, fake_marathon_tasks, (fake_mesos_task,)) == 0.8
 
 
 def test_http_metrics_provider():
@@ -348,7 +311,7 @@ def test_mesos_ram_cpu_metrics_provider_no_data_mesos():
         _,
     ):
         with raises(autoscaling_lib.MetricsProviderNoDataError):
-            autoscaling_lib.mesos_cpu_ram_metrics_provider(fake_marathon_service_config, fake_marathon_tasks, [])
+            autoscaling_lib.mesos_cpu_metrics_provider(fake_marathon_service_config, fake_marathon_tasks, [])
 
 
 def test_get_new_instance_count():


### PR DESCRIPTION
Autoscaling now only considers CPU usage by default when autoscaling