### PR TITLE
Make synapse port configurable via SystemPaastaConfig

### DIFF
--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -88,7 +88,7 @@ def when_there_are_num_which_tasks(context, num, which, state):
     # 120 * 0.5 = 60 seconds
     for _ in xrange(120):
         app = context.marathon_client.get_app(app_id, embed_tasks=True)
-        happy_count = len(get_happy_tasks(app, context.service, "fake_nerve_ns"))
+        happy_count = len(get_happy_tasks(app, context.service, "fake_nerve_ns", context.system_paasta_config))
         if state == "healthy":
             if happy_count >= context.max_tasks:
                 return
@@ -108,8 +108,8 @@ def when_deploy_service_initiated(context, bounce_method, drain_method):
             autospec=True,
             # Wrap function call so we can select a subset of tasks or test
             # intermediate steps, like when an app is not completely up
-            side_effect=lambda app, _, __, **kwargs: get_happy_tasks(
-                app, context.service, "fake_nerve_ns")[:context.max_tasks],
+            side_effect=lambda app, _, __, ___, **kwargs: get_happy_tasks(
+                app, context.service, "fake_nerve_ns", context.system_paasta_config)[:context.max_tasks],
         ),
         mock.patch('paasta_tools.bounce_lib.bounce_lock_zookeeper', autospec=True),
         mock.patch('paasta_tools.bounce_lib.create_app_lock', autospec=True),

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -54,7 +54,8 @@ def setup_marathon_client():
         'cluster': 'testcluster',
         'docker_volumes': [],
         'docker_registry': u'docker-dev.yelpcorp.com',
-        'zookeeper': zk_connection_string
+        'zookeeper': zk_connection_string,
+        'synapse_port': 3212,
     }, '/some_fake_path_to_config_dir/')
     return (client, marathon_config, system_paasta_config)
 

--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -29,7 +29,6 @@ from marathon.models import MarathonApp
 
 from paasta_tools.monitoring.replication_utils import \
     get_registered_marathon_tasks
-from paasta_tools.smartstack_tools import DEFAULT_SYNAPSE_PORT
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import load_system_paasta_config
 
@@ -214,7 +213,7 @@ def kill_old_ids(old_ids, client):
             continue
 
 
-def get_happy_tasks(app, service, nerve_ns, min_task_uptime=None, check_haproxy=False):
+def get_happy_tasks(app, service, nerve_ns, system_paasta_config, min_task_uptime=None, check_haproxy=False):
     """Given a MarathonApp object, return the subset of tasks which are considered healthy.
     With the default options, this returns tasks where at least one of the defined Marathon healthchecks passes.
     For it to do anything interesting, set min_task_uptime or check_haproxy.
@@ -242,7 +241,7 @@ def get_happy_tasks(app, service, nerve_ns, min_task_uptime=None, check_haproxy=
             synapse_host = hosts[0]
             tasks_in_smartstack.extend(get_registered_marathon_tasks(
                 synapse_host,
-                DEFAULT_SYNAPSE_PORT,
+                system_paasta_config.get_synapse_port(),
                 service_namespace,
                 tasks,
             ))

--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -242,6 +242,7 @@ def get_happy_tasks(app, service, nerve_ns, system_paasta_config, min_task_uptim
             tasks_in_smartstack.extend(get_registered_marathon_tasks(
                 synapse_host,
                 system_paasta_config.get_synapse_port(),
+                system_paasta_config.get_synapse_haproxy_url_format(),
                 service_namespace,
                 tasks,
             ))

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -41,7 +41,6 @@ import service_configuration_lib
 from paasta_tools import marathon_tools
 from paasta_tools import mesos_tools
 from paasta_tools import monitoring_tools
-from paasta_tools import smartstack_tools
 from paasta_tools.marathon_tools import format_job_id
 from paasta_tools.monitoring import replication_utils
 from paasta_tools.utils import _log
@@ -286,7 +285,7 @@ def load_smartstack_info_for_service(service, namespace, soa_dir, blacklist):
         blacklist=blacklist)
 
 
-def get_smartstack_replication_for_attribute(attribute, service, namespace, blacklist):
+def get_smartstack_replication_for_attribute(attribute, service, namespace, blacklist, synapse_port):
     """Loads smartstack replication from a host with the specified attribute
 
     :param attribute: a Mesos attribute
@@ -306,7 +305,7 @@ def get_smartstack_replication_for_attribute(attribute, service, namespace, blac
         synapse_host = hosts[0]
         repl_info = replication_utils.get_replication_for_services(
             synapse_host=synapse_host,
-            synapse_port=smartstack_tools.DEFAULT_SYNAPSE_PORT,
+            synapse_port=synapse_port,
             services=[full_name],
         )
         replication_info[value] = repl_info

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -285,7 +285,8 @@ def load_smartstack_info_for_service(service, namespace, soa_dir, blacklist):
         blacklist=blacklist)
 
 
-def get_smartstack_replication_for_attribute(attribute, service, namespace, blacklist, synapse_port):
+def get_smartstack_replication_for_attribute(attribute, service, namespace, blacklist, synapse_port,
+                                             synapse_haproxy_url_format):
     """Loads smartstack replication from a host with the specified attribute
 
     :param attribute: a Mesos attribute
@@ -306,6 +307,7 @@ def get_smartstack_replication_for_attribute(attribute, service, namespace, blac
         repl_info = replication_utils.get_replication_for_services(
             synapse_host=synapse_host,
             synapse_port=synapse_port,
+            synapse_haproxy_url_format=synapse_haproxy_url_format,
             services=[full_name],
         )
         replication_info[value] = repl_info

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -25,13 +25,13 @@ from paasta_tools.mesos_tools import get_running_tasks_from_active_frameworks
 from paasta_tools.mesos_tools import status_mesos_tasks_verbose
 from paasta_tools.monitoring.replication_utils import backend_is_up
 from paasta_tools.monitoring.replication_utils import match_backends_and_tasks
-from paasta_tools.smartstack_tools import DEFAULT_SYNAPSE_PORT
 from paasta_tools.smartstack_tools import get_backends
 from paasta_tools.utils import _log
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import format_table
 from paasta_tools.utils import is_under_replicated
+from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import remove_ansi_escape_sequences
@@ -240,7 +240,8 @@ def format_haproxy_backend_row(backend, is_correct_instance):
         return tuple(PaastaColors.grey(remove_ansi_escape_sequences(col)) for col in row)
 
 
-def status_smartstack_backends(service, instance, job_config, cluster, tasks, expected_count, soa_dir, verbose):
+def status_smartstack_backends(service, instance, job_config, cluster, tasks, expected_count, soa_dir, verbose,
+                               synapse_port):
     """Returns detailed information about smartstack backends for a service
     and instance.
     return: A newline separated string of the smarststack backend status
@@ -274,12 +275,14 @@ def status_smartstack_backends(service, instance, job_config, cluster, tasks, ex
             tasks,
             unique_attributes,
             expected_count,
-            verbose
+            verbose,
+            synapse_port,
         ))
     return "\n".join(output)
 
 
-def pretty_print_smartstack_backends_for_locations(service_instance, tasks, locations, expected_count, verbose):
+def pretty_print_smartstack_backends_for_locations(service_instance, tasks, locations, expected_count, verbose,
+                                                   synapse_port):
     """
     Pretty prints the status of smartstack backends of a specified service and instance in the specified locations
     """
@@ -291,7 +294,7 @@ def pretty_print_smartstack_backends_for_locations(service_instance, tasks, loca
         synapse_host = hosts[0]
         sorted_backends = sorted(get_backends(service_instance,
                                               synapse_host=synapse_host,
-                                              synapse_port=DEFAULT_SYNAPSE_PORT),
+                                              synapse_port=synapse_port),
                                  key=lambda backend: backend['status'],
                                  reverse=True)  # Specify reverse so that backends in 'UP' are placed above 'MAINT'
         matched_tasks = match_backends_and_tasks(sorted_backends, tasks)
@@ -337,6 +340,8 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir, app_i
     :param verbose: int verbosity level
     :returns: A unix-style return code
     """
+    system_config = load_system_paasta_config()
+
     marathon_config = marathon_tools.load_marathon_config()
     job_config = marathon_tools.load_marathon_service_config(service, instance, cluster, soa_dir=soa_dir)
     if not app_id:
@@ -382,6 +387,7 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir, app_i
                 expected_count=normal_smartstack_count,
                 soa_dir=soa_dir,
                 verbose=verbose > 0,
+                synapse_port=system_config.get_synapse_port(),
             )
     elif command == 'scale':
         scale_marathon_job(service, instance, app_id, delta, client, cluster)

--- a/paasta_tools/monitoring/check_classic_service_replication.py
+++ b/paasta_tools/monitoring/check_classic_service_replication.py
@@ -145,7 +145,7 @@ class ClassicServiceReplicationCheck(SensuPluginCheck):
                                  action='store_true',
                                  help='Turn on debug output')
 
-    def get_service_replication(self, all_services, synapse_host, synapse_port):
+    def get_service_replication(self, all_services, synapse_host, synapse_port, synapse_haproxy_url_format):
         # Get the replication data once for performance
         synapse_host_port = "%s:%s" % (synapse_host, synapse_port)
         self.log.debug(
@@ -156,6 +156,7 @@ class ClassicServiceReplicationCheck(SensuPluginCheck):
             service_replication = get_replication_for_services(
                 synapse_host,
                 synapse_port,
+                synapse_haproxy_url_format,
                 ['%s.main' % name for name in all_services]
             )
         except requests.exceptions.ConnectionError:
@@ -182,9 +183,10 @@ class ClassicServiceReplicationCheck(SensuPluginCheck):
         all_service_config = read_services_configuration()
         system_config = load_system_paasta_config()
         service_replication = self.get_service_replication(
-            all_service_config.keys(),
-            system_config.get_default_synapse_host(),
-            system_config.get_synapse_port(),
+            all_services=all_service_config.keys(),
+            synapse_host=system_config.get_default_synapse_host(),
+            synapse_port=system_config.get_synapse_port(),
+            synapse_haproxy_url_format=system_config.get_synapse_haproxy_url_format(),
         )
 
         checked_services = []

--- a/paasta_tools/monitoring/check_classic_service_replication.py
+++ b/paasta_tools/monitoring/check_classic_service_replication.py
@@ -29,8 +29,7 @@ from paasta_tools.monitoring.config_providers import (
 from paasta_tools.monitoring.replication_utils import (
     get_replication_for_services
 )
-from paasta_tools.smartstack_tools import DEFAULT_SYNAPSE_HOST
-from paasta_tools.smartstack_tools import DEFAULT_SYNAPSE_PORT
+from paasta_tools.utils import load_system_paasta_config
 
 
 def read_key(key):
@@ -146,17 +145,17 @@ class ClassicServiceReplicationCheck(SensuPluginCheck):
                                  action='store_true',
                                  help='Turn on debug output')
 
-    def get_service_replication(self, all_services):
+    def get_service_replication(self, all_services, synapse_host, synapse_port):
         # Get the replication data once for performance
-        synapse_host_port = "%s:%s" % (DEFAULT_SYNAPSE_HOST, DEFAULT_SYNAPSE_PORT)
+        synapse_host_port = "%s:%s" % (synapse_host, synapse_port)
         self.log.debug(
             "Gathering replication information from {0}".
             format(synapse_host_port))
         service_replication = {}
         try:
             service_replication = get_replication_for_services(
-                DEFAULT_SYNAPSE_HOST,
-                DEFAULT_SYNAPSE_PORT,
+                synapse_host,
+                synapse_port,
                 ['%s.main' % name for name in all_services]
             )
         except requests.exceptions.ConnectionError:
@@ -181,7 +180,12 @@ class ClassicServiceReplicationCheck(SensuPluginCheck):
     def run(self):
         self.setup_logging()
         all_service_config = read_services_configuration()
-        service_replication = self.get_service_replication(all_service_config.keys())
+        system_config = load_system_paasta_config()
+        service_replication = self.get_service_replication(
+            all_service_config.keys(),
+            system_config.get_default_synapse_host(),
+            system_config.get_synapse_port(),
+        )
 
         checked_services = []
         for service, service_config in all_service_config.iteritems():

--- a/paasta_tools/monitoring/check_synapse_replication.py
+++ b/paasta_tools/monitoring/check_synapse_replication.py
@@ -15,6 +15,7 @@
 import argparse
 import sys
 
+from paasta_tools import utils
 from paasta_tools.monitoring.replication_utils import (
     get_replication_for_services
 )
@@ -81,17 +82,25 @@ def parse_range(str_range):
         fail("Failed to parse range {0}".format(str_range))
 
 
-def parse_synapse_check_options():
+def parse_synapse_check_options(system_paasta_config):
     epilog = "RANGEs are specified 'min:max' or 'min:' or ':max'"
     parser = argparse.ArgumentParser(epilog=epilog)
 
     parser.add_argument(dest='services', nargs='+', type=str,
                         help="A series of service names to check.\n"
                         "e.g. lucy_east_0 lucy_east_1 ...")
-    parser.add_argument('-s', '--synapse-host-port',
-                        dest='synapse_host_port', type=str,
-                        help='The host and port to check',
-                        default='localhost:3212')
+    parser.add_argument('-H', '--synapse-host',
+                        dest='synapse_host', type=str,
+                        help='The host to check',
+                        default=system_paasta_config.get_default_synapse_host())
+    parser.add_argument('-P', '--synapse-port',
+                        dest='synapse_port', type=int,
+                        help='The synapse port to check',
+                        default=system_paasta_config.get_synapse_port())
+    parser.add_argument('-P', '--synapse-haproxy-url-format',
+                        dest='synapse_port', type=str,
+                        help='The synapse haproxy url format',
+                        default=system_paasta_config.get_synapse_haproxy_url_format())
     parser.add_argument('-w', '--warn', dest='warn', type=str,
                         metavar='RANGE',
                         help="Generate warning state if number of "
@@ -114,10 +123,13 @@ def fail(message, code):
 
 
 def run_synapse_check():
-    options = parse_synapse_check_options()
+    system_paasta_config = utils.load_system_paasta_config()
+    options = parse_synapse_check_options(system_paasta_config)
     try:
         service_replications = get_replication_for_services(
-            options.synapse_host_port,
+            options.synapse_host,
+            options.synapse_port,
+            options.synapse_haproxy_url_format,
             options.services
         )
 

--- a/paasta_tools/monitoring/check_synapse_replication.py
+++ b/paasta_tools/monitoring/check_synapse_replication.py
@@ -97,8 +97,8 @@ def parse_synapse_check_options(system_paasta_config):
                         dest='synapse_port', type=int,
                         help='The synapse port to check',
                         default=system_paasta_config.get_synapse_port())
-    parser.add_argument('-P', '--synapse-haproxy-url-format',
-                        dest='synapse_port', type=str,
+    parser.add_argument('-F', '--synapse-haproxy-url-format',
+                        dest='synapse_haproxy_url_format', type=str,
                         help='The synapse haproxy url format',
                         default=system_paasta_config.get_synapse_haproxy_url_format())
     parser.add_argument('-w', '--warn', dest='warn', type=str,

--- a/paasta_tools/monitoring/replication_utils.py
+++ b/paasta_tools/monitoring/replication_utils.py
@@ -17,7 +17,7 @@ import socket
 from paasta_tools.smartstack_tools import get_multiple_backends
 
 
-def get_replication_for_services(synapse_host, synapse_port, services):
+def get_replication_for_services(synapse_host, synapse_port, synapse_haproxy_url_format, services):
     """Returns the replication level for the provided services
 
     This check is intended to be used with an haproxy load balancer, and
@@ -25,6 +25,7 @@ def get_replication_for_services(synapse_host, synapse_port, services):
 
     :param synapse_host: The hose that this check should contact for replication information.
     :param synapse_port: The port number that this check should contact for replication information.
+    :param synapse_haproxy_url_format: The format of the synapse haproxy URL.
     :param services: A list of strings that are the service names
                           that should be checked for replication.
 
@@ -37,6 +38,7 @@ def get_replication_for_services(synapse_host, synapse_port, services):
         services=services,
         synapse_host=synapse_host,
         synapse_port=synapse_port,
+        synapse_haproxy_url_format=synapse_haproxy_url_format,
     )
 
     counter = collections.Counter([b['pxname'] for b in backends if backend_is_up(b)])
@@ -67,6 +69,7 @@ def ip_port_hostname_from_svname(svname):
 def get_registered_marathon_tasks(
     synapse_host,
     synapse_port,
+    synapse_haproxy_url_format,
     service,
     marathon_tasks,
 ):
@@ -74,10 +77,12 @@ def get_registered_marathon_tasks(
 
     :param synapse_host: The host that this check should contact for replication information.
     :param synapse_port: The port that this check should contact for replication information.
+    :param synapse_haproxy_url_format: The format of the synapse haproxy URL.
     :param service: A list of strings that are the service names that should be checked for replication.
     :param marathon_tasks: A list of MarathonTask objects, whose tasks we will check for in the HAProxy status.
     """
-    backends = get_multiple_backends([service], synapse_host=synapse_host, synapse_port=synapse_port)
+    backends = get_multiple_backends([service], synapse_host=synapse_host, synapse_port=synapse_port,
+                                     synapse_haproxy_url_format=synapse_host)
     healthy_tasks = []
     for backend, task in match_backends_and_tasks(backends, marathon_tasks):
         if backend is not None and task is not None and backend['status'].startswith('UP'):

--- a/paasta_tools/smartstack_tools.py
+++ b/paasta_tools/smartstack_tools.py
@@ -15,20 +15,17 @@ import csv
 
 import requests
 
-DEFAULT_SYNAPSE_HOST = 'localhost'
-DEFAULT_SYNAPSE_PORT = 3212
-SYNAPSE_HAPROXY_PATH = "http://{0}/;csv;norefresh"
+from paasta_tools.utils import DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT
 
 
-def retrieve_haproxy_csv(synapse_host=DEFAULT_SYNAPSE_HOST, synapse_port=DEFAULT_SYNAPSE_PORT):
+def retrieve_haproxy_csv(synapse_host, synapse_port, synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT):
     """Retrieves the haproxy csv from the haproxy web interface
 
     :param synapse_host_port: A string in host:port format that this check
                               should contact for replication information.
     :returns reader: a csv.DictReader object
     """
-    synapse_host_port = "%s:%s" % (synapse_host, synapse_port)
-    synapse_uri = SYNAPSE_HAPROXY_PATH.format(synapse_host_port)
+    synapse_uri = synapse_haproxy_url_format.format(host=synapse_host, port=synapse_port)
 
     # timeout after 1 second and retry 3 times
     haproxy_request = requests.Session()
@@ -44,12 +41,12 @@ def retrieve_haproxy_csv(synapse_host=DEFAULT_SYNAPSE_HOST, synapse_port=DEFAULT
     return reader
 
 
-def get_backends(service=None, synapse_host=DEFAULT_SYNAPSE_HOST, synapse_port=DEFAULT_SYNAPSE_PORT):
+def get_backends(service, synapse_host, synapse_port):
     """Fetches the CSV from haproxy and returns a list of backends,
     regardless of their state.
 
-    :param service: If specified, only return backends for this particular
-                    service
+    :param service: If None, return backends for all services, otherwise only return backends for this particular
+                    service.
     :param synapse_host_port: A string in host:port format that this check
                               should contact for replication information.
     :returns backends: A list of dicts representing the backends of all
@@ -62,11 +59,11 @@ def get_backends(service=None, synapse_host=DEFAULT_SYNAPSE_HOST, synapse_port=D
     return get_multiple_backends(services, synapse_host=synapse_host, synapse_port=synapse_port)
 
 
-def get_multiple_backends(services=None, synapse_host=DEFAULT_SYNAPSE_HOST, synapse_port=DEFAULT_SYNAPSE_PORT):
+def get_multiple_backends(services, synapse_host, synapse_port):
     """Fetches the CSV from haproxy and returns a list of backends,
     regardless of their state.
 
-    :param services: If specified, only return backends for these particular
+    :param services: If None, return backends for all services, otherwise only return backends for these particular
                      services.
     :param synapse_host_port: A string in host:port format that this check
                               should contact for replication information.

--- a/paasta_tools/smartstack_tools.py
+++ b/paasta_tools/smartstack_tools.py
@@ -15,10 +15,8 @@ import csv
 
 import requests
 
-from paasta_tools.utils import DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT
 
-
-def retrieve_haproxy_csv(synapse_host, synapse_port, synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT):
+def retrieve_haproxy_csv(synapse_host, synapse_port, synapse_haproxy_url_format):
     """Retrieves the haproxy csv from the haproxy web interface
 
     :param synapse_host_port: A string in host:port format that this check
@@ -41,7 +39,7 @@ def retrieve_haproxy_csv(synapse_host, synapse_port, synapse_haproxy_url_format=
     return reader
 
 
-def get_backends(service, synapse_host, synapse_port):
+def get_backends(service, synapse_host, synapse_port, synapse_haproxy_url_format):
     """Fetches the CSV from haproxy and returns a list of backends,
     regardless of their state.
 
@@ -56,10 +54,11 @@ def get_backends(service, synapse_host, synapse_port):
         services = [service]
     else:
         services = None
-    return get_multiple_backends(services, synapse_host=synapse_host, synapse_port=synapse_port)
+    return get_multiple_backends(services, synapse_host=synapse_host, synapse_port=synapse_port,
+                                 synapse_haproxy_url_format=synapse_haproxy_url_format)
 
 
-def get_multiple_backends(services, synapse_host, synapse_port):
+def get_multiple_backends(services, synapse_host, synapse_port, synapse_haproxy_url_format):
     """Fetches the CSV from haproxy and returns a list of backends,
     regardless of their state.
 
@@ -71,7 +70,7 @@ def get_multiple_backends(services, synapse_host, synapse_port):
                        services or the requested service
     """
 
-    reader = retrieve_haproxy_csv(synapse_host, synapse_port)
+    reader = retrieve_haproxy_csv(synapse_host, synapse_port, synapse_haproxy_url_format=synapse_haproxy_url_format)
     backends = []
 
     for line in reader:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -66,6 +66,8 @@ ANY_INSTANCE = 'N/A'
 DEFAULT_LOGLEVEL = 'event'
 no_escape = re.compile('\x1B\[[0-9;]*[mK]')
 
+DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT = "http://{host:s}:{port:d}/;csv;norefresh"
+
 log = logging.getLogger('__main__')
 
 
@@ -816,9 +818,28 @@ class SystemPaastaConfig(dict):
     def get_dockerfile_location(self):
         """Get the location of the dockerfile, as a URI.
 
-        :returns: the URI speicfied, or file:///root/.dockercfg if not specified.
+        :returns: the URI specified, or file:///root/.dockercfg if not specified.
         """
         return self.get('dockerfile_location', DEFAULT_DOCKERFILE_LOCATION)
+
+    def get_synapse_port(self):
+        """Get the port that haproxy-synapse exposes its status on. Defaults to 3212.
+
+        :returns: the haproxy-synapse status port."""
+        return int(self.get('synapse_port', 3212))
+
+    def get_default_synapse_host(self):
+        """Get the default host we should interrogate for haproxy-synapse state.
+
+        :returns: A hostname that is running haproxy-synapse."""
+        return self.get('synapse_host', 'localhost')
+
+    def get_synapse_haproxy_url_format(self):
+        """Get a format string for the URL to query for haproxy-synapse state. This format string gets two keyword
+        arguments, host and port. Defaults to "http://{host:s}:{port:d}/;csv;norefresh".
+
+        :returns: A format string for constructing the URL of haproxy-synapse's status page."""
+        return self.get('synapse_haproxy_url_format', DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT)
 
 
 def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=None, **kwargs):

--- a/tests/monitoring/test_check_classic_service_replication.py
+++ b/tests/monitoring/test_check_classic_service_replication.py
@@ -22,7 +22,8 @@ from paasta_tools.monitoring.check_classic_service_replication import ClassicSer
 from paasta_tools.monitoring.check_classic_service_replication import do_replication_check
 from paasta_tools.monitoring.check_classic_service_replication import extract_replication_info
 from paasta_tools.monitoring.check_classic_service_replication import report_event
-from paasta_tools.utils import SystemPaastaConfig, DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT
+from paasta_tools.utils import DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT
+from paasta_tools.utils import SystemPaastaConfig
 
 
 def test_report_event():

--- a/tests/monitoring/test_check_classic_service_replication.py
+++ b/tests/monitoring/test_check_classic_service_replication.py
@@ -22,7 +22,7 @@ from paasta_tools.monitoring.check_classic_service_replication import ClassicSer
 from paasta_tools.monitoring.check_classic_service_replication import do_replication_check
 from paasta_tools.monitoring.check_classic_service_replication import extract_replication_info
 from paasta_tools.monitoring.check_classic_service_replication import report_event
-from paasta_tools.utils import SystemPaastaConfig
+from paasta_tools.utils import SystemPaastaConfig, DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT
 
 
 def test_report_event():
@@ -197,7 +197,7 @@ def test_classic_replication_check_connectionerror():
         mock_init.return_value = None
         check = ClassicServiceReplicationCheck()
         check.critical = mock.Mock()
-        check.get_service_replication(['this', 'that'], 'localhost', 12345)
+        check.get_service_replication(['this', 'that'], 'localhost', 12345, DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT)
         check.critical.assert_called_once_with('Failed to connect synapse haproxy on localhost:12345')
 
 
@@ -214,5 +214,5 @@ def test_classic_replication_check_unknownexception():
         mock_init.return_value = None
         check = ClassicServiceReplicationCheck()
         check.critical = mock.Mock()
-        check.get_service_replication(['this', 'that'], 'localhost', 12345)
+        check.get_service_replication(['this', 'that'], 'localhost', 12345, DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT)
         check.critical.assert_called_once_with(mock.ANY)

--- a/tests/monitoring/test_check_classic_service_replication.py
+++ b/tests/monitoring/test_check_classic_service_replication.py
@@ -22,7 +22,6 @@ from paasta_tools.monitoring.check_classic_service_replication import ClassicSer
 from paasta_tools.monitoring.check_classic_service_replication import do_replication_check
 from paasta_tools.monitoring.check_classic_service_replication import extract_replication_info
 from paasta_tools.monitoring.check_classic_service_replication import report_event
-from paasta_tools.smartstack_tools import DEFAULT_SYNAPSE_PORT
 
 
 def test_report_event():
@@ -195,9 +194,8 @@ def test_classic_replication_check_connectionerror():
         mock_init.return_value = None
         check = ClassicServiceReplicationCheck()
         check.critical = mock.Mock()
-        check.get_service_replication(['this', 'that'])
-        check.critical.assert_called_once_with(
-            'Failed to connect synapse haproxy on localhost:%s' % DEFAULT_SYNAPSE_PORT)
+        check.get_service_replication(['this', 'that'], 'localhost', 12345)
+        check.critical.assert_called_once_with('Failed to connect synapse haproxy on localhost:12345')
 
 
 def test_classic_replication_check_unknownexception():
@@ -213,5 +211,5 @@ def test_classic_replication_check_unknownexception():
         mock_init.return_value = None
         check = ClassicServiceReplicationCheck()
         check.critical = mock.Mock()
-        check.get_service_replication(['this', 'that'])
+        check.get_service_replication(['this', 'that'], 'localhost', 12345)
         check.critical.assert_called_once_with(mock.ANY)

--- a/tests/monitoring/test_check_classic_service_replication.py
+++ b/tests/monitoring/test_check_classic_service_replication.py
@@ -22,6 +22,7 @@ from paasta_tools.monitoring.check_classic_service_replication import ClassicSer
 from paasta_tools.monitoring.check_classic_service_replication import do_replication_check
 from paasta_tools.monitoring.check_classic_service_replication import extract_replication_info
 from paasta_tools.monitoring.check_classic_service_replication import report_event
+from paasta_tools.utils import SystemPaastaConfig
 
 
 def test_report_event():
@@ -161,6 +162,7 @@ def test_classic_replication_check():
     replication_method = check_classic_module + '.get_replication_for_services'
     extract_method = check_classic_module + '.extract_replication_info'
     check_method = check_classic_module + '.do_replication_check'
+    load_system_paasta_config_module = check_classic_module + '.load_system_paasta_config'
 
     mock_service_config = {'pow': {'wat': 1}}
     mock_replication = {'pow': -1}
@@ -174,7 +176,8 @@ def test_classic_replication_check():
             mock.patch(check_method, return_value=mock_check),
             mock.patch('pysensu_yelp.send_event'),
             mock.patch.object(sys, 'argv', ['check_classic_service_replication.py']),
-    ) as (_, _, _, mcheck, _, _):
+            mock.patch(load_system_paasta_config_module, return_value=SystemPaastaConfig({}, '/fake/config'))
+    ) as (_, _, _, mcheck, _, _, _):
         with pytest.raises(SystemExit) as error:
             check = ClassicServiceReplicationCheck()
             check.run()

--- a/tests/monitoring/test_check_synapse_replication.py
+++ b/tests/monitoring/test_check_synapse_replication.py
@@ -17,10 +17,10 @@ from contextlib import nested
 import mock
 import pytest
 
-from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.monitoring.check_synapse_replication import check_replication
 from paasta_tools.monitoring.check_synapse_replication import parse_range
 from paasta_tools.monitoring.check_synapse_replication import run_synapse_check
+from paasta_tools.utils import SystemPaastaConfig
 
 
 def test_check_replication():
@@ -85,11 +85,12 @@ def test_run_synapse_check():
     def mock_check(name, replication, warn, crit):
         return mock_service_status[name], 'CHECK'
 
-    with nested(mock.patch(parse_method, return_value=mock_parse_options),
-                mock.patch(replication_method, return_value=mock_replication),
-                mock.patch(check_replication_method, new=mock_check),
-                mock.patch('paasta_tools.utils.load_system_paasta_config', autospec=True,
-                           return_value=SystemPaastaConfig({}, '/fake/config')),
+    with nested(
+        mock.patch(parse_method, return_value=mock_parse_options),
+        mock.patch(replication_method, return_value=mock_replication),
+        mock.patch(check_replication_method, new=mock_check),
+        mock.patch('paasta_tools.utils.load_system_paasta_config', autospec=True,
+                   return_value=SystemPaastaConfig({}, '/fake/config')),
     ):
         with pytest.raises(SystemExit) as error:
             run_synapse_check()

--- a/tests/monitoring/test_replication_utils.py
+++ b/tests/monitoring/test_replication_utils.py
@@ -21,6 +21,7 @@ from paasta_tools.monitoring.replication_utils import get_registered_marathon_ta
 from paasta_tools.monitoring.replication_utils import get_replication_for_services
 from paasta_tools.monitoring.replication_utils import ip_port_hostname_from_svname
 from paasta_tools.monitoring.replication_utils import match_backends_and_tasks
+from paasta_tools.utils import DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT
 
 
 def test_get_replication_for_service():
@@ -37,6 +38,7 @@ def test_get_replication_for_service():
         replication_result = get_replication_for_services(
             'fake_host',
             6666,
+            DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
             ['service1', 'service2', 'service3', 'service4']
         )
         expected = {
@@ -87,6 +89,7 @@ def test_get_registered_marathon_tasks():
             actual = get_registered_marathon_tasks(
                 'fake_host',
                 6666,
+                DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
                 'servicename.main',
                 marathon_tasks,
             )

--- a/tests/test_bounce_lib.py
+++ b/tests/test_bounce_lib.py
@@ -328,12 +328,14 @@ class TestBounceLib:
             get_registered_marathon_tasks_patch.assert_any_call(
                 'fake_host1',
                 123456,
+                utils.DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
                 'service.namespace',
                 tasks,
             )
             get_registered_marathon_tasks_patch.assert_any_call(
                 'fake_host2',
                 123456,
+                utils.DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
                 'service.namespace',
                 tasks,
             )

--- a/tests/test_bounce_lib.py
+++ b/tests/test_bounce_lib.py
@@ -18,10 +18,13 @@ import marathon
 import mock
 
 from paasta_tools import bounce_lib
-from paasta_tools.smartstack_tools import DEFAULT_SYNAPSE_PORT
+from paasta_tools import utils
 
 
 class TestBounceLib:
+
+    def fake_system_paasta_config(self):
+        return utils.SystemPaastaConfig({"synapse_port": 123456}, "/fake/configs")
 
     def test_bounce_lock(self):
         import fcntl
@@ -193,19 +196,19 @@ class TestBounceLib:
         """All running tasks with no health checks results are healthy if the app does not define healthchecks"""
         tasks = [mock.Mock(health_check_results=[]) for _ in xrange(5)]
         fake_app = mock.Mock(tasks=tasks, health_checks=[])
-        assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace') == tasks
+        assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', self.fake_system_paasta_config()) == tasks
 
     def test_get_happy_tasks_when_running_with_healthchecks_defined(self):
         """All running tasks with no health check results are unhealthy if the app defines healthchecks"""
         tasks = [mock.Mock(health_check_results=[]) for _ in xrange(5)]
         fake_app = mock.Mock(tasks=tasks, health_checks=["fake_healthcheck_definition"])
-        assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace') == []
+        assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', self.fake_system_paasta_config()) == []
 
     def test_get_happy_tasks_when_all_healthy(self):
         """All tasks with only passing healthchecks should be happy"""
         tasks = [mock.Mock(health_check_results=[mock.Mock(alive=True)]) for _ in xrange(5)]
         fake_app = mock.Mock(tasks=tasks, health_checks=[])
-        assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace') == tasks
+        assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', self.fake_system_paasta_config()) == tasks
 
     def test_get_happy_tasks_when_some_unhealthy(self):
         """Only tasks with a passing healthcheck should be happy"""
@@ -215,21 +218,23 @@ class TestBounceLib:
                  mock.Mock(health_check_results=fake_failing_healthcheck_results),
                  mock.Mock(health_check_results=fake_successful_healthcheck_results)]
         fake_app = mock.Mock(tasks=tasks, health_checks=[])
-        assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace') == tasks[-1:]
+        actual = bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', self.fake_system_paasta_config())
+        expected = tasks[-1:]
+        assert actual == expected
 
     def test_get_happy_tasks_with_multiple_healthchecks_success(self):
         """All tasks with at least one passing healthcheck should be happy"""
         fake_successful_healthcheck_results = [mock.Mock(alive=True), mock.Mock(alive=False)]
         tasks = [mock.Mock(health_check_results=fake_successful_healthcheck_results)]
         fake_app = mock.Mock(tasks=tasks, health_checks=[])
-        assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace') == tasks
+        assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', self.fake_system_paasta_config()) == tasks
 
     def test_get_happy_tasks_with_multiple_healthchecks_fail(self):
         """Only tasks with at least one passing healthcheck should be happy"""
         fake_successful_healthcheck_results = [mock.Mock(alive=False), mock.Mock(alive=False)]
         tasks = [mock.Mock(health_check_results=fake_successful_healthcheck_results)]
         fake_app = mock.Mock(tasks=tasks, health_checks=[])
-        assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace') == []
+        assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', self.fake_system_paasta_config()) == []
 
     def test_get_happy_tasks_min_task_uptime(self):
         """If we specify a minimum task age, tasks newer than that should not be considered happy."""
@@ -241,7 +246,10 @@ class TestBounceLib:
         # I would have just mocked datetime.datetime.utcnow, but that's apparently difficult; I have to mock
         # datetime.datetime instead, and give it a utcnow attribute.
         with mock.patch('paasta_tools.bounce_lib.datetime.datetime', utcnow=lambda: now, autospec=True):
-            assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', min_task_uptime=121) == tasks[3:]
+            actual = bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', self.fake_system_paasta_config(),
+                                                min_task_uptime=121)
+            expected = tasks[3:]
+            assert actual == expected
 
     def test_get_happy_tasks_min_task_uptime_when_unhealthy(self):
         """If we specify a minimum task age, tasks newer than that should not be considered happy."""
@@ -252,7 +260,10 @@ class TestBounceLib:
         fake_app = mock.Mock(tasks=tasks, health_checks=[])
 
         with mock.patch('paasta_tools.bounce_lib.datetime.datetime', utcnow=lambda: now, autospec=True):
-            assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', min_task_uptime=121) == []
+            actual = bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', self.fake_system_paasta_config(),
+                                                min_task_uptime=121)
+            expected = []
+            assert actual == expected
 
     def test_get_happy_tasks_check_haproxy(self):
         """If we specify that a task should be in haproxy, don't call it happy unless it's in haproxy."""
@@ -267,7 +278,10 @@ class TestBounceLib:
             _,
             get_mesos_slaves_grouped_by_attribute_patch,
         ):
-            assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', check_haproxy=True) == tasks[2:]
+            actual = bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', self.fake_system_paasta_config(),
+                                                check_haproxy=True)
+            expected = tasks[2:]
+            assert actual == expected
 
     def test_get_happy_tasks_check_haproxy_when_unhealthy(self):
         """If we specify that a task should be in haproxy, don't call it happy unless it's in haproxy."""
@@ -282,7 +296,10 @@ class TestBounceLib:
             _,
             get_mesos_slaves_grouped_by_attribute_patch,
         ):
-            assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', check_haproxy=True) == []
+            actual = bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', self.fake_system_paasta_config(),
+                                                check_haproxy=True)
+            expected = []
+            assert actual == expected
 
     def test_get_happy_tasks_check_haproxy_multiple_locations(self):
         """If we specify that a task should be in haproxy, don't call it happy unless it's in haproxy."""
@@ -303,16 +320,20 @@ class TestBounceLib:
                 'fake_region': ['fake_host1'],
                 'fake_other_region': ['fake_host2'],
             }
-            assert bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', check_haproxy=True) == tasks[2:]
+            actual = bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', self.fake_system_paasta_config(),
+                                                check_haproxy=True)
+            expected = tasks[2:]
+            assert actual == expected
+
             get_registered_marathon_tasks_patch.assert_any_call(
                 'fake_host1',
-                DEFAULT_SYNAPSE_PORT,
+                123456,
                 'service.namespace',
                 tasks,
             )
             get_registered_marathon_tasks_patch.assert_any_call(
                 'fake_host2',
-                DEFAULT_SYNAPSE_PORT,
+                123456,
                 'service.namespace',
                 tasks,
             )

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -20,7 +20,6 @@ import pysensu_yelp
 
 from paasta_tools import check_marathon_services_replication
 from paasta_tools.marathon_tools import MarathonServiceConfig
-from paasta_tools.smartstack_tools import DEFAULT_SYNAPSE_PORT
 from paasta_tools.utils import compose_job_id
 
 check_marathon_services_replication.log = mock.Mock()
@@ -788,7 +787,12 @@ def test_get_smartstack_replication_for_attribute():
             'fake_other_value': {}
         }
         actual = check_marathon_services_replication.get_smartstack_replication_for_attribute(
-            attribute='fake_attribute', service=fake_service, namespace=fake_namespace, blacklist=[])
+            attribute='fake_attribute',
+            service=fake_service,
+            namespace=fake_namespace,
+            blacklist=[],
+            synapse_port=54321,
+        )
         assert actual == expected
         assert mock_get_replication_for_services.call_count == 2
         mock_get_mesos_slaves_grouped_by_attribute.assert_called_once_with(
@@ -797,7 +801,7 @@ def test_get_smartstack_replication_for_attribute():
         )
         mock_get_replication_for_services.assert_any_call(
             synapse_host='fake_host_1',
-            synapse_port=DEFAULT_SYNAPSE_PORT,
+            synapse_port=54321,
             services=['fake_service.fake_main'],
         )
 

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -21,6 +21,7 @@ import pysensu_yelp
 from paasta_tools import check_marathon_services_replication
 from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT
 
 check_marathon_services_replication.log = mock.Mock()
 
@@ -792,6 +793,7 @@ def test_get_smartstack_replication_for_attribute():
             namespace=fake_namespace,
             blacklist=[],
             synapse_port=54321,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         assert actual == expected
         assert mock_get_replication_for_services.call_count == 2
@@ -802,6 +804,7 @@ def test_get_smartstack_replication_for_attribute():
         mock_get_replication_for_services.assert_any_call(
             synapse_host='fake_host_1',
             synapse_port=54321,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
             services=['fake_service.fake_main'],
         )
 

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -21,7 +21,6 @@ import mock
 
 from paasta_tools import marathon_serviceinit
 from paasta_tools import marathon_tools
-from paasta_tools.smartstack_tools import DEFAULT_SYNAPSE_PORT
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import PaastaColors
@@ -362,11 +361,12 @@ def test_status_smartstack_backends_normal():
             expected_count=len(haproxy_backends_by_task),
             soa_dir=None,
             verbose=False,
+            synapse_port=123456,
         )
         mock_get_backends.assert_called_once_with(
             service_instance,
             synapse_host='fakehost1',
-            synapse_port=3212,
+            synapse_port=123456,
         )
         assert "fake_location1" in actual
         assert "Healthy" in actual
@@ -390,6 +390,7 @@ def test_status_smartstack_backends_different_nerve_ns():
             expected_count=normal_count,
             soa_dir=None,
             verbose=False,
+            synapse_port=123456,
         )
         assert "is announced in the" in actual
         assert different_ns in actual
@@ -423,6 +424,7 @@ def test_status_smartstack_backends_no_smartstack_replication_info():
             expected_count=normal_count,
             soa_dir=None,
             verbose=False,
+            synapse_port=123456,
         )
         assert "%s is NOT in smartstack" % service_instance in actual
 
@@ -470,16 +472,17 @@ def test_status_smartstack_backends_multiple_locations():
             expected_count=len(mock_get_backends.return_value),
             soa_dir=None,
             verbose=False,
+            synapse_port=123456,
         )
         mock_get_backends.assert_any_call(
             service_instance,
             synapse_host='fakehost1',
-            synapse_port=DEFAULT_SYNAPSE_PORT,
+            synapse_port=123456,
         )
         mock_get_backends.assert_any_call(
             service_instance,
             synapse_host='fakehost2',
-            synapse_port=DEFAULT_SYNAPSE_PORT,
+            synapse_port=123456,
         )
         assert "fake_location1 - %s" % PaastaColors.green('Healthy') in actual
         assert "fake_location2 - %s" % PaastaColors.green('Healthy') in actual
@@ -532,16 +535,17 @@ def test_status_smartstack_backends_multiple_locations_expected_count():
             expected_count=normal_count,
             soa_dir=None,
             verbose=False,
+            synapse_port=123456,
         )
         mock_get_backends.assert_any_call(
             service_instance,
             synapse_host='fakehost1',
-            synapse_port=3212,
+            synapse_port=123456,
         )
         mock_get_backends.assert_any_call(
             service_instance,
             synapse_host='fakehost2',
-            synapse_port=3212,
+            synapse_port=123456,
         )
         expected_count_per_location = int(
             normal_count / len(mock_get_mesos_slaves_grouped_by_attribute.return_value))
@@ -598,11 +602,12 @@ def test_status_smartstack_backends_verbose_multiple_apps():
             expected_count=len(haproxy_backends_by_task),
             soa_dir=None,
             verbose=True,
+            synapse_port=123456,
         )
         mock_get_backends.assert_called_once_with(
             service_instance,
             synapse_host='fakehost1',
-            synapse_port=3212,
+            synapse_port=123456,
         )
         assert "fake_location1" in actual
         assert "hostname1:1001" in actual
@@ -653,16 +658,17 @@ def test_status_smartstack_backends_verbose_multiple_locations():
             expected_count=1,
             soa_dir=None,
             verbose=True,
+            synapse_port=123456,
         )
         mock_get_backends.assert_any_call(
             service_instance,
             synapse_host='fakehost1',
-            synapse_port=3212,
+            synapse_port=123456,
         )
         mock_get_backends.assert_any_call(
             service_instance,
             synapse_host='fakehost2',
-            synapse_port=3212,
+            synapse_port=123456,
         )
         mock_get_mesos_slaves_grouped_by_attribute.assert_called_once_with(
             attribute='fake_discover',
@@ -714,6 +720,7 @@ def test_status_smartstack_backends_verbose_emphasizes_maint_instances():
             expected_count=normal_count,
             soa_dir=None,
             verbose=True,
+            synapse_port=123456,
         )
         assert PaastaColors.red('MAINT') in actual
 
@@ -758,6 +765,7 @@ def test_status_smartstack_backends_verbose_demphasizes_maint_instances_for_unre
             expected_count=normal_count,
             soa_dir=None,
             verbose=True,
+            synapse_port=123456,
         )
         assert PaastaColors.red('MAINT') not in actual
         assert re.search(r"%s[^\n]*hostname1:1001" % re.escape(PaastaColors.GREY), actual)
@@ -880,6 +888,7 @@ def test_pretty_print_smartstack_backends_for_locations_verbose():
             locations=hosts_grouped_by_location,
             expected_count=3,
             verbose=True,
+            synapse_port=123456,
         )
 
         colorstripped_actual = [remove_ansi_escape_sequences(l) for l in actual]

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -25,6 +25,7 @@ from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import remove_ansi_escape_sequences
+from paasta_tools.utils import SystemPaastaConfig
 
 
 fake_marathon_job_config = marathon_tools.MarathonServiceConfig(
@@ -827,9 +828,12 @@ def test_perform_command_handles_no_docker_and_doesnt_raise():
         mock.patch('paasta_tools.marathon_serviceinit.marathon_tools.load_marathon_config', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.marathon_tools.load_marathon_service_config', autospec=True,
                    return_value=mock.Mock(format_marathon_app_dict=mock.Mock(side_effect=NoDockerImageError))),
+        mock.patch('paasta_tools.marathon_serviceinit.load_system_paasta_config', autospec=True,
+                   return_value=SystemPaastaConfig({}, "/fake/config")),
     ) as (
         mock_load_marathon_config,
         mock_load_marathon_service_config,
+        mock_load_system_paasta_config,
     ):
         actual = marathon_serviceinit.perform_command(
             'start', fake_service, fake_instance, fake_cluster, False, soa_dir)

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -26,6 +26,7 @@ from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import remove_ansi_escape_sequences
 from paasta_tools.utils import SystemPaastaConfig
+from paasta_tools.utils import DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT
 
 
 fake_marathon_job_config = marathon_tools.MarathonServiceConfig(
@@ -363,11 +364,13 @@ def test_status_smartstack_backends_normal():
             soa_dir=None,
             verbose=False,
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         mock_get_backends.assert_called_once_with(
             service_instance,
             synapse_host='fakehost1',
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         assert "fake_location1" in actual
         assert "Healthy" in actual
@@ -392,6 +395,7 @@ def test_status_smartstack_backends_different_nerve_ns():
             soa_dir=None,
             verbose=False,
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         assert "is announced in the" in actual
         assert different_ns in actual
@@ -426,6 +430,7 @@ def test_status_smartstack_backends_no_smartstack_replication_info():
             soa_dir=None,
             verbose=False,
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         assert "%s is NOT in smartstack" % service_instance in actual
 
@@ -474,16 +479,19 @@ def test_status_smartstack_backends_multiple_locations():
             soa_dir=None,
             verbose=False,
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         mock_get_backends.assert_any_call(
             service_instance,
             synapse_host='fakehost1',
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         mock_get_backends.assert_any_call(
             service_instance,
             synapse_host='fakehost2',
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         assert "fake_location1 - %s" % PaastaColors.green('Healthy') in actual
         assert "fake_location2 - %s" % PaastaColors.green('Healthy') in actual
@@ -537,16 +545,19 @@ def test_status_smartstack_backends_multiple_locations_expected_count():
             soa_dir=None,
             verbose=False,
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         mock_get_backends.assert_any_call(
             service_instance,
             synapse_host='fakehost1',
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         mock_get_backends.assert_any_call(
             service_instance,
             synapse_host='fakehost2',
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         expected_count_per_location = int(
             normal_count / len(mock_get_mesos_slaves_grouped_by_attribute.return_value))
@@ -604,11 +615,13 @@ def test_status_smartstack_backends_verbose_multiple_apps():
             soa_dir=None,
             verbose=True,
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         mock_get_backends.assert_called_once_with(
             service_instance,
             synapse_host='fakehost1',
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         assert "fake_location1" in actual
         assert "hostname1:1001" in actual
@@ -660,16 +673,19 @@ def test_status_smartstack_backends_verbose_multiple_locations():
             soa_dir=None,
             verbose=True,
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         mock_get_backends.assert_any_call(
             service_instance,
             synapse_host='fakehost1',
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         mock_get_backends.assert_any_call(
             service_instance,
             synapse_host='fakehost2',
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         mock_get_mesos_slaves_grouped_by_attribute.assert_called_once_with(
             attribute='fake_discover',
@@ -722,6 +738,7 @@ def test_status_smartstack_backends_verbose_emphasizes_maint_instances():
             soa_dir=None,
             verbose=True,
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         assert PaastaColors.red('MAINT') in actual
 
@@ -767,6 +784,7 @@ def test_status_smartstack_backends_verbose_demphasizes_maint_instances_for_unre
             soa_dir=None,
             verbose=True,
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
         assert PaastaColors.red('MAINT') not in actual
         assert re.search(r"%s[^\n]*hostname1:1001" % re.escape(PaastaColors.GREY), actual)
@@ -879,8 +897,10 @@ def test_pretty_print_smartstack_backends_for_locations_verbose():
         },
     }
     with contextlib.nested(
-        mock.patch('paasta_tools.marathon_serviceinit.get_backends', autospec=True,
-                   side_effect=lambda _, synapse_host, synapse_port: [backends[synapse_host]]),
+        mock.patch(
+            'paasta_tools.marathon_serviceinit.get_backends', autospec=True,
+            side_effect=lambda _, synapse_host, synapse_port, synapse_haproxy_url_format: [backends[synapse_host]]
+        ),
         mock.patch('socket.gethostbyname', side_effect=lambda name: host_ip_mapping[name], autospec=True),
     ) as (
         mock_get_backends,
@@ -893,6 +913,7 @@ def test_pretty_print_smartstack_backends_for_locations_verbose():
             expected_count=3,
             verbose=True,
             synapse_port=123456,
+            synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
 
         colorstripped_actual = [remove_ansi_escape_sequences(l) for l in actual]

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -22,11 +22,11 @@ import mock
 from paasta_tools import marathon_serviceinit
 from paasta_tools import marathon_tools
 from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import remove_ansi_escape_sequences
 from paasta_tools.utils import SystemPaastaConfig
-from paasta_tools.utils import DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT
 
 
 fake_marathon_job_config = marathon_tools.MarathonServiceConfig(

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -103,11 +103,14 @@ def test_get_cpu_usage_good():
         'cpus_system_time_secs': 2.5,
         'cpus_user_time_secs': 0.0,
     }
+    current_time = datetime.datetime.now()
     fake_task.__getitem__.return_value = [{
         'state': 'TASK_RUNNING',
-        'timestamp': int(datetime.datetime.now().strftime('%s')) - fake_duration,
+        'timestamp': int(current_time.strftime('%s')) - fake_duration,
     }]
-    actual = mesos_tools.get_cpu_usage(fake_task)
+    with mock.patch('paasta_tools.mesos_tools.datetime.datetime', autospec=True) as mock_datetime:
+        mock_datetime.now.return_value = current_time
+        actual = mesos_tools.get_cpu_usage(fake_task)
     assert '10.0%' == actual
 
 
@@ -119,11 +122,14 @@ def test_get_cpu_usage_bad():
         'cpus_system_time_secs': 50.0,
         'cpus_user_time_secs': 50.0,
     }
+    current_time = datetime.datetime.now()
     fake_task.__getitem__.return_value = [{
         'state': 'TASK_RUNNING',
-        'timestamp': int(datetime.datetime.now().strftime('%s')) - fake_duration,
+        'timestamp': int(current_time.strftime('%s')) - fake_duration,
     }]
-    actual = mesos_tools.get_cpu_usage(fake_task)
+    with mock.patch('paasta_tools.mesos_tools.datetime.datetime', autospec=True) as mock_datetime:
+        mock_datetime.now.return_value = current_time
+        actual = mesos_tools.get_cpu_usage(fake_task)
     assert PaastaColors.red('100.0%') in actual
 
 

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -22,6 +22,7 @@ from pytest import raises
 from paasta_tools import bounce_lib
 from paasta_tools import marathon_tools
 from paasta_tools import setup_marathon_job
+from paasta_tools import utils
 from paasta_tools.bounce_lib import list_bounce_methods
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import decompose_job_id
@@ -1170,7 +1171,7 @@ class TestSetupMarathonJob:
             mock.patch(
                 'paasta_tools.bounce_lib.get_happy_tasks',
                 autospec=True,
-                side_effect=lambda x, _, __, **kwargs: x.tasks,
+                side_effect=lambda x, _, __, ___, **kwargs: x.tasks,
             ),
             mock.patch('paasta_tools.bounce_lib.kill_old_ids', autospec=True),
             mock.patch('paasta_tools.bounce_lib.create_marathon_app', autospec=True),
@@ -1338,7 +1339,7 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
     def fake_drain_method(self):
         return mock.Mock(is_draining=lambda t: t._drain_state == 'down')
 
-    def fake_get_happy_tasks(self, app, service, nerve_ns, **kwargs):
+    def fake_get_happy_tasks(self, app, service, nerve_ns, system_paasta_config, **kwargs):
         return [t for t in app.tasks if t._happiness == 'happy']
 
     def test_get_old_happy_unhappy_draining_tasks_empty(self):
@@ -1350,6 +1351,7 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
             mock.Mock(id=fake_id, tasks=[]),
             mock.Mock(id=('%s2' % fake_id), tasks=[])
         ]
+        fake_system_paasta_config = utils.SystemPaastaConfig({}, "/fake/configs")
 
         expected_live_happy_tasks = {
             fake_apps[0].id: set(),
@@ -1371,6 +1373,7 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
                 service=fake_name,
                 nerve_ns=fake_instance,
                 bounce_health_params={},
+                system_paasta_config=fake_system_paasta_config,
             )
         actual_live_happy_tasks, actual_live_unhappy_tasks, actual_draining_tasks = actual
         assert actual_live_happy_tasks == expected_live_happy_tasks
@@ -1401,6 +1404,8 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
             ),
         ]
 
+        fake_system_paasta_config = utils.SystemPaastaConfig({}, "/fake/configs")
+
         expected_live_happy_tasks = {
             fake_apps[0].id: set([fake_apps[0].tasks[0]]),
             fake_apps[1].id: set([fake_apps[1].tasks[0]]),
@@ -1421,6 +1426,7 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
                 service=fake_name,
                 nerve_ns=fake_instance,
                 bounce_health_params={},
+                system_paasta_config=fake_system_paasta_config,
             )
         actual_live_happy_tasks, actual_live_unhappy_tasks, actual_draining_tasks = actual
         assert actual_live_happy_tasks == expected_live_happy_tasks


### PR DESCRIPTION
Like it says. Stop hard-coding synapse port, and make it configurable through the system paasta config. It defaults to the current value, so ideally even without updating our system paasta config, nothing should break.

