### PR TITLE
removed service_configuration_lib.DEFAULT_SOA_DIR

### DIFF
--- a/paasta_tools/check_chronos_jobs.py
+++ b/paasta_tools/check_chronos_jobs.py
@@ -9,12 +9,12 @@ a CRITICAL event to sensu.
 import argparse
 
 import pysensu_yelp
-import service_configuration_lib
 
 from paasta_tools import chronos_tools
 from paasta_tools import monitoring_tools
 from paasta_tools import utils
 from paasta_tools.chronos_tools import compose_check_name_for_service_instance
+from paasta_tools.chronos_tools import DEFAULT_SOA_DIR
 from paasta_tools.chronos_tools import load_chronos_job_config
 
 
@@ -22,7 +22,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description=('Check the status of Chronos jobs, and report'
                                                   'their status to Sensu.'))
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
-                        default=service_configuration_lib.DEFAULT_SOA_DIR,
+                        default=DEFAULT_SOA_DIR,
                         help="define a different soa config directory")
     args = parser.parse_args()
     return args

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -36,7 +36,6 @@ from datetime import datetime
 from datetime import timedelta
 
 import pysensu_yelp
-import service_configuration_lib
 
 from paasta_tools import marathon_tools
 from paasta_tools import mesos_tools
@@ -90,7 +89,7 @@ def parse_args():
     parser = argparse.ArgumentParser(epilog=epilog)
 
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
-                        default=service_configuration_lib.DEFAULT_SOA_DIR,
+                        default=marathon_tools.DEFAULT_SOA_DIR,
                         help="define a different soa config directory")
     parser.add_argument('-v', '--verbose', action='store_true',
                         dest="verbose", default=False)

--- a/paasta_tools/chronos_rerun.py
+++ b/paasta_tools/chronos_rerun.py
@@ -25,8 +25,6 @@ import argparse
 import copy
 import datetime
 
-import service_configuration_lib
-
 from paasta_tools import chronos_tools
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import NoDeploymentsAvailable
@@ -40,7 +38,7 @@ def parse_args():
     parser.add_argument('-v', '--verbose', action='store_true', dest="verbose", default=False,
                         help="Print out more output regarding the state of the service")
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
-                        default=service_configuration_lib.DEFAULT_SOA_DIR,
+                        default=chronos_tools.DEFAULT_SOA_DIR,
                         help="define a different soa config directory")
     parser.add_argument('service_instance', help='Instance to operate on. Eg: example_service.main')
     parser.add_argument('execution_date',

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -28,6 +28,7 @@ import service_configuration_lib
 from tron import command_context
 
 from paasta_tools.mesos_tools import get_mesos_network_for_net
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_paasta_branch
@@ -60,7 +61,6 @@ TMP_JOB_IDENTIFIER = "tmp"
 
 VALID_BOUNCE_METHODS = ['graceful']
 PATH_TO_CHRONOS_CONFIG = os.path.join(PATH_TO_SYSTEM_PAASTA_CONFIG_DIR, 'chronos.json')
-DEFAULT_SOA_DIR = service_configuration_lib.DEFAULT_SOA_DIR
 EXECUTION_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 log = logging.getLogger('__main__')
 

--- a/paasta_tools/cleanup_chronos_jobs.py
+++ b/paasta_tools/cleanup_chronos_jobs.py
@@ -31,7 +31,6 @@ import sys
 
 import dateutil.parser
 import pysensu_yelp
-import service_configuration_lib
 
 from paasta_tools import chronos_tools
 from paasta_tools.check_chronos_jobs import send_event
@@ -41,7 +40,7 @@ from paasta_tools.utils import InvalidJobNameError
 def parse_args():
     parser = argparse.ArgumentParser(description='Cleans up stale chronos jobs.')
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
-                        default=service_configuration_lib.DEFAULT_SOA_DIR,
+                        default=chronos_tools.DEFAULT_SOA_DIR,
                         help="define a different soa config directory")
     args = parser.parse_args()
     return args

--- a/paasta_tools/cleanup_marathon_jobs.py
+++ b/paasta_tools/cleanup_marathon_jobs.py
@@ -33,13 +33,13 @@ import logging
 import traceback
 
 import pysensu_yelp
-import service_configuration_lib
 
 from paasta_tools import bounce_lib
 from paasta_tools import marathon_tools
 from paasta_tools.mesos_tools import is_mesos_leader
 from paasta_tools.monitoring_tools import send_event
 from paasta_tools.utils import _log
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import load_system_paasta_config
@@ -52,7 +52,7 @@ logging.basicConfig()
 def parse_args():
     parser = argparse.ArgumentParser(description='Cleans up stale marathon jobs.')
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
-                        default=service_configuration_lib.DEFAULT_SOA_DIR,
+                        default=DEFAULT_SOA_DIR,
                         help="define a different soa config directory")
     parser.add_argument('-v', '--verbose', action='store_true',
                         dest="verbose", default=False)

--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -18,7 +18,6 @@ import os
 import re
 import urllib2
 
-from service_configuration_lib import DEFAULT_SOA_DIR
 from service_configuration_lib import read_service_configuration
 
 from paasta_tools.chronos_tools import load_chronos_job_config
@@ -37,6 +36,7 @@ from paasta_tools.marathon_tools import get_all_namespaces_for_service
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.monitoring_tools import get_team
 from paasta_tools.utils import _run
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import DEPLOY_PIPELINE_NON_DEPLOY_STEPS
 from paasta_tools.utils import get_git_url
 from paasta_tools.utils import get_service_instance_list

--- a/paasta_tools/cli/cmds/emergency_scale.py
+++ b/paasta_tools/cli/cmds/emergency_scale.py
@@ -12,14 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from service_configuration_lib import DEFAULT_SOA_DIR
-
 from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 
 

--- a/paasta_tools/cli/cmds/emergency_stop.py
+++ b/paasta_tools/cli/cmds/emergency_stop.py
@@ -12,14 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from service_configuration_lib import DEFAULT_SOA_DIR
-
 from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 
 

--- a/paasta_tools/cli/cmds/fsm.py
+++ b/paasta_tools/cli/cmds/fsm.py
@@ -16,8 +16,6 @@ import sys
 from os.path import exists
 from os.path import join
 
-from service_configuration_lib import DEFAULT_SOA_DIR
-
 from paasta_tools.cli.fsm.questions import _yamlize
 from paasta_tools.cli.fsm.questions import get_marathon_stanza
 from paasta_tools.cli.fsm.questions import get_monitoring_stanza
@@ -27,6 +25,7 @@ from paasta_tools.cli.fsm.questions import get_srvname
 from paasta_tools.cli.fsm.service import Service
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_teams
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import PaastaColors
 

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -24,7 +24,6 @@ from random import randint
 from urlparse import urlparse
 
 import requests
-import service_configuration_lib
 from docker import errors
 
 from paasta_tools.cli.cmds.check import makefile_responds_to
@@ -40,6 +39,7 @@ from paasta_tools.marathon_tools import CONTAINER_PORT
 from paasta_tools.marathon_tools import get_healthcheck_for_instance
 from paasta_tools.paasta_execute_docker_command import execute_in_container
 from paasta_tools.utils import _run
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_docker_client
 from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_username
@@ -293,7 +293,7 @@ def add_subparser(subparsers):
         '-y', '--yelpsoa-config-root',
         dest='yelpsoa_config_root',
         help='A directory from which yelpsoa-configs should be read from',
-        default=service_configuration_lib.DEFAULT_SOA_DIR,
+        default=DEFAULT_SOA_DIR,
     )
     build_pull_group = list_parser.add_mutually_exclusive_group()
     build_pull_group.add_argument(
@@ -466,7 +466,7 @@ def run_docker_container(
     healthcheck,
     healthcheck_only,
     instance_config,
-    soa_dir=service_configuration_lib.DEFAULT_SOA_DIR,
+    soa_dir=DEFAULT_SOA_DIR,
 ):
     """docker-py has issues running a container with a TTY attached, so for
     consistency we execute 'docker run' directly in both interactive and

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -15,8 +15,6 @@
 import datetime
 import socket
 
-from service_configuration_lib import DEFAULT_SOA_DIR
-
 from paasta_tools import remote_git
 from paasta_tools import utils
 from paasta_tools.chronos_tools import ChronosJobConfig
@@ -27,6 +25,7 @@ from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import list_services
 from paasta_tools.generate_deployments_for_service import get_latest_deployment_tag
 from paasta_tools.marathon_tools import MarathonServiceConfig
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 
 

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -20,7 +20,6 @@ import sys
 from socket import gaierror
 from socket import gethostbyname_ex
 
-from service_configuration_lib import DEFAULT_SOA_DIR
 from service_configuration_lib import read_services_configuration
 
 from paasta_tools.chronos_tools import load_chronos_job_config
@@ -28,6 +27,7 @@ from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.monitoring_tools import _load_sensu_team_data
 from paasta_tools.utils import _run
 from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_default_cluster_for_service
 from paasta_tools.utils import list_all_instances_for_service
 from paasta_tools.utils import load_system_paasta_config

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -43,12 +43,11 @@ import logging
 import os
 import re
 
-import service_configuration_lib
-
 from paasta_tools import remote_git
 from paasta_tools.chronos_tools import load_chronos_job_config
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.utils import atomic_file_write
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_git_url
 from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import list_clusters
@@ -61,7 +60,7 @@ TARGET_FILE = 'deployments.json'
 def parse_args():
     parser = argparse.ArgumentParser(description='Creates marathon jobs.')
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
-                        default=service_configuration_lib.DEFAULT_SOA_DIR,
+                        default=DEFAULT_SOA_DIR,
                         help="define a different soa config directory")
     parser.add_argument('-v', '--verbose', action='store_true',
                         dest="verbose", default=False)

--- a/paasta_tools/generate_services_file.py
+++ b/paasta_tools/generate_services_file.py
@@ -23,6 +23,7 @@ import service_configuration_lib
 
 from paasta_tools.marathon_tools import get_all_namespaces_for_service
 from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import DEFAULT_SOA_DIR
 
 
 def get_service_lines_for_service(service):
@@ -43,7 +44,7 @@ def get_service_lines_for_service(service):
 
 def main():
     strings = []
-    for service in sorted(os.listdir(service_configuration_lib.DEFAULT_SOA_DIR)):
+    for service in sorted(os.listdir(DEFAULT_SOA_DIR)):
         strings.extend(get_service_lines_for_service(service))
     print "\n".join(strings)
     sys.exit(0)

--- a/paasta_tools/graceful_app_drain.py
+++ b/paasta_tools/graceful_app_drain.py
@@ -3,8 +3,6 @@ import argparse
 import sys
 import time
 
-import service_configuration_lib
-
 from paasta_tools import bounce_lib
 from paasta_tools import drain_lib
 from paasta_tools import marathon_tools
@@ -28,7 +26,7 @@ def parse_args():
         '-d', '--soa-dir',
         dest="soa_dir",
         metavar="SOA_DIR",
-        default=service_configuration_lib.DEFAULT_SOA_DIR,
+        default=marathon_tools.DEFAULT_SOA_DIR,
         help="define a different soa config directory",
     )
     return parser.parse_args()

--- a/paasta_tools/list_chronos_jobs.py
+++ b/paasta_tools/list_chronos_jobs.py
@@ -29,8 +29,6 @@ Command line options:
 import argparse
 import sys
 
-import service_configuration_lib
-
 from paasta_tools import chronos_tools
 
 
@@ -40,7 +38,7 @@ def parse_args():
                         default=None,
                         help="define a specific cluster to read from")
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
-                        default=service_configuration_lib.DEFAULT_SOA_DIR,
+                        default=chronos_tools.DEFAULT_SOA_DIR,
                         help="define a different soa config directory")
     args = parser.parse_args()
     return args

--- a/paasta_tools/list_marathon_service_instances.py
+++ b/paasta_tools/list_marathon_service_instances.py
@@ -29,8 +29,7 @@ Command line options:
 import argparse
 import sys
 
-import service_configuration_lib
-
+from paasta_tools.marathon_tools import DEFAULT_SOA_DIR
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import get_services_for_cluster
 
@@ -41,7 +40,7 @@ def parse_args():
                         default=None,
                         help="define a specific cluster to read from")
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
-                        default=service_configuration_lib.DEFAULT_SOA_DIR,
+                        default=DEFAULT_SOA_DIR,
                         help="define a different soa config directory")
     args = parser.parse_args()
     return args

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -36,6 +36,7 @@ from paasta_tools.mesos_tools import get_mesos_slaves_grouped_by_attribute
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import deep_merge_dictionaries
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import deploy_blacklist_to_constraints
 from paasta_tools.utils import deploy_whitelist_to_constraints
 from paasta_tools.utils import get_code_sha_from_dockerurl
@@ -55,7 +56,6 @@ from paasta_tools.utils import timeout
 from paasta_tools.utils import ZookeeperPool
 
 CONTAINER_PORT = 8888
-DEFAULT_SOA_DIR = service_configuration_lib.DEFAULT_SOA_DIR
 # Marathon creates Mesos tasks with an id composed of the app's full name, a
 # spacer, and a UUID. This variable is that spacer. Note that we don't control
 # this spacer, i.e. you can't change it here and expect the world to change

--- a/paasta_tools/monitoring_tools.py
+++ b/paasta_tools/monitoring_tools.py
@@ -27,61 +27,62 @@ import os
 import pysensu_yelp
 import service_configuration_lib
 
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import load_system_paasta_config
 
 
 log = logging.getLogger('__main__')
 
 
-def get_team(overrides, service, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def get_team(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('team', overrides, service, soa_dir)
 
 
-def get_runbook(overrides, service, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def get_runbook(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('runbook', overrides, service, soa_dir)
 
 
-def get_tip(overrides, service, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def get_tip(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('tip', overrides, service, soa_dir)
 
 
-def get_notification_email(overrides, service, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def get_notification_email(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('notification_email', overrides, service, soa_dir)
 
 
-def get_page(overrides, service, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def get_page(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('page', overrides, service, soa_dir)
 
 
-def get_alert_after(overrides, service, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def get_alert_after(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('alert_after', overrides, service, soa_dir)
 
 
-def get_realert_every(overrides, service, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def get_realert_every(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('realert_every', overrides, service, soa_dir)
 
 
-def get_check_every(overrides, service, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def get_check_every(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('check_every', overrides, service, soa_dir)
 
 
-def get_irc_channels(overrides, service, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def get_irc_channels(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('irc_channels', overrides, service, soa_dir)
 
 
-def get_dependencies(overrides, service, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def get_dependencies(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('dependencies', overrides, service, soa_dir)
 
 
-def get_ticket(overrides, service, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def get_ticket(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('ticket', overrides, service, soa_dir)
 
 
-def get_project(overrides, service, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def get_project(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('project', overrides, service, soa_dir)
 
 
-def __get_monitoring_config_value(key, overrides, service, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def __get_monitoring_config_value(key, overrides, service, soa_dir=DEFAULT_SOA_DIR):
     general_config = service_configuration_lib.read_service_configuration(service, soa_dir=soa_dir)
     monitor_config = read_monitoring_config(service, soa_dir=soa_dir)
     service_default = general_config.get(key, monitoring_defaults(key))
@@ -102,7 +103,7 @@ def monitoring_defaults(key):
     return defaults.get(key, None)
 
 
-def get_team_email_address(service, overrides=None, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def get_team_email_address(service, overrides=None, soa_dir=DEFAULT_SOA_DIR):
     """Looks up the team email address from specific marathon or chronos config
     (most specific) to monitoring.yaml, or the global Sensu team_data.json.
     (least specific). Returns None if nothing is available.
@@ -185,7 +186,7 @@ def send_event(service, check_name, overrides, status, output, soa_dir, ttl=None
                                 **result_dict)
 
 
-def read_monitoring_config(service, soa_dir=service_configuration_lib.DEFAULT_SOA_DIR):
+def read_monitoring_config(service, soa_dir=DEFAULT_SOA_DIR):
     """Read a service's monitoring.yaml file.
 
     :param service: The service name

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -21,12 +21,11 @@ import argparse
 import logging
 import sys
 
-import service_configuration_lib
-
 from paasta_tools import chronos_serviceinit
 from paasta_tools import marathon_serviceinit
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import decompose_job_id
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import validate_service_instance
 
@@ -45,7 +44,7 @@ def parse_args():
     parser.add_argument('-D', '--debug', action='store_true', dest="debug", default=False,
                         help="Output debug logs regarding files, connections, etc")
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
-                        default=service_configuration_lib.DEFAULT_SOA_DIR,
+                        default=DEFAULT_SOA_DIR,
                         help="define a different soa config directory")
     parser.add_argument('service_instance', help='Instance to operate on. Eg: example_service.main')
     parser.add_argument('-a', '--appid', dest="app_id",

--- a/paasta_tools/setup_chronos_job.py
+++ b/paasta_tools/setup_chronos_job.py
@@ -43,7 +43,6 @@ import logging
 import sys
 
 import pysensu_yelp
-import service_configuration_lib
 
 from paasta_tools import chronos_tools
 from paasta_tools import monitoring_tools
@@ -67,7 +66,7 @@ def parse_args():
                         help="The chronos instance of the service to create or update",
                         metavar=compose_job_id("SERVICE", "INSTANCE"))
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
-                        default=service_configuration_lib.DEFAULT_SOA_DIR,
+                        default=chronos_tools.DEFAULT_SOA_DIR,
                         help="define a different soa config directory")
     parser.add_argument('-v', '--verbose', action='store_true',
                         dest="verbose", default=False)

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -47,7 +47,6 @@ import traceback
 from collections import defaultdict
 
 import pysensu_yelp
-import service_configuration_lib
 
 from paasta_tools import bounce_lib
 from paasta_tools import drain_lib
@@ -78,7 +77,7 @@ def parse_args():
                         help="The marathon instance of the service to create or update",
                         metavar="SERVICE%sINSTANCE" % SPACER)
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
-                        default=service_configuration_lib.DEFAULT_SOA_DIR,
+                        default=marathon_tools.DEFAULT_SOA_DIR,
                         help="define a different soa config directory")
     parser.add_argument('-v', '--verbose', action='store_true',
                         dest="verbose", default=False)


### PR DESCRIPTION
Also made `chronos_tools.DEFAULT_SOA_DIR` and `marathon_tools.DEFAULT_SOA_DIR` reference `utils.DEFAULT_SOA_DIR`

This makes it easier to have a configurable DEFAULT_SOA_DIR for different environments.