### PR TITLE
Switch from readthedocs.org->readthedocs.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -552,7 +552,7 @@
 **Closed issues:**
 
 - 0.16.1 Release Broke 'paasta status' [\#91](https://github.com/Yelp/paasta/issues/91)
-- http://paasta.readthedocs.org/en/latest/ references y/paasta [\#57](https://github.com/Yelp/paasta/issues/57)
+- http://paasta.readthedocs.io/en/latest/ references y/paasta [\#57](https://github.com/Yelp/paasta/issues/57)
 
 **Merged pull requests:**
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ PaaSTA is a highly-available, distributed system for building, deploying, and
 running services using containers and Apache Mesos!
 
 Want to know more about the opinions behind what makes PaaSTA special? Check
-out the [PaaSTA Principles](http://paasta.readthedocs.org/en/latest/about/paasta_principles.html).
+out the [PaaSTA Principles](http://paasta.readthedocs.io/en/latest/about/paasta_principles.html).
 
 *Note*: PaaSTA has been running in production at Yelp for more than a year,
 and has a number of "Yelpisms" still lingering in the codebase. We have made
@@ -63,12 +63,12 @@ to build a cohesive PaaS. It is not a turn-key PaaS solution.
 
 ## Getting Started
 
-See the [getting started](http://paasta.readthedocs.org/en/latest/installation/getting_started.html)
+See the [getting started](http://paasta.readthedocs.io/en/latest/installation/getting_started.html)
 documentation for how to deploy PaaSTA.
 
 ## Documentation
 
-Read the documentation at [Read the Docs](http://paasta.readthedocs.org/en/latest/).
+Read the documentation at [Read the Docs](http://paasta.readthedocs.io/en/latest/).
 
 ## Videos / Talks About PaaSTA
 

--- a/comparison.md
+++ b/comparison.md
@@ -144,7 +144,7 @@ required to run a fully working setup, assuming Postgres meets the developers'
 needs. Most other PaaS's view this problem as "out of scope", including PaaSTA.
 
 Depending on your opinions on the [Twelve-Factor App manifesto](http://12factor.net/),
-Flynn, Heroku, or [Empire](http://empire.readthedocs.org/en/latest/) may be good
+Flynn, Heroku, or [Empire](http://empire.readthedocs.io/en/latest/) may be good
 solutions for environments that have apps that already conform to the twelve-factor
 specification.
 

--- a/paasta_tools/cli/cmds/cook_image.py
+++ b/paasta_tools/cli/cmds/cook_image.py
@@ -64,7 +64,7 @@ def paasta_cook_image(args, service=None, soa_dir=None):
 
     if not makefile_responds_to('cook-image'):
         sys.stderr.write('ERROR: local-run now requires a cook-image target to be present in the Makefile. See '
-                         'http://paasta.readthedocs.org/en/latest/about/contract.html\n')
+                         'http://paasta.readthedocs.io/en/latest/about/contract.html\n')
         return 1
 
     try:

--- a/paasta_tools/cli/cmds/itest.py
+++ b/paasta_tools/cli/cmds/itest.py
@@ -32,7 +32,7 @@ def add_subparser(subparsers):
         description=(
             "'paasta itest' runs 'make itest' in the root of a service directory. "
             "It is designed to be used in conjection with the 'Jenkins' workflow: "
-            "http://paasta.readthedocs.org/en/latest/about/contract.html#jenkins-pipeline-recommended"
+            "http://paasta.readthedocs.io/en/latest/about/contract.html#jenkins-pipeline-recommended"
         )
     )
     list_parser.add_argument(

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -41,15 +41,15 @@ SCHEMA_VALID = success("Successfully validated schema")
 
 SCHEMA_INVALID = failure(
     "Failed to validate schema. More info:",
-    "http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html")
+    "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html")
 
 SCHEMA_NOT_FOUND = failure(
     "Failed to find schema to validate against. More info:",
-    "http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html")
+    "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html")
 
 FAILED_READING_FILE = failure(
     "Failed to read file. More info:",
-    "http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html")
+    "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html")
 
 UNKNOWN_SERVICE = "Unable to determine service to validate.\n" \
                   "Please supply the %s name you wish to " \
@@ -61,7 +61,7 @@ def invalid_chronos_instance(cluster, instance, output):
     return failure(
         'chronos-%s.yaml has an invalid instance: %s.\n  %s\n  '
         'More info:' % (cluster, instance, output),
-        "http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html#chronos-clustername-yaml")
+        "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html#chronos-clustername-yaml")
 
 
 def valid_chronos_instance(cluster, instance):
@@ -164,11 +164,11 @@ def check_service_path(service_path):
     """
     if not service_path or not os.path.isdir(service_path):
         print failure("%s is not a directory" % service_path,
-                      "http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html")
+                      "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html")
         return False
     if not glob(os.path.join(service_path, "*.yaml")):
         print failure("%s does not contain any .yaml files" % service_path,
-                      "http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html")
+                      "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html")
         return False
     return True
 

--- a/paasta_tools/cli/paasta_tabcomplete.sh
+++ b/paasta_tools/cli/paasta_tabcomplete.sh
@@ -18,6 +18,6 @@ if [[ -n ${ZSH_VERSION-} ]]; then
 fi
 
 # This magic eval enables tab-completion for the "paasta" command
-# http://argcomplete.readthedocs.org/en/latest/index.html#synopsis
+# http://argcomplete.readthedocs.io/en/latest/index.html#synopsis
 # This comes from the paasta-tools system package
 eval "$(/usr/share/python/paasta-tools/bin/register-python-argcomplete paasta)"

--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html#chronos-clustername-yaml",
+    "description": "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html#chronos-clustername-yaml",
     "type": "object",
     "minProperties": 1,
     "additionalProperties": {

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "http://paasta.readthedocs.org/en/latest/yelpsoa_configs.html#marathon-clustername-yaml",
+    "description": "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html#marathon-clustername-yaml",
     "type": "object",
     "minProperties": 1,
     "additionalProperties": {

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -176,38 +176,38 @@ class PaastaCheckMessages:
     MAKEFILE_FOUND = success("A Makefile is present")
     MAKEFILE_MISSING = failure(
         "No Makefile available. Please make a Makefile that responds\n"
-        "to the proper targets. More info:", "http://paasta.readthedocs.org/en/latest/about/contract.html"
+        "to the proper targets. More info:", "http://paasta.readthedocs.io/en/latest/about/contract.html"
     )
     MAKEFILE_RESPONDS_BUILD_IMAGE = success("The Makefile responds to `make cook-image`")
     MAKEFILE_RESPONDS_BUILD_IMAGE_FAIL = failure(
         "The Makefile does not have a `make cook-image` target. local-run needs\n"
         "this and expects it to build your docker image. More info:",
-        "http://paasta.readthedocs.org/en/latest/about/contract.html"
+        "http://paasta.readthedocs.io/en/latest/about/contract.html"
     )
     MAKEFILE_RESPONDS_ITEST = success("The Makefile responds to `make itest`")
     MAKEFILE_RESPONDS_ITEST_FAIL = failure(
         "The Makefile does not have a `make itest` target. Jenkins needs\n"
         "this and expects it to build and itest your docker image. More info:",
-        "http://paasta.readthedocs.org/en/latest/about/contract.html"
+        "http://paasta.readthedocs.io/en/latest/about/contract.html"
     )
     MAKEFILE_RESPONDS_TEST = success("The Makefile responds to `make test`")
     MAKEFILE_RESPONDS_TEST_FAIL = failure(
         "The Makefile does not have a `make test` target. Jenkins needs\n"
         "this and expects it to run unit tests. More info:",
-        "http://paasta.readthedocs.org/en/latest/about/contract.html"
+        "http://paasta.readthedocs.io/en/latest/about/contract.html"
     )
     MAKEFILE_HAS_A_TAB = success("The Makefile contains a tab character")
     MAKEFILE_HAS_NO_TABS = failure(
         "The Makefile contains no tab characters. Make sure you\n"
         "didn't accidentally paste spaces (which `make` does not respect)\n"
         "instead of a tab.",
-        "http://paasta.readthedocs.org/en/latest/about/contract.html",
+        "http://paasta.readthedocs.io/en/latest/about/contract.html",
     )
     MAKEFILE_HAS_DOCKER_TAG = success("The Makefile contains a docker tag")
     MAKEFILE_HAS_NO_DOCKER_TAG = failure(
         "The Makefile contains no reference to DOCKER_TAG. Make sure you\n"
         "specify a DOCKER_TAG and that your itest tags your docker image with $DOCKER_TAG.",
-        "http://paasta.readthedocs.org/en/latest/about/contract.html",
+        "http://paasta.readthedocs.io/en/latest/about/contract.html",
     )
 
     PIPELINE_FOUND = success("Jenkins build pipeline found")

--- a/yelp_package/CHANGELOG.md
+++ b/yelp_package/CHANGELOG.md
@@ -100,7 +100,7 @@
 **Closed issues:**
 
 - 0.16.1 Release Broke 'paasta status' [\#91](https://github.com/Yelp/paasta/issues/91)
-- http://paasta.readthedocs.org/en/latest/ references y/paasta [\#57](https://github.com/Yelp/paasta/issues/57)
+- http://paasta.readthedocs.io/en/latest/ references y/paasta [\#57](https://github.com/Yelp/paasta/issues/57)
 
 **Merged pull requests:**
 

--- a/yelp_package/bintray.json.in
+++ b/yelp_package/bintray.json.in
@@ -4,7 +4,7 @@
         "repo": "paasta",
         "subject": "yelp",
         "desc": "An open, distributed platform as a service",
-        "website_url": "paasta.readthedocs.org",
+        "website_url": "paasta.readthedocs.io",
         "issue_tracker_url": "https://github.com/Yelp/paasta/issues",
         "vcs_url": "https://github.com/Yelp/paasta.git",
         "github_use_tag_release_notes": true,


### PR DESCRIPTION
Read the Docs just sent out an email informing users that they are moving project subdomains from readthedocs.org to readthedocs.io. They will automatically forward users from the old domain to the new one, but they are encouraging projects to update any links they might have.