### PR TITLE
Greatly improve the output of check_marathon_services replication

### DIFF
--- a/paasta_tools/check_chronos_jobs.py
+++ b/paasta_tools/check_chronos_jobs.py
@@ -114,11 +114,17 @@ def message_for_status(status, service, instance, cluster):
         return (
             "Last run of job %(service)s%(separator)s%(instance)s failed.\n"
             "You can view the logs for the job with:\n"
-            "paasta logs -s %(service)s -i %(instance)s -c %(cluster)s .\n"
+            "\n"
+            "    paasta logs -s %(service)s -i %(instance)s -c %(cluster)s\n"
+            "\n"
             "If your job didn't manage to start up, you can view the stdout and stderr of your job using:\n"
-            "paasta status -s %(service)s -i %(instance)s -c %(cluster)s -vv .\n"
+            "\n"
+            "    paasta status -s %(service)s -i %(instance)s -c %(cluster)s -vv\n"
+            "\n"
             "If you need to rerun your job for the datetime it was started, you can do so with:\n"
-            "paasta rerun -s %(service)s -i %(instance)s -c %(cluster)s -d {datetime} .\n"
+            "\n"
+            "    paasta rerun -s %(service)s -i %(instance)s -c %(cluster)s -d {datetime}\n"
+            "\n"
             "See the docs on paasta rerun here:\n"
             "https://paasta.readthedocs.io/en/latest/workflow.html#re-running-failed-jobs for more details."
         ) % {
@@ -137,8 +143,8 @@ def sensu_message_status_for_jobs(chronos_job_config, service, instance, cluster
     if len(job_state_pairs) > 1:
         sensu_status = pysensu_yelp.Status.UNKNOWN
         output = (
-            "Unknown: somehow there was more than one enabled job for %s%s%s. "
-            "Talk to the PaaSTA team as this indicates a bug" % (service, utils.SPACER, instance)
+            "Unknown: somehow there was more than one enabled job for %s%s%s.\n"
+            "Talk to the PaaSTA team as this indicates a bug." % (service, utils.SPACER, instance)
         )
     elif len(job_state_pairs) == 0:
         if chronos_job_config.get_disabled():
@@ -168,7 +174,6 @@ def main(args):
     system_paasta_config = utils.load_system_paasta_config()
     cluster = system_paasta_config.get_cluster()
 
-    # get those jobs listed in configs
     configured_jobs = chronos_tools.get_chronos_jobs_for_cluster(cluster, soa_dir=soa_dir)
 
     service_job_mapping = build_service_job_mapping(client, configured_jobs)

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -175,11 +175,13 @@ def check_smartstack_replication_for_instance(
                 "\n"
                 "Things you can do:\n"
                 "\n"
-                "  * Widen SmartStack discovery settings\n"
-                "  * Increase the instance count\n"
                 "  * Fix the cause of the unhealthy service. Try running:\n"
                 "\n"
                 "      paasta status -s %(service)s -i %(instance)s -c %(cluster)s -vv\n"
+                "\n"
+                "  * Widen SmartStack discovery settings\n"
+                "  * Increase the instance count\n"
+                "\n"
             ) % {
                 'service': service,
                 'instance': instance,

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -158,6 +158,33 @@ def check_smartstack_replication_for_instance(
 
         if any(under_replication_per_location):
             status = pysensu_yelp.Status.CRITICAL
+            output += (
+                "\n\n"
+                "What this alert means:\n"
+                "\n"
+                "  This replication alert means that a SmartStack powered loadbalancer (haproxy)\n"
+                "  doesn't have enough healthy backends. Not having enough healthy backends\n"
+                "  means that clients of that service will get 503s (http) or connection refused\n"
+                "  (tcp) when trying to connect to it.\n"
+                "\n"
+                "Reasons this might be happening:\n"
+                "\n"
+                "  The service may simply not have enough copies or it could simply be\n"
+                "  unhealthy in that location. There also may not be enough resources\n"
+                "  in the cluster to support the requested instance count.\n"
+                "\n"
+                "Things you can do:\n"
+                "\n"
+                "  * Widen SmartStack discovery settings\n"
+                "  * Increase the instance count\n"
+                "  * Fix the cause of the unhealthy service. Try running:\n"
+                "\n"
+                "      paasta status -s %(service)s -i %(instance)s -c %(cluster)s -vv\n"
+            ) % {
+                'service': service,
+                'instance': instance,
+                'cluster': cluster,
+            }
             log.error(output)
         else:
             status = pysensu_yelp.Status.OK
@@ -210,6 +237,29 @@ def send_event_if_under_replication(
               '(threshold: %d%%)') % (full_name, num_available, expected_count, crit_threshold)
     under_replicated, _ = is_under_replicated(num_available, expected_count, crit_threshold)
     if under_replicated:
+        output += (
+            "\n\n"
+            "What this alert means:\n"
+            "\n"
+            "  This replication alert means that the service PaaSTA can't keep the\n"
+            "  requested number of copies up and healthy in the cluster.\n"
+            "\n"
+            "Reasons this might be happening:\n"
+            "\n"
+            "  The service may simply unhealthy. There also may not be enough resources\n"
+            "  in the cluster to support the requested instance count.\n"
+            "\n"
+            "Things you can do:\n"
+            "\n"
+            "  * Increase the instance count\n"
+            "  * Fix the cause of the unhealthy service. Try running:\n"
+            "\n"
+            "      paasta status -s %(service)s -i %(instance)s -c %(cluster)s -vv\n"
+        ) % {
+            'service': service,
+            'instance': instance,
+            'cluster': cluster,
+        }
         log.error(output)
         status = pysensu_yelp.Status.CRITICAL
     else:

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -152,7 +152,8 @@ def test_check_smartstack_replication_for_instance_ok_when_expecting_zero():
             cluster=cluster,
             soa_dir=soa_dir,
             status=pysensu_yelp.Status.OK,
-            output=mock.ANY)
+            output=mock.ANY,
+        )
 
 
 def test_check_smartstack_replication_for_instance_crit_when_absent():
@@ -226,7 +227,12 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication():
             cluster=cluster,
             soa_dir=soa_dir,
             status=pysensu_yelp.Status.CRITICAL,
-            output=mock.ANY)
+            output=mock.ANY,
+        )
+        _, send_event_kwargs = mock_send_event.call_args
+        alert_output = send_event_kwargs["output"]
+        assert 'Service test.zero_running has 0 out of 8 expected instances in fake_region' in alert_output
+        assert "paasta status -s test -i zero_running -c fake_cluster -vv" in alert_output
 
 
 def test_check_smartstack_replication_for_instance_crit_when_low_replication():
@@ -263,7 +269,12 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication():
             cluster=cluster,
             soa_dir=soa_dir,
             status=pysensu_yelp.Status.CRITICAL,
-            output=mock.ANY)
+            output=mock.ANY,
+        )
+        _, send_event_kwargs = mock_send_event.call_args
+        alert_output = send_event_kwargs["output"]
+        assert 'Service test.not_enough has 4 out of 8 expected instances in fake_region' in alert_output
+        assert "paasta status -s test -i not_enough -c fake_cluster -vv" in alert_output
 
 
 def test_check_smartstack_replication_for_instance_ok_with_enough_replication():
@@ -300,7 +311,11 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication():
             cluster=cluster,
             soa_dir=soa_dir,
             status=pysensu_yelp.Status.OK,
-            output=mock.ANY)
+            output=mock.ANY,
+        )
+        _, send_event_kwargs = mock_send_event.call_args
+        alert_output = send_event_kwargs["output"]
+        assert "test.everything_up has 8 out of 8 expected instances in fake_region (OK: 100%)" in alert_output
 
 
 def test_check_smartstack_replication_for_instance_ignores_things_under_a_different_namespace():
@@ -369,7 +384,12 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication_mu
             cluster=cluster,
             soa_dir=soa_dir,
             status=pysensu_yelp.Status.OK,
-            output=mock.ANY)
+            output=mock.ANY,
+        )
+        _, send_event_kwargs = mock_send_event.call_args
+        alert_output = send_event_kwargs["output"]
+        assert "test.everything_up has 1 out of 1 expected instances in fake_region" in alert_output
+        assert "test.everything_up has 1 out of 1 expected instances in fake_other_region" in alert_output
 
 
 def test_check_smartstack_replication_for_instance_crit_when_low_replication_multilocation():
@@ -406,7 +426,13 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication_mul
             cluster=cluster,
             soa_dir=soa_dir,
             status=pysensu_yelp.Status.CRITICAL,
-            output=mock.ANY)
+            output=mock.ANY,
+        )
+        _, send_event_kwargs = mock_send_event.call_args
+        alert_output = send_event_kwargs["output"]
+        assert "test.low_replication has 1 out of 1 expected instances in fake_region" in alert_output
+        assert "test.low_replication has 0 out of 1 expected instances in fake_other_region" in alert_output
+        assert "paasta status -s test -i low_replication -c fake_cluster -vv" in alert_output
 
 
 def test_check_smartstack_replication_for_instance_crit_when_zero_replication_multilocation():
@@ -443,7 +469,13 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication_mu
             cluster=cluster,
             soa_dir=soa_dir,
             status=pysensu_yelp.Status.CRITICAL,
-            output=mock.ANY)
+            output=mock.ANY,
+        )
+        _, send_event_kwargs = mock_send_event.call_args
+        alert_output = send_event_kwargs["output"]
+        assert "test.zero_running has 0 out of 1 expected instances in fake_region (CRITICAL: 0%)" in alert_output
+        assert "test.zero_running has 0 out of 1 expected instances in fake_other_region (CRITICAL: 0%)" in alert_output
+        assert "paasta status -s test -i zero_running -c fake_cluster -vv" in alert_output
 
 
 def test_check_smartstack_replication_for_instance_crit_when_missing_replication_multilocation():
@@ -480,7 +512,12 @@ def test_check_smartstack_replication_for_instance_crit_when_missing_replication
             cluster=cluster,
             soa_dir=soa_dir,
             status=pysensu_yelp.Status.CRITICAL,
-            output=mock.ANY)
+            output=mock.ANY,
+        )
+        _, send_event_kwargs = mock_send_event.call_args
+        alert_output = send_event_kwargs["output"]
+        assert "test.missing_instance has 0 out of 1 expected instances in fake_region" in alert_output
+        assert "test.missing_instance has 0 out of 1 expected instances in fake_other_region" in alert_output
 
 
 def test_check_smartstack_replication_for_instance_crit_when_no_smartstack_info():
@@ -517,7 +554,11 @@ def test_check_smartstack_replication_for_instance_crit_when_no_smartstack_info(
             cluster=cluster,
             soa_dir=soa_dir,
             status=pysensu_yelp.Status.CRITICAL,
-            output=mock.ANY)
+            output=mock.ANY,
+        )
+        _, send_event_kwargs = mock_send_event.call_args
+        alert_output = send_event_kwargs["output"]
+        assert "test.some_instance has no Smartstack replication info." in alert_output
 
 
 def test_check_service_replication_for_normal_smartstack():
@@ -578,7 +619,8 @@ def test_check_service_replication_for_non_smartstack():
             instance=instance,
             cluster=cluster,
             soa_dir=None,
-            expected_count=100)
+            expected_count=100,
+        )
 
 
 def test_get_healthy_marathon_instances_for_short_app_id_correctly_counts_alive_tasks():
@@ -718,7 +760,11 @@ def test_send_event_if_under_replication_handles_0_expected():
             cluster=cluster,
             soa_dir=soa_dir,
             status=0,
-            output=mock.ANY)
+            output=mock.ANY,
+        )
+        _, send_event_kwargs = mock_send_event.call_args
+        alert_output = send_event_kwargs["output"]
+        assert "test_service.worker has 0 out of 0 expected instances available!\n(threshold: 90%)" in alert_output
 
 
 def test_send_event_if_under_replication_good():
@@ -748,7 +794,11 @@ def test_send_event_if_under_replication_good():
             cluster=cluster,
             soa_dir=soa_dir,
             status=0,
-            output=mock.ANY)
+            output=mock.ANY,
+        )
+        _, send_event_kwargs = mock_send_event.call_args
+        alert_output = send_event_kwargs["output"]
+        assert "test_service.worker has 100 out of 100 expected instances available!\n(threshold: 90%)" in alert_output
 
 
 def test_send_event_if_under_replication_critical():
@@ -783,7 +833,12 @@ def test_send_event_if_under_replication_critical():
             cluster=cluster,
             soa_dir=soa_dir,
             status=2,
-            output=mock.ANY)
+            output=mock.ANY,
+        )
+        _, send_event_kwargs = mock_send_event.call_args
+        alert_output = send_event_kwargs["output"]
+        assert "test_service.worker has 89 out of 100 expected instances available!\n(threshold: 90%)" in alert_output
+        assert "paasta status -s test_service -i worker -c fake_cluster -vv" in alert_output
 
 
 def test_get_smartstack_replication_for_attribute():


### PR DESCRIPTION
This adds a bit more whitespace to the chronos checks to be kinda markdown-style.

Also adds lots more action items in the marathon checks, and tests!