### PR TITLE
PAASTA-4182 enable paasta_serviceinit status with multiple service instances

### DIFF
--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -43,14 +43,7 @@ Feature: paasta_serviceinit
      When we run the marathon app "test-service.main"
       And we wait for it to be deployed
      Then paasta_serviceinit status -vv for the service_instance "test-service.main" exits with return code 0 and the correct output
-
-  Scenario: paasta_serviceinit can run status -s service -i instances
-    Given a working paasta cluster
-      And I have yelpsoa-configs for the marathon job "test-service.main"
-      And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we run the marathon app "test-service.main"
-      And we wait for it to be deployed
-     Then paasta_serviceinit status -s "test-service" -i "main,test" has the correct output for instance main and exits with non-zero return code for instance test
+      And paasta_serviceinit status -s "test-service" -i "main,test" has the correct output for instance main and exits with non-zero return code for instance test
 
   Scenario: paasta_serviceinit can run emergency-stop on an enabled chronos job
     Given a working paasta cluster

--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -43,6 +43,7 @@ Feature: paasta_serviceinit
      When we run the marathon app "test-service.main"
       And we wait for it to be deployed
      Then paasta_serviceinit status -vv for the service_instance "test-service.main" exits with return code 0 and the correct output
+      And paasta_serviceinit status -s "test-service" -i "main" exits with return code 0 and the correct output
       And paasta_serviceinit status -s "test-service" -i "main,test" has the correct output for instance main and exits with non-zero return code for instance test
 
   Scenario: paasta_serviceinit can run emergency-stop on an enabled chronos job

--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -44,6 +44,14 @@ Feature: paasta_serviceinit
       And we wait for it to be deployed
      Then paasta_serviceinit status -vv for the service_instance "test-service.main" exits with return code 0 and the correct output
 
+  Scenario: paasta_serviceinit can run status -s service -i instances
+    Given a working paasta cluster
+      And I have yelpsoa-configs for the marathon job "test-service.main"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
+     When we run the marathon app "test-service.main"
+      And we wait for it to be deployed
+     Then paasta_serviceinit status -s "test-service" -i "main,test" has the correct output for instance main and exits with non-zero return code for instance test
+
   Scenario: paasta_serviceinit can run emergency-stop on an enabled chronos job
     Given a working paasta cluster
       And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -127,6 +127,21 @@ def paasta_serviceinit_tail_stdstreams(context, service_instance):
     assert "No such task has the requested file or directory" in output
 
 
+@then((u'paasta_serviceinit status -s "{service}" -i "{instances}"'
+       ' has the correct output for instance main and exits with non-zero return code for instance test'))
+def paasta_serviceinit_status_multi_instances(context, service, instances):
+    cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s -s %s -i %s status' % \
+        (context.soa_dir, service, instances)
+    print 'Running cmd %s' % cmd
+    exit_code, output = _run(cmd)
+    print 'Got exitcode %s with output:\n%s' % (exit_code, output)
+    print  # sacrificial line for behave to eat instead of our output
+
+    # one service is deployed and the other is not
+    assert "Running" in output
+    assert exit_code != 0
+
+
 @when(u'we paasta_serviceinit emergency-stop the service_instance "{service_instance}"')
 def chronos_emergency_stop_job(context, service_instance):
     cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s %s stop' % (context.soa_dir, service_instance)

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -128,6 +128,20 @@ def paasta_serviceinit_tail_stdstreams(context, service_instance):
 
 
 @then((u'paasta_serviceinit status -s "{service}" -i "{instances}"'
+       ' exits with return code 0 and the correct output'))
+def paasta_serviceinit_status_single_instance(context, service, instances):
+    cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s -s %s -i %s status' % \
+        (context.soa_dir, service, instances)
+    print 'Running cmd %s' % cmd
+    exit_code, output = _run(cmd)
+    print 'Got exitcode %s with output:\n%s' % (exit_code, output)
+    print  # sacrificial line for behave to eat instead of our output
+
+    assert "Running" in output
+    assert exit_code == 0
+
+
+@then((u'paasta_serviceinit status -s "{service}" -i "{instances}"'
        ' has the correct output for instance main and exits with non-zero return code for instance test'))
 def paasta_serviceinit_status_multi_instances(context, service, instances):
     cmd = '../paasta_tools/paasta_serviceinit.py --soa-dir %s -s %s -i %s status' % \

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -193,7 +193,7 @@ def write_soa_dir_marathon_job(context, job_id):
 
 
 @given(u'we have a deployments.json for the service "{service}" with {disabled} instance "{instance}"')
-def write_soa_dir_chronos_deployments(context, service, disabled, instance):
+def write_soa_dir_deployments(context, service, disabled, instance):
     if disabled == 'disabled':
         desired_state = 'stop'
     else:

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -12,10 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Usage: ./paasta_servceinit.py [-v] [service_instance] [-s service] [-i instances] <stop|start|restart|status|scale>
-
-Interacts with the framework APIs to start/stop/restart/get status/scale for an
-instance. Assumes that the credentials are available, so must run as root.
+"""
+Interacts with the framework APIs to start/stop/restart/get status/scale for
+instances. Assumes that the credentials are available, so must run as root.
 """
 import argparse
 import logging
@@ -73,6 +72,7 @@ def main():
         log.setLevel(logging.WARNING)
 
     instances = []
+    return_codes = []
     command = args.command
     if (args.service_instance):
         service_instance = args.service_instance
@@ -87,7 +87,6 @@ def main():
 
     cluster = load_system_paasta_config().get_cluster()
     for instance in instances:
-        print("instance:%s" % instance)
         instance_type = validate_service_instance(service, instance, cluster, args.soa_dir)
         if instance_type == 'marathon':
             return_code = marathon_serviceinit.perform_command(
@@ -114,9 +113,8 @@ def main():
                       % (instance_type, compose_job_id(service, instance)))
             return_code = 1
 
-        if return_code:
-            sys.exit(return_code)
-    sys.exit(0)
+        return_codes.append(return_code)
+    sys.exit(max(return_codes))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch enables paasta_serviceinit status to process multiple instance in one ssh session. For each instance, "instance:instance_name" is added to the output so that the client can parse accordingly.

The options added are --service and --instances.

$ sudo .tox/py27/bin/paasta_serviceinit.py -s robj-test-service -i main,memo-test status

The argument service_instance is now optional to keep backward compatibility. It will be replaced eventually when the client code is updated. At that time, service and instances will become mandatory arguments.
 
(py27)$ .tox/py27/bin/paasta_serviceinit.py
usage: paasta_serviceinit.py [-h] [-v] [-D] [-d SOA_DIR] [-s SERVICE]
                             [-i INSTANCES] [-a APP_ID] [--delta DELTA]
                             [service_instance]
                             {start,stop,restart,status,scale}

The patch is manually tested with multiple services with robj-test-service and instances main/memo-test. In addition, an itest test case is added to cover both the good (being deployed) and bad (not being deployed) service instances.