### PR TITLE
Default to using the max instance count when autoscaling without decision data

### DIFF
--- a/paasta_itests/setup_marathon_job.feature
+++ b/paasta_itests/setup_marathon_job.feature
@@ -32,9 +32,8 @@ Feature: setup_marathon_job can create a "complete" app
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we set up an app to use zookeeper scaling with 10 max instances
-      And we create a marathon app called "test-service.main" with 1 instance(s)
-      And we run setup_marathon_job until it has 1 task(s)
+     When we set up an app to use zookeeper scaling with 5 max instances
+      And we create a marathon app called "test-service.main" with 3 instance(s)
       And we set the instance count in zookeeper for service "test-service" instance "main" to 5
       And we run setup_marathon_job until it has 5 task(s)
      Then we should see the number of instances become 5
@@ -43,10 +42,10 @@ Feature: setup_marathon_job can create a "complete" app
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we set up an app to use zookeeper scaling with 10 max instances
-      And we create a marathon app called "test-service.main" with 1 instance(s)
-      And we set the instance count in zookeeper for service "test-service" instance "main" to 5
-      And we run setup_marathon_job until it has 5 task(s)
+     When we set up an app to use zookeeper scaling with 5 max instances
+      And we create a marathon app called "test-service.main" with 5 instance(s)
+      And we set the instance count in zookeeper for service "test-service" instance "main" to 3
+      And we run setup_marathon_job until it has 3 task(s)
       And we set the instance count in zookeeper for service "test-service" instance "main" to 1
       And we run setup_marathon_job until it has 1 task(s)
      Then we should see the number of instances become 1

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -43,6 +43,7 @@ def run_setup_marathon_job(context):
         _,
     ):
         mock_parse_args.return_value = mock.Mock(
+            verbose=True,
             soa_dir=context.soa_dir,
             service_instance=context.job_id,
         )
@@ -61,7 +62,7 @@ def update_context_marathon_config(context):
     whitelist_keys = set(['id', 'backoff_factor', 'backoff_seconds', 'max_instances', 'mem', 'cpus', 'instances'])
     with contextlib.nested(
         mock.patch.object(SystemPaastaConfig, 'get_zk_hosts', autospec=True, return_value=context.zk_hosts),
-        mock.patch.object(MarathonServiceConfig, 'get_min_instances', autospec=True, return_value=context.instances),
+        mock.patch.object(MarathonServiceConfig, 'get_min_instances', autospec=True, return_value=1),
         mock.patch.object(MarathonServiceConfig, 'get_max_instances', autospec=True),
     ) as (
         _,

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -220,7 +220,7 @@ class MarathonServiceConfig(InstanceConfig):
                         instance=self.instance,
                     )
                 except NoNodeError:  # zookeeper doesn't have instance data for this app
-                    return self.get_min_instances()
+                    return self.get_max_instances()
                 else:
                     return self.limit_instance_count(zk_instances)
             else:

--- a/tests/test_autoscaling_lib.py
+++ b/tests/test_autoscaling_lib.py
@@ -65,7 +65,7 @@ def test_zookeeper_pool():
         assert zk_client.stop.call_count == 1
 
 
-def test_get_zookeeper_instances_defaults_to_config_no_zk_node():
+def test_get_zookeeper_instances_defaults_to_max_instances_when_no_zk_node():
     fake_marathon_config = marathon_tools.MarathonServiceConfig(
         service='service',
         instance='instance',
@@ -84,7 +84,7 @@ def test_get_zookeeper_instances_defaults_to_config_no_zk_node():
         _,
     ):
         mock_zk_client.return_value = mock.Mock(get=mock.Mock(side_effect=NoNodeError))
-        assert fake_marathon_config.get_instances() == 5
+        assert fake_marathon_config.get_instances() == 10
 
 
 def test_get_zookeeper_instances_defaults_to_config_out_of_bounds():


### PR DESCRIPTION
cc @mjksmith @heathvini

Defaulting to max_instances is probably a safer setting than min for production services with no data at all in zk. This is also true if we have a catastrophic failure of zk.

Originally I thought I might need to edit the PID logic, but I think this achieves the desired effect?