### PR TITLE
Make the FQDN format configurable; previously hard-coded as paasta-%s.yelp

### DIFF
--- a/paasta_tools/cli/cmds/emergency_restart.py
+++ b/paasta_tools/cli/cmds/emergency_restart.py
@@ -20,6 +20,7 @@ from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import load_system_paasta_config
 
 
 def add_subparser(subparsers):
@@ -69,8 +70,9 @@ def paasta_emergency_restart(args):
     It should not be needed in normal circumstances.
     """
     service = figure_out_service_name(args, args.soa_dir)
+    system_paasta_config = load_system_paasta_config()
     print "Performing an emergency restart on %s...\n" % compose_job_id(service, args.instance)
-    execute_paasta_serviceinit_on_remote_master('restart', args.cluster, service, args.instance)
+    execute_paasta_serviceinit_on_remote_master('restart', args.cluster, service, args.instance, system_paasta_config)
     print "%s" % "\n".join(paasta_emergency_restart.__doc__.splitlines()[-7:])
     print "Run this to see the status:"
     print "paasta status --service %s --clusters %s" % (service, args.cluster)

--- a/paasta_tools/cli/cmds/emergency_scale.py
+++ b/paasta_tools/cli/cmds/emergency_scale.py
@@ -20,6 +20,7 @@ from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import load_system_paasta_config
 
 
 def add_subparser(subparsers):
@@ -80,8 +81,9 @@ def paasta_emergency_scale(args):
     For example, this can be done for Marathon apps by setting 'instances: n'
     """
     service = figure_out_service_name(args, soa_dir=args.yelpsoa_config_root)
+    system_paasta_config = load_system_paasta_config()
     print "Performing an emergency scale on %s..." % compose_job_id(service, args.instance)
     output = execute_paasta_serviceinit_on_remote_master('scale', args.cluster, service, args.instance,
-                                                         app_id=args.appid, delta=args.delta)
+                                                         system_paasta_config, app_id=args.appid, delta=args.delta)
     print "Output: %s" % output
     print "%s" % "\n".join(paasta_emergency_scale.__doc__.splitlines()[-7:])

--- a/paasta_tools/cli/cmds/emergency_stop.py
+++ b/paasta_tools/cli/cmds/emergency_stop.py
@@ -20,6 +20,7 @@ from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import load_system_paasta_config
 
 
 def add_subparser(subparsers):
@@ -80,10 +81,11 @@ def paasta_emergency_stop(args):
     For example, this can be done for Marathon apps by setting 'instances: 0', or
     for Chronos jobs by setting 'disabled: True'. Alternatively, remove the config yaml entirely.
     """
+    system_paasta_config = load_system_paasta_config()
     service = figure_out_service_name(args, soa_dir=args.yelpsoa_config_root)
     print "Performing an emergency stop on %s..." % compose_job_id(service, args.instance)
     output = execute_paasta_serviceinit_on_remote_master('stop', args.cluster, service, args.instance,
-                                                         app_id=args.appid)
+                                                         system_paasta_config, app_id=args.appid)
     print "Output: %s" % output
     print "%s" % "\n".join(paasta_emergency_stop.__doc__.splitlines()[-7:])
     print "To start this service again asap, run:"

--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -62,12 +62,12 @@ def add_subparser(subparsers):
     status_parser.set_defaults(command=paasta_metastatus)
 
 
-def print_cluster_status(cluster, verbose=0):
+def print_cluster_status(cluster, system_paasta_config, verbose=0):
     """With a given cluster and verboseness, returns the status of the cluster
     output is printed directly to provide dashbaords even if the cluster is unavailable"""
     print "Cluster: %s" % cluster
     print get_cluster_dashboards(cluster)
-    print execute_paasta_metastatus_on_remote_master(cluster, verbose)
+    print execute_paasta_metastatus_on_remote_master(cluster, verbose, system_paasta_config)
     print ""
 
 

--- a/paasta_tools/cli/cmds/rerun.py
+++ b/paasta_tools/cli/cmds/rerun.py
@@ -25,6 +25,7 @@ from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import SPACER
 
@@ -97,6 +98,7 @@ def _get_cluster_instance(cluster_dot_instance_list):
 def paasta_rerun(args):
     """Reruns a Chronos job.
     :param args: argparse.Namespace obj created from sys.args by cli"""
+    system_paasta_config = load_system_paasta_config()
     soa_dir = args.soa_dir
     service = figure_out_service_name(args, soa_dir)  # exit with an error if the service doesn't exist
     if args.execution_date:
@@ -148,7 +150,8 @@ def paasta_rerun(args):
             instancename=args.instance,
             cluster=cluster,
             verbose=args.verbose,
-            execution_date=execution_date.strftime(chronos_tools.EXECUTION_DATE_FORMAT)
+            execution_date=execution_date.strftime(chronos_tools.EXECUTION_DATE_FORMAT),
+            system_paasta_config=system_paasta_config,
         )
         if rc == 0:
             print PaastaColors.green('  successfully created job')

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -27,6 +27,7 @@ from paasta_tools.marathon_tools import load_deployments_json
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_soa_cluster_deploy_files
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import PaastaColors
 
 
@@ -128,7 +129,8 @@ def get_actual_deployments(service, soa_dir):
     return actual_deployments
 
 
-def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployments, instance_whitelist, verbose=0):
+def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployments, instance_whitelist,
+                              system_paasta_config, verbose=0):
     """With a given service and cluster, prints the status of the instances
     in that cluster"""
     print
@@ -148,7 +150,8 @@ def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployme
             formatted_instance = PaastaColors.blue(instance)
             version = actual_deployments[namespace][:8]
             # TODO: Perform sanity checks once per cluster instead of for each namespace
-            status = execute_paasta_serviceinit_on_remote_master('status', cluster, service, instance, verbose=verbose)
+            status = execute_paasta_serviceinit_on_remote_master('status', cluster, service, instance,
+                                                                 system_paasta_config, verbose=verbose)
         # Case: service NOT deployed to cluster.instance
         else:
             formatted_instance = PaastaColors.red(instance)
@@ -181,7 +184,8 @@ def report_invalid_whitelist_values(whitelist, items, item_type):
     return return_string
 
 
-def report_status(service, deploy_pipeline, actual_deployments, cluster_whitelist, instance_whitelist, verbose=0):
+def report_status(service, deploy_pipeline, actual_deployments, cluster_whitelist, instance_whitelist,
+                  system_paasta_config, verbose=0):
     pipeline_url = get_pipeline_url(service)
     print "Pipeline: %s" % pipeline_url
 
@@ -194,6 +198,7 @@ def report_status(service, deploy_pipeline, actual_deployments, cluster_whitelis
                 deploy_pipeline=deploy_pipeline,
                 actual_deployments=actual_deployments,
                 instance_whitelist=instance_whitelist,
+                system_paasta_config=system_paasta_config,
                 verbose=verbose,
             )
 
@@ -206,6 +211,8 @@ def paasta_status(args):
     soa_dir = args.soa_dir
     service = figure_out_service_name(args, soa_dir)
     actual_deployments = get_actual_deployments(service, soa_dir)
+    system_paasta_config = load_system_paasta_config()
+
     if args.clusters is not None:
         cluster_whitelist = args.clusters.split(",")
     else:
@@ -223,6 +230,7 @@ def paasta_status(args):
             actual_deployments=actual_deployments,
             cluster_whitelist=cluster_whitelist,
             instance_whitelist=instance_whitelist,
+            system_paasta_config=system_paasta_config,
             verbose=args.verbose,
         )
     else:

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -404,12 +404,13 @@ def list_teams(**kwargs):
     return teams
 
 
-def calculate_remote_masters(cluster):
+def calculate_remote_masters(cluster, system_paasta_config):
     """Given a cluster, do a DNS lookup of that cluster (which
     happens to point, eventually, to the Mesos masters in that cluster).
     Return IPs of those Mesos masters.
     """
-    cluster_fqdn = "paasta-%s.yelp" % cluster
+
+    cluster_fqdn = system_paasta_config.get_cluster_fqdn_format().format(cluster=cluster)
     try:
         _, _, ips = gethostbyname_ex(cluster_fqdn)
         output = None
@@ -503,11 +504,12 @@ def run_paasta_serviceinit(subcommand, master, service, instancename, cluster, *
     return output
 
 
-def execute_paasta_serviceinit_on_remote_master(subcommand, cluster, service, instancename, **kwargs):
+def execute_paasta_serviceinit_on_remote_master(subcommand, cluster, service, instancename, system_paasta_config,
+                                                **kwargs):
     """Returns a string containing an error message if an error occurred.
     Otherwise returns the output of run_paasta_serviceinit_status().
     """
-    masters, output = calculate_remote_masters(cluster)
+    masters, output = calculate_remote_masters(cluster, system_paasta_config)
     if masters == []:
         return 'ERROR: %s' % output
     master, output = find_connectable_master(masters)
@@ -533,11 +535,11 @@ def run_paasta_metastatus(master, verbose=0):
     return output
 
 
-def execute_paasta_metastatus_on_remote_master(cluster, verbose=0):
+def execute_paasta_metastatus_on_remote_master(cluster, system_paasta_config, verbose=0):
     """Returns a string containing an error message if an error occurred.
     Otherwise returns the output of run_paasta_metastatus().
     """
-    masters, output = calculate_remote_masters(cluster)
+    masters, output = calculate_remote_masters(cluster, system_paasta_config)
     if masters == []:
         return 'ERROR: %s' % output
     master, output = find_connectable_master(masters)
@@ -561,11 +563,11 @@ def run_chronos_rerun(master, service, instancename, **kwargs):
     return _run(command, timeout=timeout)
 
 
-def execute_chronos_rerun_on_remote_master(service, instancename, cluster, **kwargs):
+def execute_chronos_rerun_on_remote_master(service, instancename, cluster, system_paasta_config, **kwargs):
     """Returns a string containing an error message if an error occurred.
     Otherwise returns the output of run_chronos_rerun().
     """
-    masters, output = calculate_remote_masters(cluster)
+    masters, output = calculate_remote_masters(cluster, system_paasta_config)
     if masters == []:
         return (-1, 'ERROR: %s' % output)
     master, output = find_connectable_master(masters)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -855,6 +855,13 @@ class SystemPaastaConfig(dict):
     def get_cluster_autoscaling_resources(self):
         return self.get('cluster_autoscaling_resources', {})
 
+    def get_cluster_fqdn_format(self):
+        """Get a format string that constructs a DNS name pointing at the paasta masters in a cluster. This format
+        string gets one parameter: cluster. Defaults to 'paasta-{cluster:s}.yelp'.
+
+        :returns: A format string for constructing the FQDN of the masters in a given cluster."""
+        return self.get('cluster_fqdn_format', 'paasta-{cluster:s}.yelp')
+
 
 def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=None, **kwargs):
     """Given a command, run it. Return a tuple of the return code and any

--- a/tests/cli/test_cmds_metastatus.py
+++ b/tests/cli/test_cmds_metastatus.py
@@ -23,19 +23,23 @@ from paasta_tools.utils import SystemPaastaConfig
 @mock.patch('sys.stdout', new_callable=StringIO)
 def test_report_cluster_status(mock_stdout, mock_load_system_paasta_config):
     cluster = 'fake_cluster'
-    mock_load_system_paasta_config.return_value = SystemPaastaConfig({
+
+    fake_system_paasta_config = SystemPaastaConfig({
         'dashboard_links': {
             'fake_cluster': {
                 'URL': 'http://paasta-fake_cluster.yelp:5050',
             },
         },
     }, 'fake_directory')
+
+    mock_load_system_paasta_config.return_value = fake_system_paasta_config
+
     thing_to_patch = 'paasta_tools.cli.cmds.metastatus.execute_paasta_metastatus_on_remote_master'
     with mock.patch(thing_to_patch) as mock_execute_paasta_metastatus_on_remote_master:
         mock_execute_paasta_metastatus_on_remote_master.return_value = 'mock_status'
-        metastatus.print_cluster_status(cluster)
+        metastatus.print_cluster_status(cluster, fake_system_paasta_config)
         mock_execute_paasta_metastatus_on_remote_master.assert_called_once_with(
-            cluster, False
+            cluster, False, fake_system_paasta_config,
         )
         actual = mock_stdout.getvalue()
         assert 'Cluster: %s' % cluster in actual

--- a/tests/cli/test_cmds_rerun.py
+++ b/tests/cli/test_cmds_rerun.py
@@ -23,6 +23,7 @@ from pytest import mark
 from paasta_tools.chronos_tools import EXECUTION_DATE_FORMAT
 from paasta_tools.cli.cmds.rerun import add_subparser
 from paasta_tools.cli.cmds.rerun import paasta_rerun
+from paasta_tools.utils import SystemPaastaConfig
 
 
 _user_supplied_execution_date = '2016-04-08T02:37:27'
@@ -98,6 +99,7 @@ def test_rerun_validations(test_case):
         patch('paasta_tools.cli.cmds.rerun.chronos_tools.load_chronos_job_config', autospec=True),
         patch('paasta_tools.cli.cmds.rerun.chronos_tools.uses_time_variables', autospec=True),
         patch('paasta_tools.cli.cmds.rerun._get_default_execution_date', autospec=True),
+        patch('paasta_tools.cli.cmds.rerun.load_system_paasta_config', autospec=True),
     ) as (
         mock_stdout,
         mock_figure_out_service_name,
@@ -108,6 +110,7 @@ def test_rerun_validations(test_case):
         mock_load_chronos_job_config,
         mock_uses_time_variables,
         mock_get_default_execution_date,
+        mock_load_system_paasta_config,
     ):
 
         (rerun_args,
@@ -122,6 +125,7 @@ def test_rerun_validations(test_case):
         default_date = datetime.datetime(2002, 2, 2, 2, 2, 2, 2)
         mock_get_default_execution_date.return_value = default_date
         mock_execute_rerun_remote.return_value = (0, '')
+        mock_load_system_paasta_config.return_value = SystemPaastaConfig({}, '/fake/config')
 
         args = MagicMock()
         args.service = rerun_args[0]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -360,6 +360,20 @@ def test_SystemPaastaConfig_get_sensu_port():
     assert actual == expected
 
 
+def test_SystemPaastaConfig_get_cluster_fqdn_format_default():
+    fake_config = utils.SystemPaastaConfig({}, '/some/fake/dir')
+    actual = fake_config.get_cluster_fqdn_format()
+    expected = 'paasta-{cluster:s}.yelp'
+    assert actual == expected
+
+
+def test_SystemPaastaConfig_get_cluster_fqdn_format():
+    fake_config = utils.SystemPaastaConfig({"cluster_fqdn_format": "paasta-{cluster:s}.something"}, '/some/fake/dir')
+    actual = fake_config.get_cluster_fqdn_format()
+    expected = 'paasta-{cluster:s}.something'
+    assert actual == expected
+
+
 def test_atomic_file_write():
     with mock.patch('tempfile.NamedTemporaryFile', autospec=True) as ntf_patch:
         file_patch = ntf_patch().__enter__()


### PR DESCRIPTION
This makes it so you don't have to use the fake ".yelp" TLD for discovering where paasta masters are.