### PR TITLE
PAASTA-4412 monkey patch MesosMaster.state to increase caching TTL

### DIFF
--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -20,6 +20,7 @@ import socket
 import humanize
 import requests
 from kazoo.client import KazooClient
+from mesos.cli import util
 from mesos.cli.exceptions import SlaveDoesNotExist
 
 from paasta_tools.utils import format_table
@@ -77,6 +78,13 @@ MESOS_MASTER_PORT = 5050
 MESOS_SLAVE_PORT = '5051'
 from mesos.cli import master  # noqa
 import mesos.cli.cluster  # noqa
+
+
+# monkey patch MesosMaster.state to use a larger ttl
+@util.CachedProperty(ttl=60)
+def fetch_state(self):
+    return master.CURRENT.fetch("/master/state.json").json()
+master.MesosMaster.state = fetch_state
 
 # Works around a mesos-cli bug ('MesosSlave' object has no attribute 'id' - PAASTA-4119).
 # The method below gets a slave by its ID. Original code here:


### PR DESCRIPTION
With this patch, mesos master state fetches are consistently under a small fraction of a second except for the 1st fetch. requests_cache code is not touched because requests_cache alone produced fetch latencies above one second.