### PR TITLE
Be more consistent about how we log to stderr

### DIFF
--- a/paasta_tools/autoscale_cluster.py
+++ b/paasta_tools/autoscale_cluster.py
@@ -18,8 +18,7 @@ import logging
 from paasta_tools.autoscaling_lib import autoscale_local_cluster
 
 
-log = logging.getLogger('__main__')
-logging.basicConfig()
+log = logging.getLogger(__name__)
 
 
 def parse_args():
@@ -33,9 +32,9 @@ def parse_args():
 def main():
     args = parse_args()
     if args.verbose:
-        log.setLevel(logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG)
     else:
-        log.setLevel(logging.WARNING)
+        logging.basicConfig(level=logging.WARNING)
 
     autoscale_local_cluster()
 

--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -53,7 +53,8 @@ SCALER_KEY = 'scaler'
 
 AUTOSCALING_DELAY = 300
 
-log = logging.getLogger('__main__')
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 def register_autoscaling_component(name, method_type):

--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -32,7 +32,9 @@ from paasta_tools.monitoring.replication_utils import \
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import load_system_paasta_config
 
-log = logging.getLogger('__main__')
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 logging.getLogger("requests").setLevel(logging.WARNING)
 
 ZK_LOCK_CONNECT_TIMEOUT_S = 10.0  # seconds to wait to connect to zookeeper

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -51,8 +51,7 @@ from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import NoDeploymentsAvailable
 
 
-log = logging.getLogger('__main__')
-logging.basicConfig()
+log = logging.getLogger(__name__)
 
 
 def send_event(service, namespace, cluster, soa_dir, status, output):
@@ -384,11 +383,10 @@ def main():
     args = parse_args()
     soa_dir = args.soa_dir
 
-    logging.basicConfig()
     if args.verbose:
-        log.setLevel(logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG)
     else:
-        log.setLevel(logging.WARNING)
+        logging.basicConfig(level=logging.WARNING)
 
     system_paasta_config = load_system_paasta_config()
     cluster = system_paasta_config.get_cluster()

--- a/paasta_tools/check_mesos_resource_utilization.py
+++ b/paasta_tools/check_mesos_resource_utilization.py
@@ -30,7 +30,7 @@ from paasta_tools.mesos_tools import is_mesos_leader
 from paasta_tools.utils import load_system_paasta_config
 
 
-log = logging.getLogger('__main__')
+log = logging.getLogger(__name__)
 
 
 def parse_args():
@@ -106,9 +106,9 @@ def check_thresholds(percent):
 def main():
     args = parse_args()
     if args.verbose:
-        log.setLevel(logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG)
     else:
-        log.setLevel(logging.WARNING)
+        logging.basicConfig(level=logging.WARNING)
     print check_thresholds(args.percent)
 
 

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -26,8 +26,8 @@ from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import PaastaColors
 
 
-log = logging.getLogger('__main__')
-logging.basicConfig()
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 # Calls the 'manual start' endpoint in Chronos (https://mesos.github.io/chronos/docs/api.html#manually-starting-a-job),

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -62,7 +62,7 @@ TMP_JOB_IDENTIFIER = "tmp"
 VALID_BOUNCE_METHODS = ['graceful']
 PATH_TO_CHRONOS_CONFIG = os.path.join(PATH_TO_SYSTEM_PAASTA_CONFIG_DIR, 'chronos.json')
 EXECUTION_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
-log = logging.getLogger('__main__')
+log = logging.getLogger(__name__)
 
 
 class LastRunState:

--- a/paasta_tools/cleanup_marathon_jobs.py
+++ b/paasta_tools/cleanup_marathon_jobs.py
@@ -45,8 +45,7 @@ from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import load_system_paasta_config
 
 
-log = logging.getLogger('__main__')
-logging.basicConfig()
+log = logging.getLogger(__name__)
 
 
 def parse_args():
@@ -154,9 +153,10 @@ def main():
     args = parse_args()
     soa_dir = args.soa_dir
     if args.verbose:
-        log.setLevel(logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG)
     else:
-        log.setLevel(logging.WARNING)
+        logging.basicConfig(level=logging.WARNING)
+
     cleanup_apps(soa_dir)
 
 

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -53,8 +53,7 @@ from paasta_tools.utils import get_log_name_for_service
 
 DEFAULT_COMPONENTS = ['build', 'deploy', 'monitoring']
 
-log = logging.getLogger('__main__')
-logging.basicConfig()
+log = logging.getLogger(__name__)
 
 
 def add_subparser(subparsers):

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -36,8 +36,7 @@ from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import validate_service_instance
 
 
-log = logging.getLogger('__main__')
-logging.basicConfig()
+log = logging.getLogger(__name__)
 
 
 def load_method(module_name, method_name):

--- a/paasta_tools/contrib/delete_old_marathon_deployments.py
+++ b/paasta_tools/contrib/delete_old_marathon_deployments.py
@@ -23,8 +23,7 @@ from pytimeparse import timeparse
 from paasta_tools import marathon_tools
 
 
-log = logging.getLogger('__main__')
-logging.basicConfig()
+log = logging.getLogger(__name__)
 
 
 def parse_args():
@@ -72,6 +71,10 @@ def delete_deployment_if_too_old(client, deployment, max_date, dry_run):
 
 def main():
     args = parse_args()
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.WARNING)
 
     config = marathon_tools.load_marathon_config()
     client = marathon_tools.get_marathon_client(config.get_url(), config.get_username(), config.get_password())

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -52,8 +52,7 @@ from paasta_tools.utils import get_git_url
 from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import list_clusters
 
-log = logging.getLogger('__main__')
-logging.basicConfig()
+log = logging.getLogger(__name__)
 TARGET_FILE = 'deployments.json'
 
 
@@ -268,9 +267,9 @@ def main():
     soa_dir = os.path.abspath(args.soa_dir)
     service = args.service
     if args.verbose:
-        log.setLevel(logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG)
     else:
-        log.setLevel(logging.WARNING)
+        logging.basicConfig(level=logging.WARNING)
 
     generate_deployments_for_service(service=service, soa_dir=soa_dir)
 

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -36,8 +36,8 @@ from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import remove_ansi_escape_sequences
 
-log = logging.getLogger('__main__')
-logging.basicConfig()
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 def start_marathon_job(service, instance, app_id, normal_instance_count, client, cluster):

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -64,7 +64,7 @@ MESOS_TASK_SPACER = '.'
 PATH_TO_MARATHON_CONFIG = os.path.join(PATH_TO_SYSTEM_PAASTA_CONFIG_DIR, 'marathon.json')
 PUPPET_SERVICE_DIR = '/etc/nerve/puppet_services.d'
 
-log = logging.getLogger('__main__')
+log = logging.getLogger(__name__)
 logging.getLogger('marathon').setLevel(logging.WARNING)
 
 

--- a/paasta_tools/monitoring/check_classic_service_replication.py
+++ b/paasta_tools/monitoring/check_classic_service_replication.py
@@ -131,7 +131,7 @@ def extract_replication_info(service_config):
 
 
 class ClassicServiceReplicationCheck(SensuPluginCheck):
-    log = logging.getLogger('__main__')
+    log = logging.getLogger(__name__)
     log.addHandler(logging.StreamHandler(sys.stdout))
 
     def setup_logging(self):

--- a/paasta_tools/monitoring_tools.py
+++ b/paasta_tools/monitoring_tools.py
@@ -31,7 +31,7 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import load_system_paasta_config
 
 
-log = logging.getLogger('__main__')
+log = logging.getLogger(__name__)
 
 
 def get_team(overrides, service, soa_dir=DEFAULT_SOA_DIR):

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -29,8 +29,7 @@ from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import validate_service_instance
 
 
-log = logging.getLogger('__main__')
-logging.basicConfig()
+log = logging.getLogger(__name__)
 
 
 def parse_args():
@@ -67,9 +66,9 @@ def parse_args():
 def main():
     args = parse_args()
     if args.debug:
-        log.setLevel(logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG)
     else:
-        log.setLevel(logging.WARNING)
+        logging.basicConfig(level=logging.WARNING)
 
     instances = []
     return_codes = []

--- a/paasta_tools/setup_chronos_job.py
+++ b/paasta_tools/setup_chronos_job.py
@@ -56,8 +56,7 @@ from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import SPACER
 
 
-log = logging.getLogger('__main__')
-logging.basicConfig()
+log = logging.getLogger(__name__)
 
 
 def parse_args():
@@ -161,9 +160,10 @@ def main():
     args = parse_args()
     soa_dir = args.soa_dir
     if args.verbose:
-        log.setLevel(logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG)
     else:
-        log.setLevel(logging.WARNING)
+        logging.basicConfig(level=logging.WARNING)
+
     try:
         service, instance, _, __ = decompose_job_id(args.service_instance, spacer=chronos_tools.INTERNAL_SPACER)
     except InvalidJobNameError:

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -67,8 +67,7 @@ from paasta_tools.utils import SPACER
 # Marathon REST API:
 # https://github.com/mesosphere/marathon/blob/master/REST.md#post-v2apps
 
-log = logging.getLogger('__main__')
-logging.basicConfig()
+log = logging.getLogger(__name__)
 
 
 def parse_args():
@@ -561,9 +560,10 @@ def main():
     args = parse_args()
     soa_dir = args.soa_dir
     if args.verbose:
-        log.setLevel(logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG)
     else:
-        log.setLevel(logging.WARNING)
+        logging.basicConfig(level=logging.WARNING)
+
     try:
         service, instance, _, __ = decompose_job_id(args.service_instance)
     except InvalidJobNameError:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -69,7 +69,8 @@ no_escape = re.compile('\x1B\[[0-9;]*[mK]')
 
 DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT = "http://{host:s}:{port:d}/;csv;norefresh"
 
-log = logging.getLogger('__main__')
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 class InvalidInstanceConfig(Exception):


### PR DESCRIPTION
Fixes #490

primary: @Rob-Johnson 

This changes how we log to stdout/err. Notably this makes it so log level (DEBUG) is global to the thing, so *everything* will start outputting, like kazoo, marathon, etc. This is probably a good thing.

Also it corrects the logging in our library files to just use their own __name__ and not to do any basicConfig themselves.

