### PR TITLE
Show temporary status chronos jobs

### DIFF
--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -235,7 +235,7 @@ def format_chronos_job_status(job, running_tasks, verbose=0):
     :param verbose: int verbosity level
     """
     job_name = _format_job_name(job)
-    is_temporary = chronos_tools.is_temporary_job(job)
+    is_temporary = chronos_tools.is_temporary_job(job) if 'name' in job else 'UNKNOWN'
     disabled_state = _format_disabled_status(job)
     (last_result, formatted_time) = _format_last_result(job)
 

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -77,7 +77,7 @@ def get_short_task_id(task_id):
     return task_id.split(chronos_tools.MESOS_TASK_SPACER)[1]
 
 
-def _format_config_hash(job):
+def _format_job_name(job):
     job_id = job.get("name", PaastaColors.red("UNKNOWN"))
     return job_id
 
@@ -234,7 +234,8 @@ def format_chronos_job_status(job, running_tasks, verbose=0):
                           result of ``mesos_tools.get_running_tasks_from_active_frameworks()``.
     :param verbose: int verbosity level
     """
-    config_hash = _format_config_hash(job)
+    job_name = _format_job_name(job)
+    is_temporary = chronos_tools.is_temporary_job(job)
     disabled_state = _format_disabled_status(job)
     (last_result, formatted_time) = _format_last_result(job)
 
@@ -250,13 +251,15 @@ def format_chronos_job_status(job, running_tasks, verbose=0):
         mesos_status_verbose = status_mesos_tasks_verbose(job["name"], get_short_task_id, tail_stdstreams)
         mesos_status = "%s\n%s" % (mesos_status, mesos_status_verbose)
     return (
-        "Config:     %(config_hash)s\n"
-        "  Status:   %(disabled_state)s\n"
+        "Job:     %(job_name)s\n"
+        "  Status:   %(disabled_state)s"
+        "  Temporary: %(is_temporary)s\n"
         "  Last:     %(last_result)s (%(formatted_time)s)\n"
         "  %(schedule_type)s: %(schedule_value)s\n"
         "  Command:  %(command)s\n"
         "  Mesos:    %(mesos_status)s" % {
-            "config_hash": config_hash,
+            "job_name": job_name,
+            "is_temporary": is_temporary,
             "schedule_type": schedule_type,
             "disabled_state": disabled_state,
             "last_result": last_result,

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -225,6 +225,20 @@ def _format_mesos_status(job, running_tasks):
     return mesos_status
 
 
+def modify_string_for_rerun_status(string, launched_by_rerun):
+    """Appends information to include a note about
+    being launched by paasta rerun. If the param launched_by_rerun
+    is False, then the string returned is an unmodified copy of that provided
+    by the string parameter.
+    :param string: the string to be modified
+    :returns: a string with information about rerun status appended
+    """
+    if launched_by_rerun:
+        return "%s (Launched by paasta rerun)" % string
+    else:
+        return string
+
+
 def format_chronos_job_status(job, running_tasks, verbose=0):
     """Given a job, returns a pretty-printed human readable output regarding
     the status of the job.
@@ -236,7 +250,9 @@ def format_chronos_job_status(job, running_tasks, verbose=0):
     """
     job_name = _format_job_name(job)
     is_temporary = chronos_tools.is_temporary_job(job) if 'name' in job else 'UNKNOWN'
+    job_name = modify_string_for_rerun_status(job_name, is_temporary)
     disabled_state = _format_disabled_status(job)
+
     (last_result, formatted_time) = _format_last_result(job)
 
     job_type = chronos_tools.get_job_type(job)
@@ -253,7 +269,6 @@ def format_chronos_job_status(job, running_tasks, verbose=0):
     return (
         "Job:     %(job_name)s\n"
         "  Status:   %(disabled_state)s"
-        "  Launched by rerun: %(is_temporary)s\n"
         "  Last:     %(last_result)s (%(formatted_time)s)\n"
         "  %(schedule_type)s: %(schedule_value)s\n"
         "  Command:  %(command)s\n"

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -253,7 +253,7 @@ def format_chronos_job_status(job, running_tasks, verbose=0):
     return (
         "Job:     %(job_name)s\n"
         "  Status:   %(disabled_state)s"
-        "  Temporary: %(is_temporary)s\n"
+        "  Launched by rerun: %(is_temporary)s\n"
         "  Last:     %(last_result)s (%(formatted_time)s)\n"
         "  %(schedule_type)s: %(schedule_value)s\n"
         "  Command:  %(command)s\n"

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -828,3 +828,12 @@ def get_temporary_jobs_for_service_instance(client, service, instance):
         if job['name'].startswith(TMP_JOB_IDENTIFIER):
             temporary_jobs.append(job)
     return temporary_jobs
+
+
+def is_temporary_job(job):
+    """Assert whether a job is a temporary one, identifiable
+    by it's name starting with TMP_JOB_IDENTIFIER
+    :param job: the chronos job to check
+    :returns: a boolean indicating if a job is a temporary job
+    """
+    return job['name'].startswith(TMP_JOB_IDENTIFIER)

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -114,6 +114,28 @@ def test_format_chronos_job_name_exists():
     assert example_job['name'] in actual
 
 
+def test_format_chronos_job_temp_job():
+    example_job = {
+        'name': '%s my_instance gityourmom configyourdad' % chronos_tools.TMP_JOB_IDENTIFIER,
+        'schedule': 'foo'
+    }
+    running_tasks = []
+    verbose = False
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
+    assert 'Launched by rerun: True' in actual
+
+
+def test_format_chronos_job_non_temp_job():
+    example_job = {
+        'name': 'my_instance gityourmom configyourdad',
+        'schedule': 'foo'
+    }
+    running_tasks = []
+    verbose = False
+    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
+    assert 'Launched by rerun: False' in actual
+
+
 def test_format_chronos_job_name_does_not_exist():
     example_job = {
         'schedule': 'foo'

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -116,24 +116,13 @@ def test_format_chronos_job_name_exists():
 
 def test_format_chronos_job_temp_job():
     example_job = {
-        'name': '%s my_instance gityourmom configyourdad' % chronos_tools.TMP_JOB_IDENTIFIER,
+        'name': '%s my_service my_instance' % chronos_tools.TMP_JOB_IDENTIFIER,
         'schedule': 'foo'
     }
     running_tasks = []
     verbose = False
     actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
-    assert 'Launched by rerun: True' in actual
-
-
-def test_format_chronos_job_non_temp_job():
-    example_job = {
-        'name': 'my_instance gityourmom configyourdad',
-        'schedule': 'foo'
-    }
-    running_tasks = []
-    verbose = False
-    actual = chronos_serviceinit.format_chronos_job_status(example_job, running_tasks, verbose)
-    assert 'Launched by rerun: False' in actual
+    assert 'Job:     tmp my_service my_instance (Launched by paasta rerun)' in actual
 
 
 def test_format_chronos_job_name_does_not_exist():


### PR DESCRIPTION
closes #457 

I'm open to ideas for the wording here - originally I started with Temporary: False, but decided that didn't really indicate that this was a 'rerun' job
```
(py27)bash-4.1# ./paasta_tools/paasta_serviceinit.py status -s paasta_canary -i sensu_canary
Desired:    Scheduled
Job:     paasta_canary sensu_canary
  Status:   Scheduled  Launched by rerun: False
  Last:     OK (2016-05-05T04:50, 59 seconds ago)
  Schedule: R/2016-05-05T12:00:00.000Z/PT10M (UTC) Epsilon: PT60S
  Command:  sensu-scheduled-canary.sh
  Mesos:    Not running
```