### PR TITLE
fix the bad command shown in check_chronos_jobs output

### DIFF
--- a/paasta_tools/check_chronos_jobs.py
+++ b/paasta_tools/check_chronos_jobs.py
@@ -115,7 +115,7 @@ def message_for_status(status, service, instance, cluster):
             "Last run of job %(service)s%(separator)s%(instance)s failed.\n"
             "You can view the logs for the job with:\n"
             "\n"
-            "    paasta logs -s %(service)s -i %(instance)s -c %(cluster)s\n"
+            "    paasta logs -s %(service)s -c %(cluster)s\n"
             "\n"
             "If your job didn't manage to start up, you can view the stdout and stderr of your job using:\n"
             "\n"

--- a/tests/test_check_chronos_jobs.py
+++ b/tests/test_check_chronos_jobs.py
@@ -152,7 +152,7 @@ def test_message_for_status_fail():
     )
     assert "Last run of job myservice.myinstance failed.\n" in actual
     # Assert that there are helpful action items in the output
-    assert "paasta logs -s myservice -i myinstance -c mycluster\n" in actual
+    assert "paasta logs -s myservice -c mycluster\n" in actual
     assert "paasta status -s myservice -i myinstance -c mycluster -vv\n" in actual
     assert "paasta rerun -s myservice -i myinstance -c mycluster -d {datetime}\n" in actual
 


### PR DESCRIPTION
there is no -i option to paasta logs