### PR TITLE
Make marathon and chronos constraint logic a bit more consistent

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -372,7 +372,21 @@ Each job configuration MAY specify the following options:
     <https://mesos.github.io/chronos/docs/api.html#constraints>`_ for more
     information.
 
+  * ``extra_constraints``: Adds to the default placement constraints for
+    services. This acts the same as ``constraints``, but adds to the default
+    constraints instead of replacing them. See ``constraints`` for details on
+    format and the default constraints.
+
+    *Note*: While this parameter is the same as ``extra_constraints`` in ``marathon-$cluster.yaml``,
+    the Marathon constrain language isn't exactly like the Marathon constraint language.
+    Be sure to read the constraint documentation for Chronos referenced in the ``constraints``
+    section.
+
   * ``pool``: See the `marathon-[clustername].yaml`_ section for details
+
+  * ``deploy_whitelist``: See the `marathon-[clustername].yaml`_ section for details
+
+  * ``deploy_blacklist``: *Not currently supported*.
 
   * ``deploy_group``: Same as ``deploy_group`` for marathon-*.yaml.
 

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -225,11 +225,12 @@ class ChronosJobConfig(InstanceConfig):
         original_env = super(ChronosJobConfig, self).get_env()
         return [{"name": key, "value": value} for key, value in original_env.iteritems()]
 
-    def get_constraints(self):
-        if 'constraints' in self.config_dict:
-            constraints = self.config_dict.get('constraints')
+    def get_calculated_constraints(self):
+        constraints = self.get_constraints()
+        if constraints is not None:
+            return constraints
         else:
-            constraints = self.config_dict.get('extra_constraints', [])
+            constraints = self.get_extra_constraints()
             constraints.extend(self.get_deploy_constraints())
             constraints.extend(self.get_pool_constraints())
         assert isinstance(constraints, list)
@@ -411,7 +412,7 @@ class ChronosJobConfig(InstanceConfig):
             'mem': self.get_mem(),
             'cpus': self.get_cpus(),
             'disk': self.get_disk(),
-            'constraints': self.get_constraints(),
+            'constraints': self.get_calculated_constraints(),
             'command': parse_time_variables(self.get_cmd()) if self.get_cmd() else self.get_cmd(),
             'arguments': self.get_args(),
             'epsilon': self.get_epsilon(),

--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -65,6 +65,9 @@
             "env": {
                 "type": "object"
             },
+            "deploy_whitelist": {
+                "type": "array"
+            },
             "extra_volumes": {
                 "type": "array",
                 "items": {

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -126,6 +126,9 @@
             "deploy_blacklist": {
                 "type": "array"
             },
+            "deploy_whitelist": {
+                "type": "array"
+            },
             "monitoring_blacklist": {
                 "type": "array"
             },

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -332,10 +332,6 @@ class MarathonServiceConfig(InstanceConfig):
         return (deploy_blacklist_to_constraints(self.get_deploy_blacklist()) +
                 deploy_whitelist_to_constraints(self.get_deploy_whitelist()))
 
-    def get_pool_constraints(self):
-        pool = self.get_pool()
-        return [["pool", "LIKE", pool]]
-
     def format_marathon_app_dict(self):
         """Create the configuration that will be passed to the Marathon REST API.
 

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -298,22 +298,21 @@ class MarathonServiceConfig(InstanceConfig):
             default = {'delay': 30}
         return self.config_dict.get('drain_method_params', default)
 
-    def get_constraints(self, service_namespace_config):
-        """Gets the constraints specified in the service's marathon configuration.
+    def get_calculated_constraints(self, service_namespace_config):
+        """Gets the calculated constraints for a marathon instance
 
-        These are Marathon app constraints. See
-        https://mesosphere.github.io/marathon/docs/constraints.html
-
-        Defaults to `GROUP_BY region`. If the service's smartstack configuration
-        specifies a `discover` key, then defaults to `GROUP_BY <value of discover>` instead.
+        If ``constraints`` is specified in the config, it will use that regardless.
+        Otherwise it will calculate a good set of constraints from other inputs,
+        like ``pool``, blacklist/whitelist, smartstack data, etc.
 
         :param service_namespace_config: The service instance's configuration dictionary
         :returns: The constraints specified in the config, or defaults described above
         """
-        if 'constraints' in self.config_dict:
-            constraints = self.config_dict.get('constraints')
+        constraints = self.get_constraints()
+        if constraints is not None:
+            return constraints
         else:
-            constraints = self.config_dict.get('extra_constraints', [])
+            constraints = self.get_extra_constraints()
             constraints.extend(self.get_routing_constraints(service_namespace_config))
             constraints.extend(self.get_deploy_constraints())
             constraints.extend(self.get_pool_constraints())
@@ -393,7 +392,7 @@ class MarathonServiceConfig(InstanceConfig):
             'mem': float(self.get_mem()),
             'cpus': float(self.get_cpus()),
             'disk': float(self.get_disk()),
-            'constraints': self.get_constraints(service_namespace_config),
+            'constraints': self.get_calculated_constraints(service_namespace_config),
             'instances': self.get_instances(),
             'cmd': self.get_cmd(),
             'args': self.get_args(),

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -294,6 +294,10 @@ class InstanceConfig(dict):
         :returns: the "pool" attribute in your config dict, or the string "default" if not specified."""
         return self.config_dict.get('pool', 'default')
 
+    def get_pool_constraints(self):
+        pool = self.get_pool()
+        return [["pool", "LIKE", pool]]
+
     def get_net(self):
         """
         :returns: the docker networking mode the container should be started with.

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -298,6 +298,12 @@ class InstanceConfig(dict):
         pool = self.get_pool()
         return [["pool", "LIKE", pool]]
 
+    def get_constraints(self):
+        return self.config_dict.get('constraints', None)
+
+    def get_extra_constraints(self):
+        return self.config_dict.get('extra_constraints', [])
+
     def get_net(self):
         """
         :returns: the docker networking mode the container should be started with.

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -385,7 +385,7 @@ class TestChronosTools:
         assert sorted(fake_conf.get_env()) == sorted(expected_env)
 
     def test_get_constraints(self):
-        fake_constraints = 'fake_constraints'
+        fake_constraints = [['fake_constraints']]
         fake_conf = chronos_tools.ChronosJobConfig(
             service='fake_name',
             cluster='fake_cluster',
@@ -406,7 +406,7 @@ class TestChronosTools:
             branch_dict={},
         )
         actual = fake_conf.get_constraints()
-        assert actual == [['pool', 'EQUALS', 'poolname']]
+        assert actual == [['pool', 'LIKE', 'poolname']]
 
     def test_get_retries_default(self):
         fake_conf = chronos_tools.ChronosJobConfig(
@@ -874,7 +874,7 @@ class TestChronosTools:
             'scheduleTimeZone': None,
             'environmentVariables': mock.ANY,
             'arguments': None,
-            'constraints': [['pool', 'EQUALS', 'default']],
+            'constraints': [['pool', 'LIKE', 'default']],
             'retries': 2,
             'epsilon': fake_epsilon,
             'name': 'test_job',
@@ -1126,7 +1126,7 @@ class TestChronosTools:
             expected = {
                 'arguments': None,
                 'description': fake_config_hash,
-                'constraints': [['pool', 'EQUALS', 'default']],
+                'constraints': [['pool', 'LIKE', 'default']],
                 'schedule': 'R/2015-03-25T19:36:35Z/PT5M',
                 'async': False,
                 'cpus': 5.5,
@@ -1218,7 +1218,7 @@ class TestChronosTools:
             expected = {
                 'arguments': None,
                 'description': fake_config_hash,
-                'constraints': [['pool', 'EQUALS', 'default']],
+                'constraints': [['pool', 'LIKE', 'default']],
                 'schedule': 'R/2015-03-25T19:36:35Z/PT5M',
                 'async': False,
                 'cpus': 5.5,
@@ -1277,7 +1277,7 @@ class TestChronosTools:
             expected = {
                 'arguments': None,
                 'description': fake_config_hash,
-                'constraints': [['pool', 'EQUALS', 'default']],
+                'constraints': [['pool', 'LIKE', 'default']],
                 'schedule': 'R/2015-03-25T19:36:35Z/PT5M',
                 'async': False,
                 'cpus': 5.5,
@@ -1352,7 +1352,7 @@ class TestChronosTools:
             expected = {
                 'description': fake_config_hash,
                 'arguments': None,
-                'constraints': [['pool', 'EQUALS', 'default']],
+                'constraints': [['pool', 'LIKE', 'default']],
                 'schedule': 'R/2015-03-25T19:36:35Z/PT5M',
                 'async': False,
                 'cpus': 5.5,

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -384,7 +384,7 @@ class TestChronosTools:
         ]
         assert sorted(fake_conf.get_env()) == sorted(expected_env)
 
-    def test_get_constraints(self):
+    def test_get_calculated_constraints_respects_constraints_override(self):
         fake_constraints = [['fake_constraints']]
         fake_conf = chronos_tools.ChronosJobConfig(
             service='fake_name',
@@ -393,10 +393,10 @@ class TestChronosTools:
             config_dict={'constraints': fake_constraints},
             branch_dict={},
         )
-        actual = fake_conf.get_constraints()
+        actual = fake_conf.get_calculated_constraints()
         assert actual == fake_constraints
 
-    def test_get_constraints_pool(self):
+    def test_get_calculated_constraints_respects_pool(self):
         fake_pool = 'poolname'
         fake_conf = chronos_tools.ChronosJobConfig(
             service='fake_name',
@@ -405,7 +405,7 @@ class TestChronosTools:
             config_dict={'pool': fake_pool},
             branch_dict={},
         )
-        actual = fake_conf.get_constraints()
+        actual = fake_conf.get_calculated_constraints()
         assert actual == [['pool', 'LIKE', 'poolname']]
 
     def test_get_retries_default(self):

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1043,7 +1043,7 @@ class TestMarathonTools:
         )
         assert fake_conf.get_instances() == 0
 
-    def test_get_constraints_in_config_override_all_others(self):
+    def test_get_calculated_constraints_in_config_override_all_others(self):
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
         fake_conf = marathon_tools.MarathonServiceConfig(
             service='fake_name',
@@ -1056,10 +1056,10 @@ class TestMarathonTools:
             'paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
             autospec=True,
         ) as get_slaves_patch:
-            assert fake_conf.get_constraints(fake_service_namespace_config) == [['something', 'GROUP_BY']]
+            assert fake_conf.get_calculated_constraints(fake_service_namespace_config) == [['something', 'GROUP_BY']]
             assert get_slaves_patch.call_count == 0
 
-    def test_get_constraints_default(self):
+    def test_get_calculated_constraints_default(self):
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
         fake_conf = marathon_tools.MarathonServiceConfig(
             service='fake_name',
@@ -1077,9 +1077,9 @@ class TestMarathonTools:
                 ["region", "GROUP_BY", "1"],
                 ["pool", "LIKE", "default"],
             ]
-            assert fake_conf.get_constraints(fake_service_namespace_config) == expected_constraints
+            assert fake_conf.get_calculated_constraints(fake_service_namespace_config) == expected_constraints
 
-    def test_get_constraints_stringifies(self):
+    def test_get_calculated_constraints_stringifies(self):
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
         fake_conf = marathon_tools.MarathonServiceConfig(
             service='fake_name',
@@ -1098,9 +1098,9 @@ class TestMarathonTools:
                 ["region", "GROUP_BY", "1"],
                 ["pool", "LIKE", "default"],
             ]
-            assert fake_conf.get_constraints(fake_service_namespace_config) == expected_constraints
+            assert fake_conf.get_calculated_constraints(fake_service_namespace_config) == expected_constraints
 
-    def test_get_constraints_extra_constraints(self):
+    def test_get_calculated_constraints_extra_constraints(self):
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
         fake_conf = marathon_tools.MarathonServiceConfig(
             service='fake_name',
@@ -1119,9 +1119,9 @@ class TestMarathonTools:
                 ["region", "GROUP_BY", "1"],
                 ["pool", "LIKE", "default"],
             ]
-            assert fake_conf.get_constraints(fake_service_namespace_config) == expected_constraints
+            assert fake_conf.get_calculated_constraints(fake_service_namespace_config) == expected_constraints
 
-    def test_get_constraints_from_discover(self):
+    def test_get_calculated_constraints_from_discover(self):
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig({
             'mode': 'http',
             'healthcheck_uri': '/status',
@@ -1143,10 +1143,10 @@ class TestMarathonTools:
                 ["habitat", "GROUP_BY", "2"],
                 ["pool", "LIKE", "default"],
             ]
-            assert fake_conf.get_constraints(fake_service_namespace_config) == expected_constraints
+            assert fake_conf.get_calculated_constraints(fake_service_namespace_config) == expected_constraints
             get_slaves_patch.assert_called_once_with(attribute='habitat', blacklist=[], whitelist=[])
 
-    def test_get_constraints_respects_deploy_blacklist(self):
+    def test_get_calculated_constraints_respects_deploy_blacklist(self):
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
         fake_deploy_blacklist = [["region", "fake_blacklisted_region"]]
         fake_conf = marathon_tools.MarathonServiceConfig(
@@ -1166,10 +1166,10 @@ class TestMarathonTools:
             autospec=True,
         ) as get_slaves_patch:
             get_slaves_patch.return_value = {'fake_region': {}}
-            assert fake_conf.get_constraints(fake_service_namespace_config) == expected_constraints
+            assert fake_conf.get_calculated_constraints(fake_service_namespace_config) == expected_constraints
             get_slaves_patch.assert_called_once_with(attribute='region', blacklist=fake_deploy_blacklist, whitelist=[])
 
-    def test_get_constraints_respects_deploy_whitelist(self):
+    def test_get_calculated_constraints_respects_deploy_whitelist(self):
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
         fake_deploy_whitelist = ["region", ["fake_whitelisted_region"]]
         fake_conf = marathon_tools.MarathonServiceConfig(
@@ -1189,7 +1189,7 @@ class TestMarathonTools:
             autospec=True,
         ) as get_slaves_patch:
             get_slaves_patch.return_value = {'fake_region': {}}
-            assert fake_conf.get_constraints(fake_service_namespace_config) == expected_constraints
+            assert fake_conf.get_calculated_constraints(fake_service_namespace_config) == expected_constraints
             get_slaves_patch.assert_called_once_with(attribute='region', blacklist=[], whitelist=fake_deploy_whitelist)
 
     def test_instance_config_getters_in_config(self):


### PR DESCRIPTION
Primary: @Rob-Johnson 

This came out of some review feedback.

I guess the tests are passing kinda "artificially" because of inheritance. Should I move or duplicate some tests out of marathon_tools and into utils?

I'm also adding deploy_whitelist but not deploy_blacklist support, and documenting them.

Also updating the schema.

Closes #456