### PR TITLE
Use mesos.cli for get_mesos_leader

### DIFF
--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -131,7 +131,7 @@ def is_mesos_leader(hostname=MY_HOSTNAME):
 
     :param hostname: The hostname to query mesos-master on
     :returns: True if hostname is the mesos-master leader, False otherwise"""
-    return hostname in get_mesos_leader()
+    return get_mesos_leader() == hostname
 
 
 def get_current_tasks(job_id):

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -16,13 +16,13 @@ import json
 import os
 import re
 import socket
+from urlparse import urlparse
 
 import humanize
 import requests
 from kazoo.client import KazooClient
 from mesos.cli import util
 from mesos.cli.exceptions import SlaveDoesNotExist
-from urlparse import urlparse
 
 from paasta_tools.utils import format_table
 from paasta_tools.utils import PaastaColors

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -32,6 +32,7 @@ from paasta_tools.utils import TimeoutError
 
 
 log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 # mesos.cli.master reads its config file at *import* time, so we must have

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -116,8 +116,6 @@ def get_mesos_leader():
 
     :returns: The current mesos-master hostname"""
     url = master.CURRENT.host
-    print "URL: %s" % url
-    print "CFG: %s" % os.environ['MESOS_CLI_CONFIG']
     m = re.search('^https?://(.*?):\d+$', url)
     if m:
         ip = m.group(1)

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -120,9 +120,7 @@ class MesosSlaveConnectionError(Exception):
 def get_mesos_leader():
     """Get the current mesos-master leader's hostname.
     Attempts to determine this by using mesos.cli to query ZooKeeper.
-    If this fails, we fallback to following the HTTP redirect
 
-    :param hostname: The hostname to query mesos-master on (only used if we can't use ZK)
     :returns: The current mesos-master hostname"""
     try:
         url = master.CURRENT.host

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -22,7 +22,6 @@ import requests
 from kazoo.client import KazooClient
 from mesos.cli import util
 from mesos.cli.exceptions import SlaveDoesNotExist
-from mesos.cli.master import CURRENT
 
 from paasta_tools.utils import format_table
 from paasta_tools.utils import PaastaColors
@@ -116,7 +115,9 @@ def get_mesos_leader():
     """Get the current mesos-master leader's hostname.
 
     :returns: The current mesos-master hostname"""
-    url = CURRENT.host
+    url = master.CURRENT.host
+    print "URL: %s" % url
+    print "CFG: %s" % os.environ['MESOS_CLI_CONFIG']
     m = re.search('^https?://(.*?):\d+$', url)
     if m:
         ip = m.group(1)

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -14,7 +14,6 @@
 import contextlib
 import datetime
 import random
-import socket
 
 import docker
 import mesos
@@ -194,25 +193,6 @@ def test_get_mesos_leader():
         mock_gethostbyaddr.return_value = 'example.org'
         mock_getfqdn.return_value = 'example.org'
         assert mesos_tools.get_mesos_leader() == 'example.org'
-
-
-def test_get_mesos_leader_socket_exception():
-    fake_url = 'http://93.184.216.34:5050'
-    with contextlib.nested(
-        mock.patch('paasta_tools.mesos_tools.master.CURRENT'),
-        mock.patch('paasta_tools.mesos_tools.socket.gethostbyaddr'),
-        mock.patch('paasta_tools.mesos_tools.socket.getfqdn'),
-    ) as (
-        mock_CURRENT,
-        mock_gethostbyaddr,
-        mock_getfqdn,
-    ):
-        mock_CURRENT.host = fake_url
-        mock_gethostbyaddr.return_value = 'example.org'
-        mock_getfqdn.return_value = 'example.org'
-        mock_getfqdn.side_effect = socket.timeout
-        with raises(mesos_tools.MesosMasterConnectionError):
-            mesos_tools.get_mesos_leader()
 
 
 def test_get_mesos_leader_cli_exception_good():

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -179,13 +179,30 @@ def test_get_zookeeper_config():
 
 
 def test_get_mesos_leader():
+    fake_url = 'http://93.184.216.34:5050'
+    with contextlib.nested(
+        mock.patch('mesos.cli.master.CURRENT', autospec=True,),
+        mock.patch('paasta_tools.mesos_tools.socket.gethostbyaddr', autospec=True,),
+        mock.patch('paasta_tools.mesos_tools.socket.getfqdn', autospec=True,),
+    ) as (
+        mock_CURRENT,
+        mock_gethostbyaddr,
+        mock_getfqdn,
+    ):
+        mock_CURRENT.return_value.host.return_value = fake_url
+        mock_gethostbyaddr.return_value = 'example.org'
+        mock_getfqdn.return_value = 'example.org'
+        assert mesos_tools.get_mesos_leader() == 'example.org'
+
+
+def test_get_mesos_leader2():
     expected = 'mesos.master.yelpcorp.com'
     fake_master = 'false.authority.yelpcorp.com'
     with mock.patch('requests.get', autospec=True) as mock_requests_get:
         mock_requests_get.return_value = mock_response = mock.Mock()
         mock_response.return_code = 307
         mock_response.url = 'http://%s:999' % expected
-        assert mesos_tools.get_mesos_leader(fake_master) == expected
+        assert mesos_tools.get_mesos_leader() == expected
         mock_requests_get.assert_called_once_with('http://%s:5050/redirect' % fake_master, timeout=10)
 
 
@@ -197,7 +214,7 @@ def test_get_mesos_leader_connection_error():
         side_effect=requests.exceptions.ConnectionError,
     ):
         with raises(mesos_tools.MesosMasterConnectionError):
-            mesos_tools.get_mesos_leader(fake_master)
+            mesos_tools.get_mesos_leader()
 
 
 @mock.patch('paasta_tools.mesos_tools.get_mesos_leader')
@@ -205,7 +222,7 @@ def test_is_mesos_leader(mock_get_mesos_leader):
     fake_host = 'toast.host.roast'
     mock_get_mesos_leader.return_value = fake_host
     assert mesos_tools.is_mesos_leader(fake_host)
-    mock_get_mesos_leader.assert_called_once_with(fake_host)
+    mock_get_mesos_leader.assert_called_once_with()
 
 
 @mock.patch('paasta_tools.mesos_tools.KazooClient')

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -19,6 +19,7 @@ import docker
 import mesos
 import mock
 import requests
+import socket
 from pytest import mark
 from pytest import raises
 
@@ -195,11 +196,69 @@ def test_get_mesos_leader():
         assert mesos_tools.get_mesos_leader() == 'example.org'
 
 
+def test_get_mesos_leader_socket_exception():
+    fake_url = 'http://93.184.216.34:5050'
+    with contextlib.nested(
+        mock.patch('paasta_tools.mesos_tools.master.CURRENT'),
+        mock.patch('paasta_tools.mesos_tools.socket.gethostbyaddr'),
+        mock.patch('paasta_tools.mesos_tools.socket.getfqdn'),
+    ) as (
+        mock_CURRENT,
+        mock_gethostbyaddr,
+        mock_getfqdn,
+    ):
+        mock_CURRENT.host = fake_url
+        mock_gethostbyaddr.return_value = 'example.org'
+        mock_getfqdn.return_value = 'example.org'
+        mock_getfqdn.side_effect = socket.timeout
+        with raises(mesos_tools.MesosMasterConnectionError):
+            mesos_tools.get_mesos_leader()
+
+
+def test_get_mesos_leader_cli_exception_good():
+    expected = 'mesos.master.yelpcorp.com'
+    fake_master = 'false.authority.yelpcorp.com'
+    with contextlib.nested(
+        mock.patch('mesos.cli.master.MesosMaster.resolve', side_effect=mesos_tools.MesosMasterConnectionError),
+        mock.patch('requests.get', autospec=True),
+    ) as (
+        mock_resolve,
+        mock_requests_get,
+    ):
+        mock_requests_get.return_value = mock_response = mock.Mock()
+        mock_response.return_code = 307
+        mock_response.url = 'http://%s:999' % expected
+        assert mesos_tools.get_mesos_leader(fake_master) == expected
+        mock_requests_get.assert_called_once_with('http://%s:5050/redirect' % fake_master, timeout=10)
+
+
+def test_get_mesos_leader_cli_exception_bad():
+    fake_master = 'false.authority.yelpcorp.com'
+    with contextlib.nested(
+        mock.patch('mesos.cli.master.MesosMaster.resolve', side_effect=mesos_tools.MesosMasterConnectionError),
+        mock.patch('requests.get', autospec=True, side_effect=requests.exceptions.ConnectionError),
+    ) as (
+        mock_resolve,
+        _,
+    ):
+        with raises(mesos_tools.MesosMasterConnectionError):
+            mesos_tools.get_mesos_leader(fake_master)
+
+
 @mock.patch('paasta_tools.mesos_tools.get_mesos_leader')
 def test_is_mesos_leader(mock_get_mesos_leader):
     fake_host = 'toast.host.roast'
     mock_get_mesos_leader.return_value = fake_host
     assert mesos_tools.is_mesos_leader(fake_host)
+    mock_get_mesos_leader.assert_called_once_with()
+
+
+
+@mock.patch('paasta_tools.mesos_tools.get_mesos_leader')
+def test_is_mesos_leader_substring(mock_get_mesos_leader):
+    fake_host = 'toast.host.roast'
+    mock_get_mesos_leader.return_value = "fake_prefix." + fake_host + ".fake_suffix"
+    assert not mesos_tools.is_mesos_leader(fake_host)
     mock_get_mesos_leader.assert_called_once_with()
 
 

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -181,40 +181,18 @@ def test_get_zookeeper_config():
 def test_get_mesos_leader():
     fake_url = 'http://93.184.216.34:5050'
     with contextlib.nested(
-        mock.patch('mesos.cli.master.CURRENT', autospec=True,),
-        mock.patch('paasta_tools.mesos_tools.socket.gethostbyaddr', autospec=True,),
-        mock.patch('paasta_tools.mesos_tools.socket.getfqdn', autospec=True,),
+        mock.patch('paasta_tools.mesos_tools.master.CURRENT'),
+        mock.patch('paasta_tools.mesos_tools.socket.gethostbyaddr'),
+        mock.patch('paasta_tools.mesos_tools.socket.getfqdn'),
     ) as (
         mock_CURRENT,
         mock_gethostbyaddr,
         mock_getfqdn,
     ):
-        mock_CURRENT.return_value.host.return_value = fake_url
+        mock_CURRENT.host = fake_url
         mock_gethostbyaddr.return_value = 'example.org'
         mock_getfqdn.return_value = 'example.org'
         assert mesos_tools.get_mesos_leader() == 'example.org'
-
-
-def test_get_mesos_leader2():
-    expected = 'mesos.master.yelpcorp.com'
-    fake_master = 'false.authority.yelpcorp.com'
-    with mock.patch('requests.get', autospec=True) as mock_requests_get:
-        mock_requests_get.return_value = mock_response = mock.Mock()
-        mock_response.return_code = 307
-        mock_response.url = 'http://%s:999' % expected
-        assert mesos_tools.get_mesos_leader() == expected
-        mock_requests_get.assert_called_once_with('http://%s:5050/redirect' % fake_master, timeout=10)
-
-
-def test_get_mesos_leader_connection_error():
-    fake_master = 'false.authority.yelpcorp.com'
-    with mock.patch(
-        'requests.get',
-        autospec=True,
-        side_effect=requests.exceptions.ConnectionError,
-    ):
-        with raises(mesos_tools.MesosMasterConnectionError):
-            mesos_tools.get_mesos_leader()
 
 
 @mock.patch('paasta_tools.mesos_tools.get_mesos_leader')

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -14,12 +14,12 @@
 import contextlib
 import datetime
 import random
+import socket
 
 import docker
 import mesos
 import mock
 import requests
-import socket
 from pytest import mark
 from pytest import raises
 
@@ -251,7 +251,6 @@ def test_is_mesos_leader(mock_get_mesos_leader):
     mock_get_mesos_leader.return_value = fake_host
     assert mesos_tools.is_mesos_leader(fake_host)
     mock_get_mesos_leader.assert_called_once_with()
-
 
 
 @mock.patch('paasta_tools.mesos_tools.get_mesos_leader')


### PR DESCRIPTION
Our current approach to determine the mesos leader relies on following the redirects. mesos.cli uses zookeeper. Let's use that.

I will work on adding some itests to properly test this change (especially the scenarios where we are unable to connect to zookeeper for some reason).

Fixes #498 