### PR TITLE
Make paasta status use the multi-instance endpoint

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -154,11 +154,11 @@ def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployme
         # Case: service NOT deployed to cluster.instance
         else:
             print '  instance: %s' % PaastaColors.red(instance)
-            print '    Git sha:    None'
+            print '    Git sha:    None (not deployed yet)'
 
-    if len(deployed_instances):
+    if len(deployed_instances) > 0:
         status = execute_paasta_serviceinit_on_remote_master('status', cluster, service, ','.join(deployed_instances),
-                                                             system_paasta_config, verbose=verbose, stream=True)
+                                                             system_paasta_config, stream=True, verbose=verbose)
         # Status results are streamed. This print is for possible error messages.
         if status is not None:
             for line in status.rstrip().split('\n'):

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -474,7 +474,7 @@ def check_ssh_and_sudo_on_master(master, timeout=10):
     return (False, output)
 
 
-def run_paasta_serviceinit(subcommand, master, service, instancename, cluster, **kwargs):
+def run_paasta_serviceinit(subcommand, master, service, instancenames, cluster, **kwargs):
     """Run 'paasta_serviceinit <subcommand>'. Return the output from running it."""
     if 'verbose' in kwargs and kwargs['verbose'] > 0:
         verbose_flag = '-v ' * kwargs['verbose']
@@ -490,16 +490,21 @@ def run_paasta_serviceinit(subcommand, master, service, instancename, cluster, *
         delta = "--delta %s" % kwargs['delta']
     else:
         delta = ''
-    command = 'ssh -A -n %s sudo paasta_serviceinit %s%s%s %s %s' % (
+    if 'stream' in kwargs and kwargs['stream']:
+        stream = kwargs['stream']
+    else:
+        stream = False
+    command = 'ssh -A -n %s sudo paasta_serviceinit %s%s-s %s -i %s %s %s' % (
         master,
         verbose_flag,
         app_id_flag,
-        compose_job_id(service, instancename),
+        service,
+        instancenames,
         subcommand,
         delta
     )
     log.debug("Running Command: %s" % command)
-    _, output = _run(command, timeout=timeout)
+    _, output = _run(command, timeout=timeout, stream=stream)
     return output
 
 

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -287,7 +287,7 @@ def pretty_print_smartstack_backends_for_locations(service_instance, tasks, loca
     """
     Pretty prints the status of smartstack backends of a specified service and instance in the specified locations
     """
-    rows = [("      Name", "LastCheck", "LastChange", "Status")]
+    rows = [("      Name", "LastCheck", "LastChange", "Status")] if verbose else []
     expected_count_per_location = int(expected_count / len(locations))
     for location in sorted(locations):
         hosts = locations[location]

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -95,7 +95,7 @@ def main():
         # The git sha in deployment.json is simply used here.
         version = actual_deployments['.'.join((cluster, instance))][:8]
         print 'instance: %s' % PaastaColors.blue(instance)
-        print 'Git sha:    %s' % version
+        print 'Git sha:    %s (desired)' % version
 
         instance_type = validate_service_instance(service, instance, cluster, args.soa_dir)
         if instance_type == 'marathon':

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -875,13 +875,17 @@ def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=N
             proctimer.start()
         for line in iter(process.stdout.readline, ''):
             # additional indentation is for the paasta status command only
-            if stream and (' paasta_serviceinit status ' in command):
-                if 'instance: ' in line:
-                    print('  ' + line.rstrip('\n'))
+            if stream:
+                if ('paasta_serviceinit status' in command):
+                    if 'instance: ' in line:
+                        print('  ' + line.rstrip('\n'))
+                    else:
+                        print('    ' + line.rstrip('\n'))
                 else:
-                    print('    ' + line.rstrip('\n'))
+                    print(line.rstrip('\n'))
             else:
-                print(line.rstrip('\n'))
+                output.append(line.rstrip('\n'))
+
             if log:
                 _log(
                     service=service,
@@ -891,7 +895,6 @@ def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=N
                     cluster=cluster,
                     instance=instance,
                 )
-            output.append(line.rstrip('\n'))
         # when finished, get the exit code
         returncode = process.wait()
     except OSError as e:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -874,7 +874,12 @@ def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=N
             proctimer = threading.Timer(timeout, _timeout, (process,))
             proctimer.start()
         for line in iter(process.stdout.readline, ''):
-            if stream:
+            if stream and (' paasta_serviceinit ' in command and ' status ' in command):
+                if 'instance: ' in line:
+                    print('  ' + line.rstrip('\n'))
+                else:
+                    print('    ' + line.rstrip('\n'))
+            else:
                 print(line.rstrip('\n'))
             if log:
                 _log(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -874,7 +874,8 @@ def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=N
             proctimer = threading.Timer(timeout, _timeout, (process,))
             proctimer.start()
         for line in iter(process.stdout.readline, ''):
-            if stream and (' paasta_serviceinit ' in command and ' status ' in command):
+            # additional indentation is for the paasta status command only
+            if stream and (' paasta_serviceinit status ' in command):
                 if 'instance: ' in line:
                     print('  ' + line.rstrip('\n'))
                 else:

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -110,7 +110,7 @@ def test_report_status_for_cluster_displays_deployed_service(
     assert expected_output in output
     mock_execute_paasta_serviceinit_on_remote_master.assert_called_once_with(
         'status', 'fake_cluster', 'fake_service', 'fake_instance',
-        fake_system_paasta_config, verbose=0, stream=True)
+        fake_system_paasta_config, stream=True, verbose=0)
 
 
 @patch('paasta_tools.cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
@@ -190,7 +190,7 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
     assert expected_output in output
     mock_execute_paasta_serviceinit_on_remote_master.assert_called_once_with(
         'status', 'fake_cluster', 'fake_service', 'fake_instance_a,fake_instance_b',
-        fake_system_paasta_config, verbose=0, stream=True)
+        fake_system_paasta_config, stream=True, verbose=0)
 
 
 @patch('paasta_tools.cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
@@ -218,7 +218,7 @@ def test_print_cluster_status_missing_deploys_in_red(
         "\n"
         "cluster: a_cluster\n"
         "  instance: %s\n"
-        "    Git sha:    None\n"
+        "    Git sha:    None (not deployed yet)\n"
         "    %s\n"
         % (
             PaastaColors.red('b_instance'),
@@ -274,7 +274,7 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
     assert mock_execute_paasta_serviceinit_on_remote_master.call_count == 1
     mock_execute_paasta_serviceinit_on_remote_master.assert_any_call(
         'status', 'a_cluster', service, 'a_instance', fake_system_paasta_config,
-        verbose=verbosity_level, stream=True
+        stream=True, verbose=verbosity_level
     )
 
     output = mock_stdout.getvalue()
@@ -308,7 +308,7 @@ def test_report_status_for_cluster_obeys_instance_whitelist(
     )
     mock_execute_paasta_serviceinit_on_remote_master.assert_called_once_with(
         'status', 'fake_cluster', 'fake_service', 'fake_instance_a',
-        fake_system_paasta_config, verbose=0, stream=True)
+        fake_system_paasta_config, stream=True, verbose=0)
 
 
 @patch('paasta_tools.cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -140,7 +140,7 @@ def test_check_ssh_and_sudo_on_master_check_sudo_failure(mock_run):
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_status(mock_run):
     mock_run.return_value = ('unused', 'fake_output')
-    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit fake_service.fake_instance status '
+    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit -s fake_service -i fake_instance status '
 
     actual = utils.run_paasta_serviceinit(
         'status',
@@ -149,14 +149,14 @@ def test_run_paasta_serviceinit_status(mock_run):
         'fake_instance',
         'fake_cluster',
     )
-    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY)
+    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY, stream=False)
     assert actual == mock_run.return_value[1]
 
 
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_status_verbose(mock_run):
     mock_run.return_value = ('unused', 'fake_output')
-    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit -v fake_service.fake_instance status '
+    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit -v -s fake_service -i fake_instance status '
 
     actual = utils.run_paasta_serviceinit(
         'status',
@@ -166,14 +166,15 @@ def test_run_paasta_serviceinit_status_verbose(mock_run):
         'fake_cluster',
         verbose=1,
     )
-    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY)
+    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY, stream=False)
     assert actual == mock_run.return_value[1]
 
 
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_status_verbose_multi(mock_run):
     mock_run.return_value = ('unused', 'fake_output')
-    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit -v -v -v -v fake_service.fake_instance status '
+    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit -v -v -v -v ' \
+        '-s fake_service -i fake_instance status '
 
     actual = utils.run_paasta_serviceinit(
         'status',
@@ -183,7 +184,7 @@ def test_run_paasta_serviceinit_status_verbose_multi(mock_run):
         'fake_cluster',
         verbose=4,
     )
-    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY)
+    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY, stream=False)
     assert actual == mock_run.return_value[1]
 
 
@@ -242,7 +243,8 @@ def test_execute_paasta_serviceinit_status_on_remote_master_happy_path(
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_scaling(mock_run):
     mock_run.return_value = ('unused', 'fake_output')
-    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit -v fake_service.fake_instance status --delta 1'
+    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit -v ' \
+        '-s fake_service -i fake_instance status --delta 1'
 
     actual = utils.run_paasta_serviceinit(
         'status',
@@ -253,7 +255,7 @@ def test_run_paasta_serviceinit_scaling(mock_run):
         verbose=1,
         delta=1,
     )
-    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY)
+    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY, stream=False)
     assert actual == mock_run.return_value[1]
 
 

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -140,7 +140,7 @@ def test_check_ssh_and_sudo_on_master_check_sudo_failure(mock_run):
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_status(mock_run):
     mock_run.return_value = ('unused', 'fake_output')
-    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit -s fake_service -i fake_instance status '
+    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit status -s fake_service -i fake_instance '
 
     actual = utils.run_paasta_serviceinit(
         'status',
@@ -148,15 +148,16 @@ def test_run_paasta_serviceinit_status(mock_run):
         'fake_service',
         'fake_instance',
         'fake_cluster',
+        stream=True
     )
-    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY, stream=False)
+    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY, stream=True)
     assert actual == mock_run.return_value[1]
 
 
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_status_verbose(mock_run):
     mock_run.return_value = ('unused', 'fake_output')
-    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit -v -s fake_service -i fake_instance status '
+    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit status -s fake_service -i fake_instance -v '
 
     actual = utils.run_paasta_serviceinit(
         'status',
@@ -164,17 +165,18 @@ def test_run_paasta_serviceinit_status_verbose(mock_run):
         'fake_service',
         'fake_instance',
         'fake_cluster',
-        verbose=1,
+        stream=True,
+        verbose=1
     )
-    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY, stream=False)
+    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY, stream=True)
     assert actual == mock_run.return_value[1]
 
 
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_status_verbose_multi(mock_run):
     mock_run.return_value = ('unused', 'fake_output')
-    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit -v -v -v -v ' \
-        '-s fake_service -i fake_instance status '
+    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit status ' \
+        '-s fake_service -i fake_instance -v -v -v -v '
 
     actual = utils.run_paasta_serviceinit(
         'status',
@@ -182,9 +184,10 @@ def test_run_paasta_serviceinit_status_verbose_multi(mock_run):
         'fake_service',
         'fake_instance',
         'fake_cluster',
+        stream=True,
         verbose=4,
     )
-    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY, stream=False)
+    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY, stream=True)
     assert actual == mock_run.return_value[1]
 
 
@@ -236,6 +239,7 @@ def test_execute_paasta_serviceinit_status_on_remote_master_happy_path(
         service,
         instancename,
         cluster,
+        False
     )
     assert actual == mock_run_paasta_serviceinit.return_value
 
@@ -243,8 +247,8 @@ def test_execute_paasta_serviceinit_status_on_remote_master_happy_path(
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_scaling(mock_run):
     mock_run.return_value = ('unused', 'fake_output')
-    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit -v ' \
-        '-s fake_service -i fake_instance status --delta 1'
+    expected_command = 'ssh -A -n fake_master sudo paasta_serviceinit status ' \
+        '-s fake_service -i fake_instance -v --delta 1'
 
     actual = utils.run_paasta_serviceinit(
         'status',
@@ -252,10 +256,11 @@ def test_run_paasta_serviceinit_scaling(mock_run):
         'fake_service',
         'fake_instance',
         'fake_cluster',
+        stream=True,
         verbose=1,
         delta=1,
     )
-    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY, stream=False)
+    mock_run.assert_called_once_with(expected_command, timeout=mock.ANY, stream=True)
     assert actual == mock_run.return_value[1]
 
 


### PR DESCRIPTION
Multiple instances of a service is passed to the endpoint with the -i option in a comma-separated list of instances. The result of each instance is streamed back the client and prefixed with spaces accordingly, 2 for the instance line and 4 for the rest.