### PR TITLE
Make paasta_autoscale_cluster and use console_scripts for it

### DIFF
--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -1,6 +1,6 @@
 usr/share/python/paasta-tools/bin/am_i_mesos_leader.py usr/bin/am_i_mesos_leader
 usr/share/python/paasta-tools/bin/autoscale_all_services.py usr/bin/autoscale_all_services
-usr/share/python/paasta-tools/bin/paasta_autoscale_cluster usr/bin/autoscale_cluster
+usr/share/python/paasta-tools/bin/paasta_autoscale_cluster usr/bin/paasta_autoscale_cluster
 usr/share/python/paasta-tools/bin/check_classic_service_replication.py usr/bin/check_classic_service_replication
 usr/share/python/paasta-tools/bin/check_marathon_services_frontends.py usr/bin/check_marathon_services_frontends
 usr/share/python/paasta-tools/bin/check_marathon_services_replication.py usr/bin/check_marathon_services_replication

--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -1,6 +1,6 @@
 usr/share/python/paasta-tools/bin/am_i_mesos_leader.py usr/bin/am_i_mesos_leader
 usr/share/python/paasta-tools/bin/autoscale_all_services.py usr/bin/autoscale_all_services
-usr/share/python/paasta-tools/bin/autoscale_cluster.py usr/bin/autoscale_cluster
+usr/share/python/paasta-tools/bin/paasta_autoscale_cluster usr/bin/autoscale_cluster
 usr/share/python/paasta-tools/bin/check_classic_service_replication.py usr/bin/check_classic_service_replication
 usr/share/python/paasta-tools/bin/check_marathon_services_frontends.py usr/bin/check_marathon_services_frontends
 usr/share/python/paasta-tools/bin/check_marathon_services_replication.py usr/bin/check_marathon_services_replication

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(
     scripts=[
         'paasta_tools/am_i_mesos_leader.py',
         'paasta_tools/autoscale_all_services.py',
-        'paasta_tools/autoscale_cluster.py',
         'paasta_tools/check_marathon_services_replication.py',
         'paasta_tools/check_mesos_resource_utilization.py',
         'paasta_tools/cleanup_chronos_jobs.py',
@@ -89,5 +88,8 @@ setup(
         'paasta_tools/chronos_rerun.py',
     ] + glob.glob('paasta_tools/contrib/*'),
     package_data={'': ['cli/fsm/template/*/*', 'cli/schemas/*.json']},
-    entry_points={'console_scripts': ['paasta=paasta_tools.cli.cli:main']},
+    entry_points={'console_scripts': [
+        'paasta=paasta_tools.cli.cli:main',
+        'paasta_autoscale_cluster=paasta_tools.autoscale_cluster:main',
+    ]},
 )

--- a/yelp_package/dockerfiles/lucid/Dockerfile
+++ b/yelp_package/dockerfiles/lucid/Dockerfile
@@ -18,7 +18,7 @@ MAINTAINER Kyle Anderson <kwa@yelp.com>
 # Make sure we get a package suitable for building this package correctly.
 # Per dnephin we need https://github.com/spotify/dh-virtualenv/pull/20
 # Which at this time is in this package
-RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools python-dev debhelper dh-virtualenv=0.6-yelp2 python-yaml python-pytest pyflakes python2.7 python2.7-dev help2man zsh git
+RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools python-dev debhelper dh-virtualenv=0.6-yelp2 python-yaml libyaml-dev python-pytest pyflakes python2.7 python2.7-dev help2man zsh git
 
 ENV HOME /work
 ENV PWD /work

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 
 RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools \
-  python-dev debhelper python-yaml python-pytest pyflakes \
+  python-dev debhelper python-yaml libyaml-dev python-pytest pyflakes \
   git help2man zsh wget
 
 RUN cd `mktemp -d` && wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_0.11-1_all.deb && dpkg -i dh-virtualenv_0.11-1_all.deb && apt-get -f install

--- a/yelp_package/itest/ubuntu.sh
+++ b/yelp_package/itest/ubuntu.sh
@@ -17,7 +17,6 @@ set -eu
 
 SCRIPTS="am_i_mesos_leader
 autoscale_all_services
-autoscale_cluster
 check_marathon_services_replication
 cleanup_chronos_jobs
 check_chronos_jobs
@@ -29,6 +28,7 @@ generate_services_file
 generate_services_yaml
 list_chronos_jobs
 list_marathon_service_instances
+paasta_autoscale_cluster
 paasta_execute_docker_command
 paasta_metastatus
 paasta_serviceinit


### PR DESCRIPTION
I would like to start a new trend where we prepend our "plumbing" scripts with `paasta_` to make it more obvious what the command is for and where it came from.

`autoscale_cluster` is kinda unadorned. Is it for scaling a kubernetes cluster? A mysql one? Who knows.

This is actually an easy migration because in the links file you can specify multiple symlinks and deprecate the old ones. I didn't do that with this PR, but I will in the next one if shipit.