### PR TITLE
Make setup_marathon_job capable of handling a list of service.instance

### DIFF
--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -45,7 +45,7 @@ def run_setup_marathon_job(context):
         mock_parse_args.return_value = mock.Mock(
             verbose=True,
             soa_dir=context.soa_dir,
-            service_instance=context.job_id,
+            service_instance_list=[context.job_id],
         )
         try:
             setup_marathon_job.main()

--- a/paasta_tools/deploy_marathon_services
+++ b/paasta_tools/deploy_marathon_services
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 if am_i_mesos_leader >/dev/null; then
-  list_marathon_service_instances | xargs -n 64 -r -P 4 setup_marathon_job
+    list_marathon_service_instances | shuf | xargs --max-args=64 --no-run-if-empty --max-procs=4 setup_marathon_job
 fi

--- a/paasta_tools/deploy_marathon_services
+++ b/paasta_tools/deploy_marathon_services
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 if am_i_mesos_leader >/dev/null; then
-  list_marathon_service_instances | shuf | xargs -n 1 -r -P 5 setup_marathon_job
+  list_marathon_service_instances | xargs -n 64 -r -P 4 setup_marathon_job
 fi

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -73,7 +73,7 @@ log = logging.getLogger(__name__)
 def parse_args():
     parser = argparse.ArgumentParser(description='Creates marathon jobs.')
     parser.add_argument('service_instance_list', nargs='+',
-                        help="The marathon instance of the service to create or update",
+                        help="The list of marathon service instances to create or update",
                         metavar="SERVICE%sINSTANCE" % SPACER)
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
                         default=marathon_tools.DEFAULT_SOA_DIR,
@@ -581,8 +581,8 @@ def main():
             if deploy_marathon_service(service, instance, client, soa_dir, marathon_config):
                 num_failed_deployments = num_failed_deployments + 1
 
-    print("%d out of %d service.instances are successfully deployed" %
-          (len(args.service_instance_list) - num_failed_deployments, len(args.service_instance_list)))
+    log.debug("%d out of %d service.instances failed to deploy." %
+              (num_failed_deployments, len(args.service_instance_list)))
 
     sys.exit(1 if num_failed_deployments else 0)
 
@@ -598,7 +598,7 @@ def deploy_marathon_service(service, instance, client, soa_dir, marathon_config)
     except NoDeploymentsAvailable:
         log.debug("No deployments found for %s.%s in cluster %s. Skipping." %
                   (service, instance, load_system_paasta_config().get_cluster()))
-        return 1
+        return 0
     except NoConfigurationForServiceError:
         error_msg = "Could not read marathon configuration file for %s.%s in cluster %s" % \
                     (service, instance, load_system_paasta_config().get_cluster())

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -243,7 +243,7 @@ class TestSetupMarathonJob:
                 decompose_job_id(self.fake_args.service_instance_list[0])[1],
                 self.fake_cluster,
                 soa_dir=self.fake_args.soa_dir)
-            assert exc_info.value.code == 1
+            assert exc_info.value.code == 0
 
     def test_send_event(self):
         fake_service = 'fake_service'

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -54,7 +54,7 @@ class TestSetupMarathonJob:
         'password': 'admin_pass',
     }, '/fake/fake_file.json')
     fake_args = mock.MagicMock(
-        service_instance='what_is_love.bby_dont_hurt_me',
+        service_instance_list=['what_is_love.bby_dont_hurt_me'],
         soa_dir='no_more',
         verbose=False,
     )
@@ -113,14 +113,14 @@ class TestSetupMarathonJob:
                 self.fake_marathon_config.get_password(),
             )
             read_service_conf_patch.assert_called_once_with(
-                decompose_job_id(self.fake_args.service_instance)[0],
-                decompose_job_id(self.fake_args.service_instance)[1],
+                decompose_job_id(self.fake_args.service_instance_list[0])[0],
+                decompose_job_id(self.fake_args.service_instance_list[0])[1],
                 self.fake_cluster,
                 soa_dir=self.fake_args.soa_dir,
             )
             setup_service_patch.assert_called_once_with(
-                decompose_job_id(self.fake_args.service_instance)[0],
-                decompose_job_id(self.fake_args.service_instance)[1],
+                decompose_job_id(self.fake_args.service_instance_list[0])[0],
+                decompose_job_id(self.fake_args.service_instance_list[0])[1],
                 fake_client,
                 self.fake_marathon_config,
                 self.fake_marathon_service_config,
@@ -178,13 +178,13 @@ class TestSetupMarathonJob:
                 self.fake_marathon_config.get_username(),
                 self.fake_marathon_config.get_password())
             read_service_conf_patch.assert_called_once_with(
-                decompose_job_id(self.fake_args.service_instance)[0],
-                decompose_job_id(self.fake_args.service_instance)[1],
+                decompose_job_id(self.fake_args.service_instance_list[0])[0],
+                decompose_job_id(self.fake_args.service_instance_list[0])[1],
                 self.fake_cluster,
                 soa_dir=self.fake_args.soa_dir)
             setup_service_patch.assert_called_once_with(
-                decompose_job_id(self.fake_args.service_instance)[0],
-                decompose_job_id(self.fake_args.service_instance)[1],
+                decompose_job_id(self.fake_args.service_instance_list[0])[0],
+                decompose_job_id(self.fake_args.service_instance_list[0])[1],
                 fake_client,
                 self.fake_marathon_config,
                 self.fake_marathon_service_config,
@@ -239,11 +239,11 @@ class TestSetupMarathonJob:
                 self.fake_marathon_config.get_username(),
                 self.fake_marathon_config.get_password())
             read_service_conf_patch.assert_called_once_with(
-                decompose_job_id(self.fake_args.service_instance)[0],
-                decompose_job_id(self.fake_args.service_instance)[1],
+                decompose_job_id(self.fake_args.service_instance_list[0])[0],
+                decompose_job_id(self.fake_args.service_instance_list[0])[1],
                 self.fake_cluster,
                 soa_dir=self.fake_args.soa_dir)
-            assert exc_info.value.code == 0
+            assert exc_info.value.code == 1
 
     def test_send_event(self):
         fake_service = 'fake_service'


### PR DESCRIPTION
This patch enables setup_marathon_job.py handle a list of service.instance to take advantage of mesos master state caching.  
{code}
$ .tox/py27/bin/setup_marathon_job.py --help
usage: setup_marathon_job.py [-h] [-d SOA_DIR] [-v]
                             SERVICE.INSTANCE [SERVICE.INSTANCE ...]

Creates marathon jobs.
{code}

We have a 60 seconds caching TTL at this point, and we have 244 service instances on prod. I am breaking into 4 chunks, hoping each chunk can finish within 60s. In addition, I removed service list shuffling. IMO, deploying instances of the same service in the same chunk process has better locality.
{code}
list_marathon_service_instances  | xargs -n 64 -r -P 4 .tox/py27/bin/setup_marathon_job.py
{code}