### PR TITLE
Move http request cache install up to paasta serviceinit

### DIFF
--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -17,7 +17,6 @@ import logging
 import chronos_tools
 import humanize
 import isodate
-import requests_cache
 
 from paasta_tools.mesos_tools import get_running_tasks_from_active_frameworks
 from paasta_tools.mesos_tools import status_mesos_tasks_verbose
@@ -349,8 +348,6 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir):
             emergency=True,
         )
     elif command == "status":
-        # Setting up transparent cache for http API calls
-        requests_cache.install_cache("paasta_serviceinit", backend="memory")
         # Verbose mode shows previous versions.
         matching_jobs = chronos_tools.lookup_chronos_jobs(
             service=service,

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -17,7 +17,6 @@ import logging
 
 import humanize
 import isodate
-import requests_cache
 
 from paasta_tools import marathon_tools
 from paasta_tools.mesos_tools import get_mesos_slaves_grouped_by_attribute
@@ -371,9 +370,6 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir, app_i
     elif command == 'restart':
         restart_marathon_job(service, instance, app_id, normal_instance_count, client, cluster)
     elif command == 'status':
-        # Setting up transparent cache for http API calls
-        requests_cache.install_cache('paasta_serviceinit', backend='memory')
-
         print status_desired_state(service, instance, client, job_config)
         print status_marathon_job(service, instance, app_id, normal_instance_count, client)
         tasks, out = status_marathon_job_verbose(service, instance, client)

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -22,6 +22,7 @@ from urlparse import urlparse
 import humanize
 import requests
 from kazoo.client import KazooClient
+from mesos.cli import util
 from mesos.cli.exceptions import SlaveDoesNotExist
 
 from paasta_tools.utils import format_table
@@ -84,6 +85,12 @@ MESOS_SLAVE_PORT = '5051'
 from mesos.cli import master  # noqa
 import mesos.cli.cluster  # noqa
 
+
+# monkey patch MesosMaster.state to use a larger ttl
+@util.CachedProperty(ttl=60)
+def fetch_state(self):
+    return master.CURRENT.fetch("/master/state.json").json()
+master.MesosMaster.state = fetch_state
 
 # Works around a mesos-cli bug ('MesosSlave' object has no attribute 'id' - PAASTA-4119).
 # The method below gets a slave by its ID. Original code here:

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -22,7 +22,6 @@ from urlparse import urlparse
 import humanize
 import requests
 from kazoo.client import KazooClient
-from mesos.cli import util
 from mesos.cli.exceptions import SlaveDoesNotExist
 
 from paasta_tools.utils import format_table
@@ -85,12 +84,6 @@ MESOS_SLAVE_PORT = '5051'
 from mesos.cli import master  # noqa
 import mesos.cli.cluster  # noqa
 
-
-# monkey patch MesosMaster.state to use a larger ttl
-@util.CachedProperty(ttl=60)
-def fetch_state(self):
-    return master.CURRENT.fetch("/master/state.json").json()
-master.MesosMaster.state = fetch_state
 
 # Works around a mesos-cli bug ('MesosSlave' object has no attribute 'id' - PAASTA-4119).
 # The method below gets a slave by its ID. Original code here:

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -20,6 +20,8 @@ import argparse
 import logging
 import sys
 
+import requests_cache
+
 from paasta_tools import chronos_serviceinit
 from paasta_tools import marathon_serviceinit
 from paasta_tools.cli.cmds.status import get_actual_deployments
@@ -85,6 +87,9 @@ def main():
     else:
         log.error("The name of service or the name of instance to inspect is missing. Exiting.")
         sys.exit(1)
+
+    # Setting up transparent cache for http API calls
+    requests_cache.install_cache("paasta_serviceinit", backend="memory")
 
     cluster = load_system_paasta_config().get_cluster()
     actual_deployments = get_actual_deployments(service, args.soa_dir)


### PR DESCRIPTION
Current http request cache is installed at either marathon or chronos serviceinit per service.instance. Move it up at paasta serviceinit to serve all service instances.