### PR TITLE
Try to be more consistent about running 'master' scripts on the current leader

### DIFF
--- a/paasta_tools/autoscale_all_services.py
+++ b/paasta_tools/autoscale_all_services.py
@@ -16,6 +16,7 @@ import argparse
 
 from paasta_tools.autoscaling_lib import autoscale_services
 from paasta_tools.marathon_tools import DEFAULT_SOA_DIR
+from paasta_tools.mesos_tools import is_mesos_leader
 
 
 def parse_args():
@@ -33,5 +34,5 @@ def main():
     autoscale_services(soa_dir)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__" and is_mesos_leader():
     main()

--- a/paasta_tools/autoscale_cluster.py
+++ b/paasta_tools/autoscale_cluster.py
@@ -16,6 +16,7 @@ import argparse
 import logging
 
 from paasta_tools.autoscaling_lib import autoscale_local_cluster
+from paasta_tools.mesos_tools import is_mesos_leader
 
 
 log = logging.getLogger(__name__)
@@ -41,5 +42,5 @@ def main():
     autoscale_local_cluster()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__" and is_mesos_leader():
     main()

--- a/paasta_tools/check_chronos_jobs.py
+++ b/paasta_tools/check_chronos_jobs.py
@@ -16,6 +16,7 @@ from paasta_tools import utils
 from paasta_tools.chronos_tools import compose_check_name_for_service_instance
 from paasta_tools.chronos_tools import DEFAULT_SOA_DIR
 from paasta_tools.chronos_tools import load_chronos_job_config
+from paasta_tools.mesos_tools import is_mesos_leader
 
 
 def parse_args():
@@ -205,6 +206,6 @@ def main(args):
             soa_dir=soa_dir,
         )
 
-if __name__ == '__main__':
+if __name__ == "__main__" and is_mesos_leader():
     args = parse_args()
     main(args)

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -379,7 +379,6 @@ def get_smartstack_replication_for_attribute(attribute, service, namespace, blac
 
 
 def main():
-
     args = parse_args()
     soa_dir = args.soa_dir
 
@@ -407,6 +406,5 @@ def main():
         )
 
 
-if __name__ == "__main__":
-    if mesos_tools.is_mesos_leader():
-        main()
+if __name__ == "__main__" and mesos_tools.is_mesos_leader():
+    main()

--- a/paasta_tools/check_mesos_resource_utilization.py
+++ b/paasta_tools/check_mesos_resource_utilization.py
@@ -21,7 +21,6 @@ isn't the leader, the script exits immediately.
 """
 import argparse
 import logging
-import sys
 
 import pysensu_yelp
 
@@ -112,9 +111,5 @@ def main():
     print check_thresholds(args.percent)
 
 
-if __name__ == "__main__":
-    if is_mesos_leader():
-        main()
-    else:
-        print "No the leader. Exiting 0."
-        sys.exit(0)
+if __name__ == "__main__" and is_mesos_leader():
+    main()


### PR DESCRIPTION
We seem to be not very consistent with ensuring these scripts run on the current leader.

I found that my autoscale_cluster was running 3 copies at once, causing issues. It and these other script are only designed to run "one at a time" on the current leader.