### PR TITLE
Make setup_marathon_job aware of hosts marked as draining

### DIFF
--- a/paasta_itests/docker-compose.yml
+++ b/paasta_itests/docker-compose.yml
@@ -23,6 +23,30 @@ mesosslave:
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
 
+mesosslave2:
+  build: ../yelp_package/dockerfiles/itest/mesos/
+  ports:
+    - 5051
+  links:
+    - zookeeper
+  environment:
+    -CLUSTER: testcluster
+  command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret --containerizers=docker --docker=/usr/bin/docker'
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+
+mesosslave3:
+  build: ../yelp_package/dockerfiles/itest/mesos/
+  ports:
+    - 5051
+  links:
+    - zookeeper
+  environment:
+    -CLUSTER: testcluster
+  command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret --containerizers=docker --docker=/usr/bin/docker'
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+
 marathon:
   build: ../yelp_package/dockerfiles/itest/marathon/
   ports:
@@ -39,6 +63,8 @@ paastatools:
     - marathon
     - mesosmaster
     - mesosslave
+    - mesosslave2
+    - mesosslave3
     - zookeeper
     - chronos
     - hacheck

--- a/paasta_itests/docker-compose.yml
+++ b/paasta_itests/docker-compose.yml
@@ -19,31 +19,6 @@ mesosslave:
   environment:
     -CLUSTER: testcluster
   command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret --containerizers=docker --docker=/usr/bin/docker --attributes="region:fakeregion;pool:default"'
-  hostname: mesosslave.test_hostname
-  volumes:
-    - /var/run/docker.sock:/var/run/docker.sock
-
-mesosslave2:
-  build: ../yelp_package/dockerfiles/itest/mesos/
-  ports:
-    - 5051
-  links:
-    - zookeeper
-  environment:
-    -CLUSTER: testcluster
-  command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret --containerizers=docker --docker=/usr/bin/docker'
-  volumes:
-    - /var/run/docker.sock:/var/run/docker.sock
-
-mesosslave3:
-  build: ../yelp_package/dockerfiles/itest/mesos/
-  ports:
-    - 5051
-  links:
-    - zookeeper
-  environment:
-    -CLUSTER: testcluster
-  command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret --containerizers=docker --docker=/usr/bin/docker'
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
 
@@ -63,8 +38,6 @@ paastatools:
     - marathon
     - mesosmaster
     - mesosslave
-    - mesosslave2
-    - mesosslave3
     - zookeeper
     - chronos
     - hacheck

--- a/paasta_itests/paasta_api.feature
+++ b/paasta_itests/paasta_api.feature
@@ -4,7 +4,7 @@ Feature: paasta_api
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we run the marathon app "test-service.main"
+     When we run the marathon app "test-service.main" with "1" instances
       And we wait for it to be deployed
      Then instance GET should return app_count "1" and an expected number of running instances for "test-service.main"
       And instance GET should return error code "404" for "test-service.non-existent"

--- a/paasta_itests/paasta_api.feature
+++ b/paasta_itests/paasta_api.feature
@@ -6,7 +6,7 @@ Feature: paasta_api
       And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main"
       And we wait for it to be deployed
-     Then instance GET should return app_count "1" and an expected number of running instances for "test-service.main"
+     Then instance GET should return app_count "2" and an expected number of running instances for "test-service.main"
       And instance GET should return error code "404" for "test-service.non-existent"
 
 # vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2

--- a/paasta_itests/paasta_api.feature
+++ b/paasta_itests/paasta_api.feature
@@ -6,7 +6,7 @@ Feature: paasta_api
       And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main"
       And we wait for it to be deployed
-     Then instance GET should return app_count "2" and an expected number of running instances for "test-service.main"
+     Then instance GET should return app_count "1" and an expected number of running instances for "test-service.main"
       And instance GET should return error code "404" for "test-service.non-existent"
 
 # vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2

--- a/paasta_itests/paasta_metastatus.feature
+++ b/paasta_itests/paasta_metastatus.feature
@@ -14,7 +14,7 @@ Feature: paasta_metastatus describes the state of the paasta cluster
   Scenario: High memory usage
     Given a working paasta cluster
      When an app with id "memtest" using high memory is launched
-      And a task belonging to the app with id "memtest" is in the task list
+      And 3 tasks belonging to the app with id "memtest" are in the task list
      Then paasta_metastatus -v exits with return code "2" and output "CRITICAL: Less than 10% memory available."
 
   # paasta_metastatus defines "high" disk usage as > 90% of the total cluster
@@ -22,7 +22,7 @@ Feature: paasta_metastatus describes the state of the paasta cluster
   Scenario: High disk usage
     Given a working paasta cluster
     When an app with id "disktest" using high disk is launched
-     And a task belonging to the app with id "disktest" is in the task list
+     And 3 tasks belonging to the app with id "disktest" are in the task list
     Then paasta_metastatus -v exits with return code "2" and output "CRITICAL: Less than 10% disk available."
 
   # paasta_metastatus defines 'high' cpu usage as > 90% of the total cluster
@@ -37,7 +37,7 @@ Feature: paasta_metastatus describes the state of the paasta cluster
   Scenario: High cpu usage
     Given a working paasta cluster
      When an app with id "cputest" using high cpu is launched
-      And a task belonging to the app with id "cputest" is in the task list
+      And 3 tasks belonging to the app with id "cputest" are in the task list
      Then paasta_metastatus -v exits with return code "2" and output "CRITICAL: Less than 10% CPUs available."
 
   Scenario: With a launched chronos job

--- a/paasta_itests/paasta_metastatus.feature
+++ b/paasta_itests/paasta_metastatus.feature
@@ -57,6 +57,6 @@ Feature: paasta_metastatus describes the state of the paasta cluster
      When we create a trivial marathon app
      Then paasta_metastatus -v exits with return code "0" and output " "
      Then paasta_metastatus -vv exits with return code "0" and output " "
-     Then paasta_metastatus -vvv exits with return code "0" and output "mesosslave.test_hostname"
+     Then paasta_metastatus -vvv exits with return code "0" and output "Hostname"
 
 # vim: set ts=2 sw=2

--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -134,7 +134,7 @@ Feature: paasta_serviceinit
      When we run the marathon app "test-service.main"
       And we wait for it to be deployed
       And we run paasta serviceinit scale --delta "1" on "test-service.main"
-      And we wait for "test-service.main" to launch exactly 2 tasks
-     Then "test-service.main" has exactly 2 requested tasks in marathon
+      And we wait for "test-service.main" to launch exactly 3 tasks
+     Then "test-service.main" has exactly 3 requested tasks in marathon
 
 # vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2

--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -133,7 +133,7 @@ Feature: paasta_serviceinit
       And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main" with "1" instances
       And we wait for it to be deployed
-      And we run paasta serviceinit scale --delta "1" on "test-service.main"
+      And we run paasta serviceinit scale --delta "2" on "test-service.main"
       And we wait for "test-service.main" to launch exactly 3 tasks
      Then "test-service.main" has exactly 3 requested tasks in marathon
 

--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -4,7 +4,7 @@ Feature: paasta_serviceinit
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we run the marathon app "test-service.main"
+     When we run the marathon app "test-service.main" with "1" instances
       And we wait for it to be deployed
      Then marathon_serviceinit status_marathon_job should return "Healthy" for "test-service.main"
 
@@ -12,7 +12,7 @@ Feature: paasta_serviceinit
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we run the marathon app "test-service.main"
+     When we run the marathon app "test-service.main" with "1" instances
       And we wait for it to be deployed
      Then marathon_serviceinit restart should get new task_ids for "test-service.main"
 
@@ -40,7 +40,7 @@ Feature: paasta_serviceinit
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we run the marathon app "test-service.main"
+     When we run the marathon app "test-service.main" with "1" instances
       And we wait for it to be deployed
      Then paasta_serviceinit status -vv for the service_instance "test-service.main" exits with return code 0 and the correct output
       And paasta_serviceinit status -s "test-service" -i "main" exits with return code 0 and the correct output
@@ -111,7 +111,7 @@ Feature: paasta_serviceinit
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we run the marathon app "test-service.main"
+     When we run the marathon app "test-service.main" with "1" instances
       And we wait for it to be deployed
       And we run paasta serviceinit "stop" on "test-service.main"
       And we wait for "test-service.main" to launch exactly 0 tasks
@@ -121,7 +121,7 @@ Feature: paasta_serviceinit
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we run the marathon app "test-service.main"
+     When we run the marathon app "test-service.main" with "1" instances
       And we wait for it to be deployed
       And we run paasta serviceinit --appid "stop" on "test-service.main"
       And we wait for "test-service.main" to launch exactly 0 tasks
@@ -131,7 +131,7 @@ Feature: paasta_serviceinit
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we run the marathon app "test-service.main"
+     When we run the marathon app "test-service.main" with "1" instances
       And we wait for it to be deployed
       And we run paasta serviceinit scale --delta "1" on "test-service.main"
       And we wait for "test-service.main" to launch exactly 3 tasks

--- a/paasta_itests/setup_marathon_job.feature
+++ b/paasta_itests/setup_marathon_job.feature
@@ -23,13 +23,13 @@ Feature: setup_marathon_job can create a "complete" app
       And a new healthy app to be deployed, with bounce strategy "crossover" and drain method "noop" and constraints [["hostname", "UNIQUE"]]
       And an old app to be destroyed with constraints [["hostname", "UNIQUE"]]
     When there are 2 old healthy tasks
-     And we mark the host "mesosslave" as at-risk
-     And setup_service is initiated
+      And we mark the host "mesosslave" as at-risk
+      And setup_service is initiated
     When there are 2 new healthy tasks
-     And setup_service is initiated
-     And we wait a bit for the old app to disappear
+      And setup_service is initiated
+      And we wait a bit for the old app to disappear
     Then the old app should be gone
-     And the tasks on the host "mesosslave" should be drained
+      And the tasks on the host "mesosslave" should be drained
 
   Scenario: marathon apps can be scaled down
     Given a working paasta cluster

--- a/paasta_itests/setup_marathon_job.feature
+++ b/paasta_itests/setup_marathon_job.feature
@@ -29,7 +29,7 @@ Feature: setup_marathon_job can create a "complete" app
       And setup_service is initiated
       And we wait a bit for the old app to disappear
     Then the old app should be gone
-      And the tasks on the host "mesosslave" should be drained
+      And there should be 0 tasks on the host "mesosslave"
 
   Scenario: marathon apps can be scaled down
     Given a working paasta cluster

--- a/paasta_itests/setup_marathon_job.feature
+++ b/paasta_itests/setup_marathon_job.feature
@@ -18,6 +18,19 @@ Feature: setup_marathon_job can create a "complete" app
       And we run setup_marathon_job until it has 5 task(s)
      Then we should see the number of instances become 5
 
+  Scenario: marathon apps can be scaled up with at-risk hosts
+    Given a working paasta cluster
+      And a new healthy app to be deployed, with bounce strategy "crossover" and drain method "noop" and constraints [["hostname", "UNIQUE"]]
+      And an old app to be destroyed with constraints [["hostname", "UNIQUE"]]
+    When there are 2 old healthy tasks
+     And we mark the host "mesosslave" as at-risk
+     And setup_service is initiated
+    When there are 2 new healthy tasks
+     And setup_service is initiated
+     And we wait a bit for the old app to disappear
+    Then the old app should be gone
+     And the tasks on the host "mesosslave" should be drained
+
   Scenario: marathon apps can be scaled down
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"

--- a/paasta_itests/setup_marathon_job.feature
+++ b/paasta_itests/setup_marathon_job.feature
@@ -20,16 +20,29 @@ Feature: setup_marathon_job can create a "complete" app
 
   Scenario: marathon apps can be scaled up with at-risk hosts
     Given a working paasta cluster
-      And a new healthy app to be deployed, with bounce strategy "crossover" and drain method "noop" and constraints [["hostname", "UNIQUE"]]
+     And a new healthy app to be deployed, with bounce strategy "crossover" and drain method "noop" and constraints [["hostname", "UNIQUE"]]
       And an old app to be destroyed with constraints [["hostname", "UNIQUE"]]
     When there are 2 old healthy tasks
-      And we mark the host "mesosslave" as at-risk
-      And setup_service is initiated
-    When there are 2 new healthy tasks
-      And setup_service is initiated
+    When setup_service is initiated
+      And there are 2 new healthy tasks
+    When we mark a host it is running on as at-risk
+    When setup_service is initiated
+      And there are 3 new healthy tasks
       And we wait a bit for the old app to disappear
     Then the old app should be gone
-      And there should be 0 tasks on the host "mesosslave"
+      And there should be 0 tasks on that at-risk host
+
+  Scenario: marathon apps can be deployed with at-risk hosts
+    Given a working paasta cluster
+      And a new healthy app to be deployed, with bounce strategy "crossover" and drain method "noop" and constraints [["hostname", "UNIQUE"]]
+    When setup_service is initiated
+      And there are 2 new healthy tasks
+    When we mark a host it is running on as at-risk
+    When setup_service is initiated
+      And there are 3 new healthy tasks
+    When setup_service is initiated
+      And there are 2 new healthy tasks
+    Then there should be 0 tasks on that at-risk host
 
   Scenario: marathon apps can be scaled down
     Given a working paasta cluster

--- a/paasta_itests/setup_marathon_job.feature
+++ b/paasta_itests/setup_marathon_job.feature
@@ -1,5 +1,5 @@
 Feature: setup_marathon_job can create a "complete" app
-    
+
   Scenario: complete apps can be deployed
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
@@ -20,29 +20,29 @@ Feature: setup_marathon_job can create a "complete" app
 
   Scenario: marathon apps can be scaled up with at-risk hosts
     Given a working paasta cluster
-     And a new healthy app to be deployed, with bounce strategy "crossover" and drain method "noop" and constraints [["hostname", "UNIQUE"]]
+      And a new healthy app to be deployed, with bounce strategy "crossover" and drain method "noop" and constraints [["hostname", "UNIQUE"]]
       And an old app to be destroyed with constraints [["hostname", "UNIQUE"]]
-    When there are 2 old healthy tasks
-    When setup_service is initiated
+     When there are 2 old healthy tasks
+     When setup_service is initiated
       And there are 2 new healthy tasks
-    When we mark a host it is running on as at-risk
-    When setup_service is initiated
+     When we mark a host it is running on as at-risk
+     When setup_service is initiated
       And there are 3 new healthy tasks
       And we wait a bit for the old app to disappear
-    Then the old app should be gone
+     Then the old app should be gone
       And there should be 0 tasks on that at-risk host
 
   Scenario: marathon apps can be deployed with at-risk hosts
     Given a working paasta cluster
       And a new healthy app to be deployed, with bounce strategy "crossover" and drain method "noop" and constraints [["hostname", "UNIQUE"]]
-    When setup_service is initiated
+     When setup_service is initiated
       And there are 2 new healthy tasks
-    When we mark a host it is running on as at-risk
-    When setup_service is initiated
+     When we mark a host it is running on as at-risk
+     When setup_service is initiated
       And there are 3 new healthy tasks
-    When setup_service is initiated
+     When setup_service is initiated
       And there are 2 new healthy tasks
-    Then there should be 0 tasks on that at-risk host
+     Then there should be 0 tasks on that at-risk host
 
   Scenario: marathon apps can be scaled down
     Given a working paasta cluster

--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -36,7 +36,7 @@ def which_id(context, which):
 
 @given(u'a new {state} app to be deployed, with bounce strategy "{bounce_method}" and drain method "{drain_method}"')
 def given_a_new_app_to_be_deployed(context, state, bounce_method, drain_method):
-    given_a_new_app_to_be_deployed_constraints(context, state, bounce_method, drain_method, str(None))
+    given_a_new_app_to_be_deployed_constraints(context, state, bounce_method, drain_method, constraints='')
 
 
 @given(u'a new {state} app to be deployed, ' +

--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -36,7 +36,7 @@ def which_id(context, which):
 
 @given(u'a new {state} app to be deployed, with bounce strategy "{bounce_method}" and drain method "{drain_method}"')
 def given_a_new_app_to_be_deployed(context, state, bounce_method, drain_method):
-    given_a_new_app_to_be_deployed_constraints(context, state, bounce_method, drain_method, constraints='')
+    given_a_new_app_to_be_deployed_constraints(context, state, bounce_method, drain_method, str(None))
 
 
 @given(u'a new {state} app to be deployed, ' +

--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -36,7 +36,7 @@ def which_id(context, which):
 
 @given(u'a new {state} app to be deployed, with bounce strategy "{bounce_method}" and drain method "{drain_method}"')
 def given_a_new_app_to_be_deployed(context, state, bounce_method, drain_method):
-    given_a_new_app_to_be_deployed_constraints(context, state, bounce_method, drain_method, str(None))
+    given_a_new_app_to_be_deployed_constraints(context, state, bounce_method, drain_method, constraints=str(None))
 
 
 @given(u'a new {state} app to be deployed, ' +

--- a/paasta_itests/steps/marathon_steps.py
+++ b/paasta_itests/steps/marathon_steps.py
@@ -36,7 +36,8 @@ def create_trivial_marathon_app(context):
                 'image': 'busybox',
             },
         },
-        'instances': 1,
+        'instances': 3,
+        'constraints': [["hostname", "UNIQUE"]],
     }
     with mock.patch('paasta_tools.bounce_lib.create_app_lock'):
         paasta_tools.bounce_lib.create_marathon_app(app_config['id'], app_config, context.marathon_client)
@@ -63,7 +64,7 @@ def when_the_task_has_started(context):
     for _ in xrange(120):
         app = context.marathon_client.get_app(APP_ID)
         happy_count = app.tasks_running
-        if happy_count >= 1:
+        if happy_count >= 3:
             return
         time.sleep(0.5)
 

--- a/paasta_itests/steps/paasta_api_steps.py
+++ b/paasta_itests/steps/paasta_api_steps.py
@@ -39,8 +39,8 @@ def service_instance_status(context, app_count, job_id):
     request.matchdict = {'service': service, 'instance': instance}
     response = instance_status(request)
 
-    assert response['app_count'] == int(app_count)
-    assert response['marathon']['running_instance_count'] == response['marathon']['expected_instance_count']
+    assert response['app_count'] == int(app_count), response
+    assert response['marathon']['running_instance_count'] == response['marathon']['expected_instance_count'], response
 
 
 @then(u'instance GET should return error code "{error_code}" for "{job_id}"')

--- a/paasta_itests/steps/paasta_metastatus_steps.py
+++ b/paasta_itests/steps/paasta_metastatus_steps.py
@@ -42,13 +42,13 @@ def all_mesos_masters_unavailable(context):
 
 @when(u'an app with id "{app_id}" using high memory is launched')
 def run_paasta_metastatus_high_mem(context, app_id):
-    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep 1000', mem=490, instances=1,
+    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep 1000', mem=490, instances=3,
                                                            container=CONTAINER))
 
 
 @when(u'an app with id "{app_id}" using high disk is launched')
 def run_paasta_metastatus_high_disk(context, app_id):
-    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep 1000', disk=95, instances=1,
+    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep 1000', disk=95, instances=3,
                                                            container=CONTAINER))
 
 
@@ -61,14 +61,20 @@ def chronos_job_launched(context, job_name):
 
 @when(u'an app with id "{app_id}" using high cpu is launched')
 def run_paasta_metastatus_high_cpu(context, app_id):
-    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep 1000', cpus=9, instances=1,
+    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep 1000', cpus=9, instances=3,
                                                            container=CONTAINER))
 
 
 @when(u'a task belonging to the app with id "{app_id}" is in the task list')
 def marathon_task_is_ready(context, app_id):
     """Wait for a task with a matching task name to be ready. time out in 60 seconds """
-    marathon_tools.wait_for_app_to_launch_tasks(context.marathon_client, app_id, 1)
+    marathon_tasks_are_ready(context, 1, app_id)
+
+
+@when(u'{num:d} tasks belonging to the app with id "{app_id}" are in the task list')
+def marathon_tasks_are_ready(context, num, app_id):
+    """Wait for the specified number of  tasks with matching task names to be ready. time out in 60 seconds """
+    marathon_tools.wait_for_app_to_launch_tasks(context.marathon_client, app_id, num)
 
 
 @then(u'paasta_metastatus{flags} exits with return code "{expected_return_code}" and output "{expected_output}"')

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -38,6 +38,8 @@ def run_marathon_app(context, job_id):
                 'image': 'busybox',
             },
         },
+        'instances': 2,
+        'constraints': [["hostname", "UNIQUE"]],
     }
     with mock.patch('paasta_tools.bounce_lib.create_app_lock'):
         paasta_tools.bounce_lib.create_marathon_app(app_id, app_config, context.marathon_client)

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -130,10 +130,7 @@ def paasta_serviceinit_tail_stdstreams(context, service_instance):
     print  # sacrificial line for behave to eat instead of our output
 
     assert exit_code == 0
-    # The container we run doesn't really have a stdout/stderr. The message below
-    # comes from mesos.cli, proving that paasta_serviceinit tried to read stdout/sdterr,
-    # caught the Exception and presented the right information to the user.
-    assert "No such task has the requested file or directory" in output
+    assert "stdout EOF" in output
 
 
 @then((u'paasta_serviceinit status -s "{service}" -i "{instances}"'

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -24,8 +24,8 @@ from paasta_tools.utils import _run
 from paasta_tools.utils import decompose_job_id
 
 
-@when(u'we run the marathon app "{job_id}"')
-def run_marathon_app(context, job_id):
+@when(u'we run the marathon app "{job_id}" with "{instances:d}" instances')
+def run_marathon_app(context, job_id, instances):
     (service, instance, _, __) = decompose_job_id(job_id)
     app_id = marathon_tools.create_complete_config(service, instance, soa_dir=context.soa_dir)['id']
     app_config = {
@@ -38,7 +38,7 @@ def run_marathon_app(context, job_id):
                 'image': 'busybox',
             },
         },
-        'instances': 2,
+        'instances': instances,
         'constraints': [["hostname", "UNIQUE"]],
     }
     with mock.patch('paasta_tools.bounce_lib.create_app_lock'):

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -14,6 +14,7 @@
 import contextlib
 from time import sleep
 
+import mesos.cli.master
 import mock
 from behave import then
 from behave import when
@@ -22,6 +23,7 @@ from itest_utils import update_context_marathon_config
 from marathon.exceptions import MarathonHttpError
 
 from paasta_tools import marathon_tools
+from paasta_tools import paasta_maintenance
 from paasta_tools import setup_marathon_job
 from paasta_tools.autoscaling_lib import set_instances_for_marathon_service
 from paasta_tools.marathon_tools import MarathonServiceConfig
@@ -61,12 +63,18 @@ def setup_zookeeper(context, number):
 
 @when(u'we create a marathon app called "{job_id}" with {number:d} instance(s)')
 def create_app_with_instances(context, job_id, number):
+    create_app_with_instances_constraints(context, job_id, number, str(None))
+
+
+@when(u'we create a marathon app called "{job_id}" with {number:d} instance(s) and constraints {constraints}')
+def create_app_with_instances_constraints(context, job_id, number, constraints):
     set_number_instances(context, number)
     context.job_id = job_id
     (service, instance, _, __) = decompose_job_id(job_id)
     context.service = service
     context.instance = instance
     context.zk_hosts = '%s/mesos-testcluster' % get_service_connection_string('zookeeper')
+    context.constraints = constraints
     update_context_marathon_config(context)
     context.app_id = context.marathon_complete_config['id']
     run_setup_marathon_job(context)
@@ -80,7 +88,12 @@ def set_number_instances(context, number):
 @when(u'we run setup_marathon_job until it has {number:d} task(s)')
 def run_until_number_tasks(context, number):
     for _ in xrange(20):
-        run_setup_marathon_job(context)
+        with contextlib.nested(
+            mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
+        ) as (
+            _,
+        ):
+            run_setup_marathon_job(context)
         sleep(0.5)
         if marathon_tools.app_has_tasks(context.marathon_client, context.app_id, number, exact_matches_only=True):
             return
@@ -110,3 +123,33 @@ def can_run_get_app(context):
 @then(u'we should see the number of instances become {number:d}')
 def assert_instances_equals(context, number):
     assert context.marathon_client.get_app(context.app_id).instances == number
+
+
+@when(u'we mark the host "{host}" as at-risk')
+def mark_host_at_risk(context, host):
+    start = paasta_maintenance.datetime_to_nanoseconds(paasta_maintenance.now())
+    duration = paasta_maintenance.parse_timedelta('1h')
+    config = {
+        'master': '%s' % get_service_connection_string('mesosmaster'),
+        'scheme': 'http',
+        'response_timeout': 5,
+    }
+    with contextlib.nested(
+        mock.patch('paasta_tools.paasta_maintenance.load_credentials', autospec=True),
+        mock.patch.object(mesos.cli.master, 'CFG', config),
+    ) as (
+        mock_load_credentials,
+        _,
+    ):
+        mock_load_credentials.side_effect = paasta_maintenance.load_credentials(mesos_secrets='/etc/mesos-slave-secret')
+        paasta_maintenance.drain([host], start, duration)
+
+
+@then(u'the tasks on the host "{host}" should be drained')
+def tasks_on_host_drained(context, host):
+    app_id = context.new_id
+    tasks = context.marathon_client.list_tasks(app_id)
+    for task in tasks:
+        if task.host == host:
+            return False
+    return True

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -145,11 +145,12 @@ def mark_host_at_risk(context, host):
         paasta_maintenance.drain([host], start, duration)
 
 
-@then(u'the tasks on the host "{host}" should be drained')
-def tasks_on_host_drained(context, host):
+@then(u'there should be {number:d} tasks on the host "{host}"')
+def tasks_on_host_drained(context, number, host):
     app_id = context.new_id
     tasks = context.marathon_client.list_tasks(app_id)
+    count = 0
     for task in tasks:
         if task.host == host:
-            return False
-    return True
+            count += 1
+    return count == number

--- a/paasta_tools/graceful_app_drain.py
+++ b/paasta_tools/graceful_app_drain.py
@@ -7,7 +7,7 @@ from paasta_tools import bounce_lib
 from paasta_tools import drain_lib
 from paasta_tools import marathon_tools
 from paasta_tools.setup_marathon_job import do_bounce
-from paasta_tools.setup_marathon_job import get_old_happy_unhappy_draining_tasks
+from paasta_tools.setup_marathon_job import get_tasks_by_state
 from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import load_system_paasta_config
 
@@ -73,7 +73,8 @@ def main():
         (old_app_live_happy_tasks,
          old_app_live_unhappy_tasks,
          old_app_draining_tasks,
-         ) = get_old_happy_unhappy_draining_tasks(
+         old_app_at_risk_tasks,
+         ) = get_tasks_by_state(
              other_apps=[app_to_kill],
              drain_method=drain_method,
              service=service,

--- a/paasta_tools/paasta_maintenance.py
+++ b/paasta_tools/paasta_maintenance.py
@@ -143,7 +143,11 @@ def schedule():
     """Get the Mesos maintenance schedule. This contains hostname/ip mappings and their maintenance window.
     :returns: None
     """
-    schedule = get_maintenance_schedule()
+    try:
+        schedule = get_maintenance_schedule()
+    except HTTPError as e:
+        e.msg = "Error getting maintenance schedule. Got error: %s" % e.msg
+        raise
     print "%s:%s" % (schedule, schedule.text)
 
 
@@ -154,7 +158,11 @@ def get_hosts_with_state(state):
     :param state: State we are interested in ('down_machines' or 'draining_machines')
     :returns: A list of hostnames in the specified state or an empty list if no machines
     """
-    status = get_maintenance_status().json()
+    try:
+        status = get_maintenance_status().json()
+    except HTTPError as e:
+        e.msg = "Error getting maintenance status. Got error: %s" % e.msg
+        raise
     if not status or state not in status:
         return []
     return [machine['id']['hostname'] for machine in status[state]]
@@ -347,7 +355,12 @@ def drain(hostnames, start, duration):
     log.info("Draining: %s" % hostnames)
     payload = build_maintenance_schedule_payload(hostnames, start, duration, drain=True)
     client_fn = get_schedule_client()
-    print client_fn(method="POST", endpoint="", data=json.dumps(payload)).text
+    try:
+        drain_output = client_fn(method="POST", endpoint="", data=json.dumps(payload)).text
+    except HTTPError as e:
+        e.msg = "Error performing maintenance drain. Got error: %s" % e.msg
+        raise
+    print drain_output
 
 
 def undrain(hostnames):
@@ -358,7 +371,12 @@ def undrain(hostnames):
     """
     payload = build_maintenance_schedule_payload(hostnames, drain=False)
     client_fn = get_schedule_client()
-    print client_fn(method="POST", endpoint="", data=json.dumps(payload)).text
+    try:
+        undrain_output = client_fn(method="POST", endpoint="", data=json.dumps(payload)).text
+    except HTTPError as e:
+        e.msg = "Error performing maintenance drain. Got error: %s" % e.msg
+        raise
+    print undrain_output
 
 
 def down(hostnames):
@@ -368,7 +386,12 @@ def down(hostnames):
     """
     payload = build_start_maintenance_payload(hostnames)
     client_fn = master_api()
-    print client_fn(method="POST", endpoint="/machine/down", data=json.dumps(payload)).text
+    try:
+        down_output = client_fn(method="POST", endpoint="/machine/down", data=json.dumps(payload)).text
+    except HTTPError as e:
+        e.msg = "Error performing maintenance down. Got error: %s" % e.msg
+        raise
+    print down_output
 
 
 def up(hostnames):
@@ -378,7 +401,12 @@ def up(hostnames):
     """
     payload = build_start_maintenance_payload(hostnames)
     client_fn = master_api()
-    print client_fn(method="POST", endpoint="/machine/up", data=json.dumps(payload)).text
+    try:
+        up_output = client_fn(method="POST", endpoint="/machine/up", data=json.dumps(payload)).text
+    except HTTPError as e:
+        e.msg = "Error performing maintenance up. Got error: %s" % e.msg
+        raise
+    print up_output
 
 
 def status():
@@ -386,7 +414,11 @@ def status():
     down for maintenance or draining.
     :returns: None
     """
-    status = get_maintenance_status()
+    try:
+        status = get_maintenance_status()
+    except HTTPError as e:
+        e.msg = "Error performing maintenance status. Got error: %s" % e.msg
+        raise
     print "%s:%s" % (status, status.text)
 
 

--- a/paasta_tools/paasta_maintenance.py
+++ b/paasta_tools/paasta_maintenance.py
@@ -122,9 +122,9 @@ def get_schedule_client():
 
 
 def get_maintenance_schedule():
-    """Makes a GET request to the /master/maintenance API endpoint
+    """Makes a GET request to the /master/maintenance/schedule API endpoint
 
-    :returns: a function that can be called to make a request to /master/maintenance
+    :returns: a function that can be called to make a request to /master/maintenance/schedule
     """
     client_fn = get_schedule_client()
     return client_fn(method="GET", endpoint="")
@@ -135,8 +135,16 @@ def get_maintenance_status():
 
     :returns: a requests.response object representing the current maintenance status
     """
-    client_fn = get_schedule_client()
+    client_fn = maintenance_api()
     return client_fn(method="GET", endpoint="/status")
+
+
+def schedule():
+    """Get the Mesos maintenance schedule. This contains hostname/ip mappings and their maintenance window.
+    :returns: None
+    """
+    schedule = get_maintenance_schedule()
+    print "%s:%s" % (schedule, schedule.text)
 
 
 def get_hosts_with_state(state):
@@ -146,7 +154,7 @@ def get_hosts_with_state(state):
     :param state: State we are interested in ('down_machines' or 'draining_machines')
     :returns: A list of hostnames in the specified state or an empty list if no machines
     """
-    status = get_maintenance_status()
+    status = get_maintenance_status().json()
     if not status or state not in status:
         return []
     return [machine['id']['hostname'] for machine in status[state]]
@@ -380,14 +388,6 @@ def status():
     """
     status = get_maintenance_status()
     print "%s:%s" % (status, status.text)
-
-
-def schedule():
-    """Get the Mesos maintenance schedule. This contains hostname/ip mappings and their maintenance window.
-    :returns: None
-    """
-    schedule = get_maintenance_schedule()
-    print "%s:%s" % (schedule, schedule.text)
 
 
 def paasta_maintenance():

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -53,6 +53,7 @@ from paasta_tools import bounce_lib
 from paasta_tools import drain_lib
 from paasta_tools import marathon_tools
 from paasta_tools import monitoring_tools
+from paasta_tools.marathon_tools import get_num_at_risk_tasks
 from paasta_tools.marathon_tools import kill_given_tasks
 from paasta_tools.paasta_maintenance import get_draining_hosts
 from paasta_tools.utils import _log
@@ -382,23 +383,6 @@ def get_tasks_by_state(other_apps, drain_method, service, nerve_ns, bounce_healt
         old_app_at_risk_tasks[app.id] = tasks_by_state['at_risk']
 
     return old_app_live_happy_tasks, old_app_live_unhappy_tasks, old_app_draining_tasks, old_app_at_risk_tasks
-
-
-def get_num_at_risk_tasks(app):
-    """Determine how many of an application's tasks are running on
-    at-risk (Mesos Maintenance Draining) hosts.
-
-    :param app: A marathon application
-    :returns: An integer representing the number of tasks running on at-risk hosts
-    """
-    hosts_tasks_running_on = [task.host for task in app.tasks]
-    draining_hosts = get_draining_hosts()
-    num_at_risk_tasks = 0
-    for host in hosts_tasks_running_on:
-        if host in draining_hosts:
-            num_at_risk_tasks += 1
-    log.debug("%s has %d tasks running on at-risk hosts." % (app.id, num_at_risk_tasks))
-    return num_at_risk_tasks
 
 
 def undrain_tasks(to_undrain, leave_draining, drain_method, log_deploy_error):

--- a/tests/test_paasta_maintenance.py
+++ b/tests/test_paasta_maintenance.py
@@ -428,9 +428,9 @@ def test_undrain(
 ):
     fake_schedule = {'fake_schedule': 'fake_value'}
     mock_build_maintenance_schedule_payload.return_value = fake_schedule
-    undrain(hostnames=['some-host'], start='some-start', duration='some-duration')
+    undrain(hostnames=['some-host'])
     assert mock_build_maintenance_schedule_payload.call_count == 1
-    expected_args = mock.call(['some-host'], 'some-start', 'some-duration', drain=False)
+    expected_args = mock.call(['some-host'], drain=False)
     assert mock_build_maintenance_schedule_payload.call_args == expected_args
     assert mock_get_schedule_client.call_count == 1
     assert mock_get_schedule_client.return_value.call_count == 1

--- a/tests/test_paasta_maintenance.py
+++ b/tests/test_paasta_maintenance.py
@@ -382,14 +382,14 @@ def test_load_credentials_keyerror(
         assert load_credentials()
 
 
-@mock.patch('paasta_tools.paasta_maintenance.get_schedule_client')
+@mock.patch('paasta_tools.paasta_maintenance.maintenance_api')
 def test_get_maintenance_status(
-    mock_get_schedule_client,
+    mock_maintenance_api,
 ):
     get_maintenance_status()
-    assert mock_get_schedule_client.call_count == 1
-    assert mock_get_schedule_client.return_value.call_count == 1
-    assert mock_get_schedule_client.return_value.call_args == mock.call(method="GET", endpoint="/status")
+    assert mock_maintenance_api.call_count == 1
+    assert mock_maintenance_api.return_value.call_count == 1
+    assert mock_maintenance_api.return_value.call_args == mock.call(method="GET", endpoint="/status")
 
 
 @mock.patch('paasta_tools.paasta_maintenance.get_schedule_client')
@@ -506,7 +506,9 @@ def test_schedule(
 def test_get_hosts_with_state_none(
     mock_get_maintenance_status,
 ):
-    mock_get_maintenance_status.return_value = {}
+    fake_status = {}
+    mock_get_maintenance_status.return_value = mock.Mock()
+    mock_get_maintenance_status.return_value.json.return_value = fake_status
     assert get_hosts_with_state(state='fake_state') == []
 
 
@@ -530,7 +532,8 @@ def test_get_hosts_with_state_draining(
             }
         ]
     }
-    mock_get_maintenance_status.return_value = fake_status
+    mock_get_maintenance_status.return_value = mock.Mock()
+    mock_get_maintenance_status.return_value.json.return_value = fake_status
     expected = sorted(['fake-host1.fakesite.something', 'fake-host2.fakesite.something'])
     assert sorted(get_hosts_with_state(state='draining_machines')) == expected
 
@@ -555,7 +558,8 @@ def test_get_hosts_with_state_down(
             }
         ]
     }
-    mock_get_maintenance_status.return_value = fake_status
+    mock_get_maintenance_status.return_value = mock.Mock()
+    mock_get_maintenance_status.return_value.json.return_value = fake_status
     expected = sorted(['fake-host1.fakesite.something', 'fake-host2.fakesite.something'])
     assert sorted(get_hosts_with_state(state='down_machines')) == expected
 

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -296,17 +296,15 @@ class TestSetupMarathonJob:
         expected_check_name = 'paasta_bounce_progress.%s' % compose_job_id(fake_service, fake_instance)
         with contextlib.nested(
             mock.patch("paasta_tools.monitoring_tools.send_event", autospec=True),
-            mock.patch("paasta_tools.marathon_tools.load_marathon_service_config", autospec=True),
         ) as (
             send_event_patch,
-            load_marathon_service_config_patch,
         ):
-            load_marathon_service_config_patch.return_value.get_monitoring.return_value = {}
             setup_marathon_job.send_sensu_bounce_keepalive(
                 service=fake_service,
                 instance=fake_instance,
                 cluster=fake_cluster,
                 soa_dir=fake_soa_dir,
+                config={},
             )
             send_event_patch.assert_called_once_with(
                 service=fake_service,
@@ -316,13 +314,6 @@ class TestSetupMarathonJob:
                 output=mock.ANY,
                 soa_dir=fake_soa_dir,
                 ttl='1h',
-            )
-            load_marathon_service_config_patch.assert_called_once_with(
-                service=fake_service,
-                instance=fake_instance,
-                cluster=fake_cluster,
-                load_deployments=False,
-                soa_dir=fake_soa_dir,
             )
 
     def test_do_bounce_when_create_app_and_new_app_not_running(self):
@@ -657,6 +648,7 @@ class TestSetupMarathonJob:
                 instance=fake_instance,
                 cluster=self.fake_cluster,
                 soa_dir='fake_soa_dir',
+                config=fake_config,
             )
 
     def test_do_bounce_when_all_old_tasks_are_unhappy(self):

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -93,6 +93,7 @@ class TestSetupMarathonJob:
             mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.send_event', autospec=True),
             mock.patch('sys.exit', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
         ) as (
             parse_args_patch,
             get_main_conf_patch,
@@ -102,6 +103,7 @@ class TestSetupMarathonJob:
             load_system_paasta_config_patch,
             sensu_patch,
             sys_exit_patch,
+            _,
         ):
             load_system_paasta_config_patch.return_value.get_cluster = mock.Mock(return_value=self.fake_cluster)
             setup_marathon_job.main()
@@ -338,6 +340,7 @@ class TestSetupMarathonJob:
         fake_old_app_live_happy_tasks = {}
         fake_old_app_live_unhappy_tasks = {}
         fake_old_app_draining_tasks = {}
+        fake_old_app_at_risk_tasks = {}
         fake_service = 'fake_service'
         fake_serviceinstance = 'fake_service.fake_instance'
         self.fake_cluster = 'fake_cluster'
@@ -365,6 +368,7 @@ class TestSetupMarathonJob:
                 old_app_live_happy_tasks=fake_old_app_live_happy_tasks,
                 old_app_live_unhappy_tasks=fake_old_app_live_unhappy_tasks,
                 old_app_draining_tasks=fake_old_app_draining_tasks,
+                old_app_at_risk_tasks=fake_old_app_at_risk_tasks,
                 service=fake_service,
                 bounce_method=fake_bounce_method,
                 serviceinstance=fake_serviceinstance,
@@ -403,6 +407,7 @@ class TestSetupMarathonJob:
         fake_old_app_live_happy_tasks = {'fake_app_to_kill_1': set([fake_task_to_drain])}
         fake_old_app_live_unhappy_tasks = {'fake_app_to_kill_1': set()}
         fake_old_app_draining_tasks = {'fake_app_to_kill_1': set()}
+        fake_old_app_at_risk_tasks = {'fake_app_to_kill_1': set()}
         fake_service = 'fake_service'
         fake_serviceinstance = 'fake_service.fake_instance'
         self.fake_cluster = 'fake_cluster'
@@ -430,6 +435,7 @@ class TestSetupMarathonJob:
                 old_app_live_happy_tasks=fake_old_app_live_happy_tasks,
                 old_app_live_unhappy_tasks=fake_old_app_live_unhappy_tasks,
                 old_app_draining_tasks=fake_old_app_draining_tasks,
+                old_app_at_risk_tasks=fake_old_app_at_risk_tasks,
                 service=fake_service,
                 bounce_method=fake_bounce_method,
                 serviceinstance=fake_serviceinstance,
@@ -466,6 +472,7 @@ class TestSetupMarathonJob:
         fake_old_app_live_happy_tasks = {'fake_app_to_kill_1': set([fake_task_to_drain])}
         fake_old_app_live_unhappy_tasks = {'fake_app_to_kill_1': set([])}
         fake_old_app_draining_tasks = {'fake_app_to_kill_1': set([])}
+        fake_old_app_at_risk_tasks = {'fake_app_to_kill_1': set([])}
         fake_service = 'fake_service'
         fake_serviceinstance = 'fake_service.fake_instance'
         self.fake_cluster = 'fake_cluster'
@@ -493,6 +500,7 @@ class TestSetupMarathonJob:
                 old_app_live_happy_tasks=fake_old_app_live_happy_tasks,
                 old_app_live_unhappy_tasks=fake_old_app_live_unhappy_tasks,
                 old_app_draining_tasks=fake_old_app_draining_tasks,
+                old_app_at_risk_tasks=fake_old_app_at_risk_tasks,
                 service=fake_service,
                 bounce_method=fake_bounce_method,
                 serviceinstance=fake_serviceinstance,
@@ -529,6 +537,7 @@ class TestSetupMarathonJob:
         fake_old_app_live_happy_tasks = {'fake_app_to_kill_1': set()}
         fake_old_app_live_unhappy_tasks = {'fake_app_to_kill_1': set()}
         fake_old_app_draining_tasks = {'fake_app_to_kill_1': set()}
+        fake_old_app_at_risk_tasks = {'fake_app_to_kill_1': set()}
         fake_service = 'fake_service'
         fake_serviceinstance = 'fake_service.fake_instance'
         self.fake_cluster = 'fake_cluster'
@@ -555,6 +564,7 @@ class TestSetupMarathonJob:
                 old_app_live_happy_tasks=fake_old_app_live_happy_tasks,
                 old_app_live_unhappy_tasks=fake_old_app_live_unhappy_tasks,
                 old_app_draining_tasks=fake_old_app_draining_tasks,
+                old_app_at_risk_tasks=fake_old_app_at_risk_tasks,
                 service=fake_service,
                 bounce_method=fake_bounce_method,
                 serviceinstance=fake_serviceinstance,
@@ -595,6 +605,7 @@ class TestSetupMarathonJob:
         fake_old_app_live_happy_tasks = {}
         fake_old_app_live_unhappy_tasks = {}
         fake_old_app_draining_tasks = {}
+        fake_old_app_at_risk_tasks = {}
         fake_service = 'fake_service'
         fake_serviceinstance = 'fake_service.fake_instance'
         self.fake_cluster = 'fake_cluster'
@@ -626,6 +637,7 @@ class TestSetupMarathonJob:
                 old_app_live_happy_tasks=fake_old_app_live_happy_tasks,
                 old_app_live_unhappy_tasks=fake_old_app_live_unhappy_tasks,
                 old_app_draining_tasks=fake_old_app_draining_tasks,
+                old_app_at_risk_tasks=fake_old_app_at_risk_tasks,
                 service=fake_service,
                 bounce_method=fake_bounce_method,
                 serviceinstance=fake_serviceinstance,
@@ -664,6 +676,7 @@ class TestSetupMarathonJob:
         fake_old_app_live_happy_tasks = {'old_app': set([])}
         fake_old_app_live_unhappy_tasks = {'old_app': set(old_tasks)}
         fake_old_app_draining_tasks = {'old_app': set([])}
+        fake_old_app_at_risk_tasks = {'old_app': set([])}
         fake_service = 'fake_service'
         fake_serviceinstance = 'fake_service.fake_instance'
         self.fake_cluster = 'fake_cluster'
@@ -696,6 +709,7 @@ class TestSetupMarathonJob:
                 old_app_live_happy_tasks=fake_old_app_live_happy_tasks,
                 old_app_live_unhappy_tasks=fake_old_app_live_unhappy_tasks,
                 old_app_draining_tasks=fake_old_app_draining_tasks,
+                old_app_at_risk_tasks=fake_old_app_at_risk_tasks,
                 service=fake_service,
                 bounce_method=fake_bounce_method,
                 serviceinstance=fake_serviceinstance,
@@ -732,12 +746,14 @@ class TestSetupMarathonJob:
             mock.patch('paasta_tools.setup_marathon_job.marathon_tools.get_matching_apps', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.bounce_lib.get_happy_tasks', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.drain_lib.get_drain_method', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
         ) as (
             mock_log,
             mock_load_system_paasta_config,
             mock_get_matching_apps,
             mock_get_happy_tasks,
             mock_get_drain_method,
+            _,
         ):
             mock_load_system_paasta_config.return_value = mock.MagicMock(
                 get_cluster=mock.Mock(return_value='fake_cluster'))
@@ -760,6 +776,68 @@ class TestSetupMarathonJob:
             fake_client.scale_app.assert_called_once_with(
                 app_id='/some_id',
                 instances=5,
+                force=True,
+            )
+
+    def test_deploy_service_scale_up_at_risk_hosts(self):
+        fake_service = 'fake_service'
+        fake_instance = 'fake_instance'
+        fake_jobid = 'fake_jobid'
+        fake_config = {
+            'id': 'some_id',
+            'instances': 5,
+        }
+        fake_client = mock.MagicMock(scale_app=mock.Mock())
+        fake_bounce_method = 'bounce'
+        fake_drain_method_name = 'drain'
+        fake_drain_method_params = {}
+        fake_nerve_ns = 'nerve'
+        fake_bounce_health_params = {}
+        fake_soa_dir = '/soa/dir'
+        with contextlib.nested(
+            mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.marathon_tools.get_matching_apps', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.bounce_lib.get_happy_tasks', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.drain_lib.get_drain_method', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
+        ) as (
+            mock_log,
+            mock_load_system_paasta_config,
+            mock_get_matching_apps,
+            mock_get_happy_tasks,
+            mock_get_drain_method,
+            mock_get_draining_hosts,
+        ):
+            mock_load_system_paasta_config.return_value = mock.MagicMock(
+                get_cluster=mock.Mock(return_value='fake_cluster'))
+            mock_get_draining_hosts.return_value = ['fake-host1', 'fake-host2']
+            tasks = [
+                mock.Mock(host='fake-host1'),
+                mock.Mock(host='fake-host2'),
+                mock.Mock(host='fake-host3'),
+                mock.Mock(host='fake-host4'),
+                mock.Mock(host='fake-host5'),
+            ]
+            mock_get_matching_apps.return_value = [mock.Mock(id='/some_id', instances=1, tasks=tasks)]
+            mock_get_happy_tasks.return_value = []
+            mock_get_drain_method.return_value = mock.Mock(is_draining=mock.Mock(return_value=False))
+            setup_marathon_job.deploy_service(
+                service=fake_service,
+                instance=fake_instance,
+                marathon_jobid=fake_jobid,
+                config=fake_config,
+                client=fake_client,
+                bounce_method=fake_bounce_method,
+                drain_method_name=fake_drain_method_name,
+                drain_method_params=fake_drain_method_params,
+                nerve_ns=fake_nerve_ns,
+                bounce_health_params=fake_bounce_health_params,
+                soa_dir=fake_soa_dir,
+            )
+            fake_client.scale_app.assert_called_once_with(
+                app_id='/some_id',
+                instances=7,
                 force=True,
             )
 
@@ -787,6 +865,7 @@ class TestSetupMarathonJob:
             mock.patch('paasta_tools.setup_marathon_job.bounce_lib.get_bounce_method_func', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.bounce_lib.bounce_lock_zookeeper', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.do_bounce', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
         ) as (
             mock_log,
             mock_load_system_paasta_config,
@@ -796,11 +875,19 @@ class TestSetupMarathonJob:
             mock_get_bounce_method_func,
             mock_bounce_lock_zookeeper,
             mock_do_bounce,
+            _,
         ):
             mock_load_system_paasta_config.return_value = mock.MagicMock(
                 get_cluster=mock.Mock(return_value='fake_cluster'))
-            mock_get_matching_apps.return_value = [mock.Mock(id='/some_id', instances=5, tasks=range(5))]
-            mock_get_happy_tasks.return_value = range(5)
+            tasks = [
+                mock.Mock(hostname='fake-host1'),
+                mock.Mock(hostname='fake-host2'),
+                mock.Mock(hostname='fake-host3'),
+                mock.Mock(hostname='fake-host4'),
+                mock.Mock(hostname='fake-host5'),
+            ]
+            mock_get_matching_apps.return_value = [mock.Mock(id='/some_id', instances=5, tasks=tasks)]
+            mock_get_happy_tasks.return_value = tasks
             mock_get_drain_method.return_value = mock.Mock(is_draining=mock.Mock(return_value=False))
             setup_marathon_job.deploy_service(
                 service=fake_service,
@@ -815,7 +902,7 @@ class TestSetupMarathonJob:
                 bounce_health_params=fake_bounce_health_params,
                 soa_dir=fake_soa_dir,
             )
-            assert mock_do_bounce.call_args[1]['old_app_live_happy_tasks']['/some_id'] < set(range(5))
+            assert mock_do_bounce.call_args[1]['old_app_live_happy_tasks']['/some_id'] < set(tasks)
             assert len(mock_do_bounce.call_args[1]['old_app_live_happy_tasks']['/some_id']) == 4
 
     def test_deploy_service_scale_down_doesnt_undrain_scaling_tasks(self):
@@ -842,6 +929,7 @@ class TestSetupMarathonJob:
             mock.patch('paasta_tools.setup_marathon_job.bounce_lib.get_bounce_method_func', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.bounce_lib.bounce_lock_zookeeper', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.do_bounce', autospec=True),
+            mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
         ) as (
             mock_log,
             mock_load_system_paasta_config,
@@ -851,15 +939,24 @@ class TestSetupMarathonJob:
             mock_get_bounce_method_func,
             mock_bounce_lock_zookeeper,
             mock_do_bounce,
+            _,
         ):
             mock_stop_draining = mock.MagicMock()
 
             mock_load_system_paasta_config.return_value = mock.MagicMock(
                 get_cluster=mock.Mock(return_value='fake_cluster'))
-            mock_get_matching_apps.return_value = [mock.Mock(id='/some_id', instances=5, tasks=range(5))]
-            mock_get_happy_tasks.return_value = range(5)
-            # this drain method gives us 1 healthy task (0) and 4 draining tasks (1, 2, 3, 4)
-            mock_get_drain_method.return_value = mock.Mock(is_draining=lambda x: x != 0,
+            tasks = [
+                mock.Mock(host='fake-host1'),
+                mock.Mock(host='fake-host2'),
+                mock.Mock(host='fake-host3'),
+                mock.Mock(host='fake-host4'),
+                mock.Mock(host='fake-host5'),
+            ]
+            mock_get_matching_apps.return_value = [mock.Mock(id='/some_id', instances=5, tasks=tasks)]
+
+            mock_get_happy_tasks.return_value = tasks
+            # this drain method gives us 1 healthy task (fake-host1) and 4 draining tasks (fake-host[2-5])
+            mock_get_drain_method.return_value = mock.Mock(is_draining=lambda x: x.host != 'fake-host1',
                                                            stop_draining=mock_stop_draining,)
             setup_marathon_job.deploy_service(
                 service=fake_service,
@@ -874,7 +971,7 @@ class TestSetupMarathonJob:
                 bounce_health_params=fake_bounce_health_params,
                 soa_dir=fake_soa_dir,
             )
-            assert mock_do_bounce.call_args[1]['old_app_draining_tasks']['/some_id'] < set([1, 2, 3, 4])
+            assert mock_do_bounce.call_args[1]['old_app_draining_tasks']['/some_id'] < set(tasks[1:])
             assert len(mock_do_bounce.call_args[1]['old_app_draining_tasks']['/some_id']) == 2
             # we don't bounce happy tasks when draining tasks are available
             assert mock_do_bounce.call_args[1]['old_app_live_happy_tasks']['/some_id'] == set([])
@@ -908,10 +1005,15 @@ class TestSetupMarathonJob:
                 'paasta_tools.setup_marathon_job.deploy_service',
                 autospec=True,
             ),
+            mock.patch(
+                'paasta_tools.setup_marathon_job.get_draining_hosts',
+                autospec=True,
+            ),
         ) as (
             format_marathon_app_dict_patch,
             get_config_patch,
             deploy_service_patch,
+            _,
         ):
             setup_marathon_job.setup_service(
                 service=fake_name,
@@ -985,6 +1087,10 @@ class TestSetupMarathonJob:
                 return_value=fake_bounce_margin_factor,
                 autospec=True,
             ),
+            mock.patch(
+                'paasta_tools.setup_marathon_job.get_draining_hosts',
+                autospec=True,
+            ),
         ) as (
             deploy_service_patch,
             get_bounce_patch,
@@ -994,6 +1100,7 @@ class TestSetupMarathonJob:
             read_service_conf_patch,
             read_namespace_conf_patch,
             get_bounce_margin_factor_patch,
+            _,
         ):
             status, output = setup_marathon_job.setup_service(
                 service=fake_name,
@@ -1064,8 +1171,14 @@ class TestSetupMarathonJob:
             mock.patch(
                 'paasta_tools.drain_lib._drain_methods',
                 new={'exists1': mock.Mock(), 'exists2': mock.Mock()},
-            )
-        ) as (mock_log, mock_load_system_paasta_config, mock_drain_methods):
+            ),
+            mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
+        ) as (
+            mock_log,
+            mock_load_system_paasta_config,
+            mock_drain_methods,
+            _,
+        ):
             mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value='fake_cluster')
             actual = setup_marathon_job.deploy_service(
                 service=fake_name,
@@ -1101,7 +1214,12 @@ class TestSetupMarathonJob:
         with contextlib.nested(
             mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
-        ) as (mock_log, mock_load_system_paasta_config):
+            mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
+        ) as (
+            mock_log,
+            mock_load_system_paasta_config,
+            _,
+        ):
             mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value='fake_cluster')
             actual = setup_marathon_job.deploy_service(
                 service=fake_name,
@@ -1171,7 +1289,18 @@ class TestSetupMarathonJob:
             mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.drain_lib.get_drain_method', return_value=fake_drain_method),
-        ) as (_, _, _, kill_old_ids_patch, create_marathon_app_patch, mock_log, mock_load_system_paasta_config, _):
+            mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
+        ) as (
+            _,
+            _,
+            _,
+            kill_old_ids_patch,
+            create_marathon_app_patch,
+            mock_log,
+            mock_load_system_paasta_config,
+            _,
+            _,
+        ):
             mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value='fake_cluster')
             result = setup_marathon_job.deploy_service(
                 service=fake_name,
@@ -1264,7 +1393,15 @@ class TestSetupMarathonJob:
             ),
             mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
-        ) as (_, _, _, _, mock_load_system_paasta_config):
+            mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
+        ) as (
+            _,
+            _,
+            _,
+            _,
+            mock_load_system_paasta_config,
+            _,
+        ):
             mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value='fake_cluster')
             result = setup_marathon_job.deploy_service(
                 service=fake_name,
@@ -1296,7 +1433,13 @@ class TestSetupMarathonJob:
             mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.bounce_lib.get_bounce_method_func', side_effect=IOError('foo')),
             mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
-        ) as (mock_log, mock_bounce, mock_load_system_paasta_config):
+            mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
+        ) as (
+            mock_log,
+            mock_bounce,
+            mock_load_system_paasta_config,
+            _,
+        ):
             mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value='fake_cluster')
             with raises(IOError):
                 setup_marathon_job.deploy_service(
@@ -1336,7 +1479,7 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
     def fake_get_happy_tasks(self, app, service, nerve_ns, system_paasta_config, **kwargs):
         return [t for t in app.tasks if t._happiness == 'happy']
 
-    def test_get_old_happy_unhappy_draining_tasks_empty(self):
+    def test_get_tasks_by_state_empty(self):
         fake_name = 'whoa'
         fake_instance = 'the_earth_is_tiny'
         fake_id = marathon_tools.format_job_id(fake_name, fake_instance)
@@ -1359,9 +1502,19 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
             fake_apps[0].id: set(),
             fake_apps[1].id: set(),
         }
+        expected_at_risk_tasks = {
+            fake_apps[0].id: set(),
+            fake_apps[1].id: set(),
+        }
 
-        with mock.patch('paasta_tools.bounce_lib.get_happy_tasks', side_effect=self.fake_get_happy_tasks):
-            actual = setup_marathon_job.get_old_happy_unhappy_draining_tasks(
+        with contextlib.nested(
+            mock.patch('paasta_tools.bounce_lib.get_happy_tasks', side_effect=self.fake_get_happy_tasks),
+            mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
+        ) as (
+            _,
+            _,
+        ):
+            actual = setup_marathon_job.get_tasks_by_state(
                 fake_apps,
                 self.fake_drain_method(),
                 service=fake_name,
@@ -1369,12 +1522,13 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
                 bounce_health_params={},
                 system_paasta_config=fake_system_paasta_config,
             )
-        actual_live_happy_tasks, actual_live_unhappy_tasks, actual_draining_tasks = actual
+        actual_live_happy_tasks, actual_live_unhappy_tasks, actual_draining_tasks, actual_at_risk_tasks = actual
         assert actual_live_happy_tasks == expected_live_happy_tasks
         assert actual_live_unhappy_tasks == expected_live_unhappy_tasks
         assert actual_draining_tasks == expected_draining_tasks
+        assert actual_at_risk_tasks == expected_at_risk_tasks
 
-    def test_get_old_happy_unhappy_draining_tasks_not_empty(self):
+    def test_get_tasks_by_state_not_empty(self):
         fake_name = 'whoa'
         fake_instance = 'the_earth_is_tiny'
         fake_id = marathon_tools.format_job_id(fake_name, fake_instance)
@@ -1412,9 +1566,19 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
             fake_apps[0].id: set([fake_apps[0].tasks[2]]),
             fake_apps[1].id: set([fake_apps[1].tasks[2]]),
         }
+        expected_at_risk_tasks = {
+            fake_apps[0].id: set(),
+            fake_apps[1].id: set(),
+        }
 
-        with mock.patch('paasta_tools.bounce_lib.get_happy_tasks', side_effect=self.fake_get_happy_tasks):
-            actual = setup_marathon_job.get_old_happy_unhappy_draining_tasks(
+        with contextlib.nested(
+            mock.patch('paasta_tools.bounce_lib.get_happy_tasks', side_effect=self.fake_get_happy_tasks),
+            mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
+        ) as (
+            _,
+            _,
+        ):
+            actual = setup_marathon_job.get_tasks_by_state(
                 fake_apps,
                 self.fake_drain_method(),
                 service=fake_name,
@@ -1422,16 +1586,18 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
                 bounce_health_params={},
                 system_paasta_config=fake_system_paasta_config,
             )
-        actual_live_happy_tasks, actual_live_unhappy_tasks, actual_draining_tasks = actual
+        actual_live_happy_tasks, actual_live_unhappy_tasks, actual_draining_tasks, actual_at_risk_tasks = actual
         assert actual_live_happy_tasks == expected_live_happy_tasks
         assert actual_live_unhappy_tasks == expected_live_unhappy_tasks
         assert actual_draining_tasks == expected_draining_tasks
+        assert actual_at_risk_tasks == expected_at_risk_tasks
 
 
 class TestDrainTasksAndFindTasksToKill(object):
     def test_catches_exception_during_drain(self):
         tasks_to_drain = set([mock.Mock(id='to_drain')])
         already_draining_tasks = set()
+        at_risk_tasks = set()
         fake_drain_method = mock.Mock(
             drain=mock.Mock(side_effect=Exception('Hello')),
         )
@@ -1446,6 +1612,7 @@ class TestDrainTasksAndFindTasksToKill(object):
             drain_method=fake_drain_method,
             log_bounce_action=fake_log_bounce_action,
             bounce_method='fake',
+            at_risk_tasks=at_risk_tasks,
         )
 
         fake_log_bounce_action.assert_any_call(
@@ -1456,6 +1623,7 @@ class TestDrainTasksAndFindTasksToKill(object):
     def test_catches_exception_during_is_safe_to_kill(self):
         tasks_to_drain = set([mock.Mock(id='to_drain')])
         already_draining_tasks = set()
+        at_risk_tasks = set()
         fake_drain_method = mock.Mock(
             is_safe_to_kill=mock.Mock(side_effect=Exception('Hello')),
         )
@@ -1467,6 +1635,7 @@ class TestDrainTasksAndFindTasksToKill(object):
             drain_method=fake_drain_method,
             log_bounce_action=fake_log_bounce_action,
             bounce_method='fake',
+            at_risk_tasks=at_risk_tasks,
         )
 
         fake_log_bounce_action.assert_called_with(

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -739,12 +739,14 @@ class TestSetupMarathonJob:
             mock.patch('paasta_tools.setup_marathon_job.bounce_lib.get_happy_tasks', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.drain_lib.get_drain_method', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.get_draining_hosts', autospec=True),
         ) as (
             mock_log,
             mock_load_system_paasta_config,
             mock_get_matching_apps,
             mock_get_happy_tasks,
             mock_get_drain_method,
+            _,
             _,
         ):
             mock_load_system_paasta_config.return_value = mock.MagicMock(
@@ -793,6 +795,7 @@ class TestSetupMarathonJob:
             mock.patch('paasta_tools.setup_marathon_job.bounce_lib.get_happy_tasks', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.drain_lib.get_drain_method', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.get_draining_hosts', autospec=True),
         ) as (
             mock_log,
             mock_load_system_paasta_config,
@@ -800,10 +803,12 @@ class TestSetupMarathonJob:
             mock_get_happy_tasks,
             mock_get_drain_method,
             mock_get_draining_hosts,
+            mock_mt_get_draining_hosts,
         ):
             mock_load_system_paasta_config.return_value = mock.MagicMock(
                 get_cluster=mock.Mock(return_value='fake_cluster'))
             mock_get_draining_hosts.return_value = ['fake-host1', 'fake-host2']
+            mock_mt_get_draining_hosts.return_value = ['fake-host1', 'fake-host2']
             tasks = [
                 mock.Mock(host='fake-host1'),
                 mock.Mock(host='fake-host2'),
@@ -858,6 +863,7 @@ class TestSetupMarathonJob:
             mock.patch('paasta_tools.setup_marathon_job.bounce_lib.bounce_lock_zookeeper', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.do_bounce', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.get_draining_hosts', autospec=True),
         ) as (
             mock_log,
             mock_load_system_paasta_config,
@@ -867,6 +873,7 @@ class TestSetupMarathonJob:
             mock_get_bounce_method_func,
             mock_bounce_lock_zookeeper,
             mock_do_bounce,
+            _,
             _,
         ):
             mock_load_system_paasta_config.return_value = mock.MagicMock(
@@ -922,6 +929,7 @@ class TestSetupMarathonJob:
             mock.patch('paasta_tools.setup_marathon_job.bounce_lib.bounce_lock_zookeeper', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.do_bounce', autospec=True),
             mock.patch('paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.get_draining_hosts', autospec=True),
         ) as (
             mock_log,
             mock_load_system_paasta_config,
@@ -931,6 +939,7 @@ class TestSetupMarathonJob:
             mock_get_bounce_method_func,
             mock_bounce_lock_zookeeper,
             mock_do_bounce,
+            _,
             _,
         ):
             mock_stop_draining = mock.MagicMock()

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands =
     docker-compose pull --allow-insecure-ssl
     docker-compose --verbose build
     # Fire up the marathon cluster in background
-    docker-compose up -d mesosmaster mesosslave marathon chronos hacheck
+    docker-compose up -d mesosmaster mesosslave mesosslave2 mesosslave3 marathon chronos hacheck
     # Run the paastatools container in foreground to catch the output
     # the `docker-compose run` vs `docker-compose up` is important here, as docker-compose run will
     # exit with the right code.

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,8 @@ commands =
     docker-compose pull --allow-insecure-ssl
     docker-compose --verbose build
     # Fire up the marathon cluster in background
-    docker-compose up -d mesosmaster mesosslave mesosslave2 mesosslave3 marathon chronos hacheck
+    docker-compose up -d mesosmaster mesosslave marathon chronos hacheck
+    docker-compose scale mesosslave=3
     # Run the paastatools container in foreground to catch the output
     # the `docker-compose run` vs `docker-compose up` is important here, as docker-compose run will
     # exit with the right code.


### PR DESCRIPTION
This is still a work in progress. But I decided to open up a PR to get a little more visibility.

This change attempts to make setup_marathon_job aware of hosts that are marked as draining (at-risk). If it notices that an application has tasks running on such hosts, it will scale up the application by that number.

I still need to add some paasta_itests for this change.

Connects to #376 