### PR TITLE
Dont try to do mesos leader detection in any script

### DIFF
--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -408,5 +408,4 @@ def main():
 
 
 if __name__ == "__main__":
-    if mesos_tools.is_mesos_leader():
-        main()
+    main()

--- a/paasta_tools/check_mesos_resource_utilization.py
+++ b/paasta_tools/check_mesos_resource_utilization.py
@@ -21,12 +21,10 @@ isn't the leader, the script exits immediately.
 """
 import argparse
 import logging
-import sys
 
 import pysensu_yelp
 
 from paasta_tools.mesos_tools import get_mesos_stats
-from paasta_tools.mesos_tools import is_mesos_leader
 from paasta_tools.utils import load_system_paasta_config
 
 
@@ -113,8 +111,4 @@ def main():
 
 
 if __name__ == "__main__":
-    if is_mesos_leader():
-        main()
-    else:
-        print "No the leader. Exiting 0."
-        sys.exit(0)
+    main()

--- a/paasta_tools/cleanup_marathon_jobs.py
+++ b/paasta_tools/cleanup_marathon_jobs.py
@@ -36,7 +36,6 @@ import pysensu_yelp
 
 from paasta_tools import bounce_lib
 from paasta_tools import marathon_tools
-from paasta_tools.mesos_tools import is_mesos_leader
 from paasta_tools.monitoring_tools import send_event
 from paasta_tools.utils import _log
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -160,5 +159,5 @@ def main():
     cleanup_apps(soa_dir)
 
 
-if __name__ == "__main__" and is_mesos_leader():
+if __name__ == "__main__":
     main()

--- a/paasta_tools/deploy_chronos_jobs
+++ b/paasta_tools/deploy_chronos_jobs
@@ -1,4 +1,2 @@
 #!/bin/bash
-if am_i_mesos_leader >/dev/null; then
-  list_chronos_jobs | shuf | xargs -n 1 -r -P 5 setup_chronos_job
-fi
+list_chronos_jobs | shuf | xargs -n 1 -r -P 5 setup_chronos_job

--- a/paasta_tools/deploy_marathon_services
+++ b/paasta_tools/deploy_marathon_services
@@ -1,5 +1,2 @@
 #!/bin/bash
-
-if am_i_mesos_leader >/dev/null; then
-    list_marathon_service_instances | shuf | xargs -n 1 -r -P 5 setup_marathon_job
-fi
+list_marathon_service_instances | shuf | xargs -n 1 -r -P 5 setup_marathon_job


### PR DESCRIPTION
This will move the complexity of our adhoc leader-locking to the caller (cron job).

It has a nice side effect of not requiring an operator to run these scripts on the current leader.