### PR TITLE
make the command the last arg to serviceinit

### DIFF
--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -140,7 +140,7 @@ def test_check_ssh_and_sudo_on_master_check_sudo_failure(mock_run):
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_status(mock_run):
     mock_run.return_value = ('unused', 'fake_output')
-    expected_command = 'ssh -A -t fake_master sudo paasta_serviceinit status -s fake_service -i fake_instance '
+    expected_command = 'ssh -A -t fake_master sudo paasta_serviceinit -s fake_service -i fake_instance status'
 
     actual = utils.run_paasta_serviceinit(
         'status',
@@ -157,7 +157,7 @@ def test_run_paasta_serviceinit_status(mock_run):
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_status_verbose(mock_run):
     mock_run.return_value = ('unused', 'fake_output')
-    expected_command = 'ssh -A -t fake_master sudo paasta_serviceinit status -s fake_service -i fake_instance -v '
+    expected_command = 'ssh -A -t fake_master sudo paasta_serviceinit -s fake_service -i fake_instance -v status'
 
     actual = utils.run_paasta_serviceinit(
         'status',
@@ -175,8 +175,8 @@ def test_run_paasta_serviceinit_status_verbose(mock_run):
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_status_verbose_multi(mock_run):
     mock_run.return_value = ('unused', 'fake_output')
-    expected_command = 'ssh -A -t fake_master sudo paasta_serviceinit status ' \
-        '-s fake_service -i fake_instance -v -v -v -v '
+    expected_command = 'ssh -A -t fake_master sudo paasta_serviceinit ' \
+        '-s fake_service -i fake_instance -v -v -v -v status'
 
     actual = utils.run_paasta_serviceinit(
         'status',
@@ -247,8 +247,8 @@ def test_execute_paasta_serviceinit_status_on_remote_master_happy_path(
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_scaling(mock_run):
     mock_run.return_value = ('unused', 'fake_output')
-    expected_command = 'ssh -A -t fake_master sudo paasta_serviceinit status ' \
-        '-s fake_service -i fake_instance -v --delta 1'
+    expected_command = 'ssh -A -t fake_master sudo paasta_serviceinit ' \
+        '-s fake_service -i fake_instance -v --delta 1 status'
 
     actual = utils.run_paasta_serviceinit(
         'status',


### PR DESCRIPTION
The commit https://github.com/Yelp/paasta/commit/71280ede5558a75dba28b6cdbc572495294e5045#diff-7d4e89c64360b719f36a1ca16d58607cL505 changed the ordering of the args passed to paasta serviceinit. Internally, some of the sudoers rules we have in place broke because they relied on this ordering. This reverts that change, moving back to the previous layout.

This change also changes the way in which the serviceinit command is created so that whitespace arrangement is sorted in one place.

@giuliano108 primary - this fixes internal ticket PAASTA-4457