### PR TITLE
Hardcode a python2.7 dep to be compatible with all ubuntu

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,11 +2,11 @@ Source: paasta-tools
 Section: python
 Priority: optional
 Maintainer: Kyle Anderson <kwa@yelp.com>
-Build-Depends: debhelper (>= 7), python (>= 2.7), dh-virtualenv
+Build-Depends: debhelper (>= 7), python2.7, dh-virtualenv
 Standards-Version: 3.8.3
 
 Package: paasta-tools
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: python2.7, ${shlibs:Depends}, ${misc:Depends}
 Description: CLI tools for PaaSTA
 Conflicts: service-deployment-tools


### PR DESCRIPTION
Fixes #477 

The dh-virtualenv docs recommend ${Python:Depends}, but this is not going to work out great for all ubuntu's, so I chose to hard-code it instead.