### PR TITLE
install requests_cache for setup_marathon_job, restore fast bouncing

### DIFF
--- a/paasta_itests/environment.py
+++ b/paasta_itests/environment.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import time
 
+import requests_cache
 from behave_pytest.hook import install_pytest_asserts
 from itest_utils import cleanup_file
 from itest_utils import get_service_connection_string
@@ -110,6 +111,7 @@ def _clean_up_zookeeper_autoscaling(context):
 
 
 def after_scenario(context, scenario):
+    requests_cache.uninstall_cache()
     _clean_up_marathon_apps(context)
     _clean_up_chronos_jobs(context)
     _clean_up_mesos_cli_config(context)

--- a/paasta_tools/deploy_marathon_services
+++ b/paasta_tools/deploy_marathon_services
@@ -1,2 +1,2 @@
 #!/bin/bash
-list_marathon_service_instances | shuf | xargs --max-args=64 --no-run-if-empty --max-procs=4 setup_marathon_job
+list_marathon_service_instances | shuf | xargs -n 1 -r -P 5 setup_marathon_job

--- a/paasta_tools/deploy_marathon_services
+++ b/paasta_tools/deploy_marathon_services
@@ -1,2 +1,2 @@
 #!/bin/bash
-list_marathon_service_instances | shuf | xargs -n 1 -r -P 5 setup_marathon_job
+list_marathon_service_instances | shuf | xargs --max-args=64 --no-run-if-empty --max-procs=4 setup_marathon_job

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -585,9 +585,6 @@ def main():
             if deploy_marathon_service(service, instance, client, soa_dir, marathon_config):
                 num_failed_deployments = num_failed_deployments + 1
 
-    # Uninstall cache to not mess up with itest
-    requests_cache.core.uninstall_cache()
-
     log.debug("%d out of %d service.instances failed to deploy." %
               (num_failed_deployments, len(args.service_instance_list)))
 


### PR DESCRIPTION
This patch restores the fast bouncing by handling multiple instances in setup_marathon_job. requests_cache is installed to keep http requests during the execution of setup_marathon_job.