### PR TITLE
continue serviceinit when an exception occurs on one service.instance

### DIFF
--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -616,7 +616,6 @@ def deploy_marathon_service(service, instance, client, soa_dir, marathon_config)
         send_event(service, instance, soa_dir, sensu_status, output)
         return 0
     except (KeyError, TypeError, AttributeError, InvalidInstanceConfig):
-        import traceback
         error_str = traceback.format_exc()
         log.error(error_str)
         send_event(service, instance, soa_dir, pysensu_yelp.Status.CRITICAL, error_str)


### PR DESCRIPTION
An exception happened on one of the lucy instances and "paasta status" terminated.

Patch was tested simply with ".tox/py27/bin/paasta_serviceinit.py status -s robj-test-service -i main,autoscale_to_heck,memo-test". The "permission denied" exception occurs three times instead of once without the patch.