### PR TITLE
Use the force=True flag to kill marathon tasks

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1054,7 +1054,7 @@ def kill_task(client, app_id, task_id, scale):
 def kill_given_tasks(client, task_ids, scale):
     """Wrapper to the official kill_given_tasks method that is tolerant of errors"""
     try:
-        return client.kill_given_tasks(task_ids=task_ids, scale=scale)
+        return client.kill_given_tasks(task_ids=task_ids, scale=scale, force=True)
     except MarathonHttpError as e:
         # Marathon's interface is always async, so it is possible for you to see
         # a task in the interface and kill it, yet by the time it tries to kill


### PR DESCRIPTION
Using this flag will resolve the HTTP 409 exception when killing marathon tasks. Detailed root cause analysis is in paasta-4156.

Unit test was to reboot robj-test-service.memo-test and run sudo .tox/py27/bin/setup_marathon_job.py robj-test-service.memo-test to make sure the change is exercised.