### PR TITLE
remove leading slash from docker container name

### DIFF
--- a/paasta_tools/contrib/kill_orphaned_docker_containers.py
+++ b/paasta_tools/contrib/kill_orphaned_docker_containers.py
@@ -33,7 +33,7 @@ def main():
         mesos_task_id = mesos_tools.get_mesos_id_from_container(
             container=container, client=docker_client)
         if mesos_task_id not in running_mesos_task_ids:
-            orphaned_containers.append((container["Names"][0], mesos_task_id))
+            orphaned_containers.append((container["Names"][0].strip("/"), mesos_task_id))
 
     if orphaned_containers:
         print "CRIT: Docker containers are orphaned: %s%s" % (", ".join(


### PR DESCRIPTION
(Pdb) p container["Names"][0]
u'/mesos-34e6f338-dfa2-48e2-a798-40b0b0d318d5-S14.1ef2bcd1-0f65-41ae-b703-c2a1002d675c'

The leading slash needs to be removed.