### PR TITLE
Get rid of "special" config files

### DIFF
--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -47,7 +47,7 @@ def setup_marathon_client():
         'url': marathon_connection_string,
         'user': None,
         'password': None,
-    }, '/some_fake_path_to_marathon.json')
+    })
     client = marathon_tools.get_marathon_client(marathon_config.get_url(), marathon_config.get_username(),
                                                 marathon_config.get_password())
     system_paasta_config = utils.SystemPaastaConfig({
@@ -71,7 +71,7 @@ def setup_chronos_config():
         'user': None,
         'password': None,
         'url': [chronos_connection_string],
-    }, '/some_fake_path_to_chronos.json')
+    })
     return chronos_config
 
 

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -40,23 +40,35 @@ def _get_zookeeper_connection_string(chroot):
     return 'zk://%s/%s' % (get_service_connection_string('zookeeper'), chroot)
 
 
-def setup_marathon_client():
+def setup_system_paasta_config():
     marathon_connection_string = _get_marathon_connection_string()
     zk_connection_string = _get_zookeeper_connection_string('mesos-testcluster')
-    marathon_config = marathon_tools.MarathonConfig({
-        'url': marathon_connection_string,
-        'user': None,
-        'password': None,
-    })
-    client = marathon_tools.get_marathon_client(marathon_config.get_url(), marathon_config.get_username(),
-                                                marathon_config.get_password())
+    chronos_connection_string = _get_chronos_connection_string()
     system_paasta_config = utils.SystemPaastaConfig({
         'cluster': 'testcluster',
         'docker_volumes': [],
         'docker_registry': u'docker-dev.yelpcorp.com',
         'zookeeper': zk_connection_string,
         'synapse_port': 3212,
+        'marathon_config': {
+            'url': marathon_connection_string,
+            'user': None,
+            'password': None,
+        },
+        'chronos_config': {
+            'user': None,
+            'password': None,
+            'url': [chronos_connection_string],
+        },
     }, '/some_fake_path_to_config_dir/')
+    return system_paasta_config
+
+
+def setup_marathon_client():
+    system_paasta_config = setup_system_paasta_config()
+    marathon_config = marathon_tools.MarathonConfig(system_paasta_config.get_marathon_config())
+    client = marathon_tools.get_marathon_client(marathon_config.get_url(), marathon_config.get_username(),
+                                                marathon_config.get_password())
     return (client, marathon_config, system_paasta_config)
 
 
@@ -66,12 +78,8 @@ def setup_chronos_client():
 
 
 def setup_chronos_config():
-    chronos_connection_string = _get_chronos_connection_string()
-    chronos_config = chronos_tools.ChronosConfig({
-        'user': None,
-        'password': None,
-        'url': [chronos_connection_string],
-    })
+    system_paasta_config = setup_system_paasta_config()
+    chronos_config = chronos_tools.ChronosConfig(system_paasta_config.get_chronos_config())
     return chronos_config
 
 
@@ -122,8 +130,8 @@ def working_paasta_cluster(context):
     mesos_cli_config = _generate_mesos_cli_config(_get_zookeeper_connection_string('mesos-testcluster'))
     context.mesos_cli_config_filename = write_mesos_cli_config(mesos_cli_config)
     context.tag_version = 0
-    write_etc_paasta(context, context.marathon_config, 'marathon.json')
-    write_etc_paasta(context, context.chronos_config, 'chronos.json')
+    write_etc_paasta(context, {'marathon_config': context.marathon_config}, 'marathon.json')
+    write_etc_paasta(context, {'chronos_config': context.chronos_config}, 'chronos.json')
     write_etc_paasta(context, {
         "cluster": "testcluster",
         "zookeeper": "zk://fake",

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -38,6 +38,7 @@ from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import PaastaColors
+from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import timeout
 
 
@@ -108,7 +109,10 @@ class ChronosConfig(dict):
 
 
 def load_chronos_config():
-    return ChronosConfig(load_system_paasta_config().get_chronos_config())
+    try:
+        return ChronosConfig(load_system_paasta_config().get_chronos_config())
+    except PaastaNotConfiguredError:
+        raise ChronosNotConfigured("Could not find chronos_config in configuration directory")
 
 
 def get_chronos_client(config):

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 import argparse
 import datetime
-import json
 import logging
-import os
 import re
 import urlparse
 from time import sleep
@@ -40,7 +38,6 @@ from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import PaastaColors
-from paasta_tools.utils import PATH_TO_SYSTEM_PAASTA_CONFIG_DIR
 from paasta_tools.utils import timeout
 
 
@@ -61,7 +58,6 @@ MESOS_TASK_SPACER = ':'
 TMP_JOB_IDENTIFIER = "tmp"
 
 VALID_BOUNCE_METHODS = ['graceful']
-PATH_TO_CHRONOS_CONFIG = os.path.join(PATH_TO_SYSTEM_PAASTA_CONFIG_DIR, 'chronos.json')
 EXECUTION_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 log = logging.getLogger(__name__)
 
@@ -86,8 +82,7 @@ class InvalidParentError(Exception):
 
 class ChronosConfig(dict):
 
-    def __init__(self, config, path):
-        self.path = path
+    def __init__(self, config):
         super(ChronosConfig, self).__init__(config)
 
     def get_url(self):
@@ -95,29 +90,25 @@ class ChronosConfig(dict):
         try:
             return self['url']
         except KeyError:
-            raise ChronosNotConfigured('Could not find chronos url in system chronos config: %s' % self.path)
+            raise ChronosNotConfigured('Could not find chronos url in system chronos config')
 
     def get_username(self):
         """:returns: The Chronos API username"""
         try:
             return self['user']
         except KeyError:
-            raise ChronosNotConfigured('Could not find chronos user in system chronos config: %s' % self.path)
+            raise ChronosNotConfigured('Could not find chronos user in system chronos config')
 
     def get_password(self):
         """:returns: The Chronos API password"""
         try:
             return self['password']
         except KeyError:
-            raise ChronosNotConfigured('Could not find chronos password in system chronos config: %s' % self.path)
+            raise ChronosNotConfigured('Could not find chronos password in system chronos config')
 
 
-def load_chronos_config(path=PATH_TO_CHRONOS_CONFIG):
-    try:
-        with open(path) as f:
-            return ChronosConfig(json.load(f), path)
-    except IOError as e:
-        raise ChronosNotConfigured("Could not load chronos config file %s: %s" % (e.filename, e.strerror))
+def load_chronos_config():
+    return ChronosConfig(load_system_paasta_config().get_chronos_config())
 
 
 def get_chronos_client(config):

--- a/paasta_tools/cli/cmds/performance_check.py
+++ b/paasta_tools/cli/cmds/performance_check.py
@@ -12,14 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
-import os
 import sys
 
 import requests
 
 from paasta_tools.utils import get_username
-from paasta_tools.utils import PATH_TO_SYSTEM_PAASTA_CONFIG_DIR
+from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import timeout
 
 
@@ -47,11 +46,9 @@ def add_subparser(subparsers):
 
 
 def load_performance_check_config():
-    config_file = os.path.join(PATH_TO_SYSTEM_PAASTA_CONFIG_DIR, 'performance-check.json')
     try:
-        with open(config_file) as f:
-            return json.load(f)
-    except IOError as e:
+        return load_system_paasta_config().get_performance_check_config()
+    except PaastaNotConfiguredError as e:
         print "No performance check config to use. Safely bailing."
         print e.strerror
         sys.exit(0)

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -26,7 +26,6 @@ from marathon.exceptions import MarathonError
 
 from paasta_tools import chronos_tools
 from paasta_tools import marathon_tools
-from paasta_tools.chronos_tools import ChronosNotConfigured
 from paasta_tools.chronos_tools import get_chronos_client
 from paasta_tools.chronos_tools import load_chronos_config
 from paasta_tools.marathon_tools import MarathonNotConfigured
@@ -39,6 +38,7 @@ from paasta_tools.mesos_tools import get_zookeeper_config
 from paasta_tools.mesos_tools import MasterNotAvailableException
 from paasta_tools.utils import format_table
 from paasta_tools.utils import PaastaColors
+from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import print_with_indent
 
 HealthCheckResult = namedtuple('HealthCheckResult', ['message', 'healthy'])
@@ -611,7 +611,7 @@ def main():
     # Check to see if Chronos should be running here by checking for config
     try:
         chronos_config = load_chronos_config()
-    except ChronosNotConfigured:
+    except PaastaNotConfiguredError:
         chronos_results = [HealthCheckResult(message='Chronos is not configured to run here', healthy=True)]
 
     if marathon_config:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -923,7 +923,7 @@ class SystemPaastaConfig(dict):
             return self['performance_check']
         except KeyError:
             raise PaastaNotConfiguredError(
-                'Could not find performance_check in configureation directory: %s' % self.directory
+                'Could not find performance_check in configuration directory: %s' % self.directory
             )
 
     def get_marathon_config(self):
@@ -934,7 +934,7 @@ class SystemPaastaConfig(dict):
             return self['marathon_config']
         except KeyError:
             raise PaastaNotConfiguredError(
-                'Could not find marathon_config in configureation directory: %s' % self.directory
+                'Could not find marathon_config in configuration directory: %s' % self.directory
             )
 
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -911,9 +911,7 @@ class SystemPaastaConfig(dict):
         try:
             return self['chronos_config']
         except KeyError:
-            raise PaastaNotConfiguredError(
-                'Could not find chronos_config in configuration directory: %s' % self.directory
-            )
+            return {}
 
     def get_performance_check_config(self):
         """Get the performance check config
@@ -922,9 +920,7 @@ class SystemPaastaConfig(dict):
         try:
             return self['performance_check']
         except KeyError:
-            raise PaastaNotConfiguredError(
-                'Could not find performance_check in configuration directory: %s' % self.directory
-            )
+            return {}
 
     def get_marathon_config(self):
         """Get the marathon config
@@ -933,9 +929,7 @@ class SystemPaastaConfig(dict):
         try:
             return self['marathon_config']
         except KeyError:
-            raise PaastaNotConfiguredError(
-                'Could not find marathon_config in configuration directory: %s' % self.directory
-            )
+            return {}
 
 
 def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=None, **kwargs):

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -926,6 +926,17 @@ class SystemPaastaConfig(dict):
                 'Could not find performance_check in configureation directory: %s' % self.directory
             )
 
+    def get_marathon_config(self):
+        """Get the marathon config
+
+        :returns: The marathon config dictionary"""
+        try:
+            return self['marathon_config']
+        except KeyError:
+            raise PaastaNotConfiguredError(
+                'Could not find marathon_config in configureation directory: %s' % self.directory
+            )
+
 
 def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=None, **kwargs):
     """Given a command, run it. Return a tuple of the return code and any

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -915,6 +915,17 @@ class SystemPaastaConfig(dict):
                 'Could not find chronos_config in configuration directory: %s' % self.directory
             )
 
+    def get_performance_check_config(self):
+        """Get the performance check config
+
+        :returns: The performance_check config dictionary"""
+        try:
+            return self['performance_check']
+        except KeyError:
+            raise PaastaNotConfiguredError(
+                'Could not find performance_check in configureation directory: %s' % self.directory
+            )
+
 
 def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=None, **kwargs):
     """Given a command, run it. Return a tuple of the return code and any

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -904,6 +904,17 @@ class SystemPaastaConfig(dict):
         :returns: A format string for constructing the FQDN of the masters in a given cluster."""
         return self.get('cluster_fqdn_format', 'paasta-{cluster:s}.yelp')
 
+    def get_chronos_config(self):
+        """Get the chronos config
+
+        :returns: The chronos config dictionary"""
+        try:
+            return self['chronos_config']
+        except KeyError:
+            raise PaastaNotConfiguredError(
+                'Could not find chronos_config in configuration directory: %s' % self.directory
+            )
+
 
 def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=None, **kwargs):
     """Given a command, run it. Return a tuple of the return code and any

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -113,45 +113,6 @@ class TestChronosTools:
         with raises(chronos_tools.ChronosNotConfigured):
             fake_config.get_url()
 
-    def test_load_chronos_config_good(self):
-        expected = {'foo': 'bar'}
-        from_file = {'chronos_config': {'foo': 'bar'}}
-        file_mock = mock.MagicMock(spec=file)
-        with contextlib.nested(
-            mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock),
-            mock.patch('json.load', autospec=True, return_value=from_file),
-            mock.patch('os.path.isdir', autospec=True, return_value=True),
-            mock.patch('os.access', autospec=True, return_value=True),
-            mock.patch('paasta_tools.utils.get_readable_files_in_glob', autospec=True,
-                       return_value=['/some/fake/dir/some_file.json']),
-        ) as (
-            open_file_patch,
-            json_patch,
-            isdir_patch,
-            access_patch,
-            get_readable_files_patch,
-        ):
-            assert chronos_tools.load_chronos_config() == expected
-            open_file_patch.assert_called()
-            json_patch.assert_called_with(file_mock.__enter__())
-
-    def test_load_chronos_config_bad(self):
-        from_file = {}
-        expected = {}
-        file_mock = mock.MagicMock(spec=file)
-        with contextlib.nested(
-            mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock),
-            mock.patch('json.load', autospec=True, return_value=from_file),
-            mock.patch('os.path.isdir', autospec=True, return_value=True),
-            mock.patch('os.access', autospec=True, return_value=True),
-        ) as (
-            open_patch,
-            json_patch,
-            isdir_patch,
-            access_patch,
-        ):
-            assert chronos_tools.load_chronos_config() == expected
-
     def test_get_chronos_client(self):
         with contextlib.nested(
             mock.patch('chronos.connect', autospec=True),

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -137,6 +137,7 @@ class TestChronosTools:
 
     def test_load_chronos_config_bad(self):
         from_file = {}
+        expected = {}
         file_mock = mock.MagicMock(spec=file)
         with contextlib.nested(
             mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock),
@@ -149,9 +150,7 @@ class TestChronosTools:
             isdir_patch,
             access_patch,
         ):
-            with raises(chronos_tools.ChronosNotConfigured) as excinfo:
-                chronos_tools.load_chronos_config()
-            assert str(excinfo.value) == "Could not find chronos_config in configuration directory"
+            assert chronos_tools.load_chronos_config() == expected
 
     def test_get_chronos_client(self):
         with contextlib.nested(

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -120,10 +120,17 @@ class TestChronosTools:
         file_mock = mock.MagicMock(spec=file)
         with contextlib.nested(
             mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock),
-            mock.patch('json.load', autospec=True, return_value=from_file)
+            mock.patch('json.load', autospec=True, return_value=from_file),
+            mock.patch('os.path.isdir', autospec=True, return_value=True),
+            mock.patch('os.access', autospec=True, return_value=True),
+            mock.patch('paasta_tools.utils.get_readable_files_in_glob', autospec=True,
+                       return_value=['/some/fake/dir/some_file.json']),
         ) as (
             open_file_patch,
-            json_patch
+            json_patch,
+            isdir_patch,
+            access_patch,
+            get_readable_files_patch,
         ):
             assert chronos_tools.load_chronos_config() == expected
             open_file_patch.assert_called()
@@ -134,10 +141,14 @@ class TestChronosTools:
         file_mock = mock.MagicMock(spec=file)
         with contextlib.nested(
             mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock),
-            mock.patch('json.load', autospec=True, return_value=from_file)
+            mock.patch('json.load', autospec=True, return_value=from_file),
+            mock.patch('os.path.isdir', autospec=True, return_value=True),
+            mock.patch('os.access', autospec=True, return_value=True),
         ) as (
             open_patch,
-            json_patch
+            json_patch,
+            isdir_patch,
+            access_patch,
         ):
             with raises(PaastaNotConfiguredError) as excinfo:
                 chronos_tools.load_chronos_config()

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -20,7 +20,6 @@ from mock import Mock
 from pytest import raises
 
 from paasta_tools import chronos_tools
-from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
 
 
@@ -150,9 +149,9 @@ class TestChronosTools:
             isdir_patch,
             access_patch,
         ):
-            with raises(PaastaNotConfiguredError) as excinfo:
+            with raises(chronos_tools.ChronosNotConfigured) as excinfo:
                 chronos_tools.load_chronos_config()
-            assert str(excinfo.value) == "Could not find chronos_config in configuration directory: /etc/paasta/"
+            assert str(excinfo.value) == "Could not find chronos_config in configuration directory"
 
     def test_get_chronos_client(self):
         with contextlib.nested(

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -130,10 +130,14 @@ class TestChronosTools:
             json_patch.assert_called_with(file_mock.__enter__())
 
     def test_load_chronos_config_bad(self):
+        from_file = {}
+        file_mock = mock.MagicMock(spec=file)
         with contextlib.nested(
-            mock.patch('paasta_tools.chronos_tools.open', create=True, side_effect=IOError(2, 'a', 'b')),
+            mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock),
+            mock.patch('json.load', autospec=True, return_value=from_file)
         ) as (
             open_patch,
+            json_patch
         ):
             with raises(PaastaNotConfiguredError) as excinfo:
                 chronos_tools.load_chronos_config()

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -20,6 +20,7 @@ from mock import Mock
 from pytest import raises
 
 from paasta_tools import chronos_tools
+from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
 
 
@@ -84,7 +85,7 @@ class TestChronosTools:
             'password': 'fake_password',
             'url': 'fake_host'
         }
-        fake_config = chronos_tools.ChronosConfig(fake_json_contents, 'fake_path')
+        fake_config = chronos_tools.ChronosConfig(fake_json_contents)
         assert fake_config.get_username() == 'fake_user'
         assert fake_config.get_password() == 'fake_password'
         assert fake_config.get_url() == 'fake_host'
@@ -93,7 +94,7 @@ class TestChronosTools:
         fake_json_contents = {
             'password': 'fake_password',
         }
-        fake_config = chronos_tools.ChronosConfig(fake_json_contents, 'fake_path')
+        fake_config = chronos_tools.ChronosConfig(fake_json_contents)
         with raises(chronos_tools.ChronosNotConfigured):
             fake_config.get_username()
 
@@ -101,7 +102,7 @@ class TestChronosTools:
         fake_json_contents = {
             'user': 'fake_user',
         }
-        fake_config = chronos_tools.ChronosConfig(fake_json_contents, 'fake_path')
+        fake_config = chronos_tools.ChronosConfig(fake_json_contents)
         with raises(chronos_tools.ChronosNotConfigured):
             fake_config.get_password()
 
@@ -109,34 +110,34 @@ class TestChronosTools:
         fake_json_contents = {
             'user': 'fake_user',
         }
-        fake_config = chronos_tools.ChronosConfig(fake_json_contents, 'fake_path')
+        fake_config = chronos_tools.ChronosConfig(fake_json_contents)
         with raises(chronos_tools.ChronosNotConfigured):
             fake_config.get_url()
 
     def test_load_chronos_config_good(self):
         expected = {'foo': 'bar'}
+        from_file = {'chronos_config': {'foo': 'bar'}}
         file_mock = mock.MagicMock(spec=file)
         with contextlib.nested(
-            mock.patch('paasta_tools.chronos_tools.open', create=True, return_value=file_mock),
-            mock.patch('json.load', autospec=True, return_value=expected)
+            mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock),
+            mock.patch('json.load', autospec=True, return_value=from_file)
         ) as (
             open_file_patch,
             json_patch
         ):
             assert chronos_tools.load_chronos_config() == expected
-            open_file_patch.assert_called_once_with('/etc/paasta/chronos.json')
-            json_patch.assert_called_once_with(file_mock.__enter__())
+            open_file_patch.assert_called()
+            json_patch.assert_called_with(file_mock.__enter__())
 
     def test_load_chronos_config_bad(self):
-        fake_path = '/dne'
         with contextlib.nested(
             mock.patch('paasta_tools.chronos_tools.open', create=True, side_effect=IOError(2, 'a', 'b')),
         ) as (
             open_patch,
         ):
-            with raises(chronos_tools.ChronosNotConfigured) as excinfo:
-                chronos_tools.load_chronos_config(fake_path)
-            assert str(excinfo.value) == "Could not load chronos config file b: a"
+            with raises(PaastaNotConfiguredError) as excinfo:
+                chronos_tools.load_chronos_config()
+            assert str(excinfo.value) == "Could not find chronos_config in configuration directory: /etc/paasta/"
 
     def test_get_chronos_client(self):
         with contextlib.nested(
@@ -145,7 +146,7 @@ class TestChronosTools:
             mock_connect,
         ):
             fake_config = chronos_tools.ChronosConfig(
-                {'user': 'test', 'password': 'pass', 'url': ['some_fake_host']}, '/fake/path')
+                {'user': 'test', 'password': 'pass', 'url': ['some_fake_host']})
             chronos_tools.get_chronos_client(fake_config)
             assert mock_connect.call_count == 1
 
@@ -1407,7 +1408,7 @@ class TestChronosTools:
 
     def test_wait_for_job(self):
         fake_config = chronos_tools.ChronosConfig(
-            {'user': 'test', 'password': 'pass', 'url': ['some_fake_host']}, '/fake/path')
+            {'user': 'test', 'password': 'pass', 'url': ['some_fake_host']})
         client = chronos_tools.get_chronos_client(fake_config)
 
         # only provide the right response on the third attempt

--- a/tests/test_cleanup_marathon_jobs.py
+++ b/tests/test_cleanup_marathon_jobs.py
@@ -30,7 +30,7 @@ class TestCleanupMarathonJobs:
         'url': 'http://mess_url',
         'user': 'namnin',
         'password': 'pass_nememim',
-    }, '/some/fake/path/fake_file.json')
+    })
     fake_marathon_client = mock.Mock()
 
     def test_main(self):

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -245,10 +245,17 @@ class TestMarathonTools:
         file_mock = mock.MagicMock(spec=file)
         with contextlib.nested(
             mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock),
-            mock.patch('json.load', autospec=True, return_value=from_file)
+            mock.patch('json.load', autospec=True, return_value=from_file),
+            mock.patch('os.path.isdir', autospec=True, return_value=True),
+            mock.patch('os.access', autospec=True, return_value=True),
+            mock.patch('paasta_tools.utils.get_readable_files_in_glob', autospec=True,
+                       return_value=['/some/fake/dir/some_file.json']),
         ) as (
             open_file_patch,
-            json_patch
+            json_patch,
+            isdir_patch,
+            access_patch,
+            get_readable_files_patch,
         ):
             assert marathon_tools.load_marathon_config() == expected
             open_file_patch.assert_called()
@@ -257,8 +264,12 @@ class TestMarathonTools:
     def test_load_marathon_config_path_dne(self):
         with contextlib.nested(
             mock.patch('paasta_tools.marathon_tools.open', create=True, side_effect=IOError(2, 'a', 'b')),
+            mock.patch('os.path.isdir', autospec=True, return_value=True),
+            mock.patch('os.access', autospec=True, return_value=True),
         ) as (
             open_patch,
+            isdir_patch,
+            access_patch,
         ):
             with raises(marathon_tools.PaastaNotConfiguredError) as excinfo:
                 marathon_tools.load_marathon_config()

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -262,6 +262,7 @@ class TestMarathonTools:
             json_patch.assert_called_with(file_mock.__enter__())
 
     def test_load_marathon_config_path_dne(self):
+        expected = {}
         with contextlib.nested(
             mock.patch('paasta_tools.marathon_tools.open', create=True, side_effect=IOError(2, 'a', 'b')),
             mock.patch('os.path.isdir', autospec=True, return_value=True),
@@ -271,9 +272,7 @@ class TestMarathonTools:
             isdir_patch,
             access_patch,
         ):
-            with raises(marathon_tools.PaastaNotConfiguredError) as excinfo:
-                marathon_tools.load_marathon_config()
-            assert str(excinfo.value) == "Could not find marathon_config in configuration directory: /etc/paasta/"
+            assert marathon_tools.load_marathon_config() == expected
 
     def test_get_all_namespaces_for_service(self):
         name = 'vvvvvv'

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -262,7 +262,7 @@ class TestMarathonTools:
         ):
             with raises(marathon_tools.PaastaNotConfiguredError) as excinfo:
                 marathon_tools.load_marathon_config()
-            assert str(excinfo.value) == "Could not find marathon_config in configureation directory: /etc/paasta/"
+            assert str(excinfo.value) == "Could not find marathon_config in configuration directory: /etc/paasta/"
 
     def test_get_all_namespaces_for_service(self):
         name = 'vvvvvv'

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -272,7 +272,7 @@ def test_get_marathon_status(
         'url': 'fakeurl',
         'user': 'fakeuser',
         'password': 'fakepass',
-    }, '/fake_config/fake_marathon.json')
+    })
     client = mock_get_marathon_client.return_value
     client.list_apps.return_value = [
         "MarathonApp::1",
@@ -302,7 +302,7 @@ def test_get_marathon_client():
         'url': 'fakeurl',
         'user': 'fakeuser',
         'password': 'fakepass',
-    }, '/fake_config/fake_marathon.json')
+    })
     client = paasta_metastatus.get_marathon_client(fake_config)
     assert client.servers == ['fakeurl']
     assert client.auth == ('fakeuser', 'fakepass')

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -20,10 +20,10 @@ from mock import patch
 from pytest import raises
 
 from paasta_tools import paasta_metastatus
-from paasta_tools.chronos_tools import ChronosNotConfigured
 from paasta_tools.marathon_tools import MarathonConfig
 from paasta_tools.marathon_tools import MarathonNotConfigured
 from paasta_tools.utils import PaastaColors
+from paasta_tools.utils import PaastaNotConfiguredError
 
 
 def test_ok_check_threshold():
@@ -373,7 +373,7 @@ def test_main_no_marathon_config():
 def test_main_no_chronos_config():
     with contextlib.nested(
         patch('paasta_tools.marathon_tools.load_marathon_config', autospec=True),
-        patch('paasta_tools.chronos_tools.load_chronos_config', autospec=True),
+        patch('paasta_tools.paasta_metastatus.load_chronos_config', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_mesos_state_from_leader', autospec=True, return_value={}),
         patch('paasta_tools.paasta_metastatus.get_mesos_state_status', autospec=True,
               return_value=([('fake_output', True)])),
@@ -405,7 +405,7 @@ def test_main_no_chronos_config():
         get_mesos_state_status_patch.return_value = []
         get_mesos_metrics_health_patch.return_value = []
 
-        load_chronos_config_patch.side_effect = ChronosNotConfigured
+        load_chronos_config_patch.side_effect = PaastaNotConfiguredError
         with raises(SystemExit) as excinfo:
             paasta_metastatus.main()
         assert excinfo.value.code == 0

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -333,7 +333,8 @@ def test_get_chronos_status():
 def test_main_no_marathon_config():
     with contextlib.nested(
         patch('paasta_tools.marathon_tools.load_marathon_config', autospec=True),
-        patch('paasta_tools.chronos_tools.load_chronos_config', autospec=True),
+        patch('paasta_tools.paasta_metastatus.load_chronos_config', autospec=True),
+        patch('paasta_tools.paasta_metastatus.get_chronos_status', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_mesos_state_from_leader', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_mesos_state_status', autospec=True,
               return_value=([('fake_output', True)])),
@@ -345,6 +346,7 @@ def test_main_no_marathon_config():
     ) as (
         load_marathon_config_patch,
         load_chronos_config_patch,
+        load_get_chronos_status_patch,
         get_mesos_state_from_leader_patch,
         get_mesos_state_status_patch,
         get_mesos_stats_patch,

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -52,7 +52,7 @@ class TestSetupMarathonJob:
         'url': 'http://test_url',
         'user': 'admin',
         'password': 'admin_pass',
-    }, '/fake/fake_file.json')
+    })
     fake_args = mock.MagicMock(
         service_instance_list=['what_is_love.bby_dont_hurt_me'],
         soa_dir='no_more',


### PR DESCRIPTION
chronos.json, marathon.json, performance-check.json

I suspect I may have missed something(s), but all the unit and integration tests pass.

This will have to be paired with config changes in puppet too.

I'm not sure if I need to change the changelog at all? Or if there's any documentation that needs to be updated?

Closes #515 