### PR TITLE
Use sphinxcontrib-programoutput instead of sphinxcontrib-autorun

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ sys.path.append(os.path.abspath('./../../src/paasta_tools'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinxcontrib.autorun']
+extensions = ['sphinx.ext.autodoc', 'sphinxcontrib.programoutput']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -16,9 +16,7 @@ lowercase. (non alphanumeric lowercase characters are ignored)
 **Note:** All values in this file except the following will cause PaaSTA to
 `bounce <workflow.html#bouncing>`_ the service:
 
-.. runblock:: pycon
-
-    >>> from paasta_tools.marathon_tools import CONFIG_HASH_BLACKLIST; print CONFIG_HASH_BLACKLIST
+.. program-output:: python -c "from paasta_tools.marathon_tools import CONFIG_HASH_BLACKLIST; print ', '.join(CONFIG_HASH_BLACKLIST)"
 
 Top level keys are instancenames, e.g. ``main`` and ``canary``. Each
 instance MAY have:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ pre-commit==0.7.6
 pytest==2.7.3
 pytest-cov==2.2.0
 sphinx==1.4.1
-sphinxcontrib-autorun==0.1-20140415
+sphinxcontrib-programoutput==0.8


### PR DESCRIPTION
`sphinxcontrib-autorun` shows the command being executed along with its output in a syntax highlighted textarea. We really just want plain text. This is what `sphinxcontrib-programoutput` produces.