### PR TITLE
Fix command quoting issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 .pip/
 *.py?
 .*.sw?
+.idea
 paasta_tools.egg-info/
 docs/man/
 tags

--- a/general_itests/fake_soa_configs_local_run/fake_simple_service/chronos-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_local_run/fake_simple_service/chronos-test-cluster.yaml
@@ -4,3 +4,10 @@ chronos_job:
   mem: 100
   disk: 300
   schedule: 'R/2015-08-14T10:00:00+00:00/PT10M'
+
+chronos_job_with_cmd:
+  cpus: .1
+  mem: 100
+  disk: 300
+  schedule: 'R/2015-08-14T10:00:00+00:00/PT10M'
+  cmd: 'echo hello && sleep 5 && exit 42'

--- a/general_itests/local_run.feature
+++ b/general_itests/local_run.feature
@@ -12,3 +12,9 @@ Feature: paasta local-run can be used
       And a simple service to test
      When we run paasta local-run in non-interactive mode on a chronos job
      Then we should see the expected return code
+
+  Scenario: Running paasta local-run in non-interactive mode on a Chronos job with a complex command
+    Given Docker is available
+      And a simple service to test
+     When we run paasta local-run in non-interactive mode on a chronos job with cmd set to 'echo hello && sleep 5'
+     Then we should see the expected return code

--- a/general_itests/steps/local_run_steps.py
+++ b/general_itests/steps/local_run_steps.py
@@ -43,7 +43,7 @@ def non_interactive_local_run(context, var, val):
                         "--service fake_simple_service "
                         "--cluster test-cluster "
                         "--build "
-                        "--cmd '/bin/sh -c \"echo \"%s=$%s\" && sleep 2s && exit 42\"'" % (var, val))
+                        '''--cmd '/bin/sh -c "echo \\"%s=$%s\\" && sleep 2s && exit 42"' ''' % (var, val))
         context.local_run_return_code, context.local_run_output = _run(command=localrun_cmd, timeout=30)
 
 
@@ -75,4 +75,16 @@ def local_run_on_chronos_job(context):
                          "--instance chronos_job "
                          "--build "
                          "--cmd '/bin/sh -c \"sleep 2s && exit 42\"'")
+        context.local_run_return_code, context.local_run_output = _run(command=local_run_cmd, timeout=30)
+
+
+@when(u'we run paasta local-run in non-interactive mode on a chronos job with cmd set to \'echo hello && sleep 5\'')
+def local_run_on_chronos_job_with_cmd(context):
+    with Path("fake_simple_service"):
+        local_run_cmd = ("paasta local-run "
+                         "--yelpsoa-config-root ../fake_soa_configs_local_run/ "
+                         "--service fake_simple_service "
+                         "--cluster test-cluster "
+                         "--instance chronos_job_with_cmd "
+                         "--build ")
         context.local_run_return_code, context.local_run_output = _run(command=local_run_cmd, timeout=30)

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -406,9 +406,9 @@ def get_docker_run_cmd(memory, random_port, container_name, volumes, env, intera
     cmd.append('%s' % docker_hash)
     if command:
         cmd.extend((
-            'sh', '-c',
-            ' '.join(pipes.quote(part) for part in command)
+            'sh', '-c'
         ))
+        cmd.append(pipes.quote(' '.join(command)))
     return cmd
 
 
@@ -517,8 +517,7 @@ def run_docker_container(
         net=net,
         docker_params=docker_params,
     )
-    # http://stackoverflow.com/questions/4748344/whats-the-reverse-of-shlex-split
-    joined_docker_run_cmd = ' '.join(pipes.quote(word) for word in docker_run_cmd)
+    joined_docker_run_cmd = ' '.join(docker_run_cmd)
     healthcheck_mode, healthcheck_data = get_healthcheck_for_instance(
         service, instance, instance_config, random_port, soa_dir=soa_dir)
 
@@ -689,12 +688,12 @@ def configure_and_run_docker_container(
     if args.interactive is True and args.cmd is None:
         command = ['bash']
     elif args.cmd:
-        command = shlex.split(args.cmd)
+        command = shlex.split(args.cmd, posix=False)
     else:
         command_from_config = instance_config.get_cmd()
         if command_from_config:
             command_modifier = command_function_for_framework(instance_type)
-            command = shlex.split(command_modifier(command_from_config))
+            command = shlex.split(command_modifier(command_from_config), posix=False)
         else:
             command = instance_config.get_args()
 

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -543,7 +543,7 @@ def test_get_docker_run_cmd_interactive_false():
     assert '--interactive=true' not in actual
     assert '--tty=true' not in actual
     assert docker_hash in actual
-    assert ' '.join(pipes.quote(part) for part in command) in actual
+    assert ' '.join(pipes.quote(part) for part in command) in ' '.join(actual)
 
 
 def test_get_docker_run_cmd_interactive_true():


### PR DESCRIPTION
The command the container is supposed to run is being passed to
pipes.quote() once in get_docker_run_cmd() and once again in
run_docker_container().

If the string contains anything that pipes.quote thinks should be
quoted then we end up with some very weird results. For example
_"echo 'Hello' && sleep 60_" turns to "_echo foo '"'"'&&'"'"' sleep 60_".

The fix is to pass the whole command through pipes.quote() only once.

Fixes #555 