### PR TITLE
disable service_configuration_lib yaml cache when setting up marathon jobs

### DIFF
--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -48,6 +48,7 @@ from collections import defaultdict
 
 import pysensu_yelp
 import requests_cache
+import service_configuration_lib
 
 from paasta_tools import bounce_lib
 from paasta_tools import drain_lib
@@ -576,6 +577,7 @@ def main():
     client = marathon_tools.get_marathon_client(marathon_config.get_url(), marathon_config.get_username(),
                                                 marathon_config.get_password())
 
+    service_configuration_lib.disable_yaml_cache()
     num_failed_deployments = 0
     for service_instance in args.service_instance_list:
         try:


### PR DESCRIPTION
This is an alternative for https://github.com/Yelp/service_configuration_lib/pull/11 in case there are concerns for fixing service_configuration_lib.