### PR TITLE
upgrade service-configuration-lib to 0.10.1

### DIFF
--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -48,7 +48,6 @@ from collections import defaultdict
 
 import pysensu_yelp
 import requests_cache
-import service_configuration_lib
 
 from paasta_tools import bounce_lib
 from paasta_tools import drain_lib
@@ -577,7 +576,6 @@ def main():
     client = marathon_tools.get_marathon_client(marathon_config.get_url(), marathon_config.get_username(),
                                                 marathon_config.get_password())
 
-    service_configuration_lib.disable_yaml_cache()
     num_failed_deployments = 0
     for service_instance in args.service_instance_list:
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ pytz==2014.10
 requests==2.6.2
 requests-cache==0.4.10
 sensu-plugin==0.1.0
-service-configuration-lib==0.10.0
+service-configuration-lib==0.10.1
 simplejson==3.6.5
 six==1.9.0
 thriftpy==0.1.15

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'requests == 2.6.2',
         'requests-cache >= 0.4.10, <= 0.5.0',
         'sensu-plugin >= 0.1.0',
-        'service-configuration-lib >= 0.9.2',
+        'service-configuration-lib >= 0.10.1',
         'setuptools != 18.6',
         'tron == 0.6.1.1',
         'yelp_clog >= 2.2.0',


### PR DESCRIPTION
With service-configuration-lib 0.10.1, the service_configuration_lib.disable_yaml_cache workaround is no longer needed.