### PR TITLE
Make paasta_serviceinit exit more suitably when a command fails.

### DIFF
--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -475,7 +475,7 @@ def check_ssh_and_sudo_on_master(master, timeout=10):
     return (False, output)
 
 
-def run_paasta_serviceinit(subcommand, master, service, instances, cluster, stream, **kwargs):
+def run_paasta_serviceinit(subcommand, master, service, instances, cluster, stream, ssh_flags='', **kwargs):
     """Run 'paasta_serviceinit <subcommand>'. Return the output from running it."""
     if 'verbose' in kwargs and kwargs['verbose'] > 0:
         verbose_flag = ' '.join(['-v' for i in range(kwargs['verbose'])])
@@ -494,10 +494,11 @@ def run_paasta_serviceinit(subcommand, master, service, instances, cluster, stre
     else:
         delta_flag = ''
 
-    ssh_flag = '-t' if stream else '-n'
+    ssh_flags += ' -t' if stream else ' -n'
+    ssh_flags = ssh_flags.strip()
 
     command_parts = [
-        "ssh -A %s %s sudo paasta_serviceinit" % (ssh_flag, master),
+        "ssh -A %s %s sudo paasta_serviceinit" % (ssh_flags, master),
         "-s %s" % service,
         "-i %s" % instances,
         verbose_flag,
@@ -515,7 +516,7 @@ def run_paasta_serviceinit(subcommand, master, service, instances, cluster, stre
 
 
 def execute_paasta_serviceinit_on_remote_master(subcommand, cluster, service, instances, system_paasta_config,
-                                                stream=False, **kwargs):
+                                                stream=False, ignore_ssh_output=False, **kwargs):
     """Returns a string containing an error message if an error occurred.
     Otherwise returns the output of run_paasta_serviceinit_status().
     """
@@ -527,7 +528,11 @@ def execute_paasta_serviceinit_on_remote_master(subcommand, cluster, service, in
         return (
             'ERROR: could not find connectable master in cluster %s\nOutput: %s' % (cluster, output)
         )
-    return run_paasta_serviceinit(subcommand, master, service, instances, cluster, stream, **kwargs)
+    if ignore_ssh_output:
+        return run_paasta_serviceinit(subcommand, master, service, instances, cluster, stream,
+                                      ssh_flags='-o LogLevel=QUIET', **kwargs)
+    else:
+        return run_paasta_serviceinit(subcommand, master, service, instances, cluster, stream, **kwargs)
 
 
 def run_paasta_metastatus(master, verbose=0):

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -19,6 +19,7 @@ import re
 import sys
 from socket import gaierror
 from socket import gethostbyname_ex
+from subprocess import CalledProcessError
 
 from service_configuration_lib import read_services_configuration
 
@@ -507,7 +508,9 @@ def run_paasta_serviceinit(subcommand, master, service, instances, cluster, stre
     command_without_empty_strings = [part for part in command_parts if part != '']
     command = ' '.join(command_without_empty_strings)
     log.debug("Running Command: %s" % command)
-    _, output = _run(command, timeout=timeout, stream=stream)
+    return_code, output = _run(command, timeout=timeout, stream=stream)
+    if return_code != 0:
+        raise CalledProcessError(return_code, command, output)
     return output
 
 

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -129,7 +129,7 @@ def main():
                 log.error("I calculated an instance_type of %s for %s which I don't know how to handle."
                           % (instance_type, compose_job_id(service, instance)))
                 return_code = 1
-        except Exception:
+        except:
             log.error('Exception raised while looking at service %s instance %s:' % (service, instance))
             log.error(traceback.format_exc())
             return_code = 1

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -110,7 +110,7 @@ def test_report_status_for_cluster_displays_deployed_service(
     assert expected_output in output
     mock_execute_paasta_serviceinit_on_remote_master.assert_called_once_with(
         'status', 'fake_cluster', 'fake_service', 'fake_instance',
-        fake_system_paasta_config, stream=True, verbose=0)
+        fake_system_paasta_config, stream=True, verbose=0, ignore_ssh_output=True)
 
 
 @patch('paasta_tools.cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
@@ -190,7 +190,7 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
     assert expected_output in output
     mock_execute_paasta_serviceinit_on_remote_master.assert_called_once_with(
         'status', 'fake_cluster', 'fake_service', 'fake_instance_a,fake_instance_b',
-        fake_system_paasta_config, stream=True, verbose=0)
+        fake_system_paasta_config, stream=True, verbose=0, ignore_ssh_output=True)
 
 
 @patch('paasta_tools.cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
@@ -274,7 +274,7 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
     assert mock_execute_paasta_serviceinit_on_remote_master.call_count == 1
     mock_execute_paasta_serviceinit_on_remote_master.assert_any_call(
         'status', 'a_cluster', service, 'a_instance', fake_system_paasta_config,
-        stream=True, verbose=verbosity_level
+        stream=True, verbose=verbosity_level, ignore_ssh_output=True
     )
 
     output = mock_stdout.getvalue()
@@ -308,7 +308,7 @@ def test_report_status_for_cluster_obeys_instance_whitelist(
     )
     mock_execute_paasta_serviceinit_on_remote_master.assert_called_once_with(
         'status', 'fake_cluster', 'fake_service', 'fake_instance_a',
-        fake_system_paasta_config, stream=True, verbose=0)
+        fake_system_paasta_config, stream=True, verbose=0, ignore_ssh_output=True)
 
 
 @patch('paasta_tools.cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -139,7 +139,7 @@ def test_check_ssh_and_sudo_on_master_check_sudo_failure(mock_run):
 
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_status(mock_run):
-    mock_run.return_value = ('unused', 'fake_output')
+    mock_run.return_value = (0, 'fake_output')
     expected_command = 'ssh -A -t fake_master sudo paasta_serviceinit -s fake_service -i fake_instance status'
 
     actual = utils.run_paasta_serviceinit(
@@ -156,7 +156,7 @@ def test_run_paasta_serviceinit_status(mock_run):
 
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_status_verbose(mock_run):
-    mock_run.return_value = ('unused', 'fake_output')
+    mock_run.return_value = (0, 'fake_output')
     expected_command = 'ssh -A -t fake_master sudo paasta_serviceinit -s fake_service -i fake_instance -v status'
 
     actual = utils.run_paasta_serviceinit(
@@ -174,7 +174,7 @@ def test_run_paasta_serviceinit_status_verbose(mock_run):
 
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_status_verbose_multi(mock_run):
-    mock_run.return_value = ('unused', 'fake_output')
+    mock_run.return_value = (0, 'fake_output')
     expected_command = 'ssh -A -t fake_master sudo paasta_serviceinit ' \
         '-s fake_service -i fake_instance -v -v -v -v status'
 
@@ -246,7 +246,7 @@ def test_execute_paasta_serviceinit_status_on_remote_master_happy_path(
 
 @patch('paasta_tools.cli.utils._run', autospec=True)
 def test_run_paasta_serviceinit_scaling(mock_run):
-    mock_run.return_value = ('unused', 'fake_output')
+    mock_run.return_value = (0, 'fake_output')
     expected_command = 'ssh -A -t fake_master sudo paasta_serviceinit ' \
         '-s fake_service -i fake_instance -v --delta 1 status'
 


### PR DESCRIPTION
# Exit Code on control + c #525
2 parts to this fix, first, don't blindly assume a run_paasta_serviceinit command succeeds, actually check the return code to make sure. 

Secondly within paasta_serviceinit, we're catching Exception, unfortunately KeyboardInterrupt is derived from BaseException so the catch doesn't get triggered.

# No more connection messages #524
These messages are produced by the ssh command because we run with the `-t` flag. However, we don't really need informative messages out of ssh in the status command, so I've added the ability to ignore the output of ssh itself when executing paasta serviceinit remotely.

This allows critical commands like emergency scale, stop etc to still have output but allows for selective suppression.