### PR TITLE
Handle missing dashboard_links gracefully

### DIFF
--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -84,8 +84,11 @@ def get_cluster_dashboards(cluster):
     SPACER = ' '
     try:
         dashboards = load_system_paasta_config().get_dashboard_links()[cluster]
-    except KeyError:
-        output = [PaastaColors.red('No dashboards configured for %s!' % cluster)]
+    except KeyError as e:
+        if e.args[0] == cluster:
+            output = [PaastaColors.red('No dashboards configured for %s!' % cluster)]
+        else:
+            output = [PaastaColors.red('No dashboards configured!')]
     else:
         output = ['Dashboards:']
         spacing = max((len(label) for label in dashboards.keys())) + 1

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -823,11 +823,7 @@ class SystemPaastaConfig(dict):
             raise PaastaNotConfiguredError('Could not find cluster in configuration directory: %s' % self.directory)
 
     def get_dashboard_links(self):
-        try:
-            return self['dashboard_links']
-        except KeyError:
-            raise PaastaNotConfiguredError(
-                'Could not find dashboard_links in configuration directory: %s' % self.directory)
+        return self['dashboard_links']
 
     def get_fsm_template(self):
         fsm_path = os.path.dirname(sys.modules['paasta_tools.cli.fsm'].__file__)

--- a/tests/cli/test_cmds_metastatus.py
+++ b/tests/cli/test_cmds_metastatus.py
@@ -66,3 +66,26 @@ def test_get_cluster_dashboards():
         output_text = metastatus.get_cluster_dashboards('fake_cluster')
         assert 'http://paasta-fake_cluster.yelp:5050' in output_text
         assert 'URL: ' in output_text
+
+
+def test_get_cluster_no_dashboards():
+    with mock.patch('paasta_tools.cli.cmds.metastatus.load_system_paasta_config',
+                    autospec=True) as mock_load_system_paasta_config:
+        mock_load_system_paasta_config.return_value = SystemPaastaConfig(
+            {}, 'fake_directory')
+        output_text = metastatus.get_cluster_dashboards('fake_cluster')
+        assert 'No dashboards configured' in output_text
+
+
+def test_get_cluster_dashboards_unknown_cluster():
+    with mock.patch('paasta_tools.cli.cmds.metastatus.load_system_paasta_config',
+                    autospec=True) as mock_load_system_paasta_config:
+        mock_load_system_paasta_config.return_value = SystemPaastaConfig({
+            'dashboard_links': {
+                'another_fake_cluster': {
+                    'URL': 'http://paasta-fake_cluster.yelp:5050',
+                },
+            },
+        }, 'fake_directory')
+        output_text = metastatus.get_cluster_dashboards('fake_cluster')
+        assert 'No dashboards configured for fake_cluster' in output_text


### PR DESCRIPTION
Instead of throwing an exception we catch the KeyError raised when
dashboard_links has not been defined, or there is no cluster with the
name requested, and print the relevant error message.

Fixes #530 