### PR TITLE
set utilization to 0 on zero division error

### DIFF
--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -111,7 +111,10 @@ def healthcheck_result_for_resource_utilization(resource_utilization, threshold)
     :param resource_utilization: the resource_utilization tuple to check
     :returns: a HealthCheckResult
     """
-    utilization = percent_used(resource_utilization.total, resource_utilization.total - resource_utilization.free)
+    try:
+        utilization = percent_used(resource_utilization.total, resource_utilization.total - resource_utilization.free)
+    except ZeroDivisionError:
+        utilization = 0
     message = "%s: %.2f/%.2f(%.2f%%) used. Threshold (%.2f%%)" % (
         resource_utilization.metric,
         float(resource_utilization.total - resource_utilization.free),

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -630,6 +630,23 @@ def test_healthcheck_result_for_resource_utilization_unhealthy():
     ) == expected
 
 
+def test_healthcheck_result_for_resource_utilization_zero():
+    expected_message = 'cpus: 0.00/0.00(0.00%) used. Threshold (10.00%)'
+    expected = paasta_metastatus.HealthCheckResult(
+        message=expected_message,
+        healthy=True
+    )
+    resource_utilization = paasta_metastatus.ResourceUtilization(
+        metric='cpus',
+        total=0,
+        free=0,
+    )
+    assert paasta_metastatus.healthcheck_result_for_resource_utilization(
+        resource_utilization=resource_utilization,
+        threshold=10
+    ) == expected
+
+
 def test_format_table_column_for_healthcheck_resource_utilization_pair_healthy():
     fake_healthcheckresult = Mock()
     fake_healthcheckresult.healthy = True


### PR DESCRIPTION
if a slave has 0 available and 0 usage, then catch the ZeroDivisionError
and set usage to 0