### PR TITLE
Add kill threshold

### DIFF
--- a/paasta_itests/cleanup_marathon_job.feature
+++ b/paasta_itests/cleanup_marathon_job.feature
@@ -1,0 +1,59 @@
+Feature: cleanup_marathon_job removes no longer needed jobs
+    
+  Scenario: deleted apps are destroyed
+    Given a working paasta cluster
+      And I have yelpsoa-configs for the marathon job "test-service.main"
+      And I have yelpsoa-configs for the marathon job "test-service1.main"
+      And I have yelpsoa-configs for the marathon job "test-service2.main"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
+      And we have a deployments.json for the service "test-service1" with enabled instance "main"
+      And we have a deployments.json for the service "test-service2" with enabled instance "main"
+     When we create a marathon app called "test-service.main" with 1 instance(s)
+     Then we should see it in the list of apps
+     When we create a marathon app called "test-service1.main" with 1 instance(s)
+     Then we should see it in the list of apps
+     When we create a marathon app called "test-service2.main" with 1 instance(s)
+     Then we should see it in the list of apps
+     When we delete a marathon app called "test-service.main" from "testcluster" soa configs
+     Then we run cleanup_marathon_apps -v which exits with return code "0"
+     Then we should not see it in the list of apps
+
+  Scenario: paasta wont cleanup everything in one go
+    Given a working paasta cluster
+      And I have yelpsoa-configs for the marathon job "test-service.main"
+      And I have yelpsoa-configs for the marathon job "test-service1.main"
+      And I have yelpsoa-configs for the marathon job "test-service2.main"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
+      And we have a deployments.json for the service "test-service1" with enabled instance "main"
+      And we have a deployments.json for the service "test-service2" with enabled instance "main"
+     When we create a marathon app called "test-service.main" with 1 instance(s)
+     Then we should see it in the list of apps
+     When we create a marathon app called "test-service1.main" with 1 instance(s)
+     Then we should see it in the list of apps
+     When we create a marathon app called "test-service2.main" with 1 instance(s)
+     Then we should see it in the list of apps
+     When we delete a marathon app called "test-service.main" from "testcluster" soa configs
+     When we delete a marathon app called "test-service1.main" from "testcluster" soa configs
+     When we delete a marathon app called "test-service2.main" from "testcluster" soa configs
+     Then we run cleanup_marathon_apps -v which exits with return code "1"
+     Then we should see it in the list of apps
+
+  Scenario: paasta will cleanup everything in one go if we force it
+    Given a working paasta cluster
+      And I have yelpsoa-configs for the marathon job "test-service.main"
+      And I have yelpsoa-configs for the marathon job "test-service1.main"
+      And I have yelpsoa-configs for the marathon job "test-service2.main"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
+      And we have a deployments.json for the service "test-service1" with enabled instance "main"
+      And we have a deployments.json for the service "test-service2" with enabled instance "main"
+     When we create a marathon app called "test-service.main" with 1 instance(s)
+     Then we should see it in the list of apps
+     When we create a marathon app called "test-service1.main" with 1 instance(s)
+     Then we should see it in the list of apps
+     When we create a marathon app called "test-service2.main" with 1 instance(s)
+     Then we should see it in the list of apps
+     When we delete a marathon app called "test-service.main" from "testcluster" soa configs
+     When we delete a marathon app called "test-service1.main" from "testcluster" soa configs
+     When we delete a marathon app called "test-service2.main" from "testcluster" soa configs
+     Then we run cleanup_marathon_apps -v --force which exits with return code "0"
+     Then we should not see it in the list of apps

--- a/paasta_itests/itest_utils.py
+++ b/paasta_itests/itest_utils.py
@@ -11,13 +11,54 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import contextlib
 import json
 import os
 import time
 
+import mesos.cli.master
+import mock
 import requests
 
+from paasta_tools import marathon_tools
+from paasta_tools.marathon_tools import MarathonServiceConfig
+from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import timeout
+
+
+def update_context_marathon_config(context):
+    mesos_config = {
+        "master": "%s" % get_service_connection_string('mesosmaster'),
+        "scheme": "http",
+        "response_timeout": 5,
+    }
+    whitelist_keys = set(['id', 'backoff_factor', 'backoff_seconds', 'max_instances', 'mem', 'cpus', 'instances'])
+    with contextlib.nested(
+        # This seems to be necessary because mesos reads the config file at
+        # import which is sometimes before the tests get a chance to write the
+        # config file
+        mock.patch.object(mesos.cli.master, 'CFG', mesos_config),
+        mock.patch.object(SystemPaastaConfig, 'get_zk_hosts', autospec=True, return_value=context.zk_hosts),
+        mock.patch.object(MarathonServiceConfig, 'get_min_instances', autospec=True, return_value=1),
+        mock.patch.object(MarathonServiceConfig, 'get_max_instances', autospec=True),
+    ) as (
+        _,
+        _,
+        _,
+        mock_get_max_instances,
+    ):
+        mock_get_max_instances.return_value = context.max_instances if 'max_instances' in context else None
+        context.marathon_complete_config = {key: value for key, value in marathon_tools.create_complete_config(
+            context.service,
+            context.instance,
+            soa_dir=context.soa_dir,
+        ).items() if key in whitelist_keys}
+    context.marathon_complete_config.update({
+        'cmd': '/bin/sleep 1m',
+        'constraints': None,
+    })
+    if 'max_instances' not in context:
+        context.marathon_complete_config['instances'] = context.instances
 
 
 def get_service_connection_string(service):

--- a/paasta_itests/steps/cleanup_marathon_job_steps.py
+++ b/paasta_itests/steps/cleanup_marathon_job_steps.py
@@ -1,0 +1,58 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import requests_cache
+from behave import then
+from behave import when
+from itest_utils import get_service_connection_string
+from itest_utils import update_context_marathon_config
+
+from paasta_tools import marathon_tools
+from paasta_tools.utils import _run
+from paasta_tools.utils import decompose_job_id
+
+
+@when(u'we delete a marathon app called "{job_id}" from "{cluster_name}" soa configs')
+def delete_apps(context, job_id, cluster_name):
+    context.job_id = job_id
+    (service, instance, _, __) = decompose_job_id(job_id)
+    context.service = service
+    context.instance = instance
+    context.zk_hosts = '%s/mesos-testcluster' % get_service_connection_string('zookeeper')
+    update_context_marathon_config(context)
+    context.app_id = context.marathon_complete_config['id']
+    os.remove("{0}/{1}/marathon-{2}.yaml".format(context.soa_dir, service,
+                                                 cluster_name))
+    os.remove("{0}/{1}/deployments.json".format(context.soa_dir, service,
+                                                cluster_name))
+    os.rmdir("{0}/{1}".format(context.soa_dir, service))
+
+
+@then(u'we run cleanup_marathon_apps{flags} which exits with return code "{expected_return_code}"')
+def run_cleanup_marathon_job(context, flags, expected_return_code):
+    cmd = '../paasta_tools/cleanup_marathon_jobs.py --soa-dir %s %s' % (context.soa_dir, flags)
+    env = dict(os.environ)
+    env['MESOS_CLI_CONFIG'] = '/nail/etc/mesos-cli.json'  # context.mesos_cli_config_filename
+    print 'Running cmd %s with MESOS_CLI_CONFIG=%s' % (cmd, env['MESOS_CLI_CONFIG'])
+    exit_code, output = _run(cmd, env=env)
+    print output
+
+    assert exit_code == int(expected_return_code)
+
+
+@then(u'we should not see it in the list of apps')
+def not_see_it_in_list(context):
+    with requests_cache.disabled():
+        assert context.app_id not in marathon_tools.list_all_marathon_app_ids(context.marathon_client)

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -134,7 +134,7 @@ def working_paasta_cluster(context):
     write_etc_paasta(context, {'chronos_config': context.chronos_config}, 'chronos.json')
     write_etc_paasta(context, {
         "cluster": "testcluster",
-        "zookeeper": "zk://fake",
+        "zookeeper": "zk://zookeeper",
         "docker_registry": "fake.com"
     }, 'cluster.json')
     write_etc_paasta(context, {'log_writer': {'driver': "null"}}, 'logs.json')

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -188,7 +188,10 @@ def write_soa_dir_dependent_chronos_instance(context, service, disabled, instanc
 @given(u'I have yelpsoa-configs for the marathon job "{job_id}"')
 def write_soa_dir_marathon_job(context, job_id):
     (service, instance, _, __) = decompose_job_id(job_id)
-    soa_dir = mkdtemp()
+    try:
+        soa_dir = context.soa_dir
+    except AttributeError:
+        soa_dir = mkdtemp()
     if not os.path.exists(os.path.join(soa_dir, service)):
         os.makedirs(os.path.join(soa_dir, service))
     with open(os.path.join(soa_dir, service, 'marathon-%s.yaml' % context.cluster), 'w') as f:

--- a/paasta_tools/cleanup_marathon_jobs.py
+++ b/paasta_tools/cleanup_marathon_jobs.py
@@ -27,9 +27,13 @@ Command line options:
 
 - -d <SOA_DIR>, --soa-dir <SOA_DIR>: Specify a SOA config dir to read from
 - -v, --verbose: Verbose output
+- -t <KILL_THRESHOLD>, --kill-threshold: The decimal fraction of apps we think
+    is sane to kill when this job runs
+- -f, --force: Force the killing of apps if we breach the threshold
 """
 import argparse
 import logging
+import sys
 import traceback
 
 import pysensu_yelp
@@ -47,13 +51,25 @@ from paasta_tools.utils import load_system_paasta_config
 log = logging.getLogger(__name__)
 
 
+class DontKillEverythingError(Exception):
+    pass
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description='Cleans up stale marathon jobs.')
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
                         default=DEFAULT_SOA_DIR,
                         help="define a different soa config directory")
+    parser.add_argument('-t', '--kill-threshold', dest="kill_threshold",
+                        default=0.5,
+                        help="The decimal fraction of apps we think is "
+                             "sane to kill when this job runs")
     parser.add_argument('-v', '--verbose', action='store_true',
                         dest="verbose", default=False)
+    parser.add_argument('-f', '--force', action='store_true',
+                        dest="force", default=False,
+                        help="Force the cleanup if we are above the "
+                             "kill_threshold")
     args = parser.parse_args()
     return args
 
@@ -118,12 +134,15 @@ def delete_app(app_id, client, soa_dir):
         raise
 
 
-def cleanup_apps(soa_dir):
+def cleanup_apps(soa_dir, kill_threshold=0.5, force=False):
     """Clean up old or invalid jobs/apps from marathon. Retrieves
     both a list of apps currently in marathon and a list of valid
     app ids in order to determine what to kill.
 
-    :param soa_dir: The SOA config directory to read from"""
+    :param soa_dir: The SOA config directory to read from
+    :param kill_threshold: The decimal fraction of apps we think is
+        sane to kill when this job runs.
+    :param force: Force the cleanup if we are above the kill_threshold"""
     log.info("Loading marathon configuration")
     marathon_config = marathon_tools.load_marathon_config()
     log.info("Connecting to marathon")
@@ -133,30 +152,50 @@ def cleanup_apps(soa_dir):
     valid_services = get_services_for_cluster(instance_type='marathon', soa_dir=soa_dir)
     running_app_ids = marathon_tools.list_all_marathon_app_ids(client)
 
+    running_apps = []
     for app_id in running_app_ids:
-        log.debug("Checking app id %s", app_id)
         try:
-            service, instance, _, __ = marathon_tools.deformat_job_id(app_id)
+            app_id = marathon_tools.deformat_job_id(app_id)
         except InvalidJobNameError:
             log.warn("%s doesn't conform to paasta naming conventions? Skipping." % app_id)
             continue
-        if (service, instance) not in valid_services:
-            delete_app(
-                app_id=app_id,
-                client=client,
-                soa_dir=soa_dir,
-            )
+        running_apps.append(app_id)
+    apps_to_kill = [(service, instance, git_sha, config_sha)
+                    for service, instance, git_sha, config_sha in running_apps
+                    if (service, instance) not in valid_services]
+
+    log.debug("Running apps: %s" % running_apps)
+    log.debug("Valid apps: %s" % valid_services)
+    log.debug("Terminating: %s" % apps_to_kill)
+    if running_apps:
+        above_kill_threshold = float(len(apps_to_kill)) / float(len(running_apps)) > float(kill_threshold)
+        if above_kill_threshold and not force:
+            log.critical("Paasta was about to kill more than %s of the running services, this "
+                         "is probably a BAD mistake!, run again with --force if you "
+                         "really need to destroy everything" % kill_threshold)
+            raise DontKillEverythingError
+    for running_app in apps_to_kill:
+        app_id = marathon_tools.format_job_id(*running_app)
+        delete_app(
+            app_id=app_id,
+            client=client,
+            soa_dir=soa_dir,
+        )
 
 
 def main():
     args = parse_args()
     soa_dir = args.soa_dir
+    kill_threshold = args.kill_threshold
+    force = args.force
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
     else:
         logging.basicConfig(level=logging.WARNING)
-
-    cleanup_apps(soa_dir)
+    try:
+        cleanup_apps(soa_dir, kill_threshold=kill_threshold, force=force)
+    except DontKillEverythingError:
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Makes cleanup script more defensive. If it is going to delete more than half the marathon services it will now exit by default. It can be forced manually.
* Add integration tests for the cleanup script.