### PR TITLE
Reduce logging verbosity during tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     --requirement={toxinidir}/requirements-dev.txt
     --editable={toxinidir}
 commands =
-    py.test -s {posargs:tests}
+    py.test {posargs:tests}
 
 
 [testenv:coverage]


### PR DESCRIPTION
Fixes #503. Since we pass through arguments anyway, you can get full output with (stdout for a failing test is still displayed):

`tox -- -s`
