### PR TITLE
Use docker containerizer to run itests.

### DIFF
--- a/paasta_itests/docker-compose.yml
+++ b/paasta_itests/docker-compose.yml
@@ -22,7 +22,6 @@ mesosslave:
   hostname: mesosslave.test_hostname
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
-    - /usr/bin/docker:/usr/bin/docker
 
 marathon:
   build: ../yelp_package/dockerfiles/itest/marathon/

--- a/paasta_itests/docker-compose.yml
+++ b/paasta_itests/docker-compose.yml
@@ -18,8 +18,11 @@ mesosslave:
     - zookeeper
   environment:
     -CLUSTER: testcluster
-  command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret --launcher=posix'
+  command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret --containerizers=docker --docker=/usr/bin/docker'
   hostname: mesosslave.test_hostname
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    - /usr/bin/docker:/usr/bin/docker
 
 marathon:
   build: ../yelp_package/dockerfiles/itest/marathon/

--- a/paasta_itests/itest_utils.py
+++ b/paasta_itests/itest_utils.py
@@ -56,6 +56,13 @@ def update_context_marathon_config(context):
     context.marathon_complete_config.update({
         'cmd': '/bin/sleep 1m',
         'constraints': None,
+        'container': {
+            'type': 'DOCKER',
+            'docker': {
+                'network': 'BRIDGE',
+                'image': 'busybox',
+            },
+        },
     })
     if 'max_instances' not in context:
         context.marathon_complete_config['instances'] = context.instances

--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -50,6 +50,13 @@ def given_a_new_app_to_be_deployed(context, state):
         'id': 'bounce.test1.newapp.confighash',
         'cmd': '/bin/sleep 300',
         'instances': 2,
+        'container': {
+            'type': 'DOCKER',
+            'docker': {
+                'network': 'BRIDGE',
+                'image': 'busybox',
+            },
+        },
         'backoff_seconds': 1,
         'backoff_factor': 1,
         'health_checks': [
@@ -69,6 +76,13 @@ def given_an_old_app_to_be_destroyed(context):
         'id': old_app_name,
         'cmd': '/bin/sleep 300',
         'instances': 2,
+        'container': {
+            'type': 'DOCKER',
+            'docker': {
+                'network': 'BRIDGE',
+                'image': 'busybox',
+            },
+        },
         'backoff_seconds': 1,
         'backoff_factor': 1,
     }
@@ -96,7 +110,7 @@ def when_there_are_num_which_tasks(context, num, which, state):
             if len(app.tasks) - happy_count >= context.max_tasks:
                 return
         time.sleep(0.5)
-    raise Exception("timed out waiting for %d %s tasks on %s; there are %d" %
+    raise Exception("timed out waiting for %d %s tasks on %s; there are %s" %
                     (context.max_tasks, state, app_id, app.tasks))
 
 

--- a/paasta_itests/steps/marathon_steps.py
+++ b/paasta_itests/steps/marathon_steps.py
@@ -29,6 +29,13 @@ def create_trivial_marathon_app(context):
     app_config = {
         'id': APP_ID,
         'cmd': '/bin/sleep 30',
+        'container': {
+            'type': 'DOCKER',
+            'docker': {
+                'network': 'BRIDGE',
+                'image': 'busybox',
+            },
+        },
         'instances': 1,
     }
     with mock.patch('paasta_tools.bounce_lib.create_app_lock'):

--- a/paasta_itests/steps/paasta_metastatus_steps.py
+++ b/paasta_itests/steps/paasta_metastatus_steps.py
@@ -21,6 +21,14 @@ from paasta_tools import marathon_tools
 from paasta_tools.utils import _run
 from paasta_tools.utils import remove_ansi_escape_sequences
 
+CONTAINER = {
+    'type': 'DOCKER',
+    'docker': {
+        'network': 'BRIDGE',
+        'image': 'busybox',
+    },
+}
+
 
 @when(u'all zookeepers are unavailable')
 def all_zookeepers_unavailable(context):
@@ -34,12 +42,14 @@ def all_mesos_masters_unavailable(context):
 
 @when(u'an app with id "{app_id}" using high memory is launched')
 def run_paasta_metastatus_high_mem(context, app_id):
-    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep infinity', mem=490, instances=1))
+    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep infinity', mem=490, instances=1,
+                                                           container=CONTAINER))
 
 
 @when(u'an app with id "{app_id}" using high disk is launched')
 def run_paasta_metastatus_high_disk(context, app_id):
-    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep infinity', disk=95, instances=1))
+    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep infinity', disk=95, instances=1,
+                                                           container=CONTAINER))
 
 
 @when(u'a chronos job with name "{job_name}" is launched')
@@ -51,7 +61,8 @@ def chronos_job_launched(context, job_name):
 
 @when(u'an app with id "{app_id}" using high cpu is launched')
 def run_paasta_metastatus_high_cpu(context, app_id):
-    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep infinity', cpus=9, instances=1))
+    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep infinity', cpus=9, instances=1,
+                                                           container=CONTAINER))
 
 
 @when(u'a task belonging to the app with id "{app_id}" is in the task list')

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -31,6 +31,13 @@ def run_marathon_app(context, job_id):
     app_config = {
         'id': app_id,
         'cmd': '/bin/sleep 1m',
+        'container': {
+            'type': 'DOCKER',
+            'docker': {
+                'network': 'BRIDGE',
+                'image': 'busybox',
+            },
+        },
     }
     with mock.patch('paasta_tools.bounce_lib.create_app_lock'):
         paasta_tools.bounce_lib.create_marathon_app(app_id, app_config, context.marathon_client)

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -59,6 +59,38 @@ def setup_zookeeper(context, number):
     context.max_instances = number
 
 
+def update_context_marathon_config(context):
+    whitelist_keys = set(['id', 'backoff_factor', 'backoff_seconds', 'max_instances', 'mem', 'cpus', 'instances'])
+    with contextlib.nested(
+        mock.patch.object(SystemPaastaConfig, 'get_zk_hosts', autospec=True, return_value=context.zk_hosts),
+        mock.patch.object(MarathonServiceConfig, 'get_min_instances', autospec=True, return_value=1),
+        mock.patch.object(MarathonServiceConfig, 'get_max_instances', autospec=True),
+    ) as (
+        _,
+        _,
+        mock_get_max_instances,
+    ):
+        mock_get_max_instances.return_value = context.max_instances if 'max_instances' in context else None
+        context.marathon_complete_config = {key: value for key, value in marathon_tools.create_complete_config(
+            context.service,
+            context.instance,
+            soa_dir=context.soa_dir,
+        ).items() if key in whitelist_keys}
+    context.marathon_complete_config.update({
+        'cmd': '/bin/sleep 1m',
+        'constraints': None,
+        'container': {
+            'type': 'DOCKER',
+            'docker': {
+                'network': 'BRIDGE',
+                'image': 'busybox',
+            },
+        },
+    })
+    if 'max_instances' not in context:
+        context.marathon_complete_config['instances'] = context.instances
+
+
 @when(u'we create a marathon app called "{job_id}" with {number:d} instance(s)')
 def create_app_with_instances(context, job_id, number):
     set_number_instances(context, number)

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -59,38 +59,6 @@ def setup_zookeeper(context, number):
     context.max_instances = number
 
 
-def update_context_marathon_config(context):
-    whitelist_keys = set(['id', 'backoff_factor', 'backoff_seconds', 'max_instances', 'mem', 'cpus', 'instances'])
-    with contextlib.nested(
-        mock.patch.object(SystemPaastaConfig, 'get_zk_hosts', autospec=True, return_value=context.zk_hosts),
-        mock.patch.object(MarathonServiceConfig, 'get_min_instances', autospec=True, return_value=1),
-        mock.patch.object(MarathonServiceConfig, 'get_max_instances', autospec=True),
-    ) as (
-        _,
-        _,
-        mock_get_max_instances,
-    ):
-        mock_get_max_instances.return_value = context.max_instances if 'max_instances' in context else None
-        context.marathon_complete_config = {key: value for key, value in marathon_tools.create_complete_config(
-            context.service,
-            context.instance,
-            soa_dir=context.soa_dir,
-        ).items() if key in whitelist_keys}
-    context.marathon_complete_config.update({
-        'cmd': '/bin/sleep 1m',
-        'constraints': None,
-        'container': {
-            'type': 'DOCKER',
-            'docker': {
-                'network': 'BRIDGE',
-                'image': 'busybox',
-            },
-        },
-    })
-    if 'max_instances' not in context:
-        context.marathon_complete_config['instances'] = context.instances
-
-
 @when(u'we create a marathon app called "{job_id}" with {number:d} instance(s)')
 def create_app_with_instances(context, job_id, number):
     set_number_instances(context, number)

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.28.2-2.0.27.ubuntu1404
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.28.2-2.0.27.ubuntu1404 docker.io
 ADD mesos-secrets /etc/mesos-secrets
 ADD mesos-slave-secret /etc/mesos-slave-secret
 RUN chmod 600 /etc/mesos-secrets


### PR DESCRIPTION
TL;DR: this tells the mesosslave to use docker to run itests, and bind mounts /var/run/docker.sock and /usr/bin/docker into the mesosslave(s) to use the host's docker.
It also updates a bunch of tests to actually work in docker
Closes #373
Should be followed up by something to deal with #576