### PR TITLE
Paasta start/stop/restart multiple instances

### DIFF
--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -91,7 +91,7 @@ def step_paasta_mark_for_deployments_when(context):
 def step_paasta_stop_when(context):
     fake_args = mock.MagicMock(
         clusters='test_cluster',
-        instance='test_instance',
+        instances='test_instance',
         soa_dir='fake_soa_configs',
         service='fake_deployments_json_service',
     )

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -57,8 +57,9 @@ def add_subparser(subparsers):
         ).completer = lazy_choices_completer(list_instances)
         status_parser.add_argument(
             '-c', '--clusters',
-            help="A comma-separated list of clusters to view. Defaults to view all clusters.\n"
-            "For example: --clusters norcal-prod,nova-prod"
+            help="A comma-separated list of clusters to view. "
+            "For example: --clusters norcal-prod,nova-prod",
+            required=True
         ).completer = lazy_choices_completer(list_clusters)
 
         status_parser.add_argument(

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -51,9 +51,9 @@ def add_subparser(subparsers):
             help='Service that you want to %s. Like example_service.' % lower,
         ).completer = lazy_choices_completer(list_services)
         status_parser.add_argument(
-            '-i', '--instance',
-            help='Instance of the service that you want to %s. Like "main" or "canary".' % lower,
-            required=True,
+            '-i', '--instances',
+            help='A comma-separated list of instances of the service that you '
+                 'want to %s. Like --instances main,canary' % lower
         ).completer = lazy_choices_completer(list_instances)
         status_parser.add_argument(
             '-c', '--clusters',
@@ -149,7 +149,7 @@ def issue_state_change_for_service(service_config, force_bounce, desired_state):
 
 def paasta_start_or_stop(args, desired_state):
     """Requests a change of state to start or stop given branches of a service."""
-    instance = args.instance
+    instances = args.instances
     clusters = args.clusters
     soa_dir = args.soa_dir
     service = figure_out_service_name(args=args, soa_dir=soa_dir)
@@ -158,6 +158,11 @@ def paasta_start_or_stop(args, desired_state):
         clusters = args.clusters.split(",")
     else:
         clusters = list_clusters(service)
+
+    if args.instances is not None:
+        instances = args.instances.split(",")
+    else:
+        instances = list_instances()
 
     try:
         remote_refs = remote_git.list_remote_refs(utils.get_git_url(service, soa_dir))
@@ -174,25 +179,26 @@ def paasta_start_or_stop(args, desired_state):
 
     invalid_deploy_groups = []
     for cluster in clusters:
-        service_config = get_instance_config(
-            service=service,
-            cluster=cluster,
-            instance=instance,
-            soa_dir=soa_dir,
-            load_deployments=False,
-        )
-        deploy_group = service_config.get_deploy_group()
-        (deploy_tag, _) = get_latest_deployment_tag(remote_refs, deploy_group)
-
-        if deploy_tag not in remote_refs:
-            invalid_deploy_groups.append(deploy_group)
-        else:
-            force_bounce = utils.format_timestamp(datetime.datetime.utcnow())
-            issue_state_change_for_service(
-                service_config=service_config,
-                force_bounce=force_bounce,
-                desired_state=desired_state,
+        for instance in instances:
+            service_config = get_instance_config(
+                service=service,
+                cluster=cluster,
+                instance=instance,
+                soa_dir=soa_dir,
+                load_deployments=False,
             )
+            deploy_group = service_config.get_deploy_group()
+            (deploy_tag, _) = get_latest_deployment_tag(remote_refs, deploy_group)
+
+            if deploy_tag not in remote_refs:
+                invalid_deploy_groups.append(deploy_group)
+            else:
+                force_bounce = utils.format_timestamp(datetime.datetime.utcnow())
+                issue_state_change_for_service(
+                    service_config=service_config,
+                    force_bounce=force_bounce,
+                    desired_state=desired_state,
+                )
 
     return_val = 0
     if invalid_deploy_groups:

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -120,6 +120,57 @@ def test_log_event():
         )
 
 
+@mock.patch('paasta_tools.cli.cmds.start_stop_restart.issue_state_change_for_service', autospec=True)
+@mock.patch('paasta_tools.utils.format_timestamp', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.start_stop_restart.get_latest_deployment_tag', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.start_stop_restart.remote_git.list_remote_refs', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.start_stop_restart.figure_out_service_name', autospec=True)
+@mock.patch('paasta_tools.utils.InstanceConfig', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.start_stop_restart.get_instance_config', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.start_stop_restart.utils.get_git_url', autospec=True)
+def test_paasta_start_or_stop(
+    mock_get_git_url,
+    mock_get_instance_config,
+    mock_instance_config,
+    mock_figure_out_service_name,
+    mock_list_remote_refs,
+    mock_get_latest_deployment_tag,
+    mock_format_timestamp,
+    mock_issue_state_change_for_service,
+):
+    args = mock.Mock()
+    args.clusters = 'cluster1,cluster2'
+    args.instance = 'main1'
+    args.soa_dir = '/soa/dir'
+    mock_get_git_url.return_value = 'fake_git_url'
+    mock_figure_out_service_name.return_value = 'fake_service'
+    mock_get_instance_config.return_value = mock_instance_config
+    mock_instance_config.get_deploy_group.return_value = 'some_group'
+    mock_list_remote_refs.return_value = ['not_a_real_tag', 'fake_tag']
+    mock_get_latest_deployment_tag.return_value = ('not_a_real_tag', None)
+    mock_format_timestamp.return_value = 'not_a_real_timestamp'
+    ret = start_stop_restart.paasta_start_or_stop(args, 'start')
+    c1_get_instance_config_call = mock.call(service='fake_service',
+                                            cluster='cluster1',
+                                            instance='main1',
+                                            soa_dir='/soa/dir',
+                                            load_deployments=False)
+    c2_get_instance_config_call = mock.call(service='fake_service',
+                                            cluster='cluster2',
+                                            instance='main1',
+                                            soa_dir='/soa/dir',
+                                            load_deployments=False)
+    mock_get_instance_config.assert_has_calls([c1_get_instance_config_call,
+                                               c2_get_instance_config_call])
+    mock_get_latest_deployment_tag.assert_called_with(['not_a_real_tag', 'fake_tag'],
+                                                      'some_group')
+    mock_issue_state_change_for_service.assert_called_with(service_config=mock_instance_config,
+                                                           force_bounce='not_a_real_timestamp',
+                                                           desired_state='start')
+    mock_issue_state_change_for_service.call_count == 2
+    assert(ret == 0)
+
+
 @mock.patch('sys.stdout', new_callable=StringIO)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.remote_git.list_remote_refs', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.figure_out_service_name', autospec=True)

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -140,7 +140,7 @@ def test_paasta_start_or_stop(
 ):
     args = mock.Mock()
     args.clusters = 'cluster1,cluster2'
-    args.instance = 'main1'
+    args.instances = 'main1,canary'
     args.soa_dir = '/soa/dir'
     mock_get_git_url.return_value = 'fake_git_url'
     mock_figure_out_service_name.return_value = 'fake_service'
@@ -156,18 +156,30 @@ def test_paasta_start_or_stop(
                                             soa_dir='/soa/dir',
                                             load_deployments=False)
     c2_get_instance_config_call = mock.call(service='fake_service',
+                                            cluster='cluster1',
+                                            instance='canary',
+                                            soa_dir='/soa/dir',
+                                            load_deployments=False)
+    c3_get_instance_config_call = mock.call(service='fake_service',
                                             cluster='cluster2',
                                             instance='main1',
                                             soa_dir='/soa/dir',
                                             load_deployments=False)
+    c4_get_instance_config_call = mock.call(service='fake_service',
+                                            cluster='cluster2',
+                                            instance='canary',
+                                            soa_dir='/soa/dir',
+                                            load_deployments=False)
     mock_get_instance_config.assert_has_calls([c1_get_instance_config_call,
-                                               c2_get_instance_config_call])
+                                               c2_get_instance_config_call,
+                                               c3_get_instance_config_call,
+                                               c4_get_instance_config_call])
     mock_get_latest_deployment_tag.assert_called_with(['not_a_real_tag', 'fake_tag'],
                                                       'some_group')
     mock_issue_state_change_for_service.assert_called_with(service_config=mock_instance_config,
                                                            force_bounce='not_a_real_timestamp',
                                                            desired_state='start')
-    mock_issue_state_change_for_service.call_count == 2
+    mock_issue_state_change_for_service.call_count == 4
     assert(ret == 0)
 
 
@@ -205,6 +217,7 @@ def test_start_or_stop_bad_refs(mock_list_remote_refs, mock_get_instance_config,
     # To suppress any messages due to Mock making everything truthy
     args.clusters = 'fake_cluster1,fake_cluster2'
     args.soa_dir = '/fake/soa/dir'
+    args.instances = 'fake_instance'
 
     mock_figure_out_service_name.return_value = 'fake_service'
     mock_get_instance_config.return_value = MarathonServiceConfig(


### PR DESCRIPTION
This adds support to the paasta cli for specifying multiple instances when starting or stopping. This should make it easier to bounce all the instances for a service in one go or to specify a specific set of instances.