### PR TITLE
Make autoscaling wait for tasks to be healthy

### DIFF
--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -31,6 +31,7 @@ from paasta_tools.bounce_lib import ZK_LOCK_CONNECT_TIMEOUT_S
 from paasta_tools.marathon_tools import compose_autoscaling_zookeeper_root
 from paasta_tools.marathon_tools import format_job_id
 from paasta_tools.marathon_tools import get_marathon_client
+from paasta_tools.marathon_tools import is_task_healthy
 from paasta_tools.marathon_tools import load_marathon_config
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.marathon_tools import MESOS_TASK_SPACER
@@ -342,16 +343,6 @@ def humanize_error(error):
         return '%d%% overutilized' % ceil(error * 100)
     else:
         return 'utilization within thresholds'
-
-
-def is_task_healthy(task):
-    """
-    Check a marathon task has healthcheck results
-    and check that they are all healthy.
-    """
-    if task.health_check_results:
-        return all([hcr.alive for hcr in task.health_check_results])
-    return False
 
 
 def autoscale_services(soa_dir=DEFAULT_SOA_DIR):

--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -344,6 +344,16 @@ def humanize_error(error):
         return 'utilization within thresholds'
 
 
+def is_task_healthy(task):
+    """
+    Check a marathon task has healthcheck results
+    and check that they are all healthy.
+    """
+    if task.health_check_results:
+        return all([hcr.alive for hcr in task.health_check_results])
+    return False
+
+
 def autoscale_services(soa_dir=DEFAULT_SOA_DIR):
     try:
         with create_autoscaling_lock():
@@ -378,7 +388,7 @@ def autoscale_services(soa_dir=DEFAULT_SOA_DIR):
                         try:
                             job_id = format_job_id(config.service, config.instance)
                             marathon_tasks = {task.id: task for task in all_marathon_tasks
-                                              if job_id == get_short_job_id(task.id) and task.health_check_results}
+                                              if job_id == get_short_job_id(task.id) and is_task_healthy(task)}
                             if not marathon_tasks:
                                 raise MetricsProviderNoDataError("Couldn't find any healthy marathon tasks")
                             mesos_tasks = [task for task in all_mesos_tasks if task['id'] in marathon_tasks]

--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -260,10 +260,8 @@ def get_happy_tasks(app, service, nerve_ns, system_paasta_config, min_task_uptim
             continue
 
         # if there are health check results, check if at least one healthcheck is passing
-        if len(task.health_check_results) > 0:
-            task_up = any([hc_result.alive is True for hc_result in task.health_check_results])
-            if not task_up:
-                continue
+        if not marathon_tools.is_task_healthy(task, require_all=False, default_healthy=True):
+            continue
         happy.append(task)
 
     return happy

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -201,7 +201,7 @@ def get_healthy_marathon_instances_for_short_app_id(client, app_id):
 
     healthy_tasks = []
     for task in tasks_for_app:
-        if all([health_check_result.alive for health_check_result in task.health_check_results]) \
+        if marathon_tools.is_task_healthy(task, default_healthy=True) \
                 and task.started_at is not None \
                 and datetime_from_utc_to_local(task.started_at) < one_minute_ago:
             healthy_tasks.append(task)

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -144,11 +144,9 @@ def get_verbose_status_of_marathon_app(app):
             hostname = "%s:%s" % (task.host.split(".")[0], task.ports[0])
         else:
             hostname = "Unknown"
-        health_check_results = [health_check.alive for health_check in task.health_check_results
-                                if health_check.alive is not None]
-        if not health_check_results:
+        if not task.health_check_results:
             health_check_status = PaastaColors.grey("N/A")
-        elif all(health_check_results):
+        elif marathon_tools.is_task_healthy(task):
             health_check_status = PaastaColors.green("Healthy")
         else:
             health_check_status = PaastaColors.red("Unhealthy")

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1076,3 +1076,21 @@ def get_instances_from_zookeeper(service, instance):
     with ZookeeperPool() as zookeeper_client:
         (instances, _) = zookeeper_client.get('%s/instances' % compose_autoscaling_zookeeper_root(service, instance))
         return int(instances)
+
+
+def is_task_healthy(task, require_all=True, default_healthy=False):
+    """Check that a marathon task is healthy
+
+    :param task: the marathon task object
+    :param require_all: require all the healthchecks to be passing
+        false means that only one needs to pass
+    :param default_healthy: cause the function to report healthy if
+        there are no health check results
+    :returns: True if healthy, False if not"""
+    if task.health_check_results:
+        results = [hcr.alive for hcr in task.health_check_results]
+        if require_all:
+            return all(results)
+        else:
+            return any(results)
+    return default_healthy

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -2381,3 +2381,33 @@ def wait_for_app_to_launch_tasks():
         marathon_tools.wait_for_app_to_launch_tasks(mock.Mock(), 'app_id', 0)
         assert mock_app_has_tasks.call_count == 3
         assert mock_sleep.call_count == 2
+
+
+def test_is_task_healthy():
+    mock_hcrs = [mock.Mock(alive=False), mock.Mock(alive=False)]
+    mock_task = mock.Mock(health_check_results=mock_hcrs)
+    assert not marathon_tools.is_task_healthy(mock_task)
+
+    mock_hcrs = []
+    mock_task = mock.Mock(health_check_results=mock_hcrs)
+    assert not marathon_tools.is_task_healthy(mock_task)
+
+    mock_hcrs = [mock.Mock(alive=True), mock.Mock(alive=True)]
+    mock_task = mock.Mock(health_check_results=mock_hcrs)
+    assert marathon_tools.is_task_healthy(mock_task)
+
+    mock_hcrs = [mock.Mock(alive=True), mock.Mock(alive=False)]
+    mock_task = mock.Mock(health_check_results=mock_hcrs)
+    assert not marathon_tools.is_task_healthy(mock_task)
+
+    mock_hcrs = [mock.Mock(alive=True), mock.Mock(alive=False)]
+    mock_task = mock.Mock(health_check_results=mock_hcrs)
+    assert marathon_tools.is_task_healthy(mock_task, require_all=False)
+
+    mock_hcrs = [mock.Mock(alive=False), mock.Mock(alive=False)]
+    mock_task = mock.Mock(health_check_results=mock_hcrs)
+    assert not marathon_tools.is_task_healthy(mock_task, require_all=False)
+
+    mock_hcrs = []
+    mock_task = mock.Mock(health_check_results=mock_hcrs)
+    assert marathon_tools.is_task_healthy(mock_task, default_healthy=True)


### PR DESCRIPTION
This fixes #472. Previously we were only checking for a health check
result and not the actual content of the results (as the documentation
already states). Now we check that the a task is healthy before we
consider it for autoscaling.