### PR TITLE
paasta api changes to enable deployment changes in puppet

### DIFF
--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -22,6 +22,7 @@ usr/share/python/paasta-tools/bin/paasta_list_chronos_jobs usr/bin/list_chronos_
 usr/share/python/paasta-tools/bin/paasta_list_chronos_jobs usr/bin/paasta_list_chronos_jobs
 usr/share/python/paasta-tools/bin/list_marathon_service_instances.py usr/bin/list_marathon_service_instances
 usr/share/python/paasta-tools/bin/paasta usr/bin/paasta
+usr/share/python/paasta-tools/bin/paasta-api usr/bin/paasta-api
 usr/share/python/paasta-tools/bin/paasta_execute_docker_command.py usr/bin/paasta_execute_docker_command
 usr/share/python/paasta-tools/bin/paasta_maintenance.py usr/bin/paasta_maintenance
 usr/share/python/paasta-tools/bin/paasta_metastatus.py usr/bin/paasta_metastatus

--- a/paasta_itests/paasta_api.feature
+++ b/paasta_itests/paasta_api.feature
@@ -1,0 +1,12 @@
+Feature: paasta_api
+
+  Scenario: instance GET shows the status of service.instance
+    Given a working paasta cluster
+      And I have yelpsoa-configs for the marathon job "test-service.main"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
+     When we run the marathon app "test-service.main"
+      And we wait for it to be deployed
+     Then instance GET should return app_count "1" and an expected number of running instances for "test-service.main"
+      And instance GET should return error code "404" for "test-service.non-existent"
+
+# vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2

--- a/paasta_itests/steps/paasta_api_steps.py
+++ b/paasta_itests/steps/paasta_api_steps.py
@@ -1,0 +1,71 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from behave import then
+from pyramid import testing
+
+from paasta_tools import marathon_tools
+from paasta_tools.api import settings
+from paasta_tools.api.views.instance import instance_status
+from paasta_tools.api.views.instance import InstanceFailure
+from paasta_tools.utils import decompose_job_id
+from paasta_tools.utils import load_system_paasta_config
+
+
+@then(u'instance GET should return app_count "{app_count}" and an expected number of running instances for "{job_id}"')
+def service_instance_status(context, app_count, job_id):
+    marathon_config = marathon_tools.load_marathon_config()
+    settings.marathon_client = marathon_tools.get_marathon_client(
+        marathon_config.get_url(),
+        marathon_config.get_username(),
+        marathon_config.get_password()
+    )
+    settings.cluster = load_system_paasta_config().get_cluster()
+    settings.soa_dir = context.soa_dir
+
+    (service, instance, _, __) = decompose_job_id(job_id)
+
+    request = testing.DummyRequest()
+    request.matchdict = {'service': service, 'instance': instance}
+    response = instance_status(request)
+
+    assert response['app_count'] == int(app_count)
+    assert response['marathon']['running_instance_count'] == response['marathon']['expected_instance_count']
+
+
+@then(u'instance GET should return error code "{error_code}" for "{job_id}"')
+def service_instance_status_error(context, error_code, job_id):
+    marathon_config = marathon_tools.load_marathon_config()
+    settings.marathon_client = marathon_tools.get_marathon_client(
+        marathon_config.get_url(),
+        marathon_config.get_username(),
+        marathon_config.get_password()
+    )
+    settings.cluster = load_system_paasta_config().get_cluster()
+    settings.soa_dir = context.soa_dir
+
+    (service, instance, _, __) = decompose_job_id(job_id)
+
+    request = testing.DummyRequest()
+    request.matchdict = {'service': service, 'instance': instance}
+
+    response = None
+    try:
+        response = instance_status(request)
+    except InstanceFailure as exc:
+        print exc.msg
+        assert exc.err == int(error_code)
+    except:
+        raise
+
+    assert not response

--- a/paasta_tools/api/__init__.py
+++ b/paasta_tools/api/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Responds to paasta service and instance requests.
+"""
+import argparse
+import logging
+import sys
+
+import requests_cache
+from gevent.wsgi import WSGIServer
+from pyramid.config import Configurator
+
+from paasta_tools import marathon_tools
+from paasta_tools.api import settings
+from paasta_tools.utils import load_system_paasta_config
+
+log = logging.getLogger(__name__)
+
+
+def parse_paasta_api_args():
+    parser = argparse.ArgumentParser(description='Runs a PaaSTA API server')
+    parser.add_argument(
+        '-D', '--debug',
+        dest='debug',
+        action='store_true', default=False,
+        help="output the debug logs"
+    )
+    parser.add_argument(
+        'port', type=int,
+        help="port number for the api server")
+    parser.add_argument(
+        '-d', '--soa-dir',
+        dest="soa_dir",
+        help="define a different soa config directory"
+    )
+    args = parser.parse_args()
+    return args
+
+
+def make_app():
+    config = Configurator()
+    config.add_route('service.instance.status', '/v1/{service}/{instance}/status')
+    config.add_route('service.list', '/v1/{service}')
+    config.scan()
+    return config.make_wsgi_app()
+
+
+def main(argv=None):
+    args = parse_paasta_api_args()
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
+    if args.soa_dir:
+        settings.soa_dir = args.soa_dir
+
+    # Exit on exceptions while loading settings
+    settings.cluster = load_system_paasta_config().get_cluster()
+
+    marathon_config = marathon_tools.load_marathon_config()
+    settings.marathon_client = marathon_tools.get_marathon_client(
+        marathon_config.get_url(),
+        marathon_config.get_username(),
+        marathon_config.get_password()
+    )
+
+    # Set up transparent cache for http API calls. With expire_after, responses
+    # are removed only when the same request is made. Expired storage is not a
+    # concern here. Thus remove_expired_responses is not needed.
+    requests_cache.install_cache("paasta-api", backend="memory", expire_after=30)
+
+    server = WSGIServer(('', int(args.port)), make_app())
+    log.info("paasta-api started on port %d with soa_dir %s" % (args.port, settings.soa_dir))
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/paasta_tools/api/settings.py
+++ b/paasta_tools/api/settings.py
@@ -1,0 +1,21 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Settings of the paasta-api server.
+"""
+from paasta_tools.utils import DEFAULT_SOA_DIR
+
+soa_dir = DEFAULT_SOA_DIR
+cluster = None
+marathon_client = None

--- a/paasta_tools/api/views/__init__.py
+++ b/paasta_tools/api/views/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+PaaSTA service instance status/start/stop etc.
+"""
+import logging
+import traceback
+
+from pyramid.response import Response
+from pyramid.view import view_config
+
+from paasta_tools import marathon_tools
+from paasta_tools.api import settings
+from paasta_tools.cli.cmds.status import get_actual_deployments
+from paasta_tools.marathon_tools import get_marathon_app_deploy_status
+from paasta_tools.marathon_tools import MarathonDeployStatus
+from paasta_tools.paasta_serviceinit import get_deployment_version
+from paasta_tools.utils import NoDockerImageError
+from paasta_tools.utils import validate_service_instance
+
+
+log = logging.getLogger(__name__)
+
+
+def chronos_instance_status(instance_status, service, instance, verbose):
+    return
+
+
+def marathon_job_status(client, job_config):
+    mstatus = {}
+
+    try:
+        app_id = job_config.format_marathon_app_dict()['id']
+        mstatus['app_id'] = app_id
+    except NoDockerImageError:
+        error_msg = "Docker image is not in deployments.json."
+        mstatus['message'] = error_msg
+        return mstatus
+
+    if marathon_tools.is_app_id_running(app_id, client):
+        app = client.get_app(app_id)
+        deploy_status, _ = get_marathon_app_deploy_status(app, app_id, client)
+        mstatus['deploy_status'] = MarathonDeployStatus.tostring(deploy_status)
+
+        # by comparing running count with expected count, callers can figure
+        # out if the instance is in Healthy, Warning or Critical state.
+        mstatus['running_instance_count'] = app.tasks_running
+        mstatus['expected_instance_count'] = job_config.get_instances()
+    else:
+        mstatus['deploy_status'] = 'Not Running'
+
+    return mstatus
+
+
+def marathon_instance_status(instance_status, service, instance, verbose):
+    apps = marathon_tools.get_matching_appids(service, instance, settings.marathon_client)
+    job_config = marathon_tools.load_marathon_service_config(
+        service, instance, settings.cluster, soa_dir=settings.soa_dir)
+
+    # bouncing status can be inferred from app_count, ref get_bouncing_status
+    instance_status['app_count'] = len(apps)
+    instance_status['bounce_method'] = job_config.get_bounce_method()
+    instance_status['desired_state'] = job_config.get_desired_state()
+
+    instance_status['marathon'] = marathon_job_status(settings.marathon_client, job_config)
+
+
+class InstanceFailure(Exception):
+    def __init__(self, msg, err):
+        self.msg = msg
+        self.err = err
+
+
+@view_config(context=InstanceFailure)
+def instance_failure_response(exc, request):
+    """Construct an HTTP response with an error status code. This happens when
+    the API service has to stop on a 'hard' error. In contrast, the API service
+    continues to produce results on a 'soft' error. It will place a 'message'
+    field in the output. Multiple 'soft' errors are concatenated in the same
+    'message' field when errors happen in the same hierarchy.
+    """
+    log.error(exc.msg)
+
+    response = Response('ERROR: %s' % exc.msg)
+    response.status_int = exc.err
+    return response
+
+
+@view_config(route_name='service.instance.status', request_method='GET', renderer='json')
+def instance_status(request):
+    service = request.matchdict['service']
+    instance = request.matchdict['instance']
+    verbose = request.matchdict.get('verbose', False)
+
+    instance_status = {}
+    instance_status['service'] = service
+    instance_status['instance'] = instance
+
+    actual_deployments = get_actual_deployments(service, settings.soa_dir)
+    version = get_deployment_version(actual_deployments, settings.cluster, instance)
+    # exit if the deployment key is not found
+    if not version:
+        error_message = 'deployment key %s not found' % '.'.join([settings.cluster, instance])
+        raise InstanceFailure(error_message, 404)
+
+    instance_status['git_sha'] = version
+
+    try:
+        instance_type = validate_service_instance(service, instance, settings.cluster, settings.soa_dir)
+        if instance_type == 'marathon':
+            marathon_instance_status(instance_status, service, instance, verbose)
+        elif instance_type == 'chronos':
+            chronos_instance_status(instance_status, service, instance, verbose)
+        else:
+            error_message = 'Unknown instance_type %s of %s.%s' % (instance_type, service, instance)
+            raise InstanceFailure(error_message, 404)
+    except:
+        error_message = traceback.format_exc()
+        raise InstanceFailure(error_message, 500)
+
+    return instance_status

--- a/paasta_tools/api/views/service.py
+++ b/paasta_tools/api/views/service.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+PaaSTA service list (instances) etc.
+"""
+from pyramid.view import view_config
+
+from paasta_tools.api import settings
+from paasta_tools.utils import list_all_instances_for_service
+
+
+@view_config(route_name='service.list', request_method='GET', renderer='json')
+def list_instances(request):
+    service = request.matchdict['service']
+    instances = list_all_instances_for_service(service, clusters=[settings.cluster])
+    return {'instances': list(instances)}

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -108,22 +108,7 @@ def status_marathon_job(service, instance, app_id, normal_instance_count, client
     if marathon_tools.is_app_id_running(app_id, client):
         app = client.get_app(app_id)
         running_instances = app.tasks_running
-
-        # Check the launch queue to see if an app is blocked
-        is_overdue, backoff_seconds = marathon_tools.get_app_queue_status(client, app_id)
-
-        # Based on conditions at https://mesosphere.github.io/marathon/docs/marathon-ui.html
-        if is_overdue:
-            deploy_status = "%s (new tasks are not launching due to lack of capacity)" % PaastaColors.red("Waiting")
-        elif backoff_seconds:
-            deploy_status = "%s (next task won't launch for %s seconds due to previous failures)" % (
-                            PaastaColors.red("Delayed"), backoff_seconds)
-        elif len(app.deployments) > 0:
-            deploy_status = PaastaColors.yellow("Deploying")
-        elif app.instances == 0 and app.tasks_running == 0:
-            deploy_status = PaastaColors.grey("Stopped")
-        else:
-            deploy_status = PaastaColors.bold("Running")
+        deploy_status = marathon_tools.get_marathon_app_deploy_status_human(app, app_id, client)
 
         if running_instances >= normal_instance_count:
             status = PaastaColors.green("Healthy")

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -68,6 +68,11 @@ def parse_args():
     return args
 
 
+def get_deployment_version(actual_deployments, cluster, instance):
+    key = '.'.join((cluster, instance))
+    return actual_deployments[key][:8] if key in actual_deployments else None
+
+
 def main():
     args = parse_args()
     if args.debug:
@@ -99,7 +104,7 @@ def main():
         # For an instance, there might be multiple versions running, e.g. in crossover bouncing.
         # In addition, mesos master does not have information of a chronos service's git hash.
         # The git sha in deployment.json is simply used here.
-        version = actual_deployments['.'.join((cluster, instance))][:8]
+        version = get_deployment_version(actual_deployments, cluster, instance)
         print 'instance: %s' % PaastaColors.blue(instance)
         print 'Git sha:    %s (desired)' % version
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ dulwich==0.10.0
 ephemeral-port-reserve==1.0.1
 future>=0.15.2
 futures==3.0.1
+gevent==1.1.1
 httplib2==0.9
 humanize==0.5.1
 importlib==1.0.3
@@ -31,6 +32,7 @@ prettytable==0.7.2
 protobuf==2.6.1
 pyasn1==0.1.8
 pycrypto==2.6.1
+pyramid==1.7
 pysensu-yelp==0.2.2
 python-daemon==1.5.2
 python-dateutil==2.4.2

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'docker-py == 1.2.3',
         'dulwich == 0.10.0',
         'ephemeral-port-reserve >= 1.0.1',
+        'gevent == 1.1.1',
         'humanize >= 0.5.1',
         'httplib2 >= 0.9,<= 1.0',
         'isodate >= 0.5.0',
@@ -50,6 +51,7 @@ setup(
         'mesos.cli == 0.1.5',
         'ordereddict >= 1.1',
         'path.py >= 8.1',
+        'pyramid == 1.7',
         'pysensu-yelp >= 0.2.2',
         'pytimeparse >= 1.1.0',
         'python-dateutil >= 2.4.0',
@@ -88,6 +90,7 @@ setup(
     package_data={'': ['cli/fsm/template/*/*', 'cli/schemas/*.json']},
     entry_points={'console_scripts': [
         'paasta=paasta_tools.cli.cli:main',
+        'paasta-api=paasta_tools.api.api:main',
         'paasta_autoscale_cluster=paasta_tools.autoscale_cluster:main',
         'paasta_cleanup_chronos_jobs=paasta_tools.cleanup_chronos_jobs:main',
         'paasta_check_chronos_jobs=paasta_tools.check_chronos_jobs:main',

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -1,0 +1,90 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import marathon
+import mock
+from pyramid import testing
+
+from paasta_tools import marathon_tools
+from paasta_tools.api import settings
+from paasta_tools.api.views.instance import instance_status
+from paasta_tools.api.views.instance import marathon_job_status
+
+
+@mock.patch('paasta_tools.api.views.instance.marathon_job_status', autospec=True)
+@mock.patch('paasta_tools.api.views.instance.marathon_tools.get_matching_appids', autospec=True)
+@mock.patch('paasta_tools.api.views.instance.marathon_tools.load_marathon_service_config', autospec=True)
+@mock.patch('paasta_tools.api.views.instance.validate_service_instance', autospec=True)
+@mock.patch('paasta_tools.api.views.instance.get_actual_deployments', autospec=True)
+def test_instances_status(
+    mock_get_actual_deployments,
+    mock_validate_service_instance,
+    mock_load_marathon_service_config,
+    mock_get_matching_appids,
+    mock_marathon_job_status,
+):
+    settings.cluster = 'fake_cluster'
+    mock_get_actual_deployments.return_value = {'fake_cluster.fake_instance': 'GIT_SHA',
+                                                'fake_cluster.fake_instance2': 'GIT_SHA',
+                                                'fake_cluster2.fake_instance': 'GIT_SHA',
+                                                'fake_cluster2.fake_instance2': 'GIT_SHA'}
+    mock_validate_service_instance.return_value = 'marathon'
+
+    mock_marathon_config = marathon_tools.MarathonConfig(
+        {'url': 'fake_url', 'user': 'fake_user', 'password': 'fake_password'}
+    )
+    settings.marathon_client = marathon_tools.get_marathon_client(
+        mock_marathon_config.get_url(),
+        mock_marathon_config.get_username(),
+        mock_marathon_config.get_password()
+    )
+
+    mock_get_matching_appids.return_value = ['a', 'b']
+    mock_service_config = marathon_tools.MarathonServiceConfig(
+        service='fake_service',
+        cluster='fake_cluster',
+        instance='fake_instance',
+        config_dict={'bounce_method': 'fake_bounce'},
+        branch_dict={},
+    )
+    mock_load_marathon_service_config.return_value = mock_service_config
+    mock_marathon_job_status.return_value = 'fake_marathon_status'
+
+    request = testing.DummyRequest()
+    request.matchdict = {'service': 'fake_service', 'instance': 'fake_instance'}
+
+    response = instance_status(request)
+    assert response['bounce_method'] == 'fake_bounce'
+    assert response['desired_state'] == 'start'
+
+
+@mock.patch('paasta_tools.api.views.instance.marathon_tools.is_app_id_running', autospec=True)
+def test_marathon_job_status(
+    mock_is_app_id_running,
+):
+    mock_is_app_id_running.return_value = True
+
+    app = mock.create_autospec(marathon.models.app.MarathonApp)
+    app.instances = 5
+    app.tasks_running = 5
+    app.deployments = []
+
+    client = mock.create_autospec(marathon.MarathonClient)
+    client.get_app.return_value = app
+
+    job_config = mock.create_autospec(marathon_tools.MarathonServiceConfig)
+    job_config.format_marathon_app_dict.return_value = {'id': 'mock_app_id'}
+    job_config.get_instances.return_value = 5
+
+    mstatus = marathon_job_status(client, job_config)
+    assert mstatus['deploy_status'] == 'Running'

--- a/tests/api/test_service.py
+++ b/tests/api/test_service.py
@@ -1,0 +1,31 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+from pyramid import testing
+
+from paasta_tools.api.views.service import list_instances
+
+
+@mock.patch('paasta_tools.api.views.service.list_all_instances_for_service', autospec=True)
+def test_list_instances(
+    mock_list_all_instances_for_service,
+):
+    fake_instances = ['fake_instance_a', 'fake_instance_b', 'fake_instance_c']
+    mock_list_all_instances_for_service.return_value = fake_instances
+
+    request = testing.DummyRequest()
+    request.matchdict = {'service': 'fake_service'}
+
+    response = list_instances(request)
+    assert response['instances'] == fake_instances


### PR DESCRIPTION
This is the first set of paasta api changes to enable further development. The functionality is not yet complete and several important pieces (itests, swagger etc.) are not in place. 

$ curl localhost:5054/v1/robj-test-service
{"instances": "robj_test,main,autoscale_to_heck,memo-test"}

$ curl localhost:5054/v1/robj-test-service/memo-test/status
{"instance": "memo-test", "State": "Running", "Desired state": "Started", "Git sha": "29f0937c", "service": "robj-test-service"}