### PR TITLE
Make validate print better error messages

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -19,6 +19,7 @@ from glob import glob
 
 import yaml
 from jsonschema import Draft4Validator
+from jsonschema import exceptions
 from jsonschema import FormatChecker
 from jsonschema import ValidationError
 
@@ -107,10 +108,11 @@ def validate_schema(file_path, file_type):
         config_file_object = config_file
     try:
         validator.validate(config_file_object)
-    except ValidationError as e:
+    except ValidationError:
         print '%s: %s' % (SCHEMA_INVALID, file_path)
-        print '  Validation Message: %s' % e.message
-        return False
+
+        errors = validator.iter_errors(config_file_object)
+        print '  Validation Message: %s' % exceptions.best_match(errors).message
     else:
         print '%s: %s' % (SCHEMA_VALID, basename)
         return True

--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -117,7 +117,7 @@
     "definitions": {
         "jobName": {
             "type": "string",
-            "pattern": "^[a-zA-Z0-9_]+\\.[a-zA-Z0-9_]+$"
+            "pattern": "^[a-zA-Z0-9_-]+\\.[a-zA-Z0-9_-]+$"
         }
     }
 }


### PR DESCRIPTION
Following the guide on http://python-jsonschema.readthedocs.io/en/latest/errors/
This seems to be the best way to print error messages.

Before:
```bash
/yelpsoa-configs/wargames-map/chronos-PROD.yaml
  Validation Message: ['wargames-map.example_chronos_job'] is not valid under any of the given schemas
```

After:
```bash
yelpsoa-configs/wargames-map/chronos-PROD.yaml
  Validation Message: 'wargames-map.example_chronos_job' does not match u'^[a-zA-Z0-9_]+\\.[a-zA-Z0-9_]+$'
```