### PR TITLE
Make itests use "real" configs by having them call setup_service instead of deploy_service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ env:
 sudo: required
 services:
   - docker
+before_install:
+  # This probably ought to match the version in yelp_package/dockerfiles/itest/mesos/Dockerfile.
+  # Having a recent enough version is important so that docker features like --cpu-shares work properly.
+  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=1.11.2-0~trusty
 install: pip install coveralls tox
 script: if [[ -n "$MAKE_TARGET" ]]; then make "$MAKE_TARGET"; else tox; fi
 after_success:

--- a/paasta_itests/bounces.feature
+++ b/paasta_itests/bounces.feature
@@ -2,124 +2,124 @@ Feature: Bounces work as expected
 
   Scenario: The upthendown bounce works
     Given a working paasta cluster
-      And a new healthy app to be deployed
+      And a new healthy app to be deployed, with bounce strategy "upthendown" and drain method "noop"
       And an old app to be destroyed
 
      When there are 2 old healthy tasks
-      And deploy_service with bounce strategy "upthendown" and drain method "noop" is initiated
+      And setup_service is initiated
      Then the new app should be running
       And the old app should be running
 
      When there are 1 new healthy tasks
-      And deploy_service with bounce strategy "upthendown" and drain method "noop" is initiated
+      And setup_service is initiated
      Then the new app should be running
       And the old app should be running
 
      When there are 2 new healthy tasks
-      And deploy_service with bounce strategy "upthendown" and drain method "noop" is initiated
+      And setup_service is initiated
      When we wait a bit for the old app to disappear
      Then the old app should be gone
 
   Scenario: The upthendown bounce does not kill the old app if the new one is unhealthy
     Given a working paasta cluster
-      And a new unhealthy app to be deployed
+      And a new unhealthy app to be deployed, with bounce strategy "upthendown" and drain method "noop"
       And an old app to be destroyed
 
      When there are 2 old healthy tasks
-      And deploy_service with bounce strategy "upthendown" and drain method "noop" is initiated
+      And setup_service is initiated
      Then the new app should be running
       And the old app should be running
 
      When there are 2 new unhealthy tasks
-      And deploy_service with bounce strategy "upthendown" and drain method "noop" is initiated
+      And setup_service is initiated
      Then the old app should be configured to have 2 instances
       And the old app should be running
 
   Scenario: The brutal bounce works
     Given a working paasta cluster
-      And a new healthy app to be deployed
+      And a new healthy app to be deployed, with bounce strategy "brutal" and drain method "noop"
       And an old app to be destroyed
      Then the old app should be running
 
      When there are 1 old healthy tasks
-      And deploy_service with bounce strategy "brutal" and drain method "noop" is initiated
+      And setup_service is initiated
      Then the new app should be running
      When we wait a bit for the old app to disappear
      Then the old app should be gone
 
   Scenario: The crossover bounce works
     Given a working paasta cluster
-      And a new healthy app to be deployed
+      And a new healthy app to be deployed, with bounce strategy "crossover" and drain method "noop"
       And an old app to be destroyed
 
      When there are 2 old healthy tasks
-      And deploy_service with bounce strategy "crossover" and drain method "noop" is initiated
+      And setup_service is initiated
      Then the new app should be running
       And the old app should be running
 
      When there are 1 new healthy tasks
-      And deploy_service with bounce strategy "crossover" and drain method "noop" is initiated
+      And setup_service is initiated
      Then the old app should be running
       And the old app should be configured to have 1 instances
 
      When there are 2 new healthy tasks
-      And deploy_service with bounce strategy "crossover" and drain method "noop" is initiated
+      And setup_service is initiated
       And we wait a bit for the old app to disappear
      Then the old app should be gone
 
   Scenario: The crossover bounce does not kill the old app if the new one is unhealthy
     Given a working paasta cluster
-      And a new unhealthy app to be deployed
+      And a new unhealthy app to be deployed, with bounce strategy "crossover" and drain method "noop"
       And an old app to be destroyed
 
      When there are 2 old healthy tasks
-      And deploy_service with bounce strategy "crossover" and drain method "noop" is initiated
+      And setup_service is initiated
      Then the new app should be running
       And the old app should be running
 
      When there are 1 new unhealthy tasks
-      And deploy_service with bounce strategy "crossover" and drain method "noop" is initiated
+      And setup_service is initiated
      Then the old app should be configured to have 2 instances
       And the old app should be running
 
      When there are 2 new unhealthy tasks
-      And deploy_service with bounce strategy "crossover" and drain method "noop" is initiated
+      And setup_service is initiated
      Then the old app should be configured to have 2 instances
       And the old app should be running
 
   Scenario: The downthenup bounce works
     Given a working paasta cluster
-      And a new healthy app to be deployed
+      And a new healthy app to be deployed, with bounce strategy "downthenup" and drain method "noop"
       And an old app to be destroyed
      Then the old app should be running
 
      When there are 2 old healthy tasks
-      And deploy_service with bounce strategy "downthenup" and drain method "noop" is initiated
+      And setup_service is initiated
      When we wait a bit for the new app to disappear
      Then the new app should be gone
      When we wait a bit for the old app to disappear
      Then the old app should be gone
 
-     When deploy_service with bounce strategy "downthenup" and drain method "noop" is initiated
+     When setup_service is initiated
      Then the new app should be running
 
   Scenario: Bounces wait for drain method
     Given a working paasta cluster
-      And a new healthy app to be deployed
+      And a new healthy app to be deployed, with bounce strategy "crossover" and drain method "test"
       And an old app to be destroyed
 
      When there are 2 old healthy tasks
-      And deploy_service with bounce strategy "crossover" and drain method "test" is initiated
+      And setup_service is initiated
      Then the new app should be running
       And the old app should be running
 
      When there are 1 new healthy tasks
-      And deploy_service with bounce strategy "crossover" and drain method "test" is initiated
+      And setup_service is initiated
      Then the new app should be running
       And the old app should be running
       # Note: this is different from the crossover bounce scenario because one of the old tasks is still draining.
       And the old app should be configured to have 2 instances
 
      When a task has drained
-      And deploy_service with bounce strategy "crossover" and drain method "test" is initiated
+      And setup_service is initiated
      Then the old app should be configured to have 1 instances

--- a/paasta_itests/docker-compose.yml
+++ b/paasta_itests/docker-compose.yml
@@ -18,7 +18,7 @@ mesosslave:
     - zookeeper
   environment:
     -CLUSTER: testcluster
-  command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret --containerizers=docker --docker=/usr/bin/docker'
+  command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret --containerizers=docker --docker=/usr/bin/docker --attributes="region:fakeregion;pool:default"'
   hostname: mesosslave.test_hostname
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -28,15 +28,14 @@ from paasta_tools.bounce_lib import get_happy_tasks
 
 
 def which_id(context, which):
-    config = {
-        'new': context.new_config,
-        'old': context.old_app_config,
+    return {
+        'new': context.new_id,
+        'old': context.old_app_config['id'],
     }[which]
-    return config['id']
 
 
-@given(u'a new {state} app to be deployed')
-def given_a_new_app_to_be_deployed(context, state):
+@given(u'a new {state} app to be deployed, with bounce strategy "{bounce_method}" and drain method "{drain_method}"')
+def given_a_new_app_to_be_deployed(context, state, bounce_method, drain_method):
     if state == "healthy":
         cmd = "/bin/true"
     elif state == "unhealthy":
@@ -46,26 +45,28 @@ def given_a_new_app_to_be_deployed(context, state):
 
     context.service = 'bounce'
     context.instance = 'test1'
-    context.new_config = {
-        'id': 'bounce.test1.newapp.confighash',
-        'cmd': '/bin/sleep 300',
-        'instances': 2,
-        'container': {
-            'type': 'DOCKER',
-            'docker': {
-                'network': 'BRIDGE',
-                'image': 'busybox',
-            },
+    context.new_id = 'bounce.test1.newapp.confighash'
+    context.new_marathon_service_config = marathon_tools.MarathonServiceConfig(
+        service=context.service,
+        cluster=context.cluster,
+        instance=context.instance,
+        config_dict={
+            "cmd": "/bin/sleep 300",
+            "instances": 2,
+            "healthcheck_mode": "cmd",
+            "healthcheck_cmd": cmd,
+            "bounce_method": str(bounce_method),
+            "drain_method": str(drain_method),
+            "cpus": 0.001,
+            "mem": 100,
+            "disk": 10,
         },
-        'backoff_seconds': 1,
-        'backoff_factor': 1,
-        'health_checks': [
-            {
-                "protocol": "COMMAND",
-                "command": {"value": cmd}
-            }
-        ]
-    }
+        branch_dict={
+            'docker_image': 'busybox',
+            'desired_state': 'start',
+            'force_bounce': None,
+        },
+    )
 
 
 @given(u'an old app to be destroyed')
@@ -114,8 +115,8 @@ def when_there_are_num_which_tasks(context, num, which, state):
                     (context.max_tasks, state, app_id, app.tasks))
 
 
-@when(u'deploy_service with bounce strategy "{bounce_method}" and drain method "{drain_method}" is initiated')
-def when_deploy_service_initiated(context, bounce_method, drain_method):
+@when(u'setup_service is initiated')
+def when_setup_service_initiated(context):
     with contextlib.nested(
         mock.patch(
             'paasta_tools.bounce_lib.get_happy_tasks',
@@ -130,6 +131,9 @@ def when_deploy_service_initiated(context, bounce_method, drain_method):
         mock.patch('paasta_tools.bounce_lib.time.sleep', autospec=True),
         mock.patch('paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True),
         mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
+        mock.patch('paasta_tools.marathon_tools.get_config_hash', autospec=True, return_value='confighash'),
+        mock.patch('paasta_tools.marathon_tools.get_code_sha_from_dockerurl', autospec=True, return_value='newapp'),
+        mock.patch('paasta_tools.marathon_tools.get_docker_url', autospec=True, return_value='busybox'),
     ) as (
         _,
         _,
@@ -137,28 +141,26 @@ def when_deploy_service_initiated(context, bounce_method, drain_method):
         _,
         mock_load_system_paasta_config,
         _,
+        _,
+        _,
+        _,
     ):
         mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value=context.cluster)
         # 120 * 0.5 = 60 seconds
         for _ in xrange(120):
             try:
-                setup_marathon_job.deploy_service(
+                (code, message) = setup_marathon_job.setup_service(
                     service=context.service,
                     instance=context.instance,
-                    marathon_jobid=context.new_config['id'],
-                    config=context.new_config,
                     client=context.marathon_client,
-                    bounce_method=bounce_method,
-                    drain_method_name=drain_method,
-                    drain_method_params={},
-                    nerve_ns=context.instance,
-                    bounce_health_params={},
-                    soa_dir=None,
+                    service_marathon_config=context.new_marathon_service_config,
+                    soa_dir='/nail/etc/services',
                 )
+                assert code == 0, message
                 return
             except MarathonHttpError:
                 time.sleep(0.5)
-        raise Exception("Unable to qcuiqre app lock for setup_marathon_job.deploy_service")
+        raise Exception("Unable to acquire app lock for setup_marathon_job.setup_service")
 
 
 @when(u'the {which} app is down to {num} instances')

--- a/paasta_itests/steps/paasta_metastatus_steps.py
+++ b/paasta_itests/steps/paasta_metastatus_steps.py
@@ -42,13 +42,13 @@ def all_mesos_masters_unavailable(context):
 
 @when(u'an app with id "{app_id}" using high memory is launched')
 def run_paasta_metastatus_high_mem(context, app_id):
-    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep infinity', mem=490, instances=1,
+    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep 1000', mem=490, instances=1,
                                                            container=CONTAINER))
 
 
 @when(u'an app with id "{app_id}" using high disk is launched')
 def run_paasta_metastatus_high_disk(context, app_id):
-    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep infinity', disk=95, instances=1,
+    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep 1000', disk=95, instances=1,
                                                            container=CONTAINER))
 
 
@@ -61,7 +61,7 @@ def chronos_job_launched(context, job_name):
 
 @when(u'an app with id "{app_id}" using high cpu is launched')
 def run_paasta_metastatus_high_cpu(context, app_id):
-    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep infinity', cpus=9, instances=1,
+    context.marathon_client.create_app(app_id, MarathonApp(cmd='/bin/sleep 1000', cpus=9, instances=1,
                                                            container=CONTAINER))
 
 

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -129,6 +129,8 @@ def working_paasta_cluster(context):
 
     mesos_cli_config = _generate_mesos_cli_config(_get_zookeeper_connection_string('mesos-testcluster'))
     context.mesos_cli_config_filename = write_mesos_cli_config(mesos_cli_config)
+    import mesos.cli
+    mesos.cli.cfg.CURRENT.load()
     context.tag_version = 0
     write_etc_paasta(context, {'marathon_config': context.marathon_config}, 'marathon.json')
     write_etc_paasta(context, {'chronos_config': context.chronos_config}, 'chronos.json')

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -509,8 +509,7 @@ def deploy_service(
     return (0, 'Service deployed.')
 
 
-def setup_service(service, instance, client, marathon_config,
-                  service_marathon_config, soa_dir):
+def setup_service(service, instance, client, service_marathon_config, soa_dir):
     """Setup the service instance given and attempt to deploy it, if possible.
     Doesn't do anything if the service is already in Marathon and hasn't changed.
     If it's not, attempt to find old instances of the service and bounce them.
@@ -518,7 +517,6 @@ def setup_service(service, instance, client, marathon_config,
     :param service: The service name to setup
     :param instance: The instance of the service to setup
     :param client: A MarathonClient object
-    :param marathon_config: The marathon configuration dict
     :param service_marathon_config: The service instance's configuration dict
     :returns: A tuple of (status, output) to be used with send_sensu_event"""
 
@@ -618,8 +616,7 @@ def deploy_marathon_service(service, instance, client, soa_dir, marathon_config)
         return 1
 
     try:
-        status, output = setup_service(service, instance, client, marathon_config,
-                                       service_instance_config, soa_dir)
+        status, output = setup_service(service, instance, client, service_instance_config, soa_dir)
         sensu_status = pysensu_yelp.Status.CRITICAL if status else pysensu_yelp.Status.OK
         send_event(service, instance, soa_dir, sensu_status, output)
         return 0

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -122,7 +122,6 @@ class TestSetupMarathonJob:
                 decompose_job_id(self.fake_args.service_instance_list[0])[0],
                 decompose_job_id(self.fake_args.service_instance_list[0])[1],
                 fake_client,
-                self.fake_marathon_config,
                 self.fake_marathon_service_config,
                 'no_more',
             )
@@ -186,7 +185,6 @@ class TestSetupMarathonJob:
                 decompose_job_id(self.fake_args.service_instance_list[0])[0],
                 decompose_job_id(self.fake_args.service_instance_list[0])[1],
                 fake_client,
-                self.fake_marathon_config,
                 self.fake_marathon_service_config,
                 'no_more',
             )
@@ -919,7 +917,6 @@ class TestSetupMarathonJob:
                 service=fake_name,
                 instance=fake_instance,
                 client=fake_client,
-                marathon_config=self.fake_marathon_config,
                 service_marathon_config=self.fake_marathon_service_config,
                 soa_dir=None,
             )
@@ -1002,7 +999,6 @@ class TestSetupMarathonJob:
                 service=fake_name,
                 instance=fake_instance,
                 client=fake_client,
-                marathon_config=self.fake_marathon_config,
                 service_marathon_config=self.fake_marathon_service_config,
                 soa_dir=None,
             )
@@ -1041,7 +1037,6 @@ class TestSetupMarathonJob:
                 service=fake_name,
                 instance=fake_instance,
                 client=None,
-                marathon_config=None,
                 service_marathon_config=self.fake_marathon_service_config,
                 soa_dir=None,
             )

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources
 RUN echo "deb http://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 58118E89F3A912897C070ADBF76221572C52609D
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.28.2-2.0.27.ubuntu1404 docker-engine
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.28.2-2.0.27.ubuntu1404 docker-engine=1.11.2-0~trusty
 ADD mesos-secrets /etc/mesos-secrets
 ADD mesos-slave-secret /etc/mesos-slave-secret
 RUN echo '{}' > /root/.dockercfg

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -14,8 +14,11 @@
 
 FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
+RUN echo "deb http://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 58118E89F3A912897C070ADBF76221572C52609D
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.28.2-2.0.27.ubuntu1404 docker.io
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=0.28.2-2.0.27.ubuntu1404 docker-engine
 ADD mesos-secrets /etc/mesos-secrets
 ADD mesos-slave-secret /etc/mesos-slave-secret
+RUN echo '{}' > /root/.dockercfg
 RUN chmod 600 /etc/mesos-secrets


### PR DESCRIPTION
Fixes #576.

I also found that some of the tests were calling `/bin/sleep infinity` inside a container, which makes the metastatus tests a race condition -- sometimes the container dies and the resource allocation gets cleaned up before metastatus is run.

This change also paves the way for me to refactor setup_service/deploy_service/do_bounce.