### PR TITLE
Fix autoscaler metrics provider

### DIFF
--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -467,11 +467,12 @@ def spotfleet_metrics_provider(spotfleet_request_id, mesos_state, pool):
         mesos_state
     )[pool]
 
+    log.debug(pool_utilization_dict)
     free_pool_resources = pool_utilization_dict['free']
     total_pool_resources = pool_utilization_dict['total']
     utilization = 1.0 - min([
-        float(free_pool_resources[resource]) / total_pool_resources[resource]
-        for resource in free_pool_resources
+        float(float(pair[0]) / float(pair[1]))
+        for pair in zip(free_pool_resources, total_pool_resources)
     ])
     return utilization
 


### PR DESCRIPTION
The provider was getting a namedtuple from metastatus but treating it
like a dictionary and causing a TypeError. I guess metastatus changed at
some point introducing this bug.

I know this should have tests etc. but I'd rather add those on my other branch where I'm refactoring this code quite a bit.