### PR TITLE
[PAASTA-4955] Configurable app launch timeouts

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -267,6 +267,12 @@ class MarathonServiceConfig(InstanceConfig):
         else:
             return int(ceil(10.0 / instances))
 
+    def get_backoff_factor(self):
+        return self.config_dict.get('backoff_factor', 2)
+
+    def get_max_launch_delay_seconds(self):
+        return self.config_dict.get('max_launch_delay_seconds', 300)
+
     def get_bounce_method(self):
         """Get the bounce method specified in the service's marathon configuration.
 
@@ -377,7 +383,8 @@ class MarathonServiceConfig(InstanceConfig):
             },
             'uris': [system_paasta_config.get_dockercfg_location(), ],
             'backoff_seconds': self.get_backoff_seconds(),
-            'backoff_factor': 2,
+            'backoff_factor': self.get_backoff_factor(),
+            'max_launch_delay_seconds': self.get_max_launch_delay_seconds(),
             'health_checks': self.get_healthchecks(service_namespace_config),
             'env': self.get_env(),
             'mem': float(self.get_mem()),

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -854,6 +854,7 @@ class TestMarathonTools:
             'health_checks': fake_healthchecks,
             'backoff_factor': 2,
             'backoff_seconds': mock.ANY,
+            'max_launch_delay_seconds': 300,
             'accepted_resource_roles': ['ads'],
         }
         config = marathon_tools.MarathonServiceConfig(
@@ -2033,6 +2034,7 @@ def test_format_marathon_app_dict_no_smartstack():
             'args': [],
             'backoff_factor': 2,
             'backoff_seconds': mock.ANY,
+            'max_launch_delay_seconds': 300,
             'cpus': 0.25,
             'disk': 1024.0,
             'uris': ['file:///root/.dockercfg'],
@@ -2101,6 +2103,7 @@ def test_format_marathon_app_dict_with_smartstack():
             'args': [],
             'backoff_factor': 2,
             'backoff_seconds': mock.ANY,
+            'max_launch_delay_seconds': 300,
             'cpus': 0.25,
             'disk': 1024.0,
             'uris': ['file:///root/.dockercfg'],
@@ -2238,6 +2241,7 @@ def test_format_marathon_app_dict_utilizes_extra_volumes():
             'uris': ['file:///root/.dockercfg'],
             'backoff_factor': 2,
             'backoff_seconds': mock.ANY,
+            'max_launch_delay_seconds': 300,
             'health_checks': [],
             'env': mock.ANY,
             'id': fake_job_id,


### PR DESCRIPTION
This introduces two new config options, backoff_factor (default: 2) and
max_launch_delay_seconds (default: 300). For more info see
https://mesosphere.github.io/marathon/docs/rest-api.html