### PR TITLE
Log `paasta logs` errors to stderr, fixes #604. 

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -794,8 +794,10 @@ class ScribeLogReader(LogReader):
                 log.warning("Scribe stream %s is empty on %s" % (stream_name, scribe_env))
                 log.warning("Don't Panic! This may or may not be a problem depending on if you expect there to be")
                 log.warning("output within this stream.")
-                # Enter a wait so the process isn't considered dead
-                sleep(sys.maxsize)
+                # Enter a wait so the process isn't considered dead.
+                # This is just a large number, since apparently some python interpreters
+                # don't like being passed sys.maxsize.
+                sleep(2**16)
             else:
                 raise
 
@@ -876,26 +878,27 @@ def generate_start_end_time(from_string="30m", to_string=None):
 
 def validate_filtering_args(args, log_reader):
     if not log_reader.SUPPORTS_LINE_OFFSET and args.line_offset is not None:
-        print PaastaColors.red(log_reader.__class__.__name__ + " does not support line based offsets")
+        sys.stderr.write(PaastaColors.red(log_reader.__class__.__name__ + " does not support line based offsets"))
         return False
     if not log_reader.SUPPORTS_LINE_COUNT and args.line_count is not None:
-        print PaastaColors.red(log_reader.__class__.__name__ + " does not support line count based log retrieval")
+        sys.stderr.write(PaastaColors.red(log_reader.__class__.__name__ +
+                                          " does not support line count based log retrieval"))
         return False
     if not log_reader.SUPPORTS_TAILING and args.tail:
-        print PaastaColors.red(log_reader.__class__.__name__ + " does not support tailing")
+        sys.stderr.write(PaastaColors.red(log_reader.__class__.__name__ + " does not support tailing"))
         return False
     if not log_reader.SUPPORTS_TIME and (args.time_from is not None or args.time_to is not None):
-        print PaastaColors.red(log_reader.__class__.__name__ + " does not support time based offsets")
+        sys.stderr.write(PaastaColors.red(log_reader.__class__.__name__ + " does not support time based offsets"))
         return False
 
     if args.tail and (args.line_count is not None or args.time_from is not None or
                       args.time_to is not None or args.line_offset is not None):
-        print PaastaColors.red("You cannot specify line/time based filtering parameters when tailing")
+        sys.stderr.write(PaastaColors.red("You cannot specify line/time based filtering parameters when tailing"))
         return False
 
     # Can't have both
     if args.line_count is not None and args.time_from is not None:
-        print PaastaColors.red("You cannot filter based on both line counts and time")
+        sys.stderr.write(PaastaColors.red("You cannot filter based on both line counts and time"))
         return False
 
     return True
@@ -985,7 +988,7 @@ def paasta_logs(args):
     try:
         start_time, end_time = generate_start_end_time(args.time_from, args.time_to)
     except ValueError as e:
-        print PaastaColors.red(e.message)
+        sys.stderr.write(PaastaColors.red(e.message))
         return 1
 
     log_reader.print_logs_by_time(service, start_time, end_time, levels, components, clusters,


### PR DESCRIPTION
Pass an argument to time.sleep that works on more systems