### PR TITLE
Deep merge config files

### DIFF
--- a/docs/source/system_configs.rst
+++ b/docs/source/system_configs.rst
@@ -11,10 +11,8 @@ Structure
 By default, the System Paasta Configs are read by merging all files under ``/etc/paasta`` that end with ``.json``.
 You can override this path by setting the ``PAASTA_SYSTEM_CONFIG_DIR`` environment variable.
 This directory is searched recursively, so you may put configuration files in subdirectories as desired.
-The dictionaries described by each of these JSON files are merged with `python's dict.update
-<https://docs.python.org/2/library/stdtypes.html#dict.update>`_.
-This is not a deep merge, so if one file contains ``{"foo": {"bar": "one"}}`` and a later file contains
-``{"foo": {"baz": "two"}}``, then the final structure would contain only ``{"foo": {"baz": "two"}}``.
+The dictionaries described by each of these JSON files are deep merged when the config is loaded. If there
+are overlapping keys in different files the last file will win.
 
 If a file has permissions that prevent us from reading it, then that file will be ignored.
 This is useful for credentials that only some users or scripts need access to.

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -747,7 +747,8 @@ def get_readable_files_in_glob(glob, path):
 
 def load_system_paasta_config(path=PATH_TO_SYSTEM_PAASTA_CONFIG_DIR):
     """
-    Reads Paasta configs in specified directory in lexicographical order and merges duplicated keys (last file wins)
+    Reads Paasta configs in specified directory in lexicographical order and deep merges
+    the dictionaries (last file wins).
     """
     config = {}
     if not os.path.isdir(path):
@@ -759,7 +760,7 @@ def load_system_paasta_config(path=PATH_TO_SYSTEM_PAASTA_CONFIG_DIR):
     try:
         for config_file in get_readable_files_in_glob(glob="*.json", path=path):
             with open(config_file) as f:
-                config.update(json.load(f))
+                config = deep_merge_dictionaries(json.load(f), config)
     except IOError as e:
         raise PaastaNotConfiguredError("Could not load system paasta config file %s: %s" % (e.filename, e.strerror))
     return SystemPaastaConfig(config, path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -176,13 +176,15 @@ def test_load_system_paasta_config():
         mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock),
         mock.patch('paasta_tools.utils.get_readable_files_in_glob', autospec=True,
                    return_value=['/some/fake/dir/some_file.json']),
-        mock.patch('paasta_tools.utils.json.load', autospec=True, return_value=json_load_return_value)
+        mock.patch('paasta_tools.utils.json.load', autospec=True, return_value=json_load_return_value),
+        mock.patch('paasta_tools.utils.deep_merge_dictionaries', autospec=True, return_value=json_load_return_value)
     ) as (
         os_is_dir_patch,
         os_access_patch,
         open_file_patch,
         mock_get_readable_files_in_glob,
         json_patch,
+        mock_deep_merge,
     ):
         actual = utils.load_system_paasta_config()
         assert actual == expected
@@ -193,6 +195,7 @@ def test_load_system_paasta_config():
         open_file_patch.assert_any_call('/some/fake/dir/some_file.json')
         json_patch.assert_any_call(file_mock.__enter__())
         assert json_patch.call_count == 1
+        mock_deep_merge.assert_called_with(json_load_return_value, {})
 
 
 def test_load_system_paasta_config_file_non_existent_dir():


### PR DESCRIPTION
This ensures we perform a deep merge of each config file rather
than just a dict update. The motivation is for cluster autocaler
config files which are generated by terraform and currently only
the last one is active.

Here's an example where we want to have one file for each SFR but merge together in `cluster_autoscaling_resources`:
```
{
  "cluster_autoscaling_resources": {
    "aws_spot_fleet_request.${cluster_name}-slaves": {
      "type": "aws_spot_fleet_request",
      "id": "${sfr_id}",
      "pool": "${pool}",
      "min_instances": ${min_instances},
      "max_instances": ${max_instances}
    }
  }
}
```