### PR TITLE
Fix bug handling task counts in autoscaler

### DIFF
--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -562,8 +562,8 @@ def sort_slaves_to_kill(mesos_state, pool='default'):
     :returns: list of slaves"""
     slaves = get_mesos_task_count_by_slave(mesos_state, pool=pool)
     if slaves:
-        slaves_by_task_count = [slave['slave'] for slave in sorted(slaves.values(),
-                                                                   key=lambda x: (x['chronos_count'], x['count']))]
+        slaves_by_task_count = [slave.slave for slave in sorted(slaves.values(),
+                                                                key=lambda x: (x.chronos_count, x.count))]
         return slaves_by_task_count
     else:
         return []

--- a/tests/test_autoscaling_lib.py
+++ b/tests/test_autoscaling_lib.py
@@ -22,6 +22,7 @@ from pytest import raises
 
 from paasta_tools import autoscaling_lib
 from paasta_tools import marathon_tools
+from paasta_tools.mesos_tools import SlaveTaskCount
 
 
 def test_get_zookeeper_instances():
@@ -724,9 +725,9 @@ def test_sort_slaves_to_kill():
         mock_slave_1 = mock.Mock()
         mock_slave_2 = mock.Mock()
         mock_slave_3 = mock.Mock()
-        mock_task_count = {'pid1': {'count': 3, 'slave': mock_slave_1, 'chronos_count': 0},
-                           'pid2': {'count': 2, 'slave': mock_slave_2, 'chronos_count': 1},
-                           'pid3': {'count': 5, 'slave': mock_slave_3, 'chronos_count': 0}}
+        mock_task_count = {'pid1': SlaveTaskCount(count=3, slave=mock_slave_1, chronos_count=0),
+                           'pid2': SlaveTaskCount(count=2, slave=mock_slave_2, chronos_count=1),
+                           'pid3': SlaveTaskCount(count=5, slave=mock_slave_3, chronos_count=0)}
         mock_get_task_count.return_value = mock_task_count
         ret = autoscaling_lib.sort_slaves_to_kill(mock_mesos_state)
         mock_get_task_count.assert_called_with(mock_mesos_state, pool='default')


### PR DESCRIPTION
The task counts are no longer a dictionary. This fixes the resulting TypeError.