### PR TITLE
Fix delayed and suspended status when no deployments are in progress

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -935,15 +935,16 @@ def get_app_queue_status(client, app_id):
     """Returns the status of an application if it exists in Marathon's launch queue
 
     :param client: The marathon client
-    :param app_id: The Marathon app id
+    :param app_id: The Marathon app id (without the leading /)
     :returns: A tuple of the form (is_overdue, current_backoff_delay) or (None, None)
               if the app cannot be found. If is_overdue is True, then Marathon has
               not received a resource offer that satisfies the requirements for the app
     """
+    app_id = "/%s" % app_id
     app_queue = client.list_queue()
     for app_queue_item in app_queue:
         if app_queue_item.app.id == app_id:
-            return (app_queue_item.delay.overdue, app_queue_item.delay.timeLeftSeconds)
+            return (app_queue_item.delay.overdue, app_queue_item.delay.time_left_seconds)
 
     return (None, None)
 

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -227,6 +227,7 @@ def test_status_marathon_job_when_running():
     mock_tasks_running = 5
     app.tasks_running = mock_tasks_running
     app.deployments = []
+    app.instances = normal_instance_count
     with contextlib.nested(
         mock.patch('paasta_tools.marathon_tools.is_app_id_running', return_value=True),
     ) as (
@@ -247,6 +248,7 @@ def tests_status_marathon_job_when_running_running_no_tasks():
     mock_tasks_running = 0
     app.tasks_running = mock_tasks_running
     app.deployments = []
+    app.instances = normal_instance_count
     with contextlib.nested(
         mock.patch('paasta_tools.marathon_tools.is_app_id_running', return_value=True),
     ) as (
@@ -353,19 +355,19 @@ def tests_status_marathon_job_when_running_running_tasks_with_suspended_deployme
     normal_instance_count = 5
     mock_tasks_running = 0
     app.tasks_running = mock_tasks_running
-    app.deployments = ['test_deployment']
+    app.deployments = []
     app.instances = 0
     app.tasks_running = 0
     with contextlib.nested(
         mock.patch('paasta_tools.marathon_tools.is_app_id_running', return_value=True),
-        mock.patch('paasta_tools.marathon_tools.get_app_queue_status', return_value=(True, 0)),
+        mock.patch('paasta_tools.marathon_tools.get_app_queue_status', return_value=(None, None)),
     ) as (
         is_app_id_running_patch,
         get_app_queue_status_patch,
     ):
         output = marathon_serviceinit.status_marathon_job(service, instance, app_id, normal_instance_count, client)
         is_app_id_running_patch.assert_called_once_with(app_id, client)
-        assert get_app_queue_status_patch.call_count == 0
+        assert get_app_queue_status_patch.call_count == 1
         assert 'Stopped' in output
 
 

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -2389,8 +2389,8 @@ def test_get_app_queue_status():
     fake_delay = 100
     client = mock.create_autospec(marathon.MarathonClient)
     queue_item = mock.create_autospec(marathon.models.queue.MarathonQueueItem)
-    queue_item.app = mock.Mock(id=fake_app_id)
-    queue_item.delay = mock.Mock(overdue=False, timeLeftSeconds=fake_delay)
+    queue_item.app = mock.Mock(id="/%s" % fake_app_id)
+    queue_item.delay = mock.Mock(overdue=False, time_left_seconds=fake_delay)
     client.list_queue.return_value = [queue_item]
 
     is_overdue, delay_seconds = marathon_tools.get_app_queue_status(client, fake_app_id)


### PR DESCRIPTION
When no deployments are in progress, the previous logic incorrectly believes that the task is running