### PR TITLE
Allow http drain method in configs

### DIFF
--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -93,7 +93,7 @@
                 "type": "object"
             },
             "drain_method": {
-                "enum": [ "noop", "hacheck", "test" ],
+                "enum": [ "noop", "hacheck", "http", "test" ],
                 "default": "noop"
             },
             "drain_method_params": {


### PR DESCRIPTION
Fixes `paasta validate` to allow http drain method