### PR TITLE
Use packaged ephemeral-port-reserve

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ chronos-python==0.35.0
 cookiecutter==1.4.0
 docker-py==1.2.3
 dulwich==0.10.0
+ephemeral-port-reserve==1.0.1
 future>=0.15.2
 futures==3.0.1
 httplib2==0.9

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         # the Docker version deployed on PaaSTA servers
         'docker-py == 1.2.3',
         'dulwich == 0.10.0',
+        'ephemeral-port-reserve >= 1.0.1',
         'humanize >= 0.5.1',
         'httplib2 >= 0.9,<= 1.0',
         'isodate >= 0.5.0',


### PR DESCRIPTION
This will also fix the socket timeout on kernel>=4.4 and python>=2.7 (fixed in 1.0.1 in ephemeral-port-reserve)