### PR TITLE
Allow https healthcheck in ServiceNamespaceConfig, since hacheck now …

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -648,7 +648,7 @@ class ServiceNamespaceConfig(dict):
                 return None
             else:
                 return 'http'
-        elif mode in ['http', 'tcp']:
+        elif mode in ['http', 'tcp', 'https']:
             return mode
         else:
             raise InvalidSmartstackMode("Unknown mode: %s" % mode)


### PR DESCRIPTION
…supports it

We don't want to add it anywhere else, as marathon doesn't support https checks as far as I can tell