### PR TITLE
Ensure we treat instance weights as floats

### DIFF
--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -576,12 +576,7 @@ def get_spot_fleet_delta(resource, error):
             "of current %.2f%%. Just doing a %.2f%% change for now to %.2f%%." %
             (ideal_capacity, float(MAX_CLUSTER_DELTA) * 100, current_capacity,
              float(MAX_CLUSTER_DELTA) * 100, new_capacity))
-
-    if new_capacity != current_capacity:
-        print "Scaling SFR %s from %d to %d!" % (resource['id'], current_capacity, new_capacity)
-        return current_capacity, new_capacity
-    else:
-        return 0
+    return current_capacity, new_capacity
 
 
 def sort_slaves_to_kill(mesos_state, pool='default'):

--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -551,7 +551,7 @@ def get_spot_fleet_delta(resource, error):
                                       spot_fleet_request['SpotFleetRequestState'])
     current_capacity = float(spot_fleet_request['SpotFleetRequestConfig']['TargetCapacity'])
     ideal_capacity = float((1.0 + error) * current_capacity)
-    log.debug("Ideal calculated capacity is %.2f%% instances" % ideal_capacity)
+    log.debug("Ideal calculated capacity is %.2f instances" % ideal_capacity)
     new_capacity = float(min(
         max(
             float(resource['min_capacity']),
@@ -561,19 +561,19 @@ def get_spot_fleet_delta(resource, error):
         current_capacity * (1.00 + float(MAX_CLUSTER_DELTA)),
         float(resource['max_capacity']),
     ))
-    log.debug("The new capacity to scale to is %.2f%% instances" % ideal_capacity)
+    log.debug("The new capacity to scale to is %.2f instances" % ideal_capacity)
 
     if ideal_capacity > resource['max_capacity']:
-        log.warning("Our ideal capacity (%.2f%%) is over max_capacity (%.2f%%). Consider rasing max_capacity!" % (
+        log.warning("Our ideal capacity (%.2f) is over max_capacity (%.2f). Consider rasing max_capacity!" % (
             ideal_capacity, resource['max_capacity']))
     if ideal_capacity < resource['min_capacity']:
-        log.warning("Our ideal capacity (%.2f%%) is under min_capacity (%.2f%%). Consider lowering min_capacity!" % (
+        log.warning("Our ideal capacity (%.2f) is under min_capacity (%.2f). Consider lowering min_capacity!" % (
             ideal_capacity, resource['min_capacity']))
     if (ideal_capacity < current_capacity * (1.00 - float(MAX_CLUSTER_DELTA)) or
             ideal_capacity > current_capacity * (1.00 + float(MAX_CLUSTER_DELTA))):
         log.warning(
-            "Our ideal capacity (%.2f%%) would change by more than %.2f%% "
-            "of current %.2f%%. Just doing a %.2f%% change for now to %.2f%%." %
+            "Our ideal capacity (%.2f) would change by more than %.2f%% "
+            "of current %.2f. Just doing a %.2f%% change for now to %.2f." %
             (ideal_capacity, float(MAX_CLUSTER_DELTA) * 100, current_capacity,
              float(MAX_CLUSTER_DELTA) * 100, new_capacity))
     return current_capacity, new_capacity


### PR DESCRIPTION
@matthewbentley recently updated our instance weights for our SFRs. Turns out they don't have to be integers. And also there's an AWS limit on capacity so it makes sense to use smaller values!

Instance weights for SFRs don't have to be integers. This ensures that
we treat them as floats when deciding what to set as the target capacity
and how many hosts to kill.