### PR TITLE
Revert float change

### DIFF
--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -551,7 +551,7 @@ def get_spot_fleet_delta(resource, error):
                                       spot_fleet_request['SpotFleetRequestState'])
     current_capacity = float(spot_fleet_request['SpotFleetRequestConfig']['TargetCapacity'])
     ideal_capacity = float((1.0 + error) * current_capacity)
-    log.debug("Ideal calculated capacity is %.2f instances" % ideal_capacity)
+    log.debug("Ideal calculated capacity is %.2f%% instances" % ideal_capacity)
     new_capacity = float(min(
         max(
             float(resource['min_capacity']),
@@ -561,19 +561,19 @@ def get_spot_fleet_delta(resource, error):
         current_capacity * (1.00 + float(MAX_CLUSTER_DELTA)),
         float(resource['max_capacity']),
     ))
-    log.debug("The new capacity to scale to is %.2f instances" % ideal_capacity)
+    log.debug("The new capacity to scale to is %.2f%% instances" % ideal_capacity)
 
     if ideal_capacity > resource['max_capacity']:
-        log.warning("Our ideal capacity (%.2f) is over max_capacity (%.2f). Consider rasing max_capacity!" % (
+        log.warning("Our ideal capacity (%.2f%%) is over max_capacity (%.2f%%). Consider rasing max_capacity!" % (
             ideal_capacity, resource['max_capacity']))
     if ideal_capacity < resource['min_capacity']:
-        log.warning("Our ideal capacity (%.2f) is under min_capacity (%.2f). Consider lowering min_capacity!" % (
+        log.warning("Our ideal capacity (%.2f%%) is under min_capacity (%.2f%%). Consider lowering min_capacity!" % (
             ideal_capacity, resource['min_capacity']))
     if (ideal_capacity < current_capacity * (1.00 - float(MAX_CLUSTER_DELTA)) or
             ideal_capacity > current_capacity * (1.00 + float(MAX_CLUSTER_DELTA))):
         log.warning(
-            "Our ideal capacity (%.2f) would change by more than %.2f%% "
-            "of current %.2f. Just doing a %.2f%% change for now to %.2f." %
+            "Our ideal capacity (%.2f%%) would change by more than %.2f%% "
+            "of current %.2f%%. Just doing a %.2f%% change for now to %.2f%%." %
             (ideal_capacity, float(MAX_CLUSTER_DELTA) * 100, current_capacity,
              float(MAX_CLUSTER_DELTA) * 100, new_capacity))
     return current_capacity, new_capacity

--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -549,33 +549,32 @@ def get_spot_fleet_delta(resource, error):
     if spot_fleet_request['SpotFleetRequestState'] != 'active':
         raise ClusterAutoscalingError('Can not scale non-active spot fleet requests. This one is "%s"' %
                                       spot_fleet_request['SpotFleetRequestState'])
-    current_capacity = float(spot_fleet_request['SpotFleetRequestConfig']['TargetCapacity'])
-    ideal_capacity = float((1.0 + error) * current_capacity)
-    log.debug("Ideal calculated capacity is %.2f%% instances" % ideal_capacity)
-    new_capacity = float(min(
+    current_capacity = int(spot_fleet_request['SpotFleetRequestConfig']['TargetCapacity'])
+    ideal_capacity = int(ceil((1 + error) * current_capacity))
+    log.debug("Ideal calculated capacity is %d instances" % ideal_capacity)
+    new_capacity = int(min(
         max(
-            float(resource['min_capacity']),
-            current_capacity * (1.00 - float(MAX_CLUSTER_DELTA)),
+            resource['min_capacity'],
+            floor(current_capacity * (1.00 - MAX_CLUSTER_DELTA)),
             ideal_capacity,
+            1,  # A SFR cannot scale below 1 instance
         ),
-        current_capacity * (1.00 + float(MAX_CLUSTER_DELTA)),
-        float(resource['max_capacity']),
+        ceil(current_capacity * (1.00 + MAX_CLUSTER_DELTA)),
+        resource['max_capacity'],
     ))
-    log.debug("The new capacity to scale to is %.2f%% instances" % ideal_capacity)
+    log.debug("The new capacity to scale to is %d instances" % ideal_capacity)
 
     if ideal_capacity > resource['max_capacity']:
-        log.warning("Our ideal capacity (%.2f%%) is over max_capacity (%.2f%%). Consider rasing max_capacity!" % (
+        log.warning("Our ideal capacity (%d) is higher than max_capacity (%d). Consider rasing max_capacity!" % (
             ideal_capacity, resource['max_capacity']))
     if ideal_capacity < resource['min_capacity']:
-        log.warning("Our ideal capacity (%.2f%%) is under min_capacity (%.2f%%). Consider lowering min_capacity!" % (
+        log.warning("Our ideal capacity (%d) is lower than min_capacity (%d). Consider lowering min_capacity!" % (
             ideal_capacity, resource['min_capacity']))
-    if (ideal_capacity < current_capacity * (1.00 - float(MAX_CLUSTER_DELTA)) or
-            ideal_capacity > current_capacity * (1.00 + float(MAX_CLUSTER_DELTA))):
+    if (ideal_capacity < floor(current_capacity * (1.00 - MAX_CLUSTER_DELTA)) or
+            ideal_capacity > ceil(current_capacity * (1.00 + MAX_CLUSTER_DELTA))):
         log.warning(
-            "Our ideal capacity (%.2f%%) would change by more than %.2f%% "
-            "of current %.2f%%. Just doing a %.2f%% change for now to %.2f%%." %
-            (ideal_capacity, float(MAX_CLUSTER_DELTA) * 100, current_capacity,
-             float(MAX_CLUSTER_DELTA) * 100, new_capacity))
+            "Our ideal capacity (%d) is greater than %.2f%% of current %d. Just doing a %.2f%% change for now to %d." %
+            (ideal_capacity, MAX_CLUSTER_DELTA * 100, current_capacity, MAX_CLUSTER_DELTA * 100, new_capacity))
     return current_capacity, new_capacity
 
 
@@ -641,7 +640,7 @@ def wait_and_terminate(slave, dry_run):
 
 def get_instance_type_weights(sfr):
     launch_specifications = sfr['SpotFleetRequestConfig']['LaunchSpecifications']
-    return {ls['InstanceType']: float(ls['WeightedCapacity']) for ls in launch_specifications}
+    return {ls['InstanceType']: ls['WeightedCapacity'] for ls in launch_specifications}
 
 
 def filter_sfr_slaves(sorted_slaves, sfr):
@@ -718,8 +717,8 @@ def scale_aws_spot_fleet_request(resource, current_capacity, target_capacity, so
     :param target_capacity: target SFR capacity
     :param sorted_slaves: list of slaves by order to kill
     :param dry_run: Don't drain or make changes to spot fleet if True"""
-    target_capacity = float(target_capacity)
-    current_capacity = float(current_capacity)
+    target_capacity = int(target_capacity)
+    current_capacity = int(current_capacity)
     delta = target_capacity - current_capacity
     sfr_id = resource['id']
     if delta == 0:
@@ -742,7 +741,7 @@ def scale_aws_spot_fleet_request(resource, current_capacity, target_capacity, so
             if len(sfr_sorted_slaves) == 0:
                 break
             slave_to_kill = sfr_sorted_slaves.pop()
-            instance_capacity = slave_to_kill['instance_weight']
+            instance_capacity = int(slave_to_kill['instance_weight'])
             new_capacity = current_capacity - instance_capacity
             if current_capacity - instance_capacity < target_capacity:
                 log.info("Terminating instance {0} with weight {1} would take us below our target of {2}, so this is as"

--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -741,9 +741,11 @@ def scale_aws_spot_fleet_request(resource, current_capacity, target_capacity, so
             if len(sfr_sorted_slaves) == 0:
                 break
             slave_to_kill = sfr_sorted_slaves.pop()
-            instance_capacity = int(slave_to_kill['instance_weight'])
-            new_capacity = current_capacity - instance_capacity
-            if current_capacity - instance_capacity < target_capacity:
+            # Instance weights can be floats but the target has to be an integer
+            # because AWS...
+            instance_capacity = slave_to_kill['instance_weight']
+            new_capacity = int(round(current_capacity - instance_capacity))
+            if new_capacity < target_capacity:
                 log.info("Terminating instance {0} with weight {1} would take us below our target of {2}, so this is as"
                          " close to our target as we can get".format(slave_to_kill['instance_id'],
                                                                      slave_to_kill['instance_weight'],


### PR DESCRIPTION
AWS supports float values for instance weights in an SFR but only integers for target capacity, e.g. https://github.com/boto/botocore/blob/develop/botocore/data/ec2/2016-04-01/service-2.json#L15432

This reverts treating everything as a float and adds some rounding when we set target capacity.