### PR TITLE
Make paasta status print lines proprotional to how verbose they requested

### DIFF
--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -281,8 +281,12 @@ def format_chronos_job_status(client, job, running_tasks, verbose=0):
     command = _format_command(job)
     mesos_status = _format_mesos_status(job, running_tasks)
     if verbose > 0:
-        tail_stdstreams = verbose > 1
-        mesos_status_verbose = status_mesos_tasks_verbose(job["name"], get_short_task_id, tail_stdstreams)
+        tail_lines = (verbose - 1) * 10
+        mesos_status_verbose = status_mesos_tasks_verbose(
+            job_id=job["name"],
+            get_short_task_id=get_short_task_id,
+            tail_lines=tail_lines,
+        )
         mesos_status = "%s\n%s" % (mesos_status, mesos_status_verbose)
     return (
         "Job:     %(job_name)s\n"

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -21,6 +21,7 @@ import isodate
 from paasta_tools.mesos_tools import get_running_tasks_from_active_frameworks
 from paasta_tools.mesos_tools import status_mesos_tasks_verbose
 from paasta_tools.utils import _log
+from paasta_tools.utils import calculate_tail_lines
 from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import PaastaColors
 
@@ -281,7 +282,7 @@ def format_chronos_job_status(client, job, running_tasks, verbose=0):
     command = _format_command(job)
     mesos_status = _format_mesos_status(job, running_tasks)
     if verbose > 0:
-        tail_lines = (verbose - 1) * 10
+        tail_lines = calculate_tail_lines(verbose_level=verbose)
         mesos_status_verbose = status_mesos_tasks_verbose(
             job_id=job["name"],
             get_short_task_id=get_short_task_id,

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -26,6 +26,7 @@ from paasta_tools.monitoring.replication_utils import backend_is_up
 from paasta_tools.monitoring.replication_utils import match_backends_and_tasks
 from paasta_tools.smartstack_tools import get_backends
 from paasta_tools.utils import _log
+from paasta_tools.utils import calculate_tail_lines
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import format_table
@@ -373,7 +374,7 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir, app_i
             print out
         print status_mesos_tasks(service, instance, normal_instance_count)
         if verbose > 0:
-            tail_lines = (verbose - 1) * 10
+            tail_lines = calculate_tail_lines(verbose_level=verbose)
             print status_mesos_tasks_verbose(
                 job_id=app_id,
                 get_short_task_id=get_short_task_id,

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -373,8 +373,12 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir, app_i
             print out
         print status_mesos_tasks(service, instance, normal_instance_count)
         if verbose > 0:
-            tail_stdstreams = verbose > 1
-            print status_mesos_tasks_verbose(app_id, get_short_task_id, tail_stdstreams)
+            tail_lines = (verbose - 1) * 10
+            print status_mesos_tasks_verbose(
+                job_id=app_id,
+                get_short_task_id=get_short_task_id,
+                tail_lines=tail_lines,
+            )
         if proxy_port is not None:
             print status_smartstack_backends(
                 service=service,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1542,3 +1542,10 @@ class ZookeeperPool(object):
             cls.zk.stop()
             cls.zk.close()
             cls.zk = None
+
+
+def calculate_tail_lines(verbose_level):
+    if verbose_level == 1:
+        return 0
+    else:
+        return 10 ** (verbose_level - 1)

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -412,7 +412,7 @@ def test_format_chronos_job_mesos_verbose(verbosity_level):
     elif verbosity_level == 2:
         expected_tail_lines = 10
     elif verbosity_level == 3:
-        expected_tail_lines = 20
+        expected_tail_lines = 100
     mock_client = mock.Mock()
     with contextlib.nested(
         mock.patch('paasta_tools.chronos_serviceinit.status_mesos_tasks_verbose', autospec=True,

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -49,11 +49,11 @@ def test_filter_not_running_tasks():
 
 
 @mark.parametrize('test_case', [
-    [False, 0],
-    [True, 1 + 10]  # 1 running task, 10 non-running taks (truncated)
+    [0, 0],
+    [10, 1 + 10]  # 1 running task, 10 non-running taks (truncated)
 ])
 def test_status_mesos_tasks_verbose(test_case):
-    tail_stdstreams, expected_format_tail_call_count = test_case
+    tail_lines, expected_format_tail_call_count = test_case
     with contextlib.nested(
         mock.patch('paasta_tools.mesos_tools.get_running_tasks_from_active_frameworks', autospec=True,),
         mock.patch('paasta_tools.mesos_tools.get_non_running_tasks_from_active_frameworks', autospec=True,),
@@ -88,7 +88,11 @@ def test_status_mesos_tasks_verbose(test_case):
         def get_short_task_id(_):
             return 'short_task_id'
 
-        actual = mesos_tools.status_mesos_tasks_verbose(job_id, get_short_task_id, tail_stdstreams)
+        actual = mesos_tools.status_mesos_tasks_verbose(
+            job_id=job_id,
+            get_short_task_id=get_short_task_id,
+            tail_lines=tail_lines,
+        )
         assert 'Running Tasks' in actual
         assert 'Non-Running Tasks' in actual
         format_running_mesos_task_row_patch.assert_called_once_with('doing a lap', get_short_task_id)


### PR DESCRIPTION
There are times I just wanted more than 10 lines, but didn't want to run paasta logs.

This makes it so -vvvvvv will work.

Also lots of kwargs to make sure I got all the args right in the right order.