### PR TITLE
Backwards compatible way to support multiple nerve namespaces

### DIFF
--- a/docs/source/about/smartstack_interaction.rst
+++ b/docs/source/about/smartstack_interaction.rst
@@ -220,7 +220,7 @@ the same Nerve namespace. Consider this example::
         cmd: myserver.py
     canary:
         instances: 1
-        nerve_ns: main
+        registration_namespaces: ['main']
         cmd: myserver.py --experiment
 
 With this example, the ``canary`` instance gets advertised *under* the ``main`` Nerve
@@ -241,13 +241,13 @@ Sharding is another use case for using alternative namespaces::
     #marathon.yaml
     shard1:
         instances: 10
-        nerve_ns: main
+        registration_namespaces: ['main']
     shard2:
         instances: 10
-        nerve_ns: main
+        registration_namespaces: ['main']
     shard3:
         instances: 10
-        nerve_ns: main
+        registration_namespaces: ['main']
 
 These shards all end up being load-balanced in the same "main" pool. More
 complex YAML definitions can take advantage of YAML's

--- a/docs/source/deploy_groups.rst
+++ b/docs/source/deploy_groups.rst
@@ -38,7 +38,7 @@ Now let’s take a look at how instances are linked to a deploy group by taking 
    canary:
      cpus: .1
      mem: 301
-     nerve_ns: main
+     registration_namespaces: ['main']
      instances: 1
      deploy_group: dev-stage.everything
    main:

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -47,15 +47,26 @@ instance MAY have:
   * ``max_instances``: When autoscaling, the maximum number of instances that
     marathon will create for a service
 
-  * ``nerve_ns``: Specifies that this namespace should be routed to by another
-    namespace in SmartStack. In SmartStack, each service has difference pools
-    of backend servers that are listening on a particul port. In PaaSTA we call
-    these "Nerve Namespaces". By default, the Namespace assigned to a particular
-    instance in PaaSTA has the *same name*, so the ``main`` instance will correspond
-    to the ``main`` Nerve namespace defined in ``smartstack.yaml``. This ``nerve_ns``
-    option allows users to make particular instances appear under an *alternative*
-    namespace. For example ``canary`` instances can have ``nerve_ns: main`` to route
-    their traffic to the same pool as the other ``main`` instances.
+  * ``registration_namespaces`` (list of strings): Specifices that this service
+    Instance should register in the provided SmartStack Namespaces. Paasta
+    deploys Instances, SmartStack routes to Namespaces. In SmartStack, each
+    namespace of a service is a separate pools of backend servers that are
+    listening on a particul port. This ``registration_namespaces`` option
+    allows users to make particular instances appear under an *alternative*
+    namespace. For example ``canary`` instances can have
+    ``registration_namespaces: ['main']`` to route their traffic to the same
+    pool as the other ``main`` instances.
+
+    By default, the Namespace assigned to a particular Instance in PaaSTA has
+    the *same name*, so the ``main`` Instance will correspond to the ``main``
+    Namespace defined in ``smartstack.yaml``. 
+
+    The first instance in this list is assumed to be used by clients and is
+    the only one currently monitored, waited for during bounces, etc ...
+
+  * ``nerve_ns``: **DEPRECATED**, use ``registration_namespaces`` instead.
+    **WARNING**: do not supply both ``registration_namespaces`` and
+    ``nerve_ns`` as ``registration_namespces`` will take precedence.
 
   * ``backoff_factor``: PaaSTA will automatically calculate the duration of an
     application's backoff period in case of a failed launch based on the number
@@ -444,7 +455,7 @@ The ``main`` key is the service namespace.  Namespaces were introduced for
 PaaSTA services in order to support running multiple daemons from a single
 service codebase. In PaaSTA, each instance in your marathon.yaml maps to a
 smartstack namespace of the same name, unless you specify a different
-``nerve_ns``.
+``registration_namespaces``.
 
 We now describe which keys are supported within a namespace.  Note that all but
 proxy_port are optional.
@@ -705,7 +716,7 @@ A marathon service that overrides options on different instances (canary)::
         page: true
     canary:
       instances: 1
-      nerve_ns: main
+      registration_namespaces: ['main']
       monitoring:
         page: false
         ticket: true

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -58,6 +58,13 @@
             "nerve_ns": {
                 "type": "string"
             },
+            "registration_namespaces": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "uniqueItems": true
+            },
             "bounce_method": {
                 "type": "string"
             },

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -523,8 +523,18 @@ class MarathonServiceConfig(InstanceConfig):
     def get_healthcheck_max_consecutive_failures(self):
         return self.config_dict.get('healthcheck_max_consecutive_failures', 30)
 
+    # FIXME(jlynch|2016-08-02, PAASTA-4964): DEPRECATE nerve_ns and remove it
     def get_nerve_namespace(self):
-        return self.config_dict.get('nerve_ns', self.instance)
+        return self.get_registration_namespaces()[0]
+
+    def get_registration_namespaces(self):
+        registration_namespaces = self.config_dict.get('registration_namespaces', [])
+        # Backwards compatbility with nerve_ns
+        # FIXME(jlynch|2016-08-02, PAASTA-4964): DEPRECATE nerve_ns and remove it
+        if 'nerve_ns' in self.config_dict:
+            registration_namespaces.append(self.config_dict.get('nerve_ns'))
+
+        return registration_namespaces or [self.instance]
 
     def get_bounce_health_params(self, service_namespace_config):
         default = {}
@@ -766,9 +776,15 @@ def deformat_job_id(job_id):
     return decompose_job_id(job_id)
 
 
-def read_namespace_for_service_instance(name, instance, cluster=None, soa_dir=DEFAULT_SOA_DIR):
-    """Retreive a service instance's nerve namespace from its configuration file.
-    If one is not defined in the config file, returns instance instead."""
+def read_all_namespaces_for_service_instance(name, instance, cluster=None, soa_dir=DEFAULT_SOA_DIR):
+    """Retreive all registration namespaces for a particular service instance.
+
+    For example, the 'main' paasta instance may register in the 'main'
+    namespace as well as the 'bulk' namespace
+
+    If one is not defined in the config file, returns a list containing
+    instance instead.
+    """
     if not cluster:
         cluster = load_system_paasta_config().get_cluster()
     srv_info = service_configuration_lib.read_extra_service_information(
@@ -776,7 +792,26 @@ def read_namespace_for_service_instance(name, instance, cluster=None, soa_dir=DE
         "marathon-%s" % cluster,
         soa_dir
     )[instance]
-    return srv_info['nerve_ns'] if 'nerve_ns' in srv_info else instance
+
+    registration_namespaces = srv_info.get('registration_namespaces', [])
+    # Backwards compatbility with nerve_ns
+    # FIXME(jlynch|2016-08-02, PAASTA-4964): DEPRECATE nerve_ns and remove it
+    if 'nerve_ns' in srv_info:
+        registration_namespaces.append(srv_info['nerve_ns'])
+
+    return registration_namespaces or [instance]
+
+
+def read_namespace_for_service_instance(name, instance, cluster=None, soa_dir=DEFAULT_SOA_DIR):
+    """Retreive a service instance's primary registration namespace for a
+    particular service instance.
+
+    This is the namespace that clients ought talk to, as well as paasta
+    ought monitor. In this context "primary" just means the first one in the
+    list of registration namespaces.
+
+    If one is not defined in the config file, returns instance instead."""
+    return read_all_namespaces_for_service_instance(name, instance, cluster, soa_dir)[0]
 
 
 def get_proxy_port_for_instance(name, instance, cluster=None, soa_dir=DEFAULT_SOA_DIR):
@@ -867,13 +902,13 @@ def get_marathon_services_running_here_for_nerve(cluster, soa_dir):
     nerve_list = []
     for name, instance, port in marathon_services:
         try:
-            namespace = read_namespace_for_service_instance(name, instance, cluster, soa_dir)
-            nerve_dict = load_service_namespace_config(name, namespace, soa_dir)
-            if not nerve_dict.is_in_smartstack():
-                continue
-            nerve_dict['port'] = port
-            nerve_name = compose_job_id(name, namespace)
-            nerve_list.append((nerve_name, nerve_dict))
+            for namespace in read_all_namespaces_for_service_instance(name, instance, cluster, soa_dir):
+                nerve_dict = load_service_namespace_config(name, namespace, soa_dir)
+                if not nerve_dict.is_in_smartstack():
+                    continue
+                nerve_dict['port'] = port
+                nerve_name = compose_job_id(name, namespace)
+                nerve_list.append((nerve_name, nerve_dict))
         except KeyError:
             continue  # SOA configs got deleted for this app, it'll get cleaned up
     return nerve_list

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -161,6 +161,7 @@ main_http:
   instances: 2
   mem: 250
   disk: 512
+  registration_namespaces: ['main', 'http']
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -655,7 +655,6 @@ class TestMarathonTools:
             read_ns_config_patch.assert_any_call('no_docstrings', 'quatro', soa_dir)
             assert read_ns_config_patch.call_count == 4
 
-
     def test_get_marathon_services_running_here_for_nerve_when_not_in_smartstack(self):
         cluster = 'edelweiss'
         soa_dir = 'the_sound_of_music'


### PR DESCRIPTION
@EvanKrall I think that this hack is sufficient for PaaSTA to _support_ multiple namespaces being advertised from a single instance. I believe there is more cleanup to do in the drain and bounce code to fully get rid of ``nerve_ns``, but I'd like to take this iteratively since folks are blocking on  this.

What does this do:
* Adds a ``registration_namespaces`` option, maintaining backwards compatibility with ``nerve_ns``; also introduces the concept of registrations instead of tightly coupling to implementation details
* Refactors MarathonServiceConfig to provide ``get_registration_namespaces`` and powers ``get_nerve_ns`` off of that.

What is still to do in follow ups:
* Completely remove ``nerve_ns``
* Refactor the drain_lib, bounce_lib, and monitoring code to check more than just the primary namespace. This is probably the really hard part.
* DRY the registration logic between getting registrations for nerve and such, and things that use MarathonServiceConfig objects.