### PR TITLE
Change local-run to healthcheck via GET

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -72,7 +72,7 @@ def perform_http_healthcheck(url, timeout):
     try:
         with Timeout(seconds=timeout):
             try:
-                res = requests.head(url)
+                res = requests.get(url)
             except requests.ConnectionError:
                 return (False, "http request failed: connection failed")
     except TimeoutError:

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -106,7 +106,7 @@ def test_perform_tcp_healthcheck_failure(mock_socket_connect):
     assert '10 seconds' in actual[1]
 
 
-@mock.patch('requests.head')
+@mock.patch('requests.get')
 def test_perform_http_healthcheck_success(mock_http_conn):
     fake_http_url = "http://fakehost:1234/fake_status_path"
     fake_timeout = 10
@@ -116,7 +116,7 @@ def test_perform_http_healthcheck_success(mock_http_conn):
     mock_http_conn.assert_called_once_with(fake_http_url)
 
 
-@mock.patch('requests.head')
+@mock.patch('requests.get')
 def test_perform_http_healthcheck_failure(mock_http_conn):
     fake_http_url = "http://fakehost:1234/fake_status_path"
     fake_timeout = 10
@@ -127,7 +127,7 @@ def test_perform_http_healthcheck_failure(mock_http_conn):
     mock_http_conn.assert_called_once_with(fake_http_url)
 
 
-@mock.patch('requests.head', side_effect=TimeoutError)
+@mock.patch('requests.get', side_effect=TimeoutError)
 def test_perform_http_healthcheck_timeout(mock_http_conn):
     fake_http_url = "http://fakehost:1234/fake_status_path"
     fake_timeout = 10
@@ -139,7 +139,7 @@ def test_perform_http_healthcheck_timeout(mock_http_conn):
     mock_http_conn.assert_called_once_with(fake_http_url)
 
 
-@mock.patch('requests.head')
+@mock.patch('requests.get')
 def test_perform_http_healthcheck_failure_with_multiple_content_type(mock_http_conn):
     fake_http_url = "http://fakehost:1234/fake_status_path"
     fake_timeout = 10


### PR DESCRIPTION
This is what happens in real deploys, so this is what we should do.