### PR TITLE
Add validation of HTTP drain method and fix bounce errors

### DIFF
--- a/paasta_itests/setup_marathon_job.feature
+++ b/paasta_itests/setup_marathon_job.feature
@@ -1,5 +1,5 @@
 Feature: setup_marathon_job can create a "complete" app
-    
+
   Scenario: complete apps can be deployed
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -7,18 +7,56 @@
         "type": "object",
         "additionalProperties": false,
         "minProperties": 1,
-        "oneOf": [
+        "allOf":[
             {
-                "properties": {
-                    "healthcheck_mode": {"enum": ["tcp", "http"]}
-                }
-            },
-            {
-                "properties": {
-                    "healthcheck_mode": {"enum": ["cmd"]},
-                    "healthcheck_cmd": {"type": "string"}
-                },
-                "required": ["healthcheck_cmd"]
+                "oneOf": [
+                    {
+                        "properties": {
+                            "healthcheck_mode": {"enum": ["tcp", "http"]}
+                        }
+                    },
+                    {
+                        "properties": {
+                            "healthcheck_mode": {"enum": ["cmd"]},
+                            "healthcheck_cmd": {"type": "string"}
+                        },
+                        "required": ["healthcheck_cmd"]
+                    }
+                ]
+            }, {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "drain_method": {
+                                "enum": [ "noop", "hacheck", "test" ]
+                            }
+                        }
+                    },
+                    {
+                        "properties": {
+                            "drain_method": {"enum": ["http"]},
+                            "drain_method_params": {
+                                "type": "object",
+                                "properties": {
+                                    "drain": {
+                                        "type": "object"
+                                    },
+                                    "stop_draining": {
+                                        "type": "object"
+                                    },
+                                    "is_draining": {
+                                        "type": "object"
+                                    },
+                                    "is_safe_to_kill": {
+                                        "type": "object"
+                                    }
+                                },
+                                "required": ["drain", "stop_draining", "is_draining", "is_safe_to_kill"]
+                            }
+                        },
+                        "required": ["drain_method_params"]
+                    }
+                ]
             }
         ],
         "properties": {

--- a/paasta_tools/drain_lib.py
+++ b/paasta_tools/drain_lib.py
@@ -241,7 +241,7 @@ class HTTPDrainMethod(DrainMethod):
     def parse_success_codes(self, success_codes_str):
         """Expand a string like 200-399,407-409,500 to a set containing all the integers in between."""
         acceptable_response_codes = set()
-        for series_str in success_codes_str.split(','):
+        for series_str in str(success_codes_str).split(','):
             if '-' in series_str:
                 start, end = series_str.split('-')
                 acceptable_response_codes.update(range(int(start), int(end) + 1))

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -182,7 +182,6 @@ def drain_tasks_and_find_tasks_to_kill(tasks_to_drain, already_draining_tasks, d
         except Exception as e:
             log_bounce_action(
                 line=("%s bounce killing task %s due to exception when draining: %s" % (bounce_method, task.id, e)),
-                level='error',
             )
             tasks_to_kill.add(task)
 

--- a/tests/test_drain_lib.py
+++ b/tests/test_drain_lib.py
@@ -97,6 +97,7 @@ class TestHTTPDrainMethod(object):
         assert drain_method.parse_success_codes('200') == set([200])
         assert drain_method.parse_success_codes('200-203') == set([200, 201, 202, 203])
         assert drain_method.parse_success_codes('200-202,302,305-306') == set([200, 201, 202, 302, 305, 305, 306])
+        assert drain_method.parse_success_codes(200) == set([200])
 
     def test_check_response_code(self):
         drain_method = drain_lib.HTTPDrainMethod('fake_service', 'fake_instance', 'fake_nerve_ns', {}, {}, {}, {})

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -1450,7 +1450,6 @@ class TestDrainTasksAndFindTasksToKill(object):
 
         fake_log_bounce_action.assert_any_call(
             line="fake bounce killing task to_drain due to exception when draining: Hello",
-            level='error',
         )
 
     def test_catches_exception_during_is_safe_to_kill(self):


### PR DESCRIPTION
This should allow apps with working HTTP drain endpoints to at least successfully bounce. This doesn't account for all the possible errors that could happen but we aren't sure what the desired behavior should be in those cases so we'll wait until they happen.