### PR TITLE
Add support for maintenance mode to autoscaler

### DIFF
--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -613,7 +613,11 @@ def wait_and_terminate(slave, dry_run):
                     continue
                 # Check if no tasks are running or we have reached the maintenance window
                 if is_safe_to_kill(slave['hostname']):
-                    log.info("TERMINATING: {0}".format(instance_id))
+                    log.info("TERMINATING: {0} (Hostname = {1}, IP = {2})".format(
+                        instance_id,
+                        slave['hostname'],
+                        slave['ip'],
+                    ))
                     try:
                         ec2_client.terminate_instances(InstanceIds=[instance_id], DryRun=dry_run)
                     except ClientError as e:

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -646,9 +646,9 @@ def get_mesos_task_count_by_slave(mesos_state, pool=None):
             log.debug("Task framework: {0}".format(task.framework.name))
             if task.framework.name == 'chronos':
                 slaves[task.slave['id']]['chronos_count'] += 1
-    slaves = {slave_pid: SlaveTaskCount(**slave_counts) for slave_pid, slave_counts in slaves.items()}
+    slaves = {slave_counts['slave']['hostname']: SlaveTaskCount(**slave_counts) for slave_counts in slaves.values()}
     for slave in slaves.values():
-        log.info("Slave: {0}, running {1} tasks, including {2} chronos tasks".format(slave.slave['pid'],
+        log.info("Slave: {0}, running {1} tasks, including {2} chronos tasks".format(slave.slave['hostname'],
                                                                                      slave.count,
                                                                                      slave.chronos_count))
     return slaves

--- a/paasta_tools/paasta_maintenance.py
+++ b/paasta_tools/paasta_maintenance.py
@@ -457,6 +457,20 @@ def get_hosts_past_maintenance_start():
     return ret
 
 
+def get_hosts_past_maintenance_end():
+    """Get a list of hosts that have reached the end of their maintenance window
+    :returns: List of hostnames
+    """
+    schedules = get_maintenance_schedule().json()
+    current_time = datetime_to_nanoseconds(now())
+    ret = []
+    for window in schedules['windows']:
+        end = window['unavailability']['start']['nanoseconds'] + window['unavailability']['duration']['nanoseconds']
+        if end < current_time:
+            ret += [host['hostname'] for host in window['machine_ids']]
+    return ret
+
+
 def paasta_maintenance():
     """Manipulate the maintenance state of a PaaSTA host.
     :returns: None

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -646,16 +646,16 @@ def test_get_mesos_task_count_by_slave():
         mock_task4.framework = mock_marathon
         mock_tasks = [mock_task1, mock_task2, mock_task3, mock_task4]
         mock_get_running_tasks_from_active_frameworks.return_value = mock_tasks
-        mock_slave_1 = {'id': 'slave1', 'attributes': {'pool': 'default'}, 'pid': 'aa'}
-        mock_slave_2 = {'id': 'slave2', 'attributes': {'pool': 'default'}, 'pid': 'bb'}
-        mock_slave_3 = {'id': 'slave3', 'attributes': {'pool': 'another'}, 'pid': 'cc'}
+        mock_slave_1 = {'id': 'slave1', 'attributes': {'pool': 'default'}, 'hostname': 'host1'}
+        mock_slave_2 = {'id': 'slave2', 'attributes': {'pool': 'default'}, 'hostname': 'host2'}
+        mock_slave_3 = {'id': 'slave3', 'attributes': {'pool': 'another'}, 'hostname': 'host3'}
         mock_mesos_state = {'slaves': [mock_slave_1, mock_slave_2, mock_slave_3]}
         ret = mesos_tools.get_mesos_task_count_by_slave(mock_mesos_state, pool='default')
         mock_get_running_tasks_from_active_frameworks.assert_called_with('')
-        assert ret == {'slave1': mesos_tools.SlaveTaskCount(count=2, chronos_count=1, slave=mock_slave_1),
-                       'slave2': mesos_tools.SlaveTaskCount(count=2, chronos_count=0, slave=mock_slave_2)}
+        assert ret == {'host1': mesos_tools.SlaveTaskCount(count=2, chronos_count=1, slave=mock_slave_1),
+                       'host2': mesos_tools.SlaveTaskCount(count=2, chronos_count=0, slave=mock_slave_2)}
         ret = mesos_tools.get_mesos_task_count_by_slave(mock_mesos_state, pool=None)
         mock_get_running_tasks_from_active_frameworks.assert_called_with('')
-        assert ret == {'slave1': mesos_tools.SlaveTaskCount(count=2, chronos_count=1, slave=mock_slave_1),
-                       'slave2': mesos_tools.SlaveTaskCount(count=2, chronos_count=0, slave=mock_slave_2),
-                       'slave3': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)}
+        assert ret == {'host1': mesos_tools.SlaveTaskCount(count=2, chronos_count=1, slave=mock_slave_1),
+                       'host2': mesos_tools.SlaveTaskCount(count=2, chronos_count=0, slave=mock_slave_2),
+                       'host3': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)}


### PR DESCRIPTION
This starts to tick off the items in #619 

* This makes the autoscaler check that a host has drained before it
terminates the instance.
* It also passes the hostname to the drain call, which is what the
maintenance library expects.
* Adjust the times we send to the maintenance library which expects
nanoseconds.