### PR TITLE
Fix itests orphaned containers bug.

### DIFF
--- a/paasta_itests/docker-compose.yml
+++ b/paasta_itests/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - 5051
     environment:
       CLUSTER: testcluster
-    command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret --containerizers=docker --docker=/usr/bin/docker --work_dir=/tmp/mesos --attributes="region:fakeregion;pool:default"'
+    command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret --containerizers=docker --docker=/usr/bin/docker --work_dir=/tmp/mesos --attributes="region:fakeregion;pool:default" --no-docker_kill_orphans'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:


### PR DESCRIPTION
https://reviews.apache.org/r/45454/ breaks our itest/example cluster setup

This manifested in a weird way. In the itests and example cluster: slaves were dying when launched with docker errors saying that it couldn't remove a container because it was not found. The root cause was running containers from other slaves were seen as orphans by the new agents that were starting up. This leads to a race to delete in which one of the new agents succeeds but any others fail. Weirdly this worked fine on travis, presumably they do something funky with the docker socket?