### PR TITLE
Only allow whitelisted volumes as a part of extra_volumes

### DIFF
--- a/general_itests/fake_etc_paasta/volumes.json
+++ b/general_itests/fake_etc_paasta/volumes.json
@@ -1,3 +1,4 @@
 {
-    "volumes": []
+    "volumes": [],
+    "volumes_whitelist": {}
 }

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -146,7 +146,8 @@ def working_paasta_cluster(context):
             {'hostPath': u'/nail/etc/beep', 'containerPath': '/nail/etc/beep', 'mode': 'RO'},
             {'hostPath': u'/nail/etc/bop', 'containerPath': '/nail/etc/bop', 'mode': 'RO'},
             {'hostPath': u'/nail/etc/boop', 'containerPath': '/nail/etc/boop', 'mode': 'RO'},
-        ]
+        ],
+        'volumes_whitelist': {}
     }, 'volumes.json')
 
 

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -653,15 +653,15 @@ def configure_and_run_docker_container(
         docker_hash = docker_url
         docker_pull_image(docker_url)
 
-    # Warn if the service is attempting to mount disallowed volumes
+    # Warn if the service is attempting to mount non-whitelisted volumes
     extra_volumes = instance_config.get_extra_volumes()
 
-    disallowed_volumes = validate_whitelisted_volumes(instance_config)
-    if len(disallowed_volumes) > 0:
+    non_whitelisted_volumes = validate_whitelisted_volumes(instance_config)
+    if len(non_whitelisted_volumes) > 0:
         sys.stdout.write(PaastaColors.yellow(
             "Warning: Your service is attempting to mount the following extra volumes "
             "that are not whitelisted:\n\n\t%s\n\n"
-            "These mounts will fail when PaaSTA deploys your service.\n\n" % disallowed_volumes))
+            "These mounts will fail when PaaSTA deploys your service.\n\n" % non_whitelisted_volumes))
 
     for volume in system_paasta_config.get_volumes() + extra_volumes:
         volumes.append('%s:%s:%s' % (volume['hostPath'], volume['containerPath'], volume['mode'].lower()))

--- a/paasta_tools/setup_chronos_job.py
+++ b/paasta_tools/setup_chronos_job.py
@@ -217,14 +217,14 @@ def main():
         cluster=cluster,
         soa_dir=soa_dir,
     )
-    disallowed_volumes = validate_whitelisted_volumes(chronos_job_config)
-    if len(disallowed_volumes) > 0:
+    non_whitelisted_volumes = validate_whitelisted_volumes(chronos_job_config)
+    if len(non_whitelisted_volumes) > 0:
         send_event(
             service=service,
             instance=instance,
             soa_dir=soa_dir,
             status=pysensu_yelp.Status.CRITICAL,
-            output="Attempting to mount unpermitted volumes: %s" % disallowed_volumes,
+            output="Attempting to mount unpermitted volumes: %s" % non_whitelisted_volumes,
         )
 
     status, output = setup_job(

--- a/paasta_tools/setup_chronos_job.py
+++ b/paasta_tools/setup_chronos_job.py
@@ -54,6 +54,7 @@ from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import SPACER
+from paasta_tools.utils import validate_whitelisted_volumes
 
 
 log = logging.getLogger(__name__)
@@ -208,6 +209,23 @@ def main():
     except chronos_tools.InvalidParentError:
         log.warn("Skipping %s.%s: Parent job could not be found" % (service, instance))
         sys.exit(0)
+
+    # Check if the service is attempting to access un-whitelisted volumes
+    chronos_job_config = chronos_tools.load_chronos_job_config(
+        service=service,
+        instance=instance,
+        cluster=cluster,
+        soa_dir=soa_dir,
+    )
+    disallowed_volumes = validate_whitelisted_volumes(chronos_job_config)
+    if len(disallowed_volumes) > 0:
+        send_event(
+            service=service,
+            instance=instance,
+            soa_dir=soa_dir,
+            status=pysensu_yelp.Status.CRITICAL,
+            output="Attempting to mount unpermitted volumes: %s" % disallowed_volumes,
+        )
 
     status, output = setup_job(
         service=service,

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -601,10 +601,10 @@ def setup_service(service, instance, client, service_marathon_config, soa_dir):
     full_id = marathon_app_dict['id']
     service_namespace_config = marathon_tools.load_service_namespace_config(service, instance)
 
-    # Check if the service is attempting to access un-whitelisted volumes
-    disallowed_volumes = validate_whitelisted_volumes(service_marathon_config)
-    if len(disallowed_volumes) > 0:
-        output = "Attempting to mount unpermitted volumes: %s" % disallowed_volumes
+    # Check if the service is attempting to access non-whitelisted volumes
+    non_whitelisted_volumes = validate_whitelisted_volumes(service_marathon_config)
+    if len(non_whitelisted_volumes) > 0:
+        output = "Attempting to mount unpermitted volumes: %s" % non_whitelisted_volumes
         send_event(service, instance, soa_dir, pysensu_yelp.Status.CRITICAL, output)
 
     log.info("Desired Marathon instance id: %s", full_id)

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -66,6 +66,7 @@ from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import SPACER
+from paasta_tools.utils import validate_whitelisted_volumes
 
 # Marathon REST API:
 # https://github.com/mesosphere/marathon/blob/master/REST.md#post-v2apps
@@ -584,7 +585,6 @@ def setup_service(service, instance, client, service_marathon_config, soa_dir):
     :param client: A MarathonClient object
     :param service_marathon_config: The service instance's configuration dict
     :returns: A tuple of (status, output) to be used with send_sensu_event"""
-
     log.info("Setting up instance %s for service %s", instance, service)
     try:
         marathon_app_dict = service_marathon_config.format_marathon_app_dict()
@@ -600,6 +600,12 @@ def setup_service(service, instance, client, service_marathon_config, soa_dir):
 
     full_id = marathon_app_dict['id']
     service_namespace_config = marathon_tools.load_service_namespace_config(service, instance)
+
+    # Check if the service is attempting to access un-whitelisted volumes
+    disallowed_volumes = validate_whitelisted_volumes(service_marathon_config)
+    if len(disallowed_volumes) > 0:
+        output = "Attempting to mount unpermitted volumes: %s" % disallowed_volumes
+        send_event(service, instance, soa_dir, pysensu_yelp.Status.CRITICAL, output)
 
     log.info("Desired Marathon instance id: %s", full_id)
     return deploy_service(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -828,7 +828,7 @@ class SystemPaastaConfig(dict):
     def get_volumes_whitelist(self):
         """Get the list of accessible volumes per service
 
-        :returns: A dictionary that maps services to allowed
+        :returns: A dictionary that maps services to a list of volumes it may mount
         """
         try:
             return self['volumes_whitelist']

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -368,13 +368,13 @@ def validate_whitelisted_volumes(instance_config):
     all_extra_volumes = instance_config.get_extra_volumes(apply_whitelist=False)
     extra_whitelisted_volumes = instance_config.get_extra_volumes(apply_whitelist=True)
 
-    disallowed_volumes = []
+    non_whitelisted_volumes = []
     for volume in all_extra_volumes:
         v = {'hostPath': volume['hostPath'], 'mode': volume['mode']}
         if v not in extra_whitelisted_volumes:
-            disallowed_volumes.append(v)
+            non_whitelisted_volumes.append(v)
 
-    return disallowed_volumes
+    return non_whitelisted_volumes
 
 
 def validate_service_instance(service, instance, cluster, soa_dir):

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -55,6 +55,7 @@ class TestChronosTools:
         config_dict=fake_config_dict,
         branch_dict=fake_branch_dict,
     )
+    fake_chronos_job_config.get_extra_volumes = mock.Mock(return_value=[])
 
     fake_invalid_config_dict = {
         'bounce_method': 'crossover',
@@ -1188,6 +1189,7 @@ class TestChronosTools:
                     'docker_image': 'paasta-%s-%s' % (self.fake_service, self.fake_cluster),
                 }
             )
+            stopped_job_config.get_extra_volumes = mock.Mock(return_value=[])
             load_chronos_job_config_patch.return_value = stopped_job_config
             second_description = chronos_tools.create_complete_config('fake-service', 'fake-job')['description']
 
@@ -1205,6 +1207,7 @@ class TestChronosTools:
                 'docker_image': 'fake_image'
             },
         )
+        fake_chronos_job_config.get_extra_volumes = mock.Mock(return_value=[])
         fake_config_hash = 'fake_config_hash'
         with contextlib.nested(
             mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
@@ -1268,6 +1271,7 @@ class TestChronosTools:
                 'docker_image': 'fake_image'
             },
         )
+        fake_chronos_job_config.get_extra_volumes = mock.Mock(return_value=[])
         fake_config_hash = 'fake_config_hash'
         with contextlib.nested(
             mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
@@ -1336,7 +1340,6 @@ class TestChronosTools:
             }
         ]
         fake_instance_config = self.fake_config_dict
-        fake_instance_config['extra_volumes'] = fake_extra_volumes
         fake_chronos_job_config = chronos_tools.ChronosJobConfig(
             service=self.fake_service,
             cluster='',
@@ -1347,6 +1350,7 @@ class TestChronosTools:
                 'docker_image': 'fake_image'
             },
         )
+        fake_chronos_job_config.get_extra_volumes = mock.Mock(return_value=fake_extra_volumes)
         fake_config_hash = 'fake_config_hash'
         with contextlib.nested(
             mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -879,6 +879,7 @@ class TestMarathonTools:
             },
             branch_dict={'desired_state': 'start'}
         )
+        config.get_extra_volumes = mock.Mock(return_value=[])
 
         with contextlib.nested(
             mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True,
@@ -1337,6 +1338,7 @@ class TestMarathonTools:
                 'force_bounce': '88888',
             },
         )
+        fake_service_config_1.get_extra_volumes = mock.Mock(return_value=[])
 
         fake_service_config_2 = marathon_tools.MarathonServiceConfig(
             service=fake_name,
@@ -1348,6 +1350,7 @@ class TestMarathonTools:
                 'force_bounce': '99999',
             },
         )
+        fake_service_config_2.get_extra_volumes = mock.Mock(return_value=[])
 
         fake_service_config_3 = marathon_tools.MarathonServiceConfig(
             service=fake_name,
@@ -1359,6 +1362,7 @@ class TestMarathonTools:
                 'force_bounce': '99999',
             },
         )
+        fake_service_config_3.get_extra_volumes = mock.Mock(return_value=[])
 
         with contextlib.nested(
             mock.patch('paasta_tools.marathon_tools.load_system_paasta_config',
@@ -1991,6 +1995,7 @@ def test_format_marathon_app_dict_no_smartstack():
         config_dict={},
         branch_dict={'docker_image': 'abcdef'},
     )
+    fake_marathon_service_config.get_extra_volumes = mock.Mock(return_value=[])
     fake_system_paasta_config = SystemPaastaConfig({
         'volumes': [],
         'docker_registry': 'fake_docker_registry:443'
@@ -2060,6 +2065,7 @@ def test_format_marathon_app_dict_with_smartstack():
         config_dict={},
         branch_dict={'docker_image': 'abcdef'},
     )
+    fake_marathon_service_config.get_extra_volumes = mock.Mock(return_value=[])
     fake_system_paasta_config = SystemPaastaConfig({
         'volumes': [],
         'docker_registry': 'fake_docker_registry:443'
@@ -2146,6 +2152,7 @@ def test_format_marathon_app_dict_utilizes_net():
         config_dict={'net': 'host'},
         branch_dict={'docker_image': 'abcdef'},
     )
+    fake_marathon_service_config.get_extra_volumes = mock.Mock(return_value=[])
     fake_system_paasta_config = SystemPaastaConfig({
         'volumes': fake_system_volumes,
         'docker_registry': 'fake_docker_registry:443'
@@ -2192,9 +2199,10 @@ def test_format_marathon_app_dict_utilizes_extra_volumes():
         service=service_name,
         cluster='clustername',
         instance=instance_name,
-        config_dict={'extra_volumes': fake_extra_volumes},
+        config_dict={},
         branch_dict={'docker_image': 'abcdef'},
     )
+    fake_marathon_service_config.get_extra_volumes = mock.Mock(return_value=fake_extra_volumes)
     fake_system_paasta_config = SystemPaastaConfig({
         'volumes': fake_system_volumes,
         'docker_registry': 'fake_docker_registry:443'

--- a/tests/test_setup_chronos_job.py
+++ b/tests/test_setup_chronos_job.py
@@ -59,6 +59,7 @@ class TestSetupChronosJob:
         config_dict=fake_config_dict,
         branch_dict=fake_branch_dict,
     )
+    fake_chronos_job_config.get_extra_volumes = mock.Mock(return_value=[])
 
     fake_docker_registry = 'remote_registry.com'
     fake_args = mock.MagicMock(

--- a/tests/test_setup_chronos_job.py
+++ b/tests/test_setup_chronos_job.py
@@ -77,6 +77,7 @@ class TestSetupChronosJob:
                        return_value=self.fake_args,
                        autospec=True),
             mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospec=True),
+            mock.patch('paasta_tools.chronos_tools.load_chronos_job_config', autospec=True),
             mock.patch('paasta_tools.chronos_tools.get_chronos_client',
                        return_value=self.fake_client,
                        autospec=True),
@@ -92,6 +93,7 @@ class TestSetupChronosJob:
         ) as (
             parse_args_patch,
             load_chronos_config_patch,
+            load_chronos_job_config_patch,
             get_client_patch,
             create_complete_config_patch,
             setup_job_patch,
@@ -187,6 +189,56 @@ class TestSetupChronosJob:
                 % (compose_job_id(self.fake_service, self.fake_instance), self.fake_cluster)
             )
             send_event_patch.assert_called_once_with(
+                service=self.fake_service,
+                instance=self.fake_instance,
+                soa_dir=self.fake_args.soa_dir,
+                status=Status.CRITICAL,
+                output=expected_error_msg
+            )
+
+    def test_main_alerts_whitelisted_volume(self):
+        expected_status = 0
+        expected_output = 'it_is_finished'
+        fake_disallowed_volumes = ['fake_disallowed_volume']
+        expected_error_msg = "Attempting to mount unpermitted volumes: %s" % fake_disallowed_volumes
+        fake_complete_job_config = {'foo': 'bar'}
+        with contextlib.nested(
+            mock.patch('paasta_tools.setup_chronos_job.parse_args',
+                       return_value=self.fake_args,
+                       autospec=True),
+            mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospec=True),
+            mock.patch('paasta_tools.chronos_tools.load_chronos_job_config', autospec=True),
+            mock.patch('paasta_tools.chronos_tools.get_chronos_client',
+                       return_value=self.fake_client,
+                       autospec=True),
+            mock.patch('paasta_tools.chronos_tools.create_complete_config',
+                       return_value=fake_complete_job_config,
+                       autospec=True),
+            mock.patch('paasta_tools.setup_chronos_job.setup_job',
+                       return_value=(expected_status, expected_output),
+                       autospec=True),
+            mock.patch('paasta_tools.setup_chronos_job.validate_whitelisted_volumes',
+                       autospec=True, return_value=fake_disallowed_volumes),
+            mock.patch('paasta_tools.setup_chronos_job.send_event', autospec=True),
+            mock.patch('paasta_tools.setup_chronos_job.load_system_paasta_config', autospec=True),
+            mock.patch('sys.exit', autospec=True),
+        ) as (
+            parse_args_patch,
+            load_chronos_config_patch,
+            load_chronos_job_config_patch,
+            get_client_patch,
+            create_complete_config_patch,
+            setup_job_patch,
+            validate_whitelisted_volumes_patch,
+            send_event_patch,
+            load_system_paasta_config_patch,
+            sys_exit_patch,
+        ):
+            load_system_paasta_config_patch.return_value.get_cluster = mock.MagicMock(return_value=self.fake_cluster)
+            setup_chronos_job.main()
+
+            validate_whitelisted_volumes_patch.assert_called_once_with(load_chronos_job_config_patch.return_value)
+            send_event_patch.assert_any_call(
                 service=self.fake_service,
                 instance=self.fake_instance,
                 soa_dir=self.fake_args.soa_dir,

--- a/tests/test_setup_chronos_job.py
+++ b/tests/test_setup_chronos_job.py
@@ -199,8 +199,8 @@ class TestSetupChronosJob:
     def test_main_alerts_whitelisted_volume(self):
         expected_status = 0
         expected_output = 'it_is_finished'
-        fake_disallowed_volumes = ['fake_disallowed_volume']
-        expected_error_msg = "Attempting to mount unpermitted volumes: %s" % fake_disallowed_volumes
+        fake_non_whitelisted_volumes = ['fake_non_whitelisted_volume']
+        expected_error_msg = "Attempting to mount unpermitted volumes: %s" % fake_non_whitelisted_volumes
         fake_complete_job_config = {'foo': 'bar'}
         with contextlib.nested(
             mock.patch('paasta_tools.setup_chronos_job.parse_args',
@@ -218,7 +218,7 @@ class TestSetupChronosJob:
                        return_value=(expected_status, expected_output),
                        autospec=True),
             mock.patch('paasta_tools.setup_chronos_job.validate_whitelisted_volumes',
-                       autospec=True, return_value=fake_disallowed_volumes),
+                       autospec=True, return_value=fake_non_whitelisted_volumes),
             mock.patch('paasta_tools.setup_chronos_job.send_event', autospec=True),
             mock.patch('paasta_tools.setup_chronos_job.load_system_paasta_config', autospec=True),
             mock.patch('sys.exit', autospec=True),

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -1472,8 +1472,8 @@ class TestSetupMarathonJob:
             'nine': 'eaten',
             'id': full_id,
         }
-        fake_disallowed_volumes = ['fake_disallowed_volume']
-        expected_error_msg = "Attempting to mount unpermitted volumes: %s" % fake_disallowed_volumes
+        fake_non_whitelisted_volumes = ['fake_non_whitelisted_volume']
+        expected_error_msg = "Attempting to mount unpermitted volumes: %s" % fake_non_whitelisted_volumes
         with contextlib.nested(
             mock.patch.object(
                 self.fake_marathon_service_config,
@@ -1492,7 +1492,7 @@ class TestSetupMarathonJob:
             ),
             mock.patch(
                 'paasta_tools.setup_marathon_job.validate_whitelisted_volumes',
-                return_value=fake_disallowed_volumes,
+                return_value=fake_non_whitelisted_volumes,
                 autospec=True,
             ),
             mock.patch('paasta_tools.setup_marathon_job.send_event', autospec=True),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1357,17 +1357,17 @@ def test_validate_whitelisted_volumes_blocked():
     )
 
     fake_volume = {'hostPath': 'fake_vol', 'mode': 'RO'}
-    fake_disallowed_volume1 = {'hostPath': 'fake_vol', 'mode': 'RW'}
-    fake_disallowed_volume2 = {'hostPath': 'fake_disallowed_vol', 'mode': 'RO'}
+    fake_non_whitelisted_volume1 = {'hostPath': 'fake_vol', 'mode': 'RW'}
+    fake_non_whitelisted_volume2 = {'hostPath': 'fake_non_whitelisted_vol', 'mode': 'RO'}
 
     def mock_whitelist(apply_whitelist):
         if apply_whitelist:
-            # Assume everything is disallowed
+            # Assume everything is non_whitelisted
             return [fake_volume]
         else:
-            return [fake_volume, fake_disallowed_volume1, fake_disallowed_volume2]
+            return [fake_volume, fake_non_whitelisted_volume1, fake_non_whitelisted_volume2]
     fake_marathon_service_config.get_extra_volumes = mock_whitelist
-    expected_extra_volumes = [fake_disallowed_volume1, fake_disallowed_volume2]
+    expected_extra_volumes = [fake_non_whitelisted_volume1, fake_non_whitelisted_volume2]
     assert utils.validate_whitelisted_volumes(fake_marathon_service_config) == expected_extra_volumes
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1238,6 +1238,33 @@ class TestInstanceConfig:
 
             assert fake_conf.get_extra_volumes() == fake_extra_volumes[:1]
 
+    def test_extra_volumes_whitelist_disabled(self):
+        fake_config = mock.Mock(get_volumes_whitelist=mock.Mock(return_value=[]))
+        with mock.patch('paasta_tools.utils.load_system_paasta_config',
+                        autospec=True,
+                        return_value=fake_config):
+            fake_extra_volumes = [
+                {
+                    "containerPath": "/etc/a",
+                    "hostPath": "/var/data/a",
+                    "mode": "RO"
+                },
+                {
+                    "containerPath": "/etc/supersecret",
+                    "hostPath": "/var/data/a/../../supersecret",
+                    "mode": "RO"
+                },
+            ]
+            fake_conf = utils.InstanceConfig(
+                service='fake_service',
+                cluster='',
+                instance='',
+                config_dict={'extra_volumes': fake_extra_volumes},
+                branch_dict={},
+            )
+
+            assert fake_conf.get_extra_volumes(apply_whitelist=False) == fake_extra_volumes
+
     def test_get_pool(self):
         pool = "poolname"
         fake_conf = utils.InstanceConfig(

--- a/yelp_package/itest/volumes.json
+++ b/yelp_package/itest/volumes.json
@@ -15,5 +15,6 @@
             "containerPath": "/var/run/synapse/services/",
             "mode": "RO"
         }
-    ]
+    ],
+    "volumes_whitelist": {}
 }


### PR DESCRIPTION
This prevents services from mounting arbitrary host volumes that may contain sensitive information. The whitelist is configured by placing a file in the system PaaSTA configuration directory (`/etc/paasta` by default) with the following format:

```
{
  'volumes_whitelist': {
    'myservice': ['/some/dir', '/my/otherdir'],
    'otherservice': ['/some/dir', '/my/otherdir'],
  }
}
```
