### PR TITLE
Fix itest rsyslog race

### DIFF
--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -34,6 +34,6 @@ RUN echo -n 'chronos' > /etc/chronos/conf/mesos_authentication_principal
 RUN echo -n 'secret3' > /etc/chronos_framework_secret
 RUN echo -n '/etc/chronos_framework_secret' > /etc/chronos/conf/mesos_authentication_secret_file
 
-CMD rsyslogd ; (/usr/bin/chronos &) ; tail -f /var/log/syslog
+CMD rsyslogd ; sleep 1; (/usr/bin/chronos &) ; tail -f /var/log/syslog
 
 EXPOSE 8081


### PR DESCRIPTION
Syslog takes a moment to startup. Occassionally chronos was beating it
and then crashing because it was unable to log.