### PR TITLE
Autoscaler maintenance cleanup windows

### DIFF
--- a/paasta_tools/autoscale_cluster.py
+++ b/paasta_tools/autoscale_cluster.py
@@ -33,12 +33,13 @@ def parse_args():
 
 def main():
     args = parse_args()
+    log_format = '%(asctime)s:%(levelname)s:%(name)s:%(message)s'
     if args.verbose >= 2:
-        logging.basicConfig(level=logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG, format=log_format)
     elif args.verbose == 1:
-        logging.basicConfig(level=logging.INFO)
+        logging.basicConfig(level=logging.INFO, format=log_format)
     else:
-        logging.basicConfig(level=logging.WARNING)
+        logging.basicConfig(level=logging.WARNING, format=log_format)
 
     autoscale_local_cluster(dry_run=args.dry_run)
 

--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -627,7 +627,7 @@ def wait_and_terminate(slave, dry_run):
                             raise
                     break
                 else:
-                    log.debug("Instance {0}: NOT ready to kill".format(instance_id))
+                    log.info("Instance {0}: NOT ready to kill".format(instance_id))
                 log.debug("Waiting 5 seconds and then checking again")
                 time.sleep(5)
     except TimeoutError:

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -648,9 +648,9 @@ def get_mesos_task_count_by_slave(mesos_state, pool=None):
                 slaves[task.slave['id']]['chronos_count'] += 1
     slaves = {slave_counts['slave']['hostname']: SlaveTaskCount(**slave_counts) for slave_counts in slaves.values()}
     for slave in slaves.values():
-        log.info("Slave: {0}, running {1} tasks, including {2} chronos tasks".format(slave.slave['hostname'],
-                                                                                     slave.count,
-                                                                                     slave.chronos_count))
+        log.debug("Slave: {0}, running {1} tasks, including {2} chronos tasks".format(slave.slave['hostname'],
+                                                                                      slave.count,
+                                                                                      slave.chronos_count))
     return slaves
 
 

--- a/tests/test_autoscaling_lib.py
+++ b/tests/test_autoscaling_lib.py
@@ -587,12 +587,14 @@ def test_scale_aws_spot_fleet_request():
         mock.patch('time.time', autospec=True),
         mock.patch('paasta_tools.autoscaling_lib.filter_sfr_slaves', autospec=True),
         mock.patch('paasta_tools.autoscaling_lib.drain', autospec=True),
+        mock.patch('paasta_tools.autoscaling_lib.undrain', autospec=True),
         mock.patch('paasta_tools.autoscaling_lib.set_spot_fleet_request_capacity', autospec=True),
         mock.patch('paasta_tools.autoscaling_lib.wait_and_terminate', autospec=True),
     ) as (
         mock_time,
         mock_filter_sfr_slaves,
         mock_drain,
+        mock_undrain,
         mock_set_spot_fleet_request_capacity,
         mock_wait_and_terminate
     ):
@@ -622,6 +624,8 @@ def test_scale_aws_spot_fleet_request():
         terminate_call_2 = mock.call(mock_sfr_sorted_slaves[1], False)
         drain_call_1 = mock.call(['host1|10.1.1.1'], mock_start, 600 * 1000000000)
         drain_call_2 = mock.call(['host2|10.2.2.2'], mock_start, 600 * 1000000000)
+        undrain_call_1 = mock.call(['host1|10.1.1.1'])
+        undrain_call_2 = mock.call(['host2|10.2.2.2'])
         set_call_1 = mock.call('sfr-blah', 4, False)
         set_call_2 = mock.call('sfr-blah', 2, False)
         mock_filter_sfr_slaves.return_value = mock_sfr_sorted_slaves
@@ -631,6 +635,7 @@ def test_scale_aws_spot_fleet_request():
         mock_drain.assert_has_calls([drain_call_1, drain_call_2])
         mock_set_spot_fleet_request_capacity.assert_has_calls([set_call_1, set_call_2])
         mock_wait_and_terminate.assert_has_calls([terminate_call_1, terminate_call_2])
+        mock_undrain.assert_has_calls([undrain_call_1, undrain_call_2])
 
         # test scale down stop if it would take us below capacity
         mock_sfr_sorted_slaves = [{'hostname': 'host1', 'instance_id': 'i-blah123',
@@ -660,6 +665,7 @@ def test_scale_aws_spot_fleet_request():
                                                                set_call_1, set_call_3])
         mock_wait_and_terminate.assert_has_calls([terminate_call_1, terminate_call_2,
                                                   terminate_call_1, terminate_call_1])
+        mock_undrain.assert_has_calls([undrain_call_1, undrain_call_2, undrain_call_1, undrain_call_1])
 
 
 def test_autoscale_local_cluster():

--- a/tests/test_paasta_maintenance.py
+++ b/tests/test_paasta_maintenance.py
@@ -715,6 +715,12 @@ def test_get_hosts_past_maintenance_start(
     ret = get_hosts_past_maintenance_start()
     assert ret == ['host2']
 
+    mock_schedule = {}
+    mock_maintenance_dict = mock.Mock(return_value=mock_schedule)
+    mock_get_maintenance_schedule.return_value = mock.Mock(json=mock_maintenance_dict)
+    ret = get_hosts_past_maintenance_start()
+    assert ret == []
+
 
 @mock.patch('paasta_tools.paasta_maintenance.get_maintenance_schedule')
 @mock.patch('paasta_tools.paasta_maintenance.now')
@@ -763,6 +769,13 @@ def test_get_hosts_past_maintenance_end(
     mock_datetime_to_nanoseconds.return_value = 20
     ret = get_hosts_past_maintenance_end()
     assert ret == ['host2']
+
+    mock_schedule = {}
+    mock_maintenance_dict = mock.Mock(return_value=mock_schedule)
+    mock_get_maintenance_schedule.return_value = mock.Mock(json=mock_maintenance_dict)
+    mock_datetime_to_nanoseconds.return_value = 20
+    ret = get_hosts_past_maintenance_end()
+    assert ret == []
 
 
 @mock.patch('paasta_tools.paasta_maintenance.get_hosts_past_maintenance_start')


### PR DESCRIPTION
@nhandler this adds the undrain action and fixes https://github.com/Yelp/paasta/issues/619

I've been testing this out in mesosstage. Happily, it seems to work well. The draining is very fast there because the autoscaler is deliberately picking the hosts with no tasks running! It'll be interesting to test it out in a more loaded cluster.