### PR TITLE
read extra nerve key-values from the classic service file

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -918,9 +918,12 @@ def _namespaced_get_classic_service_information_for_nerve(name, namespace, soa_d
     nerve_name = compose_job_id(name, namespace)
     try:
         with open(_get_classic_service_puppet_file(name)) as extras:
-            nerve_dict.update(json.load(extras))
-    except (ValueError, IOError):
-        pass
+            if os.fstat(extras.fileno()).st_size > 0:
+                nerve_dict.update(json.load(extras))
+    except IOError:
+        log.exception("Could not open {0} for reading".format(extras.name))
+    except ValueError:
+        log.exception("Could not interpret {0} as JSON".format(extras.name))
     return (nerve_name, nerve_dict)
 
 

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -889,6 +889,7 @@ def get_marathon_services_running_here_for_nerve(cluster, soa_dir):
 def _get_classic_service_puppet_file(service):
     return os.path.join(PUPPET_SERVICE_DIR, service)
 
+
 def get_classic_services_that_run_here():
     # find all files in the PUPPET_SERVICE_DIR, but discard broken symlinks
     # this allows us to (de)register services on a machine by
@@ -918,7 +919,7 @@ def _namespaced_get_classic_service_information_for_nerve(name, namespace, soa_d
     try:
         with open(_get_classic_service_puppet_file(name)) as extras:
             nerve_dict.update(json.load(extras))
-    except (ValueError,IOError):
+    except (ValueError, IOError):
         pass
     return (nerve_name, nerve_dict)
 

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -713,7 +713,6 @@ class TestMarathonTools:
             info = marathon_tools.get_classic_service_information_for_nerve('a_test_service', '/here/is/a/soa/dir')
             assert info == ('a_test_service.main', {'mode': 'http', 'port': 80, 'hi_key': 'hello_value'})
 
-
     def test_get_classic_service_information_for_nerve_with_bad_extra(self):
         with contextlib.nested(
             mock.patch('service_configuration_lib.read_port', return_value=80),


### PR DESCRIPTION
With the intent they'll be read in https://github.com/Yelp/nerve-tools/blob/master/src/nerve_tools/configure_nerve.py#L133 and added as extra config settings.