### PR TITLE
increase wait time to alleviate itest run_until_number_tasks failures

### DIFF
--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -92,7 +92,7 @@ def run_until_number_tasks(context, number):
         'scheme': 'http',
         'response_timeout': 5,
     }
-    for _ in xrange(20):
+    for _ in xrange(30):
         with contextlib.nested(
             mock.patch('paasta_tools.paasta_maintenance.load_credentials', autospec=True),
             mock.patch.object(mesos.cli.master, 'CFG', config),
@@ -104,7 +104,7 @@ def run_until_number_tasks(context, number):
                 mesos_secrets='/etc/mesos-slave-secret',
             )
             run_setup_marathon_job(context)
-        sleep(0.5)
+        sleep(1)
         if context.marathon_client.get_app(context.app_id).instances == number:
             return
     assert context.marathon_client.get_app(context.app_id).instances == number


### PR DESCRIPTION
I don't know what has changed in travis and jenkins environments.  Since we have a good itest passing rate on dev boxes and travis/jenkins do not always fail, the failure does not seem to be a requests_cache related bug. Let's try give the test more time (maximum 20x0.5=10 to 30x1=30).