### PR TITLE
Move requests_cache uninstall out of itest scenario cleanup

### DIFF
--- a/paasta_itests/environment.py
+++ b/paasta_itests/environment.py
@@ -15,7 +15,6 @@ import os
 import shutil
 import time
 
-import requests_cache
 from behave_pytest.hook import install_pytest_asserts
 from itest_utils import cleanup_file
 from itest_utils import get_service_connection_string
@@ -111,7 +110,6 @@ def _clean_up_zookeeper_autoscaling(context):
 
 
 def after_scenario(context, scenario):
-    requests_cache.uninstall_cache()
     _clean_up_marathon_apps(context)
     _clean_up_chronos_jobs(context)
     _clean_up_mesos_cli_config(context)

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -92,7 +92,7 @@ def run_until_number_tasks(context, number):
         'scheme': 'http',
         'response_timeout': 5,
     }
-    for _ in xrange(30):
+    for _ in xrange(20):
         with contextlib.nested(
             mock.patch('paasta_tools.paasta_maintenance.load_credentials', autospec=True),
             mock.patch.object(mesos.cli.master, 'CFG', config),
@@ -104,7 +104,7 @@ def run_until_number_tasks(context, number):
                 mesos_secrets='/etc/mesos-slave-secret',
             )
             run_setup_marathon_job(context)
-        sleep(1)
+        sleep(0.5)
         if context.marathon_client.get_app(context.app_id).instances == number:
             return
     assert context.marathon_client.get_app(context.app_id).instances == number

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -656,6 +656,8 @@ def main():
             if deploy_marathon_service(service, instance, client, soa_dir, marathon_config):
                 num_failed_deployments = num_failed_deployments + 1
 
+    requests_cache.uninstall_cache()
+
     log.debug("%d out of %d service.instances failed to deploy." %
               (num_failed_deployments, len(args.service_instance_list)))
 


### PR DESCRIPTION
This change restores commit 8eb42bbe37536bf744a72bec0cf3be4ad8a15111. requests_cache will get uninstalled where it is installed. It will avoid the risk of running setup_marathon_job.main() multiple times in itests.