### PR TITLE
Autoscaler skip non deployed

### DIFF
--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -378,12 +378,14 @@ def get_configs_of_services_to_scale(cluster, soa_dir=DEFAULT_SOA_DIR):
                 cluster=cluster,
                 soa_dir=soa_dir,
             )
-            if service_config.get_max_instances() and service_config.get_desired_state() == 'start' \
-                    and service_config.get_autoscaling_params()['decision_policy'] != 'bespoke':
-                configs.append(service_config)
         except NoDeploymentsAvailable:
             log.debug("%s is not deployed yet, refusing to do autoscaling calculations for it" %
                       compose_job_id(service, instance))
+            continue
+
+        if service_config.get_max_instances() and service_config.get_desired_state() == 'start' \
+                and service_config.get_autoscaling_params()['decision_policy'] != 'bespoke':
+            configs.append(service_config)
 
     return configs
 

--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -47,10 +47,12 @@ from paasta_tools.paasta_maintenance import is_safe_to_kill
 from paasta_tools.paasta_maintenance import undrain
 from paasta_tools.paasta_metastatus import get_resource_utilization_by_grouping
 from paasta_tools.utils import _log
+from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import get_user_agent
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import Timeout
 from paasta_tools.utils import TimeoutError
 from paasta_tools.utils import ZookeeperPool
@@ -369,15 +371,20 @@ def get_configs_of_services_to_scale(cluster, soa_dir=DEFAULT_SOA_DIR):
     )
     configs = []
     for service, instance in services:
-        service_config = load_marathon_service_config(
-            service=service,
-            instance=instance,
-            cluster=cluster,
-            soa_dir=soa_dir,
-        )
-        if service_config.get_max_instances() and service_config.get_desired_state() == 'start' \
-                and service_config.get_autoscaling_params()['decision_policy'] != 'bespoke':
-            configs.append(service_config)
+        try:
+            service_config = load_marathon_service_config(
+                service=service,
+                instance=instance,
+                cluster=cluster,
+                soa_dir=soa_dir,
+            )
+            if service_config.get_max_instances() and service_config.get_desired_state() == 'start' \
+                    and service_config.get_autoscaling_params()['decision_policy'] != 'bespoke':
+                configs.append(service_config)
+        except NoDeploymentsAvailable:
+            log.debug("%s is not deployed yet, refusing to do autoscaling calculations for it" %
+                      compose_job_id(service, instance))
+
     return configs
 
 

--- a/tests/test_autoscaling_lib.py
+++ b/tests/test_autoscaling_lib.py
@@ -399,7 +399,7 @@ def test_autoscale_marathon_instance_aborts_when_task_deploying():
         assert not mock_set_instances_for_marathon_service.called
 
 
-def test_autoscale_services():
+def test_autoscale_services_happy_path():
     fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
         service='fake-service',
         instance='fake-instance',


### PR DESCRIPTION
I broke up the large autoscale_sevices function and made it skip services that haven't been deployed yet. (instead of raising an exception early.)