### PR TITLE
Log exceptions as single events, to be formatted on the tailing side. Fixes #669

### DIFF
--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -565,10 +565,8 @@ def deploy_service(
             log.error("Instance %s already being bounced. Exiting", short_id)
             return (1, "Instance %s is already being bounced." % short_id)
     except Exception:
-        loglines = ['Exception raised during deploy of service %s:' % service]
-        loglines.extend(traceback.format_exc().rstrip().split("\n"))
-        for logline in loglines:
-            log_deploy_error(logline, level='debug')
+        logline = 'Exception raised during deploy of service %s:\n%s' % (service, traceback.format_exc())
+        log_deploy_error(logline, level='debug')
         raise
 
     return (0, 'Service deployed.')

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -1456,8 +1456,10 @@ class TestSetupMarathonJob:
                     bounce_health_params={},
                     soa_dir='fake_soa_dir',
                 )
-            assert fake_name in mock_log.mock_calls[0][2]["line"]
-            assert 'Traceback' in mock_log.mock_calls[1][2]["line"]
+
+            logged_line = mock_log.mock_calls[0][2]["line"]
+            assert logged_line.startswith("Exception raised during deploy of service whoa:\nTraceback")
+            assert "IOError: foo" in logged_line
 
     def test_get_marathon_config(self):
         fake_conf = {'oh_no': 'im_a_ghost'}


### PR DESCRIPTION
fixes #669 