### PR TITLE
Make paasta_maintenance is_host_drained work for hosts not in mesos

### DIFF
--- a/paasta_tools/paasta_maintenance.py
+++ b/paasta_tools/paasta_maintenance.py
@@ -480,7 +480,10 @@ def is_host_drained(hostname):
     """
     mesos_state = get_mesos_state_from_leader()
     task_counts = get_mesos_task_count_by_slave(mesos_state)
-    slave_task_count = task_counts[hostname].count
+    if hostname in task_counts:
+        slave_task_count = task_counts[hostname].count
+    else:
+        slave_task_count = 0
     return is_host_draining(hostname=hostname) and slave_task_count == 0
 
 

--- a/tests/test_paasta_maintenance.py
+++ b/tests/test_paasta_maintenance.py
@@ -672,6 +672,12 @@ def test_is_host_drained(
     mock_is_host_draining.return_value = False
     assert not is_host_drained('host2')
 
+    mock_get_mesos_task_count_by_slave.return_value = {}
+    assert not is_host_drained('host3')
+
+    mock_is_host_draining.return_value = True
+    assert is_host_drained('host3')
+
 
 @mock.patch('paasta_tools.paasta_maintenance.get_maintenance_schedule')
 @mock.patch('paasta_tools.paasta_maintenance.now')


### PR DESCRIPTION
The `is_host_drained` function currently does not work when run against a host not known to mesos. This is problematic, as it prevents us from utilizing this function in monitoring checks. Currently, we will see a traceback like the following:

```
Traceback (most recent call last):
  File "/usr/bin/paasta_maintenance", line 594, in <module>
    if paasta_maintenance():
  File "/usr/bin/paasta_maintenance", line 580, in paasta_maintenance
    return is_safe_to_kill(hostnames[0])
  File "/usr/bin/paasta_maintenance", line 472, in is_safe_to_kill
    return is_host_drained(hostname) or hostname in 
  File "/usr/bin/paasta_maintenance", line 483, in is_host_drained
    slave_task_count = task_counts[hostname].count
KeyError: 'some-hostname'
```

This change will cause `is_host_drained` to return `True` rather than a `KeyError`.