### PR TITLE
allow to pass --ulimit arguments to docker

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -39,6 +39,16 @@ instance MAY have:
     left on device' errors if they attempt to exceed these limits, and then be
     unable to write any more data to disk.
 
+  * ``ulimit``: Dictionary of ulimit values that are passed to Docker. Defaults
+    to empty dictionary. Each ulimit value is a dictionary with the soft limit
+    specified under the 'soft' key and the optional hard limit specified under
+    the 'hard' key. Ulimit values that are not set are inherited from the
+    default ulimits set on the Docker daemon. Example::
+
+      ulimit:
+        - nofile: {"soft": 1024, "hard": 2048}
+        - nice: {"soft": 20}
+
   * ``instances``: Marathon will attempt to run this many instances of the Service
 
   * ``min_instances``: When autoscaling, the minimum number of instances that

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -907,6 +907,10 @@ class TestInstanceConfig:
                 'cfs_period_us': 200000,
                 'cpus': 1,
                 'mem': 1024,
+                'ulimit': {
+                    'nofile': {'soft': 1024, 'hard': 2048},
+                    'nice': {'soft': 20},
+                },
             },
             branch_dict={},
         )
@@ -914,6 +918,8 @@ class TestInstanceConfig:
             {"key": "memory-swap", "value": '1024m'},
             {"key": "cpu-period", "value": "200000"},
             {"key": "cpu-quota", "value": "600000"},
+            {"key": "ulimit", "value": "nice=20"},
+            {"key": "ulimit", "value": "nofile=1024:2048"},
         ]
 
     def test_full_cpu_burst(self):
@@ -969,6 +975,34 @@ class TestInstanceConfig:
             branch_dict={},
         )
         assert fake_conf.get_disk() == 1024
+
+    def test_get_ulimit_in_config(self):
+        fake_conf = utils.InstanceConfig(
+            service='',
+            instance='',
+            cluster='',
+            config_dict={
+                'ulimit': {
+                    'nofile': {'soft': 1024, 'hard': 2048},
+                    'nice': {'soft': 20},
+                }
+            },
+            branch_dict={},
+        )
+        assert list(fake_conf.get_ulimit()) == [
+            {"key": "ulimit", "value": "nice=20"},
+            {"key": "ulimit", "value": "nofile=1024:2048"},
+        ]
+
+    def test_get_ulimit_default(self):
+        fake_conf = utils.InstanceConfig(
+            service='',
+            instance='',
+            cluster='',
+            config_dict={},
+            branch_dict={},
+        )
+        assert list(fake_conf.get_ulimit()) == []
 
     def test_deploy_group_default(self):
         fake_conf = utils.InstanceConfig(


### PR DESCRIPTION
Adds a new "ulimit" configuration option that allows to pass --ulimit arguments to Docker.