### PR TITLE
remove mesos master state.json monkey patch

### DIFF
--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -23,7 +23,6 @@ from urlparse import urlparse
 import humanize
 import requests
 from kazoo.client import KazooClient
-from mesos.cli import util
 from mesos.cli.exceptions import SlaveDoesNotExist
 
 from paasta_tools.utils import format_table
@@ -89,12 +88,6 @@ MESOS_SLAVE_PORT = '5051'
 from mesos.cli import master  # noqa
 import mesos.cli.cluster  # noqa
 
-
-# monkey patch MesosMaster.state to use a larger ttl
-@util.CachedProperty(ttl=60)
-def fetch_state(self):
-    return master.CURRENT.fetch("/master/state.json").json()
-master.MesosMaster.state = fetch_state
 
 # Works around a mesos-cli bug ('MesosSlave' object has no attribute 'id' - PAASTA-4119).
 # The method below gets a slave by its ID. Original code here:


### PR DESCRIPTION
mesos.cli has a default 5 seconds caching. Extra caching is provided by requests_cache EXPLICITLY in both serviceinit and setup_marathon_job. Clients (serviceinit, setup_marathon_job) should have the capability to enable/disable caching based on their requirements. Thus, revert this IMPLICIT caching in mesos_tools.