### PR TITLE
Move paasta autoscaler config

### DIFF
--- a/paasta_tools/autoscaling_lib.py
+++ b/paasta_tools/autoscaling_lib.py
@@ -61,8 +61,8 @@ _autoscaling_components = defaultdict(dict)
 
 SERVICE_METRICS_PROVIDER_KEY = 'metrics_provider'
 CLUSTER_METRICS_PROVIDER_KEY = 'cluster_metrics_provider'
-CLUSTER_TARGET_UTILIZATION = 0.8
-CLUSTER_DRAIN_TIMEOUT = 900  # seconds
+DEFAULT_TARGET_UTILIZATION = 0.8  # decimal fraction
+DEFAULT_DRAIN_TIMEOUT = 600  # seconds
 DECISION_POLICY_KEY = 'decision_policy'
 SCALER_KEY = 'scaler'
 
@@ -459,16 +459,17 @@ def create_autoscaling_lock():
         zk.stop()
 
 
-def get_spot_fleet_instances(spotfleet_request_id):
-    ec2_client = boto3.client('ec2')
+def get_spot_fleet_instances(spotfleet_request_id, region=None):
+    ec2_client = boto3.client('ec2', region_name=region)
     spot_fleet_instances = ec2_client.describe_spot_fleet_instances(
         SpotFleetRequestId=spotfleet_request_id)['ActiveInstances']
     return spot_fleet_instances
 
 
-def get_sfr_instance_ips(sfr):
+def get_sfr_instance_ips(sfr, region=None):
     spot_fleet_instances = sfr['ActiveInstances']
-    instance_descriptions = describe_instances([instance['InstanceId'] for instance in spot_fleet_instances])
+    instance_descriptions = describe_instances([instance['InstanceId'] for instance in spot_fleet_instances],
+                                               region=region)
     instance_ips = []
     for instance in instance_descriptions:
         try:
@@ -479,8 +480,8 @@ def get_sfr_instance_ips(sfr):
     return instance_ips
 
 
-def get_sfr(spotfleet_request_id):
-    ec2_client = boto3.client('ec2')
+def get_sfr(spotfleet_request_id, region=None):
+    ec2_client = boto3.client('ec2', region_name=region)
     try:
         sfrs = ec2_client.describe_spot_fleet_requests(SpotFleetRequestIds=[spotfleet_request_id])
     except ClientError as e:
@@ -493,7 +494,7 @@ def get_sfr(spotfleet_request_id):
     return ret
 
 
-def describe_instances(instance_ids, instance_filters=None):
+def describe_instances(instance_ids, region=None, instance_filters=None):
     """This wraps ec2.describe_instances and catches instance not
     found errors. It returns a list of instance description
     dictionaries. It assumes one instance per reservation (which
@@ -505,7 +506,7 @@ def describe_instances(instance_ids, instance_filters=None):
     :returns: a list of instance description dictionaries"""
     if not instance_filters:
         instance_filters = []
-    ec2_client = boto3.client('ec2')
+    ec2_client = boto3.client('ec2', region_name=region)
     try:
         instances = ec2_client.describe_instances(InstanceIds=instance_ids, Filters=instance_filters)
     except ClientError as e:
@@ -519,15 +520,15 @@ def describe_instances(instance_ids, instance_filters=None):
 
 
 @register_autoscaling_component('aws_spot_fleet_request', CLUSTER_METRICS_PROVIDER_KEY)
-def spotfleet_metrics_provider(spotfleet_request_id, mesos_state, resource):
-    sfr = get_sfr(spotfleet_request_id)
+def spotfleet_metrics_provider(spotfleet_request_id, mesos_state, resource, pool_settings):
+    sfr = get_sfr(spotfleet_request_id, region=resource['region'])
     if not sfr or not sfr['SpotFleetRequestState'] == 'active':
         log.error("Ignoring SFR {0} that does not exist or is not active.".format(spotfleet_request_id))
         return 0, 0
-    sfr['ActiveInstances'] = get_spot_fleet_instances(spotfleet_request_id)
+    sfr['ActiveInstances'] = get_spot_fleet_instances(spotfleet_request_id, region=resource['region'])
     resource['sfr'] = sfr
     desired_instances = len(sfr['ActiveInstances'])
-    instance_ips = get_sfr_instance_ips(sfr)
+    instance_ips = get_sfr_instance_ips(sfr, region=resource['region'])
     slaves = {
         slave['id']: slave for slave in mesos_state.get('slaves', [])
         if slave_pid_to_ip(slave['pid']) in instance_ips and
@@ -556,13 +557,14 @@ def spotfleet_metrics_provider(spotfleet_request_id, mesos_state, resource):
         float(float(pair[0]) / float(pair[1]))
         for pair in zip(free_pool_resources, total_pool_resources)
     ])
-    error = utilization - CLUSTER_TARGET_UTILIZATION
+    target_utilization = pool_settings.get('target_utilization', DEFAULT_TARGET_UTILIZATION)
+    error = utilization - target_utilization
     current, target = get_spot_fleet_delta(resource, error)
     return current, target
 
 
 def get_spot_fleet_delta(resource, error):
-    ec2_client = boto3.client('ec2')
+    ec2_client = boto3.client('ec2', region_name=resource['region'])
     spot_fleet_request = ec2_client.describe_spot_fleet_requests(
         SpotFleetRequestIds=[resource['id']])['SpotFleetRequestConfigs'][0]
     if spot_fleet_request['SpotFleetRequestState'] != 'active':
@@ -614,16 +616,16 @@ def sort_slaves_to_kill(mesos_state, pool='default'):
         return []
 
 
-def wait_and_terminate(slave, dry_run):
+def wait_and_terminate(slave, drain_timeout, dry_run, region=None):
     """Currently kills a slave, will wait for draining to complete soon
 
     :param slave: dict of slave to kill
     :param dry_run: Don't drain or make changes to spot fleet if True"""
-    ec2_client = boto3.client('ec2')
+    ec2_client = boto3.client('ec2', region_name=region)
     try:
         # This loop should always finish because the maintenance window should trigger is_ready_to_kill
         # being true. Just in case though we set a timeout and terminate anyway
-        with Timeout(seconds=CLUSTER_DRAIN_TIMEOUT + 300):
+        with Timeout(seconds=drain_timeout + 300):
             while True:
                 instance_id = slave['instance_id']
                 if not instance_id:
@@ -649,7 +651,7 @@ def wait_and_terminate(slave, dry_run):
                 log.debug("Waiting 5 seconds and then checking again")
                 time.sleep(5)
     except TimeoutError:
-        log.error("Timed out after {0} waiting to drain {1}, now terminating anyway".format(CLUSTER_DRAIN_TIMEOUT,
+        log.error("Timed out after {0} waiting to drain {1}, now terminating anyway".format(drain_timeout,
                                                                                             slave['pid']))
         try:
             ec2_client.terminate_instances(InstanceIds=instance_id, DryRun=dry_run)
@@ -665,13 +667,15 @@ def get_instance_type_weights(sfr):
     return {ls['InstanceType']: ls['WeightedCapacity'] for ls in launch_specifications}
 
 
-def filter_sfr_slaves(sorted_slaves, sfr):
-    sfr_ips = get_sfr_instance_ips(sfr)
+def filter_sfr_slaves(sorted_slaves, resource):
+    sfr = resource['sfr']
+    sfr_ips = get_sfr_instance_ips(sfr, region=resource['region'])
     log.debug("IPs in SFR: {0}".format(sfr_ips))
     sfr_sorted_slaves = [slave for slave in sorted_slaves if slave_pid_to_ip(slave['pid']) in sfr_ips]
     sfr_sorted_slave_ips = [slave_pid_to_ip(slave['pid']) for slave in sfr_sorted_slaves]
-    sfr_instance_descriptions = describe_instances([], instance_filters=[{'Name': 'private-ip-address',
-                                                                          'Values': sfr_sorted_slave_ips}])
+    sfr_instance_descriptions = describe_instances([], region=resource['region'],
+                                                   instance_filters=[{'Name': 'private-ip-address',
+                                                                      'Values': sfr_sorted_slave_ips}])
     sfr_sorted_slave_instances = []
     for slave in sfr_sorted_slaves:
         ip = slave_pid_to_ip(slave['pid'])
@@ -698,16 +702,16 @@ def filter_sfr_slaves(sorted_slaves, sfr):
     return ret
 
 
-def set_spot_fleet_request_capacity(sfr_id, capacity, dry_run):
+def set_spot_fleet_request_capacity(sfr_id, capacity, dry_run, region=None):
     """ AWS won't modify a request that is already modifying. This
     function ensures we wait a few seconds in case we've just modified
     a SFR"""
-    ec2_client = boto3.client('ec2')
+    ec2_client = boto3.client('ec2', region_name=region)
     with Timeout(seconds=AWS_SPOT_MODIFY_TIMEOUT):
         try:
             state = None
             while True:
-                state = get_sfr(sfr_id)['SpotFleetRequestState']
+                state = get_sfr(sfr_id, region=region)['SpotFleetRequestState']
                 if state == 'active':
                     break
                 log.debug("SFR {0} in state {1}, waiting for state: active".format(sfr_id, state))
@@ -728,7 +732,7 @@ def set_spot_fleet_request_capacity(sfr_id, capacity, dry_run):
 
 
 @register_autoscaling_component('aws_spot_fleet_request', SCALER_KEY)
-def scale_aws_spot_fleet_request(resource, current_capacity, target_capacity, sorted_slaves, dry_run):
+def scale_aws_spot_fleet_request(resource, current_capacity, target_capacity, sorted_slaves, pool_settings, dry_run):
     """Scales a spot fleet request by delta to reach target capacity
     If scaling up we just set target capacity and let AWS take care of the rest
     If scaling down we pick the slaves we'd prefer to kill, put them in maintenance
@@ -749,10 +753,10 @@ def scale_aws_spot_fleet_request(resource, current_capacity, target_capacity, so
         return
     elif delta > 0:
         log.info("Increasing spot fleet capacity to: {0}".format(target_capacity))
-        set_spot_fleet_request_capacity(sfr_id, target_capacity, dry_run)
+        set_spot_fleet_request_capacity(sfr_id, target_capacity, dry_run, region=resource['region'])
         return
     elif delta < 0:
-        sfr_sorted_slaves = filter_sfr_slaves(sorted_slaves, resource['sfr'])
+        sfr_sorted_slaves = filter_sfr_slaves(sorted_slaves, resource)
         log.info("SFR slave kill preference: {0}".format([slave['pid'] for slave in sfr_sorted_slaves]))
         killable_capacity = sum([slave['instance_weight'] for slave in sfr_sorted_slaves])
         amount_to_decrease = delta * -1
@@ -774,11 +778,12 @@ def scale_aws_spot_fleet_request(resource, current_capacity, target_capacity, so
                                                                      slave_to_kill['instance_weight'],
                                                                      target_capacity))
                 break
+            drain_timeout = pool_settings.get('drain_timeout', DEFAULT_DRAIN_TIMEOUT)
             # The start time of the maintenance window is the point at which
             # we giveup waiting for the instance to drain and mark it for termination anyway
-            start = int(time.time() + CLUSTER_DRAIN_TIMEOUT) * 1000000000  # nanoseconds
-            # Set the duration to an hour, if we haven't cleaned up and termintated by then
-            # mesos should put the slave back into the pool
+            start = int(time.time() + drain_timeout) * 1000000000  # nanoseconds
+            # Set the duration to an hour, this is fairly arbitrary as mesos doesn't actually
+            # do anything at the end of the maintenance window.
             duration = 600 * 1000000000  # nanoseconds
             log.info("Draining {0}".format(slave_to_kill['pid']))
             if not dry_run:
@@ -790,7 +795,7 @@ def scale_aws_spot_fleet_request(resource, current_capacity, target_capacity, so
                               "on {0}: {1}\n Trying next host".format(slave_to_kill['hostname'], e))
                     continue
             log.info("Decreasing spot fleet capacity from {0} to: {1}".format(current_capacity, new_capacity))
-            if not set_spot_fleet_request_capacity(sfr_id, new_capacity, dry_run):
+            if not set_spot_fleet_request_capacity(sfr_id, new_capacity, dry_run, region=resource['region']):
                 log.error("Couldn't update spot fleet, stopping autoscaler")
                 log.info("Undraining {0}".format(slave_to_kill['pid']))
                 if not dry_run:
@@ -798,11 +803,11 @@ def scale_aws_spot_fleet_request(resource, current_capacity, target_capacity, so
                 break
             log.info("Waiting for instance to drain before we terminate")
             try:
-                wait_and_terminate(slave_to_kill, dry_run)
+                wait_and_terminate(slave_to_kill, drain_timeout, dry_run, region=resource['region'])
             except ClientError as e:
                 log.error("Failure when terminating: {0}: {1}".format(slave['pid'], e))
                 log.error("Setting spot fleet capacity back to {0}".format(current_capacity))
-                if not set_spot_fleet_request_capacity(sfr_id, current_capacity, dry_run):
+                if not set_spot_fleet_request_capacity(sfr_id, current_capacity, dry_run, region=resource['region']):
                     log.error("Couldn't update spot fleet, stopping autoscaler")
                     break
                 continue
@@ -832,12 +837,14 @@ def autoscale_local_cluster(dry_run=False):
         log.info("Running in dry_run mode, no changes should be made")
     system_config = load_system_paasta_config()
     autoscaling_resources = system_config.get_cluster_autoscaling_resources()
+    all_pool_settings = system_config.get_resource_pool_settings()
     mesos_state = get_mesos_state_from_leader()
     for identifier, resource in autoscaling_resources.items():
+        pool_settings = all_pool_settings.get(resource['pool'], {})
         log.info("Autoscaling {0}".format(identifier))
         resource_metrics_provider = get_cluster_metrics_provider(resource['type'])
         try:
-            current, target = resource_metrics_provider(resource['id'], mesos_state, resource)
+            current, target = resource_metrics_provider(resource['id'], mesos_state, resource, pool_settings)
             log.info("Target capacity: {0}, Capacity current: {1}".format(target, current))
             resource_scaler = get_scaler(resource['type'])
             if target - current < 0:
@@ -845,6 +852,6 @@ def autoscale_local_cluster(dry_run=False):
                 log.debug("Slaves by kill preference: {0}".format(sorted_slaves))
             else:
                 sorted_slaves = []
-            resource_scaler(resource, current, target, sorted_slaves, dry_run)
+            resource_scaler(resource, current, target, sorted_slaves, pool_settings, dry_run)
         except ClusterAutoscalingError as e:
             log.error('%s: %s' % (identifier, e))

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -892,6 +892,9 @@ class SystemPaastaConfig(dict):
     def get_cluster_autoscaling_resources(self):
         return self.get('cluster_autoscaling_resources', {})
 
+    def get_resource_pool_settings(self):
+        return self.get('resource_pool_settings', {})
+
     def get_cluster_fqdn_format(self):
         """Get a format string that constructs a DNS name pointing at the paasta masters in a cluster. This format
         string gets one parameter: cluster. Defaults to 'paasta-{cluster:s}.yelp'.

--- a/tests/test_autoscaling_lib.py
+++ b/tests/test_autoscaling_lib.py
@@ -615,16 +615,17 @@ def test_scale_aws_spot_fleet_request():
     ):
 
         mock_sfr = mock.Mock()
-        mock_resource = {'id': 'sfr-blah', 'sfr': mock_sfr}
+        mock_resource = {'id': 'sfr-blah', 'sfr': mock_sfr, 'region': 'westeros-1'}
+        mock_pool_settings = {'drain_timeout': 123}
         mock_set_spot_fleet_request_capacity.return_value = True
 
         # test no scale
-        autoscaling_lib.scale_aws_spot_fleet_request(mock_resource, 4, 4, [], False)
+        autoscaling_lib.scale_aws_spot_fleet_request(mock_resource, 4, 4, [], mock_pool_settings, False)
         assert not mock_set_spot_fleet_request_capacity.called
 
         # test scale up
-        autoscaling_lib.scale_aws_spot_fleet_request(mock_resource, 2, 4, [], False)
-        mock_set_spot_fleet_request_capacity.assert_called_with('sfr-blah', 4, False)
+        autoscaling_lib.scale_aws_spot_fleet_request(mock_resource, 2, 4, [], mock_pool_settings, False)
+        mock_set_spot_fleet_request_capacity.assert_called_with('sfr-blah', 4, False, region='westeros-1')
 
         # test scale down
         mock_sfr_sorted_slaves = [{'hostname': 'host1', 'instance_id': 'i-blah123',
@@ -634,19 +635,19 @@ def test_scale_aws_spot_fleet_request():
                                    'pid': 'slave(1)@10.2.2.2:5051', 'instance_weight': 2,
                                    'ip': '10.2.2.2'}]
         mock_time.return_value = int(1)
-        mock_start = (1 + autoscaling_lib.CLUSTER_DRAIN_TIMEOUT) * 1000000000
-        terminate_call_1 = mock.call(mock_sfr_sorted_slaves[0], False)
-        terminate_call_2 = mock.call(mock_sfr_sorted_slaves[1], False)
+        mock_start = (1 + 123) * 1000000000
+        terminate_call_1 = mock.call(mock_sfr_sorted_slaves[0], 123, False, region='westeros-1')
+        terminate_call_2 = mock.call(mock_sfr_sorted_slaves[1], 123, False, region='westeros-1')
         drain_call_1 = mock.call(['host1|10.1.1.1'], mock_start, 600 * 1000000000)
         drain_call_2 = mock.call(['host2|10.2.2.2'], mock_start, 600 * 1000000000)
         undrain_call_1 = mock.call(['host1|10.1.1.1'])
         undrain_call_2 = mock.call(['host2|10.2.2.2'])
-        set_call_1 = mock.call('sfr-blah', 4, False)
-        set_call_2 = mock.call('sfr-blah', 2, False)
+        set_call_1 = mock.call('sfr-blah', 4, False, region='westeros-1')
+        set_call_2 = mock.call('sfr-blah', 2, False, region='westeros-1')
         mock_filter_sfr_slaves.return_value = mock_sfr_sorted_slaves
         mock_sorted_slaves = mock.Mock()
-        autoscaling_lib.scale_aws_spot_fleet_request(mock_resource, 5, 2, mock_sorted_slaves, False)
-        mock_filter_sfr_slaves.assert_called_with(mock_sorted_slaves, mock_sfr)
+        autoscaling_lib.scale_aws_spot_fleet_request(mock_resource, 5, 2, mock_sorted_slaves, mock_pool_settings, False)
+        mock_filter_sfr_slaves.assert_called_with(mock_sorted_slaves, mock_resource)
         mock_drain.assert_has_calls([drain_call_1, drain_call_2])
         mock_set_spot_fleet_request_capacity.assert_has_calls([set_call_1, set_call_2])
         mock_wait_and_terminate.assert_has_calls([terminate_call_1, terminate_call_2])
@@ -660,8 +661,8 @@ def test_scale_aws_spot_fleet_request():
                                    'pid': 'slave(1)@10.2.2.2:5051', 'instance_weight': 5,
                                    'ip': '10.2.2.2'}]
         mock_filter_sfr_slaves.return_value = mock_sfr_sorted_slaves
-        autoscaling_lib.scale_aws_spot_fleet_request(mock_resource, 5, 2, mock_sorted_slaves, False)
-        mock_filter_sfr_slaves.assert_called_with(mock_sorted_slaves, mock_sfr)
+        autoscaling_lib.scale_aws_spot_fleet_request(mock_resource, 5, 2, mock_sorted_slaves, mock_pool_settings, False)
+        mock_filter_sfr_slaves.assert_called_with(mock_sorted_slaves, mock_resource)
         mock_drain.assert_has_calls([drain_call_1, drain_call_2, drain_call_1])
         mock_set_spot_fleet_request_capacity.assert_has_calls([set_call_1, set_call_2, set_call_1])
         mock_wait_and_terminate.assert_has_calls([terminate_call_1, terminate_call_2, terminate_call_1])
@@ -672,9 +673,9 @@ def test_scale_aws_spot_fleet_request():
                                    'pid': 'slave(1)@10.1.1.1:5051', 'instance_weight': 1,
                                    'ip': '10.1.1.1'}]
         mock_filter_sfr_slaves.return_value = mock_sfr_sorted_slaves
-        autoscaling_lib.scale_aws_spot_fleet_request(mock_resource, 5, 4, mock_sorted_slaves, False)
-        set_call_3 = mock.call('sfr-blah', 5, False)
-        mock_filter_sfr_slaves.assert_called_with(mock_sorted_slaves, mock_sfr)
+        autoscaling_lib.scale_aws_spot_fleet_request(mock_resource, 5, 4, mock_sorted_slaves, mock_pool_settings, False)
+        set_call_3 = mock.call('sfr-blah', 5, False, region='westeros-1')
+        mock_filter_sfr_slaves.assert_called_with(mock_sorted_slaves, mock_resource)
         mock_drain.assert_has_calls([drain_call_1, drain_call_2, drain_call_1, drain_call_1])
         mock_set_spot_fleet_request_capacity.assert_has_calls([set_call_1, set_call_2, set_call_1,
                                                                set_call_1, set_call_3])
@@ -699,8 +700,11 @@ def test_autoscale_local_cluster():
     ):
 
         mock_scaling_resources = {'id1': {'id': 'sfr-blah', 'type': 'sfr', 'pool': 'default'}}
+        mock_resource_pool_settings = {'default': {'drain_timeout': 123, 'target_utilization': 0.75}}
         mock_get_cluster_autoscaling_resources = mock.Mock(return_value=mock_scaling_resources)
-        mock_get_resources = mock.Mock(get_cluster_autoscaling_resources=mock_get_cluster_autoscaling_resources)
+        mock_get_resource_pool_settings = mock.Mock(return_value=mock_resource_pool_settings)
+        mock_get_resources = mock.Mock(get_cluster_autoscaling_resources=mock_get_cluster_autoscaling_resources,
+                                       get_resource_pool_settings=mock_get_resource_pool_settings)
         mock_get_paasta_config.return_value = mock_get_resources
         mock_metrics_provider = mock.Mock()
         mock_metrics_provider.return_value = (2, 6)
@@ -711,21 +715,25 @@ def test_autoscale_local_cluster():
         # test scale up
         autoscaling_lib.autoscale_local_cluster()
         mock_get_metrics_provider.assert_called_with('sfr')
-        mock_metrics_provider.assert_called_with('sfr-blah', mock_mesos_state(), {'id': 'sfr-blah', 'type': 'sfr',
-                                                                                  'pool': 'default'})
+        mock_metrics_provider.assert_called_with('sfr-blah', mock_mesos_state(),
+                                                 {'id': 'sfr-blah', 'type': 'sfr', 'pool': 'default'},
+                                                 {'drain_timeout': 123, 'target_utilization': 0.75})
         mock_get_scaler.assert_called_with('sfr')
-        mock_scaler.assert_called_with({'id': 'sfr-blah', 'type': 'sfr', 'pool': 'default'}, 2, 6, [], False)
+        mock_scaler.assert_called_with({'id': 'sfr-blah', 'type': 'sfr', 'pool': 'default'}, 2, 6, [],
+                                       {'drain_timeout': 123, 'target_utilization': 0.75}, False)
 
         # test scale down
         mock_metrics_provider.return_value = (6, 2)
         mock_sort_slaves_to_kill.return_value = ['a_slave', 'another_slave']
         autoscaling_lib.autoscale_local_cluster()
         mock_get_metrics_provider.assert_called_with('sfr')
-        mock_metrics_provider.assert_called_with('sfr-blah', mock_mesos_state(), {'id': 'sfr-blah', 'type': 'sfr',
-                                                                                  'pool': 'default'})
+        mock_metrics_provider.assert_called_with('sfr-blah', mock_mesos_state(),
+                                                 {'id': 'sfr-blah', 'type': 'sfr', 'pool': 'default'},
+                                                 {'drain_timeout': 123, 'target_utilization': 0.75})
         mock_get_scaler.assert_called_with('sfr')
         mock_scaler.assert_called_with({'id': 'sfr-blah', 'type': 'sfr', 'pool': 'default'},
-                                       6, 2, ['a_slave', 'another_slave'], False)
+                                       6, 2, ['a_slave', 'another_slave'],
+                                       {'drain_timeout': 123, 'target_utilization': 0.75}, False)
 
 
 def test_get_instances_from_ip():
@@ -754,12 +762,12 @@ def test_wait_and_terminate():
         mock_is_safe_to_kill.return_value = True
         mock_slave_to_kill = {'ip': '10.1.1.1', 'instance_id': 'i-blah123', 'pid': 'slave(1)@10.1.1.1:5051',
                               'hostname': 'hostblah'}
-        autoscaling_lib.wait_and_terminate(mock_slave_to_kill, False)
+        autoscaling_lib.wait_and_terminate(mock_slave_to_kill, 600, False, region='westeros-1')
         mock_terminate_instances.assert_called_with(InstanceIds=['i-blah123'], DryRun=False)
         mock_is_safe_to_kill.assert_called_with('hostblah')
 
         mock_is_safe_to_kill.side_effect = [False, False, True]
-        autoscaling_lib.wait_and_terminate(mock_slave_to_kill, False)
+        autoscaling_lib.wait_and_terminate(mock_slave_to_kill, 600, False, region='westeros-1')
         assert mock_is_safe_to_kill.call_count == 4
 
 
@@ -797,7 +805,7 @@ def test_get_spot_fleet_instances():
         mock_sfr = {'ActiveInstances': mock_instances}
         mock_describe_spot_fleet_instances = mock.Mock(return_value=mock_sfr)
         mock_ec2_client.return_value = mock.Mock(describe_spot_fleet_instances=mock_describe_spot_fleet_instances)
-        ret = autoscaling_lib.get_spot_fleet_instances('sfr-blah')
+        ret = autoscaling_lib.get_spot_fleet_instances('sfr-blah', region='westeros-1')
         assert ret == mock_instances
 
 
@@ -811,8 +819,8 @@ def test_get_sfr_instance_ips():
         mock_sfr = {'ActiveInstances': mock_spot_fleet_instances}
         mock_instances = [{'PrivateIpAddress': '10.1.1.1'}, {'PrivateIpAddress': '10.2.2.2'}]
         mock_describe_instances.return_value = mock_instances
-        ret = autoscaling_lib.get_sfr_instance_ips(mock_sfr)
-        mock_describe_instances.assert_called_with(['i-blah1', 'i-blah2'])
+        ret = autoscaling_lib.get_sfr_instance_ips(mock_sfr, region='westeros-1')
+        mock_describe_instances.assert_called_with(['i-blah1', 'i-blah2'], region='westeros-1')
         assert ret == ['10.1.1.1', '10.2.2.2']
 
 
@@ -826,14 +834,14 @@ def test_get_sfr():
         mock_sfr = {'SpotFleetRequestConfigs': [mock_sfr_config]}
         mock_describe_spot_fleet_requests = mock.Mock(return_value=mock_sfr)
         mock_ec2_client.return_value = mock.Mock(describe_spot_fleet_requests=mock_describe_spot_fleet_requests)
-        ret = autoscaling_lib.get_sfr('sfr-blah')
+        ret = autoscaling_lib.get_sfr('sfr-blah', region='westeros-1')
         mock_describe_spot_fleet_requests.assert_called_with(SpotFleetRequestIds=['sfr-blah'])
         assert ret == mock_sfr_config
 
         mock_error = {'Error': {'Code': 'InvalidSpotFleetRequestId.NotFound'}}
         mock_describe_spot_fleet_requests = mock.Mock(side_effect=ClientError(mock_error, 'blah'))
         mock_ec2_client.return_value = mock.Mock(describe_spot_fleet_requests=mock_describe_spot_fleet_requests)
-        ret = autoscaling_lib.get_sfr('sfr-blah')
+        ret = autoscaling_lib.get_sfr('sfr-blah', region='westeros-1')
         assert ret is None
 
 
@@ -852,6 +860,7 @@ def test_filter_sfr_slaves():
         mock_get_instance_type_weights
     ):
         mock_sfr = mock.Mock()
+        mock_resource = {'sfr': mock_sfr, 'region': 'westeros-1'}
         mock_get_sfr_instance_ips.return_value = ['10.1.1.1', '10.3.3.3']
         mock_pid_to_ip.side_effect = ['10.1.1.1', '10.2.2.2', '10.3.3.3',
                                       '10.1.1.1', '10.3.3.3', '10.1.1.1', '10.3.3.3']
@@ -875,13 +884,14 @@ def test_filter_sfr_slaves():
         mock_get_ip_call_2 = mock.call('slave(2)@10.2.2.2:5051')
         mock_get_ip_call_3 = mock.call('slave(3)@10.3.3.3:5051')
         mock_get_instance_type_weights.return_value = {'c4.blah': 2, 'm4.whatever': 5}
-        ret = autoscaling_lib.filter_sfr_slaves(mock_sfr_sorted_slaves, mock_sfr)
-        mock_get_sfr_instance_ips.assert_called_with(mock_sfr)
+        ret = autoscaling_lib.filter_sfr_slaves(mock_sfr_sorted_slaves, mock_resource)
+        mock_get_sfr_instance_ips.assert_called_with(mock_sfr, region='westeros-1')
         mock_pid_to_ip.assert_has_calls([mock_get_ip_call_1, mock_get_ip_call_2, mock_get_ip_call_3,
                                          mock_get_ip_call_1, mock_get_ip_call_3])
         mock_get_instances_from_ip.assert_has_calls([mock_get_instance_call_1, mock_get_instance_call_3])
-        mock_describe_instances.assert_called_with([], instance_filters=[{'Values': ['10.1.1.1', '10.3.3.3'],
-                                                                          'Name': 'private-ip-address'}])
+        mock_describe_instances.assert_called_with([], region='westeros-1',
+                                                   instance_filters=[{'Values': ['10.1.1.1', '10.3.3.3'],
+                                                                      'Name': 'private-ip-address'}])
         mock_get_instance_type_weights.assert_called_with(mock_sfr)
         expected = [{'pid': 'slave(1)@10.1.1.1:5051',
                      'instance_id': 'i-1',
@@ -913,12 +923,12 @@ def test_set_spot_fleet_request_capacity():
         mock_get_sfr.return_value = {'SpotFleetRequestState': 'modifying'}
         mock_modify_spot_fleet_request = mock.Mock()
         mock_ec2_client.return_value = mock.Mock(modify_spot_fleet_request=mock_modify_spot_fleet_request)
-        ret = autoscaling_lib.set_spot_fleet_request_capacity('sfr-blah', 4, False)
+        ret = autoscaling_lib.set_spot_fleet_request_capacity('sfr-blah', 4, False, region='westeros-1')
         assert not mock_modify_spot_fleet_request.called
         assert ret is False
 
         mock_get_sfr.return_value = {'SpotFleetRequestState': 'active'}
-        ret = autoscaling_lib.set_spot_fleet_request_capacity('sfr-blah', 4, False)
+        ret = autoscaling_lib.set_spot_fleet_request_capacity('sfr-blah', 4, False, region='westeros-1')
         mock_modify_spot_fleet_request.assert_called_with(SpotFleetRequestId='sfr-blah',
                                                           TargetCapacity=4,
                                                           ExcessCapacityTerminationPolicy='noTermination')
@@ -946,16 +956,16 @@ def test_describe_instance():
         mock_instances = {'Reservations': [{'Instances': [mock_instance_1]}, {'Instances': [mock_instance_2]}]}
         mock_describe_instances = mock.Mock(return_value=mock_instances)
         mock_ec2_client.return_value = mock.Mock(describe_instances=mock_describe_instances)
-        ret = autoscaling_lib.describe_instances(['i-1', 'i-2'], instance_filters=['filter1'])
+        ret = autoscaling_lib.describe_instances(['i-1', 'i-2'], region='westeros-1', instance_filters=['filter1'])
         mock_describe_instances.assert_called_with(InstanceIds=['i-1', 'i-2'], Filters=['filter1'])
         assert ret == [mock_instance_1, mock_instance_2]
 
-        ret = autoscaling_lib.describe_instances(['i-1', 'i-2'])
+        ret = autoscaling_lib.describe_instances(['i-1', 'i-2'], region='westeros-1')
         mock_describe_instances.assert_called_with(InstanceIds=['i-1', 'i-2'], Filters=[])
 
         mock_error = {'Error': {'Code': 'InvalidInstanceID.NotFound'}}
         mock_describe_instances.side_effect = ClientError(mock_error, 'blah')
-        ret = autoscaling_lib.describe_instances(['i-1', 'i-2'])
+        ret = autoscaling_lib.describe_instances(['i-1', 'i-2'], region='westeros-1')
         assert ret is None
 
 
@@ -975,7 +985,8 @@ def test_spotfleet_metrics_provider():
         mock_pid_to_ip,
         mock_get_spot_fleet_delta
     ):
-        mock_resource = {'pool': 'default'}
+        mock_resource = {'pool': 'default',
+                         'region': 'westeros-1'}
         mock_mesos_state = {'slaves': [{'id': 'id1',
                                         'attributes': {'pool': 'default'},
                                         'pid': 'pid1'},
@@ -989,26 +1000,30 @@ def test_spotfleet_metrics_provider():
         mock_get_spot_fleet_instances.return_value = [mock.Mock(), mock.Mock()]
         mock_get_sfr_instance_ips.return_value = ['10.1.1.1', '10.2.2.2']
         mock_get_spot_fleet_delta.return_value = 1, 2
+        mock_pool_settings = {}
 
         mock_get_sfr.return_value = {'SpotFleetRequestState': 'cancelled'}
-        ret = autoscaling_lib.spotfleet_metrics_provider('sfr-blah', mock_mesos_state, mock_resource)
-        mock_get_sfr.assert_called_with('sfr-blah')
+        ret = autoscaling_lib.spotfleet_metrics_provider('sfr-blah', mock_mesos_state,
+                                                         mock_resource, mock_pool_settings)
+        mock_get_sfr.assert_called_with('sfr-blah', region='westeros-1')
         assert not mock_get_spot_fleet_instances.called
         assert ret == (0, 0)
 
         mock_get_sfr.return_value = None
-        ret = autoscaling_lib.spotfleet_metrics_provider('sfr-blah', mock_mesos_state, mock_resource)
-        mock_get_sfr.assert_called_with('sfr-blah')
+        ret = autoscaling_lib.spotfleet_metrics_provider('sfr-blah', mock_mesos_state,
+                                                         mock_resource, mock_pool_settings)
+        mock_get_sfr.assert_called_with('sfr-blah', region='westeros-1')
         assert not mock_get_spot_fleet_instances.called
         assert ret == (0, 0)
 
         mock_get_sfr.return_value = {'SpotFleetRequestState': 'active'}
-        ret = autoscaling_lib.spotfleet_metrics_provider('sfr-blah', mock_mesos_state, mock_resource)
-        mock_get_sfr.assert_called_with('sfr-blah')
-        mock_get_spot_fleet_instances.assert_called_with('sfr-blah')
+        ret = autoscaling_lib.spotfleet_metrics_provider('sfr-blah', mock_mesos_state,
+                                                         mock_resource, mock_pool_settings)
+        mock_get_sfr.assert_called_with('sfr-blah', region='westeros-1')
+        mock_get_spot_fleet_instances.assert_called_with('sfr-blah', region='westeros-1')
         expected_get_ip_call = mock_get_sfr.return_value.copy()
         expected_get_ip_call['ActiveInstances'] = mock_get_spot_fleet_instances.return_value
-        mock_get_sfr_instance_ips.assert_called_with(expected_get_ip_call)
+        mock_get_sfr_instance_ips.assert_called_with(expected_get_ip_call, region='westeros-1')
         mock_pid_to_ip.assert_has_calls([mock.call('pid1'), mock.call('pid2')])
         mock_get_resource_utilization_by_grouping.assert_called_with(mock.ANY, mock_mesos_state)
         mock_get_spot_fleet_delta.assert_called_with(mock_resource, float(0.5) - float(0.8))


### PR DESCRIPTION
This moves the AWS region to be set per autoscaling resources. This
means we don't have to assume that the paasta master only governs one
AWS region.

This moves the drain timeout and target utilization to be per pool
configurable in the paasta system config. This supports moving slow
draining containers to their own pool.