### PR TITLE
Make paasta emergency-stop kill an apps tasks harder

### DIFF
--- a/paasta_itests/paasta_api.feature
+++ b/paasta_itests/paasta_api.feature
@@ -5,7 +5,7 @@ Feature: paasta_api
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main" with "1" instances
-      And we wait for it to be deployed
+     And we wait for "test-service.main" to launch exactly 1 tasks
      Then instance GET should return app_count "1" and an expected number of running instances for "test-service.main"
       And instance GET should return error code "404" for "test-service.non-existent"
 

--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -5,7 +5,7 @@ Feature: paasta_serviceinit
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main" with "1" instances
-      And we wait for it to be deployed
+      And we wait for "test-service.main" to launch exactly 1 tasks
      Then marathon_serviceinit status_marathon_job should return "Healthy" for "test-service.main"
 
   Scenario: marathon_serviceinit can restart tasks
@@ -13,7 +13,7 @@ Feature: paasta_serviceinit
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main" with "1" instances
-      And we wait for it to be deployed
+      And we wait for "test-service.main" to launch exactly 1 tasks
      Then marathon_serviceinit restart should get new task_ids for "test-service.main"
 
   Scenario: paasta_serviceinit can run status on chronos jobs
@@ -41,7 +41,8 @@ Feature: paasta_serviceinit
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main" with "1" instances
-      And we wait for it to be deployed
+      And we wait for "test-service.main" to launch exactly 1 tasks
+     Then marathon_serviceinit restart should get new task_ids for "test-service.main"
      Then paasta_serviceinit status -vv for the service_instance "test-service.main" exits with return code 0 and the correct output
       And paasta_serviceinit status -s "test-service" -i "main" exits with return code 0 and the correct output
       And paasta_serviceinit status -s "test-service" -i "main,test" has the correct output for instance main and exits with non-zero return code for instance test
@@ -112,16 +113,17 @@ Feature: paasta_serviceinit
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main" with "1" instances
-      And we wait for it to be deployed
+      And we wait for "test-service.main" to launch exactly 1 tasks
       And we run paasta serviceinit "stop" on "test-service.main"
-     Then there should be no matching appids for service "test-service" instance "main"
+      And we wait for "test-service.main" to launch exactly 0 tasks
+     Then "test-service.main" has exactly 0 requested tasks in marathon
 
   Scenario: paasta_serviceinit can run emergency-stop on a marathon app via appid
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main" with "1" instances
-      And we wait for it to be deployed
+      And we wait for "test-service.main" to launch exactly 1 tasks
       And we run paasta serviceinit --appid "stop" on "test-service.main"
       And we wait for "test-service.main" to launch exactly 0 tasks
      Then "test-service.main" has exactly 0 requested tasks in marathon
@@ -131,7 +133,7 @@ Feature: paasta_serviceinit
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And we have a deployments.json for the service "test-service" with enabled instance "main"
      When we run the marathon app "test-service.main" with "1" instances
-      And we wait for it to be deployed
+      And we wait for "test-service.main" to launch exactly 1 tasks
       And we run paasta serviceinit scale --delta "2" on "test-service.main"
       And we wait for "test-service.main" to launch exactly 3 tasks
      Then "test-service.main" has exactly 3 requested tasks in marathon

--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -114,8 +114,7 @@ Feature: paasta_serviceinit
      When we run the marathon app "test-service.main" with "1" instances
       And we wait for it to be deployed
       And we run paasta serviceinit "stop" on "test-service.main"
-      And we wait for "test-service.main" to launch exactly 0 tasks
-     Then "test-service.main" has exactly 0 requested tasks in marathon
+     Then there should be no matching appids for service "test-service" instance "main"
 
   Scenario: paasta_serviceinit can run emergency-stop on a marathon app via appid
     Given a working paasta cluster

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -250,4 +250,10 @@ def marathon_app_task_count(context, job_id, task_count):
     assert len(tasks) == task_count
 
 
+@then(u'there should be no matching appids for service "{service}" instance "{instance}"')
+def no_matching_app_ids(context, service, instance):
+    matching_apps = marathon_tools.get_matching_appids(
+        service=service, instance=instance, client=context.marathon_client)
+    assert len(matching_apps) == 0, matching_apps
+
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -46,12 +46,6 @@ def run_marathon_app(context, job_id, instances):
         paasta_tools.bounce_lib.create_marathon_app(app_id, app_config, context.marathon_client)
 
 
-@when(u'we wait for it to be deployed')
-def wait_for_deploy(context):
-    print "Sleeping 10 seconds to wait for deployment..."
-    time.sleep(10)
-
-
 @then(u'marathon_serviceinit status_marathon_job should return "{status}" for "{job_id}"')
 def status_marathon_job(context, status, job_id):
     normal_instance_count = 1
@@ -86,7 +80,7 @@ def marathon_restart_gets_new_task_ids(context, job_id):
             cluster
         )
     print "Sleeping 7 seconds to wait for %s to be restarted." % service
-    time.sleep(7)
+    time.sleep(5)
     new_tasks = context.marathon_client.get_app(app_id).tasks
     print "Tasks before the restart: %s" % old_tasks
     print "Tasks after  the restart: %s" % new_tasks

--- a/paasta_tools/cli/cmds/emergency_stop.py
+++ b/paasta_tools/cli/cmds/emergency_stop.py
@@ -26,9 +26,9 @@ from paasta_tools.utils import load_system_paasta_config
 def add_subparser(subparsers):
     status_parser = subparsers.add_parser(
         'emergency-stop',
-        help="Stop a PaaSTA service instance in an emergency",
+        help="Kills PaaSTA service tasks in an emergency",
         description=(
-            "'emergency-stop' stops a Marathon service instance by scaling it down to 0. If the "
+            "'emergency-stop' kills a Marathon service tasks, allowing fresh ones to replace them. If the "
             "provided 'instance' name refers to a Chronos job, 'emergency-stop' will cancel the "
             "chronos job if it is currently running."
         ),

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -65,7 +65,7 @@ def stop_marathon_job(service, instance, app_id, client, cluster):
         instance=instance
     )
     client.scale_app(app_id, instances=0, force=True)
-    client.delete_app(app_id)
+    client.delete_app(app_id, force=True)
 
 
 def restart_marathon_job(service, instance, app_id, normal_instance_count, client, cluster):

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -65,7 +65,13 @@ def stop_marathon_job(service, instance, app_id, client, cluster):
         instance=instance
     )
     client.scale_app(app_id, instances=0, force=True)
-    client.delete_app(app_id, force=True)
+    log.info("Waiting for remaining tasks to die...")
+    marathon_tools.wait_for_app_to_launch_tasks(
+        client=client,
+        app_id=app_id,
+        expected_tasks=0,
+        exact_matches_only=True
+    )
 
 
 def restart_marathon_job(service, instance, app_id, normal_instance_count, client, cluster):

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -58,13 +58,14 @@ def stop_marathon_job(service, instance, app_id, client, cluster):
     name = PaastaColors.cyan(compose_job_id(service, instance))
     _log(
         service=service,
-        line="EmergencyStop: Scaling %s down to 0 instances" % (name),
+        line="EmergencyStop: Killing %s's in-flight tasks for Marathon to replace with new ones." % name,
         component='deploy',
         level='event',
         cluster=cluster,
         instance=instance
     )
-    client.scale_app(app_id, instances=0, force=True)  # TODO do we want to capture the return val of any client calls?
+    client.scale_app(app_id, instances=0, force=True)
+    client.delete_app(app_id)
 
 
 def restart_marathon_job(service, instance, app_id, normal_instance_count, client, cluster):

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -69,7 +69,7 @@ def test_stop_marathon_job():
     with mock.patch('paasta_tools.marathon_serviceinit._log'):
         marathon_serviceinit.stop_marathon_job(service, instance, app_id, client, cluster)
     client.scale_app.assert_called_once_with(app_id, instances=0, force=True)
-    client.delete_app.assert_called_once_with(app_id)
+    client.delete_app.assert_called_once_with(app_id, force=True)
 
 
 def test_scale_marathon_job():

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -69,6 +69,7 @@ def test_stop_marathon_job():
     with mock.patch('paasta_tools.marathon_serviceinit._log'):
         marathon_serviceinit.stop_marathon_job(service, instance, app_id, client, cluster)
     client.scale_app.assert_called_once_with(app_id, instances=0, force=True)
+    client.delete_app.assert_called_once_with(app_id)
 
 
 def test_scale_marathon_job():

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -69,7 +69,6 @@ def test_stop_marathon_job():
     with mock.patch('paasta_tools.marathon_serviceinit._log'):
         marathon_serviceinit.stop_marathon_job(service, instance, app_id, client, cluster)
     client.scale_app.assert_called_once_with(app_id, instances=0, force=True)
-    client.delete_app.assert_called_once_with(app_id, force=True)
 
 
 def test_scale_marathon_job():


### PR DESCRIPTION
I guess just be more honest about what emergency stop does?