### PR TITLE
Move print statements in paasta_maintenance

### DIFF
--- a/paasta_tools/paasta_maintenance.py
+++ b/paasta_tools/paasta_maintenance.py
@@ -165,7 +165,7 @@ def schedule():
     except HTTPError as e:
         e.msg = "Error getting maintenance schedule. Got error: %s" % e.msg
         raise
-    print "%s" % schedule.text
+    return schedule.text
 
 
 def get_hosts_with_state(state):
@@ -469,7 +469,7 @@ def is_safe_to_kill(hostname):
     :param hostname: hostname to check
     :returns: True or False
     """
-    return is_host_drained(hostname) or hostname in get_hosts_past_maintenance_start()
+    return is_host_drained(hostname) or is_host_past_maintenance_start(hostname)
 
 
 def is_host_drained(hostname):
@@ -514,7 +514,6 @@ def get_hosts_past_maintenance_start():
         for window in schedules['windows']:
             if window['unavailability']['start']['nanoseconds'] < current_time:
                 ret += [host['hostname'] for host in window['machine_ids']]
-    print ret
     return ret
 
 
@@ -578,11 +577,15 @@ def paasta_maintenance():
     elif action == 'status':
         return status()
     elif action == 'schedule':
-        return schedule()
+        ret = schedule()
+        print "%s" % ret
+        return ret
     elif action == 'is_safe_to_kill':
         return is_safe_to_kill(hostnames[0])
     elif action == 'is_host_drained':
-        return is_host_drained(hostnames[0])
+        ret = is_host_drained(hostnames[0])
+        print ret
+        return ret
     elif action == 'is_host_down':
         return is_host_down(hostnames[0])
     elif action == 'is_host_draining':

--- a/tests/test_paasta_maintenance.py
+++ b/tests/test_paasta_maintenance.py
@@ -507,18 +507,12 @@ def test_status(
     assert output == "fake_text\n"
 
 
-@mock.patch('sys.stdout', new_callable=StringIO)
 @mock.patch('paasta_tools.paasta_maintenance.get_maintenance_schedule')
 def test_schedule(
     mock_get_maintenance_schedule,
-    mock_stdout,
 ):
-    mock_get_maintenance_schedule.return_value.__str__ = mock.Mock()
-    mock_get_maintenance_schedule.return_value.text = 'fake_text'
     schedule()
-    output = mock_stdout.getvalue()
     assert mock_get_maintenance_schedule.call_count == 1
-    assert output == "fake_text\n"
 
 
 @mock.patch('paasta_tools.paasta_maintenance.get_maintenance_status')


### PR DESCRIPTION
Moving print statements so they don't show up in logs which use this as a library.

@nhandler I've just moved the print statements that were showing up in the autoscaler log. Would you be happy if I took this further and moved all the printing into `paasta_maintenance()`?