### PR TITLE
Add version to metastatus

### DIFF
--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -63,6 +63,7 @@ def make_app():
     config.include('pyramid_swagger')
     config.add_route('service.instance.status', '/v1/services/{service}/{instance}/status')
     config.add_route('service.list', '/v1/services/{service}')
+    config.add_route('version', '/v1/version')
     config.scan()
     return config.make_wsgi_app()
 

--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -61,8 +61,8 @@ def make_app():
     })
 
     config.include('pyramid_swagger')
-    config.add_route('service.instance.status', '/v1/{service}/{instance}/status')
-    config.add_route('service.list', '/v1/{service}')
+    config.add_route('service.instance.status', '/v1/services/{service}/{instance}/status')
+    config.add_route('service.list', '/v1/services/{service}')
     config.scan()
     return config.make_wsgi_app()
 

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -20,7 +20,7 @@
     }
   ],
   "paths": {
-    "/{service}": {
+    "/services/{service}": {
       "get": {
         "responses": {
           "200": {
@@ -50,7 +50,7 @@
         ]
       }
     },
-    "/{service}/{instance}/status": {
+    "/services/{service}/{instance}/status": {
       "get": {
         "responses": {
           "200": {

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -20,6 +20,20 @@
     }
   ],
   "paths": {
+    "/version": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Version of paasta_tools package",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "summary": "Version of paasta_tools package",
+        "operationId": "showVersion"
+      }
+    },
     "/services/{service}": {
       "get": {
         "responses": {

--- a/paasta_tools/api/views/version.py
+++ b/paasta_tools/api/views/version.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+PaaSTA service list (instances) etc.
+"""
+from pyramid.view import view_config
+
+from paasta_tools import __version__
+
+
+@view_config(route_name='version', request_method='GET', renderer='json')
+def version(request):
+    return __version__

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -25,6 +25,7 @@ from httplib2 import ServerNotFoundError
 from humanize import naturalsize
 from marathon.exceptions import MarathonError
 
+from paasta_tools import __version__
 from paasta_tools import chronos_tools
 from paasta_tools import marathon_tools
 from paasta_tools.chronos_tools import get_chronos_client
@@ -648,6 +649,7 @@ def main():
         print_results_for_healthchecks(marathon_ok, marathon_results, args.verbose)
         print chronos_summary
         print_results_for_healthchecks(chronos_ok, chronos_results, args.verbose)
+        print "Master paasta_tools version: {0}".format(__version__)
     elif args.verbose == 2:
         print mesos_summary
         print_results_for_healthchecks(mesos_ok, all_mesos_results, args.verbose)
@@ -679,6 +681,7 @@ def main():
         print_results_for_healthchecks(marathon_ok, marathon_results, args.verbose)
         print chronos_summary
         print_results_for_healthchecks(chronos_ok, chronos_results, args.verbose)
+        print "Master paasta_tools version: {0}".format(__version__)
     else:
         print mesos_summary
         print_results_for_healthchecks(mesos_ok, all_mesos_results, args.verbose)
@@ -733,6 +736,7 @@ def main():
             all_rows.extend(table_rows)
         for line in format_table(all_rows):
             print_with_indent(line, 4)
+        print "Master paasta_tools version: {0}".format(__version__)
 
     if not healthy_exit:
         sys.exit(2)


### PR DESCRIPTION
I've wanted to find out the remote paasta version a few times so I've added it to metastatus here.

I've added a version endpoint in the API too for when we start using the API in our command line clients. @huadongliu can you check I haven't broken anything by moving the services endpoint?