### PR TITLE
allow to pass --cap-add arguments to docker

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -49,6 +49,11 @@ instance MAY have:
         - nofile: {"soft": 1024, "hard": 2048}
         - nice: {"soft": 20}
 
+  * ``cap_add``: List of capabilities that are passed to Docker. Defaults
+    to empty list. Example::
+
+      "cap_add": ["IPC_LOCK", "SYS_PTRACE"]
+
   * ``instances``: Marathon will attempt to run this many instances of the Service
 
   * ``min_instances``: When autoscaling, the minimum number of instances that

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -187,6 +187,17 @@ class InstanceConfig(dict):
                 combined_val += ':%i' % hard
             yield {"key": "ulimit", "value": "{0}={1}".format(key, combined_val)}
 
+    def get_cap_add(self):
+        """Get the --cap-add options to be passed to docker
+        Generated from the cap_add configuration option, which is a list of
+        capabilities.
+
+        Example configuration: {'cap_add': ['IPC_LOCK', 'SYS_PTRACE']}
+
+        :returns: A generator of cap_add options to be passed as --cap-add flags"""
+        for value in self.config_dict.get('cap_add', []):
+            yield {"key": "cap-add", "value": "{0}".format(value)}
+
     def format_docker_parameters(self):
         """Formats extra flags for running docker.  Will be added in the format
         `["--%s=%s" % (e['key'], e['value']) for e in list]` to the `docker run` command
@@ -197,6 +208,7 @@ class InstanceConfig(dict):
                       {"key": "cpu-period", "value": "%s" % int(self.get_cpu_period())},
                       {"key": "cpu-quota", "value": "%s" % int(self.get_cpu_quota())}]
         parameters.extend(self.get_ulimit())
+        parameters.extend(self.get_cap_add())
         return parameters
 
     def get_disk(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -911,6 +911,7 @@ class TestInstanceConfig:
                     'nofile': {'soft': 1024, 'hard': 2048},
                     'nice': {'soft': 20},
                 },
+                'cap_add': ['IPC_LOCK', 'SYS_PTRACE'],
             },
             branch_dict={},
         )
@@ -920,6 +921,8 @@ class TestInstanceConfig:
             {"key": "cpu-quota", "value": "600000"},
             {"key": "ulimit", "value": "nice=20"},
             {"key": "ulimit", "value": "nofile=1024:2048"},
+            {"key": "cap-add", "value": "IPC_LOCK"},
+            {"key": "cap-add", "value": "SYS_PTRACE"},
         ]
 
     def test_full_cpu_burst(self):
@@ -1003,6 +1006,31 @@ class TestInstanceConfig:
             branch_dict={},
         )
         assert list(fake_conf.get_ulimit()) == []
+
+    def test_get_cap_add_in_config(self):
+        fake_conf = utils.InstanceConfig(
+            service='',
+            instance='',
+            cluster='',
+            config_dict={
+                'cap_add': ['IPC_LOCK', 'SYS_PTRACE'],
+            },
+            branch_dict={},
+        )
+        assert list(fake_conf.get_cap_add()) == [
+            {"key": "cap-add", "value": "IPC_LOCK"},
+            {"key": "cap-add", "value": "SYS_PTRACE"},
+        ]
+
+    def test_get_cap_add_default(self):
+        fake_conf = utils.InstanceConfig(
+            service='',
+            instance='',
+            cluster='',
+            config_dict={},
+            branch_dict={},
+        )
+        assert list(fake_conf.get_cap_add()) == []
 
     def test_deploy_group_default(self):
         fake_conf = utils.InstanceConfig(


### PR DESCRIPTION
Adds a new "cap-add" configuration option that allows to pass --cap-add arguments to Docker.