### PR TITLE
Added a paasta status option to use the api endpoint

### DIFF
--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -11,12 +11,8 @@
   "produces": ["application/json"],
   "tags": [
     {
-      "name": "instances",
-      "description": "Instances of a service"
-    },
-    {
-      "name": "status",
-      "description": "Status of a serivce instance"
+      "name": "service",
+      "description": "information about a paasta serivce"
     }
   ],
   "paths": {
@@ -51,8 +47,8 @@
           }
         },
         "summary": "List instances of service_name",
-        "operationId": "listInstances",
-        "tags": ["instances"],
+        "operationId": "list_instances",
+        "tags": ["service"],
         "parameters": [
           {
             "in": "path",
@@ -81,8 +77,8 @@
           }
         },
         "summary": "Get status of service_name.instance_name",
-        "operationId": "statusInstance",
-        "tags": ["status"],
+        "operationId": "status_instance",
+        "tags": ["service"],
         "parameters": [
           {
             "in": "path",

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -137,6 +137,10 @@
           "format": "int32",
           "description": "The number of different running versions of the same service (0 for stopped, 1 for running and 1+ for bouncing)"
         },
+        "app_id": {
+          "type": "string",
+          "description": "ID of the desired version of a service instance"
+        },
         "bounce_method": {
           "type": "string",
           "description": "Method to transit between new and old versions of a service",
@@ -145,7 +149,12 @@
         "deploy_status": {
           "type": "string",
           "description": "Deploy status of a marathon service",
-          "enum": ["Running", "Deploying", "Stopped", "Delayed", "Waiting", "Not Running"]
+          "enum": ["Running", "Deploying", "Stopped", "Delayed", "Waiting", "NotRunning"]
+        },
+        "backoff_seconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "backoff in seconds before launching the next task"
         },
         "running_instance_count": {
           "type": "integer",

--- a/paasta_tools/api/client.py
+++ b/paasta_tools/api/client.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Client interface for the Paasta rest api.
+"""
+import logging
+
+import requests
+
+from paasta_tools.utils import get_user_agent
+from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import PaastaNotConfiguredError
+
+
+log = logging.getLogger(__name__)
+
+
+class PaastaApiError(Exception):
+    pass
+
+
+class PaastaApiClient(object):
+    def __init__(self, cluster=None, system_paasta_config=None, timeout=30):
+        """Create a PaastaApiClient instance.
+        :param str cluster: name of the cluster of an api server
+        :param int timeout: Timeout (in seconds) for a request to an api endpoint
+        :param :class:`requests.Session` session: the session for request and response
+        """
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.headers.update({'User-Agent': get_user_agent()})
+
+        try:
+            if not system_paasta_config:
+                system_paasta_config = load_system_paasta_config()
+            api_endpoints = system_paasta_config.get_api_endpoints()
+            if not cluster:
+                cluster = system_paasta_config.get_cluster()
+            self.server = api_endpoints[cluster]
+        except:
+            raise PaastaNotConfiguredError(
+                "Could not find cluster {0} in system paasta configuration directory".format(cluster))
+
+    def _do_request(self, method, path, params=None, data=None):
+        """Hit the api server."""
+        headers = {
+            'Content-Type': 'application/json', 'Accept': 'application/json'}
+        url = ''.join([self.server.rstrip('/'), path])
+        try:
+            response = self.session.request(method,
+                                            url,
+                                            params=params,
+                                            data=data,
+                                            headers=headers,
+                                            timeout=self.timeout)
+        except requests.exceptions.RequestException as e:
+            log.error('Paasta api error while calling %s: %s', url, str(e))
+            raise PaastaApiError('No remaining Marathon servers to try')
+
+        if response.status_code >= 300:
+            log.error('Paasta api got HTTP {code}: {body}'.format(
+                code=response.status_code, body=response.text))
+            raise PaastaApiError(response)
+        else:
+            log.debug('Paasta api got HTTP {code}: {body}'.format(
+                code=response.status_code, body=response.text))
+
+        return response
+
+    def list_instances(self, service):
+        """List instances of a paasta service."""
+        response = self._do_request(
+            'GET', '/v1/services/{service_name}'.format(service_name=service))
+        response_json = response.json()
+        if 'instances' in response_json:
+            return response_json['instances']
+        else:
+            log.error('Paasta api list_instances got HTTP {code}: {body}'.format(
+                code=response.status_code, body=response.text))
+            raise PaastaApiError(response)
+
+    def instance_status(self, service, instance, verbose=False):
+        """Get status of a paasta service instance."""
+        params = {'verbose': verbose}
+        response = self._do_request(
+            'GET', '/v1/services/{service_name}/{instance_name}/status'.format(
+                service_name=service, instance_name=instance),
+            params=params)
+        response_json = response.json()
+        if service == response_json['service'] and instance == response_json['instance']:
+            return response_json
+        else:
+            log.error('Paasta api instance_status got HTTP {code}: {body}'.format(
+                code=response.status_code, body=response.text))
+            raise PaastaApiError(response)

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -12,11 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import sys
+from distutils.util import strtobool
 from subprocess import CalledProcessError
 
 from service_configuration_lib import read_deploy
 
+from paasta_tools.api.client import PaastaApiClient
 from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_pipeline_url
@@ -24,7 +27,12 @@ from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import PaastaCheckMessages
 from paasta_tools.cli.utils import x_mark
+from paasta_tools.marathon_serviceinit import bouncing_status_human
+from paasta_tools.marathon_serviceinit import desired_state_human
+from paasta_tools.marathon_serviceinit import marathon_app_deploy_status_human
+from paasta_tools.marathon_serviceinit import status_marathon_job_human
 from paasta_tools.marathon_tools import load_deployments_json
+from paasta_tools.marathon_tools import MarathonDeployStatus
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_soa_cluster_deploy_files
 from paasta_tools.utils import list_clusters
@@ -130,8 +138,41 @@ def get_actual_deployments(service, soa_dir):
     return actual_deployments
 
 
+def paasta_status_on_api_endpoint(cluster, service, instance, system_paasta_config, verbose):
+    api_client = PaastaApiClient(cluster=cluster, system_paasta_config=system_paasta_config)
+    status = api_client.instance_status(service, instance, verbose)
+
+    print 'instance: %s' % PaastaColors.blue(instance)
+    print 'Git sha:    %s (desired)' % status['git_sha']
+
+    marathon_status = status['marathon']
+    if 'error_message' in marathon_status:
+        print marathon_status['error_message']
+        return
+
+    bouncing_status = bouncing_status_human(marathon_status['app_count'],
+                                            marathon_status['bounce_method'])
+    desired_state = desired_state_human(marathon_status['desired_state'],
+                                        marathon_status['expected_instance_count'])
+    print "State:      %s - Desired state: %s" % (bouncing_status, desired_state)
+
+    status = MarathonDeployStatus.fromstring(marathon_status['deploy_status'])
+    if status != MarathonDeployStatus.NotRunning:
+        if status == MarathonDeployStatus.Delayed:
+            deploy_status = marathon_app_deploy_status_human(status, marathon_status['backoff_seconds'])
+        else:
+            deploy_status = marathon_app_deploy_status_human(status)
+    else:
+        deploy_status = 'NotRunning'
+
+    print status_marathon_job_human(service, instance, deploy_status,
+                                    marathon_status['app_id'],
+                                    marathon_status['running_instance_count'],
+                                    marathon_status['expected_instance_count'])
+
+
 def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployments, instance_whitelist,
-                              system_paasta_config, verbose=0):
+                              system_paasta_config, verbose=0, use_api_endpoint=False):
     """With a given service and cluster, prints the status of the instances
     in that cluster"""
     print
@@ -158,13 +199,18 @@ def report_status_for_cluster(service, cluster, deploy_pipeline, actual_deployme
             print '    Git sha:    None (not deployed yet)'
 
     if len(deployed_instances) > 0:
-        status = execute_paasta_serviceinit_on_remote_master('status', cluster, service, ','.join(deployed_instances),
-                                                             system_paasta_config, stream=True, verbose=verbose,
-                                                             ignore_ssh_output=True)
-        # Status results are streamed. This print is for possible error messages.
-        if status is not None:
-            for line in status.rstrip().split('\n'):
-                print '    %s' % line
+        if use_api_endpoint:
+            for instance in deployed_instances:
+                paasta_status_on_api_endpoint(cluster, service, instance, system_paasta_config, verbose=verbose)
+        else:
+            status = execute_paasta_serviceinit_on_remote_master(
+                'status', cluster, service, ','.join(deployed_instances),
+                system_paasta_config, stream=True, verbose=verbose,
+                ignore_ssh_output=True)
+            # Status results are streamed. This print is for possible error messages.
+            if status is not None:
+                for line in status.rstrip().split('\n'):
+                    print '    %s' % line
 
     print report_invalid_whitelist_values(instance_whitelist, seen_instances, 'instance')
 
@@ -187,7 +233,7 @@ def report_invalid_whitelist_values(whitelist, items, item_type):
 
 
 def report_status(service, deploy_pipeline, actual_deployments, cluster_whitelist, instance_whitelist,
-                  system_paasta_config, verbose=0):
+                  system_paasta_config, verbose=0, use_api_endpoint=False):
     pipeline_url = get_pipeline_url(service)
     print "Pipeline: %s" % pipeline_url
 
@@ -202,6 +248,7 @@ def report_status(service, deploy_pipeline, actual_deployments, cluster_whitelis
                 instance_whitelist=instance_whitelist,
                 system_paasta_config=system_paasta_config,
                 verbose=verbose,
+                use_api_endpoint=use_api_endpoint
             )
 
     print report_invalid_whitelist_values(cluster_whitelist, deployed_clusters, 'cluster')
@@ -214,6 +261,10 @@ def paasta_status(args):
     service = figure_out_service_name(args, soa_dir)
     actual_deployments = get_actual_deployments(service, soa_dir)
     system_paasta_config = load_system_paasta_config()
+    if 'USE_API_ENDPOINT' in os.environ:
+        use_api_endpoint = strtobool(os.environ.get('USE_API_ENDPOINT'))
+    else:
+        use_api_endpoint = False
 
     if args.clusters is not None:
         cluster_whitelist = args.clusters.split(",")
@@ -235,6 +286,7 @@ def paasta_status(args):
                 instance_whitelist=instance_whitelist,
                 system_paasta_config=system_paasta_config,
                 verbose=args.verbose,
+                use_api_endpoint=use_api_endpoint
             )
         except CalledProcessError as e:
             print PaastaColors.grey(PaastaColors.bold(e.cmd + " exited with non-zero return code."))

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -861,6 +861,9 @@ class SystemPaastaConfig(dict):
     def get_dashboard_links(self):
         return self['dashboard_links']
 
+    def get_api_endpoints(self):
+        return self['api_endpoints']
+
     def get_fsm_template(self):
         fsm_path = os.path.dirname(sys.modules['paasta_tools.cli.fsm'].__file__)
         template_path = os.path.join(fsm_path, "template")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,6 @@ pep8==1.5.7
 pre-commit==0.7.6
 pytest==2.7.3
 pytest-cov==2.2.0
+requests-mock==1.0.0
 sphinx==1.4.1
 sphinxcontrib-programoutput==0.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,5 @@ pep8==1.5.7
 pre-commit==0.7.6
 pytest==2.7.3
 pytest-cov==2.2.0
-requests-mock==1.0.0
 sphinx==1.4.1
 sphinxcontrib-programoutput==0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,10 @@ argparse==1.2.1
 backports.ssl-match-hostname==3.4.0.2
 blessings==1.6
 boto3==1.3.0
+bravado==8.3.0
 chronos-python==0.35.0
 cookiecutter==1.4.0
+cryptography==1.4
 docker-py==1.2.3
 dulwich==0.10.0
 ephemeral-port-reserve==1.0.1
@@ -18,7 +20,7 @@ httplib2==0.9
 humanize==0.5.1
 importlib==1.0.3
 isodate==0.5.1
-jsonschema==2.5.1
+jsonschema[format]==2.5.1
 kazoo==2.2
 lockfile==0.9.1
 marathon==0.8.5

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,10 @@ setup(
         # argparse is pinned to 1.2.1 since it comes in the core python2.7
         # libs and pip can't seem to override it
         'argparse == 1.2.1',
+        'bravado == 8.3.0',
         'chronos-python == 0.35.0',
         'cookiecutter == 1.4.0',
+        'cryptography == 1.4',
         # Don't update this unless you have confirmed the client works with
         # the Docker version deployed on PaaSTA servers
         'docker-py == 1.2.3',
@@ -46,7 +48,7 @@ setup(
         'humanize >= 0.5.1',
         'httplib2 >= 0.9,<= 1.0',
         'isodate >= 0.5.0',
-        'jsonschema',
+        'jsonschema[format]',
         'kazoo >= 2.0.0',
         'marathon >= 0.8.1',
         'mesos.cli == 0.1.5',
@@ -54,6 +56,7 @@ setup(
         'ordereddict >= 1.1',
         'path.py >= 8.1',
         'pyramid == 1.7',
+        'pyramid-swagger == 2.2.3',
         'pysensu-yelp >= 0.2.2',
         'pytimeparse >= 1.1.0',
         'python-dateutil >= 2.4.0',
@@ -61,7 +64,6 @@ setup(
         'requests-cache >= 0.4.10,<= 0.5.0',
         'sensu-plugin >= 0.1.0',
         'service-configuration-lib >= 0.10.1',
-        'setuptools != 18.6',
         'ujson == 1.35',
         'yelp_clog >= 2.2.0',
     ],

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -1,0 +1,75 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+import mock
+import requests_mock
+
+from paasta_tools.api.client import PaastaApiClient
+from paasta_tools.cli.cmds.status import paasta_status_on_api_endpoint
+from paasta_tools.utils import SystemPaastaConfig
+
+
+@requests_mock.mock()
+def test_list_instances(m):
+    fake_response = '{"instances": ["main", "test"]}'
+    m.get('http://fake_cluster:5054/v1/services/fake_service', text=fake_response)
+
+    with mock.patch('paasta_tools.api.client.load_system_paasta_config',
+                    autospec=True) as mock_load_system_paasta_config:
+        mock_load_system_paasta_config.return_value = SystemPaastaConfig({
+            'api_endpoints': {
+                'fake_cluster': "http://fake_cluster:5054"
+            },
+            'cluster': 'fake_cluster'
+        }, 'fake_directory')
+
+        client = PaastaApiClient(cluster="fake_cluster")
+        assert client.list_instances("fake_service") == ["main", "test"]
+
+
+@requests_mock.mock()
+def test_instance_status(m):
+    fake_response = '{"service": "fake_service", "instance": "fake_instance"}'
+    m.get('http://fake_cluster:5054/v1/services/fake_service/fake_instance/status', text=fake_response)
+
+    with mock.patch('paasta_tools.api.client.load_system_paasta_config',
+                    autospec=True) as mock_load_system_paasta_config:
+        mock_load_system_paasta_config.return_value = SystemPaastaConfig({
+            'api_endpoints': {
+                'fake_cluster': "http://fake_cluster:5054"
+            },
+            'cluster': 'fake_cluster'
+        }, 'fake_directory')
+
+        client = PaastaApiClient(cluster="fake_cluster")
+        assert client.instance_status("fake_service", "fake_instance") == json.loads(fake_response)
+
+
+@requests_mock.mock()
+def test_paasta_status(m):
+    fake_response = '{"git_sha": "fake_git_sha", "instance": "fake_instance", "service": "fake_service",\
+                      "marathon": {"desired_state": "start", "app_id": "fake_app_id",\
+                                   "running_instance_count": 2, "expected_instance_count": 2,\
+                                   "deploy_status": "Running", "app_count": 1, "bounce_method": "crossover"}}'
+    m.get('http://fake_cluster:5054/v1/services/fake_service/fake_instance/status', text=fake_response)
+
+    system_paasta_config = SystemPaastaConfig({
+        'api_endpoints': {
+            'fake_cluster': "http://fake_cluster:5054"
+        },
+        'cluster': 'fake_cluster'
+    }, 'fake_directory')
+
+    paasta_status_on_api_endpoint('fake_cluster', 'fake_service', 'fake_instance', system_paasta_config, verbose=False)

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -453,6 +453,7 @@ def test_status_calls_sergeants(
         instance_whitelist=[],
         system_paasta_config=fake_system_paasta_config,
         verbose=0,
+        use_api_endpoint=False
     )
 
 
@@ -505,7 +506,8 @@ def test_report_status_obeys_cluster_whitelist(
         actual_deployments=actual_deployments,
         instance_whitelist=instance_whitelist,
         system_paasta_config=fake_system_paasta_config,
-        verbose=0
+        verbose=0,
+        use_api_endpoint=False
     )
 
 
@@ -539,7 +541,8 @@ def test_report_status_handle_none_whitelist(
         actual_deployments=actual_deployments,
         instance_whitelist=instance_whitelist,
         system_paasta_config=fake_system_paasta_config,
-        verbose=0
+        verbose=0,
+        use_api_endpoint=False
     )
     mock_report_status_for_cluster.assert_any_call(
         service=service,
@@ -548,7 +551,8 @@ def test_report_status_handle_none_whitelist(
         actual_deployments=actual_deployments,
         instance_whitelist=instance_whitelist,
         system_paasta_config=fake_system_paasta_config,
-        verbose=0
+        verbose=0,
+        use_api_endpoint=False
     )
     mock_report_status_for_cluster.assert_any_call(
         service=service,
@@ -557,5 +561,6 @@ def test_report_status_handle_none_whitelist(
         actual_deployments=actual_deployments,
         instance_whitelist=instance_whitelist,
         system_paasta_config=fake_system_paasta_config,
-        verbose=0
+        verbose=0,
+        use_api_endpoint=False
     )

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -109,7 +109,7 @@ def test_status_desired_state():
     ) as mock_get_bouncing_status:
         mock_get_bouncing_status.return_value = 'Bouncing (fake_bounce)'
         fake_complete_config = mock.Mock()
-        fake_complete_config.get_desired_state_human = mock.Mock(return_value='Started')
+        fake_complete_config.get_desired_state = mock.Mock(return_value='start')
         actual = marathon_serviceinit.status_desired_state(
             'fake_service',
             'fake_instance',
@@ -316,7 +316,7 @@ def tests_status_marathon_job_when_running_running_tasks_with_delayed_deployment
     ):
         output = marathon_serviceinit.status_marathon_job(service, instance, app_id, normal_instance_count, client)
         is_app_id_running_patch.assert_called_once_with(app_id, client)
-        get_app_queue_status_patch.assert_called_once_with(client, app_id)
+        get_app_queue_status_patch.assert_called_with(client, app_id)
         assert 'Delayed' in output
 
 

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -21,6 +21,7 @@ from mock import patch
 from pytest import raises
 
 from paasta_tools import marathon_tools
+from paasta_tools.marathon_serviceinit import desired_state_human
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DeploymentsJson
 from paasta_tools.utils import SystemPaastaConfig
@@ -2023,7 +2024,7 @@ class TestMarathonServiceConfig(object):
             config_dict={},
             branch_dict={'desired_state': 'stop'},
         )
-        assert 'Stopped' in fake_conf.get_desired_state_human()
+        assert 'Stopped' in desired_state_human(fake_conf.get_desired_state(), fake_conf.get_instances())
 
     def test_get_desired_state_human_started_with_instances(self):
         fake_conf = marathon_tools.MarathonServiceConfig(
@@ -2033,7 +2034,7 @@ class TestMarathonServiceConfig(object):
             config_dict={'instances': 42},
             branch_dict={'desired_state': 'start'},
         )
-        assert 'Started' in fake_conf.get_desired_state_human()
+        assert 'Started' in desired_state_human(fake_conf.get_desired_state(), fake_conf.get_instances())
 
     def test_get_desired_state_human_with_0_instances(self):
         fake_conf = marathon_tools.MarathonServiceConfig(
@@ -2043,7 +2044,7 @@ class TestMarathonServiceConfig(object):
             config_dict={'instances': 0},
             branch_dict={'desired_state': 'start'},
         )
-        assert 'Stopped' in fake_conf.get_desired_state_human()
+        assert 'Stopped' in desired_state_human(fake_conf.get_desired_state(), fake_conf.get_instances())
 
 
 class TestServiceNamespaceConfig(object):
@@ -2446,7 +2447,9 @@ def test_marathon_service_config_get_desired_state_human_invalid_desired_state()
     )
     with mock.patch.object(marathon_tools.MarathonServiceConfig, 'get_desired_state', autospec=True,
                            return_value='fake-state'):
-        assert 'Unknown (desired_state: fake-state)' in fake_marathon_service_config.get_desired_state_human()
+        fake_desired_state = desired_state_human(fake_marathon_service_config.get_desired_state(),
+                                                 fake_marathon_service_config.get_instances())
+        assert 'Unknown (desired_state: fake-state)' in fake_desired_state
 
 
 def test_read_namespace_for_service_instance_no_cluster():

--- a/yelp_package/dockerfiles/lucid/Dockerfile
+++ b/yelp_package/dockerfiles/lucid/Dockerfile
@@ -18,7 +18,7 @@ MAINTAINER Kyle Anderson <kwa@yelp.com>
 # Make sure we get a package suitable for building this package correctly.
 # Per dnephin we need https://github.com/spotify/dh-virtualenv/pull/20
 # Which at this time is in this package
-RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools python-dev debhelper dh-virtualenv=0.6-yelp2 python-yaml libyaml-dev python-pytest pyflakes python2.7 python2.7-dev help2man zsh git
+RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools python-dev libffi-dev libssl-dev debhelper dh-virtualenv=0.6-yelp2 python-yaml libyaml-dev python-pytest pyflakes python2.7 python2.7-dev help2man zsh git
 
 ENV HOME /work
 ENV PWD /work

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:trusty
 
 RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools \
-  python-dev debhelper python-yaml libyaml-dev python-pytest pyflakes \
+  python-dev libffi-dev libssl-dev debhelper python-yaml libyaml-dev python-pytest pyflakes \
   git help2man zsh wget
 
 RUN cd `mktemp -d` && wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_0.11-1_all.deb && dpkg -i dh-virtualenv_0.11-1_all.deb && apt-get -f install


### PR DESCRIPTION
$ USE_API_ENDPOINT=true .tox/py27/bin/paasta status -s robj-test-service -i main
Pipeline: https://jenkins.yelpcorp.com/view/services-robj-test-service
cluster: mesosstage
instance: main
Git sha:    72ac8530 (desired)
State:      Bouncing (crossover) - Desired state: Started
Marathon:   Healthy - up with (2/2) instances. Status: Running

$ paasta status -s robj-test-service -i main
Pipeline: https://jenkins.yelpcorp.com/view/services-robj-test-service
cluster: mesosstage
instance: main
Git sha:    72ac8530 (desired)
State:      Bouncing (crossover) - Desired state: Started
Marathon:   Healthy - up with (2/2) instances. Status: Running
Mesos:      Healthy - (4/2) tasks in the TASK_RUNNING state.
Smartstack:
    norcal-devc - Critical - in haproxy with (0/2, 0%) total backends UP in this namespace.