### PR TITLE
Remove print statements

### DIFF
--- a/paasta_tools/paasta_maintenance.py
+++ b/paasta_tools/paasta_maintenance.py
@@ -33,7 +33,6 @@ from paasta_tools.mesos_tools import get_mesos_task_count_by_slave
 from paasta_tools.mesos_tools import MESOS_MASTER_PORT
 
 log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
 
 
 def parse_args():
@@ -76,6 +75,13 @@ def parse_args():
         default=[getfqdn()],
         help='Hostname(s) of machine(s) to start draining. '
         'You can specify <hostname>|<ip> to avoid querying DNS to determine the corresponding IP.',
+    )
+    parser.add_argument(
+        '-v', '--verbose',
+        action='count',
+        dest="verbose",
+        default=0,
+        help="Print out more output."
     )
     return parser.parse_args()
 
@@ -369,14 +375,14 @@ def load_credentials(mesos_secrets='/nail/etc/mesos-slave-secret'):
         with open(mesos_secrets) as data_file:
             data = json.load(data_file)
     except EnvironmentError:
-        print "paasta_maintenance must be run on a Mesos slave containing valid credentials (%s)" % mesos_secrets
+        log.error("paasta_maintenance must be run on a Mesos slave containing valid credentials (%s)" % mesos_secrets)
         raise
     try:
         username = data['principal']
         password = data['secret']
     except KeyError:
-        print "%s does not contain Mesos slave credentials in the expected format." % mesos_secrets
-        print "See http://mesos.apache.org/documentation/latest/authentication/ for details"
+        log.error("%s does not contain Mesos slave credentials in the expected format. "
+                  "See http://mesos.apache.org/documentation/latest/authentication/ for details" % mesos_secrets)
         raise
     return username, password
 
@@ -396,8 +402,7 @@ def drain(hostnames, start, duration):
     except HTTPError as e:
         e.msg = "Error performing maintenance drain. Got error: %s" % e.msg
         raise
-    print drain_output
-    return 0
+    return drain_output
 
 
 def undrain(hostnames):
@@ -414,8 +419,7 @@ def undrain(hostnames):
     except HTTPError as e:
         e.msg = "Error performing maintenance drain. Got error: %s" % e.msg
         raise
-    print undrain_output
-    return 0
+    return undrain_output
 
 
 def down(hostnames):
@@ -431,8 +435,7 @@ def down(hostnames):
     except HTTPError as e:
         e.msg = "Error performing maintenance down. Got error: %s" % e.msg
         raise
-    print down_output
-    return 0
+    return down_output
 
 
 def up(hostnames):
@@ -448,8 +451,7 @@ def up(hostnames):
     except HTTPError as e:
         e.msg = "Error performing maintenance up. Got error: %s" % e.msg
         raise
-    print up_output
-    return 0
+    return up_output
 
 
 def status():
@@ -462,8 +464,7 @@ def status():
     except HTTPError as e:
         e.msg = "Error performing maintenance status. Got error: %s" % e.msg
         raise
-    print "%s" % status.text
-    return 0
+    return status.text
 
 
 def is_safe_to_kill(hostname):
@@ -539,6 +540,7 @@ def get_hosts_past_maintenance_start():
         for window in schedules['windows']:
             if window['unavailability']['start']['nanoseconds'] < current_time:
                 ret += [host['hostname'] for host in window['machine_ids']]
+    log.debug("Hosts past maintenance start: {0}".format(ret))
     return ret
 
 
@@ -554,7 +556,7 @@ def get_hosts_past_maintenance_end():
             end = window['unavailability']['start']['nanoseconds'] + window['unavailability']['duration']['nanoseconds']
             if end < current_time:
                 ret += [host['hostname'] for host in window['machine_ids']]
-    print ret
+    log.debug("Hosts past maintenance end: {0}".format(ret))
     return ret
 
 
@@ -563,6 +565,13 @@ def paasta_maintenance():
     :returns: None
     """
     args = parse_args()
+
+    if args.verbose >= 2:
+        logging.basicConfig(level=logging.DEBUG)
+    elif args.verbose == 1:
+        logging.basicConfig(level=logging.INFO)
+    else:
+        logging.basicConfig(level=logging.WARNING)
 
     action = args.action
     hostnames = args.hostname
@@ -574,38 +583,37 @@ def paasta_maintenance():
     start = args.start
     duration = args.duration
 
+    ret = "Done"
     if action == 'drain':
-        return drain(hostnames, start, duration)
+        drain(hostnames, start, duration)
     elif action == 'undrain':
-        return undrain(hostnames)
+        undrain(hostnames)
     elif action == 'down':
-        return down(hostnames)
+        down(hostnames)
     elif action == 'up':
-        return up(hostnames)
+        up(hostnames)
     elif action == 'status':
-        return status()
+        ret = "%s" % status()
     elif action == 'schedule':
-        ret = schedule()
-        print "%s" % ret
-        return ret
+        ret = "%s" % schedule()
     elif action == 'is_safe_to_drain':
-        return is_safe_to_drain(hostnames[0])
+        ret = is_safe_to_drain(hostnames[0])
     elif action == 'is_safe_to_kill':
-        return is_safe_to_kill(hostnames[0])
+        ret = is_safe_to_kill(hostnames[0])
     elif action == 'is_host_drained':
         ret = is_host_drained(hostnames[0])
-        print ret
-        return ret
     elif action == 'is_host_down':
-        return is_host_down(hostnames[0])
+        ret = is_host_down(hostnames[0])
     elif action == 'is_host_draining':
-        return is_host_draining(hostnames[0])
+        ret = is_host_draining(hostnames[0])
     elif action == 'is_host_past_maintenance_start':
-        return is_host_past_maintenance_start(hostnames[0])
+        ret = is_host_past_maintenance_start(hostnames[0])
     elif action == 'is_host_past_maintenance_end':
-        return is_host_past_maintenance_end(hostnames[0])
+        ret = is_host_past_maintenance_end(hostnames[0])
     else:
         raise NotImplementedError("Action: '%s' is not implemented." % action)
+    print ret
+    return ret
 
 if __name__ == '__main__':
     if paasta_maintenance():

--- a/tests/test_paasta_maintenance.py
+++ b/tests/test_paasta_maintenance.py
@@ -14,7 +14,6 @@
 import argparse
 import datetime
 import json
-from StringIO import StringIO
 
 import mock
 import pytest
@@ -495,18 +494,12 @@ def test_up(
     assert mock_master_api.return_value.call_args == expected_args
 
 
-@mock.patch('sys.stdout', new_callable=StringIO)
 @mock.patch('paasta_tools.paasta_maintenance.get_maintenance_status')
 def test_status(
     mock_get_maintenance_status,
-    mock_stdout,
 ):
-    mock_get_maintenance_status.return_value.__str__ = mock.Mock()
-    mock_get_maintenance_status.return_value.text = 'fake_text'
     status()
-    output = mock_stdout.getvalue()
     assert mock_get_maintenance_status.call_count == 1
-    assert output == "fake_text\n"
 
 
 @mock.patch('paasta_tools.paasta_maintenance.get_maintenance_schedule')


### PR DESCRIPTION
Move print statements out of function calls to prevent them showing up when these functions are imported elsewhere.

Follow up to #687