### PR TITLE
Add PAASTA_DOCKER_IMAGE environment variable.

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -74,7 +74,7 @@ instance MAY have:
 
     By default, the Namespace assigned to a particular Instance in PaaSTA has
     the *same name*, so the ``main`` Instance will correspond to the ``main``
-    Namespace defined in ``smartstack.yaml``. 
+    Namespace defined in ``smartstack.yaml``.
 
     The first instance in this list is assumed to be used by clients and is
     the only one currently monitored, waited for during bounces, etc ...
@@ -174,10 +174,10 @@ instance MAY have:
     * ``PAASTA_SERVICE``: The service name
     * ``PAASTA_INSTANCE``: The instance name
     * ``PAASTA_CLUSTER``: The cluster name
+    * ``PAASTA_DOCKER_IMAGE``: The docker image name
 
-    Additionally, there are ``MARATHON_`` prefixed variables available. See the
-    `docs <https://mesosphere.github.io/marathon/docs/task-environment-vars.html>`_
-    for more information about these variables.
+    Additionally, when scheduled under Marathon, there are ``MARATHON_`` prefixed variables available.
+    See the `docs <https://mesosphere.github.io/marathon/docs/task-environment-vars.html>`_ for more information about these variables.
 
   * ``extra_volumes``: An array of dictionaries specifying extra bind-mounts
     inside the container. Can be used to expose filesystem resources available

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -235,6 +235,7 @@ class InstanceConfig(dict):
             "PAASTA_SERVICE": self.service,
             "PAASTA_INSTANCE": self.instance,
             "PAASTA_CLUSTER": self.cluster,
+            "PAASTA_DOCKER_IMAGE": self.get_docker_image(),
         }
         user_env = self.config_dict.get('env', {})
         env.update(user_env)
@@ -1604,5 +1605,4 @@ def is_deploy_step(step):
     Returns true if the given step deploys to an instancename
     Returns false if the step is a predefined step-type, e.g. itest or command-*
     """
-    return not ((step in DEPLOY_PIPELINE_NON_DEPLOY_STEPS)
-                or (step.startswith('command-')))
+    return not ((step in DEPLOY_PIPELINE_NON_DEPLOY_STEPS) or (step.startswith('command-')))

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -354,6 +354,7 @@ class TestChronosTools:
             {"name": "PAASTA_CLUSTER", "value": "fake_cluster"},
             {"name": "PAASTA_SERVICE", "value": "fake_name"},
             {"name": "PAASTA_INSTANCE", "value": "fake_instance"},
+            {"name": "PAASTA_DOCKER_IMAGE", "value": ""},
             {"name": "foo", "value": "bar"},
             {"name": "biz", "value": "baz"},
         ]

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -886,6 +886,7 @@ class TestMarathonTools:
             'PAASTA_CLUSTER': '',
             'PAASTA_INSTANCE': 'yes_i_can',
             'PAASTA_SERVICE': 'can_you_dig_it',
+            'PAASTA_DOCKER_IMAGE': '',
         }
         fake_cpus = .42
         fake_disk = 1234.5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1094,6 +1094,7 @@ class TestInstanceConfig:
             'PAASTA_SERVICE': 'fake_service',
             'PAASTA_INSTANCE': 'fake_instance',
             'PAASTA_CLUSTER': 'fake_cluster',
+            'PAASTA_DOCKER_IMAGE': '',
         }
 
     def test_get_env_with_config(self):
@@ -1102,13 +1103,14 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={'env': {'SPECIAL_ENV': 'TRUE'}},
-            branch_dict={},
+            branch_dict={'docker_image': 'something'},
         )
         assert fake_conf.get_env() == {
             'SPECIAL_ENV': 'TRUE',
             'PAASTA_SERVICE': '',
             'PAASTA_INSTANCE': '',
             'PAASTA_CLUSTER': '',
+            'PAASTA_DOCKER_IMAGE': 'something',
         }
 
     def test_get_args_default_no_cmd(self):


### PR DESCRIPTION
This provides a unified environment variable for applications to look at regardless of how they're scheduled.