### PR TITLE
 Added readiness_check boilerplate

### DIFF
--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -26,6 +26,7 @@ usr/share/python/paasta-tools/bin/paasta-api usr/bin/paasta-api
 usr/share/python/paasta-tools/bin/paasta_execute_docker_command.py usr/bin/paasta_execute_docker_command
 usr/share/python/paasta-tools/bin/paasta_maintenance.py usr/bin/paasta_maintenance
 usr/share/python/paasta-tools/bin/paasta_metastatus.py usr/bin/paasta_metastatus
+usr/share/python/paasta-tools/bin/paasta_readiness_check usr/bin/paasta_readiness_check
 usr/share/python/paasta-tools/bin/paasta_serviceinit.py usr/bin/paasta_serviceinit
 usr/share/python/paasta-tools/bin/paasta_tabcomplete.sh /etc/bash_completion.d/paasta.bash
 usr/share/python/paasta-tools/bin/paasta_setup_chronos_job usr/bin/setup_chronos_job

--- a/paasta_tools/readiness_check.py
+++ b/paasta_tools/readiness_check.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import logging
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            'paasta_readiness_check is a tool to verfiy if changes are safe to '
+            'be made to a host.\n\n'
+            'It does this by inspecting the running tasks on localhost, and returns '
+            'non-0 if any of thoses tasks are "at-risk"\n\n'
+            'A task is at-risk if it is low in replication as determined by the replication '
+            'count compared to the desired count.'
+        )
+    )
+    parser.add_argument('-v', '--verbose', action='count', dest="verbose", default=0,
+                        help="Print out more output regarding the state of the cluster")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.WARNING)
+    print "Everything is fine (not implemented yet"
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ setup(
         'paasta_cleanup_chronos_jobs=paasta_tools.cleanup_chronos_jobs:main',
         'paasta_check_chronos_jobs=paasta_tools.check_chronos_jobs:main',
         'paasta_list_chronos_jobs=paasta_tools.list_chronos_jobs:main',
+        'paasta_readiness_check=paasta_tools.readiness_check:main',
         'paasta_setup_chronos_job=paasta_tools.setup_chronos_job:main',
         'paasta_chronos_rerun=paasta_tools.chronos_rerun:main',
     ]},

--- a/yelp_package/itest/ubuntu.sh
+++ b/yelp_package/itest/ubuntu.sh
@@ -31,6 +31,7 @@ list_marathon_service_instances
 paasta_autoscale_cluster
 paasta_execute_docker_command
 paasta_metastatus
+paasta_readiness_check
 paasta_serviceinit
 setup_chronos_job
 chronos_rerun


### PR DESCRIPTION
This is the boilerplate for the paasta_readiness_check command, that will eventually be run by puppet as a fact to prevent it from doing potentially disruptive changes.

I mostly want to get this out of the way early so when I have business logic to review it is more clear.