### PR TITLE
Fix local-run --dry-run

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -692,9 +692,13 @@ def paasta_local_run(args):
         if args.dry_run:
             sys.stderr.write('Running in dry mode. Assuming --pull\n')
             args.pull = True
-        else:
-            sys.stderr.write("Neither --pull or --build were passed. Assuming --build\n")
+        elif makefile_responds_to('cook-image'):
+            sys.stderr.write("Local Makefile with 'cook-image' target detected. Assuming --build\n")
             args.build = True
+        else:
+            sys.stderr.write("A local Makefile with a 'cook-image' target is required for --build\n")
+            sys.stderr.write("If you meant to pull the docker image from the registry, explicitly pass --pull\n")
+            return 1
 
     service = figure_out_service_name(args, soa_dir=args.yelpsoa_config_root)
     cluster = guess_cluster(service=service, args=args)

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -687,22 +687,14 @@ def configure_and_run_docker_container(
     )
 
 
-def local_makefile_present():
-    if makefile_responds_to('cook-image'):
-        sys.stderr.write("Local Makefile with 'cook-image' target detected. Assuming --build\n")
-        return True
-    else:
-        return False
-
-
 def paasta_local_run(args):
-    if (args.pull is None) and (args.build is None):
-        # Default to --build if neither is specified
-        if not local_makefile_present():
-            sys.stderr.write("A local Makefile with a 'cook-image' target is required for --build\n")
-            sys.stderr.write("If you meant to pull the docker image from the registry, explicitly pass --pull\n")
-            return 1
-        args.build = True
+    if args.pull is None and args.build is None:
+        if args.dry_run:
+            sys.stderr.write('Running in dry mode. Assuming --pull\n')
+            args.pull = True
+        else:
+            sys.stderr.write("Neither --pull or --build were passed. Assuming --build\n")
+            args.build = True
 
     service = figure_out_service_name(args, soa_dir=args.yelpsoa_config_root)
     cluster = guess_cluster(service=service, args=args)

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -65,7 +65,7 @@ def test_dry_run(
 
     # Should pass and produce something
     with raises(SystemExit) as excinfo:
-        main(('local-run', '--pull', '--dry-run', '--cluster', 'fake_cluster', '--instance', 'fake_instance'))
+        main(('local-run', '--dry-run', '--cluster', 'fake_cluster', '--instance', 'fake_instance'))
     ret = excinfo.value.code
     out, err = capsys.readouterr()
     assert ret == 0

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -452,8 +452,7 @@ def test_run_success(
     args.service = 'fake_service'
     args.healthcheck = False
     args.interactive = False
-    args.build = None
-    args.pull = True
+    args.action = 'pull'
     assert paasta_local_run(args) is None
 
 
@@ -476,9 +475,7 @@ def test_run_cook_image_fails(
     args.service = 'fake_service'
     args.healthcheck = False
     args.interactive = False
-    args.pull = None
-    args.build = True
-    args.dry_run = False
+    args.action = 'build'
     assert paasta_local_run(args) == 1
     assert not mock_run_docker_container.called
 


### PR DESCRIPTION
This fixes #698 and reverts the test change. The test should not have been changed as it would have caught the regression.