### PR TITLE
add ulimit and cap_add settings to json schema

### DIFF
--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -222,6 +222,28 @@
             "replication_threshold": {
                 "type": "integer",
                 "minimum": 0
+            },
+            "ulimit": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                        "soft": {
+                            "type": "number"
+                        },
+                        "hard": {
+                            "type": "number"
+                        }
+                    },
+                    "required": ["soft"],
+                    "additionalProperties": false
+                }
+            },
+            "cap_add": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
             }
         }
     }


### PR DESCRIPTION
I recently added two new options, but forgot to add them to the json schema for the marathon config.