### PR TITLE
use the /slaves endpoint rather than /state where possible

### DIFF
--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -238,12 +238,15 @@ def get_happy_tasks(app, service, nerve_ns, system_paasta_config, min_task_uptim
 
         service_namespace_config = marathon_tools.load_service_namespace_config(service, nerve_ns)
         discover_location_type = service_namespace_config.get_discover()
-        unique_values = mesos_tools.get_mesos_slaves_grouped_by_attribute(discover_location_type)
+        unique_values = mesos_tools.get_mesos_slaves_grouped_by_attribute(
+            slaves=mesos_tools.get_slaves(),
+            attribute=discover_location_type
+        )
 
         for value, hosts in unique_values.iteritems():
-            synapse_host = hosts[0]
+            synapse_hostname = hosts[0]['hostname']
             tasks_in_smartstack.extend(get_registered_marathon_tasks(
-                synapse_host,
+                synapse_hostname,
                 system_paasta_config.get_synapse_port(),
                 system_paasta_config.get_synapse_haproxy_url_format(),
                 service_namespace,

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -343,12 +343,23 @@ class MarathonServiceConfig(InstanceConfig):
         discover_level = service_namespace_config.get_discover()
         slaves = get_slaves()
         if not slaves:
-            raise NoSlavesAvailableError
+            raise NoSlavesAvailableError(
+                "No slaves could be found in the cluster."
+            )
         filtered_slaves = filter_mesos_slaves_by_blacklist(
             slaves=slaves,
             blacklist=self.get_deploy_blacklist(),
             whitelist=self.get_deploy_whitelist(),
         )
+        if not filtered_slaves:
+            raise NoSlavesAvailableError(
+                "No suitable slaves could be found in the cluster for %s.%s"
+                "There are %d total slaves in the cluster, but after filtering"
+                "those available to the app according to the constraints set"
+                "by the deploy_blacklist and deploy_whitelist, there are 0"
+                "available."
+            )
+
         value_dict = get_mesos_slaves_grouped_by_attribute(
             filtered_slaves,
             discover_level

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -529,16 +529,16 @@ def get_mesos_slaves_grouped_by_attribute(slaves, attribute):
     """
     sorted_slaves = sorted(
         slaves,
-        key=lambda slave: slave['attributes'].get(attribute, 'unknown')
+        key=lambda slave: slave['attributes'].get(attribute)
     )
     return {key: list(group) for key, group in itertools.groupby(
         sorted_slaves,
         key=lambda slave: slave['attributes'].get(attribute)
-    )}
+    ) if key}
 
 
 def get_slaves():
-    return master.CURRENT.fetch("/master/slaves")
+    return master.CURRENT.fetch("/master/slaves").json()['slaves']
 
 
 def filter_mesos_slaves_by_blacklist(slaves, blacklist, whitelist):

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -153,7 +153,6 @@ def is_mesos_leader(hostname=MY_HOSTNAME):
 
 def get_current_tasks(job_id):
     """ Returns a list of all the tasks with a given job id.
-    Note: this will only return tasks from active frameworks.
     :param job_id: the job id of the tasks.
     :return tasks: a list of mesos.cli.Task.
     """
@@ -539,7 +538,7 @@ def get_mesos_slaves_grouped_by_attribute(slaves, attribute):
 
 
 def get_slaves():
-    return master.CURRENT.slaves()
+    return master.CURRENT.fetch("/master/slaves")
 
 
 def filter_mesos_slaves_by_blacklist(slaves, blacklist, whitelist):

--- a/tests/test_bounce_lib.py
+++ b/tests/test_bounce_lib.py
@@ -272,11 +272,14 @@ class TestBounceLib:
         fake_app = mock.Mock(tasks=tasks, health_checks=[])
         with contextlib.nested(
             mock.patch('paasta_tools.bounce_lib.get_registered_marathon_tasks', return_value=tasks[2:], autospec=True),
-            mock.patch('paasta_tools.mesos_tools.get_mesos_slaves_grouped_by_attribute',
-                       return_value={'fake_region': ['fake_host']}, autospec=True),
+            mock.patch('paasta_tools.bounce_lib.mesos_tools.get_mesos_slaves_grouped_by_attribute',
+                       return_value={'fake_region': [{'hostname': 'fakehost'}]}, autospec=True),
+            mock.patch('paasta_tools.mesos_tools.get_slaves',
+                       return_value=[], autospec=True),
         ) as (
             _,
             get_mesos_slaves_grouped_by_attribute_patch,
+            __
         ):
             actual = bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', self.fake_system_paasta_config(),
                                                 check_haproxy=True)
@@ -291,10 +294,12 @@ class TestBounceLib:
         with contextlib.nested(
             mock.patch('paasta_tools.bounce_lib.get_registered_marathon_tasks', return_value=tasks[2:], autospec=True),
             mock.patch('paasta_tools.mesos_tools.get_mesos_slaves_grouped_by_attribute',
-                       return_value={'fake_region': ['fake_host']}, autospec=True),
+                       return_value={'fake_region': [{'hostname': 'fake_host'}]}, autospec=True),
+            mock.patch('paasta_tools.mesos_tools.get_slaves', return_value=[], autospec=True),
         ) as (
             _,
             get_mesos_slaves_grouped_by_attribute_patch,
+            _,
         ):
             actual = bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', self.fake_system_paasta_config(),
                                                 check_haproxy=True)
@@ -312,13 +317,15 @@ class TestBounceLib:
                 side_effect=[tasks[2:3], tasks[3:]], autospec=True,
             ),
             mock.patch('paasta_tools.mesos_tools.get_mesos_slaves_grouped_by_attribute', autospec=True),
+            mock.patch('paasta_tools.mesos_tools.get_slaves', return_value=[], autospec=True),
         ) as (
             get_registered_marathon_tasks_patch,
             get_mesos_slaves_grouped_by_attribute_patch,
+            _
         ):
             get_mesos_slaves_grouped_by_attribute_patch.return_value = {
-                'fake_region': ['fake_host1'],
-                'fake_other_region': ['fake_host2'],
+                'fake_region': [{'hostname': 'fake_host1'}],
+                'fake_other_region': [{'hostname': 'fake_host2'}]
             }
             actual = bounce_lib.get_happy_tasks(fake_app, 'service', 'namespace', self.fake_system_paasta_config(),
                                                 check_haproxy=True)

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -976,7 +976,10 @@ class TestMarathonTools:
 
         with contextlib.nested(
             mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True,
-                       return_value={'fake_region': {}}),
+                       return_value={'fake_region': [{}]}),
+            mock.patch('paasta_tools.marathon_tools.get_slaves', autospec=True, return_value=[{}]),
+            mock.patch('paasta_tools.marathon_tools.filter_mesos_slaves_by_blacklist',
+                       autospec=True, return_value=[{}]),
             mock.patch('paasta_tools.marathon_tools.get_docker_url', autospec=True, return_value=fake_url),
             mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True,
                        return_value=fake_service_namespace_config),
@@ -985,6 +988,8 @@ class TestMarathonTools:
                                               get_dockercfg_location=mock.Mock(
                                                   return_value='file:///root/.dockercfg'))),
         ) as (
+            _,
+            _,
             _,
             _,
             _,
@@ -1179,11 +1184,17 @@ class TestMarathonTools:
             config_dict={},
             branch_dict={},
         )
-        with mock.patch(
-            'paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
-            autospec=True,
-        ) as get_slaves_patch:
-            get_slaves_patch.return_value = {'fake_region': {}}
+        with contextlib.nested(
+            mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.get_slaves', autospec=True, return_value=[{}]),
+            mock.patch('paasta_tools.marathon_tools.filter_mesos_slaves_by_blacklist',
+                       autospec=True, return_value=[{}]),
+        ) as (
+            get_slaves_patch,
+            _,
+            _,
+        ):
+            get_slaves_patch.return_value = {'fake_region': [{}]}
             expected_constraints = [
                 ["region", "GROUP_BY", "1"],
                 ["pool", "LIKE", "default"],
@@ -1199,10 +1210,16 @@ class TestMarathonTools:
             config_dict={'extra_constraints': [['foo', 1]]},
             branch_dict={},
         )
-        with mock.patch(
-            'paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
-            autospec=True,
-        ) as get_slaves_patch:
+        with contextlib.nested(
+            mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.get_slaves', autospec=True, return_value=[{}]),
+            mock.patch('paasta_tools.marathon_tools.filter_mesos_slaves_by_blacklist',
+                       autospec=True, return_value=[{}]),
+        ) as (
+            get_slaves_patch,
+            _,
+            _,
+        ):
             get_slaves_patch.return_value = {'fake_region': {}}
             expected_constraints = [
                 ["foo", "1"],
@@ -1220,10 +1237,16 @@ class TestMarathonTools:
             config_dict={'extra_constraints': [['extra', 'constraint']]},
             branch_dict={},
         )
-        with mock.patch(
-            'paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
-            autospec=True,
-        ) as get_slaves_patch:
+        with contextlib.nested(
+            mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.get_slaves', autospec=True, return_value=[{}]),
+            mock.patch('paasta_tools.marathon_tools.filter_mesos_slaves_by_blacklist',
+                       autospec=True, return_value=[{}]),
+        ) as (
+            get_slaves_patch,
+            _,
+            _,
+        ):
             get_slaves_patch.return_value = {'fake_region': {}}
             expected_constraints = [
                 ['extra', 'constraint'],
@@ -1245,17 +1268,23 @@ class TestMarathonTools:
             config_dict={},
             branch_dict={},
         )
-        with mock.patch(
-            'paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
-            autospec=True,
-        ) as get_slaves_patch:
+        with contextlib.nested(
+            mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.get_slaves', autospec=True, return_value=[{}]),
+            mock.patch('paasta_tools.marathon_tools.filter_mesos_slaves_by_blacklist',
+                       autospec=True, return_value=[{}]),
+        ) as (
+            get_slaves_patch,
+            _,
+            _,
+        ):
             get_slaves_patch.return_value = {'fake_region': {}, 'fake_other_region': {}}
             expected_constraints = [
                 ["habitat", "GROUP_BY", "2"],
                 ["pool", "LIKE", "default"],
             ]
             assert fake_conf.get_calculated_constraints(fake_service_namespace_config) == expected_constraints
-            get_slaves_patch.assert_called_once_with(attribute='habitat', blacklist=[], whitelist=[])
+            get_slaves_patch.assert_called_once_with([{}], 'habitat')
 
     def test_get_calculated_constraints_respects_deploy_blacklist(self):
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
@@ -1272,13 +1301,19 @@ class TestMarathonTools:
             ["region", "UNLIKE", "fake_blacklisted_region"],
             ["pool", "LIKE", "default"],
         ]
-        with mock.patch(
-            'paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
-            autospec=True,
-        ) as get_slaves_patch:
+        with contextlib.nested(
+            mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.get_slaves', autospec=True, return_value=[{}]),
+            mock.patch('paasta_tools.marathon_tools.filter_mesos_slaves_by_blacklist',
+                       autospec=True, return_value=[{}]),
+        ) as (
+            get_slaves_patch,
+            _,
+            _,
+        ):
             get_slaves_patch.return_value = {'fake_region': {}}
             assert fake_conf.get_calculated_constraints(fake_service_namespace_config) == expected_constraints
-            get_slaves_patch.assert_called_once_with(attribute='region', blacklist=fake_deploy_blacklist, whitelist=[])
+            get_slaves_patch.assert_called_once_with([{}], 'region')
 
     def test_get_calculated_constraints_respects_deploy_whitelist(self):
         fake_service_namespace_config = marathon_tools.ServiceNamespaceConfig()
@@ -1295,13 +1330,19 @@ class TestMarathonTools:
             ["region", "LIKE", "fake_whitelisted_region"],
             ["pool", "LIKE", "default"],
         ]
-        with mock.patch(
-            'paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
-            autospec=True,
-        ) as get_slaves_patch:
+        with contextlib.nested(
+            mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.get_slaves', autospec=True, return_value=[{}]),
+            mock.patch('paasta_tools.marathon_tools.filter_mesos_slaves_by_blacklist',
+                       autospec=True, return_value=[{}]),
+        ) as (
+            get_slaves_patch,
+            _,
+            _,
+        ):
             get_slaves_patch.return_value = {'fake_region': {}}
             assert fake_conf.get_calculated_constraints(fake_service_namespace_config) == expected_constraints
-            get_slaves_patch.assert_called_once_with(attribute='region', blacklist=[], whitelist=fake_deploy_whitelist)
+            get_slaves_patch.assert_called_once_with([{}], 'region')
 
     def test_instance_config_getters_in_config(self):
         fake_conf = marathon_tools.MarathonServiceConfig(
@@ -1464,12 +1505,17 @@ class TestMarathonTools:
             mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True,
                        return_value=self.fake_service_namespace_config),
             mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
-                       autospec=True, return_value={'fake_region': {}})
+                       autospec=True, return_value={'fake_region': {}}),
+            mock.patch('paasta_tools.marathon_tools.get_slaves', autospec=True, return_value=[{}]),
+            mock.patch('paasta_tools.marathon_tools.filter_mesos_slaves_by_blacklist',
+                       autospec=True, return_value=[{}]),
         ) as (
             load_system_paasta_config_patch,
             docker_url_patch,
             _,
-            __,
+            _,
+            _,
+            _
         ):
             load_system_paasta_config_patch.return_value.get_cluster = mock.Mock(return_value=fake_cluster)
             first_id = fake_service_config_1.format_marathon_app_dict()['id']
@@ -2101,11 +2147,17 @@ def test_format_marathon_app_dict_no_smartstack():
         ),
         mock.patch('paasta_tools.marathon_tools.format_job_id', return_value=fake_job_id),
         mock.patch('paasta_tools.marathon_tools.load_system_paasta_config', return_value=fake_system_paasta_config),
+        mock.patch('paasta_tools.marathon_tools.get_slaves', autospec=True, return_value=[{}]),
+        mock.patch('paasta_tools.marathon_tools.filter_mesos_slaves_by_blacklist', autospec=True, return_value=[{}]),
         mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
-                   autospec=True, return_value={'fake_region': {}})
+                   autospec=True, return_value={'fake_region': [{}]}),
+        mock.patch('paasta_tools.marathon_tools.load_system_paasta_config', return_value=fake_system_paasta_config),
     ) as (
         mock_load_service_namespace_config,
         mock_format_job_id,
+        _,
+        _,
+        _,
         _,
         _,
     ):
@@ -2169,14 +2221,18 @@ def test_format_marathon_app_dict_with_smartstack():
             return_value=fake_service_namespace_config,
         ),
         mock.patch('paasta_tools.marathon_tools.format_job_id', return_value=fake_job_id),
-        mock.patch('paasta_tools.marathon_tools.load_system_paasta_config', return_value=fake_system_paasta_config),
         mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
-                   autospec=True, return_value={'fake_region': {}})
+                   autospec=True, return_value={'fake_region': {}}),
+        mock.patch('paasta_tools.marathon_tools.get_slaves', autospec=True, return_value=[{}]),
+        mock.patch('paasta_tools.marathon_tools.filter_mesos_slaves_by_blacklist', autospec=True, return_value=[{}]),
+        mock.patch('paasta_tools.marathon_tools.load_system_paasta_config', return_value=fake_system_paasta_config),
     ) as (
         mock_load_service_namespace_config,
         mock_format_job_id,
         mock_system_paasta_config,
         _,
+        _,
+        _
     ):
         actual = fake_marathon_service_config.format_marathon_app_dict()
         expected = {
@@ -2257,11 +2313,15 @@ def test_format_marathon_app_dict_utilizes_net():
         mock.patch('paasta_tools.marathon_tools.format_job_id', return_value=fake_job_id),
         mock.patch('paasta_tools.marathon_tools.load_system_paasta_config', return_value=fake_system_paasta_config),
         mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
-                   autospec=True, return_value={'fake_region': {}})
+                   autospec=True, return_value={'fake_region': {}}),
+        mock.patch('paasta_tools.marathon_tools.get_slaves', autospec=True, return_value=[{}]),
+        mock.patch('paasta_tools.marathon_tools.filter_mesos_slaves_by_blacklist', autospec=True, return_value=[{}]),
     ) as (
         mock_load_service_namespace_config,
         mock_format_job_id,
         mock_system_paasta_config,
+        _,
+        _,
         _,
     ):
         assert fake_marathon_service_config.format_marathon_app_dict()['container']['docker']['network'] == 'HOST'
@@ -2306,11 +2366,15 @@ def test_format_marathon_app_dict_utilizes_extra_volumes():
         mock.patch('paasta_tools.marathon_tools.format_job_id', return_value=fake_job_id),
         mock.patch('paasta_tools.marathon_tools.load_system_paasta_config', return_value=fake_system_paasta_config),
         mock.patch('paasta_tools.marathon_tools.get_mesos_slaves_grouped_by_attribute',
-                   autospec=True, return_value={'fake_region': {}})
+                   autospec=True, return_value={'fake_region': {}}),
+        mock.patch('paasta_tools.marathon_tools.get_slaves', autospec=True, return_value=[{}]),
+        mock.patch('paasta_tools.marathon_tools.filter_mesos_slaves_by_blacklist', autospec=True, return_value=[{}]),
     ) as (
         mock_load_service_namespace_config,
         mock_format_job_id,
         mock_system_paasta_config,
+        _,
+        _,
         _,
     ):
         actual = fake_marathon_service_config.format_marathon_app_dict()


### PR DESCRIPTION
``mesos_tools.get_mesos_slaves_grouped_by_attribute`` previously called the ``/state`` endpoint to gather info about slaves. switch to using the ``/slaves`` endpoint instead, and refactor a little to move some filtering to the callers.

I think this could be a fairly big win, given that it was called in the bounce lib's ``get_happy_tasks`` function