### PR TITLE
Removed zookeper scaling itests

### DIFF
--- a/paasta_itests/setup_marathon_job.feature
+++ b/paasta_itests/setup_marathon_job.feature
@@ -53,25 +53,3 @@ Feature: setup_marathon_job can create a "complete" app
       And we set the number of instances to 1
       And we run setup_marathon_job until it has 1 task(s)
      Then we should see the number of instances become 1
-
-  Scenario: zookeeper records can be used to scale services up
-    Given a working paasta cluster
-      And I have yelpsoa-configs for the marathon job "test-service.main"
-      And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we set up an app to use zookeeper scaling with 5 max instances
-      And we create a marathon app called "test-service.main" with 3 instance(s)
-      And we set the instance count in zookeeper for service "test-service" instance "main" to 5
-      And we run setup_marathon_job until it has 5 task(s)
-     Then we should see the number of instances become 5
-
-  Scenario: zookeeper records can be used to scale services down
-    Given a working paasta cluster
-      And I have yelpsoa-configs for the marathon job "test-service.main"
-      And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we set up an app to use zookeeper scaling with 5 max instances
-      And we create a marathon app called "test-service.main" with 5 instance(s)
-      And we set the instance count in zookeeper for service "test-service" instance "main" to 3
-      And we run setup_marathon_job until it has 3 task(s)
-      And we set the instance count in zookeeper for service "test-service" instance "main" to 1
-      And we run setup_marathon_job until it has 1 task(s)
-     Then we should see the number of instances become 1


### PR DESCRIPTION
Dare me?

The argument here is that these are providing relatively little value if we already have confidence that `get_instances()` works correctly, regardless of whether that value comes from ZK or from on disk.

We already have itests that setup_marathon_job can smoothly scale up and down in response to instance count.