### PR TITLE
use the full state endpoint in metastatus again

### DIFF
--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -32,7 +32,7 @@ from paasta_tools.chronos_tools import get_chronos_client
 from paasta_tools.chronos_tools import load_chronos_config
 from paasta_tools.mesos_tools import get_all_tasks_from_state
 from paasta_tools.mesos_tools import get_mesos_quorum
-from paasta_tools.mesos_tools import get_mesos_state_summary_from_leader
+from paasta_tools.mesos_tools import get_mesos_state_from_leader
 from paasta_tools.mesos_tools import get_mesos_stats
 from paasta_tools.mesos_tools import get_number_of_mesos_masters
 from paasta_tools.mesos_tools import get_zookeeper_host_path
@@ -584,7 +584,7 @@ def main():
     args = parse_args()
 
     try:
-        mesos_state = get_mesos_state_summary_from_leader()
+        mesos_state = get_mesos_state_from_leader()
     except MasterNotAvailableException as e:
         # if we can't connect to master at all,
         # then bomb out early

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -333,7 +333,7 @@ def test_main_no_marathon_config():
         patch('paasta_tools.marathon_tools.load_marathon_config', autospec=True),
         patch('paasta_tools.paasta_metastatus.load_chronos_config', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_chronos_status', autospec=True),
-        patch('paasta_tools.paasta_metastatus.get_mesos_state_summary_from_leader', autospec=True),
+        patch('paasta_tools.paasta_metastatus.get_mesos_state_from_leader', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_mesos_state_status', autospec=True,
               return_value=([('fake_output', True)])),
         patch('paasta_tools.paasta_metastatus.get_mesos_stats', autospec=True),
@@ -345,7 +345,7 @@ def test_main_no_marathon_config():
         load_marathon_config_patch,
         load_chronos_config_patch,
         load_get_chronos_status_patch,
-        get_mesos_state_summary_from_leader_patch,
+        get_mesos_state_from_leader_patch,
         get_mesos_state_status_patch,
         get_mesos_stats_patch,
         get_mesos_metrics_health_patch,
@@ -355,7 +355,7 @@ def test_main_no_marathon_config():
         fake_args = Mock(
             verbose=0,
         )
-        get_mesos_state_summary_from_leader_patch.return_value = {}
+        get_mesos_state_from_leader_patch.return_value = {}
         get_mesos_stats_patch.return_value = {}
 
         get_mesos_state_status_patch.return_value = []
@@ -372,7 +372,7 @@ def test_main_no_chronos_config():
     with contextlib.nested(
         patch('paasta_tools.marathon_tools.load_marathon_config', autospec=True),
         patch('paasta_tools.paasta_metastatus.load_chronos_config', autospec=True),
-        patch('paasta_tools.paasta_metastatus.get_mesos_state_summary_from_leader', autospec=True, return_value={}),
+        patch('paasta_tools.paasta_metastatus.get_mesos_state_from_leader', autospec=True, return_value={}),
         patch('paasta_tools.paasta_metastatus.get_mesos_state_status', autospec=True,
               return_value=([('fake_output', True)])),
         patch('paasta_tools.paasta_metastatus.get_mesos_stats', autospec=True),
@@ -383,7 +383,7 @@ def test_main_no_chronos_config():
     ) as (
         load_marathon_config_patch,
         load_chronos_config_patch,
-        get_mesos_state_summary_from_leader_patch,
+        get_mesos_state_from_leader_patch,
         get_mesos_state_status_patch,
         get_mesos_stats_patch,
         get_mesos_metrics_health_patch,
@@ -397,7 +397,7 @@ def test_main_no_chronos_config():
         parse_args_patch.return_value = fake_args
         load_marathon_config_patch.return_value = {}
 
-        get_mesos_state_summary_from_leader_patch.return_value = {}
+        get_mesos_state_from_leader_patch.return_value = {}
         get_mesos_stats_patch.return_value = {}
 
         get_mesos_state_status_patch.return_value = []


### PR DESCRIPTION
this fixes #708 until I can fix this 'properly'. @solarkennedy I've run the itest locally and the output is correct again - please merge + release as we discussed? FYI, I couldn't just revert the previous commit because it included some other logic now required, including adding the ``get_mesos_state_summary_from_leader`` function. (me--)