### PR TITLE
Removed external tron dependency

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,8 @@ omit =
     /usr/*
     */tmp*
     setup.py
+    paasta_tools/tron_command_context.py
+    paasta_tools/tron_timeutils.py
 
 [report]
 exclude_lines =

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -24,7 +24,7 @@ import dateutil
 import isodate
 import monitoring_tools
 import service_configuration_lib
-from tron import command_context
+import tron_command_context
 
 from paasta_tools.mesos_tools import get_mesos_network_for_net
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -773,7 +773,7 @@ def parse_time_variables(input_string, parse_time=None):
         parse_time = datetime.datetime.now()
     # We build up a tron context object that has the right
     # methods to parse tron-style time syntax
-    job_context = command_context.JobRunContext(command_context.CommandContext())
+    job_context = tron_command_context.JobRunContext(tron_command_context.CommandContext())
     # The tron context object needs the run_time attibute set so it knows
     # how to interpret the date strings
     job_context.job_run.run_time = parse_time

--- a/paasta_tools/tron_command_context.py
+++ b/paasta_tools/tron_command_context.py
@@ -1,0 +1,196 @@
+"""Command Context is how we construct the command line for a command which may
+have variables that need to be rendered.
+This is a COPY of https://github.com/Yelp/Tron/blob/master/tron/command_context.py.
+"""
+import operator
+
+import tron_timeutils
+
+
+def build_context(object, parent):
+    """Construct a CommandContext for object. object must have a property
+    'context_class'.
+    """
+    return CommandContext(object.context_class(object), parent)
+
+
+def build_filled_context(*context_objects):
+    """Create a CommandContext chain from context_objects, using a Filler
+    object to pass to each CommandContext. Can be used to validate a format
+    string.
+    """
+    if not context_objects:
+        return CommandContext()
+
+    filler = Filler()
+
+    def build(current, next):
+        return CommandContext(next(filler), current)
+
+    return reduce(build, context_objects, None)
+
+
+class CommandContext(object):
+    """A CommandContext object is a wrapper around any object which has values
+    to be used to render a command for execution.  It looks up values by name.
+
+    It's lookup order is:
+        base[name],
+        base.__getattr__(name),
+        next[name],
+        next.__getattr__(name)
+    """
+
+    def __init__(self, base=None, next=None):
+        """
+          base - Object to look for attributes in
+          next - Next place to look for more pieces of context
+                 Generally this will be another instance of CommandContext
+        """
+        self.base = base or {}
+        self.next = next or {}
+
+    def get(self, name, default=None):
+        try:
+            return self.__getitem__(name)
+        except KeyError:
+            return default
+
+    def __getitem__(self, name):
+        getters = [operator.itemgetter(name), operator.attrgetter(name)]
+        for target in [self.base, self.next]:
+            for getter in getters:
+                try:
+                    return getter(target)
+                except (KeyError, TypeError, AttributeError):
+                    pass
+
+        raise KeyError(name)
+
+    def __eq__(self, other):
+        return self.base == other.base and self.next == other.next
+
+    def __ne__(self, other):
+        return not self == other
+
+
+class JobContext(object):
+    """A class which exposes properties for rendering commands."""
+
+    def __init__(self, job):
+        self.job = job
+
+    @property
+    def name(self):
+        return self.job.name
+
+    def __getitem__(self, item):
+        date_name, date_spec = self._get_date_spec_parts(item)
+        if not date_spec:
+            raise KeyError(item)
+
+        if date_name == 'last_success':
+            last_success = self.job.runs.last_success
+            last_success = last_success.run_time if last_success else None
+
+            time_value = tron_timeutils.DateArithmetic.parse(date_spec, last_success)
+            if time_value:
+                return time_value
+
+        raise KeyError(item)
+
+    def _get_date_spec_parts(self, name):
+        parts = name.rsplit(':', 1)
+        if len(parts) != 2:
+            return name, None
+        return parts
+
+
+class JobRunContext(object):
+
+    def __init__(self, job_run):
+        self.job_run = job_run
+
+    @property
+    def runid(self):
+        return self.job_run.id
+
+    @property
+    def cleanup_job_status(self):
+        """Provide 'SUCCESS' or 'FAILURE' to a cleanup action context based on
+        the status of the other steps
+        """
+        if self.job_run.action_runs.is_failed:
+            return 'FAILURE'
+        elif self.job_run.action_runs.is_complete_without_cleanup:
+            return 'SUCCESS'
+        return 'UNKNOWN'
+
+    def __getitem__(self, name):
+        """Attempt to parse date arithmetic syntax and apply to run_time."""
+        run_time = self.job_run.run_time
+        time_value = tron_timeutils.DateArithmetic.parse(name, run_time)
+        if time_value:
+            return time_value
+
+        raise KeyError(name)
+
+
+class ActionRunContext(object):
+    """Context object that gives us access to data about the action run."""
+
+    def __init__(self, action_run):
+        self.action_run = action_run
+
+    @property
+    def actionname(self):
+        return self.action_run.action_name
+
+    @property
+    def node(self):
+        return self.action_run.node.hostname
+
+
+class ServiceInstancePidContext(object):
+
+    def __init__(self, service_instance):
+        self.service_instance = service_instance
+
+    @property
+    def instance_number(self):
+        return self.service_instance.instance_number
+
+    @property
+    def node(self):
+        return self.service_instance.node.hostname
+
+    @property
+    def name(self):
+        return self.service_instance.config.name
+
+
+class ServiceInstanceContext(ServiceInstancePidContext):
+
+    @property
+    def pid_file(self):
+        context = CommandContext(self, self.service_instance.parent_context)
+        return self.service_instance.config.pid_file % context
+
+
+class Filler(object):
+    """Filler object for using CommandContext during config parsing. This class
+    is used as a substitute for objects that would be passed to Context objects.
+    This allows the Context objects to be used directly for config validation.
+    """
+
+    def __getattr__(self, _):
+        return self
+
+    def __str__(self):
+        return "%(...)s"
+
+    def __mod__(self, _):
+        return self
+
+    def __nonzero__(self):
+        return False

--- a/paasta_tools/tron_timeutils.py
+++ b/paasta_tools/tron_timeutils.py
@@ -1,0 +1,103 @@
+"""Functions for working with dates and timestamps.
+This is a COPY of https://github.com/Yelp/Tron/blob/master/tron/utils/timeutils.py.
+"""
+from __future__ import division
+
+import datetime
+import re
+import time
+
+
+def current_time():
+    """Return the current datetime."""
+    return datetime.datetime.now()
+
+
+def current_timestamp():
+    """Return the current time as a timestamp."""
+    return to_timestamp(current_time())
+
+
+def to_timestamp(time_val):
+    """Generate a unix timestamp for the given datetime instance"""
+    return time.mktime(time_val.timetuple())
+
+
+def delta_total_seconds(td):
+    """Equivalent to timedelta.total_seconds() available in Python 2.7.
+    """
+    microseconds, seconds, days = td.microseconds, td.seconds, td.days
+    return (microseconds + (seconds + days * 24 * 3600) * 10**6) / 10**6
+
+
+def macro_timedelta(start_date, years=0, months=0, days=0, hours=0):
+    """Since datetime doesn't provide timedeltas at the year or month level,
+    this function generates timedeltas of the appropriate sizes.
+    """
+    delta = datetime.timedelta(days=days, hours=hours)
+
+    new_month = start_date.month + months
+    while new_month > 12:
+        new_month -= 12
+        years += 1
+    while new_month < 1:
+        new_month += 12
+        years -= 1
+
+    end_date = datetime.datetime(
+        start_date.year + years, new_month, start_date.day, start_date.hour)
+    delta += end_date - start_date
+
+    return delta
+
+
+def duration(start_time, end_time=None):
+    """Get a timedelta between end_time and start_time, where end_time defaults
+    to now().
+    """
+    if not start_time:
+        return None
+    last_time = end_time if end_time else current_time()
+    return last_time - start_time
+
+
+class DateArithmetic(object):
+    """Parses a string which contains a date arithmetic pattern and returns
+    a date with the delta added or subtracted.
+    """
+
+    DATE_TYPE_PATTERN = re.compile(r'(\w+)([+-]\d+)?')
+
+    DATE_FORMATS = {
+        'year': '%Y',
+        'month': '%m',
+        'day': '%d',
+        'hour': '%H',
+        'shortdate': '%Y-%m-%d'
+    }
+
+    @classmethod
+    def parse(cls, date_str, dt=None):
+        """Parse a date arithmetic pattern (Ex: 'shortdate-1'). Supports
+        date strings: shortdate, year, month, day, unixtime, daynumber.
+        Supports subtraction and addition operations of integers. Time unit is
+        based on date format (Ex: seconds for unixtime, days for day).
+        """
+        dt = dt or current_time()
+        match = cls.DATE_TYPE_PATTERN.match(date_str)
+        if not match:
+            return
+        attr, value = match.groups()
+        delta = int(value) if value else 0
+
+        if attr in ('shortdate', 'year', 'month', 'day', 'hour'):
+            if delta:
+                kwargs = {'days' if attr == 'shortdate' else attr + 's': delta}
+                dt += macro_timedelta(dt, **kwargs)
+            return dt.strftime(cls.DATE_FORMATS[attr])
+
+        if attr == 'unixtime':
+            return int(to_timestamp(dt)) + delta
+
+        if attr == 'daynumber':
+            return dt.toordinal() + delta

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,6 @@ service-configuration-lib==0.10.1
 simplejson==3.6.5
 six==1.9.0
 thriftpy==0.1.15
-tron==0.6.2.0
 ujson==1.35
 websocket-client==0.32.0
 wsgiref==0.1.2

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         'sensu-plugin >= 0.1.0',
         'service-configuration-lib >= 0.10.1',
         'setuptools != 18.6',
-        'tron == 0.6.2.0',
         'ujson == 1.35',
         'yelp_clog >= 2.2.0',
     ],


### PR DESCRIPTION
bravado swagger client is preferred by paasta-api. bravado requires 'twisted >= 14.0.0'. However, paasta-tools currently uses tron which requires 'Twisted >=10.0.0, <=12.3'. This patch is to copy the minimum required files from tron to paasta-tools. 

I didn't pull corresponding unit tests because command_context_test.py requires other tron modules. timeutils_test.py is clean but I want to treat it the same as command_context_test.py.