### PR TITLE
Manpage Version of Generated Docs

### DIFF
--- a/build-manpages.sh
+++ b/build-manpages.sh
@@ -49,3 +49,7 @@ done
 
 # And then finally the "main" paasta command
 help2man --name='paasta' --version-string=$VERSION "paasta" > docs/man/paasta.1
+
+# Make our generated docs available at 'man paasta_tools"
+sphinx-build -b man docs/source docs/man
+mv docs/man/paasta{_,-}tools.1

--- a/docs/source/isolation.rst
+++ b/docs/source/isolation.rst
@@ -91,7 +91,7 @@ By default, PaaSTA uses the 'Docker' executor everywhere. This means that *all*
 tasks launched by Marathon and Chronos are done so with a Docker container.
 
 How Tasks are isolated from eachother.
--------------------------------------
+--------------------------------------
 
 Given that a slave may run multiple tasks, we need to ensure that tasks cannot
 'interfere' with one another. We do this on a file system level using Docker -
@@ -106,7 +106,7 @@ host. The next section aims to explain how PaaSTA services are protected from
 so-called 'noisy neighbours' that can starve others from resources.
 
 CGroups
-^^^^^^
+^^^^^^^
 Docker uses cgroups to enforce resource isolation. Cgroups are a part of the
 linux kernel, and can be used to restrict the resources available to groups of
 processes. In our setup, each Docker container that is launched (and any child


### PR DESCRIPTION
We have a lot of useful information in our generated documentation. Sometimes, it is useful to be able to reference it right from the terminal without needing to open up a browser. This change will allow you to type `man paasta-tools` to do so.

I also fixed a few warnings that were appearing because of ioslation.rst

I was also toying with the idea of generating PDF or single-page HTML docs, but I felt that might be overkill.