### PR TITLE
Fix itest_trusty libffi error

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,4 +26,4 @@ override_dh_auto_test:
 	true
 
 override_dh_virtualenv:
-	dh_virtualenv --extra-index-url 'https://pypi.yelpcorp.com/simple' --python=/usr/bin/python2.7
+	dh_virtualenv --extra-index-url 'https://pypi.yelpcorp.com/simple' --python=/usr/bin/python2.7 --extra-pip-arg '--no-use-wheel'

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'docker-py == 1.2.3',
         'dulwich == 0.10.0',
         'ephemeral-port-reserve >= 1.0.1',
+        'functools32',
         'gevent == 1.1.1',
         'humanize >= 0.5.1',
         'httplib2 >= 0.9,<= 1.0',


### PR DESCRIPTION
This is to address jenkins itest_trusty failure.

03:45:57 dpkg-shlibdeps: error: couldn't find library libffi.so.5 needed by debian/paasta-tools/usr/share/python/paasta-tools/lib/python2.7/site-packages/_cffi_backend.so (ELF format: 'elf64-x86-64'; RPATH: '')