### PR TITLE
Add percentages for attribute usage in metastatus

### DIFF
--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -538,14 +538,18 @@ def format_table_column_for_healthcheck_resource_utilization_pair(healthcheck_ut
     """
     color_func = PaastaColors.green if healthcheck_utilization_pair[0].healthy else PaastaColors.red
     if humanize and healthcheck_utilization_pair[1].metric != 'cpus':
-        return color_func('%s/%s' % (
+        return color_func('%s/%s (%.2f%%)' % (
             naturalsize(healthcheck_utilization_pair[1].free * 1024 * 1024, gnu=True),
-            naturalsize(healthcheck_utilization_pair[1].total * 1024 * 1024, gnu=True)
+            naturalsize(healthcheck_utilization_pair[1].total * 1024 * 1024, gnu=True),
+            float(healthcheck_utilization_pair[1].total - healthcheck_utilization_pair[1].free) /
+            float(healthcheck_utilization_pair[1].total) * 100
         ))
     else:
-        return color_func('%s/%s' % (
+        return color_func('%s/%s (%.2f%%)' % (
             healthcheck_utilization_pair[1].free,
-            healthcheck_utilization_pair[1].total
+            healthcheck_utilization_pair[1].total,
+            float(healthcheck_utilization_pair[1].total - healthcheck_utilization_pair[1].free) /
+            float(healthcheck_utilization_pair[1].total) * 100
         ))
 
 

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -653,7 +653,7 @@ def test_format_table_column_for_healthcheck_resource_utilization_pair_healthy()
     fake_resource_utilization = Mock()
     fake_resource_utilization.free = 10
     fake_resource_utilization.total = 20
-    expected = PaastaColors.green("10/20")
+    expected = PaastaColors.green("10/20 (50.00%)")
     assert paasta_metastatus.format_table_column_for_healthcheck_resource_utilization_pair(
         (fake_healthcheckresult, fake_resource_utilization),
         False
@@ -667,7 +667,7 @@ def test_format_table_column_for_healthcheck_resource_utilization_pair_unhealthy
     fake_resource_utilization = Mock()
     fake_resource_utilization.free = 10
     fake_resource_utilization.total = 20
-    expected = PaastaColors.red("10/20")
+    expected = PaastaColors.red("10/20 (50.00%)")
     assert paasta_metastatus.format_table_column_for_healthcheck_resource_utilization_pair(
         (fake_healthcheckresult, fake_resource_utilization),
         False
@@ -681,7 +681,7 @@ def test_format_table_column_for_healthcheck_resource_utilization_pair_healthy_h
     fake_resource_utilization = Mock()
     fake_resource_utilization.free = 10
     fake_resource_utilization.total = 20
-    expected = PaastaColors.green("10.0M/20.0M")
+    expected = PaastaColors.green("10.0M/20.0M (50.00%)")
     assert paasta_metastatus.format_table_column_for_healthcheck_resource_utilization_pair(
         (fake_healthcheckresult, fake_resource_utilization),
         True
@@ -695,7 +695,7 @@ def test_format_table_column_for_healthcheck_resource_utilization_pair_unhealthy
     fake_resource_utilization = Mock()
     fake_resource_utilization.free = 10
     fake_resource_utilization.total = 20
-    expected = PaastaColors.red("10.0M/20.0M")
+    expected = PaastaColors.red("10.0M/20.0M (50.00%)")
     assert paasta_metastatus.format_table_column_for_healthcheck_resource_utilization_pair(
         (fake_healthcheckresult, fake_resource_utilization),
         True


### PR DESCRIPTION
So I don't have to keep getting out a calculator, this adds a percentage
utilization for per-attribute groupings in paasta metastatus.