### PR TITLE
Disable service_configuration_lib caching of service configs in paasta-api

### DIFF
--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -21,12 +21,14 @@ import os
 import sys
 
 import requests_cache
+import service_configuration_lib
 from gevent.wsgi import WSGIServer
 from pyramid.config import Configurator
 
 from paasta_tools import marathon_tools
 from paasta_tools.api import settings
 from paasta_tools.utils import load_system_paasta_config
+
 
 log = logging.getLogger(__name__)
 
@@ -77,6 +79,9 @@ def main(argv=None):
 
     if args.soa_dir:
         settings.soa_dir = args.soa_dir
+
+    # pyinotify is a better solution than turning off file caching completely
+    service_configuration_lib.disable_yaml_cache()
 
     # Exit on exceptions while loading settings
     settings.cluster = load_system_paasta_config().get_cluster()


### PR DESCRIPTION
service_configuration_lib caches files by default. This is a quick fix to unblock mmb by disabling service_configuration_lib caching completely. In the long term, pyinotify should offer a better solution since we don't expect service configs to change frequently. Unit test:

1. run paasta-api;
2. curl service/instance/status;
3. change services/service/marathon-cluster.yaml, e.g. mem;
4. curl service/instance/status again and verify config sha is different.