### PR TITLE
Make get_job_for_service_instance only return one chronos job ever

### DIFF
--- a/paasta_itests/setup_chronos_job.feature
+++ b/paasta_itests/setup_chronos_job.feature
@@ -38,14 +38,6 @@ Feature: setup_chronos_job can create and bounce jobs
      Then we should get exit code 0
       And there should be 1 enabled jobs for the service "testservice" and instance "dependentjob"
 
-  Scenario: dependent jobs created before their parent are skipped
-    Given a working paasta cluster
-      And we have yelpsoa-configs for the service "testservice" with enabled dependent chronos instance "dependentjob" and parent "testservice.testinstance"
-      And we have a deployments.json for the service "testservice" with enabled instance "dependentjob"
-     When we run setup_chronos_job for service_instance "testservice.dependentjob"
-     Then we should get exit code 0
-      And setup_chronos_job exits with return code "0" and the output contains "Parent job could not be found"
-
   Scenario: stopped jobs are disabled
     Given a working paasta cluster
       And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"

--- a/paasta_itests/steps/chronos_steps.py
+++ b/paasta_itests/steps/chronos_steps.py
@@ -95,7 +95,8 @@ def chronos_check_job_state(context, field, job_name, value):
         service=service,
         instance=instance,
         client=context.chronos_client,
-        include_disabled=True
+        include_disabled=True,
+        include_temporary=True,
     )
     assert len(jobs) == 1
     # we cast to a string so you can correctly assert that a value is True/False

--- a/paasta_itests/steps/setup_chronos_job_steps.py
+++ b/paasta_itests/steps/setup_chronos_job_steps.py
@@ -26,6 +26,8 @@ def job_exists(context, service, instance):
         client=context.chronos_client,
         service=service,
         instance=instance,
+        include_temporary=True,
+        include_disabled=True,
     )
     assert len(matching_jobs) == 1
 
@@ -68,6 +70,7 @@ def should_be_disabled_jobs(context, disabled, job_count, service, instance):
         instance=instance,
         client=context.chronos_client,
         include_disabled=True,
+        include_temporary=True,
     )
     filtered_jobs = [job for job in all_jobs if job["disabled"] is is_disabled]
     assert len(filtered_jobs) == int(job_count)

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -170,7 +170,7 @@ def _format_parents_verbose(job):
     parent_service_instances = [tuple(chronos_tools.decompose_job_id(parent)) for parent in parents]
 
     # find matching parent jobs
-    parent_jobs = [chronos_tools.get_job_for_service_instance(*service_instance)
+    parent_jobs = [chronos_tools.get_job_for_service_instance(*service_instance, include_disabled=False)
                    for service_instance in parent_service_instances]
 
     # get the status of the last run of each parent job

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -172,7 +172,7 @@ def _format_parents_verbose(job):
     # find matching parent jobs
     parent_jobs = [
         chronos_tools.get_jobs_for_service_instance(
-            *service_instance, include_disabled=False, include_temporary=False)[0]
+            *service_instance, include_disabled=True, include_temporary=False)[0]
         for service_instance in parent_service_instances
     ]
 

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -170,8 +170,11 @@ def _format_parents_verbose(job):
     parent_service_instances = [tuple(chronos_tools.decompose_job_id(parent)) for parent in parents]
 
     # find matching parent jobs
-    parent_jobs = [chronos_tools.get_job_for_service_instance(*service_instance, include_disabled=False)
-                   for service_instance in parent_service_instances]
+    parent_jobs = [
+        chronos_tools.get_jobs_for_service_instance(
+            *service_instance, include_disabled=False, include_temporary=False)[0]
+        for service_instance in parent_service_instances
+    ]
 
     # get the status of the last run of each parent job
     parent_statuses = [(parent, _format_last_result(job)) for parent in parent_jobs]

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -154,10 +154,6 @@ class UnknownChronosJobError(Exception):
     pass
 
 
-class MultipleChronosJobs(Exception):
-    pass
-
-
 def read_chronos_jobs_for_service(service, cluster, soa_dir=DEFAULT_SOA_DIR):
     chronos_conf_file = 'chronos-%s' % cluster
     log.info("Reading Chronos configuration file: %s/%s/chronos-%s.yaml" % (soa_dir, service, cluster))
@@ -426,7 +422,7 @@ class ChronosJobConfig(InstanceConfig):
         else:
             # The input to parents is the normal paasta syntax, but for chronos we have to
             # convert it to what chronos expects, which uses its own spacer
-            complete_config["parents"] = map(paasta_to_chronos_job_name, self.get_parents())
+            complete_config["parents"] = [paasta_to_chronos_job_name(parent) for parent in self.get_parents()]
         return complete_config
 
     # 'docker job' requirements: https://mesos.github.io/chronos/docs/api.html#adding-a-docker-job
@@ -832,6 +828,7 @@ def get_jobs_for_service_instance(service, instance, include_disabled=True, incl
     :param service: the service to be queried
     :param instance: the instance to be queried
     :param include_disabled: include disabled jobs in the search. default: True
+    :param include_temporary: include temporary in the search. default: False
     :returns: the jobs for a given service instance
     """
     chronos_config = load_chronos_config()

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -353,11 +353,11 @@ def test_format_parents_verbose():
     example_status = (fake_last_datetime, chronos_tools.LastRunState.Success)
     with contextlib.nested(
         mock.patch(
-            'paasta_tools.chronos_tools.get_job_for_service_instance',
+            'paasta_tools.chronos_tools.get_jobs_for_service_instance',
             autospec=True,
-            return_value={
+            return_value=[{
                 'name': 'testservice testinstance'
-            }
+            }]
         ),
         mock.patch(
             'paasta_tools.chronos_tools.get_status_last_run',

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1557,7 +1557,7 @@ class TestChronosTools:
     @mock.patch('paasta_tools.chronos_tools.lookup_chronos_jobs', autospect=True)
     @mock.patch('paasta_tools.chronos_tools.get_chronos_client', autospect=True)
     @mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospect=True)
-    def test_find_matching_parent_job_none_matching(
+    def test_get_job_for_service_instance_returns_none(
         self,
         mock_lookup_chronos_jobs,
         mock_get_chronos_client,
@@ -1570,7 +1570,7 @@ class TestChronosTools:
     @mock.patch('paasta_tools.chronos_tools.lookup_chronos_jobs', autospec=True)
     @mock.patch('paasta_tools.chronos_tools.get_chronos_client', autospec=True)
     @mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospec=True)
-    def test_find_matching_parent_job(
+    def test_get_job_for_service_instance_returns_one(
         self,
         mock_load_chronos_config,
         mock_get_chronos_client, mock_lookup_chronos_jobs,
@@ -1580,6 +1580,20 @@ class TestChronosTools:
         mock_load_chronos_config.return_value = {}
         matching = chronos_tools.get_job_for_service_instance('service', 'instance')
         assert matching == mock_matching_jobs[0]
+
+    @mock.patch('paasta_tools.chronos_tools.lookup_chronos_jobs', autospec=True)
+    @mock.patch('paasta_tools.chronos_tools.get_chronos_client', autospec=True)
+    @mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospec=True)
+    def test_get_job_for_service_instance_raises_on_multiple(
+        self,
+        mock_load_chronos_config,
+        mock_get_chronos_client, mock_lookup_chronos_jobs,
+    ):
+        mock_matching_jobs = [{'name': 'service instance'}, {'name': 'service instance_2'}]
+        mock_lookup_chronos_jobs.return_value = mock_matching_jobs
+        mock_load_chronos_config.return_value = {}
+        with raises(chronos_tools.MultipleChronosJobs):
+            chronos_tools.get_job_for_service_instance('service', 'instance')
 
     def test_determine_disabled_state(self):
         assert chronos_tools.determine_disabled_state('start', False) is False

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -78,6 +78,17 @@ class TestChronosTools:
         'bad_job': fake_invalid_config_dict,
     }
 
+    fake_dependent_job_config_dict = copy.deepcopy(fake_config_dict)
+    fake_dependent_job_config_dict.pop("schedule")
+    fake_dependent_job_config_dict["parents"] = ["test-service.parent1", "test-service.parent2"]
+    fake_dependent_chronos_job_config = chronos_tools.ChronosJobConfig(
+        service=fake_service,
+        cluster=fake_cluster,
+        instance=fake_job_name,
+        config_dict=fake_dependent_job_config_dict,
+        branch_dict=fake_branch_dict,
+    )
+
     def test_chronos_config_object_normal(self):
         fake_json_contents = {
             'user': 'fake_user',
@@ -976,6 +987,7 @@ class TestChronosTools:
                 service=fake_service,
                 instance=fake_instance,
                 include_disabled=False,
+                include_temporary=False,
             )
 
     def test_get_chronos_status_for_job(self):
@@ -1019,6 +1031,7 @@ class TestChronosTools:
             service=None,
             instance=None,
             include_disabled=True,
+            include_temporary=True,
         )
         assert sorted(actual) == sorted(expected)
 
@@ -1047,6 +1060,7 @@ class TestChronosTools:
             service=fake_service,
             instance=fake_instance,
             include_disabled=False,
+            include_temporary=True,
         )
         assert sorted(actual) == sorted(expected)
 
@@ -1089,6 +1103,7 @@ class TestChronosTools:
             service=fake_service,
             instance=fake_instance,
             include_disabled=True,
+            include_temporary=True,
         )
         assert sorted(actual) == sorted(expected)
 
@@ -1104,6 +1119,7 @@ class TestChronosTools:
             service='whatever',
             instance='whatever',
             include_disabled=False,
+            include_temporary=True,
         )
         # The main thing here is that InvalidJobNameError is not raised.
         assert actual == []
@@ -1160,6 +1176,29 @@ class TestChronosTools:
                 'shell': True,
             }
             assert actual == expected
+
+    def test_create_complete_config_understands_parents(self):
+        fake_owner = 'test_team'
+        fake_config_hash = 'fake_config_hash'
+        with contextlib.nested(
+            mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
+            mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
+                       autospec=True, return_value=self.fake_dependent_chronos_job_config),
+            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner),
+            mock.patch('paasta_tools.chronos_tools.get_config_hash', return_value=fake_config_hash),
+        ) as (
+            load_system_paasta_config_patch,
+            load_chronos_job_config_patch,
+            mock_get_team,
+            mock_get_config_hash,
+        ):
+            load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=[])
+            load_system_paasta_config_patch.return_value.get_docker_registry = mock.Mock(return_value='fake_registry')
+            load_system_paasta_config_patch.return_value.get_dockercfg_location = \
+                mock.Mock(return_value='file:///root/.dockercfg')
+            actual = chronos_tools.create_complete_config('fake-service', 'fake-job')
+            assert actual["parents"] == ['test-service parent1', 'test-service parent2']
+            assert "schedule" not in actual
 
     def test_create_complete_config_considers_disabled(self):
         fake_owner = 'test_team'
@@ -1554,23 +1593,10 @@ class TestChronosTools:
     def test_check_format_job_ok(self):
         assert chronos_tools.check_parent_format("foo.bar") is True
 
-    @mock.patch('paasta_tools.chronos_tools.lookup_chronos_jobs', autospect=True)
-    @mock.patch('paasta_tools.chronos_tools.get_chronos_client', autospect=True)
-    @mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospect=True)
-    def test_get_job_for_service_instance_returns_none(
-        self,
-        mock_lookup_chronos_jobs,
-        mock_get_chronos_client,
-        mock_load_chronos_config,
-    ):
-        mock_lookup_chronos_jobs.return_value = []
-        matching = chronos_tools.get_job_for_service_instance('service', 'instance')
-        assert matching is None
-
     @mock.patch('paasta_tools.chronos_tools.lookup_chronos_jobs', autospec=True)
     @mock.patch('paasta_tools.chronos_tools.get_chronos_client', autospec=True)
     @mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospec=True)
-    def test_get_job_for_service_instance_returns_one(
+    def test_get_jobs_for_service_instance_returns_one(
         self,
         mock_load_chronos_config,
         mock_get_chronos_client, mock_lookup_chronos_jobs,
@@ -1578,28 +1604,8 @@ class TestChronosTools:
         mock_matching_jobs = [{'name': 'service instance'}]
         mock_lookup_chronos_jobs.return_value = mock_matching_jobs
         mock_load_chronos_config.return_value = {}
-        matching = chronos_tools.get_job_for_service_instance('service', 'instance')
-        assert matching == mock_matching_jobs[0]
-
-    @mock.patch('paasta_tools.chronos_tools.lookup_chronos_jobs', autospec=True)
-    @mock.patch('paasta_tools.chronos_tools.get_chronos_client', autospec=True)
-    @mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospec=True)
-    def test_get_job_for_service_instance_raises_on_multiple(
-        self,
-        mock_load_chronos_config,
-        mock_get_chronos_client, mock_lookup_chronos_jobs,
-    ):
-        mock_matching_jobs = [{'name': 'service instance'}, {'name': 'service instance_2'}]
-        mock_lookup_chronos_jobs.return_value = mock_matching_jobs
-        mock_load_chronos_config.return_value = {}
-        with raises(chronos_tools.MultipleChronosJobs):
-            chronos_tools.get_job_for_service_instance('service', 'instance')
-
-    def test_determine_disabled_state(self):
-        assert chronos_tools.determine_disabled_state('start', False) is False
-        assert chronos_tools.determine_disabled_state('stop', False) is True
-        assert chronos_tools.determine_disabled_state('start', True) is True
-        assert chronos_tools.determine_disabled_state('stop', True) is True
+        matching = chronos_tools.get_jobs_for_service_instance('service', 'instance')
+        assert matching == mock_matching_jobs
 
     def test_filter_non_temporary_jobs(self):
         fake_jobs = [


### PR DESCRIPTION
This function is kinda leftover from when we had multiple jobs per instance in chronos, where it was "ok" to see a bunch and discards all the duplicates and pick the most "recent" one.

This is now "wrong" in many cases and has lead to bugs where setup_chronos_job is picking the "first" one, which is a tmp job!

This change makes it so we don't even include disabled (tmp/rerun) jobs, and raises an exception if we ever are silently trying to discard duplicate jobs, which really should not happen anymore, right?

If I'm wrong, then at the very lease this thing should be called `get_jobs` and let the caller discard things I think? To me it is an exception if a caller asks to get the job for a service/instance and the code can't figure out which job is correct.