### PR TITLE
added a flag to list_marathon_service_instances to only show bouncing…

### DIFF
--- a/paasta_tools/list_marathon_service_instances.py
+++ b/paasta_tools/list_marathon_service_instances.py
@@ -52,7 +52,7 @@ def parse_args():
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
                         default=DEFAULT_SOA_DIR,
                         help="define a different soa config directory")
-    parser.add_argument('-m', '--minimal', dest='minimal', default=False,
+    parser.add_argument('-m', '--minimal', dest='minimal', action='store_true',
                         help="show only service instances that need bouncing")
     args = parser.parse_args()
     return args

--- a/paasta_tools/list_marathon_service_instances.py
+++ b/paasta_tools/list_marathon_service_instances.py
@@ -74,7 +74,7 @@ def get_current_apps():
     return {app.id.lstrip('/'): app for app in marathon_client.list_apps()}
 
 
-def get_desired_marathon_configs(cluster, soa_dir):
+def get_desired_marathon_configs(soa_dir):
     cluster = load_system_paasta_config().get_cluster()
     instances = get_services_for_cluster(
         instance_type='marathon',

--- a/paasta_tools/list_marathon_service_instances.py
+++ b/paasta_tools/list_marathon_service_instances.py
@@ -102,7 +102,7 @@ def get_service_instances_that_need_bouncing(soa_dir):
     actual_ids = set(current_apps.keys())
 
     apps_that_need_bouncing = actual_ids.symmetric_difference(desired_ids)
-    apps_that_need_bouncing = {long_job_id_to_short_job_id(app) for app in apps_that_need_bouncing}
+    apps_that_need_bouncing = {long_job_id_to_short_job_id(app_id) for app_id in apps_that_need_bouncing}
 
     for app_id, app in current_apps.items():
         short_app_id = long_job_id_to_short_job_id(app_id)

--- a/paasta_tools/list_marathon_service_instances.py
+++ b/paasta_tools/list_marathon_service_instances.py
@@ -36,9 +36,9 @@ from paasta_tools.marathon_tools import get_num_at_risk_tasks
 from paasta_tools.marathon_tools import load_marathon_config
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.utils import compose_job_id
-from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import long_job_id_to_short_job_id
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import use_requests_cache
 
@@ -56,11 +56,6 @@ def parse_args():
                         help="show only service instances that need bouncing")
     args = parser.parse_args()
     return args
-
-
-def long_job_id_to_short_job_id(long_job_id):
-    service, instance, _, __ = decompose_job_id(long_job_id)
-    return compose_job_id(service, instance)
 
 
 def get_current_apps():

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -41,6 +41,7 @@ from subprocess import Popen
 from subprocess import STDOUT
 
 import dateutil.tz
+import requests_cache
 import service_configuration_lib
 import yaml
 from docker import Client
@@ -1609,3 +1610,14 @@ def is_deploy_step(step):
     Returns false if the step is a predefined step-type, e.g. itest or command-*
     """
     return not ((step in DEPLOY_PIPELINE_NON_DEPLOY_STEPS) or (step.startswith('command-')))
+
+
+def use_requests_cache(cache_name, backend='memory', **kwargs):
+    def wrap(fun):
+        def fun_with_cache(*args, **kwargs):
+            requests_cache.install_cache(cache_name, backend=backend, **kwargs)
+            result = fun(*args, **kwargs)
+            requests_cache.uninstall_cache()
+            return result
+        return fun_with_cache
+    return wrap

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1621,3 +1621,8 @@ def use_requests_cache(cache_name, backend='memory', **kwargs):
             return result
         return fun_with_cache
     return wrap
+
+
+def long_job_id_to_short_job_id(long_job_id):
+    service, instance, _, __ = decompose_job_id(long_job_id)
+    return compose_job_id(service, instance)

--- a/tests/test_list_marathon_service_instances.py
+++ b/tests/test_list_marathon_service_instances.py
@@ -1,0 +1,132 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import contextlib
+
+import mock
+
+from paasta_tools import list_marathon_service_instances
+
+
+def test_long_job_id_to_short_job_id():
+    assert list_marathon_service_instances.long_job_id_to_short_job_id(
+        'service.instance.git.config') == 'service.instance'
+
+
+def list_get_current_apps():
+    with contextlib.nested(
+        mock.patch('paasta_tools.list_marathon_service_instances.load_marathon_config'),
+        mock.patch('paasta_tools.list_marathon_service_instances.get_marathon_client'),
+    ) as (
+        mock_load_marathon_config,
+        mock_get_marathon_client,
+    ):
+        mock_task = mock.MagicMock(id='/service.instance.git.config')
+
+        mock_load_marathon_config.return_value = mock.MagicMock()
+        mock_get_marathon_client.return_value = mock.MagicMock(
+            list_apps=mock.MagicMock(return_value=[mock_task]),
+        )
+        assert list_marathon_service_instances.get_current_apps() == {'/service.instance.git.config': mock_task}
+
+
+def test_get_desired_marathon_configs():
+    with contextlib.nested(
+        mock.patch('paasta_tools.list_marathon_service_instances.get_services_for_cluster'),
+        mock.patch('paasta_tools.list_marathon_service_instances.load_marathon_service_config'),
+        mock.patch('paasta_tools.list_marathon_service_instances.load_system_paasta_config'),
+    ) as (
+        mock_get_services_for_cluster,
+        mock_load_marathon_service_config,
+        _,
+    ):
+        mock_app_dict = {'id': '/service.instance.git.configs'}
+        mock_get_services_for_cluster.return_value = [('service', 'instance')]
+        mock_load_marathon_service_config.return_value = mock.MagicMock(
+            format_marathon_app_dict=mock.MagicMock(return_value=mock_app_dict),
+        )
+        assert list_marathon_service_instances.get_desired_marathon_configs(
+            'fake-cluster', '/fake/soa/dir') == {'service.instance.git.configs': mock_app_dict}
+
+
+def test_get_service_instances_that_need_bouncing():
+    with contextlib.nested(
+        mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs'),
+        mock.patch('paasta_tools.list_marathon_service_instances.get_current_apps'),
+        mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks'),
+    ) as (
+        mock_get_desired_marathon_configs,
+        mock_get_current_apps,
+        mock_get_num_at_risk_tasks,
+    ):
+        mock_get_desired_marathon_configs.return_value = {
+            'fake--service.fake--instance.sha.config': {'instances': 5},
+            'fake--service2.fake--instance.sha.config': {'instances': 5},
+        }
+        mock_get_current_apps.return_value = {
+            'fake--service.fake--instance.sha.config2': mock.MagicMock(instances=5),
+            'fake--service2.fake--instance.sha.config': mock.MagicMock(instances=5),
+        }
+        mock_get_num_at_risk_tasks.return_value = 0
+        assert set(list_marathon_service_instances.get_service_instances_that_need_bouncing(
+            '/fake/soa/dir')) == {'fake_service.fake_instance'}
+
+
+def test_get_service_instances_that_need_bouncing_no_difference():
+    with contextlib.nested(
+        mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs'),
+        mock.patch('paasta_tools.list_marathon_service_instances.get_current_apps'),
+        mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks'),
+    ) as (
+        mock_get_desired_marathon_configs,
+        mock_get_current_apps,
+        mock_get_num_at_risk_tasks,
+    ):
+        mock_get_desired_marathon_configs.return_value = {'fake--service.fake--instance.sha.config': {'instances': 5}}
+        mock_get_current_apps.return_value = {'fake--service.fake--instance.sha.config': mock.MagicMock(instances=5)}
+        mock_get_num_at_risk_tasks.return_value = 0
+        assert set(list_marathon_service_instances.get_service_instances_that_need_bouncing('/fake/soa/dir')) == set()
+
+
+def test_get_service_instances_that_need_bouncing_instances_difference():
+    with contextlib.nested(
+        mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs'),
+        mock.patch('paasta_tools.list_marathon_service_instances.get_current_apps'),
+        mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks'),
+    ) as (
+        mock_get_desired_marathon_configs,
+        mock_get_current_apps,
+        mock_get_num_at_risk_tasks,
+    ):
+        mock_get_desired_marathon_configs.return_value = {'fake--service.fake--instance.sha.config': {'instances': 5}}
+        mock_get_current_apps.return_value = {'fake--service.fake--instance.sha.config': mock.MagicMock(instances=4)}
+        mock_get_num_at_risk_tasks.return_value = 0
+        assert set(list_marathon_service_instances.get_service_instances_that_need_bouncing(
+            '/fake/soa/dir')) == {'fake_service.fake_instance'}
+
+
+def test_get_service_instances_that_need_bouncing_at_risk():
+    with contextlib.nested(
+        mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs'),
+        mock.patch('paasta_tools.list_marathon_service_instances.get_current_apps'),
+        mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks'),
+    ) as (
+        mock_get_desired_marathon_configs,
+        mock_get_current_apps,
+        mock_get_num_at_risk_tasks,
+    ):
+        mock_get_desired_marathon_configs.return_value = {'fake--service.fake--instance.sha.config': {'instances': 5}}
+        mock_get_current_apps.return_value = {'fake--service.fake--instance.sha.config': mock.MagicMock(instances=5)}
+        mock_get_num_at_risk_tasks.return_value = 1
+        assert set(list_marathon_service_instances.get_service_instances_that_need_bouncing(
+            '/fake/soa/dir')) == {'fake_service.fake_instance'}

--- a/tests/test_list_marathon_service_instances.py
+++ b/tests/test_list_marathon_service_instances.py
@@ -77,6 +77,28 @@ def test_get_service_instances_that_need_bouncing():
             '/fake/soa/dir')) == {'fake_service.fake_instance'}
 
 
+def test_get_service_instances_that_need_bouncing_two_existing_services():
+    with contextlib.nested(
+        mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs'),
+        mock.patch('paasta_tools.list_marathon_service_instances.get_current_apps'),
+        mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks'),
+    ) as (
+        mock_get_desired_marathon_configs,
+        mock_get_current_apps,
+        mock_get_num_at_risk_tasks,
+    ):
+        mock_get_desired_marathon_configs.return_value = {
+            'fake--service.fake--instance.sha.config': {'instances': 5},
+        }
+        mock_get_current_apps.return_value = {
+            'fake--service.fake--instance.sha.config': mock.MagicMock(instances=5),
+            'fake--service.fake--instance.sha.config2': mock.MagicMock(instances=5),
+        }
+        mock_get_num_at_risk_tasks.return_value = 0
+        assert set(list_marathon_service_instances.get_service_instances_that_need_bouncing(
+            '/fake/soa/dir')) == {'fake_service.fake_instance'}
+
+
 def test_get_service_instances_that_need_bouncing_no_difference():
     with contextlib.nested(
         mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs'),

--- a/tests/test_list_marathon_service_instances.py
+++ b/tests/test_list_marathon_service_instances.py
@@ -18,11 +18,6 @@ import mock
 from paasta_tools import list_marathon_service_instances
 
 
-def test_long_job_id_to_short_job_id():
-    assert list_marathon_service_instances.long_job_id_to_short_job_id(
-        'service.instance.git.config') == 'service.instance'
-
-
 def list_get_current_apps():
     with contextlib.nested(
         mock.patch('paasta_tools.list_marathon_service_instances.load_marathon_config'),

--- a/tests/test_list_marathon_service_instances.py
+++ b/tests/test_list_marathon_service_instances.py
@@ -18,23 +18,6 @@ import mock
 from paasta_tools import list_marathon_service_instances
 
 
-def list_get_current_apps():
-    with contextlib.nested(
-        mock.patch('paasta_tools.list_marathon_service_instances.load_marathon_config'),
-        mock.patch('paasta_tools.list_marathon_service_instances.get_marathon_client'),
-    ) as (
-        mock_load_marathon_config,
-        mock_get_marathon_client,
-    ):
-        mock_task = mock.MagicMock(id='/service.instance.git.config')
-
-        mock_load_marathon_config.return_value = mock.MagicMock()
-        mock_get_marathon_client.return_value = mock.MagicMock(
-            list_apps=mock.MagicMock(return_value=[mock_task]),
-        )
-        assert list_marathon_service_instances.get_current_apps() == {'/service.instance.git.config': mock_task}
-
-
 def test_get_desired_marathon_configs():
     with contextlib.nested(
         mock.patch('paasta_tools.list_marathon_service_instances.get_services_for_cluster'),
@@ -57,93 +40,89 @@ def test_get_desired_marathon_configs():
 def test_get_service_instances_that_need_bouncing():
     with contextlib.nested(
         mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs'),
-        mock.patch('paasta_tools.list_marathon_service_instances.get_current_apps'),
         mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks'),
     ) as (
         mock_get_desired_marathon_configs,
-        mock_get_current_apps,
         mock_get_num_at_risk_tasks,
     ):
         mock_get_desired_marathon_configs.return_value = {
             'fake--service.fake--instance.sha.config': {'instances': 5},
             'fake--service2.fake--instance.sha.config': {'instances': 5},
         }
-        mock_get_current_apps.return_value = {
-            'fake--service.fake--instance.sha.config2': mock.MagicMock(instances=5),
-            'fake--service2.fake--instance.sha.config': mock.MagicMock(instances=5),
-        }
+        fake_apps = [
+            mock.MagicMock(instances=5, id='/fake--service.fake--instance.sha.config2'),
+            mock.MagicMock(instances=5, id='/fake--service2.fake--instance.sha.config'),
+        ]
+        mock_client = mock.MagicMock(list_apps=mock.MagicMock(return_value=fake_apps))
         mock_get_num_at_risk_tasks.return_value = 0
         assert set(list_marathon_service_instances.get_service_instances_that_need_bouncing(
-            '/fake/soa/dir')) == {'fake_service.fake_instance'}
+            mock_client, '/fake/soa/dir')) == {'fake_service.fake_instance'}
 
 
 def test_get_service_instances_that_need_bouncing_two_existing_services():
     with contextlib.nested(
         mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs'),
-        mock.patch('paasta_tools.list_marathon_service_instances.get_current_apps'),
         mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks'),
     ) as (
         mock_get_desired_marathon_configs,
-        mock_get_current_apps,
         mock_get_num_at_risk_tasks,
     ):
         mock_get_desired_marathon_configs.return_value = {
             'fake--service.fake--instance.sha.config': {'instances': 5},
         }
-        mock_get_current_apps.return_value = {
-            'fake--service.fake--instance.sha.config': mock.MagicMock(instances=5),
-            'fake--service.fake--instance.sha.config2': mock.MagicMock(instances=5),
-        }
+        fake_apps = [
+            mock.MagicMock(instances=5, id='/fake--service.fake--instance.sha.config'),
+            mock.MagicMock(instances=5, id='/fake--service.fake--instance.sha.config2'),
+        ]
+        mock_client = mock.MagicMock(list_apps=mock.MagicMock(return_value=fake_apps))
         mock_get_num_at_risk_tasks.return_value = 0
         assert set(list_marathon_service_instances.get_service_instances_that_need_bouncing(
-            '/fake/soa/dir')) == {'fake_service.fake_instance'}
+            mock_client, '/fake/soa/dir')) == {'fake_service.fake_instance'}
 
 
 def test_get_service_instances_that_need_bouncing_no_difference():
     with contextlib.nested(
         mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs'),
-        mock.patch('paasta_tools.list_marathon_service_instances.get_current_apps'),
         mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks'),
     ) as (
         mock_get_desired_marathon_configs,
-        mock_get_current_apps,
         mock_get_num_at_risk_tasks,
     ):
         mock_get_desired_marathon_configs.return_value = {'fake--service.fake--instance.sha.config': {'instances': 5}}
-        mock_get_current_apps.return_value = {'fake--service.fake--instance.sha.config': mock.MagicMock(instances=5)}
+        fake_apps = [mock.MagicMock(instances=5, id='/fake--service.fake--instance.sha.config')]
+        mock_client = mock.MagicMock(list_apps=mock.MagicMock(return_value=fake_apps))
         mock_get_num_at_risk_tasks.return_value = 0
-        assert set(list_marathon_service_instances.get_service_instances_that_need_bouncing('/fake/soa/dir')) == set()
+        assert set(list_marathon_service_instances.get_service_instances_that_need_bouncing(
+            mock_client, '/fake/soa/dir')) == set()
 
 
 def test_get_service_instances_that_need_bouncing_instances_difference():
     with contextlib.nested(
         mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs'),
-        mock.patch('paasta_tools.list_marathon_service_instances.get_current_apps'),
         mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks'),
     ) as (
         mock_get_desired_marathon_configs,
-        mock_get_current_apps,
         mock_get_num_at_risk_tasks,
     ):
         mock_get_desired_marathon_configs.return_value = {'fake--service.fake--instance.sha.config': {'instances': 5}}
-        mock_get_current_apps.return_value = {'fake--service.fake--instance.sha.config': mock.MagicMock(instances=4)}
+        fake_apps = [mock.MagicMock(instances=4, id='/fake--service.fake--instance.sha.config')]
+        mock_client = mock.MagicMock(list_apps=mock.MagicMock(return_value=fake_apps))
         mock_get_num_at_risk_tasks.return_value = 0
         assert set(list_marathon_service_instances.get_service_instances_that_need_bouncing(
-            '/fake/soa/dir')) == {'fake_service.fake_instance'}
+            mock_client, '/fake/soa/dir')) == {'fake_service.fake_instance'}
 
 
 def test_get_service_instances_that_need_bouncing_at_risk():
     with contextlib.nested(
         mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs'),
-        mock.patch('paasta_tools.list_marathon_service_instances.get_current_apps'),
         mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks'),
     ) as (
         mock_get_desired_marathon_configs,
-        mock_get_current_apps,
         mock_get_num_at_risk_tasks,
     ):
         mock_get_desired_marathon_configs.return_value = {'fake--service.fake--instance.sha.config': {'instances': 5}}
-        mock_get_current_apps.return_value = {'fake--service.fake--instance.sha.config': mock.MagicMock(instances=5)}
+        fake_apps = [mock.MagicMock(instances=5, id='/fake--service.fake--instance.sha.config')]
+        mock_client = mock.MagicMock(list_apps=mock.MagicMock(return_value=fake_apps))
         mock_get_num_at_risk_tasks.return_value = 1
         assert set(list_marathon_service_instances.get_service_instances_that_need_bouncing(
-            '/fake/soa/dir')) == {'fake_service.fake_instance'}
+            mock_client, '/fake/soa/dir')) == {'fake_service.fake_instance'}

--- a/tests/test_list_marathon_service_instances.py
+++ b/tests/test_list_marathon_service_instances.py
@@ -56,7 +56,7 @@ def test_get_desired_marathon_configs():
             format_marathon_app_dict=mock.MagicMock(return_value=mock_app_dict),
         )
         assert list_marathon_service_instances.get_desired_marathon_configs(
-            'fake-cluster', '/fake/soa/dir') == {'service.instance.git.configs': mock_app_dict}
+            '/fake/soa/dir') == {'service.instance.git.configs': mock_app_dict}
 
 
 def test_get_service_instances_that_need_bouncing():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1552,3 +1552,7 @@ def test_is_deploy_step():
     assert not utils.is_deploy_step('itest')
     assert not utils.is_deploy_step('performance-check')
     assert not utils.is_deploy_step('command-thingy')
+
+
+def test_long_job_id_to_short_job_id():
+    assert utils.long_job_id_to_short_job_id('service.instance.git.config') == 'service.instance'


### PR DESCRIPTION
… jobs

Sample output on internal JIRA ticket PAASTA-6418 (note this has been corrected to properly deformat job id)

This is about 185x faster than running setup_marathon_job on every service (maybe even faster now that we're not running multiple jobs per setup_marathon_job instance so we're not taking advantage of caching)