### PR TITLE
Add backoff_factor and max_launch_delay seconds to marathon schema

### DIFF
--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -96,6 +96,14 @@
             "nerve_ns": {
                 "type": "string"
             },
+            "backoff_factor": {
+                "type": "integer",
+                "default": 2
+            },
+            "max_launch_delay_seconds": {
+                "type": "integer",
+                "default": 300
+            },
             "registration_namespaces": {
                 "type": "array",
                 "items": {


### PR DESCRIPTION
We added support for these options a while ago (and list them in our docs), but we never updated the schema file to support them. As a result, `paasta validate` claims they are invalid fields.