### PR TITLE
Add api to docker playground

### DIFF
--- a/example_cluster/docker-compose.override.yml
+++ b/example_cluster/docker-compose.override.yml
@@ -8,6 +8,7 @@ services:
     build: ../yelp_package/dockerfiles/mesos-paasta/
     ports:
       - '5050:5050'
+      - '5054:5054'
       - 22
     depends_on:
       - mesosbase

--- a/example_cluster/paasta/api.json
+++ b/example_cluster/paasta/api.json
@@ -1,0 +1,5 @@
+{
+  "api_endpoints": {
+    "testcluster": "http://mesosmaster:5054"
+  }
+}

--- a/yelp_package/dockerfiles/mesos-paasta/start.sh
+++ b/yelp_package/dockerfiles/mesos-paasta/start.sh
@@ -16,4 +16,5 @@ pip install --no-index --find-links=/var/tmp/pip_cache -e /work
 while read link; do echo $link|sed -e 's/usr\/share\/python\/paasta-tools\//\/usr\/local\//'| sed -e 's/\ usr/\ \/usr/'| xargs ln -s; done < /work/debian/paasta-tools.links
 /usr/sbin/rsyslogd
 cron
+paasta-api 5054 &
 mesos-master --zk=zk://zookeeper:2181/mesos-testcluster --registry=in_memory --quorum=1 --authenticate --authenticate_slaves --credentials=/etc/mesos-secrets --hostname=$(hostname)


### PR DESCRIPTION
This enables the new paasta-api server on the mesosmaster in the docker-compose playground. It also exposes it to localhost on 5054