### PR TITLE
Fix potential paasta_metastatus DivizionByZero

### DIFF
--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -537,19 +537,22 @@ def format_table_column_for_healthcheck_resource_utilization_pair(healthcheck_ut
     :returns: a string representing the ResourceUtilization.
     """
     color_func = PaastaColors.green if healthcheck_utilization_pair[0].healthy else PaastaColors.red
+    utilization = float(healthcheck_utilization_pair[1].total - healthcheck_utilization_pair[1].free)
+    if int(healthcheck_utilization_pair[1].total) == 0:
+        utilization_perc = 100
+    else:
+        utilization_perc = utilization / float(healthcheck_utilization_pair[1].total) * 100
     if humanize and healthcheck_utilization_pair[1].metric != 'cpus':
         return color_func('%s/%s (%.2f%%)' % (
             naturalsize(healthcheck_utilization_pair[1].free * 1024 * 1024, gnu=True),
             naturalsize(healthcheck_utilization_pair[1].total * 1024 * 1024, gnu=True),
-            float(healthcheck_utilization_pair[1].total - healthcheck_utilization_pair[1].free) /
-            float(healthcheck_utilization_pair[1].total) * 100
+            utilization_perc,
         ))
     else:
         return color_func('%s/%s (%.2f%%)' % (
             healthcheck_utilization_pair[1].free,
             healthcheck_utilization_pair[1].total,
-            float(healthcheck_utilization_pair[1].total - healthcheck_utilization_pair[1].free) /
-            float(healthcheck_utilization_pair[1].total) * 100
+            utilization_perc,
         ))
 
 

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -674,6 +674,20 @@ def test_format_table_column_for_healthcheck_resource_utilization_pair_unhealthy
     ) == expected
 
 
+def test_format_table_column_for_healthcheck_resource_utilization_pair_zero():
+    fake_healthcheckresult = Mock()
+    fake_healthcheckresult.healthy = False
+    fake_healthcheckresult.metric = 'mem'
+    fake_resource_utilization = Mock()
+    fake_resource_utilization.free = 0
+    fake_resource_utilization.total = 0
+    expected = PaastaColors.red("0/0 (100.00%)")
+    assert paasta_metastatus.format_table_column_for_healthcheck_resource_utilization_pair(
+        (fake_healthcheckresult, fake_resource_utilization),
+        False
+    ) == expected
+
+
 def test_format_table_column_for_healthcheck_resource_utilization_pair_healthy_human():
     fake_healthcheckresult = Mock()
     fake_healthcheckresult.healthy = True
@@ -696,6 +710,20 @@ def test_format_table_column_for_healthcheck_resource_utilization_pair_unhealthy
     fake_resource_utilization.free = 10
     fake_resource_utilization.total = 20
     expected = PaastaColors.red("10.0M/20.0M (50.00%)")
+    assert paasta_metastatus.format_table_column_for_healthcheck_resource_utilization_pair(
+        (fake_healthcheckresult, fake_resource_utilization),
+        True
+    ) == expected
+
+
+def test_format_table_column_for_healthcheck_resource_utilization_pair_zero_human():
+    fake_healthcheckresult = Mock()
+    fake_healthcheckresult.healthy = False
+    fake_healthcheckresult.metric = 'mem'
+    fake_resource_utilization = Mock()
+    fake_resource_utilization.free = 0
+    fake_resource_utilization.total = 0
+    expected = PaastaColors.red("0B/0B (100.00%)")
     assert paasta_metastatus.format_table_column_for_healthcheck_resource_utilization_pair(
         (fake_healthcheckresult, fake_resource_utilization),
         True


### PR DESCRIPTION
Due to #730, in paasta metastatus -vvv, it is possible to get a DivizionByZero error if the host has all resources reserved, giving it a total of 0 resources.