### PR TITLE
import mesos_cli as a subpackage in paasta_tools

### DIFF
--- a/paasta_itests/itest_utils.py
+++ b/paasta_itests/itest_utils.py
@@ -16,12 +16,12 @@ import json
 import os
 import time
 
-import mesos.cli.master
 import mock
 import requests
 import requests_cache
 from marathon import NotFoundError
 
+import paasta_tools.mesos.master
 from paasta_tools import marathon_tools
 from paasta_tools.marathon_tools import app_has_tasks
 from paasta_tools.marathon_tools import MarathonServiceConfig
@@ -37,7 +37,7 @@ def patch_mesos_cli_master_config():
         "response_timeout": 5,
     }
 
-    with mock.patch.object(mesos.cli.master, 'CFG', mesos_config):
+    with mock.patch.object(paasta_tools.mesos.master, 'CFG', mesos_config):
         yield
 
 

--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -14,7 +14,6 @@
 import contextlib
 import time
 
-import mesos.cli.master
 import mock
 from behave import given
 from behave import then
@@ -22,6 +21,7 @@ from behave import when
 from itest_utils import get_service_connection_string
 from marathon import MarathonHttpError
 
+import paasta_tools.mesos.master
 from paasta_tools import bounce_lib
 from paasta_tools import drain_lib
 from paasta_tools import marathon_tools
@@ -161,7 +161,7 @@ def when_setup_service_initiated(context):
         mock.patch('paasta_tools.marathon_tools.get_code_sha_from_dockerurl', autospec=True, return_value='newapp'),
         mock.patch('paasta_tools.marathon_tools.get_docker_url', autospec=True, return_value='busybox'),
         mock.patch('paasta_tools.mesos_maintenance.load_credentials', autospec=True),
-        mock.patch.object(mesos.cli.master, 'CFG', config),
+        mock.patch.object(paasta_tools.mesos.master, 'CFG', config),
     ) as (
         _,
         _,

--- a/paasta_itests/steps/mesos_steps.py
+++ b/paasta_itests/steps/mesos_steps.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 import contextlib
 
-import mesos.cli.master
 import mock
 from behave import then
 from behave import when
 from itest_utils import get_service_connection_string
 
+import paasta_tools.mesos.master
 from paasta_tools import check_mesos_resource_utilization
 
 
@@ -32,7 +32,7 @@ def check_mesos_utilization(context, percent):
 
     with contextlib.nested(
         mock.patch('paasta_tools.check_mesos_resource_utilization.send_event'),
-        mock.patch.object(mesos.cli.master, 'CFG', config),
+        mock.patch.object(paasta_tools.mesos.master, 'CFG', config),
     ) as (
         mock_events,
         mock_cfg,

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -14,7 +14,6 @@
 import contextlib
 from time import sleep
 
-import mesos.cli.master
 import mock
 from behave import then
 from behave import when
@@ -22,6 +21,7 @@ from itest_utils import get_service_connection_string
 from itest_utils import update_context_marathon_config
 from marathon.exceptions import MarathonHttpError
 
+import paasta_tools.mesos.master
 from paasta_tools import marathon_tools
 from paasta_tools import mesos_maintenance
 from paasta_tools import setup_marathon_job
@@ -95,7 +95,7 @@ def run_until_number_tasks(context, number):
     for _ in xrange(20):
         with contextlib.nested(
             mock.patch('paasta_tools.mesos_maintenance.load_credentials', autospec=True),
-            mock.patch.object(mesos.cli.master, 'CFG', config),
+            mock.patch.object(paasta_tools.mesos.master, 'CFG', config),
         ) as (
             mock_load_credentials,
             _,
@@ -154,7 +154,7 @@ def mark_host_at_risk(context, host):
     }
     with contextlib.nested(
         mock.patch('paasta_tools.mesos_maintenance.load_credentials', autospec=True),
-        mock.patch.object(mesos.cli.master, 'CFG', config),
+        mock.patch.object(paasta_tools.mesos.master, 'CFG', config),
     ) as (
         mock_load_credentials,
         _,

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -129,8 +129,8 @@ def working_paasta_cluster(context):
 
     mesos_cli_config = _generate_mesos_cli_config(_get_zookeeper_connection_string('mesos-testcluster'))
     context.mesos_cli_config_filename = write_mesos_cli_config(mesos_cli_config)
-    import mesos.cli
-    mesos.cli.cfg.CURRENT.load()
+    import paasta_tools.mesos as mesos
+    mesos.cfg.CURRENT.load()
     context.tag_version = 0
     write_etc_paasta(context, {'marathon_config': context.marathon_config}, 'marathon.json')
     write_etc_paasta(context, {'chronos_config': context.chronos_config}, 'chronos.json')

--- a/paasta_tools/mesos/cfg.py
+++ b/paasta_tools/mesos/cfg.py
@@ -1,0 +1,112 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import print_function
+
+import errno
+import json
+import os
+
+
+class Config(object):
+
+    _default_profile = "default"
+
+    DEFAULTS = {
+        "debug": "false",
+        "log_file": None,
+        "log_level": "warning",
+        "master": "localhost:5050",
+        "max_workers": 5,
+        "scheme": "http",
+        "response_timeout": 5
+    }
+
+    cfg_name = ".mesos.json"
+
+    _default_config_location = os.path.join(os.path.expanduser("~"), cfg_name)
+
+    search_path = [os.path.join(x, cfg_name) for x in [
+        ".",
+        os.path.expanduser("~"),
+        "/etc",
+        "/usr/etc",
+        "/usr/local/etc"
+    ]]
+
+    def __init__(self):
+        self.__items = {self._default_profile: self.DEFAULTS}
+        self["profile"] = self._default_profile
+
+        self.load()
+
+    def __str__(self):
+        return json.dumps(self.__items, indent=4)
+
+    def _config_file(self):
+        for path in self.search_path:
+            if os.path.exists(path):
+                return path
+
+        # default to creating a user level config file
+        return self._default_config_location
+
+    def _get_path(self):
+        return os.environ.get(
+            'MESOS_CLI_CONFIG', self._config_file())
+
+    @property
+    def _profile_key(self):
+        return self.__items.get("profile", self._default_profile)
+
+    @property
+    def _profile(self):
+        return self.__items.get(self._profile_key, {})
+
+    def __getitem__(self, item):
+        if item == "profile":
+            return self.__items[item]
+        return self._profile.get(item, self.DEFAULTS[item])
+
+    def __setitem__(self, k, v):
+        if k == "profile":
+            self.__items[k] = v
+            return
+
+        profile = self._profile
+        profile[k] = v
+        self.__items[self._profile_key] = profile
+
+    def load(self):
+        try:
+            with open(self._get_path(), 'rt') as f:
+                try:
+                    data = json.load(f)
+                except ValueError as e:
+                    raise ValueError(
+                        'Invalid %s JSON: %s [%s]' %
+                        (type(self).__name__, e.message, self._get_path())
+                    )
+                self.__items.update(data)
+        except IOError as e:
+            if e.errno != errno.ENOENT:
+                raise
+
+    def save(self):
+        with open(self._get_path(), "wb") as f:
+            f.write(str(self))
+
+CURRENT = Config()

--- a/paasta_tools/mesos/cluster.py
+++ b/paasta_tools/mesos/cluster.py
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import print_function
+
+import itertools
+
+from . import exceptions
+from . import log
+from . import parallel
+from .master import CURRENT as MASTER
+
+dne = True
+missing_slave = set([])
+
+
+def files(fn, fltr, flist, active_only=False, fail=True):
+    global dne
+
+    tlist = MASTER.tasks(fltr, active_only=active_only)
+    dne = True
+
+    def process((task, fname)):
+        global dne
+
+        try:
+            fobj = task.file(fname)
+        except exceptions.SlaveDoesNotExist:
+            if task["id"] not in missing_slave:
+                print("%s:%s" % (task["id"], fname))
+                print("Slave no longer exists.")
+
+            missing_slave.add(task["id"])
+            raise exceptions.SkipResult
+
+        if fobj.exists():
+
+            dne = False
+            return fn(fobj)
+
+    elements = itertools.chain(
+        *[[(task, fname) for fname in flist] for task in tlist])
+
+    for result in parallel.stream(process, elements):
+        if not result:
+            continue
+        yield result
+
+    if dne and fail:
+        log.fatal("No such task has the requested file or directory")

--- a/paasta_tools/mesos/completion_helpers.py
+++ b/paasta_tools/mesos/completion_helpers.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+from . import exceptions
+from .master import CURRENT as MASTER
+
+
+def task(prefix, parsed_args, **kwargs):
+    return [x["id"] for x in MASTER.tasks(prefix)]
+
+
+def slave(prefix, parsed_args, **kwargs):
+    return [s["id"] for s in MASTER.slaves(prefix)]
+
+
+def file(prefix, parsed_args, **kwargs):
+    files = set([])
+    split = prefix.rsplit("/", 1)
+    base = ""
+    if len(split) == 2:
+        base = split[0]
+    pattern = split[-1]
+
+    for task in MASTER.tasks(parsed_args.task):
+        # It is possible for the master to have completed tasks that no longer
+        # have files and/or executors
+        try:
+            for file_meta in task.file_list(base):
+                rel = os.path.relpath(file_meta["path"], task.directory)
+                if rel.rsplit("/", 1)[-1].startswith(pattern):
+                    if file_meta["mode"].startswith("d"):
+                        rel += "/"
+                    files.add(rel)
+        except exceptions.MissingExecutor:
+            pass
+    return files

--- a/paasta_tools/mesos/exceptions.py
+++ b/paasta_tools/mesos/exceptions.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class MesosCLIException(Exception):
+    pass
+
+
+class FileDoesNotExist(MesosCLIException):
+    pass
+
+
+class MissingExecutor(MesosCLIException):
+    pass
+
+
+class SlaveDoesNotExist(MesosCLIException):
+    pass
+
+
+class SkipResult(MesosCLIException):
+    pass

--- a/paasta_tools/mesos/framework.py
+++ b/paasta_tools/mesos/framework.py
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import print_function
+
+
+class Framework(object):
+    def __init__(self, items):
+        self.__items = items
+
+    def __getitem__(self, name):
+        return self.__items[name]
+
+    def __str__(self):
+        return "{0}:{1}".format(self.name, self.id)
+
+    @property
+    def id(self):
+        return self['id']
+
+    @property
+    def name(self):
+        return self['name']
+
+    @property
+    def hostname(self):
+        return self['hostname']
+
+    @property
+    def active(self):
+        return self['active']
+
+    @property
+    def task_count(self):
+        return len(self['tasks'])
+
+    @property
+    def user(self):
+        return self['user']
+
+    @property
+    def cpu_allocated(self):
+        return self._resource_allocated("cpus")
+
+    @property
+    def mem_allocated(self):
+        return self._resource_allocated("mem")
+
+    @property
+    def disk_allocated(self):
+        return self._resource_allocated("disk")
+
+    def _resource_allocated(self, resource):
+        return self["resources"][resource]

--- a/paasta_tools/mesos/log.py
+++ b/paasta_tools/mesos/log.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import print_function
+
+import functools
+import logging
+import sys
+import time
+
+debug = logging.debug
+
+
+def fatal(msg, code=1):
+    sys.stdout.write(msg + "\n")
+    logging.error(msg)
+    sys.exit(code)
+
+
+def fn(f, *args, **kwargs):
+    logging.debug("{0}: {1} {2}".format(repr(f), args, kwargs))
+    return f(*args, **kwargs)
+
+
+def duration(fn):
+    @functools.wraps(fn)
+    def timer(*args, **kwargs):
+        start = time.time()
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            debug("duration: {0}.{1}: {2:2.2f}s".format(
+                fn.__module__,
+                fn.__name__,
+                time.time() - start))
+
+    return timer

--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -1,0 +1,233 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import print_function
+
+import fnmatch
+import itertools
+import json
+import os
+import re
+import urlparse
+
+import google.protobuf.message
+import kazoo.client
+import kazoo.exceptions
+import kazoo.handlers.threading
+import mesos.interface.mesos_pb2
+import requests
+import requests.exceptions
+
+from . import exceptions
+from . import framework
+from . import log
+from . import mesos_file
+from . import slave
+from . import task
+from . import util
+from . import zookeeper
+from .cfg import CURRENT as CFG
+
+ZOOKEEPER_TIMEOUT = 1
+
+INVALID_PATH = "{0} does not have a valid path. Did you forget /mesos?"
+
+MISSING_MASTER = """unable to connect to a master at {0}.
+
+Try running `mesos config master zk://localhost:2181/mesos`. See the README for
+more examples."""
+
+MULTIPLE_SLAVES = "There are multiple slaves with that id. Please choose one: "
+
+
+class MesosMaster(object):
+
+    def __str__(self):
+        return "<master: {0}>".format(self.key())
+
+    def key(self):
+        return CFG["master"]
+
+    @util.CachedProperty()
+    def host(self):
+        return "{0}://{1}".format(CFG["scheme"], self.resolve(CFG["master"]))
+
+    @log.duration
+    def fetch(self, url, **kwargs):
+        try:
+            return requests.get(
+                urlparse.urljoin(self.host, url),
+                timeout=CFG["response_timeout"],
+                **kwargs)
+        except requests.exceptions.ConnectionError:
+            log.fatal(MISSING_MASTER.format(self.host))
+
+    def _file_resolver(self, cfg):
+        return self.resolve(open(cfg[6:], "r+").read().strip())
+
+    def _zookeeper_resolver(self, cfg):
+        hosts, path = cfg[5:].split("/", 1)
+        path = "/" + path
+
+        with zookeeper.client(hosts=hosts, read_only=True) as zk:
+            try:
+                def master_id(key):
+                    return int(key.split("_")[-1])
+
+                def get_masters():
+                    return [x for x in zk.get_children(path)
+                            if re.search("\d+", x)]
+
+                leader = sorted(get_masters(), key=lambda x: master_id(x))
+
+                if len(leader) == 0:
+                    log.fatal("cannot find any masters at {0}".format(cfg,))
+                data, stat = zk.get(os.path.join(path, leader[0]))
+            except kazoo.exceptions.NoNodeError:
+                log.fatal(INVALID_PATH.format(cfg))
+
+            if not data:
+                log.fatal("Cannot retrieve valid MasterInfo data from ZooKeeper")
+
+            # The serialization of the Master's PID to ZK has changed over time.
+            # Prior to 0.20 just the PID value was written to the znode; then the binary
+            # serialization of the `MasterInfo` Protobuf was written and then, as of 0.24.x,
+            # the protobuf is actually serialized as JSON.
+            # We try all strategies, starting with the most recent, falling back if we cannot
+            # parse the value.
+
+            # Try JSON first:
+            try:
+                parsed = json.loads(data)
+                if parsed and "address" in parsed:
+                    ip = parsed["address"].get("ip")
+                    port = parsed["address"].get("port")
+                    if ip and port:
+                        return "{ip}:{port}".format(ip=ip, port=port)
+            except ValueError as parse_error:
+                log.debug("[WARN] No JSON content, probably connecting to older Mesos version. "
+                          "Reason: {}".format(parse_error))
+
+            # Try to deserialize the MasterInfo protobuf next:
+            try:
+                info = mesos.interface.mesos_pb2.MasterInfo()
+                info.ParseFromString(data)
+                return info.pid
+            except google.protobuf.message.DecodeError as parse_error:
+                log.debug("[WARN] Cannot deserialize Protobuf either, probably connecting to a "
+                          "legacy Mesos version, please consider upgrading. Reason: {}".format(
+                              parse_error))
+                # Finally try to just interpret the PID as a string:
+                if '@' in data:
+                    return data.split("@")[-1]
+            log.fatal("Could not retrieve the MasterInfo from ZooKeeper; the data in '{}' was:"
+                      "{}".format(path, data))
+
+    @log.duration
+    def resolve(self, cfg):
+        """Resolve the URL to the mesos master.
+
+        The value of cfg should be one of:
+            - host:port
+            - zk://host1:port1,host2:port2/path
+            - zk://username:password@host1:port1/path
+            - file:///path/to/file (where file contains one of the above)
+        """
+        if cfg.startswith("zk:"):
+            return self._zookeeper_resolver(cfg)
+        elif cfg.startswith("file:"):
+            return self._file_resolver(cfg)
+        else:
+            return cfg
+
+    @util.CachedProperty(ttl=5)
+    def state(self):
+        return self.fetch("/master/state.json").json()
+
+    @util.memoize
+    def slave(self, fltr):
+        lst = self.slaves(fltr)
+
+        log.debug("master.slave({0})".format(fltr))
+
+        if len(lst) == 0:
+            raise exceptions.SlaveDoesNotExist(
+                "Slave {0} no longer exists.".format(fltr))
+
+        elif len(lst) > 1:
+            result = [MULTIPLE_SLAVES]
+            result += ['\t{0}'.format(slave.id) for slave in lst]
+            log.fatal('\n'.join(result))
+
+        return lst[0]
+
+    def slaves(self, fltr=""):
+        return list(map(
+            lambda x: slave.MesosSlave(x),
+            itertools.ifilter(
+                lambda x: fltr in x["id"], self.state["slaves"])))
+
+    def _task_list(self, active_only=False):
+        keys = ["tasks"]
+        if not active_only:
+            keys.append("completed_tasks")
+        return itertools.chain(
+            *[util.merge(x, *keys) for x in self._framework_list(active_only)])
+
+    def task(self, fltr):
+        lst = self.tasks(fltr)
+
+        if len(lst) == 0:
+            log.fatal("Cannot find a task by that name.")
+
+        elif len(lst) > 1:
+            msg = ["There are multiple tasks with that id. Please choose one:"]
+            msg += ["\t{0}".format(t["id"]) for t in lst]
+            log.fatal("\n".join(msg))
+
+        return lst[0]
+
+    # XXX - need to filter on task state as well as id
+    def tasks(self, fltr="", active_only=False):
+        return list(map(
+            lambda x: task.Task(self, x),
+            itertools.ifilter(
+                lambda x: fltr in x["id"] or fnmatch.fnmatch(x["id"], fltr),
+                self._task_list(active_only))))
+
+    def framework(self, fwid):
+        return list(filter(
+            lambda x: x.id == fwid,
+            self.frameworks()))[0]
+
+    def _framework_list(self, active_only=False):
+        keys = ["frameworks"]
+        if not active_only:
+            keys.append("completed_frameworks")
+        return util.merge(self.state, *keys)
+
+    def frameworks(self, active_only=False):
+        keys = ["frameworks"]
+        if not active_only:
+            keys.append("completed_frameworks")
+        return list(map(lambda x: framework.Framework(x), self._framework_list(active_only)))
+
+    @property
+    @util.memoize
+    def log(self):
+        return mesos_file.File(self, path="/master/log")
+
+CURRENT = MesosMaster()

--- a/paasta_tools/mesos/mesos_file.py
+++ b/paasta_tools/mesos/mesos_file.py
@@ -129,11 +129,14 @@ class File(object):
     def _read(self, size=None):
         start = self.tell()
 
-        fn = lambda: self._get_chunk(
-            self.tell(),
-            size=self._length(start, size))
-        pre = lambda x: x == ""
-        post = lambda x: size and (self.tell() - start) >= size
+        def fn():
+            return self._get_chunk(self.tell(), size=self._length(start, size))
+
+        def pre(x):
+            return x == ""
+
+        def post(x):
+            return size and (self.tell() - start) >= size
 
         for blob in util.iter_until(fn, pre, post):
             yield blob

--- a/paasta_tools/mesos/mesos_file.py
+++ b/paasta_tools/mesos/mesos_file.py
@@ -1,0 +1,187 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+
+from . import exceptions
+from . import util
+
+
+class File(object):
+
+    chunk_size = 1024
+
+    def __init__(self, host, task=None, path=None):
+        self.host = host
+        self.task = task
+        self.path = path
+
+        if self.task is None:
+            self._host_path = self.path
+        else:
+            self._host_path = os.path.join(self.task.directory, self.path)
+
+        self._offset = 0
+
+        # Used during fetch, class level so the dict isn't constantly alloc'd
+        self._params = {
+            "path": self._host_path,
+            "offset": -1,
+            "length": self.chunk_size
+        }
+
+    def __iter__(self):
+        for line in self._readlines():
+            yield line
+
+    def __eq__(self, y):
+        return self.key() == y.key()
+
+    def __hash__(self):
+        return hash(self.__str__())
+
+    def __repr__(self):
+        return "<open file '{0}', for '{1}'>".format(self.path, self._where)
+
+    def __str__(self):
+        return "{0}:{1}".format(self._where, self.path)
+
+    def key(self):
+        return "{0}:{1}".format(self.host.key(), self._host_path)
+
+    @property
+    def _where(self):
+        return self.task["id"] if self.task is not None else self.host.key()
+
+    def __reversed__(self):
+        for i, line in enumerate(self._readlines_reverse()):
+            # Don't include the terminator when reading in reverse.
+            if i == 0 and line == "":
+                continue
+            yield line
+
+    def _fetch(self):
+        resp = self.host.fetch("/files/read.json", params=self._params)
+        if resp.status_code == 404:
+            raise exceptions.FileDoesNotExist("No such file or directory.")
+        return resp.json()
+
+    def exists(self):
+        try:
+            self.size
+            return True
+        except exceptions.FileDoesNotExist:
+            return False
+        except exceptions.SlaveDoesNotExist:
+            return False
+
+    # When reading a file, it is common to first check whether it exists, then
+    # look at the size to determine where to seek. Instead of requiring
+    # multiple requests to the slave, the size is cached for a very short
+    # period of time.
+    @util.CachedProperty(ttl=0.5)
+    def size(self):
+        return self._fetch()["offset"]
+
+    def seek(self, offset, whence=os.SEEK_SET):
+        if whence == os.SEEK_SET:
+            self._offset = 0 + offset
+        elif whence == os.SEEK_CUR:
+            self._offset += offset
+        elif whence == os.SEEK_END:
+            self._offset = self.size + offset
+
+    def tell(self):
+        return self._offset
+
+    def _length(self, start, size):
+        if size and self.tell() - start + self.chunk_size > size:
+            return size - (self.tell() - start)
+        return self.chunk_size
+
+    def _get_chunk(self, loc, size=None):
+        if size is None:
+            size = self.chunk_size
+
+        self.seek(loc, os.SEEK_SET)
+        self._params["offset"] = loc
+        self._params["length"] = size
+
+        data = self._fetch()["data"]
+        self.seek(len(data), os.SEEK_CUR)
+        return data
+
+    def _read(self, size=None):
+        start = self.tell()
+
+        fn = lambda: self._get_chunk(
+            self.tell(),
+            size=self._length(start, size))
+        pre = lambda x: x == ""
+        post = lambda x: size and (self.tell() - start) >= size
+
+        for blob in util.iter_until(fn, pre, post):
+            yield blob
+
+    def _read_reverse(self, size=None):
+        fsize = self.size
+        if not size:
+            size = fsize
+
+        def next_block():
+            current = fsize
+            while (current - self.chunk_size) > (fsize - size):
+                current -= self.chunk_size
+                yield current
+
+        for pos in next_block():
+            yield self._get_chunk(pos)
+
+        yield self._get_chunk(fsize - size, size % self.chunk_size)
+
+    def read(self, size=None):
+        return ''.join(self._read(size))
+
+    def readline(self, size=None):
+        for line in self._readlines(size):
+            return line
+
+    def _readlines(self, size=None):
+        last = ""
+        for blob in self._read(size):
+
+            # This is not streaming and assumes small chunk sizes
+            blob_lines = (last + blob).split("\n")
+            for line in blob_lines[:len(blob_lines) - 1]:
+                yield line
+
+            last = blob_lines[-1]
+
+    def _readlines_reverse(self, size=None):
+        buf = ""
+        for blob in self._read_reverse(size):
+
+            blob_lines = (blob + buf).split("\n")
+            for line in reversed(blob_lines[1:]):
+                yield line
+
+            buf = blob_lines[0]
+        yield buf
+
+    def readlines(self, size=None):
+        return list(self._readlines(size))

--- a/paasta_tools/mesos/parallel.py
+++ b/paasta_tools/mesos/parallel.py
@@ -88,6 +88,7 @@ def by_fn(keyfn, fn, items):
 def by_slave(fn, tasks):
     """Execute a function against tasks partitioned by slave."""
 
-    keyfn = lambda x: x.slave["id"]
+    def keyfn(x):
+        return x.slave["id"]
     tasks = sorted(tasks, key=keyfn)
     return by_fn(keyfn, fn, tasks)

--- a/paasta_tools/mesos/parallel.py
+++ b/paasta_tools/mesos/parallel.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import print_function
+
+import contextlib
+import itertools
+
+import concurrent.futures
+
+from . import exceptions
+from .cfg import CURRENT as CFG
+
+
+@contextlib.contextmanager
+def execute():
+    try:
+        executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=CFG["max_workers"])
+        yield executor
+    except KeyboardInterrupt:
+        # Threads in the ThreadPoolExecutor are created with
+        # daemon=True. There is, therefore, an atexit function registered
+        # that allows all the currently running threads to stop before
+        # allowing the interpreter to stop. Because we don't care whether
+        # the worker threads exit cleanly or not, we force shutdown to be
+        # immediate.
+        concurrent.futures.thread._threads_queues.clear()
+        raise
+    finally:
+        executor.shutdown(wait=False)
+
+
+def stream(fn, elements):
+    """Yield the results of fn as jobs complete."""
+    jobs = []
+
+    with execute() as executor:
+        for elem in elements:
+            jobs.append(executor.submit(fn, elem))
+
+        for job in concurrent.futures.as_completed(jobs):
+            try:
+                yield job.result()
+            except exceptions.SkipResult:
+                pass
+
+
+def by_fn(keyfn, fn, items):
+    """Call fn in parallel across items based on keyfn.
+
+    Extensive caching/memoization is utilized when fetching data.
+    When you run a function against tasks in a completely parallel way, the
+    caching is skipped and there is the possibility that your endpoint will
+    receive multiple requests. For most use cases, this significantly slows
+    the result down (instead of speeding it up).
+
+    The solution to this predicament is to execute fn in parallel but only
+    across a specific partition function (slave ids in this example).
+    """
+
+    # itertools.groupby returns a list of (key, generator) tuples. A job
+    # is submitted and then the local execution context continues. The
+    # partitioned generator is destroyed and you only end up executing fn
+    # over a small subset of the desired partition. Therefore, the list()
+    # conversion when submitting the partition for execution is very
+    # important.
+    for result in stream(
+            lambda (k, part): [fn(i) for i in list(part)],
+            itertools.groupby(items, keyfn)):
+        for l in result:
+            yield l
+
+
+def by_slave(fn, tasks):
+    """Execute a function against tasks partitioned by slave."""
+
+    keyfn = lambda x: x.slave["id"]
+    tasks = sorted(tasks, key=keyfn)
+    return by_fn(keyfn, fn, tasks)

--- a/paasta_tools/mesos/parser.py
+++ b/paasta_tools/mesos/parser.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+
+from . import completion_helpers
+
+
+class ArgumentParser(argparse.ArgumentParser):
+
+    def enable_print_header(self):
+        self.add_argument(
+            '-q', action='store_true',
+            help="Suppresses printing of headers when multiple tasks are " +
+                 "being examined"
+        )
+
+    def task_argument(self, optional=False):
+        kwargs = {
+            "default": "",
+            "type": str,
+            "help": "ID of the task. May match multiple tasks (or all)"
+        }
+        if optional:
+            kwargs["nargs"] = "?"
+
+        self.add_argument('task', **kwargs).completer = completion_helpers.task
+
+    def file_argument(self):
+        self.add_argument(
+            'file', nargs="*", default=["stdout"],
+            help="Path to the file inside the task's sandbox."
+        ).completer = completion_helpers.file
+
+    def path_argument(self):
+        self.add_argument(
+            'path', type=str, nargs="?", default="",
+            help="""Path to view."""
+        ).completer = completion_helpers.file

--- a/paasta_tools/mesos/slave.py
+++ b/paasta_tools/mesos/slave.py
@@ -1,0 +1,115 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import print_function
+
+import urlparse
+
+import requests
+import requests.exceptions
+
+from . import exceptions
+from . import log
+from . import mesos_file
+from . import util
+from .cfg import CURRENT as CFG
+
+
+class MesosSlave(object):
+
+    def __init__(self, items):
+        self.__items = items
+
+    def __getitem__(self, name):
+        return self.__items[name]
+
+    def __str__(self):
+        return self.key()
+
+    def key(self):
+        return self["pid"].split('@')[-1]
+
+    @property
+    def host(self):
+        return "{0}://{1}:{2}".format(
+            CFG["scheme"],
+            self["hostname"],
+            self["pid"].split(":")[-1])
+
+    @log.duration
+    def fetch(self, url, **kwargs):
+        try:
+            return requests.get(urlparse.urljoin(
+                self.host, url), timeout=CFG["response_timeout"], **kwargs)
+        except requests.exceptions.ConnectionError:
+            raise exceptions.SlaveDoesNotExist(
+                "Unable to connect to the slave at {0}".format(self.host))
+
+    @util.CachedProperty(ttl=5)
+    def state(self):
+        return self.fetch("/slave(1)/state.json").json()
+
+    @property
+    def frameworks(self):
+        return util.merge(self.state, "frameworks", "completed_frameworks")
+
+    def task_executor(self, task_id):
+        for fw in self.frameworks:
+            for exc in util.merge(fw, "executors", "completed_executors"):
+                if task_id in list(map(
+                        lambda x: x["id"],
+                        util.merge(
+                            exc, "completed_tasks", "tasks", "queued_tasks"))):
+                    return exc
+        raise exceptions.MissingExecutor("No executor has a task by that id")
+
+    def file_list(self, path):
+        # The sandbox does not exist on the slave.
+        if path == "":
+            return []
+
+        resp = self.fetch("/files/browse.json", params={"path": path})
+        if resp.status_code == 404:
+            return []
+        return resp.json()
+
+    def file(self, task, path):
+        return mesos_file.File(self, task, path)
+
+    @util.CachedProperty(ttl=1)
+    def stats(self):
+        return self.fetch("/monitor/statistics.json").json()
+
+    def executor_stats(self, _id):
+        return list(filter(lambda x: x["executor_id"]))
+
+    def task_stats(self, _id):
+        eid = self.task_executor(_id)["id"]
+        stats = list(filter(
+            lambda x: x["executor_id"] == eid,
+            self.stats
+        ))
+
+        # Tasks that are not yet in a RUNNING state have no stats.
+        if len(stats) == 0:
+            return {}
+        else:
+            return stats[0]["statistics"]
+
+    @property
+    @util.memoize
+    def log(self):
+        return mesos_file.File(self, path="/slave/log")

--- a/paasta_tools/mesos/task.py
+++ b/paasta_tools/mesos/task.py
@@ -1,0 +1,107 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import print_function
+
+import datetime
+import os
+import re
+
+from . import exceptions
+from . import framework
+from . import mesos_file
+from . import util
+
+
+class Task(object):
+
+    cmd_re = re.compile("\(Command: (.+)\)")
+
+    def __init__(self, master, items):
+        self.master = master
+        self.__items = items
+
+    def __str__(self):
+        return "{0}:{1}".format(self.slave, self["id"])
+
+    def __getitem__(self, name):
+        return self.__items[name]
+
+    @property
+    def executor(self):
+        return self.slave.task_executor(self["id"])
+
+    @property
+    def framework(self):
+        return framework.Framework(self.master.framework(self["framework_id"]))
+
+    @util.CachedProperty()
+    def directory(self):
+        try:
+            return self.executor["directory"]
+        except exceptions.MissingExecutor:
+            return ""
+
+    @util.CachedProperty()
+    def slave(self):
+        return self.master.slave(self["slave_id"])
+
+    def file(self, path):
+        return mesos_file.File(self.slave, self, path)
+
+    def file_list(self, path):
+        return self.slave.file_list(os.path.join(self.directory, path))
+
+    @property
+    def stats(self):
+        try:
+            return self.slave.task_stats(self["id"])
+        except exceptions.MissingExecutor:
+            return {}
+
+    @property
+    def cpu_time(self):
+        st = self.stats
+        secs = st.get("cpus_user_time_secs", 0) + \
+            st.get("cpus_system_time_secs", 0)
+        # timedelta has a resolution of .000000 while mesos only keeps .00
+        return str(datetime.timedelta(seconds=secs)).rsplit(".", 1)[0]
+
+    @property
+    def cpu_limit(self):
+        return self.stats.get("cpus_limit", 0)
+
+    @property
+    def mem_limit(self):
+        return self.stats.get("mem_limit_bytes", 0)
+
+    @property
+    def rss(self):
+        return self.stats.get("mem_rss_bytes", 0)
+
+    @property
+    def command(self):
+        try:
+            result = self.cmd_re.search(self.executor["name"])
+        except exceptions.MissingExecutor:
+            result = None
+        if not result:
+            return "none"
+        return result.group(1)
+
+    @property
+    def user(self):
+        return self.framework.user

--- a/paasta_tools/mesos/util.py
+++ b/paasta_tools/mesos/util.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import print_function
+
+import functools
+import itertools
+import time
+
+
+def merge(obj, *keys):
+    return itertools.chain(*[obj[k] for k in keys])
+
+
+def iter_until(func, pre=lambda x: False, post=lambda x: False):
+    while 1:
+        val = func()
+        if pre(val):
+            break
+        yield val
+        if post(val):
+            break
+
+
+class CachedProperty(object):
+
+    def __init__(self, ttl=300):
+        self.ttl = ttl
+
+    def __call__(self, fget, doc=None):
+        self.fget = fget
+        self.__doc__ = doc or fget.__doc__
+        self.__name__ = fget.__name__
+        self.__module__ = fget.__module__
+        return self
+
+    def __get__(self, inst, owner):
+        try:
+            value, last_update = inst._cache[self.__name__]
+            if self.ttl > 0 and time.time() - last_update > self.ttl:
+                raise AttributeError
+        except (KeyError, AttributeError):
+            value = self.fget(inst)
+            try:
+                cache = inst._cache
+            except AttributeError:
+                cache = inst._cache = {}
+            cache[self.__name__] = (value, time.time())
+        return value
+
+
+def memoize(obj):
+    cache = obj.cache = {}
+
+    @functools.wraps(obj)
+    def memoizer(*args, **kwargs):
+        key = str(args) + str(kwargs)
+        if key not in cache:
+            cache[key] = obj(*args, **kwargs)
+        return cache[key]
+    return memoizer
+
+
+def humanize_bytes(b):
+    abbrevs = (
+        (1 << 30, 'GB'),
+        (1 << 20, 'MB'),
+        (1 << 10, 'kB'),
+        (1, 'B')
+    )
+    for factor, suffix in abbrevs:
+        if b >= factor:
+            break
+    return '%.*f %s' % (2, b / float(factor), suffix)

--- a/paasta_tools/mesos/zookeeper.py
+++ b/paasta_tools/mesos/zookeeper.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import print_function
+
+import contextlib
+
+import kazoo.client
+import kazoo.exceptions
+import kazoo.handlers.threading
+
+from . import log
+
+TIMEOUT = 1
+
+# Helper for testing
+client_class = kazoo.client.KazooClient
+
+
+@contextlib.contextmanager
+def client(*args, **kwargs):
+    zk = client_class(*args, **kwargs)
+    try:
+        zk.start(timeout=TIMEOUT)
+    except kazoo.handlers.threading.KazooTimeoutError:
+        log.fatal(
+            "Could not connect to zookeeper. " +
+            "Change your config via `mesos config master`")
+    try:
+        yield zk
+    finally:
+        zk.stop()
+        zk.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ kazoo==2.2
 lockfile==0.9.1
 marathon==0.8.5
 mccabe==0.3.1
-mesos.cli==0.1.5
 mesos.interface==0.28.0
 ordereddict==1.1
 path.py==8.1

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         'jsonschema[format]',
         'kazoo >= 2.0.0',
         'marathon >= 0.8.1',
-        'mesos.cli == 0.1.5',
         'mesos.interface == 0.28.0',
         'ordereddict >= 1.1',
         'path.py >= 8.1',


### PR DESCRIPTION
rather than forking, let's bring this into the paasta
project. This brings in everything that was needed for
the itests to pass - we'll save clearing out the bits we don't
need for the future.

Note that I've had to change [this](https://github.com/Yelp/paasta/compare/vendor-mesos-cli?expand=1#diff-b32f029cd959a6adcdcdb50bbdf326d2R43). I think I need to update the license at the top of the file to [make a note of what's changed?](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0))

itests pass locally for me. I'll iterate from here to try and pick out the bits that we actually need (but follow up with separate PRs)