### PR TITLE
upgrade chronos-python and remove catching socket exceptions

### DIFF
--- a/paasta_tools/check_chronos_jobs.py
+++ b/paasta_tools/check_chronos_jobs.py
@@ -8,11 +8,9 @@ a CRITICAL event to sensu.
 """
 import argparse
 import sys
-from socket import error as socket_error
 
 import chronos
 import pysensu_yelp
-from httplib2 import ServerNotFoundError
 
 from paasta_tools import chronos_tools
 from paasta_tools import monitoring_tools
@@ -221,7 +219,7 @@ def main():
                 message=sensu_output,
                 soa_dir=soa_dir,
             )
-    except (ServerNotFoundError, chronos.ChronosAPIError, socket_error) as e:
+    except (chronos.ChronosAPIError) as e:
         print(utils.PaastaColors.red("CRITICAL: Unable to contact Chronos! Error: %s" % e))
         sys.exit(2)
 

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -19,9 +19,8 @@ import sys
 from collections import Counter
 from collections import namedtuple
 from collections import OrderedDict
-from socket import error as socket_error
 
-from httplib2 import ServerNotFoundError
+import chronos
 from humanize import naturalsize
 from marathon.exceptions import MarathonError
 
@@ -626,7 +625,7 @@ def main():
         chronos_client = get_chronos_client(chronos_config)
         try:
             chronos_results = get_chronos_status(chronos_client)
-        except (ServerNotFoundError, socket_error) as e:
+        except (chronos.ChronosAPIError) as e:
             print(PaastaColors.red("CRITICAL: Unable to contact Chronos! Error: %s" % e))
             sys.exit(2)
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ backports.ssl-match-hostname==3.4.0.2
 blessings==1.6
 boto3==1.3.0
 bravado==8.3.0
-chronos-python==0.35.0
+chronos-python==0.36.0
 cookiecutter==1.4.0
 cryptography==1.4
 docker-py==1.2.3

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         # libs and pip can't seem to override it
         'argparse == 1.2.1',
         'bravado == 8.3.0',
-        'chronos-python == 0.35.0',
+        'chronos-python == 0.36.0',
         'cookiecutter == 1.4.0',
         'cryptography == 1.4',
         # Don't update this unless you have confirmed the client works with


### PR DESCRIPTION
closes internal PAASTA-6590

with the changes in [#24](https://github.com/asher/chronos-python/pull/24) we can now remove the checks for socket errors.