### PR TITLE
Add is_safe_to_drain logic to protect healthy instances

### DIFF
--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -45,6 +45,7 @@ from paasta_tools.monitoring import replication_utils
 from paasta_tools.utils import _log
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import datetime_from_utc_to_local
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import is_under_replicated
 from paasta_tools.utils import load_system_paasta_config
@@ -87,7 +88,7 @@ def parse_args():
     parser = argparse.ArgumentParser(epilog=epilog)
 
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
-                        default=marathon_tools.DEFAULT_SOA_DIR,
+                        default=DEFAULT_SOA_DIR,
                         help="define a different soa config directory")
     parser.add_argument('-v', '--verbose', action='store_true',
                         dest="verbose", default=False)
@@ -315,7 +316,7 @@ def check_service_replication(client, service, instance, cluster, soa_dir, syste
         )
 
 
-def load_smartstack_info_for_service(service, namespace, soa_dir, blacklist, system_paasta_config):
+def load_smartstack_info_for_service(service, namespace, blacklist, system_paasta_config, soa_dir=DEFAULT_SOA_DIR):
     """Retrives number of available backends for given services
 
     :param service_instances: A list of tuples of (service, instance)

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -791,7 +791,7 @@ def deformat_job_id(job_id):
     return decompose_job_id(job_id)
 
 
-def read_all_namespaces_for_service_instance(name, instance, cluster=None, soa_dir=DEFAULT_SOA_DIR):
+def read_all_namespaces_for_service_instance(service, instance, cluster=None, soa_dir=DEFAULT_SOA_DIR):
     """Retreive all registration namespaces for a particular service instance.
 
     For example, the 'main' paasta instance may register in the 'main'
@@ -804,13 +804,13 @@ def read_all_namespaces_for_service_instance(name, instance, cluster=None, soa_d
         cluster = load_system_paasta_config().get_cluster()
 
     marathon_service_config = load_marathon_service_config(
-        name, instance, cluster, load_deployments=False, soa_dir=soa_dir
+        service, instance, cluster, load_deployments=False, soa_dir=soa_dir
     )
 
     return marathon_service_config.get_registration_namespaces()
 
 
-def read_namespace_for_service_instance(name, instance, cluster=None, soa_dir=DEFAULT_SOA_DIR):
+def read_namespace_for_service_instance(service, instance, cluster=None, soa_dir=DEFAULT_SOA_DIR):
     """Retreive a service instance's primary registration namespace for a
     particular service instance.
 
@@ -819,7 +819,7 @@ def read_namespace_for_service_instance(name, instance, cluster=None, soa_dir=DE
     list of registration namespaces.
 
     If one is not defined in the config file, returns instance instead."""
-    return read_all_namespaces_for_service_instance(name, instance, cluster, soa_dir)[0]
+    return read_all_namespaces_for_service_instance(service, instance, cluster, soa_dir)[0]
 
 
 def get_proxy_port_for_instance(name, instance, cluster=None, soa_dir=DEFAULT_SOA_DIR):

--- a/paasta_tools/paasta_maintenance.py
+++ b/paasta_tools/paasta_maintenance.py
@@ -15,11 +15,21 @@
 import argparse
 import logging
 import sys
+import traceback
 from socket import getfqdn
+from socket import gethostbyname
 from socket import gethostname
 
 from paasta_tools import mesos_maintenance
-
+from paasta_tools import utils
+from paasta_tools.check_marathon_services_replication import load_smartstack_info_for_service
+from paasta_tools.marathon_tools import get_expected_instance_count_for_namespace
+from paasta_tools.marathon_tools import marathon_services_running_here
+from paasta_tools.marathon_tools import read_namespace_for_service_instance
+from paasta_tools.monitoring.replication_utils import backend_is_up
+from paasta_tools.monitoring.replication_utils import get_replication_for_services
+from paasta_tools.monitoring.replication_utils import ip_port_hostname_from_svname
+from paasta_tools.smartstack_tools import get_backends
 
 log = logging.getLogger(__name__)
 
@@ -104,8 +114,69 @@ def is_safe_to_drain(hostname):
     return not are_local_tasks_in_danger()
 
 
-def are_local_tasks_in_danger():
+def is_healthy_in_haproxy(local_port, backends):
+    local_ip = gethostbyname(gethostname())
+    for backend in backends:
+        ip, port, _ = ip_port_hostname_from_svname(backend['svname'])
+        if ip == local_ip and port == local_port:
+            if backend_is_up(backend):
+                log.debug("Found a healthy local backend: %s" % backend)
+                return True
+            else:
+                log.debug("Found a unhealthy local backend: %s" % backend)
+                return False
+    log.debug("Couldn't find any haproxy backend listening on %s" % local_port)
     return False
+
+
+def synapse_replication_is_low(service, instance, system_paasta_config, local_backends):
+    crit_threshold = 80
+    namespace = read_namespace_for_service_instance(service=service, instance=instance)
+    smartstack_replication_info = load_smartstack_info_for_service(
+        service=service,
+        namespace=namespace,
+        blacklist=[],
+        system_paasta_config=system_paasta_config,
+    )
+    expected_count = get_expected_instance_count_for_namespace(service=service, namespace=namespace)
+    expected_count_per_location = int(expected_count / len(smartstack_replication_info))
+    synapse_name = "%s.%s" % (service, namespace)
+    local_replication = get_replication_for_services(
+        synapse_host=system_paasta_config.get_default_synapse_host(),
+        synapse_port=system_paasta_config.get_synapse_port(),
+        synapse_haproxy_url_format=system_paasta_config.get_synapse_haproxy_url_format(),
+        services=[synapse_name],
+    )
+    num_available = local_replication.get(synapse_name, 0)
+    under_replicated, ratio = utils.is_under_replicated(
+        num_available, expected_count_per_location, crit_threshold)
+    log.info('Service %s.%s has %d out of %d expected instances' % (
+        service, instance, num_available, expected_count_per_location))
+    return under_replicated
+
+
+def are_local_tasks_in_danger():
+    try:
+        system_paasta_config = utils.load_system_paasta_config()
+        local_services = marathon_services_running_here()
+        local_backends = get_backends(
+            service=None,
+            synapse_host=system_paasta_config.get_default_synapse_host(),
+            synapse_port=system_paasta_config.get_synapse_port(),
+            synapse_haproxy_url_format=system_paasta_config.get_synapse_haproxy_url_format()
+        )
+        for service, instance, port in local_services:
+            log.info("Inspecting %s.%s on %s" % (service, instance, port))
+            if is_healthy_in_haproxy(port, local_backends) and \
+               synapse_replication_is_low(service, instance, system_paasta_config, local_backends=local_backends):
+                log.warning("%s.%s on port %s is healthy but the service is in danger!" % (
+                    service, instance, port
+                ))
+                return True
+        return False
+    except Exception:
+        log.warning(traceback.format_exc())
+        return False
 
 
 def paasta_maintenance():

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1484,7 +1484,7 @@ def is_under_replicated(num_available, expected_count, crit_threshold):
     else:
         ratio = (num_available / float(expected_count)) * 100
 
-    if ratio < crit_threshold:
+    if ratio < int(crit_threshold):
         return (True, ratio)
     else:
         return (False, ratio)

--- a/tests/test_paasta_maintenance.py
+++ b/tests/test_paasta_maintenance.py
@@ -59,3 +59,132 @@ def test_is_hostname_local_works(
     assert paasta_maintenance.is_hostname_local('foo') is True
     assert paasta_maintenance.is_hostname_local('foo.bar') is True
     assert paasta_maintenance.is_hostname_local('something_different') is False
+
+
+@mock.patch('paasta_tools.paasta_maintenance.utils.load_system_paasta_config', autospec=True)
+def test_are_local_tasks_in_danger_fails_safe_with_false(
+    mock_load_system_paasta_config,
+):
+    """If something unexpected happens that we don't know how to
+    interpret, we make sure that we fail with "False" so that processes
+    move on and don't deadlock. In general the answer to "is it safe to drain"
+    is "yes" if mesos can't be reached, etc"""
+    mock_load_system_paasta_config.side_effect = Exception
+    assert paasta_maintenance.are_local_tasks_in_danger() is False
+
+
+@mock.patch('paasta_tools.paasta_maintenance.utils.load_system_paasta_config', autospec=True)
+@mock.patch('paasta_tools.paasta_maintenance.marathon_services_running_here', autospec=True)
+def test_are_local_tasks_in_danger_is_false_with_nothing_running(
+    mock_marathon_services_running_here,
+    mock_load_system_paasta_config,
+):
+    mock_marathon_services_running_here.return_value = []
+    assert paasta_maintenance.are_local_tasks_in_danger() is False
+
+
+@mock.patch('paasta_tools.paasta_maintenance.utils.load_system_paasta_config', autospec=True)
+@mock.patch('paasta_tools.paasta_maintenance.marathon_services_running_here', autospec=True)
+@mock.patch('paasta_tools.paasta_maintenance.get_backends', autospec=True)
+@mock.patch('paasta_tools.paasta_maintenance.is_healthy_in_haproxy', autospec=True)
+def test_are_local_tasks_in_danger_is_false_with_an_unhealthy_service(
+    mock_is_healthy_in_haproxy,
+    mock_get_backends,
+    mock_marathon_services_running_here,
+    mock_load_system_paasta_config,
+):
+    mock_is_healthy_in_haproxy.return_value = False
+    mock_marathon_services_running_here.return_value = [("service", "instance", 42)]
+    assert paasta_maintenance.are_local_tasks_in_danger() is False
+    mock_is_healthy_in_haproxy.assert_called_once_with(42, mock.ANY)
+
+
+@mock.patch('paasta_tools.paasta_maintenance.utils.load_system_paasta_config', autospec=True)
+@mock.patch('paasta_tools.paasta_maintenance.marathon_services_running_here', autospec=True)
+@mock.patch('paasta_tools.paasta_maintenance.get_backends', autospec=True)
+@mock.patch('paasta_tools.paasta_maintenance.is_healthy_in_haproxy', autospec=True)
+@mock.patch('paasta_tools.paasta_maintenance.synapse_replication_is_low', autospec=True)
+def test_are_local_tasks_in_danger_is_true_with_an_healthy_service_in_danger(
+    mock_synapse_replication_is_low,
+    mock_is_healthy_in_haproxy,
+    mock_get_backends,
+    mock_marathon_services_running_here,
+    mock_load_system_paasta_config,
+):
+    mock_is_healthy_in_haproxy.return_value = True
+    mock_synapse_replication_is_low.return_value = True
+    mock_marathon_services_running_here.return_value = [("service", "instance", 42)]
+    assert paasta_maintenance.are_local_tasks_in_danger() is True
+    mock_is_healthy_in_haproxy.assert_called_once_with(42, mock.ANY)
+    assert mock_synapse_replication_is_low.call_count == 1
+
+
+@mock.patch('paasta_tools.paasta_maintenance.read_namespace_for_service_instance', autospec=True)
+@mock.patch('paasta_tools.paasta_maintenance.load_smartstack_info_for_service', autospec=True)
+@mock.patch('paasta_tools.paasta_maintenance.get_expected_instance_count_for_namespace', autospec=True)
+@mock.patch('paasta_tools.paasta_maintenance.get_replication_for_services', autospec=True)
+def test_synapse_replication_is_low_understands_underreplicated_services(
+    mock_get_replication_for_services,
+    mock_get_expected_instance_count_for_namespace,
+    mock_load_smartstack_info_for_service,
+    mock_read_namespace_for_service_instance,
+):
+    mock_read_namespace_for_service_instance.return_value = "main"
+    mock_get_expected_instance_count_for_namespace.return_value = 3
+    mock_load_smartstack_info_for_service.return_value = {
+        "local_region": {"service.main": "up"}
+    }
+    mock_get_replication_for_services.return_value = {"service.main": 1}
+    local_backends = ["foo"]
+    system_paasta_config = mock.MagicMock()
+    assert paasta_maintenance.synapse_replication_is_low(
+        service='service',
+        instance='instance',
+        system_paasta_config=system_paasta_config,
+        local_backends=local_backends,
+    ) is True
+
+
+@mock.patch('paasta_tools.paasta_maintenance.gethostbyname', autospec=True)
+def test_is_healthy_in_harproxy_healthy_path(
+    mock_gethostbyname
+):
+    mock_gethostbyname.return_value = '192.0.2.1'
+    local_port = 42
+    backends = [
+        {'status': 'UP', 'pxname': 'service.main', 'svname': '192.0.2.1:42_hostname'}
+    ]
+    assert paasta_maintenance.is_healthy_in_haproxy(
+        local_port=local_port,
+        backends=backends,
+    ) is True
+
+
+@mock.patch('paasta_tools.paasta_maintenance.gethostbyname', autospec=True)
+def test_is_healthy_in_haproxy_unhealthy_path(
+    mock_gethostbyname
+):
+    mock_gethostbyname.return_value = '192.0.2.1'
+    local_port = 42
+    backends = [
+        {'status': 'DOWN', 'pxname': 'service.main', 'svname': '192.0.2.1:42_hostname'}
+    ]
+    assert paasta_maintenance.is_healthy_in_haproxy(
+        local_port=local_port,
+        backends=backends,
+    ) is False
+
+
+@mock.patch('paasta_tools.paasta_maintenance.gethostbyname', autospec=True)
+def test_is_healthy_in_haproxy_missing_backend_entirely(
+    mock_gethostbyname
+):
+    mock_gethostbyname.return_value = '192.0.2.1'
+    local_port = 42
+    backends = [
+        {'status': 'DOWN', 'pxname': 'service.main', 'svname': '192.0.2.4:666_otherhostname'}
+    ]
+    assert paasta_maintenance.is_healthy_in_haproxy(
+        local_port=local_port,
+        backends=backends,
+    ) is False


### PR DESCRIPTION
I would like to get this code out for early review.

No, there are not tests, it is mostly me experimenting with all the different smartstack replication-related stuff and putting them together in a "slave-centric" way.

I tried to reuse as many of the existing functions I could to extract the data I need.