### PR TITLE
remove import-time config loading in mesos-cli

### DIFF
--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -18,10 +18,8 @@ import mock
 from behave import given
 from behave import then
 from behave import when
-from itest_utils import get_service_connection_string
 from marathon import MarathonHttpError
 
-import paasta_tools.mesos.master
 from paasta_tools import bounce_lib
 from paasta_tools import drain_lib
 from paasta_tools import marathon_tools
@@ -138,11 +136,6 @@ def when_there_are_num_which_tasks(context, num, which, state):
 
 @when(u'setup_service is initiated')
 def when_setup_service_initiated(context):
-    config = {
-        'master': '%s' % get_service_connection_string('mesosmaster'),
-        'scheme': 'http',
-        'response_timeout': 5,
-    }
     with contextlib.nested(
         mock.patch(
             'paasta_tools.bounce_lib.get_happy_tasks',
@@ -161,7 +154,6 @@ def when_setup_service_initiated(context):
         mock.patch('paasta_tools.marathon_tools.get_code_sha_from_dockerurl', autospec=True, return_value='newapp'),
         mock.patch('paasta_tools.marathon_tools.get_docker_url', autospec=True, return_value='busybox'),
         mock.patch('paasta_tools.mesos_maintenance.load_credentials', autospec=True),
-        mock.patch.object(paasta_tools.mesos.master, 'CFG', config),
     ) as (
         _,
         _,
@@ -173,7 +165,6 @@ def when_setup_service_initiated(context):
         _,
         _,
         mock_load_credentials,
-        _,
     ):
         mock_load_credentials.side_effect = mesos_maintenance.load_credentials(mesos_secrets='/etc/mesos-slave-secret')
         mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value=context.cluster)

--- a/paasta_itests/steps/cleanup_marathon_job_steps.py
+++ b/paasta_itests/steps/cleanup_marathon_job_steps.py
@@ -43,10 +43,8 @@ def delete_apps(context, job_id, cluster_name):
 @then(u'we run cleanup_marathon_apps{flags} which exits with return code "{expected_return_code}"')
 def run_cleanup_marathon_job(context, flags, expected_return_code):
     cmd = '../paasta_tools/cleanup_marathon_jobs.py --soa-dir %s %s' % (context.soa_dir, flags)
-    env = dict(os.environ)
-    env['MESOS_CLI_CONFIG'] = '/nail/etc/mesos-cli.json'  # context.mesos_cli_config_filename
-    print 'Running cmd %s with MESOS_CLI_CONFIG=%s' % (cmd, env['MESOS_CLI_CONFIG'])
-    exit_code, output = _run(cmd, env=env)
+    print 'Running cmd %s' % (cmd)
+    exit_code, output = _run(cmd)
     print output
 
     assert exit_code == int(expected_return_code)

--- a/paasta_itests/steps/paasta_metastatus_steps.py
+++ b/paasta_itests/steps/paasta_metastatus_steps.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-
 import itest_utils
 from behave import then
 from behave import when
@@ -83,10 +81,8 @@ def check_metastatus_return_code_with_flags(context, flags, expected_return_code
     # default it will check every cluster. This is also the way sensu invokes
     # this check.
     cmd = '../paasta_tools/paasta_metastatus.py%s' % flags
-    env = dict(os.environ)
-    env['MESOS_CLI_CONFIG'] = context.mesos_cli_config_filename
-    print 'Running cmd %s with MESOS_CLI_CONFIG=%s' % (cmd, env['MESOS_CLI_CONFIG'])
-    exit_code, output = _run(cmd, env=env)
+    print 'Running cmd %s' % (cmd)
+    exit_code, output = _run(cmd)
 
     # we don't care about the colouring here, so remove any ansi escape sequences
     escaped_output = remove_ansi_escape_sequences(output)

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -21,7 +21,6 @@ from itest_utils import get_service_connection_string
 from itest_utils import update_context_marathon_config
 from marathon.exceptions import MarathonHttpError
 
-import paasta_tools.mesos.master
 from paasta_tools import marathon_tools
 from paasta_tools import mesos_maintenance
 from paasta_tools import setup_marathon_job
@@ -87,18 +86,11 @@ def set_number_instances(context, number):
 
 @when(u'we run setup_marathon_job until it has {number:d} task(s)')
 def run_until_number_tasks(context, number):
-    config = {
-        'master': '%s' % get_service_connection_string('mesosmaster'),
-        'scheme': 'http',
-        'response_timeout': 5,
-    }
     for _ in xrange(20):
         with contextlib.nested(
             mock.patch('paasta_tools.mesos_maintenance.load_credentials', autospec=True),
-            mock.patch.object(paasta_tools.mesos.master, 'CFG', config),
         ) as (
             mock_load_credentials,
-            _,
         ):
             mock_load_credentials.side_effect = mesos_maintenance.load_credentials(
                 mesos_secrets='/etc/mesos-slave-secret',
@@ -147,17 +139,10 @@ def mark_host_running_on_at_risk(context):
 def mark_host_at_risk(context, host):
     start = mesos_maintenance.datetime_to_nanoseconds(mesos_maintenance.now())
     duration = mesos_maintenance.parse_timedelta('1h')
-    config = {
-        'master': '%s' % get_service_connection_string('mesosmaster'),
-        'scheme': 'http',
-        'response_timeout': 5,
-    }
     with contextlib.nested(
         mock.patch('paasta_tools.mesos_maintenance.load_credentials', autospec=True),
-        mock.patch.object(paasta_tools.mesos.master, 'CFG', config),
     ) as (
         mock_load_credentials,
-        _,
     ):
         mock_load_credentials.side_effect = mesos_maintenance.load_credentials(mesos_secrets='/etc/mesos-slave-secret')
         mesos_maintenance.drain([host], start, duration)

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -128,9 +128,7 @@ def working_paasta_cluster(context):
         print 'Chronos connection already established'
 
     mesos_cli_config = _generate_mesos_cli_config(_get_zookeeper_connection_string('mesos-testcluster'))
-    context.mesos_cli_config_filename = write_mesos_cli_config(mesos_cli_config)
-    import paasta_tools.mesos as mesos
-    mesos.cfg.CURRENT.load()
+    mesos_cli_config_filename = write_mesos_cli_config(mesos_cli_config)
     context.tag_version = 0
     write_etc_paasta(context, {'marathon_config': context.marathon_config}, 'marathon.json')
     write_etc_paasta(context, {'chronos_config': context.chronos_config}, 'chronos.json')
@@ -148,6 +146,11 @@ def working_paasta_cluster(context):
             {'hostPath': u'/nail/etc/boop', 'containerPath': '/nail/etc/boop', 'mode': 'RO'},
         ]
     }, 'volumes.json')
+    write_etc_paasta(context, {
+        'mesos_config': {
+            "path": mesos_cli_config_filename
+        }
+    }, 'mesos.json')
 
 
 @given(u'we have yelpsoa-configs for the service "{service}" with {disabled} scheduled chronos instance "{instance}"')

--- a/paasta_tools/mesos/cfg.py
+++ b/paasta_tools/mesos/cfg.py
@@ -47,7 +47,8 @@ class Config(object):
         "/usr/local/etc"
     ]]
 
-    def __init__(self):
+    def __init__(self, config_path):
+        self.config_path = config_path
         self.__items = {self._default_profile: self.DEFAULTS}
         self["profile"] = self._default_profile
 
@@ -92,7 +93,7 @@ class Config(object):
 
     def load(self):
         try:
-            with open(self._get_path(), 'rt') as f:
+            with open(self.config_path, 'rt') as f:
                 try:
                     data = json.load(f)
                 except ValueError as e:
@@ -108,5 +109,3 @@ class Config(object):
     def save(self):
         with open(self._get_path(), "wb") as f:
             f.write(str(self))
-
-CURRENT = Config()

--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -39,7 +39,6 @@ from . import slave
 from . import task
 from . import util
 from . import zookeeper
-from .cfg import CURRENT as CFG
 
 ZOOKEEPER_TIMEOUT = 1
 
@@ -55,22 +54,25 @@ MULTIPLE_SLAVES = "There are multiple slaves with that id. Please choose one: "
 
 class MesosMaster(object):
 
+    def __init__(self, config):
+        self.config = config
+
     def __str__(self):
         return "<master: {0}>".format(self.key())
 
     def key(self):
-        return CFG["master"]
+        return self.config["master"]
 
     @util.CachedProperty()
     def host(self):
-        return "{0}://{1}".format(CFG["scheme"], self.resolve(CFG["master"]))
+        return "{0}://{1}".format(self.config["scheme"], self.resolve(self.config["master"]))
 
     @log.duration
     def fetch(self, url, **kwargs):
         try:
             return requests.get(
                 urlparse.urljoin(self.host, url),
-                timeout=CFG["response_timeout"],
+                timeout=self.config["response_timeout"],
                 **kwargs)
         except requests.exceptions.ConnectionError:
             log.fatal(MISSING_MASTER.format(self.host))
@@ -229,5 +231,3 @@ class MesosMaster(object):
     @util.memoize
     def log(self):
         return mesos_file.File(self, path="/master/log")
-
-CURRENT = MesosMaster()

--- a/paasta_tools/mesos/slave.py
+++ b/paasta_tools/mesos/slave.py
@@ -25,12 +25,12 @@ from . import exceptions
 from . import log
 from . import mesos_file
 from . import util
-from .cfg import CURRENT as CFG
 
 
 class MesosSlave(object):
 
-    def __init__(self, items):
+    def __init__(self, config, items):
+        self.config = config
         self.__items = items
 
     def __getitem__(self, name):
@@ -45,7 +45,7 @@ class MesosSlave(object):
     @property
     def host(self):
         return "{0}://{1}:{2}".format(
-            CFG["scheme"],
+            self.config["scheme"],
             self["hostname"],
             self["pid"].split(":")[-1])
 
@@ -53,7 +53,7 @@ class MesosSlave(object):
     def fetch(self, url, **kwargs):
         try:
             return requests.get(urlparse.urljoin(
-                self.host, url), timeout=CFG["response_timeout"], **kwargs)
+                self.host, url), timeout=self.config["response_timeout"], **kwargs)
         except requests.exceptions.ConnectionError:
             raise exceptions.SlaveDoesNotExist(
                 "Unable to connect to the slave at {0}".format(self.host))

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -970,6 +970,13 @@ class SystemPaastaConfig(dict):
         except KeyError:
             return {}
 
+    def get_mesos_cli_config(self):
+        """Get the config for mesos-cli
+
+        :returns: The mesos cli config
+        """
+        return self.get("mesos_config", {})
+
 
 def _run(command, env=os.environ, timeout=None, log=False, stream=False, stdin=None, **kwargs):
     """Given a command, run it. Return a tuple of the return code and any


### PR DESCRIPTION
closes #484

previously we had hacks around the codebase to ensure
that environment variables were set before importing
mesos-cli because of it's load-at-import-time behaviour.
This removes that, and makes the configuration a parameter
to the constructor methods of those objects in mesos-cli
that use them.

to do this, I've added a new ``mesos_config`` config dict to the
system paasta config, wherein the operator can declare a 'path'
variable defining the path to the mesos-cli config. Right now,
I've added in a default to the current location, which points at
the previously hardcoded ``/nail/etc/mesos-cli.json``.
In future, it'd be nice if we didn't have such a file at all, and instead
created the config in this same ``mesos_config`` dict, but this is a
reasonable first step.

Finally, I've removed the unused ``by_fn`` and ``by_slave`` functions
that were part of the ``parallel`` module in mesos-cli.