### PR TITLE
Make setup_marathon_job dynamically reserve resources

### DIFF
--- a/paasta_itests/environment.py
+++ b/paasta_itests/environment.py
@@ -29,8 +29,8 @@ from kazoo.exceptions import NoNodeError
 
 from paasta_tools import marathon_tools
 from paasta_tools import mesos_tools
-from paasta_tools.paasta_maintenance import load_credentials
-from paasta_tools.paasta_maintenance import undrain
+from paasta_tools.mesos_maintenance import load_credentials
+from paasta_tools.mesos_maintenance import undrain
 
 
 def before_all(context):
@@ -134,15 +134,15 @@ def _clean_up_maintenance(context):
     """If a host is marked as draining/down for maintenance, bring it back up"""
     if hasattr(context, 'at_risk_host'):
         with contextlib.nested(
-            mock.patch('paasta_tools.paasta_maintenance.get_principal', autospec=True),
-            mock.patch('paasta_tools.paasta_maintenance.get_secret', autospec=True),
+            mock.patch('paasta_tools.mesos_maintenance.get_principal', autospec=True),
+            mock.patch('paasta_tools.mesos_maintenance.get_secret', autospec=True),
         ) as (
             mock_get_principal,
             mock_get_secret,
         ):
             credentials = load_credentials(mesos_secrets='/etc/mesos-slave-secret')
-            mock_get_principal.return_value = credentials[0]
-            mock_get_secret.return_value = credentials[1]
+            mock_get_principal.return_value = credentials.principal
+            mock_get_secret.return_value = credentials.secret
             undrain([context.at_risk_host])
             del context.at_risk_host
 
@@ -150,6 +150,7 @@ def _clean_up_maintenance(context):
 def after_scenario(context, scenario):
     _clean_up_marathon_apps(context)
     _clean_up_chronos_jobs(context)
+    _clean_up_maintenance(context)
     _clean_up_mesos_cli_config(context)
     _clean_up_soa_dir(context)
     _clean_up_zookeeper_autoscaling(context)

--- a/paasta_itests/setup_marathon_job.feature
+++ b/paasta_itests/setup_marathon_job.feature
@@ -32,13 +32,15 @@ Feature: setup_marathon_job can create a "complete" app
     Given a working paasta cluster
       And a new healthy app to be deployed, with bounce strategy "crossover" and drain method "noop" and constraints [["hostname", "UNIQUE"]]
       And an old app to be destroyed with constraints [["hostname", "UNIQUE"]]
-     When there are 2 old healthy tasks
+     When there are exactly 2 old healthy tasks
      When setup_service is initiated
-      And there are 2 new healthy tasks
+      And there are exactly 2 new healthy tasks
      When we mark a host it is running on as at-risk
      When setup_service is initiated
-      And there are 3 new healthy tasks
+      And there are exactly 3 new healthy tasks
       And we wait a bit for the old app to disappear
+      And setup_service is initiated
+      And there are exactly 2 new healthy tasks
      Then the old app should be gone
       And there should be 0 tasks on that at-risk host
 
@@ -46,10 +48,11 @@ Feature: setup_marathon_job can create a "complete" app
     Given a working paasta cluster
       And a new healthy app to be deployed, with bounce strategy "crossover" and drain method "noop" and constraints [["hostname", "UNIQUE"]]
      When setup_service is initiated
-      And there are 2 new healthy tasks
+      And there are exactly 2 new healthy tasks
      When we mark a host it is running on as at-risk
      When setup_service is initiated
-      And there are 3 new healthy tasks
+      And there are exactly 3 new healthy tasks
      When setup_service is initiated
-      And there are 2 new healthy tasks
+      And there are exactly 2 new healthy tasks
+      And setup_service is initiated
      Then there should be 0 tasks on that at-risk host

--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -170,9 +170,8 @@ def when_setup_service_initiated(context):
         mock.patch('paasta_tools.marathon_tools.get_config_hash', autospec=True, return_value='confighash'),
         mock.patch('paasta_tools.marathon_tools.get_code_sha_from_dockerurl', autospec=True, return_value='newapp'),
         mock.patch('paasta_tools.marathon_tools.get_docker_url', autospec=True, return_value='busybox'),
-        mock.patch('paasta_tools.paasta_maintenance.get_principal', autospec=True),
-        mock.patch('paasta_tools.paasta_maintenance.get_secret', autospec=True),
-        mock.patch.object(mesos.cli.master, 'CFG', config),
+        mock.patch('paasta_tools.mesos_maintenance.get_principal', autospec=True),
+        mock.patch('paasta_tools.mesos_maintenance.get_secret', autospec=True),
     ) as (
         _,
         _,
@@ -185,11 +184,10 @@ def when_setup_service_initiated(context):
         _,
         mock_get_principal,
         mock_get_secret,
-        _,
     ):
-        credentials = paasta_maintenance.load_credentials(mesos_secrets='/etc/mesos-slave-secret')
-        mock_get_principal.return_value = credentials[0]
-        mock_get_secret.return_value = credentials[1]
+        credentials = mesos_maintenance.load_credentials(mesos_secrets='/etc/mesos-slave-secret')
+        mock_get_principal.return_value = credentials.principal
+        mock_get_secret.return_value = credentials.secret
         mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value=context.cluster)
         # 120 * 0.5 = 60 seconds
         for _ in xrange(120):

--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -172,7 +172,9 @@ def when_setup_service_initiated(context):
         mock.patch('paasta_tools.marathon_tools.get_config_hash', autospec=True, return_value='confighash'),
         mock.patch('paasta_tools.marathon_tools.get_code_sha_from_dockerurl', autospec=True, return_value='newapp'),
         mock.patch('paasta_tools.marathon_tools.get_docker_url', autospec=True, return_value='busybox'),
-        mock.patch('paasta_tools.mesos_maintenance.load_credentials', autospec=True),
+        mock.patch('paasta_tools.paasta_maintenance.get_principal', autospec=True),
+        mock.patch('paasta_tools.paasta_maintenance.get_secret', autospec=True),
+        mock.patch.object(mesos.cli.master, 'CFG', config),
     ) as (
         _,
         _,
@@ -183,9 +185,13 @@ def when_setup_service_initiated(context):
         _,
         _,
         _,
-        mock_load_credentials,
+        mock_get_principal,
+        mock_get_secret,
+        _,
     ):
-        mock_load_credentials.side_effect = mesos_maintenance.load_credentials(mesos_secrets='/etc/mesos-slave-secret')
+        credentials = paasta_maintenance.load_credentials(mesos_secrets='/etc/mesos-slave-secret')
+        mock_get_principal.return_value = credentials[0]
+        mock_get_secret.return_value = credentials[1]
         mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value=context.cluster)
         # 120 * 0.5 = 60 seconds
         for _ in xrange(120):

--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -131,8 +131,6 @@ def there_are_num_which_tasks(context, num, which, state, exact):
     for _ in xrange(120):
         app = context.marathon_client.get_app(app_id, embed_tasks=True)
         happy_tasks = get_happy_tasks(app, context.service, "fake_nerve_ns", context.system_paasta_config)
-        for task in happy_tasks:
-            print "Happy Task: %s" % task
         happy_count = len(happy_tasks)
         if state == "healthy":
             if exact:

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -162,4 +162,4 @@ def tasks_on_host_drained(context, number, host):
     for task in tasks:
         if task.host == host:
             count += 1
-    return count == number
+    assert count == number

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -140,12 +140,18 @@ def mark_host_at_risk(context, host):
     start = mesos_maintenance.datetime_to_nanoseconds(mesos_maintenance.now())
     duration = mesos_maintenance.parse_timedelta('1h')
     with contextlib.nested(
-        mock.patch('paasta_tools.mesos_maintenance.load_credentials', autospec=True),
+        mock.patch.object(mesos.cli.master, 'CFG', config),
+        mock.patch('paasta_tools.paasta_maintenance.get_principal', autospec=True),
+        mock.patch('paasta_tools.paasta_maintenance.get_secret', autospec=True),
     ) as (
-        mock_load_credentials,
+        _,
+        mock_get_principal,
+        mock_get_secret,
     ):
-        mock_load_credentials.side_effect = mesos_maintenance.load_credentials(mesos_secrets='/etc/mesos-slave-secret')
-        mesos_maintenance.drain([host], start, duration)
+        credentials = paasta_maintenance.load_credentials(mesos_secrets='/etc/mesos-slave-secret')
+        mock_get_principal.return_value = credentials[0]
+        mock_get_secret.return_value = credentials[1]
+        paasta_maintenance.drain([host], start, duration)
         context.at_risk_host = host
 
 

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -140,18 +140,16 @@ def mark_host_at_risk(context, host):
     start = mesos_maintenance.datetime_to_nanoseconds(mesos_maintenance.now())
     duration = mesos_maintenance.parse_timedelta('1h')
     with contextlib.nested(
-        mock.patch.object(mesos.cli.master, 'CFG', config),
-        mock.patch('paasta_tools.paasta_maintenance.get_principal', autospec=True),
-        mock.patch('paasta_tools.paasta_maintenance.get_secret', autospec=True),
+        mock.patch('paasta_tools.mesos_maintenance.get_principal', autospec=True),
+        mock.patch('paasta_tools.mesos_maintenance.get_secret', autospec=True),
     ) as (
-        _,
         mock_get_principal,
         mock_get_secret,
     ):
-        credentials = paasta_maintenance.load_credentials(mesos_secrets='/etc/mesos-slave-secret')
-        mock_get_principal.return_value = credentials[0]
-        mock_get_secret.return_value = credentials[1]
-        paasta_maintenance.drain([host], start, duration)
+        credentials = mesos_maintenance.load_credentials(mesos_secrets='/etc/mesos-slave-secret')
+        mock_get_principal.return_value = credentials.principal
+        mock_get_secret.return_value = credentials.secret
+        mesos_maintenance.drain([host], start, duration)
         context.at_risk_host = host
 
 

--- a/paasta_tools/mesos_maintenance.py
+++ b/paasta_tools/mesos_maintenance.py
@@ -271,7 +271,7 @@ def build_start_maintenance_payload(hostnames):
     return get_machine_ids(hostnames)
 
 
-def hostnames_to_componenets(hostnames, resolve=False):
+def hostnames_to_components(hostnames, resolve=False):
     """Converts a list of 'host[|ip]' entries into namedtuples containing 'host' and 'ip' attributes,
     optionally performing a DNS lookup to resolve the hostname into an IP address
     :param hostnames: a list of hostnames where each hostname can be of the form 'host[|ip]'
@@ -298,7 +298,7 @@ def get_machine_ids(hostnames):
     :returns: a dictionary representing the list of machines to bring up/down for maintenance
     """
     machine_ids = []
-    components = hostnames_to_componenets(hostnames, resolve=True)
+    components = hostnames_to_components(hostnames, resolve=True)
     for component in components:
         machine_id = {
             'hostname': component.host,
@@ -458,7 +458,7 @@ def unreserve(slave_id, resources):
 def reserve_all_resources(hostnames):
     mesos_state = get_mesos_master().state_summary()
     hosts = []
-    components = hostnames_to_componenets(hostnames)
+    components = hostnames_to_components(hostnames)
     for component in components:
         hosts.append(component.host)
     for slave in mesos_state['slaves']:
@@ -482,7 +482,7 @@ def reserve_all_resources(hostnames):
 def unreserve_all_resources(hostnames):
     mesos_state = get_mesos_master().state_summary()
     hosts = []
-    components = hostnames_to_componenets(hostnames)
+    components = hostnames_to_components(hostnames)
     for component in components:
         hosts.append(component.host)
     for slave in mesos_state['slaves']:

--- a/paasta_tools/mesos_maintenance.py
+++ b/paasta_tools/mesos_maintenance.py
@@ -58,8 +58,8 @@ def base_api():
             )
             resp.raise_for_status()
             return resp
-        except HTTPError as e:
-            e.msg = "Error executing API request calling %s. Got error: %s" % (url, e.msg)
+        except HTTPError:
+            log.debug("Error executing API request calling %s." % url)
             raise
     return execute_request
 
@@ -143,8 +143,8 @@ def schedule():
     """
     try:
         schedule = get_maintenance_schedule()
-    except HTTPError as e:
-        e.msg = "Error getting maintenance schedule. Got error: %s" % e.msg
+    except HTTPError:
+        log.debug("Error getting maintenance schedule.")
         raise
     return schedule.text
 
@@ -158,12 +158,12 @@ def get_hosts_with_state(state):
     """
     try:
         status = get_maintenance_status().json()
-    except HTTPError as e:
-        e.msg = "Error getting maintenance status. Got error: %s" % e.msg
+    except HTTPError:
+        log.debug("Error getting maintenance status.")
         raise
     if not status or state not in status:
         return []
-    return [machine['id']['hostname'] for machine in status[state]]
+    return [machine['hostname'] for machine in status[state]]
 
 
 def get_draining_hosts():
@@ -429,8 +429,8 @@ def reserve(slave_id, resources):
     client_fn = reserve_api()
     try:
         reserve_output = client_fn(method="POST", endpoint="", data=payload).text
-    except HTTPError as e:
-        e.msg = "Error adding dynamic reservation. Got error: %s" % e.msg
+    except HTTPError:
+        log.debug("Error adding dynamic reservation.")
         raise
     return reserve_output
 
@@ -449,8 +449,8 @@ def unreserve(slave_id, resources):
     client_fn = unreserve_api()
     try:
         unreserve_output = client_fn(method="POST", endpoint="", data=payload).text
-    except HTTPError as e:
-        e.msg = "Error adding dynamic unreservation. Got error: %s" % e.msg
+    except HTTPError:
+        log.debug("Error adding dynamic unreservation.")
         raise
     return unreserve_output
 
@@ -515,8 +515,8 @@ def drain(hostnames, start, duration):
     client_fn = get_schedule_client()
     try:
         drain_output = client_fn(method="POST", endpoint="", data=json.dumps(payload)).text
-    except HTTPError as e:
-        e.msg = "Error performing maintenance drain. Got error: %s" % e.msg
+    except HTTPError:
+        log.debug("Error performing maintenance drain.")
         raise
     return drain_output
 
@@ -533,8 +533,8 @@ def undrain(hostnames):
     client_fn = get_schedule_client()
     try:
         undrain_output = client_fn(method="POST", endpoint="", data=json.dumps(payload)).text
-    except HTTPError as e:
-        e.msg = "Error performing maintenance undrain. Got error: %s" % e.msg
+    except HTTPError:
+        log.debug("Error performing maintenance undrain.")
         raise
     return undrain_output
 
@@ -549,8 +549,8 @@ def down(hostnames):
     client_fn = master_api()
     try:
         down_output = client_fn(method="POST", endpoint="/machine/down", data=json.dumps(payload)).text
-    except HTTPError as e:
-        e.msg = "Error performing maintenance down. Got error: %s" % e.msg
+    except HTTPError:
+        log.debug("Error performing maintenance down.")
         raise
     return down_output
 
@@ -565,8 +565,8 @@ def up(hostnames):
     client_fn = master_api()
     try:
         up_output = client_fn(method="POST", endpoint="/machine/up", data=json.dumps(payload)).text
-    except HTTPError as e:
-        e.msg = "Error performing maintenance up. Got error: %s" % e.msg
+    except HTTPError:
+        log.debug("Error performing maintenance up.")
         raise
     return up_output
 
@@ -578,8 +578,8 @@ def status():
     """
     try:
         status = get_maintenance_status()
-    except HTTPError as e:
-        e.msg = "Error performing maintenance status. Got error: %s" % e.msg
+    except HTTPError:
+        log.debug("Error performing maintenance status.")
         raise
     return status.text
 

--- a/paasta_tools/mesos_maintenance.py
+++ b/paasta_tools/mesos_maintenance.py
@@ -163,7 +163,10 @@ def get_hosts_with_state(state):
         raise
     if not status or state not in status:
         return []
-    return [machine['hostname'] for machine in status[state]]
+    if 'id' in status[state][0]:
+        return [machine['id']['hostname'] for machine in status[state]]
+    else:
+        return [machine['hostname'] for machine in status[state]]
 
 
 def get_draining_hosts():

--- a/paasta_tools/paasta_maintenance.py
+++ b/paasta_tools/paasta_maintenance.py
@@ -15,19 +15,21 @@
 import argparse
 import logging
 import sys
+import traceback
 from socket import getfqdn
+from socket import gethostbyname
 from socket import gethostname
 
 from paasta_tools import mesos_maintenance
 from paasta_tools import utils
+from paasta_tools.check_marathon_services_replication import load_smartstack_info_for_service
 from paasta_tools.marathon_tools import get_expected_instance_count_for_namespace
 from paasta_tools.marathon_tools import marathon_services_running_here
 from paasta_tools.marathon_tools import read_namespace_for_service_instance
-from paasta_tools.smartstack_tools import backend_is_up
+from paasta_tools.monitoring.replication_utils import backend_is_up
+from paasta_tools.monitoring.replication_utils import get_replication_for_services
+from paasta_tools.monitoring.replication_utils import ip_port_hostname_from_svname
 from paasta_tools.smartstack_tools import get_backends
-from paasta_tools.smartstack_tools import get_replication_for_services
-from paasta_tools.smartstack_tools import ip_port_hostname_from_svname
-from paasta_tools.smartstack_tools import load_smartstack_info_for_service
 
 log = logging.getLogger(__name__)
 
@@ -112,8 +114,69 @@ def is_safe_to_drain(hostname):
     return not are_local_tasks_in_danger()
 
 
-def are_local_tasks_in_danger():
+def is_healthy_in_haproxy(local_port, backends):
+    local_ip = gethostbyname(gethostname())
+    for backend in backends:
+        ip, port, _ = ip_port_hostname_from_svname(backend['svname'])
+        if ip == local_ip and port == local_port:
+            if backend_is_up(backend):
+                log.debug("Found a healthy local backend: %s" % backend)
+                return True
+            else:
+                log.debug("Found a unhealthy local backend: %s" % backend)
+                return False
+    log.debug("Couldn't find any haproxy backend listening on %s" % local_port)
     return False
+
+
+def synapse_replication_is_low(service, instance, system_paasta_config, local_backends):
+    crit_threshold = 80
+    namespace = read_namespace_for_service_instance(service=service, instance=instance)
+    smartstack_replication_info = load_smartstack_info_for_service(
+        service=service,
+        namespace=namespace,
+        blacklist=[],
+        system_paasta_config=system_paasta_config,
+    )
+    expected_count = get_expected_instance_count_for_namespace(service=service, namespace=namespace)
+    expected_count_per_location = int(expected_count / len(smartstack_replication_info))
+    synapse_name = "%s.%s" % (service, namespace)
+    local_replication = get_replication_for_services(
+        synapse_host=system_paasta_config.get_default_synapse_host(),
+        synapse_port=system_paasta_config.get_synapse_port(),
+        synapse_haproxy_url_format=system_paasta_config.get_synapse_haproxy_url_format(),
+        services=[synapse_name],
+    )
+    num_available = local_replication.get(synapse_name, 0)
+    under_replicated, ratio = utils.is_under_replicated(
+        num_available, expected_count_per_location, crit_threshold)
+    log.info('Service %s.%s has %d out of %d expected instances' % (
+        service, instance, num_available, expected_count_per_location))
+    return under_replicated
+
+
+def are_local_tasks_in_danger():
+    try:
+        system_paasta_config = utils.load_system_paasta_config()
+        local_services = marathon_services_running_here()
+        local_backends = get_backends(
+            service=None,
+            synapse_host=system_paasta_config.get_default_synapse_host(),
+            synapse_port=system_paasta_config.get_synapse_port(),
+            synapse_haproxy_url_format=system_paasta_config.get_synapse_haproxy_url_format()
+        )
+        for service, instance, port in local_services:
+            log.info("Inspecting %s.%s on %s" % (service, instance, port))
+            if is_healthy_in_haproxy(port, local_backends) and \
+               synapse_replication_is_low(service, instance, system_paasta_config, local_backends=local_backends):
+                log.warning("%s.%s on port %s is healthy but the service is in danger!" % (
+                    service, instance, port
+                ))
+                return True
+        return False
+    except Exception:
+        log.warning(traceback.format_exc())
+        return False
 
 
 def paasta_maintenance():

--- a/paasta_tools/paasta_maintenance.py
+++ b/paasta_tools/paasta_maintenance.py
@@ -22,14 +22,14 @@ from socket import gethostname
 
 from paasta_tools import mesos_maintenance
 from paasta_tools import utils
-from paasta_tools.check_marathon_services_replication import load_smartstack_info_for_service
 from paasta_tools.marathon_tools import get_expected_instance_count_for_namespace
 from paasta_tools.marathon_tools import marathon_services_running_here
 from paasta_tools.marathon_tools import read_namespace_for_service_instance
-from paasta_tools.monitoring.replication_utils import backend_is_up
-from paasta_tools.monitoring.replication_utils import get_replication_for_services
-from paasta_tools.monitoring.replication_utils import ip_port_hostname_from_svname
+from paasta_tools.smartstack_tools import backend_is_up
 from paasta_tools.smartstack_tools import get_backends
+from paasta_tools.smartstack_tools import get_replication_for_services
+from paasta_tools.smartstack_tools import ip_port_hostname_from_svname
+from paasta_tools.smartstack_tools import load_smartstack_info_for_service
 
 log = logging.getLogger(__name__)
 

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -82,6 +82,11 @@ def get_mesos_cpu_status(metrics, mesos_state):
 
     total = metrics['master/cpus_total']
     used = metrics['master/cpus_used']
+
+    for slave in mesos_state['slaves']:
+        for role in slave['reserved_resources']:
+            used -= slave['reserved_resources'][role]['cpus']
+
     available = total - used
     return total, used, available
 
@@ -162,6 +167,11 @@ def assert_cpu_health(metrics, mesos_state, threshold=10):
 def assert_memory_health(metrics, mesos_state, threshold=10):
     total = metrics['master/mem_total'] / float(1024)
     used = metrics['master/mem_used'] / float(1024)
+
+    for slave in mesos_state['slaves']:
+        for role in slave['reserved_resources']:
+            used -= slave['reserved_resources'][role]['mem']
+
     try:
         perc_used = percent_used(total, used)
     except ZeroDivisionError:
@@ -185,6 +195,11 @@ def assert_memory_health(metrics, mesos_state, threshold=10):
 def assert_disk_health(metrics, mesos_state, threshold=10):
     total = metrics['master/disk_total'] / float(1024)
     used = metrics['master/disk_used'] / float(1024)
+
+    for slave in mesos_state['slaves']:
+        for role in slave['reserved_resources']:
+            used -= slave['reserved_resources'][role]['disk']
+
     try:
         perc_used = percent_used(total, used)
     except ZeroDivisionError:

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -439,8 +439,8 @@ def deploy_service(
     if new_app_running:
         num_at_risk_tasks = get_num_at_risk_tasks(new_app)
         if new_app.instances < config['instances'] + num_at_risk_tasks:
-            log.debug("Scaling %s from %d to %d instances." %
-                      (new_app.id, new_app.instances, config['instances'] + num_at_risk_tasks))
+            log.info("Scaling %s from %d to %d instances." %
+                     (new_app.id, new_app.instances, config['instances'] + num_at_risk_tasks))
             client.scale_app(app_id=new_app.id, instances=config['instances'] + num_at_risk_tasks, force=True)
         # If we have more than the specified number of instances running, we will want to drain some of them.
         # We will start by draining any tasks running on at-risk hosts.

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -56,6 +56,7 @@ from paasta_tools import monitoring_tools
 from paasta_tools.marathon_tools import get_num_at_risk_tasks
 from paasta_tools.marathon_tools import kill_given_tasks
 from paasta_tools.mesos_maintenance import get_draining_hosts
+from paasta_tools.mesos_maintenance import reserve_all_resources
 from paasta_tools.utils import _log
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import decompose_job_id
@@ -241,6 +242,11 @@ def do_bounce(
     )
 
     kill_given_tasks(client=client, task_ids=[task.id for task in tasks_to_kill], scale=True)
+
+    for task in bounce_lib.flatten_tasks(old_app_at_risk_tasks):
+        if task in tasks_to_kill:
+            hostname = task.host
+            reserve_all_resources([hostname])
 
     apps_to_kill = []
     for app in old_app_live_happy_tasks.keys():

--- a/tests/test_mesos_maintenance.py
+++ b/tests/test_mesos_maintenance.py
@@ -241,7 +241,7 @@ def test_build_maintenance_schedule_payload_no_schedule_undrain(
     assert actual == expected
 
 
-@mock.patch('paasta_tools.mesos_maintenance.load_credentials')
+@mock.patch('paasta_tools.mesos_maintenance.load_credentials', autospec=True)
 def test_build_reservation_payload(
     mock_load_credentials,
 ):
@@ -267,8 +267,8 @@ def test_build_reservation_payload(
     assert actual == expected
 
 
-@mock.patch('paasta_tools.mesos_maintenance.get_maintenance_schedule')
-@mock.patch('paasta_tools.mesos_maintenance.get_machine_ids')
+@mock.patch('paasta_tools.mesos_maintenance.get_maintenance_schedule', autospec=True)
+@mock.patch('paasta_tools.mesos_maintenance.get_machine_ids', autospec=True)
 def test_build_maintenance_schedule_payload_schedule(
     mock_get_machine_ids,
     mock_get_maintenance_schedule,
@@ -511,8 +511,8 @@ def test_undrain(
     assert mock_get_schedule_client.return_value.call_args == expected_args
 
 
-@mock.patch('paasta_tools.mesos_maintenance.build_reservation_payload')
-@mock.patch('paasta_tools.mesos_maintenance.reserve_api')
+@mock.patch('paasta_tools.mesos_maintenance.build_reservation_payload', autospec=True)
+@mock.patch('paasta_tools.mesos_maintenance.reserve_api', autospec=True)
 def test_reserve(
     mock_reserve_api,
     mock_build_reservation_payload,
@@ -530,8 +530,8 @@ def test_reserve(
     assert mock_reserve_api.return_value.call_count == 1
 
 
-@mock.patch('paasta_tools.mesos_maintenance.build_reservation_payload')
-@mock.patch('paasta_tools.mesos_maintenance.unreserve_api')
+@mock.patch('paasta_tools.mesos_maintenance.build_reservation_payload', autospec=True)
+@mock.patch('paasta_tools.mesos_maintenance.unreserve_api', autospec=True)
 def test_unreserve(
     mock_unreserve_api,
     mock_build_reservation_payload,
@@ -549,8 +549,8 @@ def test_unreserve(
     assert mock_unreserve_api.return_value.call_count == 1
 
 
-@mock.patch('paasta_tools.mesos_maintenance.master_api')
-@mock.patch('paasta_tools.mesos_maintenance.build_start_maintenance_payload')
+@mock.patch('paasta_tools.mesos_maintenance.master_api', autospec=True)
+@mock.patch('paasta_tools.mesos_maintenance.build_start_maintenance_payload', autospec=True)
 def test_down(
     mock_build_start_maintenance_payload,
     mock_master_api,

--- a/tests/test_mesos_maintenance.py
+++ b/tests/test_mesos_maintenance.py
@@ -616,16 +616,12 @@ def test_get_hosts_with_state_draining(
     fake_status = {
         "draining_machines": [
             {
-                "id": {
-                    "hostname": "fake-host1.fakesite.something",
-                    "ip": "0.0.0.0"
-                }
+                "hostname": "fake-host1.fakesite.something",
+                "ip": "0.0.0.0"
             },
             {
-                "id": {
-                    "hostname": "fake-host2.fakesite.something",
-                    "ip": "0.0.0.1"
-                }
+                "hostname": "fake-host2.fakesite.something",
+                "ip": "0.0.0.1"
             }
         ]
     }
@@ -642,16 +638,12 @@ def test_get_hosts_with_state_down(
     fake_status = {
         "down_machines": [
             {
-                "id": {
-                    "hostname": "fake-host1.fakesite.something",
-                    "ip": "0.0.0.0"
-                }
+                "hostname": "fake-host1.fakesite.something",
+                "ip": "0.0.0.0"
             },
             {
-                "id": {
-                    "hostname": "fake-host2.fakesite.something",
-                    "ip": "0.0.0.1"
-                }
+                "hostname": "fake-host2.fakesite.something",
+                "ip": "0.0.0.1"
             }
         ]
     }

--- a/tests/test_mesos_maintenance.py
+++ b/tests/test_mesos_maintenance.py
@@ -14,7 +14,6 @@
 import argparse
 import datetime
 import json
-from collections import namedtuple
 
 import mock
 import pytest
@@ -44,15 +43,13 @@ from paasta_tools.mesos_maintenance import load_credentials
 from paasta_tools.mesos_maintenance import parse_datetime
 from paasta_tools.mesos_maintenance import parse_timedelta
 from paasta_tools.mesos_maintenance import reserve
+from paasta_tools.mesos_maintenance import Resource
 from paasta_tools.mesos_maintenance import schedule
 from paasta_tools.mesos_maintenance import seconds_to_nanoseconds
 from paasta_tools.mesos_maintenance import status
 from paasta_tools.mesos_maintenance import undrain
 from paasta_tools.mesos_maintenance import unreserve
 from paasta_tools.mesos_maintenance import up
-
-
-Resource = namedtuple('Resource', ['name', 'amount'])
 
 
 def test_parse_timedelta_none():

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -614,6 +614,8 @@ def test_get_resource_utilization_per_slave():
                 'disk': 250,
                 'mem': 100,
             },
+            'reserved_resources': {
+            },
             'attributes': {
                 'habitat': 'somenametest-habitat',
             },
@@ -625,6 +627,13 @@ def test_get_resource_utilization_per_slave():
                 'cpus': 500,
                 'disk': 200,
                 'mem': 750,
+            },
+            'reserved_resources': {
+                'some-role': {
+                    'cpus': 10,
+                    'disk': 0,
+                    'mem': 150,
+                },
             },
             'attributes': {
                 'habitat': 'somenametest-habitat-2',
@@ -642,9 +651,9 @@ def test_get_resource_utilization_per_slave():
         mem=850
     )
     assert actual['free'] == paasta_metastatus.ResourceInfo(
-        cpus=555,
+        cpus=545,
         disk=430,
-        mem=830
+        mem=680
     )
 
 

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -37,7 +37,14 @@ def test_get_mesos_cpu_status():
         'master/cpus_total': 3,
         'master/cpus_used': 1,
     }
-    total, used, available = paasta_metastatus.get_mesos_cpu_status(fake_metrics)
+    fake_mesos_state = {
+        'slaves': [
+            {
+                'reserved_resources': {},
+            },
+        ],
+    }
+    total, used, available = paasta_metastatus.get_mesos_cpu_status(fake_metrics, fake_mesos_state)
     assert total == 3
     assert used == 1
     assert available == 2
@@ -48,7 +55,14 @@ def test_ok_cpu_health():
         'master/cpus_total': 10,
         'master/cpus_used': 1,
     }
-    ok_output, ok_health = paasta_metastatus.assert_cpu_health(ok_metrics)
+    fake_mesos_state = {
+        'slaves': [
+            {
+                'reserved_resources': {},
+            },
+        ],
+    }
+    ok_output, ok_health = paasta_metastatus.assert_cpu_health(ok_metrics, fake_mesos_state)
     assert ok_health
     assert "CPUs: 1.00 / 10 in use (%s)" % PaastaColors.green("10.00%") in ok_output
 
@@ -58,7 +72,14 @@ def test_bad_cpu_health():
         'master/cpus_total': 10,
         'master/cpus_used': 9,
     }
-    failure_output, failure_health = paasta_metastatus.assert_cpu_health(failure_metrics)
+    fake_mesos_state = {
+        'slaves': [
+            {
+                'reserved_resources': {},
+            },
+        ],
+    }
+    failure_output, failure_health = paasta_metastatus.assert_cpu_health(failure_metrics, fake_mesos_state)
     assert not failure_health
     assert "CRITICAL: Less than 10% CPUs available. (Currently using 90.00% of 10)" in failure_output
 
@@ -68,7 +89,14 @@ def test_assert_memory_health():
         'master/mem_total': 1024,
         'master/mem_used': 512,
     }
-    ok_output, ok_health = paasta_metastatus.assert_memory_health(ok_metrics)
+    fake_mesos_state = {
+        'slaves': [
+            {
+                'reserved_resources': {},
+            },
+        ],
+    }
+    ok_output, ok_health = paasta_metastatus.assert_memory_health(ok_metrics, fake_mesos_state)
     assert ok_health
     assert "Memory: 0.50 / 1.00GB in use (%s)" % PaastaColors.green("50.00%") in ok_output
 
@@ -78,7 +106,14 @@ def test_failing_memory_health():
         'master/mem_total': 1024,
         'master/mem_used': 1000,
     }
-    failure_output, failure_health = paasta_metastatus.assert_memory_health(failure_metrics)
+    fake_mesos_state = {
+        'slaves': [
+            {
+                'reserved_resources': {},
+            },
+        ],
+    }
+    failure_output, failure_health = paasta_metastatus.assert_memory_health(failure_metrics, fake_mesos_state)
     assert not failure_health
     assert "CRITICAL: Less than 10% memory available. (Currently using 97.66% of 1.00GB)" in failure_output
 
@@ -88,7 +123,14 @@ def test_assert_disk_health():
         'master/disk_total': 1024,
         'master/disk_used': 512,
     }
-    ok_output, ok_health = paasta_metastatus.assert_disk_health(ok_metrics)
+    fake_mesos_state = {
+        'slaves': [
+            {
+                'reserved_resources': {},
+            },
+        ],
+    }
+    ok_output, ok_health = paasta_metastatus.assert_disk_health(ok_metrics, fake_mesos_state)
     assert ok_health
     assert "Disk: 0.50 / 1.00GB in use (%s)" % PaastaColors.green("50.00%") in ok_output
 
@@ -98,7 +140,14 @@ def test_failing_disk_health():
         'master/disk_total': 1024,
         'master/disk_used': 1000,
     }
-    failure_output, failure_health = paasta_metastatus.assert_disk_health(failure_metrics)
+    fake_mesos_state = {
+        'slaves': [
+            {
+                'reserved_resources': {},
+            },
+        ],
+    }
+    failure_output, failure_health = paasta_metastatus.assert_disk_health(failure_metrics, fake_mesos_state)
     assert not failure_health
     assert "CRITICAL: Less than 10% disk available. (Currently using 97.66%)" in failure_output
 
@@ -337,7 +386,7 @@ def test_main_no_marathon_config():
         patch('paasta_tools.paasta_metastatus.get_mesos_state_status', autospec=True,
               return_value=([('fake_output', True)])),
         patch('paasta_tools.paasta_metastatus.get_mesos_stats', autospec=True),
-        patch('paasta_tools.paasta_metastatus.get_mesos_metrics_health', autospec=True),
+        patch('paasta_tools.paasta_metastatus.get_mesos_resource_utilization_health', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_marathon_status', autospec=True,
               return_value=([('fake_output', True)])),
         patch('paasta_tools.paasta_metastatus.parse_args', autospec=True),
@@ -348,7 +397,7 @@ def test_main_no_marathon_config():
         get_mesos_master,
         get_mesos_state_status_patch,
         get_mesos_stats_patch,
-        get_mesos_metrics_health_patch,
+        get_mesos_resource_utilization_health_patch,
         load_get_marathon_status_patch,
         parse_args_patch,
     ):
@@ -360,7 +409,7 @@ def test_main_no_marathon_config():
         get_mesos_stats_patch.return_value = {}
 
         get_mesos_state_status_patch.return_value = []
-        get_mesos_metrics_health_patch.return_value = []
+        get_mesos_resource_utilization_health_patch.return_value = []
 
         parse_args_patch.return_value = fake_args
         load_marathon_config_patch.return_value = {}
@@ -377,7 +426,7 @@ def test_main_no_chronos_config():
         patch('paasta_tools.paasta_metastatus.get_mesos_state_status', autospec=True,
               return_value=([('fake_output', True)])),
         patch('paasta_tools.paasta_metastatus.get_mesos_stats', autospec=True),
-        patch('paasta_tools.paasta_metastatus.get_mesos_metrics_health', autospec=True),
+        patch('paasta_tools.paasta_metastatus.get_mesos_resource_utilization_health', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_marathon_status', autospec=True,
               return_value=([('fake_output', True)])),
         patch('paasta_tools.paasta_metastatus.parse_args', autospec=True),
@@ -387,7 +436,7 @@ def test_main_no_chronos_config():
         get_mesos_master,
         get_mesos_state_status_patch,
         get_mesos_stats_patch,
-        get_mesos_metrics_health_patch,
+        get_mesos_resource_utilization_health_patch,
         load_get_marathon_status_patch,
         parse_args_patch,
     ):
@@ -404,7 +453,7 @@ def test_main_no_chronos_config():
         get_mesos_stats_patch.return_value = {}
 
         get_mesos_state_status_patch.return_value = []
-        get_mesos_metrics_health_patch.return_value = []
+        get_mesos_resource_utilization_health_patch.return_value = []
 
         load_chronos_config_patch.return_value = {}
         with raises(SystemExit) as excinfo:

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -33,6 +33,8 @@ RUN apt-get install -yq mesos=0.28.2-2.0.27.ubuntu1404 && \
 	zip -r /root/mesos.native-0.28.2-py27-none-any.whl mesos/native mesos.native-0.28.2.dist-info && \
 	apt-get remove -yq mesos
 
+ADD mesos-slave-secret /etc/mesos-slave-secret
+
 ENV HOME /work
 ENV PWD /work
 WORKDIR /work

--- a/yelp_package/dockerfiles/trusty/mesos-slave-secret
+++ b/yelp_package/dockerfiles/trusty/mesos-slave-secret
@@ -1,0 +1,4 @@
+{
+  "principal": "slave",
+  "secret": "secret1"
+}


### PR DESCRIPTION
Due to the way we implemented maintenance mode's "draining", it is possible for tasks to get rescheduled onto the at-risk/draining host. To help avoid this and speed up the draining process, we decided to use dynamic reservations. Now, when a host is marked as 'draining', we will create a dynamic reservation for all free resources on the box (preventing anything new from being scheduled there). We will continue to dynamically reserve all free resources each time we kill a task running on the box. Eventually, all resources on the host will be dynamically reserved. The reservations will be removed once the box is undrained.

This change also updates `paasta_metastatus` so that dynamically reserved resources count as `used` resources. This should help us catch issues where we dynamically reserve too many resources in a cluster and no longer have sufficient capacity for new things to run.

I have also filed https://issues.apache.org/jira/browse/MESOS-6175 to try and get some dynamic reservation metrics into the `/metrics/snapshot` endpoint to allow simplifying/optimizing the metastatus code.

Connects to #376 