### PR TITLE
cleanup patching of mesos modules in mesos_tools

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -29,13 +29,13 @@ from marathon import MarathonClient
 from marathon import MarathonHttpError
 from marathon import NotFoundError
 
+from paasta_tools.mesos.exceptions import NoSlavesAvailableError
 from paasta_tools.mesos_maintenance import get_draining_hosts
 from paasta_tools.mesos_tools import filter_mesos_slaves_by_blacklist
 from paasta_tools.mesos_tools import get_local_slave_state
 from paasta_tools.mesos_tools import get_mesos_network_for_net
 from paasta_tools.mesos_tools import get_mesos_slaves_grouped_by_attribute
 from paasta_tools.mesos_tools import get_slaves
-from paasta_tools.mesos_tools import NoSlavesAvailableError
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import deep_merge_dictionaries

--- a/paasta_tools/mesos/cluster.py
+++ b/paasta_tools/mesos/cluster.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 import itertools
 
 from . import exceptions
-from . import log
 from . import parallel
 
 dne = True
@@ -57,4 +56,9 @@ def get_files_for_tasks(task_list, file_list, max_workers, fail=True):
         yield result
 
     if dne and fail:
-        log.fatal("No such task has the requested file or directory")
+        raise exceptions.FileNotFoundForTask(
+            "None of the tasks in %s contin the files in list %s" % (
+                ",".join([task["id"] for task in task]),
+                ",".join(file_list)
+            )
+        )

--- a/paasta_tools/mesos/exceptions.py
+++ b/paasta_tools/mesos/exceptions.py
@@ -23,6 +23,26 @@ class MesosCLIException(Exception):
     pass
 
 
+class MasterNotAvailableException(Exception):
+    pass
+
+
+class NoSlavesAvailableError(Exception):
+    pass
+
+
+class MultipleSlavesForIDError(Exception):
+    pass
+
+
+class TaskNotFoundException(Exception):
+    pass
+
+
+class FileNotFoundForTaskException(Exception):
+    pass
+
+
 class FileDoesNotExist(MesosCLIException):
     pass
 

--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -24,9 +24,6 @@ import re
 import urlparse
 
 import google.protobuf.message
-import kazoo.client
-import kazoo.exceptions
-import kazoo.handlers.threading
 import mesos.interface.mesos_pb2
 import requests
 import requests.exceptions
@@ -75,7 +72,7 @@ class MesosMaster(object):
                 timeout=self.config["response_timeout"],
                 **kwargs)
         except requests.exceptions.ConnectionError:
-            log.fatal(MISSING_MASTER.format(self.host))
+            raise exceptions.MasterNotAvailableException(MISSING_MASTER.format(self.host))
 
     def _file_resolver(self, cfg):
         return self.resolve(open(cfg[6:], "r+").read().strip())
@@ -85,24 +82,21 @@ class MesosMaster(object):
         path = "/" + path
 
         with zookeeper.client(hosts=hosts, read_only=True) as zk:
-            try:
-                def master_id(key):
-                    return int(key.split("_")[-1])
+            def master_id(key):
+                return int(key.split("_")[-1])
 
-                def get_masters():
-                    return [x for x in zk.get_children(path)
-                            if re.search("\d+", x)]
+            def get_masters():
+                return [x for x in zk.get_children(path)
+                        if re.search("\d+", x)]
 
-                leader = sorted(get_masters(), key=lambda x: master_id(x))
+            leader = sorted(get_masters(), key=lambda x: master_id(x))
 
-                if len(leader) == 0:
-                    log.fatal("cannot find any masters at {0}".format(cfg,))
-                data, stat = zk.get(os.path.join(path, leader[0]))
-            except kazoo.exceptions.NoNodeError:
-                log.fatal(INVALID_PATH.format(cfg))
+            if len(leader) == 0:
+                raise exceptions.MasterNotAvailableException("cannot find any masters at {0}".format(cfg,))
+            data, stat = zk.get(os.path.join(path, leader[0]))
 
             if not data:
-                log.fatal("Cannot retrieve valid MasterInfo data from ZooKeeper")
+                exceptions.MasterNotAvailableException("Cannot retrieve valid MasterInfo data from ZooKeeper")
 
             # The serialization of the Master's PID to ZK has changed over time.
             # Prior to 0.20 just the PID value was written to the znode; then the binary
@@ -135,8 +129,10 @@ class MesosMaster(object):
                 # Finally try to just interpret the PID as a string:
                 if '@' in data:
                     return data.split("@")[-1]
-            log.fatal("Could not retrieve the MasterInfo from ZooKeeper; the data in '{}' was:"
-                      "{}".format(path, data))
+                raise exceptions.MasterNotAvailableException(
+                    "Could not retrieve the MasterInfo from ZooKeeper; the data in '{}' was:"
+                    "{}".format(path, data)
+                )
 
     @log.duration
     def resolve(self, cfg):
@@ -159,6 +155,9 @@ class MesosMaster(object):
     def state(self):
         return self.fetch("/master/state.json").json()
 
+    def state_summary(self):
+        return self.fetch("/master/state-summary").json()
+
     @util.memoize
     def slave(self, fltr):
         lst = self.slaves(fltr)
@@ -170,17 +169,20 @@ class MesosMaster(object):
                 "Slave {0} no longer exists.".format(fltr))
 
         elif len(lst) > 1:
-            result = [MULTIPLE_SLAVES]
-            result += ['\t{0}'.format(slave.id) for slave in lst]
-            log.fatal('\n'.join(result))
+            raise exceptions.MultipleSlavesForIDError(
+                "Multiple slaves matching filter %s. %s" % (
+                    fltr,
+                    ",".join([slave.id for slave in lst])
+                )
+            )
 
         return lst[0]
 
     def slaves(self, fltr=""):
         return list(map(
-            lambda x: slave.MesosSlave(x),
+            lambda x: slave.MesosSlave(self.config, x),
             itertools.ifilter(
-                lambda x: fltr in x["id"], self.state["slaves"])))
+                lambda x: fltr == x['id'], self.state['slaves'])))
 
     def _task_list(self, active_only=False):
         keys = ["tasks"]
@@ -193,13 +195,15 @@ class MesosMaster(object):
         lst = self.tasks(fltr)
 
         if len(lst) == 0:
-            log.fatal("Cannot find a task by that name.")
+            raise exceptions.TaskNotFoundException("Cannot find a task with filter %s" % fltr)
 
         elif len(lst) > 1:
-            msg = ["There are multiple tasks with that id. Please choose one:"]
-            msg += ["\t{0}".format(t["id"]) for t in lst]
-            log.fatal("\n".join(msg))
-
+            raise exceptions.MultipleTasksForIDError(
+                "Multiple tasks matching filter %s. %s" % (
+                    fltr,
+                    ",".join([slave.id for task in lst])
+                )
+            )
         return lst[0]
 
     # XXX - need to filter on task state as well as id

--- a/paasta_tools/mesos/zookeeper.py
+++ b/paasta_tools/mesos/zookeeper.py
@@ -22,8 +22,6 @@ import kazoo.client
 import kazoo.exceptions
 import kazoo.handlers.threading
 
-from . import log
-
 TIMEOUT = 1
 
 # Helper for testing
@@ -33,12 +31,7 @@ client_class = kazoo.client.KazooClient
 @contextlib.contextmanager
 def client(*args, **kwargs):
     zk = client_class(*args, **kwargs)
-    try:
-        zk.start(timeout=TIMEOUT)
-    except kazoo.handlers.threading.KazooTimeoutError:
-        log.fatal(
-            "Could not connect to zookeeper. " +
-            "Change your config via `mesos config master`")
+    zk.start(timeout=TIMEOUT)
     try:
         yield zk
     finally:

--- a/paasta_tools/mesos_maintenance.py
+++ b/paasta_tools/mesos_maintenance.py
@@ -26,7 +26,7 @@ from requests import Session
 from requests.exceptions import HTTPError
 
 from paasta_tools.mesos_tools import get_mesos_leader
-from paasta_tools.mesos_tools import get_mesos_state_summary_from_leader
+from paasta_tools.mesos_tools import get_mesos_master
 from paasta_tools.mesos_tools import get_mesos_task_count_by_slave
 from paasta_tools.mesos_tools import MESOS_MASTER_PORT
 
@@ -420,7 +420,7 @@ def is_host_drained(hostname):
     :param hostname: hostname to check
     :returns: True or False
     """
-    mesos_state = get_mesos_state_summary_from_leader()
+    mesos_state = get_mesos_master().state_summary()
     task_counts = get_mesos_task_count_by_slave(mesos_state)
     if hostname in task_counts:
         slave_task_count = task_counts[hostname].count

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -29,13 +29,13 @@ from paasta_tools import chronos_tools
 from paasta_tools import marathon_tools
 from paasta_tools.chronos_tools import get_chronos_client
 from paasta_tools.chronos_tools import load_chronos_config
+from paasta_tools.mesos.exceptions import MasterNotAvailableException
 from paasta_tools.mesos_tools import get_all_tasks_from_state
+from paasta_tools.mesos_tools import get_mesos_master
 from paasta_tools.mesos_tools import get_mesos_quorum
-from paasta_tools.mesos_tools import get_mesos_state_from_leader
 from paasta_tools.mesos_tools import get_mesos_stats
 from paasta_tools.mesos_tools import get_number_of_mesos_masters
 from paasta_tools.mesos_tools import get_zookeeper_host_path
-from paasta_tools.mesos_tools import MasterNotAvailableException
 from paasta_tools.utils import format_table
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import print_with_indent
@@ -589,8 +589,9 @@ def main():
     chronos_config = None
     args = parse_args()
 
+    master = get_mesos_master()
     try:
-        mesos_state = get_mesos_state_from_leader()
+        mesos_state = master.state
     except MasterNotAvailableException as e:
         # if we can't connect to master at all,
         # then bomb out early

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -22,7 +22,7 @@ from pytest import raises
 
 from paasta_tools import marathon_tools
 from paasta_tools.marathon_serviceinit import desired_state_human
-from paasta_tools.mesos_tools import NoSlavesAvailableError
+from paasta_tools.mesos.exceptions import NoSlavesAvailableError
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DeploymentsJson
 from paasta_tools.utils import SystemPaastaConfig

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -333,7 +333,7 @@ def test_main_no_marathon_config():
         patch('paasta_tools.marathon_tools.load_marathon_config', autospec=True),
         patch('paasta_tools.paasta_metastatus.load_chronos_config', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_chronos_status', autospec=True),
-        patch('paasta_tools.paasta_metastatus.get_mesos_state_from_leader', autospec=True),
+        patch('paasta_tools.paasta_metastatus.get_mesos_master', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_mesos_state_status', autospec=True,
               return_value=([('fake_output', True)])),
         patch('paasta_tools.paasta_metastatus.get_mesos_stats', autospec=True),
@@ -345,7 +345,7 @@ def test_main_no_marathon_config():
         load_marathon_config_patch,
         load_chronos_config_patch,
         load_get_chronos_status_patch,
-        get_mesos_state_from_leader_patch,
+        get_mesos_master,
         get_mesos_state_status_patch,
         get_mesos_stats_patch,
         get_mesos_metrics_health_patch,
@@ -355,7 +355,8 @@ def test_main_no_marathon_config():
         fake_args = Mock(
             verbose=0,
         )
-        get_mesos_state_from_leader_patch.return_value = {}
+        get_mesos_master = Mock()
+        get_mesos_master.state_summary.return_value = {}
         get_mesos_stats_patch.return_value = {}
 
         get_mesos_state_status_patch.return_value = []
@@ -372,7 +373,7 @@ def test_main_no_chronos_config():
     with contextlib.nested(
         patch('paasta_tools.marathon_tools.load_marathon_config', autospec=True),
         patch('paasta_tools.paasta_metastatus.load_chronos_config', autospec=True),
-        patch('paasta_tools.paasta_metastatus.get_mesos_state_from_leader', autospec=True, return_value={}),
+        patch('paasta_tools.paasta_metastatus.get_mesos_master', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_mesos_state_status', autospec=True,
               return_value=([('fake_output', True)])),
         patch('paasta_tools.paasta_metastatus.get_mesos_stats', autospec=True),
@@ -383,7 +384,7 @@ def test_main_no_chronos_config():
     ) as (
         load_marathon_config_patch,
         load_chronos_config_patch,
-        get_mesos_state_from_leader_patch,
+        get_mesos_master,
         get_mesos_state_status_patch,
         get_mesos_stats_patch,
         get_mesos_metrics_health_patch,
@@ -394,10 +395,12 @@ def test_main_no_chronos_config():
         fake_args = Mock(
             verbose=0,
         )
+        get_mesos_master = Mock()
+        get_mesos_master.state.return_value = {}
+
         parse_args_patch.return_value = fake_args
         load_marathon_config_patch.return_value = {}
 
-        get_mesos_state_from_leader_patch.return_value = {}
         get_mesos_stats_patch.return_value = {}
 
         get_mesos_state_status_patch.return_value = []


### PR DESCRIPTION
more cleanup. This time, I've targeted the monkey patching we were doing in ``mesos_tools``. 

- I've removed the ``log.fatal`` calls from the mesos-cli modules, instead replacing them with the relevant exceptions (we were monkey patching log.fatal to get this behaviour before).
- Replaced the implementation of ``mesos.Master.slaves`` with the version we had in mesos-tools, wherein we exact match on the id, rather than partial matching
- removed the ``get_mesos_state_from_current_leader`` function in ``mesos_tools``. When you create a new ``mesos.Master`` object, it calculates the current leader in it's constructor and redirects all requests to that leader, so we don't need this extra level of checking.
- removed the ``get_mesos_state_summary_from_current_leader`` function from ``mesos_tools``, replacing it with a ``state_summary`` function on the ``mesos.Master`` class.
- completely removed the zk timeout catching - before we were just rethrowing another exception, for no real benefit.