### PR TITLE
update mesos master to retry zk connection PAASTA-5245

### DIFF
--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -30,6 +30,7 @@ import kazoo.handlers.threading
 import mesos.interface.mesos_pb2
 import requests
 import requests.exceptions
+from kazoo.retry import KazooRetry
 
 from . import exceptions
 from . import framework
@@ -82,7 +83,8 @@ class MesosMaster(object):
         hosts, path = cfg[5:].split("/", 1)
         path = "/" + path
 
-        with zookeeper.client(hosts=hosts, read_only=True) as zk:
+        retry = KazooRetry(max_tries=10)
+        with zookeeper.client(hosts=hosts, read_only=True, connection_retry=retry) as zk:
             try:
                 def master_id(key):
                     return int(key.split("_")[-1])


### PR DESCRIPTION
this will mean that we retry the ZK connection if a node is down.

the ``max_tries`` number is 10 here - any ideas for a better magic number? 5 doesn't make too much sense, because it'll pick a random host in the cluster (so we can't guarantee that 5 retries == 5 unique hosts)