### PR TITLE
pre-commit hook that checks for mock.patch invocations without autospec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,4 @@
         entry: paasta_tools/contrib/mock_patch_checker.py
         language: script
         files: ^tests/.*\.py$
+        language_version: python2.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 -   repo: https://github.com/pre-commit/pre-commit-hooks.git
-    sha: cf550fcab3f12015f8676b8278b30e1a5bc10e70
+    sha: 18d7035de5388cc7775be57f529c154bf541aab9
     hooks:
     -   id: trailing-whitespace
         language_version: python2.7
@@ -12,13 +12,13 @@
     -   id: check-json
         language_version: python2.7
     -   id: check-yaml
-        # Exclude fsm cookiecutter files
         files: ^(?!.*template).*\.(yaml|yml|eyaml)$
         language_version: python2.7
     -   id: debug-statements
         language_version: python2.7
     -   id: name-tests-test
-        args: [--django]
+        args:
+        - --django
         files: ^tests/.*\.py$
         language_version: python2.7
     -   id: requirements-txt-fixer
@@ -27,7 +27,15 @@
         exclude: ^docs/source/conf.py$
         language_version: python2.7
 -   repo: https://github.com/asottile/reorder_python_imports.git
-    sha: 3d86483455ab5bd06cc1069fdd5ac57be5463f10
+    sha: b022734351abe44d0b05a71a4fa1175287c59b49
     hooks:
     -   id: reorder-python-imports
         language_version: python2.7
+-   repo: local
+    hooks:
+    -   id: patch-enforce-autospec
+        name: mock.patch enforce autospec
+        description: This hook ensures all mock.patch invocations specify an autospec
+        entry: paasta_tools/contrib/mock_patch_checker.py
+        language: script
+        files: ^tests/.*\.py$

--- a/paasta_tools/contrib/mock_patch_checker.py
+++ b/paasta_tools/contrib/mock_patch_checker.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python2.7
+import compiler
+import sys
+
+
+class MockChecker(object):
+    def __init__(self):
+        self.errors = 0
+        self.init_module_imports()
+
+    def init_module_imports(self):
+        self.imported_patch = False
+        self.imported_mock = False
+
+    def check_files(self, files):
+        for file in files:
+            self.check_file(file)
+
+    def check_file(self, filename):
+        self.current_filename = filename
+        try:
+            ast = compiler.parseFile(filename)
+        except SyntaxError, error:
+            print "SyntaxError on file %s:%d" % (filename, error.lineno)
+            return
+        compiler.walk(ast, self)
+        self.init_module_imports()
+
+    def visitImport(self, node):
+        if (name for name in node.names if 'mock' in name):
+            self.imported_mock = True
+
+    def visitFrom(self, node):
+        if node.modname == 'mock' and (name for name in node.names if 'patch' in name):
+            self.imported_patch = True
+
+    def visitCallFunc(self, node):
+        try:
+            if (self.imported_patch and node.node.name == 'patch') or \
+                    (self.imported_mock and node.node.expr.name == 'mock' and node.node.attrname == 'patch'):
+                if not any(
+                        [arg for arg in node.args if isinstance(arg, compiler.ast.Keyword) and arg.name == 'autospec']):
+                    print "%s:%d: Found a mock without an autospec!" % (self.current_filename, node.lineno)
+                    self.errors += 1
+        except AttributeError:
+            pass
+
+
+def main(filenames):
+    checker = MockChecker()
+    checker.check_files(filenames)
+    if checker.errors == 0:
+        sys.exit(0)
+    else:
+        print "You probably meant to specify 'autospec=True' in these tests."
+        print "If you really don't want to, specify 'autospec=None'"
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/paasta_tools/contrib/mock_patch_checker.py
+++ b/paasta_tools/contrib/mock_patch_checker.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python2.7
 import compiler
 import sys
+from compiler.visitor import ASTVisitor
 
 
-class MockChecker(object):
+class MockChecker(ASTVisitor):
     def __init__(self):
         self.errors = 0
         self.init_module_imports()
@@ -44,6 +45,8 @@ class MockChecker(object):
                     self.errors += 1
         except AttributeError:
             pass
+        for child in node.getChildNodes():
+            self.visit(child)
 
 
 def main(filenames):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-PyStaticConfiguration==0.9.0
-PyYAML==3.11
-Pygments==2.0.2
 argcomplete==0.8.1
 argparse==1.2.1
 backports.ssl-match-hostname==3.4.0.2
@@ -33,13 +30,16 @@ prettytable==0.7.2
 protobuf==2.6.1
 pyasn1==0.1.8
 pycrypto==2.6.1
+Pygments==2.0.2
 pyramid==1.7
 pyramid-swagger==2.2.3
 pysensu-yelp==0.2.2
+PyStaticConfiguration==0.9.0
 python-daemon==1.5.2
 python-dateutil==2.4.2
 pytimeparse==1.1.5
 pytz==2014.10
+PyYAML==3.11
 requests==2.6.2
 requests-cache==0.4.10
 sensu-plugin==0.1.0


### PR DESCRIPTION
Example:

```
(general_itests)matts@some-hostname:~/paasta (master) $ pre-commit run --all-files
Trim Trailing Whitespace...........................................................................................................................................Passed
Fix End of Files...................................................................................................................................................Passed
autopep8 wrapper...................................................................................................................................................Passed
Check docstring is first...........................................................................................................................................Passed
Check JSON.........................................................................................................................................................Passed
Check Yaml.........................................................................................................................................................Passed
Debug Statements (Python)..........................................................................................................................................Passed
Tests should end in _test.py.......................................................................................................................................Passed
Fix requirements.txt...............................................................................................................................................Passed
Flake8.............................................................................................................................................................Passed
Reorder python imports.............................................................................................................................................Failed
hookid: reorder-python-imports

Files were modified by this hook.

mock.patch enforce autospec........................................................................................................................................Failed
hookid: patch-enforce-autospec

tests/cli/test_cmds_check.py:42: Found a mock without an autospec!
tests/cli/test_cmds_check.py:43: Found a mock without an autospec!
tests/cli/test_cmds_check.py:44: Found a mock without an autospec!
tests/cli/test_cmds_check.py:45: Found a mock without an autospec!
...............
tests/test_marathon_serviceinit.py:958: Found a mock without an autospec!
tests/test_marathon_serviceinit.py:968: Found a mock without an autospec!
You probably meant to specify 'autospec=True' in these tests.
If you really can't use autospec, please specify 'autospec=False'

```