### PR TITLE
Test main methods in autoscaling scripts

### DIFF
--- a/tests/test_autoscale_all_services.py
+++ b/tests/test_autoscale_all_services.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+
+from paasta_tools.autoscale_all_services import main
+
+
+@mock.patch('paasta_tools.autoscale_all_services.logging', autospec=True)
+@mock.patch('paasta_tools.autoscale_all_services.autoscale_services', autospec=True)
+@mock.patch('paasta_tools.autoscale_all_services.parse_args', autospec=True)
+def test_main(mock_parse_args, mock_autoscale_services, logging):
+    mock_parse_args.return_value = mock.Mock(soa_dir='/nail/blah')
+    main()
+    mock_autoscale_services.assert_called_with(soa_dir='/nail/blah')

--- a/tests/test_autoscale_cluster.py
+++ b/tests/test_autoscale_cluster.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+
+from paasta_tools.autoscale_cluster import main
+
+
+@mock.patch('paasta_tools.autoscale_cluster.logging', autospec=True)
+@mock.patch('paasta_tools.autoscale_cluster.autoscale_local_cluster', autospec=True)
+@mock.patch('paasta_tools.autoscale_cluster.parse_args', autospec=True)
+def test_main(mock_parse_args, mock_autoscale_local_cluster, logging):
+    mock_parse_args.return_value = mock.Mock(dry_run=True)
+    main()
+    mock_autoscale_local_cluster.assert_called_with(dry_run=True)


### PR DESCRIPTION
Kind of a noddy test but would have picked up some ImportErrors that I
introduced recently so better than 0 coverage.

@nhandler this covers your comment in https://github.com/Yelp/paasta/pull/763 itests are pretty difficult with the autoscaler(s) but this would have at least caught the ImportError.