### PR TITLE
PaaSTA docker_exec, docker_stop, sysdig, docker_inspect

### DIFF
--- a/example_cluster/docker-compose.override.yml
+++ b/example_cluster/docker-compose.override.yml
@@ -22,10 +22,17 @@ services:
       - ssh-data:/root/.ssh
     command: '/start.sh'
   mesosslave:
+    ports:
+      - 5051
+      - 22
     build: ../yelp_package/dockerfiles/mesos-paasta/
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ssh-data:/root/.ssh
     depends_on:
       - mesosbase
       - zookeeper
+    command: '/start-slave.sh'
   marathon:
     ports:
       - '8080:8080'

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -24,10 +24,10 @@ from pyramid.view import view_config
 from paasta_tools import marathon_tools
 from paasta_tools.api import settings
 from paasta_tools.cli.cmds.status import get_actual_deployments
+from paasta_tools.mesos_tools import get_running_tasks_from_active_frameworks
 from paasta_tools.paasta_serviceinit import get_deployment_version
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import validate_service_instance
-from paasta_tools.mesos_tools import get_running_tasks_from_active_frameworks
 
 
 log = logging.getLogger(__name__)

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -27,6 +27,7 @@ from paasta_tools.cli.cmds.status import get_actual_deployments
 from paasta_tools.paasta_serviceinit import get_deployment_version
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import validate_service_instance
+from paasta_tools.mesos_tools import get_running_tasks_from_active_frameworks
 
 
 log = logging.getLogger(__name__)
@@ -46,6 +47,7 @@ def marathon_job_status(mstatus, client, job_config):
         return
 
     mstatus['app_id'] = app_id
+    mstatus['slaves'] = list({task.slave['hostname'] for task in get_running_tasks_from_active_frameworks(app_id)})
     mstatus['expected_instance_count'] = job_config.get_instances()
 
     deploy_status = marathon_tools.get_marathon_app_deploy_status(client, app_id)

--- a/paasta_tools/cli/cmds/docker_exec.py
+++ b/paasta_tools/cli/cmds/docker_exec.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 import subprocess
 
-from paasta_tools.mesos_tools import get_container_name
-from paasta_tools.cli.utils import get_subparser
 from paasta_tools.cli.utils import get_status_for_instance
+from paasta_tools.cli.utils import get_subparser
 from paasta_tools.cli.utils import pick_slave_from_status
+from paasta_tools.mesos_tools import get_container_name
 
 
 def add_subparser(subparsers):
@@ -30,6 +30,7 @@ def add_subparser(subparsers):
                                subparsers=subparsers)
     new_parser.add_argument('exec_command',
                             help='Command to append to docker docker_exec',
+                            nargs='?',
                             default='/bin/bash')
 
 

--- a/paasta_tools/cli/cmds/docker_exec.py
+++ b/paasta_tools/cli/cmds/docker_exec.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import subprocess
+
+from paasta_tools.mesos_tools import get_container_name
+from paasta_tools.cli.utils import get_subparser
+from paasta_tools.cli.utils import get_status_for_instance
+from paasta_tools.cli.utils import pick_slave_from_status
+
+
+def add_subparser(subparsers):
+    new_parser = get_subparser(description="'paasta docker_exec' works by picking a container running your service "
+                                           "at random. It then runs docker exec -ti <container_id> <commands> "
+                                           "where commands are those that you specify",
+                               help_text="Docker exec against a container running your service",
+                               command='docker_exec',
+                               function=paasta_docker_exec,
+                               subparsers=subparsers)
+    new_parser.add_argument('exec_command',
+                            help='Command to append to docker docker_exec',
+                            default='/bin/bash')
+
+
+def paasta_docker_exec(args):
+    status = get_status_for_instance(cluster=args.cluster,
+                                     service=args.service,
+                                     instance=args.instance)
+    slave = pick_slave_from_status(status=status,
+                                   host=args.host)
+    container = get_container_name(status.marathon.app_id, slave_hostname=slave, task_id=args.mesos_id)
+    command = "sudo docker exec -ti {0} ''{1}''".format(container, args.exec_command)
+    subprocess.call(["ssh", "-o", "LogLevel=QUIET", "-tA", slave, command])

--- a/paasta_tools/cli/cmds/docker_inspect.py
+++ b/paasta_tools/cli/cmds/docker_inspect.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import subprocess
+
+from paasta_tools.mesos_tools import get_container_name
+from paasta_tools.cli.utils import get_subparser
+from paasta_tools.cli.utils import get_status_for_instance
+from paasta_tools.cli.utils import pick_slave_from_status
+
+
+def add_subparser(subparsers):
+    get_subparser(description="'paasta docker_inspect' works by picking a container running your service "
+                              "at random. It then runs docker docker_inspect <container_id> ",
+                  help_text="Docker inspect against a container running your service",
+                  command='docker_inspect',
+                  function=paasta_docker_inspect,
+                  subparsers=subparsers)
+
+
+def paasta_docker_inspect(args):
+    status = get_status_for_instance(cluster=args.cluster,
+                                     service=args.service,
+                                     instance=args.instance)
+    slave = pick_slave_from_status(status=status,
+                                   host=args.host)
+    container = get_container_name(status.marathon.app_id, slave_hostname=slave, task_id=args.mesos_id)
+    command = "sudo docker inspect {0}".format(container)
+    subprocess.call(["ssh", "-o", "LogLevel=QUIET", "-tA", slave, command])

--- a/paasta_tools/cli/cmds/docker_inspect.py
+++ b/paasta_tools/cli/cmds/docker_inspect.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 import subprocess
 
-from paasta_tools.mesos_tools import get_container_name
-from paasta_tools.cli.utils import get_subparser
 from paasta_tools.cli.utils import get_status_for_instance
+from paasta_tools.cli.utils import get_subparser
 from paasta_tools.cli.utils import pick_slave_from_status
+from paasta_tools.mesos_tools import get_container_name
 
 
 def add_subparser(subparsers):

--- a/paasta_tools/cli/cmds/docker_stop.py
+++ b/paasta_tools/cli/cmds/docker_stop.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import subprocess
+
+from paasta_tools.mesos_tools import get_container_name
+from paasta_tools.cli.utils import get_subparser
+from paasta_tools.cli.utils import get_status_for_instance
+from paasta_tools.cli.utils import pick_slave_from_status
+
+
+def add_subparser(subparsers):
+    new_parser = get_subparser(description="'paasta docker_stop' works by picking a container running your service "
+                                           "at random. It then runs docker stop <container_id> to stop the container. "
+                                           "You should expect marathon to then replace the dead container. "
+                                           "Note this doesn't do any draining of the connections to this container!",
+                               help_text="Docker stop a container running your service",
+                               command='docker_stop',
+                               function=paasta_docker_stop,
+                               subparsers=subparsers)
+
+
+def paasta_docker_stop(args):
+    status = get_status_for_instance(cluster=args.cluster,
+                                     service=args.service,
+                                     instance=args.instance)
+    slave = pick_slave_from_status(status=status,
+                                   host=args.host)
+    container = get_container_name(status.marathon.app_id, slave_hostname=slave, task_id=args.mesos_id)
+    command = "sudo docker stop {0}".format(container)
+    subprocess.call(["ssh", "-o", "LogLevel=QUIET", "-tA", slave, command])

--- a/paasta_tools/cli/cmds/docker_stop.py
+++ b/paasta_tools/cli/cmds/docker_stop.py
@@ -14,21 +14,21 @@
 # limitations under the License.
 import subprocess
 
-from paasta_tools.mesos_tools import get_container_name
-from paasta_tools.cli.utils import get_subparser
 from paasta_tools.cli.utils import get_status_for_instance
+from paasta_tools.cli.utils import get_subparser
 from paasta_tools.cli.utils import pick_slave_from_status
+from paasta_tools.mesos_tools import get_container_name
 
 
 def add_subparser(subparsers):
-    new_parser = get_subparser(description="'paasta docker_stop' works by picking a container running your service "
-                                           "at random. It then runs docker stop <container_id> to stop the container. "
-                                           "You should expect marathon to then replace the dead container. "
-                                           "Note this doesn't do any draining of the connections to this container!",
-                               help_text="Docker stop a container running your service",
-                               command='docker_stop',
-                               function=paasta_docker_stop,
-                               subparsers=subparsers)
+    get_subparser(description="'paasta docker_stop' works by picking a container running your service "
+                              "at random. It then runs docker stop <container_id> to stop the container. "
+                              "You should expect marathon to then replace the dead container. "
+                              "Note this doesn't do any draining of the connections to this container!",
+                  help_text="Docker stop a container running your service",
+                  command='docker_stop',
+                  function=paasta_docker_stop,
+                  subparsers=subparsers)
 
 
 def paasta_docker_stop(args):

--- a/paasta_tools/cli/cmds/sysdig.py
+++ b/paasta_tools/cli/cmds/sysdig.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import shlex
+import subprocess
+import sys
+from urlparse import urlparse
+
+from paasta_tools.api import client
+from paasta_tools.cli.utils import calculate_remote_masters
+from paasta_tools.cli.utils import find_connectable_master
+from paasta_tools.cli.utils import lazy_choices_completer
+from paasta_tools.cli.utils import list_services
+from paasta_tools.marathon_tools import load_marathon_config
+from paasta_tools.mesos_tools import get_mesos_master
+from paasta_tools.mesos_tools import get_running_tasks_from_active_frameworks
+from paasta_tools.utils import _run
+from paasta_tools.utils import list_clusters
+from paasta_tools.utils import load_system_paasta_config
+
+
+def add_subparser(subparsers):
+    sysdig_parser = subparsers.add_parser(
+        'sysdig',
+        help="Run sysdig on a remote host and filter to a service and instance",
+        description=(
+            "'paasta sysdig' works by SSH'ing to remote PaaSTA masters and "
+            "running sysdig with the neccessary filters"
+        ),
+        epilog=(
+            "Note: This command requires SSH and sudo privileges on the remote PaaSTA "
+            "nodes."
+        ),
+    )
+    sysdig_parser.add_argument(
+        '-s', '--service',
+        help='The name of the service you wish to inspect',
+        required=True
+    ).completer = lazy_choices_completer(list_services)
+    sysdig_parser.add_argument(
+        '-c', '--cluster',
+        help="Cluster on which the service is running"
+             "For example: --cluster norcal-prod",
+        required=True
+    ).completer = lazy_choices_completer(list_clusters)
+    sysdig_parser.add_argument(
+        '-i', '--instance',
+        help="The instance that you wish to inspect with sysdig"
+             "For example: --instance main",
+        required=True,
+        default='main'
+    )  # No completer because we need to know service first and we can't until some other stuff has happened
+    sysdig_parser.add_argument(
+        '-l', '--local',
+        help="Run the script here rather than SSHing to a PaaSTA master",
+        default=False,
+        action='store_true'
+    )
+    sysdig_parser.add_argument(
+        '-H', '--host',
+        dest="host",
+        default=None,
+        help="Specify a specific host on which to run sysdig. Defaults to"
+             " one that is running the service chosen at random"
+    )
+    sysdig_parser.set_defaults(command=paasta_sysdig)
+
+
+def paasta_sysdig(args):
+    if not args.local:
+        system_paasta_config = load_system_paasta_config()
+        masters, output = calculate_remote_masters(args.cluster, system_paasta_config)
+        if masters == []:
+            print 'ERROR: %s' % output
+        mesos_master, output = find_connectable_master(masters)
+        if not mesos_master:
+            print 'ERROR: could not find connectable master in cluster %s\nOutput: %s' % (args.cluster, output)
+        ssh_cmd = 'ssh -At -o LogLevel=QUIET {0} "sudo paasta {1} --local"'.format(mesos_master, ' '.join(sys.argv[1:]))
+        return_code, output = _run(ssh_cmd)
+        if return_code != 0:
+            print output
+            sys.exit(return_code)
+        slave, command = output.split(':', 1)
+        print command
+        subprocess.call(shlex.split("ssh -tA {0} '{1}'".format(slave, command.strip())))
+        sys.exit(0)
+    api = client.get_paasta_api_client(cluster=args.cluster)
+    if not api:
+        sys.exit(1)
+    status = api.service.status_instance(service=args.service, instance=args.instance).result()
+    app_id = status.marathon.app_id
+    if args.host:
+        slave = args.host
+    else:
+        slaves = [task.slave['hostname'] for task in get_running_tasks_from_active_frameworks(status.marathon.app_id)]
+        slave = slaves[0]
+    marathon_config = load_marathon_config()
+    marathon_url = marathon_config.get_url()[0]
+    marathon_user = marathon_config.get_username()
+    marathon_pass = marathon_config.get_password()
+    mesos_url = get_mesos_master().host
+    marathon_parsed_url = urlparse(marathon_url)
+    marathon_creds_url = marathon_parsed_url._replace(netloc="{0}:{1}@{2}".format(marathon_user, marathon_pass,
+                                                                                  marathon_parsed_url.netloc))
+    sysdig_mesos = '{0},{1}'.format(mesos_url, marathon_creds_url.geturl())
+    command = 'sudo csysdig -m {0} marathon.app.id="{1}" -v mesos_tasks'.format(sysdig_mesos, app_id)
+    print slave + ":" + command

--- a/paasta_tools/cli/cmds/sysdig.py
+++ b/paasta_tools/cli/cmds/sysdig.py
@@ -17,94 +17,61 @@ import subprocess
 import sys
 from urlparse import urlparse
 
-from paasta_tools.api import client
 from paasta_tools.cli.utils import calculate_remote_masters
 from paasta_tools.cli.utils import find_connectable_master
-from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.cli.utils import list_services
+from paasta_tools.cli.utils import get_subparser
+from paasta_tools.cli.utils import get_status_for_instance
+from paasta_tools.cli.utils import pick_slave_from_status
 from paasta_tools.marathon_tools import load_marathon_config
 from paasta_tools.mesos_tools import get_mesos_master
-from paasta_tools.mesos_tools import get_running_tasks_from_active_frameworks
 from paasta_tools.utils import _run
-from paasta_tools.utils import list_clusters
 from paasta_tools.utils import load_system_paasta_config
 
 
 def add_subparser(subparsers):
-    sysdig_parser = subparsers.add_parser(
-        'sysdig',
-        help="Run sysdig on a remote host and filter to a service and instance",
-        description=(
-            "'paasta sysdig' works by SSH'ing to remote PaaSTA masters and "
-            "running sysdig with the neccessary filters"
-        ),
-        epilog=(
-            "Note: This command requires SSH and sudo privileges on the remote PaaSTA "
-            "nodes."
-        ),
-    )
-    sysdig_parser.add_argument(
-        '-s', '--service',
-        help='The name of the service you wish to inspect',
-        required=True
-    ).completer = lazy_choices_completer(list_services)
-    sysdig_parser.add_argument(
-        '-c', '--cluster',
-        help="Cluster on which the service is running"
-             "For example: --cluster norcal-prod",
-        required=True
-    ).completer = lazy_choices_completer(list_clusters)
-    sysdig_parser.add_argument(
-        '-i', '--instance',
-        help="The instance that you wish to inspect with sysdig"
-             "For example: --instance main",
-        required=True,
-        default='main'
-    )  # No completer because we need to know service first and we can't until some other stuff has happened
-    sysdig_parser.add_argument(
+    new_parser = get_subparser(description="'paasta sysdig' works by SSH'ing to remote PaaSTA masters and "
+                                           "running sysdig with the neccessary filters",
+                               help_text="Run sysdig on a remote host and filter to a service and instance",
+                               command='sysdig',
+                               function=paasta_sysdig,
+                               subparsers=subparsers)
+    new_parser.add_argument(
         '-l', '--local',
         help="Run the script here rather than SSHing to a PaaSTA master",
         default=False,
         action='store_true'
     )
-    sysdig_parser.add_argument(
-        '-H', '--host',
-        dest="host",
-        default=None,
-        help="Specify a specific host on which to run sysdig. Defaults to"
-             " one that is running the service chosen at random"
-    )
-    sysdig_parser.set_defaults(command=paasta_sysdig)
+
+
+def get_any_mesos_master(cluster):
+    system_paasta_config = load_system_paasta_config()
+    masters, output = calculate_remote_masters(cluster, system_paasta_config)
+    if not masters:
+        print 'ERROR: %s' % output
+        sys.exit(1)
+    mesos_master, output = find_connectable_master(masters)
+    if not mesos_master:
+        print 'ERROR: could not find connectable master in cluster %s\nOutput: %s' % (cluster, output)
+        sys.exit(1)
+    return mesos_master
 
 
 def paasta_sysdig(args):
     if not args.local:
-        system_paasta_config = load_system_paasta_config()
-        masters, output = calculate_remote_masters(args.cluster, system_paasta_config)
-        if masters == []:
-            print 'ERROR: %s' % output
-        mesos_master, output = find_connectable_master(masters)
-        if not mesos_master:
-            print 'ERROR: could not find connectable master in cluster %s\nOutput: %s' % (args.cluster, output)
+        mesos_master = get_any_mesos_master(cluster=args.cluster)
         ssh_cmd = 'ssh -At -o LogLevel=QUIET {0} "sudo paasta {1} --local"'.format(mesos_master, ' '.join(sys.argv[1:]))
         return_code, output = _run(ssh_cmd)
         if return_code != 0:
             print output
             sys.exit(return_code)
         slave, command = output.split(':', 1)
-        print command
         subprocess.call(shlex.split("ssh -tA {0} '{1}'".format(slave, command.strip())))
-        sys.exit(0)
-    api = client.get_paasta_api_client(cluster=args.cluster)
-    if not api:
-        sys.exit(1)
-    status = api.service.status_instance(service=args.service, instance=args.instance).result()
-    app_id = status.marathon.app_id
-    if args.host:
-        slave = args.host
-    else:
-        slaves = [task.slave['hostname'] for task in get_running_tasks_from_active_frameworks(status.marathon.app_id)]
-        slave = slaves[0]
+        return
+    status = get_status_for_instance(cluster=args.cluster,
+                                     service=args.service,
+                                     instance=args.instance)
+    slave = pick_slave_from_status(status=status,
+                                   host=args.host)
     marathon_config = load_marathon_config()
     marathon_url = marathon_config.get_url()[0]
     marathon_user = marathon_config.get_username()
@@ -113,6 +80,10 @@ def paasta_sysdig(args):
     marathon_parsed_url = urlparse(marathon_url)
     marathon_creds_url = marathon_parsed_url._replace(netloc="{0}:{1}@{2}".format(marathon_user, marathon_pass,
                                                                                   marathon_parsed_url.netloc))
-    sysdig_mesos = '{0},{1}'.format(mesos_url, marathon_creds_url.geturl())
+    print format_mesos_command(slave, status.marathon.app_id, mesos_url, marathon_creds_url.geturl())
+
+
+def format_mesos_command(slave, app_id, mesos_url, marathon_url):
+    sysdig_mesos = '{0},{1}'.format(mesos_url, marathon_url)
     command = 'sudo csysdig -m {0} marathon.app.id="{1}" -v mesos_tasks'.format(sysdig_mesos, app_id)
-    print slave + ":" + command
+    return slave + ":" + command

--- a/paasta_tools/cli/cmds/sysdig.py
+++ b/paasta_tools/cli/cmds/sysdig.py
@@ -19,8 +19,8 @@ from urlparse import urlparse
 
 from paasta_tools.cli.utils import calculate_remote_masters
 from paasta_tools.cli.utils import find_connectable_master
-from paasta_tools.cli.utils import get_subparser
 from paasta_tools.cli.utils import get_status_for_instance
+from paasta_tools.cli.utils import get_subparser
 from paasta_tools.cli.utils import pick_slave_from_status
 from paasta_tools.marathon_tools import load_marathon_config
 from paasta_tools.mesos_tools import get_mesos_master

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -33,7 +33,6 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_default_cluster_for_service
 from paasta_tools.utils import list_all_instances_for_service
 from paasta_tools.utils import list_clusters
-from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import validate_service_instance

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -68,10 +68,16 @@ def test_instances_status(
     assert response['marathon']['desired_state'] == 'start'
 
 
+@mock.patch('paasta_tools.api.views.instance.get_running_tasks_from_active_frameworks', autospec=True)
 @mock.patch('paasta_tools.api.views.instance.marathon_tools.is_app_id_running', autospec=True)
 def test_marathon_job_status(
     mock_is_app_id_running,
+    mock_get_running_tasks_from_active_frameworks,
 ):
+    mock_tasks = [mock.Mock(slave={'hostname': 'host1'}),
+                  mock.Mock(slave={'hostname': 'host1'}),
+                  mock.Mock(slave={'hostname': 'host2'})]
+    mock_get_running_tasks_from_active_frameworks.return_value = mock_tasks
     mock_is_app_id_running.return_value = True
 
     app = mock.create_autospec(marathon.models.app.MarathonApp)
@@ -88,4 +94,9 @@ def test_marathon_job_status(
 
     mstatus = {}
     marathon_job_status(mstatus, client, job_config)
-    assert mstatus['deploy_status'] == 'Running'
+    expected = {'deploy_status': 'Running',
+                'running_instance_count': 5,
+                'expected_instance_count': 5,
+                'app_id': 'mock_app_id',
+                'slaves': ['host2', 'host1']}
+    assert mstatus == expected

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -97,6 +97,8 @@ def test_marathon_job_status(
     expected = {'deploy_status': 'Running',
                 'running_instance_count': 5,
                 'expected_instance_count': 5,
-                'app_id': 'mock_app_id',
-                'slaves': ['host2', 'host1']}
+                'app_id': 'mock_app_id'}
+    expected_slaves = ['host2', 'host1']
+    slaves = mstatus.pop('slaves')
+    assert len(slaves) == len(expected_slaves) and sorted(slaves) == sorted(expected_slaves)
     assert mstatus == expected

--- a/tests/cli/test_cmds_docker_exec.py
+++ b/tests/cli/test_cmds_docker_exec.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import mock
 from mock import patch
+
 from paasta_tools.cli.cmds import docker_exec
 
 
@@ -23,6 +24,7 @@ def test_add_subparser(mock_get_subparser):
     assert mock_get_subparser.called
     mock_get_subparser.return_value.add_argument.assert_called_with('exec_command',
                                                                     help='Command to append to docker docker_exec',
+                                                                    nargs='?',
                                                                     default='/bin/bash')
 
 
@@ -40,7 +42,7 @@ def test_paasta_docker_exec(mock_get_status_for_instance, mock_pick_slave_from_s
                           host='host1',
                           mesos_id=None,
                           exec_command='/bin/bash')
-    mock_pick_slave_from_status.return_value='host1'
+    mock_pick_slave_from_status.return_value = 'host1'
 
     docker_exec.paasta_docker_exec(mock_args)
     mock_get_status_for_instance.assert_called_with(cluster='cluster1',

--- a/tests/cli/test_cmds_docker_exec.py
+++ b/tests/cli/test_cmds_docker_exec.py
@@ -1,0 +1,55 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+from mock import patch
+from paasta_tools.cli.cmds import docker_exec
+
+
+@patch('paasta_tools.cli.cmds.docker_exec.get_subparser', autospec=True)
+def test_add_subparser(mock_get_subparser):
+    mock_subparsers = mock.Mock()
+    docker_exec.add_subparser(mock_subparsers)
+    assert mock_get_subparser.called
+    mock_get_subparser.return_value.add_argument.assert_called_with('exec_command',
+                                                                    help='Command to append to docker docker_exec',
+                                                                    default='/bin/bash')
+
+
+@patch('paasta_tools.cli.cmds.docker_exec.subprocess', autospec=True)
+@patch('paasta_tools.cli.cmds.docker_exec.get_container_name', autospec=True)
+@patch('paasta_tools.cli.cmds.docker_exec.pick_slave_from_status', autospec=True)
+@patch('paasta_tools.cli.cmds.docker_exec.get_status_for_instance', autospec=True)
+def test_paasta_docker_exec(mock_get_status_for_instance, mock_pick_slave_from_status, mock_get_container_name,
+                            mock_subprocess):
+    mock_status = mock.Mock(marathon=mock.Mock(app_id='appID1'))
+    mock_get_status_for_instance.return_value = mock_status
+    mock_args = mock.Mock(cluster='cluster1',
+                          service='mock_service',
+                          instance='mock_instance',
+                          host='host1',
+                          mesos_id=None,
+                          exec_command='/bin/bash')
+    mock_pick_slave_from_status.return_value='host1'
+
+    docker_exec.paasta_docker_exec(mock_args)
+    mock_get_status_for_instance.assert_called_with(cluster='cluster1',
+                                                    service='mock_service',
+                                                    instance='mock_instance')
+    mock_pick_slave_from_status.assert_called_with(status=mock_status,
+                                                   host='host1')
+
+    mock_get_container_name.assert_called_with('appID1', slave_hostname='host1', task_id=None)
+    expected = ["ssh", "-o", "LogLevel=QUIET", "-tA", mock_pick_slave_from_status.return_value,
+                "sudo docker exec -ti {0} ''/bin/bash''".format(mock_get_container_name.return_value)]
+    mock_subprocess.call.assert_called_with(expected)

--- a/tests/cli/test_cmds_docker_inspect.py
+++ b/tests/cli/test_cmds_docker_inspect.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import mock
 from mock import patch
+
 from paasta_tools.cli.cmds import docker_inspect
 
 
@@ -28,7 +29,7 @@ def test_add_subparser(mock_get_subparser):
 @patch('paasta_tools.cli.cmds.docker_inspect.pick_slave_from_status', autospec=True)
 @patch('paasta_tools.cli.cmds.docker_inspect.get_status_for_instance', autospec=True)
 def test_paasta_docker_inspect(mock_get_status_for_instance, mock_pick_slave_from_status, mock_get_container_name,
-                            mock_subprocess):
+                               mock_subprocess):
     mock_status = mock.Mock(marathon=mock.Mock(app_id='appID1'))
     mock_get_status_for_instance.return_value = mock_status
     mock_args = mock.Mock(cluster='cluster1',
@@ -36,7 +37,7 @@ def test_paasta_docker_inspect(mock_get_status_for_instance, mock_pick_slave_fro
                           instance='mock_instance',
                           host='host1',
                           mesos_id=None)
-    mock_pick_slave_from_status.return_value='host1'
+    mock_pick_slave_from_status.return_value = 'host1'
 
     docker_inspect.paasta_docker_inspect(mock_args)
     mock_get_status_for_instance.assert_called_with(cluster='cluster1',

--- a/tests/cli/test_cmds_docker_inspect.py
+++ b/tests/cli/test_cmds_docker_inspect.py
@@ -1,0 +1,51 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+from mock import patch
+from paasta_tools.cli.cmds import docker_inspect
+
+
+@patch('paasta_tools.cli.cmds.docker_inspect.get_subparser', autospec=True)
+def test_add_subparser(mock_get_subparser):
+    mock_subparsers = mock.Mock()
+    docker_inspect.add_subparser(mock_subparsers)
+    assert mock_get_subparser.called
+
+
+@patch('paasta_tools.cli.cmds.docker_inspect.subprocess', autospec=True)
+@patch('paasta_tools.cli.cmds.docker_inspect.get_container_name', autospec=True)
+@patch('paasta_tools.cli.cmds.docker_inspect.pick_slave_from_status', autospec=True)
+@patch('paasta_tools.cli.cmds.docker_inspect.get_status_for_instance', autospec=True)
+def test_paasta_docker_inspect(mock_get_status_for_instance, mock_pick_slave_from_status, mock_get_container_name,
+                            mock_subprocess):
+    mock_status = mock.Mock(marathon=mock.Mock(app_id='appID1'))
+    mock_get_status_for_instance.return_value = mock_status
+    mock_args = mock.Mock(cluster='cluster1',
+                          service='mock_service',
+                          instance='mock_instance',
+                          host='host1',
+                          mesos_id=None)
+    mock_pick_slave_from_status.return_value='host1'
+
+    docker_inspect.paasta_docker_inspect(mock_args)
+    mock_get_status_for_instance.assert_called_with(cluster='cluster1',
+                                                    service='mock_service',
+                                                    instance='mock_instance')
+    mock_pick_slave_from_status.assert_called_with(status=mock_status,
+                                                   host='host1')
+
+    mock_get_container_name.assert_called_with('appID1', slave_hostname='host1', task_id=None)
+    expected = ["ssh", "-o", "LogLevel=QUIET", "-tA", mock_pick_slave_from_status.return_value,
+                "sudo docker inspect {0}".format(mock_get_container_name.return_value)]
+    mock_subprocess.call.assert_called_with(expected)

--- a/tests/cli/test_cmds_docker_stop.py
+++ b/tests/cli/test_cmds_docker_stop.py
@@ -1,0 +1,51 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+from mock import patch
+from paasta_tools.cli.cmds import docker_stop
+
+
+@patch('paasta_tools.cli.cmds.docker_stop.get_subparser', autospec=True)
+def test_add_subparser(mock_get_subparser):
+    mock_subparsers = mock.Mock()
+    docker_stop.add_subparser(mock_subparsers)
+    assert mock_get_subparser.called
+
+
+@patch('paasta_tools.cli.cmds.docker_stop.subprocess', autospec=True)
+@patch('paasta_tools.cli.cmds.docker_stop.get_container_name', autospec=True)
+@patch('paasta_tools.cli.cmds.docker_stop.pick_slave_from_status', autospec=True)
+@patch('paasta_tools.cli.cmds.docker_stop.get_status_for_instance', autospec=True)
+def test_paasta_docker_stop(mock_get_status_for_instance, mock_pick_slave_from_status, mock_get_container_name,
+                            mock_subprocess):
+    mock_status = mock.Mock(marathon=mock.Mock(app_id='appID1'))
+    mock_get_status_for_instance.return_value = mock_status
+    mock_args = mock.Mock(cluster='cluster1',
+                          service='mock_service',
+                          instance='mock_instance',
+                          host='host1',
+                          mesos_id=None)
+    mock_pick_slave_from_status.return_value='host1'
+
+    docker_stop.paasta_docker_stop(mock_args)
+    mock_get_status_for_instance.assert_called_with(cluster='cluster1',
+                                                    service='mock_service',
+                                                    instance='mock_instance')
+    mock_pick_slave_from_status.assert_called_with(status=mock_status,
+                                                   host='host1')
+
+    mock_get_container_name.assert_called_with('appID1', slave_hostname='host1', task_id=None)
+    expected = ["ssh", "-o", "LogLevel=QUIET", "-tA", mock_pick_slave_from_status.return_value,
+                "sudo docker stop {0}".format(mock_get_container_name.return_value)]
+    mock_subprocess.call.assert_called_with(expected)

--- a/tests/cli/test_cmds_docker_stop.py
+++ b/tests/cli/test_cmds_docker_stop.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import mock
 from mock import patch
+
 from paasta_tools.cli.cmds import docker_stop
 
 
@@ -36,7 +37,7 @@ def test_paasta_docker_stop(mock_get_status_for_instance, mock_pick_slave_from_s
                           instance='mock_instance',
                           host='host1',
                           mesos_id=None)
-    mock_pick_slave_from_status.return_value='host1'
+    mock_pick_slave_from_status.return_value = 'host1'
 
     docker_stop.paasta_docker_stop(mock_args)
     mock_get_status_for_instance.assert_called_with(cluster='cluster1',

--- a/tests/cli/test_cmds_sysdig.py
+++ b/tests/cli/test_cmds_sysdig.py
@@ -11,11 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
+
 import mock
 from mock import patch
-from paasta_tools.cli.cmds import sysdig
 from pytest import raises
-import sys
+
+from paasta_tools.cli.cmds import sysdig
 
 
 @patch('paasta_tools.cli.cmds.sysdig.get_subparser', autospec=True)
@@ -91,14 +93,14 @@ def test_format_mesos_command():
     assert ret == expected
 
 
-@patch('paasta_tools.cli.cmds.sysdig.load_system_paasta_config', autosec=True)
-@patch('paasta_tools.cli.cmds.sysdig.calculate_remote_masters', autosec=True)
-@patch('paasta_tools.cli.cmds.sysdig.find_connectable_master', autosec=True)
+@patch('paasta_tools.cli.cmds.sysdig.load_system_paasta_config', autospec=True)
+@patch('paasta_tools.cli.cmds.sysdig.calculate_remote_masters', autospec=True)
+@patch('paasta_tools.cli.cmds.sysdig.find_connectable_master', autospec=True)
 def test_get_any_mesos_master(mock_find_connectable_master, mock_calculate_remote_masters, mock_load_system_config):
     mock_calculate_remote_masters.return_value = ([], 'fakeERROR')
     with raises(SystemExit):
         sysdig.get_any_mesos_master('cluster1')
-    mock_load_system_config.assert_called()
+    assert mock_load_system_config.called
     mock_calculate_remote_masters.assert_called_with('cluster1',
                                                      mock_load_system_config.return_value)
 

--- a/tests/cli/test_cmds_sysdig.py
+++ b/tests/cli/test_cmds_sysdig.py
@@ -1,0 +1,113 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+from mock import patch
+from paasta_tools.cli.cmds import sysdig
+from pytest import raises
+import sys
+
+
+@patch('paasta_tools.cli.cmds.sysdig.get_subparser', autospec=True)
+def test_add_subparser(mock_get_subparser):
+    mock_subparsers = mock.Mock()
+    sysdig.add_subparser(mock_subparsers)
+    assert mock_get_subparser.called
+
+
+@patch.object(sys, 'argv', ['paasta', 'sysdig', 'blah', 'blah'])
+@patch('paasta_tools.cli.cmds.sysdig.format_mesos_command', autospec=True)
+@patch('paasta_tools.cli.cmds.sysdig.get_mesos_master', autospec=True)
+@patch('paasta_tools.cli.cmds.sysdig.load_marathon_config', autospec=True)
+@patch('paasta_tools.cli.cmds.sysdig._run', autospec=True)
+@patch('paasta_tools.cli.cmds.sysdig.get_any_mesos_master', autospec=True)
+@patch('paasta_tools.cli.cmds.sysdig.subprocess', autospec=True)
+@patch('paasta_tools.cli.cmds.sysdig.pick_slave_from_status', autospec=True)
+@patch('paasta_tools.cli.cmds.sysdig.get_status_for_instance', autospec=True)
+def test_paasta_sysdig(mock_get_status_for_instance,
+                       mock_pick_slave_from_status,
+                       mock_subprocess,
+                       mock_get_any_mesos_master,
+                       mock__run,
+                       mock_load_marathon_config,
+                       mock_get_mesos_master,
+                       mock_format_mesos_command):
+
+    mock_status = mock.Mock(marathon=mock.Mock(app_id='appID1'))
+    mock_get_status_for_instance.return_value = mock_status
+    mock_args = mock.Mock(cluster='cluster1',
+                          service='mock_service',
+                          instance='mock_instance',
+                          host='host1',
+                          mesos_id=None,
+                          local=False)
+    mock_pick_slave_from_status.return_value = 'host1'
+    mock_get_any_mesos_master.return_value = 'master1'
+    mock__run.return_value = (0, 'slave:command123')
+
+    sysdig.paasta_sysdig(mock_args)
+    mock_get_any_mesos_master.assert_called_with(cluster='cluster1')
+    mock__run.assert_called_with('ssh -At -o LogLevel=QUIET master1 "sudo paasta sysdig blah blah --local"')
+    mock_subprocess.call.assert_called_with(["ssh", "-tA", 'slave', 'command123'])
+
+    mock__run.return_value = (1, 'slave:command123')
+    with raises(SystemExit):
+        sysdig.paasta_sysdig(mock_args)
+
+    mock_args = mock.Mock(cluster='cluster1',
+                          service='mock_service',
+                          instance='mock_instance',
+                          host='host1',
+                          mesos_id=None,
+                          local=True)
+    mock_pick_slave_from_status.return_value = 'slave1'
+    mock_load_marathon_config.return_value = mock.Mock(get_url=mock.Mock(return_value=['http://blah']),
+                                                       get_username=mock.Mock(return_value='user'),
+                                                       get_password=mock.Mock(return_value='pass'))
+    mock_get_mesos_master.return_value = mock.Mock(host='http://foo')
+    sysdig.paasta_sysdig(mock_args)
+    mock_get_status_for_instance.assert_called_with(cluster='cluster1',
+                                                    service='mock_service',
+                                                    instance='mock_instance')
+    mock_pick_slave_from_status.assert_called_with(status=mock_status,
+                                                   host='host1')
+    assert mock_load_marathon_config.called
+    mock_format_mesos_command.assert_called_with('slave1', 'appID1', 'http://foo', 'http://user:pass@blah')
+
+
+def test_format_mesos_command():
+    ret = sysdig.format_mesos_command('slave1', 'appID1', 'http://foo', 'http://user:pass@blah')
+    expected = 'slave1:sudo csysdig -m http://foo,http://user:pass@blah marathon.app.id="appID1" -v mesos_tasks'
+    assert ret == expected
+
+
+@patch('paasta_tools.cli.cmds.sysdig.load_system_paasta_config', autosec=True)
+@patch('paasta_tools.cli.cmds.sysdig.calculate_remote_masters', autosec=True)
+@patch('paasta_tools.cli.cmds.sysdig.find_connectable_master', autosec=True)
+def test_get_any_mesos_master(mock_find_connectable_master, mock_calculate_remote_masters, mock_load_system_config):
+    mock_calculate_remote_masters.return_value = ([], 'fakeERROR')
+    with raises(SystemExit):
+        sysdig.get_any_mesos_master('cluster1')
+    mock_load_system_config.assert_called()
+    mock_calculate_remote_masters.assert_called_with('cluster1',
+                                                     mock_load_system_config.return_value)
+
+    mock_masters = mock.Mock()
+    mock_calculate_remote_masters.return_value = (mock_masters, 'fake')
+    mock_find_connectable_master.return_value = (False, 'fakeERROR')
+    with raises(SystemExit):
+        sysdig.get_any_mesos_master('cluster1')
+
+    mock_master = mock.Mock()
+    mock_find_connectable_master.return_value = (mock_master, 'fake')
+    assert sysdig.get_any_mesos_master('cluster1') == mock_master

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -686,7 +686,7 @@ def test_get_container_name():
         mock_executor = {'tasks': [{'slave_id': 'fake_slave'}], 'container': 'abc123'}
         mock_task_1 = mock.Mock(slave={'hostname': 'host1'},
                                 executor=mock_executor,
-                                __getitem__=mock.Mock(side_effect = mock_getitem))
+                                __getitem__=mock.Mock(side_effect=mock_getitem))
         mock_get_running_tasks_from_active_frameworks.return_value = [mock_task_1]
         expected = 'mesos-fake_slave.abc123'
 
@@ -704,4 +704,3 @@ def test_get_container_name():
 
         with raises(TaskNotFound):
             ret = mesos_tools.get_container_name('fake_app_id', slave_hostname='not-found')
-

--- a/yelp_package/dockerfiles/mesos-paasta/Dockerfile
+++ b/yelp_package/dockerfiles/mesos-paasta/Dockerfile
@@ -9,3 +9,4 @@ RUN mkdir -p /nail/etc
 RUN ln -s /etc/mesos-slave-secret /nail/etc/mesos-slave-secret
 RUN ln -s /etc/paasta/mesos-cli.json /nail/etc/mesos-cli.json
 ADD ./start.sh /start.sh
+ADD ./start-slave.sh /start-slave.sh

--- a/yelp_package/dockerfiles/mesos-paasta/start-slave.sh
+++ b/yelp_package/dockerfiles/mesos-paasta/start-slave.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+/usr/sbin/sshd
+mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret --containerizers=docker --docker=/usr/bin/docker --work_dir=/tmp/mesos --attributes="region:fakeregion;pool:default" --no-docker_kill_orphans

--- a/yelp_package/dockerfiles/playground/Dockerfile
+++ b/yelp_package/dockerfiles/playground/Dockerfile
@@ -3,4 +3,6 @@ RUN apt-get update && apt-get install -y openssh-server docker.io curl vim
 RUN mkdir -p /var/log/paasta_logs 
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 RUN mkdir /var/run/sshd
+RUN mkdir -p /nail/etc
+RUN ln -s /etc/paasta/mesos-cli.json /nail/etc/mesos-cli.json
 ADD ./start.sh /start.sh


### PR DESCRIPTION
I've been playing with this on the sly since I had the idea at mesoscon but thought I'd post it up to see if anyone's interested.

It's a bit hacky, but the idea is: you run `paasta sysdig -s my-service -i main -c my-cluster` and you get jumped over SSH to a random host that's running the service and `csysdig` is launched with filters to show the mesos tasks running for that instance on that host. You can then jump into the containers or process etc.

If others like the idea I'll tidy it up and add some tests but I wanted to get some opinions before I spend the time.

Some issues:
* We have to ssh first to a box in the cluster to get the marathon credentials.
* The marathon credentials are embedded in the URL that then ends up in the command line (so anyone else on the paasta node running `ps` could see them)
* I've seen some issues when sysdig hits the mesos api for master/state.json which I think are because it times out after 5s: https://github.com/draios/sysdig/blob/a1af66ceb7bbd132a5f7154a8071fb4ac43aea15/userspace/libsinsp/mesos_http.h#L27 We could probably ask for that to be increased or configurable.