### PR TITLE
remove @CachedProperty decorator from master + slave state

### DIFF
--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -153,7 +153,6 @@ class MesosMaster(object):
         else:
             return cfg
 
-    @util.CachedProperty(ttl=5)
     def state(self):
         return self.fetch("/master/state.json").json()
 
@@ -184,7 +183,7 @@ class MesosMaster(object):
         return list(map(
             lambda x: slave.MesosSlave(self.config, x),
             itertools.ifilter(
-                lambda x: fltr == x['id'], self.state['slaves'])))
+                lambda x: fltr == x['id'], self.state()['slaves'])))
 
     def _task_list(self, active_only=False):
         keys = ["tasks"]
@@ -225,7 +224,7 @@ class MesosMaster(object):
         keys = ["frameworks"]
         if not active_only:
             keys.append("completed_frameworks")
-        return util.merge(self.state, *keys)
+        return util.merge(self.state(), *keys)
 
     def frameworks(self, active_only=False):
         keys = ["frameworks"]

--- a/paasta_tools/mesos/slave.py
+++ b/paasta_tools/mesos/slave.py
@@ -58,13 +58,12 @@ class MesosSlave(object):
             raise exceptions.SlaveDoesNotExist(
                 "Unable to connect to the slave at {0}".format(self.host))
 
-    @util.CachedProperty(ttl=5)
     def state(self):
         return self.fetch("/slave(1)/state.json").json()
 
     @property
     def frameworks(self):
-        return util.merge(self.state, "frameworks", "completed_frameworks")
+        return util.merge(self.state(), "frameworks", "completed_frameworks")
 
     def task_executor(self, task_id):
         for fw in self.frameworks:

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -591,7 +591,7 @@ def main():
 
     master = get_mesos_master()
     try:
-        mesos_state = master.state
+        mesos_state = master.state()
     except MasterNotAvailableException as e:
         # if we can't connect to master at all,
         # then bomb out early


### PR DESCRIPTION
For two reasons:
- it makes the interface to functions in the api
inconsistent (property based vs function based)
- it *forces* caching on the user of the api.