### PR TITLE
Make paasta emergency-restart simply kill inflight tasks

### DIFF
--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -8,14 +8,6 @@ Feature: paasta_serviceinit
       And we wait for it to be deployed
      Then marathon_serviceinit status_marathon_job should return "Healthy" for "test-service.main"
 
-  Scenario: marathon_serviceinit can restart tasks
-    Given a working paasta cluster
-      And I have yelpsoa-configs for the marathon job "test-service.main"
-      And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we run the marathon app "test-service.main" with "1" instances
-      And we wait for it to be deployed
-     Then marathon_serviceinit restart should get new task_ids for "test-service.main"
-
   Scenario: paasta_serviceinit can run status on chronos jobs
     Given a working paasta cluster
       And we have yelpsoa-configs for the service "testservice" with disabled scheduled chronos instance "testinstance"
@@ -106,25 +98,5 @@ Feature: paasta_serviceinit
       And we paasta_serviceinit emergency-restart the service_instance "testservice.testinstance"
      Then the job stored as "myjob" is enabled in chronos
       And the job stored as "myjob" has running tasks
-
-  Scenario: paasta_serviceinit can run emergency-stop on a marathon app
-    Given a working paasta cluster
-      And I have yelpsoa-configs for the marathon job "test-service.main"
-      And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we run the marathon app "test-service.main" with "1" instances
-      And we wait for it to be deployed
-      And we run paasta serviceinit "stop" on "test-service.main"
-      And we wait for "test-service.main" to launch exactly 0 tasks
-     Then "test-service.main" has exactly 0 requested tasks in marathon
-
-  Scenario: paasta_serviceinit can run emergency-stop on a marathon app via appid
-    Given a working paasta cluster
-      And I have yelpsoa-configs for the marathon job "test-service.main"
-      And we have a deployments.json for the service "test-service" with enabled instance "main"
-     When we run the marathon app "test-service.main" with "1" instances
-      And we wait for it to be deployed
-      And we run paasta serviceinit --appid "stop" on "test-service.main"
-      And we wait for "test-service.main" to launch exactly 0 tasks
-     Then "test-service.main" has exactly 0 requested tasks in marathon
 
 # vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2

--- a/paasta_tools/cli/cmds/emergency_restart.py
+++ b/paasta_tools/cli/cmds/emergency_restart.py
@@ -35,8 +35,6 @@ def add_subparser(subparsers):
             "'emergency-restart' can do this, but at the cost of the safety of the normal "
             "bouncing procedures. In other words, and emergency-restart is fast, but not safe "
             "and will cause dropped traffic.\n\n"
-            "'paasta emergency-restart' is the equivalent to a 'paasta emergency-stop' followed "
-            "by a 'paasta emergency-start'."
         ),
     )
     status_parser.add_argument(

--- a/paasta_tools/cli/cmds/emergency_start.py
+++ b/paasta_tools/cli/cmds/emergency_start.py
@@ -27,13 +27,10 @@ from paasta_tools.utils import PaastaColors
 def add_subparser(subparsers):
     status_parser = subparsers.add_parser(
         'emergency-start',
-        help="Resumes normal operation of a PaaSTA service instance by scaling to the configured instance count",
+        help="Kicks off a chronos job run. Not implemented for Marathon instances.",
         description=(
-            "'emergency-start' scales a PaaSTA service instance up to the configured instance count for a "
-            "Marathon service. It does nothing to an existing Marathon service that already has the desired "
-            "instance count.\n\n"
-            "On a Chronos job, 'emergency-start' has the effect of forcing a job to run outside of its normal "
-            "schedule."
+            "Chronos Jobs: Forces a job to run outside of its normal schedule.\n"
+            "Marathon Apps: Not implemented.\n"
         ),
     )
     status_parser.add_argument(
@@ -63,12 +60,6 @@ def add_subparser(subparsers):
 def paasta_emergency_start(args):
     """Performs an emergency start on a given service instance on a given cluster
 
-    Warning: This command is not magic and cannot actually get a service to start if it couldn't
-    run before. This includes configurations that prevent the service from running,
-    such as 'instances: 0' (for Marathon apps).
-
-    All it does for Marathon apps is ask Marathon to resume normal operation by scaling up to
-    the instance count defined in the service's config.
     All it does for Chronos jobs is send the latest version of the job config to Chronos and run it immediately.
     """
     system_paasta_config = load_system_paasta_config()

--- a/paasta_tools/cli/cmds/emergency_stop.py
+++ b/paasta_tools/cli/cmds/emergency_stop.py
@@ -28,19 +28,8 @@ def add_subparser(subparsers):
         'emergency-stop',
         help="Stop a PaaSTA service instance in an emergency",
         description=(
-            "'emergency-stop' stops a Marathon service instance by scaling it down to 0. If the "
-            "provided 'instance' name refers to a Chronos job, 'emergency-stop' will cancel the "
-            "chronos job if it is currently running."
-        ),
-        epilog=(
-            "Warning: 'emergency-stop' does not interact with load balancers, so any in-flight "
-            "traffic will be dropped after stopping. Additionally the 'desired state' of a service "
-            "is not changed after an 'emergency-stop', therefore alerts will fire for the service "
-            "after an emergency stop.\n\n"
-            "'emergency-stop' is not a permanant declaration of state. If the operator wishes to "
-            "stop a service permanently, they should run 'paasta stop', or configure the service to "
-            "have '0' instances. Otherwise, subsequent changes or bounces to a service will start "
-            "it right back up."
+            "Chronos jobs: Stops and kills and inflight run.\n"
+            "Marathon apps: Not implemented."
         ),
     )
     status_parser.add_argument(
@@ -58,11 +47,6 @@ def add_subparser(subparsers):
         required=True,
     ).completer = lazy_choices_completer(list_clusters)
     status_parser.add_argument(
-        '-a', '--appid',
-        help="The complete marathon appid to stop. Like 'example-service.main.gitf0cfd3a0.config7a2a00b7",
-        required=False,
-    )
-    status_parser.add_argument(
         '-d', '--soa-dir',
         dest="soa_dir",
         metavar="SOA_DIR",
@@ -74,13 +58,6 @@ def add_subparser(subparsers):
 
 def paasta_emergency_stop(args):
     """Performs an emergency stop on a given service instance on a given cluster
-
-    Warning: This command does not permanently stop the service. The next time the service is updated
-    (config change, deploy, bounce, etc.), those settings will override the emergency stop.
-
-    If you want this stop to be permanant, adjust the relevant config file to reflect that.
-    For example, this can be done for Marathon apps by setting 'instances: 0', or
-    for Chronos jobs by setting 'disabled: True'. Alternatively, remove the config yaml entirely.
     """
     system_paasta_config = load_system_paasta_config()
     service = figure_out_service_name(args, soa_dir=args.soa_dir)
@@ -91,7 +68,6 @@ def paasta_emergency_stop(args):
         service=service,
         instances=args.instance,
         system_paasta_config=system_paasta_config,
-        app_id=args.appid
     )
     print "Output: %s" % output
     print "%s" % "\n".join(paasta_emergency_stop.__doc__.splitlines()[-7:])

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -12,10 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Interacts with the framework APIs to start/stop/restart/get status/scale for
-instances. Assumes that the credentials are available, so must run as root.
-"""
 import argparse
 import logging
 import sys
@@ -39,7 +35,7 @@ log = logging.getLogger(__name__)
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description='Runs start/stop/restart/status/scale on a PaaSTA service in a given cluster.',
+        description='Runs start/stop/restart/status on a PaaSTA service in a given cluster.',
     )
     parser.add_argument('-v', '--verbose', action='count', dest="verbose", default=0,
                         help="Print out more output regarding the state of the service. "
@@ -62,7 +58,7 @@ def parse_args():
                         help="app ID as returned by paasta status -v to operate on")
     parser.add_argument('--delta', dest="delta",
                         help="Number of instances you want to scale up (positive number) or down (negative number)")
-    command_choices = ['start', 'stop', 'restart', 'status', 'scale']
+    command_choices = ['start', 'stop', 'restart', 'status']
     parser.add_argument('command', choices=command_choices, help='Command to run. Eg: status')
     args = parser.parse_args()
     return args

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -48,29 +48,6 @@ fake_marathon_job_config = marathon_tools.MarathonServiceConfig(
 )
 
 
-def test_start_marathon_job():
-    client = mock.create_autospec(marathon.MarathonClient)
-    cluster = 'my_cluster'
-    service = 'my_service'
-    instance = 'my_instance'
-    app_id = 'mock_app_id'
-    normal_instance_count = 5
-    with mock.patch('paasta_tools.marathon_serviceinit._log', autospec=True):
-        marathon_serviceinit.start_marathon_job(service, instance, app_id, normal_instance_count, client, cluster)
-    client.scale_app.assert_called_once_with(app_id, instances=normal_instance_count, force=True)
-
-
-def test_stop_marathon_job():
-    client = mock.create_autospec(marathon.MarathonClient)
-    cluster = 'my_cluster'
-    service = 'my_service'
-    instance = 'my_instance'
-    app_id = 'mock_app_id'
-    with mock.patch('paasta_tools.marathon_serviceinit._log', autospec=True):
-        marathon_serviceinit.stop_marathon_job(service, instance, app_id, client, cluster)
-    client.scale_app.assert_called_once_with(app_id, instances=0, force=True)
-
-
 def test_get_bouncing_status():
     with contextlib.nested(
         mock.patch('paasta_tools.marathon_serviceinit.marathon_tools.get_matching_appids', autospec=True),


### PR DESCRIPTION
IRL, the actual effect of these emergency commands is what normal users would call a "restart", because old tasks die and new tasks get launched by the bounce.

Therefore, that is what I've called the new command, as it "restarts" tasks ungracefully.

In practice, the implementation is to scale down the marathon app to 0 and let the bounce bring it back up.