### PR TITLE
Use proper version of mesos in trusty dockerfile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ kazoo==2.2
 lockfile==0.9.1
 marathon==0.8.6
 mccabe==0.3.1
-mesos.interface==0.28.0
+mesos.interface==1.0.1
 ordereddict==1.1
 path.py==8.1
 ply==3.4

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'jsonschema[format]',
         'kazoo >= 2.0.0',
         'marathon >= 0.8.1',
-        'mesos.interface == 0.28.0',
+        'mesos.interface == 1.0.1',
         'ordereddict >= 1.1',
         'path.py >= 8.1',
         'pyramid == 1.7',

--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,7 @@ deps =
     behave-pytest==0.1.1
     # This .whl is created in yelp_package/dockerfiles/trusty/Dockerfile
     /root/mesos.executor-1.0.1-py27-none-any.whl
+    /root/mesos.scheduler-1.0.1-py27-none-any.whl
     /root/mesos.native-1.0.1-py27-none-any.whl
 commands =
     python -m behave {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ deps =
     behave==1.2.4
     behave-pytest==0.1.1
     # This .whl is created in yelp_package/dockerfiles/trusty/Dockerfile
-    /root/mesos.native-0.28.2-py27-none-any.whl
+    /root/mesos.native-1.0.1-py27-none-any.whl
 commands =
     python -m behave {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,7 @@ deps =
     behave==1.2.4
     behave-pytest==0.1.1
     # This .whl is created in yelp_package/dockerfiles/trusty/Dockerfile
+    /root/mesos.executor-1.0.1-py27-none-any.whl
     /root/mesos.native-1.0.1-py27-none-any.whl
 commands =
     python -m behave {posargs}

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -31,6 +31,7 @@ RUN cd `mktemp -d` && wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-v
 RUN apt-get install -yq mesos=1.0.1-2.0.93.ubuntu1404 && \
     cd /usr/lib/python2.7/site-packages && \
 	zip -r /root/mesos.native-1.0.1-py27-none-any.whl mesos/native mesos.native-1.0.1.dist-info && \
+	zip -r /root/mesos.executor-1.0.1-py27-none-any.whl mesos/executor mesos.executor-1.0.1.dist-info && \
 	apt-get remove -yq mesos
 
 ADD mesos-slave-secret /etc/mesos-slave-secret

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get install -yq mesos=1.0.1-2.0.93.ubuntu1404 && \
     cd /usr/lib/python2.7/site-packages && \
 	zip -r /root/mesos.native-1.0.1-py27-none-any.whl mesos/native mesos.native-1.0.1.dist-info && \
 	zip -r /root/mesos.executor-1.0.1-py27-none-any.whl mesos/executor mesos.executor-1.0.1.dist-info && \
+	zip -r /root/mesos.scheduler-1.0.1-py27-none-any.whl mesos/scheduler mesos.scheduler-1.0.1.dist-info && \
 	apt-get remove -yq mesos
 
 ADD mesos-slave-secret /etc/mesos-slave-secret

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -28,9 +28,9 @@ RUN cd `mktemp -d` && wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-v
 # Conveniently, the .so's included in this wheel seem to be self-contained and don't link against the system libmesos.
 # So that we know if this changes, we remove the mesos system package after creating the .whl, so itests run without
 # a system mesos package.
-RUN apt-get install -yq mesos=0.28.2-2.0.27.ubuntu1404 && \
+RUN apt-get install -yq mesos=1.0.1-2.0.93.ubuntu1404 && \
     cd /usr/lib/python2.7/site-packages && \
-	zip -r /root/mesos.native-0.28.2-py27-none-any.whl mesos/native mesos.native-0.28.2.dist-info && \
+	zip -r /root/mesos.native-1.0.1-py27-none-any.whl mesos/native mesos.native-1.0.1.dist-info && \
 	apt-get remove -yq mesos
 
 ADD mesos-slave-secret /etc/mesos-slave-secret


### PR DESCRIPTION
Looks like we forgot to bump this version during the mesos upgrade.