### PR TITLE
Fix FileNotFoundForTask exception error

### DIFF
--- a/paasta_tools/mesos/cluster.py
+++ b/paasta_tools/mesos/cluster.py
@@ -56,7 +56,7 @@ def get_files_for_tasks(task_list, file_list, max_workers, fail=True):
         yield result
 
     if dne and fail:
-        raise exceptions.FileNotFoundForTask(
+        raise exceptions.FileNotFoundForTaskException(
             "None of the tasks in %s contin the files in list %s" % (
                 ",".join([task["id"] for task in task]),
                 ",".join(file_list)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ flake8==2.5.0
 mock==1.0.1
 pep8==1.5.7
 pre-commit==0.7.6
+pylint==1.6.4
 pytest==2.7.3
 pytest-cov==2.2.0
 sphinx==1.4.1

--- a/tox.ini
+++ b/tox.ini
@@ -94,6 +94,7 @@ deps =
 commands =
     pre-commit install -f --install-hooks
     pre-commit run --all-files
+    pylint -E paasta_tools/mesos/ --ignore master.py,task.py
     python -m behave {posargs}
 
 [flake8]


### PR DESCRIPTION
Without writing a bunch of tests for all the mesos_cli code, I want to catch errors like these. I'm not sure how they really slipped through the cracks this whole time?

Syntastic in my editor can tell this is a typo! I want travis to do the same, so I'm adding pylint.
The problem is... it is detecting a lot of errors. I'm starting off with just this one file and then we can expand?

I'm adding a failing test first so you can see the error and then a commit to make the tests pass.