### PR TITLE
more cleanup with hints from pylint

### DIFF
--- a/paasta_tools/mesos/exceptions.py
+++ b/paasta_tools/mesos/exceptions.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,10 +13,6 @@ from __future__ import print_function
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-class MesosCLIException(Exception):
-    pass
 
 
 class MasterNotAvailableException(Exception):
@@ -43,17 +35,21 @@ class FileNotFoundForTaskException(Exception):
     pass
 
 
-class FileDoesNotExist(MesosCLIException):
+class MultipleTasksForIDError(Exception):
     pass
 
 
-class MissingExecutor(MesosCLIException):
+class FileDoesNotExist(Exception):
     pass
 
 
-class SlaveDoesNotExist(MesosCLIException):
+class MissingExecutor(Exception):
     pass
 
 
-class SkipResult(MesosCLIException):
+class SlaveDoesNotExist(Exception):
+    pass
+
+
+class SkipResult(Exception):
     pass


### PR DESCRIPTION
@solarkennedy here is some more 'cleanup' - some of this was hinted at from pylint, and some just from observation.

- added in the missing ``MultipleTasksForIDError``
- removed some of the compatibility layer that attempted to parse the old format that mesos used to serialize the current leader to ZK
- fix a typo in the ``task`` function.

The remaining pylint things are:

```
(py27) robj@robj-yelp-mb:~/workspace/paasta_tools cleanup-pylint % pylint -E paasta_tools/mesos/
No config file found, using default configuration
************* Module paasta_tools.mesos.cluster
E: 59,14: Module 'paasta_tools.mesos.exceptions' has no 'FileNotFoundForTask' member (no-member)
************* Module paasta_tools.mesos.master
E:161,43: Value 'self.state' is unsubscriptable (unsubscriptable-object)
************* Module paasta_tools.mesos.task
E: 45,15: Method 'slave' has no 'task_executor' member (no-member)
E: 66,15: Method 'slave' has no 'file_list' member (no-member)
E: 71,19: Method 'slave' has no 'task_stats' member (no-member)
```

The first one is taken care of by #791, and I think the others are because of uses of the ``CachedProperty`` decorator which turns regular functions into properties - pylint can't pick up the change. I want to get rid of them in the long term, but I'm not too fussed about them for now
 