### PR TITLE
Configure the API for development mode

### DIFF
--- a/paasta_tools/api/development.ini
+++ b/paasta_tools/api/development.ini
@@ -1,0 +1,34 @@
+[app:main]
+use = egg:paasta_tools#paasta-api-config
+
+[server:main]
+use = egg:pyramid#wsgiref
+host = 0.0.0.0
+port = 5054
+
+[loggers]
+keys = root, paasta_tools
+
+[logger_paasta_tools]
+level = DEBUG
+handlers = console
+qualname = paasta_tools
+
+[logger_root]
+level = INFO
+handlers = console
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic

--- a/setup.py
+++ b/setup.py
@@ -101,5 +101,8 @@ setup(
         'paasta_list_chronos_jobs=paasta_tools.list_chronos_jobs:main',
         'paasta_setup_chronos_job=paasta_tools.setup_chronos_job:main',
         'paasta_chronos_rerun=paasta_tools.chronos_rerun:main',
+    ],
+        'paste.app_factory': [
+        'paasta-api-config=paasta_tools.api.api:make_app'
     ]},
 )

--- a/yelp_package/dockerfiles/mesos-paasta/start.sh
+++ b/yelp_package/dockerfiles/mesos-paasta/start.sh
@@ -16,5 +16,5 @@ pip install --no-index --find-links=/var/tmp/pip_cache -e /work
 while read link; do echo $link|sed -e 's/usr\/share\/python\/paasta-tools\//\/usr\/local\//'| sed -e 's/\ usr/\ \/usr/'| xargs ln -s; done < /work/debian/paasta-tools.links
 /usr/sbin/rsyslogd
 cron
-paasta-api 5054 &
+pserve /work/paasta_tools/api/development.ini --reload &
 mesos-master --zk=zk://zookeeper:2181/mesos-testcluster --registry=in_memory --quorum=1 --authenticate --authenticate_slaves --credentials=/etc/mesos-secrets --hostname=$(hostname)


### PR DESCRIPTION
This allows us to run the API in a development mode with sensible
logging and auto reloading on code changes.

This shouldn't change how things are working if you call the `paasta-api` script but should allow us to use `pserve`

@mjksmith this solves our internal ticket PAASTA-6599