### PR TITLE
Added KeyboardInterrupt handling for mark_for_deployment

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -169,6 +169,16 @@ def paasta_mark_for_deployment(args):
                 line=line,
                 level='event'
             )
+        except KeyboardInterrupt:
+            print "Waiting for deployment aborted. PaaSTA will continue to try to deploy this code."
+            print "If you wish to see the status, run:"
+            print ""
+            print "    paasta status -s %s -v" % service
+            print ""
+            print "Or if you wish to rollback:"
+            print ""
+            print "    paasta rollback -s %s -d %s" % (service, args.deploy_group)
+            sys.exit(1)
         except TimeoutError:
             sys.exit(1)
     return ret


### PR DESCRIPTION
I think our codebase could use more ctrl-c help in many places to make it more friendly.