### PR TITLE
Check connected frameworks

### DIFF
--- a/paasta_itests/environment.py
+++ b/paasta_itests/environment.py
@@ -121,7 +121,7 @@ def _clean_up_paasta_native_frameworks(context):
     # context.etc_paasta signals that we actually have configured the mesos-cli.json; without this, we don't know where
     # to connect to clean up paasta native frameworks.
     if hasattr(context, 'etc_paasta'):
-        for framework in mesos_tools.get_all_frameworks(active_only=True):
+        for framework in mesos_tools.get_mesos_master().frameworks(active_only=True):
             if framework.name.startswith('paasta '):
                 print "cleaning up framework %s" % framework.name
                 try:

--- a/paasta_tools/mesos/framework.py
+++ b/paasta_tools/mesos/framework.py
@@ -65,3 +65,9 @@ class Framework(object):
 
     def _resource_allocated(self, resource):
         return self["resources"][resource]
+
+    def __eq__(self, other):
+        return self.__items == other.__items
+
+    def __ne__(self, other):
+        return not self.__eq__

--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -59,7 +59,7 @@ class MesosMaster(object):
     def key(self):
         return self.config["master"]
 
-    @util.CachedProperty()
+    @util.CachedProperty(ttl=5)
     def host(self):
         return "{0}://{1}".format(self.config["scheme"], self.resolve(self.config["master"]))
 
@@ -199,13 +199,10 @@ class MesosMaster(object):
         keys = ["frameworks"]
         if not active_only:
             keys.append("completed_frameworks")
-        return util.merge(self.state, *keys)
+        return util.merge(self.fetch("/master/frameworks").json(), *keys)
 
     def frameworks(self, active_only=False):
-        keys = ["frameworks"]
-        if not active_only:
-            keys.append("completed_frameworks")
-        return list(map(lambda x: framework.Framework(x), self._framework_list(active_only)))
+        return [framework.Framework(f) for f in self._framework_list(active_only)]
 
     @property
     @util.memoize

--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -204,6 +204,9 @@ class MesosMaster(object):
     def frameworks(self, active_only=False):
         return [framework.Framework(f) for f in self._framework_list(active_only)]
 
+    def metrics_snapshot(self):
+        return self.fetch("/metrics/snapshot").json()
+
     @property
     @util.memoize
     def log(self):

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -391,13 +391,6 @@ def status_mesos_tasks_verbose(job_id, get_short_task_id, tail_lines=0):
     return "\n".join(output)
 
 
-def get_mesos_stats():
-    """Queries the mesos stats api and returns a dictionary of the results"""
-    response = get_mesos_master().fetch('metrics/snapshot')
-    response.raise_for_status()
-    return response.json()
-
-
 def get_local_slave_state():
     """Fetches mesos slave state and returns it as a dict."""
     hostname = socket.getfqdn()

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -563,7 +563,8 @@ def status_for_results(healthcheck_results):
     return [result.healthy for result in healthcheck_results]
 
 
-def print_results_for_healthchecks(ok, results, verbose, indent=2):
+def print_results_for_healthchecks(summary, ok, results, verbose, indent=2):
+    print summary
     if verbose >= 1:
         for health_check_result in results:
             if health_check_result.healthy:
@@ -632,7 +633,6 @@ def format_row_for_resource_utilization_healthchecks(healthcheck_utilization_pai
 
 def get_table_rows_for_resource_info_dict(attribute_value, healthcheck_utilization_pairs, humanize):
     """ A wrapper method to join together
-
 
     :param attribute: The attribute value and formatted columns to be shown in
     a single row.  :param attribute_value: The value of the attribute
@@ -707,20 +707,9 @@ def main():
 
     healthy_exit = True if all([mesos_ok, marathon_ok, chronos_ok]) else False
 
-    if args.verbose == 0:
-        print mesos_summary
-        print marathon_summary
-        print chronos_summary
-    elif args.verbose == 1:
-        print mesos_summary
-        print_results_for_healthchecks(mesos_ok, all_mesos_results, args.verbose)
-        print marathon_summary
-        print_results_for_healthchecks(marathon_ok, marathon_results, args.verbose)
-        print chronos_summary
-        print_results_for_healthchecks(chronos_ok, chronos_results, args.verbose)
-    else:
-        print mesos_summary
-        print_results_for_healthchecks(mesos_ok, all_mesos_results, args.verbose)
+    print "Master paasta_tools version: {0}".format(__version__)
+    print_results_for_healthchecks(mesos_summary, mesos_ok, all_mesos_results, args.verbose)
+    if args.verbose > 1:
         for grouping in args.groupings:
             print_with_indent('Resources Grouped by %s' % grouping, 2)
             resource_info_dict = get_resource_utilization_by_grouping(key_func_for_attribute(grouping), mesos_state)
@@ -773,12 +762,8 @@ def main():
                 all_rows.extend(table_rows)
             for line in format_table(all_rows):
                 print_with_indent(line, 4)
-
-        print marathon_summary
-        print_results_for_healthchecks(marathon_ok, marathon_results, args.verbose)
-        print chronos_summary
-        print_results_for_healthchecks(chronos_ok, chronos_results, args.verbose)
-        print "Master paasta_tools version: {0}".format(__version__)
+    print_results_for_healthchecks(marathon_summary, marathon_ok, marathon_results, args.verbose)
+    print_results_for_healthchecks(chronos_summary, chronos_ok, chronos_results, args.verbose)
 
     if not healthy_exit:
         sys.exit(2)

--- a/tests/mesos/test_master.py
+++ b/tests/mesos/test_master.py
@@ -1,0 +1,36 @@
+from mock import patch
+
+from paasta_tools.mesos import framework
+from paasta_tools.mesos import master
+
+
+@patch.object(master.MesosMaster, '_framework_list', autospec=True)
+def test_frameworks(mock_framework_list):
+    fake_frameworks = [
+        {
+            'name': 'test_framework1',
+        },
+        {
+            'name': 'test_framework2',
+        },
+    ]
+    mock_framework_list.return_value = fake_frameworks
+    expected_frameworks = [framework.Framework(config) for config in fake_frameworks]
+    mesos_master = master.MesosMaster({})
+    assert expected_frameworks == mesos_master.frameworks()
+
+
+@patch.object(master.MesosMaster, '_framework_list', autospec=True)
+def test_framework_list_includes_completed_frameworks(mock_framework_list):
+    fake_frameworks = [
+        {
+            'name': 'test_framework1',
+        },
+        {
+            'name': 'test_framework2',
+        },
+    ]
+    mock_framework_list.return_value = fake_frameworks
+    expected_frameworks = [framework.Framework(config) for config in fake_frameworks]
+    mesos_master = master.MesosMaster({})
+    assert expected_frameworks == mesos_master.frameworks()

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -229,6 +229,42 @@ def test_duplicate_frameworks():
     assert not ok
 
 
+def assert_connected_frameworks():
+    metrics = {
+        'master/frameworks_connected': 2,
+    }
+    hcr = paasta_metastatus.assert_connected_frameworks(metrics)
+    assert hcr.healthy
+    assert "Connected Frameworks: expected: 2 actual: 2" in hcr.message
+
+
+def assert_disconnected_frameworks():
+    metrics = {
+        'master/frameworks_disconnected': 1
+    }
+    hcr = paasta_metastatus.assert_connected_frameworks(metrics)
+    assert not hcr.healthy
+    assert "Disconnected Frameworks: expected: 0 actual: 1" in hcr.message
+
+
+def test_assert_active_frameworks():
+    metrics = {
+        'master/frameworks_active': 2
+    }
+    hcr = paasta_metastatus.assert_active_frameworks(metrics)
+    assert hcr.healthy
+    assert "Active Frameworks: expected: 2 actual: 2" in hcr.message
+
+
+def test_assert_inactive_frameworks():
+    metrics = {
+        'master/frameworks_inactive': 0,
+    }
+    hcr = paasta_metastatus.assert_inactive_frameworks(metrics)
+    assert not hcr.healthy
+    assert "Inactive Frameworks: expected: 0 actual: 0" in hcr.message
+
+
 @patch('paasta_tools.marathon_tools.get_marathon_client', autospec=True)
 def test_ok_marathon_apps(mock_get_marathon_client):
     client = mock_get_marathon_client.return_value
@@ -385,7 +421,6 @@ def test_main_no_marathon_config():
         patch('paasta_tools.paasta_metastatus.get_mesos_master', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_mesos_state_status', autospec=True,
               return_value=([('fake_output', True)])),
-        patch('paasta_tools.paasta_metastatus.get_mesos_stats', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_mesos_resource_utilization_health', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_marathon_status', autospec=True,
               return_value=([('fake_output', True)])),
@@ -396,7 +431,6 @@ def test_main_no_marathon_config():
         load_get_chronos_status_patch,
         get_mesos_master,
         get_mesos_state_status_patch,
-        get_mesos_stats_patch,
         get_mesos_resource_utilization_health_patch,
         load_get_marathon_status_patch,
         parse_args_patch,
@@ -406,7 +440,6 @@ def test_main_no_marathon_config():
         )
         get_mesos_master = Mock()
         get_mesos_master.state_summary.return_value = {}
-        get_mesos_stats_patch.return_value = {}
 
         get_mesos_state_status_patch.return_value = []
         get_mesos_resource_utilization_health_patch.return_value = []
@@ -425,7 +458,6 @@ def test_main_no_chronos_config():
         patch('paasta_tools.paasta_metastatus.get_mesos_master', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_mesos_state_status', autospec=True,
               return_value=([('fake_output', True)])),
-        patch('paasta_tools.paasta_metastatus.get_mesos_stats', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_mesos_resource_utilization_health', autospec=True),
         patch('paasta_tools.paasta_metastatus.get_marathon_status', autospec=True,
               return_value=([('fake_output', True)])),
@@ -435,7 +467,6 @@ def test_main_no_chronos_config():
         load_chronos_config_patch,
         get_mesos_master,
         get_mesos_state_status_patch,
-        get_mesos_stats_patch,
         get_mesos_resource_utilization_health_patch,
         load_get_marathon_status_patch,
         parse_args_patch,
@@ -449,8 +480,6 @@ def test_main_no_chronos_config():
 
         parse_args_patch.return_value = fake_args
         load_marathon_config_patch.return_value = {}
-
-        get_mesos_stats_patch.return_value = {}
 
         get_mesos_state_status_patch.return_value = []
         get_mesos_resource_utilization_health_patch.return_value = []

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -261,7 +261,7 @@ def test_assert_inactive_frameworks():
         'master/frameworks_inactive': 0,
     }
     hcr = paasta_metastatus.assert_inactive_frameworks(metrics)
-    assert not hcr.healthy
+    assert hcr.healthy
     assert "Inactive Frameworks: expected: 0 actual: 0" in hcr.message
 
 
@@ -438,8 +438,15 @@ def test_main_no_marathon_config():
         fake_args = Mock(
             verbose=0,
         )
-        get_mesos_master = Mock()
-        get_mesos_master.state_summary.return_value = {}
+        fake_master = Mock(autospace=True)
+        fake_master.metrics_snapshot.return_value = {
+            'master/frameworks_active': 2,
+            'master/frameworks_inactive': 0,
+            'master/frameworks_connected': 2,
+            'master/frameworks_disconnected': 0,
+        }
+        fake_master.state.return_value = {}
+        get_mesos_master.return_value = fake_master
 
         get_mesos_state_status_patch.return_value = []
         get_mesos_resource_utilization_health_patch.return_value = []
@@ -475,8 +482,15 @@ def test_main_no_chronos_config():
         fake_args = Mock(
             verbose=0,
         )
-        get_mesos_master = Mock()
-        get_mesos_master.state.return_value = {}
+        fake_master = Mock(autospace=True)
+        fake_master.metrics_snapshot.return_value = {
+            'master/frameworks_active': 2,
+            'master/frameworks_inactive': 0,
+            'master/frameworks_connected': 2,
+            'master/frameworks_disconnected': 0,
+        }
+        fake_master.state.return_value = {}
+        get_mesos_master.return_value = fake_master
 
         parse_args_patch.return_value = fake_args
         load_marathon_config_patch.return_value = {}


### PR DESCRIPTION
closes #798 

- add healthcheck functions to metastatus for asserting the number of connected, disconnected, active, inactive frameworks
- update the ttl of the cached leader in MesosMaster to 5 seconds
- remove some duplication from metastatus
- update the MesosMaster.frameworks function to use the ``/master/frameworks`` endpoint, rather than ``state``