### PR TITLE
Performance-check uses a config file

### DIFF
--- a/paasta_tools/cli/cmds/performance_check.py
+++ b/paasta_tools/cli/cmds/performance_check.py
@@ -41,19 +41,20 @@ def add_subparser(subparsers):
 
 
 def load_performance_check_config(service, soa_dir):
-    performance_check_config = read_extra_service_information(
+    return read_extra_service_information(
         service_name=service,
         extra_info='performance-check',
         soa_dir=soa_dir,
     )
 
-    if not performance_check_config:
-        raise Exception("No performance check config found. Check your performance-check.yaml file.")
-    return performance_check_config
-
 
 def submit_performance_check_job(service, soa_dir):
     performance_check_config = load_performance_check_config(service, soa_dir)
+
+    if not performance_check_config:
+        print "No performance-check.yaml. Skipping performance-check."
+        return
+
     endpoint = performance_check_config.pop('endpoint')
     r = requests.post(
         url=endpoint,

--- a/paasta_tools/cli/cmds/performance_check.py
+++ b/paasta_tools/cli/cmds/performance_check.py
@@ -12,13 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import sys
-
 import requests
+from service_configuration_lib import read_extra_service_information
 
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import timeout
-from service_configuration_lib import read_extra_service_information
 
 
 def add_subparser(subparsers):

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -952,15 +952,6 @@ class SystemPaastaConfig(dict):
         except KeyError:
             return {}
 
-    def get_performance_check_config(self):
-        """Get the performance check config
-
-        :returns: The performance_check config dictionary"""
-        try:
-            return self['performance_check']
-        except KeyError:
-            return {}
-
     def get_marathon_config(self):
         """Get the marathon config
 

--- a/tests/cli/test_cmds_performance_check.py
+++ b/tests/cli/test_cmds_performance_check.py
@@ -19,23 +19,19 @@ from paasta_tools.cli.cmds import performance_check
 
 @mock.patch('requests.post', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.performance_check.load_performance_check_config', autospec=True)
-@mock.patch('paasta_tools.cli.cmds.performance_check.get_username', autospec=True)
 def test_submit_performance_check_job_happy(
-    mock_get_username,
     mock_load_performance_check_config,
     mock_requests_post,
 ):
     fake_endpoint = 'http://foo:1234/submit'
-    mock_load_performance_check_config.return_value = {'endpoint': fake_endpoint}
-    mock_get_username.return_value = 'fake_user'
-    performance_check.submit_performance_check_job('fake_service', 'fake_commit', 'fake_image')
+    mock_load_performance_check_config.return_value = {
+        'endpoint': fake_endpoint,
+        'fake_param': 'fake_value',
+    }
+    performance_check.submit_performance_check_job('fake_service', 'fake_soa_dir')
     mock_requests_post.assert_called_once_with(
         url=fake_endpoint,
-        data={'submitter': 'fake_user',
-              'commit': 'fake_commit',
-              'service': 'fake_service',
-              'image': 'fake_image'},
-        headers=mock.ANY
+        params={'fake_param': 'fake_value'}
     )
 
 
@@ -45,10 +41,10 @@ def test_main_safely_returns_when_exceptions(
 ):
     fake_args = mock.Mock()
     fake_args.service = 'fake_service'
-    fake_args.commit = 'fake_commit'
-    fake_args.image = 'fake_image'
+    fake_args.soa_dir = 'fake_soa_dir'
     mock_submit_performance_check_job.side_effect = raises(Exception)
     performance_check.perform_performance_check(fake_args)
     mock_submit_performance_check_job.assert_called_once_with(
-        service='fake_service', commit='fake_commit', image='fake_image'
+        service='fake_service',
+        soa_dir='fake_soa_dir',
     )


### PR DESCRIPTION
Performance-check used to take in 'commit' and 'image' parameters and passed those explicitly to a performance check service endpoint defined in paasta configs.

This change makes it so that the service endpoint and general params are defined in a performance-check.yaml file in soa-configs. If no performance-check.yaml file is found then this command exits immediately.