### PR TITLE
Start supporting xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - TOXENV=general_itests
   - TOXENV=paasta_itests
   - MAKE_TARGET=itest_trusty
+  - MAKE_TARGET=itest_xenial
 sudo: required
 services:
   - docker

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -21,6 +21,7 @@ UID:=`id -u`
 GID:=`id -g`
 DOCKER_RUN_LUCID:=docker run -t -v  $(CURDIR)/../:/work:rw paastatools_lucid_container
 DOCKER_RUN_TRUSTY:=docker run -t -v  $(CURDIR)/../:/work:rw paastatools_trusty_container
+DOCKER_RUN_XENIAL:=docker run -t -v  $(CURDIR)/../:/work:rw paastatools_xenial_container
 
 NOOP = true
 ifeq ($(PAASTA_ENV),YELP)
@@ -68,6 +69,23 @@ package_trusty: build_trusty_docker
 	$(DOCKER_RUN_TRUSTY) chown -R $(UID):$(GID) /work
 itest_trusty: package_trusty bintray.json
 	$(DOCKER_RUN_TRUSTY) /work/yelp_package/itest/ubuntu.sh paasta-tools_$(ACTUAL_PACKAGE_VERSION)_amd64.deb
+
+build_xenial_docker:
+	[ -d ../dist ] || mkdir ../dist
+	cd dockerfiles/xenial/ && docker build -t "paastatools_xenial_container" .
+package_xenial: build_xenial_docker
+	# Copy these files to .old before maybe clobbering them
+	cp ../requirements.txt ../requirements.txt.old
+	cp ../debian/changelog ../debian/changelog.old
+	$(ADD_MISSING_DEPS_MAYBE)
+	$(ADD_YELP_PREFIX_MAYBE)
+	$(DOCKER_RUN_XENIAL) /bin/bash -c "dpkg-buildpackage -d && mv ../*.deb dist/"
+	# then move them back
+	mv ../requirements.txt.old ../requirements.txt
+	mv ../debian/changelog.old ../debian/changelog
+	$(DOCKER_RUN_XENIAL) chown -R $(UID):$(GID) /work
+itest_xenial: package_xenial
+	$(DOCKER_RUN_XENIAL) /work/yelp_package/itest/ubuntu.sh paasta-tools_$(ACTUAL_PACKAGE_VERSION)_amd64.deb
 
 DATE := $(shell date +'%Y-%m-%d' -d "`dpkg-parsechangelog -l../debian/changelog | sed -n 's/^Date: //p'`")
 PAASTAVERSION := $(shell dpkg-parsechangelog -l../debian/changelog | sed -n 's/^Version: //p')

--- a/yelp_package/dockerfiles/xenial/Dockerfile
+++ b/yelp_package/dockerfiles/xenial/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:xenial
+
+RUN echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
+
+RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools \
+  python-dev libssl-dev libffi-dev debhelper python-yaml libyaml-dev python-pytest pyflakes \
+  git help2man zsh wget zip
+
+RUN cd `mktemp -d` && wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_0.11-1_all.deb && dpkg -i dh-virtualenv_0.11-1_all.deb && apt-get -f install
+
+# mesos.native is not available on pypi, so we can either build mesos from
+# source or do this, and building from source takes a long time.
+# Conveniently, the .so's included in this wheel seem to be self-contained and don't link against the system libmesos.
+# So that we know if this changes, we remove the mesos system package after creating the .whl, so itests run without
+# a system mesos package.
+RUN apt-get install -yq mesos=1.0.1-2.0.93.ubuntu1604 && \
+    cd /usr/lib/python2.7/site-packages && \
+	zip -r /root/mesos.native-1.0.1-py27-none-any.whl mesos/native mesos.native-1.0.1.dist-info && \
+	zip -r /root/mesos.executor-1.0.1-py27-none-any.whl mesos/executor mesos.executor-1.0.1.dist-info && \
+	zip -r /root/mesos.scheduler-1.0.1-py27-none-any.whl mesos/scheduler mesos.scheduler-1.0.1.dist-info && \
+	apt-get remove -yq mesos
+
+ADD mesos-slave-secret /etc/mesos-slave-secret
+
+ENV HOME /work
+ENV PWD /work
+WORKDIR /work

--- a/yelp_package/dockerfiles/xenial/mesos-slave-secret
+++ b/yelp_package/dockerfiles/xenial/mesos-slave-secret
@@ -1,0 +1,4 @@
+{
+  "principal": "slave",
+  "secret": "secret1"
+}


### PR DESCRIPTION
This change makes Travis start to build paasta-tools for xenial. It does *not* change the version of Ubuntu we use in things like `paasta_itests` (that remains `trusty` for now). It also doesn't touch the bintray upload settings (which are set to only upload when `make itest_trusty` is called on a tagged release). So overall, this should be a pretty simple and low-risk change.