### PR TITLE
add info about queuing chronos tasks to metastatus

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ backports.ssl-match-hostname==3.4.0.2
 blessings==1.6
 boto3==1.3.0
 bravado==8.3.0
-chronos-python==0.36.0
+chronos-python==0.37.0
 cookiecutter==1.4.0
 cryptography==1.4
 docker-py==1.2.3

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         # libs and pip can't seem to override it
         'argparse == 1.2.1',
         'bravado == 8.3.0',
-        'chronos-python == 0.36.0',
+        'chronos-python == 0.37.0',
         'cookiecutter == 1.4.0',
         'cryptography == 1.4',
         # Don't update this unless you have confirmed the client works with

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -401,16 +401,41 @@ def test_assert_chronos_scheduled_jobs():
     assert results == ('Enabled chronos jobs: 1', True)
 
 
-def test_get_chronos_status():
-    client = Mock()
-    client.list.return_value = [
-        {'name': 'fake_job1', 'disabled': False},
-        {'name': 'fake_job2', 'disabled': False},
+def test_assert_chronos_queued_jobs():
+    mock_client = Mock()
+    mock_client.metrics.return_value = {
+        'gauges': {
+            paasta_metastatus.HIGH_QUEUE_GAUGE: {'value': 0},
+            paasta_metastatus.QUEUE_GAUGE: {'value': 0}
+        }
+    }
+    mock_client.list.return_value = [
+        {'name': 'myjob', 'disabled': False},
+        {'name': 'myjob', 'disabled': True},
     ]
-    expected_jobs_output = ("Enabled chronos jobs: 2", True)
-    results = paasta_metastatus.get_chronos_status(client)
+    assert paasta_metastatus.assert_chronos_queued_jobs(mock_client) == paasta_metastatus.HealthCheckResult(
+        message="Jobs Queued: 0 (0%)",
+        healthy=True
+    )
 
-    assert expected_jobs_output in results
+
+@patch('paasta_tools.paasta_metastatus.assert_chronos_queued_jobs', autospec=True)
+@patch('paasta_tools.paasta_metastatus.assert_chronos_scheduled_jobs', autospec=True)
+def test_get_chronos_status(mock_queued_jobs, mock_scheduled_jobs):
+    mock_scheduled_jobs_result = paasta_metastatus.HealthCheckResult(
+        message='Enabled chronos jobs: 1',
+        healthy=True
+    )
+    mock_queued_jobs_result = paasta_metastatus.HealthCheckResult(
+        message="Jobs Queued: 0 (0%)",
+        healthy=True
+    )
+    mock_queued_jobs.return_value = mock_queued_jobs_result
+    mock_scheduled_jobs.return_value = mock_scheduled_jobs_result
+
+    expected_results = [mock_queued_jobs_result, mock_scheduled_jobs_result]
+
+    assert paasta_metastatus.get_chronos_status(Mock()) == expected_results
 
 
 def test_main_no_marathon_config():


### PR DESCRIPTION
closes #806 
For now, this always returns OK, so won't ever trigger a page.