### PR TITLE
Fix metastatus

### DIFF
--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -86,7 +86,7 @@ def get_mesos_cpu_status(metrics, mesos_state):
 
     for slave in mesos_state['slaves']:
         for role in slave['reserved_resources']:
-            used -= slave['reserved_resources'][role]['cpus']
+            used += slave['reserved_resources'][role]['cpus']
 
     available = total - used
     return total, used, available
@@ -171,7 +171,7 @@ def assert_memory_health(metrics, mesos_state, threshold=10):
 
     for slave in mesos_state['slaves']:
         for role in slave['reserved_resources']:
-            used -= slave['reserved_resources'][role]['mem']
+            used += slave['reserved_resources'][role]['mem']
 
     try:
         perc_used = percent_used(total, used)
@@ -199,7 +199,7 @@ def assert_disk_health(metrics, mesos_state, threshold=10):
 
     for slave in mesos_state['slaves']:
         for role in slave['reserved_resources']:
-            used -= slave['reserved_resources'][role]['disk']
+            used += slave['reserved_resources'][role]['disk']
 
     try:
         perc_used = percent_used(total, used)

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -40,14 +40,18 @@ def test_get_mesos_cpu_status():
     fake_mesos_state = {
         'slaves': [
             {
-                'reserved_resources': {},
+                'reserved_resources': {
+                    'some-role': {
+                        'cpus': 1,
+                    },
+                },
             },
         ],
     }
     total, used, available = paasta_metastatus.get_mesos_cpu_status(fake_metrics, fake_mesos_state)
     assert total == 3
-    assert used == 1
-    assert available == 2
+    assert used == 2
+    assert available == 1
 
 
 def test_ok_cpu_health():


### PR DESCRIPTION
My dynamic reservation change broke our calculations of available resources in metastatus. I meant to treat a reserved resource as used, as if we reserve all the resources on a box, it has no free resources for tasks to run. But I put a `-` instead of a `+`.