### PR TITLE
Add cleanup_maintenance script

### DIFF
--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -10,6 +10,7 @@ usr/share/python/paasta-tools/bin/paasta_cleanup_chronos_jobs usr/bin/paasta_cle
 usr/share/python/paasta-tools/bin/paasta_check_chronos_jobs usr/bin/check_chronos_jobs
 usr/share/python/paasta-tools/bin/paasta_check_chronos_jobs usr/bin/paasta_check_chronos_jobs
 usr/share/python/paasta-tools/bin/cleanup_marathon_jobs.py usr/bin/cleanup_marathon_jobs
+usr/share/python/paasta-tools/bin/cleanup_maintenance.py usr/bin/cleanup_maintenance
 usr/share/python/paasta-tools/bin/paasta_deploy_chronos_jobs usr/bin/deploy_chronos_jobs
 usr/share/python/paasta-tools/bin/paasta_deploy_chronos_jobs usr/bin/paasta_deploy_chronos_jobs
 usr/share/python/paasta-tools/bin/deploy_marathon_services usr/bin/deploy_marathon_services

--- a/paasta_tools/cleanup_maintenance.py
+++ b/paasta_tools/cleanup_maintenance.py
@@ -26,6 +26,7 @@ from paasta_tools.mesos_maintenance import get_draining_hosts
 from paasta_tools.mesos_maintenance import get_hosts_forgotten_down
 from paasta_tools.mesos_maintenance import get_hosts_forgotten_draining
 from paasta_tools.mesos_maintenance import reserve_all_resources
+from paasta_tools.mesos_maintenance import seconds_to_nanoseconds
 from paasta_tools.mesos_maintenance import undrain
 from paasta_tools.mesos_maintenance import unreserve_all_resources
 from paasta_tools.mesos_maintenance import up
@@ -44,13 +45,15 @@ def parse_args():
 def cleanup_forgotten_draining():
     """Clean up hosts forgotten draining"""
     log.debug("Cleaning up hosts forgotten draining")
-    undrain(hostnames=get_hosts_forgotten_draining())
+    hosts_forgotten_draining = get_hosts_forgotten_draining(grace=seconds_to_nanoseconds(10 * 60))
+    undrain(hostnames=hosts_forgotten_draining)
 
 
 def cleanup_forgotten_down():
     """Clean up hosts forgotten down"""
     log.debug("Cleaning up hosts forgotten down")
-    up(hostnames=get_hosts_forgotten_down())
+    hosts_forgotten_down = get_hosts_forgotten_down(grace=seconds_to_nanoseconds(10 * 60))
+    up(hostnames=hosts_forgotten_down)
 
 
 def unreserve_all_resources_on_non_draining_hosts():

--- a/paasta_tools/cleanup_maintenance.py
+++ b/paasta_tools/cleanup_maintenance.py
@@ -72,7 +72,7 @@ def reserve_all_resources_on_draining_hosts():
     reserve_all_resources(hostnames=get_draining_hosts())
 
 
-def cleanup_maintenance():
+def main():
     log.debug("Cleaning up maintenance cruft")
     parse_args()
 
@@ -83,6 +83,6 @@ def cleanup_maintenance():
 
 
 if __name__ == "__main__":
-    if cleanup_maintenance():
+    if main():
         sys.exit(0)
     sys.exit(1)

--- a/paasta_tools/cleanup_maintenance.py
+++ b/paasta_tools/cleanup_maintenance.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# Copyright 2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Usage: ./cleanup_maintenance.py
+
+Clean up boxes that should no longer be marked as 'draining' or 'down' for
+maintenance. Also cleanup the associated dynamic reservations.
+"""
+import argparse
+import logging
+import sys
+
+from paasta_tools.mesos_maintenance import get_draining_hosts
+from paasta_tools.mesos_maintenance import get_hosts_forgotten_down
+from paasta_tools.mesos_maintenance import get_hosts_forgotten_draining
+from paasta_tools.mesos_maintenance import reserve_all_resources
+from paasta_tools.mesos_maintenance import undrain
+from paasta_tools.mesos_maintenance import unreserve_all_resources
+from paasta_tools.mesos_maintenance import up
+from paasta_tools.mesos_tools import get_slaves
+
+
+log = logging.getLogger(__name__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Cleans up forgotten maintenance cruft.')
+    args = parser.parse_args()
+    return args
+
+
+def cleanup_forgotten_draining():
+    """Clean up hosts forgotten draining"""
+    log.debug("Cleaning up hosts forgotten draining")
+    undrain(hostnames=get_hosts_forgotten_draining())
+
+
+def cleanup_forgotten_down():
+    """Clean up hosts forgotten down"""
+    log.debug("Cleaning up hosts forgotten down")
+    up(hostnames=get_hosts_forgotten_down())
+
+
+def unreserve_all_resources_on_non_draining_hosts():
+    """Unreserve all resources on non-draining hosts"""
+    log.debug("Unreserving all resources on non-draining hosts")
+    slaves = get_slaves()
+    hostnames = map((lambda slave: slave['hostname']), slaves)
+    draining_hosts = get_draining_hosts()
+    non_draining_hosts = list(set(hostnames) - set(draining_hosts))
+    unreserve_all_resources(hostnames=non_draining_hosts)
+
+
+def reserve_all_resources_on_draining_hosts():
+    """Reserve all resources on draining hosts"""
+    log.debug("Reserving all resources on draining hosts")
+    reserve_all_resources(hostnames=get_draining_hosts())
+
+
+def cleanup_maintenance():
+    log.debug("Cleaning up maintenance cruft")
+    parse_args()
+
+    cleanup_forgotten_draining()
+    cleanup_forgotten_down()
+    unreserve_all_resources_on_non_draining_hosts()
+    reserve_all_resources_on_draining_hosts()
+
+
+if __name__ == "__main__":
+    if cleanup_maintenance():
+        sys.exit(0)
+    sys.exit(1)

--- a/paasta_tools/cleanup_maintenance.py
+++ b/paasta_tools/cleanup_maintenance.py
@@ -57,7 +57,7 @@ def unreserve_all_resources_on_non_draining_hosts():
     """Unreserve all resources on non-draining hosts"""
     log.debug("Unreserving all resources on non-draining hosts")
     slaves = get_slaves()
-    hostnames = map((lambda slave: slave['hostname']), slaves)
+    hostnames = [slave['hostname'] for slave in slaves]
     draining_hosts = get_draining_hosts()
     non_draining_hosts = list(set(hostnames) - set(draining_hosts))
     unreserve_all_resources(hostnames=non_draining_hosts)

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         'paasta_tools/autoscale_all_services.py',
         'paasta_tools/check_marathon_services_replication.py',
         'paasta_tools/cleanup_marathon_jobs.py',
+        'paasta_tools/cleanup_maintenance.py',
         'paasta_tools/paasta_deploy_chronos_jobs',
         'paasta_tools/deploy_marathon_services',
         'paasta_tools/generate_all_deployments',

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,6 @@ setup(
         'paasta_tools/autoscale_all_services.py',
         'paasta_tools/check_marathon_services_replication.py',
         'paasta_tools/cleanup_marathon_jobs.py',
-        'paasta_tools/cleanup_maintenance.py',
         'paasta_tools/paasta_deploy_chronos_jobs',
         'paasta_tools/deploy_marathon_services',
         'paasta_tools/generate_all_deployments',
@@ -102,6 +101,7 @@ setup(
         'paasta_list_chronos_jobs=paasta_tools.list_chronos_jobs:main',
         'paasta_setup_chronos_job=paasta_tools.setup_chronos_job:main',
         'paasta_chronos_rerun=paasta_tools.chronos_rerun:main',
+        'paasta_cleanup_maintenance=paasta_tools.cleanup_maintenance:main',
     ],
         'paste.app_factory': [
         'paasta-api-config=paasta_tools.api.api:make_app'


### PR DESCRIPTION
We've ended up with resources left reserved for maintenance on boxes that are marked as `up`. We have boxes marked as `draining` and `down` that are either non-existent or no longer preparing for a change that prevents them from being `up`.

This is a first pass at a cleanup script. It is designed to run in a cron job on the leader in each cluster.

Is this a bit extreme? Possibly. It relies on the assumption that the majority of our draining will be handled by tools with strictly enforced timeouts. In the event a human is manually performing maintenance, they will need to be very careful to set the maintenance window appropriately (but this is becoming more and more rare).