### PR TITLE
Strip "service-" from service parameter in performance_check

### DIFF
--- a/paasta_tools/cli/cmds/performance_check.py
+++ b/paasta_tools/cli/cmds/performance_check.py
@@ -15,6 +15,7 @@
 import requests
 from service_configuration_lib import read_extra_service_information
 
+from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import timeout
 
@@ -68,9 +69,14 @@ def submit_performance_check_job(service, soa_dir):
 
 @timeout()
 def perform_performance_check(args):
+    service = args.service
+    if service.startswith('services-'):
+        service = service.split('services-', 1)[1]
+    validate_service_name(service, args.soa_dir)
+    print service
     try:
         submit_performance_check_job(
-            service=args.service,
+            service=service,
             soa_dir=args.soa_dir,
         )
     except Exception as e:

--- a/paasta_tools/cli/cmds/performance_check.py
+++ b/paasta_tools/cli/cmds/performance_check.py
@@ -73,7 +73,7 @@ def perform_performance_check(args):
     if service.startswith('services-'):
         service = service.split('services-', 1)[1]
     validate_service_name(service, args.soa_dir)
-    print service
+
     try:
         submit_performance_check_job(
             service=service,

--- a/tests/cli/test_cmds_performance_check.py
+++ b/tests/cli/test_cmds_performance_check.py
@@ -17,17 +17,20 @@ from pytest import raises
 from paasta_tools.cli.cmds import performance_check
 
 
+@mock.patch('paasta_tools.cli.cmds.performance_check.validate_service_name', autospec=True)
 @mock.patch('requests.post', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.performance_check.load_performance_check_config', autospec=True)
 def test_submit_performance_check_job_happy(
     mock_load_performance_check_config,
     mock_requests_post,
+    mock_validate_service_name,
 ):
     fake_endpoint = 'http://foo:1234/submit'
     mock_load_performance_check_config.return_value = {
         'endpoint': fake_endpoint,
         'fake_param': 'fake_value',
     }
+    mock_validate_service_name.return_value = True
     performance_check.submit_performance_check_job('fake_service', 'fake_soa_dir')
     mock_requests_post.assert_called_once_with(
         url=fake_endpoint,
@@ -35,12 +38,15 @@ def test_submit_performance_check_job_happy(
     )
 
 
+@mock.patch('paasta_tools.cli.cmds.performance_check.validate_service_name', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.performance_check.submit_performance_check_job', autospec=True)
 def test_main_safely_returns_when_exceptions(
     mock_submit_performance_check_job,
+    mock_validate_service_name,
 ):
+    mock_validate_service_name.return_value = True
     fake_args = mock.Mock()
-    fake_args.service = 'fake_service'
+    fake_args.service = 'services-fake_service'
     fake_args.soa_dir = 'fake_soa_dir'
     mock_submit_performance_check_job.side_effect = raises(Exception)
     performance_check.perform_performance_check(fake_args)


### PR DESCRIPTION
Added logic to strip "service-" from the beginning of the service param that's passed in to the performance-check command. I followed the same pattern used for the cook-image command.