### PR TITLE
Make mark for deployment more resilient

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -219,7 +219,10 @@ def are_instances_deployed(cluster, service, instances, git_sha):
                 log.warning("Can't get status for instance {0}, service {1} in cluster {2}. "
                             "This is normally because it is a new service that hasn't been "
                             "deployed by PaaSTA yet".format(instance, service, cluster))
-                statuses.append(None)
+            else:
+                log.warning("Error getting service status from PaaSTA API: {0}: {1}".format(e.response.status_code,
+                                                                                            e.response.text))
+            statuses.append(None)
     results = []
     for status in statuses:
         if not status:
@@ -234,7 +237,7 @@ def are_instances_deployed(cluster, service, instances, git_sha):
                            status.marathon.app_count == 1 and
                            status.marathon.deploy_status == 'Running' and
                            status.marathon.expected_instance_count == status.marathon.running_instance_count)
-    return all(results)
+    return results and all(results)
 
 
 def wait_for_deployment(service, deploy_group, git_sha, soa_dir, timeout):

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -84,7 +84,7 @@ def test_mark_for_deployment_sad(mock_create_remote_refs, mock__log):
 
 
 def mock_status_instance_side_effect(service, instance):
-    if instance in ['instance1', 'instance6', 'notaninstance']:
+    if instance in ['instance1', 'instance6', 'notaninstance', 'api_error']:
         # valid completed instance
         mock_mstatus = Mock(app_count=1, deploy_status='Running',
                             expected_instance_count=2,
@@ -130,6 +130,9 @@ def mock_status_instance_side_effect(service, instance):
     if instance == 'notaninstance':
         # not an instance paasta can find
         mock_status_instance.result.side_effect = HTTPError(response=Mock(status_code=404))
+    if instance == 'api_error':
+        # not an instance paasta can find
+        mock_status_instance.result.side_effect = HTTPError(response=Mock(status_code=500))
     return mock_status_instance
 
 
@@ -147,6 +150,7 @@ def test_are_instances_deployed(mock_get_paasta_api_client, mock__log):
     assert mark_for_deployment.are_instances_deployed('cluster', 'service1', ['instance5', 'instance1'], 'somesha')
     assert not mark_for_deployment.are_instances_deployed('cluster', 'service1', ['instance6'], 'somesha')
     assert not mark_for_deployment.are_instances_deployed('cluster', 'service1', ['notaninstance'], 'somesha')
+    assert not mark_for_deployment.are_instances_deployed('cluster', 'service1', ['api_error'], 'somesha')
     assert mark_for_deployment.are_instances_deployed('cluster', 'service1', ['instance7'], 'somesha')
     assert mark_for_deployment.are_instances_deployed('cluster', 'service1', ['instance8'], 'somesha')
 


### PR DESCRIPTION
Haven't seen this happen but mark-for-deployment could incorrectly say
an instance is deployed if there is an error returned from the paasta
api. This seems undesirable so this widens the exception handling to
make it assume the instance isn't deployed if the paasta api returns
errors.