### PR TITLE
Add caching on frameworks endpoint in mesos-cli

### DIFF
--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -199,7 +199,11 @@ class MesosMaster(object):
         keys = ["frameworks"]
         if not active_only:
             keys.append("completed_frameworks")
-        return util.merge(self.fetch("/master/frameworks").json(), *keys)
+        return util.merge(self._frameworks, *keys)
+
+    @util.CachedProperty(ttl=5)
+    def _frameworks(self):
+        return self.fetch("/master/frameworks").json()
 
     def frameworks(self, active_only=False):
         return [framework.Framework(f) for f in self._framework_list(active_only)]

--- a/tests/mesos/test_master.py
+++ b/tests/mesos/test_master.py
@@ -1,3 +1,4 @@
+from mock import Mock
 from mock import patch
 
 from paasta_tools.mesos import framework
@@ -34,3 +35,29 @@ def test_framework_list_includes_completed_frameworks(mock_framework_list):
     expected_frameworks = [framework.Framework(config) for config in fake_frameworks]
     mesos_master = master.MesosMaster({})
     assert expected_frameworks == mesos_master.frameworks()
+
+
+@patch.object(master.MesosMaster, 'fetch', autospec=True)
+def test__frameworks(mock_fetch):
+    mesos_master = master.MesosMaster({})
+    mock_frameworks = Mock()
+    mock_fetch.return_value = Mock(json=Mock(return_value=mock_frameworks))
+    ret = mesos_master._frameworks
+    mock_fetch.assert_called_with(mesos_master, "/master/frameworks")
+    assert ret == mock_frameworks
+
+
+@patch.object(master.MesosMaster, '_frameworks', autospec=True)
+def test__framework_list(mock__frameworks):
+    mock_frameworks = Mock()
+    mock_completed = Mock()
+    mock__frameworks.__get__ = Mock(return_value={'frameworks': [mock_frameworks],
+                                                  'completed_frameworks': [mock_completed]})
+    mesos_master = master.MesosMaster({})
+    ret = mesos_master._framework_list()
+    expected = [mock_frameworks, mock_completed]
+    assert list(ret) == expected
+
+    ret = mesos_master._framework_list(active_only=True)
+    expected = [mock_frameworks]
+    assert list(ret) == expected


### PR DESCRIPTION
After 3d07cbeacc4cfe0e9556500a1e51cbe4b49e5f4c we are getting the
frameworks from the proper endpoint. However, we aren't caching the
response as we were with the state endpoint. This means that anywhere
which calls the master.framework (which includes things like
task.framework) had to make a new HTTP call to /master/frameworks each
time.

This manifested in slow runs of the autoscaler where we happen to call
task.framework once per task in the cluster. See
get_mesos_task_count_by_slave in mesos_tools.

This adds the same caching as is used on the state.json endpoint.