### PR TITLE
Validate paasta api update_autoscaler_count request

### DIFF
--- a/paasta_itests/steps/paasta_api_steps.py
+++ b/paasta_itests/steps/paasta_api_steps.py
@@ -15,8 +15,8 @@ from behave import then
 from pyramid import testing
 
 from paasta_tools.api import settings
+from paasta_tools.api.views.exception import ApiFailure
 from paasta_tools.api.views.instance import instance_status
-from paasta_tools.api.views.instance import InstanceFailure
 from paasta_tools.utils import decompose_job_id
 
 
@@ -44,7 +44,7 @@ def service_instance_status_error(context, error_code, job_id):
     response = None
     try:
         response = instance_status(request)
-    except InstanceFailure as exc:
+    except ApiFailure as exc:
         assert 'not found' in exc.msg
         assert exc.err == int(error_code)
     except:

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -101,7 +101,7 @@
       "get": {
         "responses": {
           "200": {
-            "description": "Desired instance count for a service instance",
+            "description": "Get desired instance count for a service instance",
             "schema": {
               "type": "object",
               "properties": {
@@ -141,12 +141,15 @@
       "post": {
         "responses": {
           "202": {
-            "description": "Desired instance count for a service instance",
+            "description": "Set desired instance count for a service instance",
             "schema": {
               "type": "object",
               "properties": {
                 "desired_instances": {
                   "type": "integer"
+                },
+                "status": {
+                  "type": "string"
                 }
               }
             }

--- a/paasta_tools/api/views/exception.py
+++ b/paasta_tools/api/views/exception.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+PaaSTA API error handling.
+"""
+import logging
+
+from pyramid.response import Response
+from pyramid.view import view_config
+
+
+log = logging.getLogger(__name__)
+
+
+class ApiFailure(Exception):
+    def __init__(self, msg, err):
+        self.msg = msg
+        self.err = err
+
+
+@view_config(context=ApiFailure)
+def api_failure_response(exc, request):
+    """Construct an HTTP response with an error status code. This happens when
+    the API service has to stop on a 'hard' error. In contrast, the API service
+    continues to produce results on a 'soft' error. It will place a 'message'
+    field in the output. Multiple 'soft' errors are concatenated in the same
+    'message' field when errors happen in the same hierarchy.
+    """
+    log.error(exc.msg)
+
+    response = Response('ERROR: %s' % exc.msg)
+    response.status_int = exc.err
+    return response

--- a/tests/api/test_autoscaler.py
+++ b/tests/api/test_autoscaler.py
@@ -31,7 +31,8 @@ def test_get_autoscaler_count():
         assert response.json_body['desired_instances'] == 123
 
 
-def test_update_autoscaler_count():
+@mock.patch('paasta_tools.api.views.autoscaler.load_marathon_service_config', autospec=True)
+def test_update_autoscaler_count(mock_load_marathon_service_config):
     request = testing.DummyRequest()
     request.swagger_data = {
         'service': 'fake_service',
@@ -39,8 +40,36 @@ def test_update_autoscaler_count():
         'json_body': {'desired_instances': 123},
     }
 
+    mock_load_marathon_service_config.return_value = mock.MagicMock(
+        get_min_instances=mock.MagicMock(return_value=100),
+        get_max_instances=mock.MagicMock(return_value=200)
+    )
+
     with mock.patch('paasta_tools.api.views.autoscaler.set_instances_for_marathon_service',
                     autospec=True) as mock_set_instances:
         response = autoscaler.update_autoscaler_count(request)
         assert response.json_body['desired_instances'] == 123
         mock_set_instances.assert_called_once_with(service='fake_service', instance='fake_instance', instance_count=123)
+
+
+@mock.patch('paasta_tools.api.views.autoscaler.load_marathon_service_config', autospec=True)
+@mock.patch('paasta_tools.api.views.autoscaler.set_instances_for_marathon_service', autospec=True)
+def test_update_autoscaler_count_warning(
+    mock_set_instances_for_marathon_service,
+    mock_load_marathon_service_config
+):
+    request = testing.DummyRequest()
+    request.swagger_data = {
+        'service': 'fake_service',
+        'instance': 'fake_instance',
+        'json_body': {'desired_instances': 123},
+    }
+
+    mock_load_marathon_service_config.return_value = mock.MagicMock(
+        get_min_instances=mock.MagicMock(return_value=10),
+        get_max_instances=mock.MagicMock(return_value=100)
+    )
+
+    response = autoscaler.update_autoscaler_count(request)
+    assert response.json_body['desired_instances'] == 100
+    assert 'WARNING' in response.json_body['status']


### PR DESCRIPTION
We want to make sure the service.instance exists and the desired_instance count is between min and max instance counts.

> $ curl -X POST -d '{"desired_instances":4}' http://paasta-mesosstage.yelp:5055/v1/services/robj-test-service/autoscale_to_heck2/autoscaler
> ERROR: Unable to load service config for robj-test-service.autoscale_to_heck2
> 
> $ curl -X POST -d '{"desired_instances":3}' http://paasta-mesosstage.yelp:5055/v1/services/robj-test-service/autoscale_to_heck/autoscaler
> {"status":"SUCCESS","desired_instances":3}
> 
> $ paasta status -s robj-test-service -i autoscale_to_heck
> cluster: mesosstage
> instance: autoscale_to_heck
> Git sha:    ba88d9ce (desired)
> State:      Running - Desired state: Started
> Marathon:   Healthy - up with (4/3) instances. Status: Deploying
> Mesos:      Healthy - (4/3) tasks in the TASK_RUNNING state.
> 
> $ curl -X POST -d '{"desired_instances":1}' http://paasta-mesosstage.yelp:5055/v1/services/robj-test-service/autoscale_to_heck/autoscaler
> {"status":"WARNING desired_instances is less than min_instances 2","desired_instances":2}
> 
> $ paasta status -s robj-test-service -i autoscale_to_heck
> cluster: mesosstage
> instance: autoscale_to_heck
> Git sha:    ba88d9ce (desired)
> WARNING:paasta_tools.marathon_tools:Returning limited instance count 2. (zk had 1)
> State:      Running - Desired state: Started
> Marathon:   Healthy - up with (4/2) instances. Status: Deploying
> Mesos:      Healthy - (4/2) tasks in the TASK_RUNNING state.
> 
> $ curl -X POST -d '{"desired_instances":5}' http://paasta-mesosstage.yelp:5055/v1/services/robj-test-service/autoscale_to_heck/autoscaler
> {"status":"WARNING desired_instances is greater than max_instances 4","desired_instances":4}
> 
> $ paasta status -s robj-test-service -i autoscale_to_heck
> cluster: mesosstage
> instance: autoscale_to_heck
> Git sha:    ba88d9ce (desired)
> WARNING:paasta_tools.marathon_tools:Returning limited instance count 4. (zk had 5)
> State:      Running - Desired state: Started
> Marathon:   Warning - up with (3/4) instances. Status: Deploying
> Mesos:      Healthy - (4/4) tasks in the TASK_RUNNING state.
> 
> $ curl -X POST -d '{"desired_instances":4}' http://paasta-mesosstage.yelp:5055/v1/services/robj-test-service/main/autoscaler
> ERROR: Autoscaling is not enabled for robj-test-service.main