### PR TITLE
Change the words a bit on paasta status

### DIFF
--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -140,7 +140,7 @@ def paasta_serviceinit_status_single_instance(context, service, instances):
     print 'Got exitcode %s with output:\n%s' % (exit_code, output)
     print  # sacrificial line for behave to eat instead of our output
 
-    assert "Running" in output
+    assert "Configured" in output
     assert exit_code == 0
 
 
@@ -155,7 +155,7 @@ def paasta_serviceinit_status_multi_instances(context, service, instances):
     print  # sacrificial line for behave to eat instead of our output
 
     # one service is deployed and the other is not
-    assert "Running" in output
+    assert "Configured" in output
     assert exit_code != 0
 
 

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -100,7 +100,6 @@ def _format_job_name(job):
 
 
 def _format_disabled_status(job):
-    status = PaastaColors.red("UNKNOWN")
     if job.get("disabled", False):
         status = PaastaColors.grey("Not scheduled")
     else:

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -56,9 +56,9 @@ def restart_marathon_job(service, instance, app_id, client, cluster):
 
 def bouncing_status_human(app_count, bounce_method):
     if app_count == 0:
-        return PaastaColors.red("Stopped")
+        return PaastaColors.red("Disabled")
     elif app_count == 1:
-        return PaastaColors.green("Running")
+        return PaastaColors.green("Configured")
     elif app_count > 1:
         return PaastaColors.yellow("Bouncing (%s)" % bounce_method)
     else:
@@ -200,7 +200,7 @@ def status_marathon_job_verbose(service, instance, client):
             all_tasks.extend(tasks)
             all_output.append(output)
         else:
-            all_output.append("Warning: App %s not running." % app_id)
+            all_output.append("Warning: App %s is not running yet." % app_id)
     return all_tasks, "\n".join(all_output)
 
 


### PR DESCRIPTION
It is a super common question when users say "why does it say running" when their service is "stopped".