### PR TITLE
Add code to cleanup cancelled SFRs

### DIFF
--- a/paasta_tools/autoscale_cluster.py
+++ b/paasta_tools/autoscale_cluster.py
@@ -27,6 +27,9 @@ def parse_args():
                         help="Print out more output.")
     parser.add_argument('-d', '--dry-run', action='store_true',
                         help="Perform no actions, only print what to do")
+    parser.add_argument('-a', '--autoscaler-configs',
+                        help="Path to autoscaler config files",
+                        default='/etc/paasta/cluster_autoscaling')
     args = parser.parse_args()
     return args
 
@@ -41,7 +44,7 @@ def main():
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    autoscale_local_cluster(dry_run=args.dry_run)
+    autoscale_local_cluster(dry_run=args.dry_run, config_folder=args.autoscaler_configs)
 
 
 if __name__ == '__main__':

--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -139,6 +139,7 @@ def spotfleet_metrics_provider(spotfleet_request_id, resource, pool_settings):
         return 0, 0
     current, target = get_spot_fleet_delta(resource, error)
     if sfr['SpotFleetRequestState'] == 'cancelled_running':
+        resource['min_capacity'] = 0
         if current - target < 0:
             log.info("Not scaling cancelled SFR {0} because we are under provisioned".format(spotfleet_request_id))
             return 0, 0

--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -442,6 +442,7 @@ def downscale_spot_fleet_request(resource, filtered_slaves, current_capacity, ta
     while True:
         filtered_sorted_slaves = sort_slaves_to_kill(filtered_slaves)
         if len(filtered_sorted_slaves) == 0:
+            log.info("ALL slaves killed so moving on to next pool!")
             break
         log.info("SFR slave kill preference: {0}".format([slave['hostname'] for slave in filtered_sorted_slaves]))
         filtered_sorted_slaves.reverse()
@@ -468,7 +469,10 @@ def downscale_spot_fleet_request(resource, filtered_slaves, current_capacity, ta
             break
         current_capacity = new_capacity
         mesos_state = get_mesos_master().state_summary()
-        filtered_slaves = get_mesos_task_count_by_slave(mesos_state, slaves_list=filtered_sorted_slaves)
+        if filtered_sorted_slaves:
+            filtered_slaves = get_mesos_task_count_by_slave(mesos_state, slaves_list=filtered_sorted_slaves)
+        else:
+            filtered_slaves = filtered_sorted_slaves
 
 
 class ClusterAutoscalingError(Exception):

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -320,7 +320,10 @@ def test_autoscale_local_cluster():
 
         autoscaling_cluster_lib.autoscale_local_cluster(config_folder='/nail/blah')
         assert mock_get_paasta_config.called
-        mock_is_resource_cancelled.assert_called_with(mock_scaling_resources['id1'])
+        is_cancelled_calls = [mock.call(mock_scaling_resources['id1']),
+                              mock.call(mock_scaling_resources['id2']),
+                              mock.call(mock_scaling_resources['id3'])]
+        mock_is_resource_cancelled.assert_has_calls(is_cancelled_calls, any_order=True)
         autoscale_calls = [mock.call(identifier='id3',
                                      resource=mock_scaling_result['id3'],
                                      config_folder='/nail/blah',

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -183,8 +183,7 @@ def test_downscale_spot_fleet_request():
                                                    mock.call(mock_get_mesos_task_count_by_slave.return_value)])
         assert mock_get_mesos_master.called
         mock_gracefully_terminate_slave.assert_has_calls([mock_terminate_call_1, mock_terminate_call_2])
-        mock_get_task_count_calls = [mock.call(mock_mesos_state, slaves_list=[mock_slave_2]),
-                                     mock.call(mock_mesos_state, slaves_list=[])]
+        mock_get_task_count_calls = [mock.call(mock_mesos_state, slaves_list=[mock_slave_2])]
         mock_get_mesos_task_count_by_slave.assert_has_calls(mock_get_task_count_calls)
 
         # test non integer scale down

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -717,6 +717,9 @@ def test_spotfleet_metrics_provider():
         assert ret == (0, 0)
         mock_get_spot_fleet_delta.return_value = 2, 1
         ret = autoscaling_cluster_lib.spotfleet_metrics_provider('sfr-blah', mock_resource, mock_pool_settings)
+        mock_capacity_resource = mock_resource.copy()
+        mock_capacity_resource['min_capacity'] = 0
+        mock_get_spot_fleet_delta.assert_called_with(mock_capacity_resource, float(-1))
         assert ret == (2, 0)
         mock_get_spot_fleet_delta.return_value = 4, 2
         ret = autoscaling_cluster_lib.spotfleet_metrics_provider('sfr-blah', mock_resource, mock_pool_settings)

--- a/tests/test_autoscale_cluster.py
+++ b/tests/test_autoscale_cluster.py
@@ -21,6 +21,6 @@ from paasta_tools.autoscale_cluster import main
 @mock.patch('paasta_tools.autoscale_cluster.autoscale_local_cluster', autospec=True)
 @mock.patch('paasta_tools.autoscale_cluster.parse_args', autospec=True)
 def test_main(mock_parse_args, mock_autoscale_local_cluster, logging):
-    mock_parse_args.return_value = mock.Mock(dry_run=True)
+    mock_parse_args.return_value = mock.Mock(dry_run=True, autoscaler_configs='/nail/blah')
     main()
-    mock_autoscale_local_cluster.assert_called_with(dry_run=True)
+    mock_autoscale_local_cluster.assert_called_with(dry_run=True, config_folder='/nail/blah')


### PR DESCRIPTION
I'll want to try this out in mesosstage before I do much more work on it. Feel free to have a look and give me some feedback but you may want to hold off giving a thorough review until I'm confident this works!

Major changes:
* Use FulfilledCapacity rather than current TargetCapacity as base for calculation of new TargetCapacity
* Set a property on each resource marking it as cancelled and process these resources first.
* If scaling a cancelled resource: only remove instances if the cluster is otherwise over provisioned or at target.
* Gradually scale down cancelled resources