### PR TITLE
PAASTA-6732 fix exception in cluster.py when trying to throw FileNotFoundForTaskException

### DIFF
--- a/paasta_tools/mesos/cluster.py
+++ b/paasta_tools/mesos/cluster.py
@@ -24,7 +24,7 @@ from . import parallel
 missing_slave = set([])
 
 
-def get_files_for_tasks(task_list, file_list, max_workers, fail=True):
+def get_files_for_tasks(task_list, file_list, max_workers):
     no_files_found = True
 
     def process((task, fname)):
@@ -49,7 +49,7 @@ def get_files_for_tasks(task_list, file_list, max_workers, fail=True):
             no_files_found = False
             yield result
 
-    if no_files_found and fail:
+    if no_files_found:
         raise exceptions.FileNotFoundForTaskException(
             "None of the tasks in %s contain the files in list %s" % (
                 ",".join([task["id"] for task in task_list]),

--- a/paasta_tools/mesos/cluster.py
+++ b/paasta_tools/mesos/cluster.py
@@ -57,8 +57,8 @@ def get_files_for_tasks(task_list, file_list, max_workers, fail=True):
 
     if dne and fail:
         raise exceptions.FileNotFoundForTaskException(
-            "None of the tasks in %s contin the files in list %s" % (
-                ",".join([task["id"] for task in task]),
+            "None of the tasks in %s contain the files in list %s" % (
+                ",".join([task["id"] for task in task_list]),
                 ",".join(file_list)
             )
         )

--- a/tests/mesos/test_cluster.py
+++ b/tests/mesos/test_cluster.py
@@ -1,0 +1,44 @@
+from mock import MagicMock
+from mock import Mock
+from pytest import raises
+
+from paasta_tools.mesos import cluster
+from paasta_tools.mesos import exceptions
+
+
+def test_get_files_for_tasks_no_files():
+    attrs = {'id': 'foo'}
+    mock_task = MagicMock()
+    mock_task.__getitem__.side_effect = lambda x: attrs[x]
+    mock_file = Mock()
+    mock_file.exists.return_value = False
+    mock_task.file.return_value = mock_file
+    files = cluster.get_files_for_tasks([mock_task], ['myfile'], 1)
+    with raises(exceptions.FileNotFoundForTaskException) as excinfo:
+        files = list(files)
+    assert 'None of the tasks in foo contain the files in list myfile' in str(excinfo.value)
+
+
+def test_get_files_for_tasks_all():
+    attrs = {'id': 'foo'}
+    mock_task = MagicMock()
+    mock_task.__getitem__.side_effect = lambda x: attrs[x]
+    mock_file = Mock()
+    mock_file.exists.return_value = True
+    mock_task.file.return_value = mock_file
+    files = cluster.get_files_for_tasks([mock_task], ['myfile'], 1)
+    files = list(files)
+    assert files == [mock_file]
+
+
+def test_get_files_for_tasks_some():
+    attrs = {'id': 'foo'}
+    mock_task = MagicMock()
+    mock_task.__getitem__.side_effect = lambda x: attrs[x]
+    mock_file = Mock()
+    mock_file_2 = Mock()
+    mock_file.exists.side_effect = [False, True]
+    mock_task.file.side_effect = [mock_file, mock_file_2]
+    files = cluster.get_files_for_tasks([mock_task], ['myfile', 'myotherfile'], 1)
+    files = list(files)
+    assert files == [mock_file_2]


### PR DESCRIPTION
closes PAASTA-6732

- fix the typo causing the original bug
- remove the globals in use
- remove the option to *not* make this throw an exception.
- add some tests to better understand its behaviour