### PR TITLE
Support multiple scribe environments per cluster

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -813,15 +813,15 @@ class ScribeLogReader(LogReader):
         envs = []
         for component in components:
             # If a component has a 'source_env', we use that
-            # otherwise we lookup what scribe env is associated with a given cluster
-            env = LOG_COMPONENTS[component].get('source_env', self.cluster_to_scribe_env(cluster))
+            # otherwise we lookup a list of scribe envs associated with a given cluster
+            cluster_envs = LOG_COMPONENTS[component].get('source_envs', self.cluster_to_scribe_envs(cluster))
             if 'additional_source_envs' in LOG_COMPONENTS[component]:
                 envs += LOG_COMPONENTS[component]['additional_source_envs']
-            envs.append(env)
+            envs += cluster_envs
         return set(envs)
 
-    def cluster_to_scribe_env(self, cluster):
-        """Looks up the particular scribe env associated with a given paasta cluster.
+    def cluster_to_scribe_envs(self, cluster):
+        """Looks up the list of scribe envs associated with a given paasta cluster.
 
         Scribe has its own "environment" key, which doesn't always map 1:1 with our
         cluster names, so we have to maintain a manual mapping.
@@ -829,12 +829,12 @@ class ScribeLogReader(LogReader):
         This mapping is deployed as a config file via puppet as part of the public
         config deployed to every server.
         """
-        env = self.cluster_map.get(cluster, None)
-        if env is None:
+        envs = self.cluster_map.get(cluster, None)
+        if envs is None:
             print "I don't know where scribe logs for %s live?" % cluster
             sys.exit(1)
         else:
-            return env
+            return envs
 
 
 def generate_start_end_time(from_string="30m", to_string=None):

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -499,7 +499,7 @@ LOG_COMPONENTS = OrderedDict([
     ('build', {
         'color': PaastaColors.blue,
         'help': 'Jenkins build jobs output, like the itest, promotion, security checks, etc.',
-        'source_env': 'devc',
+        'source_envs': ['devc'],
     }),
     ('deploy', {
         'color': PaastaColors.cyan,

--- a/tests/cli/test_cmds_logs.py
+++ b/tests/cli/test_cmds_logs.py
@@ -39,16 +39,16 @@ except ImportError:
 
 def test_cluster_to_scribe_env_good():
     with mock.patch('paasta_tools.cli.cmds.logs.scribereader', autospec=True):
-        scribe_log_reader = logs.ScribeLogReader(cluster_map={'mesosstage': 'env1'})
-        actual = scribe_log_reader.cluster_to_scribe_env('mesosstage')
-        assert actual == 'env1'
+        scribe_log_reader = logs.ScribeLogReader(cluster_map={'mesosstage': ['env1']})
+        actual = scribe_log_reader.cluster_to_scribe_envs('mesosstage')
+        assert actual == ['env1']
 
 
 def test_cluster_to_scribe_env_bad():
     with mock.patch('paasta_tools.cli.cmds.logs.scribereader', autospec=True):
         scribe_log_reader = logs.ScribeLogReader(cluster_map={})
         with raises(SystemExit) as sys_exit:
-            scribe_log_reader.cluster_to_scribe_env('dne')
+            scribe_log_reader.cluster_to_scribe_envs('dne')
             assert sys_exit.value.code == 1
 
 
@@ -891,10 +891,10 @@ def test_determine_scribereader_envs():
         mock_scribereader,
     ):
         cluster_map = {
-            cluster: 'fake_scribe_env',
+            cluster: ['fake_scribe_env', 'another_region'],
         }
         actual = logs.ScribeLogReader(cluster_map=cluster_map).determine_scribereader_envs(components, cluster)
-        assert actual == set(['devc', 'fake_scribe_env'])
+        assert actual == set(['devc', 'fake_scribe_env', 'another_region'])
 
 
 def test_determine_scribereader_additional_envs():
@@ -904,7 +904,7 @@ def test_determine_scribereader_additional_envs():
             mock.patch('paasta_tools.cli.cmds.logs.LOG_COMPONENTS',
                        spec_set=dict, autospec=None) as mock_LOG_COMPONENTS:
         cluster_map = {
-            cluster: 'fake_scribe_env',
+            cluster: ['fake_scribe_env'],
         }
         LOG_COMPONENTS = {
             'fake_component': {


### PR DESCRIPTION
This allows for the case when you have multiple scribe environments per
cluster. The internal ticket is PAASTA-6744.

This change will need to be made in conjunction with a change to the
config files that define the cluster map.