### PR TITLE
added request caching for service autoscaler

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -43,6 +43,7 @@ from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import get_user_agent
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import NoDeploymentsAvailable
+from paasta_tools.utils import use_requests_cache
 from paasta_tools.utils import ZookeeperPool
 
 SERVICE_METRICS_PROVIDER_KEY = 'metrics_provider'
@@ -347,6 +348,7 @@ def get_configs_of_services_to_scale(cluster, soa_dir=DEFAULT_SOA_DIR):
     return configs
 
 
+@use_requests_cache('service_autoscaler')
 def autoscale_services(soa_dir=DEFAULT_SOA_DIR):
     try:
         with create_autoscaling_lock():


### PR DESCRIPTION
This speeds up the autoscaler in our largest cluster by 7x.