### PR TITLE
Added tab-completion where we use deploy_groups

### DIFF
--- a/paasta_tools/cli/cmds/get_latest_deployment.py
+++ b/paasta_tools/cli/cmds/get_latest_deployment.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from paasta_tools.cli.utils import lazy_choices_completer
+from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import PaastaColors
 from paasta_tools.cli.utils import validate_service_name
@@ -33,10 +34,10 @@ def add_subparser(subparsers):
         required=True,
     ).completer = lazy_choices_completer(list_services)
     list_parser.add_argument(
-        '-i', '--deploy-group',
+        '-l', '--deploy-group',
         help='Name of the deploy group which you want to get the latest deployment for.',
         required=True,
-    )
+    ).completer = lazy_choices_completer(list_deploy_groups)
     list_parser.add_argument(
         '-d', '--soa-dir',
         help='A directory from which soa-configs should be read from',

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -23,10 +23,10 @@ from bravado.exception import HTTPError
 
 from paasta_tools import remote_git
 from paasta_tools.api import client
-from paasta_tools.cli.utils import validate_full_git_sha
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import list_services
+from paasta_tools.cli.utils import validate_full_git_sha
 from paasta_tools.cli.utils import validate_given_deploy_groups
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.generate_deployments_for_service import get_cluster_instance_map_for_service

--- a/tests/cli/test_cmds_rollback.py
+++ b/tests/cli/test_cmds_rollback.py
@@ -22,10 +22,9 @@ from paasta_tools.cli.cmds.rollback import get_git_shas_for_service
 from paasta_tools.cli.cmds.rollback import list_previously_deployed_shas
 from paasta_tools.cli.cmds.rollback import paasta_rollback
 from paasta_tools.cli.cmds.rollback import validate_given_deploy_groups
-from paasta_tools.marathon_tools import MarathonServiceConfig
 
 
-@patch('paasta_tools.cli.cmds.rollback.get_instance_config_for_service', autospec=True)
+@patch('paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.figure_out_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.get_git_url', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.mark_for_deployment', autospec=True)
@@ -33,7 +32,7 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_figure_out_service_name,
-    mock_get_instance_config,
+    mock_list_deploy_groups,
 ):
 
     fake_args = Mock(
@@ -44,13 +43,7 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
 
-    mock_get_instance_config.return_value = [MarathonServiceConfig(
-        service='',
-        cluster='',
-        instance='',
-        branch_dict={},
-        config_dict={'deploy_group': 'fake_deploy_groups'},
-    )]
+    mock_list_deploy_groups.return_value = ['fake_deploy_groups']
 
     mock_mark_for_deployment.return_value = 0
     assert paasta_rollback(fake_args) == 0
@@ -65,7 +58,7 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
     assert mock_mark_for_deployment.call_count == 1
 
 
-@patch('paasta_tools.cli.cmds.rollback.get_instance_config_for_service', autospec=True)
+@patch('paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.figure_out_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.get_git_url', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.mark_for_deployment', autospec=True)
@@ -73,7 +66,7 @@ def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_figure_out_service_name,
-    mock_get_instance_config,
+    mock_list_deploy_groups,
 ):
 
     fake_args = Mock(
@@ -84,22 +77,8 @@ def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
 
-    mock_get_instance_config.return_value = [
-        MarathonServiceConfig(
-            service=mock_figure_out_service_name.return_value,
-            cluster='',
-            instance='',
-            config_dict={'deploy_group': 'fake_deploy_group'},
-            branch_dict={},
-        ),
-        MarathonServiceConfig(
-            service=mock_figure_out_service_name.return_value,
-            cluster='fake_cluster',
-            instance='fake_instance',
-            config_dict={},
-            branch_dict={},
-        ),
-    ]
+    mock_list_deploy_groups.return_value = [
+        'fake_deploy_group', 'fake_cluster.fake_instance']
 
     mock_mark_for_deployment.return_value = 0
     assert paasta_rollback(fake_args) == 0
@@ -124,7 +103,7 @@ def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
     assert mock_mark_for_deployment.call_count == 2
 
 
-@patch('paasta_tools.cli.cmds.rollback.get_instance_config_for_service', autospec=True)
+@patch('paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.figure_out_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.get_git_url', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.mark_for_deployment', autospec=True)
@@ -132,7 +111,7 @@ def test_paasta_rollback_mark_for_deployment_wrong_deploy_group_args(
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_figure_out_service_name,
-    mock_get_instance_config_for_service,
+    mock_list_deploy_groups,
 ):
 
     fake_args = Mock(
@@ -143,21 +122,13 @@ def test_paasta_rollback_mark_for_deployment_wrong_deploy_group_args(
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
 
-    mock_get_instance_config_for_service.return_value = [
-        MarathonServiceConfig(
-            instance='some_other_instance',
-            cluster='some_other_cluster',
-            service=mock_figure_out_service_name.return_value,
-            config_dict={},
-            branch_dict={},
-        ),
-    ]
+    mock_list_deploy_groups.return_value = ['some_other_instance.some_other_cluster']
 
     assert paasta_rollback(fake_args) == 1
     assert mock_mark_for_deployment.call_count == 0
 
 
-@patch('paasta_tools.cli.cmds.rollback.get_instance_config_for_service', autospec=True)
+@patch('paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.figure_out_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.get_git_url', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.mark_for_deployment', autospec=True)
@@ -165,7 +136,7 @@ def test_paasta_rollback_mark_for_deployment_multiple_instance_args(
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_figure_out_service_name,
-    mock_get_instance_config_for_service,
+    mock_list_deploy_groups,
 ):
 
     fake_args = Mock(
@@ -176,21 +147,8 @@ def test_paasta_rollback_mark_for_deployment_multiple_instance_args(
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
 
-    mock_get_instance_config_for_service.return_value = [
-        MarathonServiceConfig(
-            instance='instance1',
-            cluster='cluster',
-            service=mock_figure_out_service_name.return_value,
-            config_dict={},
-            branch_dict={},
-        ),
-        MarathonServiceConfig(
-            instance='instance2',
-            cluster='cluster',
-            service=mock_figure_out_service_name.return_value,
-            config_dict={},
-            branch_dict={},
-        ),
+    mock_list_deploy_groups.return_value = [
+        'cluster.instance1', 'cluster.instance2'
     ]
 
     mock_mark_for_deployment.return_value = 0
@@ -285,17 +243,12 @@ def test_list_previously_deployed_shas():
         'refs/tags/paasta-test.deploy.group-00000000T000000-deploy': 'SHA_IN_OUTPUT',
         'refs/tags/paasta-other.deploy.group-00000000T000000-deploy': 'NOT_IN_OUTPUT',
     }
-    fake_configs = [MarathonServiceConfig(
-        service='fake_service',
-        instance='fake_instance',
-        cluster='fake_cluster',
-        config_dict={'deploy_group': 'test.deploy.group'},
-        branch_dict={},
-    )]
+    fake_deploy_groups = ['test.deploy.group']
+
     with contextlib.nested(
             patch('paasta_tools.cli.cmds.rollback.list_remote_refs', autospec=True, return_value=fake_refs),
-            patch('paasta_tools.cli.cmds.rollback.get_instance_config_for_service', autospec=True,
-                  return_value=fake_configs),
+            patch('paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True,
+                  return_value=fake_deploy_groups),
     ) as (
         _,
         _,
@@ -314,26 +267,12 @@ def test_list_previously_deployed_shas_no_deploy_groups():
         'refs/tags/paasta-other.deploy.group-00000000T000000-deploy': 'SHA_IN_OUTPUT_2',
         'refs/tags/paasta-nonexistant.deploy.group-00000000T000000-deploy': 'SHA_NOT_IN_OUTPUT',
     }
-    fake_configs = [
-        MarathonServiceConfig(
-            service='fake_service',
-            instance='fake_instance',
-            cluster='fake_cluster',
-            config_dict={'deploy_group': 'test.deploy.group'},
-            branch_dict={},
-        ),
-        MarathonServiceConfig(
-            service='fake_service',
-            instance='fake_instance',
-            cluster='fake_cluster',
-            config_dict={'deploy_group': 'other.deploy.group'},
-            branch_dict={},
-        ),
-    ]
+    fake_deploy_groups = ['test.deploy.group', 'other.deploy.group']
+
     with contextlib.nested(
             patch('paasta_tools.cli.cmds.rollback.list_remote_refs', autospec=True, return_value=fake_refs),
-            patch('paasta_tools.cli.cmds.rollback.get_instance_config_for_service', autospec=True,
-                  return_value=fake_configs),
+            patch('paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True,
+                  return_value=fake_deploy_groups),
     ) as (
         _,
         _,

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -21,6 +21,7 @@ from pytest import mark
 from pytest import raises
 
 from paasta_tools.cli import utils
+from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import SystemPaastaConfig
 
@@ -693,3 +694,27 @@ def test_git_sha_validation():
         '060ce8bc10efe0030c048a4711ad5dd85de5adac') == '060ce8bc10efe0030c048a4711ad5dd85de5adac'
     with raises(argparse.ArgumentTypeError):
         utils.validate_full_git_sha('BAD')
+
+
+@patch('paasta_tools.cli.utils.get_instance_configs_for_service', autospec=True)
+def test_list_deploy_groups_parses_configs(
+    mock_get_instance_configs_for_service,
+):
+    mock_get_instance_configs_for_service.return_value = [
+        MarathonServiceConfig(
+            service='foo',
+            cluster='',
+            instance='',
+            config_dict={'deploy_group': 'fake_deploy_group'},
+            branch_dict={},
+        ),
+        MarathonServiceConfig(
+            service='foo',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        ),
+    ]
+    actual = utils.list_deploy_groups(service="foo")
+    assert actual == set(['fake_deploy_group', 'fake_cluster.fake_instance'])

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -62,17 +62,17 @@ def test_get_deploy_group_mappings():
         },
     }
     with contextlib.nested(
-        mock.patch('paasta_tools.generate_deployments_for_service.get_instance_config_for_service',
+        mock.patch('paasta_tools.generate_deployments_for_service.get_instance_configs_for_service',
                    return_value=fake_service_configs, autospec=True),
         mock.patch('paasta_tools.remote_git.list_remote_refs',
                    return_value=fake_remote_refs, autospec=True),
     ) as (
-        get_instance_config_for_service_patch,
+        get_instance_configs_for_service_patch,
         list_remote_refs_patch,
     ):
         actual = generate_deployments_for_service.get_deploy_group_mappings(fake_soa_dir,
                                                                             fake_service, fake_old_mappings)
-        get_instance_config_for_service_patch.assert_called_once_with(soa_dir=fake_soa_dir, service=fake_service)
+        get_instance_configs_for_service_patch.assert_called_once_with(soa_dir=fake_soa_dir, service=fake_service)
         assert list_remote_refs_patch.call_count == 1
         assert expected == actual
 
@@ -102,13 +102,13 @@ def test_get_cluster_instance_map_for_service():
         ),
     ]
     with contextlib.nested(
-        mock.patch('paasta_tools.generate_deployments_for_service.get_instance_config_for_service',
+        mock.patch('paasta_tools.generate_deployments_for_service.get_instance_configs_for_service',
                    return_value=fake_service_configs, autospec=True),
     ) as (
-        mock_get_instance_config_for_service,
+        mock_get_instance_configs_for_service,
     ):
         ret = generate_deployments_for_service.get_cluster_instance_map_for_service('/nail/blah', 'service1', 'try_me')
-        mock_get_instance_config_for_service.assert_called_with('/nail/blah', 'service1')
+        mock_get_instance_configs_for_service.assert_called_with(soa_dir='/nail/blah', service='service1')
         expected = {'clusterA': {'instances': ['canary']}, 'clusterB': {'instances': ['main']}}
         assert ret == expected
 


### PR DESCRIPTION
A number of things related to deploy groups / rollback / mark-for-deployment that I've addressed while working with the tools:
* Added tab completion wherever I could
* Made mark-for-deployment not require a git url like rollback
* Added a deploy_group column to rollback's suggestions (more to come on that front after this PR)
* `get_instance_config_for_service` => `get_instance_configs_for_service`
* Moved `get_instance_configs_for_service` to utils (can't move it to the big utils due to cross-imports)
* Tried to make the cli short-args more universal without breaking things

Let me know if this is too much and I can split up some things, but some of this has to be shipped together.