### PR TITLE
Added type validation on git commit cli inputs

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -23,6 +23,7 @@ from bravado.exception import HTTPError
 
 from paasta_tools import remote_git
 from paasta_tools.api import client
+from paasta_tools.cli.utils import validate_full_git_sha
 from paasta_tools.cli.utils import validate_given_deploy_groups
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.generate_deployments_for_service import get_cluster_instance_map_for_service
@@ -65,6 +66,7 @@ def add_subparser(subparsers):
         '-c', '--commit',
         help='Git sha to mark for deployment',
         required=True,
+        type=validate_full_git_sha,
     )
     list_parser.add_argument(
         '-l', '--deploy-group', '--clusterinstance',

--- a/paasta_tools/cli/cmds/push_to_registry.py
+++ b/paasta_tools/cli/cmds/push_to_registry.py
@@ -16,6 +16,7 @@
 image to a registry.
 """
 from paasta_tools.cli.utils import get_jenkins_build_output_url
+from paasta_tools.cli.utils import validate_full_git_sha
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.utils import _log
 from paasta_tools.utils import _run
@@ -49,6 +50,7 @@ def add_subparser(subparsers):
         '-c', '--commit',
         help='Git sha after which to name the remote image',
         required=True,
+        type=validate_full_git_sha,
     )
     list_parser.add_argument(
         '-d', '--soa-dir',

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -19,6 +19,7 @@ from paasta_tools.cli.utils import extract_tags
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_services
+from paasta_tools.cli.utils import validate_full_git_sha
 from paasta_tools.cli.utils import validate_given_deploy_groups
 from paasta_tools.generate_deployments_for_service import get_instance_config_for_service
 from paasta_tools.remote_git import list_remote_refs
@@ -51,6 +52,7 @@ def add_subparser(subparsers):
         "A commit to rollback to is required for paasta rollback to run. However if one is not provided, "
         "paasta rollback will instead output a list of valid git shas to rollback to.",
         required=False,
+        type=validate_full_git_sha,
     ).completer = lazy_choices_completer(list_previously_deployed_shas)
     list_parser.add_argument(
         '-d', '--deploy-groups',

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import fnmatch
 import logging
 import os
@@ -676,6 +677,14 @@ def validate_given_deploy_groups(service_deploy_groups, args_deploy_groups):
         invalid_deploy_groups = set(args_deploy_groups).difference(service_deploy_groups)
 
     return valid_deploy_groups, invalid_deploy_groups
+
+
+def validate_full_git_sha(value):
+    pattern = re.compile('[a-f0-9]{40}')
+    if not pattern.match(value):
+        raise argparse.ArgumentTypeError(
+            "%s is not a full git sha, and PaaSTA needs the full sha" % value)
+    return value
 
 
 def get_subparser(subparsers, function, command, help_text, description):

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import contextlib
 from socket import gaierror
 
@@ -685,3 +686,10 @@ def test_pick_slave_from_status():
     mock_status = mock.Mock(marathon=mock.Mock(slaves=mock_slaves))
     assert utils.pick_slave_from_status(mock_status, host=None) == 1
     assert utils.pick_slave_from_status(mock_status, host='lolhost') == 'lolhost'
+
+
+def test_git_sha_validation():
+    assert utils.validate_full_git_sha(
+        '060ce8bc10efe0030c048a4711ad5dd85de5adac') == '060ce8bc10efe0030c048a4711ad5dd85de5adac'
+    with raises(argparse.ArgumentTypeError):
+        utils.validate_full_git_sha('BAD')


### PR DESCRIPTION
I had hard time using this tool with y-m when I tried to feed it short urls. It wasn't failing fast, but with this it will.