### PR TITLE
Don't use force when deleting a deployment

### DIFF
--- a/paasta_tools/contrib/delete_old_marathon_deployments.py
+++ b/paasta_tools/contrib/delete_old_marathon_deployments.py
@@ -63,7 +63,7 @@ def delete_deployment_if_too_old(client, deployment, max_date, dry_run):
             log.warning("Would delete %s for %s as it is %s old" % (deployment.id, deployment.affected_apps[0], age))
         else:
             log.warning("Deleting %s for %s as it is %s old" % (deployment.id, deployment.affected_apps[0], age))
-            client.delete_deployment(deployment_id=deployment.id, force=True)
+            client.delete_deployment(deployment_id=deployment.id, force=False)
     else:
         if dry_run is True:
             log.warning("NOT deleting %s for %s as it is %s old" % (deployment.id, deployment.affected_apps[0], age))


### PR DESCRIPTION
Per the advice in https://github.com/mesosphere/marathon/issues/4581

Additionally I've added an internal review to stop running this script, I bet we don't need it anymore.