### PR TITLE
Made mark-for-deployment way more verbose and have a progress bar

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -225,7 +225,7 @@ def instances_deployed(cluster, service, instances, git_sha):
         return False
     statuses = []
     for instance in instances:
-        log.debug("Inspecting the deployment status of {}.{} on {}".format(service, instance, cluster))
+        log.info("Inspecting the deployment status of {}.{} on {}".format(service, instance, cluster))
         try:
             status = api.service.status_instance(service=service, instance=instance).result()
             statuses.append(status)
@@ -244,40 +244,40 @@ def instances_deployed(cluster, service, instances, git_sha):
     results = []
     for status in statuses:
         if not status:
-            log.debug("No status for an unknown instance in {}. Not deployed yet.".format(cluster))
+            log.info("No status for an unknown instance in {}. Not deployed yet.".format(cluster))
             results.append(False)
         elif not status.marathon:
-            log.debug("{}.{} in {} is not a Marathon job. Marked as deployed.".format(
-                      service, status.instance, cluster))
+            log.info("{}.{} in {} is not a Marathon job. Marked as deployed.".format(
+                service, status.instance, cluster))
             results.append(True)
         elif status.marathon.expected_instance_count == 0 or status.marathon.desired_state == 'stop':
-            log.debug("{}.{} in {} is marked as stopped. Marked as deployed.".format(
-                      service, status.instance, cluster))
+            log.info("{}.{} in {} is marked as stopped. Marked as deployed.".format(
+                service, status.instance, cluster))
             results.append(True)
         else:
             if status.marathon.app_count != 1:
-                log.debug("{}.{} on {} is still bouncing, {} versions running".format(
-                          service, status.instance, cluster, status.marathon.app_count))
+                log.info("{}.{} on {} is still bouncing, {} versions running".format(
+                    service, status.instance, cluster, status.marathon.app_count))
                 results.append(False)
                 continue
             if not git_sha.startswith(status.git_sha):
-                log.debug("{}.{} on {} doesn't have the right sha yet: {}".format(
-                          service, status.instance, cluster, status.git_sha))
+                log.info("{}.{} on {} doesn't have the right sha yet: {}".format(
+                    service, status.instance, cluster, status.git_sha))
                 results.append(False)
                 continue
             if status.marathon.deploy_status != 'Running':
-                log.debug("{}.{} on {} in't running yet: {}".format(
-                          service, status.instance, cluster, status.marathon.deploy_status))
+                log.info("{}.{} on {} in't running yet: {}".format(
+                    service, status.instance, cluster, status.marathon.deploy_status))
                 results.append(False)
                 continue
             if status.marathon.expected_instance_count != status.marathon.running_instance_count:
-                log.debug("{}.{} on {} isn't scaled up yet, has {} out of {}".format(
-                          service, status.instance, cluster, status.marathon.running_instance_count,
-                          status.marathon.expected_instance_count))
+                log.info("{}.{} on {} isn't scaled up yet, has {} out of {}".format(
+                    service, status.instance, cluster, status.marathon.running_instance_count,
+                    status.marathon.expected_instance_count))
                 results.append(False)
                 continue
-            log.debug("{}.{} on {} looks 100% deployed at {} instances on {}".format(
-                      service, status.instance, cluster, status.marathon.running_instance_count, status.git_sha))
+            log.info("{}.{} on {} looks 100% deployed at {} instances on {}".format(
+                service, status.instance, cluster, status.marathon.running_instance_count, status.git_sha))
             results.append(True)
 
     return sum(results)
@@ -309,7 +309,7 @@ def wait_for_deployment(service, deploy_group, git_sha, soa_dir, timeout):
                             git_sha=git_sha)
                         if cluster_map[cluster]['deployed'] == len(cluster_map[cluster]['instances']):
                             instance_csv = ", ".join(cluster_map[cluster]['instances'])
-                            print "Deploy to %s complete! (%s)" % (cluster, instance_csv)
+                            print "Deploy to %s complete! (instances: %s)" % (cluster, instance_csv)
                     bar.update(sum([v["deployed"] for v in cluster_map.values()]))
                 if all([cluster['deployed'] == len(cluster["instances"]) for cluster in cluster_map.values()]):
                     bar.finish()

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -19,7 +19,9 @@ import logging
 import sys
 import time
 
+import progressbar
 from bravado.exception import HTTPError
+from requests.exceptions import ConnectionError
 
 from paasta_tools import remote_git
 from paasta_tools.api import client
@@ -187,14 +189,13 @@ def paasta_mark_for_deployment(args):
     )
     if args.block:
         try:
-            line = "Waiting for deployment of {0} to {1} complete".format(args.commit, args.deploy_group)
-            log.info(line)
+            print "Waiting for deployment of {0} for '{1}' complete...".format(args.commit, args.deploy_group)
             wait_for_deployment(service=service,
                                 deploy_group=args.deploy_group,
                                 git_sha=args.commit,
                                 soa_dir=args.soa_dir,
                                 timeout=args.timeout)
-            line = "Deployment of {0} to {1} complete".format(args.commit, args.deploy_group)
+            line = "Deployment of {0} for {1} complete".format(args.commit, args.deploy_group)
             _log(
                 service=service,
                 component='deploy',
@@ -202,7 +203,8 @@ def paasta_mark_for_deployment(args):
                 level='event'
             )
         except KeyboardInterrupt:
-            print "Waiting for deployment aborted. PaaSTA will continue to try to deploy this code."
+            print "Waiting for deployment aborted."
+            print "PaaSTA %s continue to try to deploy this code." % PaastaColors.bold('will')
             print "If you wish to see the status, run:"
             print ""
             print "    paasta status -s %s -v" % service
@@ -216,15 +218,17 @@ def paasta_mark_for_deployment(args):
     return ret
 
 
-def are_instances_deployed(cluster, service, instances, git_sha):
+def instances_deployed(cluster, service, instances, git_sha):
     api = client.get_paasta_api_client(cluster=cluster)
     if not api:
-        # Assume not deployed if we can't reach API
+        log.warning("Couldn't reach the PaaSTA api for {}! Assuming it is not deployed there yet.".format(cluster))
         return False
     statuses = []
     for instance in instances:
+        log.debug("Inspecting the deployment status of {}.{} on {}".format(service, instance, cluster))
         try:
-            statuses.append(api.service.status_instance(service=service, instance=instance).result())
+            status = api.service.status_instance(service=service, instance=instance).result()
+            statuses.append(status)
         except HTTPError as e:
             if e.response.status_code == 404:
                 log.warning("Can't get status for instance {0}, service {1} in cluster {2}. "
@@ -234,21 +238,50 @@ def are_instances_deployed(cluster, service, instances, git_sha):
                 log.warning("Error getting service status from PaaSTA API: {0}: {1}".format(e.response.status_code,
                                                                                             e.response.text))
             statuses.append(None)
+        except ConnectionError as e:
+            log.warning("Error getting service status from PaaSTA API for {0}: {1}".format(cluster, e))
+            statuses.append(None)
     results = []
     for status in statuses:
         if not status:
+            log.debug("No status for an unknown instance in {}. Not deployed yet.".format(cluster))
             results.append(False)
-        # if it's a chronos service etc then skip waiting for it to deploy
         elif not status.marathon:
+            log.debug("{}.{} in {} is not a Marathon job. Marked as deployed.".format(
+                      service, status.instance, cluster))
             results.append(True)
         elif status.marathon.expected_instance_count == 0 or status.marathon.desired_state == 'stop':
+            log.debug("{}.{} in {} is marked as stopped. Marked as deployed.".format(
+                      service, status.instance, cluster))
             results.append(True)
         else:
-            results.append(git_sha.startswith(status.git_sha) and
-                           status.marathon.app_count == 1 and
-                           status.marathon.deploy_status == 'Running' and
-                           status.marathon.expected_instance_count == status.marathon.running_instance_count)
-    return results and all(results)
+            if status.marathon.app_count == 1:
+                if git_sha.startswith(status.git_sha):
+                    if status.marathon.deploy_status == 'Running':
+                        if status.marathon.expected_instance_count == status.marathon.running_instance_count:
+                            log.debug("{}.{} on {} looks 100% deployed at {} instances on {}".format(
+                                      service, status.instance, cluster, status.marathon.running_instance_count,
+                                      status.git_sha))
+                            results.append(True)
+                        else:
+                            log.debug("{}.{} on {} isn't scaled up yet, has {} out of {}".format(
+                                service, status.instance, cluster, status.marathon.running_instance_count,
+                                status.marathon.expected_instance_count))
+                            results.append(False)
+                    else:
+                        log.debug("{}.{} on {} in't running yet: {}".format(service, status.instance, cluster,
+                                                                            status.marathon.deploy_status))
+                        results.append(False)
+                else:
+                    log.debug("{}.{} on {} doesn't have the right sha yet: {}".format(
+                              service, status.instance, cluster, status.git_sha))
+                    results.append(False)
+            else:
+                log.debug("{}.{} on {} is still bouncing, {} versions running".format(
+                          service, status.instance, cluster, status.marathon.app_count))
+                results.append(False)
+
+    return sum(results)
 
 
 def wait_for_deployment(service, deploy_group, git_sha, soa_dir, timeout):
@@ -263,19 +296,26 @@ def wait_for_deployment(service, deploy_group, git_sha, soa_dir, timeout):
         )
         raise NoInstancesFound
     for cluster in cluster_map.values():
-        cluster['deployed'] = False
+        cluster['deployed'] = 0
     try:
         with Timeout(seconds=timeout):
-            while True:
+            total_instances = sum([len(v["instances"]) for v in cluster_map.values()])
+            with progressbar.ProgressBar(maxval=total_instances) as bar:
                 for cluster, instances in cluster_map.items():
-                    if not cluster_map[cluster]['deployed']:
-                        cluster_map[cluster]['deployed'] = are_instances_deployed(cluster=cluster,
-                                                                                  service=service,
-                                                                                  instances=instances['instances'],
-                                                                                  git_sha=git_sha)
-                if all([cluster['deployed'] for cluster in cluster_map.values()]):
-                    break
-                time.sleep(10)
+                    if cluster_map[cluster]['deployed'] != len(cluster_map[cluster]['instances']):
+                        cluster_map[cluster]['deployed'] = instances_deployed(
+                            cluster=cluster,
+                            service=service,
+                            instances=instances['instances'],
+                            git_sha=git_sha)
+                        if cluster_map[cluster]['deployed'] == len(cluster_map[cluster]['instances']):
+                            instance_csv = ", ".join(cluster_map[cluster]['instances'])
+                            print "Deploy to %s complete! (%s)" % (cluster, instance_csv)
+                    bar.update(sum([v["deployed"] for v in cluster_map.values()]))
+                if all([cluster['deployed'] == len(cluster["instances"]) for cluster in cluster_map.values()]):
+                    bar.finish()
+                else:
+                    time.sleep(10)
     except TimeoutError:
         human_status = ["{0}: {1}".format(cluster, data['deployed']) for cluster, data in cluster_map.items()]
         line = "\nCurrent deployment status of {0} per cluster:\n".format(deploy_group) + "\n".join(human_status)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ ordereddict==1.1
 path.py==8.1
 ply==3.4
 prettytable==0.7.2
+progressbar2==3.10.1
 protobuf==2.6.1
 pyasn1==0.1.8
 pycrypto==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'mesos.interface == 1.0.1',
         'ordereddict >= 1.1',
         'path.py >= 8.1',
+        'progressbar2 >= 3.10.0',
         'pyramid == 1.7',
         'pyramid-swagger == 2.2.3',
         'pysensu-yelp >= 0.2.2',

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -138,24 +138,24 @@ def mock_status_instance_side_effect(service, instance):
 
 @patch('paasta_tools.cli.cmds.mark_for_deployment._log', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment.client.get_paasta_api_client', autospec=True)
-def test_are_instances_deployed(mock_get_paasta_api_client, mock__log):
+def test_instances_deployed(mock_get_paasta_api_client, mock__log):
     mock_paasta_api_client = Mock()
     mock_get_paasta_api_client.return_value = mock_paasta_api_client
     mock_paasta_api_client.service.status_instance.side_effect = mock_status_instance_side_effect
 
-    assert mark_for_deployment.are_instances_deployed('cluster', 'service1', ['instance1'], 'somesha')
-    assert not mark_for_deployment.are_instances_deployed('cluster', 'service1', ['instance2', 'instance1'], 'somesha')
-    assert not mark_for_deployment.are_instances_deployed('cluster', 'service1', ['instance3'], 'somesha')
-    assert not mark_for_deployment.are_instances_deployed('cluster', 'service1', ['instance4'], 'somesha')
-    assert mark_for_deployment.are_instances_deployed('cluster', 'service1', ['instance5', 'instance1'], 'somesha')
-    assert not mark_for_deployment.are_instances_deployed('cluster', 'service1', ['instance6'], 'somesha')
-    assert not mark_for_deployment.are_instances_deployed('cluster', 'service1', ['notaninstance'], 'somesha')
-    assert not mark_for_deployment.are_instances_deployed('cluster', 'service1', ['api_error'], 'somesha')
-    assert mark_for_deployment.are_instances_deployed('cluster', 'service1', ['instance7'], 'somesha')
-    assert mark_for_deployment.are_instances_deployed('cluster', 'service1', ['instance8'], 'somesha')
+    assert mark_for_deployment.instances_deployed('cluster', 'service1', ['instance1'], 'somesha') == 1
+    assert mark_for_deployment.instances_deployed('cluster', 'service1', ['instance2', 'instance1'], 'somesha') == 1
+    assert mark_for_deployment.instances_deployed('cluster', 'service1', ['instance3'], 'somesha') == 0
+    assert mark_for_deployment.instances_deployed('cluster', 'service1', ['instance4'], 'somesha') == 0
+    assert mark_for_deployment.instances_deployed('cluster', 'service1', ['instance5', 'instance1'], 'somesha') == 2
+    assert mark_for_deployment.instances_deployed('cluster', 'service1', ['instance6'], 'somesha') == 0
+    assert mark_for_deployment.instances_deployed('cluster', 'service1', ['notaninstance'], 'somesha') == 0
+    assert mark_for_deployment.instances_deployed('cluster', 'service1', ['api_error'], 'somesha') == 0
+    assert mark_for_deployment.instances_deployed('cluster', 'service1', ['instance7'], 'somesha') == 1
+    assert mark_for_deployment.instances_deployed('cluster', 'service1', ['instance8'], 'somesha') == 1
 
 
-def are_instances_deployed_side_effect(cluster, service, instances, git_sha):
+def instances_deployed_side_effect(cluster, service, instances, git_sha):
     if instances == ['instance1', 'instance2']:
         return True
     return False
@@ -163,27 +163,28 @@ def are_instances_deployed_side_effect(cluster, service, instances, git_sha):
 
 @patch('paasta_tools.cli.cmds.mark_for_deployment.get_cluster_instance_map_for_service', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment._log', autospec=True)
-@patch('paasta_tools.cli.cmds.mark_for_deployment.are_instances_deployed', autospec=True)
+@patch('paasta_tools.cli.cmds.mark_for_deployment.instances_deployed', autospec=True)
 @patch('time.sleep', autospec=True)
-def test_wait_for_deployment(mock_sleep, mock_are_instances_deployed, mock__log,
+def test_wait_for_deployment(mock_sleep, mock_instances_deployed, mock__log,
                              mock_get_cluster_instance_map_for_service):
     mock_cluster_map = {'cluster1': {'instances': ['instance1', 'instance2', 'instance3']}}
     mock_get_cluster_instance_map_for_service.return_value = mock_cluster_map
 
-    mock_are_instances_deployed.side_effect = are_instances_deployed_side_effect
+    mock_instances_deployed.side_effect = instances_deployed_side_effect
     mock_sleep.side_effect = TimeoutError()
     with raises(TimeoutError):
         mark_for_deployment.wait_for_deployment('service', 'deploy_group_1', 'somesha', '/nail/soa', 1)
     mock_get_cluster_instance_map_for_service.assert_called_with('/nail/soa', 'service', 'deploy_group_1')
-    mock_are_instances_deployed.assert_called_with(cluster='cluster1',
-                                                   service='service',
-                                                   instances=mock_cluster_map['cluster1']['instances'],
-                                                   git_sha='somesha')
+    mock_instances_deployed.assert_called_with(cluster='cluster1',
+                                               service='service',
+                                               instances=mock_cluster_map['cluster1']['instances'],
+                                               git_sha='somesha')
 
     mock_cluster_map = {'cluster1': {'instances': ['instance1', 'instance2']},
                         'cluster2': {'instances': ['instance1', 'instance2']}}
     mock_get_cluster_instance_map_for_service.return_value = mock_cluster_map
-    mark_for_deployment.wait_for_deployment('service', 'deploy_group_1', 'somesha', '/nail/soa', 1)
+    with raises(TimeoutError):
+        mark_for_deployment.wait_for_deployment('service', 'deploy_group_1', 'somesha', '/nail/soa', 1)
 
     mock_cluster_map = {'cluster1': {'instances': ['instance1', 'instance2']},
                         'cluster2': {'instances': ['instance1', 'instance3']}}

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -157,8 +157,8 @@ def test_instances_deployed(mock_get_paasta_api_client, mock__log):
 
 def instances_deployed_side_effect(cluster, service, instances, git_sha):
     if instances == ['instance1', 'instance2']:
-        return True
-    return False
+        return 2
+    return 0
 
 
 @patch('paasta_tools.cli.cmds.mark_for_deployment.get_cluster_instance_map_for_service', autospec=True)
@@ -183,8 +183,7 @@ def test_wait_for_deployment(mock_sleep, mock_instances_deployed, mock__log,
     mock_cluster_map = {'cluster1': {'instances': ['instance1', 'instance2']},
                         'cluster2': {'instances': ['instance1', 'instance2']}}
     mock_get_cluster_instance_map_for_service.return_value = mock_cluster_map
-    with raises(TimeoutError):
-        mark_for_deployment.wait_for_deployment('service', 'deploy_group_1', 'somesha', '/nail/soa', 1)
+    assert mark_for_deployment.wait_for_deployment('service', 'deploy_group_1', 'somesha', '/nail/soa', 1)
 
     mock_cluster_map = {'cluster1': {'instances': ['instance1', 'instance2']},
                         'cluster2': {'instances': ['instance1', 'instance3']}}


### PR DESCRIPTION
This adds a progress bar and *lots* more debug logging available with -v.

I dare say at yelp we should make -v the default in jenkins. It isn't like humans are looking at it all day, but when it *does* fail, we will want to see the debug logs I've added here. 

Here is what it looks like with verbose mode:
```
$ paasta mark-for-deployment --wait-for-deployment -c c19f9731c2665b4508d69f6263a8f502ad247489 -s paasta_canary -l everything -u git@git.yelpcorp.com:services/paasta_canary   -v
Marked c19f9731c2665b4508d69f6263a8f502ad247489 in for deployment in deploy group everything
Waiting for deployment of c19f9731c2665b4508d69f6263a8f502ad247489 for 'everything' complete...
  0% ( 0 of 18) |                                                                                                        | Elapsed Time: 0:00:00 ETA:  --:--:--DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.main on nova-prod
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.sensu_canary on nova-prod
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:paasta_canary.main on nova-prod is still bouncing, 2 versions running
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:paasta_canary.sensu_canary in nova-prod is not a Marathon job. Marked as deployed.
Deploy to nova-prod complete! (main, sensu_canary)
 11% ( 2 of 18) |###########                                                                                               | Elapsed Time: 0:00:06 ETA: 0:00:52DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.main on everywhere-testopia
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:paasta_canary.main on everywhere-testopia is still bouncing, 2 versions running
Deploy to everywhere-testopia complete! (main)
 16% ( 3 of 18) |#################                                                                                         | Elapsed Time: 0:00:09 ETA: 0:00:46DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.main on pnw-devc
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.sensu_canary on pnw-devc
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:paasta_canary.main on pnw-devc is still bouncing, 2 versions running
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:paasta_canary.sensu_canary in pnw-devc is not a Marathon job. Marked as deployed.
Deploy to pnw-devc complete! (main, sensu_canary)
 27% ( 5 of 18) |#############################                                                                             | Elapsed Time: 0:00:11 ETA: 0:00:30DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.main on norcal-prod
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.sensu_canary on norcal-prod
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:paasta_canary.main on norcal-prod in't running yet: NotRunning
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:paasta_canary.sensu_canary in norcal-prod is not a Marathon job. Marked as deployed.
Deploy to norcal-prod complete! (main, sensu_canary)
 38% ( 7 of 18) |#########################################                                                                 | Elapsed Time: 0:00:16 ETA: 0:00:25DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.mesosstage_canary on mesosstage
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.mesosstage_main on mesosstage
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.sensu_canary on mesosstage
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:paasta_canary.mesosstage_canary on mesosstage looks 100% deployed at 1 instances on c19f9731
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:paasta_canary.mesosstage_main on mesosstage is still bouncing, 2 versions running
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:paasta_canary.sensu_canary in mesosstage is not a Marathon job. Marked as deployed.
Deploy to mesosstage complete! (mesosstage_canary, mesosstage_main, sensu_canary)
 55% (10 of 18) |##########################################################                                                | Elapsed Time: 0:00:20 ETA: 0:00:16DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.main on norcal-devc
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.sensu_canary on norcal-devc
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:paasta_canary.main on norcal-devc in't running yet: NotRunning
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:paasta_canary.sensu_canary in norcal-devc is not a Marathon job. Marked as deployed.
Deploy to norcal-devc complete! (main, sensu_canary)
 66% (12 of 18) |######################################################################                                    | Elapsed Time: 0:00:22 ETA: 0:00:11DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.main on pnw-stagef
WARNING:paasta_tools.cli.cmds.mark_for_deployment:Error getting service status from PaaSTA API for pnw-stagef: ('Connection aborted.', gaierror(-2, 'Name or service not known'))
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:No status for an unknown instance in pnw-stagef. Not deployed yet.
Deploy to pnw-stagef complete! (main)
 72% (13 of 18) |############################################################################                              | Elapsed Time: 0:00:22 ETA: 0:00:09DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.main on pnw-stageg
WARNING:paasta_tools.cli.cmds.mark_for_deployment:Error getting service status from PaaSTA API for pnw-stageg: ('Connection aborted.', gaierror(-2, 'Name or service not known'))
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:No status for an unknown instance in pnw-stageg. Not deployed yet.
Deploy to pnw-stageg complete! (main)
 77% (14 of 18) |##################################################################################                        | Elapsed Time: 0:00:22 ETA: 0:00:06DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.main on pnw-prod
WARNING:paasta_tools.cli.cmds.mark_for_deployment:Error getting service status from PaaSTA API for pnw-prod: ('Connection aborted.', gaierror(-2, 'Name or service not known'))
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.sensu_canary on pnw-prod
WARNING:paasta_tools.cli.cmds.mark_for_deployment:Error getting service status from PaaSTA API for pnw-prod: ('Connection aborted.', gaierror(-2, 'Name or service not known'))
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:No status for an unknown instance in pnw-prod. Not deployed yet.
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:No status for an unknown instance in pnw-prod. Not deployed yet.
Deploy to pnw-prod complete! (main, sensu_canary)
 88% (16 of 18) |##############################################################################################            | Elapsed Time: 0:00:23 ETA: 0:00:03DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.main on norcal-stageg
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:paasta_canary.main on norcal-stageg is still bouncing, 2 versions running
Deploy to norcal-stageg complete! (main)
 94% (17 of 18) |####################################################################################################      | Elapsed Time: 0:00:25 ETA: 0:00:01DEBUG:paasta_tools.cli.cmds.mark_for_deployment:Inspecting the deployment status of paasta_canary.main on norcal-stagef
DEBUG:paasta_tools.cli.cmds.mark_for_deployment:paasta_canary.main on norcal-stagef is still bouncing, 2 versions running
Deploy to norcal-stagef complete! (main)
100% (18 of 18) |#########################################################################################################| Elapsed Time: 0:00:28 Time: 0:00:28
100% (18 of 18) |#########################################################################################################| Elapsed Time: 0:00:28 Time: 0:00:28
Deployment of c19f9731c2665b4508d69f6263a8f502ad247489 for everything complete
```

To make the ETA more accurate, I converted the deployment detector to count the instances deployed instead of just a bool.