### PR TITLE
Remove catchall excepts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,4 +39,8 @@
         entry: paasta_tools/contrib/mock_patch_checker.py
         language: script
         files: ^tests/.*\.py$
-        language_version: python2.7
+    -   id: no-catchall-except
+        name: Prevent catchall except
+        entry: 'except:$'
+        language: pcre
+        files: '\.py$'

--- a/paasta_itests/steps/paasta_api_steps.py
+++ b/paasta_itests/steps/paasta_api_steps.py
@@ -47,7 +47,5 @@ def service_instance_status_error(context, error_code, job_id):
     except ApiFailure as exc:
         assert 'not found' in exc.msg
         assert exc.err == int(error_code)
-    except:
-        raise
 
     assert not response

--- a/paasta_tools/api/views/autoscaler.py
+++ b/paasta_tools/api/views/autoscaler.py
@@ -38,7 +38,7 @@ def get_autoscaler_count(request):
             soa_dir=soa_dir,
             load_deployments=False,
         )
-    except:
+    except Exception:
         error_message = 'Unable to load service config for %s.%s' % (service, instance)
         raise ApiFailure(error_message, 404)
 
@@ -60,7 +60,7 @@ def update_autoscaler_count(request):
             soa_dir=settings.soa_dir,
             load_deployments=False,
         )
-    except:
+    except Exception:
         error_message = 'Unable to load service config for %s.%s' % (service, instance)
         raise ApiFailure(error_message, 404)
 

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -90,7 +90,7 @@ def instance_status(request):
 
     try:
         actual_deployments = get_actual_deployments(service, settings.soa_dir)
-    except:
+    except Exception:
         error_message = traceback.format_exc()
         raise ApiFailure(error_message, 500)
 
@@ -111,7 +111,7 @@ def instance_status(request):
         else:
             error_message = 'Unknown instance_type %s of %s.%s' % (instance_type, service, instance)
             raise ApiFailure(error_message, 404)
-    except:
+    except Exception:
         error_message = traceback.format_exc()
         raise ApiFailure(error_message, 500)
 
@@ -131,7 +131,7 @@ def instance_task(request):
         task = get_task(task_id, app_id=mstatus['app_id'])
     except TaskNotFound:
         raise ApiFailure("Task with id {0} not found".format(task_id), 404)
-    except:
+    except Exception:
         error_message = traceback.format_exc()
         raise ApiFailure(error_message, 500)
     if verbose:

--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -211,7 +211,7 @@ def kill_old_ids(old_ids, client):
         try:
             log.info("Killing %s", app)
             delete_marathon_app(app, client)
-        except:
+        except Exception:
             continue
 
 

--- a/paasta_tools/cli/fsm/autosuggest.py
+++ b/paasta_tools/cli/fsm/autosuggest.py
@@ -47,7 +47,7 @@ def suggest_smartstack_proxy_port(yelpsoa_config_root, range_min=20000, range_ma
                 try:
                     proxy_port = _get_smartstack_proxy_port_from_file(root, f)
                     available_proxy_ports.discard(proxy_port)
-                except:
+                except Exception:
                     pass
 
     try:

--- a/paasta_tools/mesos_maintenance.py
+++ b/paasta_tools/mesos_maintenance.py
@@ -277,7 +277,7 @@ def parse_datetime(value):
     error_msg = "'%s' is not a valid datetime expression" % value
     try:
         dt = parser.parse(value)
-    except:
+    except Exception:
         raise argparse.ArgumentTypeError(error_msg)
     if not dt:
         raise argparse.ArgumentTypeError(error_msg)

--- a/paasta_tools/monitoring/check_synapse_replication.py
+++ b/paasta_tools/monitoring/check_synapse_replication.py
@@ -76,7 +76,7 @@ def parse_range(str_range):
         int_range[1] = sys.maxint
     try:
         return tuple(map(int, int_range))
-    except:
+    except Exception:
         fail("Failed to parse range {0}".format(str_range))
 
 

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -130,7 +130,7 @@ def main():
                 log.error("I calculated an instance_type of %s for %s which I don't know how to handle."
                           % (instance_type, compose_job_id(service, instance)))
                 return_code = 1
-        except:
+        except Exception:
             log.error('Exception raised while looking at service %s instance %s:' % (service, instance))
             log.error(traceback.format_exc())
             return_code = 1


### PR DESCRIPTION
This probably fixes #609

I also added a hook to prevent this from regressing

If you actually want to catch `SystemExit`, `KeyboardInterrupt`, `SystemError`, explicitly use `except BaseException:`