### PR TITLE
Added get_currently_deployed_sha and better rollback hints

### DIFF
--- a/paasta_tools/cli/cmds/get_latest_deployment.py
+++ b/paasta_tools/cli/cmds/get_latest_deployment.py
@@ -17,10 +17,8 @@ from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import PaastaColors
 from paasta_tools.cli.utils import validate_service_name
-from paasta_tools.generate_deployments_for_service import get_latest_deployment_tag
-from paasta_tools.remote_git import list_remote_refs
+from paasta_tools.deployment_utils import get_currently_deployed_sha
 from paasta_tools.utils import DEFAULT_SOA_DIR
-from paasta_tools.utils import get_git_url
 
 
 def add_subparser(subparsers):
@@ -53,13 +51,7 @@ def paasta_get_latest_deployment(args):
     soa_dir = args.soa_dir
     validate_service_name(service, soa_dir)
 
-    git_url = get_git_url(
-        service=service,
-        soa_dir=soa_dir,
-    )
-    remote_refs = list_remote_refs(git_url)
-
-    _, git_sha = get_latest_deployment_tag(remote_refs, deploy_group)
+    git_sha = get_currently_deployed_sha(service=service, deploy_group=deploy_group, soa_dir=soa_dir)
     if not git_sha:
         print PaastaColors.red("A deployment could not be found for %s in %s" % (deploy_group, service))
         return 1

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -16,7 +16,6 @@
 deployment to a cluster.instance.
 """
 import logging
-import sys
 import time
 
 from bravado.exception import HTTPError
@@ -29,6 +28,7 @@ from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import validate_full_git_sha
 from paasta_tools.cli.utils import validate_given_deploy_groups
 from paasta_tools.cli.utils import validate_service_name
+from paasta_tools.deployment_utils import get_currently_deployed_sha
 from paasta_tools.generate_deployments_for_service import get_cluster_instance_map_for_service
 from paasta_tools.utils import _log
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -179,6 +179,11 @@ def paasta_mark_for_deployment(args):
     if args.git_url is None:
         args.git_url = get_git_url(service=service, soa_dir=args.soa_dir)
 
+    old_git_sha = get_currently_deployed_sha(service=service, deploy_group=args.deploy_group)
+    if old_git_sha == args.commit:
+        print "Warning: The sha asked to be deployed already matches what is set to be deployed."
+        print "Continuing anyway."
+
     ret = mark_for_deployment(
         git_url=args.git_url,
         deploy_group=args.deploy_group,
@@ -201,18 +206,17 @@ def paasta_mark_for_deployment(args):
                 line=line,
                 level='event'
             )
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, TimeoutError):
             print "Waiting for deployment aborted. PaaSTA will continue to try to deploy this code."
             print "If you wish to see the status, run:"
             print ""
             print "    paasta status -s %s -v" % service
             print ""
-            print "Or if you wish to rollback:"
-            print ""
-            print "    paasta rollback -s %s -d %s" % (service, args.deploy_group)
-            sys.exit(1)
-        except TimeoutError:
-            sys.exit(1)
+            ret = 1
+    print "If you wish to roll back, you can run:"
+    print ""
+    print PaastaColors.bold("    paasta rollback --service %s --deploy-group %s --commit %s " % (
+        service, args.deploy_group, old_git_sha))
     return ret
 
 

--- a/paasta_tools/deployment_utils.py
+++ b/paasta_tools/deployment_utils.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from paasta_tools.generate_deployments_for_service import get_latest_deployment_tag
+from paasta_tools.remote_git import list_remote_refs
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import get_git_url
+
+
+def get_currently_deployed_sha(service, deploy_group, soa_dir=DEFAULT_SOA_DIR):
+    git_url = get_git_url(
+        service=service,
+        soa_dir=soa_dir,
+    )
+    remote_refs = list_remote_refs(git_url)
+    _, old_git_sha = get_latest_deployment_tag(remote_refs, deploy_group)
+    return old_git_sha

--- a/tests/cli/test_cmds_get_latest_deployment.py
+++ b/tests/cli/test_cmds_get_latest_deployment.py
@@ -28,15 +28,11 @@ def test_get_latest_deployment():
     )
     with contextlib.nested(
         patch('sys.stdout', new_callable=StringIO, autospec=None),
-        patch('paasta_tools.cli.cmds.get_latest_deployment.get_latest_deployment_tag',
-              return_value=(None, "FAKE_SHA"), autospec=True),
-        patch('paasta_tools.cli.cmds.get_latest_deployment.get_git_url', autospec=True),
-        patch('paasta_tools.cli.cmds.get_latest_deployment.list_remote_refs', autospec=True),
+        patch('paasta_tools.cli.cmds.get_latest_deployment.get_currently_deployed_sha',
+              return_value="FAKE_SHA", autospec=True),
         patch('paasta_tools.cli.cmds.get_latest_deployment.validate_service_name', autospec=True),
     ) as (
         mock_stdout,
-        _,
-        _,
         _,
         _,
     ):
@@ -52,15 +48,11 @@ def test_get_latest_deployment_no_deployment_tag():
     )
     with contextlib.nested(
         patch('sys.stdout', new_callable=StringIO, autospec=None),
-        patch('paasta_tools.cli.cmds.get_latest_deployment.get_latest_deployment_tag',
-              return_value=(None, None), autospec=True),
-        patch('paasta_tools.cli.cmds.get_latest_deployment.get_git_url', autospec=True),
-        patch('paasta_tools.cli.cmds.get_latest_deployment.list_remote_refs', autospec=True),
+        patch('paasta_tools.cli.cmds.get_latest_deployment.get_currently_deployed_sha',
+              return_value=None, autospec=True),
         patch('paasta_tools.cli.cmds.get_latest_deployment.validate_service_name', autospec=True),
     ) as (
         mock_stdout,
-        _,
-        _,
         _,
         _,
     ):

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -33,7 +33,9 @@ class fake_args:
 
 @patch('paasta_tools.cli.cmds.mark_for_deployment.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment.mark_for_deployment', autospec=True)
+@patch('paasta_tools.cli.cmds.mark_for_deployment.get_currently_deployed_sha', autospec=True)
 def test_paasta_mark_for_deployment_acts_like_main(
+    mock_get_currently_deployed_sha,
     mock_mark_for_deployment,
     mock_validate_service_name,
 ):

--- a/tests/test_deployment_utils.py
+++ b/tests/test_deployment_utils.py
@@ -1,0 +1,35 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+
+from paasta_tools import deployment_utils
+
+
+@mock.patch('paasta_tools.deployment_utils.get_git_url', autospec=True)
+@mock.patch('paasta_tools.deployment_utils.list_remote_refs', autospec=True)
+@mock.patch('paasta_tools.deployment_utils.get_latest_deployment_tag', autospec=True)
+def test_get_currently_deployed_sha(
+    mock_get_latest_deployment_tag,
+    mock_list_remote_refs,
+    mock_get_git_url,
+):
+    mock_get_git_url.return_value = "fake_git_url"
+    mock_list_remote_refs.return_value = "fake_refs"
+    mock_get_latest_deployment_tag.return_value = (None, "1234")
+
+    actual = deployment_utils.get_currently_deployed_sha(
+        service='fake_service',
+        deploy_group='fake_deploy_group',
+    )
+    assert actual == "1234"


### PR DESCRIPTION
I'm noticing that `rollback`, `mark-for-deployment`, `generate-deployments-for-service`, and `get-latest-deployment`, are all sharing or cross-importing. So I think I would like to start a `deployment_utils` to store this kind of thing.

Also, I'm enhancing `mark-for-deployment` to give very obvious rollback instructions, to help bring it up to parity with the usability of our existing yelp-main scripts.

Although this is "slow" because getting the latest sha currently uses git. @mjksmith is working on making deployments.json store this information directly.