### PR TITLE
Breaking: Removed multiple deploy-group options from rollback and mak…

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -27,7 +27,6 @@ from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import validate_full_git_sha
-from paasta_tools.cli.utils import validate_given_deploy_groups
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.generate_deployments_for_service import get_cluster_instance_map_for_service
 from paasta_tools.utils import _log
@@ -164,11 +163,9 @@ def paasta_mark_for_deployment(args):
         service=service,
         soa_dir=args.soa_dir,
     )
-    _, invalid_deploy_groups = validate_given_deploy_groups(in_use_deploy_groups, [args.deploy_group])
-
-    if len(invalid_deploy_groups) == 1:
+    if args.deploy_group not in in_use_deploy_groups:
         print PaastaColors.red(
-            "ERROR: These deploy groups are not currently used anywhere: %s.\n" % (",").join(invalid_deploy_groups))
+            "ERROR: '%s' are not currently used anywhere.\n" % args.deploy_group)
         print PaastaColors.red(
             "This isn't technically wrong because you can mark-for-deployment before deploying there")
         print PaastaColors.red("but this is probably a typo. Did you mean one of these in-use deploy groups?:")

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -12,23 +12,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
+
 from humanize import naturaltime
 
 from paasta_tools.cli.cmds.mark_for_deployment import mark_for_deployment
+from paasta_tools.cli.cmds.mark_for_deployment import wait_for_deployment
 from paasta_tools.cli.utils import extract_tags
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import validate_full_git_sha
-from paasta_tools.cli.utils import validate_given_deploy_groups
 from paasta_tools.remote_git import list_remote_refs
+from paasta_tools.utils import _log
 from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import format_table
 from paasta_tools.utils import get_git_url
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import parse_timestamp
+from paasta_tools.utils import TimeoutError
 
 
 def add_subparser(subparsers):
@@ -55,10 +59,9 @@ def add_subparser(subparsers):
         type=validate_full_git_sha,
     ).completer = lazy_choices_completer(list_previously_deployed_shas)
     list_parser.add_argument(
-        '-l', '--deploy-groups',
-        help='Mark one or more deploy groups to roll back (e.g. '
-        '"all.main", "all.main,all.canary"). If no deploy groups specified,'
-        ' all deploy groups for that service are rolled back',
+        '-l', '--deploy-group',
+        help='A deploy groups to roll back (e.g. "all.main", "all.main,all.canary") '
+        'If no deploy groups specified the some will be suggested.',
         default='',
         required=False,
     ).completer = lazy_choices_completer(list_deploy_groups)
@@ -79,54 +82,54 @@ def add_subparser(subparsers):
 def list_previously_deployed_shas(parsed_args, **kwargs):
     service = parsed_args.service
     soa_dir = parsed_args.soa_dir
-    deploy_groups = {deploy_group for deploy_group in parsed_args.deploy_groups.split(',') if deploy_group}
-    return (sha for sha, _ in get_git_shas_for_service(service, deploy_groups, soa_dir))
+    return (sha for sha, _ in get_git_shas_for_service(service, parsed_args.deploy_group, soa_dir))
 
 
-def get_git_shas_for_service(service, deploy_groups, soa_dir):
+def get_git_shas_for_service(service, deploy_group, soa_dir):
     """Returns a dictionary of 2-tuples of the form (timestamp, deploy_group) for each deploy sha"""
     if service is None:
         return []
     git_url = get_git_url(service=service, soa_dir=soa_dir)
-    all_deploy_groups = list_deploy_groups(
-        service=service,
-        soa_dir=soa_dir,
-    )
-    deploy_groups, _ = validate_given_deploy_groups(all_deploy_groups, deploy_groups)
     previously_deployed_shas = {}
     for ref, sha in list_remote_refs(git_url).items():
         regex_match = extract_tags(ref)
         try:
-            deploy_group = regex_match['deploy_group']
+            dg = regex_match['deploy_group']
             tstamp = regex_match['tstamp']
         except KeyError:
             pass
         else:
             # note that all strings are greater than ''
-            if deploy_group in deploy_groups and tstamp > previously_deployed_shas.get(sha, ''):
+            if dg == deploy_group and tstamp > previously_deployed_shas.get(sha, ''):
                 previously_deployed_shas[sha] = (tstamp, deploy_group)
     return previously_deployed_shas.items()
 
 
-def list_previous_commits(service, deploy_groups, any_given_deploy_groups, soa_dir):
+def list_previous_commits(service, deploy_group, soa_dir):
     def format_timestamp(tstamp):
         return naturaltime(datetime_from_utc_to_local(parse_timestamp(tstamp)))
 
     print "Please specify a commit to mark for rollback (-k, --commit). Below is a list of recent commits:"
-    git_shas = sorted(get_git_shas_for_service(service, deploy_groups, soa_dir), key=lambda x: x[1], reverse=True)[:10]
+    git_shas = sorted(get_git_shas_for_service(service, deploy_group, soa_dir), key=lambda x: x[1], reverse=True)[:10]
     rows = [('Timestamp -- UTC', 'Human time', 'deploy_group', 'Git SHA')]
     for sha, (timestamp, deploy_group) in git_shas:
-        print timestamp
         rows.extend([(timestamp, format_timestamp(timestamp), deploy_group, sha)])
     for line in format_table(rows):
         print line
     if len(git_shas) >= 2:
         print ""
         sha, (timestamp, deploy_group) = git_shas[1]
-        deploy_groups_arg_line = '-d %s ' % ','.join(deploy_groups) if any_given_deploy_groups else ''
         print "For example, to use the second to last commit from %s used on %s, run:" % (
             format_timestamp(timestamp), PaastaColors.bold(deploy_group))
-        print PaastaColors.bold("    paasta rollback -s %s %s-k %s" % (service, deploy_groups_arg_line, sha))
+        print PaastaColors.bold("    paasta rollback --service %s --deploy-group %s --commit %s" % (
+            service, deploy_group, sha))
+
+
+def print_deploy_group_suggestions(all_deploy_groups):
+    print ""
+    for deploy_group in all_deploy_groups:
+        print PaastaColors.bold("    " + " ".join(sys.argv[1:]) + " --deploy-group " + deploy_group)
+    print ""
 
 
 def paasta_rollback(args):
@@ -139,34 +142,52 @@ def paasta_rollback(args):
     service = figure_out_service_name(args, soa_dir)
 
     git_url = get_git_url(service, soa_dir)
-    given_deploy_groups = {deploy_group for deploy_group in args.deploy_groups.split(",") if deploy_group}
 
     all_deploy_groups = list_deploy_groups(service=service, soa_dir=soa_dir)
-    deploy_groups, invalid = validate_given_deploy_groups(all_deploy_groups, given_deploy_groups)
-
-    if len(invalid) > 0:
-        print PaastaColors.yellow("These deploy groups are not valid and will be skipped: %s.\n" % (",").join(invalid))
-
-    if len(deploy_groups) == 0:
-        print PaastaColors.red("ERROR: No valid deploy groups specified for %s.\n" % (service))
+    deploy_group = args.deploy_group
+    if deploy_group is None:
+        print "A deploy group was not specified. Please pick one of the following:"
+        print_deploy_group_suggestions(all_deploy_groups)
+        return 1
+    elif deploy_group not in all_deploy_groups:
+        print "%s is not a valid deploy group. Please try a different invocation:" % deploy_group
+        print_deploy_group_suggestions(all_deploy_groups)
         return 1
 
     commit = args.commit
     if not commit:
-        list_previous_commits(service, deploy_groups, bool(given_deploy_groups), soa_dir)
+        list_previous_commits(service, deploy_group, soa_dir)
         return 1
 
-    returncode = 0
+    returncode = mark_for_deployment(
+        git_url=git_url,
+        service=service,
+        deploy_group=deploy_group,
+        commit=commit,
+    )
+    if returncode != 0:
+        return returncode
 
-    for deploy_group in deploy_groups:
-        returncode = max(
-            mark_for_deployment(
-                git_url=git_url,
-                service=service,
-                deploy_group=deploy_group,
-                commit=commit,
-            ),
-            returncode,
+    try:
+        print "Waiting for deployment of {0} to {1} complete...".format(commit, deploy_group)
+        wait_for_deployment(service=service,
+                            deploy_group=deploy_group,
+                            git_sha=commit,
+                            soa_dir=args.soa_dir,
+                            timeout=120)
+        line = "Deployment of {0} to {1} complete".format(commit, args.deploy_group)
+        _log(
+            service=service,
+            component='deploy',
+            line=line,
+            level='event'
         )
+    except (KeyboardInterrupt, TimeoutError):
+        print "Waiting for deployment aborted. PaaSTA will continue to try to deploy this code."
+        print "If you wish to see the status, run:"
+        print ""
+        print "    paasta status -s %s -v" % service
+        print ""
+        returncode = 1
 
     return returncode

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -673,24 +673,6 @@ def list_deploy_groups(parsed_args=None, service=None, soa_dir=DEFAULT_SOA_DIR, 
     )])
 
 
-def validate_given_deploy_groups(all_deploy_groups, args_deploy_groups):
-    """Given two lists of deploy groups, return the intersection and difference between them.
-
-    :param all_deploy_groups: instances actually belonging to a service
-    :param args_deploy_groups: the desired instances
-    :returns: a tuple with (common, difference) indicating deploy groups common in both
-        lists and those only in args_deploy_groups
-    """
-    if len(args_deploy_groups) is 0:
-        valid_deploy_groups = set(all_deploy_groups)
-        invalid_deploy_groups = set([])
-    else:
-        valid_deploy_groups = set(args_deploy_groups).intersection(all_deploy_groups)
-        invalid_deploy_groups = set(args_deploy_groups).difference(all_deploy_groups)
-
-    return valid_deploy_groups, invalid_deploy_groups
-
-
 def validate_full_git_sha(value):
     pattern = re.compile('[a-f0-9]{40}')
     if not pattern.match(value):

--- a/tests/cli/test_cmds_rollback.py
+++ b/tests/cli/test_cmds_rollback.py
@@ -12,23 +12,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import contextlib
-
-from mock import call
 from mock import Mock
 from mock import patch
 
 from paasta_tools.cli.cmds.rollback import get_git_shas_for_service
 from paasta_tools.cli.cmds.rollback import list_previously_deployed_shas
 from paasta_tools.cli.cmds.rollback import paasta_rollback
-from paasta_tools.cli.cmds.rollback import validate_given_deploy_groups
 
 
 @patch('paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.figure_out_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.get_git_url', autospec=True)
 @patch('paasta_tools.cli.cmds.rollback.mark_for_deployment', autospec=True)
+@patch('paasta_tools.cli.cmds.rollback.wait_for_deployment', autospec=True)
+@patch('paasta_tools.cli.cmds.rollback._log', autospec=True)
 def test_paasta_rollback_mark_for_deployment_simple_invocation(
+    mock_log,
+    mock_wait_for_deployment,
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_figure_out_service_name,
@@ -36,21 +36,21 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
 ):
 
     fake_args = Mock(
-        deploy_groups='fake_deploy_groups',
+        deploy_group='fake_deploy_group',
         commit='123456'
     )
 
     mock_get_git_url.return_value = 'git://git.repo'
     mock_figure_out_service_name.return_value = 'fakeservice'
 
-    mock_list_deploy_groups.return_value = ['fake_deploy_groups']
+    mock_list_deploy_groups.return_value = ['fake_deploy_group']
 
     mock_mark_for_deployment.return_value = 0
     assert paasta_rollback(fake_args) == 0
 
     mock_mark_for_deployment.assert_called_once_with(
         git_url=mock_get_git_url.return_value,
-        deploy_group=fake_args.deploy_groups,
+        deploy_group=fake_args.deploy_group,
         service=mock_figure_out_service_name.return_value,
         commit=fake_args.commit
     )
@@ -71,7 +71,7 @@ def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
 
     fake_args = Mock(
         commit='123456',
-        deploy_groups='',
+        deploy_group=None,
     )
 
     mock_get_git_url.return_value = 'git://git.repo'
@@ -81,26 +81,7 @@ def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
         'fake_deploy_group', 'fake_cluster.fake_instance']
 
     mock_mark_for_deployment.return_value = 0
-    assert paasta_rollback(fake_args) == 0
-
-    expected = [
-        call(
-            git_url=mock_get_git_url.return_value,
-            service=mock_figure_out_service_name.return_value,
-            commit=fake_args.commit,
-            deploy_group='fake_cluster.fake_instance',
-        ),
-        call(
-            git_url=mock_get_git_url.return_value,
-            service=mock_figure_out_service_name.return_value,
-            commit=fake_args.commit,
-            deploy_group='fake_deploy_group',
-        ),
-    ]
-
-    assert all([x in expected for x in mock_mark_for_deployment.mock_calls])
-    assert len(expected) == len(mock_mark_for_deployment.mock_calls)
-    assert mock_mark_for_deployment.call_count == 2
+    assert paasta_rollback(fake_args) == 1
 
 
 @patch('paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True)
@@ -116,7 +97,7 @@ def test_paasta_rollback_mark_for_deployment_wrong_deploy_group_args(
 
     fake_args = Mock(
         commit='123456',
-        deploy_groups='test_group,fake_deploy.group',
+        deploy_group='test_group,fake_deploy.group',
     )
 
     mock_get_git_url.return_value = 'git://git.repo'
@@ -128,161 +109,18 @@ def test_paasta_rollback_mark_for_deployment_wrong_deploy_group_args(
     assert mock_mark_for_deployment.call_count == 0
 
 
-@patch('paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.figure_out_service_name', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.get_git_url', autospec=True)
-@patch('paasta_tools.cli.cmds.rollback.mark_for_deployment', autospec=True)
-def test_paasta_rollback_mark_for_deployment_multiple_instance_args(
-    mock_mark_for_deployment,
-    mock_get_git_url,
-    mock_figure_out_service_name,
-    mock_list_deploy_groups,
-):
-
-    fake_args = Mock(
-        deploy_groups='cluster.instance1,cluster.instance2',
-        commit='123456',
-    )
-
-    mock_get_git_url.return_value = 'git://git.repo'
-    mock_figure_out_service_name.return_value = 'fakeservice'
-
-    mock_list_deploy_groups.return_value = [
-        'cluster.instance1', 'cluster.instance2'
-    ]
-
-    mock_mark_for_deployment.return_value = 0
-    assert paasta_rollback(fake_args) == 0
-
-    expected = [
-        call(
-            git_url=mock_get_git_url.return_value,
-            service=mock_figure_out_service_name.return_value,
-            commit=fake_args.commit,
-            deploy_group='cluster.instance1',
-        ),
-        call(
-            git_url=mock_get_git_url.return_value,
-            service=mock_figure_out_service_name.return_value,
-            commit=fake_args.commit,
-            deploy_group='cluster.instance2',
-        ),
-    ]
-
-    mock_mark_for_deployment.assert_has_calls(expected, any_order=True)
-    assert mock_mark_for_deployment.call_count == 2
-
-
-def test_validate_given_deploy_groups_no_arg():
-    service_deploy_groups = ['deploy_group1', 'deploy_group2']
-    given_deploy_groups = []
-
-    expected_valid = set(['deploy_group1', 'deploy_group2'])
-    expected_invalid = set([])
-
-    actual_valid, actual_invalid = validate_given_deploy_groups(service_deploy_groups, given_deploy_groups)
-
-    assert actual_valid == expected_valid
-    assert actual_invalid == expected_invalid
-
-
-def test_validate_given_deploy_groups_wrong_arg():
-    service_deploy_groups = ['deploy_group1', 'deploy_group2']
-    given_deploy_groups = ['deploy_group0', 'not_an_deploy_group']
-
-    expected_valid = set([])
-    expected_invalid = set(['deploy_group0', 'not_an_deploy_group'])
-
-    actual_valid, actual_invalid = validate_given_deploy_groups(service_deploy_groups, given_deploy_groups)
-
-    assert actual_valid == expected_valid
-    assert actual_invalid == expected_invalid
-
-
-def test_validate_given_deploy_groups_single_arg():
-    service_deploy_groups = ['deploy_group1', 'deploy_group2']
-    given_deploy_groups = ['deploy_group1']
-
-    expected_valid = set(['deploy_group1'])
-    expected_invalid = set([])
-
-    actual_valid, actual_invalid = validate_given_deploy_groups(service_deploy_groups, given_deploy_groups)
-
-    assert actual_valid == expected_valid
-    assert actual_invalid == expected_invalid
-
-
-def test_validate_given_deploy_groups_multiple_args():
-    service_deploy_groups = ['deploy_group1', 'deploy_group2', 'deploy_group3']
-    given_deploy_groups = ['deploy_group1', 'deploy_group2']
-
-    expected_valid = set(['deploy_group1', 'deploy_group2'])
-    expected_invalid = set([])
-
-    actual_valid, actual_invalid = validate_given_deploy_groups(service_deploy_groups, given_deploy_groups)
-
-    assert actual_valid == expected_valid
-    assert actual_invalid == expected_invalid
-
-
-def test_validate_given_deploy_groups_duplicate_args():
-    service_deploy_groups = ['deploy_group1', 'deploy_group2', 'deploy_group3']
-    given_deploy_groups = ['deploy_group1', 'deploy_group1']
-
-    expected_valid = set(['deploy_group1'])
-    expected_invalid = set([])
-
-    actual_valid, actual_invalid = validate_given_deploy_groups(service_deploy_groups, given_deploy_groups)
-
-    assert actual_valid == expected_valid
-    assert actual_invalid == expected_invalid
-
-
 def test_list_previously_deployed_shas():
     fake_refs = {
         'refs/tags/paasta-test.deploy.group-00000000T000000-deploy': 'SHA_IN_OUTPUT',
         'refs/tags/paasta-other.deploy.group-00000000T000000-deploy': 'NOT_IN_OUTPUT',
     }
-    fake_deploy_groups = ['test.deploy.group']
-
-    with contextlib.nested(
-            patch('paasta_tools.cli.cmds.rollback.list_remote_refs', autospec=True, return_value=fake_refs),
-            patch('paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True,
-                  return_value=fake_deploy_groups),
-    ) as (
-        _,
-        _,
-    ):
+    with patch('paasta_tools.cli.cmds.rollback.list_remote_refs', autospec=True, return_value=fake_refs):
         fake_args = Mock(
             service='fake_service',
-            deploy_groups='test.deploy.group,nonexistant.deploy.group',
+            deploy_group='test.deploy.group',
             soa_dir='/fake/soa/dir',
         )
         assert set(list_previously_deployed_shas(fake_args)) == {'SHA_IN_OUTPUT'}
-
-
-def test_list_previously_deployed_shas_no_deploy_groups():
-    fake_refs = {
-        'refs/tags/paasta-test.deploy.group-00000000T000000-deploy': 'SHA_IN_OUTPUT',
-        'refs/tags/paasta-other.deploy.group-00000000T000000-deploy': 'SHA_IN_OUTPUT_2',
-        'refs/tags/paasta-nonexistant.deploy.group-00000000T000000-deploy': 'SHA_NOT_IN_OUTPUT',
-    }
-    fake_deploy_groups = ['test.deploy.group', 'other.deploy.group']
-
-    with contextlib.nested(
-            patch('paasta_tools.cli.cmds.rollback.list_remote_refs', autospec=True, return_value=fake_refs),
-            patch('paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True,
-                  return_value=fake_deploy_groups),
-    ) as (
-        _,
-        _,
-    ):
-        fake_args = Mock(
-            service='fake_service',
-            deploy_groups='',
-            soa_dir='/fake/soa/dir',
-        )
-        assert set(list_previously_deployed_shas(fake_args)) == {'SHA_IN_OUTPUT', 'SHA_IN_OUTPUT_2'}
 
 
 def test_get_git_shas_for_service_no_service_name():


### PR DESCRIPTION
…e it wait for the deployment


This is a large change, but makes it simpler for the code, and hopefully more robust.

It does mean that you can't "roll back everything" in a panic, and instead makes you specify the deploy group.

Hopefully this is helped by the fact that we have:
* tab completion
* It suggested deploy groups for you
* @mjksmith is going to add a "chooser" library so we can just ask the user, so they don't have to "remember" what their deploy groups are called

In return, it makes it easier for us to block after the rollback, which I think 99% of our users want and expect when they run a rollback command.