### PR TITLE
store docker image by deploy group

### DIFF
--- a/general_itests/deployments_json.feature
+++ b/general_itests/deployments_json.feature
@@ -17,4 +17,3 @@ Feature: Per-Service Deployments.json can be written and read back
 	Given a test git repo is setup with commits
 	 When paasta mark-for-deployments is run against the repo
 	 Then the repository should be correctly tagged
-	  And the repository should not have old style branches

--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -32,7 +32,6 @@ from paasta_tools.cli.cmds.mark_for_deployment import paasta_mark_for_deployment
 from paasta_tools.cli.cmds.start_stop_restart import paasta_stop
 from paasta_tools.utils import format_tag
 from paasta_tools.utils import format_timestamp
-from paasta_tools.utils import get_paasta_branch_from_deploy_group
 from paasta_tools.utils import get_paasta_tag_from_deploy_group
 from paasta_tools.utils import load_deployments_json
 
@@ -174,10 +173,3 @@ def step_impl_then_correctly_tagged(context):
     expected_formatted_tag = format_tag(expected_tag)
     assert expected_formatted_tag in context.test_git_repo.refs
     assert context.test_git_repo.refs[expected_formatted_tag] == context.expected_commit
-
-
-@then(u'the repository should not have old style branches')
-def step_impl_then_no_old_style_branches(context):
-    old_style_branch = get_paasta_branch_from_deploy_group(identifier='test_cluster.test_instance')
-    formatted_old_style_branch = 'refs/heads/%s' % old_style_branch
-    assert formatted_old_style_branch not in context.test_git_repo.refs

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -232,7 +232,7 @@ def write_soa_dir_deployments(context, service, disabled, instance):
     with open(os.path.join(context.soa_dir, service, 'deployments.json'), 'w') as dp:
         dp.write(json.dumps({
             'v1': {
-                '%s:%s' % (service, utils.get_paasta_branch(context.cluster, instance)): {
+                '%s:paasta-%s' % (service, utils.get_paasta_branch(context.cluster, instance)): {
                     'docker_image': 'test-image-foobar%d' % context.tag_version,
                     'desired_state': desired_state,
                 }

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -74,7 +74,7 @@ def add_subparser(subparsers):
 
 
 def format_tag(branch, force_bounce, desired_state):
-    return 'refs/tags/paasta-%s-%s-%s' % (branch, force_bounce, desired_state)
+    return 'refs/tags/%s-%s-%s' % (branch, force_bounce, desired_state)
 
 
 def make_mutate_refs_func(service_config, force_bounce, desired_state):

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -150,6 +150,7 @@ def get_deploy_group_mappings(soa_dir, service, old_mappings):
         if deploy_ref_name in remote_refs:
             commit_sha = remote_refs[deploy_ref_name]
             control_branch_alias = '%s:paasta-%s' % (service, control_branch)
+            control_branch_alias_v2 = '%s:%s' % (service, control_branch)
             docker_image = build_docker_image_name(service, commit_sha)
             log.info('Mapping %s to docker image %s', control_branch, docker_image)
             mapping = mappings.setdefault(control_branch_alias, {})
@@ -164,8 +165,8 @@ def get_deploy_group_mappings(soa_dir, service, old_mappings):
             )
             mapping['desired_state'] = desired_state
             mapping['force_bounce'] = force_bounce
-            v2_mappings['controls'].setdefault(control_branch_alias, {})['desired_state'] = desired_state
-            v2_mappings['controls'][control_branch_alias]['force_bounce'] = force_bounce
+            v2_mappings['controls'].setdefault(control_branch_alias_v2, {})['desired_state'] = desired_state
+            v2_mappings['controls'][control_branch_alias_v2]['force_bounce'] = force_bounce
     return mappings, v2_mappings
 
 
@@ -191,7 +192,7 @@ def get_desired_state(branch, remote_refs, deploy_group):
     """
     # (?:paasta-){1,2} supports a previous mistake where some tags would be called
     # paasta-paasta-cluster.instance
-    tag_pattern = r'^refs/tags/(?:paasta-){1,2}%s-(?P<force_bounce>[^-]+)-(?P<state>(start|stop))$' % branch
+    tag_pattern = r'^refs/tags/(?:paasta-){0,2}%s-(?P<force_bounce>[^-]+)-(?P<state>(start|stop))$' % branch
 
     states = []
     (_, head_sha) = get_latest_deployment_tag(remote_refs, deploy_group)

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -132,14 +132,14 @@ def load_marathon_service_config(service, instance, cluster, load_deployments=Tr
     log.info("Reading general configuration file: service.yaml")
     general_config = service_configuration_lib.read_service_configuration(
         service,
-        soa_dir=soa_dir
+        soa_dir=soa_dir,
     )
     marathon_conf_file = "marathon-%s" % cluster
     log.info("Reading marathon configuration file: %s.yaml", marathon_conf_file)
     instance_configs = service_configuration_lib.read_extra_service_information(
         service,
         marathon_conf_file,
-        soa_dir=soa_dir
+        soa_dir=soa_dir,
     )
 
     if instance not in instance_configs:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1387,11 +1387,38 @@ def load_deployments_json(service, soa_dir=DEFAULT_SOA_DIR):
         raise NoDeploymentsAvailable
 
 
+def load_v2_deployments_json(service, soa_dir=DEFAULT_SOA_DIR):
+    deployment_file = os.path.join(soa_dir, service, 'deployments.json')
+    if os.path.isfile(deployment_file):
+        with open(deployment_file) as f:
+            return DeploymentsJson(json.load(f)['v2'])
+    else:
+        raise NoDeploymentsAvailable
+
+
 class DeploymentsJson(dict):
 
     def get_branch_dict(self, service, branch):
         full_branch = '%s:%s' % (service, branch)
         return self.get(full_branch, {})
+
+    def get_docker_image_for_deploy_group(self, deploy_group):
+        try:
+            return self['deployments'][deploy_group]['docker_image']
+        except KeyError:
+            raise NoDeploymentsAvailable
+
+    def get_git_sha_for_deploy_group(self, deploy_group):
+        try:
+            return self['deployments'][deploy_group]['git_sha']
+        except KeyError:
+            raise NoDeploymentsAvailable
+
+    def get_desired_state_for_branch(self, control_branch):
+        return self['controls'][control_branch].get('desired_state', 'start')
+
+    def get_force_bounce_for_branch(self, control_branch):
+        return self['controls'][control_branch].get('force_bounce', None)
 
 
 def get_paasta_branch_from_deploy_group(identifier):

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -117,7 +117,7 @@ class InstanceConfig(dict):
         return self.service
 
     def get_branch(self):
-        return SPACER.join((self.get_cluster(), self.get_instance()))
+        return get_paasta_branch(cluster=self.get_cluster(), instance=self.get_instance())
 
     def get_deploy_group(self):
         return self.config_dict.get('deploy_group', self.get_branch())
@@ -1399,7 +1399,7 @@ def load_v2_deployments_json(service, soa_dir=DEFAULT_SOA_DIR):
 class DeploymentsJson(dict):
 
     def get_branch_dict(self, service, branch):
-        full_branch = '%s:%s' % (service, branch)
+        full_branch = '%s:paasta-%s' % (service, branch)
         return self.get(full_branch, {})
 
     def get_docker_image_for_deploy_group(self, deploy_group):
@@ -1421,12 +1421,8 @@ class DeploymentsJson(dict):
         return self['controls'][control_branch].get('force_bounce', None)
 
 
-def get_paasta_branch_from_deploy_group(identifier):
-    return 'paasta-%s' % (identifier)
-
-
 def get_paasta_branch(cluster, instance):
-    return get_paasta_branch_from_deploy_group('%s.%s' % (cluster, instance))
+    return SPACER.join((cluster, instance))
 
 
 def parse_timestamp(tstamp):

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -22,7 +22,7 @@ from paasta_tools.marathon_tools import MarathonServiceConfig
 
 
 def test_format_tag():
-    expected = 'refs/tags/paasta-BRANCHNAME-TIMESTAMP-stop'
+    expected = 'refs/tags/BRANCHNAME-TIMESTAMP-stop'
     actual = start_stop_restart.format_tag(
         branch='BRANCHNAME',
         force_bounce='TIMESTAMP',
@@ -84,7 +84,7 @@ def test_make_mutate_refs_func():
 
     expected = dict(old_refs)
     expected.update({
-        'refs/tags/paasta-fake_cluster.fake_instance-FORCEBOUNCE-stop': 'hash_for_a',
+        'refs/tags/fake_cluster.fake_instance-FORCEBOUNCE-stop': 'hash_for_a',
     })
 
     actual = mutate_refs(old_refs)

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -73,11 +73,11 @@ def test_get_deploy_group_mappings():
             },
         },
         'controls': {
-            'fake_service:paasta-clusterA.main': {
+            'fake_service:clusterA.main': {
                 'desired_state': 'start',
                 'force_bounce': None,
             },
-            'fake_service:paasta-clusterB.main': {
+            'fake_service:clusterB.main': {
                 'desired_state': 'stop',
                 'force_bounce': '123',
             },

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -236,7 +236,7 @@ class TestMarathonTools:
             assert expected.config_dict == actual.config_dict
             assert expected.branch_dict == actual.branch_dict
 
-            deployments_json_mock.get_branch_dict.assert_called_once_with(fake_name, 'paasta-amnesia.solo')
+            deployments_json_mock.get_branch_dict.assert_called_once_with(fake_name, 'amnesia.solo')
             assert read_service_configuration_patch.call_count == 1
             read_service_configuration_patch.assert_any_call(fake_name, soa_dir=fake_dir)
             assert read_extra_info_patch.call_count == 1


### PR DESCRIPTION
We're starting to run into problems from storing docker image by git branch instead of by deploy group (adhoc batches, paasta get_currently_deployed_sha).

As far as I remember we kept this in when we were switching to deploy groups because it allowed per-serviceinstance rollbacks and didn't involve changing `deployments.json` so it was easy to validate that deploy groups were working (just diff old and new `deployments.json` and expect no changes).

After this, a second change needs to be pushed that removes the v1 `deployments.json` and switches the rest of paasta over to v2.