### PR TITLE
Revert "Try not scaling down before deleting marathon apps."

### DIFF
--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -192,6 +192,10 @@ def delete_marathon_app(app_id, client):
     :param app_id: The marathon app id to be deleted
     :param client: A MarathonClient object"""
     with nested(create_app_lock(), time_limit(1)):
+        # Scale app to 0 first to work around
+        # https://github.com/mesosphere/marathon/issues/725
+        client.scale_app(app_id, instances=0, force=True)
+        time.sleep(1)
         client.delete_app(app_id, force=True)
         wait_for_delete(app_id, client)
 

--- a/tests/test_bounce_lib.py
+++ b/tests/test_bounce_lib.py
@@ -101,12 +101,16 @@ class TestBounceLib:
         with contextlib.nested(
             mock.patch('paasta_tools.bounce_lib.create_app_lock', spec=contextlib.contextmanager, autospec=None),
             mock.patch('paasta_tools.bounce_lib.wait_for_delete', autospec=True),
+            mock.patch('time.sleep', autospec=True)
         ) as (
             lock_patch,
             wait_patch,
+            sleep_patch
         ):
             bounce_lib.delete_marathon_app(fake_id, fake_client)
+            fake_client.scale_app.assert_called_once_with(fake_id, instances=0, force=True)
             fake_client.delete_app.assert_called_once_with(fake_id, force=True)
+            sleep_patch.assert_called_once_with(1)
             wait_patch.assert_called_once_with(fake_id, fake_client)
             assert lock_patch.called
 


### PR DESCRIPTION
This reverts commit 6ad55802ff01e101151fecfd04746cc888dc8463.

Although I can't explain "why", this is the only change I've made recently related to marathon bouncing/killing/scaling. So I would like to revert it in an attempt to make marathon more stable.