### PR TITLE
Multiple registrations

### DIFF
--- a/docs/source/about/smartstack_interaction.rst
+++ b/docs/source/about/smartstack_interaction.rst
@@ -220,7 +220,7 @@ the same Nerve namespace. Consider this example::
         cmd: myserver.py
     canary:
         instances: 1
-        nerve_ns: main
+        registrations: ['service.main']
         cmd: myserver.py --experiment
 
 With this example, the ``canary`` instance gets advertised *under* the ``main`` Nerve
@@ -241,13 +241,13 @@ Sharding is another use case for using alternative namespaces::
     #marathon.yaml
     shard1:
         instances: 10
-        nerve_ns: main
+        registrations: ['service.main']
     shard2:
         instances: 10
-        nerve_ns: main
+        registrations: ['service.main']
     shard3:
         instances: 10
-        nerve_ns: main
+        registrations: ['service.main']
 
 These shards all end up being load-balanced in the same "main" pool. More
 complex YAML definitions can take advantage of YAML's

--- a/docs/source/deploy_groups.rst
+++ b/docs/source/deploy_groups.rst
@@ -38,7 +38,7 @@ Now let’s take a look at how instances are linked to a deploy group by taking 
    canary:
      cpus: .1
      mem: 301
-     nerve_ns: main
+     registrations: ['service.main']
      instances: 1
      deploy_group: dev-stage.everything
    main:

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -62,14 +62,19 @@ instance MAY have:
   * ``max_instances``: When autoscaling, the maximum number of instances that
     marathon will create for a service
 
-  * ``nerve_ns``: Specifies that this namespace should be routed to by another
-    namespace in SmartStack. In SmartStack, each service has difference pools
-    of backend servers that are listening on a particul port. In PaaSTA we call
-    these "Nerve Namespaces". By default, the Namespace assigned to a particular
-    instance in PaaSTA has the *same name*, so the ``main`` instance will correspond
-    to the ``main`` Nerve namespace defined in ``smartstack.yaml``. This ``nerve_ns``
-    option allows users to make particular instances appear under an *alternative*
-    namespace. For example ``canary`` instances can have ``nerve_ns: main`` to route
+  * ``nerve_ns``: **DEPRECATED** please use ``registrations``.
+
+  * ``registrations``: A list of SmartStack registrations (service.namespace)
+    where instances of this PaaSTA service ought register in. In SmartStack,
+    each service has difference pools of backend servers that are listening on
+    a particul port. In PaaSTA we call these "Registrations". By default, the
+    Registration assigned to a particular instance in PaaSTA has the *same name*,
+    so a service ``foo`` with a ``main`` instance will correspond to the
+    ``foo.main`` Registration. This would correspond to the SmartStack
+    namespace defined in the Registration service's ``smartstack.yaml``. This
+    ``registrations`` option allows users to make PaaSTA instances appear
+    under an *alternative* namespace (or even service). For example
+    ``canary`` instances can have ``registrations: ['foo.main']`` to route
     their traffic to the same pool as the other ``main`` instances.
 
   * ``backoff_factor``: PaaSTA will automatically calculate the duration of an
@@ -449,7 +454,7 @@ The ``main`` key is the service namespace.  Namespaces were introduced for
 PaaSTA services in order to support running multiple daemons from a single
 service codebase. In PaaSTA, each instance in your marathon.yaml maps to a
 smartstack namespace of the same name, unless you specify a different
-``nerve_ns``.
+``registrations``.
 
 We now describe which keys are supported within a namespace.  Note that all but
 proxy_port are optional.
@@ -722,7 +727,7 @@ A marathon service that overrides options on different instances (canary)::
         page: true
     canary:
       instances: 1
-      nerve_ns: main
+      registrations: ['service.main']
       monitoring:
         page: false
         ticket: true

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -104,7 +104,7 @@
                 "type": "integer",
                 "default": 300
             },
-            "registration_namespaces": {
+            "registrations": {
                 "type": "array",
                 "items": {
                     "type": "string"

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -2,8 +2,11 @@ import logging
 
 import service_configuration_lib
 
+from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import InstanceConfig
+from paasta_tools.utils import InvalidJobNameError
 
 log = logging.getLogger(__name__)
 logging.getLogger('marathon').setLevel(logging.WARNING)
@@ -42,16 +45,27 @@ class LongRunningServiceConfig(InstanceConfig):
 
     # FIXME(jlynch|2016-08-02, PAASTA-4964): DEPRECATE nerve_ns and remove it
     def get_nerve_namespace(self):
-        return self.get_registration_namespaces()[0]
+        return decompose_job_id(self.get_registrations()[0])[1]
 
-    def get_registration_namespaces(self):
-        registration_namespaces = self.config_dict.get('registration_namespaces', [])
+    def get_registrations(self):
+        registrations = self.config_dict.get('registrations', [])
+        for registration in registrations:
+            try:
+                decompose_job_id(registration)
+            except InvalidJobNameError:
+                log.error(
+                    'Provided registration {0} for service '
+                    '{1} is invalid'.format(registration, self.service)
+                )
+
         # Backwards compatbility with nerve_ns
         # FIXME(jlynch|2016-08-02, PAASTA-4964): DEPRECATE nerve_ns and remove it
-        if not registration_namespaces and 'nerve_ns' in self.config_dict:
-            registration_namespaces.append(self.config_dict.get('nerve_ns'))
+        if not registrations and 'nerve_ns' in self.config_dict:
+            registrations.append(
+                compose_job_id(self.service, self.config_dict['nerve_ns'])
+            )
 
-        return registration_namespaces or [self.instance]
+        return registrations or [compose_job_id(self.service, self.instance)]
 
 
 def load_service_namespace_config(service, namespace, soa_dir=DEFAULT_SOA_DIR):

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -261,8 +261,9 @@ def status_smartstack_backends(service, instance, job_config, cluster, tasks, ex
     return: A newline separated string of the smarststack backend status
     """
     output = []
-    nerve_ns = marathon_tools.read_namespace_for_service_instance(service, instance, cluster)
-    service_instance = compose_job_id(service, nerve_ns)
+    service_instance = marathon_tools.read_registration_for_service_instance(
+        service, instance, cluster
+    )
 
     service_namespace_config = marathon_tools.load_service_namespace_config(service, instance, soa_dir=soa_dir)
     discover_location_type = service_namespace_config.get_discover()

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -161,7 +161,7 @@ main_http:
   instances: 2
   mem: 250
   disk: 512
-  registration_namespaces: ['main', 'http']
+  registrations: ['foo.bar', 'bar.baz']
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -127,13 +127,13 @@ def test_check_smartstack_replication_for_instance_ok_when_expecting_zero():
 
     with contextlib.nested(
         mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
-                   autospec=True, return_value=instance),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
+                   autospec=True, return_value=compose_job_id(service, instance)),
         mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
-        mock_read_namespace_for_service_instance,
+        mock_read_registration_for_service_instance,
         mock_load_smartstack_info_for_service,
         mock_load_marathon_service_config,
     ):
@@ -167,13 +167,13 @@ def test_check_smartstack_replication_for_instance_crit_when_absent():
     crit = 90
     with contextlib.nested(
         mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
-                   autospec=True, return_value=instance),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
+                   autospec=True, return_value=compose_job_id(service, instance)),
         mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
-        mock_read_namespace_for_service_instance,
+        mock_read_registration_for_service_instance,
         mock_load_smartstack_info_for_service,
         mock_load_marathon_service_config,
     ):
@@ -204,13 +204,13 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication():
     crit = 90
     with contextlib.nested(
         mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
-                   autospec=True, return_value=instance),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
+                   autospec=True, return_value=compose_job_id(service, instance)),
         mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
-        mock_read_namespace_for_service_instance,
+        mock_read_registration_for_service_instance,
         mock_load_smartstack_info_for_service,
         mock_load_marathon_service_config,
     ):
@@ -246,13 +246,13 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication():
     crit = 90
     with contextlib.nested(
         mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
-                   autospec=True, return_value=instance),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
+                   autospec=True, return_value=compose_job_id(service, instance)),
         mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
-        mock_read_namespace_for_service_instance,
+        mock_read_registration_for_service_instance,
         mock_load_smartstack_info_for_service,
         mock_load_marathon_service_config,
     ):
@@ -288,13 +288,13 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication():
     crit = 90
     with contextlib.nested(
         mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
-                   autospec=True, return_value=instance),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
+                   autospec=True, return_value=compose_job_id(service, instance)),
         mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
-        mock_read_namespace_for_service_instance,
+        mock_read_registration_for_service_instance,
         mock_load_smartstack_info_for_service,
         mock_load_marathon_service_config,
     ):
@@ -330,13 +330,13 @@ def test_check_smartstack_replication_for_instance_ignores_things_under_a_differ
     crit = 90
     with contextlib.nested(
         mock.patch('paasta_tools.check_marathon_services_replication.send_event_if_under_replication', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
                    autospec=True, return_value=namespace),
         mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event_if_under_replication,
-        mock_read_namespace_for_service_instance,
+        mock_read_registration_for_service_instance,
         mock_load_smartstack_info_for_service,
         mock_load_marathon_service_config,
     ):
@@ -361,13 +361,13 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication_mu
     crit = 90
     with contextlib.nested(
         mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
-                   autospec=True, return_value=instance),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
+                   autospec=True, return_value=compose_job_id(service, instance)),
         mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True),
     ) as (
         mock_send_event,
-        mock_read_namespace_for_service_instance,
+        mock_read_registration_for_service_instance,
         mock_load_smartstack_info_for_service,
         mock_load_marathon_service_config,
     ):
@@ -403,13 +403,13 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication_mul
     crit = 90
     with contextlib.nested(
         mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
-                   autospec=True, return_value=instance),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
+                   autospec=True, return_value=compose_job_id(service, instance)),
         mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
-        mock_read_namespace_for_service_instance,
+        mock_read_registration_for_service_instance,
         mock_load_smartstack_info_for_service,
         mock_load_marathon_service_config,
     ):
@@ -446,13 +446,13 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication_mu
     crit = 90
     with contextlib.nested(
         mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
-                   autospec=True, return_value=instance),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
+                   autospec=True, return_value=compose_job_id(service, instance)),
         mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
-        mock_read_namespace_for_service_instance,
+        mock_read_registration_for_service_instance,
         mock_load_smartstack_info_for_service,
         mock_load_marathon_service_config,
     ):
@@ -489,13 +489,13 @@ def test_check_smartstack_replication_for_instance_crit_when_missing_replication
     crit = 90
     with contextlib.nested(
         mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
-                   autospec=True, return_value=instance),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
+                   autospec=True, return_value=compose_job_id(service, instance)),
         mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
-        mock_read_namespace_for_service_instance,
+        mock_read_registration_for_service_instance,
         mock_load_smartstack_info_for_service,
         mock_load_marathon_service_config,
     ):
@@ -531,13 +531,13 @@ def test_check_smartstack_replication_for_instance_crit_when_no_smartstack_info(
     crit = 90
     with contextlib.nested(
         mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
-                   autospec=True, return_value=instance),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
+                   autospec=True, return_value=compose_job_id(service, instance)),
         mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
         mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
     ) as (
         mock_send_event,
-        mock_read_namespace_for_service_instance,
+        mock_read_registration_for_service_instance,
         mock_load_smartstack_info_for_service,
         mock_load_marathon_service_config,
     ):

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -377,13 +377,13 @@ def test_status_smartstack_backends_normal():
 
     with contextlib.nested(
         mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance', autospec=True),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_backends', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.match_backends_and_tasks', autospec=True),
     ) as (
         mock_load_service_namespace_config,
-        mock_read_ns,
+        mock_read_reg,
         mock_get_all_slaves_for_blacklist_whitelist,
         mock_get_backends,
         mock_match_backends_and_tasks,
@@ -396,7 +396,7 @@ def test_status_smartstack_backends_normal():
             }
         }]
 
-        mock_read_ns.return_value = instance
+        mock_read_reg.return_value = service_instance
         mock_get_backends.return_value = haproxy_backends_by_task.values()
         mock_match_backends_and_tasks.return_value = [
             (haproxy_backends_by_task[good_task], good_task),
@@ -447,18 +447,16 @@ def test_status_smartstack_backends_different_nerve_ns():
 
     with contextlib.nested(
         mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance', autospec=True),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_backends', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.match_backends_and_tasks', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance', autospec=True)
     ) as (
         mock_load_service_namespace_config,
-        mock_read_ns,
+        mock_read_reg,
         mock_get_all_slaves_for_blacklist_whitelist,
         mock_get_backends,
         mock_match_backends_and_tasks,
-        mock_read_ns
     ):
         mock_load_service_namespace_config.return_value.get_discover.return_value = 'fake_discover'
         mock_get_all_slaves_for_blacklist_whitelist.return_value = [{
@@ -468,14 +466,14 @@ def test_status_smartstack_backends_different_nerve_ns():
             }
         }]
 
-        mock_read_ns.return_value = instance
+        mock_read_reg.return_value = service_instance
         mock_get_backends.return_value = haproxy_backends_by_task.values()
         mock_match_backends_and_tasks.return_value = [
             (haproxy_backends_by_task[good_task], good_task),
             (haproxy_backends_by_task[bad_task], None),
             (None, other_task),
         ]
-        mock_read_ns.return_value = different_ns
+        mock_read_reg.return_value = compose_job_id(service, different_ns)
         tasks = [good_task, other_task]
         actual = marathon_serviceinit.status_smartstack_backends(
             service=service,
@@ -508,15 +506,15 @@ def test_status_smartstack_backends_no_smartstack_replication_info():
     normal_count = 10
     with contextlib.nested(
         mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance', autospec=True),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True),
     ) as (
         mock_load_service_namespace_config,
-        mock_read_ns,
+        mock_read_reg,
         mock_get_all_slaves_for_blacklist_whitelist,
     ):
         mock_load_service_namespace_config.return_value.get_discover.return_value = 'fake_discover'
-        mock_read_ns.return_value = instance
+        mock_read_reg.return_value = service_instance
         mock_get_all_slaves_for_blacklist_whitelist.return_value = {}
         actual = marathon_serviceinit.status_smartstack_backends(
             service=service,
@@ -545,19 +543,19 @@ def test_status_smartstack_backends_multiple_locations():
                     'check_status': 'L7OK', 'check_duration': 1}
     with contextlib.nested(
         mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance', autospec=True),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_backends', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.match_backends_and_tasks', autospec=True),
     ) as (
         mock_load_service_namespace_config,
-        mock_read_ns,
+        mock_read_reg,
         mock_get_all_slaves_for_blacklist_whitelist,
         mock_get_backends,
         mock_match_backends_and_tasks,
     ):
         mock_load_service_namespace_config.return_value.get_discover.return_value = 'fake_discover'
-        mock_read_ns.return_value = instance
+        mock_read_reg.return_value = service_instance
         mock_get_backends.return_value = [fake_backend]
         mock_match_backends_and_tasks.return_value = [
             (fake_backend, good_task),
@@ -619,21 +617,21 @@ def test_status_smartstack_backends_multiple_locations_expected_count():
                     'check_status': 'L7OK', 'check_duration': 1}
     with contextlib.nested(
         mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance', autospec=True),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_backends', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.match_backends_and_tasks', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.haproxy_backend_report', autospec=True),
     ) as (
         mock_load_service_namespace_config,
-        mock_read_ns,
+        mock_read_reg,
         mock_get_all_slaves_for_blacklist_whitelist,
         mock_get_backends,
         mock_match_backends_and_tasks,
         mock_haproxy_backend_report,
     ):
         mock_load_service_namespace_config.return_value.get_discover.return_value = 'fake_discover'
-        mock_read_ns.return_value = instance
+        mock_read_reg.return_value = service_instance
         mock_get_backends.return_value = [fake_backend]
         mock_match_backends_and_tasks.return_value = [
             (fake_backend, good_task),
@@ -701,19 +699,19 @@ def test_status_smartstack_backends_verbose_multiple_apps():
 
     with contextlib.nested(
         mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance', autospec=True),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_backends', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.match_backends_and_tasks', autospec=True),
     ) as (
         mock_load_service_namespace_config,
-        mock_read_ns,
+        mock_read_reg,
         mock_get_all_slaves_for_blacklist_whitelist,
         mock_get_backends,
         mock_match_backends_and_tasks,
     ):
         mock_load_service_namespace_config.return_value.get_discover.return_value = 'fake_discover'
-        mock_read_ns.return_value = instance
+        mock_read_reg.return_value = service_instance
         mock_get_backends.return_value = haproxy_backends_by_task.values()
         mock_match_backends_and_tasks.return_value = [
             (haproxy_backends_by_task[good_task], good_task),
@@ -767,7 +765,7 @@ def test_status_smartstack_backends_verbose_multiple_locations():
                           'check_status': 'L7OK', 'check_duration': 1}
     with contextlib.nested(
         mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance', autospec=True),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_backends', autospec=True,
                    side_effect=[[fake_backend], [fake_other_backend]]),
@@ -775,13 +773,13 @@ def test_status_smartstack_backends_verbose_multiple_locations():
                    autospec=True, side_effect=[[(fake_backend, good_task)], [(fake_other_backend, good_task)]]),
     ) as (
         mock_load_service_namespace_config,
-        mock_read_ns,
+        mock_read_reg,
         mock_get_all_slaves_for_blacklist_whitelist,
         mock_get_backends,
         mock_match_backends_and_tasks,
     ):
         mock_load_service_namespace_config.return_value.get_discover.return_value = 'fake_discover'
-        mock_read_ns.return_value = instance
+        mock_read_reg.return_value = service_instance
         mock_get_all_slaves_for_blacklist_whitelist.return_value = [
             {
                 'hostname': 'hostname1',
@@ -843,13 +841,13 @@ def test_status_smartstack_backends_verbose_emphasizes_maint_instances():
                     'check_status': 'L7OK', 'check_duration': 1}
     with contextlib.nested(
         mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance', autospec=True),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_backends', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.match_backends_and_tasks', autospec=True),
     ) as (
         mock_load_service_namespace_config,
-        mock_read_ns,
+        mock_read_reg,
         mock_get_mesos_slaves_for_blacklist_whitelist,
         mock_get_backends,
         mock_match_backends_and_tasks,
@@ -863,7 +861,7 @@ def test_status_smartstack_backends_verbose_emphasizes_maint_instances():
             }
         ]
         mock_load_service_namespace_config.return_value.get_discover.return_value = 'fake_discover'
-        mock_read_ns.return_value = instance
+        mock_read_reg.return_value = compose_job_id(service, instance)
         mock_get_backends.return_value = [fake_backend]
         mock_match_backends_and_tasks.return_value = [
             (fake_backend, good_task),
@@ -896,13 +894,13 @@ def test_status_smartstack_backends_verbose_demphasizes_maint_instances_for_unre
                     'check_status': 'L7OK', 'check_duration': 1}
     with contextlib.nested(
         mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance', autospec=True),
+        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.get_backends', autospec=True),
         mock.patch('paasta_tools.marathon_serviceinit.match_backends_and_tasks', autospec=True),
     ) as (
         mock_load_service_namespace_config,
-        mock_read_ns,
+        mock_read_reg,
         mock_get_all_slaves_for_blacklist_whitelist,
         mock_get_backends,
         mock_match_backends_and_tasks,
@@ -916,7 +914,7 @@ def test_status_smartstack_backends_verbose_demphasizes_maint_instances_for_unre
             }
         ]
         mock_load_service_namespace_config.return_value.get_discover.return_value = 'fake_discover'
-        mock_read_ns.return_value = instance
+        mock_read_reg.return_value = compose_job_id(service, instance)
         mock_get_backends.return_value = [fake_backend]
         mock_match_backends_and_tasks.return_value = [
             (fake_backend, None),

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -332,8 +332,8 @@ class TestMarathonTools:
         fake_port = 1234567890
         fake_nerve = long_running_service_tools.ServiceNamespaceConfig({'proxy_port': fake_port})
         with contextlib.nested(
-            mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
-                       autospec=True, return_value=namespace),
+            mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
+                       autospec=True, return_value=compose_job_id(name, namespace)),
             mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
                        autospec=True, return_value=fake_nerve)
         ) as (
@@ -353,8 +353,8 @@ class TestMarathonTools:
         namespace = 'thirsty_mock'
         expected = None
         with contextlib.nested(
-            mock.patch('paasta_tools.marathon_tools.read_namespace_for_service_instance',
-                       autospec=True, return_value=namespace),
+            mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
+                       autospec=True, return_value=compose_job_id(name, namespace)),
             mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
                        autospec=True, return_value={})
         ) as (
@@ -483,7 +483,7 @@ class TestMarathonTools:
             read_service_configuration_patch.assert_called_once_with(name, soa_dir)
 
     @mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
-    def test_read_namespace_for_service_instance_has_value_with_nerve_ns(self, load_config_patch):
+    def test_read_registration_for_service_instance_has_value_with_nerve_ns(self, load_config_patch):
         name = 'dont_worry'
         instance = 'im_a_professional'
         cluster = 'andromeda'
@@ -496,48 +496,55 @@ class TestMarathonTools:
             config_dict={'nerve_ns': namespace},
             branch_dict={},
         )
-        actual = marathon_tools.read_namespace_for_service_instance(name, instance, cluster, soa_dir)
-        assert actual == namespace
+        actual = marathon_tools.read_registration_for_service_instance(name, instance, cluster, soa_dir)
+        assert actual == compose_job_id(name, namespace)
         load_config_patch.assert_called_once_with(name, instance, cluster, load_deployments=False, soa_dir=soa_dir)
 
     @mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
-    def test_read_namespace_for_service_instance_has_value(self, load_config_patch):
+    def test_read_registration_for_service_instance_has_value(self, load_config_patch):
         name = 'dont_worry'
         instance = 'im_a_professional'
         cluster = 'andromeda'
-        namespace = 'spacename'
         soa_dir = 'dirdirdir'
         load_config_patch.return_value = marathon_tools.MarathonServiceConfig(
             service=name,
             cluster=cluster,
             instance=instance,
-            config_dict={'registration_namespaces': [namespace, 'something else']},
+            config_dict={
+                'registrations': [
+                    compose_job_id(name, instance),
+                    compose_job_id(name, 'something else')
+                ]
+            },
             branch_dict={},
         )
-        actual = marathon_tools.read_namespace_for_service_instance(name, instance, cluster, soa_dir)
-        assert actual == namespace
+        actual = marathon_tools.read_registration_for_service_instance(name, instance, cluster, soa_dir)
+        assert actual == compose_job_id(name, instance)
         load_config_patch.assert_called_once_with(name, instance, cluster, load_deployments=False, soa_dir=soa_dir)
 
     @mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
-    def test_read_all_namespaces_for_service_instance_has_value(self, load_config_patch):
+    def test_read_all_registrations_for_service_instance_has_value(self, load_config_patch):
         name = 'dont_worry'
         instance = 'im_a_professional'
         cluster = 'andromeda'
         namespaces = ['spacename', 'spaceiscool', 'rocketsarecooler']
+        registrations = [compose_job_id(name, ns) for ns in namespaces]
         soa_dir = 'dirdirdir'
         load_config_patch.return_value = marathon_tools.MarathonServiceConfig(
             service=name,
             cluster=cluster,
             instance=instance,
-            config_dict={'registration_namespaces': namespaces},
+            config_dict={'registrations': registrations},
             branch_dict={},
         )
-        actual_registrations = marathon_tools.read_all_namespaces_for_service_instance(name, instance, cluster, soa_dir)
-        assert set(actual_registrations) == set(namespaces)
+        actual_registrations = marathon_tools.read_all_registrations_for_service_instance(
+            name, instance, cluster, soa_dir
+        )
+        assert set(actual_registrations) == set(registrations)
         load_config_patch.assert_called_once_with(name, instance, cluster, load_deployments=False, soa_dir=soa_dir)
 
     @mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
-    def test_read_namespace_for_service_instance_no_value(self, load_config_patch):
+    def test_read_registration_for_service_instance_no_value(self, load_config_patch):
         name = 'wall_light'
         instance = 'ceiling_light'
         cluster = 'no_light'
@@ -550,8 +557,8 @@ class TestMarathonTools:
             branch_dict={},
         )
 
-        actual = marathon_tools.read_namespace_for_service_instance(name, instance, cluster, soa_dir)
-        assert actual == instance
+        actual = marathon_tools.read_registration_for_service_instance(name, instance, cluster, soa_dir)
+        assert actual == compose_job_id(name, instance)
         load_config_patch.assert_called_once_with(name, instance, cluster, load_deployments=False, soa_dir=soa_dir)
 
     @mock.patch('paasta_tools.marathon_tools.get_local_slave_state', autospec=True)
@@ -610,7 +617,10 @@ class TestMarathonTools:
         soa_dir = 'the_sound_of_music'
         fake_marathon_services = [('no_test', 'left_behind', 1111),
                                   ('no_docstrings', 'forever_abandoned', 2222)]
-        namespaces = [['dos'], ['uno']]
+        registrations = [
+            ['no_docstrings.dos'],
+            ['no_test.uno']
+        ]
         nerve_dicts = [long_running_service_tools.ServiceNamespaceConfig({'binary': 1, 'proxy_port': 6666}),
                        long_running_service_tools.ServiceNamespaceConfig({'clock': 0, 'proxy_port': 6666})]
         expected = [('no_test.uno', {'clock': 0, 'port': 1111, 'proxy_port': 6666}),
@@ -619,9 +629,9 @@ class TestMarathonTools:
             mock.patch('paasta_tools.marathon_tools.marathon_services_running_here',
                        autospec=True,
                        return_value=fake_marathon_services),
-            mock.patch('paasta_tools.marathon_tools.read_all_namespaces_for_service_instance',
+            mock.patch('paasta_tools.marathon_tools.read_all_registrations_for_service_instance',
                        autospec=True,
-                       side_effect=lambda a, b, c, d: namespaces.pop()),
+                       side_effect=lambda a, b, c, d: registrations.pop()),
             mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
                        autospec=True,
                        side_effect=lambda a, b, c: nerve_dicts.pop()),
@@ -645,7 +655,10 @@ class TestMarathonTools:
         soa_dir = 'the_sound_of_music'
         fake_marathon_services = [('no_test', 'left_behind', 1111),
                                   ('no_docstrings', 'forever_abandoned', 2222)]
-        namespaces = [['quatro'], ['uno', 'dos', 'tres']]
+        namespaces = [
+            ['no_docstrings.quatro'],
+            ['no_test.uno', 'no_test.dos', 'no_test.tres']
+        ]
         nerve_dicts = {
             ('no_test', 'uno'): long_running_service_tools.ServiceNamespaceConfig({'proxy_port': 6666}),
             ('no_test', 'dos'): long_running_service_tools.ServiceNamespaceConfig({'proxy_port': 6667}),
@@ -660,7 +673,7 @@ class TestMarathonTools:
             mock.patch('paasta_tools.marathon_tools.marathon_services_running_here',
                        autospec=True,
                        return_value=fake_marathon_services),
-            mock.patch('paasta_tools.marathon_tools.read_all_namespaces_for_service_instance',
+            mock.patch('paasta_tools.marathon_tools.read_all_registrations_for_service_instance',
                        autospec=True,
                        side_effect=lambda a, b, c, d: namespaces.pop()),
             mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
@@ -688,7 +701,10 @@ class TestMarathonTools:
         soa_dir = 'the_sound_of_music'
         fake_marathon_services = [('no_test', 'left_behind', 1111),
                                   ('no_docstrings', 'forever_abandoned', 2222)]
-        namespaces = [['dos'], ['uno']]
+        registrations = [
+            ['no_docstrings.dos'],
+            ['no_test.uno']
+        ]
         nerve_dicts = [long_running_service_tools.ServiceNamespaceConfig({'binary': 1}),
                        long_running_service_tools.ServiceNamespaceConfig({'clock': 0, 'proxy_port': 6666})]
         expected = [('no_test.uno', {'clock': 0, 'port': 1111, 'proxy_port': 6666})]
@@ -696,9 +712,9 @@ class TestMarathonTools:
             mock.patch('paasta_tools.marathon_tools.marathon_services_running_here',
                        autospec=True,
                        return_value=fake_marathon_services),
-            mock.patch('paasta_tools.marathon_tools.read_all_namespaces_for_service_instance',
+            mock.patch('paasta_tools.marathon_tools.read_all_registrations_for_service_instance',
                        autospec=True,
-                       side_effect=lambda a, b, c, d: namespaces.pop()),
+                       side_effect=lambda a, b, c, d: registrations.pop()),
             mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
                        autospec=True,
                        side_effect=lambda a, b, c: nerve_dicts.pop()),
@@ -2569,7 +2585,7 @@ def test_marathon_service_config_get_desired_state_human_invalid_desired_state()
         assert 'Unknown (desired_state: fake-state)' in fake_desired_state
 
 
-def test_read_namespace_for_service_instance_no_cluster():
+def test_read_registration_for_service_instance_no_cluster():
     mock_get_cluster = mock.Mock()
     with contextlib.nested(
             mock.patch('paasta_tools.marathon_tools.load_marathon_service_config',
@@ -2580,7 +2596,7 @@ def test_read_namespace_for_service_instance_no_cluster():
         _,
         _,
     ):
-        marathon_tools.read_namespace_for_service_instance(mock.Mock(), mock.Mock())
+        marathon_tools.read_registration_for_service_instance(mock.Mock(), mock.Mock())
         mock_get_cluster.assert_called_once_with()
 
 

--- a/tests/test_paasta_maintenance.py
+++ b/tests/test_paasta_maintenance.py
@@ -119,7 +119,7 @@ def test_are_local_tasks_in_danger_is_true_with_an_healthy_service_in_danger(
     assert mock_synapse_replication_is_low.call_count == 1
 
 
-@mock.patch('paasta_tools.paasta_maintenance.read_namespace_for_service_instance', autospec=True)
+@mock.patch('paasta_tools.paasta_maintenance.read_registration_for_service_instance', autospec=True)
 @mock.patch('paasta_tools.paasta_maintenance.load_smartstack_info_for_service', autospec=True)
 @mock.patch('paasta_tools.paasta_maintenance.get_expected_instance_count_for_namespace', autospec=True)
 @mock.patch('paasta_tools.paasta_maintenance.get_replication_for_services', autospec=True)
@@ -127,9 +127,9 @@ def test_synapse_replication_is_low_understands_underreplicated_services(
     mock_get_replication_for_services,
     mock_get_expected_instance_count_for_namespace,
     mock_load_smartstack_info_for_service,
-    mock_read_namespace_for_service_instance,
+    mock_read_registration_for_service_instance,
 ):
-    mock_read_namespace_for_service_instance.return_value = "main"
+    mock_read_registration_for_service_instance.return_value = "service.main"
     mock_get_expected_instance_count_for_namespace.return_value = 3
     mock_load_smartstack_info_for_service.return_value = {
         "local_region": {"service.main": "up"}


### PR DESCRIPTION
This PR adds support for multiple registrations from a single PaaSTA instance. Allowing things like exposing a single container under multiple smartstack advertisements.
