### PR TITLE
Use marathon 1.4.0-snap18 in our itests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ isodate==0.5.1
 jsonschema[format]==2.5.1
 kazoo==2.2
 lockfile==0.9.1
-marathon==0.8.6
+marathon==0.8.7
 mccabe==0.3.1
 mesos.interface==1.0.1
 ordereddict==1.1

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -29,8 +29,7 @@ RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set
 RUN echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections
 RUN apt-get update && apt-get -y install lsb-release oracle-java8-installer
 
-RUN apt-get -y install libsasl2-modules
-RUN apt-get -y --allow-unauthenticated install marathon=1.4.0-0.1.20161020234102.snap18.ubuntu1404
+RUN apt-get -y --allow-unauthenticated install marathon=1.4.0-0.1.20161021221011.snap19.ubuntu1404
 
 RUN echo -n "secret2" > /etc/marathon_framework_secret
 

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 FROM ubuntu:trusty
+
+RUN apt-get update && apt-get -y install apt-transport-https
+
+RUN echo "deb https://dl.bintray.com/yelp/paasta trusty main" > /etc/apt/sources.list.d/paasta.list
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
 RUN apt-get update && apt-get -y install libsasl2-modules mesos=1.0.1-2.0.93.ubuntu1404
@@ -25,7 +29,8 @@ RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set
 RUN echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections
 RUN apt-get update && apt-get -y install lsb-release oracle-java8-installer
 
-RUN apt-get -y install libsasl2-modules marathon=1.3.0-1.0.506.ubuntu1404
+RUN apt-get -y install libsasl2-modules
+RUN apt-get -y --allow-unauthenticated install marathon=1.4.0-0.1.20161020234102.snap18.ubuntu1404
 
 RUN echo -n "secret2" > /etc/marathon_framework_secret
 


### PR DESCRIPTION
This is a test to see if marathon 1.4.0-snap18 behaves better than 1.3.0.

The bintray debs were built by our internal package building infrastructure and then manually uploaded. If we decide to stick with this unreleased version of marathon, I'll get automatic uploads to bintray setup.