### PR TITLE
Use v2 deployments

### DIFF
--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -36,7 +36,7 @@ from paasta_tools.cli.cmds.start_stop_restart import paasta_stop
 from paasta_tools.utils import format_tag
 from paasta_tools.utils import format_timestamp
 from paasta_tools.utils import get_paasta_tag_from_deploy_group
-from paasta_tools.utils import load_deployments_json
+from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import paasta_print
 
 
@@ -141,17 +141,23 @@ def step_impl_when(context):
 
 @then('that deployments.json can be read back correctly')
 def step_impl_then(context):
-    deployments = load_deployments_json('fake_deployments_json_service', soa_dir='fake_soa_configs')
+    deployments = load_v2_deployments_json('fake_deployments_json_service', soa_dir='fake_soa_configs')
     expected_deployments = {
-        'fake_deployments_json_service:paasta-test_cluster.test_instance': {
-            'force_bounce': context.force_bounce_timestamp,
-            'desired_state': 'stop',
-            'docker_image': 'services-fake_deployments_json_service:paasta-%s' % context.expected_commit
+        'deployments': {
+            'test_cluster.test_instance': {
+                'docker_image': 'services-fake_deployments_json_service:paasta-%s' % context.expected_commit,
+                'git_sha': context.expected_commit,
+            },
         },
-        'fake_deployments_json_service:paasta-test_cluster.test_instance_2': {
-            'force_bounce': None,
-            'desired_state': 'start',
-            'docker_image': 'services-fake_deployments_json_service:paasta-%s' % context.expected_commit,
+        'controls': {
+            'fake_deployments_json_service:test_cluster.test_instance': {
+                'force_bounce': context.force_bounce_timestamp,
+                'desired_state': 'stop',
+            },
+            'fake_deployments_json_service:test_cluster.test_instance_2': {
+                'force_bounce': None,
+                'desired_state': 'start',
+            },
         },
     }
     assert expected_deployments == deployments, "actual: %s\nexpected:%s" % (deployments, expected_deployments)
@@ -159,8 +165,9 @@ def step_impl_then(context):
 
 @then('that deployments.json has a desired_state of "{expected_state}"')
 def step_impl_then_desired_state(context, expected_state):
-    deployments = load_deployments_json('fake_deployments_json_service', soa_dir='fake_soa_configs')
-    latest = sorted(deployments.iteritems(), key=lambda(key, value): value['force_bounce'], reverse=True)[0][1]
+    deployments = load_v2_deployments_json('fake_deployments_json_service', soa_dir='fake_soa_configs')
+    latest = sorted(
+        deployments['controls'].iteritems(), key=lambda(key, value): value['force_bounce'], reverse=True)[0][1]
     desired_state = latest['desired_state']
     assert desired_state == expected_state, "actual: %s\nexpected: %s" % (desired_state, expected_state)
 

--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -36,7 +36,7 @@ from paasta_tools.cli.cmds.start_stop_restart import paasta_stop
 from paasta_tools.utils import format_tag
 from paasta_tools.utils import format_timestamp
 from paasta_tools.utils import get_paasta_tag_from_deploy_group
-from paasta_tools.utils import load_v2_deployments_json
+from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import paasta_print
 
 
@@ -141,7 +141,7 @@ def step_impl_when(context):
 
 @then('that deployments.json can be read back correctly')
 def step_impl_then(context):
-    deployments = load_v2_deployments_json('fake_deployments_json_service', soa_dir='fake_soa_configs')
+    deployments = load_deployments_json('fake_deployments_json_service', soa_dir='fake_soa_configs')
     expected_deployments = {
         'deployments': {
             'test_cluster.test_instance': {
@@ -165,7 +165,7 @@ def step_impl_then(context):
 
 @then('that deployments.json has a desired_state of "{expected_state}"')
 def step_impl_then_desired_state(context, expected_state):
-    deployments = load_v2_deployments_json('fake_deployments_json_service', soa_dir='fake_soa_configs')
+    deployments = load_deployments_json('fake_deployments_json_service', soa_dir='fake_soa_configs')
     latest = sorted(
         deployments['controls'].iteritems(), key=lambda(key, value): value['force_bounce'], reverse=True)[0][1]
     desired_state = latest['desired_state']

--- a/paasta_itests/steps/paasta_native_steps.py
+++ b/paasta_itests/steps/paasta_native_steps.py
@@ -121,12 +121,19 @@ def write_paasta_native_cluster_yaml_files(context, service, instance):
         }))
     with open(os.path.join(context.soa_dir, service, 'deployments.json'), 'w') as f:
         json.dump({
-            'v1': {
-                '%s:paasta-%s.%s' % (service, context.cluster, instance): {
-                    'docker_image': 'busybox',
-                    'desired_state': 'start',
-                    'force_bounce': None,
-                }
+            'v2': {
+                'controls': {
+                    '%s:%s.%s' % (service, context.cluster, instance): {
+                        'desired_state': 'start',
+                        'force_bounce': None,
+                    },
+                },
+                'deployments': {
+                    '%s.%s' % (context.cluster, instance): {
+                        'docker_image': 'busybox',
+                        'git_sha': 'DEADBEEF',
+                    },
+                },
             }
         }, f)
 

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -240,7 +240,21 @@ def write_soa_dir_deployments(context, service, disabled, instance):
                     'docker_image': 'test-image-foobar%d' % context.tag_version,
                     'desired_state': desired_state,
                 }
-            }
+            },
+            'v2': {
+                'deployments': {
+                    utils.get_paasta_branch(context.cluster, instance): {
+                        'docker_image': 'test-image-foobar%d' % context.tag_version,
+                        'git_sha': context.tag_version
+                    },
+                },
+                'controls': {
+                    '%s:%s' % (service, utils.get_paasta_branch(context.cluster, instance)): {
+                        'desired_state': desired_state,
+                        'force_bounce': None,
+                    },
+                },
+            },
         }))
 
 

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -233,23 +233,18 @@ def write_soa_dir_deployments(context, service, disabled, instance):
 
     if not os.path.exists(os.path.join(context.soa_dir, service)):
         os.makedirs(os.path.join(context.soa_dir, service))
+    branch = utils.get_paasta_branch(context.cluster, instance)
     with open(os.path.join(context.soa_dir, service, 'deployments.json'), 'w') as dp:
         dp.write(json.dumps({
-            'v1': {
-                '%s:paasta-%s' % (service, utils.get_paasta_branch(context.cluster, instance)): {
-                    'docker_image': 'test-image-foobar%d' % context.tag_version,
-                    'desired_state': desired_state,
-                }
-            },
             'v2': {
                 'deployments': {
-                    utils.get_paasta_branch(context.cluster, instance): {
+                    branch: {
                         'docker_image': 'test-image-foobar%d' % context.tag_version,
-                        'git_sha': context.tag_version
+                        'git_sha': 'test_git_sha',
                     },
                 },
                 'controls': {
-                    '%s:%s' % (service, utils.get_paasta_branch(context.cluster, instance)): {
+                    '%s:%s' % (service, branch): {
                         'desired_state': desired_state,
                         'force_bounce': None,
                     },

--- a/paasta_tools/adhoc_tools.py
+++ b/paasta_tools/adhoc_tools.py
@@ -22,7 +22,7 @@ from paasta_tools.long_running_service_tools import LongRunningServiceConfig
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_paasta_branch
-from paasta_tools.utils import load_v2_deployments_json
+from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import prompt_pick_one
@@ -53,10 +53,10 @@ def load_adhoc_job_config(service, instance, cluster, load_deployments=True, soa
 
     branch_dict = {}
     if load_deployments:
-        deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
+        deployments_json = load_deployments_json(service, soa_dir=soa_dir)
         branch = general_config.get('branch', get_paasta_branch(cluster, instance))
         deploy_group = general_config.get('deploy_group', branch)
-        branch_dict = deployments_json.get_branch_dict_v2(service, branch, deploy_group)
+        branch_dict = deployments_json.get_branch_dict(service, branch, deploy_group)
 
     return AdhocJobConfig(
         service=service,
@@ -101,7 +101,7 @@ def get_default_interactive_config(service, cluster, soa_dir, load_deployments=F
             service=service, instance='interactive', cluster=cluster, soa_dir=soa_dir, load_deployments=False)
 
     if not job_config.branch_dict and load_deployments:
-        deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
+        deployments_json = load_deployments_json(service, soa_dir=soa_dir)
         deploy_group = prompt_pick_one(deployments_json['deployments'].keys(), choosing='deploy group')
         job_config.config_dict['deploy_group'] = deploy_group
         job_config.branch_dict['docker_image'] = deployments_json.get_docker_image_for_deploy_group(deploy_group)

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -25,12 +25,12 @@ from pyramid.view import view_config
 from paasta_tools import marathon_tools
 from paasta_tools.api import settings
 from paasta_tools.api.views.exception import ApiFailure
-from paasta_tools.cli.cmds.status import get_actual_deployments
+from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.mesos_tools import get_running_tasks_from_active_frameworks
 from paasta_tools.mesos_tools import get_task
 from paasta_tools.mesos_tools import get_tasks_from_app_id
 from paasta_tools.mesos_tools import TaskNotFound
-from paasta_tools.paasta_serviceinit import get_deployment_version
+from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import validate_service_instance
 
@@ -91,22 +91,26 @@ def instance_status(request):
     instance_status['service'] = service
     instance_status['instance'] = instance
 
+    soa_dir = settings.soa_dir
+    cluster = settings.cluster
+
     try:
-        actual_deployments = get_actual_deployments(service, settings.soa_dir)
+        deployments_json = load_v2_deployments_json(service=service, soa_dir=soa_dir)
     except Exception:
         error_message = traceback.format_exc()
         raise ApiFailure(error_message, 500)
 
-    version = get_deployment_version(actual_deployments, settings.cluster, instance)
+    instance_config = get_instance_config(service=service, instance=instance, cluster=cluster, soa_dir=soa_dir)
+    version = deployments_json.get_git_sha_for_deploy_group(instance_config.get_deploy_group())
     # exit if the deployment key is not found
     if not version:
-        error_message = 'deployment key %s not found' % '.'.join([settings.cluster, instance])
+        error_message = 'deployment key %s not found' % '.'.join([cluster, instance])
         raise ApiFailure(error_message, 404)
 
     instance_status['git_sha'] = version
 
     try:
-        instance_type = validate_service_instance(service, instance, settings.cluster, settings.soa_dir)
+        instance_type = validate_service_instance(service, instance, cluster, soa_dir)
         if instance_type == 'marathon':
             instance_status['marathon'] = marathon_instance_status(instance_status, service, instance, verbose)
         elif instance_type == 'chronos':

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -30,7 +30,7 @@ from paasta_tools.mesos_tools import get_running_tasks_from_active_frameworks
 from paasta_tools.mesos_tools import get_task
 from paasta_tools.mesos_tools import get_tasks_from_app_id
 from paasta_tools.mesos_tools import TaskNotFound
-from paasta_tools.utils import load_v2_deployments_json
+from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import validate_service_instance
@@ -96,7 +96,7 @@ def instance_status(request):
     cluster = settings.cluster
 
     try:
-        deployments_json = load_v2_deployments_json(service=service, soa_dir=soa_dir)
+        deployments_json = load_deployments_json(service=service, soa_dir=soa_dir)
     except Exception:
         error_message = traceback.format_exc()
         raise ApiFailure(error_message, 500)

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -38,8 +38,8 @@ from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import InvalidJobNameError
+from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
-from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
@@ -172,10 +172,10 @@ def load_chronos_job_config(service, instance, cluster, load_deployments=True, s
     general_config = service_chronos_jobs[instance]
     branch_dict = {}
     if load_deployments:
-        deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
+        deployments_json = load_deployments_json(service, soa_dir=soa_dir)
         branch = get_paasta_branch(cluster=cluster, instance=instance)
         deploy_group = general_config.get('deploy_group', branch)
-        branch_dict = deployments_json.get_branch_dict_v2(service, branch, deploy_group)
+        branch_dict = deployments_json.get_branch_dict(service, branch, deploy_group)
     return ChronosJobConfig(
         service=service,
         cluster=cluster,

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -38,8 +38,8 @@ from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import InvalidJobNameError
-from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
@@ -169,16 +169,18 @@ def load_chronos_job_config(service, instance, cluster, load_deployments=True, s
     service_chronos_jobs = read_chronos_jobs_for_service(service, cluster, soa_dir=soa_dir)
     if instance not in service_chronos_jobs:
         raise NoConfigurationForServiceError('No job named "%s" in config file chronos-%s.yaml' % (instance, cluster))
+    general_config = service_chronos_jobs[instance]
     branch_dict = {}
     if load_deployments:
-        deployments_json = load_deployments_json(service, soa_dir=soa_dir)
+        deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
         branch = get_paasta_branch(cluster=cluster, instance=instance)
-        branch_dict = deployments_json.get_branch_dict(service, branch)
+        deploy_group = general_config.get('deploy_group', branch)
+        branch_dict = deployments_json.get_branch_dict_v2(service, branch, deploy_group)
     return ChronosJobConfig(
         service=service,
         cluster=cluster,
         instance=instance,
-        config_dict=service_chronos_jobs[instance],
+        config_dict=general_config,
         branch_dict=branch_dict,
     )
 

--- a/paasta_tools/cli/cmds/info.py
+++ b/paasta_tools/cli/cmds/info.py
@@ -17,7 +17,6 @@ from __future__ import unicode_literals
 
 from service_configuration_lib import read_service_configuration
 
-from paasta_tools.cli.cmds.status import get_actual_deployments
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_services
@@ -25,8 +24,10 @@ from paasta_tools.marathon_tools import get_all_namespaces_for_service
 from paasta_tools.marathon_tools import load_service_namespace_config
 from paasta_tools.monitoring_tools import get_runbook
 from paasta_tools.monitoring_tools import get_team
+from paasta_tools.utils import decompose_paasta_control_branch
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_git_url
+from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
@@ -64,14 +65,6 @@ def add_subparser(subparsers):
     list_parser.set_defaults(command=paasta_info)
 
 
-def deployments_to_clusters(deployments):
-    clusters = []
-    for deployment in deployments:
-        cluster, _ = deployment.split('.')
-        clusters.append(cluster)
-    return set(clusters)
-
-
 def get_smartstack_endpoints(service, soa_dir):
     endpoints = []
     for name, config in get_all_namespaces_for_service(service, full_name=False, soa_dir=soa_dir):
@@ -86,15 +79,15 @@ def get_smartstack_endpoints(service, soa_dir):
 def get_deployments_strings(service, soa_dir):
     output = []
     try:
-        deployments = get_actual_deployments(service, soa_dir)
+        deployments = load_v2_deployments_json(service=service, soa_dir=soa_dir)
     except NoDeploymentsAvailable:
-        deployments = {}
-    if deployments == {}:
         output.append(' - N/A: Not deployed to any PaaSTA Clusters')
     else:
         service_config = load_service_namespace_config(service, 'main', soa_dir)
         service_mode = service_config.get_mode()
-        for cluster in deployments_to_clusters(deployments):
+        clusters = {decompose_paasta_control_branch(
+            control_branch)[1] for control_branch in deployments['controls'].keys()}
+        for cluster in clusters:
             if service_mode == "tcp":
                 service_port = service_config.get('proxy_port')
                 link = PaastaColors.cyan('%s://paasta-%s.yelp:%d/' % (service_mode, cluster, service_port))

--- a/paasta_tools/cli/cmds/info.py
+++ b/paasta_tools/cli/cmds/info.py
@@ -27,7 +27,7 @@ from paasta_tools.monitoring_tools import get_team
 from paasta_tools.utils import decompose_paasta_control_branch
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_git_url
-from paasta_tools.utils import load_v2_deployments_json
+from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
@@ -79,7 +79,7 @@ def get_smartstack_endpoints(service, soa_dir):
 def get_deployments_strings(service, soa_dir):
     output = []
     try:
-        deployments = load_v2_deployments_json(service=service, soa_dir=soa_dir)
+        deployments = load_deployments_json(service=service, soa_dir=soa_dir)
     except NoDeploymentsAvailable:
         output.append(' - N/A: Not deployed to any PaaSTA Clusters')
     else:

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -37,9 +37,9 @@ from paasta_tools.marathon_tools import MarathonDeployStatus
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_soa_cluster_deploy_files
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
-from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import PaastaColors
 
 
@@ -124,7 +124,7 @@ def list_deployed_clusters(pipeline, actual_deployments):
 
 
 def get_actual_deployments(service, soa_dir):
-    deployments_json = load_v2_deployments_json(service, soa_dir)
+    deployments_json = load_deployments_json(service, soa_dir)
     if not deployments_json:
         paasta_print("Warning: it looks like %s has not been deployed anywhere yet!" % service, file=sys.stderr)
     # Create a dictionary of actual $service Jenkins deployments

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -25,6 +25,7 @@ from service_configuration_lib import read_deploy
 from paasta_tools.api.client import get_paasta_api_client
 from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
+from paasta_tools.cli.utils import get_instance_configs_for_service
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import PaastaCheckMessages
@@ -36,9 +37,9 @@ from paasta_tools.marathon_tools import MarathonDeployStatus
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_soa_cluster_deploy_files
 from paasta_tools.utils import list_clusters
-from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
+from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import PaastaColors
 
 
@@ -123,17 +124,14 @@ def list_deployed_clusters(pipeline, actual_deployments):
 
 
 def get_actual_deployments(service, soa_dir):
-    deployments_json = load_deployments_json(service, soa_dir)
+    deployments_json = load_v2_deployments_json(service, soa_dir)
     if not deployments_json:
         paasta_print("Warning: it looks like %s has not been deployed anywhere yet!" % service, file=sys.stderr)
     # Create a dictionary of actual $service Jenkins deployments
     actual_deployments = {}
-    for key in deployments_json:
-        service, namespace = key.split(':')
-        if service == service:
-            value = deployments_json[key]['docker_image']
-            sha = value[value.rfind('-') + 1:]
-            actual_deployments[namespace.replace('paasta-', '', 1)] = sha
+    for config in get_instance_configs_for_service(service=service, soa_dir=soa_dir):
+        actual_deployments[config.get_branch()] = deployments_json.get_git_sha_for_deploy_group(
+            config.get_deploy_group())
     return actual_deployments
 
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -32,11 +32,11 @@ from paasta_tools.marathon_serviceinit import bouncing_status_human
 from paasta_tools.marathon_serviceinit import desired_state_human
 from paasta_tools.marathon_serviceinit import marathon_app_deploy_status_human
 from paasta_tools.marathon_serviceinit import status_marathon_job_human
-from paasta_tools.marathon_tools import load_deployments_json
 from paasta_tools.marathon_tools import MarathonDeployStatus
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_soa_cluster_deploy_files
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors

--- a/paasta_tools/deployment_utils.py
+++ b/paasta_tools/deployment_utils.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from paasta_tools.utils import DEFAULT_SOA_DIR
-from paasta_tools.utils import load_v2_deployments_json
+from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import NoDeploymentsAvailable
 
 
@@ -24,7 +24,7 @@ def get_currently_deployed_sha(service, deploy_group, soa_dir=DEFAULT_SOA_DIR):
     """Tries to determine the currently deployed sha for a service and deploy_group,
     returns None if there isn't one ready yet"""
     try:
-        deployments = load_v2_deployments_json(service=service, soa_dir=soa_dir)
+        deployments = load_deployments_json(service=service, soa_dir=soa_dir)
         return deployments.get_git_sha_for_deploy_group(deploy_group=deploy_group)
     except NoDeploymentsAvailable:
         return None

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -195,7 +195,7 @@ def get_desired_state(branch, remote_refs, deploy_group):
     """
     # (?:paasta-){1,2} supports a previous mistake where some tags would be called
     # paasta-paasta-cluster.instance
-    tag_pattern = r'^refs/tags/(?:paasta-){0,2}%s-(?P<force_bounce>[^-]+)-(?P<state>(start|stop))$' % branch
+    tag_pattern = r'^refs/tags/(?:paasta-){1,2}%s-(?P<force_bounce>[^-]+)-(?P<state>(start|stop))$' % branch
 
     states = []
     (_, head_sha) = get_latest_deployment_tag(remote_refs, deploy_group)

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -110,14 +110,12 @@ def get_latest_deployment_tag(refs, deploy_group):
     return most_recent_ref, most_recent_sha
 
 
-def get_deploy_group_mappings(soa_dir, service, old_mappings):
+def get_deploy_group_mappings(soa_dir, service):
     """Gets mappings from service:deploy_group to services-service:paasta-hash,
     where hash is the current SHA at the HEAD of branch_name.
     This is done for all services in soa_dir.
 
     :param soa_dir: The SOA configuration directory to read from
-    :param old_mappings: A dictionary like the return dictionary. Used for fallback if there is a problem with a new
-                         mapping.
     :returns: A dictionary mapping service:deploy_group to a dictionary containing:
 
     - 'docker_image': something like "services-service:paasta-hash". This is relative to the paasta docker
@@ -126,8 +124,7 @@ def get_deploy_group_mappings(soa_dir, service, old_mappings):
     - 'force_bounce': An arbitrary value, which may be None. A change in this value should trigger a bounce, even if
       the other properties of this app have not changed.
     """
-    mappings = {}
-    v2_mappings = {
+    mappings = {
         'deployments': {},
         'controls': {},
     }
@@ -152,25 +149,20 @@ def get_deploy_group_mappings(soa_dir, service, old_mappings):
         (deploy_ref_name, _) = get_latest_deployment_tag(remote_refs, deploy_group)
         if deploy_ref_name in remote_refs:
             commit_sha = remote_refs[deploy_ref_name]
-            control_branch_alias = '%s:paasta-%s' % (service, control_branch)
-            control_branch_alias_v2 = '%s:%s' % (service, control_branch)
+            control_branch_alias = '%s:%s' % (service, control_branch)
             docker_image = build_docker_image_name(service, commit_sha)
-            log.info('Mapping %s to docker image %s', control_branch, docker_image)
-            mapping = mappings.setdefault(control_branch_alias, {})
-            mapping['docker_image'] = docker_image
-            v2_mappings['deployments'].setdefault(deploy_group, {})['docker_image'] = docker_image
-            v2_mappings['deployments'][deploy_group]['git_sha'] = commit_sha
+            log.info('Mapping %s to docker image %s', deploy_group, docker_image)
+            mappings['deployments'].setdefault(deploy_group, {})['docker_image'] = docker_image
+            mappings['deployments'][deploy_group]['git_sha'] = commit_sha
 
             desired_state, force_bounce = get_desired_state(
                 branch=control_branch,
                 remote_refs=remote_refs,
                 deploy_group=deploy_group,
             )
-            mapping['desired_state'] = desired_state
-            mapping['force_bounce'] = force_bounce
-            v2_mappings['controls'].setdefault(control_branch_alias_v2, {})['desired_state'] = desired_state
-            v2_mappings['controls'][control_branch_alias_v2]['force_bounce'] = force_bounce
-    return mappings, v2_mappings
+            mappings['controls'].setdefault(control_branch_alias, {})['desired_state'] = desired_state
+            mappings['controls'][control_branch_alias]['force_bounce'] = force_bounce
+    return mappings
 
 
 def build_docker_image_name(service, sha):
@@ -216,39 +208,17 @@ def get_desired_state(branch, remote_refs, deploy_group):
         return ('start', None)
 
 
-def get_deployments_dict_from_deploy_group_mappings(deploy_group_mappings, v2_deploy_group_mappings):
-    return {'v1': deploy_group_mappings, 'v2': v2_deploy_group_mappings}
-
-
-def get_deploy_group_mappings_from_deployments_dict(deployments_dict):
-    try:
-        return deployments_dict['v1']
-    except KeyError:
-        deploy_group_mappings = {}
-        for deploy_group, image in deployments_dict.items():
-            if isinstance(image, basestring):
-                deploy_group_mappings[deploy_group] = {
-                    'docker_image': image,
-                    'desired_state': 'start',
-                    'force_bounce': None,
-                }
-        return deploy_group_mappings
+def get_deployments_dict_from_deploy_group_mappings(deploy_group_mappings):
+    return {'v2': deploy_group_mappings}
 
 
 def generate_deployments_for_service(service, soa_dir):
-    try:
-        with open(os.path.join(soa_dir, service, TARGET_FILE), 'r') as f:
-            old_deployments_dict = json.load(f)
-            old_mappings = get_deploy_group_mappings_from_deployments_dict(old_deployments_dict)
-    except (IOError, ValueError):
-        old_mappings = {}
-    mappings, v2_mappings = get_deploy_group_mappings(
-        soa_dir=soa_dir,
+    mappings = get_deploy_group_mappings(
         service=service,
-        old_mappings=old_mappings,
+        soa_dir=soa_dir,
     )
 
-    deployments_dict = get_deployments_dict_from_deploy_group_mappings(mappings, v2_mappings)
+    deployments_dict = get_deployments_dict_from_deploy_group_mappings(mappings)
 
     with atomic_file_write(os.path.join(soa_dir, service, TARGET_FILE)) as f:
         json.dump(deployments_dict, f)

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -51,7 +51,6 @@ from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_paasta_branch
 from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import get_user_agent
-from paasta_tools.utils import InvalidInstanceConfig
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -51,8 +51,9 @@ from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_paasta_branch
 from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import get_user_agent
-from paasta_tools.utils import load_deployments_json
+from paasta_tools.utils import InvalidInstanceConfig
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaNotConfiguredError
@@ -152,9 +153,10 @@ def load_marathon_service_config(service, instance, cluster, load_deployments=Tr
 
     branch_dict = {}
     if load_deployments:
-        deployments_json = load_deployments_json(service, soa_dir=soa_dir)
+        deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
         branch = general_config.get('branch', get_paasta_branch(cluster, instance))
-        branch_dict = deployments_json.get_branch_dict(service, branch)
+        deploy_group = general_config.get('deploy_group', branch)
+        branch_dict = deployments_json.get_branch_dict_v2(service, branch, deploy_group)
 
     return MarathonServiceConfig(
         service=service,

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -51,8 +51,8 @@ from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_paasta_branch
 from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import get_user_agent
+from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
-from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaNotConfiguredError
@@ -152,10 +152,10 @@ def load_marathon_service_config(service, instance, cluster, load_deployments=Tr
 
     branch_dict = {}
     if load_deployments:
-        deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
+        deployments_json = load_deployments_json(service, soa_dir=soa_dir)
         branch = general_config.get('branch', get_paasta_branch(cluster, instance))
         deploy_group = general_config.get('deploy_group', branch)
-        branch_dict = deployments_json.get_branch_dict_v2(service, branch, deploy_group)
+        branch_dict = deployments_json.get_branch_dict(service, branch, deploy_group)
 
     return MarathonServiceConfig(
         service=service,

--- a/paasta_tools/native_mesos_scheduler.py
+++ b/paasta_tools/native_mesos_scheduler.py
@@ -33,7 +33,7 @@ from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_paasta_branch
-from paasta_tools.utils import load_deployments_json
+from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import get_services_for_cluster
 
@@ -399,16 +399,18 @@ def load_paasta_native_job_config(service, instance, cluster, load_deployments=T
             'No job named "%s" in config file %s: \n%s' % (instance, filename, open(filename).read())
         )
     branch_dict = {}
+    general_config = service_paasta_native_jobs[instance]
     if load_deployments:
-        deployments_json = load_deployments_json(service, soa_dir=soa_dir)
+        deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
         branch = get_paasta_branch(cluster=cluster, instance=instance)
-        branch_dict = deployments_json.get_branch_dict(service, branch)
+        deploy_group = general_config.get('deploy_group', branch)
+        branch_dict = deployments_json.get_branch_dict_v2(service, branch, deploy_group)
 
     service_config = PaastaNativeServiceConfig(
         service=service,
         cluster=cluster,
         instance=instance,
-        config_dict=service_paasta_native_jobs[instance],
+        config_dict=general_config,
         branch_dict=branch_dict,
     )
 

--- a/paasta_tools/native_mesos_scheduler.py
+++ b/paasta_tools/native_mesos_scheduler.py
@@ -33,7 +33,7 @@ from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_paasta_branch
-from paasta_tools.utils import load_v2_deployments_json
+from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import get_services_for_cluster
 
@@ -401,10 +401,10 @@ def load_paasta_native_job_config(service, instance, cluster, load_deployments=T
     branch_dict = {}
     general_config = service_paasta_native_jobs[instance]
     if load_deployments:
-        deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
+        deployments_json = load_deployments_json(service, soa_dir=soa_dir)
         branch = get_paasta_branch(cluster=cluster, instance=instance)
         deploy_group = general_config.get('deploy_group', branch)
-        branch_dict = deployments_json.get_branch_dict_v2(service, branch, deploy_group)
+        branch_dict = deployments_json.get_branch_dict(service, branch, deploy_group)
 
     service_config = PaastaNativeServiceConfig(
         service=service,

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -105,15 +105,9 @@ def main():
         # For an instance, there might be multiple versions running, e.g. in crossover bouncing.
         # In addition, mesos master does not have information of a chronos service's git hash.
         # The git sha in deployment.json is simply used here.
-<<<<<<< 467531157ea6a0787caf387e67951d7c644fa6d8
-        version = get_deployment_version(actual_deployments, cluster, instance)
+        version = deployments_json.get_git_sha_for_deploy_group(instance_config.get_deploy_group())
         paasta_print('instance: %s' % PaastaColors.blue(instance))
         paasta_print('Git sha:    %s (desired)' % version)
-=======
-        version = deployments_json.get_git_sha_for_deploy_group(instance_config.get_deploy_group())
-        print 'instance: %s' % PaastaColors.blue(instance)
-        print 'Git sha:    %s (desired)' % version
->>>>>>> converted everything to v2 except rerun and status
 
         try:
             instance_type = validate_service_instance(service, instance, cluster, args.soa_dir)

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -24,12 +24,13 @@ import requests_cache
 
 from paasta_tools import chronos_serviceinit
 from paasta_tools import marathon_serviceinit
-from paasta_tools.cli.cmds.status import get_actual_deployments
+from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
+from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import validate_service_instance
 
@@ -70,11 +71,6 @@ def parse_args():
     return args
 
 
-def get_deployment_version(actual_deployments, cluster, instance):
-    key = '.'.join((cluster, instance))
-    return actual_deployments[key][:8] if key in actual_deployments else None
-
-
 def main():
     args = parse_args()
     if args.debug:
@@ -100,15 +96,24 @@ def main():
     requests_cache.install_cache("paasta_serviceinit", backend="memory")
 
     cluster = load_system_paasta_config().get_cluster()
-    actual_deployments = get_actual_deployments(service, args.soa_dir)
+    soa_dir = args.soa_dir
+
+    deployments_json = load_v2_deployments_json(service=service, soa_dir=soa_dir)
 
     for instance in instances:
+        instance_config = get_instance_config(service=service, instance=instance, cluster=cluster, soa_dir=soa_dir)
         # For an instance, there might be multiple versions running, e.g. in crossover bouncing.
         # In addition, mesos master does not have information of a chronos service's git hash.
         # The git sha in deployment.json is simply used here.
+<<<<<<< 467531157ea6a0787caf387e67951d7c644fa6d8
         version = get_deployment_version(actual_deployments, cluster, instance)
         paasta_print('instance: %s' % PaastaColors.blue(instance))
         paasta_print('Git sha:    %s (desired)' % version)
+=======
+        version = deployments_json.get_git_sha_for_deploy_group(instance_config.get_deploy_group())
+        print 'instance: %s' % PaastaColors.blue(instance)
+        print 'Git sha:    %s (desired)' % version
+>>>>>>> converted everything to v2 except rerun and status
 
         try:
             instance_type = validate_service_instance(service, instance, cluster, args.soa_dir)

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -28,9 +28,9 @@ from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
-from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import validate_service_instance
 
@@ -98,7 +98,7 @@ def main():
     cluster = load_system_paasta_config().get_cluster()
     soa_dir = args.soa_dir
 
-    deployments_json = load_v2_deployments_json(service=service, soa_dir=soa_dir)
+    deployments_json = load_deployments_json(service=service, soa_dir=soa_dir)
 
     for instance in instances:
         instance_config = get_instance_config(service=service, instance=instance, cluster=cluster, soa_dir=soa_dir)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1376,7 +1376,7 @@ class NoDeploymentsAvailable(Exception):
     pass
 
 
-def load_v2_deployments_json(service, soa_dir=DEFAULT_SOA_DIR):
+def load_deployments_json(service, soa_dir=DEFAULT_SOA_DIR):
     deployment_file = os.path.join(soa_dir, service, 'deployments.json')
     if os.path.isfile(deployment_file):
         with open(deployment_file) as f:
@@ -1387,11 +1387,7 @@ def load_v2_deployments_json(service, soa_dir=DEFAULT_SOA_DIR):
 
 class DeploymentsJson(dict):
 
-    def get_branch_dict(self, service, branch):
-        full_branch = '%s:paasta-%s' % (service, branch)
-        return self.get(full_branch, {})
-
-    def get_branch_dict_v2(self, service, branch, deploy_group):
+    def get_branch_dict(self, service, branch, deploy_group):
         full_branch = '%s:%s' % (service, branch)
         branch_dict = {
             'docker_image': self.get_docker_image_for_deploy_group(deploy_group),

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1376,15 +1376,6 @@ class NoDeploymentsAvailable(Exception):
     pass
 
 
-def load_deployments_json(service, soa_dir=DEFAULT_SOA_DIR):
-    deployment_file = os.path.join(soa_dir, service, 'deployments.json')
-    if os.path.isfile(deployment_file):
-        with open(deployment_file) as f:
-            return DeploymentsJson(json.load(f)['v1'])
-    else:
-        raise NoDeploymentsAvailable
-
-
 def load_v2_deployments_json(service, soa_dir=DEFAULT_SOA_DIR):
     deployment_file = os.path.join(soa_dir, service, 'deployments.json')
     if os.path.isfile(deployment_file):

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1439,6 +1439,12 @@ def get_paasta_branch(cluster, instance):
     return SPACER.join((cluster, instance))
 
 
+def decompose_paasta_control_branch(control_branch):
+    service, branch = control_branch.split(':')
+    cluster, instance = branch.split('.')
+    return service, cluster, instance
+
+
 def parse_timestamp(tstamp):
     return datetime.datetime.strptime(tstamp, '%Y%m%dT%H%M%S')
 

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -23,26 +23,48 @@ from paasta_tools import marathon_tools
 from paasta_tools.api import settings
 from paasta_tools.api.views import instance
 from paasta_tools.api.views.exception import ApiFailure
+from paasta_tools.utils import DeploymentsJson
 
 
 @mock.patch('paasta_tools.api.views.instance.marathon_job_status', autospec=True)
 @mock.patch('paasta_tools.api.views.instance.marathon_tools.get_matching_appids', autospec=True)
 @mock.patch('paasta_tools.api.views.instance.marathon_tools.load_marathon_service_config', autospec=True)
 @mock.patch('paasta_tools.api.views.instance.validate_service_instance', autospec=True)
-@mock.patch('paasta_tools.api.views.instance.get_actual_deployments', autospec=True)
+@mock.patch('paasta_tools.api.views.instance.get_instance_config', autospec=True)
+@mock.patch('paasta_tools.api.views.instance.load_v2_deployments_json', autospec=True)
 def test_instances_status(
-    mock_get_actual_deployments,
+    mock_load_deployments_json,
+    mock_get_instance_config,
     mock_validate_service_instance,
     mock_load_marathon_service_config,
     mock_get_matching_appids,
     mock_marathon_job_status,
 ):
     settings.cluster = 'fake_cluster'
-    mock_get_actual_deployments.return_value = {'fake_cluster.fake_instance': 'GIT_SHA',
-                                                'fake_cluster.fake_instance2': 'GIT_SHA',
-                                                'fake_cluster2.fake_instance': 'GIT_SHA',
-                                                'fake_cluster2.fake_instance2': 'GIT_SHA'}
+    mock_load_deployments_json.return_value = DeploymentsJson({
+        'deployments': {
+            'fake_cluster.fake_instance': {
+                'git_sha': 'GIT_SHA',
+            },
+            'fake_cluster.fake_instance2': {
+                'git_sha': 'GIT_SHA',
+            },
+            'fake_cluster2.fake_instance': {
+                'git_sha': 'GIT_SHA',
+            },
+            'fake_cluster2.fake_instance2': {
+                'git_sha': 'GIT_SHA',
+            },
+        },
+    })
     mock_validate_service_instance.return_value = 'marathon'
+    mock_get_instance_config.return_value = marathon_tools.MarathonServiceConfig(
+        service='fake_service',
+        instance='fake_instance',
+        cluster='fake_cluster',
+        config_dict={},
+        branch_dict={},
+    )
 
     mock_marathon_config = marathon_tools.MarathonConfig(
         {'url': 'fake_url', 'user': 'fake_user', 'password': 'fake_password'}

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -31,7 +31,7 @@ from paasta_tools.utils import DeploymentsJson
 @mock.patch('paasta_tools.api.views.instance.marathon_tools.load_marathon_service_config', autospec=True)
 @mock.patch('paasta_tools.api.views.instance.validate_service_instance', autospec=True)
 @mock.patch('paasta_tools.api.views.instance.get_instance_config', autospec=True)
-@mock.patch('paasta_tools.api.views.instance.load_v2_deployments_json', autospec=True)
+@mock.patch('paasta_tools.api.views.instance.load_deployments_json', autospec=True)
 def test_instances_status(
     mock_load_deployments_json,
     mock_get_instance_config,

--- a/tests/cli/test_cmds_info.py
+++ b/tests/cli/test_cmds_info.py
@@ -21,6 +21,7 @@ import mock
 from paasta_tools.cli.cmds import info
 from paasta_tools.cli.utils import PaastaColors
 from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
+from paasta_tools.utils import DeploymentsJson
 from paasta_tools.utils import NoDeploymentsAvailable
 
 
@@ -30,14 +31,14 @@ def test_get_service_info():
         mock.patch('paasta_tools.cli.cmds.info.get_runbook', autospec=True),
         mock.patch('paasta_tools.cli.cmds.info.read_service_configuration', autospec=True),
         mock.patch('service_configuration_lib.read_service_configuration', autospec=True),
-        mock.patch('paasta_tools.cli.cmds.info.get_actual_deployments', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.info.load_v2_deployments_json', autospec=True),
         mock.patch('paasta_tools.cli.cmds.info.get_smartstack_endpoints', autospec=True),
     ) as (
         mock_get_team,
         mock_get_runbook,
         mock_read_service_configuration,
         mock_scl_read_service_configuration,
-        mock_get_actual_deployments,
+        mock_load_deployments_json,
         mock_get_smartstack_endpoints,
     ):
         mock_get_team.return_value = 'fake_team'
@@ -60,7 +61,12 @@ def test_get_service_info():
                 }
             }
         }
-        mock_get_actual_deployments.return_value = ['clusterA.main', 'clusterB.main']
+        mock_load_deployments_json.return_value = DeploymentsJson({
+            'controls': {
+                'fake_service:clusterA.main': {},
+                'fake_service:clusterB.main': {},
+            },
+        })
         mock_get_smartstack_endpoints.return_value = ['http://foo:1234', 'tcp://bar:1234']
         actual = info.get_service_info('fake_service', '/fake/soa/dir')
         assert 'Service Name: fake_service' in actual
@@ -80,13 +86,6 @@ def test_get_service_info():
         assert '%s (Sensu Alerts)' % PaastaColors.cyan('https://uchiwa.yelpcorp.com/#/events?q=fake_service') in actual
         mock_get_team.assert_called_with(service='fake_service', overrides={})
         mock_get_runbook.assert_called_with(service='fake_service', overrides={})
-
-
-def test_deployments_to_clusters():
-    deployments = ['A.main', 'A.canary', 'B.main', 'C.othermain']
-    expected = set(['A', 'B', 'C'])
-    actual = info.deployments_to_clusters(deployments)
-    assert actual == expected
 
 
 def test_get_smartstack_endpoints_http():
@@ -124,13 +123,18 @@ def test_get_smartstack_endpoints_tcp():
 
 def test_get_deployments_strings_default_case_with_smartstack():
     with contextlib.nested(
-        mock.patch('paasta_tools.cli.cmds.info.get_actual_deployments', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.info.load_v2_deployments_json', autospec=True),
         mock.patch('service_configuration_lib.read_service_configuration', autospec=True),
     ) as (
-        mock_get_actual_deployments,
+        mock_load_deployments_json,
         mock_read_service_configuration,
     ):
-        mock_get_actual_deployments.return_value = ['clusterA.main', 'clusterB.main']
+        mock_load_deployments_json.return_value = DeploymentsJson({
+            'controls': {
+                'fake_service:clusterA.main': {},
+                'fake_service:clusterB.main': {},
+            },
+        })
         mock_read_service_configuration.return_value = {
             'smartstack': {
                 'main': {
@@ -145,10 +149,15 @@ def test_get_deployments_strings_default_case_with_smartstack():
 
 def test_get_deployments_strings_protocol_tcp_case():
     with contextlib.nested(
-        mock.patch('paasta_tools.cli.cmds.info.get_actual_deployments', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.info.load_v2_deployments_json', autospec=True),
         mock.patch('paasta_tools.cli.cmds.info.load_service_namespace_config', autospec=True),
-    ) as (mock_get_actual_deployments, mock_load_service_namespace_config):
-        mock_get_actual_deployments.return_value = ['clusterA.main', 'clusterB.main']
+    ) as (mock_load_deployments_json, mock_load_service_namespace_config):
+        mock_load_deployments_json.return_value = DeploymentsJson({
+            'controls': {
+                'fake_service:clusterA.main': {},
+                'fake_service:clusterB.main': {},
+            },
+        })
         mock_load_service_namespace_config.return_value = ServiceNamespaceConfig({'mode': 'tcp', 'proxy_port': 8080})
         actual = info.get_deployments_strings('unused', '/fake/soa/dir')
         assert ' - clusterA (%s)' % PaastaColors.cyan('tcp://paasta-clusterA.yelp:8080/') in actual
@@ -157,10 +166,15 @@ def test_get_deployments_strings_protocol_tcp_case():
 
 def test_get_deployments_strings_non_listening_service():
     with contextlib.nested(
-        mock.patch('paasta_tools.cli.cmds.info.get_actual_deployments', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.info.load_v2_deployments_json', autospec=True),
         mock.patch('paasta_tools.cli.cmds.info.load_service_namespace_config', autospec=True),
-    ) as (mock_get_actual_deployments, mock_load_service_namespace_config):
-        mock_get_actual_deployments.return_value = ['clusterA.main', 'clusterB.main']
+    ) as (mock_load_deployments_json, mock_load_service_namespace_config):
+        mock_load_deployments_json.return_value = DeploymentsJson({
+            'controls': {
+                'fake_service:clusterA.main': {},
+                'fake_service:clusterB.main': {},
+            },
+        })
         mock_load_service_namespace_config.return_value = ServiceNamespaceConfig()
         actual = info.get_deployments_strings('unused', '/fake/soa/dir')
         assert ' - clusterA (N/A)' in actual
@@ -169,8 +183,8 @@ def test_get_deployments_strings_non_listening_service():
 
 def test_get_deployments_strings_no_deployments():
     with mock.patch(
-        'paasta_tools.cli.cmds.info.get_actual_deployments', autospec=True
-    ) as mock_get_actual_deployments:
-        mock_get_actual_deployments.side_effect = NoDeploymentsAvailable
+        'paasta_tools.cli.cmds.info.load_v2_deployments_json', autospec=True
+    ) as mock_load_deployments_json:
+        mock_load_deployments_json.side_effect = NoDeploymentsAvailable
         actual = info.get_deployments_strings('unused', '/fake/soa/dir')
         assert 'N/A: Not deployed' in actual[0]

--- a/tests/cli/test_cmds_info.py
+++ b/tests/cli/test_cmds_info.py
@@ -31,7 +31,7 @@ def test_get_service_info():
         mock.patch('paasta_tools.cli.cmds.info.get_runbook', autospec=True),
         mock.patch('paasta_tools.cli.cmds.info.read_service_configuration', autospec=True),
         mock.patch('service_configuration_lib.read_service_configuration', autospec=True),
-        mock.patch('paasta_tools.cli.cmds.info.load_v2_deployments_json', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.info.load_deployments_json', autospec=True),
         mock.patch('paasta_tools.cli.cmds.info.get_smartstack_endpoints', autospec=True),
     ) as (
         mock_get_team,
@@ -123,7 +123,7 @@ def test_get_smartstack_endpoints_tcp():
 
 def test_get_deployments_strings_default_case_with_smartstack():
     with contextlib.nested(
-        mock.patch('paasta_tools.cli.cmds.info.load_v2_deployments_json', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.info.load_deployments_json', autospec=True),
         mock.patch('service_configuration_lib.read_service_configuration', autospec=True),
     ) as (
         mock_load_deployments_json,
@@ -149,7 +149,7 @@ def test_get_deployments_strings_default_case_with_smartstack():
 
 def test_get_deployments_strings_protocol_tcp_case():
     with contextlib.nested(
-        mock.patch('paasta_tools.cli.cmds.info.load_v2_deployments_json', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.info.load_deployments_json', autospec=True),
         mock.patch('paasta_tools.cli.cmds.info.load_service_namespace_config', autospec=True),
     ) as (mock_load_deployments_json, mock_load_service_namespace_config):
         mock_load_deployments_json.return_value = DeploymentsJson({
@@ -166,7 +166,7 @@ def test_get_deployments_strings_protocol_tcp_case():
 
 def test_get_deployments_strings_non_listening_service():
     with contextlib.nested(
-        mock.patch('paasta_tools.cli.cmds.info.load_v2_deployments_json', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.info.load_deployments_json', autospec=True),
         mock.patch('paasta_tools.cli.cmds.info.load_service_namespace_config', autospec=True),
     ) as (mock_load_deployments_json, mock_load_service_namespace_config):
         mock_load_deployments_json.return_value = DeploymentsJson({
@@ -183,7 +183,7 @@ def test_get_deployments_strings_non_listening_service():
 
 def test_get_deployments_strings_no_deployments():
     with mock.patch(
-        'paasta_tools.cli.cmds.info.load_v2_deployments_json', autospec=True
+        'paasta_tools.cli.cmds.info.load_deployments_json', autospec=True
     ) as mock_load_deployments_json:
         mock_load_deployments_json.side_effect = NoDeploymentsAvailable
         actual = info.get_deployments_strings('unused', '/fake/soa/dir')

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -393,7 +393,7 @@ def test_status_pending_pipeline_build_message(
 
 
 @patch('paasta_tools.cli.cmds.status.get_instance_configs_for_service', autospec=True)
-@patch('paasta_tools.cli.cmds.status.load_v2_deployments_json', autospec=True)
+@patch('paasta_tools.cli.cmds.status.load_deployments_json', autospec=True)
 def test_get_actual_deployments(mock_get_deployments, mock_get_instance_configs_for_serivce,):
     mock_get_deployments.return_value = utils.DeploymentsJson({
         'deployments': {

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -392,16 +392,29 @@ def test_status_pending_pipeline_build_message(
     assert expected_output in output
 
 
-@patch('paasta_tools.cli.cmds.status.load_deployments_json', autospec=True)
-def test_get_actual_deployments(mock_get_deployments,):
+@patch('paasta_tools.cli.cmds.status.get_instance_configs_for_service', autospec=True)
+@patch('paasta_tools.cli.cmds.status.load_v2_deployments_json', autospec=True)
+def test_get_actual_deployments(mock_get_deployments, mock_get_instance_configs_for_serivce,):
     mock_get_deployments.return_value = utils.DeploymentsJson({
-        'fake_service:paasta-b_cluster.b_instance': {
-            'docker_image': 'this_is_a_sha',
+        'deployments': {
+            'b_cluster.b_instance': {
+                'git_sha': 'this_is_a_sha',
+            },
+            'a_cluster.a_instance': {
+                'git_sha': 'this_is_a_sha',
+            },
         },
-        'fake_service:paasta-a_cluster.a_instance': {
-            'docker_image': 'this_is_a_sha',
-        }
     })
+    mock_get_instance_configs_for_serivce.return_value = [
+        Mock(
+            get_deploy_group=Mock(return_value='a_cluster.a_instance'),
+            get_branch=Mock(return_value='a_cluster.a_instance'),
+        ),
+        Mock(
+            get_deploy_group=Mock(return_value='b_cluster.b_instance'),
+            get_branch=Mock(return_value='b_cluster.b_instance'),
+        ),
+    ]
     expected = {
         'a_cluster.a_instance': 'this_is_a_sha',
         'b_cluster.b_instance': 'this_is_a_sha',

--- a/tests/test_adhoc_tools.py
+++ b/tests/test_adhoc_tools.py
@@ -51,7 +51,7 @@ def test_get_default_interactive_config_reads_from_tty():
     with contextlib.nested(
         mock.patch('paasta_tools.adhoc_tools.prompt_pick_one', autospec=True),
         mock.patch('paasta_tools.adhoc_tools.load_adhoc_job_config', autospec=True),
-        mock.patch('paasta_tools.adhoc_tools.load_v2_deployments_json', autospec=True),
+        mock.patch('paasta_tools.adhoc_tools.load_deployments_json', autospec=True),
     ) as (
         mock_prompt_pick_one,
         mock_load_adhoc_job_config,

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -163,7 +163,7 @@ class TestChronosTools:
         fake_soa_dir = '/tmp/'
         expected_chronos_conf_file = 'chronos-penguin'
         with contextlib.nested(
-            mock.patch('paasta_tools.chronos_tools.load_v2_deployments_json', autospec=True,),
+            mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True,),
             mock.patch('service_configuration_lib.read_extra_service_information', autospec=True),
         ) as (
             mock_load_deployments_json,
@@ -182,7 +182,7 @@ class TestChronosTools:
     def test_load_chronos_job_config(self):
         fake_soa_dir = '/tmp/'
         with contextlib.nested(
-            mock.patch('paasta_tools.chronos_tools.load_v2_deployments_json', autospec=True,),
+            mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True,),
             mock.patch('paasta_tools.chronos_tools.read_chronos_jobs_for_service', autospec=True),
         ) as (
             mock_load_deployments_json,
@@ -203,7 +203,7 @@ class TestChronosTools:
     def test_load_chronos_job_config_can_ignore_deployments(self):
         fake_soa_dir = '/tmp/'
         with contextlib.nested(
-            mock.patch('paasta_tools.chronos_tools.load_v2_deployments_json', autospec=True,),
+            mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True,),
             mock.patch('paasta_tools.chronos_tools.read_chronos_jobs_for_service', autospec=True),
         ) as (
             mock_load_deployments_json,

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -163,7 +163,7 @@ class TestChronosTools:
         fake_soa_dir = '/tmp/'
         expected_chronos_conf_file = 'chronos-penguin'
         with contextlib.nested(
-            mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True,),
+            mock.patch('paasta_tools.chronos_tools.load_v2_deployments_json', autospec=True,),
             mock.patch('service_configuration_lib.read_extra_service_information', autospec=True),
         ) as (
             mock_load_deployments_json,
@@ -182,7 +182,7 @@ class TestChronosTools:
     def test_load_chronos_job_config(self):
         fake_soa_dir = '/tmp/'
         with contextlib.nested(
-            mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True,),
+            mock.patch('paasta_tools.chronos_tools.load_v2_deployments_json', autospec=True,),
             mock.patch('paasta_tools.chronos_tools.read_chronos_jobs_for_service', autospec=True),
         ) as (
             mock_load_deployments_json,
@@ -203,7 +203,7 @@ class TestChronosTools:
     def test_load_chronos_job_config_can_ignore_deployments(self):
         fake_soa_dir = '/tmp/'
         with contextlib.nested(
-            mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True,),
+            mock.patch('paasta_tools.chronos_tools.load_v2_deployments_json', autospec=True,),
             mock.patch('paasta_tools.chronos_tools.read_chronos_jobs_for_service', autospec=True),
         ) as (
             mock_load_deployments_json,
@@ -1395,7 +1395,7 @@ class TestChronosTools:
             mock.patch('paasta_tools.chronos_tools.load_system_paasta_config', autospec=True),
             mock.patch('paasta_tools.chronos_tools.load_chronos_job_config',
                        autospec=True, return_value=fake_chronos_job_config),
-            mock.patch('paasta_tools.monitoring_tools.get_team', return_value=fake_owner, autospec=True),
+            mock.patch('paasta_tools.chronos_tools.monitoring_tools.get_team', return_value=fake_owner, autospec=True),
             mock.patch('paasta_tools.chronos_tools.get_config_hash', return_value=fake_config_hash, autospec=True),
         ) as (
             load_system_paasta_config_patch,

--- a/tests/test_deployment_utils.py
+++ b/tests/test_deployment_utils.py
@@ -20,11 +20,11 @@ from paasta_tools import deployment_utils
 from paasta_tools.utils import DeploymentsJson
 
 
-@mock.patch('paasta_tools.deployment_utils.load_v2_deployments_json', autospec=True)
+@mock.patch('paasta_tools.deployment_utils.load_deployments_json', autospec=True)
 def test_get_currently_deployed_sha(
-    mock_load_v2_deployments_json,
+    mock_load_deployments_json,
 ):
-    mock_load_v2_deployments_json.return_value = DeploymentsJson({
+    mock_load_deployments_json.return_value = DeploymentsJson({
         "controls": {},
         "deployments": {
             "everything": {

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -51,20 +51,7 @@ def test_get_deploy_group_mappings():
         'refs/tags/paasta-nah-20160308T053933-deploy': 'j8yiomwer',
     }
 
-    fake_old_mappings = ['']
     expected = {
-        'fake_service:paasta-clusterA.main': {
-            'docker_image': 'services-fake_service:paasta-789009',
-            'desired_state': 'start',
-            'force_bounce': None,
-        },
-        'fake_service:paasta-clusterB.main': {
-            'docker_image': 'services-fake_service:paasta-123456',
-            'desired_state': 'stop',
-            'force_bounce': '123',
-        },
-    }
-    expected_v2 = {
         'deployments': {
             'try_me': {
                 'docker_image': 'services-fake_service:paasta-123456',
@@ -95,12 +82,11 @@ def test_get_deploy_group_mappings():
         get_instance_configs_for_service_patch,
         list_remote_refs_patch,
     ):
-        actual, actual_v2 = generate_deployments_for_service.get_deploy_group_mappings(fake_soa_dir,
-                                                                                       fake_service, fake_old_mappings)
+        actual = generate_deployments_for_service.get_deploy_group_mappings(fake_soa_dir,
+                                                                            fake_service)
         get_instance_configs_for_service_patch.assert_called_once_with(soa_dir=fake_soa_dir, service=fake_service)
         assert list_remote_refs_patch.call_count == 1
         assert expected == actual
-        assert expected_v2 == actual_v2
 
 
 def test_get_cluster_instance_map_for_service():
@@ -152,7 +138,6 @@ def test_get_service_from_docker_image():
 
 def test_main():
     fake_soa_dir = '/etc/true/null'
-    file_mock = mock.MagicMock(spec=file)
     with contextlib.nested(
         mock.patch('paasta_tools.generate_deployments_for_service.parse_args',
                    return_value=mock.Mock(verbose=False, soa_dir=fake_soa_dir, service='fake_service'),
@@ -160,23 +145,18 @@ def test_main():
         mock.patch('os.path.abspath', return_value='ABSOLUTE', autospec=True),
         mock.patch(
             'paasta_tools.generate_deployments_for_service.get_deploy_group_mappings',
-            return_value=({'MAP': {'docker_image': 'PINGS', 'desired_state': 'start'}}, mock.sentinel.v2_mappings),
+            return_value=(mock.sentinel.mappings),
             autospec=True,
         ),
         mock.patch('os.path.join', return_value='JOIN', autospec=True),
-        mock.patch('paasta_tools.generate_deployments_for_service.open',
-                   create=True, return_value=file_mock, autospec=None),
         mock.patch('json.dump', autospec=True),
-        mock.patch('json.load', return_value={'OLD_MAP': 'PINGS'}, autospec=True),
         mock.patch('paasta_tools.generate_deployments_for_service.atomic_file_write', autospec=True),
     ) as (
         parse_patch,
         abspath_patch,
         mappings_patch,
         join_patch,
-        open_patch,
         json_dump_patch,
-        json_load_patch,
         atomic_file_write_patch,
     ):
         generate_deployments_for_service.main()
@@ -185,46 +165,25 @@ def test_main():
         mappings_patch.assert_called_once_with(
             soa_dir='ABSOLUTE',
             service='fake_service',
-            old_mappings={'OLD_MAP': {'desired_state': 'start', 'docker_image': 'PINGS', 'force_bounce': None}},
         ),
 
         join_patch.assert_any_call('ABSOLUTE', 'fake_service', generate_deployments_for_service.TARGET_FILE),
-        assert join_patch.call_count == 2
+        assert join_patch.call_count == 1
 
         atomic_file_write_patch.assert_called_once_with('JOIN')
-        open_patch.assert_called_once_with('JOIN', 'r')
         json_dump_patch.assert_called_once_with(
             {
-                'v1': {
-                    'MAP': {'docker_image': 'PINGS', 'desired_state': 'start'}
-                },
-                'v2': mock.sentinel.v2_mappings,
+                'v2': mock.sentinel.mappings,
             },
             atomic_file_write_patch().__enter__(),
         )
-        json_load_patch.assert_called_once_with(file_mock.__enter__())
 
 
 def test_get_deployments_dict():
-    branch_mappings = {
-        'app1': {
-            'docker_image': 'image1',
-            'desired_state': 'start',
-            'force_bounce': '1418951213',
-        },
-        'app2': {
-            'docker_image': 'image2',
-            'desired_state': 'stop',
-            'force_bounce': '1412345678',
-        },
-    }
+    mappings = mock.sentinel.mappings
 
-    v2_mappings = mock.sentinel.v2_mappings
-
-    assert generate_deployments_for_service.get_deployments_dict_from_deploy_group_mappings(
-        branch_mappings, v2_mappings) == {
-        'v1': branch_mappings,
-        'v2': mock.sentinel.v2_mappings,
+    assert generate_deployments_for_service.get_deployments_dict_from_deploy_group_mappings(mappings) == {
+        'v2': mock.sentinel.mappings,
     }
 
 

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -88,7 +88,7 @@ class TestMarathonTools:
         fake_cluster = 'amnesia'
         fake_dir = '/nail/home/sanfran'
         with contextlib.nested(
-            mock.patch('paasta_tools.marathon_tools.load_v2_deployments_json', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.load_deployments_json', autospec=True),
             mock.patch('service_configuration_lib.read_service_configuration', autospec=True),
             mock.patch('service_configuration_lib.read_extra_service_information', autospec=True),
             mock.patch('paasta_tools.marathon_tools.deep_merge_dictionaries', autospec=True),
@@ -115,7 +115,7 @@ class TestMarathonTools:
         fake_cluster = 'amnesia'
         fake_dir = '/nail/home/sanfran'
         with contextlib.nested(
-            mock.patch('paasta_tools.marathon_tools.load_v2_deployments_json', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.load_deployments_json', autospec=True),
             mock.patch('service_configuration_lib.read_service_configuration', autospec=True),
             mock.patch('service_configuration_lib.read_extra_service_information', autospec=True),
         ) as (
@@ -198,7 +198,7 @@ class TestMarathonTools:
         },
         deployments_json_mock = mock.Mock(
             spec=DeploymentsJson,
-            get_branch_dict_v2=mock.Mock(return_value=fake_branch_dict),
+            get_branch_dict=mock.Mock(return_value=fake_branch_dict),
         )
 
         with contextlib.nested(
@@ -213,7 +213,7 @@ class TestMarathonTools:
                 return_value={fake_instance: config_copy},
             ),
             mock.patch(
-                'paasta_tools.marathon_tools.load_v2_deployments_json',
+                'paasta_tools.marathon_tools.load_deployments_json',
                 autospec=True,
                 return_value=deployments_json_mock,
             ),
@@ -244,7 +244,7 @@ class TestMarathonTools:
             assert expected.config_dict == actual.config_dict
             assert expected.branch_dict == actual.branch_dict
 
-            deployments_json_mock.get_branch_dict_v2.assert_called_once_with(fake_name, 'amnesia.solo', 'amnesia.solo')
+            deployments_json_mock.get_branch_dict.assert_called_once_with(fake_name, 'amnesia.solo', 'amnesia.solo')
             assert read_service_configuration_patch.call_count == 1
             read_service_configuration_patch.assert_any_call(fake_name, soa_dir=fake_dir)
             assert read_extra_info_patch.call_count == 1

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -88,7 +88,7 @@ class TestMarathonTools:
         fake_cluster = 'amnesia'
         fake_dir = '/nail/home/sanfran'
         with contextlib.nested(
-            mock.patch('paasta_tools.marathon_tools.load_deployments_json', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.load_v2_deployments_json', autospec=True),
             mock.patch('service_configuration_lib.read_service_configuration', autospec=True),
             mock.patch('service_configuration_lib.read_extra_service_information', autospec=True),
             mock.patch('paasta_tools.marathon_tools.deep_merge_dictionaries', autospec=True),
@@ -115,7 +115,7 @@ class TestMarathonTools:
         fake_cluster = 'amnesia'
         fake_dir = '/nail/home/sanfran'
         with contextlib.nested(
-            mock.patch('paasta_tools.marathon_tools.load_deployments_json', autospec=True),
+            mock.patch('paasta_tools.marathon_tools.load_v2_deployments_json', autospec=True),
             mock.patch('service_configuration_lib.read_service_configuration', autospec=True),
             mock.patch('service_configuration_lib.read_extra_service_information', autospec=True),
         ) as (
@@ -190,10 +190,15 @@ class TestMarathonTools:
         fake_docker = 'no_docker:9.9'
         config_copy = self.fake_marathon_app_config.config_dict.copy()
 
-        fake_branch_dict = {'desired_state': 'stop', 'force_bounce': '12345', 'docker_image': fake_docker},
+        fake_branch_dict = {
+            'desired_state': 'stop',
+            'force_bounce': '12345',
+            'docker_image': fake_docker,
+            'git_sha': mock.sentinel.get_sha,
+        },
         deployments_json_mock = mock.Mock(
             spec=DeploymentsJson,
-            get_branch_dict=mock.Mock(return_value=fake_branch_dict),
+            get_branch_dict_v2=mock.Mock(return_value=fake_branch_dict),
         )
 
         with contextlib.nested(
@@ -208,7 +213,7 @@ class TestMarathonTools:
                 return_value={fake_instance: config_copy},
             ),
             mock.patch(
-                'paasta_tools.marathon_tools.load_deployments_json',
+                'paasta_tools.marathon_tools.load_v2_deployments_json',
                 autospec=True,
                 return_value=deployments_json_mock,
             ),
@@ -239,7 +244,7 @@ class TestMarathonTools:
             assert expected.config_dict == actual.config_dict
             assert expected.branch_dict == actual.branch_dict
 
-            deployments_json_mock.get_branch_dict.assert_called_once_with(fake_name, 'amnesia.solo')
+            deployments_json_mock.get_branch_dict_v2.assert_called_once_with(fake_name, 'amnesia.solo', 'amnesia.solo')
             assert read_service_configuration_patch.call_count == 1
             read_service_configuration_patch.assert_any_call(fake_name, soa_dir=fake_dir)
             assert read_extra_info_patch.call_count == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1640,3 +1640,7 @@ def test_prompt_pick_one_exits_no_choices():
         mock_stdin.isatty.return_value = True
         with raises(SystemExit):
             utils.prompt_pick_one([], 'test')
+
+
+def test_decompose_paasta_control_branch():
+    assert utils.decompose_paasta_control_branch('service:cluster.instance') == ('service', 'cluster', 'instance')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -705,18 +705,6 @@ def test_DeploymentsJson_read():
     fake_dir = '/var/dir_of_fake'
     fake_path = '/var/dir_of_fake/fake_service/deployments.json'
     fake_json = {
-        'v1': {
-            'no_srv:blaster': {
-                'docker_image': 'test_rocker:9.9',
-                'desired_state': 'start',
-                'force_bounce': None,
-            },
-            'dont_care:about': {
-                'docker_image': 'this:guy',
-                'desired_state': 'stop',
-                'force_bounce': '12345',
-            },
-        },
         'v2': {
             'deployments': {
                 'blaster': {
@@ -749,14 +737,12 @@ def test_DeploymentsJson_read():
         json_patch,
         isfile_patch,
     ):
-        actual = utils.load_deployments_json('fake_service', fake_dir)
-        actual_v2 = utils.load_v2_deployments_json('fake_service', fake_dir)
+        actual = utils.load_v2_deployments_json('fake_service', fake_dir)
         open_patch.assert_called_with(fake_path)
         assert open_patch.call_count == 2
         json_patch.assert_called_with(file_mock.__enter__())
         assert json_patch.call_count == 2
-        assert actual == fake_json['v1']
-        assert actual_v2 == fake_json['v2']
+        assert actual == fake_json['v2']
 
 
 def test_get_docker_url_no_error():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -739,9 +739,9 @@ def test_DeploymentsJson_read():
     ):
         actual = utils.load_v2_deployments_json('fake_service', fake_dir)
         open_patch.assert_called_with(fake_path)
-        assert open_patch.call_count == 2
+        assert open_patch.call_count == 1
         json_patch.assert_called_with(file_mock.__enter__())
-        assert json_patch.call_count == 2
+        assert json_patch.call_count == 1
         assert actual == fake_json['v2']
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -717,6 +717,28 @@ def test_DeploymentsJson_read():
                 'force_bounce': '12345',
             },
         },
+        'v2': {
+            'deployments': {
+                'blaster': {
+                    'docker_image': 'test_rocker:9.9',
+                    'git_sha': 'asdf',
+                },
+                'about': {
+                    'docker_image': 'this:guy',
+                    'git_sha': 'hjkl',
+                },
+            },
+            'controls': {
+                'no_srv:blaster': {
+                    'desired_state': 'start',
+                    'force_bounce': None,
+                },
+                'dont_care:about': {
+                    'desired_state': 'stop',
+                    'force_bounce': '12345',
+                },
+            },
+        },
     }
     with contextlib.nested(
         mock.patch('paasta_tools.utils.open', create=True, return_value=file_mock, autospec=None),
@@ -728,9 +750,13 @@ def test_DeploymentsJson_read():
         isfile_patch,
     ):
         actual = utils.load_deployments_json('fake_service', fake_dir)
-        open_patch.assert_called_once_with(fake_path)
-        json_patch.assert_called_once_with(file_mock.__enter__())
+        actual_v2 = utils.load_v2_deployments_json('fake_service', fake_dir)
+        open_patch.assert_called_with(fake_path)
+        assert open_patch.call_count == 2
+        json_patch.assert_called_with(file_mock.__enter__())
+        assert json_patch.call_count == 2
         assert actual == fake_json['v1']
+        assert actual_v2 == fake_json['v2']
 
 
 def test_get_docker_url_no_error():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -737,7 +737,7 @@ def test_DeploymentsJson_read():
         json_patch,
         isfile_patch,
     ):
-        actual = utils.load_v2_deployments_json('fake_service', fake_dir)
+        actual = utils.load_deployments_json('fake_service', fake_dir)
         open_patch.assert_called_with(fake_path)
         assert open_patch.call_count == 1
         json_patch.assert_called_with(file_mock.__enter__())


### PR DESCRIPTION
This removes the v1 deployments json and make all of `paasta_tools` use the new v2 format.
