### PR TITLE
Update `makefile_responds_to` to handle common recursive Makefile pattern

### DIFF
--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -116,19 +116,18 @@ def docker_check():
 
 
 def makefile_responds_to(target):
-    """Runs `make -q <target>` to detect if a makefile responds to the
+    """Runs `make --dry-run <target>` to detect if a makefile responds to the
     specified target."""
-    cmd = 'make -q %s' % target
+    # `make -q` is commonly used to detect whether a Makefile responds to a specified target.
+    # However, this doesn't work when the Makefile includes the common pattern `$(MAKE) -c SOMETHING $(MFLAGS)`,
+    # and `SOMETHING/Makefile` needs to be updated; the `$(MAKE)` means that line executes even in question mode,
+    # and passing `$(MFLAGS)` (which includes `-q` in our case) means that the command causes a Make error even when successful.
+    cmd = 'make --dry-run %s' % target
     # Per the docs
     # http://www.gnu.org/software/make/manual/make.html#index-exit-status-of-make
-    # 0 and 1 are ok. 2 Means Error
-    # In question mode:
-    # http://linux.die.net/man/1/make (see Exit Status)
-    # 0 - Nothing to do
-    # 1 - Things to do
-    # 2 - Don't know what you are talking about
+    # 0 means OK, 2 means error
     returncode, _ = _run(cmd, timeout=5)
-    return returncode in [0, 1]
+    return returncode == 0
 
 
 def makefile_has_a_tab(makefile_path):

--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -118,14 +118,9 @@ def docker_check():
 def makefile_responds_to(target):
     """Runs `make --dry-run <target>` to detect if a makefile responds to the
     specified target."""
-    # `make -q` is commonly used to detect whether a Makefile responds to a specified target.
-    # However, this doesn't work when the Makefile includes the common pattern `$(MAKE) -c SOMETHING $(MFLAGS)`,
-    # and `SOMETHING/Makefile` needs to be updated; the `$(MAKE)` means that line executes even in question mode,
-    # and passing `$(MFLAGS)` (which includes `-q` in our case) means that the command causes a Make error even when successful.
     cmd = 'make --dry-run %s' % target
-    # Per the docs
-    # http://www.gnu.org/software/make/manual/make.html#index-exit-status-of-make
-    # 0 means OK, 2 means error
+    # According to http://www.gnu.org/software/make/manual/make.html#index-exit-status-of-make,
+    # 0 means OK, and 2 means error
     returncode, _ = _run(cmd, timeout=5)
     return returncode == 0
 

--- a/tests/cli/test_cmds_check.py
+++ b/tests/cli/test_cmds_check.py
@@ -351,7 +351,7 @@ def test_check_smartstack_check_is_ok_when_no_smartstack(mock_stdout, mock_is_fi
 
 @patch('paasta_tools.cli.cmds.check._run', autospec=True)
 def test_makefile_responds_to_good(mock_run):
-    mock_run.return_value = (1, 'Output')
+    mock_run.return_value = (0, 'Output')
     actual = makefile_responds_to('present-target')
     assert actual is True
 


### PR DESCRIPTION
`paasta check` uses the `makefile_responds_to` function to check if the Makefile responds to a given target. However, the way that function works sometimes gives false negatives - the check fails sometimes when the Makefile actually does respond to a given target.

When a Makefile includes `$(MAKE) -C SOME_DIR $(MFLAGS)` and `SOME_DIR/Makefile` is a makefile, that line gets executed even when we specify the `-q` flag - see https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html#MAKE-Variable.

Here, the `-q` flag is passed into the inner MAKE invocation via `$(MFLAGS)`, which causes the inner invocation to exit with 0 or 1 if successful. If the inner MAKE exits with 1, the original MAKE gives an error.

In other words, with this pattern, `make test`  works fine, but `make -q test` fails with Error 1.

To get around this, we can use `make --dry-run` instead of `make -q`. This ensures the Makefile is checked more like it would be if we were actually running make normally.