### PR TITLE
Install sphinxcontrib-programoutput from github

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 flake8==2.5.0
+git+git://github.com/lunaryorn/sphinxcontrib-programoutput@0.8#egg=package-two
 mock==1.0.1
 pep8==1.5.7
 pre-commit==0.7.6
@@ -7,4 +8,3 @@ pylint==1.6.4
 pytest==2.7.3
 pytest-cov==2.2.0
 sphinx==1.4.1
-sphinxcontrib-programoutput==0.8


### PR DESCRIPTION
This module seems to have disappeared from pypi...

This installs it from github for now. To keep the build passing.