### PR TITLE
Make check_chronos_jobs ignore fresh jobs

### DIFF
--- a/tests/test_check_chronos_jobs.py
+++ b/tests/test_check_chronos_jobs.py
@@ -130,7 +130,7 @@ def test_sensu_event_for_last_run_state_fail():
 
 def test_sensu_event_for_last_run_state_not_run():
     result = check_chronos_jobs.sensu_event_for_last_run_state(chronos_tools.LastRunState.NotRun)
-    assert result == pysensu_yelp.Status.OK
+    assert result is None
 
 
 def test_sensu_event_for_last_run_state_invalid():


### PR DESCRIPTION
We should not send OK for when a chronos job is "fresh". They are "fresh" all the time because we update the job all the time.

Instead this state means we just shouldn't send an event, because we don't have any information. We shouldn't report it as failing (we don't know that yet) nor should we send a resolve (as it hasn't actually run properly yet)

So I think the right thing to do is simply skip and move on until we have data.

There are a lot of ways to do this though, let me know if you don't like this approach.

Internal ticket PAASTA-6658