### PR TITLE
Revert "Revert "added support for adhoc jobs""

### DIFF
--- a/general_itests/fake_soa_configs_local_run/fake_simple_service/adhoc-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_local_run/fake_simple_service/adhoc-test-cluster.yaml
@@ -1,0 +1,7 @@
+---
+sample_adhoc_job:
+    cpus: .1
+    mem: 100
+    disk: 450
+    instances: 1
+    cmd: 'echo Hello && sleep 5 && exit 42'

--- a/general_itests/local_run.feature
+++ b/general_itests/local_run.feature
@@ -18,3 +18,9 @@ Feature: paasta local-run can be used
       And a simple service to test
      When we run paasta local-run in non-interactive mode on a chronos job with cmd set to 'echo hello && sleep 5'
      Then we should see the expected return code
+
+  Scenario: Running paasta local-run against an adhoc job
+     Given Docker is available
+       And a simple service to test
+      When we run paasta local-run on an interactive job
+      Then we should see the expected return code

--- a/general_itests/steps/local_run_steps.py
+++ b/general_itests/steps/local_run_steps.py
@@ -42,6 +42,7 @@ def non_interactive_local_run(context, var, val):
                         "--yelpsoa-config-root ../fake_soa_configs_local_run/ "
                         "--service fake_simple_service "
                         "--cluster test-cluster "
+                        "--instance main "
                         "--build "
                         '''--cmd '/bin/sh -c "echo \\"%s=$%s\\" && sleep 2s && exit 42"' ''' % (var, val))
         context.local_run_return_code, context.local_run_output = _run(command=localrun_cmd, timeout=60)
@@ -75,6 +76,18 @@ def local_run_on_chronos_job(context):
                          "--instance chronos_job "
                          "--build "
                          "--cmd '/bin/sh -c \"sleep 2s && exit 42\"'")
+        context.local_run_return_code, context.local_run_output = _run(command=local_run_cmd, timeout=60)
+
+
+@when(u'we run paasta local-run on an interactive job')
+def local_run_on_adhoc_job(context):
+    with Path("fake_simple_service"):
+        local_run_cmd = ("paasta local-run "
+                         "--yelpsoa-config-root ../fake_soa_configs_local_run/ "
+                         "--service fake_simple_service "
+                         "--cluster test-cluster "
+                         "--instance sample_adhoc_job "
+                         "--build ")
         context.local_run_return_code, context.local_run_output = _run(command=local_run_cmd, timeout=60)
 
 

--- a/paasta_tools/adhoc_tools.py
+++ b/paasta_tools/adhoc_tools.py
@@ -1,0 +1,109 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+import service_configuration_lib
+
+from paasta_tools.long_running_service_tools import LongRunningServiceConfig
+from paasta_tools.utils import deep_merge_dictionaries
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import get_paasta_branch
+from paasta_tools.utils import load_v2_deployments_json
+from paasta_tools.utils import NoConfigurationForServiceError
+from paasta_tools.utils import NoDeploymentsAvailable
+from paasta_tools.utils import prompt_pick_one
+
+
+log = logging.getLogger(__name__)
+
+
+def load_adhoc_job_config(service, instance, cluster, load_deployments=True, soa_dir=DEFAULT_SOA_DIR):
+    general_config = service_configuration_lib.read_service_configuration(
+        service,
+        soa_dir=soa_dir
+    )
+    adhoc_conf_file = "adhoc-%s" % cluster
+    log.info("Reading adhoc configuration file: %s.yaml", adhoc_conf_file)
+    instance_configs = service_configuration_lib.read_extra_service_information(
+        service_name=service,
+        extra_info=adhoc_conf_file,
+        soa_dir=soa_dir
+    )
+
+    if instance not in instance_configs:
+        raise NoConfigurationForServiceError(
+            "%s not found in config file %s/%s/%s.yaml." % (instance, soa_dir, service, adhoc_conf_file)
+        )
+
+    general_config = deep_merge_dictionaries(overrides=instance_configs[instance], defaults=general_config)
+
+    branch_dict = {}
+    if load_deployments:
+        deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
+        branch = general_config.get('branch', get_paasta_branch(cluster, instance))
+        deploy_group = general_config.get('deploy_group', branch)
+        branch_dict = deployments_json.get_branch_dict_v2(service, branch, deploy_group)
+
+    return AdhocJobConfig(
+        service=service,
+        cluster=cluster,
+        instance=instance,
+        config_dict=general_config,
+        branch_dict=branch_dict,
+    )
+
+
+class AdhocJobConfig(LongRunningServiceConfig):
+
+    def __init__(self, service, instance, cluster, config_dict, branch_dict):
+        super(AdhocJobConfig, self).__init__(
+            cluster=cluster,
+            instance=instance,
+            service=service,
+            config_dict=config_dict,
+            branch_dict=branch_dict,
+        )
+
+
+def get_default_interactive_config(service, cluster, soa_dir):
+    default_job_config = {
+        'cpus': 4,
+        'mem': 10240,
+        'disk': 1024
+    }
+
+    try:
+        job_config = load_adhoc_job_config(service=service, instance='interactive', cluster=cluster, soa_dir=soa_dir)
+    except NoConfigurationForServiceError:
+        job_config = AdhocJobConfig(
+            service=service,
+            instance='interactive',
+            cluster=cluster,
+            config_dict={},
+            branch_dict={},
+        )
+    except NoDeploymentsAvailable:
+        job_config = load_adhoc_job_config(
+            service=service, instance='interactive', cluster=cluster, soa_dir=soa_dir, load_deployments=False)
+
+    if not job_config.branch_dict:
+        deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
+        deploy_group = prompt_pick_one(deployments_json['deployments'].keys(), choosing='deploy group')
+        job_config.config_dict['deploy_group'] = deploy_group
+        job_config.branch_dict['docker_image'] = deployments_json.get_docker_image_for_deploy_group(deploy_group)
+
+    for key, value in default_job_config.items():
+        job_config.config_dict.setdefault(key, value)
+
+    return job_config

--- a/paasta_tools/chronos_rerun.py
+++ b/paasta_tools/chronos_rerun.py
@@ -27,6 +27,7 @@ import datetime
 
 from paasta_tools import chronos_tools
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import NoDockerImageError
 
@@ -174,7 +175,7 @@ def main():
             args.service_instance, cluster)
         print error_msg
         raise e
-    except chronos_tools.UnknownChronosJobError as e:
+    except NoConfigurationForServiceError as e:
         error_msg = (
             "Could not read chronos configuration file for %s in cluster %s\n" % (args.service_instance, cluster) +
             "Error was: %s" % str(e))

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -38,6 +38,7 @@ from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import timeout
@@ -150,10 +151,6 @@ class InvalidChronosConfigError(Exception):
     pass
 
 
-class UnknownChronosJobError(Exception):
-    pass
-
-
 def read_chronos_jobs_for_service(service, cluster, soa_dir=DEFAULT_SOA_DIR):
     chronos_conf_file = 'chronos-%s' % cluster
     log.info("Reading Chronos configuration file: %s/%s/chronos-%s.yaml" % (soa_dir, service, cluster))
@@ -168,7 +165,7 @@ def read_chronos_jobs_for_service(service, cluster, soa_dir=DEFAULT_SOA_DIR):
 def load_chronos_job_config(service, instance, cluster, load_deployments=True, soa_dir=DEFAULT_SOA_DIR):
     service_chronos_jobs = read_chronos_jobs_for_service(service, cluster, soa_dir=soa_dir)
     if instance not in service_chronos_jobs:
-        raise UnknownChronosJobError('No job named "%s" in config file chronos-%s.yaml' % (instance, cluster))
+        raise NoConfigurationForServiceError('No job named "%s" in config file chronos-%s.yaml' % (instance, cluster))
     branch_dict = {}
     if load_deployments:
         deployments_json = load_deployments_json(service, soa_dir=soa_dir)

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -29,18 +29,17 @@ import ephemeral_port_reserve
 import requests
 from docker import errors
 
+from paasta_tools.adhoc_tools import get_default_interactive_config
 from paasta_tools.chronos_tools import parse_time_variables
 from paasta_tools.cli.cmds.check import makefile_responds_to
 from paasta_tools.cli.cmds.cook_image import paasta_cook_image
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_instance_config
-from paasta_tools.cli.utils import guess_cluster
-from paasta_tools.cli.utils import guess_instance
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import list_services
+from paasta_tools.long_running_service_tools import get_healthcheck_for_instance
 from paasta_tools.marathon_tools import CONTAINER_PORT
-from paasta_tools.marathon_tools import get_healthcheck_for_instance
 from paasta_tools.paasta_execute_docker_command import execute_in_container
 from paasta_tools.utils import _run
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -49,6 +48,7 @@ from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_username
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import PaastaColors
@@ -265,7 +265,8 @@ def add_subparser(subparsers):
     ).completer = lazy_choices_completer(list_services)
     list_parser.add_argument(
         '-c', '--cluster',
-        help='The name of the cluster you wish to simulate. If omitted, attempts to guess a cluster to simulate',
+        help=("The name of the cluster you wish to simulate. "
+              "If omitted, uses the default cluster defined in the paasta local-run configs"),
     ).completer = lazy_choices_completer(list_clusters)
     list_parser.add_argument(
         '-y', '--yelpsoa-config-root',
@@ -318,7 +319,7 @@ def add_subparser(subparsers):
     )
     list_parser.add_argument(
         '-i', '--instance',
-        help='Simulate a docker run for a particular instance of the service, like "main" or "canary"',
+        help=("Simulate a docker run for a particular instance of the service, like 'main' or 'canary'"),
         required=False,
         default=None,
     ).completer = lazy_choices_completer(list_instances)
@@ -595,10 +596,15 @@ def command_function_for_framework(framework):
         interpolated_command = parse_time_variables(cmd, datetime.datetime.now())
         return interpolated_command
 
+    def format_adhoc_command(cmd):
+        return cmd
+
     if framework == 'chronos':
         return format_chronos_command
     elif framework == 'marathon':
         return format_marathon_command
+    elif framework == 'adhoc':
+        return format_adhoc_command
     else:
         raise ValueError("Invalid Framework")
 
@@ -609,6 +615,7 @@ def configure_and_run_docker_container(
         service,
         instance,
         cluster,
+        system_paasta_config,
         args,
         pull_image=False,
         dry_run=False
@@ -617,32 +624,33 @@ def configure_and_run_docker_container(
     Run Docker container by image hash with args set in command line.
     Function prints the output of run command in stdout.
     """
-    try:
-        system_paasta_config = load_system_paasta_config()
-    except PaastaNotConfiguredError:
-        sys.stdout.write(PaastaColors.yellow(
-            "Warning: Couldn't load config files from '/etc/paasta'. This indicates\n"
-            "PaaSTA is not configured locally on this host, and local-run may not behave\n"
-            "the same way it would behave on a server configured for PaaSTA.\n"
-        ))
-        system_paasta_config = SystemPaastaConfig({"volumes": []}, '/etc/paasta')
 
     soa_dir = args.yelpsoa_config_root
 
     volumes = list()
 
-    instance_type = validate_service_instance(service, instance, cluster, soa_dir)
-
     load_deployments = docker_hash is None or pull_image
 
+    interactive = args.interactive
+
     try:
-        instance_config = get_instance_config(
-            service=service,
-            instance=instance,
-            cluster=cluster,
-            load_deployments=load_deployments,
-            soa_dir=soa_dir,
-        )
+        if instance is None:
+            instance_type = 'adhoc'
+            instance = 'interactive'
+            instance_config = get_default_interactive_config(service=service, cluster=cluster, soa_dir=soa_dir)
+            interactive = True
+        else:
+            instance_type = validate_service_instance(service, instance, cluster, soa_dir)
+            instance_config = get_instance_config(
+                service=service,
+                instance=instance,
+                cluster=cluster,
+                load_deployments=load_deployments,
+                soa_dir=soa_dir,
+            )
+    except NoConfigurationForServiceError as e:
+        sys.stderr.write(str(e) + '\n')
+        return
     except NoDeploymentsAvailable:
         sys.stderr.write(PaastaColors.red(
             "Error: No deployments.json found in %(soa_dir)s/%(service)s.\n"
@@ -659,7 +667,7 @@ def configure_and_run_docker_container(
             sys.stderr.write(PaastaColors.red(
                 "Error: No sha has been marked for deployment for the %s deploy group.\n"
                 "Please ensure this service has either run through a jenkins pipeline "
-                "or paasta mark-for-deployment has been run for %s" % (instance_config.get_deploy_group(), service)))
+                "or paasta mark-for-deployment has been run for %s\n" % (instance_config.get_deploy_group(), service)))
             return
         docker_hash = docker_url
 
@@ -674,7 +682,7 @@ def configure_and_run_docker_container(
     for volume in system_paasta_config.get_volumes() + extra_volumes:
         volumes.append('%s:%s:%s' % (volume['hostPath'], volume['containerPath'], volume['mode'].lower()))
 
-    if args.interactive is True and args.cmd is None:
+    if interactive is True and args.cmd is None:
         command = ['bash']
     elif args.cmd:
         command = shlex.split(args.cmd, posix=False)
@@ -694,7 +702,7 @@ def configure_and_run_docker_container(
         instance=instance,
         docker_hash=docker_hash,
         volumes=volumes,
-        interactive=args.interactive,
+        interactive=interactive,
         command=command,
         hostname=hostname,
         healthcheck=args.healthcheck,
@@ -712,9 +720,30 @@ def paasta_local_run(args):
         sys.stderr.write("If you meant to pull the docker image from the registry, explicitly pass --pull\n")
         return 1
 
+    try:
+        system_paasta_config = load_system_paasta_config()
+    except PaastaNotConfiguredError:
+        sys.stdout.write(PaastaColors.yellow(
+            "Warning: Couldn't load config files from '/etc/paasta'. This indicates\n"
+            "PaaSTA is not configured locally on this host, and local-run may not behave\n"
+            "the same way it would behave on a server configured for PaaSTA.\n"
+        ))
+        system_paasta_config = SystemPaastaConfig({"volumes": []}, '/etc/paasta')
+
+    local_run_config = system_paasta_config.get_local_run_config()
+
     service = figure_out_service_name(args, soa_dir=args.yelpsoa_config_root)
-    cluster = guess_cluster(service=service, args=args)
-    instance = guess_instance(service=service, cluster=cluster, args=args)
+    if args.cluster:
+        cluster = args.cluster
+    else:
+        try:
+            cluster = local_run_config['default_cluster']
+        except KeyError:
+            sys.stderr.write(PaastaColors.red(
+                "PaaSTA on this machine has not been configured with a default cluster.\n"
+                "Please pass one to local-run using '-c'.\n"))
+            return 1
+    instance = args.instance
     docker_client = get_docker_client()
 
     if args.action == 'build':
@@ -741,6 +770,7 @@ def paasta_local_run(args):
             cluster=cluster,
             args=args,
             pull_image=pull_image,
+            system_paasta_config=system_paasta_config,
             dry_run=args.action == 'dry_run',
         )
     except errors.APIError as e:

--- a/paasta_tools/cli/cmds/rerun.py
+++ b/paasta_tools/cli/cmds/rerun.py
@@ -26,6 +26,7 @@ from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import SPACER
 
@@ -139,7 +140,7 @@ def paasta_rerun(args):
                 print ("  Warning: \"%s\" uses time variables interpolation, "
                        "please supply a `--execution_date` argument." % args.instance)
                 continue
-        except chronos_tools.UnknownChronosJobError as e:
+        except NoConfigurationForServiceError as e:
             print "  Warning: %s" % e.message
             continue
         if execution_date is None:

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -132,7 +132,7 @@ def validate_all_schemas(service_path):
         if os.path.islink(file_name):
             continue
         basename = os.path.basename(file_name)
-        for file_type in ['chronos', 'marathon']:
+        for file_type in ['chronos', 'marathon', 'adhoc']:
             if basename.startswith(file_type):
                 if not validate_schema(file_name, file_type):
                     returncode = False

--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -1,0 +1,90 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html#adhoc-clustername-yaml",
+    "type": "object",
+    "minProperties": 1,
+    "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "minProperties": 1,
+        "properties": {
+            "cpus": {
+                "type": "number",
+                "minimum": 0,
+                "exclusiveMinimum": true,
+                "default": 1
+            },
+            "mem": {
+                "type": "number",
+                "minimum": 0,
+                "exclusiveMinimum": true,
+                "default": 1024
+            },
+            "disk": {
+                "type": "number",
+                "minimum": 0,
+                "exclusiveMinimum": true,
+                "default": 1024
+            },
+            "cmd": {
+                "type": "string"
+            },
+            "args": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "env": {
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+            },
+            "extra_volumes": {
+                "type": "array",
+                "items": {
+                    "type": "object"
+                },
+                "uniqueItems": true
+            },
+            "deploy_group": {
+                "type": "string"
+            },
+            "net": {
+                "type": "string"
+            },
+            "ulimit": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                        "soft": {
+                            "type": "number"
+                        },
+                        "hard": {
+                            "type": "number"
+                        }
+                    },
+                    "required": ["soft"],
+                    "additionalProperties": false
+                }
+            },
+            "cap_add": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "cfs_period_us": {
+                "type": "integer",
+                "minimum": "1000",
+                "maximum": "1000000",
+                "exclusiveMinimum": false
+            },
+            "cpu_burst_pct": {
+                "type": "integer",
+                "minimum": "0",
+                "exclusiveMinimum": false
+            }
+        }
+    }
+}

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -26,6 +26,7 @@ from bravado.exception import HTTPError
 from bravado.exception import HTTPNotFound
 from service_configuration_lib import read_services_configuration
 
+from paasta_tools.adhoc_tools import load_adhoc_job_config
 from paasta_tools.api import client
 from paasta_tools.chronos_tools import load_chronos_job_config
 from paasta_tools.marathon_tools import load_marathon_service_config
@@ -33,11 +34,9 @@ from paasta_tools.monitoring_tools import _load_sensu_team_data
 from paasta_tools.utils import _run
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
-from paasta_tools.utils import get_default_cluster_for_service
 from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import list_all_instances_for_service
 from paasta_tools.utils import list_clusters
-from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import validate_service_instance
 
@@ -306,44 +305,6 @@ def guess_service_name():
     :return : A string representing the service name
     """
     return os.path.basename(os.getcwd())
-
-
-def guess_instance(service, cluster, args):
-    """Returns instance from args if available, otherwise uses 'main' if it is a valid instance,
-    otherwise takes a good guess and returns the first instance available"""
-    if args.instance:
-        instance = args.instance
-    else:
-        try:
-            instances = list_all_instances_for_service(
-                service=service, clusters=[cluster], instance_type=None, soa_dir=args.yelpsoa_config_root)
-            if 'main' in instances:
-                instance = 'main'
-            else:
-                instance = list(instances)[0]
-        except NoConfigurationForServiceError:
-            sys.stderr.write(PaastaColors.red(
-                'Could not automatically detect instance to emulate. Please specify one with the --instance option.\n'))
-            sys.exit(2)
-        sys.stderr.write(PaastaColors.yellow(
-            'Guessing instance configuration for %s. To override, use the --instance option.\n' % instance))
-    return instance
-
-
-def guess_cluster(service, args):
-    """Returns the cluster from args if available, otherwise uses the "default" one"""
-    if args.cluster:
-        cluster = args.cluster
-    else:
-        try:
-            cluster = get_default_cluster_for_service(service, soa_dir=args.yelpsoa_config_root)
-        except NoConfigurationForServiceError:
-            sys.stderr.write(PaastaColors.red(
-                'Could not automatically detect cluster to emulate. Please specify one with the --cluster option.\n'))
-            sys.exit(2)
-        sys.stderr.write(PaastaColors.yellow(
-            'Guessing cluster configuration for %s. To override, use the --cluster option.\n' % cluster))
-    return cluster
 
 
 def validate_service_name(service, soa_dir=DEFAULT_SOA_DIR):
@@ -643,6 +604,8 @@ def get_instance_config(service, instance, cluster, soa_dir, load_deployments=Fa
         instance_config_load_function = load_marathon_service_config
     elif instance_type == 'chronos':
         instance_config_load_function = load_chronos_job_config
+    elif instance_type == 'adhoc':
+        instance_config_load_function = load_adhoc_job_config
     else:
         raise NotImplementedError(
             "instance is %s of type %s which is not supported by paasta"
@@ -790,6 +753,19 @@ def get_instance_configs_for_service(service, soa_dir):
             soa_dir=soa_dir,
         ):
             yield load_chronos_job_config(
+                service=service,
+                instance=instance,
+                cluster=cluster,
+                soa_dir=soa_dir,
+                load_deployments=False,
+            )
+        for _, instance in get_service_instance_list(
+            service=service,
+            cluster=cluster,
+            instance_type='adhoc',
+            soa_dir=soa_dir,
+        ):
+            yield load_adhoc_job_config(
                 service=service,
                 instance=instance,
                 cluster=cluster,

--- a/paasta_tools/setup_chronos_job.py
+++ b/paasta_tools/setup_chronos_job.py
@@ -51,6 +51,7 @@ from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import SPACER
@@ -90,7 +91,7 @@ def send_event(service, instance, soa_dir, status, output):
             cluster=cluster,
             soa_dir=soa_dir,
         ).get_monitoring()
-    except chronos_tools.UnknownChronosJobError:
+    except NoConfigurationForServiceError:
         monitoring_overrides = {}
     # In order to let sensu know how often to expect this check to fire,
     # we need to set the ``check_every`` to the frequency of our cron job, which
@@ -192,7 +193,7 @@ def main():
         )
         log.error(error_msg)
         sys.exit(0)
-    except chronos_tools.UnknownChronosJobError as e:
+    except NoConfigurationForServiceError as e:
         error_msg = (
             "Could not read chronos configuration file for %s in cluster %s\n" % (args.service_instance, cluster) +
             "Error was: %s" % str(e))

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -40,6 +40,7 @@ from subprocess import PIPE
 from subprocess import Popen
 from subprocess import STDOUT
 
+import choice
 import dateutil.tz
 import requests_cache
 import service_configuration_lib
@@ -79,7 +80,7 @@ DEFAULT_CPU_BURST_PCT = 900
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
-INSTANCE_TYPES = ('marathon', 'chronos', 'paasta_native')
+INSTANCE_TYPES = ('marathon', 'chronos', 'paasta_native', 'adhoc')
 
 
 class InvalidInstanceConfig(Exception):
@@ -391,9 +392,9 @@ def validate_service_instance(service, instance, cluster, soa_dir):
         if (service, instance) in services:
             return instance_type
     else:
-        print ("Error: %s doesn't look like it has been deployed to this cluster! (%s)"
-               % (compose_job_id(service, instance), cluster))
-        sys.exit(3)
+        raise NoConfigurationForServiceError(
+            "Error: %s doesn't look like it has been deployed to this cluster! (%s)" % (
+                compose_job_id(service, instance), cluster))
 
 
 def compose(func_one, func_two):
@@ -947,19 +948,19 @@ class SystemPaastaConfig(dict):
         """Get the chronos config
 
         :returns: The chronos config dictionary"""
-        try:
-            return self['chronos_config']
-        except KeyError:
-            return {}
+        return self.get('chronos_config', {})
 
     def get_marathon_config(self):
         """Get the marathon config
 
         :returns: The marathon config dictionary"""
-        try:
-            return self['marathon_config']
-        except KeyError:
-            return {}
+        return self.get('marathon_config', {})
+
+    def get_local_run_config(self):
+        """Get the local-run config
+
+        :returns: The local-run job config dictionary"""
+        return self.get('local_run_config', {})
 
     def get_paasta_native_config(self):
         return self.get('paasta_native', {})
@@ -1195,19 +1196,6 @@ def get_username():
     return os.environ.get('SUDO_USER', pwd.getpwuid(os.getuid())[0])
 
 
-def get_default_cluster_for_service(service, soa_dir=DEFAULT_SOA_DIR):
-    cluster = None
-    try:
-        cluster = load_system_paasta_config().get_cluster()
-    except PaastaNotConfiguredError:
-        clusters_deployed_to = list_clusters(service, soa_dir=soa_dir)
-        if len(clusters_deployed_to) > 0:
-            cluster = clusters_deployed_to[0]
-        else:
-            raise NoConfigurationForServiceError("No cluster configuration found for service %s" % service)
-    return cluster
-
-
 def get_soa_cluster_deploy_files(service=None, soa_dir=DEFAULT_SOA_DIR, instance_type=None):
     if service is None:
         service = '*'
@@ -1402,6 +1390,16 @@ class DeploymentsJson(dict):
         full_branch = '%s:paasta-%s' % (service, branch)
         return self.get(full_branch, {})
 
+    def get_branch_dict_v2(self, service, branch, deploy_group):
+        full_branch = '%s:%s' % (service, branch)
+        branch_dict = {
+            'docker_image': self.get_docker_image_for_deploy_group(deploy_group),
+            'git_sha': self.get_git_sha_for_deploy_group(deploy_group),
+            'desired_state': self.get_desired_state_for_branch(full_branch),
+            'force_bounce': self.get_force_bounce_for_branch(full_branch),
+        }
+        return branch_dict
+
     def get_docker_image_for_deploy_group(self, deploy_group):
         try:
             return self['deployments'][deploy_group]['docker_image']
@@ -1415,10 +1413,16 @@ class DeploymentsJson(dict):
             raise NoDeploymentsAvailable
 
     def get_desired_state_for_branch(self, control_branch):
-        return self['controls'][control_branch].get('desired_state', 'start')
+        try:
+            return self['controls'][control_branch].get('desired_state', 'start')
+        except KeyError:
+            raise NoDeploymentsAvailable
 
     def get_force_bounce_for_branch(self, control_branch):
-        return self['controls'][control_branch].get('force_bounce', None)
+        try:
+            return self['controls'][control_branch].get('force_bounce', None)
+        except KeyError:
+            raise NoDeploymentsAvailable
 
 
 def get_paasta_branch(cluster, instance):
@@ -1657,3 +1661,27 @@ def mean(iterable):
     Returns the average value of an iterable
     """
     return sum(iterable) / len(iterable)
+
+
+def prompt_pick_one(sequence, choosing):
+    if not sys.stdin.isatty():
+        sys.stderr.write('No {choosing} specified and no TTY present to ask.'
+                         ' Please specify a {choosing} using the cli.\n'.format(choosing=choosing))
+        sys.exit(1)
+
+    QUIT_ACTION = 'Quit'
+    global_actions = [QUIT_ACTION]
+    choices = [(item, item) for item in sequence]
+
+    chooser = choice.Menu(choices, global_actions=global_actions)
+    chooser.title = 'Please pick a {choosing} from the choices below:'.format(choosing=choosing)
+    try:
+        result = chooser.ask()
+    except KeyboardInterrupt:
+        sys.stdout.write('\n')
+        sys.exit(1)
+
+    if isinstance(result, tuple) and result[1] == QUIT_ACTION:
+        sys.exit(1)
+    else:
+        return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ backports.ssl-match-hostname==3.4.0.2
 blessings==1.6
 boto3==1.3.0
 bravado==8.4.0
+choice==0.1
 chronos-python==0.37.0
 cookiecutter==1.4.0
 cryptography==1.4

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         # libs and pip can't seem to override it
         'argparse == 1.2.1',
         'bravado == 8.4.0',
+        'choice == 0.1',
         'chronos-python == 0.37.0',
         'cookiecutter == 1.4.0',
         'cryptography == 1.4',

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import contextlib
 import json
 import pipes
 import shlex
@@ -19,6 +20,7 @@ import docker
 import mock
 from pytest import raises
 
+from paasta_tools.adhoc_tools import AdhocJobConfig
 from paasta_tools.cli.cli import main
 from paasta_tools.cli.cmds.local_run import command_function_for_framework
 from paasta_tools.cli.cmds.local_run import configure_and_run_docker_container
@@ -36,6 +38,7 @@ from paasta_tools.cli.cmds.local_run import run_healthcheck_on_container
 from paasta_tools.cli.cmds.local_run import simulate_healthcheck_on_service
 from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.utils import InstanceConfig
+from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import TimeoutError
 
@@ -304,23 +307,21 @@ def test_get_container_name(mock_get_username, mock_randint):
 
 @mock.patch('paasta_tools.cli.cmds.local_run.socket.getfqdn', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True)
-@mock.patch('paasta_tools.cli.cmds.local_run.load_system_paasta_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.get_instance_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.validate_service_instance', autospec=True)
 def test_configure_and_run_command_uses_cmd_from_config(
     mock_validate_service_instance,
     mock_get_instance_config,
-    mock_load_system_paasta_config,
     mock_run_docker_container,
     mock_socket_getfqdn,
 ):
     mock_validate_service_instance.return_value = 'marathon'
-    mock_load_system_paasta_config.return_value = SystemPaastaConfig(
-        {'cluster': 'fake_cluster', 'volumes': []}, '/fake_dir/')
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)
     mock_get_instance_config.return_value.get_cmd.return_value = 'fake_command'
     mock_socket_getfqdn.return_value = 'fake_hostname'
 
+    mock_system_paasta_config = SystemPaastaConfig(
+        {'cluster': 'fake_cluster', 'volumes': []}, '/fake_dir/')
     fake_service = 'fake_service'
     docker_hash = '8' * 40
     args = mock.MagicMock()
@@ -338,6 +339,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
         service=fake_service,
         instance='fake_instance',
         cluster='fake_cluster',
+        system_paasta_config=mock_system_paasta_config,
         args=args,
     ) is None
     mock_run_docker_container.assert_called_once_with(
@@ -360,22 +362,20 @@ def test_configure_and_run_command_uses_cmd_from_config(
 
 @mock.patch('paasta_tools.cli.cmds.local_run.socket.getfqdn', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True)
-@mock.patch('paasta_tools.cli.cmds.local_run.load_system_paasta_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.get_instance_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.validate_service_instance', autospec=True)
 def test_configure_and_run_uses_bash_by_default_when_interactive(
     mock_validate_service_instance,
     mock_get_instance_config,
-    mock_load_system_paasta_config,
     mock_run_docker_container,
     mock_socket_getfqdn,
 ):
     mock_validate_service_instance.return_value = 'marathon'
-    mock_load_system_paasta_config.return_value = SystemPaastaConfig(
-        {'cluster': 'fake_cluster', 'volumes': []}, '/fake_dir/')
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)
     mock_socket_getfqdn.return_value = 'fake_hostname'
 
+    mock_system_paasta_config = SystemPaastaConfig(
+        {'cluster': 'fake_cluster', 'volumes': []}, '/fake_dir/')
     fake_service = 'fake_service'
     docker_hash = '8' * 40
     args = mock.MagicMock()
@@ -393,6 +393,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
         service=fake_service,
         instance='fake_instance',
         cluster='fake_cluster',
+        system_paasta_config=mock_system_paasta_config,
         args=args,
     ) is None
     mock_run_docker_container.assert_called_once_with(
@@ -416,23 +417,21 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
 @mock.patch('paasta_tools.cli.cmds.local_run.socket.getfqdn', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.docker_pull_image', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True)
-@mock.patch('paasta_tools.cli.cmds.local_run.load_system_paasta_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.get_instance_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.validate_service_instance', autospec=True)
 def test_configure_and_run_pulls_image_when_asked(
     mock_validate_service_instance,
     mock_get_instance_config,
-    mock_load_system_paasta_config,
     mock_run_docker_container,
     mock_docker_pull_image,
     mock_socket_getfqdn,
 ):
     mock_validate_service_instance.return_value = 'marathon'
-    mock_load_system_paasta_config.return_value = SystemPaastaConfig(
-        {'cluster': 'fake_cluster', 'volumes': [], 'docker_registry': 'fake_registry'}, '/fake_dir/')
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)
     mock_socket_getfqdn.return_value = 'fake_hostname'
 
+    mock_system_paasta_config = SystemPaastaConfig(
+        {'cluster': 'fake_cluster', 'volumes': [], 'docker_registry': 'fake_registry'}, '/fake_dir/')
     fake_instance_config = mock.MagicMock(InstanceConfig)
     fake_instance_config.get_docker_image.return_value = 'fake_image'
     mock_get_instance_config.return_value = fake_instance_config
@@ -453,6 +452,7 @@ def test_configure_and_run_pulls_image_when_asked(
         instance='fake_instance',
         cluster='fake_cluster',
         args=args,
+        system_paasta_config=mock_system_paasta_config,
         pull_image=True,
     ) is None
     mock_docker_pull_image.assert_called_once_with('fake_registry/fake_image')
@@ -472,6 +472,61 @@ def test_configure_and_run_pulls_image_when_asked(
         dry_run=False,
         json_dict=False,
     )
+
+
+def test_configure_and_run_docker_container_defaults_to_interactive_instance():
+    with contextlib.nested(
+        mock.patch('paasta_tools.cli.cmds.local_run.validate_service_instance', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.local_run.socket.getfqdn', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.local_run.get_default_interactive_config', autospec=True),
+    ) as (
+        mock_validate_service_instance,
+        mock_socket_get_fqdn,
+        mock_run_docker_container,
+        mock_get_default_interactive_config,
+    ):
+        mock_validate_service_instance.side_effect = NoConfigurationForServiceError
+        mock_docker_client = mock.MagicMock(spec_set=docker.Client)
+        mock_socket_get_fqdn.return_value = 'fake_hostname'
+
+        mock_system_paasta_config = SystemPaastaConfig(
+            {'cluster': 'fake_cluster', 'volumes': [], 'docker_registry': 'fake_registry'}, '/fake_dir/')
+        args = mock.MagicMock()
+        args.cmd = None
+        args.service = 'fake_service'
+        args.healthcheck = False
+        args.healthcheck_only = False
+        args.interactive = False
+        args.dry_run_json_dict = False
+
+        mock_config = mock.create_autospec(AdhocJobConfig)
+        mock_get_default_interactive_config.return_value = mock_config
+        assert configure_and_run_docker_container(
+            docker_client=mock_docker_client,
+            docker_hash='fake_hash',
+            service='fake_service',
+            instance=None,
+            cluster='fake_cluster',
+            args=args,
+            system_paasta_config=mock_system_paasta_config,
+        ) is None
+        mock_run_docker_container.assert_called_once_with(
+            docker_client=mock_docker_client,
+            service='fake_service',
+            instance='interactive',
+            docker_hash='fake_hash',
+            volumes=[],
+            interactive=True,
+            command=['bash'],
+            hostname='fake_hostname',
+            healthcheck=args.healthcheck,
+            healthcheck_only=args.healthcheck_only,
+            instance_config=mock_config,
+            soa_dir=args.yelpsoa_config_root,
+            dry_run=False,
+            json_dict=False,
+        )
 
 
 @mock.patch('paasta_tools.cli.cmds.local_run.figure_out_service_name', autospec=True)

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -24,7 +24,6 @@ from pytest import raises
 
 from paasta_tools.cli import utils
 from paasta_tools.marathon_tools import MarathonServiceConfig
-from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import SystemPaastaConfig
 
 
@@ -493,79 +492,6 @@ def test_list_teams():
 def test_lazy_choices_completer():
     completer = utils.lazy_choices_completer(lambda: ['1', '2', '3'])
     assert completer(prefix='') == ['1', '2', '3']
-
-
-def test_guess_cluster_uses_provided_cluster():
-    args = mock.MagicMock()
-    args.cluster = 'fake_cluster'
-    actual = utils.guess_cluster(service='fake_service', args=args)
-    assert actual == 'fake_cluster'
-
-
-@mock.patch('paasta_tools.cli.utils.get_default_cluster_for_service', autospec=True)
-def test_guess_cluster_when_missing_cluster_exception(
-    mock_get_default_cluster_for_service,
-):
-    mock_get_default_cluster_for_service.side_effect = NoConfigurationForServiceError()
-    fake_service = 'fake_service'
-    args = mock.MagicMock()
-    args.service = fake_service
-    args.instance = 'fake_instance'
-    args.cluster = None
-    with raises(SystemExit) as excinfo:
-        utils.guess_cluster(
-            service=fake_service,
-            args=args,
-        )
-    assert excinfo.value.code == 2
-
-
-def test_guess_instance_uses_provided_cluster():
-    args = mock.MagicMock()
-    args.instance = 'fake_instance1'
-    actual = utils.guess_instance(service='fake_service', cluster=None, args=args)
-    assert actual == 'fake_instance1'
-
-
-@mock.patch('paasta_tools.cli.utils.list_all_instances_for_service', autospec=True)
-def test_guess_instances_uses_main_if_available(
-    mock_list_all_instances_for_service,
-):
-    mock_list_all_instances_for_service.return_value = ['a', 'b', 'main', 'c']
-    args = mock.MagicMock()
-    args.instance = None
-    actual = utils.guess_instance(service='fake_service', cluster=None, args=args)
-    assert actual == 'main'
-
-
-@mock.patch('paasta_tools.cli.utils.list_all_instances_for_service', autospec=True)
-def test_guess_instances_picks_something(
-    mock_list_all_instances_for_service,
-):
-    mock_list_all_instances_for_service.return_value = ['a', 'b', 'c']
-    args = mock.MagicMock()
-    args.instance = None
-    actual = utils.guess_instance(service='fake_service', cluster=None, args=args)
-    assert actual in ['a', 'b', 'c']
-
-
-@mock.patch('paasta_tools.cli.utils.list_all_instances_for_service', autospec=True)
-def test_guess_instance_fails_when_instance_is_not_provided(
-    mock_list_all_instances_for_service,
-):
-    mock_list_all_instances_for_service.side_effect = NoConfigurationForServiceError()
-    fake_service = 'fake_service'
-    args = mock.MagicMock()
-    args.service = fake_service
-    args.cluster = None
-    args.instance = None
-    with raises(SystemExit) as excinfo:
-        utils.guess_instance(
-            service=fake_service,
-            cluster=None,
-            args=args,
-        )
-    assert excinfo.value.code == 2
 
 
 def test_modules_in_pkg():

--- a/tests/test_adhoc_tools.py
+++ b/tests/test_adhoc_tools.py
@@ -1,0 +1,63 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import contextlib
+
+import mock
+
+from paasta_tools import adhoc_tools
+from paasta_tools.utils import DeploymentsJson
+from paasta_tools.utils import NoConfigurationForServiceError
+
+
+def test_get_default_interactive_config():
+    with contextlib.nested(
+        mock.patch('paasta_tools.adhoc_tools.load_adhoc_job_config', autospec=True),
+    ) as (
+        mock_load_adhoc_job_config,
+    ):
+        mock_load_adhoc_job_config.return_value = adhoc_tools.AdhocJobConfig(
+            service='fake_service',
+            instance='interactive',
+            cluster='fake_cluster',
+            config_dict={},
+            branch_dict={'deploy_group': 'fake_deploy_group'},
+        )
+        result = adhoc_tools.get_default_interactive_config('fake_serivce', 'fake_cluster', '/fake/soa/dir')
+        assert result.get_cpus() == 4
+        assert result.get_mem() == 10240
+        assert result.get_disk() == 1024
+
+
+def test_get_default_interactive_config_reads_from_tty():
+    with contextlib.nested(
+        mock.patch('paasta_tools.adhoc_tools.prompt_pick_one', autospec=True),
+        mock.patch('paasta_tools.adhoc_tools.load_adhoc_job_config', autospec=True),
+        mock.patch('paasta_tools.adhoc_tools.load_v2_deployments_json', autospec=True),
+    ) as (
+        mock_prompt_pick_one,
+        mock_load_adhoc_job_config,
+        mock_load_deployments_json,
+    ):
+        mock_prompt_pick_one.return_value = 'fake_deploygroup'
+        mock_load_adhoc_job_config.side_effect = NoConfigurationForServiceError
+        mock_load_deployments_json.return_value = DeploymentsJson({
+            'deployments': {
+                'fake_deploygroup': {
+                    'docker_image': mock.sentinel.docker_image,
+                },
+            },
+        })
+        result = adhoc_tools.get_default_interactive_config('fake_serivce', 'fake_cluster', '/fake/soa/dir')
+        assert result.get_deploy_group() == 'fake_deploygroup'
+        assert result.get_docker_image() == mock.sentinel.docker_image

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -20,6 +20,7 @@ from mock import Mock
 from pytest import raises
 
 from paasta_tools import chronos_tools
+from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import SystemPaastaConfig
 
 
@@ -224,7 +225,7 @@ class TestChronosTools:
             mock_read_chronos_jobs_for_service,
         ):
             mock_read_chronos_jobs_for_service.return_value = []
-            with raises(chronos_tools.UnknownChronosJobError) as exc:
+            with raises(NoConfigurationForServiceError) as exc:
                 chronos_tools.load_chronos_job_config(service='fake_service',
                                                       instance='fake_job',
                                                       cluster='fake_cluster',

--- a/tests/test_long_running_service_tools.py
+++ b/tests/test_long_running_service_tools.py
@@ -1,0 +1,224 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import contextlib
+
+import mock
+from pytest import raises
+
+from paasta_tools import long_running_service_tools
+from paasta_tools.utils import InvalidInstanceConfig
+
+
+class TestLongRunningServiceConfig(object):
+
+    def test_get_healthcheck_cmd_happy(self):
+        fake_conf = long_running_service_tools.LongRunningServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'healthcheck_cmd': 'test_cmd'},
+            branch_dict={},
+        )
+        actual = fake_conf.get_healthcheck_cmd()
+        assert actual == 'test_cmd'
+
+    def test_get_healthcheck_cmd_raises_when_unset(self):
+        fake_conf = long_running_service_tools.LongRunningServiceConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={},
+            branch_dict={},
+        )
+        with raises(InvalidInstanceConfig) as exc:
+            fake_conf.get_healthcheck_cmd()
+        assert "healthcheck mode 'cmd' requires a healthcheck_cmd to run" in str(exc.value)
+
+    def test_get_healthcheck_for_instance_http(self):
+        fake_service = 'fake_service'
+        fake_namespace = 'fake_namespace'
+        fake_hostname = 'fake_hostname'
+        fake_random_port = 666
+
+        fake_path = '/fake_path'
+        fake_service_config = long_running_service_tools.LongRunningServiceConfig(
+            service=fake_service,
+            cluster='fake_cluster',
+            instance=fake_namespace,
+            config_dict={},
+            branch_dict={},
+        )
+        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({
+            'mode': 'http',
+            'healthcheck_uri': fake_path,
+        })
+        with contextlib.nested(
+            mock.patch('paasta_tools.long_running_service_tools.load_service_namespace_config',
+                       autospec=True,
+                       return_value=fake_service_namespace_config),
+            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
+        ) as (
+            load_service_namespace_config_patch,
+            hostname_patch
+        ):
+            expected = ('http', 'http://%s:%d%s' % (fake_hostname, fake_random_port, fake_path))
+            actual = long_running_service_tools.get_healthcheck_for_instance(
+                fake_service, fake_namespace, fake_service_config, fake_random_port)
+            assert expected == actual
+
+    def test_get_healthcheck_for_instance_tcp(self):
+        fake_service = 'fake_service'
+        fake_namespace = 'fake_namespace'
+        fake_hostname = 'fake_hostname'
+        fake_random_port = 666
+
+        fake_service_config = long_running_service_tools.LongRunningServiceConfig(
+            service=fake_service,
+            cluster='fake_cluster',
+            instance=fake_namespace,
+            config_dict={},
+            branch_dict={},
+        )
+        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({
+            'mode': 'tcp',
+        })
+        with contextlib.nested(
+            mock.patch('paasta_tools.long_running_service_tools.load_service_namespace_config',
+                       autospec=True,
+                       return_value=fake_service_namespace_config),
+            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
+        ) as (
+            load_service_namespace_config_patch,
+            hostname_patch
+        ):
+            expected = ('tcp', 'tcp://%s:%d' % (fake_hostname, fake_random_port))
+            actual = long_running_service_tools.get_healthcheck_for_instance(
+                fake_service, fake_namespace, fake_service_config, fake_random_port)
+            assert expected == actual
+
+    def test_get_healthcheck_for_instance_cmd(self):
+        fake_service = 'fake_service'
+        fake_namespace = 'fake_namespace'
+        fake_hostname = 'fake_hostname'
+        fake_random_port = 666
+        fake_cmd = '/bin/fake_command'
+        fake_service_config = long_running_service_tools.LongRunningServiceConfig(
+            service=fake_service,
+            cluster='fake_cluster',
+            instance=fake_namespace,
+            config_dict={
+                'healthcheck_mode': 'cmd',
+                'healthcheck_cmd': fake_cmd
+            },
+            branch_dict={},
+        )
+        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
+        with contextlib.nested(
+            mock.patch('paasta_tools.long_running_service_tools.load_service_namespace_config',
+                       autospec=True,
+                       return_value=fake_service_namespace_config),
+            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
+        ) as (
+            load_service_namespace_config_patch,
+            hostname_patch
+        ):
+            expected = ('cmd', fake_cmd)
+            actual = long_running_service_tools.get_healthcheck_for_instance(
+                fake_service, fake_namespace, fake_service_config, fake_random_port)
+            assert expected == actual
+
+    def test_get_healthcheck_for_instance_other(self):
+        fake_service = 'fake_service'
+        fake_namespace = 'fake_namespace'
+        fake_hostname = 'fake_hostname'
+        fake_random_port = 666
+        fake_service_config = long_running_service_tools.LongRunningServiceConfig(
+            service=fake_service,
+            cluster='fake_cluster',
+            instance=fake_namespace,
+            config_dict={
+                'healthcheck_mode': None,
+            },
+            branch_dict={},
+        )
+        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
+        with contextlib.nested(
+            mock.patch('paasta_tools.long_running_service_tools.load_service_namespace_config',
+                       autospec=True,
+                       return_value=fake_service_namespace_config),
+            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
+        ) as (
+            load_service_namespace_config_patch,
+            hostname_patch
+        ):
+            expected = (None, None)
+            actual = long_running_service_tools.get_healthcheck_for_instance(
+                fake_service, fake_namespace, fake_service_config, fake_random_port)
+            assert expected == actual
+
+    def test_get_healthcheck_for_instance_custom_soadir(self):
+        fake_service = 'fake_service'
+        fake_namespace = 'fake_namespace'
+        fake_hostname = 'fake_hostname'
+        fake_random_port = 666
+        fake_soadir = '/fake/soadir'
+        fake_service_config = long_running_service_tools.LongRunningServiceConfig(
+            service=fake_service,
+            cluster='fake_cluster',
+            instance=fake_namespace,
+            config_dict={
+                'healthcheck_mode': None,
+            },
+            branch_dict={},
+        )
+        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
+        with contextlib.nested(
+            mock.patch('paasta_tools.long_running_service_tools.load_service_namespace_config',
+                       autospec=True,
+                       return_value=fake_service_namespace_config),
+            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
+        ) as (
+            load_service_namespace_config_patch,
+            hostname_patch
+        ):
+            expected = (None, None)
+            actual = long_running_service_tools.get_healthcheck_for_instance(
+                fake_service, fake_namespace, fake_service_config, fake_random_port, soa_dir=fake_soadir)
+            assert expected == actual
+            load_service_namespace_config_patch.assert_called_once_with(fake_service, fake_namespace, fake_soadir)
+
+
+class TestServiceNamespaceConfig(object):
+
+    def test_get_mode_default(self):
+        assert long_running_service_tools.ServiceNamespaceConfig().get_mode() is None
+
+    def test_get_mode_default_when_port_specified(self):
+        config = {'proxy_port': 1234}
+        assert long_running_service_tools.ServiceNamespaceConfig(config).get_mode() == 'http'
+
+    def test_get_mode_valid(self):
+        config = {'mode': 'tcp'}
+        assert long_running_service_tools.ServiceNamespaceConfig(config).get_mode() == 'tcp'
+
+    def test_get_mode_invalid(self):
+        config = {'mode': 'paasta'}
+        with raises(long_running_service_tools.InvalidSmartstackMode):
+            long_running_service_tools.ServiceNamespaceConfig(config).get_mode()
+
+    def test_get_healthcheck_uri_default(self):
+        assert long_running_service_tools.ServiceNamespaceConfig().get_healthcheck_uri() == '/status'
+
+    def test_get_discover_default(self):
+        assert long_running_service_tools.ServiceNamespaceConfig().get_discover() == 'region'

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1642,202 +1642,6 @@ class TestMarathonTools:
         actual = marathon_tools.get_matching_appids('fake_service', 'fake_instance', fake_client)
         assert actual == expected
 
-    def test_get_healthcheck_cmd_happy(self):
-        fake_conf = marathon_tools.MarathonServiceConfig(
-            service='fake_name',
-            cluster='fake_cluster',
-            instance='fake_instance',
-            config_dict={'healthcheck_cmd': 'test_cmd'},
-            branch_dict={},
-        )
-        actual = fake_conf.get_healthcheck_cmd()
-        assert actual == 'test_cmd'
-
-    def test_get_healthcheck_cmd_raises_when_unset(self):
-        fake_conf = marathon_tools.MarathonServiceConfig(
-            service='fake_name',
-            cluster='fake_cluster',
-            instance='fake_instance',
-            config_dict={},
-            branch_dict={},
-        )
-        with raises(marathon_tools.InvalidInstanceConfig) as exc:
-            fake_conf.get_healthcheck_cmd()
-        assert "healthcheck mode 'cmd' requires a healthcheck_cmd to run" in str(exc.value)
-
-    def test_get_healthcheck_for_instance_http(self):
-        fake_service = 'fake_service'
-        fake_namespace = 'fake_namespace'
-        fake_hostname = 'fake_hostname'
-        fake_random_port = 666
-
-        fake_path = '/fake_path'
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-            service=fake_service,
-            cluster='fake_cluster',
-            instance=fake_namespace,
-            config_dict={},
-            branch_dict={},
-        )
-        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({
-            'mode': 'http',
-            'healthcheck_uri': fake_path,
-        })
-        with contextlib.nested(
-            mock.patch('paasta_tools.marathon_tools.load_marathon_service_config',
-                       autospec=True,
-                       return_value=fake_marathon_service_config),
-            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
-                       autospec=True,
-                       return_value=fake_service_namespace_config),
-            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
-        ) as (
-            read_config_patch,
-            load_service_namespace_config_patch,
-            hostname_patch
-        ):
-            expected = ('http', 'http://%s:%d%s' % (fake_hostname, fake_random_port, fake_path))
-            actual = marathon_tools.get_healthcheck_for_instance(
-                fake_service, fake_namespace, fake_marathon_service_config, fake_random_port)
-            assert expected == actual
-
-    def test_get_healthcheck_for_instance_tcp(self):
-        fake_service = 'fake_service'
-        fake_namespace = 'fake_namespace'
-        fake_hostname = 'fake_hostname'
-        fake_random_port = 666
-
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-            service=fake_service,
-            cluster='fake_cluster',
-            instance=fake_namespace,
-            config_dict={},
-            branch_dict={},
-        )
-        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({
-            'mode': 'tcp',
-        })
-        with contextlib.nested(
-            mock.patch('paasta_tools.marathon_tools.load_marathon_service_config',
-                       autospec=True,
-                       return_value=fake_marathon_service_config),
-            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
-                       autospec=True,
-                       return_value=fake_service_namespace_config),
-            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
-        ) as (
-            read_config_patch,
-            load_service_namespace_config_patch,
-            hostname_patch
-        ):
-            expected = ('tcp', 'tcp://%s:%d' % (fake_hostname, fake_random_port))
-            actual = marathon_tools.get_healthcheck_for_instance(
-                fake_service, fake_namespace, fake_marathon_service_config, fake_random_port)
-            assert expected == actual
-
-    def test_get_healthcheck_for_instance_cmd(self):
-        fake_service = 'fake_service'
-        fake_namespace = 'fake_namespace'
-        fake_hostname = 'fake_hostname'
-        fake_random_port = 666
-        fake_cmd = '/bin/fake_command'
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-            service=fake_service,
-            cluster='fake_cluster',
-            instance=fake_namespace,
-            config_dict={
-                'healthcheck_mode': 'cmd',
-                'healthcheck_cmd': fake_cmd
-            },
-            branch_dict={},
-        )
-        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
-        with contextlib.nested(
-            mock.patch('paasta_tools.marathon_tools.load_marathon_service_config',
-                       autospec=True,
-                       return_value=fake_marathon_service_config),
-            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
-                       autospec=True,
-                       return_value=fake_service_namespace_config),
-            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
-        ) as (
-            read_config_patch,
-            load_service_namespace_config_patch,
-            hostname_patch
-        ):
-            expected = ('cmd', fake_cmd)
-            actual = marathon_tools.get_healthcheck_for_instance(
-                fake_service, fake_namespace, fake_marathon_service_config, fake_random_port)
-            assert expected == actual
-
-    def test_get_healthcheck_for_instance_other(self):
-        fake_service = 'fake_service'
-        fake_namespace = 'fake_namespace'
-        fake_hostname = 'fake_hostname'
-        fake_random_port = 666
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-            service=fake_service,
-            cluster='fake_cluster',
-            instance=fake_namespace,
-            config_dict={
-                'healthcheck_mode': None,
-            },
-            branch_dict={},
-        )
-        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
-        with contextlib.nested(
-            mock.patch('paasta_tools.marathon_tools.load_marathon_service_config',
-                       autospec=True,
-                       return_value=fake_marathon_service_config),
-            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
-                       autospec=True,
-                       return_value=fake_service_namespace_config),
-            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
-        ) as (
-            read_config_patch,
-            load_service_namespace_config_patch,
-            hostname_patch
-        ):
-            expected = (None, None)
-            actual = marathon_tools.get_healthcheck_for_instance(
-                fake_service, fake_namespace, fake_marathon_service_config, fake_random_port)
-            assert expected == actual
-
-    def test_get_healthcheck_for_instance_custom_soadir(self):
-        fake_service = 'fake_service'
-        fake_namespace = 'fake_namespace'
-        fake_hostname = 'fake_hostname'
-        fake_random_port = 666
-        fake_soadir = '/fake/soadir'
-        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
-            service=fake_service,
-            cluster='fake_cluster',
-            instance=fake_namespace,
-            config_dict={
-                'healthcheck_mode': None,
-            },
-            branch_dict={},
-        )
-        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
-        with contextlib.nested(
-            mock.patch('paasta_tools.marathon_tools.load_marathon_service_config',
-                       autospec=True,
-                       return_value=fake_marathon_service_config),
-            mock.patch('paasta_tools.marathon_tools.load_service_namespace_config',
-                       autospec=True,
-                       return_value=fake_service_namespace_config),
-            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
-        ) as (
-            read_config_patch,
-            load_service_namespace_config_patch,
-            hostname_patch
-        ):
-            expected = (None, None)
-            actual = marathon_tools.get_healthcheck_for_instance(
-                fake_service, fake_namespace, fake_marathon_service_config, fake_random_port, soa_dir=fake_soadir)
-            assert expected == actual
-            load_service_namespace_config_patch.assert_called_once_with(fake_service, fake_namespace, fake_soadir)
-
 
 class TestMarathonServiceConfig(object):
 
@@ -1888,7 +1692,7 @@ class TestMarathonServiceConfig(object):
             config_dict={'healthcheck_mode': 'udp'},
             branch_dict={},
         )
-        with raises(marathon_tools.InvalidMarathonHealthcheckMode):
+        with raises(long_running_service_tools.InvalidHealthcheckMode):
             marathon_config.get_healthcheck_mode(namespace_config)
 
     def test_get_healthcheck_mode_explicit_none(self):
@@ -2053,7 +1857,7 @@ class TestMarathonServiceConfig(object):
             branch_dict={},
         )
         namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
-        with raises(marathon_tools.InvalidMarathonHealthcheckMode):
+        with raises(long_running_service_tools.InvalidHealthcheckMode):
             marathon_config.get_healthchecks(namespace_config)
 
     def test_get_backoff_seconds_scales_up(self):
@@ -2135,31 +1939,6 @@ class TestMarathonServiceConfig(object):
             branch_dict={'desired_state': 'start'},
         )
         assert 'Stopped' in desired_state_human(fake_conf.get_desired_state(), fake_conf.get_instances())
-
-
-class TestServiceNamespaceConfig(object):
-
-    def test_get_mode_default(self):
-        assert long_running_service_tools.ServiceNamespaceConfig().get_mode() is None
-
-    def test_get_mode_default_when_port_specified(self):
-        config = {'proxy_port': 1234}
-        assert long_running_service_tools.ServiceNamespaceConfig(config).get_mode() == 'http'
-
-    def test_get_mode_valid(self):
-        config = {'mode': 'tcp'}
-        assert long_running_service_tools.ServiceNamespaceConfig(config).get_mode() == 'tcp'
-
-    def test_get_mode_invalid(self):
-        config = {'mode': 'paasta'}
-        with raises(long_running_service_tools.InvalidSmartstackMode):
-            long_running_service_tools.ServiceNamespaceConfig(config).get_mode()
-
-    def test_get_healthcheck_uri_default(self):
-        assert long_running_service_tools.ServiceNamespaceConfig().get_healthcheck_uri() == '/status'
-
-    def test_get_discover_default(self):
-        assert long_running_service_tools.ServiceNamespaceConfig().get_discover() == 'region'
 
 
 def test_deformat_job_id():
@@ -2550,7 +2329,7 @@ def test_marathon_service_config_get_healthchecks_invalid_type():
     )
     with mock.patch.object(marathon_tools.MarathonServiceConfig, 'get_healthcheck_mode', autospec=True,
                            return_value='fake-mode'):
-        with raises(marathon_tools.InvalidMarathonHealthcheckMode):
+        with raises(long_running_service_tools.InvalidHealthcheckMode):
             fake_marathon_service_config.get_healthchecks(mock.Mock())
 
 

--- a/tests/test_setup_chronos_job.py
+++ b/tests/test_setup_chronos_job.py
@@ -22,6 +22,7 @@ from pytest import raises
 from paasta_tools import chronos_tools
 from paasta_tools import setup_chronos_job
 from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 
 
@@ -162,7 +163,7 @@ class TestSetupChronosJob:
                        autospec=True),
             mock.patch('paasta_tools.chronos_tools.create_complete_config',
                        autospec=True,
-                       side_effect=chronos_tools.UnknownChronosJobError('test bad configuration')),
+                       side_effect=NoConfigurationForServiceError('test bad configuration')),
             mock.patch('paasta_tools.setup_chronos_job.setup_job',
                        return_value=(0, 'it_is_finished'),
                        autospec=True),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -548,36 +548,6 @@ def test_remove_ansi_escape_sequences():
     assert utils.remove_ansi_escape_sequences(colored_string) == plain_string
 
 
-def test_get_default_cluster_for_service():
-    fake_service = 'fake_service'
-    fake_clusters = ['fake_cluster-1', 'fake_cluster-2']
-    with contextlib.nested(
-        mock.patch('paasta_tools.utils.list_clusters', autospec=True, return_value=fake_clusters),
-        mock.patch('paasta_tools.utils.load_system_paasta_config', autospec=True),
-    ) as (
-        mock_list_clusters,
-        mock_load_system_paasta_config,
-    ):
-        mock_load_system_paasta_config.side_effect = utils.PaastaNotConfiguredError
-        assert utils.get_default_cluster_for_service(fake_service) == 'fake_cluster-1'
-        mock_list_clusters.assert_called_once_with(fake_service, soa_dir=mock.ANY)
-
-
-def test_get_default_cluster_for_service_empty_deploy_config():
-    fake_service = 'fake_service'
-    with contextlib.nested(
-        mock.patch('paasta_tools.utils.list_clusters', autospec=True, return_value=[]),
-        mock.patch('paasta_tools.utils.load_system_paasta_config', autospec=True),
-    ) as (
-        mock_list_clusters,
-        mock_load_system_paasta_config,
-    ):
-        mock_load_system_paasta_config.side_effect = utils.PaastaNotConfiguredError
-        with raises(utils.NoConfigurationForServiceError):
-            utils.get_default_cluster_for_service(fake_service)
-        mock_list_clusters.assert_called_once_with(fake_service, soa_dir=mock.ANY)
-
-
 def test_list_clusters_no_service_given_lists_all_of_them():
     fake_soa_dir = '/nail/etc/services'
     fake_cluster_configs = ['/nail/etc/services/service1/marathon-cluster1.yaml',
@@ -662,8 +632,16 @@ def test_get_service_instance_list():
     fake_dir = '/nail/home/hipster'
     fake_job_config = {fake_instance_1: {},
                        fake_instance_2: {}}
-    expected = [(fake_name, fake_instance_1), (fake_name, fake_instance_1), (fake_name, fake_instance_1),
-                (fake_name, fake_instance_2), (fake_name, fake_instance_2), (fake_name, fake_instance_2), ]
+    expected = [
+        (fake_name, fake_instance_1),
+        (fake_name, fake_instance_1),
+        (fake_name, fake_instance_1),
+        (fake_name, fake_instance_1),
+        (fake_name, fake_instance_2),
+        (fake_name, fake_instance_2),
+        (fake_name, fake_instance_2),
+        (fake_name, fake_instance_2),
+    ]
     with contextlib.nested(
         mock.patch('paasta_tools.utils.service_configuration_lib.read_extra_service_information', autospec=True,
                    return_value=fake_job_config),
@@ -674,7 +652,7 @@ def test_get_service_instance_list():
         read_extra_info_patch.assert_any_call(fake_name, 'marathon-16floz', soa_dir=fake_dir)
         read_extra_info_patch.assert_any_call(fake_name, 'chronos-16floz', soa_dir=fake_dir)
         read_extra_info_patch.assert_any_call(fake_name, 'paasta_native-16floz', soa_dir=fake_dir)
-        assert read_extra_info_patch.call_count == 3
+        assert read_extra_info_patch.call_count == 4
         assert sorted(expected) == sorted(actual)
 
 
@@ -1356,6 +1334,7 @@ def test_validate_service_instance_invalid():
     mock_marathon_services = [('service1', 'main'), ('service2', 'main')]
     mock_chronos_services = [('service1', 'worker'), ('service2', 'tailer')]
     mock_paasta_native_services = [('service1', 'main2'), ('service2', 'main2')]
+    mock_adhoc_services = [('service1', 'interactive'), ('service2', 'interactive')]
     my_service = 'bad_service'
     my_instance = 'main'
     fake_cluster = 'fake_cluster'
@@ -1363,11 +1342,12 @@ def test_validate_service_instance_invalid():
     with contextlib.nested(
         mock.patch('paasta_tools.utils.get_services_for_cluster',
                    autospec=True,
-                   side_effect=[mock_marathon_services, mock_chronos_services, mock_paasta_native_services]),
-        mock.patch('sys.exit', autospec=True),
+                   side_effect=[mock_marathon_services, mock_chronos_services,
+                                mock_paasta_native_services, mock_adhoc_services]),
+        raises(utils.NoConfigurationForServiceError),
     ) as (
         get_services_for_cluster_patch,
-        sys_exit_patch,
+        _,
     ):
         utils.validate_service_instance(
             my_service,
@@ -1375,7 +1355,6 @@ def test_validate_service_instance_invalid():
             fake_cluster,
             fake_soa_dir,
         )
-        sys_exit_patch.assert_called_once_with(3)
 
 
 def test_terminal_len():
@@ -1563,3 +1542,51 @@ def test_long_job_id_to_short_job_id():
 def test_mean():
     iterable = [1.0, 2.0, 3.0]
     assert utils.mean(iterable) == 2.0
+
+
+def test_prompt_pick_one():
+    with contextlib.nested(
+        mock.patch('paasta_tools.utils.sys.stdin', autospec=True),
+        mock.patch('paasta_tools.utils.choice.Menu', autospec=True),
+    ) as (
+        mock_stdin,
+        mock_menu,
+    ):
+        mock_stdin.isatty.return_value = True
+        mock_menu.return_value = mock.Mock(ask=mock.Mock(return_value='choiceA'))
+        assert utils.prompt_pick_one(['choiceA'], 'test') == 'choiceA'
+
+
+def test_prompt_pick_one_quit():
+    with contextlib.nested(
+        mock.patch('paasta_tools.utils.sys.stdin', autospec=True),
+        mock.patch('paasta_tools.utils.choice.Menu', autospec=True),
+    ) as (
+        mock_stdin,
+        mock_menu,
+    ):
+        mock_stdin.isatty.return_value = True
+        mock_menu.return_value = mock.Mock(ask=mock.Mock(return_value=(None, 'Quit')))
+        with raises(SystemExit):
+            utils.prompt_pick_one(['choiceA', 'choiceB'], 'test')
+
+
+def test_prompt_pick_one_keyboard_interrupt():
+    with contextlib.nested(
+        mock.patch('paasta_tools.utils.sys.stdin', autospec=True),
+        mock.patch('paasta_tools.utils.choice.Menu', autospec=True),
+    ) as (
+        mock_stdin,
+        mock_menu,
+    ):
+        mock_stdin.isatty.return_value = True
+        mock_menu.return_value = mock.Mock(ask=mock.Mock(side_effect=KeyboardInterrupt))
+        with raises(SystemExit):
+            utils.prompt_pick_one(['choiceA', 'choiceB'], 'test')
+
+
+def test_prompt_pick_one_returns_none_no_tty():
+    with mock.patch('paasta_tools.utils.sys.stdin', autospec=True) as mock_stdin:
+        mock_stdin.isatty.return_value = False
+        with raises(SystemExit):
+            utils.prompt_pick_one(['choiceA', 'choiceB'], 'test')


### PR DESCRIPTION
We need to hold off shipping this until we fix all of the Makefiles and jenkins jobs that don't specify `-i`.