### PR TITLE
Fix stuck downscaling of SFRs

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -508,8 +508,9 @@ def downscale_spot_fleet_request(resource, filtered_slaves, current_capacity, ta
                      " close to our target as we can get".format(slave_to_kill['instance_id'],
                                                                  slave_to_kill['instance_weight'],
                                                                  target_capacity))
-            if resource['sfr']['SpotFleetRequestState'] == 'cancelled_running' and killed_slaves == 0:
-                log.info("This is a cancelled SFR so we must kill at least one slave to prevent it lingering")
+            if killed_slaves == 0:
+                log.info("This is a SFR so we must kill at least one slave to prevent the autoscaler "
+                         "getting stuck whilst scaling down gradually")
             else:
                 break
         try:

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -122,18 +122,7 @@ def test_downscale_spot_fleet_request():
                                           dry_run=False,
                                           new_capacity=3)
 
-        # test stop when reach capacity
-        mock_sort_slaves_to_kill.return_value = mock_sfr_sorted_slaves_2[:]
-        autoscaling_cluster_lib.downscale_spot_fleet_request(resource=mock_resource,
-                                                             filtered_slaves=mock_filtered_slaves,
-                                                             pool_settings=mock_pool_settings,
-                                                             current_capacity=5,
-                                                             target_capacity=4,
-                                                             dry_run=False)
-        assert not mock_gracefully_terminate_slave.called
-
-        # test we kill at least one instance if SFR cancelled
-        mock_resource = {'sfr': {'SpotFleetRequestState': 'cancelled_running'}}
+        # test we kill only one instance on scale down and then reach capacity
         mock_sort_slaves_to_kill.return_value = mock_sfr_sorted_slaves_2[:]
         autoscaling_cluster_lib.downscale_spot_fleet_request(resource=mock_resource,
                                                              filtered_slaves=mock_filtered_slaves,
@@ -142,7 +131,6 @@ def test_downscale_spot_fleet_request():
                                                              target_capacity=4,
                                                              dry_run=False)
         assert mock_gracefully_terminate_slave.call_count == 1
-        mock_resource = {'sfr': {'SpotFleetRequestState': 'active'}}
 
         # test stop if FailSetSpotCapacity
         mock_gracefully_terminate_slave.side_effect = autoscaling_cluster_lib.FailSetSpotCapacity


### PR DESCRIPTION
Because we use non integer weights for spots and because we are
conservative when scaling down it is possible for the autoscaler to get
stuck when scaling down SFRs

This applies the same fix applied for cancelled SFRs where we force the
autoscaler to kill at least one instance when it is scaling down.