### PR TITLE
Added get_currently_deployed_sha and better rollback hints

### DIFF
--- a/paasta_tools/cli/cmds/get_latest_deployment.py
+++ b/paasta_tools/cli/cmds/get_latest_deployment.py
@@ -17,10 +17,8 @@ from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import PaastaColors
 from paasta_tools.cli.utils import validate_service_name
-from paasta_tools.generate_deployments_for_service import get_latest_deployment_tag
-from paasta_tools.remote_git import list_remote_refs
+from paasta_tools.deployment_utils import get_currently_deployed_sha
 from paasta_tools.utils import DEFAULT_SOA_DIR
-from paasta_tools.utils import get_git_url
 
 
 def add_subparser(subparsers):
@@ -53,13 +51,7 @@ def paasta_get_latest_deployment(args):
     soa_dir = args.soa_dir
     validate_service_name(service, soa_dir)
 
-    git_url = get_git_url(
-        service=service,
-        soa_dir=soa_dir,
-    )
-    remote_refs = list_remote_refs(git_url)
-
-    _, git_sha = get_latest_deployment_tag(remote_refs, deploy_group)
+    git_sha = get_currently_deployed_sha(service=service, deploy_group=deploy_group, soa_dir=soa_dir)
     if not git_sha:
         print PaastaColors.red("A deployment could not be found for %s in %s" % (deploy_group, service))
         return 1

--- a/paasta_tools/deployment_utils.py
+++ b/paasta_tools/deployment_utils.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import load_v2_deployments_json
+from paasta_tools.utils import NoDeploymentsAvailable
+
+
+def get_currently_deployed_sha(service, deploy_group, soa_dir=DEFAULT_SOA_DIR):
+    """Tries to determine the currently deployed sha for a service and deploy_group,
+    returns None if there isn't one ready yet"""
+    try:
+        deployments = load_v2_deployments_json(service=service, soa_dir=soa_dir)
+        return deployments.get_git_sha_for_deploy_group(deploy_group=deploy_group)
+    except NoDeploymentsAvailable:
+        return None

--- a/tests/cli/test_cmds_get_latest_deployment.py
+++ b/tests/cli/test_cmds_get_latest_deployment.py
@@ -28,15 +28,11 @@ def test_get_latest_deployment():
     )
     with contextlib.nested(
         patch('sys.stdout', new_callable=StringIO, autospec=None),
-        patch('paasta_tools.cli.cmds.get_latest_deployment.get_latest_deployment_tag',
-              return_value=(None, "FAKE_SHA"), autospec=True),
-        patch('paasta_tools.cli.cmds.get_latest_deployment.get_git_url', autospec=True),
-        patch('paasta_tools.cli.cmds.get_latest_deployment.list_remote_refs', autospec=True),
+        patch('paasta_tools.cli.cmds.get_latest_deployment.get_currently_deployed_sha',
+              return_value="FAKE_SHA", autospec=True),
         patch('paasta_tools.cli.cmds.get_latest_deployment.validate_service_name', autospec=True),
     ) as (
         mock_stdout,
-        _,
-        _,
         _,
         _,
     ):
@@ -52,15 +48,11 @@ def test_get_latest_deployment_no_deployment_tag():
     )
     with contextlib.nested(
         patch('sys.stdout', new_callable=StringIO, autospec=None),
-        patch('paasta_tools.cli.cmds.get_latest_deployment.get_latest_deployment_tag',
-              return_value=(None, None), autospec=True),
-        patch('paasta_tools.cli.cmds.get_latest_deployment.get_git_url', autospec=True),
-        patch('paasta_tools.cli.cmds.get_latest_deployment.list_remote_refs', autospec=True),
+        patch('paasta_tools.cli.cmds.get_latest_deployment.get_currently_deployed_sha',
+              return_value=None, autospec=True),
         patch('paasta_tools.cli.cmds.get_latest_deployment.validate_service_name', autospec=True),
     ) as (
         mock_stdout,
-        _,
-        _,
         _,
         _,
     ):

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -33,7 +33,9 @@ class fake_args:
 
 @patch('paasta_tools.cli.cmds.mark_for_deployment.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment.mark_for_deployment', autospec=True)
+@patch('paasta_tools.cli.cmds.mark_for_deployment.get_currently_deployed_sha', autospec=True)
 def test_paasta_mark_for_deployment_acts_like_main(
+    mock_get_currently_deployed_sha,
     mock_mark_for_deployment,
     mock_validate_service_name,
 ):

--- a/tests/test_deployment_utils.py
+++ b/tests/test_deployment_utils.py
@@ -1,0 +1,34 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+
+from paasta_tools import deployment_utils
+from paasta_tools.utils import DeploymentsJson
+
+
+@mock.patch('paasta_tools.deployment_utils.load_v2_deployments_json', autospec=True)
+def test_get_currently_deployed_sha(
+    mock_load_v2_deployments_json,
+):
+    mock_load_v2_deployments_json.return_value = DeploymentsJson({
+        "controls": {},
+        "deployments": {
+            "everything": {
+                "git_sha": "abc",
+                "docker_image": "foo",
+            }
+        }
+    })
+    actual = deployment_utils.get_currently_deployed_sha(service='service', deploy_group='everything')
+    assert actual == "abc"


### PR DESCRIPTION
Now that @mjksmith has v2 deployments out, extracting the existing deployed git sha is trivial.

After this ships it will be very easy to add auto-rollback.