### PR TITLE
Made paasta status and paasta metastatus return nonzero on ssh error

### DIFF
--- a/paasta_tools/cli/cmds/emergency_restart.py
+++ b/paasta_tools/cli/cmds/emergency_restart.py
@@ -70,13 +70,16 @@ def paasta_emergency_restart(args):
     service = figure_out_service_name(args, args.soa_dir)
     system_paasta_config = load_system_paasta_config()
     print "Performing an emergency restart on %s...\n" % compose_job_id(service, args.instance)
-    execute_paasta_serviceinit_on_remote_master(
+    return_code, output = execute_paasta_serviceinit_on_remote_master(
         subcommand='restart',
         cluster=args.cluster,
         service=args.service,
         instances=args.instance,
         system_paasta_config=system_paasta_config
     )
+    print "Output: %s" % output
     print "%s" % "\n".join(paasta_emergency_restart.__doc__.splitlines()[-7:])
     print "Run this to see the status:"
     print "paasta status --service %s --clusters %s" % (service, args.cluster)
+
+    return return_code

--- a/paasta_tools/cli/cmds/emergency_start.py
+++ b/paasta_tools/cli/cmds/emergency_start.py
@@ -65,7 +65,7 @@ def paasta_emergency_start(args):
     system_paasta_config = load_system_paasta_config()
     service = figure_out_service_name(args, soa_dir=args.soa_dir)
     print "Performing an emergency start on %s..." % compose_job_id(service, args.instance)
-    output = execute_paasta_serviceinit_on_remote_master(
+    return_code, output = execute_paasta_serviceinit_on_remote_master(
         subcommand='start',
         cluster=args.cluster,
         service=service,
@@ -76,3 +76,5 @@ def paasta_emergency_start(args):
     print "Output: %s" % PaastaColors.grey(output)
     print "Run this command to see the status:"
     print "paasta status --service %s --clusters %s" % (service, args.cluster)
+
+    return return_code

--- a/paasta_tools/cli/cmds/emergency_stop.py
+++ b/paasta_tools/cli/cmds/emergency_stop.py
@@ -62,7 +62,7 @@ def paasta_emergency_stop(args):
     system_paasta_config = load_system_paasta_config()
     service = figure_out_service_name(args, soa_dir=args.soa_dir)
     print "Performing an emergency stop on %s..." % compose_job_id(service, args.instance)
-    output = execute_paasta_serviceinit_on_remote_master(
+    return_code, output = execute_paasta_serviceinit_on_remote_master(
         subcommand='stop',
         cluster=args.cluster,
         service=service,
@@ -73,3 +73,5 @@ def paasta_emergency_stop(args):
     print "%s" % "\n".join(paasta_emergency_stop.__doc__.splitlines()[-7:])
     print "To start this service again asap, run:"
     print "paasta emergency-start --service %s --instance %s --cluster %s" % (service, args.instance, args.cluster)
+
+    return return_code

--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -140,4 +140,4 @@ def paasta_metastatus(args):
         else:
             print "Cluster %s doesn't look like a valid cluster?" % args.clusters
             print "Try using tab completion to help complete the cluster name"
-    return all([return_code == 0 for return_code in return_codes])
+    return 0 if all([return_code == 0 for return_code in return_codes]) else 1

--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -77,16 +77,20 @@ def add_subparser(subparsers):
 def print_cluster_status(cluster, system_paasta_config, humanize, groupings, verbose=0):
     """With a given cluster and verboseness, returns the status of the cluster
     output is printed directly to provide dashbaords even if the cluster is unavailable"""
-    print "Cluster: %s" % cluster
-    print get_cluster_dashboards(cluster)
-    print execute_paasta_metastatus_on_remote_master(
+    return_code, output = execute_paasta_metastatus_on_remote_master(
         cluster=cluster,
         system_paasta_config=system_paasta_config,
         humanize=humanize,
         groupings=groupings,
         verbose=verbose
     )
+
+    print "Cluster: %s" % cluster
+    print get_cluster_dashboards(cluster)
+    print output
     print ""
+
+    return return_code
 
 
 def figure_out_clusters_to_inspect(args, all_clusters):
@@ -121,15 +125,19 @@ def paasta_metastatus(args):
     system_paasta_config = load_system_paasta_config()
     all_clusters = list_clusters(soa_dir=soa_dir)
     clusters_to_inspect = figure_out_clusters_to_inspect(args, all_clusters)
+    return_codes = []
     for cluster in clusters_to_inspect:
         if cluster in all_clusters:
-            print_cluster_status(
-                cluster=cluster,
-                system_paasta_config=system_paasta_config,
-                humanize=args.humanize,
-                groupings=args.groupings,
-                verbose=args.verbose
+            return_codes.append(
+                print_cluster_status(
+                    cluster=cluster,
+                    system_paasta_config=system_paasta_config,
+                    humanize=args.humanize,
+                    groupings=args.groupings,
+                    verbose=args.verbose,
+                )
             )
         else:
             print "Cluster %s doesn't look like a valid cluster?" % args.clusters
             print "Try using tab completion to help complete the cluster name"
+    return all([return_code == 0 for return_code in return_codes])

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 flake8==2.5.0
 git+git://github.com/solarkennedy/sphinxcontrib-programoutput#egg=package-two
-mock==1.0.1
+mock==2.0.0
 pep8==1.5.7
 pre-commit==0.7.6
 pylint==1.6.4

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -136,9 +136,9 @@ def test_downscale_spot_fleet_request():
         mock_gracefully_terminate_slave.side_effect = autoscaling_cluster_lib.FailSetSpotCapacity
         mock_sfr_sorted_slaves_1 = [mock_slave_1, mock_slave_2]
         mock_sfr_sorted_slaves_2 = [mock_slave_2]
-        mock_sort_slaves_to_kill.side_effect = iter([mock_sfr_sorted_slaves_1,
-                                                     mock_sfr_sorted_slaves_2,
-                                                     []])
+        mock_sort_slaves_to_kill.side_effect = [mock_sfr_sorted_slaves_1,
+                                                mock_sfr_sorted_slaves_2,
+                                                []]
         autoscaling_cluster_lib.downscale_spot_fleet_request(resource=mock_resource,
                                                              filtered_slaves=mock_filtered_slaves,
                                                              pool_settings=mock_pool_settings,
@@ -152,9 +152,9 @@ def test_downscale_spot_fleet_request():
         mock_gracefully_terminate_slave.reset_mock()
         mock_sfr_sorted_slaves_1 = [mock_slave_1, mock_slave_2]
         mock_sfr_sorted_slaves_2 = [mock_slave_2]
-        mock_sort_slaves_to_kill.side_effect = iter([mock_sfr_sorted_slaves_1,
-                                                     mock_sfr_sorted_slaves_2,
-                                                     []])
+        mock_sort_slaves_to_kill.side_effect = [mock_sfr_sorted_slaves_1,
+                                                mock_sfr_sorted_slaves_2,
+                                                []]
         autoscaling_cluster_lib.downscale_spot_fleet_request(resource=mock_resource,
                                                              filtered_slaves=mock_filtered_slaves,
                                                              pool_settings=mock_pool_settings,
@@ -170,9 +170,9 @@ def test_downscale_spot_fleet_request():
         mock_sort_slaves_to_kill.reset_mock()
         mock_sfr_sorted_slaves_1 = [mock_slave_1, mock_slave_2]
         mock_sfr_sorted_slaves_2 = [mock_slave_2]
-        mock_sort_slaves_to_kill.side_effect = iter([mock_sfr_sorted_slaves_1,
-                                                     mock_sfr_sorted_slaves_2,
-                                                     []])
+        mock_sort_slaves_to_kill.side_effect = [mock_sfr_sorted_slaves_1,
+                                                mock_sfr_sorted_slaves_2,
+                                                []]
         autoscaling_cluster_lib.downscale_spot_fleet_request(resource=mock_resource,
                                                              filtered_slaves=mock_filtered_slaves,
                                                              pool_settings=mock_pool_settings,
@@ -196,8 +196,8 @@ def test_downscale_spot_fleet_request():
         mock_get_mesos_task_count_by_slave.reset_mock()
         mock_sort_slaves_to_kill.reset_mock()
         mock_sfr_sorted_slaves = [mock_slave_1] * 10
-        mock_sort_slaves_to_kill.side_effect = iter([mock_sfr_sorted_slaves] +
-                                                    [mock_sfr_sorted_slaves[x:-1] for x in range(0, 10)])
+        mock_sort_slaves_to_kill.side_effect = [mock_sfr_sorted_slaves] + \
+            [mock_sfr_sorted_slaves[x:-1] for x in range(0, 10)]
         autoscaling_cluster_lib.downscale_spot_fleet_request(resource=mock_resource,
                                                              filtered_slaves=mock_filtered_slaves,
                                                              pool_settings=mock_pool_settings,
@@ -409,7 +409,7 @@ def test_wait_and_terminate():
         mock_terminate_instances.assert_called_with(InstanceIds=['i-blah123'], DryRun=False)
         mock_is_safe_to_kill.assert_called_with('hostblah')
 
-        mock_is_safe_to_kill.side_effect = iter([False, False, True])
+        mock_is_safe_to_kill.side_effect = [False, False, True]
         autoscaling_cluster_lib.wait_and_terminate(mock_slave_to_kill, 600, False, region='westeros-1')
         assert mock_is_safe_to_kill.call_count == 4
 
@@ -497,9 +497,9 @@ def test_filter_sfr_slaves():
         mock_sfr = mock.Mock()
         mock_resource = {'sfr': mock_sfr, 'region': 'westeros-1'}
         mock_get_sfr_instance_ips.return_value = ['10.1.1.1', '10.3.3.3']
-        mock_pid_to_ip.side_effect = iter(['10.1.1.1', '10.2.2.2', '10.3.3.3',
-                                           '10.1.1.1', '10.3.3.3', '10.1.1.1', '10.3.3.3'])
-        mock_get_instances_from_ip.side_effect = iter([[{'InstanceId': 'i-1'}], [{'InstanceId': 'i-3'}]])
+        mock_pid_to_ip.side_effect = ['10.1.1.1', '10.2.2.2', '10.3.3.3',
+                                      '10.1.1.1', '10.3.3.3', '10.1.1.1', '10.3.3.3']
+        mock_get_instances_from_ip.side_effect = [[{'InstanceId': 'i-1'}], [{'InstanceId': 'i-3'}]]
         mock_instances = [{'InstanceId': 'i-1',
                            'InstanceType': 'c4.blah'},
                           {'InstanceId': 'i-2',

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -1135,8 +1135,7 @@ def test_simulate_healthcheck_on_service_enabled_failure(mock_run_healthcheck_on
 @mock.patch('time.sleep', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run.run_healthcheck_on_container', autospec=True)
 def test_simulate_healthcheck_on_service_enabled_partial_failure(mock_run_healthcheck_on_container, mock_sleep):
-    mock_run_healthcheck_on_container.side_effect = iter([
-        (False, ""), (False, ""), (False, ""), (False, ""), (True, "")])
+    mock_run_healthcheck_on_container.side_effect = [(False, ""), (False, ""), (False, ""), (False, ""), (True, "")]
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)
     mock_service_manifest = MarathonServiceConfig(
         service='fake_name',
@@ -1199,8 +1198,7 @@ def test_simulate_healthcheck_on_service_enabled_honors_grace_period(
     capsys,
 ):
     # change time to make sure we are sufficiently past grace period
-    mock_run_healthcheck_on_container.side_effect = iter([
-        (False, "400 noop"), (False, "400 noop"), (True, "200 noop")])
+    mock_run_healthcheck_on_container.side_effect = [(False, "400 noop"), (False, "400 noop"), (True, "200 noop")]
 
     mock_time.side_effect = [0, 1, 5]
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)

--- a/tests/cli/test_cmds_metastatus.py
+++ b/tests/cli/test_cmds_metastatus.py
@@ -103,7 +103,7 @@ def test_get_cluster_dashboards_unknown_cluster():
         assert 'No dashboards configured for fake_cluster' in output_text
 
 
-def paasta_metastatus_returns_zero_all_clusters_ok():
+def test_paasta_metastatus_returns_zero_all_clusters_ok():
     args = mock.Mock(
         soa_dir=mock.sentinel.soa_dir,
         clusters='cluster1,cluster2,cluster3',
@@ -123,9 +123,10 @@ def paasta_metastatus_returns_zero_all_clusters_ok():
 
         return_code = metastatus.paasta_metastatus(args)
         assert return_code == 0
+        assert mock_print_cluster_status.call_count == 3
 
 
-def paasta_metastatus_returns_one_on_error():
+def test_paasta_metastatus_returns_one_on_error():
     args = mock.Mock(
         soa_dir=mock.sentinel.soa_dir,
         clusters='cluster1,cluster2,cluster3',
@@ -145,3 +146,4 @@ def paasta_metastatus_returns_one_on_error():
 
         return_code = metastatus.paasta_metastatus(args)
         assert return_code == 1
+        assert mock_print_cluster_status.call_count == 3

--- a/tests/cli/test_cmds_metastatus.py
+++ b/tests/cli/test_cmds_metastatus.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import contextlib
 from StringIO import StringIO
 
 import mock
@@ -36,8 +37,8 @@ def test_report_cluster_status(mock_stdout, mock_load_system_paasta_config):
 
     thing_to_patch = 'paasta_tools.cli.cmds.metastatus.execute_paasta_metastatus_on_remote_master'
     with mock.patch(thing_to_patch, autospec=True) as mock_execute_paasta_metastatus_on_remote_master:
-        mock_execute_paasta_metastatus_on_remote_master.return_value = mock.sentinel.return_vlaue, 'mock_status'
-        metastatus.print_cluster_status(
+        mock_execute_paasta_metastatus_on_remote_master.return_value = mock.sentinel.return_value, 'mock_status'
+        return_code = metastatus.print_cluster_status(
             cluster,
             fake_system_paasta_config,
             False,
@@ -54,6 +55,7 @@ def test_report_cluster_status(mock_stdout, mock_load_system_paasta_config):
         actual = mock_stdout.getvalue()
         assert 'Cluster: %s' % cluster in actual
         assert 'mock_status' in actual
+        assert return_code == mock.sentinel.return_value
 
 
 def test_figure_out_clusters_to_inspect_respects_the_user():
@@ -99,3 +101,47 @@ def test_get_cluster_dashboards_unknown_cluster():
         }, 'fake_directory')
         output_text = metastatus.get_cluster_dashboards('fake_cluster')
         assert 'No dashboards configured for fake_cluster' in output_text
+
+
+def paasta_metastatus_returns_zero_all_clusters_ok():
+    args = mock.Mock(
+        soa_dir=mock.sentinel.soa_dir,
+        clusters='cluster1,cluster2,cluster3',
+    )
+
+    with contextlib.nested(
+        mock.patch('paasta_tools.cli.cmds.metastatus.list_clusters', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.metastatus.print_cluster_status', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.metastatus.load_system_paasta_config', autospec=True),
+    ) as (
+        mock_list_clusters,
+        mock_print_cluster_status,
+        _
+    ):
+        mock_list_clusters.return_value = ['cluster1', 'cluster2', 'cluster3']
+        mock_print_cluster_status.side_effect = [0, 0, 0]
+
+        return_code = metastatus.paasta_metastatus(args)
+        assert return_code == 0
+
+
+def paasta_metastatus_returns_one_on_error():
+    args = mock.Mock(
+        soa_dir=mock.sentinel.soa_dir,
+        clusters='cluster1,cluster2,cluster3',
+    )
+
+    with contextlib.nested(
+        mock.patch('paasta_tools.cli.cmds.metastatus.list_clusters', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.metastatus.print_cluster_status', autospec=True),
+        mock.patch('paasta_tools.cli.cmds.metastatus.load_system_paasta_config', autospec=True),
+    ) as (
+        mock_list_clusters,
+        mock_print_cluster_status,
+        _
+    ):
+        mock_list_clusters.return_value = ['cluster1', 'cluster2', 'cluster3']
+        mock_print_cluster_status.side_effect = [0, 0, 255]
+
+        return_code = metastatus.paasta_metastatus(args)
+        assert return_code == 1

--- a/tests/cli/test_cmds_metastatus.py
+++ b/tests/cli/test_cmds_metastatus.py
@@ -36,7 +36,7 @@ def test_report_cluster_status(mock_stdout, mock_load_system_paasta_config):
 
     thing_to_patch = 'paasta_tools.cli.cmds.metastatus.execute_paasta_metastatus_on_remote_master'
     with mock.patch(thing_to_patch, autospec=True) as mock_execute_paasta_metastatus_on_remote_master:
-        mock_execute_paasta_metastatus_on_remote_master.return_value = 'mock_status'
+        mock_execute_paasta_metastatus_on_remote_master.return_value = mock.sentinel.return_vlaue, 'mock_status'
         metastatus.print_cluster_status(
             cluster,
             fake_system_paasta_config,

--- a/tests/test_check_chronos_jobs.py
+++ b/tests/test_check_chronos_jobs.py
@@ -145,9 +145,9 @@ def test_respect_latest_run_after_rerun(mock_lookup_chronos_jobs):
         'lastSuccess': '2016-07-26T22:00:00+00:00',
         'lastError': '2016-07-26T22:01:00+00:00'
     }
-    mock_lookup_chronos_jobs.side_effect = iter([[
+    mock_lookup_chronos_jobs.side_effect = [[
         fake_job
-    ]])
+    ]]
 
     fake_configured_jobs = [('service1', 'chronos_job')]
     fake_client = Mock(list=Mock(return_value=[('service1', 'chronos_job')]))
@@ -162,10 +162,10 @@ def test_respect_latest_run_after_rerun(mock_lookup_chronos_jobs):
         'lastSuccess': '2016-07-26T22:12:00+00:00',
     }
     reran_job = chronos_rerun.set_tmp_naming_scheme(reran_job)
-    mock_lookup_chronos_jobs.side_effect = iter([[
+    mock_lookup_chronos_jobs.side_effect = [[
         fake_job,
         reran_job
-    ]])
+    ]]
     assert check_chronos_jobs.build_service_job_mapping(fake_client, fake_configured_jobs) == {
         ('service1', 'chronos_job'): [(reran_job, chronos_tools.LastRunState.Success)]
     }
@@ -174,9 +174,6 @@ def test_respect_latest_run_after_rerun(mock_lookup_chronos_jobs):
 @patch('paasta_tools.check_chronos_jobs.chronos_tools.lookup_chronos_jobs', autospec=True)
 @patch('paasta_tools.check_chronos_jobs.chronos_tools.filter_enabled_jobs', autospec=True)
 def test_build_service_job_mapping(mock_filter_enabled_jobs, mock_lookup_chronos_jobs):
-    # iter() is a workaround
-    # (http://lists.idyll.org/pipermail/testing-in-python/2013-April/005527.html)
-    # for a bug in mock (http://bugs.python.org/issue17826)
     services = ['service1', 'service2', 'service3']
     latest_time = '2016-07-26T22:03:00+00:00'
     fake_jobs = [[
@@ -192,8 +189,8 @@ def test_build_service_job_mapping(mock_filter_enabled_jobs, mock_lookup_chronos
             'name': service + ' foo'
         }
     ] for service in services]
-    mock_lookup_chronos_jobs.side_effect = iter(fake_jobs)
-    mock_filter_enabled_jobs.side_effect = iter([[{}, {}, {}] for x in range(0, 3)])
+    mock_lookup_chronos_jobs.side_effect = fake_jobs
+    mock_filter_enabled_jobs.side_effect = [[{}, {}, {}] for _ in range(0, 3)]
 
     fake_configured_jobs = [('service1', 'main'), ('service2', 'main'), ('service3', 'main')]
     fake_client = Mock(list=Mock(return_value=[('service1', 'main'), ('service2', 'main'), ('service3', 'main')]))

--- a/tests/test_cleanup_chronos_jobs.py
+++ b/tests/test_cleanup_chronos_jobs.py
@@ -54,10 +54,10 @@ def test_deployed_job_names():
 def test_filter_expired_tmp_jobs(mock_get_temporary_jobs):
     two_days_ago = datetime.datetime.now(dateutil.tz.tzutc()) - datetime.timedelta(days=2)
     one_hour_ago = datetime.datetime.now(dateutil.tz.tzutc()) - datetime.timedelta(hours=1)
-    mock_get_temporary_jobs.side_effect = iter([
+    mock_get_temporary_jobs.side_effect = [
         [{'name': 'tmp foo bar', 'lastSuccess': two_days_ago.isoformat()}],
         [{'name': 'tmp anotherservice anotherinstance', 'lastSuccess': one_hour_ago.isoformat()}],
-    ])
+    ]
     actual = cleanup_chronos_jobs.filter_expired_tmp_jobs(mock.Mock(), ['foo bar', 'anotherservice anotherinstance'])
     assert actual == ['foo bar']
 


### PR DESCRIPTION
Fixes #718 

Also upgraded `mock` to `2.0.0` to fix a bug with `side_effect` that caused some unexpected behaviour.