### PR TITLE
Added back in healthcheck_port smartstack parameter

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -251,6 +251,10 @@ options:
     defined for this instance in ``smartstack.yaml``. If set to ``cmd`` then
     PaaSTA will execute ``healthcheck_cmd`` and examine the return code.
 
+  * ``healthcheck_port``: an alternative port to use for healthchecking your
+    service. This is not required; it defaults to the port your service instance
+    is running on.
+
   * ``healthcheck_cmd``: If ``healthcheck_mode`` is set to ``cmd``, then this
     command is executed inside the container as a healthcheck. It must exit
     with status code 0 to signify a successful healthcheck. Any other exit code

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -134,6 +134,7 @@ def load_service_namespace_config(service, namespace, soa_dir=DEFAULT_SOA_DIR):
 
     - proxy_port: the proxy port defined for the given namespace
     - healthcheck_mode: the mode for the healthcheck (http or tcp)
+    - healthcheck_port: An alternate port to use for health checking
     - healthcheck_uri: URI target for healthchecking
     - healthcheck_timeout_s: healthcheck timeout in seconds
     - updown_timeout_s: updown_service timeout in seconds
@@ -169,6 +170,7 @@ def load_service_namespace_config(service, namespace, soa_dir=DEFAULT_SOA_DIR):
     key_whitelist = set([
         'healthcheck_mode',
         'healthcheck_uri',
+        'healthcheck_port',
         'healthcheck_timeout_s',
         'updown_timeout_s',
         'proxy_port',


### PR DESCRIPTION
Turns out we did need this! Relates to #745.