### PR TITLE
add minimum 32MB memory requirement PAASTA-7052

### DIFF
--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -16,7 +16,7 @@
             },
             "mem": {
                 "type": "number",
-                "minimum": 0,
+                "minimum": 32,
                 "exclusiveMinimum": true,
                 "default": 1024
             },

--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -45,7 +45,7 @@
             },
             "mem": {
                 "type": "number",
-                "minimum": 0,
+                "minimum": 32,
                 "exclusiveMinimum": true,
                 "default": 1024
             },

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -68,7 +68,7 @@
             },
             "mem": {
                 "type": "number",
-                "minimum": 0,
+                "minimum": 32,
                 "exclusiveMinimum": true,
                 "default": 1024
             },


### PR DESCRIPTION
internal PAASTA-7052

To quote:

The docker containerizer silently rewrites your memory requirements to 32MB if you set memory to a number below that [code](https://github.com/apache/mesos/blob/ceee0c386d5126880733e1ede07f3522272cf75b/src/slave/containerizer/docker.cpp#L1694). When it does so, it doesn't update the memory-swap limit too (which we use to make sure that containers cannot swap). As a result, docker fails to launch your container with the following error:
```
Nov 14 09:02:30 myhost dockerd: time="2016-11-14T09:02:30.359740861-08:00" level=error msg="Handler for POST /v1.22/containers/create returned error: Minimum memoryswap limit should be larger than memory limit, see usage."
```

It's pretty non obvious why this happens, so lets just force this on users in paasta validate.