### PR TITLE
Removed the soa_dir option from generate-pipeline

### DIFF
--- a/paasta_tools/cli/cmds/generate_pipeline.py
+++ b/paasta_tools/cli/cmds/generate_pipeline.py
@@ -43,13 +43,6 @@ def add_subparser(subparsers):
         '-s', '--service',
         help='Name of service for which you wish to generate a Jenkins pipeline',
     ).completer = lazy_choices_completer(list_services)
-    list_parser.add_argument(
-        '-d', '--soa-dir',
-        dest="soa_dir",
-        metavar="SOA_DIR",
-        default=DEFAULT_SOA_DIR,
-        help="define a different soa config directory",
-    )
     list_parser.set_defaults(command=paasta_generate_pipeline)
 
 
@@ -57,7 +50,7 @@ def paasta_generate_pipeline(args):
     """Generate a Jenkins build pipeline.
     :param args: argparse.Namespace obj created from sys.args by cli"""
     service = args.service or guess_service_name()
-    soa_dir = args.soa_dir
+    soa_dir = DEFAULT_SOA_DIR
     try:
         validate_service_name(service, soa_dir=soa_dir)
     except NoSuchService as service_not_found:

--- a/tests/cli/test_cmds_generate_pipeline.py
+++ b/tests/cli/test_cmds_generate_pipeline.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from StringIO import StringIO
 
+from mock import ANY
 from mock import MagicMock
 from mock import patch
 from pytest import raises
@@ -121,7 +122,7 @@ def test_generate_pipeline_uses_team_name_as_fallback_for_owner(
 @patch('paasta_tools.cli.cmds.generate_pipeline.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.generate_pipeline.guess_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.generate_pipeline.generate_pipeline', autospec=True)
-def test_paasta_generate_pipeline_success_no_opts(
+def test_paasta_generate_pipeline_success_guesses_service_name(
         mock_generate_pipeline,
         mock_guess_service_name,
         mock_validate_service_name):
@@ -130,23 +131,21 @@ def test_paasta_generate_pipeline_success_no_opts(
     mock_validate_service_name.return_value = None
     args = MagicMock()
     args.service = None
-    args.soa_dir = '/fake/soa/dir'
     assert paasta_generate_pipeline(args) is None
-    mock_generate_pipeline.assert_called_once_with(service='fake_service', soa_dir='/fake/soa/dir')
+    mock_generate_pipeline.assert_called_once_with(service='fake_service', soa_dir=ANY)
 
 
 @patch('paasta_tools.cli.cmds.generate_pipeline.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.generate_pipeline.generate_pipeline', autospec=True)
-def test_generate_pipeline_success_with_opts(
+def test_generate_pipeline_success_with_no_opts(
         mock_generate_pipeline,
         mock_validate_service_name):
     # paasta generate succeeds when service name provided as arg
     mock_validate_service_name.return_value = None
     args = MagicMock()
     args.service = 'fake_service'
-    args.soa_dir = '/fake/soa/dir'
     assert paasta_generate_pipeline(args) is None
-    mock_generate_pipeline.assert_called_once_with(service='fake_service', soa_dir='/fake/soa/dir')
+    mock_generate_pipeline.assert_called_once_with(service='fake_service', soa_dir=ANY)
 
 
 @patch('paasta_tools.cli.cmds.generate_pipeline.get_git_url', autospec=True)


### PR DESCRIPTION
Resolves #895.

Realistically we are not going to make fab_repo soa-dir aware any time soon, so I would rather we remove this misleading option.

If we do make all the yelp repo tools parameterized or we change to jenkins job builder or something, we can easily add this option back in.