### PR TITLE
Local run build fix

### DIFF
--- a/paasta_tools/adhoc_tools.py
+++ b/paasta_tools/adhoc_tools.py
@@ -76,7 +76,7 @@ class AdhocJobConfig(LongRunningServiceConfig):
         )
 
 
-def get_default_interactive_config(service, cluster, soa_dir):
+def get_default_interactive_config(service, cluster, soa_dir, load_deployments=False):
     default_job_config = {
         'cpus': 4,
         'mem': 10240,
@@ -97,7 +97,7 @@ def get_default_interactive_config(service, cluster, soa_dir):
         job_config = load_adhoc_job_config(
             service=service, instance='interactive', cluster=cluster, soa_dir=soa_dir, load_deployments=False)
 
-    if not job_config.branch_dict:
+    if not job_config.branch_dict and load_deployments:
         deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
         deploy_group = prompt_pick_one(deployments_json['deployments'].keys(), choosing='deploy group')
         job_config.config_dict['deploy_group'] = deploy_group

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -637,7 +637,12 @@ def configure_and_run_docker_container(
         if instance is None:
             instance_type = 'adhoc'
             instance = 'interactive'
-            instance_config = get_default_interactive_config(service=service, cluster=cluster, soa_dir=soa_dir)
+            instance_config = get_default_interactive_config(
+                service=service,
+                cluster=cluster,
+                soa_dir=soa_dir,
+                load_deployments=load_deployments,
+            )
             interactive = True
         else:
             instance_type = validate_service_instance(service, instance, cluster, soa_dir)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1680,6 +1680,10 @@ def prompt_pick_one(sequence, choosing):
                          ' Please specify a {choosing} using the cli.\n'.format(choosing=choosing))
         sys.exit(1)
 
+    if not sequence:
+        sys.stderr.write('PaaSTA needs to pick a {choosing} but none were found.\n'.format(choosing=choosing))
+        sys.exit(1)
+
     QUIT_ACTION = 'Quit'
     global_actions = [QUIT_ACTION]
     choices = [(item, item) for item in sequence]

--- a/tests/test_adhoc_tools.py
+++ b/tests/test_adhoc_tools.py
@@ -33,7 +33,12 @@ def test_get_default_interactive_config():
             config_dict={},
             branch_dict={'deploy_group': 'fake_deploy_group'},
         )
-        result = adhoc_tools.get_default_interactive_config('fake_serivce', 'fake_cluster', '/fake/soa/dir')
+        result = adhoc_tools.get_default_interactive_config(
+            'fake_serivce',
+            'fake_cluster',
+            '/fake/soa/dir',
+            load_deployments=False,
+        )
         assert result.get_cpus() == 4
         assert result.get_mem() == 10240
         assert result.get_disk() == 1024
@@ -58,6 +63,11 @@ def test_get_default_interactive_config_reads_from_tty():
                 },
             },
         })
-        result = adhoc_tools.get_default_interactive_config('fake_serivce', 'fake_cluster', '/fake/soa/dir')
+        result = adhoc_tools.get_default_interactive_config(
+            'fake_serivce',
+            'fake_cluster',
+            '/fake/soa/dir',
+            load_deployments=True,
+        )
         assert result.get_deploy_group() == 'fake_deploygroup'
         assert result.get_docker_image() == mock.sentinel.docker_image

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1599,8 +1599,15 @@ def test_prompt_pick_one_eoferror():
             utils.prompt_pick_one(['choiceA', 'choiceB'], 'test')
 
 
-def test_prompt_pick_one_returns_none_no_tty():
+def test_prompt_pick_one_exits_no_tty():
     with mock.patch('paasta_tools.utils.sys.stdin', autospec=True) as mock_stdin:
         mock_stdin.isatty.return_value = False
         with raises(SystemExit):
             utils.prompt_pick_one(['choiceA', 'choiceB'], 'test')
+
+
+def test_prompt_pick_one_exits_no_choices():
+    with mock.patch('paasta_tools.utils.sys.stdin', autospec=True) as mock_stdin:
+        mock_stdin.isatty.return_value = True
+        with raises(SystemExit):
+            utils.prompt_pick_one([], 'test')


### PR DESCRIPTION
Right now `local-run --build` prompts for a deploy group even though it doesn't need to know the git sha