### PR TITLE
Add cron support

### DIFF
--- a/paasta_itests/setup_chronos_job.feature
+++ b/paasta_itests/setup_chronos_job.feature
@@ -71,6 +71,7 @@ Feature: setup_chronos_job can create and bounce jobs
   Scenario: Jobs using cron-style schedules can be launched
     Given a working paasta cluster
       And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+      And we have a deployments.json for the service "testservice" with enabled instance "testinstance"
      When we set the "schedule" field of the chronos config for service "testservice" and instance "testinstance" to "* * * * *"
      When we run setup_chronos_job for service_instance "testservice.testinstance"
      Then there should be 1 enabled jobs for the service "testservice" and instance "testinstance"

--- a/paasta_itests/setup_chronos_job.feature
+++ b/paasta_itests/setup_chronos_job.feature
@@ -67,3 +67,10 @@ Feature: setup_chronos_job can create and bounce jobs
       And we have a deployments.json for the service "testservice" with enabled instance "testinstance"
      When we run setup_chronos_job for service_instance "testservice.testinstance"
      Then there should be 1 disabled jobs for the service "testservice" and instance "testinstance"
+
+  Scenario: Jobs using cron-style schedules can be launched
+    Given a working paasta cluster
+      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+     When we set the "schedule" field of the chronos config for service "testservice" and instance "testinstance" to "* * * * *"
+     When we run setup_chronos_job for service_instance "testservice.testinstance"
+     Then there should be 1 enabled jobs for the service "testservice" and instance "testinstance"

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -312,7 +312,7 @@ class ChronosJobConfig(InstanceConfig):
                     repeat, start_time, interval = schedule.split('/')  # the parts have separate validators
                 except ValueError:
                     return (False, ('The specified schedule "%s" is neither a valid cron schedule nor a valid'
-                                    ' ISO8601 schedule' % schedule))
+                                    ' ISO 8601 schedule' % schedule))
 
                 # an empty start time is not valid ISO8601 but Chronos accepts it: '' == current time
                 if start_time == '':
@@ -324,8 +324,8 @@ class ChronosJobConfig(InstanceConfig):
                         if not hasattr(dt, 'tzinfo'):
                             msgs.append('The specified start time "%s" must contain a time zone' % start_time)
                     except isodate.ISO8601Error as exc:
-                        msgs.append('The specified start time "%s" in schedule "%s" '
-                                    'does not conform to the ISO8601 format:\n%s' % (start_time, schedule, exc.message))
+                        msgs.append('The specified start time "%s" in schedule "%s" does '
+                                    'not conform to the ISO 8601 format:\n%s' % (start_time, schedule, exc.message))
 
                 parsed_interval = None
                 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ pyramid==1.7
 pyramid-swagger==2.2.3
 pysensu-yelp==0.2.2
 PyStaticConfiguration==0.9.0
+python-crontab==2.1.1
 python-daemon==1.5.2
 python-dateutil==2.4.2
 pytimeparse==1.1.5

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'pysensu-yelp >= 0.2.2',
         'pytimeparse >= 1.1.0',
         'pytz >= 2014.10',
+        'python-crontab>=2.1.1',
         'python-dateutil >= 2.4.0',
         'retry',
         'requests == 2.6.2',

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -635,6 +635,47 @@ class TestChronosTools:
         assert okay is True
         assert msg == ''
 
+    def test_check_schedule_valid_cron(self):
+        fake_schedule = '* * * * *'
+        chronos_config = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'schedule': fake_schedule},
+            branch_dict={},
+        )
+        okay, msg = chronos_config.check_schedule()
+        assert okay is True
+        assert msg == ''
+
+    def test_check_schedule_invalid_cron_sixth_field(self):
+        fake_schedule = '* * * * * *'
+        chronos_config = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'schedule': fake_schedule},
+            branch_dict={},
+        )
+        okay, msg = chronos_config.check_schedule()
+        assert okay is False
+        assert msg == ('The specified schedule "* * * * * *" '
+                       'is neither a valid cron schedule nor a valid ISO8601 schedule')
+
+    def test_check_schedule_invalid_cron_L_field(self):
+        fake_schedule = '0 16 L * *'
+        chronos_config = chronos_tools.ChronosJobConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={'schedule': fake_schedule},
+            branch_dict={},
+        )
+        okay, msg = chronos_config.check_schedule()
+        assert okay is False
+        assert msg == ('The specified schedule "0 16 L * *" '
+                       'is neither a valid cron schedule nor a valid ISO8601 schedule')
+
     def test_check_schedule_invalid_empty_start_time(self):
         fake_schedule = 'R10//PT70S'
         chronos_config = chronos_tools.ChronosJobConfig(
@@ -947,7 +988,8 @@ class TestChronosTools:
         )
         with raises(chronos_tools.InvalidChronosConfigError) as exc:
             invalid_config.format_chronos_job_dict(docker_url='', docker_volumes=[], dockercfg_location={})
-        assert 'The specified schedule "%s" is invalid' % fake_schedule in exc.value
+        assert ('The specified schedule "%s" is neither a valid '
+                'cron schedule nor a valid ISO8601 schedule' % fake_schedule) in exc.value
 
     def test_list_job_names(self):
         fake_name = 'vegetables'

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -663,7 +663,7 @@ class TestChronosTools:
         okay, msg = chronos_config.check_schedule()
         assert okay is False
         assert msg == ('The specified schedule "* * * * * *" '
-                       'is neither a valid cron schedule nor a valid ISO8601 schedule')
+                       'is neither a valid cron schedule nor a valid ISO 8601 schedule')
 
     def test_check_schedule_invalid_cron_L_field(self):
         fake_schedule = '0 16 L * *'
@@ -677,7 +677,7 @@ class TestChronosTools:
         okay, msg = chronos_config.check_schedule()
         assert okay is False
         assert msg == ('The specified schedule "0 16 L * *" '
-                       'is neither a valid cron schedule nor a valid ISO8601 schedule')
+                       'is neither a valid cron schedule nor a valid ISO 8601 schedule')
 
     def test_check_schedule_invalid_empty_start_time(self):
         fake_schedule = 'R10//PT70S'
@@ -992,7 +992,7 @@ class TestChronosTools:
         with raises(chronos_tools.InvalidChronosConfigError) as exc:
             invalid_config.format_chronos_job_dict(docker_url='', docker_volumes=[], dockercfg_location={})
         assert ('The specified schedule "%s" is neither a valid '
-                'cron schedule nor a valid ISO8601 schedule' % fake_schedule) in exc.value
+                'cron schedule nor a valid ISO 8601 schedule' % fake_schedule) in exc.value
 
     def test_list_job_names(self):
         fake_name = 'vegetables'

--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 7B2C3B0889BF5709A105D03A
 RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
 RUN echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections
 RUN apt-get update && apt-get -y install lsb-release oracle-java8-installer
-RUN apt-get -y --allow-unauthenticated install chronos=2.5.0-yelp18-1.ubuntu1404
+RUN apt-get -y --allow-unauthenticated install chronos=2.5.0-yelp19-1.ubuntu1404
 
 # Chronos will look in here for zk config, so we blow away the bogus defaults
 RUN rm -rf /etc/mesos/


### PR DESCRIPTION
Updates validation of the ``schedule`` field to allow cron-style schedule strings. I've verified that the library being used, ``python-crontab``, has a specification for the cron-schedule strings consistent with that which the library used in Chronos does.

Taken from internal ticket PAASTA-7161:

> I've kind of done an adhoc integration test to see which cron schedules Chronos will be able to parse  from the current Tronfig. I took all the current tronfig cron schedules and parsed them with the same parser Chronos uses.

```
scala> val lines = fromFile("/tmp/test-crons").getLines
lines: Iterator[String] = non-empty iterator

scala> val parsed = lines.map(cron => Try(unixCronParser.parse(cron)))
parsed: Iterator[scala.util.Try[com.cronutils.model.Cron]] = non-empty iterator

scala> parsed.toArray.foreach(println)
Success(com.cronutils.model.Cron@1dfcf85a)
Success(com.cronutils.model.Cron@590dea35)
Success(com.cronutils.model.Cron@6550ce46)
Success(com.cronutils.model.Cron@69f69078)
Success(com.cronutils.model.Cron@13b29b34)
Success(com.cronutils.model.Cron@25589735)
Success(com.cronutils.model.Cron@46994f26)
Success(com.cronutils.model.Cron@1bb172dd)
Success(com.cronutils.model.Cron@1cdd31a4)
Success(com.cronutils.model.Cron@7dddfc35)
Success(com.cronutils.model.Cron@71316cd7)
Success(com.cronutils.model.Cron@6106dfb6)
Success(com.cronutils.model.Cron@14239223)
Success(com.cronutils.model.Cron@68df8c6)
Success(com.cronutils.model.Cron@7c206b14)
Success(com.cronutils.model.Cron@2b8cf049)
Success(com.cronutils.model.Cron@2336cd91)
Success(com.cronutils.model.Cron@4a944af9)
Success(com.cronutils.model.Cron@3593e074)
Success(com.cronutils.model.Cron@79d14037)
Success(com.cronutils.model.Cron@6c1e40d9)
Success(com.cronutils.model.Cron@4b50c21)
Success(com.cronutils.model.Cron@2e0fdc83)
Success(com.cronutils.model.Cron@5dacf18d)
Success(com.cronutils.model.Cron@432a6a69)
Success(com.cronutils.model.Cron@6f52a229)
Success(com.cronutils.model.Cron@3fe98084)
Success(com.cronutils.model.Cron@5f33e6d)
Success(com.cronutils.model.Cron@151a6598)
Success(com.cronutils.model.Cron@6fa3def8)
Success(com.cronutils.model.Cron@1c3d9e28)
Success(com.cronutils.model.Cron@a1cb94)
Success(com.cronutils.model.Cron@46d148bd)
Success(com.cronutils.model.Cron@37f41a81)
Success(com.cronutils.model.Cron@47c81e89)
Success(com.cronutils.model.Cron@49bb808f)
Success(com.cronutils.model.Cron@563ada5)
Failure(java.lang.IllegalArgumentException: Invalid chars in expression! Expression: L Invalid chars: L)
Success(com.cronutils.model.Cron@12548f9a)
Success(com.cronutils.model.Cron@156ff70f)
Success(com.cronutils.model.Cron@c5a2d5)
Failure(java.lang.IllegalArgumentException: Cron expression contains 6 parts but we expect one of [5])
Failure(java.lang.IllegalArgumentException: Cron expression contains 6 parts but we expect one of [5])
Success(com.cronutils.model.Cron@185339ed)
Success(com.cronutils.model.Cron@2e4d4d22)
Success(com.cronutils.model.Cron@4470106b)
Success(com.cronutils.model.Cron@690ed13a)
Success(com.cronutils.model.Cron@681311a7)
Success(com.cronutils.model.Cron@2c7375da)
Success(com.cronutils.model.Cron@68c4db77)
Success(com.cronutils.model.Cron@775c4054)
Success(com.cronutils.model.Cron@7b2e931)
Success(com.cronutils.model.Cron@305881b8)
Success(com.cronutils.model.Cron@7e89eba7)
Success(com.cronutils.model.Cron@6bc25ac2)
Success(com.cronutils.model.Cron@7b29cdea)
Success(com.cronutils.model.Cron@f08d676)
Success(com.cronutils.model.Cron@3eedd0e3)
Success(com.cronutils.model.Cron@478089b6)
Success(com.cronutils.model.Cron@72f35a31)
Success(com.cronutils.model.Cron@3b01897f)
Success(com.cronutils.model.Cron@6b3b2c34)
Success(com.cronutils.model.Cron@28b5d5dc)
Success(com.cronutils.model.Cron@407f2029)
Success(com.cronutils.model.Cron@77020328)
Success(com.cronutils.model.Cron@45eacb70)
Success(com.cronutils.model.Cron@4377ed24)
Success(com.cronutils.model.Cron@7a30e30b)
Success(com.cronutils.model.Cron@1dcca426)
Success(com.cronutils.model.Cron@e6e5da4)
Success(com.cronutils.model.Cron@720c8f80)
Success(com.cronutils.model.Cron@f591271)
Success(com.cronutils.model.Cron@77cc6a28)
Success(com.cronutils.model.Cron@b339a08)
Success(com.cronutils.model.Cron@1d556461)
Success(com.cronutils.model.Cron@5a583720)
Success(com.cronutils.model.Cron@4ed19b69)
Success(com.cronutils.model.Cron@59a5bb61)
Success(com.cronutils.model.Cron@6f65aa58)
Success(com.cronutils.model.Cron@749f61a3)
Success(com.cronutils.model.Cron@36d7a68a)
Success(com.cronutils.model.Cron@42dd7d82)
Success(com.cronutils.model.Cron@2838eb)
Success(com.cronutils.model.Cron@fb5d334)
Success(com.cronutils.model.Cron@45dc7be)
```

> Those that fail have a 6th field - I think this is representing a 'year' field. Cron doesn't support this by default according to https://linux.die.net/man/5/crontab

> Given that the value is ``*`` in both instances, I think we're safe.

```
robj@dev4-uswest1cdevc:~/tronfig master % git grep -h "schedule: \"cron" | awk '{$1=$2=""; print $0}' | awk '{$1=$1;print}'| sed 's/".*$//' | awk 'NF == 6 { print $0 } '
*/5 9-23 * * 1 *
*/5 8-14 * * 2 *
```

The other failure is a task using the extra "L" syntax representing last day of month.
```
robj@dev4-uswest1cdevc:~/tronfig master % git grep -h "schedule: \"cron" | awk '{$1=$2=""; print $0}' | awk '{$1=$1;print}'| sed 's/".*$//' | grep "L"
0 16 L * *
```

And cross validating with those that the python library considers to be acceptable schedules:

```
>>> from crontab import CronSlices
>>> f = open('/tmp/test-crons')
>>> lines = f.readlines()
>>> lines = map(lambda line: line.strip(), lines)
>>> filter(lambda x: not x[1], map(lambda line: (line, CronSlices.is_valid(line)), lines))
[('0 16 L * *', False), ('*/5 9-23 * * 1 *', False), ('*/5 8-14 * * 2 *', False)]
```

This is good: the python library rejects the same schedules as Chronos.

I've ran the itests locally with the right deb installed and observed them passing.

Here's the output from ``paasta status`` of a test job (note the ``schedule`` field):

```
root@44a82df1df8d:/work/paasta_tools# ./paasta_serviceinit.py -s hello-world -i test_chronos status
instance: test_chronos
Git sha:    9cdf957d (desired)
Desired:    Scheduled
Job:     hello-world test_chronos
  Status:   Scheduled (idle)  Last:     OK (2016-12-01T13:05, 30 seconds ago)
  Schedule: * * * * * (UTC) Epsilon: PT60S
  Command:  echo "hello world"
  Mesos:    Not running
```




NB: The integration tests will fail until I merge https://github.com/Yelp/chronos/pull/46 and update the integration tests to use the latest deb package.

