### PR TITLE
Move requirements to build for example cluster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!yelp_package/*
+!requirements*

--- a/docs/source/installation/example_cluster.rst
+++ b/docs/source/installation/example_cluster.rst
@@ -15,12 +15,11 @@ the files locally but run them in the containers.
 
 To get started run: ``docker-compose run playground``. This should give
 you a shell with the paasta\_tools package installed in development
-mode. The first time this runs it will take a while because we fetch and
-compile various python packages, however we store a cache on the docker
-host so that it is quicker next time. If you need to update a python
-package you probably want to
-``pip wheel /work --wheel-dir=/var/tmp/pip_cache`` and then restart the
-container.
+mode.
+
+If you have added a new python dependency you may need to run
+``docker-compose build`` to re-build the containers. Then you can restart
+everything with ``docker-compose down && docker-compose run playground``.
 
 Try it out
 ----------

--- a/example_cluster/docker-compose.override.yml
+++ b/example_cluster/docker-compose.override.yml
@@ -5,7 +5,9 @@ services:
   mesosbase:
     build: ../yelp_package/dockerfiles/itest/mesos/
   mesosmaster:
-    build: ../yelp_package/dockerfiles/mesos-paasta/
+    build:
+      context: ../
+      dockerfile: ./yelp_package/dockerfiles/mesos-paasta/Dockerfile
     ports:
       - '5050:5050'
       - '5054:5054'
@@ -14,7 +16,6 @@ services:
       - mesosbase
       - zookeeper
     volumes:
-      - /var/tmp/pip_cache1:/var/tmp/pip_cache
       - ../:/work:rw
       - ./paasta:/etc/paasta:rw
       - ./example-services:/nail/etc/services:rw
@@ -25,7 +26,9 @@ services:
     ports:
       - 5051
       - 22
-    build: ../yelp_package/dockerfiles/mesos-paasta/
+    build:
+      context: ../
+      dockerfile: ./yelp_package/dockerfiles/mesos-paasta/Dockerfile
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ssh-data:/root/.ssh
@@ -41,9 +44,10 @@ services:
   itest_trusty:
     build: ../yelp_package/dockerfiles/trusty/
   playground:
-    build: ../yelp_package/dockerfiles/playground/
+    build:
+      context: ../
+      dockerfile: ./yelp_package/dockerfiles/playground/Dockerfile
     volumes:
-      - /var/tmp/pip_cache2:/var/tmp/pip_cache
       - ../:/work:rw
       - ./paasta:/etc/paasta:rw
       - ./example-services:/nail/etc/services:rw

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 flake8==2.5.0
 git+git://github.com/solarkennedy/sphinxcontrib-programoutput#egg=package-two
+ipython
 mock==2.0.0
 pep8==1.5.7
 pre-commit==0.7.6

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -29,7 +29,7 @@ RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set
 RUN echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections
 RUN apt-get update && apt-get -y install lsb-release oracle-java8-installer
 
-RUN apt-get -y --allow-unauthenticated install marathon=1.4.0-0.1.20161021221011.snap19.ubuntu1404
+RUN apt-get update && apt-get -y --allow-unauthenticated install marathon=1.4.0-0.1.20161021221011.snap19.ubuntu1404
 
 RUN echo -n "secret2" > /etc/marathon_framework_secret
 

--- a/yelp_package/dockerfiles/mesos-paasta/Dockerfile
+++ b/yelp_package/dockerfiles/mesos-paasta/Dockerfile
@@ -4,9 +4,12 @@ RUN apt-get update && apt-get -y install python-tox python-setuptools \
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 RUN mkdir -p /var/log/paasta_logs 
 RUN mkdir /var/run/sshd
-ADD ./cron.d /etc/cron.d
+ADD ./yelp_package/dockerfiles/mesos-paasta/cron.d /etc/cron.d
 RUN mkdir -p /nail/etc
 RUN ln -s /etc/mesos-slave-secret /nail/etc/mesos-slave-secret
 RUN ln -s /etc/paasta/mesos-cli.json /nail/etc/mesos-cli.json
-ADD ./start.sh /start.sh
-ADD ./start-slave.sh /start-slave.sh
+ADD ./requirements-dev.txt /paasta/requirements-dev.txt
+ADD ./requirements.txt /paasta/requirements.txt
+RUN pip install -r /paasta/requirements-dev.txt
+ADD ./yelp_package/dockerfiles/mesos-paasta/start.sh /start.sh
+ADD ./yelp_package/dockerfiles/mesos-paasta/start-slave.sh /start-slave.sh

--- a/yelp_package/dockerfiles/mesos-paasta/start.sh
+++ b/yelp_package/dockerfiles/mesos-paasta/start.sh
@@ -5,13 +5,9 @@ ssh-keygen -f /root/.ssh/id_rsa -N ''
 cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
 chmod 700 /root/.ssh
 chmod 600 /root/.ssh/*
-
 /usr/sbin/sshd
-if [ ! -f /var/tmp/pip_cache/built_wheels ]; then
-    pip wheel /work --wheel-dir=/var/tmp/pip_cache
-    touch /var/tmp/pip_cache/built_wheels
-fi
-pip install --no-index --find-links=/var/tmp/pip_cache -e /work
+
+pip install -e /work
 # This is a hack because we're not creating a real package which would create symlinks for the .py scripts
 while read link; do echo $link|sed -e 's/usr\/share\/python\/paasta-tools\//\/usr\/local\//'| sed -e 's/\ usr/\ \/usr/'| xargs ln -s; done < /work/debian/paasta-tools.links
 /usr/sbin/rsyslogd

--- a/yelp_package/dockerfiles/playground/Dockerfile
+++ b/yelp_package/dockerfiles/playground/Dockerfile
@@ -5,4 +5,7 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 RUN mkdir /var/run/sshd
 RUN mkdir -p /nail/etc
 RUN ln -s /etc/paasta/mesos-cli.json /nail/etc/mesos-cli.json
-ADD ./start.sh /start.sh
+ADD ./requirements-dev.txt /paasta/requirements-dev.txt
+ADD ./requirements.txt /paasta/requirements.txt
+RUN pip install -r /paasta/requirements-dev.txt
+ADD ./yelp_package/dockerfiles/playground/start.sh /start.sh

--- a/yelp_package/dockerfiles/playground/start.sh
+++ b/yelp_package/dockerfiles/playground/start.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-if [ ! -f /var/tmp/pip_cache/built_wheels ]; then
-    pip wheel . --wheel-dir=/var/tmp/pip_cache
-    touch /var/tmp/pip_cache/built_wheels
-fi
-pip install --no-index --find-links=/var/tmp/pip_cache -e .
+pip install -e .
 # This is a hack because we're not creating a real package which would create symlinks for the .py scripts
 while read link; do echo $link|sed -e 's/usr\/share\/python\/paasta-tools\//\/usr\/local\//'| sed -e 's/\ usr/\ \/usr/'| xargs ln -s; done < /work/debian/paasta-tools.links
 /bin/bash


### PR DESCRIPTION
This moves the installation of the python requirements into the docker
build. This speeds up the startup a bunch and also means that you can
make sure you have the correct requirements by running `docker-compose
build` to rebuild all the containers.

@Rob-Johnson as I mentioned this is possible because of being able to customise the context in docker-compose. Previously I couldn't think of a way to do it.