### PR TITLE
Reduce the number of different soa_dir argument definitions

### DIFF
--- a/paasta_tools/cli/argparse_helper.py
+++ b/paasta_tools/cli/argparse_helper.py
@@ -1,0 +1,20 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from paasta_tools.utils import DEFAULT_SOA_DIR
+
+
+def add_argument_soa_dir(parser):
+    return parser.add_argument('-d', '--soa-dir', dest="soa_dir",
+                               metavar="SOA_DIR", default=DEFAULT_SOA_DIR,
+                               help="define a different soa config directory")

--- a/paasta_tools/cli/cmds/emergency_restart.py
+++ b/paasta_tools/cli/cmds/emergency_restart.py
@@ -12,13 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from paasta_tools.cli import argparse_helper
 from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import compose_job_id
-from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import load_system_paasta_config
 
@@ -51,13 +51,7 @@ def add_subparser(subparsers):
         help="The PaaSTA cluster that has the service you want to restart. Like 'norcal-prod'.",
         required=True,
     ).completer = lazy_choices_completer(list_clusters)
-    status_parser.add_argument(
-        '-d', '--soa-dir',
-        dest="soa_dir",
-        metavar="SOA_DIR",
-        default=DEFAULT_SOA_DIR,
-        help="define a different soa config directory",
-    )
+    argparse_helper.add_argument_soa_dir(status_parser)
     status_parser.set_defaults(command=paasta_emergency_restart)
 
 

--- a/paasta_tools/cli/cmds/emergency_start.py
+++ b/paasta_tools/cli/cmds/emergency_start.py
@@ -12,13 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from paasta_tools.cli import argparse_helper
 from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import compose_job_id
-from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import PaastaColors
@@ -47,13 +47,7 @@ def add_subparser(subparsers):
         help="The PaaSTA cluster that has the service instance you want to start. Like 'norcal-prod'.",
         required=True,
     ).completer = lazy_choices_completer(list_clusters)
-    status_parser.add_argument(
-        '-d', '--soa-dir',
-        dest="soa_dir",
-        metavar="SOA_DIR",
-        default=DEFAULT_SOA_DIR,
-        help="define a different soa config directory",
-    )
+    argparse_helper.add_argument_soa_dir(status_parser)
     status_parser.set_defaults(command=paasta_emergency_start)
 
 

--- a/paasta_tools/cli/cmds/emergency_stop.py
+++ b/paasta_tools/cli/cmds/emergency_stop.py
@@ -12,13 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from paasta_tools.cli import argparse_helper
 from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import compose_job_id
-from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import load_system_paasta_config
 
@@ -46,13 +46,7 @@ def add_subparser(subparsers):
         help="The PaaSTA cluster that has the service instance you want to stop. Like 'norcal-prod'.",
         required=True,
     ).completer = lazy_choices_completer(list_clusters)
-    status_parser.add_argument(
-        '-d', '--soa-dir',
-        dest="soa_dir",
-        metavar="SOA_DIR",
-        default=DEFAULT_SOA_DIR,
-        help="define a different soa config directory",
-    )
+    argparse_helper.add_argument_soa_dir(status_parser)
     status_parser.set_defaults(command=paasta_emergency_stop)
 
 

--- a/paasta_tools/cli/cmds/get_latest_deployment.py
+++ b/paasta_tools/cli/cmds/get_latest_deployment.py
@@ -12,13 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from paasta_tools.cli import argparse_helper
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import PaastaColors
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.deployment_utils import get_currently_deployed_sha
-from paasta_tools.utils import DEFAULT_SOA_DIR
 
 
 def add_subparser(subparsers):
@@ -36,11 +36,7 @@ def add_subparser(subparsers):
         help='Name of the deploy group which you want to get the latest deployment for.',
         required=True,
     ).completer = lazy_choices_completer(list_deploy_groups)
-    list_parser.add_argument(
-        '-d', '--soa-dir',
-        help='A directory from which soa-configs should be read from',
-        default=DEFAULT_SOA_DIR,
-    )
+    argparse_helper.add_argument_soa_dir(list_parser)
 
     list_parser.set_defaults(command=paasta_get_latest_deployment)
 

--- a/paasta_tools/cli/cmds/info.py
+++ b/paasta_tools/cli/cmds/info.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 from service_configuration_lib import read_service_configuration
 
+from paasta_tools.cli import argparse_helper
 from paasta_tools.cli.cmds.status import get_actual_deployments
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
@@ -22,7 +23,6 @@ from paasta_tools.marathon_tools import get_all_namespaces_for_service
 from paasta_tools.marathon_tools import load_service_namespace_config
 from paasta_tools.monitoring_tools import get_runbook
 from paasta_tools.monitoring_tools import get_team
-from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_git_url
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import PaastaColors
@@ -50,13 +50,7 @@ def add_subparser(subparsers):
         '-s', '--service',
         help='The name of the service you wish to inspect'
     ).completer = lazy_choices_completer(list_services)
-    list_parser.add_argument(
-        '-d', '--soa-dir',
-        dest="soa_dir",
-        metavar="SOA_DIR",
-        default=DEFAULT_SOA_DIR,
-        help="define a different soa config directory",
-    )
+    argparse_helper.add_argument_soa_dir(list_parser)
     list_parser.set_defaults(command=paasta_info)
 
 

--- a/paasta_tools/cli/cmds/itest.py
+++ b/paasta_tools/cli/cmds/itest.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import os
 
+from paasta_tools.cli import argparse_helper
 from paasta_tools.cli.utils import get_jenkins_build_output_url
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_services
@@ -22,7 +23,6 @@ from paasta_tools.utils import _log
 from paasta_tools.utils import _run
 from paasta_tools.utils import build_docker_tag
 from paasta_tools.utils import check_docker_image
-from paasta_tools.utils import DEFAULT_SOA_DIR
 
 
 def add_subparser(subparsers):
@@ -47,12 +47,8 @@ def add_subparser(subparsers):
         help='Git sha used to construct tag for built image',
         required=True,
     )
-    list_parser.add_argument(
-        '-d', '--soa-dir',
-        dest='soa_dir',
-        help='A directory from which soa-configs should be read from',
-        default=DEFAULT_SOA_DIR,
-    ).completer = lazy_choices_completer(list_services)
+    argparse_helper.add_argument_soa_dir(list_parser).completer = \
+        lazy_choices_completer(list_services)
     list_parser.set_defaults(command=paasta_itest)
 
 

--- a/paasta_tools/cli/cmds/list_clusters.py
+++ b/paasta_tools/cli/cmds/list_clusters.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.cli import argparse_helper
 from paasta_tools.utils import list_clusters
 
 
@@ -26,13 +26,7 @@ def add_subparser(subparsers):
             "The command can only report those clusters that are actually used by some services."
         ),
     )
-    list_parser.add_argument(
-        '-d', '--soa-dir',
-        dest="soa_dir",
-        metavar="SOA_DIR",
-        default=DEFAULT_SOA_DIR,
-        help="define a different soa config directory",
-    )
+    argparse_helper.add_argument_soa_dir(list_parser)
     list_parser.set_defaults(command=paasta_list_clusters)
 
 

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -40,6 +40,7 @@ from pytimeparse.timeparse import timeparse
 
 from paasta_tools import chronos_tools
 from paasta_tools.marathon_tools import format_job_id
+from paasta_tools.cli import argparse_helper
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import guess_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
@@ -48,7 +49,6 @@ from paasta_tools.utils import ANY_CLUSTER
 from paasta_tools.utils import datetime_convert_timezone
 from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import DEFAULT_LOGLEVEL
-from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import format_log_line
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import list_clusters
@@ -104,14 +104,7 @@ def add_subparser(subparsers):
         dest='raw_mode', default=False,
         help="Don't pretty-print logs; emit them exactly as they are in scribe.",
     )
-    status_parser.add_argument(
-        '-d', '--soa-dir',
-        dest="soa_dir",
-        metavar="SOA_DIR",
-        default=DEFAULT_SOA_DIR,
-        help="define a different soa config directory",
-    )
-
+    argparse_helper.add_argument_soa_dir(status_parser)
     status_parser.add_argument(
         '-a', '--from', '--after', dest='time_from',
         help='The time to start gettings logs from. This can be an ISO-8601 timestamp or a human readable duration '

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -24,6 +24,7 @@ from requests.exceptions import ConnectionError
 
 from paasta_tools import remote_git
 from paasta_tools.api import client
+from paasta_tools.cli import argparse_helper
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import list_services
@@ -33,7 +34,6 @@ from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.deployment_utils import get_currently_deployed_sha
 from paasta_tools.generate_deployments_for_service import get_cluster_instance_map_for_service
 from paasta_tools.utils import _log
-from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import format_tag
 from paasta_tools.utils import get_git_url
 from paasta_tools.utils import get_paasta_tag_from_deploy_group
@@ -116,13 +116,7 @@ def add_subparser(subparsers):
         action='store_true',
         default=False
     )
-    list_parser.add_argument(
-        '-d', '--soa-dir',
-        dest="soa_dir",
-        metavar="SOA_DIR",
-        default=DEFAULT_SOA_DIR,
-        help="define a different soa config directory",
-    )
+    argparse_helper.add_argument_soa_dir(list_parser)
     list_parser.add_argument(
         '-v', '--verbose',
         action='count',

--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -12,9 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from paasta_tools.cli import argparse_helper
 from paasta_tools.cli.utils import execute_paasta_metastatus_on_remote_master
 from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import PaastaColors
@@ -52,13 +52,7 @@ def add_subparser(subparsers):
         '-c', '--clusters',
         help=clusters_help,
     ).completer = lazy_choices_completer(list_clusters)
-    status_parser.add_argument(
-        '-d', '--soa-dir',
-        dest="soa_dir",
-        metavar="SOA_DIR",
-        default=DEFAULT_SOA_DIR,
-        help="define a different soa config directory",
-    )
+    argparse_helper.add_argument_soa_dir(status_parser)
     status_parser.add_argument(
         '-g',
         '--groupings',

--- a/paasta_tools/cli/cmds/performance_check.py
+++ b/paasta_tools/cli/cmds/performance_check.py
@@ -17,8 +17,8 @@ import argparse
 import requests
 from service_configuration_lib import read_extra_service_information
 
+from paasta_tools.cli import argparse_helper
 from paasta_tools.cli.utils import validate_service_name
-from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import timeout
 
 
@@ -37,13 +37,7 @@ def add_subparser(subparsers):
         '-k', '--commit',
         help=argparse.SUPPRESS,
     )
-    list_parser.add_argument(
-        '-d', '--soa-dir',
-        dest='soa_dir',
-        metavar='SOA_DIR',
-        default=DEFAULT_SOA_DIR,
-        help='Define a different soa config directory',
-    )
+    argparse_helper.add_argument_soa_dir(list_parser)
     list_parser.set_defaults(command=perform_performance_check)
 
 

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -18,6 +18,7 @@ import socket
 from paasta_tools import remote_git
 from paasta_tools import utils
 from paasta_tools.chronos_tools import ChronosJobConfig
+from paasta_tools.cli import argparse_helper
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.cli.utils import lazy_choices_completer
@@ -26,7 +27,6 @@ from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import list_services
 from paasta_tools.generate_deployments_for_service import get_latest_deployment_tag
 from paasta_tools.marathon_tools import MarathonServiceConfig
-from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 
 
@@ -63,13 +63,7 @@ def add_subparser(subparsers):
             required=True
         ).completer = lazy_choices_completer(list_clusters)
 
-        status_parser.add_argument(
-            '-d', '--soa-dir',
-            dest="soa_dir",
-            metavar="SOA_DIR",
-            default=DEFAULT_SOA_DIR,
-            help="define a different soa config directory",
-        )
+        argparse_helper.add_argument_soa_dir(status_parser)
         status_parser.set_defaults(command=cmd_func)
 
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -20,6 +20,7 @@ from bravado.exception import HTTPError
 from service_configuration_lib import read_deploy
 
 from paasta_tools.api.client import get_paasta_api_client
+from paasta_tools.cli import argparse_helper
 from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
@@ -31,7 +32,6 @@ from paasta_tools.marathon_serviceinit import marathon_app_deploy_status_human
 from paasta_tools.marathon_serviceinit import status_marathon_job_human
 from paasta_tools.marathon_tools import load_deployments_json
 from paasta_tools.marathon_tools import MarathonDeployStatus
-from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_soa_cluster_deploy_files
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import load_system_paasta_config
@@ -73,13 +73,7 @@ def add_subparser(subparsers):
         help="A comma-separated list of instances to view. Defaults to view all instances.\n"
              "For example: --instances canary,main"
     )  # No completer because we need to know service first and we can't until some other stuff has happened
-    status_parser.add_argument(
-        '-d', '--soa-dir',
-        dest="soa_dir",
-        metavar="SOA_DIR",
-        default=DEFAULT_SOA_DIR,
-        help="define a different soa config directory",
-    )
+    argparse_helper.add_argument_soa_dir(status_parser)
     status_parser.set_defaults(command=paasta_status)
 
 


### PR DESCRIPTION
Replace multiple soa_dir argument definitions by the one defined in paasta_tools.cli.argparse_helper