### PR TITLE
fixed local run 'no tty message' not appearing with --build

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -632,18 +632,25 @@ def configure_and_run_docker_container(
     Function prints the output of run command in stdout.
     """
 
+    if instance is None and args.healthcheck:
+        paasta_print(
+            "With --healthcheck, --instance must be provided!",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if instance is None and not sys.stdin.isatty():
+        paasta_print(
+            "--instance and --cluster must be specified when using paasta local-run without a tty!",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     soa_dir = args.yelpsoa_config_root
-
     volumes = list()
-
     load_deployments = docker_hash is None or pull_image
-
     interactive = args.interactive
 
     try:
-        if instance is None and args.healthcheck:
-            paasta_print("With --healthcheck, --instance must be provided!", file=sys.stderr)
-            sys.exit(1)
         if instance is None:
             instance_type = 'adhoc'
             instance = 'interactive'

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -479,11 +479,13 @@ def test_configure_and_run_pulls_image_when_asked(
 
 def test_configure_and_run_docker_container_defaults_to_interactive_instance():
     with contextlib.nested(
+        mock.patch('paasta_tools.cli.cmds.local_run.sys.stdin.isatty', autospec=True, return_value=True),
         mock.patch('paasta_tools.cli.cmds.local_run.validate_service_instance', autospec=True),
         mock.patch('paasta_tools.cli.cmds.local_run.socket.getfqdn', autospec=True),
         mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True),
         mock.patch('paasta_tools.cli.cmds.local_run.get_default_interactive_config', autospec=True),
     ) as (
+        _,
         mock_validate_service_instance,
         mock_socket_get_fqdn,
         mock_run_docker_container,

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -479,18 +479,19 @@ def test_configure_and_run_pulls_image_when_asked(
 
 def test_configure_and_run_docker_container_defaults_to_interactive_instance():
     with contextlib.nested(
-        mock.patch('paasta_tools.cli.cmds.local_run.sys.stdin.isatty', autospec=True, return_value=True),
+        mock.patch('paasta_tools.cli.cmds.local_run.sys.stdin', autospec=True),
         mock.patch('paasta_tools.cli.cmds.local_run.validate_service_instance', autospec=True),
         mock.patch('paasta_tools.cli.cmds.local_run.socket.getfqdn', autospec=True),
         mock.patch('paasta_tools.cli.cmds.local_run.run_docker_container', autospec=True),
         mock.patch('paasta_tools.cli.cmds.local_run.get_default_interactive_config', autospec=True),
     ) as (
-        _,
+        mock_stdin,
         mock_validate_service_instance,
         mock_socket_get_fqdn,
         mock_run_docker_container,
         mock_get_default_interactive_config,
     ):
+        mock_stdin.isatty.return_value = True
         mock_validate_service_instance.side_effect = NoConfigurationForServiceError
         mock_docker_client = mock.MagicMock(spec_set=docker.Client)
         mock_socket_get_fqdn.return_value = 'fake_hostname'


### PR DESCRIPTION
Sample error:
```
Warning! You're running a container in interactive mode.
This is *NOT* how Mesos runs containers.
To run the container exactly as Mesos does, omit the -I flag.

cannot enable tty mode on non tty input
make: *** [itest] Error 1
```