### PR TITLE
Cosmetic cleanups for wait_for_deployment

### DIFF
--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -32,6 +32,7 @@ class fake_args:
     soa_dir = 'fake_soa_dir'
     block = False
     verbose = False
+    auto_rollback = False
 
 
 @patch('paasta_tools.cli.cmds.mark_for_deployment.validate_service_name', autospec=True)


### PR DESCRIPTION
Also addresses #894 a bit by doing a normal print with some whitespace indentation instead of a verbose logline.

Also don't print rollback instructions twice, and especially not with auto-rollback.