### PR TITLE
make python-crontab less noisy

### DIFF
--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -69,6 +69,10 @@ EXECUTION_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
 log = logging.getLogger(__name__)
 
+# we never want to hear from this - this means
+# that callers don't have to worry about setting this
+logging.getLogger("crontab").setLevel(logging.CRITICAL)
+
 
 class LastRunState:
     """Cheap enum to represent the state of the last run"""


### PR DESCRIPTION
It was logging messages whenever it couldn't parse a cron, which happens
every time we run setup_chronos_job with on a job with an ISO8601 schedule.
Turn down the logging.