### PR TITLE
made send_event not load deployments

### DIFF
--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -67,7 +67,12 @@ def send_event(service, namespace, cluster, soa_dir, status, output):
     :param output: The output to emit for this event"""
     # This function assumes the input is a string like "mumble.main"
     monitoring_overrides = marathon_tools.load_marathon_service_config(
-        service, namespace, cluster).get_monitoring()
+        service=service,
+        instance=namespace,
+        cluster=cluster,
+        soa_dir=soa_dir,
+        load_deployments=False,
+    ).get_monitoring()
     if 'alert_after' not in monitoring_overrides:
         monitoring_overrides['alert_after'] = '2m'
     monitoring_overrides['check_every'] = '1m'

--- a/paasta_tools/setup_chronos_job.py
+++ b/paasta_tools/setup_chronos_job.py
@@ -93,6 +93,7 @@ def send_event(service, instance, soa_dir, status, output):
             instance=instance,
             cluster=cluster,
             soa_dir=soa_dir,
+            load_deployments=False,
         ).get_monitoring()
     except NoConfigurationForServiceError:
         monitoring_overrides = {}

--- a/tests/test_setup_chronos_job.py
+++ b/tests/test_setup_chronos_job.py
@@ -364,6 +364,7 @@ class TestSetupChronosJob:
                 instance=self.fake_instance,
                 cluster=mock_load_system_paasta_config.return_value.get_cluster.return_value,
                 soa_dir=fake_soa_dir,
+                load_deployments=False,
             )
 
     def test_bounce_chronos_job_takes_actions(self):


### PR DESCRIPTION
This causes `setup_chronos_job` to not fail when a chronos service has not been deployed yet