### PR TITLE
fix parsing of backend names in haproxy

### DIFF
--- a/paasta_tools/smartstack_tools.py
+++ b/paasta_tools/smartstack_tools.py
@@ -215,13 +215,25 @@ def backend_is_up(backend):
 
 
 def ip_port_hostname_from_svname(svname):
-    """This parses the haproxy svname that smartstack creates, which is in the form ip:port_hostname.
+    """This parses the haproxy svname that smartstack creates.
+    In old versions of synapse, this is in the format ip:port_hostname.
+    In versions newer than dd5843c987740a5d5ce1c83b12b258b7253784a8 it is
+    hostname_ip:port
 
-    :param svname: A string in the format ip:port_hostname
+    :param svname: A svname, in either of the formats described above
     :returns ip_port_hostname: A tuple of ip, port, hostname.
     """
-    ip, port_hostname = svname.split(':', 1)
-    port, hostname = port_hostname.split('_', 1)
+    # split into parts
+    parts = set(svname.split("_"))
+
+    # find those that can be split by : - this is the ip:port
+    # there will only be 1 of these
+    ip_ports = {part for part in parts if len(part.split(":")) == 2}
+
+    # the one *not* in the list is the hostname
+    hostname = parts.difference(ip_ports).pop()
+
+    ip, port = ip_ports.pop().split(":")
     return ip, int(port), hostname
 
 

--- a/tests/test_smartstack_tools.py
+++ b/tests/test_smartstack_tools.py
@@ -194,8 +194,12 @@ def test_backend_is_up():
     assert False is backend_is_up({"status": "MAINT"})
 
 
-def test_ip_port_hostname_from_svname():
-    assert ("1.2.3.4", 5, "six") == ip_port_hostname_from_svname("1.2.3.4:5_six")
+def test_ip_port_hostname_from_svname_new_format():
+    assert ("10.40.10.155", 31219, "myhost") == ip_port_hostname_from_svname("myhost_10.40.10.155:31219")
+
+
+def test_ip_port_hostname_from_svname_old_format():
+    assert ("10.85.5.101", 3744, "myhost") == ip_port_hostname_from_svname("10.85.5.101:3744_myhost")
 
 
 def test_match_backends_and_tasks():


### PR DESCRIPTION
synapse commit dd5843c987740a5d5ce1c83b12b258b7253784a8 reordered the
parts in the backend name generated by synapse. The commit adds
backwards compatible support for the new new layout

primary @mjksmith 