### PR TITLE
[WIP] Removed duplication from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,6 @@ commands =
     sphinx-build -b html -d docs/build/doctrees docs/source docs/build/html
 
 [testenv:manpages]
-<<<<<<< HEAD
 commands = ./build-manpages.sh
 
 [testenv:paasta_itests]

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ indexserver =
     private = https://pypi.yelpcorp.com/simple
 
 [testenv]
+basepython = python2.7
 setenv=
     TZ = UTC
 deps =
@@ -16,20 +17,11 @@ commands =
 
 
 [testenv:coverage]
-setenv=
-    TZ = UTC
-basepython = python2.7
-deps =
-    --requirement={toxinidir}/requirements-dev.txt
-    --editable={toxinidir}
 commands =
     python -m pytest --cov-config .coveragerc --cov=paasta_tools --cov-report=term-missing --cov-report=html -s {posargs:tests}
 
 
 [testenv:docs]
-basepython = python2.7
-deps =
-    {[testenv]deps}
 commands =
     /bin/rm -rf docs/source/generated/
     # The last arg to apidoc is a list of excluded paths
@@ -37,14 +29,10 @@ commands =
     sphinx-build -b html -d docs/build/doctrees docs/source docs/build/html
 
 [testenv:manpages]
-basepython = python2.7
-deps =
-    {[testenv]deps}
-install_command= pip install {opts} {packages}
+<<<<<<< HEAD
 commands = ./build-manpages.sh
 
 [testenv:paasta_itests]
-basepython = python2.7
 changedir=paasta_itests/
 passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
 deps =
@@ -67,7 +55,6 @@ commands =
     docker-compose rm --force
 
 [testenv:paasta_itests_inside_container]
-basepython = python2.7
 envdir=/tmp/
 setenv =
     DOCKER_COMPOSE_PROJECT_NAME = paastatools_inside_container
@@ -86,7 +73,6 @@ commands =
 [testenv:general_itests]
 setenv =
     PAASTA_SYSTEM_CONFIG_DIR = {toxinidir}/general_itests/fake_etc_paasta
-basepython = python2.7
 changedir=general_itests/
 passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
 deps =


### PR DESCRIPTION
I'm pretty sure someone told me that we needed all of these `basepython`s and other things for a reason, but reading the tox docs and the fact that the tests still pass (pending Travis' confirmation) seems to indicate that we're just making our toxfile needlessly confusing.