### PR TITLE
PAASTA-7038 include rerun jobs in emergency-stop

### DIFF
--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -63,7 +63,7 @@ Feature: paasta_serviceinit
      When we run chronos_rerun for service_instance testservice testinstance
      Then we should get exit code 0
       And there is a temporary job for the service testservice and instance testinstance
-     When we store the name of the rerun job for the service serice and instance testinstance as rerunjob
+     When we store the name of the rerun job for the service testservice and instance testinstance as rerunjob
       And we paasta_serviceinit emergency-stop the service_instance "testservice.testinstance"
      Then the job stored as "rerunjob" is disabled in chronos
       And the job stored as "rerunjob" has no running tasks

--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -52,6 +52,22 @@ Feature: paasta_serviceinit
      Then the job stored as "myjob" is disabled in chronos
       And the job stored as "myjob" has no running tasks
 
+  Scenario: paasta_serviceinit emergency-stop kills rerun jobs
+    Given a working paasta cluster
+      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+      And we have a deployments.json for the service "testservice" with enabled instance "testinstance"
+     When we run setup_chronos_job for service_instance "testservice.testinstance"
+     Then we should get exit code 0
+     When we store the name of the job for the service testservice and instance testinstance as myjob
+      And we wait for the chronos job stored as "myjob" to appear in the job list
+     When we run chronos_rerun for service_instance testservice testinstance
+     Then we should get exit code 0
+      And there is a temporary job for the service testservice and instance testinstance
+     When we store the name of the rerun job for the service serice and instance testinstance as rerunjob
+      And we paasta_serviceinit emergency-stop the service_instance "testservice.testinstance"
+     Then the job stored as "rerunjob" is disabled in chronos
+      And the job stored as "rerunjob" has no running tasks
+
   Scenario: paasta_serviceinit can run emergency-start on an enabled chronos job
     Given a working paasta cluster
       And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"

--- a/paasta_itests/steps/chronos_steps.py
+++ b/paasta_itests/steps/chronos_steps.py
@@ -51,6 +51,18 @@ def create_chronos_job_config_object_from_configs(context, service, instance, jo
     context.jobs[job_name] = job_config
 
 
+@when('we store the name of the rerun job for the service {service} and instance {instance} as {job_name}')
+def get_rerun_jobs_for_service_instance_from_chronos(context, service, instance, job_name):
+    jobs_for_service = chronos_tools.get_jobs_for_service_instance(
+        service,
+        instance,
+        include_disabled=True,
+        include_temporary=True
+    )
+    all_tmp_jobs = [job for job in jobs_for_service if job['name'].startswith(chronos_tools.TMP_JOB_IDENTIFIER)]
+    context.jobs[job_name] = all_tmp_jobs[0]
+
+
 @when('we send the job to chronos')
 def send_job_to_chronos(context):
     context.chronos_client.add(context.chronos_job_config)

--- a/paasta_tools/chronos_serviceinit.py
+++ b/paasta_tools/chronos_serviceinit.py
@@ -374,6 +374,7 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir):
             instance=instance,
             client=client,
             include_disabled=True,
+            include_temporary=True
         )
         stop_chronos_job(service, instance, client, cluster, matching_jobs, emergency=True)
     elif command == "restart":


### PR DESCRIPTION
before now, there was no way to interrupt in-flight tasks for a job
launched with 'paasta rerun'. This change includes the tasks launched by
paasta rerun in those killed by paasta emergency-stop