### PR TITLE
PAASTA-7203 validate chronos cmds

### DIFF
--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -307,7 +307,7 @@ class ChronosJobConfig(InstanceConfig):
                 parse_time_variables(command)
                 return True, ""
             except (ValueError, KeyError, TypeError):
-                return False, "Unparseable command. Hint: do you need to escape % chars?"
+                return False, ("Unparseable command '%s'. Hint: do you need to escape %% chars?") % command
         else:
             return True, ""
 

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -300,6 +300,14 @@ class ChronosJobConfig(InstanceConfig):
                                % ", ".join(badly_formatted))
         return True, ''
 
+    def check_cmd(self):
+        command = self.get_cmd()
+        try:
+            parse_time_variables(command)
+            return True, ""
+        except (ValueError, KeyError, TypeError):
+            return False, "Unparseable command. Hint: do you need to escape % chars?"
+
     # a valid 'repeat_string' is 'R' or 'Rn', where n is a positive integer representing the number of times to repeat
     # more info: https://en.wikipedia.org/wiki/ISO_8601#Repeating_intervals
     def _check_schedule_repeat_helper(self, repeat_string):
@@ -381,8 +389,9 @@ class ChronosJobConfig(InstanceConfig):
             'schedule': self.check_schedule,
             'scheduleTimeZone': self.check_schedule_time_zone,
             'parents': self.check_parents,
+            'cmd': self.check_cmd,
         }
-        supported_params_without_checks = ['description', 'command', 'owner', 'disabled']
+        supported_params_without_checks = ['description', 'owner', 'disabled']
         if param in check_methods:
             return check_methods[param]()
         elif param in supported_params_without_checks:
@@ -436,7 +445,8 @@ class ChronosJobConfig(InstanceConfig):
         # Use InstanceConfig to validate shared config keys like cpus and mem
         error_msgs.extend(super(ChronosJobConfig, self).validate())
 
-        for param in ['epsilon', 'retries', 'cpus', 'mem', 'disk', 'schedule', 'scheduleTimeZone', 'parents']:
+        for param in ['epsilon', 'retries', 'cpus', 'mem', 'disk',
+                      'schedule', 'scheduleTimeZone', 'parents', 'cmd']:
             check_passed, check_msg = self.check(param)
             if not check_passed:
                 error_msgs.append(check_msg)

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -302,11 +302,14 @@ class ChronosJobConfig(InstanceConfig):
 
     def check_cmd(self):
         command = self.get_cmd()
-        try:
-            parse_time_variables(command)
+        if command:
+            try:
+                parse_time_variables(command)
+                return True, ""
+            except (ValueError, KeyError, TypeError):
+                return False, "Unparseable command. Hint: do you need to escape % chars?"
+        else:
             return True, ""
-        except (ValueError, KeyError, TypeError):
-            return False, "Unparseable command. Hint: do you need to escape % chars?"
 
     # a valid 'repeat_string' is 'R' or 'Rn', where n is a positive integer representing the number of times to repeat
     # more info: https://en.wikipedia.org/wiki/ISO_8601#Repeating_intervals

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -229,7 +229,7 @@ class InstanceConfig(dict):
     def get_cmd(self):
         """Get the docker cmd specified in the service's configuration.
 
-        Defaults to null if not specified in the config.
+        Defaults to None if not specified in the config.
 
         :returns: A string specified in the config, None if not specified"""
         return self.config_dict.get('cmd', None)

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1502,6 +1502,38 @@ class TestChronosTools:
         actual = chronos_tools.parse_time_variables(input_string=test_input, parse_time=input_time)
         assert actual == expected
 
+    def test_parse_time_variables_parses_percent(self):
+        input_time = datetime.datetime(2012, 3, 14)
+        test_input = './mycommand --date %(shortdate-1)s --format foo/logs/%%L/%%Y/%%m/%%d/'
+        expected = './mycommand --date 2012-03-13 --format foo/logs/%L/%Y/%m/%d/'
+        actual = chronos_tools.parse_time_variables(input_string=test_input, parse_time=input_time)
+        assert actual == expected
+
+    def test_check_cmd_escaped_percent(self):
+        test_input = './mycommand --date %(shortdate-1)s --format foo/logs/%%L/%%Y/%%m/%%d/'
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'cmd': test_input},
+            branch_dict={},
+        )
+        okay, msg = fake_conf.check_cmd()
+        assert okay is True
+        assert msg == ''
+
+    def test_check_cmd_unescaped_percent(self):
+        test_input = './mycommand --date %(shortdate-1)s --format foo/logs/%L/%Y/%m/%d/'
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'cmd': test_input},
+            branch_dict={},
+        )
+        okay, msg = fake_conf.check_cmd()
+        assert okay is False
+
     def test_cmp_datetimes(self):
         before = '2015-09-22T16:46:25.111Z'
         after = '2015-09-24T16:54:38.917Z'

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -326,7 +326,7 @@ class TestChronosTools:
             )
             fake_chronos_job_config.format_chronos_job_dict(fake_docker_url, fake_docker_volumes,
                                                             dummy_config.get_dockercfg_location())
-            mock_parse_time_variables.assert_called_once_with(fake_cmd)
+            mock_parse_time_variables.assert_called_with(fake_cmd)
 
     def test_get_owner(self):
         fake_owner = 'fake_team'

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1533,6 +1533,7 @@ class TestChronosTools:
         )
         okay, msg = fake_conf.check_cmd()
         assert okay is False
+        assert './mycommand --date %(shortdate-1)s --format foo/logs/%L/%Y/%m/%d/' in msg
 
     def test_cmp_datetimes(self):
         before = '2015-09-22T16:46:25.111Z'


### PR DESCRIPTION
Given that we don't validate, you won't get any errors until deploy
time. This adds validation to the chronos cmd so we pick it up with
paasta validate