### PR TITLE
pin docutils dependency to old version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+docutils==0.12
 flake8==2.5.0
 git+git://github.com/solarkennedy/sphinxcontrib-programoutput#egg=package-two
 mock==2.0.0


### PR DESCRIPTION
closes #932 

the new version was throwing errors. this is the easy fix for now.