### PR TITLE
Upgrade mesos to 1.1.0

### DIFF
--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get -y install apt-transport-https
 RUN echo "deb https://dl.bintray.com/yelp/paasta trusty main" > /etc/apt/sources.list.d/paasta.list
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install libsasl2-modules mesos=1.0.1-2.0.93.ubuntu1404
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=1.1.0-2.0.107.ubuntu1404
 
 RUN apt-get install -y software-properties-common
 RUN add-apt-repository ppa:webupd8team/java

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get -y install apt-transport-https
 RUN echo "deb https://dl.bintray.com/yelp/paasta trusty main" > /etc/apt/sources.list.d/paasta.list
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install libsasl2-modules mesos=1.0.1-2.0.93.ubuntu1404
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=1.1.0-2.0.107.ubuntu1404
 
 # Install Java 8 PPA
 RUN apt-get install -y software-properties-common

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources
 RUN echo "deb http://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 58118E89F3A912897C070ADBF76221572C52609D
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install libsasl2-modules mesos=1.0.1-2.0.93.ubuntu1404
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=1.1.0-2.0.107.ubuntu1404
 
 RUN apt-get -y install docker-engine=1.10.3-0~trusty
 ADD mesos-secrets /etc/mesos-secrets


### PR DESCRIPTION
We will need to do this upgrade before we can upgrade Marathon. Let's start testing it out.