### PR TITLE
Make local-run pass through return_codes for proper exititing

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -402,7 +402,7 @@ def validate_service_instance(service, instance, cluster, soa_dir):
             return instance_type
     else:
         raise NoConfigurationForServiceError(
-            "Error: %s doesn't look like it has been deployed to this cluster! (%s)" % (
+            "Error: %s doesn't look like it has been configured to run on the %s cluster." % (
                 compose_job_id(service, instance), cluster))
 
 


### PR DESCRIPTION
I'm not really sure "when" it is right to "fail fast" and when it is right to just bubble up a return code.

But for this PR I'm bubbling up the return code more in the hopes that we get better exit codes.

Internal ticket PAASTA-7261