### PR TITLE
Make local-run healthchecking more strict about error codes. Fixes #678

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -90,8 +90,8 @@ def perform_http_healthcheck(url, timeout):
     # check if response code is valid per https://mesosphere.github.io/marathon/docs/health-checks.html
     elif res.status_code >= 200 and res.status_code < 400:
         return (True, "http request succeeded, code %d" % res.status_code)
-    elif res.status_code >= 400:
-        return (False, "http request failed, code %d" % res.status_code)
+    else:
+        return (False, "http request failed, code %s" % str(res.status_code))
 
 
 def perform_tcp_healthcheck(url, timeout):

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -164,13 +164,26 @@ def test_perform_http_healthcheck_success(mock_http_conn):
 
 
 @mock.patch('requests.get', autospec=True)
-def test_perform_http_healthcheck_failure(mock_http_conn):
+def test_perform_http_healthcheck_failure_known_high(mock_http_conn):
     fake_http_url = "http://fakehost:1234/fake_status_path"
     fake_timeout = 10
 
     mock_http_conn.return_value = mock.Mock(status_code=400, headers={})
     result, reason = perform_http_healthcheck(fake_http_url, fake_timeout)
     assert result is False
+    assert '400' in reason
+    mock_http_conn.assert_called_once_with(fake_http_url)
+
+
+@mock.patch('requests.get', autospec=True)
+def test_perform_http_healthcheck_failure_known_low(mock_http_conn):
+    fake_http_url = "http://fakehost:1234/fake_status_path"
+    fake_timeout = 10
+
+    mock_http_conn.return_value = mock.Mock(status_code=100, headers={})
+    result, reason = perform_http_healthcheck(fake_http_url, fake_timeout)
+    assert result is False
+    assert '100' in reason
     mock_http_conn.assert_called_once_with(fake_http_url)
 
 


### PR DESCRIPTION
Fixes #678 