### PR TITLE
Fix paths in example cluster

### DIFF
--- a/yelp_package/dockerfiles/mesos-paasta/start.sh
+++ b/yelp_package/dockerfiles/mesos-paasta/start.sh
@@ -9,7 +9,7 @@ chmod 600 /root/.ssh/*
 
 pip install -e /work
 # This is a hack because we're not creating a real package which would create symlinks for the .py scripts
-while read link; do echo $link|sed -e 's/usr\/share\/python\/paasta-tools\//\/usr\/local\//'| sed -e 's/\ usr/\ \/usr/'| xargs ln -s; done < /work/debian/paasta-tools.links
+while read link; do echo $link|sed -e 's/opt\/venvs\/paasta-tools\//\/usr\/local\//'| sed -e 's/\ usr/\ \/usr/'| xargs ln -s; done < /work/debian/paasta-tools.links
 /usr/sbin/rsyslogd
 cron
 mesos-master --zk=zk://zookeeper:2181/mesos-testcluster --registry=in_memory --quorum=1 --authenticate --authenticate_slaves --credentials=/etc/mesos-secrets --hostname=$(hostname) &

--- a/yelp_package/dockerfiles/playground/start.sh
+++ b/yelp_package/dockerfiles/playground/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 pip install -e .
 # This is a hack because we're not creating a real package which would create symlinks for the .py scripts
-while read link; do echo $link|sed -e 's/usr\/share\/python\/paasta-tools\//\/usr\/local\//'| sed -e 's/\ usr/\ \/usr/'| xargs ln -s; done < /work/debian/paasta-tools.links
+while read link; do echo $link|sed -e 's/opt\/venvs\/paasta-tools\//\/usr\/local\//'| sed -e 's/\ usr/\ \/usr/'| xargs ln -s; done < /work/debian/paasta-tools.links
 /bin/bash


### PR DESCRIPTION
After https://github.com/Yelp/paasta/pull/941 the paths changed so we
need to fix our symlink hack that simulates installing the deb in the
example cluster.