### PR TITLE
catch InternalServerError talking to Marathon

### DIFF
--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -20,6 +20,7 @@ import logging
 import sys
 
 import chronos
+from marathon.exceptions import InternalServerError
 from marathon.exceptions import MarathonError
 
 from paasta_tools import __version__
@@ -97,8 +98,8 @@ def main():
         marathon_client = metastatus_lib.get_marathon_client(marathon_config)
         try:
             marathon_results = metastatus_lib.get_marathon_status(marathon_client)
-        except MarathonError as e:
-            paasta_print(PaastaColors.red("CRITICAL: Unable to contact Marathon! Error: %s" % e))
+        except (MarathonError, InternalServerError) as e:
+            paasta_print(PaastaColors.red("CRITICAL: Unable to contact Marathon! Is the cluster healthy?"))
             sys.exit(2)
     else:
         marathon_results = [metastatus_lib.HealthCheckResult(message='Marathon is not configured to run here',


### PR DESCRIPTION
this was seen in PAASTA-7696 when Marathon couldn't elect a leader.
by catching it, metastatus will return 1 when marathon throws this
kind of error.

I've removed the printing of the error message, because they're often unhelpful, as in the case of this ticket where the error from the marathon client was actually a JSON decoding error caused by marathon returning plain HTML