### PR TITLE
Fix multiple instances per reservation

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -115,15 +115,16 @@ def describe_instances(instance_ids, region=None, instance_filters=None):
         instance_filters = []
     ec2_client = boto3.client('ec2', region_name=region)
     try:
-        instances = ec2_client.describe_instances(InstanceIds=instance_ids, Filters=instance_filters)
+        instance_descriptions = ec2_client.describe_instances(InstanceIds=instance_ids, Filters=instance_filters)
     except ClientError as e:
         if e.response['Error']['Code'] == 'InvalidInstanceID.NotFound':
             log.warn('Cannot find one or more instance from IDs {0}'.format(instance_ids))
             return None
         else:
             raise
-    ret = [reservation['Instances'][0] for reservation in instances['Reservations']]
-    return ret
+    instance_reservations = [reservation['Instances'] for reservation in instance_descriptions['Reservations']]
+    instances = [instance for reservation in instance_reservations for instance in reservation]
+    return instances
 
 
 @register_autoscaling_component('aws_spot_fleet_request', CLUSTER_METRICS_PROVIDER_KEY)

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -606,6 +606,7 @@ def test_describe_instance():
     ):
         mock_instance_1 = mock.Mock()
         mock_instance_2 = mock.Mock()
+        mock_instance_3 = mock.Mock()
         mock_instances = {'Reservations': [{'Instances': [mock_instance_1]}, {'Instances': [mock_instance_2]}]}
         mock_describe_instances = mock.Mock(return_value=mock_instances)
         mock_ec2_client.return_value = mock.Mock(describe_instances=mock_describe_instances)
@@ -622,6 +623,13 @@ def test_describe_instance():
         mock_describe_instances.side_effect = ClientError(mock_error, 'blah')
         ret = autoscaling_cluster_lib.describe_instances(['i-1', 'i-2'], region='westeros-1')
         assert ret is None
+
+        mock_instances = {'Reservations': [{'Instances': [mock_instance_1, mock_instance_2]},
+                                           {'Instances': [mock_instance_3]}]}
+        mock_describe_instances = mock.Mock(return_value=mock_instances)
+        mock_ec2_client.return_value = mock.Mock(describe_instances=mock_describe_instances)
+        ret = autoscaling_cluster_lib.describe_instances(['i-1', 'i-2', 'i-3'], region='westeros-1')
+        assert ret == [mock_instance_1, mock_instance_2, mock_instance_3]
 
 
 def test_get_spot_fleet_delta():


### PR DESCRIPTION
SFRs only return one instance per reservation from the describe ec2
instances call. However ASGs do return several instances per
reservation. This makes it so we just build one list of instances which
is compatible for both.

Also suddenly today so do SFRs. I guess AWS changed something or we've just been "luckily" getting one instance per reservation in the past...