### PR TITLE
Correct task count objects

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -218,7 +218,7 @@ class ClusterAutoscaler(object):
 
         :param slaves: list of slaves dict
         :returns: list of slaves dicts"""
-        return sorted(slaves, key=lambda x: (x['task_counts'].chronos_count, x['task_counts'].count))
+        return sorted(slaves, key=lambda x: (x.task_counts.chronos_count, x.task_counts.count))
 
     def scale_resource(self, current_capacity, target_capacity):
         """Scales an AWS resource based on current and target capacity
@@ -343,9 +343,12 @@ class ClusterAutoscaler(object):
             current_capacity = new_capacity
             mesos_state = get_mesos_master().state_summary()
             if filtered_sorted_slaves:
-                filtered_slaves = get_mesos_task_count_by_slave(mesos_state, slaves_list=filtered_sorted_slaves)
-            else:
-                filtered_slaves = filtered_sorted_slaves
+                task_counts = get_mesos_task_count_by_slave(mesos_state,
+                                                            slaves_list=[{'task_counts': slave.task_counts}
+                                                                         for slave in filtered_sorted_slaves])
+                for i, slave in enumerate(filtered_sorted_slaves):
+                    slave.task_counts = task_counts[i]['task_counts']
+            filtered_slaves = filtered_sorted_slaves
 
 
 class SpotAutoscaler(ClusterAutoscaler):

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -611,7 +611,7 @@ def get_mesos_task_count_by_slave(mesos_state, slaves_list=None, pool=None):
                 slaves[task.slave['id']]['chronos_count'] += 1
     if slaves_list:
         for slave in slaves_list:
-            slave['task_counts'] = SlaveTaskCount(**slaves[slave['id']])
+            slave['task_counts'] = SlaveTaskCount(**slaves[slave['task_counts'].slave['id']])
         slaves = slaves_list
     elif pool:
         slaves = [{'task_counts': SlaveTaskCount(**slave_counts)} for slave_counts in slaves.values()

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -639,14 +639,14 @@ def test_get_mesos_task_count_by_slave():
         mock_task2.framework = mock_marathon
         mock_tasks = [mock_task1, mock_task2, mock_task3, mock_task4]
         mock_get_running_tasks_from_active_frameworks.return_value = mock_tasks
+        mock_slaves_list = [{'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_1)},
+                            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_2)},
+                            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)}]
         ret = mesos_tools.get_mesos_task_count_by_slave(mock_mesos_state,
-                                                        slaves_list=[mock_slave_1, mock_slave_2, mock_slave_3])
-        expected = [{'id': 'slave1', 'attributes': {'pool': 'default'}, 'hostname': 'host1',
-                     'task_counts': mesos_tools.SlaveTaskCount(count=1, chronos_count=1, slave=mock_slave_1)},
-                    {'id': 'slave2', 'attributes': {'pool': 'default'}, 'hostname': 'host2',
-                     'task_counts': mesos_tools.SlaveTaskCount(count=3, chronos_count=0, slave=mock_slave_2)},
-                    {'id': 'slave3', 'attributes': {'pool': 'another'}, 'hostname': 'host3',
-                     'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)}]
+                                                        slaves_list=mock_slaves_list)
+        expected = [{'task_counts': mesos_tools.SlaveTaskCount(count=1, chronos_count=1, slave=mock_slave_1)},
+                    {'task_counts': mesos_tools.SlaveTaskCount(count=3, chronos_count=0, slave=mock_slave_2)},
+                    {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)}]
         assert len(ret) == len(expected) and sorted(ret) == sorted(expected)
 
 


### PR DESCRIPTION
After the change in c266cf76d8e0e78b5f7889d61c9a4638f5fdd2d3 the
interaction with mesos_tools is incorrect. This corrects it so that we
pass the input mesos tools is expecting and then update the
PaastaAWSSlave object locally.

@Rob-Johnson can you sanity check this. I'd really like to do away with the weird dictionary that comes back from `get_mesos_task_count_by_slave`. But this feels like a slightly easier and safer change for now. This is just to merge it into my autoscaler-asg branch before I merge the lot to master and cut a release.