### PR TITLE
Revert "Use marathon-python compatible with marathon 1.4"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ isodate==0.5.1
 jsonschema[format]==2.5.1
 kazoo==2.2
 lockfile==0.9.1
-marathon==0.8.9
+marathon==0.8.7
 mccabe==0.3.1
 mesos.interface==1.0.1
 ordereddict==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ isodate==0.5.1
 jsonschema[format]==2.5.1
 kazoo==2.2
 lockfile==0.9.1
-marathon==0.8.10
+marathon==0.8.9
 mccabe==0.3.1
 mesos.interface==1.0.1
 ordereddict==1.1

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -29,12 +29,8 @@ RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set
 RUN echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections
 RUN apt-get update && apt-get -y install lsb-release oracle-java8-installer
 
-RUN apt-get -y install unzip
-RUN wget https://s3.amazonaws.com/repos.mesosphere.com/ubuntu/pool/main/m/marathon/marathon_1.4.0-1.0.562.ubuntu1404_amd64.deb \
-    && dpkg -i marathon_1.4.0-1.0.562.ubuntu1404_amd64.deb && rm marathon_1.4.0-1.0.562.ubuntu1404_amd64.deb
+RUN apt-get update && apt-get -y --allow-unauthenticated install marathon=1.4.0-0.1.20161021221011.snap19.ubuntu1404
 
 RUN echo -n "secret2" > /etc/marathon_framework_secret
-
-RUN locale-gen "en_US.UTF-8" && dpkg-reconfigure locales
 
 EXPOSE 8080


### PR DESCRIPTION
This reverts commit 392ff704c2926ece75abc850d73a8c9e949c216b.

Seeing some 422 errors when deploying marathon services. Yelp internal
ticket: PAASTA-7849

cc @Rob-Johnson 