### PR TITLE
async version of wait-for-deployment

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -275,8 +275,11 @@ class ClusterData:
     :type instances_queue: Queue
     """
 
-    def __init__(self, **kwargs):
-        self.__dict__ = kwargs
+    def __init__(self, cluster, service, git_sha, instances_queue):
+        self.cluster = cluster
+        self.service = service
+        self.git_sha = git_sha
+        self.instances_queue = instances_queue
 
 
 def instances_deployed(cluster_data, instances_out, green_light):

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -110,29 +110,29 @@ def test_instances_deployed(mock_get_paasta_api_client, mock__log):
     instances_in.put('instance1')
     instances_out = Queue()
     f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
-    assert instances_in.empty() == True
-    assert instances_out.empty() == True
+    assert instances_in.empty()
+    assert instances_out.empty()
 
     instances_in = Queue()
     instances_in.put('instance1')
     instances_in.put('instance2')
     instances_out = Queue()
     f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
-    assert instances_in.empty() == True
+    assert instances_in.empty()
     assert instances_out.get() == 'instance2'
 
     instances_in = Queue()
     instances_in.put('instance3')
     instances_out = Queue()
     f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
-    assert instances_in.empty() == True
+    assert instances_in.empty()
     assert instances_out.get() == 'instance3'
 
     instances_in = Queue()
     instances_in.put('instance4')
     instances_out = Queue()
     f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
-    assert instances_in.empty() == True
+    assert instances_in.empty()
     assert instances_out.get() == 'instance4'
 
     instances_in = Queue()
@@ -140,43 +140,43 @@ def test_instances_deployed(mock_get_paasta_api_client, mock__log):
     instances_in.put('instance1')
     instances_out = Queue()
     f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
-    assert instances_in.empty() == True
-    assert instances_out.empty() == True
+    assert instances_in.empty()
+    assert instances_out.empty()
 
     instances_in = Queue()
     instances_in.put('instance6')
     instances_out = Queue()
     f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
-    assert instances_in.empty() == True
+    assert instances_in.empty()
     assert instances_out.get(block=False) == 'instance6'
 
     instances_in = Queue()
     instances_in.put('notaninstance')
     instances_out = Queue()
     f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
-    assert instances_in.empty() == True
+    assert instances_in.empty()
     assert instances_out.get(block=False) == 'notaninstance'
 
     instances_in = Queue()
     instances_in.put('api_error')
     instances_out = Queue()
     f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
-    assert instances_in.empty() == True
+    assert instances_in.empty()
     assert instances_out.get(block=False) == 'api_error'
 
     instances_in = Queue()
     instances_in.put('instance7')
     instances_out = Queue()
     f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
-    assert instances_in.empty() == True
-    assert instances_out.empty() == True
+    assert instances_in.empty()
+    assert instances_out.empty()
 
     instances_in = Queue()
     instances_in.put('instance8')
     instances_out = Queue()
     f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
-    assert instances_in.empty() == True
-    assert instances_out.empty() == True
+    assert instances_in.empty()
+    assert instances_out.empty()
 
 
 def instances_deployed_side_effect(cluster, service, instances_in,

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -14,6 +14,9 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from Queue import Queue
+from threading import Event
+
 from bravado.exception import HTTPError
 from mock import Mock
 from mock import patch
@@ -24,17 +27,6 @@ from paasta_tools.cli.cmds.wait_for_deployment import get_latest_marked_sha
 from paasta_tools.cli.cmds.wait_for_deployment import paasta_wait_for_deployment
 from paasta_tools.cli.utils import NoSuchService
 from paasta_tools.utils import TimeoutError
-
-
-class MockSleep:
-    def __init__(self):
-        self.call_count = 0
-
-    def mock_sleep_side_effect(self, time):
-        if self.call_count == 5:
-            raise TimeoutError()
-        self.call_count += 1
-        return
 
 
 class fake_args:
@@ -112,67 +104,113 @@ def test_instances_deployed(mock_get_paasta_api_client, mock__log):
         mock_status_instance_side_effect
 
     f = mark_for_deployment.instances_deployed
-    assert f('cluster', 'service1', ['instance1'], 'somesha') == ['instance1']
+    e = Event()
+    e.set()
+    instances_in = Queue()
+    instances_in.put('instance1')
+    instances_out = Queue()
+    f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
+    assert instances_in.empty() == True
+    assert instances_out.empty() == True
 
-    assert f('cluster', 'service1', ['instance2', 'instance1'],
-             'somesha') == ['instance1']
+    instances_in = Queue()
+    instances_in.put('instance1')
+    instances_in.put('instance2')
+    instances_out = Queue()
+    f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
+    assert instances_in.empty() == True
+    assert instances_out.get() == 'instance2'
 
-    assert f('cluster', 'service1', ['instance3'], 'somesha') == []
+    instances_in = Queue()
+    instances_in.put('instance3')
+    instances_out = Queue()
+    f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
+    assert instances_in.empty() == True
+    assert instances_out.get() == 'instance3'
 
-    assert f('cluster', 'service1', ['instance4'], 'somesha') == []
+    instances_in = Queue()
+    instances_in.put('instance4')
+    instances_out = Queue()
+    f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
+    assert instances_in.empty() == True
+    assert instances_out.get() == 'instance4'
 
-    assert f('cluster', 'service1', ['instance5', 'instance1'],
-             'somesha') == ['instance5', 'instance1']
+    instances_in = Queue()
+    instances_in.put('instance5')
+    instances_in.put('instance1')
+    instances_out = Queue()
+    f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
+    assert instances_in.empty() == True
+    assert instances_out.empty() == True
 
-    assert f('cluster', 'service1', ['instance6'], 'somesha') == []
+    instances_in = Queue()
+    instances_in.put('instance6')
+    instances_out = Queue()
+    f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
+    assert instances_in.empty() == True
+    assert instances_out.get(block=False) == 'instance6'
 
-    assert f('cluster', 'service1', ['notaninstance'], 'somesha') == []
+    instances_in = Queue()
+    instances_in.put('notaninstance')
+    instances_out = Queue()
+    f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
+    assert instances_in.empty() == True
+    assert instances_out.get(block=False) == 'notaninstance'
 
-    assert f('cluster', 'service1', ['api_error'], 'somesha') == []
+    instances_in = Queue()
+    instances_in.put('api_error')
+    instances_out = Queue()
+    f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
+    assert instances_in.empty() == True
+    assert instances_out.get(block=False) == 'api_error'
 
-    assert f('cluster', 'service1', ['instance7'], 'somesha') == ['instance7']
+    instances_in = Queue()
+    instances_in.put('instance7')
+    instances_out = Queue()
+    f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
+    assert instances_in.empty() == True
+    assert instances_out.empty() == True
 
-    assert f('cluster', 'service1', ['instance8'], 'somesha') == ['instance8']
+    instances_in = Queue()
+    instances_in.put('instance8')
+    instances_out = Queue()
+    f('cluster', 'service1', instances_in, instances_out, 'somesha', e)
+    assert instances_in.empty() == True
+    assert instances_out.empty() == True
 
 
-def instances_deployed_side_effect(cluster, service, instances, git_sha):
-    if instances == ['instance1', 'instance2']:
-        return instances
-    return []
+def instances_deployed_side_effect(cluster, service, instances_in,
+                                   instances_out, git_sha, green_light):
+    while not instances_in.empty():
+        instance = instances_in.get()
+        if instance not in ['instance1', 'instance2']:
+            instances_out.put(instance)
+        instances_in.task_done()
 
 
 @patch('paasta_tools.cli.cmds.mark_for_deployment.get_cluster_instance_map_for_service', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment._log', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment.instances_deployed', autospec=True)
-@patch('time.sleep', autospec=True)
-def test_wait_for_deployment(mock_sleep, mock_instances_deployed, mock__log,
+def test_wait_for_deployment(mock_instances_deployed, mock__log,
                              mock_get_cluster_instance_map_for_service):
     mock_cluster_map = {'cluster1': {'instances': ['instance1', 'instance2', 'instance3']}}
     mock_get_cluster_instance_map_for_service.return_value = mock_cluster_map
     mock_instances_deployed.side_effect = instances_deployed_side_effect
-    mock_sleeper = MockSleep()
-    mock_sleep.side_effect = mock_sleeper.mock_sleep_side_effect
 
     with raises(TimeoutError):
         mark_for_deployment.wait_for_deployment('service', 'deploy_group_1', 'somesha', '/nail/soa', 1)
-
     mock_get_cluster_instance_map_for_service.assert_called_with('/nail/soa', 'service', 'deploy_group_1')
-    mock_instances_deployed.assert_called_with(cluster='cluster1',
-                                               service='service',
-                                               instances=mock_cluster_map['cluster1']['instances'],
-                                               git_sha='somesha')
 
     mock_cluster_map = {'cluster1': {'instances': ['instance1', 'instance2']},
                         'cluster2': {'instances': ['instance1', 'instance2']}}
     mock_get_cluster_instance_map_for_service.return_value = mock_cluster_map
-    assert mark_for_deployment.wait_for_deployment('service', 'deploy_group_1', 'somesha', '/nail/soa', 1) == 0
+    assert mark_for_deployment.wait_for_deployment('service', 'deploy_group_2', 'somesha', '/nail/soa', 5) == 0
 
     mock_cluster_map = {'cluster1': {'instances': ['instance1', 'instance2']},
                         'cluster2': {'instances': ['instance1', 'instance3']}}
     mock_get_cluster_instance_map_for_service.return_value = mock_cluster_map
-    mock_sleeper.call_count = 0
     with raises(TimeoutError):
-        mark_for_deployment.wait_for_deployment('service', 'deploy_group_1', 'somesha', '/nail/soa', 1)
+        mark_for_deployment.wait_for_deployment('service', 'deploy_group_3', 'somesha', '/nail/soa', 1)
 
 
 @patch('paasta_tools.cli.cmds.wait_for_deployment.validate_service_name', autospec=True)


### PR DESCRIPTION
This change reduces wait-for-deployment running time (when git_sha is already deployed) from 4m50 to 1m12 for yelp-main prod.
It creates separate threads for each paasta cluster and up to 5 threads per cluster to query API.