### PR TITLE
Check marathon IDs are valid

### DIFF
--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -2,268 +2,271 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html#marathon-clustername-yaml",
     "type": "object",
+    "additionalProperties": false,
     "minProperties": 1,
-    "additionalProperties": {
-        "type": "object",
-        "additionalProperties": false,
-        "minProperties": 1,
-        "allOf":[
-            {
-                "oneOf": [
-                    {
-                        "properties": {
-                            "healthcheck_mode": {"enum": ["tcp", "http"]}
-                        }
-                    },
-                    {
-                        "properties": {
-                            "healthcheck_mode": {"enum": ["cmd"]},
-                            "healthcheck_cmd": {"type": "string"}
-                        },
-                        "required": ["healthcheck_cmd"]
-                    }
-                ]
-            }, {
-                "oneOf": [
-                    {
-                        "properties": {
-                            "drain_method": {
-                                "enum": [ "noop", "hacheck", "test" ]
-                            }
-                        }
-                    },
-                    {
-                        "properties": {
-                            "drain_method": {"enum": ["http"]},
-                            "drain_method_params": {
-                                "type": "object",
-                                "properties": {
-                                    "drain": {
-                                        "type": "object"
-                                    },
-                                    "stop_draining": {
-                                        "type": "object"
-                                    },
-                                    "is_draining": {
-                                        "type": "object"
-                                    },
-                                    "is_safe_to_kill": {
-                                        "type": "object"
-                                    }
-                                },
-                                "required": ["drain", "stop_draining", "is_draining", "is_safe_to_kill"]
+    "patternProperties": {
+        "^([a-z0-9]|[a-z0-9][a-z0-9_-]*[a-z0-9])*$": {
+            "type": "object",
+            "additionalProperties": false,
+            "minProperties": 1,
+            "allOf":[
+                {
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "healthcheck_mode": {"enum": ["tcp", "http"]}
                             }
                         },
-                        "required": ["drain_method_params"]
-                    }
-                ]
-            }
-        ],
-        "properties": {
-            "cpus": {
-                "type": "number",
-                "minimum": 0,
-                "exclusiveMinimum": true,
-                "default": 0.25
-            },
-            "mem": {
-                "type": "number",
-                "minimum": 32,
-                "exclusiveMinimum": true,
-                "default": 1024
-            },
-            "disk": {
-                "type": "number",
-                "minimum": 0,
-                "exclusiveMinimum": true,
-                "default": 1024
-            },
-            "instances": {
-                "type": "integer",
-                "minimum": 0,
-                "exclusiveMinimum": false
-            },
-            "min_instances": {
-                "type": "integer",
-                "minimum": 0,
-                "exclusiveMinimum": false
-            },
-            "max_instances": {
-                "type": "integer",
-                "minimum": 0,
-                "exclusiveMinimum": false
-            },
-            "nerve_ns": {
-                "type": "string"
-            },
-            "backoff_factor": {
-                "type": "integer",
-                "default": 2
-            },
-            "max_launch_delay_seconds": {
-                "type": "integer",
-                "default": 300
-            },
-            "registrations": {
-                "type": "array",
-                "items": {
+                        {
+                            "properties": {
+                                "healthcheck_mode": {"enum": ["cmd"]},
+                                "healthcheck_cmd": {"type": "string"}
+                            },
+                            "required": ["healthcheck_cmd"]
+                        }
+                    ]
+                }, {
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "drain_method": {
+                                    "enum": [ "noop", "hacheck", "test" ]
+                                }
+                            }
+                        },
+                        {
+                            "properties": {
+                                "drain_method": {"enum": ["http"]},
+                                "drain_method_params": {
+                                    "type": "object",
+                                    "properties": {
+                                        "drain": {
+                                            "type": "object"
+                                        },
+                                        "stop_draining": {
+                                            "type": "object"
+                                        },
+                                        "is_draining": {
+                                            "type": "object"
+                                        },
+                                        "is_safe_to_kill": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "required": ["drain", "stop_draining", "is_draining", "is_safe_to_kill"]
+                                }
+                            },
+                            "required": ["drain_method_params"]
+                        }
+                    ]
+                }
+            ],
+            "properties": {
+                "cpus": {
+                    "type": "number",
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
+                    "default": 0.25
+                },
+                "mem": {
+                    "type": "number",
+                    "minimum": 32,
+                    "exclusiveMinimum": true,
+                    "default": 1024
+                },
+                "disk": {
+                    "type": "number",
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
+                    "default": 1024
+                },
+                "instances": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": false
+                },
+                "min_instances": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": false
+                },
+                "max_instances": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": false
+                },
+                "nerve_ns": {
                     "type": "string"
                 },
-                "uniqueItems": true
-            },
-            "bounce_method": {
-                "type": "string"
-            },
-            "bounce_method_params": {
-                "type": "object",
-                "properties": {
-                    "check_haproxy": {
-                        "type": "boolean",
-                        "default": true
+                "backoff_factor": {
+                    "type": "integer",
+                    "default": 2
+                },
+                "max_launch_delay_seconds": {
+                    "type": "integer",
+                    "default": 300
+                },
+                "registrations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     },
-                    "min_task_uptime": {
-                        "type": "number"
-                    }
-                }
-            },
-            "bounce_health_params": {
-                "type": "object",
-                "properties": {
-                    "check_haproxy": {
-                        "type": "boolean",
-                        "default": true
-                    }
-                }
-            },
-            "bounce_margin_factor": {
-                "type": "number",
-                "default": 1
-            },
-            "deploy_group": {
-                "type": "string"
-            },
-            "autoscaling": {
-                "type": "object"
-            },
-            "drain_method": {
-                "enum": [ "noop", "hacheck", "http", "test" ],
-                "default": "noop"
-            },
-            "drain_method_params": {
-                "type": "object"
-            },
-            "constraints": {
-                "type": "array",
-                "items": {
-                    "type": "array"
+                    "uniqueItems": true
                 },
-                "uniqueItems": true
-            },
-            "extra_constraints": {
-                "type": "array",
-                "items": {
-                    "type": "array"
-                },
-                "uniqueItems": true
-            },
-            "pool": {
-                "type": "string"
-            },
-            "cmd": {
-                "type": "string"
-            },
-            "args": {
-                "type": "array",
-                "items": {
+                "bounce_method": {
                     "type": "string"
-                }
-            },
-            "env": {
-                "type": "object",
-                "additionalProperties": { "type": "string" }
-            },
-            "extra_volumes": {
-                "type": "array",
-                "items": {
-                    "type": "object"
                 },
-                "uniqueItems": true
-            },
-            "monitoring": {
-                "type": "object"
-            },
-            "net": {
-                "type": "string"
-            },
-            "deploy_blacklist": {
-                "type": "array"
-            },
-            "deploy_whitelist": {
-                "type": "array"
-            },
-            "monitoring_blacklist": {
-                "type": "array"
-            },
-            "healthcheck_mode": {
-                "enum": [ "cmd", "tcp", "http" ]
-            },
-            "healthcheck_cmd": {
-                "type": "string",
-                "default": "/bin/true"
-            },
-            "healthcheck_grace_period_seconds": {
-                "type": "number",
-                "default": 60
-            },
-            "healthcheck_interval_seconds": {
-                "type": "number",
-                "default": 10
-            },
-            "healthcheck_timeout_seconds": {
-                "type": "number",
-                "default": 10
-            },
-            "healthcheck_max_consecutive_failures": {
-                "type": "integer",
-                "default": 6
-            },
-            "replication_threshold": {
-                "type": "integer",
-                "minimum": 0
-            },
-            "ulimit": {
-                "type": "object",
-                "additionalProperties": {
+                "bounce_method_params": {
                     "type": "object",
                     "properties": {
-                        "soft": {
-                            "type": "number"
+                        "check_haproxy": {
+                            "type": "boolean",
+                            "default": true
                         },
-                        "hard": {
+                        "min_task_uptime": {
                             "type": "number"
                         }
-                    },
-                    "required": ["soft"],
-                    "additionalProperties": false
-                }
-            },
-            "cap_add": {
-                "type": "array",
-                "items": {
+                    }
+                },
+                "bounce_health_params": {
+                    "type": "object",
+                    "properties": {
+                        "check_haproxy": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                },
+                "bounce_margin_factor": {
+                    "type": "number",
+                    "default": 1
+                },
+                "deploy_group": {
                     "type": "string"
+                },
+                "autoscaling": {
+                    "type": "object"
+                },
+                "drain_method": {
+                    "enum": [ "noop", "hacheck", "http", "test" ],
+                    "default": "noop"
+                },
+                "drain_method_params": {
+                    "type": "object"
+                },
+                "constraints": {
+                    "type": "array",
+                    "items": {
+                        "type": "array"
+                    },
+                    "uniqueItems": true
+                },
+                "extra_constraints": {
+                    "type": "array",
+                    "items": {
+                        "type": "array"
+                    },
+                    "uniqueItems": true
+                },
+                "pool": {
+                    "type": "string"
+                },
+                "cmd": {
+                    "type": "string"
+                },
+                "args": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "env": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                },
+                "extra_volumes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    },
+                    "uniqueItems": true
+                },
+                "monitoring": {
+                    "type": "object"
+                },
+                "net": {
+                    "type": "string"
+                },
+                "deploy_blacklist": {
+                    "type": "array"
+                },
+                "deploy_whitelist": {
+                    "type": "array"
+                },
+                "monitoring_blacklist": {
+                    "type": "array"
+                },
+                "healthcheck_mode": {
+                    "enum": [ "cmd", "tcp", "http" ]
+                },
+                "healthcheck_cmd": {
+                    "type": "string",
+                    "default": "/bin/true"
+                },
+                "healthcheck_grace_period_seconds": {
+                    "type": "number",
+                    "default": 60
+                },
+                "healthcheck_interval_seconds": {
+                    "type": "number",
+                    "default": 10
+                },
+                "healthcheck_timeout_seconds": {
+                    "type": "number",
+                    "default": 10
+                },
+                "healthcheck_max_consecutive_failures": {
+                    "type": "integer",
+                    "default": 6
+                },
+                "replication_threshold": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "ulimit": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                            "soft": {
+                                "type": "number"
+                            },
+                            "hard": {
+                                "type": "number"
+                            }
+                        },
+                        "required": ["soft"],
+                        "additionalProperties": false
+                    }
+                },
+                "cap_add": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "cfs_period_us": {
+                    "type": "integer",
+                    "minimum": "1000",
+                    "maximum": "1000000",
+                    "exclusiveMinimum": false
+                },
+                "cpu_burst_pct": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": false
                 }
-            },
-            "cfs_period_us": {
-                "type": "integer",
-                "minimum": "1000",
-                "maximum": "1000000",
-                "exclusiveMinimum": false
-            },
-            "cpu_burst_pct": {
-                "type": "integer",
-                "minimum": 0,
-                "exclusiveMinimum": false
             }
-        }
+	}
     }
 }

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -210,6 +210,83 @@ main_worker:
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 @patch('sys.stdout', new_callable=StringIO, autospec=None)
+def test_marathon_validate_id(
+    mock_stdout,
+    mock_get_file_contents
+):
+    marathon_content = """
+---
+valid:
+  cpus: 0.1
+  instances: 2
+  mem: 250
+  disk: 512
+  cmd: virtualenv_run/bin/python adindexer/adindex_worker.py
+"""
+    mock_get_file_contents.return_value = marathon_content
+    assert validate_schema('unused_service_path.yaml', 'marathon')
+    output = mock_stdout.getvalue().decode('utf-8')
+    assert SCHEMA_VALID in output
+
+    marathon_content = """
+---
+this_is_okay_too_1:
+  cpus: 0.1
+  instances: 2
+  mem: 250
+  disk: 512
+  cmd: virtualenv_run/bin/python adindexer/adindex_worker.py
+"""
+    mock_get_file_contents.return_value = marathon_content
+    assert validate_schema('unused_service_path.yaml', 'marathon')
+    output = mock_stdout.getvalue().decode('utf-8')
+    assert SCHEMA_VALID in output
+
+    marathon_content = """
+---
+dashes-are-okay-too:
+  cpus: 0.1
+  instances: 2
+  mem: 250
+  disk: 512
+  cmd: virtualenv_run/bin/python adindexer/adindex_worker.py
+"""
+    mock_get_file_contents.return_value = marathon_content
+    assert validate_schema('unused_service_path.yaml', 'marathon')
+    output = mock_stdout.getvalue().decode('utf-8')
+    assert SCHEMA_VALID in output
+
+    marathon_content = """
+---
+main_worker_CAPITALS_INVALID:
+  cpus: 0.1
+  instances: 2
+  mem: 250
+  disk: 512
+  cmd: virtualenv_run/bin/python adindexer/adindex_worker.py
+"""
+    mock_get_file_contents.return_value = marathon_content
+    assert not validate_schema('unused_service_path.yaml', 'marathon')
+    output = mock_stdout.getvalue().decode('utf-8')
+    assert SCHEMA_INVALID in output
+
+    marathon_content = """
+---
+$^&*()(&*^%&definitely_not_okay:
+  cpus: 0.1
+  instances: 2
+  mem: 250
+  disk: 512
+  cmd: virtualenv_run/bin/python adindexer/adindex_worker.py
+"""
+    mock_get_file_contents.return_value = marathon_content
+    assert not validate_schema('unused_service_path.yaml', 'marathon')
+    output = mock_stdout.getvalue().decode('utf-8')
+    assert SCHEMA_INVALID in output
+
+
+@patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
+@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_marathon_validate_schema_healthcheck_cmd_has_cmd(
     mock_stdout,
     mock_get_file_contents


### PR DESCRIPTION
This should validate the top level key in marathon-<cluster>.yaml which
becomes the marathon app ID. It compares it to an adapted regex that
marathon itself uses to validate the app ID.

https://github.com/Yelp/paasta/compare/validate-marathon-ids?expand=1#diff-0f83d210889c5e0c676f023e9b29c835R8 is the new line (lol structured data in a diff)

@solarkennedy this should do what you suggested