### PR TITLE
Remove use of the sphinxcontrib-programoutput module in docs

### DIFF
--- a/docs/source/bouncing.rst
+++ b/docs/source/bouncing.rst
@@ -10,9 +10,13 @@ A "Bounce" can happen for one of these reasons:
 
 * A new version of the code is deployed (a git sha change)
 * A change of `soa-configs <yelpsoa_configs.html>`_ for a service. (Change in ram, cpu, environment variables, etc)
-* * With the exception of these keys:
 
-.. program-output:: python -c "from paasta_tools.marathon_tools import CONFIG_HASH_BLACKLIST; print ', '.join(CONFIG_HASH_BLACKLIST)"
+  * With the exception of these keys:
+
+    * ``min_instances``
+    * ``instances``
+    * ``max_instances``
+    * ``backoff_seconds``
 
 * An issue of a ``paasta restart`` (or partially from a start/stop)
 * A change in system-wide PaaSTA configuration (defaults for volumes, ram, cpu, etc)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ sys.path.append(os.path.abspath('./../../src/paasta_tools'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinxcontrib.programoutput']
+extensions = ['sphinx.ext.autodoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -16,7 +16,10 @@ lowercase. (non alphanumeric lowercase characters are ignored)
 **Note:** All values in this file except the following will cause PaaSTA to
 `bounce <workflow.html#bouncing>`_ the service:
 
-.. program-output:: python -c "from paasta_tools.marathon_tools import CONFIG_HASH_BLACKLIST; print ', '.join(CONFIG_HASH_BLACKLIST)"
+* ``min_instances``
+* ``instances``
+* ``max_instances``
+* ``backoff_seconds``
 
 Top level keys are instancenames, e.g. ``main`` and ``canary``. Each
 instance MAY have:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 docutils==0.12
 flake8==2.5.0
-git+git://github.com/solarkennedy/sphinxcontrib-programoutput#egg=package-two
 mock==2.0.0
 pep8==1.5.7
 pre-commit==0.7.6


### PR DESCRIPTION
This module has caused us issues on a number of occasions. We are using it minimally, and nobody really seems to care about it. Let's just remove it and go back to static lists.