### PR TITLE
Fix the build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ retry==0.9.2
 sensu-plugin==0.1.0
 service-configuration-lib==0.10.1
 simplejson==3.6.5
-six==1.9.0
+six>=1.9.0
 thriftpy==0.1.15
 ujson==1.35
 websocket-client==0.32.0

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -35,6 +35,9 @@ RUN apt-get install -yq mesos=1.0.1-2.0.93.ubuntu1404 && \
 	zip -r /root/mesos.scheduler-1.0.1-py27-none-any.whl mesos/scheduler mesos.scheduler-1.0.1.dist-info && \
 	apt-get remove -yq mesos
 
+RUN pip install -U pip
+RUN pip install -U virtualenv
+
 ADD mesos-slave-secret /etc/mesos-slave-secret
 
 ENV HOME /work


### PR DESCRIPTION
Think I've tracked this down to the fact that we have pinned six==1.9.0
and setuptools now needs a newer version.

Can't see any reason why it was pinned so let's see if the tests pass
with the new version.