### PR TITLE
Add intermediate venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 dist/
 .tox
+.paasta
 .pip/
 *.py?
 .*.sw?

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,7 @@ docs:
 	tox -e docs
 
 test:
-	rm -rf .tox
-	tox
+	./test.sh
 
 itest: test
 	tox -e general_itests

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+rm -rf .tox
+rm -rf .paasta
+virtualenv .paasta
+source ./.paasta/bin/activate
+pip install -U pip
+pip install -U virtualenv
+pip install -U tox
+tox


### PR DESCRIPTION
I know this is kinda nuts but it does make the tests pass on a dev box.
I'm basically adding an intermediate venv which we install the latest
versions of pip + virtualenv. This way tox creates a virtualenv with
sufficiently new tools to work consistently.