### PR TITLE
Spread the extra venv to other tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,13 @@ endif
 .PHONY: all docs test itest
 
 docs:
-	tox -e docs
+	./docs.sh
 
 test:
 	./test.sh
 
 itest: test
-	tox -e general_itests
-	tox -e paasta_itests
+	./itest.sh
 
 itest_%:
 	# See the makefile in yelp_package/Makefile for packaging stuff

--- a/docs.sh
+++ b/docs.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+rm -rf .paasta
+virtualenv .paasta
+source ./.paasta/bin/activate
+pip install -U pip
+pip install -U virtualenv
+pip install -U tox
+tox -e docs

--- a/itest.sh
+++ b/itest.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+source ./.paasta/bin/activate
+tox -e general_itests
+tox -e paasta_itests


### PR DESCRIPTION
As per 012b276696017760c3026d0c6e8c56e2719e607c this makes our tox
commands run in an intermediate virtual env. This is a workaround to the
requirements not installing in a venv without the latest version of pip
+ virtualenv etc.