### PR TITLE
Latest pip + venv on lucid too

### DIFF
--- a/yelp_package/dockerfiles/lucid/Dockerfile
+++ b/yelp_package/dockerfiles/lucid/Dockerfile
@@ -20,6 +20,9 @@ MAINTAINER Kyle Anderson <kwa@yelp.com>
 # Which at this time is in this package
 RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools python-dev libssl-dev libffi-dev debhelper dh-virtualenv python-yaml libyaml-dev python-pytest pyflakes python2.7 python2.7-dev help2man zsh git
 
+RUN pip install -U pip
+RUN pip install -U virtualenv
+
 ENV HOME /work
 ENV PWD /work
 WORKDIR /work


### PR DESCRIPTION
As per 95ed63dface91540b32e6801674bf5b1ffc78c0f

As mentioned in https://github.com/Yelp/paasta/pull/976 I thought we
might need to bump the lucid versions too...