### PR TITLE
Remove possible block while getting next instance from instances_queue

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -320,11 +320,12 @@ def _run_instance_worker(cluster_data, instances_out, green_light):
         log.warning("Couldn't reach the PaaSTA api for {}! Assuming it is not "
                     "deployed there yet.".format(cluster_data.cluster))
         while not cluster_data.instances_queue.empty():
-            instances_out.put(cluster_data.instances_queue.get())
+            instance = cluster_data.instances_queue.get(block=False)
             cluster_data.instances_queue.task_done()
+            instances_out.put(instance)
 
     while not cluster_data.instances_queue.empty() and green_light.is_set():
-        instance = cluster_data.instances_queue.get()
+        instance = cluster_data.instances_queue.get(block=False)
         log.debug("Inspecting the deployment status of {}.{} on {}"
                   .format(cluster_data.service, instance, cluster_data.cluster))
         try:

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -122,21 +122,21 @@ def test_instances_deployed(mock_get_paasta_api_client, mock__log):
     instances_out = Queue()
     f(cluster_data, instances_out, e)
     assert cluster_data.instances_queue.empty()
-    assert instances_out.get() == 'instance2'
+    assert instances_out.get(block=True) == 'instance2'
 
     cluster_data.instances_queue = Queue()
     cluster_data.instances_queue.put('instance3')
     instances_out = Queue()
     f(cluster_data, instances_out, e)
     assert cluster_data.instances_queue.empty()
-    assert instances_out.get() == 'instance3'
+    assert instances_out.get(block=True) == 'instance3'
 
     cluster_data.instances_queue = Queue()
     cluster_data.instances_queue.put('instance4')
     instances_out = Queue()
     f(cluster_data, instances_out, e)
     assert cluster_data.instances_queue.empty()
-    assert instances_out.get() == 'instance4'
+    assert instances_out.get(block=True) == 'instance4'
 
     cluster_data.instances_queue = Queue()
     cluster_data.instances_queue.put('instance5')


### PR DESCRIPTION
#993 

Queue.get() is a blocking operation.
When there is only one instance in the queue, it is not empty, but only one thread will be able to read from it, while all other threads will be blocked.

block=False causes Queue.get() not to block and to raise an exception if nothing is available, and that will terminate the running thread.