### PR TITLE
Some python3 changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.cache
 build/
 dist/
 .tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ branches:
 language: python
 env:
   - TOXENV=py27
+  - TOXENV=py3
   - TOXENV=coverage
   - TOXENV=docs
   - TOXENV=general_itests

--- a/debian/rules
+++ b/debian/rules
@@ -1,12 +1,6 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
-export DH_VIRTUALENV_INSTALL_ROOT=/opt/venvs
-
-# This has to be exported to make some magic below work.
-export DH_OPTIONS
-
-
 %:
 	dh $@ --with python-virtualenv
 
@@ -25,4 +19,4 @@ override_dh_auto_test:
 	true
 
 override_dh_virtualenv:
-	dh_virtualenv --extra-index-url 'https://pypi.yelpcorp.com/simple' --python=/usr/bin/python2.7 --extra-pip-arg '--no-use-wheel'
+	dh_virtualenv --extra-index-url 'https://pypi.yelpcorp.com/simple' --python=/usr/bin/python2.7 --preinstall no-manylinux1 --preinstall pip-custom-platform --pip-tool pip-custom-platform

--- a/general_itests/pylintrc
+++ b/general_itests/pylintrc
@@ -1,0 +1,2 @@
+[TYPECHECK]
+ignored-modules=six.moves

--- a/paasta_tools/api/client.py
+++ b/paasta_tools/api/client.py
@@ -22,9 +22,9 @@ import json
 import logging
 import os
 import sys
-from urlparse import urlparse
 
 from bravado.client import SwaggerClient
+from six.moves.urllib_parse import urlparse
 
 from paasta_tools.utils import load_system_paasta_config
 

--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -23,7 +23,6 @@ import os
 import signal
 import time
 from contextlib import contextmanager
-from contextlib import nested
 
 from kazoo.client import KazooClient
 from kazoo.exceptions import LockTimeout
@@ -171,7 +170,7 @@ def create_marathon_app(app_id, config, client):
 
     :param config: The marathon configuration to be deployed
     :param client: A MarathonClient object"""
-    with nested(create_app_lock(), time_limit(1)):
+    with create_app_lock(), time_limit(1):
         client.create_app(app_id, MarathonApp(**config))
         wait_for_create(app_id, client)
 
@@ -193,7 +192,7 @@ def delete_marathon_app(app_id, client):
 
     :param app_id: The marathon app id to be deleted
     :param client: A MarathonClient object"""
-    with nested(create_app_lock(), time_limit(1)):
+    with create_app_lock(), time_limit(1):
         # Scale app to 0 first to work around
         # https://github.com/mesosphere/marathon/issues/725
         client.scale_app(app_id, instances=0, force=True)

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -19,7 +19,6 @@ import csv
 import datetime
 import logging
 import re
-import urlparse
 from time import sleep
 
 import chronos
@@ -27,6 +26,7 @@ import dateutil
 import isodate
 import service_configuration_lib
 from crontab import CronSlices
+from six.moves.urllib_parse import urlsplit
 
 from paasta_tools import monitoring_tools
 from paasta_tools.mesos_tools import get_mesos_network_for_net
@@ -129,7 +129,7 @@ def load_chronos_config():
 def get_chronos_client(config):
     """Returns a chronos client object for interacting with the API"""
     chronos_hosts = config.get_url()
-    chronos_hostnames = [urlparse.urlsplit(hostname).netloc for hostname in chronos_hosts]
+    chronos_hostnames = [urlsplit(hostname).netloc for hostname in chronos_hosts]
     log.info("Attempting to connect to Chronos servers: %s" % chronos_hosts)
     return chronos.connect(servers=chronos_hostnames,
                            username=config.get_username(),

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -26,11 +26,11 @@ import sys
 import time
 from os import execlp
 from random import randint
-from urlparse import urlparse
 
 import ephemeral_port_reserve
 import requests
 from docker import errors
+from six.moves.urllib_parse import urlparse
 
 from paasta_tools.adhoc_tools import get_default_interactive_config
 from paasta_tools.chronos_tools import parse_time_variables

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -25,13 +25,13 @@ from collections import namedtuple
 from contextlib import contextmanager
 from multiprocessing import Process
 from multiprocessing import Queue
-from Queue import Empty
 from time import sleep
 
 import dateutil
 import isodate
 import pytz
 import ujson as json
+from six.moves.queue import Empty
 
 from paasta_tools.utils import paasta_print
 
@@ -170,7 +170,7 @@ def build_component_descriptions(components):
     """Returns a colored description string for every log component
     based on its help attribute"""
     output = []
-    for k, v in components.iteritems():
+    for k, v in components.items():
         output.append("     %s: %s" % (v['color'](k), v['help']))
     return '\n'.join(output)
 

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -21,14 +21,14 @@ from __future__ import unicode_literals
 import logging
 import sys
 import time
-from Queue import Empty
-from Queue import Queue
 from threading import Event
 from threading import Thread
 
 import progressbar
 from bravado.exception import HTTPError
 from requests.exceptions import ConnectionError
+from six.moves.queue import Empty
+from six.moves.queue import Queue
 
 from paasta_tools import remote_git
 from paasta_tools.api import client

--- a/paasta_tools/cli/cmds/sysdig.py
+++ b/paasta_tools/cli/cmds/sysdig.py
@@ -18,7 +18,8 @@ from __future__ import unicode_literals
 import shlex
 import subprocess
 import sys
-from urlparse import urlparse
+
+from six.moves.urllib_parse import urlparse
 
 from paasta_tools.cli.utils import calculate_remote_masters
 from paasta_tools.cli.utils import find_connectable_master

--- a/paasta_tools/mesos/cfg.py
+++ b/paasta_tools/mesos/cfg.py
@@ -21,6 +21,9 @@ import json
 import os
 
 
+_cfg_name = ".mesos.json"
+
+
 class Config(object):
 
     _default_profile = "default"
@@ -35,17 +38,16 @@ class Config(object):
         "response_timeout": 5
     }
 
-    cfg_name = ".mesos.json"
+    cfg_name = _cfg_name
+    _default_config_location = os.path.join(os.path.expanduser("~"), _cfg_name)
 
-    _default_config_location = os.path.join(os.path.expanduser("~"), cfg_name)
-
-    search_path = [os.path.join(x, cfg_name) for x in [
+    search_path = [os.path.join(x, _cfg_name) for x in (
         ".",
         os.path.expanduser("~"),
         "/etc",
         "/usr/etc",
         "/usr/local/etc"
-    ]]
+    )]
 
     def __init__(self, config_path):
         self.config_path = config_path

--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -22,13 +22,13 @@ import json
 import logging
 import os
 import re
-import urlparse
 
 import requests
 import requests.exceptions
 from kazoo.handlers.threading import KazooTimeoutError
 from kazoo.retry import KazooRetry
 from retry import retry
+from six.moves.urllib_parse import urljoin
 
 from . import exceptions
 from . import framework
@@ -72,7 +72,7 @@ class MesosMaster(object):
     def fetch(self, url, **kwargs):
         try:
             return requests.get(
-                urlparse.urljoin(self.host, url),
+                urljoin(self.host, url),
                 timeout=self.config["response_timeout"],
                 **kwargs)
         except requests.exceptions.ConnectionError:

--- a/paasta_tools/mesos/slave.py
+++ b/paasta_tools/mesos/slave.py
@@ -16,10 +16,9 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import urlparse
-
 import requests
 import requests.exceptions
+from six.moves.urllib_parse import urljoin
 
 from . import exceptions
 from . import log
@@ -52,7 +51,7 @@ class MesosSlave(object):
     @log.duration
     def fetch(self, url, **kwargs):
         try:
-            return requests.get(urlparse.urljoin(
+            return requests.get(urljoin(
                 self.host, url), timeout=self.config["response_timeout"], **kwargs)
         except requests.exceptions.ConnectionError:
             raise exceptions.SlaveDoesNotExist(

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -21,11 +21,11 @@ import logging
 import re
 import socket
 from collections import namedtuple
-from urlparse import urlparse
 
 import humanize
 import requests
 from kazoo.client import KazooClient
+from six.moves.urllib_parse import urlparse
 
 import paasta_tools.mesos.cluster as cluster
 import paasta_tools.mesos.exceptions as mesos_exceptions

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -22,7 +22,6 @@ import errno
 import fcntl
 import glob
 import hashlib
-import importlib
 import io
 import json
 import logging
@@ -46,6 +45,7 @@ import choice
 import dateutil.tz
 import requests_cache
 import service_configuration_lib
+import six
 import yaml
 from docker import Client
 from docker.utils import kwargs_from_env
@@ -683,7 +683,7 @@ def get_log_name_for_service(service, prefix=None):
 @register_log_writer('scribe')
 class ScribeLogWriter(LogWriter):
     def __init__(self, scribe_host='169.254.255.254', scribe_port=1463, scribe_disable=False, **kwargs):
-        self.clog = importlib.import_module('clog')
+        self.clog = __import__('clog')
         self.clog.config.configure(scribe_host=scribe_host, scribe_port=scribe_port, scribe_disable=scribe_disable)
 
     def log(self, service, line, component, level=DEFAULT_LOGLEVEL, cluster=ANY_CLUSTER, instance=ANY_INSTANCE):
@@ -1712,9 +1712,8 @@ def prompt_pick_one(sequence, choosing):
 
 
 def paasta_print(*args, **kwargs):
-    string = (
-        s.encode('utf-8') if isinstance(s, unicode) else s
+    args = (
+        s.encode('utf-8') if isinstance(s, six.text_type) else s
         for s in args
     )
-
-    print(*string, **kwargs)
+    print(*args, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ git+git://github.com/sensu/sensu-plugin-python@bf00ac33
 git+git://github.com/Yelp/yelp_clog@v2.6.0
 httplib2==0.9
 humanize==0.5.1
-importlib==1.0.3
 isodate==0.5.1
 jsonschema[format]==2.5.1
 kazoo==2.2
@@ -37,10 +36,9 @@ pycrypto==2.6.1
 Pygments==2.0.2
 pyramid==1.7
 pyramid-swagger==2.2.3
-pysensu-yelp==0.2.2
+pysensu-yelp==0.3.3
 PyStaticConfiguration==0.9.0
 python-crontab==2.1.1
-python-daemon==1.5.2
 python-dateutil==2.4.2
 pytimeparse==1.1.5
 pytz==2014.10
@@ -54,5 +52,4 @@ six>=1.9.0
 thriftpy==0.1.15
 ujson==1.35
 websocket-client==0.32.0
-wsgiref==0.1.2
 zope.interface==4.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ ephemeral-port-reserve==1.0.1
 future>=0.15.2
 futures==3.0.1
 gevent==1.1.1
+git+git://github.com/sensu/sensu-plugin-python@bf00ac33
 git+git://github.com/Yelp/yelp_clog@v2.6.0
 httplib2==0.9
 humanize==0.5.1
@@ -47,7 +48,6 @@ PyYAML==3.11
 requests==2.6.2
 requests-cache==0.4.10
 retry==0.9.2
-sensu-plugin==0.1.0
 service-configuration-lib==0.10.1
 simplejson==3.6.5
 six>=1.9.0

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'argcomplete >= 0.8.1',
-        # argparse is pinned to 1.2.1 since it comes in the core python2.7
-        # libs and pip can't seem to override it
-        'argparse == 1.2.1',
         'bravado == 8.4.0',
         'choice == 0.1',
         'chronos-python == 0.37.0',
@@ -48,7 +45,6 @@ setup(
         'docker-py == 1.2.3',
         'dulwich == 0.10.0',
         'ephemeral-port-reserve >= 1.0.1',
-        'functools32',
         'futures',
         'gevent == 1.1.1',
         'humanize >= 0.5.1',
@@ -100,19 +96,21 @@ setup(
         'paasta_tools/setup_marathon_job.py',
         'paasta_tools/synapse_srv_namespaces_fact.py',
     ] + glob.glob('paasta_tools/contrib/*'),
-    package_data={b'': [b'cli/fsm/template/*/*', b'cli/schemas/*.json', b'api/api_docs/*.json']},
-    entry_points={'console_scripts': [
-        'paasta=paasta_tools.cli.cli:main',
-        'paasta-api=paasta_tools.api.api:main',
-        'paasta_autoscale_cluster=paasta_tools.autoscale_cluster:main',
-        'paasta_cleanup_chronos_jobs=paasta_tools.cleanup_chronos_jobs:main',
-        'paasta_check_chronos_jobs=paasta_tools.check_chronos_jobs:main',
-        'paasta_list_chronos_jobs=paasta_tools.list_chronos_jobs:main',
-        'paasta_setup_chronos_job=paasta_tools.setup_chronos_job:main',
-        'paasta_chronos_rerun=paasta_tools.chronos_rerun:main',
-        'paasta_cleanup_maintenance=paasta_tools.cleanup_maintenance:main',
-    ],
+    package_data={str(''): [str('cli/fsm/template/*/*'), str('cli/schemas/*.json'), str('api/api_docs/*.json')]},
+    entry_points={
+        'console_scripts': [
+            'paasta=paasta_tools.cli.cli:main',
+            'paasta-api=paasta_tools.api.api:main',
+            'paasta_autoscale_cluster=paasta_tools.autoscale_cluster:main',
+            'paasta_cleanup_chronos_jobs=paasta_tools.cleanup_chronos_jobs:main',
+            'paasta_check_chronos_jobs=paasta_tools.check_chronos_jobs:main',
+            'paasta_list_chronos_jobs=paasta_tools.list_chronos_jobs:main',
+            'paasta_setup_chronos_job=paasta_tools.setup_chronos_job:main',
+            'paasta_chronos_rerun=paasta_tools.chronos_rerun:main',
+            'paasta_cleanup_maintenance=paasta_tools.cleanup_maintenance:main',
+        ],
         'paste.app_factory': [
-        'paasta-api-config=paasta_tools.api.api:make_app'
-    ]},
+            'paasta-api-config=paasta_tools.api.api:make_app'
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,8 @@ setup(
         'retry',
         'requests == 2.6.2',
         'requests-cache >= 0.4.10,<= 0.5.0',
-        'sensu-plugin >= 0.1.0',
+        # We install this from git
+        # 'sensu-plugin >= 0.2.0',
         'service-configuration-lib >= 0.10.1',
         'ujson == 1.35',
         'yelp_clog >= 2.2.0',

--- a/tests/cli/test_cmds_check.py
+++ b/tests/cli/test_cmds_check.py
@@ -16,7 +16,6 @@ from __future__ import unicode_literals
 
 import contextlib
 import os
-from StringIO import StringIO
 
 from mock import call
 from mock import MagicMock
@@ -98,92 +97,79 @@ def test_check_paasta_check_calls_everything(
 
 
 @patch('paasta_tools.cli.cmds.check.validate_service_name', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_check_service_dir_check_pass(mock_stdout, mock_validate_service_name):
+def test_check_service_dir_check_pass(mock_validate_service_name, capsys):
     mock_validate_service_name.return_value = None
     service = 'fake_service'
     soa_dir = '/fake_yelpsoa_configs'
     expected_output = \
         "%s\n" % PaastaCheckMessages.service_dir_found(service, soa_dir)
     service_dir_check(service, soa_dir)
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.validate_service_name', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_check_service_dir_check_fail(mock_stdout, mock_validate_service_name):
+def test_check_service_dir_check_fail(mock_validate_service_name, capsys):
     service = 'fake_service'
     soa_dir = '/fake_yelpsoa_configs'
     mock_validate_service_name.side_effect = NoSuchService(service)
     expected_output = "%s\n" \
                       % PaastaCheckMessages.service_dir_missing(service, soa_dir)
     service_dir_check(service, soa_dir)
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_check_deploy_check_pass(mock_stdout, mock_is_file_in_dir):
+def test_check_deploy_check_pass(mock_is_file_in_dir, capsys):
     # Deploy check passes when file found in service path
 
     mock_is_file_in_dir.return_value = True
 
     deploy_check('service_path')
     expected_output = "%s\n" % PaastaCheckMessages.DEPLOY_YAML_FOUND
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_check_deploy_check_fail(mock_stdout, mock_is_file_in_dir):
+def test_check_deploy_check_fail(mock_is_file_in_dir, capsys):
     # Deploy check fails when file not in service path
 
     mock_is_file_in_dir.return_value = False
 
     deploy_check('service_path')
     expected_output = "%s\n" % PaastaCheckMessages.DEPLOY_YAML_MISSING
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_check_docker_exists_and_is_valid(
-    mock_stdout,
-    mock_is_file_in_dir,
-):
+def test_check_docker_exists_and_is_valid(mock_is_file_in_dir, capsys):
     mock_is_file_in_dir.return_value = "/fake/path"
 
     docker_check()
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert PaastaCheckMessages.DOCKERFILE_FOUND in output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_check_docker_check_file_not_found(
-    mock_stdout,
-    mock_is_file_in_dir
-):
+def test_check_docker_check_file_not_found(mock_is_file_in_dir, capsys):
     mock_is_file_in_dir.return_value = False
 
     docker_check()
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert PaastaCheckMessages.DOCKERFILE_MISSING in output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_check_yaml_check_pass(mock_stdout, mock_is_file_in_dir):
+def test_check_yaml_check_pass(mock_is_file_in_dir, capsys):
     # marathon.yaml exists and is valid
 
     mock_is_file_in_dir.return_value = "/fake/path"
@@ -191,30 +177,27 @@ def test_check_yaml_check_pass(mock_stdout, mock_is_file_in_dir):
                                     PaastaCheckMessages.CHRONOS_YAML_FOUND)
 
     yaml_check('path')
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_check_yaml_check_fail(mock_stdout, mock_is_file_in_dir):
+def test_check_yaml_check_fail(mock_is_file_in_dir, capsys):
     # marathon.yaml exists and is valid
 
     mock_is_file_in_dir.return_value = False
     expected_output = "%s\n" % PaastaCheckMessages.YAML_MISSING
 
     yaml_check('path')
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
 @patch('paasta_tools.cli.cmds.check.get_team', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_check_sensu_check_pass(mock_stdout, mock_get_team,
-                                mock_is_file_in_dir):
+def test_check_sensu_check_pass(mock_get_team, mock_is_file_in_dir, capsys):
     # monitoring.yaml exists and team is found
 
     mock_is_file_in_dir.return_value = "/fake/path"
@@ -224,8 +207,8 @@ def test_check_sensu_check_pass(mock_stdout, mock_get_team,
                                     PaastaCheckMessages.sensu_team_found(team))
 
     sensu_check(service='fake_service', service_path='path', soa_dir='path')
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert output == expected_output
     mock_get_team.assert_called_once_with(service='fake_service', overrides={},
                                           soa_dir='path')
@@ -233,9 +216,7 @@ def test_check_sensu_check_pass(mock_stdout, mock_get_team,
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
 @patch('paasta_tools.cli.cmds.check.get_team', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_check_sensu_team_missing(mock_stdout, mock_get_team,
-                                  mock_is_file_in_dir):
+def test_check_sensu_team_missing(mock_get_team, mock_is_file_in_dir, capsys):
     # monitoring.yaml exists but team is not found
 
     mock_is_file_in_dir.return_value = "/fake/path"
@@ -244,31 +225,30 @@ def test_check_sensu_team_missing(mock_stdout, mock_get_team,
                                     PaastaCheckMessages.SENSU_TEAM_MISSING)
 
     sensu_check(service='fake_service', service_path='path', soa_dir='path')
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_check_sensu_check_fail(mock_stdout, mock_is_file_in_dir):
+def test_check_sensu_check_fail(mock_is_file_in_dir, capsys):
     # monitoring.yaml doest exist
 
     mock_is_file_in_dir.return_value = False
     expected_output = "%s\n" % PaastaCheckMessages.SENSU_MONITORING_MISSING
 
     sensu_check(service='fake_service', service_path='path', soa_dir='path')
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert output == expected_output
 
 
 @patch('service_configuration_lib.'
        'read_service_configuration', autospec=True)
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_check_smartstack_check_pass(mock_stdout, mock_is_file_in_dir,
-                                     mock_read_service_info):
+def test_check_smartstack_check_pass(
+        mock_is_file_in_dir, mock_read_service_info, capsys,
+):
     # smartstack.yaml exists and port is found
 
     mock_is_file_in_dir.return_value = True
@@ -288,17 +268,17 @@ def test_check_smartstack_check_pass(mock_stdout, mock_is_file_in_dir,
                              instance, port))
 
     smartstack_check(service='fake_service', service_path='path', soa_dir='path')
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert output == expected_output
 
 
 @patch('service_configuration_lib.'
        'read_service_configuration', autospec=True)
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_check_smartstack_check_missing_port(
-        mock_stdout, mock_is_file_in_dir, mock_read_service_info):
+        mock_is_file_in_dir, mock_read_service_info, capsys,
+):
     # smartstack.yaml, instance exists, but no ports found
 
     mock_is_file_in_dir.return_value = True
@@ -314,17 +294,16 @@ def test_check_smartstack_check_missing_port(
                          PaastaCheckMessages.SMARTSTACK_PORT_MISSING)
 
     smartstack_check(service='fake_service', service_path='path', soa_dir='path')
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.'
        'read_service_configuration', autospec=True)
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_check_smartstack_check_missing_instance(
-        mock_stdout, mock_is_file_in_dir, mock_read_service_info):
+        mock_is_file_in_dir, mock_read_service_info, capsys):
     # smartstack.yaml exists, but no instances found
 
     mock_is_file_in_dir.return_value = True
@@ -335,20 +314,19 @@ def test_check_smartstack_check_missing_instance(
                          PaastaCheckMessages.SMARTSTACK_PORT_MISSING)
 
     smartstack_check(service='fake_service', service_path='path', soa_dir='path')
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_check_smartstack_check_is_ok_when_no_smartstack(mock_stdout, mock_is_file_in_dir):
+def test_check_smartstack_check_is_ok_when_no_smartstack(mock_is_file_in_dir, capsys):
 
     mock_is_file_in_dir.return_value = False
     expected_output = ""
     smartstack_check(service='fake_service', service_path='path', soa_dir='path')
-    output = mock_stdout.getvalue().decode('utf-8')
 
+    output, _ = capsys.readouterr()
     assert output == expected_output
 
 
@@ -426,9 +404,8 @@ def test_makefile_has_docker_tag_false():
         assert makefile_has_docker_tag(fake_makefile_path) is False
 
 
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 @patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
-def test_deploy_has_security_check_false(mock_pipeline_config, mock_stdout):
+def test_deploy_has_security_check_false(mock_pipeline_config, capsys):
     mock_pipeline_config.return_value = [
         {'step': 'itest', },
         {'step': 'push-to-registry', },
@@ -439,9 +416,8 @@ def test_deploy_has_security_check_false(mock_pipeline_config, mock_stdout):
     assert actual is False
 
 
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 @patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
-def test_deploy_has_security_check_true(mock_pipeline_config, mock_stdout):
+def test_deploy_has_security_check_true(mock_pipeline_config, capsys):
     mock_pipeline_config.return_value = [
         {'step': 'itest', },
         {'step': 'security-check', },
@@ -453,9 +429,8 @@ def test_deploy_has_security_check_true(mock_pipeline_config, mock_stdout):
     assert actual is True
 
 
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 @patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
-def test_deploy_has_performance_check_false(mock_pipeline_config, mock_stdout):
+def test_deploy_has_performance_check_false(mock_pipeline_config, capsys):
     mock_pipeline_config.return_value = [
         {'step': 'itest', },
         {'step': 'push-to-registry', },
@@ -466,9 +441,8 @@ def test_deploy_has_performance_check_false(mock_pipeline_config, mock_stdout):
     assert actual is False
 
 
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 @patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
-def test_deploy_has_performance_check_true(mock_pipeline_config, mock_stdout):
+def test_deploy_has_performance_check_true(mock_pipeline_config, capsys):
     mock_pipeline_config.return_value = [
         {'step': 'itest', },
         {'step': 'performance-check', },
@@ -503,13 +477,12 @@ def test_get_marathon_steps(
     assert actual == expected
 
 
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 @patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
 @patch('paasta_tools.cli.cmds.check.get_marathon_steps', autospec=True)
 def test_marathon_deployments_check_good(
     mock_get_marathon_steps,
     mock_get_pipeline_config,
-    mock_stdout,
+    capsys,
 ):
     mock_get_pipeline_config.return_value = [
         {'step': 'itest', },
@@ -526,13 +499,12 @@ def test_marathon_deployments_check_good(
     assert actual is True
 
 
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 @patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
 @patch('paasta_tools.cli.cmds.check.get_marathon_steps', autospec=True)
 def test_marathon_deployments_deploy_but_not_marathon(
     mock_get_marathon_steps,
     mock_get_pipeline_config,
-    mock_stdout,
+    capsys,
 ):
     mock_get_pipeline_config.return_value = [
         {'step': 'itest', },
@@ -548,16 +520,15 @@ def test_marathon_deployments_deploy_but_not_marathon(
     ]
     actual = deployments_check(service='fake_service', soa_dir='/fake/service')
     assert actual is False
-    assert 'EXTRA' in mock_stdout.getvalue().decode('utf-8')
+    assert 'EXTRA' in capsys.readouterr()[0]
 
 
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 @patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
 @patch('paasta_tools.cli.cmds.check.get_marathon_steps', autospec=True)
 def test_marathon_deployments_marathon_but_not_deploy(
     mock_get_marathon_steps,
     mock_get_pipeline_config,
-    mock_stdout,
+    capsys,
 ):
     mock_get_pipeline_config.return_value = [
         {'step': 'itest', },
@@ -573,7 +544,7 @@ def test_marathon_deployments_marathon_but_not_deploy(
     ]
     actual = deployments_check(service='fake_service', soa_dir='/fake/path')
     assert actual is False
-    assert 'BOGUS' in mock_stdout.getvalue().decode('utf-8')
+    assert 'BOGUS' in capsys.readouterr()[0]
 
 
 def test_makefile_check():

--- a/tests/cli/test_cmds_generate_pipeline.py
+++ b/tests/cli/test_cmds_generate_pipeline.py
@@ -14,8 +14,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from StringIO import StringIO
-
 from mock import ANY
 from mock import MagicMock
 from mock import patch
@@ -30,9 +28,8 @@ from paasta_tools.cli.utils import NoSuchService
 
 @patch('paasta_tools.cli.cmds.generate_pipeline.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.generate_pipeline.guess_service_name', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_paasta_generate_pipeline_service_not_found(
-        mock_stdout, mock_guess_service_name, mock_validate_service_name):
+        mock_guess_service_name, mock_validate_service_name, capsys):
     # paasta generate cannot guess service name and none is provided
 
     mock_guess_service_name.return_value = 'not_a_service'
@@ -43,7 +40,7 @@ def test_paasta_generate_pipeline_service_not_found(
     expected_output = "%s\n" % NoSuchService.GUESS_ERROR_MSG
 
     assert paasta_generate_pipeline(args) == 1
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert output == expected_output
 
 

--- a/tests/cli/test_cmds_get_latest_deployment.py
+++ b/tests/cli/test_cmds_get_latest_deployment.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import contextlib
-from StringIO import StringIO
 
 from mock import MagicMock
 from mock import patch
@@ -23,42 +22,32 @@ from mock import patch
 from paasta_tools.cli.cmds import get_latest_deployment
 
 
-def test_get_latest_deployment():
+def test_get_latest_deployment(capsys):
     mock_args = MagicMock(
         service='',
         deploy_group='',
         soa_dir='',
     )
     with contextlib.nested(
-        patch('sys.stdout', new_callable=StringIO, autospec=None),
         patch('paasta_tools.cli.cmds.get_latest_deployment.get_currently_deployed_sha',
               return_value="FAKE_SHA", autospec=True),
         patch('paasta_tools.cli.cmds.get_latest_deployment.validate_service_name', autospec=True),
-    ) as (
-        mock_stdout,
-        _,
-        _,
     ):
         assert get_latest_deployment.paasta_get_latest_deployment(mock_args) == 0
-        assert "FAKE_SHA" in mock_stdout.getvalue().decode('utf-8')
+        assert "FAKE_SHA" in capsys.readouterr()[0]
 
 
-def test_get_latest_deployment_no_deployment_tag():
+def test_get_latest_deployment_no_deployment_tag(capsys):
     mock_args = MagicMock(
         service='fake_service',
         deploy_group='fake_deploy_group',
         soa_dir='',
     )
     with contextlib.nested(
-        patch('sys.stdout', new_callable=StringIO, autospec=None),
         patch('paasta_tools.cli.cmds.get_latest_deployment.get_currently_deployed_sha',
               return_value=None, autospec=True),
         patch('paasta_tools.cli.cmds.get_latest_deployment.validate_service_name', autospec=True),
-    ) as (
-        mock_stdout,
-        _,
-        _,
     ):
         assert get_latest_deployment.paasta_get_latest_deployment(mock_args) == 1
         assert "A deployment could not be found for fake_deploy_group in fake_service" in \
-            mock_stdout.getvalue().decode('utf-8')
+            capsys.readouterr()[0]

--- a/tests/cli/test_cmds_list.py
+++ b/tests/cli/test_cmds_list.py
@@ -14,16 +14,13 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from StringIO import StringIO
-
 import mock
 
 from paasta_tools.cli.cmds.list import paasta_list
 
 
-@mock.patch('sys.stdout', new_callable=StringIO, autospec=None)
 @mock.patch('paasta_tools.cli.cmds.list.list_services', autospec=True)
-def test_list_paasta_list(mock_list_services, mock_stdout):
+def test_list_paasta_list(mock_list_services, capsys):
     """ paasta_list print each service returned by get_services """
 
     mock_services = ['service_1', 'service_2']
@@ -33,13 +30,12 @@ def test_list_paasta_list(mock_list_services, mock_stdout):
     args.print_instances = False
     paasta_list(args)
 
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert output == 'service_1\nservice_2\n'
 
 
-@mock.patch('sys.stdout', new_callable=StringIO, autospec=None)
 @mock.patch('paasta_tools.cli.cmds.list.list_service_instances', autospec=True)
-def test_list_paasta_list_instances(mock_list_service_instances, mock_stdout):
+def test_list_paasta_list_instances(mock_list_service_instances, capsys):
     """ paasta_list print each service.instance """
 
     mock_services = ['service_1.main', 'service_2.canary']
@@ -49,5 +45,5 @@ def test_list_paasta_list_instances(mock_list_service_instances, mock_stdout):
     args.print_instances = True
     paasta_list(args)
 
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert output == 'service_1.main\nservice_2.canary\n'

--- a/tests/cli/test_cmds_logs.py
+++ b/tests/cli/test_cmds_logs.py
@@ -18,12 +18,12 @@ import contextlib
 import datetime
 import json
 from multiprocessing import Queue
-from Queue import Empty
 
 import isodate
 import mock
 import pytest
 from pytest import raises
+from six.moves.queue import Empty
 
 
 try:

--- a/tests/cli/test_cmds_metastatus.py
+++ b/tests/cli/test_cmds_metastatus.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import contextlib
-from StringIO import StringIO
 
 import mock
 
@@ -24,8 +23,7 @@ from paasta_tools.utils import SystemPaastaConfig
 
 
 @mock.patch('paasta_tools.cli.cmds.metastatus.load_system_paasta_config', autospec=True)
-@mock.patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_report_cluster_status(mock_stdout, mock_load_system_paasta_config):
+def test_report_cluster_status(mock_load_system_paasta_config, capsys):
     cluster = 'fake_cluster'
 
     fake_system_paasta_config = SystemPaastaConfig({
@@ -55,7 +53,7 @@ def test_report_cluster_status(mock_stdout, mock_load_system_paasta_config):
             groupings=[],
             verbose=0,
         )
-        actual = mock_stdout.getvalue().decode('utf-8')
+        actual, _ = capsys.readouterr()
         assert 'Cluster: %s' % cluster in actual
         assert 'mock_status' in actual
         assert return_code == mock.sentinel.return_value

--- a/tests/cli/test_cmds_rerun.py
+++ b/tests/cli/test_cmds_rerun.py
@@ -17,7 +17,6 @@ from __future__ import unicode_literals
 import argparse
 import contextlib
 import datetime
-from StringIO import StringIO
 
 from mock import MagicMock
 from mock import patch
@@ -91,9 +90,8 @@ _planned_deployments = ['cluster1.instance1', 'cluster1.instance2', 'cluster2.in
         ' or has not been deployed to "cluster1" yet',
     ]
 ])
-def test_rerun_validations(test_case):
+def test_rerun_validations(test_case, capsys):
     with contextlib.nested(
-        patch('sys.stdout', new_callable=StringIO, autospec=None),
         patch('paasta_tools.cli.cmds.rerun.figure_out_service_name', autospec=True),
         patch('paasta_tools.cli.cmds.rerun.list_clusters', autospec=True),
         patch('paasta_tools.cli.cmds.rerun.get_actual_deployments', autospec=True),
@@ -104,7 +102,6 @@ def test_rerun_validations(test_case):
         patch('paasta_tools.cli.cmds.rerun._get_default_execution_date', autospec=True),
         patch('paasta_tools.cli.cmds.rerun.load_system_paasta_config', autospec=True),
     ) as (
-        mock_stdout,
         mock_figure_out_service_name,
         mock_list_clusters,
         mock_get_actual_deployments,
@@ -152,7 +149,7 @@ def test_rerun_validations(test_case):
         if args.execution_date is not None and mock_uses_time_variables.return_value:
             assert mock_execute_rerun_remote.call_args[1]['execution_date'] == _user_supplied_execution_date
 
-        output = mock_stdout.getvalue().decode('utf-8')
+        output, _ = capsys.readouterr()
         assert expected_output in output
 
 

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import contextlib
-from StringIO import StringIO
 
 import mock
 
@@ -258,7 +257,6 @@ def test_stop_or_start_figures_out_correct_instances(
     assert(ret == 0)
 
 
-@mock.patch('sys.stdout', new_callable=StringIO, autospec=None)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.remote_git.list_remote_refs', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.figure_out_service_name', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.get_instance_config', autospec=True)
@@ -270,7 +268,7 @@ def test_stop_or_start_handle_ls_remote_failures(
     mock_get_instance_config,
     mock_figure_out_service_name,
     mock_list_remote_refs,
-    mock_stdout,
+    capsys,
 ):
     args = mock.Mock()
     args.clusters = 'cluster1'
@@ -283,21 +281,22 @@ def test_stop_or_start_handle_ls_remote_failures(
     mock_list_remote_refs.side_effect = remote_git.LSRemoteException
 
     assert start_stop_restart.paasta_start_or_stop(args, 'restart') == 1
-    assert "may be down" in mock_stdout.getvalue().decode('utf-8')
+    assert "may be down" in capsys.readouterr()[0]
 
 
-@mock.patch('sys.stdout', new_callable=StringIO, autospec=None)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.figure_out_service_name', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.get_instance_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.remote_git.list_remote_refs', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.list_all_instances_for_service', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.list_clusters', autospec=True)
-def test_start_or_stop_bad_refs(mock_list_clusters,
-                                mock_list_all_instances,
-                                mock_list_remote_refs,
-                                mock_get_instance_config,
-                                mock_figure_out_service_name, mock_stdout):
-
+def test_start_or_stop_bad_refs(
+    mock_list_clusters,
+    mock_list_all_instances,
+    mock_list_remote_refs,
+    mock_get_instance_config,
+    mock_figure_out_service_name,
+    capsys,
+):
     args = mock.Mock()
     # To suppress any messages due to Mock making everything truthy
     args.clusters = 'fake_cluster1,fake_cluster2'
@@ -318,7 +317,7 @@ def test_start_or_stop_bad_refs(mock_list_clusters,
         "refs/tags/paasta-deliberatelyinvalidref-20160304T053919-deploy": "70f7245ccf039d778c7e527af04eac00d261d783"}
     mock_list_all_instances.return_value = {args.instances}
     assert start_stop_restart.paasta_start_or_stop(args, 'restart') == 1
-    assert "No branches found for" in mock_stdout.getvalue().decode('utf-8')
+    assert "No branches found for" in capsys.readouterr()[0]
 
 
 def test_cluster_list_defaults_to_all():
@@ -326,12 +325,12 @@ def test_cluster_list_defaults_to_all():
 
 
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.figure_out_service_name', autospec=True)
-@mock.patch('sys.stdout', new_callable=StringIO, autospec=None)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.list_clusters', autospec=True)
 def test_cluster_throws_exception_for_invalid_cluster_no_instances(
         mock_list_clusters,
-        mock_stdout,
-        mock_figure_out_service_name):
+        mock_figure_out_service_name,
+        capsys,
+):
     mock_args = mock.Mock()
     mock_args.soa_dir = '/foo'
     mock_args.instances = None
@@ -341,17 +340,18 @@ def test_cluster_throws_exception_for_invalid_cluster_no_instances(
     mock_figure_out_service_name.return_value = 'fake_service'
 
     assert start_stop_restart.paasta_start_or_stop(mock_args, 'restart') == 1
-    assert "Invalid cluster name(s) specified: fake_cluster_1" in mock_stdout.getvalue().decode('utf-8')
-    assert "Valid options: fake_cluster_2" in mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
+    assert "Invalid cluster name(s) specified: fake_cluster_1" in output
+    assert "Valid options: fake_cluster_2" in output
 
 
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.figure_out_service_name', autospec=True)
-@mock.patch('sys.stdout', new_callable=StringIO, autospec=None)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.list_clusters', autospec=True)
 def test_cluster_throws_exception_no_matching_instance_clusters(
         mock_list_clusters,
-        mock_stdout,
-        mock_figure_out_service_name):
+        mock_figure_out_service_name,
+        capsys,
+):
     mock_args = mock.Mock()
     mock_args.soa_dir = '/foo'
     mock_args.clusters = "fake_cluster_1,fake_cluster_2,fake_cluster_3"
@@ -363,5 +363,6 @@ def test_cluster_throws_exception_no_matching_instance_clusters(
     mock_figure_out_service_name.return_value = 'fake_service'
 
     assert start_stop_restart.paasta_start_or_stop(mock_args, 'restart') == 1
-    assert "Invalid cluster name(s) specified: fake_cluster_3" in mock_stdout.getvalue().decode('utf-8')
-    assert "Valid options: fake_cluster_1 fake_cluster_2" in mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
+    assert "Invalid cluster name(s) specified: fake_cluster_3" in output
+    assert "Valid options: fake_cluster_1 fake_cluster_2" in output

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -14,8 +14,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from StringIO import StringIO
-
 from mock import MagicMock
 from mock import Mock
 from mock import patch
@@ -35,9 +33,9 @@ from paasta_tools.cli.utils import PaastaColors
 
 
 @patch('paasta_tools.cli.utils.validate_service_name', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_figure_out_service_name_not_found(mock_stdout,
-                                           mock_validate_service_name):
+def test_figure_out_service_name_not_found(
+        mock_validate_service_name, capsys,
+):
     # paasta_status with invalid -s service_name arg results in error
     mock_validate_service_name.side_effect = NoSuchService(None)
     parsed_args = Mock()
@@ -49,16 +47,16 @@ def test_figure_out_service_name_not_found(mock_stdout,
     with raises(SystemExit) as sys_exit:
         status.figure_out_service_name(parsed_args)
 
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert sys_exit.value.code == 1
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.utils.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.utils.guess_service_name', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_status_arg_service_not_found(mock_stdout, mock_guess_service_name,
-                                      mock_validate_service_name):
+def test_status_arg_service_not_found(
+    mock_guess_service_name, mock_validate_service_name, capsys,
+):
     # paasta_status with no args and non-service directory results in error
     mock_guess_service_name.return_value = 'not_a_service'
     error = NoSuchService('fake_service')
@@ -72,18 +70,17 @@ def test_status_arg_service_not_found(mock_stdout, mock_guess_service_name,
     with raises(SystemExit) as sys_exit:
         paasta_status(args)
 
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert sys_exit.value.code == 1
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
 @patch('paasta_tools.cli.cmds.status.report_invalid_whitelist_values', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_report_status_for_cluster_displays_deployed_service(
-    mock_stdout,
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
+    capsys,
 ):
     # paasta_status with no args displays deploy info - vanilla case
     service = 'fake_service'
@@ -113,7 +110,7 @@ def test_report_status_for_cluster_displays_deployed_service(
         instance_whitelist=instance_whitelist,
         system_paasta_config=fake_system_paasta_config,
     )
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert expected_output in output
     mock_execute_paasta_serviceinit_on_remote_master.assert_called_once_with(
         'status', 'fake_cluster', 'fake_service', 'fake_instance',
@@ -122,11 +119,10 @@ def test_report_status_for_cluster_displays_deployed_service(
 
 @patch('paasta_tools.cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
 @patch('paasta_tools.cli.cmds.status.report_invalid_whitelist_values', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_serviceinit_on_remote_master(
-    mock_stdout,
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
+    capsys,
 ):
     # paasta_status with no args displays deploy info - vanilla case
     service = 'fake_service'
@@ -155,17 +151,16 @@ def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_s
         instance_whitelist=instance_whitelist,
         system_paasta_config=fake_system_paasta_config,
     )
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert expected_output in output
 
 
 @patch('paasta_tools.cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
 @patch('paasta_tools.cli.cmds.status.report_invalid_whitelist_values', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_report_status_for_cluster_instance_sorts_in_deploy_order(
-    mock_stdout,
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
+    capsys,
 ):
     # paasta_status with no args displays deploy info
     service = 'fake_service'
@@ -199,7 +194,7 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
         instance_whitelist=instance_whitelist,
         system_paasta_config=fake_system_paasta_config,
     )
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert expected_output in output
     mock_execute_paasta_serviceinit_on_remote_master.assert_called_once_with(
         'status', 'fake_cluster', 'fake_service', 'fake_instance_a,fake_instance_b',
@@ -208,11 +203,10 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
 
 @patch('paasta_tools.cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
 @patch('paasta_tools.cli.cmds.status.report_invalid_whitelist_values', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_print_cluster_status_missing_deploys_in_red(
-    mock_stdout,
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
+    capsys,
 ):
     # paasta_status displays missing deploys in red
     service = 'fake_service'
@@ -250,19 +244,18 @@ def test_print_cluster_status_missing_deploys_in_red(
         instance_whitelist=instance_whitelist,
         system_paasta_config=fake_system_paasta_config,
     )
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert expected_output in output
 
 
 @mark.parametrize('verbosity_level', [0, 2])
 @patch('paasta_tools.cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
 @patch('paasta_tools.cli.cmds.status.report_invalid_whitelist_values', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
-    mock_stdout,
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
     verbosity_level,
+    capsys,
 ):
     service = 'fake_service'
     planned_deployments = [
@@ -296,17 +289,16 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
         stream=True, verbose=verbosity_level, ignore_ssh_output=True
     )
 
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert expected_output in output
 
 
 @patch('paasta_tools.cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
 @patch('paasta_tools.cli.cmds.status.report_invalid_whitelist_values', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_report_status_for_cluster_obeys_instance_whitelist(
-    mock_stdout,
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
+    capsys,
 ):
     service = 'fake_service'
     planned_deployments = ['fake_cluster.fake_instance_a', 'fake_cluster.fake_instance_b']
@@ -337,11 +329,10 @@ def test_report_status_for_cluster_obeys_instance_whitelist(
 
 @patch('paasta_tools.cli.cmds.status.execute_paasta_serviceinit_on_remote_master', autospec=True)
 @patch('paasta_tools.cli.cmds.status.report_invalid_whitelist_values', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_report_status_calls_report_invalid_whitelist_values(
-    mock_stdout,
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
+    capsys,
 ):
     service = 'fake_service'
     planned_deployments = ['cluster.instance1', 'cluster.instance2']
@@ -368,10 +359,10 @@ def test_report_status_calls_report_invalid_whitelist_values(
 @patch('paasta_tools.cli.cmds.status.figure_out_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.status.get_deploy_info', autospec=True)
 @patch('paasta_tools.cli.cmds.status.get_actual_deployments', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_status_pending_pipeline_build_message(
-        mock_stdout, mock_get_actual_deployments, mock_get_deploy_info,
-        mock_figure_out_service_name, mock_load_system_paasta_config):
+        mock_get_actual_deployments, mock_get_deploy_info,
+        mock_figure_out_service_name, mock_load_system_paasta_config, capsys,
+):
     # If deployments.json is missing SERVICE, output the appropriate message
     service = 'fake_service'
     mock_figure_out_service_name.return_value = service
@@ -388,7 +379,7 @@ def test_status_pending_pipeline_build_message(
     args.service = service
 
     paasta_status(args)
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert expected_output in output
 
 
@@ -420,13 +411,12 @@ def test_get_deploy_info_exists(mock_read_deploy):
 
 
 @patch('paasta_tools.cli.cmds.status.read_deploy', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_get_deploy_info_does_not_exist(mock_stdout, mock_read_deploy):
+def test_get_deploy_info_does_not_exist(mock_read_deploy, capsys):
     mock_read_deploy.return_value = False
     expected_output = '%s\n' % PaastaCheckMessages.DEPLOY_YAML_MISSING
     with raises(SystemExit) as sys_exit:
         status.get_deploy_info('fake_service')
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert sys_exit.value.code == 1
     assert output == expected_output
 
@@ -436,14 +426,13 @@ def test_get_deploy_info_does_not_exist(mock_stdout, mock_read_deploy):
 @patch('paasta_tools.cli.cmds.status.get_actual_deployments', autospec=True)
 @patch('paasta_tools.cli.cmds.status.get_planned_deployments', autospec=True)
 @patch('paasta_tools.cli.cmds.status.report_status', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_status_calls_sergeants(
-    mock_stdout,
     mock_report_status,
     mock_get_planned_deployments,
     mock_get_actual_deployments,
     mock_figure_out_service_name,
     mock_load_system_paasta_config,
+    capsys,
 ):
     service = 'fake_service'
     mock_figure_out_service_name.return_value = service
@@ -504,11 +493,10 @@ def test_report_invalid_whitelist_values_with_whitelists():
 
 @patch('paasta_tools.cli.cmds.status.report_status_for_cluster', autospec=True)
 @patch('paasta_tools.cli.cmds.status.report_invalid_whitelist_values', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_report_status_returns_zero_when_clusters_pass(
-    mock_stdout,
     mock_report_invalid_whitelist_values,
     mock_report_status_for_cluster,
+    capsys,
 ):
     service = 'fake_service'
     cluster_whitelist = []
@@ -534,11 +522,10 @@ def test_report_status_returns_zero_when_clusters_pass(
 
 @patch('paasta_tools.cli.cmds.status.report_status_for_cluster', autospec=True)
 @patch('paasta_tools.cli.cmds.status.report_invalid_whitelist_values', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_report_status_returns_one_when_clusters_pass(
-    mock_stdout,
     mock_report_invalid_whitelist_values,
     mock_report_status_for_cluster,
+    capsys,
 ):
     service = 'fake_service'
     cluster_whitelist = []
@@ -564,11 +551,10 @@ def test_report_status_returns_one_when_clusters_pass(
 
 @patch('paasta_tools.cli.cmds.status.report_status_for_cluster', autospec=True)
 @patch('paasta_tools.cli.cmds.status.report_invalid_whitelist_values', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_report_status_obeys_cluster_whitelist(
-    mock_stdout,
     mock_report_invalid_whitelist_values,
     mock_report_status_for_cluster,
+    capsys,
 ):
     service = 'fake_service'
     cluster_whitelist = ['cluster1']
@@ -600,11 +586,10 @@ def test_report_status_obeys_cluster_whitelist(
 
 @patch('paasta_tools.cli.cmds.status.report_status_for_cluster', autospec=True)
 @patch('paasta_tools.cli.cmds.status.report_invalid_whitelist_values', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_report_status_handle_none_whitelist(
-    mock_stdout,
     mock_report_invalid_whitelist_values,
     mock_report_status_for_cluster,
+    capsys,
 ):
     service = 'fake_service'
     cluster_whitelist = []

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import os
-from StringIO import StringIO
 
 import mock
 from mock import patch
@@ -62,17 +61,13 @@ def test_paasta_validate_calls_everything(
     assert mock_validate_chronos.called
 
 
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_get_service_path_unknown(
-    mock_stdout
-):
+def test_get_service_path_unknown(capsys):
     service = None
     soa_dir = 'unused'
 
     assert get_service_path(service, soa_dir) is None
 
-    output = mock_stdout.getvalue().decode('utf-8')
-
+    output, _ = capsys.readouterr()
     assert UNKNOWN_SERVICE in output
 
 
@@ -144,10 +139,8 @@ def test_get_schema_missing():
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_marathon_validate_schema_list_hashes_good(
-    mock_stdout,
-    mock_get_file_contents
+    mock_get_file_contents, capsys,
 ):
     marathon_content = """
 ---
@@ -168,15 +161,13 @@ main_http:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_marathon_validate_schema_healthcheck_non_cmd(
-    mock_stdout,
-    mock_get_file_contents
+    mock_get_file_contents, capsys,
 ):
     marathon_content = """
 ---
@@ -190,7 +181,7 @@ main_worker:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
     marathon_content = """
 ---
@@ -202,17 +193,14 @@ main_worker:
   cmd: virtualenv_run/bin/python adindexer/adindex_worker.py
 """
     mock_get_file_contents.return_value = marathon_content
-    mock_stdout.truncate(0)
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_marathon_validate_id(
-    mock_stdout,
-    mock_get_file_contents
+    mock_get_file_contents, capsys,
 ):
     marathon_content = """
 ---
@@ -225,7 +213,7 @@ valid:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
     marathon_content = """
@@ -239,7 +227,7 @@ this_is_okay_too_1:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
     marathon_content = """
@@ -253,7 +241,7 @@ dashes-are-okay-too:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
     marathon_content = """
@@ -267,7 +255,7 @@ main_worker_CAPITALS_INVALID:
 """
     mock_get_file_contents.return_value = marathon_content
     assert not validate_schema('unused_service_path.yaml', 'marathon')
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
     marathon_content = """
@@ -281,15 +269,13 @@ $^&*()(&*^%&definitely_not_okay:
 """
     mock_get_file_contents.return_value = marathon_content
     assert not validate_schema('unused_service_path.yaml', 'marathon')
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_marathon_validate_schema_healthcheck_cmd_has_cmd(
-    mock_stdout,
-    mock_get_file_contents
+    mock_get_file_contents, capsys,
 ):
     marathon_content = """
 ---
@@ -303,7 +289,7 @@ main_worker:
 """
     mock_get_file_contents.return_value = marathon_content
     assert not validate_schema('unused_service_path.yaml', 'marathon')
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
     marathon_content = """
 ---
@@ -317,17 +303,14 @@ main_worker:
   healthcheck_cmd: '/bin/true'
 """
     mock_get_file_contents.return_value = marathon_content
-    mock_stdout.truncate(0)
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_marathon_validate_schema_keys_outside_instance_blocks_bad(
-    mock_stdout,
-    mock_get_file_contents
+    mock_get_file_contents, capsys,
 ):
     mock_get_file_contents.return_value = """
 {
@@ -339,16 +322,13 @@ def test_marathon_validate_schema_keys_outside_instance_blocks_bad(
 """
     assert not validate_schema('unused_service_path.json', 'marathon')
 
-    output = mock_stdout.getvalue().decode('utf-8')
-
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_marathon_validate_invalid_key_bad(
-    mock_stdout,
-    mock_get_file_contents
+    mock_get_file_contents, capsys,
 ):
     mock_get_file_contents.return_value = """
 {
@@ -359,16 +339,13 @@ def test_marathon_validate_invalid_key_bad(
 """
     assert not validate_schema('unused_service_path.json', 'marathon')
 
-    output = mock_stdout.getvalue().decode('utf-8')
-
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_chronos_validate_schema_list_hashes_good(
-    mock_stdout,
-    mock_get_file_contents
+    mock_get_file_contents, capsys,
 ):
     mock_get_file_contents.return_value = """
 {
@@ -382,16 +359,13 @@ def test_chronos_validate_schema_list_hashes_good(
 """
     assert validate_schema('unused_service_path.json', 'chronos')
 
-    output = mock_stdout.getvalue().decode('utf-8')
-
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_chronos_validate_schema_keys_outside_instance_blocks_bad(
-    mock_stdout,
-    mock_get_file_contents
+    mock_get_file_contents, capsys,
 ):
     mock_get_file_contents.return_value = """
 {
@@ -403,8 +377,7 @@ def test_chronos_validate_schema_keys_outside_instance_blocks_bad(
 """
     assert not validate_schema('unused_service_path.json', 'chronos')
 
-    output = mock_stdout.getvalue().decode('utf-8')
-
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
 
@@ -413,14 +386,13 @@ def test_chronos_validate_schema_keys_outside_instance_blocks_bad(
 @patch('paasta_tools.cli.cmds.validate.list_all_instances_for_service', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.load_chronos_job_config', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_failing_chronos_job_validate(
-    mock_stdout,
     mock_path_to_soa_dir_service,
     mock_load_chronos_job_config,
     mock_list_all_instances_for_service,
     mock_list_clusters,
-    mock_get_services_for_cluster
+    mock_get_services_for_cluster,
+    capsys,
 ):
     fake_service = 'fake-service'
     fake_instance = 'fake-instance'
@@ -438,8 +410,7 @@ def test_failing_chronos_job_validate(
 
     assert not validate_chronos('fake_service_path')
 
-    output = mock_stdout.getvalue().decode('utf-8')
-
+    output, _ = capsys.readouterr()
     expected_output = 'something is wrong with the config'
     assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
 
@@ -449,14 +420,13 @@ def test_failing_chronos_job_validate(
 @patch('paasta_tools.cli.cmds.validate.list_all_instances_for_service', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.load_chronos_job_config', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_failing_chronos_job_self_dependent(
-    mock_stdout,
     mock_path_to_soa_dir_service,
     mock_load_chronos_job_config,
     mock_list_all_instances_for_service,
     mock_list_clusters,
-    mock_get_services_for_cluster
+    mock_get_services_for_cluster,
+    capsys,
 ):
     fake_service = 'fake-service'
     fake_instance = 'fake-instance'
@@ -475,8 +445,7 @@ def test_failing_chronos_job_self_dependent(
 
     assert not validate_chronos('fake_service_path')
 
-    output = mock_stdout.getvalue().decode('utf-8')
-
+    output, _ = capsys.readouterr()
     expected_output = 'Job fake-service.fake-instance cannot depend on itself'
     assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
 
@@ -486,14 +455,13 @@ def test_failing_chronos_job_self_dependent(
 @patch('paasta_tools.cli.cmds.validate.list_all_instances_for_service', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.load_chronos_job_config', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_failing_chronos_job_missing_parent(
-    mock_stdout,
     mock_path_to_soa_dir_service,
     mock_load_chronos_job_config,
     mock_list_all_instances_for_service,
     mock_list_clusters,
-    mock_get_services_for_cluster
+    mock_get_services_for_cluster,
+    capsys,
 ):
     fake_service = 'fake-service'
     fake_instance = 'fake-instance'
@@ -512,8 +480,7 @@ def test_failing_chronos_job_missing_parent(
 
     assert not validate_chronos('fake_service_path')
 
-    output = mock_stdout.getvalue().decode('utf-8')
-
+    output, _ = capsys.readouterr()
     expected_output = 'Parent job fake-service.parent-1 could not be found'
     assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
 
@@ -523,14 +490,13 @@ def test_failing_chronos_job_missing_parent(
 @patch('paasta_tools.cli.cmds.validate.list_all_instances_for_service', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.load_chronos_job_config', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 def test_validate_chronos_valid_instance(
-    mock_stdout,
     mock_path_to_soa_dir_service,
     mock_load_chronos_job_config,
     mock_list_all_instances_for_service,
     mock_list_clusters,
-    mock_get_services_for_cluster
+    mock_get_services_for_cluster,
+    capsys,
 ):
     fake_service = 'fake-service'
     fake_instance = 'fake-instance'
@@ -548,47 +514,35 @@ def test_validate_chronos_valid_instance(
 
     assert validate_chronos('fake_service_path')
 
-    output = mock_stdout.getvalue().decode('utf-8')
-
+    output, _ = capsys.readouterr()
     assert valid_chronos_instance(fake_cluster, fake_instance) in output
 
 
 @patch("paasta_tools.chronos_tools.TMP_JOB_IDENTIFIER", 'tmp', autospec=None)
 @patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service', autospec=True)
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_validate_chronos_tmp_job(
-    mock_stdout,
-    mock_path_to_soa_dir_service,
-):
+def test_validate_chronos_tmp_job(mock_path_to_soa_dir_service, capsys):
     mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'tmp')
     assert validate_chronos('fake_path/tmp') is False
     assert ("Services using scheduled tasks cannot be named tmp, as it clashes"
             " with the identifier used for temporary jobs") in \
-        mock_stdout.getvalue().decode('utf-8')
+        capsys.readouterr()[0]
 
 
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
-def test_check_service_path_none(
-    mock_stdout
-):
+def test_check_service_path_none(capsys):
     service_path = None
     assert not check_service_path(service_path)
 
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert "%s is not a directory" % service_path in output
 
 
-@patch('sys.stdout', new_callable=StringIO, autospec=None)
 @patch('paasta_tools.cli.cmds.validate.os.path.isdir', autospec=True)
-def test_check_service_path_empty(
-    mock_isdir,
-    mock_stdout
-):
+def test_check_service_path_empty(mock_isdir, capsys):
     mock_isdir.return_value = True
     service_path = 'fake/path'
     assert not check_service_path(service_path)
 
-    output = mock_stdout.getvalue().decode('utf-8')
+    output, _ = capsys.readouterr()
     assert "%s does not contain any .yaml files" % service_path in output
 
 

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -14,13 +14,13 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from Queue import Queue
 from threading import Event
 
 from bravado.exception import HTTPError
 from mock import Mock
 from mock import patch
 from pytest import raises
+from six.moves.queue import Queue
 
 from paasta_tools.cli.cmds import mark_for_deployment
 from paasta_tools.cli.cmds.wait_for_deployment import get_latest_marked_sha

--- a/tests/monitoring/test_check_classic_service_replication.py
+++ b/tests/monitoring/test_check_classic_service_replication.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import sys
-from contextlib import nested
 
 import mock
 import pytest
@@ -75,9 +74,10 @@ def test_do_replication_check():
         }
     }
 
-    with nested(
-        mock.patch(check_method, return_value=(-1, 'bar'), autospec=True),
-        mock.patch(read_key_method, return_value=-2, autospec=True),
+    with mock.patch(
+        check_method, return_value=(-1, 'bar'), autospec=True,
+    ), mock.patch(
+        read_key_method, return_value=-2, autospec=True,
     ):
         expected = {
             'name': 'replication_test_service',
@@ -193,16 +193,22 @@ def test_classic_replication_check():
         'name': 'fake-name',
     }
 
-    with nested(
-            mock.patch(read_config_method, return_value=mock_service_config, autospec=True),
-            mock.patch(replication_method, return_value=mock_replication, autospec=True),
-            mock.patch(extract_method, return_value=(True, mock_monitoring), autospec=True),
-            mock.patch(check_method, return_value=mock_check, autospec=True),
-            mock.patch('pysensu_yelp.send_event', autospec=True),
-            mock.patch.object(sys, 'argv', ['check_classic_service_replication.py']),
-            mock.patch(load_system_paasta_config_module,
-                       return_value=SystemPaastaConfig({}, '/fake/config'), autospec=True),
-    ) as (_, _, _, mcheck, _, _, _):
+    with mock.patch(
+        read_config_method, return_value=mock_service_config, autospec=True,
+    ), mock.patch(
+        replication_method, return_value=mock_replication, autospec=True,
+    ), mock.patch(
+        extract_method, return_value=(True, mock_monitoring), autospec=True,
+    ), mock.patch(
+        check_method, return_value=mock_check, autospec=True,
+    ) as mcheck, mock.patch(
+        'pysensu_yelp.send_event', autospec=True,
+    ), mock.patch.object(
+        sys, 'argv', ['check_classic_service_replication.py'],
+    ), mock.patch(
+        load_system_paasta_config_module,
+        return_value=SystemPaastaConfig({}, '/fake/config'), autospec=True,
+    ):
         with pytest.raises(SystemExit) as error:
             check = ClassicServiceReplicationCheck()
             check.run()
@@ -211,15 +217,13 @@ def test_classic_replication_check():
 
 
 def test_classic_replication_check_connectionerror():
-    with nested(
-        mock.patch('paasta_tools.monitoring.check_classic_service_replication.get_replication_for_services',
-                   autospec=True),
-        mock.patch('paasta_tools.monitoring.check_classic_service_replication.ClassicServiceReplicationCheck.__init__',
-                   autospec=True),
-    ) as (
-        mock_get_replication_for_services,
-        mock_init,
-    ):
+    with mock.patch(
+        'paasta_tools.monitoring.check_classic_service_replication.get_replication_for_services',
+        autospec=True,
+    ) as mock_get_replication_for_services, mock.patch(
+        'paasta_tools.monitoring.check_classic_service_replication.ClassicServiceReplicationCheck.__init__',
+        autospec=True,
+    ) as mock_init:
         mock_get_replication_for_services.side_effect = requests.exceptions.ConnectionError
         mock_init.return_value = None
         check = ClassicServiceReplicationCheck()
@@ -229,16 +233,13 @@ def test_classic_replication_check_connectionerror():
 
 
 def test_classic_replication_check_unknownexception():
-    with nested(
-        mock.patch('paasta_tools.monitoring.check_classic_service_replication.get_replication_for_services',
-                   autospec=True),
-        mock.patch(
-            'paasta_tools.monitoring.check_classic_service_replication.ClassicServiceReplicationCheck.__init__',
-            autospec=True),
-    ) as (
-        mock_get_replication_for_services,
-        mock_init,
-    ):
+    with mock.patch(
+        'paasta_tools.monitoring.check_classic_service_replication.get_replication_for_services',
+        autospec=True,
+    ) as mock_get_replication_for_services, mock.patch(
+        'paasta_tools.monitoring.check_classic_service_replication.ClassicServiceReplicationCheck.__init__',
+        autospec=True,
+    ) as mock_init:
         mock_get_replication_for_services.side_effect = Exception
         mock_init.return_value = None
         check = ClassicServiceReplicationCheck()

--- a/tests/monitoring/test_check_synapse_replication.py
+++ b/tests/monitoring/test_check_synapse_replication.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import sys
-from contextlib import nested
 
 import mock
 import pytest
@@ -71,12 +70,15 @@ def test_run_synapse_check():
     mock_replication = {'wat': 2, 'service': 1, 'is': 0}
 
     for return_value in range(0, 4):
-        with nested(
-            mock.patch(parse_method, return_value=mock_parse_options, autospec=True),
-            mock.patch(replication_method, return_value=mock_replication, autospec=True),
-            mock.patch(check_replication_method, return_value=(return_value, 'CHECK'), autospec=True),
-            mock.patch('paasta_tools.utils.load_system_paasta_config', autospec=True,
-                       return_value=SystemPaastaConfig({}, '/fake/config')),
+        with mock.patch(
+            parse_method, return_value=mock_parse_options, autospec=True,
+        ), mock.patch(
+            replication_method, return_value=mock_replication, autospec=True,
+        ), mock.patch(
+            check_replication_method, return_value=(return_value, 'CHECK'), autospec=True,
+        ), mock.patch(
+            'paasta_tools.utils.load_system_paasta_config', autospec=True,
+            return_value=SystemPaastaConfig({}, '/fake/config'),
         ):
             with pytest.raises(SystemExit) as error:
                 run_synapse_check()
@@ -88,12 +90,15 @@ def test_run_synapse_check():
     def mock_check(name, replication, warn, crit):
         return mock_service_status[name], 'CHECK'
 
-    with nested(
-        mock.patch(parse_method, return_value=mock_parse_options, autospec=True),
-        mock.patch(replication_method, return_value=mock_replication, autospec=True),
-        mock.patch(check_replication_method, new=mock_check, autospec=None),
-        mock.patch('paasta_tools.utils.load_system_paasta_config', autospec=True,
-                   return_value=SystemPaastaConfig({}, '/fake/config')),
+    with mock.patch(
+        parse_method, return_value=mock_parse_options, autospec=True,
+    ), mock.patch(
+        replication_method, return_value=mock_replication, autospec=True,
+    ), mock.patch(
+        check_replication_method, new=mock_check, autospec=None,
+    ), mock.patch(
+        'paasta_tools.utils.load_system_paasta_config', autospec=True,
+        return_value=SystemPaastaConfig({}, '/fake/config'),
     ):
         with pytest.raises(SystemExit) as error:
             run_synapse_check()

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ indexserver =
     private = https://pypi.yelpcorp.com/simple
 
 [testenv]
-basepython = python2.7
+basepython = /usr/bin/python2.7
 setenv=
     TZ = UTC
 deps =
@@ -15,6 +15,8 @@ deps =
 commands =
     py.test {posargs:tests}
 
+[testenv:py3]
+basepython = /usr/bin/python3
 
 [testenv:coverage]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,10 @@ commands =
 
 [testenv:py3]
 basepython = /usr/bin/python3
+commands =
+    # TODO: actually upgrade protobuf once this is resolved
+    pip install protobuf==3.2.0
+    py.test {posargs:tests} --collect-only
 
 [testenv:coverage]
 commands =

--- a/yelp_package/dockerfiles/lucid/Dockerfile
+++ b/yelp_package/dockerfiles/lucid/Dockerfile
@@ -12,19 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker-dev.yelpcorp.com/lucid_yelp
+FROM docker-dev.yelpcorp.com/lucid_pkgbuild
 MAINTAINER Kyle Anderson <kwa@yelp.com>
 
 # Make sure we get a package suitable for building this package correctly.
 # Per dnephin we need https://github.com/spotify/dh-virtualenv/pull/20
 # Which at this time is in this package
-RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools python-dev libssl-dev libffi-dev debhelper dh-virtualenv python-yaml libyaml-dev python-pytest pyflakes python2.7 python2.7-dev help2man zsh git
+RUN apt-get update && apt-get -y install dpkg-dev python-pip python-tox python-setuptools python-dev libssl-dev libffi-dev debhelper dh-virtualenv python-yaml libyaml-dev python-pytest pyflakes python2.7 python2.7-dev help2man zsh git
 
-RUN easy_install pip
-RUN pip install -U virtualenv
-RUN pip install -U tox
+RUN pip install -U virtualenv tox
 
-
-ENV HOME /work
-ENV PWD /work
 WORKDIR /work

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -14,14 +14,35 @@
 
 FROM ubuntu:trusty
 
-RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
+RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
 
-RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools \
-  python-dev libssl-dev libffi-dev debhelper python-yaml libyaml-dev python-pytest pyflakes \
-  git help2man zsh wget zip
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        debhelper \
+        dpkg-dev \
+        gcc \
+        gdebi-core \
+        git \
+        help2man \
+        libffi-dev \
+        libssl-dev \
+        libyaml-dev \
+        pyflakes \
+        python-dev \
+        python-pip \
+        python-pytest \
+        python-setuptools \
+        python-tox \
+        python-yaml \
+        wget \
+        zip \
+        zsh \
+    && apt-get clean
 
-RUN cd `mktemp -d` && wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_0.11-1_all.deb && dpkg -i dh-virtualenv_0.11-1_all.deb && apt-get -f install
+RUN cd /tmp && \
+    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
+    gdebi -n dh-virtualenv*.deb && \
+    rm dh-virtualenv_*.deb
 
 # mesos.native is not available on pypi, so we can either build mesos from
 # source or do this, and building from source takes a long time.
@@ -35,11 +56,8 @@ RUN apt-get install -yq mesos=1.0.1-2.0.93.ubuntu1404 && \
 	zip -r /root/mesos.scheduler-1.0.1-py27-none-any.whl mesos/scheduler mesos.scheduler-1.0.1.dist-info && \
 	apt-get remove -yq mesos
 
-RUN pip install -U pip
-RUN pip install -U virtualenv
+RUN pip install --upgrade virtualenv
 
 ADD mesos-slave-secret /etc/mesos-slave-secret
 
-ENV HOME /work
-ENV PWD /work
 WORKDIR /work

--- a/yelp_package/dockerfiles/xenial/Dockerfile
+++ b/yelp_package/dockerfiles/xenial/Dockerfile
@@ -14,14 +14,34 @@
 
 FROM ubuntu:xenial
 
-RUN echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
+RUN echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
 
-RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools \
-  python-dev libssl-dev libffi-dev debhelper python-yaml libyaml-dev python-pytest pyflakes \
-  git help2man zsh wget zip
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        debhelper \
+        dpkg-dev \
+        gcc \
+        gdebi-core \
+        git \
+        help2man \
+        libffi-dev \
+        libssl-dev \
+        libyaml-dev \
+        pyflakes \
+        python-dev \
+        python-pytest \
+        python-setuptools \
+        python-tox \
+        python-yaml \
+        wget \
+        zip \
+        zsh \
+    && apt-get clean
 
-RUN cd `mktemp -d` && wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_0.11-1_all.deb && dpkg -i dh-virtualenv_0.11-1_all.deb && apt-get -f install
+RUN cd /tmp && \
+    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
+    gdebi -n dh-virtualenv*.deb && \
+    rm dh-virtualenv_*.deb
 
 # mesos.native is not available on pypi, so we can either build mesos from
 # source or do this, and building from source takes a long time.
@@ -37,6 +57,4 @@ RUN apt-get install -yq mesos=1.0.1-2.0.93.ubuntu1604 && \
 
 ADD mesos-slave-secret /etc/mesos-slave-secret
 
-ENV HOME /work
-ENV PWD /work
 WORKDIR /work


### PR DESCRIPTION
Just some quick changes before I had to run off to other things:

- Adds a py3 tox env, it doesn't pass yet but it can at least be attempted
- Change basepython to use `/usr/bin/...` syntax, this allows environments to be recreated while active
- The py3 environment can successfully build, but not yet pass the tests (before it wasn't even installing correctly)
- Remove dep on `importlib`, paasta wasn't actually using anything that wasn't in python2.7 anyway (and it also wasn't necessary, `__import__` sufficed)
- Change a single `unicode` -> `six.text_type`: started to fix tests
- Upgrade python-daemon to get python3 support
- Remove `wsgiref`, this has been in the stdlib since python2.5
- Remove `argparse`, this has been in the stdlib since python2.7
- Remove `functools32`, this isn't imported
- Use `str('')` for native string literals in setup.py to appease setuptools