### PR TITLE
Fix quotes typo

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -215,7 +215,7 @@ instance MAY have:
 
   * ``deploy_whitelist``: A list of lists indicating a set of locations where deployment is allowed.  For example:
 
-      ``deploy_whitelist: ['region', ['uswest1-prod", 'uswest2-prod]]``
+      ``deploy_whitelist: ["region", ["uswest1-prod", "uswest2-prod"]]``
 
     would indicate that PaaSTA can **only** deploy in ``uswest1-prod`` or ``uswest2-prod``.  If this list
     is empty (the default), then deployment is allowed anywhere.  This is superseded by the blacklist; if


### PR DESCRIPTION
deploy_whitelist example is incorrectly formatted.