### PR TITLE
Make more tests pass in python3

### DIFF
--- a/paasta_tools/autoscale_cluster.py
+++ b/paasta_tools/autoscale_cluster.py
@@ -24,7 +24,7 @@ from paasta_tools.autoscaling.autoscaling_cluster_lib import autoscale_local_clu
 log = logging.getLogger(__name__)
 
 
-def parse_args():
+def parse_args(argv):
     parser = argparse.ArgumentParser(description='Autoscales the local PaaSTA cluster')
     parser.add_argument('-v', '--verbose', action='count', dest="verbose", default=0,
                         help="Print out more output.")
@@ -33,12 +33,11 @@ def parse_args():
     parser.add_argument('-a', '--autoscaler-configs',
                         help="Path to autoscaler config files",
                         default='/etc/paasta/cluster_autoscaling')
-    args = parser.parse_args()
-    return args
+    return parser.parse_args(argv)
 
 
-def main():
-    args = parse_args()
+def main(argv=None):
+    args = parse_args(argv)
     log_format = '%(asctime)s:%(levelname)s:%(name)s:%(message)s'
     if args.verbose >= 2:
         logging.basicConfig(level=logging.DEBUG, format=log_format)

--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -83,18 +83,17 @@ def bounce_lock(name):
 
     :param name: The lock name to acquire"""
     lockfile = '/var/lock/%s.lock' % name
-    fd = open(lockfile, 'w')
-    remove = False
-    try:
-        fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        remove = True
-        yield
-    except IOError:
-        raise LockHeldException("Service %s is already being bounced!" % name)
-    finally:
-        fd.close()
-        if remove:
-            os.remove(lockfile)
+    with open(lockfile, 'w') as fd:
+        remove = False
+        try:
+            fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            remove = True
+            yield
+        except IOError:
+            raise LockHeldException("Service %s is already being bounced!" % name)
+        finally:
+            if remove:
+                os.remove(lockfile)
 
 
 @contextmanager
@@ -244,7 +243,7 @@ def get_happy_tasks(app, service, nerve_ns, system_paasta_config, min_task_uptim
             attribute=discover_location_type
         )
 
-        for value, hosts in unique_values.iteritems():
+        for value, hosts in unique_values.items():
             synapse_hostname = hosts[0]['hostname']
             tasks_in_smartstack.extend(get_registered_marathon_tasks(
                 synapse_hostname,

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -158,7 +158,7 @@ def check_smartstack_replication_for_instance(
         output = ''
         under_replication_per_location = []
 
-        for location, available_backends in sorted(smartstack_replication_info.iteritems()):
+        for location, available_backends in sorted(smartstack_replication_info.items()):
             num_available_in_location = available_backends.get(full_name, 0)
             under_replicated, ratio = is_under_replicated(
                 num_available_in_location, expected_count_per_location, crit_threshold)

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -46,6 +46,8 @@ import logging
 import os
 import re
 
+import six
+
 from paasta_tools import remote_git
 from paasta_tools.cli.utils import get_instance_configs_for_service
 from paasta_tools.utils import atomic_file_write
@@ -99,11 +101,11 @@ def get_latest_deployment_tag(refs, deploy_group):
     most_recent_sha = None
     pattern = re.compile("^refs/tags/paasta-%s-(\d{8}T\d{6})-deploy$" % deploy_group)
 
-    for ref_name, sha in refs.iteritems():
+    for ref_name, sha in refs.items():
         match = pattern.match(ref_name)
         if match:
             dtime = match.groups()[0]
-            if dtime > most_recent_dtime:
+            if most_recent_dtime is None or dtime > most_recent_dtime:
                 most_recent_dtime = dtime
                 most_recent_ref = ref_name
                 most_recent_sha = sha
@@ -200,7 +202,7 @@ def get_desired_state(branch, remote_refs, deploy_group):
     states = []
     (_, head_sha) = get_latest_deployment_tag(remote_refs, deploy_group)
 
-    for ref_name, sha in remote_refs.iteritems():
+    for ref_name, sha in remote_refs.items():
         if sha == head_sha:
             match = re.match(tag_pattern, ref_name)
             if match:
@@ -226,7 +228,7 @@ def get_deploy_group_mappings_from_deployments_dict(deployments_dict):
     except KeyError:
         deploy_group_mappings = {}
         for deploy_group, image in deployments_dict.items():
-            if isinstance(image, basestring):
+            if isinstance(image, six.string_types):
                 deploy_group_mappings[deploy_group] = {
                     'docker_image': image,
                     'desired_state': 'start',

--- a/paasta_tools/monitoring/check_classic_service_replication.py
+++ b/paasta_tools/monitoring/check_classic_service_replication.py
@@ -85,7 +85,7 @@ def do_replication_check(service, monitoring_config, service_replication):
         # appear in the replication_map, either way use the default
         goal_replication = replication_default
 
-    warn_range = (goal_replication, sys.maxint)
+    warn_range = (goal_replication, sys.maxsize)
     crit_range = warn_range
 
     status_code, message = check_replication(service,

--- a/paasta_tools/monitoring/check_synapse_replication.py
+++ b/paasta_tools/monitoring/check_synapse_replication.py
@@ -77,7 +77,7 @@ def parse_range(str_range):
     if int_range[0] == '':
         int_range[0] = 0
     if int_range[1] == '':
-        int_range[1] = sys.maxint
+        int_range[1] = sys.maxsize
     try:
         return tuple(map(int, int_range))
     except Exception:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -181,7 +181,7 @@ class InstanceConfig(dict):
         Example configuration: {'nofile': {soft: 1024, hard: 2048}, 'nice': {soft: 20}}
 
         :returns: A generator of ulimit options to be passed as --ulimit flags"""
-        for key, val in sorted(self.config_dict.get('ulimit', {}).iteritems()):
+        for key, val in sorted(self.config_dict.get('ulimit', {}).items()):
             soft = val.get('soft')
             hard = val.get('hard')
             if soft is None:
@@ -754,7 +754,7 @@ class FileLogWriter(LogWriter):
 
         with io.FileIO(path, mode=self.mode, closefd=True) as f:
             with self.maybe_flock(f):
-                f.write(to_write)
+                f.write(to_write.encode('UTF-8'))
 
 
 def _timeout(process):
@@ -1084,7 +1084,8 @@ def atomic_file_write(target_path):
     with tempfile.NamedTemporaryFile(
         dir=dirname,
         prefix=('.%s-' % basename),
-        delete=False
+        delete=False,
+        mode='w',
     ) as f:
         temp_target_path = f.name
         yield f
@@ -1568,14 +1569,14 @@ def format_table(rows, min_spacing=2):
     :returns: A string containing rows formatted as a table.
     """
 
-    list_rows = [r for r in rows if not isinstance(r, basestring)]
+    list_rows = [r for r in rows if not isinstance(r, six.string_types)]
 
     # If all of the rows are strings, we have nothing to do, so short-circuit.
     if not list_rows:
         return rows
 
     widths = []
-    for i in xrange(len(list_rows[0])):
+    for i in range(len(list_rows[0])):
         widths.append(max(terminal_len(r[i]) for r in list_rows))
 
     expanded_rows = []

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -19,6 +19,7 @@ import contextlib
 from socket import gaierror
 
 import mock
+import six
 from bravado.exception import HTTPError
 from bravado.exception import HTTPNotFound
 from mock import patch
@@ -410,7 +411,7 @@ def test_execute_chronos_rerun_on_remote_master(test_case):
         assert type(outcome) == tuple and \
             len(outcome) == 2 and \
             type(outcome[0]) == int and \
-            isinstance(outcome[1], basestring)
+            isinstance(outcome[1], six.string_types)
         assert bool(mock_find_connectable_master.return_value) == mock_find_connectable_master.called
         assert bool(mock_run_chronos_rerun.return_value) == mock_run_chronos_rerun.called
 

--- a/tests/monitoring/test_check_synapse_replication.py
+++ b/tests/monitoring/test_check_synapse_replication.py
@@ -50,7 +50,7 @@ def test_check_replication():
 def test_parse_range():
     range_data = ["0:1", "1:", "100:", "20:30", ":2", ":200"]
     expected_ranges = [
-        (0, 1), (1, sys.maxint), (100, sys.maxint), (20, 30), (0, 2), (0, 200)
+        (0, 1), (1, sys.maxsize), (100, sys.maxsize), (20, 30), (0, 2), (0, 200)
     ]
 
     computed_ranges = map(parse_range, range_data)

--- a/tests/test_adhoc_tools.py
+++ b/tests/test_adhoc_tools.py
@@ -14,8 +14,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import contextlib
-
 import mock
 
 from paasta_tools import adhoc_tools
@@ -24,11 +22,9 @@ from paasta_tools.utils import NoConfigurationForServiceError
 
 
 def test_get_default_interactive_config():
-    with contextlib.nested(
-        mock.patch('paasta_tools.adhoc_tools.load_adhoc_job_config', autospec=True),
-    ) as (
-        mock_load_adhoc_job_config,
-    ):
+    with mock.patch(
+        'paasta_tools.adhoc_tools.load_adhoc_job_config', autospec=True,
+    ) as mock_load_adhoc_job_config:
         mock_load_adhoc_job_config.return_value = adhoc_tools.AdhocJobConfig(
             service='fake_service',
             instance='interactive',
@@ -48,15 +44,13 @@ def test_get_default_interactive_config():
 
 
 def test_get_default_interactive_config_reads_from_tty():
-    with contextlib.nested(
-        mock.patch('paasta_tools.adhoc_tools.prompt_pick_one', autospec=True),
-        mock.patch('paasta_tools.adhoc_tools.load_adhoc_job_config', autospec=True),
-        mock.patch('paasta_tools.adhoc_tools.load_v2_deployments_json', autospec=True),
-    ) as (
-        mock_prompt_pick_one,
-        mock_load_adhoc_job_config,
-        mock_load_deployments_json,
-    ):
+    with mock.patch(
+        'paasta_tools.adhoc_tools.prompt_pick_one', autospec=True,
+    ) as mock_prompt_pick_one, mock.patch(
+        'paasta_tools.adhoc_tools.load_adhoc_job_config', autospec=True,
+    ) as mock_load_adhoc_job_config, mock.patch(
+        'paasta_tools.adhoc_tools.load_v2_deployments_json', autospec=True,
+    ) as mock_load_deployments_json:
         mock_prompt_pick_one.return_value = 'fake_deploygroup'
         mock_load_adhoc_job_config.side_effect = NoConfigurationForServiceError
         mock_load_deployments_json.return_value = DeploymentsJson({

--- a/tests/test_autoscale_cluster.py
+++ b/tests/test_autoscale_cluster.py
@@ -22,8 +22,6 @@ from paasta_tools.autoscale_cluster import main
 
 @mock.patch('paasta_tools.autoscale_cluster.logging', autospec=True)
 @mock.patch('paasta_tools.autoscale_cluster.autoscale_local_cluster', autospec=True)
-@mock.patch('paasta_tools.autoscale_cluster.parse_args', autospec=True)
-def test_main(mock_parse_args, mock_autoscale_local_cluster, logging):
-    mock_parse_args.return_value = mock.Mock(dry_run=True, autoscaler_configs='/nail/blah')
-    main()
+def test_main(mock_autoscale_local_cluster, logging):
+    main(('--dry-run', '--autoscaler-configs=/nail/blah'))
     mock_autoscale_local_cluster.assert_called_with(dry_run=True, config_folder='/nail/blah')

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -39,17 +39,15 @@ def test_send_event_users_monitoring_tools_send_event_properly():
     fake_soa_dir = '/hi/hello/hey'
     fake_cluster = 'fake_cluster'
     expected_check_name = 'check_marathon_services_replication.%s' % compose_job_id(fake_service_name, fake_namespace)
-    with contextlib.nested(
-        mock.patch("paasta_tools.monitoring_tools.send_event", autospec=True),
-        mock.patch('paasta_tools.check_marathon_services_replication.load_system_paasta_config', autospec=True),
-        mock.patch("paasta_tools.check_marathon_services_replication._log", autospec=True),
-        mock.patch("paasta_tools.marathon_tools.load_marathon_service_config", autospec=True),
-    ) as (
-        send_event_patch,
-        load_system_paasta_config_patch,
-        log_patch,
-        load_marathon_service_config_patch,
-    ):
+    with mock.patch(
+        "paasta_tools.monitoring_tools.send_event", autospec=True,
+    ) as send_event_patch, mock.patch(
+        'paasta_tools.check_marathon_services_replication.load_system_paasta_config', autospec=True,
+    ), mock.patch(
+        "paasta_tools.check_marathon_services_replication._log", autospec=True,
+    ), mock.patch(
+        "paasta_tools.marathon_tools.load_marathon_service_config", autospec=True,
+    ) as load_marathon_service_config_patch:
         load_marathon_service_config_patch.return_value.get_monitoring.return_value = fake_monitoring_overrides
         check_marathon_services_replication.send_event(fake_service_name,
                                                        fake_namespace,
@@ -83,17 +81,15 @@ def test_send_event_users_monitoring_tools_send_event_respects_alert_after():
     fake_soa_dir = '/hi/hello/hey'
     fake_cluster = 'fake_cluster'
     expected_check_name = 'check_marathon_services_replication.%s' % compose_job_id(fake_service_name, fake_namespace)
-    with contextlib.nested(
-        mock.patch("paasta_tools.monitoring_tools.send_event", autospec=True),
-        mock.patch('paasta_tools.check_marathon_services_replication.load_system_paasta_config', autospec=True),
-        mock.patch("paasta_tools.check_marathon_services_replication._log", autospec=True),
-        mock.patch("paasta_tools.marathon_tools.load_marathon_service_config", autospec=True),
-    ) as (
-        send_event_patch,
-        load_system_paasta_config_patch,
-        log_patch,
-        load_marathon_service_config_patch,
-    ):
+    with mock.patch(
+        "paasta_tools.monitoring_tools.send_event", autospec=True,
+    ) as send_event_patch, mock.patch(
+        'paasta_tools.check_marathon_services_replication.load_system_paasta_config', autospec=True,
+    ), mock.patch(
+        "paasta_tools.check_marathon_services_replication._log", autospec=True,
+    ), mock.patch(
+        "paasta_tools.marathon_tools.load_marathon_service_config", autospec=True,
+    ) as load_marathon_service_config_patch:
         load_marathon_service_config_patch.return_value.get_monitoring.return_value = fake_monitoring_overrides
         check_marathon_services_replication.send_event(fake_service_name,
                                                        fake_namespace,
@@ -128,18 +124,16 @@ def test_check_smartstack_replication_for_instance_ok_when_expecting_zero():
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
 
-    with contextlib.nested(
-        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
-                   autospec=True, return_value=compose_job_id(service, instance)),
-        mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
-    ) as (
-        mock_send_event,
-        mock_read_registration_for_service_instance,
-        mock_load_smartstack_info_for_service,
-        mock_load_marathon_service_config,
-    ):
+    with mock.patch(
+        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
+    ) as mock_send_event, mock.patch(
+        'paasta_tools.marathon_tools.read_registration_for_service_instance',
+        autospec=True, return_value=compose_job_id(service, instance),
+    ), mock.patch(
+        'paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True,
+    ) as mock_load_smartstack_info_for_service, mock.patch(
+        'paasta_tools.marathon_tools.load_marathon_service_config', autospec=True,
+    ) as mock_load_marathon_service_config:
         mock_load_smartstack_info_for_service.return_value = available
 
         mock_service_job_config = mock.MagicMock(spec_set=MarathonServiceConfig)
@@ -168,18 +162,16 @@ def test_check_smartstack_replication_for_instance_crit_when_absent():
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
-    with contextlib.nested(
-        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
-                   autospec=True, return_value=compose_job_id(service, instance)),
-        mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
-    ) as (
-        mock_send_event,
-        mock_read_registration_for_service_instance,
-        mock_load_smartstack_info_for_service,
-        mock_load_marathon_service_config,
-    ):
+    with mock.patch(
+        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
+    ) as mock_send_event, mock.patch(
+        'paasta_tools.marathon_tools.read_registration_for_service_instance',
+        autospec=True, return_value=compose_job_id(service, instance),
+    ), mock.patch(
+        'paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True,
+    ) as mock_load_smartstack_info_for_service, mock.patch(
+        'paasta_tools.marathon_tools.load_marathon_service_config', autospec=True,
+    ) as mock_load_marathon_service_config:
         mock_load_smartstack_info_for_service.return_value = available
         mock_service_job_config = mock.MagicMock(spec_set=MarathonServiceConfig)
         mock_service_job_config.get_replication_crit_percentage.return_value = crit
@@ -205,18 +197,16 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication():
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
-    with contextlib.nested(
-        mock.patch('paasta_tools.check_marathon_services_replication.send_event', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance',
-                   autospec=True, return_value=compose_job_id(service, instance)),
-        mock.patch('paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.load_marathon_service_config', autospec=True)
-    ) as (
-        mock_send_event,
-        mock_read_registration_for_service_instance,
-        mock_load_smartstack_info_for_service,
-        mock_load_marathon_service_config,
-    ):
+    with mock.patch(
+        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
+    ) as mock_send_event, mock.patch(
+        'paasta_tools.marathon_tools.read_registration_for_service_instance',
+        autospec=True, return_value=compose_job_id(service, instance),
+    ), mock.patch(
+        'paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True,
+    ) as mock_load_smartstack_info_for_service, mock.patch(
+        'paasta_tools.marathon_tools.load_marathon_service_config', autospec=True,
+    ) as mock_load_marathon_service_config:
         mock_load_smartstack_info_for_service.return_value = available
         mock_service_job_config = mock.MagicMock(spec_set=MarathonServiceConfig)
         mock_service_job_config.get_replication_crit_percentage.return_value = crit

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,37 @@ commands =
     # TODO: actually upgrade protobuf once this is resolved
     pip install protobuf==3.2.0
     py.test {posargs:tests} --collect-only
+    # Test files which are known to pass in python3
+    # Generated with:
+    # .tox/py3/bin/py.test tests |& grep -E '^tests[^ ]+ \.+$' | cut -d' ' -f1 | sort | xargs --replace echo '        {} \' | sed '$ s/ .$//'
+    py.test \
+        tests/api/test_autoscaler.py \
+        tests/api/test_service.py \
+        tests/cli/test_cmds_cook_image.py \
+        tests/cli/test_cmds_docker_exec.py \
+        tests/cli/test_cmds_docker_inspect.py \
+        tests/cli/test_cmds_docker_stop.py \
+        tests/cli/test_cmds_generate_pipeline.py \
+        tests/cli/test_cmds_help.py \
+        tests/cli/test_cmds_itest.py \
+        tests/cli/test_cmds_mark_for_deployment.py \
+        tests/cli/test_cmds_performance_check.py \
+        tests/cli/test_cmds_push_to_registry.py \
+        tests/cli/test_cmds_sysdig.py \
+        tests/mesos/test_cluster.py \
+        tests/monitoring/test_config_providers.py \
+        tests/test_adhoc_tools.py \
+        tests/test_autoscale_all_services.py \
+        tests/test_autoscale_cluster.py \
+        tests/test_bounce_lib.py \
+        tests/test_check_chronos_jobs.py \
+        tests/test_chronos_rerun.py \
+        tests/test_cleanup_chronos_jobs.py \
+        tests/test_deployment_utils.py \
+        tests/test_drain_lib.py \
+        tests/test_generate_deployments_for_service.py \
+        tests/test_paasta_maintenance.py \
+        tests/test_utils.py
 
 [testenv:coverage]
 commands =


### PR DESCRIPTION
This gets ~some of the tests passing in python3 and gives us a way to whitelist in file-by-file as files are converted to passing (while preventing them from regressing)