### PR TITLE
Remove extra undrain call

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -302,7 +302,6 @@ class ClusterAutoscaler(ResourceLogMixin):
             self.log.error("Failure when terminating: {0}: {1}".format(slave_to_kill.pid, e))
             self.log.error("Setting resource capacity back to {0}".format(current_capacity))
             self.set_capacity(current_capacity)
-        finally:
             self.log.info("Undraining {0}".format(slave_to_kill.pid))
             if not self.dry_run:
                 undrain([drain_host_string])

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -852,7 +852,6 @@ class TestClusterAutoscaler(unittest.TestCase):
             set_call_1 = mock.call(self.autoscaler, 4)
             mock_set_capacity.assert_has_calls([set_call_1])
             mock_wait_and_terminate.assert_called_with(self.autoscaler, mock_slave, 123, False, region='westeros-1')
-            mock_undrain.assert_called_with(['host1|10.1.1.1'])
 
             # test we cleanup if a termination fails
             set_call_2 = mock.call(self.autoscaler, 5)


### PR DESCRIPTION
This call is unnecessary if we are terminating the box. When we
shutdown we run "down" and then "up" which clears the draining state on
the master. We also have cleanup scripts running. So we should only
undrain if we fail to terminate etc.

@nhandler should be primary on this