### PR TITLE
Make paasta_maintenance status human-friendly

### DIFF
--- a/paasta_tools/mesos_maintenance.py
+++ b/paasta_tools/mesos_maintenance.py
@@ -634,16 +634,37 @@ def up(hostnames):
     return up_output
 
 
-def status():
+def raw_status():
     """Get the Mesos maintenance status. This contains hostname/ip mappings for hosts that are either marked as being
     down for maintenance or draining.
-    :returns: None
+    :returns: Response Object containing status
     """
     try:
         status = get_maintenance_status()
     except HTTPError:
         raise HTTPError("Error performing maintenance status.")
-    return status.text
+    return status
+
+
+def status():
+    """Get the Mesos maintenance status. This contains hostname/ip mappings for hosts that are either marked as being
+    down for maintenance or draining.
+    :returns: Text representation of the status
+    """
+    return raw_status().text
+
+
+def friendly_status():
+    """Display the Mesos maintenance status in a human-friendly way.
+    :returns: Text representation of the human-friendly status
+    """
+    status = raw_status().json()
+    ret = ""
+    for machine in status.get('draining_machines', []):
+        ret += "%s (%s): Draining\n" % (machine['id']['hostname'], machine['id']['ip'])
+    for machine in status.get('down_machines', []):
+        ret += "%s (%s): Down\n" % (machine['hostname'], machine['ip'])
+    return ret
 
 
 def is_host_drained(hostname):

--- a/paasta_tools/paasta_maintenance.py
+++ b/paasta_tools/paasta_maintenance.py
@@ -56,6 +56,7 @@ def parse_args():
     parser.add_argument(
         'action',
         choices=[
+            'cluster_status',
             'down',
             'drain',
             'is_host_down',
@@ -221,6 +222,8 @@ def paasta_maintenance():
     elif action == 'up':
         mesos_maintenance.up(hostnames)
     elif action == 'status':
+        ret = "%s" % mesos_maintenance.friendly_status()
+    elif action == 'cluster_status':
         ret = "%s" % mesos_maintenance.status()
     elif action == 'schedule':
         ret = "%s" % mesos_maintenance.schedule()

--- a/paasta_tools/paasta_maintenance.py
+++ b/paasta_tools/paasta_maintenance.py
@@ -222,11 +222,11 @@ def paasta_maintenance():
     elif action == 'up':
         mesos_maintenance.up(hostnames)
     elif action == 'status':
-        ret = "%s" % mesos_maintenance.friendly_status()
+        ret = mesos_maintenance.friendly_status()
     elif action == 'cluster_status':
-        ret = "%s" % mesos_maintenance.status()
+        ret = mesos_maintenance.status()
     elif action == 'schedule':
-        ret = "%s" % mesos_maintenance.schedule()
+        ret = mesos_maintenance.schedule()
     elif action == 'is_safe_to_drain':
         ret = is_safe_to_drain(hostnames[0])
     elif action == 'is_safe_to_kill':

--- a/tests/test_mesos_maintenance.py
+++ b/tests/test_mesos_maintenance.py
@@ -599,6 +599,7 @@ def test_raw_status(
     raw_status()
     assert mock_get_maintenance_status.call_count == 1
 
+
 @mock.patch('paasta_tools.mesos_maintenance.raw_status', autospec=True)
 def test_status(
     mock_raw_status,

--- a/tests/test_mesos_maintenance.py
+++ b/tests/test_mesos_maintenance.py
@@ -32,6 +32,7 @@ from paasta_tools.mesos_maintenance import datetime_seconds_from_now
 from paasta_tools.mesos_maintenance import datetime_to_nanoseconds
 from paasta_tools.mesos_maintenance import down
 from paasta_tools.mesos_maintenance import drain
+from paasta_tools.mesos_maintenance import friendly_status
 from paasta_tools.mesos_maintenance import get_down_hosts
 from paasta_tools.mesos_maintenance import get_draining_hosts
 from paasta_tools.mesos_maintenance import get_hosts_forgotten_down
@@ -52,6 +53,7 @@ from paasta_tools.mesos_maintenance import is_host_past_maintenance_start
 from paasta_tools.mesos_maintenance import load_credentials
 from paasta_tools.mesos_maintenance import parse_datetime
 from paasta_tools.mesos_maintenance import parse_timedelta
+from paasta_tools.mesos_maintenance import raw_status
 from paasta_tools.mesos_maintenance import reserve
 from paasta_tools.mesos_maintenance import Resource
 from paasta_tools.mesos_maintenance import schedule
@@ -591,11 +593,26 @@ def test_up(
 
 
 @mock.patch('paasta_tools.mesos_maintenance.get_maintenance_status', autospec=True)
-def test_status(
+def test_raw_status(
     mock_get_maintenance_status,
 ):
-    status()
+    raw_status()
     assert mock_get_maintenance_status.call_count == 1
+
+@mock.patch('paasta_tools.mesos_maintenance.raw_status', autospec=True)
+def test_status(
+    mock_raw_status,
+):
+    status()
+    assert mock_raw_status.call_count == 1
+
+
+@mock.patch('paasta_tools.mesos_maintenance.raw_status', autospec=True)
+def test_friendly_status(
+    mock_raw_status,
+):
+    friendly_status()
+    assert mock_raw_status.call_count == 1
 
 
 @mock.patch('paasta_tools.mesos_maintenance.get_maintenance_schedule', autospec=True)


### PR DESCRIPTION
We have received reports that `paasta_maintenance status` is hard to understand. This is because it spits out the raw json (you can pipe it to `jq` to make it pretty). This change makes `paasta_maintenance status` use a more human-friendly output format. The old output is available under a `paasta_maintenance cluster_status` command.

This is internal ticket PAASTA-6990