### PR TITLE
Docker compose down before we start the itests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,7 @@ passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
 deps =
     docker-compose==1.7.1
 commands =
+    docker-compose down
     docker-compose pull
     docker-compose --verbose build
     # Fire up the marathon cluster in background


### PR DESCRIPTION
This makes it easier to hit rebuild if you see a transient failure
because one of the itest containers is slow/hanging.