### PR TITLE
Make realert_every be a function of the interval

### DIFF
--- a/paasta_tools/check_chronos_jobs.py
+++ b/paasta_tools/check_chronos_jobs.py
@@ -72,6 +72,17 @@ def compose_monitoring_overrides_for_service(chronos_job_config, soa_dir):
     return monitoring_overrides
 
 
+def add_realert_status(sensu_output, realert_every_in_minutes):
+    if realert_every_in_minutes is None or realert_every_in_minutes == -1:
+        return "{}\n\nThis check will not realert.".format(sensu_output)
+    else:
+        hours = realert_every_in_minutes // 60
+        minutes = realert_every_in_minutes % 60
+        interval_string = (hours > 0) * ('%sh' % hours) + (minutes > 0) * ('%sm' % minutes)
+        return ("{}\n\nThis check realerts every {}."
+                .format(sensu_output, interval_string))
+
+
 def send_event(service, instance, monitoring_overrides, soa_dir, status_code, message):
     check_name = compose_check_name_for_service_instance('check_chronos_jobs', service, instance)
 
@@ -80,7 +91,7 @@ def send_event(service, instance, monitoring_overrides, soa_dir, status_code, me
         check_name=check_name,
         overrides=monitoring_overrides,
         status=status_code,
-        output=message,
+        output=add_realert_status(message, monitoring_overrides.get('realert_every')),
         soa_dir=soa_dir,
     )
 

--- a/paasta_tools/check_chronos_jobs.py
+++ b/paasta_tools/check_chronos_jobs.py
@@ -74,7 +74,7 @@ def compose_monitoring_overrides_for_service(chronos_job_config, soa_dir):
 
 def add_realert_status(sensu_output, realert_every_in_minutes):
     if realert_every_in_minutes is None or realert_every_in_minutes == -1:
-        return "{}\n\nThis check will not realert.".format(sensu_output)
+        return sensu_output
     else:
         hours = realert_every_in_minutes // 60
         minutes = realert_every_in_minutes % 60

--- a/paasta_tools/monitoring_tools.py
+++ b/paasta_tools/monitoring_tools.py
@@ -37,6 +37,19 @@ from paasta_tools.utils import load_system_paasta_config
 log = logging.getLogger(__name__)
 
 
+def monitoring_defaults(key):
+    defaults = {
+        'runbook': 'Please set a `runbook` field in your monitoring.yaml. Like "y/rb-mesos". Docs: '
+                   'https://paasta.readthedocs.io/en/latest/yelpsoa_configs.html#monitoring-yaml',
+        'tip': 'Please set a `tip` field in your monitoring.yaml. Docs: '
+               'https://paasta.readthedocs.io/en/latest/yelpsoa_configs.html#monitoring-yaml',
+        'ticket': False,
+        'project': None,
+        'realert_every': -1
+    }
+    return defaults.get(key, None)
+
+
 def get_team(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('team', overrides, service, soa_dir)
 
@@ -61,8 +74,13 @@ def get_alert_after(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('alert_after', overrides, service, soa_dir)
 
 
-def get_realert_every(overrides, service, soa_dir=DEFAULT_SOA_DIR):
-    return __get_monitoring_config_value('realert_every', overrides, service, soa_dir)
+def get_realert_every(overrides, service, soa_dir=DEFAULT_SOA_DIR,
+                      monitoring_defaults=monitoring_defaults):
+    return __get_monitoring_config_value('realert_every',
+                                         overrides=overrides,
+                                         service=service,
+                                         soa_dir=soa_dir,
+                                         monitoring_defaults=monitoring_defaults)
 
 
 def get_check_every(overrides, service, soa_dir=DEFAULT_SOA_DIR):
@@ -85,26 +103,15 @@ def get_project(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('project', overrides, service, soa_dir)
 
 
-def __get_monitoring_config_value(key, overrides, service, soa_dir=DEFAULT_SOA_DIR):
+def __get_monitoring_config_value(key, overrides, service,
+                                  soa_dir=DEFAULT_SOA_DIR,
+                                  monitoring_defaults=monitoring_defaults):
     general_config = service_configuration_lib.read_service_configuration(service, soa_dir=soa_dir)
     monitor_config = read_monitoring_config(service, soa_dir=soa_dir)
     service_default = general_config.get(key, monitoring_defaults(key))
     service_default = general_config.get('monitoring', {key: service_default}).get(key, service_default)
     service_default = monitor_config.get(key, service_default)
     return overrides.get(key, service_default)
-
-
-def monitoring_defaults(key):
-    defaults = {
-        'runbook': 'Please set a `runbook` field in your monitoring.yaml. Like "y/rb-mesos". Docs: '
-                   'https://paasta.readthedocs.io/en/latest/yelpsoa_configs.html#monitoring-yaml',
-        'tip': 'Please set a `tip` field in your monitoring.yaml. Docs: '
-               'https://paasta.readthedocs.io/en/latest/yelpsoa_configs.html#monitoring-yaml',
-        'ticket': False,
-        'project': None,
-        'realert_every': -1
-    }
-    return defaults.get(key, None)
 
 
 def get_team_email_address(service, overrides=None, soa_dir=DEFAULT_SOA_DIR):

--- a/tests/test_check_chronos_jobs.py
+++ b/tests/test_check_chronos_jobs.py
@@ -110,7 +110,7 @@ def test_compose_check_name_for_job():
 
 
 @patch('paasta_tools.chronos_tools.monitoring_tools.send_event', autospec=True)
-def test_send_event_to_sensu(mock_send_event):
+def test_send_event_with_no_realert_every_to_sensu(mock_send_event):
     check_chronos_jobs.send_event(
         service='myservice',
         instance='myinstance',
@@ -124,7 +124,27 @@ def test_send_event_to_sensu(mock_send_event):
         check_name='check_chronos_jobs.myservice.myinstance',
         overrides={},
         status=0,
-        output='this is great',
+        output='this is great\n\nThis check will not realert.',
+        soa_dir='soadir',
+    )
+
+
+@patch('paasta_tools.chronos_tools.monitoring_tools.send_event', autospec=True)
+def test_send_event_with_realert_every_to_sensu(mock_send_event):
+    check_chronos_jobs.send_event(
+        service='myservice',
+        instance='myinstance',
+        monitoring_overrides={'realert_every': 150},
+        soa_dir='soadir',
+        status_code=0,
+        message='this is great',
+    )
+    mock_send_event.assert_called_once_with(
+        service='myservice',
+        check_name='check_chronos_jobs.myservice.myinstance',
+        overrides={'realert_every': 150},
+        status=0,
+        output='this is great\n\nThis check realerts every 2h30m.',
         soa_dir='soadir',
     )
 

--- a/tests/test_check_chronos_jobs.py
+++ b/tests/test_check_chronos_jobs.py
@@ -124,7 +124,7 @@ def test_send_event_with_no_realert_every_to_sensu(mock_send_event):
         check_name='check_chronos_jobs.myservice.myinstance',
         overrides={},
         status=0,
-        output='this is great\n\nThis check will not realert.',
+        output='this is great',
         soa_dir='soadir',
     )
 

--- a/tests/test_monitoring_tools.py
+++ b/tests/test_monitoring_tools.py
@@ -134,9 +134,10 @@ class TestMonitoring_Tools:
         with mock.patch(
             'paasta_tools.monitoring_tools.__get_monitoring_config_value', autospec=True
         ) as get_monitoring_config_value_patch:
-            monitoring_tools.get_realert_every(self.overrides, self.service, self.soa_dir)
+            monitoring_defaults = mock.Mock()
+            monitoring_tools.get_realert_every(self.overrides, self.service, self.soa_dir, monitoring_defaults)
             get_monitoring_config_value_patch.assert_called_once_with('realert_every', self.overrides,
-                                                                      self.service, self.soa_dir)
+                                                                      self.service, self.soa_dir, monitoring_defaults)
 
     def test_get_check_every(self):
         with mock.patch(


### PR DESCRIPTION
internal ticket: PAASTA-7870

* If realert_every is defined in chronos-<cluster>.yaml for the job, that value will be used.
* If the job doesn't have 'realert_every' in chronos-<cluster>.yaml, the value will be guessed based on the job interval.
* If the job doesn't have interval and has no 'realert_every' in chronos-<cluster>.yaml, paasta will read it from monitoring.yaml or will use the default value -1.

I'm not sure whether the guessed value should be more preferable than the one from monitoring.yaml or not.

On the one hand silently overriding values set in monitoring.yaml doesn't look good to me.
On the other hand if we don't override monitoring.yaml, people will have to remove 'realert_after' from monitoring.yaml and put it to marathon-<cluster>.yaml for every instance to be able to use this guessing logic for chronos jobs. 