### PR TITLE
Handle create app lock failure gracefully

### DIFF
--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -525,6 +525,10 @@ def deploy_service(
             soa_dir=soa_dir,
             bounce_margin_factor=bounce_margin_factor,
         )
+    except bounce_lib.LockHeldException:
+        logline = 'Failed to get lock to create marathon app for %s.%s' % (service, instance)
+        log_deploy_error(logline, level='debug')
+        return (0, "Couldn't get marathon lock, skipping until next time")
     except Exception:
         logline = 'Exception raised during deploy of service %s:\n%s' % (service, traceback.format_exc())
         log_deploy_error(logline, level='debug')


### PR DESCRIPTION
We get these exceptions pretty frequently in our large clusters when we
are creating multiple apps at the same time. Currently the exception is
raised all the way up which causes setup_marathon_job to exit 1 and for
our deploy loop to start over. This catches the exception and continues
on. I think it should be safe because we will simply try again next time
to create the new marathon app.