### PR TITLE
catch ValueError when getting marathon status

### DIFF
--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -98,8 +98,10 @@ def main():
         marathon_client = metastatus_lib.get_marathon_client(marathon_config)
         try:
             marathon_results = metastatus_lib.get_marathon_status(marathon_client)
-        except (MarathonError, InternalServerError) as e:
-            paasta_print(PaastaColors.red("CRITICAL: Unable to contact Marathon! Is the cluster healthy?"))
+        except (MarathonError, InternalServerError, ValueError) as e:
+            # catch ValueError until marathon-python/pull/167 is merged and this is handled upstream
+            paasta_print(PaastaColors.red(("CRITICAL: Unable to contact Marathon cluster at %s!"
+                                           "Is the cluster healthy?".format(marathon_config["url"]))))
             sys.exit(2)
     else:
         marathon_results = [metastatus_lib.HealthCheckResult(message='Marathon is not configured to run here',

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -20,6 +20,7 @@ import contextlib
 from mock import Mock
 from mock import patch
 from pytest import raises
+from simplejson import JSONDecodeError
 
 from paasta_tools import paasta_metastatus
 
@@ -113,3 +114,52 @@ def test_main_no_chronos_config():
         with raises(SystemExit) as excinfo:
             paasta_metastatus.main()
         assert excinfo.value.code == 0
+
+
+def test_main_marathon_jsondecode_error():
+    with contextlib.nested(
+        patch('paasta_tools.marathon_tools.load_marathon_config', autospec=True),
+        patch('paasta_tools.paasta_metastatus.load_chronos_config', autospec=True),
+        patch('paasta_tools.paasta_metastatus.get_mesos_master', autospec=True),
+        patch('paasta_tools.metrics.metastatus_lib.get_mesos_state_status', autospec=True,
+              return_value=([('fake_output', True)])),
+        patch('paasta_tools.metrics.metastatus_lib.get_mesos_resource_utilization_health', autospec=True),
+        patch('paasta_tools.metrics.metastatus_lib.get_marathon_client', autospec=True),
+        patch('paasta_tools.metrics.metastatus_lib.get_marathon_status', autospec=True),
+        patch('paasta_tools.paasta_metastatus.parse_args', autospec=True),
+    ) as (
+        load_marathon_config_patch,
+        load_chronos_config_patch,
+        get_mesos_master,
+        get_mesos_state_status_patch,
+        get_mesos_resource_utilization_health_patch,
+        get_marathon_client_patch,
+        get_marathon_status_patch,
+        parse_args_patch,
+    ):
+
+        fake_args = Mock(
+            verbose=0,
+        )
+        fake_master = Mock(autospace=True)
+        fake_master.metrics_snapshot.return_value = {
+            'master/frameworks_active': 2,
+            'master/frameworks_inactive': 0,
+            'master/frameworks_connected': 2,
+            'master/frameworks_disconnected': 0,
+        }
+        fake_master.state.return_value = {}
+        get_mesos_master.return_value = fake_master
+
+        parse_args_patch.return_value = fake_args
+        load_marathon_config_patch.return_value = {"url": "http://foo"}
+        get_marathon_client_patch.return_value = Mock()
+
+        get_marathon_status_patch.side_effect = JSONDecodeError("y", "x", 100)
+
+        get_mesos_state_status_patch.return_value = []
+        get_mesos_resource_utilization_health_patch.return_value = []
+
+        with raises(SystemExit) as excinfo:
+            paasta_metastatus.main()
+        assert excinfo.value.code == 2


### PR DESCRIPTION
this will be reverted when
https://github.com/thefactory/marathon-python/pull/167 is merged, but
until then we need to catch this to fire off an alert when Marathon
can't agree on a leader