### PR TITLE
Add a get_mesos_leader script

### DIFF
--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -1,4 +1,5 @@
 opt/venvs/paasta-tools/bin/am_i_mesos_leader.py usr/bin/am_i_mesos_leader
+opt/venvs/paasta-tools/bin/get_mesos_leader.py usr/bin/get_mesos_leader
 opt/venvs/paasta-tools/bin/autoscale_all_services.py usr/bin/autoscale_all_services
 opt/venvs/paasta-tools/bin/paasta_autoscale_cluster usr/bin/paasta_autoscale_cluster
 opt/venvs/paasta-tools/bin/check_classic_service_replication.py usr/bin/check_classic_service_replication

--- a/paasta_tools/get_mesos_leader.py
+++ b/paasta_tools/get_mesos_leader.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# Copyright 2017 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Usage: ./get_mesos_leader.py
+
+Displays the hostname of the current mesos-master leader.
+"""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from sys import exit
+
+from paasta_tools.mesos_tools import get_mesos_leader
+from paasta_tools.utils import paasta_print
+
+
+def main():
+    paasta_print(get_mesos_leader())
+    exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/paasta_tools/get_mesos_leader.py
+++ b/paasta_tools/get_mesos_leader.py
@@ -28,7 +28,6 @@ from paasta_tools.utils import paasta_print
 
 def main():
     paasta_print(get_mesos_leader())
-    exit(0)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
         'paasta_tools/generate_deployments_for_service.py',
         'paasta_tools/generate_services_file.py',
         'paasta_tools/generate_services_yaml.py',
+        'paasta_tools/get_mesos_leader.py',
         'paasta_tools/list_marathon_service_instances.py',
         'paasta_tools/monitoring/check_classic_service_replication.py',
         'paasta_tools/monitoring/check_synapse_replication.py',


### PR DESCRIPTION
We have an `am_i_mesos_leader` script, but we don't have any easy way to get the hostname of the current leader. This change adds a new `get_mesos_leader` script to do that.

CC @somic @EvanKrall 