### PR TITLE
Ensure the cluster scaler jumps to min_capacity

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -459,6 +459,7 @@ class SpotAutoscaler(ClusterAutoscaler):
             ceil(current_capacity * (1.00 + MAX_CLUSTER_DELTA)),
             self.resource['max_capacity'],
         ))
+        new_capacity = max(new_capacity, self.resource['min_capacity'])
         self.log.debug("The ideal capacity to scale to is %d instances" % ideal_capacity)
         self.log.debug("The capacity we will scale to is %d instances" % new_capacity)
         if ideal_capacity > self.resource['max_capacity']:
@@ -584,6 +585,7 @@ class AsgAutoscaler(ClusterAutoscaler):
                 # if max and min set to 0 we still drain gradually
                 max(self.resource['max_capacity'], floor(current_capacity * (1.00 - MAX_CLUSTER_DELTA)))
             ))
+        new_capacity = max(new_capacity, self.resource['min_capacity'])
         self.log.debug("The ideal capacity to scale to is %d instances" % ideal_capacity)
         self.log.debug("The capacity we will scale to is %d instances" % new_capacity)
         if ideal_capacity > self.resource['max_capacity']:

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -244,6 +244,15 @@ class TestAsgAutoscaler(unittest.TestCase):
         ret = self.autoscaler.get_asg_delta(-0.5)
         assert ret == (20, int(floor(20 * (1.0 - autoscaling_cluster_lib.MAX_CLUSTER_DELTA))))
 
+        current_instances = int((10 * (1 - autoscaling_cluster_lib.MAX_CLUSTER_DELTA)) - 1)
+        self.autoscaler.resource = {
+            'min_capacity': 10,
+            'max_capacity': 40
+        }
+        self.autoscaler.asg = {'Instances': [mock.Mock()] * current_instances}
+        ret = self.autoscaler.get_asg_delta(-1)
+        assert ret == (current_instances, 10)
+
     def test_asg_metrics_provider(self):
         with contextlib.nested(
             mock.patch('paasta_tools.autoscaling.autoscaling_cluster_lib.AsgAutoscaler.get_asg_delta', autospec=True),
@@ -488,6 +497,15 @@ class TestSpotAutoscaler(unittest.TestCase):
         self.autoscaler.sfr = {'SpotFleetRequestConfig': {'FulfilledCapacity': 20}}
         ret = self.autoscaler.get_spot_fleet_delta(-0.5)
         assert ret == (20, int(floor(20 * (1.0 - autoscaling_cluster_lib.MAX_CLUSTER_DELTA))))
+
+        current_instances = (10 * (1 - autoscaling_cluster_lib.MAX_CLUSTER_DELTA)) - 1
+        self.autoscaler.resource = {
+            'min_capacity': 10,
+            'max_capacity': 40
+        }
+        self.autoscaler.sfr = {'SpotFleetRequestConfig': {'FulfilledCapacity': current_instances}}
+        ret = self.autoscaler.get_spot_fleet_delta(-1)
+        assert ret == (current_instances, 10)
 
     def test_spotfleet_metrics_provider(self):
         with contextlib.nested(


### PR DESCRIPTION
Fixes #979

We currently constrain to a `MAX_CLUSTER_DELTA` when scaling up or down.
This prevents sudden large changes when the autoscaler has made a
mistake. However, an operator increasing `min_capacity` on a resource
should trump this situation. This commit makes it so that we never set a
new capacity that is lower than the current `min_capacity`.