### PR TITLE
Catch 409 conflict when bouncing marathon apps

### DIFF
--- a/paasta_itests/setup_marathon_job.feature
+++ b/paasta_itests/setup_marathon_job.feature
@@ -8,6 +8,15 @@ Feature: setup_marathon_job can create a "complete" app
      Then we should see it in the list of apps
      Then we can run get_app
 
+  Scenario: duplicate create app does not fail with conflict
+    Given a working paasta cluster
+      And I have yelpsoa-configs for the marathon job "test-service.main"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
+     When we create a marathon app called "test-service.main" with 1 instance(s)
+     Then we should see it in the list of apps
+     Then we can run get_app
+     When we create a marathon app called "test-service.main" with 1 instance(s) with no apps found running
+
   Scenario: marathon apps can be scaled up
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"


### PR DESCRIPTION
In 0c950d0e43434222b598d8b8fc7da8c1383a666e we moved the lock in
`setup_marathon_job` to prevent race conditions between multiple bounce
loops which run at the same time. One motivation was seeing HTTP 409
conflicts from marathon when the bounce attempts to create the same app
twice. It turns out that this is still possible since we
`get_all_marathon_apps` outside the lock which can lead to two bounces
deciding to create the same app, resulting in HTTP 409 from marathon.

We could move this call into the lock but this would incurr a
performance hit as it would be called once per service instance. Instead
I am catching the error which I am pretty sure is safe. Essentially a
second bounce may decide it needs to create an app that already exists
but this is now a silent failure and the bounce will stop there.