### PR TITLE
Even more tests pass in python3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,6 @@
 [run]
 branch = True
-source =
-    paasta_tools
+source = .
 omit =
     .tox/*
     /usr/*
@@ -11,7 +10,12 @@ omit =
     paasta_tools/tron_timeutils.py
 
 [report]
+skip_covered = True
+show_missing = True
 exclude_lines =
+    # Have to re-enable the standard pragma
+    \#\s*pragma: no cover
+
     # Don't complain if tests don't hit defensive assertion code:
     ^\s*raise AssertionError\b
     ^\s*raise NotImplementedError\b

--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -160,7 +160,7 @@ def step_impl_then(context):
 @then('that deployments.json has a desired_state of "{expected_state}"')
 def step_impl_then_desired_state(context, expected_state):
     deployments = load_deployments_json('fake_deployments_json_service', soa_dir='fake_soa_configs')
-    latest = sorted(deployments.iteritems(), key=lambda kv: kv[1]['force_bounce'], reverse=True)[0][1]
+    latest = sorted(deployments.items(), key=lambda kv: kv[1]['force_bounce'], reverse=True)[0][1]
     desired_state = latest['desired_state']
     assert desired_state == expected_state, "actual: %s\nexpected: %s" % (desired_state, expected_state)
 

--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -131,7 +131,7 @@ def there_are_num_which_tasks(context, num, which, state, exact):
     app_id = which_id(context, which)
 
     # 120 * 0.5 = 60 seconds
-    for _ in xrange(120):
+    for _ in range(120):
         app = context.marathon_client.get_app(app_id, embed_tasks=True)
         happy_tasks = get_happy_tasks(app, context.service, "fake_nerve_ns", context.system_paasta_config)
         happy_count = len(happy_tasks)
@@ -193,7 +193,7 @@ def when_setup_service_initiated(context):
         mock_get_secret.return_value = credentials.secret
         mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value=context.cluster)
         # 120 * 0.5 = 60 seconds
-        for _ in xrange(120):
+        for _ in range(120):
             try:
                 marathon_apps = marathon_tools.get_all_marathon_apps(context.marathon_client, embed_failures=True)
                 (code, message) = setup_marathon_job.setup_service(
@@ -230,7 +230,7 @@ def then_the_which_app_should_be_running(context, which):
 def then_the_which_app_should_be_configured_to_have_num_instances(context, which, num, retries=10):
     app_id = which_id(context, which)
 
-    for _ in xrange(retries):
+    for _ in range(retries):
         app = context.marathon_client.get_app(app_id)
         if app.instances == int(num):
             return
@@ -248,7 +248,7 @@ def then_the_which_app_should_be_gone(context, which):
 def and_we_wait_a_bit_for_the_app_to_disappear(context, which):
     """ Marathon will not make the app disappear until after all the tasks have died
     https://github.com/mesosphere/marathon/issues/1431 """
-    for _ in xrange(10):
+    for _ in range(10):
         if marathon_tools.is_app_id_running(which_id(context, which), context.marathon_client) is True:
             time.sleep(0.5)
         else:

--- a/paasta_itests/steps/chronos_steps.py
+++ b/paasta_itests/steps/chronos_steps.py
@@ -90,7 +90,7 @@ def chronos_check_running_tasks(context, job_name, has_or_not):
     # to get more detailed per-job task information from Chronos
     job_id = context.jobs[job_name]['name']
     service, instance = chronos_tools.decompose_job_id(job_id)
-    for _ in xrange(10):
+    for _ in range(10):
         status = chronos_tools.get_chronos_status_for_job(context.chronos_client, service, instance)
         if has_or_not == "has no":
             if status == "idle":

--- a/paasta_itests/steps/marathon_steps.py
+++ b/paasta_itests/steps/marathon_steps.py
@@ -64,7 +64,7 @@ def marathon_services_running_here_works(context):
 @when('the task has started')
 def when_the_task_has_started(context):
     # 120 * 0.5 = 60 seconds
-    for _ in xrange(120):
+    for _ in range(120):
         app = context.marathon_client.get_app(APP_ID)
         happy_count = app.tasks_running
         if happy_count >= 3:

--- a/paasta_itests/steps/paasta_native_steps.py
+++ b/paasta_itests/steps/paasta_native_steps.py
@@ -78,7 +78,7 @@ def start_paasta_native_framework(context, reconcile_backoff):
     if not hasattr(context, 'framework_ids'):
         context.framework_ids = []
 
-    for _ in xrange(10):
+    for _ in range(10):
         if context.scheduler.framework_id:
             context.framework_ids.append(context.scheduler.framework_id)
             break
@@ -91,7 +91,7 @@ def start_paasta_native_framework(context, reconcile_backoff):
 def should_eventually_start_num_tasks(context, num):
     num = int(num)
 
-    for _ in xrange(20):
+    for _ in range(20):
         actual_num = len([p for p in context.scheduler.tasks_with_flags.values() if p.mesos_task_state == TASK_RUNNING])
         if actual_num >= num:
             return
@@ -199,7 +199,7 @@ def we_change_force_bounce_back(context):
 @then('it should eventually drain {num} tasks')
 def it_should_drain_num_tasks(context, num):
     num = int(num)
-    for _ in xrange(10):
+    for _ in range(10):
         if len(drain_lib.TestDrainMethod.downed_task_ids) >= num:
             # set() to make a copy.
             context.drained_tasks = set(drain_lib.TestDrainMethod.downed_task_ids)
@@ -217,7 +217,7 @@ def it_should_undrain_and_drain(context, num_undrain_expected, num_drain_expecte
     num_undrain_expected = int(num_undrain_expected)
     num_drain_expected = int(num_drain_expected)
 
-    for _ in xrange(10):
+    for _ in range(10):
         paasta_print("currently drained: %r" % drain_lib.TestDrainMethod.downed_task_ids)
         paasta_print("drained previously: %r" % context.drained_tasks)
         num_drained = len(drain_lib.TestDrainMethod.downed_task_ids - context.drained_tasks)
@@ -238,7 +238,7 @@ def it_should_undrain_and_drain(context, num_undrain_expected, num_drain_expecte
 def it_should_eventually_have_only_num_tasks(context, num):
     num = int(num)
 
-    for _ in xrange(30):
+    for _ in range(30):
         actual_num = len([p for p in context.scheduler.tasks_with_flags.values() if p.mesos_task_state == TASK_RUNNING])
         if actual_num <= num:
             return
@@ -268,7 +268,7 @@ def should_not_start_tasks_for_num_seconds(context, num):
 
 @then('periodic() should eventually be called')
 def periodic_should_eventually_be_called(context):
-    for _ in xrange(30):
+    for _ in range(30):
         for scheduler in context.main_schedulers:
             if hasattr(scheduler, 'periodic_was_called'):
                 return

--- a/paasta_itests/steps/setup_chronos_job_steps.py
+++ b/paasta_itests/steps/setup_chronos_job_steps.py
@@ -57,7 +57,7 @@ def check_exit_code(context, expected_exit_code):
 
 @when('we create {job_count:d} disabled jobs that look like the job stored as "{job_name}"')
 def old_jobs_leftover(context, job_count, job_name):
-    for i in xrange(job_count):
+    for i in range(job_count):
         job_definition = copy.deepcopy(context.jobs[job_name])
         # modify the name by replacing the last character in the config hash
         modified_name = "%s%s" % (job_definition['name'][:-1], i)

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -89,7 +89,7 @@ def set_number_instances(context, number):
 
 @when('we run setup_marathon_job until it has {number:d} task(s)')
 def run_until_number_tasks(context, number):
-    for _ in xrange(20):
+    for _ in range(20):
         with contextlib.nested(
             mock.patch('paasta_tools.mesos_maintenance.load_credentials', autospec=True),
         ) as (

--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -189,8 +189,8 @@ def get_http_utilization_for_all_tasks(marathon_service_config, marathon_tasks, 
             log.debug("Recieved a timeout when querying %s on %s:%s. Assuming the service is at full utilization." % (
                 marathon_service_config.get_service(), task.host, task.ports[0]))
         except Exception as e:
-            log.debug("Caught excpetion when querying %s on %s:%s : '%s'" % (
-                marathon_service_config.get_service(), task.host, task.ports[0], e.message))
+            log.debug("Caught exception when querying %s on %s:%s : %s" % (
+                marathon_service_config.get_service(), task.host, task.ports[0], str(e)))
     if not utilization:
         raise MetricsProviderNoDataError("Couldn't get any data from http endpoint %s for %s.%s" % (
             endpoint, marathon_service_config.service, marathon_service_config.instance))

--- a/paasta_tools/cleanup_marathon_jobs.py
+++ b/paasta_tools/cleanup_marathon_jobs.py
@@ -58,7 +58,7 @@ class DontKillEverythingError(Exception):
     pass
 
 
-def parse_args():
+def parse_args(argv):
     parser = argparse.ArgumentParser(description='Cleans up stale marathon jobs.')
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
                         default=DEFAULT_SOA_DIR,
@@ -73,8 +73,7 @@ def parse_args():
                         dest="force", default=False,
                         help="Force the cleanup if we are above the "
                              "kill_threshold")
-    args = parser.parse_args()
-    return args
+    return parser.parse_args(argv)
 
 
 def delete_app(app_id, client, soa_dir):
@@ -178,8 +177,8 @@ def cleanup_apps(soa_dir, kill_threshold=0.5, force=False):
         )
 
 
-def main():
-    args = parse_args()
+def main(argv=None):
+    args = parse_args(argv)
     soa_dir = args.soa_dir
     kill_threshold = args.kill_threshold
     force = args.force

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -369,7 +369,7 @@ def get_container_name():
 def get_docker_run_cmd(memory, random_port, container_name, volumes, env, interactive,
                        docker_hash, command, net, docker_params):
     cmd = ['docker', 'run']
-    for k, v in env.iteritems():
+    for k, v in env.items():
         cmd.append('--env=\"%s=%s\"' % (k, v))
     cmd.append('--memory=%dm' % memory)
     for i in docker_params:

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -796,7 +796,7 @@ class ScribeLogReader(LogReader):
                             line = {'raw_line': line, 'sort_key': timestamp}
                             aggregated_logs.append(line)
             except StreamTailerSetupError as e:
-                if 'No data in stream' in e.message:
+                if 'No data in stream' in str(e):
                     log.warning("Scribe stream %s is empty on %s" % (stream_name, scribe_env))
                     log.warning("Don't Panic! This may or may not be a problem depending on if you expect there to be")
                     log.warning("output within this stream.")
@@ -869,7 +869,7 @@ class ScribeLogReader(LogReader):
             # traces.
             pass
         except StreamTailerSetupError as e:
-            if 'No data in stream' in e.message:
+            if 'No data in stream' in str(e):
                 log.warning("Scribe stream %s is empty on %s" % (stream_name, scribe_env))
                 log.warning("Don't Panic! This may or may not be a problem depending on if you expect there to be")
                 log.warning("output within this stream.")
@@ -1152,7 +1152,7 @@ def paasta_logs(args):
     try:
         start_time, end_time = generate_start_end_time(args.time_from, args.time_to)
     except ValueError as e:
-        paasta_print(PaastaColors.red(e.message), file=sys.stderr)
+        paasta_print(PaastaColors.red(str(e)), file=sys.stderr)
         return 1
 
     log_reader.print_logs_by_time(

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -295,7 +295,7 @@ def instances_deployed(cluster_data, instances_out, green_light):
     num_threads = min(5, cluster_data.instances_queue.qsize())
 
     workers_launched = []
-    for _ in xrange(num_threads):
+    for _ in range(num_threads):
         worker = Thread(target=_run_instance_worker,
                         args=(cluster_data, instances_out, green_light))
         worker.start()

--- a/paasta_tools/cli/cmds/rerun.py
+++ b/paasta_tools/cli/cmds/rerun.py
@@ -145,7 +145,7 @@ def paasta_rerun(args):
                               "please supply a `--execution_date` argument." % args.instance))
                 continue
         except NoConfigurationForServiceError as e:
-            paasta_print("  Warning: %s" % e.message)
+            paasta_print("  Warning: %s" % e)
             continue
         if execution_date is None:
             execution_date = _get_default_execution_date()

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -80,7 +80,7 @@ def get_schema(file_type):
     """
     schema_path = 'schemas/%s_schema.json' % file_type
     try:
-        schema = pkgutil.get_data('paasta_tools.cli', schema_path)
+        schema = pkgutil.get_data('paasta_tools.cli', schema_path).decode()
     except IOError:
         return None
     return json.loads(schema)

--- a/paasta_tools/cli/cmds/wait_for_deployment.py
+++ b/paasta_tools/cli/cmds/wait_for_deployment.py
@@ -122,8 +122,11 @@ def get_latest_marked_sha(git_url, deploy_group):
     refs = list_remote_refs(git_url)
     last_ref = ''
     for ref in refs:
-        if (ref.startswith('refs/tags/paasta-{}-'.format(deploy_group)) and
-                ref.endswith('-deploy')) and ref > last_ref:
+        if (
+            ref.startswith('refs/tags/paasta-{}-'.format(deploy_group)) and
+            ref.endswith('-deploy') and
+            ref > last_ref
+        ):
             last_ref = ref
     return refs[last_ref] if last_ref else ''
 

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -99,7 +99,7 @@ def get_latest_deployment_tag(refs, deploy_group):
     most_recent_dtime = None
     most_recent_ref = None
     most_recent_sha = None
-    pattern = re.compile("^refs/tags/paasta-%s-(\d{8}T\d{6})-deploy$" % deploy_group)
+    pattern = re.compile('^refs/tags/paasta-%s-(\d{8}T\d{6})-deploy$' % deploy_group)
 
     for ref_name, sha in refs.items():
         match = pattern.match(ref_name)

--- a/paasta_tools/generate_services_file.py
+++ b/paasta_tools/generate_services_file.py
@@ -35,7 +35,7 @@ from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 
 
-YOCALHOST = b'169.254.255.254'
+YOCALHOST = '169.254.255.254'
 
 
 def parse_args():
@@ -76,7 +76,7 @@ def write_yaml_file(filename):
                 now=datetime.now().isoformat(),
             ),
         )
-        yaml.dump(
+        yaml.safe_dump(
             configuration,
             fp,
             indent=2,
@@ -93,9 +93,9 @@ def generate_configuration():
         proxy_port = data.get('proxy_port')
         if proxy_port is None:
             continue
-        config[name.encode('utf-8')] = {
-            b'host': YOCALHOST,
-            b'port': int(proxy_port),
+        config[name] = {
+            'host': YOCALHOST,
+            'port': int(proxy_port),
         }
     return config
 

--- a/paasta_tools/generate_services_yaml.py
+++ b/paasta_tools/generate_services_yaml.py
@@ -24,7 +24,7 @@ import yaml
 from paasta_tools.marathon_tools import get_all_namespaces
 from paasta_tools.utils import atomic_file_write
 
-YOCALHOST = b'169.254.255.254'
+YOCALHOST = '169.254.255.254'
 
 
 def generate_configuration():
@@ -35,9 +35,9 @@ def generate_configuration():
         proxy_port = data.get('proxy_port')
         if proxy_port is None:
             continue
-        config[name.encode('utf-8')] = {
-            b'host': YOCALHOST,
-            b'port': int(proxy_port),
+        config[name] = {
+            'host': YOCALHOST,
+            'port': int(proxy_port),
         }
 
     return config
@@ -58,7 +58,7 @@ def main(argv=None):
                 now=datetime.now().isoformat(),
             ),
         )
-        yaml.dump(
+        yaml.safe_dump(
             configuration,
             fp,
             indent=2,

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -475,7 +475,7 @@ class MarathonDeployStatus:
 
     @classmethod
     def tostring(cls, val):
-        for k, v in vars(cls).iteritems():
+        for k, v in vars(cls).items():
             if v == val:
                 return k
 
@@ -715,7 +715,7 @@ def get_puppet_services_that_run_here():
 
 def get_puppet_services_running_here_for_nerve(soa_dir):
     puppet_services = []
-    for service, namespaces in sorted(get_puppet_services_that_run_here().iteritems()):
+    for service, namespaces in sorted(get_puppet_services_that_run_here().items()):
         for namespace in namespaces:
             puppet_services.append(
                 _namespaced_get_classic_service_information_for_nerve(

--- a/paasta_tools/mesos/cfg.py
+++ b/paasta_tools/mesos/cfg.py
@@ -101,7 +101,7 @@ class Config(object):
                 except ValueError as e:
                     raise ValueError(
                         'Invalid %s JSON: %s [%s]' %
-                        (type(self).__name__, e.message, self._get_path())
+                        (type(self).__name__, str(e), self._get_path())
                     )
                 self.__items.update(data)
         except IOError as e:

--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -161,10 +161,11 @@ class MesosMaster(object):
         return lst[0]
 
     def slaves(self, fltr=""):
-        return list(map(
-            lambda x: slave.MesosSlave(self.config, x),
-            itertools.ifilter(
-                lambda x: fltr == x['id'], self.state['slaves'])))
+        return [
+            slave.MesosSlave(self.config, x)
+            for x in self.state['slaves']
+            if fltr == x['id']
+        ]
 
     def _task_list(self, active_only=False):
         keys = ["tasks"]
@@ -193,11 +194,11 @@ class MesosMaster(object):
 
     # XXX - need to filter on task state as well as id
     def tasks(self, fltr="", active_only=False):
-        return list(map(
-            lambda x: task.Task(self, x),
-            itertools.ifilter(
-                lambda x: fltr in x["id"] or fnmatch.fnmatch(x["id"], fltr),
-                self._task_list(active_only))))
+        return [
+            task.Task(self, x)
+            for x in self._task_list(active_only)
+            if fltr in x['id'] or fnmatch.fnmatch(x['id'], fltr)
+        ]
 
     def framework(self, fwid):
         return list(filter(

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -292,7 +292,7 @@ def format_stdstreams_tail_for_task(task, get_short_task_id, nlines=10):
             # mesos.cli is smart and can efficiently read a file backwards
             reversed_file = reversed(fobj)
             tail = []
-            for _ in xrange(nlines):
+            for _ in range(nlines):
                 line = next(reversed_file, None)
                 if line is None:
                     break
@@ -305,7 +305,7 @@ def format_stdstreams_tail_for_task(task, get_short_task_id, nlines=10):
             mesos_exceptions.SlaveDoesNotExist,
             mesos_exceptions.TaskNotFoundException,
             mesos_exceptions.FileNotFoundForTaskException) as e:
-        output.append(error_message % (get_short_task_id(task['id']), e.message))
+        output.append(error_message % (get_short_task_id(task['id']), str(e)))
     except TimeoutError:
         output.append(error_message % (get_short_task_id(task['id']), 'timeout'))
     return output
@@ -319,7 +319,7 @@ def zip_tasks_verbose_output(table, stdstreams):
     if len(table) != len(stdstreams):
         raise ValueError('Can only zip same-length lists')
     output = []
-    for i in xrange(len(table)):
+    for i in range(len(table)):
         output.append(table[i])
         output.extend([line for line in stdstreams[i]])
     return output
@@ -431,7 +431,7 @@ def get_local_slave_state():
         raise MesosSlaveConnectionError(
             'Could not connect to the mesos slave to see which services are running\n'
             'on %s. Is the mesos-slave running?\n'
-            'Error was: %s\n' % (e.request.url, e.message)
+            'Error was: %s\n' % (e.request.url, str(e))
         )
     response.raise_for_status()
     return json.loads(response.text)

--- a/paasta_tools/metrics/metastatus_lib.py
+++ b/paasta_tools/metrics/metastatus_lib.py
@@ -228,7 +228,7 @@ def assert_no_duplicate_frameworks(state):
     output = ["Frameworks:"]
     ok = True
 
-    for framework, count in framework_counts.iteritems():
+    for framework, count in framework_counts.items():
         if count > 1:
             ok = False
             output.append("    CRITICAL: Framework %s has %d instances running--expected no more than 1."

--- a/paasta_tools/monitoring/check_classic_service_replication.py
+++ b/paasta_tools/monitoring/check_classic_service_replication.py
@@ -170,10 +170,10 @@ class ClassicServiceReplicationCheck(SensuPluginCheck):
         except Exception as e:
             self.log.error(
                 'Unable to collect replication information on {0}: {1}'.
-                format(synapse_host_port, e.message))
+                format(synapse_host_port, str(e)))
             self.critical(
                 'Unable to collect replication information: {0}'.
-                format(e.message))
+                format(str(e)))
         self.log.debug(
             "Finished gathering replication information from {0}".
             format(synapse_host_port))
@@ -191,7 +191,7 @@ class ClassicServiceReplicationCheck(SensuPluginCheck):
         )
 
         checked_services = []
-        for service, service_config in all_service_config.iteritems():
+        for service, service_config in all_service_config.items():
             do_monitoring, monitoring_config = extract_replication_info(
                 service_config
             )

--- a/paasta_tools/monitoring/check_synapse_replication.py
+++ b/paasta_tools/monitoring/check_synapse_replication.py
@@ -136,7 +136,7 @@ def run_synapse_check():
         )
 
         all_codes = []
-        for name, replication in service_replications.iteritems():
+        for name, replication in service_replications.items():
             code, message = check_replication(name, replication,
                                               options.warn, options.crit)
             all_codes.append(code)

--- a/paasta_tools/native_mesos_scheduler.py
+++ b/paasta_tools/native_mesos_scheduler.py
@@ -139,7 +139,7 @@ class PaastaScheduler(mesos.interface.Scheduler):
     def need_more_tasks(self, name):
         """Returns whether we need to start more tasks."""
         num_have = 0
-        for task, parameters in self.tasks_with_flags.iteritems():
+        for task, parameters in self.tasks_with_flags.items():
             if self.is_task_new(name, task) and (parameters.mesos_task_state in LIVE_TASK_STATES):
                 num_have += 1
         return num_have < self.service_config.get_desired_instances()
@@ -297,7 +297,7 @@ class PaastaScheduler(mesos.interface.Scheduler):
         for task in actions['tasks_to_drain']:
             self.drain_task(task)
 
-        for task in [task for task, parameters in self.tasks_with_flags.iteritems() if parameters.is_draining]:
+        for task in [task for task, parameters in self.tasks_with_flags.items() if parameters.is_draining]:
             if self.drain_method.is_safe_to_kill(DrainTask(id=task)):
                 self.kill_task(driver, task)
 
@@ -312,7 +312,7 @@ class PaastaScheduler(mesos.interface.Scheduler):
 
     def get_draining_tasks(self, tasks):
         """Filter a list of tasks to those that are draining."""
-        return [t for t, p in self.tasks_with_flags.iteritems() if p.is_draining]
+        return [t for t, p in self.tasks_with_flags.items() if p.is_draining]
 
     def undrain_task(self, task):
         self.drain_method.stop_draining(DrainTask(id=task))

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -41,7 +41,7 @@ logging.basicConfig()
 logging.getLogger("kazoo").setLevel(logging.CRITICAL)
 
 
-def parse_args():
+def parse_args(argv):
     parser = argparse.ArgumentParser(
         description='',
     )
@@ -60,13 +60,13 @@ def parse_args():
                         help="Print out more output regarding the state of the cluster")
     parser.add_argument('-H', '--humanize', action='store_true', dest="humanize", default=False,
                         help="Print human-readable sizes")
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
-def main():
+def main(argv=None):
     marathon_config = None
     chronos_config = None
-    args = parse_args()
+    args = parse_args(argv)
 
     master = get_mesos_master()
     try:
@@ -74,7 +74,7 @@ def main():
     except MasterNotAvailableException as e:
         # if we can't connect to master at all,
         # then bomb out early
-        paasta_print(PaastaColors.red("CRITICAL:  %s" % e.message))
+        paasta_print(PaastaColors.red("CRITICAL:  %s" % str(e)))
         sys.exit(2)
 
     mesos_state_status = metastatus_lib.get_mesos_state_status(

--- a/paasta_tools/remote_git.py
+++ b/paasta_tools/remote_git.py
@@ -64,7 +64,8 @@ def list_remote_refs(git_url):
     """Get the refs from a remote git repo as a dictionary of name->hash."""
     client, path = dulwich.client.get_transport_and_path(git_url)
     try:
-        return client.fetch_pack(path, lambda refs: [], None, None)
+        refs = client.fetch_pack(path, lambda refs: [], None, lambda data: None)
+        return {k.decode(): v.decode() for k, v in refs.items()}
     except dulwich.errors.HangupException as e:
         raise LSRemoteException("Unable to fetch remote refs: %s" % e)
 

--- a/paasta_tools/smartstack_tools.py
+++ b/paasta_tools/smartstack_tools.py
@@ -162,7 +162,7 @@ def get_smartstack_replication_for_attribute(attribute, service, namespace, blac
 
     full_name = compose_job_id(service, namespace)
 
-    for value, hosts in attribute_slave_dict.iteritems():
+    for value, hosts in attribute_slave_dict.items():
         # arbitrarily choose the first host with a given attribute to query for replication stats
         synapse_host = hosts[0]['hostname']
         repl_info = get_replication_for_services(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1726,9 +1726,20 @@ def prompt_pick_one(sequence, choosing):
         return result
 
 
+def _to_bytes(obj):
+    if isinstance(obj, bytes):
+        return obj
+    elif isinstance(obj, six.text_type):
+        return obj.encode('UTF-8')
+    else:
+        return six.text_type(obj).encode('UTF-8')
+
+
 def paasta_print(*args, **kwargs):
-    args = (
-        s.encode('utf-8') if isinstance(s, six.text_type) else s
-        for s in args
-    )
-    print(*args, **kwargs)
+    f = kwargs.pop('file', sys.stdout)
+    f = getattr(f, 'buffer', f)
+    end = _to_bytes(kwargs.pop('end', '\n'))
+    sep = _to_bytes(kwargs.pop('sep', ' '))
+    assert not kwargs, kwargs
+    to_print = sep.join(_to_bytes(x) for x in args) + end
+    f.write(to_print)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+coverage
 docutils==0.12
 flake8==2.5.0
 mock==2.0.0
@@ -6,5 +7,4 @@ pep8==1.5.7
 pre-commit==0.12.1
 pylint==1.6.4
 pytest==2.7.3
-pytest-cov==2.2.0
 sphinx==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ chronos-python==0.37.0
 cookiecutter==1.4.0
 cryptography==1.4
 docker-py==1.2.3
-dulwich==0.10.0
+dulwich==0.16.3
 ephemeral-port-reserve==1.0.1
 future>=0.15.2
 futures==3.0.1

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         # Don't update this unless you have confirmed the client works with
         # the Docker version deployed on PaaSTA servers
         'docker-py == 1.2.3',
-        'dulwich == 0.10.0',
+        'dulwich',
         'ephemeral-port-reserve >= 1.0.1',
         'futures',
         'gevent == 1.1.1',

--- a/tests.py
+++ b/tests.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
-from paasta_tools.utils import paasta_print
-
-paasta_print('🔥')
-paasta_print(unicode('🔥:'))

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -130,7 +130,10 @@ def test_instance_tasks(mock_get_tasks_from_app_id, mock_instance_status, mock_a
                                           mock.call(mock_add_executor_info.return_value)])
     expected = [mock_add_slave_info.return_value._Task__items,
                 mock_add_slave_info.return_value._Task__items]
-    assert len(ret) == len(expected) and sorted(expected) == sorted(ret)
+
+    def ids(l):
+        return {id(x) for x in l}
+    assert len(ret) == len(expected) and ids(expected) == ids(ret)
 
     mock_instance_status.return_value = {'chronos': {}}
     with raises(ApiFailure):
@@ -162,11 +165,6 @@ def test_instance_task(mock_get_task, mock_instance_status, mock_add_slave_info,
     mock_instance_status.return_value = {'chronos': {}}
     with raises(ApiFailure):
         ret = instance.instance_task(mock_request)
-
-
-def mock_getitem(key):
-    if key == 'id':
-        return 'fakeID'
 
 
 def test_add_executor_info():

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -967,12 +967,11 @@ class TestClusterAutoscaler(unittest.TestCase):
             assert ret == ['10.1.1.1', '10.2.2.2']
 
     def mock_pid_to_ip_side(self, pid):
-        if pid == 'slave(1)@10.1.1.1:5051':
-            return '10.1.1.1'
-        elif pid == 'slave(2)@10.2.2.2:5051':
-            return '10.2.2.2'
-        elif pid == 'slave(3)@10.3.3.3:5051':
-            return '10.3.3.3'
+        return {
+            'slave(1)@10.1.1.1:5051': '10.1.1.1',
+            'slave(2)@10.2.2.2:5051': '10.2.2.2',
+            'slave(3)@10.3.3.3:5051': '10.3.3.3',
+        }[pid]
 
     def test_filter_aws_slaves(self):
         with contextlib.nested(

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -349,7 +349,8 @@ def test_get_http_utilization_for_all_tasks_no_data():
         branch_dict={},
     )
     fake_marathon_tasks = [mock.Mock(id='fake-service.fake-instance', host='fake_host', ports=[30101])]
-    mock_json_mapper = mock.Mock(side_effect=KeyError('Detailed message'))  # KeyError simulates an invalid response
+    # KeyError simulates an invalid response
+    mock_json_mapper = mock.Mock(side_effect=KeyError(str('Detailed message')))
 
     with contextlib.nested(
         mock.patch('paasta_tools.autoscaling.autoscaling_service_lib.log.debug', autospec=True),
@@ -366,7 +367,7 @@ def test_get_http_utilization_for_all_tasks_no_data():
                 json_mapper=mock_json_mapper,
             )
         mock_log_debug.assert_called_once_with(
-            "Caught excpetion when querying fake-service on fake_host:30101 : 'Detailed message'")
+            "Caught exception when querying fake-service on fake_host:30101 : 'Detailed message'")
 
 
 def test_http_metrics_provider():
@@ -529,7 +530,7 @@ def test_autoscale_marathon_instance_below_min_instances():
         _,
     ):
         autoscaling_service_lib.autoscale_marathon_instance(fake_marathon_service_config,
-                                                            [mock.Mock() for i in xrange(current_instances)],
+                                                            [mock.Mock() for i in range(current_instances)],
                                                             [mock.Mock()])
         mock_set_instances_for_marathon_service.assert_called_once_with(
             service='fake-service', instance='fake-instance', instance_count=5)
@@ -563,7 +564,7 @@ def test_autoscale_marathon_instance_above_max_instances():
         _,
     ):
         autoscaling_service_lib.autoscale_marathon_instance(fake_marathon_service_config,
-                                                            [mock.Mock() for i in xrange(current_instances)],
+                                                            [mock.Mock() for i in range(current_instances)],
                                                             [mock.Mock()])
         mock_set_instances_for_marathon_service.assert_called_once_with(
             service='fake-service', instance='fake-instance', instance_count=10)
@@ -597,7 +598,7 @@ def test_autoscale_marathon_instance_drastic_downscaling():
         _,
     ):
         autoscaling_service_lib.autoscale_marathon_instance(fake_marathon_service_config,
-                                                            [mock.Mock() for i in xrange(current_instances)],
+                                                            [mock.Mock() for i in range(current_instances)],
                                                             [mock.Mock()])
         mock_set_instances_for_marathon_service.assert_called_once_with(
             service='fake-service', instance='fake-instance', instance_count=int(current_instances * 0.7))

--- a/tests/cli/fsm/test_autosuggest.py
+++ b/tests/cli/fsm/test_autosuggest.py
@@ -22,7 +22,7 @@ from paasta_tools.cli.fsm import autosuggest
 
 class TestGetSmartstackProxyPortFromFile:
     def test_multiple_stanzas_per_file(self):
-        with mock.patch("__builtin__.open", autospec=True):
+        with mock.patch('six.moves.builtins.open', autospec=True):
             with mock.patch("paasta_tools.cli.fsm.autosuggest.yaml", autospec=True) as mock_yaml:
                 mock_yaml.safe_load.return_value = {
                     "main": {

--- a/tests/cli/test_cmds_check.py
+++ b/tests/cli/test_cmds_check.py
@@ -14,7 +14,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import contextlib
 import os
 
 from mock import call
@@ -97,7 +96,7 @@ def test_check_paasta_check_calls_everything(
 
 
 @patch('paasta_tools.cli.cmds.check.validate_service_name', autospec=True)
-def test_check_service_dir_check_pass(mock_validate_service_name, capsys):
+def test_check_service_dir_check_pass(mock_validate_service_name, capfd):
     mock_validate_service_name.return_value = None
     service = 'fake_service'
     soa_dir = '/fake_yelpsoa_configs'
@@ -105,12 +104,12 @@ def test_check_service_dir_check_pass(mock_validate_service_name, capsys):
         "%s\n" % PaastaCheckMessages.service_dir_found(service, soa_dir)
     service_dir_check(service, soa_dir)
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.validate_service_name', autospec=True)
-def test_check_service_dir_check_fail(mock_validate_service_name, capsys):
+def test_check_service_dir_check_fail(mock_validate_service_name, capfd):
     service = 'fake_service'
     soa_dir = '/fake_yelpsoa_configs'
     mock_validate_service_name.side_effect = NoSuchService(service)
@@ -118,12 +117,12 @@ def test_check_service_dir_check_fail(mock_validate_service_name, capsys):
                       % PaastaCheckMessages.service_dir_missing(service, soa_dir)
     service_dir_check(service, soa_dir)
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-def test_check_deploy_check_pass(mock_is_file_in_dir, capsys):
+def test_check_deploy_check_pass(mock_is_file_in_dir, capfd):
     # Deploy check passes when file found in service path
 
     mock_is_file_in_dir.return_value = True
@@ -131,12 +130,12 @@ def test_check_deploy_check_pass(mock_is_file_in_dir, capsys):
     deploy_check('service_path')
     expected_output = "%s\n" % PaastaCheckMessages.DEPLOY_YAML_FOUND
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-def test_check_deploy_check_fail(mock_is_file_in_dir, capsys):
+def test_check_deploy_check_fail(mock_is_file_in_dir, capfd):
     # Deploy check fails when file not in service path
 
     mock_is_file_in_dir.return_value = False
@@ -144,32 +143,32 @@ def test_check_deploy_check_fail(mock_is_file_in_dir, capsys):
     deploy_check('service_path')
     expected_output = "%s\n" % PaastaCheckMessages.DEPLOY_YAML_MISSING
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-def test_check_docker_exists_and_is_valid(mock_is_file_in_dir, capsys):
+def test_check_docker_exists_and_is_valid(mock_is_file_in_dir, capfd):
     mock_is_file_in_dir.return_value = "/fake/path"
 
     docker_check()
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert PaastaCheckMessages.DOCKERFILE_FOUND in output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-def test_check_docker_check_file_not_found(mock_is_file_in_dir, capsys):
+def test_check_docker_check_file_not_found(mock_is_file_in_dir, capfd):
     mock_is_file_in_dir.return_value = False
 
     docker_check()
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert PaastaCheckMessages.DOCKERFILE_MISSING in output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-def test_check_yaml_check_pass(mock_is_file_in_dir, capsys):
+def test_check_yaml_check_pass(mock_is_file_in_dir, capfd):
     # marathon.yaml exists and is valid
 
     mock_is_file_in_dir.return_value = "/fake/path"
@@ -178,12 +177,12 @@ def test_check_yaml_check_pass(mock_is_file_in_dir, capsys):
 
     yaml_check('path')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-def test_check_yaml_check_fail(mock_is_file_in_dir, capsys):
+def test_check_yaml_check_fail(mock_is_file_in_dir, capfd):
     # marathon.yaml exists and is valid
 
     mock_is_file_in_dir.return_value = False
@@ -191,13 +190,13 @@ def test_check_yaml_check_fail(mock_is_file_in_dir, capsys):
 
     yaml_check('path')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
 @patch('paasta_tools.cli.cmds.check.get_team', autospec=True)
-def test_check_sensu_check_pass(mock_get_team, mock_is_file_in_dir, capsys):
+def test_check_sensu_check_pass(mock_get_team, mock_is_file_in_dir, capfd):
     # monitoring.yaml exists and team is found
 
     mock_is_file_in_dir.return_value = "/fake/path"
@@ -208,7 +207,7 @@ def test_check_sensu_check_pass(mock_get_team, mock_is_file_in_dir, capsys):
 
     sensu_check(service='fake_service', service_path='path', soa_dir='path')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == expected_output
     mock_get_team.assert_called_once_with(service='fake_service', overrides={},
                                           soa_dir='path')
@@ -216,7 +215,7 @@ def test_check_sensu_check_pass(mock_get_team, mock_is_file_in_dir, capsys):
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
 @patch('paasta_tools.cli.cmds.check.get_team', autospec=True)
-def test_check_sensu_team_missing(mock_get_team, mock_is_file_in_dir, capsys):
+def test_check_sensu_team_missing(mock_get_team, mock_is_file_in_dir, capfd):
     # monitoring.yaml exists but team is not found
 
     mock_is_file_in_dir.return_value = "/fake/path"
@@ -226,12 +225,12 @@ def test_check_sensu_team_missing(mock_get_team, mock_is_file_in_dir, capsys):
 
     sensu_check(service='fake_service', service_path='path', soa_dir='path')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-def test_check_sensu_check_fail(mock_is_file_in_dir, capsys):
+def test_check_sensu_check_fail(mock_is_file_in_dir, capfd):
     # monitoring.yaml doest exist
 
     mock_is_file_in_dir.return_value = False
@@ -239,7 +238,7 @@ def test_check_sensu_check_fail(mock_is_file_in_dir, capsys):
 
     sensu_check(service='fake_service', service_path='path', soa_dir='path')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == expected_output
 
 
@@ -247,7 +246,7 @@ def test_check_sensu_check_fail(mock_is_file_in_dir, capsys):
        'read_service_configuration', autospec=True)
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
 def test_check_smartstack_check_pass(
-        mock_is_file_in_dir, mock_read_service_info, capsys,
+        mock_is_file_in_dir, mock_read_service_info, capfd,
 ):
     # smartstack.yaml exists and port is found
 
@@ -269,7 +268,7 @@ def test_check_smartstack_check_pass(
 
     smartstack_check(service='fake_service', service_path='path', soa_dir='path')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == expected_output
 
 
@@ -277,7 +276,7 @@ def test_check_smartstack_check_pass(
        'read_service_configuration', autospec=True)
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
 def test_check_smartstack_check_missing_port(
-        mock_is_file_in_dir, mock_read_service_info, capsys,
+        mock_is_file_in_dir, mock_read_service_info, capfd,
 ):
     # smartstack.yaml, instance exists, but no ports found
 
@@ -295,7 +294,7 @@ def test_check_smartstack_check_missing_port(
 
     smartstack_check(service='fake_service', service_path='path', soa_dir='path')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == expected_output
 
 
@@ -303,7 +302,7 @@ def test_check_smartstack_check_missing_port(
        'read_service_configuration', autospec=True)
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
 def test_check_smartstack_check_missing_instance(
-        mock_is_file_in_dir, mock_read_service_info, capsys):
+        mock_is_file_in_dir, mock_read_service_info, capfd):
     # smartstack.yaml exists, but no instances found
 
     mock_is_file_in_dir.return_value = True
@@ -315,18 +314,18 @@ def test_check_smartstack_check_missing_instance(
 
     smartstack_check(service='fake_service', service_path='path', soa_dir='path')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == expected_output
 
 
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)
-def test_check_smartstack_check_is_ok_when_no_smartstack(mock_is_file_in_dir, capsys):
+def test_check_smartstack_check_is_ok_when_no_smartstack(mock_is_file_in_dir, capfd):
 
     mock_is_file_in_dir.return_value = False
     expected_output = ""
     smartstack_check(service='fake_service', service_path='path', soa_dir='path')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == expected_output
 
 
@@ -347,14 +346,10 @@ def test_makefile_responds_to_run(mock_run):
 def test_makefile_has_a_tab_true():
     fake_makefile_path = 'UNUSED'
     fake_contents = 'target:\n\tcommand'
-    with contextlib.nested(
-        patch(
-            'paasta_tools.cli.cmds.check.get_file_contents',
-            autospec=True,
-            return_value=fake_contents
-        ),
-    ) as (
-        mock_get_file_contents,
+    with patch(
+        'paasta_tools.cli.cmds.check.get_file_contents',
+        autospec=True,
+        return_value=fake_contents
     ):
         assert makefile_has_a_tab(fake_makefile_path) is True
 
@@ -362,14 +357,10 @@ def test_makefile_has_a_tab_true():
 def test_makefile_has_a_tab_false():
     fake_makefile_path = 'UNUSED'
     fake_contents = 'target:\n    command'
-    with contextlib.nested(
-        patch(
-            'paasta_tools.cli.cmds.check.get_file_contents',
-            autospec=True,
-            return_value=fake_contents
-        ),
-    ) as (
-        mock_get_file_contents,
+    with patch(
+        'paasta_tools.cli.cmds.check.get_file_contents',
+        autospec=True,
+        return_value=fake_contents
     ):
         assert makefile_has_a_tab(fake_makefile_path) is False
 
@@ -377,14 +368,10 @@ def test_makefile_has_a_tab_false():
 def test_makefile_has_docker_tag_true():
     fake_makefile_path = 'UNUSED'
     fake_contents = 'Blah\nDOCKER_TAG ?= something:\ntarget:\n    command'
-    with contextlib.nested(
-        patch(
-            'paasta_tools.cli.cmds.check.get_file_contents',
-            autospec=True,
-            return_value=fake_contents
-        ),
-    ) as (
-        mock_get_file_contents,
+    with patch(
+        'paasta_tools.cli.cmds.check.get_file_contents',
+        autospec=True,
+        return_value=fake_contents
     ):
         assert makefile_has_docker_tag(fake_makefile_path) is True
 
@@ -392,20 +379,16 @@ def test_makefile_has_docker_tag_true():
 def test_makefile_has_docker_tag_false():
     fake_makefile_path = 'UNUSED'
     fake_contents = 'target:\n    command'
-    with contextlib.nested(
-        patch(
-            'paasta_tools.cli.cmds.check.get_file_contents',
-            autospec=True,
-            return_value=fake_contents
-        ),
-    ) as (
-        mock_get_file_contents,
+    with patch(
+        'paasta_tools.cli.cmds.check.get_file_contents',
+        autospec=True,
+        return_value=fake_contents
     ):
         assert makefile_has_docker_tag(fake_makefile_path) is False
 
 
 @patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
-def test_deploy_has_security_check_false(mock_pipeline_config, capsys):
+def test_deploy_has_security_check_false(mock_pipeline_config, capfd):
     mock_pipeline_config.return_value = [
         {'step': 'itest', },
         {'step': 'push-to-registry', },
@@ -417,7 +400,7 @@ def test_deploy_has_security_check_false(mock_pipeline_config, capsys):
 
 
 @patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
-def test_deploy_has_security_check_true(mock_pipeline_config, capsys):
+def test_deploy_has_security_check_true(mock_pipeline_config, capfd):
     mock_pipeline_config.return_value = [
         {'step': 'itest', },
         {'step': 'security-check', },
@@ -430,7 +413,7 @@ def test_deploy_has_security_check_true(mock_pipeline_config, capsys):
 
 
 @patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
-def test_deploy_has_performance_check_false(mock_pipeline_config, capsys):
+def test_deploy_has_performance_check_false(mock_pipeline_config, capfd):
     mock_pipeline_config.return_value = [
         {'step': 'itest', },
         {'step': 'push-to-registry', },
@@ -442,7 +425,7 @@ def test_deploy_has_performance_check_false(mock_pipeline_config, capsys):
 
 
 @patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
-def test_deploy_has_performance_check_true(mock_pipeline_config, capsys):
+def test_deploy_has_performance_check_true(mock_pipeline_config, capfd):
     mock_pipeline_config.return_value = [
         {'step': 'itest', },
         {'step': 'performance-check', },
@@ -482,7 +465,7 @@ def test_get_marathon_steps(
 def test_marathon_deployments_check_good(
     mock_get_marathon_steps,
     mock_get_pipeline_config,
-    capsys,
+    capfd,
 ):
     mock_get_pipeline_config.return_value = [
         {'step': 'itest', },
@@ -504,7 +487,7 @@ def test_marathon_deployments_check_good(
 def test_marathon_deployments_deploy_but_not_marathon(
     mock_get_marathon_steps,
     mock_get_pipeline_config,
-    capsys,
+    capfd,
 ):
     mock_get_pipeline_config.return_value = [
         {'step': 'itest', },
@@ -520,7 +503,7 @@ def test_marathon_deployments_deploy_but_not_marathon(
     ]
     actual = deployments_check(service='fake_service', soa_dir='/fake/service')
     assert actual is False
-    assert 'EXTRA' in capsys.readouterr()[0]
+    assert 'EXTRA' in capfd.readouterr()[0]
 
 
 @patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
@@ -528,7 +511,7 @@ def test_marathon_deployments_deploy_but_not_marathon(
 def test_marathon_deployments_marathon_but_not_deploy(
     mock_get_marathon_steps,
     mock_get_pipeline_config,
-    capsys,
+    capfd,
 ):
     mock_get_pipeline_config.return_value = [
         {'step': 'itest', },
@@ -544,41 +527,29 @@ def test_marathon_deployments_marathon_but_not_deploy(
     ]
     actual = deployments_check(service='fake_service', soa_dir='/fake/path')
     assert actual is False
-    assert 'BOGUS' in capsys.readouterr()[0]
+    assert 'BOGUS' in capfd.readouterr()[0]
 
 
 def test_makefile_check():
     fake_makefile_path = 'UNUSED'
     fake_contents = "DOCKER_TAG ?= something\ntest:\n\tsomething\nitest:\n\tsomething"
-    with contextlib.nested(
-        patch(
-            'paasta_tools.cli.cmds.check.get_file_contents',
-            autospec=True,
-            return_value=fake_contents
-        ),
-        patch(
-            'paasta_tools.cli.cmds.check.makefile_has_a_tab',
-            autospec=True,
-        ),
-        patch(
-            'paasta_tools.cli.cmds.check.makefile_responds_to',
-            autospec=True,
-        ),
-        patch(
-            'paasta_tools.cli.cmds.check.makefile_has_docker_tag',
-            autospec=True,
-        ),
-        patch(
-            'paasta_tools.cli.cmds.check.is_file_in_dir',
-            autospec=True,
-            return_value=fake_makefile_path
-        ),
-    ) as (
-        mock_get_file_contents,
-        mock_makefile_has_a_tab,
-        mock_makefile_responds_to,
-        mock_makefile_has_docker_tag,
-        mock_is_file_in_dir,
+    with patch(
+        'paasta_tools.cli.cmds.check.get_file_contents',
+        autospec=True,
+        return_value=fake_contents
+    ), patch(
+        'paasta_tools.cli.cmds.check.makefile_has_a_tab',
+        autospec=True,
+    ) as mock_makefile_has_a_tab, patch(
+        'paasta_tools.cli.cmds.check.makefile_responds_to',
+        autospec=True,
+    ) as mock_makefile_responds_to, patch(
+        'paasta_tools.cli.cmds.check.makefile_has_docker_tag',
+        autospec=True,
+    ) as mock_makefile_has_docker_tag, patch(
+        'paasta_tools.cli.cmds.check.is_file_in_dir',
+        autospec=True,
+        return_value=fake_makefile_path
     ):
         makefile_check()
         assert mock_makefile_has_a_tab.call_count == 1

--- a/tests/cli/test_cmds_generate_pipeline.py
+++ b/tests/cli/test_cmds_generate_pipeline.py
@@ -29,7 +29,7 @@ from paasta_tools.cli.utils import NoSuchService
 @patch('paasta_tools.cli.cmds.generate_pipeline.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.generate_pipeline.guess_service_name', autospec=True)
 def test_paasta_generate_pipeline_service_not_found(
-        mock_guess_service_name, mock_validate_service_name, capsys):
+        mock_guess_service_name, mock_validate_service_name, capfd):
     # paasta generate cannot guess service name and none is provided
 
     mock_guess_service_name.return_value = 'not_a_service'
@@ -40,7 +40,7 @@ def test_paasta_generate_pipeline_service_not_found(
     expected_output = "%s\n" % NoSuchService.GUESS_ERROR_MSG
 
     assert paasta_generate_pipeline(args) == 1
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == expected_output
 
 
@@ -172,5 +172,5 @@ def test_validate_git_url_for_fab_repo_invalid():
     bad_git_url = 'git@github.com:foobar'
     with raises(NotImplementedError) as exc:
         validate_git_url_for_fab_repo(bad_git_url)
-        assert 'cannot handle' in exc.value
-        assert bad_git_url in exc.value
+    assert 'cannot currently handle' in str(exc.value)
+    assert bad_git_url in str(exc.value)

--- a/tests/cli/test_cmds_get_latest_deployment.py
+++ b/tests/cli/test_cmds_get_latest_deployment.py
@@ -14,40 +14,40 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import contextlib
-
 from mock import MagicMock
 from mock import patch
 
 from paasta_tools.cli.cmds import get_latest_deployment
 
 
-def test_get_latest_deployment(capsys):
+def test_get_latest_deployment(capfd):
     mock_args = MagicMock(
         service='',
         deploy_group='',
         soa_dir='',
     )
-    with contextlib.nested(
-        patch('paasta_tools.cli.cmds.get_latest_deployment.get_currently_deployed_sha',
-              return_value="FAKE_SHA", autospec=True),
-        patch('paasta_tools.cli.cmds.get_latest_deployment.validate_service_name', autospec=True),
+    with patch(
+        'paasta_tools.cli.cmds.get_latest_deployment.get_currently_deployed_sha',
+        return_value="FAKE_SHA", autospec=True,
+    ), patch(
+        'paasta_tools.cli.cmds.get_latest_deployment.validate_service_name', autospec=True,
     ):
         assert get_latest_deployment.paasta_get_latest_deployment(mock_args) == 0
-        assert "FAKE_SHA" in capsys.readouterr()[0]
+        assert "FAKE_SHA" in capfd.readouterr()[0]
 
 
-def test_get_latest_deployment_no_deployment_tag(capsys):
+def test_get_latest_deployment_no_deployment_tag(capfd):
     mock_args = MagicMock(
         service='fake_service',
         deploy_group='fake_deploy_group',
         soa_dir='',
     )
-    with contextlib.nested(
-        patch('paasta_tools.cli.cmds.get_latest_deployment.get_currently_deployed_sha',
-              return_value=None, autospec=True),
-        patch('paasta_tools.cli.cmds.get_latest_deployment.validate_service_name', autospec=True),
+    with patch(
+        'paasta_tools.cli.cmds.get_latest_deployment.get_currently_deployed_sha',
+        return_value=None, autospec=True,
+    ), patch(
+        'paasta_tools.cli.cmds.get_latest_deployment.validate_service_name', autospec=True,
     ):
         assert get_latest_deployment.paasta_get_latest_deployment(mock_args) == 1
         assert "A deployment could not be found for fake_deploy_group in fake_service" in \
-            capsys.readouterr()[0]
+            capfd.readouterr()[0]

--- a/tests/cli/test_cmds_help.py
+++ b/tests/cli/test_cmds_help.py
@@ -38,12 +38,12 @@ def each_command():
 
 
 @pytest.mark.parametrize('cmd', each_command())
-def test_help(cmd, capsys):
+def test_help(cmd, capfd):
     # Should pass and produce something
     with pytest.raises(SystemExit) as excinfo:
         main((cmd, '--help'))
     assert excinfo.value.code == 0
-    assert cmd in capsys.readouterr()[0]
+    assert cmd in capfd.readouterr()[0]
 
 
 def test_invalid_arguments_returns_non_zero():

--- a/tests/cli/test_cmds_info.py
+++ b/tests/cli/test_cmds_info.py
@@ -14,8 +14,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import contextlib
-
 import mock
 
 from paasta_tools.cli.cmds import info
@@ -25,21 +23,19 @@ from paasta_tools.utils import NoDeploymentsAvailable
 
 
 def test_get_service_info():
-    with contextlib.nested(
-        mock.patch('paasta_tools.cli.cmds.info.get_team', autospec=True),
-        mock.patch('paasta_tools.cli.cmds.info.get_runbook', autospec=True),
-        mock.patch('paasta_tools.cli.cmds.info.read_service_configuration', autospec=True),
-        mock.patch('service_configuration_lib.read_service_configuration', autospec=True),
-        mock.patch('paasta_tools.cli.cmds.info.get_actual_deployments', autospec=True),
-        mock.patch('paasta_tools.cli.cmds.info.get_smartstack_endpoints', autospec=True),
-    ) as (
-        mock_get_team,
-        mock_get_runbook,
-        mock_read_service_configuration,
-        mock_scl_read_service_configuration,
-        mock_get_actual_deployments,
-        mock_get_smartstack_endpoints,
-    ):
+    with mock.patch(
+        'paasta_tools.cli.cmds.info.get_team', autospec=True,
+    ) as mock_get_team, mock.patch(
+        'paasta_tools.cli.cmds.info.get_runbook', autospec=True,
+    ) as mock_get_runbook, mock.patch(
+        'paasta_tools.cli.cmds.info.read_service_configuration', autospec=True,
+    ) as mock_read_service_configuration, mock.patch(
+        'service_configuration_lib.read_service_configuration', autospec=True,
+    ) as mock_scl_read_service_configuration, mock.patch(
+        'paasta_tools.cli.cmds.info.get_actual_deployments', autospec=True,
+    ) as mock_get_actual_deployments, mock.patch(
+        'paasta_tools.cli.cmds.info.get_smartstack_endpoints', autospec=True,
+    ) as mock_get_smartstack_endpoints:
         mock_get_team.return_value = 'fake_team'
         mock_get_runbook.return_value = 'fake_runbook'
         mock_read_service_configuration.return_value = {
@@ -123,13 +119,11 @@ def test_get_smartstack_endpoints_tcp():
 
 
 def test_get_deployments_strings_default_case_with_smartstack():
-    with contextlib.nested(
-        mock.patch('paasta_tools.cli.cmds.info.get_actual_deployments', autospec=True),
-        mock.patch('service_configuration_lib.read_service_configuration', autospec=True),
-    ) as (
-        mock_get_actual_deployments,
-        mock_read_service_configuration,
-    ):
+    with mock.patch(
+        'paasta_tools.cli.cmds.info.get_actual_deployments', autospec=True,
+    ) as mock_get_actual_deployments, mock.patch(
+        'service_configuration_lib.read_service_configuration', autospec=True,
+    ) as mock_read_service_configuration:
         mock_get_actual_deployments.return_value = ['clusterA.main', 'clusterB.main']
         mock_read_service_configuration.return_value = {
             'smartstack': {
@@ -144,10 +138,11 @@ def test_get_deployments_strings_default_case_with_smartstack():
 
 
 def test_get_deployments_strings_protocol_tcp_case():
-    with contextlib.nested(
-        mock.patch('paasta_tools.cli.cmds.info.get_actual_deployments', autospec=True),
-        mock.patch('paasta_tools.cli.cmds.info.load_service_namespace_config', autospec=True),
-    ) as (mock_get_actual_deployments, mock_load_service_namespace_config):
+    with mock.patch(
+        'paasta_tools.cli.cmds.info.get_actual_deployments', autospec=True,
+    ) as mock_get_actual_deployments, mock.patch(
+        'paasta_tools.cli.cmds.info.load_service_namespace_config', autospec=True,
+    ) as mock_load_service_namespace_config:
         mock_get_actual_deployments.return_value = ['clusterA.main', 'clusterB.main']
         mock_load_service_namespace_config.return_value = ServiceNamespaceConfig({'mode': 'tcp', 'proxy_port': 8080})
         actual = info.get_deployments_strings('unused', '/fake/soa/dir')
@@ -156,10 +151,11 @@ def test_get_deployments_strings_protocol_tcp_case():
 
 
 def test_get_deployments_strings_non_listening_service():
-    with contextlib.nested(
-        mock.patch('paasta_tools.cli.cmds.info.get_actual_deployments', autospec=True),
-        mock.patch('paasta_tools.cli.cmds.info.load_service_namespace_config', autospec=True),
-    ) as (mock_get_actual_deployments, mock_load_service_namespace_config):
+    with mock.patch(
+        'paasta_tools.cli.cmds.info.get_actual_deployments', autospec=True,
+    ) as mock_get_actual_deployments, mock.patch(
+        'paasta_tools.cli.cmds.info.load_service_namespace_config', autospec=True,
+    ) as mock_load_service_namespace_config:
         mock_get_actual_deployments.return_value = ['clusterA.main', 'clusterB.main']
         mock_load_service_namespace_config.return_value = ServiceNamespaceConfig()
         actual = info.get_deployments_strings('unused', '/fake/soa/dir')

--- a/tests/cli/test_cmds_list.py
+++ b/tests/cli/test_cmds_list.py
@@ -20,7 +20,7 @@ from paasta_tools.cli.cmds.list import paasta_list
 
 
 @mock.patch('paasta_tools.cli.cmds.list.list_services', autospec=True)
-def test_list_paasta_list(mock_list_services, capsys):
+def test_list_paasta_list(mock_list_services, capfd):
     """ paasta_list print each service returned by get_services """
 
     mock_services = ['service_1', 'service_2']
@@ -30,12 +30,12 @@ def test_list_paasta_list(mock_list_services, capsys):
     args.print_instances = False
     paasta_list(args)
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == 'service_1\nservice_2\n'
 
 
 @mock.patch('paasta_tools.cli.cmds.list.list_service_instances', autospec=True)
-def test_list_paasta_list_instances(mock_list_service_instances, capsys):
+def test_list_paasta_list_instances(mock_list_service_instances, capfd):
     """ paasta_list print each service.instance """
 
     mock_services = ['service_1.main', 'service_2.canary']
@@ -45,5 +45,5 @@ def test_list_paasta_list_instances(mock_list_service_instances, capsys):
     args.print_instances = True
     paasta_list(args)
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert output == 'service_1.main\nservice_2.canary\n'

--- a/tests/cli/test_cmds_metastatus.py
+++ b/tests/cli/test_cmds_metastatus.py
@@ -14,8 +14,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import contextlib
-
 import mock
 
 from paasta_tools.cli.cmds import metastatus
@@ -23,7 +21,7 @@ from paasta_tools.utils import SystemPaastaConfig
 
 
 @mock.patch('paasta_tools.cli.cmds.metastatus.load_system_paasta_config', autospec=True)
-def test_report_cluster_status(mock_load_system_paasta_config, capsys):
+def test_report_cluster_status(mock_load_system_paasta_config, capfd):
     cluster = 'fake_cluster'
 
     fake_system_paasta_config = SystemPaastaConfig({
@@ -53,7 +51,7 @@ def test_report_cluster_status(mock_load_system_paasta_config, capsys):
             groupings=[],
             verbose=0,
         )
-        actual, _ = capsys.readouterr()
+        actual, _ = capfd.readouterr()
         assert 'Cluster: %s' % cluster in actual
         assert 'mock_status' in actual
         assert return_code == mock.sentinel.return_value
@@ -110,14 +108,12 @@ def test_paasta_metastatus_returns_zero_all_clusters_ok():
         clusters='cluster1,cluster2,cluster3',
     )
 
-    with contextlib.nested(
-        mock.patch('paasta_tools.cli.cmds.metastatus.list_clusters', autospec=True),
-        mock.patch('paasta_tools.cli.cmds.metastatus.print_cluster_status', autospec=True),
-        mock.patch('paasta_tools.cli.cmds.metastatus.load_system_paasta_config', autospec=True),
-    ) as (
-        mock_list_clusters,
-        mock_print_cluster_status,
-        _
+    with mock.patch(
+        'paasta_tools.cli.cmds.metastatus.list_clusters', autospec=True,
+    ) as mock_list_clusters, mock.patch(
+        'paasta_tools.cli.cmds.metastatus.print_cluster_status', autospec=True,
+    ) as mock_print_cluster_status, mock.patch(
+        'paasta_tools.cli.cmds.metastatus.load_system_paasta_config', autospec=True,
     ):
         mock_list_clusters.return_value = ['cluster1', 'cluster2', 'cluster3']
         mock_print_cluster_status.side_effect = [0, 0, 0]
@@ -133,14 +129,12 @@ def test_paasta_metastatus_returns_one_on_error():
         clusters='cluster1,cluster2,cluster3',
     )
 
-    with contextlib.nested(
-        mock.patch('paasta_tools.cli.cmds.metastatus.list_clusters', autospec=True),
-        mock.patch('paasta_tools.cli.cmds.metastatus.print_cluster_status', autospec=True),
-        mock.patch('paasta_tools.cli.cmds.metastatus.load_system_paasta_config', autospec=True),
-    ) as (
-        mock_list_clusters,
-        mock_print_cluster_status,
-        _
+    with mock.patch(
+        'paasta_tools.cli.cmds.metastatus.list_clusters', autospec=True,
+    ) as mock_list_clusters, mock.patch(
+        'paasta_tools.cli.cmds.metastatus.print_cluster_status', autospec=True,
+    ) as mock_print_cluster_status, mock.patch(
+        'paasta_tools.cli.cmds.metastatus.load_system_paasta_config', autospec=True,
     ):
         mock_list_clusters.return_value = ['cluster1', 'cluster2', 'cluster3']
         mock_print_cluster_status.side_effect = [0, 0, 255]

--- a/tests/cli/test_cmds_rerun.py
+++ b/tests/cli/test_cmds_rerun.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import argparse
-import contextlib
 import datetime
 
 from mock import MagicMock
@@ -90,29 +89,26 @@ _planned_deployments = ['cluster1.instance1', 'cluster1.instance2', 'cluster2.in
         ' or has not been deployed to "cluster1" yet',
     ]
 ])
-def test_rerun_validations(test_case, capsys):
-    with contextlib.nested(
-        patch('paasta_tools.cli.cmds.rerun.figure_out_service_name', autospec=True),
-        patch('paasta_tools.cli.cmds.rerun.list_clusters', autospec=True),
-        patch('paasta_tools.cli.cmds.rerun.get_actual_deployments', autospec=True),
-        patch('paasta_tools.cli.cmds.rerun.get_planned_deployments', autospec=True),
-        patch('paasta_tools.cli.cmds.rerun.execute_chronos_rerun_on_remote_master', autospec=True),
-        patch('paasta_tools.cli.cmds.rerun.chronos_tools.load_chronos_job_config', autospec=True),
-        patch('paasta_tools.cli.cmds.rerun.chronos_tools.uses_time_variables', autospec=True),
-        patch('paasta_tools.cli.cmds.rerun._get_default_execution_date', autospec=True),
-        patch('paasta_tools.cli.cmds.rerun.load_system_paasta_config', autospec=True),
-    ) as (
-        mock_figure_out_service_name,
-        mock_list_clusters,
-        mock_get_actual_deployments,
-        mock_get_planned_deployments,
-        mock_execute_rerun_remote,
-        mock_load_chronos_job_config,
-        mock_uses_time_variables,
-        mock_get_default_execution_date,
-        mock_load_system_paasta_config,
-    ):
-
+def test_rerun_validations(test_case, capfd):
+    with patch(
+        'paasta_tools.cli.cmds.rerun.figure_out_service_name', autospec=True,
+    ) as mock_figure_out_service_name, patch(
+        'paasta_tools.cli.cmds.rerun.list_clusters', autospec=True,
+    ) as mock_list_clusters, patch(
+        'paasta_tools.cli.cmds.rerun.get_actual_deployments', autospec=True,
+    ) as mock_get_actual_deployments, patch(
+        'paasta_tools.cli.cmds.rerun.get_planned_deployments', autospec=True,
+    ) as mock_get_planned_deployments, patch(
+        'paasta_tools.cli.cmds.rerun.execute_chronos_rerun_on_remote_master', autospec=True,
+    ) as mock_execute_rerun_remote, patch(
+        'paasta_tools.cli.cmds.rerun.chronos_tools.load_chronos_job_config', autospec=True,
+    ) as mock_load_chronos_job_config, patch(
+        'paasta_tools.cli.cmds.rerun.chronos_tools.uses_time_variables', autospec=True,
+    ) as mock_uses_time_variables, patch(
+        'paasta_tools.cli.cmds.rerun._get_default_execution_date', autospec=True,
+    ) as mock_get_default_execution_date, patch(
+        'paasta_tools.cli.cmds.rerun.load_system_paasta_config', autospec=True,
+    ) as mock_load_system_paasta_config:
         (rerun_args,
          mock_figure_out_service_name.return_value,
          mock_list_clusters.return_value,
@@ -146,10 +142,11 @@ def test_rerun_validations(test_case, capsys):
                 == default_date.strftime(EXECUTION_DATE_FORMAT)
 
         # The job does use time vars interpolation. Make sure the User supplied date was used.
-        if args.execution_date is not None and mock_uses_time_variables.return_value:
-            assert mock_execute_rerun_remote.call_args[1]['execution_date'] == _user_supplied_execution_date
+        # TODO: this if statement is never true
+        # if args.execution_date is not None and mock_uses_time_variables.return_value:
+        #    assert mock_execute_rerun_remote.call_args[1]['execution_date'] == _user_supplied_execution_date
 
-        output, _ = capsys.readouterr()
+        output, _ = capfd.readouterr()
         assert expected_output in output
 
 

--- a/tests/cli/test_cmds_rollback.py
+++ b/tests/cli/test_cmds_rollback.py
@@ -15,8 +15,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import contextlib
-
 from mock import call
 from mock import Mock
 from mock import patch
@@ -248,13 +246,11 @@ def test_list_previously_deployed_shas():
     }
     fake_deploy_groups = ['test.deploy.group']
 
-    with contextlib.nested(
-            patch('paasta_tools.cli.cmds.rollback.list_remote_refs', autospec=True, return_value=fake_refs),
-            patch('paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True,
-                  return_value=fake_deploy_groups),
-    ) as (
-        _,
-        _,
+    with patch(
+        'paasta_tools.cli.cmds.rollback.list_remote_refs', autospec=True, return_value=fake_refs,
+    ), patch(
+        'paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True,
+        return_value=fake_deploy_groups,
     ):
         fake_args = Mock(
             service='fake_service',
@@ -272,13 +268,11 @@ def test_list_previously_deployed_shas_no_deploy_groups():
     }
     fake_deploy_groups = ['test.deploy.group', 'other.deploy.group']
 
-    with contextlib.nested(
-            patch('paasta_tools.cli.cmds.rollback.list_remote_refs', autospec=True, return_value=fake_refs),
-            patch('paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True,
-                  return_value=fake_deploy_groups),
-    ) as (
-        _,
-        _,
+    with patch(
+        'paasta_tools.cli.cmds.rollback.list_remote_refs', autospec=True, return_value=fake_refs,
+    ), patch(
+        'paasta_tools.cli.cmds.rollback.list_deploy_groups', autospec=True,
+        return_value=fake_deploy_groups,
     ):
         fake_args = Mock(
             service='fake_service',

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -34,7 +34,7 @@ from paasta_tools.cli.utils import PaastaColors
 
 @patch('paasta_tools.cli.utils.validate_service_name', autospec=True)
 def test_figure_out_service_name_not_found(
-        mock_validate_service_name, capsys,
+        mock_validate_service_name, capfd,
 ):
     # paasta_status with invalid -s service_name arg results in error
     mock_validate_service_name.side_effect = NoSuchService(None)
@@ -47,7 +47,7 @@ def test_figure_out_service_name_not_found(
     with raises(SystemExit) as sys_exit:
         status.figure_out_service_name(parsed_args)
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert sys_exit.value.code == 1
     assert output == expected_output
 
@@ -55,7 +55,7 @@ def test_figure_out_service_name_not_found(
 @patch('paasta_tools.cli.utils.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.utils.guess_service_name', autospec=True)
 def test_status_arg_service_not_found(
-    mock_guess_service_name, mock_validate_service_name, capsys,
+    mock_guess_service_name, mock_validate_service_name, capfd,
 ):
     # paasta_status with no args and non-service directory results in error
     mock_guess_service_name.return_value = 'not_a_service'
@@ -70,7 +70,7 @@ def test_status_arg_service_not_found(
     with raises(SystemExit) as sys_exit:
         paasta_status(args)
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert sys_exit.value.code == 1
     assert output == expected_output
 
@@ -80,7 +80,7 @@ def test_status_arg_service_not_found(
 def test_report_status_for_cluster_displays_deployed_service(
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
-    capsys,
+    capfd,
 ):
     # paasta_status with no args displays deploy info - vanilla case
     service = 'fake_service'
@@ -110,7 +110,7 @@ def test_report_status_for_cluster_displays_deployed_service(
         instance_whitelist=instance_whitelist,
         system_paasta_config=fake_system_paasta_config,
     )
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert expected_output in output
     mock_execute_paasta_serviceinit_on_remote_master.assert_called_once_with(
         'status', 'fake_cluster', 'fake_service', 'fake_instance',
@@ -122,7 +122,7 @@ def test_report_status_for_cluster_displays_deployed_service(
 def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_serviceinit_on_remote_master(
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
-    capsys,
+    capfd,
 ):
     # paasta_status with no args displays deploy info - vanilla case
     service = 'fake_service'
@@ -151,7 +151,7 @@ def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_s
         instance_whitelist=instance_whitelist,
         system_paasta_config=fake_system_paasta_config,
     )
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert expected_output in output
 
 
@@ -160,7 +160,7 @@ def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_s
 def test_report_status_for_cluster_instance_sorts_in_deploy_order(
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
-    capsys,
+    capfd,
 ):
     # paasta_status with no args displays deploy info
     service = 'fake_service'
@@ -194,7 +194,7 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
         instance_whitelist=instance_whitelist,
         system_paasta_config=fake_system_paasta_config,
     )
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert expected_output in output
     mock_execute_paasta_serviceinit_on_remote_master.assert_called_once_with(
         'status', 'fake_cluster', 'fake_service', 'fake_instance_a,fake_instance_b',
@@ -206,7 +206,7 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
 def test_print_cluster_status_missing_deploys_in_red(
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
-    capsys,
+    capfd,
 ):
     # paasta_status displays missing deploys in red
     service = 'fake_service'
@@ -244,7 +244,7 @@ def test_print_cluster_status_missing_deploys_in_red(
         instance_whitelist=instance_whitelist,
         system_paasta_config=fake_system_paasta_config,
     )
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert expected_output in output
 
 
@@ -255,7 +255,7 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
     verbosity_level,
-    capsys,
+    capfd,
 ):
     service = 'fake_service'
     planned_deployments = [
@@ -289,7 +289,7 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
         stream=True, verbose=verbosity_level, ignore_ssh_output=True
     )
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert expected_output in output
 
 
@@ -298,7 +298,7 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
 def test_report_status_for_cluster_obeys_instance_whitelist(
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
-    capsys,
+    capfd,
 ):
     service = 'fake_service'
     planned_deployments = ['fake_cluster.fake_instance_a', 'fake_cluster.fake_instance_b']
@@ -332,7 +332,7 @@ def test_report_status_for_cluster_obeys_instance_whitelist(
 def test_report_status_calls_report_invalid_whitelist_values(
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
-    capsys,
+    capfd,
 ):
     service = 'fake_service'
     planned_deployments = ['cluster.instance1', 'cluster.instance2']
@@ -361,7 +361,7 @@ def test_report_status_calls_report_invalid_whitelist_values(
 @patch('paasta_tools.cli.cmds.status.get_actual_deployments', autospec=True)
 def test_status_pending_pipeline_build_message(
         mock_get_actual_deployments, mock_get_deploy_info,
-        mock_figure_out_service_name, mock_load_system_paasta_config, capsys,
+        mock_figure_out_service_name, mock_load_system_paasta_config, capfd,
 ):
     # If deployments.json is missing SERVICE, output the appropriate message
     service = 'fake_service'
@@ -379,7 +379,7 @@ def test_status_pending_pipeline_build_message(
     args.service = service
 
     paasta_status(args)
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert expected_output in output
 
 
@@ -411,12 +411,12 @@ def test_get_deploy_info_exists(mock_read_deploy):
 
 
 @patch('paasta_tools.cli.cmds.status.read_deploy', autospec=True)
-def test_get_deploy_info_does_not_exist(mock_read_deploy, capsys):
+def test_get_deploy_info_does_not_exist(mock_read_deploy, capfd):
     mock_read_deploy.return_value = False
     expected_output = '%s\n' % PaastaCheckMessages.DEPLOY_YAML_MISSING
     with raises(SystemExit) as sys_exit:
         status.get_deploy_info('fake_service')
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert sys_exit.value.code == 1
     assert output == expected_output
 
@@ -432,7 +432,7 @@ def test_status_calls_sergeants(
     mock_get_actual_deployments,
     mock_figure_out_service_name,
     mock_load_system_paasta_config,
-    capsys,
+    capfd,
 ):
     service = 'fake_service'
     mock_figure_out_service_name.return_value = service
@@ -496,7 +496,7 @@ def test_report_invalid_whitelist_values_with_whitelists():
 def test_report_status_returns_zero_when_clusters_pass(
     mock_report_invalid_whitelist_values,
     mock_report_status_for_cluster,
-    capsys,
+    capfd,
 ):
     service = 'fake_service'
     cluster_whitelist = []
@@ -525,7 +525,7 @@ def test_report_status_returns_zero_when_clusters_pass(
 def test_report_status_returns_one_when_clusters_pass(
     mock_report_invalid_whitelist_values,
     mock_report_status_for_cluster,
-    capsys,
+    capfd,
 ):
     service = 'fake_service'
     cluster_whitelist = []
@@ -554,7 +554,7 @@ def test_report_status_returns_one_when_clusters_pass(
 def test_report_status_obeys_cluster_whitelist(
     mock_report_invalid_whitelist_values,
     mock_report_status_for_cluster,
-    capsys,
+    capfd,
 ):
     service = 'fake_service'
     cluster_whitelist = ['cluster1']
@@ -589,7 +589,7 @@ def test_report_status_obeys_cluster_whitelist(
 def test_report_status_handle_none_whitelist(
     mock_report_invalid_whitelist_values,
     mock_report_status_for_cluster,
-    capsys,
+    capfd,
 ):
     service = 'fake_service'
     cluster_whitelist = []

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -61,13 +61,13 @@ def test_paasta_validate_calls_everything(
     assert mock_validate_chronos.called
 
 
-def test_get_service_path_unknown(capsys):
+def test_get_service_path_unknown(capfd):
     service = None
     soa_dir = 'unused'
 
     assert get_service_path(service, soa_dir) is None
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert UNKNOWN_SERVICE in output
 
 
@@ -140,7 +140,7 @@ def test_get_schema_missing():
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_schema_list_hashes_good(
-    mock_get_file_contents, capsys,
+    mock_get_file_contents, capfd,
 ):
     marathon_content = """
 ---
@@ -161,13 +161,13 @@ main_http:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_schema_healthcheck_non_cmd(
-    mock_get_file_contents, capsys,
+    mock_get_file_contents, capfd,
 ):
     marathon_content = """
 ---
@@ -181,7 +181,7 @@ main_worker:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert SCHEMA_VALID in output
     marathon_content = """
 ---
@@ -194,13 +194,13 @@ main_worker:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_id(
-    mock_get_file_contents, capsys,
+    mock_get_file_contents, capfd,
 ):
     marathon_content = """
 ---
@@ -213,7 +213,7 @@ valid:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert SCHEMA_VALID in output
 
     marathon_content = """
@@ -227,7 +227,7 @@ this_is_okay_too_1:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert SCHEMA_VALID in output
 
     marathon_content = """
@@ -241,7 +241,7 @@ dashes-are-okay-too:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert SCHEMA_VALID in output
 
     marathon_content = """
@@ -255,7 +255,7 @@ main_worker_CAPITALS_INVALID:
 """
     mock_get_file_contents.return_value = marathon_content
     assert not validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert SCHEMA_INVALID in output
 
     marathon_content = """
@@ -269,13 +269,13 @@ $^&*()(&*^%&definitely_not_okay:
 """
     mock_get_file_contents.return_value = marathon_content
     assert not validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert SCHEMA_INVALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_schema_healthcheck_cmd_has_cmd(
-    mock_get_file_contents, capsys,
+    mock_get_file_contents, capfd,
 ):
     marathon_content = """
 ---
@@ -289,7 +289,7 @@ main_worker:
 """
     mock_get_file_contents.return_value = marathon_content
     assert not validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert SCHEMA_INVALID in output
     marathon_content = """
 ---
@@ -304,13 +304,13 @@ main_worker:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_schema_keys_outside_instance_blocks_bad(
-    mock_get_file_contents, capsys,
+    mock_get_file_contents, capfd,
 ):
     mock_get_file_contents.return_value = """
 {
@@ -322,13 +322,13 @@ def test_marathon_validate_schema_keys_outside_instance_blocks_bad(
 """
     assert not validate_schema('unused_service_path.json', 'marathon')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert SCHEMA_INVALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_invalid_key_bad(
-    mock_get_file_contents, capsys,
+    mock_get_file_contents, capfd,
 ):
     mock_get_file_contents.return_value = """
 {
@@ -339,13 +339,13 @@ def test_marathon_validate_invalid_key_bad(
 """
     assert not validate_schema('unused_service_path.json', 'marathon')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert SCHEMA_INVALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_chronos_validate_schema_list_hashes_good(
-    mock_get_file_contents, capsys,
+    mock_get_file_contents, capfd,
 ):
     mock_get_file_contents.return_value = """
 {
@@ -359,13 +359,13 @@ def test_chronos_validate_schema_list_hashes_good(
 """
     assert validate_schema('unused_service_path.json', 'chronos')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_chronos_validate_schema_keys_outside_instance_blocks_bad(
-    mock_get_file_contents, capsys,
+    mock_get_file_contents, capfd,
 ):
     mock_get_file_contents.return_value = """
 {
@@ -377,7 +377,7 @@ def test_chronos_validate_schema_keys_outside_instance_blocks_bad(
 """
     assert not validate_schema('unused_service_path.json', 'chronos')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert SCHEMA_INVALID in output
 
 
@@ -392,7 +392,7 @@ def test_failing_chronos_job_validate(
     mock_list_all_instances_for_service,
     mock_list_clusters,
     mock_get_services_for_cluster,
-    capsys,
+    capfd,
 ):
     fake_service = 'fake-service'
     fake_instance = 'fake-instance'
@@ -410,7 +410,7 @@ def test_failing_chronos_job_validate(
 
     assert not validate_chronos('fake_service_path')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     expected_output = 'something is wrong with the config'
     assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
 
@@ -426,7 +426,7 @@ def test_failing_chronos_job_self_dependent(
     mock_list_all_instances_for_service,
     mock_list_clusters,
     mock_get_services_for_cluster,
-    capsys,
+    capfd,
 ):
     fake_service = 'fake-service'
     fake_instance = 'fake-instance'
@@ -445,7 +445,7 @@ def test_failing_chronos_job_self_dependent(
 
     assert not validate_chronos('fake_service_path')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     expected_output = 'Job fake-service.fake-instance cannot depend on itself'
     assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
 
@@ -461,7 +461,7 @@ def test_failing_chronos_job_missing_parent(
     mock_list_all_instances_for_service,
     mock_list_clusters,
     mock_get_services_for_cluster,
-    capsys,
+    capfd,
 ):
     fake_service = 'fake-service'
     fake_instance = 'fake-instance'
@@ -480,7 +480,7 @@ def test_failing_chronos_job_missing_parent(
 
     assert not validate_chronos('fake_service_path')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     expected_output = 'Parent job fake-service.parent-1 could not be found'
     assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
 
@@ -496,7 +496,7 @@ def test_validate_chronos_valid_instance(
     mock_list_all_instances_for_service,
     mock_list_clusters,
     mock_get_services_for_cluster,
-    capsys,
+    capfd,
 ):
     fake_service = 'fake-service'
     fake_instance = 'fake-instance'
@@ -514,35 +514,35 @@ def test_validate_chronos_valid_instance(
 
     assert validate_chronos('fake_service_path')
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert valid_chronos_instance(fake_cluster, fake_instance) in output
 
 
 @patch("paasta_tools.chronos_tools.TMP_JOB_IDENTIFIER", 'tmp', autospec=None)
 @patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service', autospec=True)
-def test_validate_chronos_tmp_job(mock_path_to_soa_dir_service, capsys):
+def test_validate_chronos_tmp_job(mock_path_to_soa_dir_service, capfd):
     mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'tmp')
     assert validate_chronos('fake_path/tmp') is False
     assert ("Services using scheduled tasks cannot be named tmp, as it clashes"
             " with the identifier used for temporary jobs") in \
-        capsys.readouterr()[0]
+        capfd.readouterr()[0]
 
 
-def test_check_service_path_none(capsys):
+def test_check_service_path_none(capfd):
     service_path = None
     assert not check_service_path(service_path)
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert "%s is not a directory" % service_path in output
 
 
 @patch('paasta_tools.cli.cmds.validate.os.path.isdir', autospec=True)
-def test_check_service_path_empty(mock_isdir, capsys):
+def test_check_service_path_empty(mock_isdir, capfd):
     mock_isdir.return_value = True
     service_path = 'fake/path'
     assert not check_service_path(service_path)
 
-    output, _ = capsys.readouterr()
+    output, _ = capfd.readouterr()
     assert "%s does not contain any .yaml files" % service_path in output
 
 

--- a/tests/cli/test_cmds_version.py
+++ b/tests/cli/test_cmds_version.py
@@ -21,9 +21,9 @@ import pytest
 from paasta_tools.cli.cli import main
 
 
-def test_paasta_version(capsys):
+def test_paasta_version(capfd):
     with pytest.raises(SystemExit) as excinfo:
         main(('-V',))
     assert excinfo.value.code == 0
-    output = capsys.readouterr()[1]
+    output = capfd.readouterr()[1]
     assert re.match('^paasta-tools \d+\.\d+\.\d+\n$', output)

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import argparse
-import contextlib
 from socket import gaierror
 
 import mock
@@ -387,15 +386,13 @@ def test_execute_paasta_metastatus_on_remote_no_connectable_master(
 def test_execute_chronos_rerun_on_remote_master(test_case):
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
 
-    with contextlib.nested(
-        patch('paasta_tools.cli.utils.calculate_remote_masters', autospec=True),
-        patch('paasta_tools.cli.utils.find_connectable_master', autospec=True),
-        patch('paasta_tools.cli.utils.run_chronos_rerun', autospec=True),
-    ) as (
-        mock_calculate_remote_masters,
-        mock_find_connectable_master,
-        mock_run_chronos_rerun,
-    ):
+    with patch(
+        'paasta_tools.cli.utils.calculate_remote_masters', autospec=True,
+    ) as mock_calculate_remote_masters, patch(
+        'paasta_tools.cli.utils.find_connectable_master', autospec=True,
+    ) as mock_find_connectable_master, patch(
+        'paasta_tools.cli.utils.run_chronos_rerun', autospec=True,
+    ) as mock_run_chronos_rerun:
         (mock_calculate_remote_masters.return_value,
          mock_find_connectable_master.return_value,
          mock_run_chronos_rerun.return_value) = test_case
@@ -573,7 +570,7 @@ def test_get_instance_config_unknown(
             cluster='fake_cluster',
             soa_dir='fake_soa_dir',
         )
-        assert mock_validate_service_instance.call_count == 1
+    assert mock_validate_service_instance.call_count == 1
 
 
 @patch('paasta_tools.cli.utils._run', autospec=True)

--- a/tests/mesos/test_cluster.py
+++ b/tests/mesos/test_cluster.py
@@ -23,9 +23,7 @@ def test_get_files_for_tasks_no_files():
 
 
 def test_get_files_for_tasks_all():
-    attrs = {'id': 'foo'}
     mock_task = MagicMock()
-    mock_task.__getitem__.side_effect = lambda x: attrs[x]
     mock_file = Mock()
     mock_file.exists.return_value = True
     mock_task.file.return_value = mock_file
@@ -35,9 +33,7 @@ def test_get_files_for_tasks_all():
 
 
 def test_get_files_for_tasks_some():
-    attrs = {'id': 'foo'}
     mock_task = MagicMock()
-    mock_task.__getitem__.side_effect = lambda x: attrs[x]
     mock_file = Mock()
     mock_file_2 = Mock()
     mock_file.exists.side_effect = [False, True]

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -231,8 +231,10 @@ def test_assert_no_duplicate_frameworks():
     }
     output, ok = metastatus_lib.assert_no_duplicate_frameworks(state)
 
-    expected_output = "\n".join(["Frameworks:"] +
-                                map(lambda x: '    Framework: %s count: 1' % x['name'], state['frameworks']))
+    expected_output = "\n".join(
+        ["Frameworks:"] +
+        ['    Framework: %s count: 1' % x['name'] for x in state['frameworks']]
+    )
     assert output == expected_output
     assert ok
 

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -17,6 +17,7 @@ from __future__ import unicode_literals
 
 import inspect
 
+import mock
 from mock import Mock
 from mock import patch
 
@@ -182,32 +183,35 @@ def test_failing_disk_health():
     assert "CRITICAL: Less than 10% disk available. (Currently using 97.66%)" in failure_output
 
 
-def assert_cpu_health_mesos_reports_zero():
+def test_cpu_health_mesos_reports_zero():
     mesos_metrics = {
         'master/cpus_total': 0,
         'master/cpus_used': 1,
     }
-    failure_output, failure_health = metastatus_lib.assert_cpu_health(mesos_metrics)
+    fake_mesos_state = {'slaves': []}
+    failure_output, failure_health = metastatus_lib.assert_cpu_health(mesos_metrics, fake_mesos_state)
     assert failure_output == "Error reading total available cpu from mesos!"
     assert failure_health is False
 
 
-def assert_memory_health_mesos_reports_zero():
+def test_memory_health_mesos_reports_zero():
     mesos_metrics = {
         'master/mem_total': 0,
         'master/mem_used': 1,
     }
-    failure_output, failure_health = metastatus_lib.assert_memory_health(mesos_metrics)
+    fake_mesos_state = {'slaves': []}
+    failure_output, failure_health = metastatus_lib.assert_memory_health(mesos_metrics, fake_mesos_state)
     assert failure_output == "Error reading total available memory from mesos!"
     assert failure_health is False
 
 
-def assert_disk_health_mesos_reports_zero():
+def test_disk_health_mesos_reports_zero():
     mesos_metrics = {
         'master/disk_total': 0,
         'master/disk_used': 1,
     }
-    failure_output, failure_health = metastatus_lib.assert_disk_health(mesos_metrics)
+    fake_mesos_state = {'slaves': []}
+    failure_output, failure_health = metastatus_lib.assert_disk_health(mesos_metrics, fake_mesos_state)
     assert failure_output == "Error reading total available disk from mesos!"
     assert failure_health is False
 
@@ -261,7 +265,7 @@ def test_duplicate_frameworks():
     assert not ok
 
 
-def assert_connected_frameworks():
+def test_connected_frameworks():
     metrics = {
         'master/frameworks_connected': 2,
     }
@@ -270,11 +274,11 @@ def assert_connected_frameworks():
     assert "Connected Frameworks: expected: 2 actual: 2" in hcr.message
 
 
-def assert_disconnected_frameworks():
+def test_disconnected_frameworks():
     metrics = {
         'master/frameworks_disconnected': 1
     }
-    hcr = metastatus_lib.assert_connected_frameworks(metrics)
+    hcr = metastatus_lib.assert_disconnected_frameworks(metrics)
     assert not hcr.healthy
     assert "Disconnected Frameworks: expected: 0 actual: 1" in hcr.message
 
@@ -597,7 +601,7 @@ def test_get_resource_utilization_by_grouping(
         'slaves': [{}]
     }
     actual = metastatus_lib.get_resource_utilization_by_grouping(
-        grouping_func=lambda slave: slave['attributes']['habitat'],
+        grouping_func=mock.sentinel.grouping_func,
         mesos_state=state,
     )
     mock_get_all_tasks_from_state.assert_called_with(state, include_orphans=True)

--- a/tests/monitoring/test_check_classic_service_replication.py
+++ b/tests/monitoring/test_check_classic_service_replication.py
@@ -210,9 +210,8 @@ def test_classic_replication_check():
         return_value=SystemPaastaConfig({}, '/fake/config'), autospec=True,
     ):
         with pytest.raises(SystemExit) as error:
-            check = ClassicServiceReplicationCheck()
-            check.run()
-            assert mcheck.assert_called_with('pow', {'wat': 1}, -1)
+            ClassicServiceReplicationCheck()
+        mcheck.assert_called_with('pow', {'pow': 'bar'}, 0)
         assert error.value.code == 0
 
 

--- a/tests/monitoring/test_check_synapse_replication.py
+++ b/tests/monitoring/test_check_synapse_replication.py
@@ -53,7 +53,7 @@ def test_parse_range():
         (0, 1), (1, sys.maxsize), (100, sys.maxsize), (20, 30), (0, 2), (0, 200)
     ]
 
-    computed_ranges = map(parse_range, range_data)
+    computed_ranges = [parse_range(x) for x in range_data]
     assert computed_ranges == expected_ranges
 
 

--- a/tests/test_chronos_serviceinit.py
+++ b/tests/test_chronos_serviceinit.py
@@ -397,12 +397,11 @@ def test_format_chronos_job_mesos_verbose(verbosity_level):
         'schedule': 'foo',
     }
     running_tasks = ['slay the nemean lion']
-    if verbosity_level == 1:
-        expected_tail_lines = 0
-    elif verbosity_level == 2:
-        expected_tail_lines = 10
-    elif verbosity_level == 3:
-        expected_tail_lines = 100
+    expected_tail_lines = {
+        1: 0,
+        2: 10,
+        3: 100
+    }[verbosity_level]
     mock_client = mock.Mock()
     with mock.patch(
         'paasta_tools.chronos_serviceinit.status_mesos_tasks_verbose', autospec=True,

--- a/tests/test_cleanup_marathon_jobs.py
+++ b/tests/test_cleanup_marathon_jobs.py
@@ -15,8 +15,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import contextlib
-
 import mock
 from pytest import raises
 
@@ -38,19 +36,11 @@ class TestCleanupMarathonJobs:
 
     def test_main(self):
         soa_dir = 'paasta_maaaachine'
-        fake_args = mock.Mock(verbose=False, soa_dir=soa_dir,
-                              kill_threshold=0.5, force=False)
-        with contextlib.nested(
-            mock.patch('paasta_tools.cleanup_marathon_jobs.parse_args', return_value=fake_args, autospec=True),
-            mock.patch('paasta_tools.cleanup_marathon_jobs.cleanup_apps', autospec=True),
-        ) as (
-            args_patch,
-            cleanup_patch
-        ):
-            cleanup_marathon_jobs.main()
-            args_patch.assert_called_once_with()
-            cleanup_patch.assert_called_once_with(soa_dir, kill_threshold=0.5,
-                                                  force=False)
+        with mock.patch('paasta_tools.cleanup_marathon_jobs.cleanup_apps', autospec=True) as cleanup_patch:
+            cleanup_marathon_jobs.main(('--soa-dir', soa_dir))
+            cleanup_patch.assert_called_once_with(
+                soa_dir, kill_threshold=0.5, force=False,
+            )
 
     def test_cleanup_apps(self):
         soa_dir = 'not_really_a_dir'
@@ -58,21 +48,19 @@ class TestCleanupMarathonJobs:
         fake_app_ids = [mock.Mock(id='present.away.gone.wtf'), mock.Mock(id='on-app.off.stop.jrm'),
                         mock.Mock(id='not-here.oh.no.weirdo')]
         self.fake_marathon_client.list_apps = mock.Mock(return_value=fake_app_ids)
-        with contextlib.nested(
-            mock.patch('paasta_tools.cleanup_marathon_jobs.get_services_for_cluster',
-                       return_value=expected_apps, autospec=True),
-            mock.patch('paasta_tools.marathon_tools.load_marathon_config',
-                       autospec=True,
-                       return_value=self.fake_marathon_config),
-            mock.patch('paasta_tools.marathon_tools.get_marathon_client', autospec=True,
-                       return_value=self.fake_marathon_client),
-            mock.patch('paasta_tools.cleanup_marathon_jobs.delete_app', autospec=True),
-        ) as (
-            get_services_for_cluster_patch,
-            config_patch,
-            client_patch,
-            delete_patch,
-        ):
+        with mock.patch(
+            'paasta_tools.cleanup_marathon_jobs.get_services_for_cluster',
+            return_value=expected_apps, autospec=True,
+        ) as get_services_for_cluster_patch, mock.patch(
+                'paasta_tools.marathon_tools.load_marathon_config',
+                autospec=True,
+                return_value=self.fake_marathon_config,
+        ) as config_patch, mock.patch(
+            'paasta_tools.marathon_tools.get_marathon_client', autospec=True,
+            return_value=self.fake_marathon_client,
+        ) as client_patch, mock.patch(
+            'paasta_tools.cleanup_marathon_jobs.delete_app', autospec=True,
+        ) as delete_patch:
             cleanup_marathon_jobs.cleanup_apps(soa_dir)
             config_patch.assert_called_once_with()
             get_services_for_cluster_patch.assert_called_once_with(instance_type='marathon', soa_dir=soa_dir)
@@ -91,21 +79,19 @@ class TestCleanupMarathonJobs:
         fake_app_ids = [mock.Mock(id='present.away.gone.wtf'), mock.Mock(id='on-app.off.stop.jrm'),
                         mock.Mock(id='not-here.oh.no.weirdo')]
         self.fake_marathon_client.list_apps = mock.Mock(return_value=fake_app_ids)
-        with contextlib.nested(
-            mock.patch('paasta_tools.cleanup_marathon_jobs.get_services_for_cluster',
-                       return_value=expected_apps, autospec=True),
-            mock.patch('paasta_tools.marathon_tools.load_marathon_config',
-                       autospec=True,
-                       return_value=self.fake_marathon_config),
-            mock.patch('paasta_tools.marathon_tools.get_marathon_client', autospec=True,
-                       return_value=self.fake_marathon_client),
-            mock.patch('paasta_tools.cleanup_marathon_jobs.delete_app', autospec=True),
-        ) as (
-            get_services_for_cluster_patch,
-            config_patch,
-            client_patch,
-            delete_patch,
-        ):
+        with mock.patch(
+            'paasta_tools.cleanup_marathon_jobs.get_services_for_cluster',
+            return_value=expected_apps, autospec=True,
+        ) as get_services_for_cluster_patch, mock.patch(
+            'paasta_tools.marathon_tools.load_marathon_config',
+            autospec=True,
+            return_value=self.fake_marathon_config,
+        ) as config_patch, mock.patch(
+            'paasta_tools.marathon_tools.get_marathon_client', autospec=True,
+            return_value=self.fake_marathon_client,
+        ) as client_patch, mock.patch(
+            'paasta_tools.cleanup_marathon_jobs.delete_app', autospec=True,
+        ) as delete_patch:
             with raises(cleanup_marathon_jobs.DontKillEverythingError):
                 cleanup_marathon_jobs.cleanup_apps(soa_dir)
             config_patch.assert_called_once_with()
@@ -123,21 +109,19 @@ class TestCleanupMarathonJobs:
                         mock.Mock(id='not-here.oh.no.weirdo')]
         self.fake_marathon_client.list_apps = mock.Mock(
             return_value=fake_app_ids)
-        with contextlib.nested(
-            mock.patch('paasta_tools.cleanup_marathon_jobs.get_services_for_cluster',
-                       return_value=expected_apps, autospec=True),
-            mock.patch('paasta_tools.marathon_tools.load_marathon_config',
-                       autospec=True,
-                       return_value=self.fake_marathon_config),
-            mock.patch('paasta_tools.marathon_tools.get_marathon_client', autospec=True,
-                       return_value=self.fake_marathon_client),
-            mock.patch('paasta_tools.cleanup_marathon_jobs.delete_app', autospec=True),
-        ) as (
-            get_services_for_cluster_patch,
-            config_patch,
-            client_patch,
-            delete_patch,
-        ):
+        with mock.patch(
+            'paasta_tools.cleanup_marathon_jobs.get_services_for_cluster',
+            return_value=expected_apps, autospec=True,
+        ) as get_services_for_cluster_patch, mock.patch(
+            'paasta_tools.marathon_tools.load_marathon_config',
+            autospec=True,
+            return_value=self.fake_marathon_config,
+        ) as config_patch, mock.patch(
+            'paasta_tools.marathon_tools.get_marathon_client', autospec=True,
+            return_value=self.fake_marathon_client,
+        ) as client_patch, mock.patch(
+            'paasta_tools.cleanup_marathon_jobs.delete_app', autospec=True,
+        ) as delete_patch:
             cleanup_marathon_jobs.cleanup_apps(soa_dir, force=True)
             config_patch.assert_called_once_with()
             get_services_for_cluster_patch.assert_called_once_with(instance_type='marathon', soa_dir=soa_dir)
@@ -151,40 +135,36 @@ class TestCleanupMarathonJobs:
         expected_apps = [('present', 'away'), ('on-app', 'off')]
         fake_app_ids = [mock.Mock(id='non_conforming_app')]
         self.fake_marathon_client.list_apps = mock.Mock(return_value=fake_app_ids)
-        with contextlib.nested(
-            mock.patch('paasta_tools.cleanup_marathon_jobs.get_services_for_cluster',
-                       return_value=expected_apps, autospec=True),
-            mock.patch('paasta_tools.marathon_tools.load_marathon_config',
-                       autospec=True,
-                       return_value=self.fake_marathon_config),
-            mock.patch('paasta_tools.marathon_tools.get_marathon_client', autospec=True,
-                       return_value=self.fake_marathon_client),
-            mock.patch('paasta_tools.cleanup_marathon_jobs.delete_app', autospec=True),
-        ) as (
-            get_services_for_cluster_patch,
-            config_patch,
-            client_patch,
-            delete_patch,
-        ):
+        with mock.patch(
+            'paasta_tools.cleanup_marathon_jobs.get_services_for_cluster',
+            return_value=expected_apps, autospec=True,
+        ), mock.patch(
+            'paasta_tools.marathon_tools.load_marathon_config',
+            autospec=True,
+            return_value=self.fake_marathon_config,
+        ), mock.patch(
+            'paasta_tools.marathon_tools.get_marathon_client', autospec=True,
+            return_value=self.fake_marathon_client,
+        ), mock.patch(
+            'paasta_tools.cleanup_marathon_jobs.delete_app', autospec=True,
+        ) as delete_patch:
             cleanup_marathon_jobs.cleanup_apps(soa_dir)
             assert delete_patch.call_count == 0
 
     def test_delete_app(self):
         app_id = 'example--service.main.git93340779.configddb38a65'
         client = self.fake_marathon_client
-        with contextlib.nested(
-            mock.patch('paasta_tools.cleanup_marathon_jobs.load_system_paasta_config', autospec=True),
-            mock.patch('paasta_tools.bounce_lib.bounce_lock_zookeeper', autospec=True),
-            mock.patch('paasta_tools.bounce_lib.delete_marathon_app', autospec=True),
-            mock.patch('paasta_tools.cleanup_marathon_jobs._log', autospec=True),
-            mock.patch('paasta_tools.cleanup_marathon_jobs.send_event', autospec=True)
-        ) as (
-            mock_load_system_paasta_config,
-            mock_bounce_lock_zookeeper,
-            mock_delete_marathon_app,
-            mock_log,
-            mock_send_sensu_event,
-        ):
+        with mock.patch(
+            'paasta_tools.cleanup_marathon_jobs.load_system_paasta_config', autospec=True,
+        ) as mock_load_system_paasta_config, mock.patch(
+            'paasta_tools.bounce_lib.bounce_lock_zookeeper', autospec=True,
+        ), mock.patch(
+            'paasta_tools.bounce_lib.delete_marathon_app', autospec=True,
+        ) as mock_delete_marathon_app, mock.patch(
+            'paasta_tools.cleanup_marathon_jobs._log', autospec=True,
+        ) as mock_log, mock.patch(
+            'paasta_tools.cleanup_marathon_jobs.send_event', autospec=True,
+        ) as mock_send_sensu_event:
             mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value='fake_cluster')
             cleanup_marathon_jobs.delete_app(app_id, client, 'fake_soa_dir')
             mock_delete_marathon_app.assert_called_once_with(app_id, client)
@@ -207,17 +187,15 @@ class TestCleanupMarathonJobs:
         app_id = 'example--service.main.git93340779.configddb38a65'
         client = self.fake_marathon_client
 
-        with contextlib.nested(
-            mock.patch('paasta_tools.cleanup_marathon_jobs.load_system_paasta_config', autospec=True),
-            mock.patch('paasta_tools.bounce_lib.bounce_lock_zookeeper', autospec=True),
-            mock.patch('paasta_tools.bounce_lib.delete_marathon_app', side_effect=ValueError('foo'), autospec=True),
-            mock.patch('paasta_tools.cleanup_marathon_jobs._log', autospec=True),
-        ) as (
-            mock_load_system_paasta_config,
-            mock_bounce_lock_zookeeper,
-            mock_delete_marathon_app,
-            mock_log,
-        ):
+        with mock.patch(
+            'paasta_tools.cleanup_marathon_jobs.load_system_paasta_config', autospec=True,
+        ), mock.patch(
+            'paasta_tools.bounce_lib.bounce_lock_zookeeper', autospec=True,
+        ), mock.patch(
+            'paasta_tools.bounce_lib.delete_marathon_app', side_effect=ValueError('foo'), autospec=True,
+        ), mock.patch(
+            'paasta_tools.cleanup_marathon_jobs._log', autospec=True,
+        ) as mock_log:
             with raises(ValueError):
                 cleanup_marathon_jobs.delete_app(app_id, client, 'fake_soa_dir')
             assert 'example_service' in mock_log.mock_calls[0][2]["line"]

--- a/tests/test_list_marathon_service_instances.py
+++ b/tests/test_list_marathon_service_instances.py
@@ -14,22 +14,18 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import contextlib
-
 import mock
 
 from paasta_tools import list_marathon_service_instances
 
 
 def test_get_desired_marathon_configs():
-    with contextlib.nested(
-        mock.patch('paasta_tools.list_marathon_service_instances.get_services_for_cluster', autospec=True),
-        mock.patch('paasta_tools.list_marathon_service_instances.load_marathon_service_config', autospec=True),
-        mock.patch('paasta_tools.list_marathon_service_instances.load_system_paasta_config', autospec=True),
-    ) as (
-        mock_get_services_for_cluster,
-        mock_load_marathon_service_config,
-        _,
+    with mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_services_for_cluster', autospec=True,
+    ) as mock_get_services_for_cluster, mock.patch(
+        'paasta_tools.list_marathon_service_instances.load_marathon_service_config', autospec=True,
+    ) as mock_load_marathon_service_config, mock.patch(
+        'paasta_tools.list_marathon_service_instances.load_system_paasta_config', autospec=True,
     ):
         mock_app_dict = {'id': '/service.instance.git.configs'}
         mock_get_services_for_cluster.return_value = [('service', 'instance')]
@@ -41,13 +37,11 @@ def test_get_desired_marathon_configs():
 
 
 def test_get_service_instances_that_need_bouncing():
-    with contextlib.nested(
-        mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True),
-        mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True),
-    ) as (
-        mock_get_desired_marathon_configs,
-        mock_get_num_at_risk_tasks,
-    ):
+    with mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True,
+    ) as mock_get_desired_marathon_configs, mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True,
+    ) as mock_get_num_at_risk_tasks:
         mock_get_desired_marathon_configs.return_value = {
             'fake--service.fake--instance.sha.config': {'instances': 5},
             'fake--service2.fake--instance.sha.config': {'instances': 5},
@@ -63,13 +57,11 @@ def test_get_service_instances_that_need_bouncing():
 
 
 def test_get_service_instances_that_need_bouncing_two_existing_services():
-    with contextlib.nested(
-        mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True),
-        mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True),
-    ) as (
-        mock_get_desired_marathon_configs,
-        mock_get_num_at_risk_tasks,
-    ):
+    with mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True,
+    ) as mock_get_desired_marathon_configs, mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True,
+    ) as mock_get_num_at_risk_tasks:
         mock_get_desired_marathon_configs.return_value = {
             'fake--service.fake--instance.sha.config': {'instances': 5},
         }
@@ -84,13 +76,11 @@ def test_get_service_instances_that_need_bouncing_two_existing_services():
 
 
 def test_get_service_instances_that_need_bouncing_no_difference():
-    with contextlib.nested(
-        mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True),
-        mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True),
-    ) as (
-        mock_get_desired_marathon_configs,
-        mock_get_num_at_risk_tasks,
-    ):
+    with mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True,
+    ) as mock_get_desired_marathon_configs, mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True,
+    ) as mock_get_num_at_risk_tasks:
         mock_get_desired_marathon_configs.return_value = {'fake--service.fake--instance.sha.config': {'instances': 5}}
         fake_apps = [mock.MagicMock(instances=5, id='/fake--service.fake--instance.sha.config')]
         mock_client = mock.MagicMock(list_apps=mock.MagicMock(return_value=fake_apps))
@@ -100,13 +90,11 @@ def test_get_service_instances_that_need_bouncing_no_difference():
 
 
 def test_get_service_instances_that_need_bouncing_instances_difference():
-    with contextlib.nested(
-        mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True),
-        mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True),
-    ) as (
-        mock_get_desired_marathon_configs,
-        mock_get_num_at_risk_tasks,
-    ):
+    with mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True,
+    ) as mock_get_desired_marathon_configs, mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True,
+    ) as mock_get_num_at_risk_tasks:
         mock_get_desired_marathon_configs.return_value = {'fake--service.fake--instance.sha.config': {'instances': 5}}
         fake_apps = [mock.MagicMock(instances=4, id='/fake--service.fake--instance.sha.config')]
         mock_client = mock.MagicMock(list_apps=mock.MagicMock(return_value=fake_apps))
@@ -116,13 +104,11 @@ def test_get_service_instances_that_need_bouncing_instances_difference():
 
 
 def test_get_service_instances_that_need_bouncing_at_risk():
-    with contextlib.nested(
-        mock.patch('paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True),
-        mock.patch('paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True),
-    ) as (
-        mock_get_desired_marathon_configs,
-        mock_get_num_at_risk_tasks,
-    ):
+    with mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True,
+    ) as mock_get_desired_marathon_configs, mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True,
+    ) as mock_get_num_at_risk_tasks:
         mock_get_desired_marathon_configs.return_value = {'fake--service.fake--instance.sha.config': {'instances': 5}}
         fake_apps = [mock.MagicMock(instances=5, id='/fake--service.fake--instance.sha.config')]
         mock_client = mock.MagicMock(list_apps=mock.MagicMock(return_value=fake_apps))

--- a/tests/test_long_running_service_tools.py
+++ b/tests/test_long_running_service_tools.py
@@ -14,8 +14,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import contextlib
-
 import mock
 from pytest import raises
 
@@ -66,14 +64,12 @@ class TestLongRunningServiceConfig(object):
             'mode': 'http',
             'healthcheck_uri': fake_path,
         })
-        with contextlib.nested(
-            mock.patch('paasta_tools.long_running_service_tools.load_service_namespace_config',
-                       autospec=True,
-                       return_value=fake_service_namespace_config),
-            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
-        ) as (
-            load_service_namespace_config_patch,
-            hostname_patch
+        with mock.patch(
+            'paasta_tools.long_running_service_tools.load_service_namespace_config',
+            autospec=True,
+            return_value=fake_service_namespace_config,
+        ), mock.patch(
+            'socket.getfqdn', autospec=True, return_value=fake_hostname,
         ):
             expected = ('http', 'http://%s:%d%s' % (fake_hostname, fake_random_port, fake_path))
             actual = long_running_service_tools.get_healthcheck_for_instance(
@@ -96,14 +92,12 @@ class TestLongRunningServiceConfig(object):
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({
             'mode': 'tcp',
         })
-        with contextlib.nested(
-            mock.patch('paasta_tools.long_running_service_tools.load_service_namespace_config',
-                       autospec=True,
-                       return_value=fake_service_namespace_config),
-            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
-        ) as (
-            load_service_namespace_config_patch,
-            hostname_patch
+        with mock.patch(
+            'paasta_tools.long_running_service_tools.load_service_namespace_config',
+            autospec=True,
+            return_value=fake_service_namespace_config,
+        ), mock.patch(
+            'socket.getfqdn', autospec=True, return_value=fake_hostname,
         ):
             expected = ('tcp', 'tcp://%s:%d' % (fake_hostname, fake_random_port))
             actual = long_running_service_tools.get_healthcheck_for_instance(
@@ -128,14 +122,12 @@ class TestLongRunningServiceConfig(object):
             branch_dict={},
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
-        with contextlib.nested(
-            mock.patch('paasta_tools.long_running_service_tools.load_service_namespace_config',
-                       autospec=True,
-                       return_value=fake_service_namespace_config),
-            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
-        ) as (
-            load_service_namespace_config_patch,
-            hostname_patch
+        with mock.patch(
+            'paasta_tools.long_running_service_tools.load_service_namespace_config',
+            autospec=True,
+            return_value=fake_service_namespace_config,
+        ), mock.patch(
+            'socket.getfqdn', autospec=True, return_value=fake_hostname,
         ):
             expected = ('cmd', fake_cmd)
             actual = long_running_service_tools.get_healthcheck_for_instance(
@@ -157,14 +149,12 @@ class TestLongRunningServiceConfig(object):
             branch_dict={},
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
-        with contextlib.nested(
-            mock.patch('paasta_tools.long_running_service_tools.load_service_namespace_config',
-                       autospec=True,
-                       return_value=fake_service_namespace_config),
-            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
-        ) as (
-            load_service_namespace_config_patch,
-            hostname_patch
+        with mock.patch(
+            'paasta_tools.long_running_service_tools.load_service_namespace_config',
+            autospec=True,
+            return_value=fake_service_namespace_config,
+        ), mock.patch(
+            'socket.getfqdn', autospec=True, return_value=fake_hostname,
         ):
             expected = (None, None)
             actual = long_running_service_tools.get_healthcheck_for_instance(
@@ -187,14 +177,12 @@ class TestLongRunningServiceConfig(object):
             branch_dict={},
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
-        with contextlib.nested(
-            mock.patch('paasta_tools.long_running_service_tools.load_service_namespace_config',
-                       autospec=True,
-                       return_value=fake_service_namespace_config),
-            mock.patch('socket.getfqdn', autospec=True, return_value=fake_hostname),
-        ) as (
-            load_service_namespace_config_patch,
-            hostname_patch
+        with mock.patch(
+            'paasta_tools.long_running_service_tools.load_service_namespace_config',
+            autospec=True,
+            return_value=fake_service_namespace_config,
+        ) as load_service_namespace_config_patch, mock.patch(
+            'socket.getfqdn', autospec=True, return_value=fake_hostname,
         ):
             expected = (None, None)
             actual = long_running_service_tools.get_healthcheck_for_instance(

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -52,11 +52,9 @@ fake_marathon_job_config = marathon_tools.MarathonServiceConfig(
 
 
 def test_get_bouncing_status():
-    with contextlib.nested(
-        mock.patch('paasta_tools.marathon_serviceinit.marathon_tools.get_matching_appids', autospec=True),
-    ) as (
-        mock_get_matching_appids,
-    ):
+    with mock.patch(
+        'paasta_tools.marathon_serviceinit.marathon_tools.get_matching_appids', autospec=True,
+    ) as mock_get_matching_appids:
         mock_get_matching_appids.return_value = ['a', 'b']
         mock_config = marathon_tools.MarathonServiceConfig(
             service='fake_service',
@@ -95,15 +93,13 @@ def test_status_marathon_job_verbose():
     service = 'my_service'
     instance = 'my_instance'
     task = mock.Mock()
-    with contextlib.nested(
-        mock.patch('paasta_tools.marathon_serviceinit.marathon_tools.get_matching_appids', autospec=True),
-        mock.patch('paasta_tools.marathon_serviceinit.get_verbose_status_of_marathon_app', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True),
-    ) as (
-        mock_get_matching_appids,
-        mock_get_verbose_app,
-        mock_is_app_id_running,
-    ):
+    with mock.patch(
+        'paasta_tools.marathon_serviceinit.marathon_tools.get_matching_appids', autospec=True,
+    ) as mock_get_matching_appids, mock.patch(
+        'paasta_tools.marathon_serviceinit.get_verbose_status_of_marathon_app', autospec=True,
+    ) as mock_get_verbose_app, mock.patch(
+        'paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True,
+    ) as mock_is_app_id_running:
         mock_get_matching_appids.return_value = ['/app1']
         mock_get_verbose_app.return_value = ([task], 'fake_return')
         tasks, out = marathon_serviceinit.status_marathon_job_verbose(service, instance, client)
@@ -120,15 +116,13 @@ def test_status_marathon_job_verbose_when_not_running():
     client.get_app.return_value = app
     service = 'my_service'
     instance = 'my_instance'
-    with contextlib.nested(
-        mock.patch('paasta_tools.marathon_serviceinit.marathon_tools.get_matching_appids', autospec=True),
-        mock.patch('paasta_tools.marathon_serviceinit.get_verbose_status_of_marathon_app', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.is_app_id_running', return_value=False, autospec=True),
-    ) as (
-        mock_get_matching_appids,
-        mock_get_verbose_app,
-        mock_is_app_id_running,
-    ):
+    with mock.patch(
+        'paasta_tools.marathon_serviceinit.marathon_tools.get_matching_appids', autospec=True,
+    ) as mock_get_matching_appids, mock.patch(
+        'paasta_tools.marathon_serviceinit.get_verbose_status_of_marathon_app', autospec=True,
+    ) as mock_get_verbose_app, mock.patch(
+        'paasta_tools.marathon_tools.is_app_id_running', return_value=False, autospec=True,
+    ) as mock_is_app_id_running:
         mock_get_matching_appids.return_value = ['/app1']
         tasks, out = marathon_serviceinit.status_marathon_job_verbose(service, instance, client)
         mock_is_app_id_running.assert_called_once_with('/app1', client)
@@ -196,11 +190,9 @@ def test_status_marathon_job_when_running():
     app.tasks_running = mock_tasks_running
     app.deployments = []
     app.instances = normal_instance_count
-    with contextlib.nested(
-        mock.patch('paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True),
-    ) as (
-        is_app_id_running_patch,
-    ):
+    with mock.patch(
+        'paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True,
+    ) as is_app_id_running_patch:
         marathon_serviceinit.status_marathon_job(service, instance, app_id, normal_instance_count, client)
         is_app_id_running_patch.assert_called_once_with(app_id, client)
 
@@ -217,26 +209,23 @@ def tests_status_marathon_job_when_running_running_no_tasks():
     app.tasks_running = mock_tasks_running
     app.deployments = []
     app.instances = normal_instance_count
-    with contextlib.nested(
-        mock.patch('paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True),
-    ) as (
-        is_app_id_running_patch,
-    ):
+    with mock.patch(
+        'paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True,
+    ) as is_app_id_running_patch:
         marathon_serviceinit.status_marathon_job(service, instance, app_id, normal_instance_count, client)
         is_app_id_running_patch.assert_called_once_with(app_id, client)
 
 
 def tests_status_marathon_job_when_running_not_running():
     client = mock.create_autospec(marathon.MarathonClient)
+    client.get_app.return_value.tasks_running = 0
     service = 'my_service'
     instance = 'my_instance'
     app_id = 'mock_app_id'
     normal_instance_count = 5
-    with contextlib.nested(
-        mock.patch('paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True),
-    ) as (
-        is_app_id_running_patch,
-    ):
+    with mock.patch(
+        'paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True,
+    ) as is_app_id_running_patch:
         marathon_serviceinit.status_marathon_job(service, instance, app_id, normal_instance_count, client)
         is_app_id_running_patch.assert_called_once_with(app_id, client)
 
@@ -253,11 +242,9 @@ def tests_status_marathon_job_when_running_running_tasks_with_deployments():
     app.tasks_running = mock_tasks_running
     app.deployments = ['test_deployment']
     app.instances = normal_instance_count
-    with contextlib.nested(
-        mock.patch('paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True),
-    ) as (
-        is_app_id_running_patch,
-    ):
+    with mock.patch(
+        'paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True,
+    ) as is_app_id_running_patch:
         output = marathon_serviceinit.status_marathon_job(service, instance, app_id, normal_instance_count, client)
         is_app_id_running_patch.assert_called_once_with(app_id, client)
         assert 'Deploying' in output
@@ -275,13 +262,11 @@ def tests_status_marathon_job_when_running_running_tasks_with_delayed_deployment
     app.tasks_running = mock_tasks_running
     app.deployments = ['test_deployment']
     app.instances = normal_instance_count
-    with contextlib.nested(
-        mock.patch('paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True),
-        mock.patch('paasta_tools.marathon_tools.get_app_queue_status', return_value=(False, 10), autospec=True),
-    ) as (
-        is_app_id_running_patch,
-        get_app_queue_status_patch,
-    ):
+    with mock.patch(
+        'paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True,
+    ) as is_app_id_running_patch, mock.patch(
+        'paasta_tools.marathon_tools.get_app_queue_status', return_value=(False, 10), autospec=True,
+    ) as get_app_queue_status_patch:
         output = marathon_serviceinit.status_marathon_job(service, instance, app_id, normal_instance_count, client)
         is_app_id_running_patch.assert_called_once_with(app_id, client)
         get_app_queue_status_patch.assert_called_with(client, app_id)
@@ -300,13 +285,11 @@ def tests_status_marathon_job_when_running_running_tasks_with_waiting_deployment
     app.tasks_running = mock_tasks_running
     app.deployments = ['test_deployment']
     app.instances = normal_instance_count
-    with contextlib.nested(
-        mock.patch('paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True),
-        mock.patch('paasta_tools.marathon_tools.get_app_queue_status', return_value=(True, 0), autospec=True),
-    ) as (
-        is_app_id_running_patch,
-        get_app_queue_status_patch,
-    ):
+    with mock.patch(
+        'paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True,
+    ) as is_app_id_running_patch, mock.patch(
+        'paasta_tools.marathon_tools.get_app_queue_status', return_value=(True, 0), autospec=True,
+    ) as get_app_queue_status_patch:
         output = marathon_serviceinit.status_marathon_job(service, instance, app_id, normal_instance_count, client)
         is_app_id_running_patch.assert_called_once_with(app_id, client)
         get_app_queue_status_patch.assert_called_once_with(client, app_id)
@@ -326,13 +309,11 @@ def tests_status_marathon_job_when_running_running_tasks_with_suspended_deployme
     app.deployments = []
     app.instances = 0
     app.tasks_running = 0
-    with contextlib.nested(
-        mock.patch('paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True),
-        mock.patch('paasta_tools.marathon_tools.get_app_queue_status', return_value=(None, None), autospec=True),
-    ) as (
-        is_app_id_running_patch,
-        get_app_queue_status_patch,
-    ):
+    with mock.patch(
+        'paasta_tools.marathon_tools.is_app_id_running', return_value=True, autospec=True,
+    ) as is_app_id_running_patch, mock.patch(
+        'paasta_tools.marathon_tools.get_app_queue_status', return_value=(None, None), autospec=True,
+    ) as get_app_queue_status_patch:
         output = marathon_serviceinit.status_marathon_job(service, instance, app_id, normal_instance_count, client)
         is_app_id_running_patch.assert_called_once_with(app_id, client)
         assert get_app_queue_status_patch.call_count == 1
@@ -378,19 +359,17 @@ def test_status_smartstack_backends_normal():
                    'check_status': 'L7OK', 'check_duration': 1},
     }
 
-    with contextlib.nested(
-        mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True),
-        mock.patch('paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True),
-        mock.patch('paasta_tools.marathon_serviceinit.get_backends', autospec=True),
-        mock.patch('paasta_tools.marathon_serviceinit.match_backends_and_tasks', autospec=True),
-    ) as (
-        mock_load_service_namespace_config,
-        mock_read_reg,
-        mock_get_all_slaves_for_blacklist_whitelist,
-        mock_get_backends,
-        mock_match_backends_and_tasks,
-    ):
+    with mock.patch(
+        'paasta_tools.marathon_tools.load_service_namespace_config', autospec=True,
+    ) as mock_load_service_namespace_config, mock.patch(
+        'paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True,
+    ) as mock_read_reg, mock.patch(
+        'paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True,
+    ) as mock_get_all_slaves_for_blacklist_whitelist, mock.patch(
+        'paasta_tools.marathon_serviceinit.get_backends', autospec=True,
+    ) as mock_get_backends, mock.patch(
+        'paasta_tools.marathon_serviceinit.match_backends_and_tasks', autospec=True,
+    ) as mock_match_backends_and_tasks:
         mock_load_service_namespace_config.return_value.get_discover.return_value = 'fake_discover'
         mock_get_all_slaves_for_blacklist_whitelist.return_value = [{
             'hostname': 'fakehost',
@@ -448,19 +427,17 @@ def test_status_smartstack_backends_different_nerve_ns():
                    'check_status': 'L7OK', 'check_duration': 1},
     }
 
-    with contextlib.nested(
-        mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True),
-        mock.patch('paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True),
-        mock.patch('paasta_tools.marathon_serviceinit.get_backends', autospec=True),
-        mock.patch('paasta_tools.marathon_serviceinit.match_backends_and_tasks', autospec=True),
-    ) as (
-        mock_load_service_namespace_config,
-        mock_read_reg,
-        mock_get_all_slaves_for_blacklist_whitelist,
-        mock_get_backends,
-        mock_match_backends_and_tasks,
-    ):
+    with mock.patch(
+        'paasta_tools.marathon_tools.load_service_namespace_config', autospec=True,
+    ) as mock_load_service_namespace_config, mock.patch(
+        'paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True,
+    ) as mock_read_reg, mock.patch(
+        'paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True,
+    ) as mock_get_all_slaves_for_blacklist_whitelist, mock.patch(
+        'paasta_tools.marathon_serviceinit.get_backends', autospec=True,
+    ) as mock_get_backends, mock.patch(
+        'paasta_tools.marathon_serviceinit.match_backends_and_tasks', autospec=True,
+    ) as mock_match_backends_and_tasks:
         mock_load_service_namespace_config.return_value.get_discover.return_value = 'fake_discover'
         mock_get_all_slaves_for_blacklist_whitelist.return_value = [{
             'hostname': 'fakehost',
@@ -507,15 +484,13 @@ def test_status_smartstack_backends_no_smartstack_replication_info():
     cluster = 'fake_cluster'
     tasks = mock.Mock()
     normal_count = 10
-    with contextlib.nested(
-        mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True),
-        mock.patch('paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True),
-    ) as (
-        mock_load_service_namespace_config,
-        mock_read_reg,
-        mock_get_all_slaves_for_blacklist_whitelist,
-    ):
+    with mock.patch(
+        'paasta_tools.marathon_tools.load_service_namespace_config', autospec=True,
+    ) as mock_load_service_namespace_config, mock.patch(
+        'paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True,
+    ) as mock_read_reg, mock.patch(
+        'paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True,
+    ) as mock_get_all_slaves_for_blacklist_whitelist:
         mock_load_service_namespace_config.return_value.get_discover.return_value = 'fake_discover'
         mock_read_reg.return_value = service_instance
         mock_get_all_slaves_for_blacklist_whitelist.return_value = {}
@@ -544,19 +519,17 @@ def test_status_smartstack_backends_multiple_locations():
     fake_backend = {'status': 'UP', 'lastchg': '1', 'last_chk': 'OK',
                     'check_code': '200', 'svname': 'ipaddress1:1001_hostname1',
                     'check_status': 'L7OK', 'check_duration': 1}
-    with contextlib.nested(
-        mock.patch('paasta_tools.marathon_tools.load_service_namespace_config', autospec=True),
-        mock.patch('paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True),
-        mock.patch('paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True),
-        mock.patch('paasta_tools.marathon_serviceinit.get_backends', autospec=True),
-        mock.patch('paasta_tools.marathon_serviceinit.match_backends_and_tasks', autospec=True),
-    ) as (
-        mock_load_service_namespace_config,
-        mock_read_reg,
-        mock_get_all_slaves_for_blacklist_whitelist,
-        mock_get_backends,
-        mock_match_backends_and_tasks,
-    ):
+    with mock.patch(
+        'paasta_tools.marathon_tools.load_service_namespace_config', autospec=True,
+    ) as mock_load_service_namespace_config, mock.patch(
+        'paasta_tools.marathon_tools.read_registration_for_service_instance', autospec=True,
+    ) as mock_read_reg, mock.patch(
+        'paasta_tools.marathon_serviceinit.get_all_slaves_for_blacklist_whitelist', autospec=True,
+    ) as mock_get_all_slaves_for_blacklist_whitelist, mock.patch(
+        'paasta_tools.marathon_serviceinit.get_backends', autospec=True,
+    ) as mock_get_backends, mock.patch(
+        'paasta_tools.marathon_serviceinit.match_backends_and_tasks', autospec=True,
+    ) as mock_match_backends_and_tasks:
         mock_load_service_namespace_config.return_value.get_discover.return_value = 'fake_discover'
         mock_read_reg.return_value = service_instance
         mock_get_backends.return_value = [fake_backend]
@@ -1048,15 +1021,11 @@ def test_pretty_print_smartstack_backends_for_locations_verbose():
             'lastchg': 0
         },
     }
-    with contextlib.nested(
-        mock.patch(
-            'paasta_tools.marathon_serviceinit.get_backends', autospec=True,
-            side_effect=lambda _, synapse_host, synapse_port, synapse_haproxy_url_format: [backends[synapse_host]]
-        ),
-        mock.patch('socket.gethostbyname', side_effect=lambda name: host_ip_mapping[name], autospec=True),
-    ) as (
-        mock_get_backends,
-        mock_gethostbyname,
+    with mock.patch(
+        'paasta_tools.marathon_serviceinit.get_backends', autospec=True,
+        side_effect=lambda _, synapse_host, synapse_port, synapse_haproxy_url_format: [backends[synapse_host]]
+    ), mock.patch(
+        'socket.gethostbyname', side_effect=lambda name: host_ip_mapping[name], autospec=True,
     ):
         actual = marathon_serviceinit.pretty_print_smartstack_backends_for_locations(
             service_instance='fake_service.fake_instance',

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1577,15 +1577,11 @@ class TestMarathonTools:
                     'force_bounce': '99999',
                 },
             )
-            with raises(NoSlavesAvailableError) as e:
+            with raises(NoSlavesAvailableError) as excinfo:
                 fake_service_config.get_routing_constraints(self.fake_service_namespace_config)
-                assert e.value.message == (
-                    "No suitable slaves could be found in the cluster for fake_name.fake_instance"
-                    "There are 0 total slaves in the cluster, but after filtering"
-                    " those available to the app according to the constraints set"
-                    " by the deploy_blacklist and deploy_whitelist, there are 0"
-                    " available."
-                )
+            assert str(excinfo.value) == (
+                "No slaves could be found in the cluster."
+            )
 
     def test_get_routing_constraints_no_slaves_after_filter(self):
         with contextlib.nested(
@@ -1606,15 +1602,15 @@ class TestMarathonTools:
                     'force_bounce': '99999',
                 },
             )
-            with raises(NoSlavesAvailableError) as e:
+            with raises(NoSlavesAvailableError) as excinfo:
                 fake_service_config.get_routing_constraints(self.fake_service_namespace_config)
-                assert e.value.message == (
-                    "No suitable slaves could be found in the cluster for fake_name.fake_instance"
-                    "There are 1 total slaves in the cluster, but after filtering"
-                    " those available to the app according to the constraints set"
-                    " by the deploy_blacklist and deploy_whitelist, there are 0"
-                    " available."
-                )
+            assert str(excinfo.value) == (
+                "No suitable slaves could be found in the cluster for fake_name.fake_instance"
+                "There are 1 total slaves in the cluster, but after filtering"
+                " those available to the app according to the constraints set"
+                " by the deploy_blacklist and deploy_whitelist, there are 0"
+                " available."
+            )
 
     def test_get_expected_instance_count_for_namespace(self):
         service = 'red'

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -78,7 +78,7 @@ def test_status_mesos_tasks_verbose(test_case):
             'state': 'NOT_RUNNING',
         }
         non_running_mesos_tasks = []
-        for _ in xrange(15):  # excercise the code that sorts/truncates the list of non running tasks
+        for _ in range(15):  # excercise the code that sorts/truncates the list of non running tasks
             task_return = template_task_return.copy()
             task_return['statuses'][0]['timestamp'] = str(1457109986 + random.randrange(-60 * 60 * 24, 60 * 60 * 24))
             non_running_mesos_tasks.append(task_return)
@@ -89,17 +89,14 @@ def test_status_mesos_tasks_verbose(test_case):
         format_stdstreams_tail_for_task_patch.return_value = ['tail']
         job_id = format_job_id('fake_service', 'fake_instance'),
 
-        def get_short_task_id(_):
-            return 'short_task_id'
-
         actual = mesos_tools.status_mesos_tasks_verbose(
             job_id=job_id,
-            get_short_task_id=get_short_task_id,
+            get_short_task_id=mock.sentinel.get_short_task_id,
             tail_lines=tail_lines,
         )
         assert 'Running Tasks' in actual
         assert 'Non-Running Tasks' in actual
-        format_running_mesos_task_row_patch.assert_called_once_with('doing a lap', get_short_task_id)
+        format_running_mesos_task_row_patch.assert_called_once_with('doing a lap', mock.sentinel.get_short_task_id)
         assert format_non_running_mesos_task_row_patch.call_count == 10  # maximum n of tasks we display
         assert format_stdstreams_tail_for_task_patch.call_count == expected_format_tail_call_count
 
@@ -672,11 +669,6 @@ def test_get_count_running_tasks_on_slave():
         assert mesos_tools.get_count_running_tasks_on_slave('host3') == 0
         assert mock_master.state_summary.called
         mock_get_mesos_task_count_by_slave.assert_called_with(mock_mesos_state)
-
-
-def mock_getitem(key):
-    if key == 'id':
-        return 'fakeID'
 
 
 def test_get_tasks_from_app_id():

--- a/tests/test_native_mesos_scheduler.py
+++ b/tests/test_native_mesos_scheduler.py
@@ -58,7 +58,7 @@ class TestPaastaScheduler(object):
         cluster = "cluster"
 
         service_configs = []
-        for force_bounce in xrange(2):
+        for force_bounce in range(2):
             service_configs.append(native_mesos_scheduler.PaastaNativeServiceConfig(
                 service=service_name,
                 instance=instance_name,
@@ -149,9 +149,7 @@ class TestPaastaScheduler(object):
             scheduler.statusUpdate(fake_driver, mock.Mock(task_id=task.task_id, state=TASK_KILLED))
 
         # Clean up the TestDrainMethod for the rest of this test.
-        for task in list(scheduler.drain_method.downed_task_ids):
-            scheduler.drain_method.stop_draining(mock.Mock(id=task))
-        assert len(scheduler.drain_method.downed_task_ids) == 0
+        assert not list(scheduler.drain_method.downed_task_ids)
 
         # Now scale down old app
         scheduler.service_config.config_dict['instances'] = 2
@@ -207,7 +205,7 @@ class TestPaastaScheduler(object):
                 assert resource.ranges.range[0].end == 12345
                 break
         else:
-            raise Exception("never saw a ports resource")
+            raise AssertionError("never saw a ports resource")
 
 
 class TestPaastaNativeServiceConfig(object):
@@ -267,7 +265,9 @@ class TestPaastaNativeServiceConfig(object):
                 assert resource.scalar.value == 0.1
             elif resource.name == "mem":
                 assert resource.scalar.value == 50
-            elif resource.name == "port":
+            elif resource.name == 'ports':
                 pass
+            else:
+                raise AssertionError('Unreachable: {}'.format(resource.name))
 
         assert task.name.startswith("service_name.instance_name.gitfake/bus.config")

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -15,8 +15,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import contextlib
-
 from mock import Mock
 from mock import patch
 from pytest import raises
@@ -26,30 +24,23 @@ from paasta_tools import paasta_metastatus
 
 
 def test_main_no_marathon_config():
-    with contextlib.nested(
-        patch('paasta_tools.marathon_tools.load_marathon_config', autospec=True),
-        patch('paasta_tools.paasta_metastatus.load_chronos_config', autospec=True),
-        patch('paasta_tools.metrics.metastatus_lib.get_chronos_status', autospec=True),
-        patch('paasta_tools.paasta_metastatus.get_mesos_master', autospec=True),
-        patch('paasta_tools.metrics.metastatus_lib.get_mesos_state_status', autospec=True,
-              return_value=([('fake_output', True)])),
-        patch('paasta_tools.metrics.metastatus_lib.get_mesos_resource_utilization_health', autospec=True),
-        patch('paasta_tools.metrics.metastatus_lib.get_marathon_status', autospec=True,
-              return_value=([('fake_output', True)])),
-        patch('paasta_tools.paasta_metastatus.parse_args', autospec=True),
-    ) as (
-        load_marathon_config_patch,
-        load_chronos_config_patch,
-        load_get_chronos_status_patch,
-        get_mesos_master,
-        get_mesos_state_status_patch,
-        get_mesos_resource_utilization_health_patch,
-        load_get_marathon_status_patch,
-        parse_args_patch,
+    with patch(
+        'paasta_tools.marathon_tools.load_marathon_config', autospec=True,
+    ) as load_marathon_config_patch, patch(
+        'paasta_tools.paasta_metastatus.load_chronos_config', autospec=True,
+    ), patch(
+        'paasta_tools.metrics.metastatus_lib.get_chronos_status', autospec=True,
+    ), patch(
+        'paasta_tools.paasta_metastatus.get_mesos_master', autospec=True,
+    ) as get_mesos_master, patch(
+        'paasta_tools.metrics.metastatus_lib.get_mesos_state_status', autospec=True,
+        return_value=([('fake_output', True)]),
+    ) as get_mesos_state_status_patch, patch(
+        'paasta_tools.metrics.metastatus_lib.get_mesos_resource_utilization_health', autospec=True,
+    ) as get_mesos_resource_utilization_health_patch, patch(
+        'paasta_tools.metrics.metastatus_lib.get_marathon_status', autospec=True,
+        return_value=([('fake_output', True)]),
     ):
-        fake_args = Mock(
-            verbose=0,
-        )
         fake_master = Mock(autospace=True)
         fake_master.metrics_snapshot.return_value = {
             'master/frameworks_active': 2,
@@ -63,37 +54,28 @@ def test_main_no_marathon_config():
         get_mesos_state_status_patch.return_value = []
         get_mesos_resource_utilization_health_patch.return_value = []
 
-        parse_args_patch.return_value = fake_args
         load_marathon_config_patch.return_value = {}
         with raises(SystemExit) as excinfo:
-            paasta_metastatus.main()
+            paasta_metastatus.main(())
         assert excinfo.value.code == 0
 
 
 def test_main_no_chronos_config():
-    with contextlib.nested(
-        patch('paasta_tools.marathon_tools.load_marathon_config', autospec=True),
-        patch('paasta_tools.paasta_metastatus.load_chronos_config', autospec=True),
-        patch('paasta_tools.paasta_metastatus.get_mesos_master', autospec=True),
-        patch('paasta_tools.metrics.metastatus_lib.get_mesos_state_status', autospec=True,
-              return_value=([('fake_output', True)])),
-        patch('paasta_tools.metrics.metastatus_lib.get_mesos_resource_utilization_health', autospec=True),
-        patch('paasta_tools.metrics.metastatus_lib.get_marathon_status', autospec=True,
-              return_value=([('fake_output', True)])),
-        patch('paasta_tools.paasta_metastatus.parse_args', autospec=True),
-    ) as (
-        load_marathon_config_patch,
-        load_chronos_config_patch,
-        get_mesos_master,
-        get_mesos_state_status_patch,
-        get_mesos_resource_utilization_health_patch,
-        load_get_marathon_status_patch,
-        parse_args_patch,
+    with patch(
+        'paasta_tools.marathon_tools.load_marathon_config', autospec=True,
+    ) as load_marathon_config_patch, patch(
+        'paasta_tools.paasta_metastatus.load_chronos_config', autospec=True,
+    ) as load_chronos_config_patch, patch(
+        'paasta_tools.paasta_metastatus.get_mesos_master', autospec=True,
+    ) as get_mesos_master, patch(
+        'paasta_tools.metrics.metastatus_lib.get_mesos_state_status', autospec=True,
+        return_value=([('fake_output', True)]),
+    ) as get_mesos_state_status_patch, patch(
+        'paasta_tools.metrics.metastatus_lib.get_mesos_resource_utilization_health', autospec=True,
+    ) as get_mesos_resource_utilization_health_patch, patch(
+        'paasta_tools.metrics.metastatus_lib.get_marathon_status', autospec=True,
+        return_value=([('fake_output', True)]),
     ):
-
-        fake_args = Mock(
-            verbose=0,
-        )
         fake_master = Mock(autospace=True)
         fake_master.metrics_snapshot.return_value = {
             'master/frameworks_active': 2,
@@ -104,7 +86,6 @@ def test_main_no_chronos_config():
         fake_master.state.return_value = {}
         get_mesos_master.return_value = fake_master
 
-        parse_args_patch.return_value = fake_args
         load_marathon_config_patch.return_value = {}
 
         get_mesos_state_status_patch.return_value = []
@@ -112,35 +93,27 @@ def test_main_no_chronos_config():
 
         load_chronos_config_patch.return_value = {}
         with raises(SystemExit) as excinfo:
-            paasta_metastatus.main()
+            paasta_metastatus.main(())
         assert excinfo.value.code == 0
 
 
 def test_main_marathon_jsondecode_error():
-    with contextlib.nested(
-        patch('paasta_tools.marathon_tools.load_marathon_config', autospec=True),
-        patch('paasta_tools.paasta_metastatus.load_chronos_config', autospec=True),
-        patch('paasta_tools.paasta_metastatus.get_mesos_master', autospec=True),
-        patch('paasta_tools.metrics.metastatus_lib.get_mesos_state_status', autospec=True,
-              return_value=([('fake_output', True)])),
-        patch('paasta_tools.metrics.metastatus_lib.get_mesos_resource_utilization_health', autospec=True),
-        patch('paasta_tools.metrics.metastatus_lib.get_marathon_client', autospec=True),
-        patch('paasta_tools.metrics.metastatus_lib.get_marathon_status', autospec=True),
-        patch('paasta_tools.paasta_metastatus.parse_args', autospec=True),
-    ) as (
-        load_marathon_config_patch,
-        load_chronos_config_patch,
-        get_mesos_master,
-        get_mesos_state_status_patch,
-        get_mesos_resource_utilization_health_patch,
-        get_marathon_client_patch,
-        get_marathon_status_patch,
-        parse_args_patch,
-    ):
-
-        fake_args = Mock(
-            verbose=0,
-        )
+    with patch(
+        'paasta_tools.marathon_tools.load_marathon_config', autospec=True,
+    ) as load_marathon_config_patch, patch(
+        'paasta_tools.paasta_metastatus.load_chronos_config', autospec=True,
+    ), patch(
+        'paasta_tools.paasta_metastatus.get_mesos_master', autospec=True,
+    ) as get_mesos_master, patch(
+        'paasta_tools.metrics.metastatus_lib.get_mesos_state_status', autospec=True,
+        return_value=([('fake_output', True)]),
+    ) as get_mesos_state_status_patch, patch(
+        'paasta_tools.metrics.metastatus_lib.get_mesos_resource_utilization_health', autospec=True,
+    ) as get_mesos_resource_utilization_health_patch, patch(
+        'paasta_tools.metrics.metastatus_lib.get_marathon_client', autospec=True,
+    ) as get_marathon_client_patch, patch(
+        'paasta_tools.metrics.metastatus_lib.get_marathon_status', autospec=True,
+    ) as get_marathon_status_patch:
         fake_master = Mock(autospace=True)
         fake_master.metrics_snapshot.return_value = {
             'master/frameworks_active': 2,
@@ -151,7 +124,6 @@ def test_main_marathon_jsondecode_error():
         fake_master.state.return_value = {}
         get_mesos_master.return_value = fake_master
 
-        parse_args_patch.return_value = fake_args
         load_marathon_config_patch.return_value = {"url": "http://foo"}
         get_marathon_client_patch.return_value = Mock()
 
@@ -161,5 +133,5 @@ def test_main_marathon_jsondecode_error():
         get_mesos_resource_utilization_health_patch.return_value = []
 
         with raises(SystemExit) as excinfo:
-            paasta_metastatus.main()
+            paasta_metastatus.main(())
         assert excinfo.value.code == 2

--- a/tests/test_remote_git.py
+++ b/tests/test_remote_git.py
@@ -43,7 +43,7 @@ def test_make_determine_wants_func():
         lambda x: {'foo': 'bar'}
     )
     actual = determine_wants(refs)
-    expected = dict(refs.items() + [('foo', 'bar')])
+    expected = dict(refs, foo='bar')
     assert actual == expected
 
 
@@ -73,20 +73,15 @@ def test_make_force_push_mutate_refs_func_overwrites_shas():
     assert actual == expected
 
 
-def identity(x):
-    return x
-
-
 @mock.patch('dulwich.client', autospec=True)
 @mock.patch('paasta_tools.remote_git._make_determine_wants_func', autospec=True)
 def test_create_remote_refs_is_safe_by_default(mock_make_determine_wants_func, mock_dulwich_client):
     git_url = 'fake_git_url'
-    ref_mutator = identity
     fake_git_client = mock.Mock()
     mock_dulwich_client.get_transport_and_path.return_value = fake_git_client, 'fake_path'
     remote_git.create_remote_refs(
         git_url=git_url,
-        ref_mutator=ref_mutator,
+        ref_mutator=mock.sentinel.ref_mutator,
     )
     fake_git_client.send_pack.assert_called_once_with(
         'fake_path', mock_make_determine_wants_func.return_value, mock.ANY)
@@ -95,13 +90,12 @@ def test_create_remote_refs_is_safe_by_default(mock_make_determine_wants_func, m
 @mock.patch('dulwich.client', autospec=True)
 def test_create_remote_refs_allows_force_and_uses_the_provided_mutator(mock_dulwich_client):
     git_url = 'fake_git_url'
-    ref_mutator = identity
     fake_git_client = mock.Mock()
     mock_dulwich_client.get_transport_and_path.return_value = fake_git_client, 'fake_path'
     remote_git.create_remote_refs(
         git_url=git_url,
-        ref_mutator=ref_mutator,
+        ref_mutator=mock.sentinel.ref_mutator,
         force=True,
     )
     fake_git_client.send_pack.assert_called_once_with(
-        'fake_path', ref_mutator, mock.ANY)
+        'fake_path', mock.sentinel.ref_mutator, mock.ANY)

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -333,9 +333,7 @@ class TestSetupMarathonJob:
         fake_bounce_method = 'fake_bounce_method'
         fake_drain_method = mock.Mock(is_safe_to_kill=lambda t: False)
         fake_marathon_jobid = 'fake.marathon.jobid'
-        fake_client = mock.create_autospec(
-            marathon.MarathonClient
-        )
+        fake_client = mock.create_autospec(marathon.MarathonClient)
         expected_new_task_count = fake_config["instances"] - len(fake_happy_new_tasks)
         expected_drain_task_count = len(fake_bounce_func_return['tasks_to_drain'])
 
@@ -400,9 +398,7 @@ class TestSetupMarathonJob:
         fake_bounce_method = 'fake_bounce_method'
         fake_drain_method = mock.Mock(is_safe_to_kill=lambda t: False)
         fake_marathon_jobid = 'fake.marathon.jobid'
-        fake_client = mock.create_autospec(
-            marathon.MarathonClient
-        )
+        fake_client = mock.create_autospec(marathon.MarathonClient)
         expected_new_task_count = fake_config["instances"] - len(fake_happy_new_tasks)
         expected_drain_task_count = len(fake_bounce_func_return['tasks_to_drain'])
 
@@ -465,9 +461,7 @@ class TestSetupMarathonJob:
         fake_bounce_method = 'fake_bounce_method'
         fake_drain_method = mock.Mock(is_safe_to_kill=lambda t: False)
         fake_marathon_jobid = 'fake.marathon.jobid'
-        fake_client = mock.create_autospec(
-            marathon.MarathonClient
-        )
+        fake_client = mock.create_autospec(marathon.MarathonClient)
         expected_new_task_count = fake_config["instances"] - len(fake_happy_new_tasks)
         expected_drain_task_count = len(fake_bounce_func_return['tasks_to_drain'])
 
@@ -530,9 +524,7 @@ class TestSetupMarathonJob:
         fake_bounce_method = 'fake_bounce_method'
         fake_drain_method = mock.Mock()
         fake_marathon_jobid = 'fake.marathon.jobid'
-        fake_client = mock.create_autospec(
-            marathon.MarathonClient
-        )
+        fake_client = mock.create_autospec(marathon.MarathonClient)
         expected_new_task_count = fake_config["instances"] - len(fake_happy_new_tasks)
 
         with contextlib.nested(
@@ -598,9 +590,7 @@ class TestSetupMarathonJob:
         fake_bounce_method = 'fake_bounce_method'
         fake_drain_method = mock.Mock()
         fake_marathon_jobid = 'fake.marathon.jobid'
-        fake_client = mock.create_autospec(
-            marathon.MarathonClient
-        )
+        fake_client = mock.create_autospec(marathon.MarathonClient)
 
         with contextlib.nested(
             mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
@@ -661,9 +651,7 @@ class TestSetupMarathonJob:
         fake_drain_method = mock.Mock()
         fake_drain_method.is_safe_to_kill.return_value = False
         fake_marathon_jobid = 'fake.marathon.jobid'
-        fake_client = mock.create_autospec(
-            marathon.MarathonClient
-        )
+        fake_client = mock.create_autospec(marathon.MarathonClient)
 
         with contextlib.nested(
             mock.patch('paasta_tools.setup_marathon_job._log', autospec=True),
@@ -1301,9 +1289,11 @@ class TestSetupMarathonJob:
 
         old_app = mock.Mock(id="/%s" % old_app_id, tasks=[old_task_to_drain, old_task_is_draining, old_task_dont_drain])
 
-        fake_client = mock.MagicMock(
+        fake_client = mock.MagicMock(  # pragma: no branch (only used for interface)
             list_apps=mock.Mock(return_value=[old_app]),
-            kill_given_tasks=mock.Mock(spec=lambda task_ids, scale=False: None),
+            kill_given_tasks=mock.Mock(
+                spec=lambda task_ids, scale=False: None,
+            ),
         )
 
         fake_bounce_func = mock.create_autospec(
@@ -1684,7 +1674,7 @@ class TestDrainTasksAndFindTasksToKill(object):
 
 
 def test_undrain_tasks():
-    all_tasks = [mock.Mock(id="task%d" % x) for x in xrange(5)]
+    all_tasks = [mock.Mock(id="task%d" % x) for x in range(5)]
     to_undrain = all_tasks[:4]
     leave_draining = all_tasks[2:]
     fake_drain_method = mock.Mock(

--- a/tests/test_smartstack_tools.py
+++ b/tests/test_smartstack_tools.py
@@ -14,7 +14,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import contextlib
 import os
 
 import mock
@@ -31,14 +30,12 @@ from paasta_tools.utils import SystemPaastaConfig
 
 
 def test_load_smartstack_info_for_service():
-    with contextlib.nested(
-        mock.patch('paasta_tools.smartstack_tools.marathon_tools.load_service_namespace_config',
-                   autospec=True),
-        mock.patch('paasta_tools.smartstack_tools.get_smartstack_replication_for_attribute',
-                   autospec=True),
-    ) as (
-        mock_load_service_namespace_config,
-        mock_get_smartstack_replication_for_attribute,
+    with mock.patch(
+        'paasta_tools.smartstack_tools.marathon_tools.load_service_namespace_config',
+        autospec=True,
+    ), mock.patch(
+        'paasta_tools.smartstack_tools.get_smartstack_replication_for_attribute',
+        autospec=True,
     ):
         # just a smoke test for now.
         smartstack_tools.load_smartstack_info_for_service(
@@ -69,15 +66,13 @@ def test_get_smartstack_replication_for_attribute():
     ]
 
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
-    with contextlib.nested(
-        mock.patch('paasta_tools.mesos_tools.get_all_slaves_for_blacklist_whitelist',
-                   return_value=mock_filtered_slaves, autospec=True),
-        mock.patch('paasta_tools.smartstack_tools.get_replication_for_services',
-                   return_value={}, autospec=True),
-    ) as (
-        mock_get_all_slaves_for_blacklist_whitelist,
-        mock_get_replication_for_services,
-    ):
+    with mock.patch(
+        'paasta_tools.mesos_tools.get_all_slaves_for_blacklist_whitelist',
+        return_value=mock_filtered_slaves, autospec=True,
+    ) as mock_get_all_slaves_for_blacklist_whitelist, mock.patch(
+        'paasta_tools.smartstack_tools.get_replication_for_services',
+        return_value={}, autospec=True,
+    ) as mock_get_replication_for_services:
         expected = {
             'foo': {},
             'bar': {}
@@ -238,4 +233,7 @@ def test_match_backends_and_tasks():
             (backends[4], None),
         ]
         actual = match_backends_and_tasks(backends, tasks)
-        assert sorted(actual) == sorted(expected)
+
+        def keyfunc(t):
+            return tuple(sorted((t[0] or {}).items())), t[1]
+        assert sorted(actual, key=keyfunc) == sorted(expected, key=keyfunc)

--- a/tox.ini
+++ b/tox.ini
@@ -26,20 +26,38 @@ commands =
     # TZ=UTC .tox/py3/bin/py.test tests |& grep -E '^tests[^ ]+ \.+$' | cut -d' ' -f1 | sort | xargs --replace echo '        {} \' | sed '$ s/ .$//'
     py.test \
         tests/api/test_autoscaler.py \
+        tests/api/test_client.py \
+        tests/api/test_instance.py \
         tests/api/test_service.py \
+        tests/cli/fsm/test_autosuggest.py \
+        tests/cli/test_cmds_check.py \
         tests/cli/test_cmds_cook_image.py \
         tests/cli/test_cmds_docker_exec.py \
         tests/cli/test_cmds_docker_inspect.py \
         tests/cli/test_cmds_docker_stop.py \
         tests/cli/test_cmds_generate_pipeline.py \
+        tests/cli/test_cmds_get_latest_deployment.py \
         tests/cli/test_cmds_help.py \
+        tests/cli/test_cmds_info.py \
         tests/cli/test_cmds_itest.py \
+        tests/cli/test_cmds_list.py \
+        tests/cli/test_cmds_local_run.py \
         tests/cli/test_cmds_mark_for_deployment.py \
+        tests/cli/test_cmds_metastatus.py \
         tests/cli/test_cmds_performance_check.py \
         tests/cli/test_cmds_push_to_registry.py \
+        tests/cli/test_cmds_rerun.py \
+        tests/cli/test_cmds_rollback.py \
+        tests/cli/test_cmds_start_stop_restart.py \
+        tests/cli/test_cmds_status.py \
         tests/cli/test_cmds_sysdig.py \
+        tests/cli/test_cmds_validate.py \
+        tests/cli/test_cmds_wait_for_deployment.py \
+        tests/cli/test_utils.py \
         tests/mesos/test_cluster.py \
+        tests/mesos/test_master.py \
         tests/metrics/test_metastatus_lib.py \
+        tests/monitoring/test_check_classic_service_replication.py \
         tests/monitoring/test_check_synapse_replication.py \
         tests/monitoring/test_config_providers.py \
         tests/test_adhoc_tools.py \
@@ -59,12 +77,21 @@ commands =
         tests/test_generate_services_file.py \
         tests/test_generate_services_yaml.py \
         tests/test_list_marathon_service_instances.py \
+        tests/test_long_running_service_tools.py \
         tests/test_paasta_maintenance.py \
+        tests/test_paasta_metastatus.py \
+        tests/test_remote_git.py \
+        tests/test_smartstack_tools.py \
         tests/test_utils.py
 
 [testenv:coverage]
 commands =
-    python -m pytest --cov-config .coveragerc --cov=paasta_tools --cov-report=term-missing --cov-report=html -s {posargs:tests}
+    coverage run -m pytest {posargs:tests}
+    coverage report
+    coverage html
+    # tests should always have 100% coverage, this protects against accidental
+    # dead code or never-called assertions
+    coverage report --include 'tests*' --fail-under 100
 
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,8 @@ commands =
         tests/cli/test_cmds_push_to_registry.py \
         tests/cli/test_cmds_sysdig.py \
         tests/mesos/test_cluster.py \
+        tests/metrics/test_metastatus_lib.py \
+        tests/monitoring/test_check_synapse_replication.py \
         tests/monitoring/test_config_providers.py \
         tests/test_adhoc_tools.py \
         tests/test_autoscale_all_services.py \
@@ -50,9 +52,13 @@ commands =
         tests/test_chronos_serviceinit.py \
         tests/test_chronos_tools.py \
         tests/test_cleanup_chronos_jobs.py \
+        tests/test_cleanup_marathon_jobs.py \
         tests/test_deployment_utils.py \
         tests/test_drain_lib.py \
         tests/test_generate_deployments_for_service.py \
+        tests/test_generate_services_file.py \
+        tests/test_generate_services_yaml.py \
+        tests/test_list_marathon_service_instances.py \
         tests/test_paasta_maintenance.py \
         tests/test_utils.py
 


### PR DESCRIPTION
Also in this:
- 100% coverage for files in ./tests is now enforced -- I also had to fix 20-30 programming errors similar to:

```python
with pytest.raises(error_type) as excinfo:
    function_that_raises_error_type()
    assert assertion_about_excinfo()  # this line is never called
```