### PR TITLE
Send git refs as byte strings

### DIFF
--- a/paasta_tools/remote_git.py
+++ b/paasta_tools/remote_git.py
@@ -81,5 +81,6 @@ def make_force_push_mutate_refs_func(targets, sha):
     def mutate_refs(refs):
         for target in targets:
             refs[target] = sha
+        refs = {k.encode('UTF-8'): v.encode('UTF-8') for k, v in refs.items()}
         return refs
     return mutate_refs

--- a/tests/test_remote_git.py
+++ b/tests/test_remote_git.py
@@ -65,7 +65,6 @@ def test_non_ascii_tags():
 
 def test_make_force_push_mutate_refs_func_overwrites_shas():
     targets = ['refs/heads/targeta', 'refs/tags/targetb']
-    newsha = 'newsha'
     input_refs = {
         'refs/heads/foo': '12345',
         'refs/heads/targeta': '12345',
@@ -74,19 +73,20 @@ def test_make_force_push_mutate_refs_func_overwrites_shas():
         'refs/tags/blah': '12345',
     }
     expected = {
-        'refs/heads/foo': '12345',
-        'refs/heads/targeta': newsha,
-        'refs/tags/targetb': newsha,
-        'refs/heads/ignored': '12345',
-        'refs/tags/blah': '12345',
+        b'refs/heads/foo': b'12345',
+        b'refs/heads/targeta': b'newsha',
+        b'refs/tags/targetb': b'newsha',
+        b'refs/heads/ignored': b'12345',
+        b'refs/tags/blah': b'12345',
     }
 
     mutate_refs_func = remote_git.make_force_push_mutate_refs_func(
         targets=targets,
-        sha=newsha,
+        sha='newsha',
     )
     actual = mutate_refs_func(input_refs)
     assert actual == expected
+    assert all([isinstance(k, bytes) for k in actual])
 
 
 @mock.patch('dulwich.client', autospec=True)


### PR DESCRIPTION
After we changed to decoding git refs to unicode strings we also need to
make sure to encode back to bytes before we send to dulwich. Otherwise
we see: refname is not a bytestring: u'refs/tags...'

I've also converted the shas back to bytes although I'm not sure we
really needed to...

I'm going to try and add some itests that will catch bugs like this in
the future. But I'll do that seperately. cc @asottile 