### PR TITLE
Add example cluster test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,7 @@ deploy:
       tags: true
       condition: $MAKE_TARGET == itest_trusty || $MAKE_TARGET == itest_xenial
       repo: Yelp/paasta
+matrix:
+  allow_failures:
+    - env: TOXENV=example_cluster
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - TOXENV=general_itests
   - TOXENV=general_itests_py3
   - TOXENV=paasta_itests
+  - TOXENV=example_cluster
   - MAKE_TARGET=itest_trusty
   - MAKE_TARGET=itest_xenial
 sudo: required

--- a/example_cluster/example-cluster-test.sh
+++ b/example_cluster/example-cluster-test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+try_and_retry() {
+   n=0
+   until [ $n -ge 5 ]
+   do
+      echo "Running $1"
+      $1 && echo "$1 PASSED" && return # substitute your command here
+      n=$[$n+1]
+      echo "$1 FAILED, sleeping 15 and retrying"
+      sleep 15
+   done
+   exit 1
+}
+
+echo "exit" | /start.sh
+cd /tmp
+git clone root@git:dockercloud-hello-world
+cd dockercloud-hello-world
+/work/example_cluster/tests/start-new-service.sh
+try_and_retry /work/example_cluster/tests/check-metastatus.sh
+try_and_retry /work/example_cluster/tests/check-status.sh
+try_and_retry /work/example_cluster/tests/check-api.sh
+paasta stop -s hello-world -c testcluster

--- a/example_cluster/example-cluster-test.sh
+++ b/example_cluster/example-cluster-test.sh
@@ -23,3 +23,4 @@ try_and_retry /work/example_cluster/tests/check-metastatus.sh
 try_and_retry /work/example_cluster/tests/check-status.sh
 try_and_retry /work/example_cluster/tests/check-api.sh
 paasta stop -s hello-world -c testcluster
+sleep 30

--- a/example_cluster/example-services/hello-world/marathon-testcluster.yaml
+++ b/example_cluster/example-services/hello-world/marathon-testcluster.yaml
@@ -1,8 +1,7 @@
 ---
 main:
   cpus: 1
-  min_instances: 1
-  max_instances: 5
+  instances: 2
   mem: 100
   deploy_group: testcluster.everything
   disk: 40

--- a/example_cluster/tests/check-api.sh
+++ b/example_cluster/tests/check-api.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+test_url (){
+    STATUSCODE=$(curl --silent --output /dev/stderr --write-out "%{http_code}" $1)
+    if test $STATUSCODE -ne 200; then
+        exit 1
+    fi
+}
+
+test_url mesosmaster:5054/v1/version
+test_url mesosmaster:5054/v1/services/hello-world
+test_url mesosmaster:5054/v1/services/hello-world
+STATUS=$(test_url mesosmaster:5054/v1/services/hello-world/main/status 2>&1 | jq -r '.["marathon"]["deploy_status"]')
+if [ "$STATUS" != "Running" ]; then
+    echo "Status should be Running not $STATUS"
+    exit 1
+fi

--- a/example_cluster/tests/check-metastatus.sh
+++ b/example_cluster/tests/check-metastatus.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+paasta metastatus -vvv

--- a/example_cluster/tests/check-status.sh
+++ b/example_cluster/tests/check-status.sh
@@ -1,0 +1,1 @@
+paasta status -s hello-world -i main -vvv

--- a/example_cluster/tests/start-new-service.sh
+++ b/example_cluster/tests/start-new-service.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+paasta itest -s hello-world -c `git rev-parse HEAD`
+paasta push-to-registry -s hello-world -c `git rev-parse HEAD`
+paasta mark-for-deployment --git-url root@git:dockercloud-hello-world --commit `git rev-parse HEAD` --clusterinstance testcluster.everything --service hello-world

--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,27 @@ commands =
     docker-compose stop
     docker-compose rm --force
 
+[testenv:example_cluster]
+changedir=example_cluster/
+passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
+deps =
+    docker-compose==1.7.1
+commands =
+    docker-compose down
+    docker-compose pull
+    docker-compose --verbose build
+    # Fire up the marathon cluster in background
+    # Run the paastatools container in foreground to catch the output
+    # the `docker-compose run` vs `docker-compose up` is important here, as docker-compose run will
+    # exit with the right code.
+    #
+    # dnephin says we need the --rm otherwise these containers won't be cleaned
+    # up. I guess we only need this for run'd containers, not up'd containers?
+    # IDK, the docs don't really specify.
+    docker-compose run --rm playground ./example_cluster/example-cluster-test.sh
+    docker-compose stop
+    docker-compose rm --force
+
 [testenv:paasta_itests_inside_container]
 envdir=/tmp/
 setenv =

--- a/yelp_package/dockerfiles/mesos-paasta/Dockerfile
+++ b/yelp_package/dockerfiles/mesos-paasta/Dockerfile
@@ -5,6 +5,7 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 RUN mkdir -p /var/log/paasta_logs 
 RUN mkdir /var/run/sshd
 ADD ./yelp_package/dockerfiles/mesos-paasta/cron.d /etc/cron.d
+RUN chmod -R 600 /etc/cron.d
 RUN mkdir -p /nail/etc
 RUN ln -s /etc/mesos-slave-secret /nail/etc/mesos-slave-secret
 RUN ln -s /etc/paasta/mesos-cli.json /nail/etc/mesos-cli.json

--- a/yelp_package/dockerfiles/mesos-paasta/Dockerfile
+++ b/yelp_package/dockerfiles/mesos-paasta/Dockerfile
@@ -10,6 +10,8 @@ RUN ln -s /etc/mesos-slave-secret /nail/etc/mesos-slave-secret
 RUN ln -s /etc/paasta/mesos-cli.json /nail/etc/mesos-cli.json
 ADD ./requirements-dev.txt /paasta/requirements-dev.txt
 ADD ./requirements.txt /paasta/requirements.txt
+RUN pip install --upgrade pip
+RUN pip install --upgrade virtualenv
 RUN pip install -r /paasta/requirements-dev.txt
 ADD ./yelp_package/dockerfiles/mesos-paasta/start.sh /start.sh
 ADD ./yelp_package/dockerfiles/mesos-paasta/start-slave.sh /start-slave.sh

--- a/yelp_package/dockerfiles/playground/Dockerfile
+++ b/yelp_package/dockerfiles/playground/Dockerfile
@@ -1,5 +1,5 @@
 FROM examplecluster_itest_trusty
-RUN apt-get update && apt-get install -y openssh-server docker.io curl vim
+RUN apt-get update && apt-get install -y openssh-server docker.io curl vim jq
 RUN mkdir -p /var/log/paasta_logs 
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 RUN mkdir /var/run/sshd
@@ -7,5 +7,7 @@ RUN mkdir -p /nail/etc
 RUN ln -s /etc/paasta/mesos-cli.json /nail/etc/mesos-cli.json
 ADD ./requirements-dev.txt /paasta/requirements-dev.txt
 ADD ./requirements.txt /paasta/requirements.txt
+RUN pip install --upgrade pip
+RUN pip install --upgrade virtualenv
 RUN pip install -r /paasta/requirements-dev.txt
 ADD ./yelp_package/dockerfiles/playground/start.sh /start.sh


### PR DESCRIPTION
Our itests are slightly limited. This aims to test a few cases that may
be missed by the itests. It is essentially a set of bash tests for
paasta that run basic paasta commands and expect a 0 error code.

For the first iteration we are:
* deploying a new service by running the same commands we run in Jenkins
pipelines
* running metastatus and status commands
* checking that the paasta api runs
* checking that the api shows that the hello world service is "Running"