### PR TITLE
Don't stream already logged loglines

### DIFF
--- a/paasta_tools/cli/cmds/itest.py
+++ b/paasta_tools/cli/cmds/itest.py
@@ -87,7 +87,6 @@ def paasta_itest(args):
         component='build',
         service=service,
         loglevel='debug',
-        stream=True,
     )
     if returncode != 0:
         loglines.append(

--- a/paasta_tools/cli/cmds/push_to_registry.py
+++ b/paasta_tools/cli/cmds/push_to_registry.py
@@ -89,7 +89,6 @@ def paasta_push_to_registry(args):
         cmd,
         timeout=3600,
         log=True,
-        stream=True,
         component='build',
         service=service,
         loglevel='debug'


### PR DESCRIPTION
There are still some use cases where we *don't* want to stream the output (where we capture it instead), but for itest and push I think it is ok to log and not stream. (as all logs go to stdout/err anyway).

Should I put a check to not allow a caller to stream and log at the same time to prevent someone from duplicating output again?

Fixes #1004 