### PR TITLE
Give the mesos wheel names more-correct impl / plat

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -76,9 +76,9 @@ deps =
     behave==1.2.4
     behave-pytest==0.1.1
     # This .whl is created in yelp_package/dockerfiles/trusty/Dockerfile
-    /root/mesos.executor-1.0.1-py27-none-any.whl
-    /root/mesos.scheduler-1.0.1-py27-none-any.whl
-    /root/mesos.native-1.0.1-py27-none-any.whl
+    /root/mesos.executor-1.0.1-cp27-none-linux_x86_64.whl
+    /root/mesos.scheduler-1.0.1-cp27-none-linux_x86_64.whl
+    /root/mesos.native-1.0.1-cp27-none-linux_x86_64.whl
 commands =
     behave {posargs}
 

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -51,9 +51,9 @@ RUN cd /tmp && \
 # a system mesos package.
 RUN apt-get install -yq mesos=1.0.1-2.0.93.ubuntu1404 && \
     cd /usr/lib/python2.7/site-packages && \
-	zip -r /root/mesos.native-1.0.1-py27-none-any.whl mesos/native mesos.native-1.0.1.dist-info && \
-	zip -r /root/mesos.executor-1.0.1-py27-none-any.whl mesos/executor mesos.executor-1.0.1.dist-info && \
-	zip -r /root/mesos.scheduler-1.0.1-py27-none-any.whl mesos/scheduler mesos.scheduler-1.0.1.dist-info && \
+	zip -r /root/mesos.native-1.0.1-cp27-none-linux_x86_64.whl mesos/native mesos.native-1.0.1.dist-info && \
+	zip -r /root/mesos.executor-1.0.1-cp27-none-linux_x86_64.whl mesos/executor mesos.executor-1.0.1.dist-info && \
+	zip -r /root/mesos.scheduler-1.0.1-cp27-none-linux_x86_64.whl mesos/scheduler mesos.scheduler-1.0.1.dist-info && \
 	apt-get remove -yq mesos
 
 RUN pip install --upgrade virtualenv

--- a/yelp_package/dockerfiles/xenial/Dockerfile
+++ b/yelp_package/dockerfiles/xenial/Dockerfile
@@ -50,9 +50,9 @@ RUN cd /tmp && \
 # a system mesos package.
 RUN apt-get install -yq mesos=1.0.1-2.0.93.ubuntu1604 && \
     cd /usr/lib/python2.7/site-packages && \
-	zip -r /root/mesos.native-1.0.1-py27-none-any.whl mesos/native mesos.native-1.0.1.dist-info && \
-	zip -r /root/mesos.executor-1.0.1-py27-none-any.whl mesos/executor mesos.executor-1.0.1.dist-info && \
-	zip -r /root/mesos.scheduler-1.0.1-py27-none-any.whl mesos/scheduler mesos.scheduler-1.0.1.dist-info && \
+	zip -r /root/mesos.native-1.0.1-cp27-none-linux_x86_64.whl mesos/native mesos.native-1.0.1.dist-info && \
+	zip -r /root/mesos.executor-1.0.1-cp27-none-linux_x86_64.whl mesos/executor mesos.executor-1.0.1.dist-info && \
+	zip -r /root/mesos.scheduler-1.0.1-cp27-none-linux_x86_64.whl mesos/scheduler mesos.scheduler-1.0.1.dist-info && \
 	apt-get remove -yq mesos
 
 ADD mesos-slave-secret /etc/mesos-slave-secret


### PR DESCRIPTION
pyxx-none-any means "pure python, any platform".  These are actually cpython2.7 wheels for linux_x86_64 and are *not* compatible with python3 or other versions of cpython or pypy