### PR TITLE
Add basic support for NUMA cpu affinity settings. This enable the use…

### DIFF
--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -472,7 +472,7 @@ class TestMain(object):
             '--env=MARATHON_APP_RESOURCE_CPUS=2',
         )]
 
-    def test_numa_req_too_many_cores(self, mock_execlp):
+    def test_numa_too_many_cores_requested(self, mock_execlp):
         argv = [
             'docker',
             'run',
@@ -499,7 +499,7 @@ class TestMain(object):
             '--env=MARATHON_APP_RESOURCE_CPUS=3.0',
         )]
 
-    def test_numa_enabled_no_marathon(self, mock_execlp):
+    def test_numa_enabled_unknown_cpu_requirement_skips_cpusets(self, mock_execlp):
         argv = [
             'docker',
             'run',
@@ -551,7 +551,7 @@ class TestMain(object):
             '--env=PIN_TO_NUMA_NODE=2',
         )]
 
-    def test_numa_single_cpu(self, mock_execlp):
+    def test_numa_single_cpu_doesnt_bother_with_cpusets(self, mock_execlp):
         argv = [
             'docker',
             'run',

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -258,11 +258,12 @@ class TestMain(object):
             ],
         ):
             docker_wrapper.main(argv)
-        argv = [
+        assert mock_execlp.mock_calls == [mock.call(
+            'docker',
             'docker',
             'run',
             '--env=PIN_TO_NUMA_NODE=1',
-        ]
+            '--env=MARATHON_APP_RESOURCE_CPUS=1.5')]
 
     def test_marathon_bogus_value(self, mock_execlp):
         argv = [


### PR DESCRIPTION
Control which physical CPU and memory node docker will be running on using
docker options "--cpuset-cpus" and "--cpuset-mems". To enable it, simply
pass as a docker environment variable PIN_TO_NUMA_NODE=n where n is the
id of a physical CPU (usually 0 or 1 on a dual CPU machine)