### PR TITLE
Do not fail wait-for-deployment when the git server is unreachable

### DIFF
--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -25,7 +25,9 @@ from six.moves.queue import Queue
 from paasta_tools.cli.cmds import mark_for_deployment
 from paasta_tools.cli.cmds.wait_for_deployment import get_latest_marked_sha
 from paasta_tools.cli.cmds.wait_for_deployment import paasta_wait_for_deployment
+from paasta_tools.cli.cmds.wait_for_deployment import validate_git_sha
 from paasta_tools.cli.utils import NoSuchService
+from paasta_tools.remote_git import LSRemoteException
 from paasta_tools.utils import TimeoutError
 
 
@@ -281,3 +283,11 @@ def test_get_latest_marked_sha_bad(mock_list_remote_refs):
             '968b948b3fca457326718dc7b2e278f89ccc5c87',
     }
     assert get_latest_marked_sha('', 'fake_group1') == ''
+
+
+@patch('paasta_tools.cli.cmds.wait_for_deployment.list_remote_refs', autospec=True)
+def test_validate_deploy_group_when_is_git_not_available(mock_list_remote_refs):
+    test_error_message = 'Git error'
+    mock_list_remote_refs.side_effect = LSRemoteException(test_error_message)
+    assert validate_git_sha('fake sha', 'fake_git_url',
+                            'fake_group', 'fake_service') is None


### PR DESCRIPTION
Do not fail wait-for-deployment when the git server is temporary unreachable.

internal ticket: PAASTA-8599