### PR TITLE
Assume task with no started at is new

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -961,7 +961,7 @@ def is_old_task_missing_healthchecks(task, marathon_client):
     and healthy but marathon has simply decided to stop healthchecking it.
     """
     health_checks = marathon_client.get_app(task.app_id).health_checks
-    if not task.health_check_results and health_checks:
+    if not task.health_check_results and health_checks and task.started_at:
         healthcheck_startup_time = datetime.timedelta(seconds=health_checks[0].grace_period_seconds) + \
             datetime.timedelta(seconds=health_checks[0].interval_seconds * 5)
         is_task_old = task.started_at + healthcheck_startup_time < datetime.datetime.now()

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -2378,6 +2378,11 @@ def test_is_old_task_missing_healthchecks():
                           started_at=datetime.datetime.now())
     assert not marathon_tools.is_old_task_missing_healthchecks(mock_task, mock_marathon_client)
 
+    # test missing started at time
+    mock_task = mock.Mock(health_check_results=[],
+                          started_at=None)
+    assert not marathon_tools.is_old_task_missing_healthchecks(mock_task, mock_marathon_client)
+
     # test no health checks
     mock_marathon_app = mock.Mock(health_checks=[])
     mock_get_app = mock.Mock(return_value=mock_marathon_app)


### PR DESCRIPTION
Marathon can return None for started_at if the task is brand new. In
this case the `is_old_task_missing_healthchecks` should return False
because the task can't be considered old. Currently it is throwing an
exception which is not helpful!