### PR TITLE
Add optional autoscaling info to metastatus

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -385,7 +385,7 @@ class SpotAutoscaler(ClusterAutoscaler):
 
     @property
     def exists(self):
-        return True if self.sfr else False
+        return False if not self.sfr or self.sfr['SpotFleetRequestState'] == 'cancelled' else True
 
     def get_sfr(self, spotfleet_request_id, region=None):
         ec2_client = boto3.client('ec2', region_name=region)
@@ -783,7 +783,7 @@ def autoscaling_info_for_resource(resource, pool_settings):
         dry_run=True
     )
     if not scaler.exists:
-        log.info("no scaler for resource {}. ignoring").format(resource['id'])
+        log.info("no scaler for resource {}. ignoring".format(resource['id']))
         return None
     try:
         current_capacity, target_capacity = scaler.metrics_provider()

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -25,6 +25,7 @@ from marathon.exceptions import MarathonError
 
 from paasta_tools import __version__
 from paasta_tools import marathon_tools
+from paasta_tools.autoscaling.autoscaling_cluster_lib import get_autoscaling_info
 from paasta_tools.chronos_tools import get_chronos_client
 from paasta_tools.chronos_tools import load_chronos_config
 from paasta_tools.mesos.exceptions import MasterNotAvailableException
@@ -39,6 +40,7 @@ from paasta_tools.utils import print_with_indent
 logging.basicConfig()
 # kazoo can be really noisy - turn it down
 logging.getLogger("kazoo").setLevel(logging.CRITICAL)
+logging.getLogger("paasta_tools.autoscaling.autoscaling_cluster_lib").setLevel(logging.ERROR)
 
 
 def parse_args(argv):
@@ -56,6 +58,8 @@ def parse_args(argv):
         )
     )
     parser.add_argument('-t', '--threshold', type=int, default=90)
+    parser.add_argument('-a', '--autoscaling-info', action='store_true', default=False,
+                        dest="autoscaling_info")
     parser.add_argument('-v', '--verbose', action='count', dest="verbose", default=0,
                         help="Print out more output regarding the state of the cluster")
     parser.add_argument('-H', '--humanize', action='store_true', dest="humanize", default=False,
@@ -157,6 +161,12 @@ def main(argv=None):
             table_rows = sorted(table_rows, key=lambda x: x[0])
             all_rows.extend(table_rows)
             for line in format_table(all_rows):
+                print_with_indent(line, 4)
+
+        if args.autoscaling_info:
+            print_with_indent("Autoscaling resources:", 2)
+            autoscaling_info = get_autoscaling_info()
+            for line in format_table(autoscaling_info):
                 print_with_indent(line, 4)
 
         if args.verbose == 3:


### PR DESCRIPTION
This adds optional info on the cluster autoscaler to metastatus. It
works by using the autoscaling library to retrieve details on the
resources it is responsible for and contacting AWS to find the current
capacities of the resources. The motivation is so an operator can
easily see the settings relavent to the autoscaler and the current
capacity. Fixes #984

It is behind a command line flag so should be safe to ship as is. At
yelp this will need a wrapper script on the master that ensures the
autoscaling configs are synced from S3 and that there are AWS
credentials in the environment.