### PR TITLE
don't strip argv[0] twice in docker_wrapper

### DIFF
--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -86,7 +86,7 @@ def add_hostname(args, hostname):
 
 
 def main(argv=None):
-    argv = argv if argv is not None else sys.argv[1:]
+    argv = argv if argv is not None else sys.argv
 
     env_args = parse_env_args(argv)
     fqdn = socket.getfqdn()


### PR DESCRIPTION
This didn't get caught during tests because the tests specify args themselves rather than sys.argv. 


% venv/bin/paasta_docker_wrapper --version
Docker version 1.11.2, build e2d06fe