### PR TITLE
Make local_run use the new docker wrapper

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -368,9 +368,9 @@ def get_container_name():
 
 def get_docker_run_cmd(memory, random_port, container_name, volumes, env, interactive,
                        docker_hash, command, net, docker_params):
-    cmd = ['docker', 'run']
+    cmd = ['paasta_docker_wrapper', 'run']
     for k, v in env.items():
-        cmd.append('--env=\"%s=%s\"' % (k, v))
+        cmd.append('--env=%s=%s' % (k, v))
     cmd.append('--memory=%dm' % memory)
     for i in docker_params:
         cmd.append('--%s=%s' % (i['key'], i['value']))
@@ -490,7 +490,6 @@ def get_local_run_environment_vars(instance_config, port0, framework):
         env['CHRONOS_JOB_NAME'] = "%s %s" % (instance_config.get_service(), instance_config.get_instance())
         env['CHRONOS_JOB_RUN_ATTEMPT'] = str(0),
         env['mesos_task_id'] = 'ct:simulated-task-id'
-
     return env
 
 
@@ -558,7 +557,7 @@ def run_docker_container(
     if interactive:
         # NOTE: This immediately replaces us with the docker run cmd. Docker
         # run knows how to clean up the running container in this situation.
-        execlp('docker', *docker_run_cmd)
+        execlp('paasta_docker_wrapper', *docker_run_cmd)
         # For testing, when execlp is patched out and doesn't replace us, we
         # still want to bail out.
         return 0

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -468,7 +468,7 @@ def get_local_run_environment_vars(instance_config, port0, framework):
         'MESOS_TASK_ID': 'simulated_mesos_task_id',
         'PAASTA_DOCKER_IMAGE': docker_image,
     }
-    if framework == "marathon":
+    if framework == 'marathon':
         env['MARATHON_PORT'] = str(port0)
         env['MARATHON_PORT0'] = str(port0)
         env['MARATHON_PORTS'] = str(port0)
@@ -486,9 +486,9 @@ def get_local_run_environment_vars(instance_config, port0, framework):
         env['CHRONOS_RESOURCE_CPU'] = str(instance_config.get_cpus())
         env['CHRONOS_RESOURCE_MEM'] = str(instance_config.get_mem())
         env['CHRONOS_JOB_OWNER'] = 'simulated-owner'
-        env['CHRONOS_JOB_RUN_TIME'] = str(time.gmtime())
+        env['CHRONOS_JOB_RUN_TIME'] = str(int(time.time()))
         env['CHRONOS_JOB_NAME'] = "%s %s" % (instance_config.get_service(), instance_config.get_instance())
-        env['CHRONOS_JOB_RUN_ATTEMPT'] = str(0),
+        env['CHRONOS_JOB_RUN_ATTEMPT'] = str(0)
         env['mesos_task_id'] = 'ct:simulated-task-id'
     return env
 

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -370,7 +370,7 @@ def get_docker_run_cmd(memory, random_port, container_name, volumes, env, intera
                        docker_hash, command, net, docker_params):
     cmd = ['paasta_docker_wrapper', 'run']
     for k, v in env.items():
-        cmd.append('--env=%s=%s' % (k, v))
+        cmd.append("--env='%s=%s'" % (k, v))
     cmd.append('--memory=%dm' % memory)
     for i in docker_params:
         cmd.append('--%s=%s' % (i['key'], i['value']))

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -624,8 +624,8 @@ def test_get_docker_run_cmd_with_env_vars():
     docker_params = []
     actual = get_docker_run_cmd(memory, random_port, container_name, volumes, env,
                                 interactive, docker_hash, command, net, docker_params)
-    assert '--env=foo=bar' in actual
-    assert '--env=baz=qux' in actual
+    assert "--env='foo=bar'" in actual
+    assert "--env='baz=qux'" in actual
 
 
 def test_get_docker_run_cmd_interactive_false():

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -624,9 +624,8 @@ def test_get_docker_run_cmd_with_env_vars():
     docker_params = []
     actual = get_docker_run_cmd(memory, random_port, container_name, volumes, env,
                                 interactive, docker_hash, command, net, docker_params)
-    assert '--env="foo=bar"' in actual
-    assert '--env="baz=qux"' in actual
-    assert '--env="x= with spaces"' in actual
+    assert '--env=foo=bar' in actual
+    assert '--env=baz=qux' in actual
 
 
 def test_get_docker_run_cmd_interactive_false():


### PR DESCRIPTION
cc @bchess 

Do we support env vars with spaces in them?
Because when local run was passing `--env="MESOS_TASK_ID=foo"` to the wrapper it interpreted the var as `u'"MESOS_TASK_ID': foo"'}`