### PR TITLE
Integrated test.sh in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,7 @@ test: .paasta/bin/activate
 	touch .paasta/bin/activate
 
 itest: test .paasta/bin/activate
-	.paasta/bin/tox -e general_itests
-	.paasta/bin/tox -e paasta_itests
+	./itest.sh
 
 itest_%:
 	# See the makefile in yelp_package/Makefile for packaging stuff

--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,22 @@ endif
 
 .PHONY: all docs test itest
 
-docs:
-	./docs.sh
+docs: .paasta/bin/activate
+	.paasta/bin/tox -e docs
 
-test:
-	./test.sh
+test: .paasta/bin/activate
+	.paasta/bin/tox
 
-itest: test
-	./itest.sh
+.paasta/bin/activate: requirements.txt requirements-dev.txt
+	test -d .paasta/bin/activate || virtualenv -p python2.7 .paasta
+	.paasta/bin/pip install -U pip==9.0.1
+	.paasta/bin/pip install -U virtualenv==15.1.0
+	.paasta/bin/pip install -U tox==2.6.0
+	touch .paasta/bin/activate
+
+itest: test .paasta/bin/activate
+	.paasta/bin/tox -e general_itests
+	.paasta/bin/tox -e paasta_itests
 
 itest_%:
 	# See the makefile in yelp_package/Makefile for packaging stuff
@@ -41,7 +49,6 @@ itest_%:
 release:
 	make -C yelp_package release
 
-
 clean:
 	rm -rf ./dist
 	make -C yelp_package clean
@@ -49,3 +56,4 @@ clean:
 	find . -name '*.pyc' -delete
 	find . -name '__pycache__' -delete
 	rm -rf .tox
+	rm -rf .paasta

--- a/docs.sh
+++ b/docs.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-rm -rf .paasta
-virtualenv .paasta
-source ./.paasta/bin/activate
-pip install -U pip
-pip install -U virtualenv
-pip install -U tox
-tox -e docs

--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-rm -rf .tox
-rm -rf .paasta
-virtualenv .paasta
-source ./.paasta/bin/activate
-pip install -U pip
-pip install -U virtualenv
-pip install -U tox
-tox

--- a/yelp_package/dockerfiles/lucid/Dockerfile
+++ b/yelp_package/dockerfiles/lucid/Dockerfile
@@ -20,6 +20,6 @@ MAINTAINER Kyle Anderson <kwa@yelp.com>
 # Which at this time is in this package
 RUN apt-get update && apt-get -y install dpkg-dev python-pip python-tox python-setuptools python-dev libssl-dev libffi-dev debhelper dh-virtualenv python-yaml libyaml-dev python-pytest pyflakes python2.7 python2.7-dev help2man zsh git
 
-RUN pip install -U virtualenv tox
+RUN pip install -U virtualenv==15.1.0 tox==2.6.0
 
 WORKDIR /work

--- a/yelp_package/dockerfiles/mesos-paasta/Dockerfile
+++ b/yelp_package/dockerfiles/mesos-paasta/Dockerfile
@@ -11,8 +11,8 @@ RUN ln -s /etc/mesos-slave-secret /nail/etc/mesos-slave-secret
 RUN ln -s /etc/paasta/mesos-cli.json /nail/etc/mesos-cli.json
 ADD ./requirements-dev.txt /paasta/requirements-dev.txt
 ADD ./requirements.txt /paasta/requirements.txt
-RUN pip install --upgrade pip
-RUN pip install --upgrade virtualenv
+RUN pip install --upgrade pip==9.0.1
+RUN pip install --upgrade virtualenv==15.1.0
 RUN pip install -r /paasta/requirements-dev.txt
 ADD ./yelp_package/dockerfiles/mesos-paasta/start.sh /start.sh
 ADD ./yelp_package/dockerfiles/mesos-paasta/start-slave.sh /start-slave.sh

--- a/yelp_package/dockerfiles/playground/Dockerfile
+++ b/yelp_package/dockerfiles/playground/Dockerfile
@@ -7,8 +7,8 @@ RUN mkdir -p /nail/etc
 RUN ln -s /etc/paasta/mesos-cli.json /nail/etc/mesos-cli.json
 ADD ./requirements-dev.txt /paasta/requirements-dev.txt
 ADD ./requirements.txt /paasta/requirements.txt
-RUN pip install --upgrade pip
-RUN pip install --upgrade virtualenv
+RUN pip install --upgrade pip==9.0.1
+RUN pip install --upgrade virtualenv==15.1.0
 RUN pip install -r /paasta/requirements-dev.txt
 RUN wget http://downloads.mesosphere.io/master/ubuntu/14.04/mesos-0.27.0-py2.7-linux-x86_64.egg
 RUN easy_install mesos-0.27.0-py2.7-linux-x86_64.egg

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get install -yq mesos=1.0.1-2.0.93.ubuntu1404 && \
 	zip -r /root/mesos.scheduler-1.0.1-cp27-none-linux_x86_64.whl mesos/scheduler mesos.scheduler-1.0.1.dist-info && \
 	apt-get remove -yq mesos
 
-RUN pip install --upgrade virtualenv
+RUN pip install --upgrade virtualenv==15.1.0
 
 ADD mesos-slave-secret /etc/mesos-slave-secret
 


### PR DESCRIPTION
Now make test is a little bit smarter. It doesn't systematically delete the .paasta virtualenv
Non primary runs of make test now takes 8 seconds on my laptop.