### PR TITLE
Properly quote custom paasta local-run command

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -19,7 +19,6 @@ import datetime
 import functools
 import json
 import os
-import shlex
 import socket
 import sys
 import time
@@ -390,7 +389,7 @@ def get_docker_run_cmd(memory, random_port, container_name, volumes, env, intera
         cmd.extend((
             'sh', '-c'
         ))
-        cmd.append(' '.join(command))
+        cmd.append(command)
     return cmd
 
 
@@ -565,7 +564,7 @@ def run_docker_container(
     container_started = False
     container_id = None
     try:
-        (returncode, output) = _run(joined_docker_run_cmd)
+        (returncode, output) = _run(docker_run_cmd)
         if returncode != 0:
             paasta_print(
                 'Failure trying to start your container!'
@@ -758,14 +757,14 @@ def configure_and_run_docker_container(
         volumes.append('%s:%s:%s' % (volume['hostPath'], volume['containerPath'], volume['mode'].lower()))
 
     if interactive is True and args.cmd is None:
-        command = ['bash']
+        command = 'bash'
     elif args.cmd:
-        command = shlex.split(args.cmd, posix=False)
+        command = args.cmd
     else:
         command_from_config = instance_config.get_cmd()
         if command_from_config:
             command_modifier = command_function_for_framework(instance_type)
-            command = shlex.split(command_modifier(command_from_config), posix=False)
+            command = command_modifier(command_from_config)
         else:
             command = instance_config.get_args()
 

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -19,7 +19,6 @@ import datetime
 import functools
 import json
 import os
-import pipes
 import shlex
 import socket
 import sys
@@ -391,7 +390,7 @@ def get_docker_run_cmd(memory, random_port, container_name, volumes, env, intera
         cmd.extend((
             'sh', '-c'
         ))
-        cmd.append(pipes.quote(' '.join(command)))
+        cmd.append(' '.join(command))
     return cmd
 
 

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -709,6 +709,24 @@ def test_get_docker_run_cmd_host_networking():
     assert '--net=host' in actual
 
 
+def test_get_docker_run_cmd_quote_cmd():
+    # Regression test to ensure we properly quote multiword custom commands
+    memory = 555
+    random_port = 666
+    container_name = 'Docker' * 6 + 'Doc'
+    volumes = ['7_Brides_for_7_Brothers', '7-Up', '7-11']
+    env = {}
+    interactive = True
+    docker_hash = '8' * 40
+    command = ['make', 'test']
+    net = 'host'
+    docker_params = []
+    actual = get_docker_run_cmd(memory, random_port, container_name, volumes, env,
+                                interactive, docker_hash, command, net, docker_params)
+
+    assert actual[-3:] == [u'sh', u'-c', u'make test']
+
+
 def test_get_container_id():
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)
     fake_containers = [

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -15,8 +15,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import json
-import pipes
-import shlex
 
 import docker
 import mock
@@ -363,7 +361,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
         docker_hash=docker_hash,
         volumes=[],
         interactive=args.interactive,
-        command=shlex.split(mock_get_instance_config.return_value.get_cmd.return_value),
+        command=mock_get_instance_config.return_value.get_cmd.return_value,
         healthcheck=args.healthcheck,
         healthcheck_only=args.healthcheck_only,
         instance_config=mock_get_instance_config.return_value,
@@ -416,7 +414,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
         docker_hash=docker_hash,
         volumes=[],
         interactive=args.interactive,
-        command=['bash'],
+        command='bash',
         healthcheck=args.healthcheck,
         healthcheck_only=args.healthcheck_only,
         instance_config=mock_get_instance_config.return_value,
@@ -475,7 +473,7 @@ def test_configure_and_run_pulls_image_when_asked(
         docker_hash='fake_registry/fake_image',
         volumes=[],
         interactive=args.interactive,
-        command=['bash'],
+        command='bash',
         healthcheck=args.healthcheck,
         healthcheck_only=args.healthcheck_only,
         instance_config=mock_get_instance_config.return_value,
@@ -529,7 +527,7 @@ def test_configure_and_run_docker_container_defaults_to_interactive_instance():
             docker_hash='fake_hash',
             volumes=[],
             interactive=True,
-            command=['bash'],
+            command='bash',
             healthcheck=args.healthcheck,
             healthcheck_only=args.healthcheck_only,
             instance_config=mock_config,
@@ -637,7 +635,7 @@ def test_get_docker_run_cmd_interactive_false():
     env = {}
     interactive = False
     docker_hash = '8' * 40
-    command = ['IE9.exe', '/VERBOSE', '/ON_ERROR_RESUME_NEXT']
+    command = 'IE9.exe /VERBOSE /ON_ERROR_RESUME_NEXT'
     net = 'bridge'
     docker_params = []
     actual = get_docker_run_cmd(memory, random_port, container_name, volumes, env,
@@ -651,7 +649,7 @@ def test_get_docker_run_cmd_interactive_false():
     assert '--interactive=true' not in actual
     assert '--tty=true' not in actual
     assert docker_hash in actual
-    assert ' '.join(pipes.quote(part) for part in command) in ' '.join(actual)
+    assert command in ' '.join(actual)
 
 
 def test_get_docker_run_cmd_interactive_true():
@@ -662,7 +660,7 @@ def test_get_docker_run_cmd_interactive_true():
     env = {}
     interactive = True
     docker_hash = '8' * 40
-    command = ['IE9.exe', '/VERBOSE', '/ON_ERROR_RESUME_NEXT']
+    command = 'IE9.exe /VERBOSE /ON_ERROR_RESUME_NEXT'
     net = 'bridge'
     docker_params = []
     actual = get_docker_run_cmd(memory, random_port, container_name, volumes, env,
@@ -680,7 +678,7 @@ def test_get_docker_run_docker_params():
     env = {}
     interactive = False
     docker_hash = '8' * 40
-    command = ['IE9.exe', '/VERBOSE', '/ON_ERROR_RESUME_NEXT']
+    command = 'IE9.exe /VERBOSE /ON_ERROR_RESUME_NEXT'
     net = 'bridge'
     docker_params = [{'key': 'memory-swap', 'value': '%sm' % memory},
                      {'key': 'cpu-period', 'value': '200000'},
@@ -700,7 +698,7 @@ def test_get_docker_run_cmd_host_networking():
     env = {}
     interactive = True
     docker_hash = '8' * 40
-    command = ['IE9.exe', '/VERBOSE', '/ON_ERROR_RESUME_NEXT']
+    command = 'IE9.exe /VERBOSE /ON_ERROR_RESUME_NEXT'
     net = 'host'
     docker_params = []
     actual = get_docker_run_cmd(memory, random_port, container_name, volumes, env,
@@ -718,7 +716,7 @@ def test_get_docker_run_cmd_quote_cmd():
     env = {}
     interactive = True
     docker_hash = '8' * 40
-    command = ['make', 'test']
+    command = 'make test'
     net = 'host'
     docker_params = []
     actual = get_docker_run_cmd(memory, random_port, container_name, volumes, env,


### PR DESCRIPTION
We're double quoting the custom command received via `paasta local-run -C`. This is probably fine if the command is a single word, but it fails if it's something slightly more complex like "make test" since bash will now consider the entire string as the command name.

I'm not sure if this is the best way to check the command inside the docker run args list, but afaik the custom command must always be at the end of the docker run, so this should be fine.

With `pipes.quote`, the test failed like:
```
    def test_get_docker_run_cmd_quote_cmd():
        memory = 555
        random_port = 666
        container_name = 'Docker' * 6 + 'Doc'
        volumes = ['7_Brides_for_7_Brothers', '7-Up', '7-11']
        env = {}
        interactive = True
        docker_hash = '8' * 40
        command = ['make', 'test']
        net = 'host'
        docker_params = []
        actual = get_docker_run_cmd(memory, random_port, container_name, volumes, env,
                                    interactive, docker_hash, command, net, docker_params)

>       assert actual[-3:] == [u'sh', u'-c', u'make test']
E       assert ['sh', '-c', "'make test'"] == ['sh', '-c', 'make test']
E         At index 2 diff: u"'make test'" != u'make test'
E         Full diff:
E         - [u'sh', u'-c', u"'make test'"]
E         ?                 -           -
E         + [u'sh', u'-c', u'make test']

tests/cli/test_cmds_local_run.py:727: AssertionError
```