### PR TITLE
Fix crontab interval

### DIFF
--- a/paasta_tools/check_chronos_jobs.py
+++ b/paasta_tools/check_chronos_jobs.py
@@ -13,11 +13,11 @@ import argparse
 import sys
 from datetime import datetime
 from datetime import timedelta
-from datetime import tzinfo
 
 import chronos
 import isodate
 import pysensu_yelp
+import pytz
 
 from paasta_tools import chronos_tools
 from paasta_tools import monitoring_tools
@@ -144,23 +144,11 @@ def message_for_status(status, service, instance, cluster):
         raise ValueError('unknown sensu status: %s' % status)
 
 
-class TZ(tzinfo):
-
-    def utcoffset(self, dt):
-        return timedelta(minutes=0)
-
-    def dst(self, dt):
-        return timedelta(minutes=0)
-
-
-utc = TZ()
-
-
 def job_is_stuck(last_run_iso_time, interval_in_seconds):
     if last_run_iso_time is None or interval_in_seconds is None:
         return False
     last_run_datatime = isodate.parse_datetime(last_run_iso_time)
-    return last_run_datatime + timedelta(seconds=interval_in_seconds) < datetime.now(utc)
+    return last_run_datatime + timedelta(seconds=interval_in_seconds) < datetime.now(pytz.utc)
 
 
 def message_for_stuck_job(service, instance, cluster, last_run_iso_time, interval_in_seconds, schedule):

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -24,6 +24,7 @@ from time import sleep
 import chronos
 import dateutil
 import isodate
+import pytz
 import service_configuration_lib
 from croniter import croniter
 from crontab import CronSlices
@@ -271,7 +272,11 @@ class ChronosJobConfig(InstanceConfig):
             return None
 
         if CronSlices.is_valid(schedule):
-            c = croniter(schedule)
+            try:
+                job_tz = pytz.timezone(self.get_schedule_time_zone())
+            except (pytz.exceptions.UnknownTimeZoneError, AttributeError):
+                job_tz = pytz.utc
+            c = croniter(schedule, datetime.datetime.now(job_tz))
             return c.get_next() - c.get_prev()
         else:
             try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ PyStaticConfiguration==0.9.0
 python-crontab==2.1.1
 python-dateutil==2.4.2
 pytimeparse==1.1.5
-pytz==2014.10
+pytz==2016.10
 PyYAML==3.11
 requests==2.6.2
 requests-cache==0.4.10

--- a/tests/test_check_chronos_jobs.py
+++ b/tests/test_check_chronos_jobs.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from datetime import timedelta
 
 import pysensu_yelp
+import pytz
 from mock import Mock
 from mock import patch
 from pytest import raises
@@ -282,14 +283,11 @@ def test_sensu_message_status_disabled():
     assert status == pysensu_yelp.Status.OK
 
 
-utc = check_chronos_jobs.TZ()
-
-
 def test_sensu_message_status_stuck():
     fake_job = {
         'name': 'fake_job_id',
         'disabled': False,
-        'lastSuccess': (datetime.now(utc) - timedelta(hours=4)).isoformat(),
+        'lastSuccess': (datetime.now(pytz.utc) - timedelta(hours=4)).isoformat(),
         'schedule': '* * * * *'
     }
     output, status = check_chronos_jobs.sensu_message_status_for_jobs(
@@ -317,10 +315,10 @@ def test_job_is_stuck_when_no_last_run():
 
 
 def test_job_is_stuck_when_not_stuck():
-    last_time_run = datetime.now(utc) - timedelta(hours=4)
+    last_time_run = datetime.now(pytz.utc) - timedelta(hours=4)
     assert not check_chronos_jobs.job_is_stuck(last_time_run.isoformat(), 60 * 60 * 24)
 
 
 def test_job_is_stuck_when_stuck():
-    last_time_run = datetime.now(utc) - timedelta(hours=25)
+    last_time_run = datetime.now(pytz.utc) - timedelta(hours=25)
     assert check_chronos_jobs.job_is_stuck(last_time_run.isoformat(), 60 * 60 * 24)


### PR DESCRIPTION
* take the job timezone into account when calculating interval for crontab-format schedules
* replace my custom UTC TZ class with pytz.utc.
* bump pytz 

I wasn't able to add a test for this case, because datetime objects can't be monkey-patched.