### PR TITLE
Cache expensive endpoints more

### DIFF
--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -133,7 +133,7 @@ class MesosMaster(object):
         else:
             return cfg
 
-    @util.CachedProperty(ttl=5)
+    @util.CachedProperty(ttl=15)
     def state(self):
         return self.fetch("/master/state.json").json()
 
@@ -211,7 +211,7 @@ class MesosMaster(object):
             keys.append("completed_frameworks")
         return util.merge(self._frameworks, *keys)
 
-    @util.CachedProperty(ttl=5)
+    @util.CachedProperty(ttl=15)
     def _frameworks(self):
         return self.fetch("/master/frameworks").json()
 


### PR DESCRIPTION
Just putting this up there as a potential easy thing that might
alleviate our performance issues in our biggest clusters.

Currently can take ~4s to get state.json so a 5s cache can't be helping
a lot. We could make this configurable if anyone feels strongly?
Otherwise I can't see it hurting that much.

cc @EvanKrall @solarkennedy not really a real fix but it is at least an easy one. I think we call `_frameworks` quite a bit because it seems to be used to get a list of tasks. i.e. `mesos.master.tasks`