### PR TITLE
Increase internal query timeout in wait-for-deployment to 60 seconds

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -498,7 +498,7 @@ def wait_for_deployment(service, deploy_group, git_sha, soa_dir, timeout):
                 sys.stdout.flush()
                 return 0
             else:
-                time.sleep(min(10, timeout))
+                time.sleep(min(60, timeout))
             sys.stdout.flush()
 
     _log(


### PR DESCRIPTION
to prevent re-querying status of the same instances every 10 seconds.