### PR TITLE
Change words for desired state in marathon_serviceinit

### DIFF
--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -90,7 +90,7 @@ def desired_state_human(desired_state, instances):
 def status_desired_state(service, instance, client, job_config):
     status = get_bouncing_status(service, instance, client, job_config)
     desired_state = desired_state_human(job_config.get_desired_state(), job_config.get_instances())
-    return "State:      %s - Desired state: %s" % (status, desired_state)
+    return "Desired State:      %s and %s" % (status, desired_state)
 
 
 def status_marathon_job_human(service, instance, deploy_status, app_id,


### PR DESCRIPTION
People were interpreting this with the left hand side being the "existing" state (configured) and the right hand side as the "desired" state (start/stopped) and thinking that a mistmatch meant that it was wrong.