### PR TITLE
Don't specify path to Python 3 executable in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
     py.test {posargs:tests}
 
 [testenv:py3]
-basepython = /usr/bin/python3
+basepython = python3
 commands =
     # TODO: actually upgrade protobuf once this is resolved
     pip install protobuf==3.2.0
@@ -119,7 +119,7 @@ commands =
     behave {posargs}
 
 [testenv:general_itests_py3]
-basepython = /usr/bin/python3
+basepython = python3
 setenv = {[testenv:general_itests]setenv}
 changedir = {[testenv:general_itests]changedir}
 passenv = {[testenv:general_itests]passenv}


### PR DESCRIPTION
MacOS doesn't have `/usr/bin/python3`, let's just use `python3` instead. The only reason we specify an interpreter executable with a full path is because we don't want to get into trouble if a virtual environment is already active. Since the one activated for Paasta in the Makefile is a Python 2 one we shouldn't run into issues.