### PR TITLE
Don't use yelp's pypi if not available

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,4 +19,7 @@ override_dh_auto_test:
 	true
 
 override_dh_virtualenv:
-	dh_virtualenv --extra-index-url 'https://pypi.yelpcorp.com/simple' --python=/usr/bin/python2.7 --preinstall no-manylinux1 --preinstall pip-custom-platform --pip-tool pip-custom-platform
+	dh_virtualenv `host pypi.yelpcorp.com >/dev/null 2>&1 && echo '--extra-index-url https://pypi.yelpcorp.com/simple'` \
+	--python=/usr/bin/python2.7 --preinstall no-manylinux1 \
+	--preinstall pip-custom-platform --pip-tool pip-custom-platform
+


### PR DESCRIPTION
this causes pip to try downloading packages from non-reachable host with 4 retries.