### PR TITLE
Remote run constraints support

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -109,20 +109,11 @@ def add_subparser(subparsers):
         default=False,
     )
     list_parser.add_argument(
-        '-E', '--cons-eq',
-        help='Mesos EQUALS constraint, --cons-eq <attr>,<value>',
-        required=False,
-        action='append'
-    )
-    list_parser.add_argument(
-        '-L', '--cons-like',
-        help='Mesos LIKE constraint, --cons-like <attr>,<value>',
-        required=False,
-        action='append'
-    )
-    list_parser.add_argument(
-        '-U', '--cons-unlike',
-        help='Mesos UNLIKE constraint, --cons-unlike <attr>,<value>',
+        '-X', '--cons',
+        help='Constraint option, format: <attr>,OP[,<value>], OP can be one of '
+        'the following: EQUALS matches attribute value exactly, LIKE and '
+        'UNLIKE match on regular expression, MAX_PER constrains number of '
+        'tasks per attribute value, UNIQUE is the same as MAX_PER,1',
         required=False,
         action='append'
     )
@@ -172,14 +163,9 @@ def paasta_remote_run(args):
         elif not isinstance(value, bool):
             cmd_parts.extend(['--%s' % arg_key, value])
 
-    constraints = []
-    for k, v in {'eq': 'EQUALS', 'like': 'LIKE', 'unlike': 'UNLIKE'}.items():
-        constraints.extend(
-            map(lambda e: e.replace(',', ',%s,' % v).split(',', 2),
-                args_vars['cons_%s' % k] or []))
-
+    constraints = map(lambda x: x.split(',', 2), args_vars['cons'])
     if len(constraints) > 0:
-        cmd_parts.extend(['--constraints', quote(json.dumps(constraints))])
+        cmd_parts.extend(['--constraints-json', quote(json.dumps(constraints))])
 
     paasta_print('Running on master: %s' % ' '.join(cmd_parts))
     return_code, status = run_on_master(

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -163,7 +163,7 @@ def paasta_remote_run(args):
         elif not isinstance(value, bool):
             cmd_parts.extend(['--%s' % arg_key, value])
 
-    constraints = map(lambda x: x.split(',', 2), args_vars['cons'])
+    constraints = [x.split(',', 2) for x in args_vars['cons']]
     if len(constraints) > 0:
         cmd_parts.extend(['--constraints-json', quote(json.dumps(constraints))])
 

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -109,7 +109,7 @@ def add_subparser(subparsers):
         default=False,
     )
     list_parser.add_argument(
-        '-X', '--cons',
+        '-X', '--constraint',
         help='Constraint option, format: <attr>,OP[,<value>], OP can be one of '
         'the following: EQUALS matches attribute value exactly, LIKE and '
         'UNLIKE match on regular expression, MAX_PER constrains number of '
@@ -163,7 +163,7 @@ def paasta_remote_run(args):
         elif not isinstance(value, bool):
             cmd_parts.extend(['--%s' % arg_key, value])
 
-    constraints = [x.split(',', 2) for x in args_vars['cons']]
+    constraints = [x.split(',', 2) for x in args_vars['constraint']]
     if len(constraints) > 0:
         cmd_parts.extend(['--constraints-json', quote(json.dumps(constraints))])
 

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -605,7 +605,7 @@ def run_on_master(cluster, system_paasta_config, cmd_parts,
         ssh_parts.append(' '.join(cmd_parts))
 
     if dry:
-        return (0, "Would have run: %s" % ssh_parts)
+        return (0, "Would have run: %s" % ' '.join(ssh_parts))
     else:
         return _run(ssh_parts, timeout=timeout)
 

--- a/paasta_tools/frameworks/adhoc_scheduler.py
+++ b/paasta_tools/frameworks/adhoc_scheduler.py
@@ -43,16 +43,18 @@ class AdhocScheduler(NativeScheduler):
         if self.need_to_stop():
             driver.stop()
 
-    def tasks_for_offer(self, driver, offer):
+    def tasks_and_state_for_offer(self, driver, offer, state):
         # In dry run satisfy exit-conditions after we got the offer
         if self.dry_run or self.need_to_stop():
             if self.dry_run:
-                tasks = super(AdhocScheduler, self).tasks_for_offer(driver, offer)
+                tasks, _ = super(AdhocScheduler, self). \
+                    tasks_and_state_for_offer(driver, offer, state)
                 paasta_print("Would have launched: ", tasks)
             driver.stop()
-            return None
+            return None, state
 
-        return super(AdhocScheduler, self).tasks_for_offer(driver, offer)
+        return super(AdhocScheduler, self). \
+            tasks_and_state_for_offer(driver, offer, state)
 
     def kill_tasks_if_necessary(self, *args, **kwargs):
         return

--- a/paasta_tools/frameworks/constraints.py
+++ b/paasta_tools/frameworks/constraints.py
@@ -8,10 +8,11 @@ import re
 from paasta_tools.utils import paasta_print
 
 
-def max_per(cv, ov, at, st):
-    if not cv:
-        cv = 1
-    return st.get('MAX_PER', {}).get(at, {}).get(ov, 0) <= int(cv)
+def max_per(constraint_value, offer_value, attribute, state):
+    if not constraint_value:
+        constraint_value = 1
+    state_value = state.get('MAX_PER', {}).get(attribute, {}).get(offer_value, 0)
+    return state_value <= int(constraint_value)
 
 
 # lambda arg: [constraint value, offer value, attribute, state]

--- a/paasta_tools/frameworks/constraints.py
+++ b/paasta_tools/frameworks/constraints.py
@@ -7,6 +7,14 @@ import re
 
 from paasta_tools.utils import paasta_print
 
+
+def max_per(args):
+    cv, ov, at, st = args
+    if not cv:
+        cv = 1
+    return st.get('MAX_PER', {}).get(at, {}).get(ov, 0) <= int(cv)
+
+
 # lambda args: [constraint value, offer value, attribute, state]
 CONS_OPS = {
     'EQUALS': lambda pair: pair[0] == pair[1],
@@ -18,8 +26,8 @@ CONS_OPS = {
     #   offer value:      default
     #   attribute:        pool
     #   state:            {'MAX_PER' => {'pool' => {'default' => 6}}}
-    'MAX_PER': lambda quad: quad[3]['MAX_PER'][quad[2]][quad[1]] <= quad[0],
-    'UNIQUE': lambda quad: quad[3]['UNIQUE'][quad[2]][quad[1]] <= 1,
+    'MAX_PER': max_per,
+    'UNIQUE': max_per,
 }
 
 
@@ -56,7 +64,7 @@ def test_offer_constraints(offer, constraints, state):
                 return False
             elif not(CONS_OPS[op]([val, offer_attr.text.value,
                                    offer_attr.name, state])):
-                paasta_print("Constraint not satisfied: [%s %s %s for %s]" % (
+                paasta_print("Constraint not satisfied: [%s %s %s] for %s with %s" % (
                     attr, op, val, offer_attr.text.value, state))
                 return False
         except Exception as err:

--- a/paasta_tools/frameworks/constraints.py
+++ b/paasta_tools/frameworks/constraints.py
@@ -47,7 +47,7 @@ UPDATE_OPS = {
     'LIKE': lambda _: None,
     'UNLIKE': lambda _: None,
     'MAX_PER': lambda x: nested_inc('MAX_PER', x),
-    'UNIQUE': lambda x: nested_inc('UNIQUE', x),
+    'UNIQUE': lambda x: nested_inc('MAX_PER', x),
 }
 
 

--- a/paasta_tools/frameworks/constraints.py
+++ b/paasta_tools/frameworks/constraints.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# Without this, the import of mesos.interface breaks because paasta_tools.mesos exists
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import re
+
+from paasta_tools.utils import paasta_print
+
+# lambda args: [constraint value, offer value, attribute, state]
+CONS_OPS = {
+    'EQUALS': lambda pair: pair[0] == pair[1],
+    'LIKE': lambda pair: re.match(pair[0], pair[1]),
+    'UNLIKE': lambda pair: not(re.match(pair[0], pair[1])),
+
+    # example: ['pool', 'MAX_PER', 5]
+    #   constraint value: 5
+    #   offer value:      default
+    #   attribute:        pool
+    #   state:            {'MAX_PER' => {'pool' => {'default' => 6}}}
+    'MAX_PER': lambda quad: quad[3]['MAX_PER'][quad[2]][quad[1]] <= quad[0],
+    'UNIQUE': lambda quad: quad[3]['UNIQUE'][quad[2]][quad[1]] <= 1,
+}
+
+
+def nested_inc(op, args):
+    """Increments relevant counter by step from args array"""
+    _, attr_val, attr_name, state, step = args
+    oph = state.setdefault(op, {})
+    nameh = oph.setdefault(attr_name, {})
+    nameh.setdefault(attr_val, 0)
+    nameh[attr_val] += step
+    return state
+
+
+# lambda args same as CONS_OPS + update step
+UPDATE_OPS = {
+    'EQUALS': lambda _: None,
+    'LIKE': lambda _: None,
+    'UNLIKE': lambda _: None,
+    'MAX_PER': lambda x: nested_inc('MAX_PER', x),
+    'UNIQUE': lambda x: nested_inc('UNIQUE', x),
+}
+
+
+def test_offer_constraints(offer, constraints, state):
+    """Returns True if all constraints are satisfied by offer's attributes,
+    returns False otherwise. Prints a error message and re-raises if an error
+    was thrown."""
+    for (attr, op, val) in constraints:
+        try:
+            offer_attr = next(
+                (x for x in offer.attributes if x.name == attr), None)
+            if offer_attr is None:
+                paasta_print("Attribute not found for a constraint: %s" % attr)
+                return False
+            elif not(CONS_OPS[op]([val, offer_attr.text.value,
+                                   offer_attr.name, state])):
+                paasta_print("Constraint not satisfied: [%s %s %s for %s]" % (
+                    attr, op, val, offer_attr.text.value, state))
+                return False
+        except Exception as err:
+            paasta_print("Error while mathing constraint: [%s %s %s] %s" % (
+                attr, op, val, str(err)))
+            raise err
+
+    return True
+
+
+def update_constraint_state(offer, constraints, state, step=1):
+    """Mutates state for each offer attribute found in constraints by calling
+    relevant UPDATE_OP lambda"""
+    for (attr, op, val) in constraints:
+        for oa in offer.attributes:
+            if attr == oa.name:
+                UPDATE_OPS[op]([val, oa.text.value, attr, state, step])

--- a/paasta_tools/frameworks/constraints.py
+++ b/paasta_tools/frameworks/constraints.py
@@ -15,7 +15,7 @@ def max_per(args):
     return st.get('MAX_PER', {}).get(at, {}).get(ov, 0) <= int(cv)
 
 
-# lambda args: [constraint value, offer value, attribute, state]
+# lambda arg: [constraint value, offer value, attribute, state]
 CONS_OPS = {
     'EQUALS': lambda pair: pair[0] == pair[1],
     'LIKE': lambda pair: re.match(pair[0], pair[1]),

--- a/paasta_tools/frameworks/native_scheduler.py
+++ b/paasta_tools/frameworks/native_scheduler.py
@@ -258,13 +258,13 @@ class NativeScheduler(mesos.interface.Scheduler):
                 if offer_attr is None:
                     paasta_print("Attribute not found for a constraint: %s" % attr)
                     return False
-                elif not(CONS_OPS[op](val, offer_attr.text.value)):
+                elif not(CONS_OPS[op]([val, offer_attr.text.value])):
                     paasta_print("Constraint not satisfied: [%s %s %s for %s]" % (
                         attr, op, val, offer_attr.text.value))
                     return False
             except Exception as err:
                 paasta_print("Error while mathing constraint: [%s %s %s] %s" % (
-                    attr, op, val, err.strerror))
+                    attr, op, val, str(err)))
                 raise err
 
         return True

--- a/paasta_tools/frameworks/native_scheduler.py
+++ b/paasta_tools/frameworks/native_scheduler.py
@@ -156,7 +156,9 @@ class NativeScheduler(mesos.interface.Scheduler):
                 launched_tasks.extend(tasks)
                 self.constraint_state = new_state
             else:
-                driver.declineOffer(offer.id)
+                filters = mesos_pb2.Filters()
+                filters.refuse_seconds = 60
+                driver.declineOffer(offer.id, filters)
             self.constraint_state_lock.release()
 
         return launched_tasks

--- a/paasta_tools/frameworks/native_scheduler.py
+++ b/paasta_tools/frameworks/native_scheduler.py
@@ -40,7 +40,7 @@ from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_docker_url
 
 from paasta_tools.frameworks.constraints import update_constraint_state
-from paasta_tools.frameworks.constraints import test_offer_constraints
+from paasta_tools.frameworks.constraints import check_offer_constraints
 
 log = logging.getLogger(__name__)
 
@@ -254,8 +254,8 @@ class NativeScheduler(mesos.interface.Scheduler):
                    len(remainingPorts) >= 1):
                 break
 
-            if not(test_offer_constraints(offer, self.constraints,
-                                          new_constraint_state)):
+            if not(check_offer_constraints(offer, self.constraints,
+                                           new_constraint_state)):
                 failed_constraints += 1
                 break
 
@@ -278,13 +278,11 @@ class NativeScheduler(mesos.interface.Scheduler):
             remainingMem -= task_mem
             remainingPorts -= {task_port}
 
+            update_constraint_state(offer, self.constraints, new_constraint_state)
+
         # raise constraint error but only if no other tasks fit/fail the offer
         if total > 0 and failed_constraints == total:
             raise ConstraintFailAllTasksError
-
-        if len(tasks) > 0:
-            update_constraint_state(offer, self.constraints,
-                                    new_constraint_state, step=len(tasks))
 
         return tasks, new_constraint_state
 

--- a/paasta_tools/frameworks/native_scheduler.py
+++ b/paasta_tools/frameworks/native_scheduler.py
@@ -88,7 +88,7 @@ class NativeScheduler(mesos.interface.Scheduler):
                  system_paasta_config, soa_dir=DEFAULT_SOA_DIR,
                  service_config=None, reconcile_backoff=30,
                  instance_type='paasta_native', service_config_overrides=None,
-                 reconcile_start_time=float('inf'), constraints=None):
+                 reconcile_start_time=float('inf')):
         self.service_name = service_name
         self.instance_name = instance_name
         self.instance_type = instance_type
@@ -97,7 +97,6 @@ class NativeScheduler(mesos.interface.Scheduler):
         self.soa_dir = soa_dir
         self.tasks_with_flags = {}
         self.service_config_overrides = service_config_overrides or {}
-        self.constraints = constraints or []
         self.constraint_state = {}
         self.constraint_state_lock = threading.Lock()
 
@@ -449,8 +448,7 @@ class NativeScheduler(mesos.interface.Scheduler):
         )
 
     def reload_constraints(self):
-        if len(self.constraints) == 0 and self.service_config.get_constraints():
-            self.constraints = self.service_config.get_constraints()
+        self.constraints = self.service_config.get_constraints() or []
 
 
 class DrainTask(object):

--- a/paasta_tools/frameworks/native_scheduler.py
+++ b/paasta_tools/frameworks/native_scheduler.py
@@ -112,7 +112,7 @@ class NativeScheduler(mesos.interface.Scheduler):
 
         if service_config is not None:
             self.service_config = service_config
-            self.service_config.config_dict.update(service_config_overrides)
+            self.service_config.config_dict.update(self.service_config_overrides)
             self.recreate_drain_method()
             self.reload_constraints()
         else:

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -85,9 +85,16 @@ def main(argv):
         instance_type = validate_service_instance(service, instance, cluster, soa_dir)
 
     try:
-        constraints = json.loads(args.constraints_json or '[]')
+        constraints = json.loads(args.constraints_json)
     except Exception as e:
+        constraints = None
         paasta_print("Error while parsing constraints: %s", e)
+
+    overrides_dict = {}
+    if command:
+        overrides_dict['cmd'] = command
+    if constraints:
+        overrides_dict['constraints'] = constraints
 
     paasta_print('Scheduling a task on Mesos')
     scheduler = AdhocScheduler(
@@ -99,8 +106,7 @@ def main(argv):
         soa_dir=soa_dir,
         reconcile_backoff=0,
         dry_run=dry_run,
-        service_config_overrides={'cmd': command},
-        constraints=constraints
+        service_config_overrides=overrides_dict,
     )
     driver = create_driver(
         framework_name="paasta-remote %s %s" % (

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -37,8 +37,8 @@ def parse_args(argv):
     parser = argparse.ArgumentParser(description='')
     add_remote_run_args(parser)
     parser.add_argument(
-        '-X', '--constraints',
-        help=('Mesos constraints'),
+        '-X', '--constraints-json',
+        help=('Mesos constraints JSON'),
         required=False,
         default=None,
     )
@@ -85,7 +85,7 @@ def main(argv):
         instance_type = validate_service_instance(service, instance, cluster, soa_dir)
 
     try:
-        constraints = json.loads(args.constraints or '[]')
+        constraints = json.loads(args.constraints_json or '[]')
     except Exception as e:
         paasta_print("Error while parsing constraints: %s", e)
 

--- a/tests/frameworks/test_adhoc_scheduler.py
+++ b/tests/frameworks/test_adhoc_scheduler.py
@@ -82,9 +82,12 @@ class TestAdhocScheduler(object):
         fake_driver = mock.Mock()
 
         # Check that offers with invalid pool don't get accepted
-        tasks = scheduler.tasks_for_offer(fake_driver, make_fake_offer(pool='notdefault'))
+        tasks, _ = scheduler.tasks_and_state_for_offer(
+            fake_driver, make_fake_offer(pool='notdefault'), {})
         assert len(tasks) == 0
-        tasks = scheduler.tasks_for_offer(fake_driver, make_fake_offer(pool=None))
+
+        tasks, _ = scheduler.tasks_and_state_for_offer(
+            fake_driver, make_fake_offer(pool=None), {})
         assert len(tasks) == 0
 
         tasks = scheduler.launch_tasks_for_offers(fake_driver, [make_fake_offer()])

--- a/tests/frameworks/test_constraints.py
+++ b/tests/frameworks/test_constraints.py
@@ -5,20 +5,17 @@ from mock import Mock
 
 from paasta_tools.frameworks import constraints
 
-# nested_inc
-
 
 def test_nested_inc_increments_by_step():
     op, av, an, st = 'MAX_PER', 'default', 'pool', {}
-    constraints.nested_inc(op, [None, av, an, st, 3])
+    constraints.nested_inc(op, None, av, an, st, 3)
     assert st['MAX_PER']['pool']['default'] == 3
 
-    constraints.nested_inc(op, [None, av, an, st, -1])
+    constraints.nested_inc(op, None, av, an, st, -1)
     assert st['MAX_PER']['pool']['default'] == 2
 
 
-# test_offer_constraints
-def test_test_offer_constraints_returns_true_when_satisfied():
+def test_check_offer_constraints_returns_true_when_satisfied():
     attr = Mock(text=Mock(value='test'))
     attr.configure_mock(name='pool')
     offer = Mock(attributes=[attr])
@@ -27,12 +24,11 @@ def test_test_offer_constraints_returns_true_when_satisfied():
             ['pool', 'LIKE', 'te.*$'],
             ['pool', 'UNLIKE', 'ta.*']]
     state = {'MAX_PER': {'pool': {'test': 0}}}
-    assert constraints.test_offer_constraints(offer, cons, state) is True
+    assert constraints.check_offer_constraints(offer, cons, state) is True
     state = {'MAX_PER': {'pool': {'test': 6}}}
-    assert constraints.test_offer_constraints(offer, cons, state) is False
+    assert constraints.check_offer_constraints(offer, cons, state) is False
 
 
-# update_constraint_state
 def test_update_constraint_state_increments_counters():
     attr = Mock(text=Mock(value='test'))
     attr.configure_mock(name='pool')

--- a/tests/frameworks/test_constraints.py
+++ b/tests/frameworks/test_constraints.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from mock import Mock
+
+from paasta_tools.frameworks import constraints
+
+# nested_inc
+
+
+def test_nested_inc_increments_by_step():
+    op, av, an, st = 'MAX_PER', 'default', 'pool', {}
+    constraints.nested_inc(op, [None, av, an, st, 3])
+    assert st['MAX_PER']['pool']['default'] == 3
+
+    constraints.nested_inc(op, [None, av, an, st, -1])
+    assert st['MAX_PER']['pool']['default'] == 2
+
+
+# test_offer_constraints
+def test_test_offer_constraints_returns_true_when_satisfied():
+    attr = Mock(text=Mock(value='test'))
+    attr.configure_mock(name='pool')
+    offer = Mock(attributes=[attr])
+    cons = [['pool', 'MAX_PER', '5'],
+            ['pool', 'EQUALS', 'test'],
+            ['pool', 'LIKE', 'te.*$'],
+            ['pool', 'UNLIKE', 'ta.*']]
+    state = {'MAX_PER': {'pool': {'test': 0}}}
+    assert constraints.test_offer_constraints(offer, cons, state) is True
+    state = {'MAX_PER': {'pool': {'test': 6}}}
+    assert constraints.test_offer_constraints(offer, cons, state) is False
+
+
+# update_constraint_state
+def test_update_constraint_state_increments_counters():
+    attr = Mock(text=Mock(value='test'))
+    attr.configure_mock(name='pool')
+    offer = Mock(attributes=[attr])
+    cons = [['pool', 'MAX_PER', '5']]
+    state = {}
+    constraints.update_constraint_state(offer, cons, state)
+    assert state['MAX_PER']['pool']['test'] == 1

--- a/tests/frameworks/test_native_scheduler.py
+++ b/tests/frameworks/test_native_scheduler.py
@@ -189,8 +189,8 @@ class TestNativeScheduler(object):
             reconcile_start_time=0,
         )
 
-        tasks = scheduler.tasks_for_offer(
-            mock.Mock(), make_fake_offer(port_begin=12345, port_end=12345))
+        tasks, _ = scheduler.tasks_and_state_for_offer(
+            mock.Mock(), make_fake_offer(port_begin=12345, port_end=12345), {})
 
         assert len(tasks) == 1
         for task in tasks:


### PR DESCRIPTION
constraints for #1087 

this supports EQUALS, LIKE, UNLIKE, MAX_PER and UNIQUE

in CLI this adds repeatable adrgument to remote-run: `--cons <attr>,<OP>[,<val>]`, in paasta_remote_run, `--constraints-json`

all constraint-related code is in paasta_tools/frameworks/constraints.py, in native scheduler we have `self.constraints` read from configs or cli (cli has precedence), `self.constraint_state` and `self.constraint_state_lock` for stateful constraints (only max_per for now), state is swapped every time call to `driver.acceptOffers` succeeds. state is locked around processing each offer and in statusUpdate when processing dead tasks.