### PR TITLE
RFC: Added service and instance docker labels to everything

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -216,9 +216,13 @@ class InstanceConfig(dict):
         Note: values must be strings
 
         :returns: A list of parameters to be added to docker run"""
-        parameters = [{"key": "memory-swap", "value": self.get_mem_swap()},
-                      {"key": "cpu-period", "value": "%s" % int(self.get_cpu_period())},
-                      {"key": "cpu-quota", "value": "%s" % int(self.get_cpu_quota())}]
+        parameters = [
+            {"key": "memory-swap", "value": self.get_mem_swap()},
+            {"key": "cpu-period", "value": "%s" % int(self.get_cpu_period())},
+            {"key": "cpu-quota", "value": "%s" % int(self.get_cpu_quota())},
+            {"key": "label", "value": "service=%s" % self.service()},
+            {"key": "label", "value": "instance=%s" % self.service()},
+        ]
         parameters.extend(self.get_ulimit())
         parameters.extend(self.get_cap_add())
         return parameters


### PR DESCRIPTION
RFC: I would like to provide cloudhealth with enough metadata that we can create curated projects and stuff. Using mesos's api to query this data makes sense, but I don't want them to even look at the mesos task id at all. Not only do we not directly control it, but often it will just be lies.

With this change, I add service and instance as **docker labels**, which can be read by cloudhealth via mesos, regardless of what framework we decide to use to launch containers.

Once this metadata is in here, we can consume it in cloudhealth without every developer having to add additional configuration in their services.

cc @bchess