### PR TITLE
Revert "Don't specify path to Python 3 executable in tox.ini"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
     py.test {posargs:tests}
 
 [testenv:py3]
-basepython = python3
+basepython = /usr/bin/python3
 commands =
     # TODO: actually upgrade protobuf once this is resolved
     pip install protobuf==3.2.0
@@ -119,7 +119,7 @@ commands =
     behave {posargs}
 
 [testenv:general_itests_py3]
-basepython = python3
+basepython = /usr/bin/python3
 setenv = {[testenv:general_itests]setenv}
 changedir = {[testenv:general_itests]changedir}
 passenv = {[testenv:general_itests]passenv}


### PR DESCRIPTION
Reverts Yelp/paasta#1085

brew is not recommended way to install python apparently