### PR TITLE
add contrib script for calculating utilization

### DIFF
--- a/paasta_tools/contrib/utilization_check.py
+++ b/paasta_tools/contrib/utilization_check.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+"""Reads a list of hosts to stdin and produces
+a utilization report for those hosts.
+"""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import json
+import sys
+
+from paasta_tools.mesos.exceptions import MasterNotAvailableException
+from paasta_tools.mesos_tools import get_mesos_master
+from paasta_tools.metrics.metastatus_lib import calculate_resource_utilization_for_slaves
+from paasta_tools.metrics.metastatus_lib import filter_tasks_for_slaves
+from paasta_tools.metrics.metastatus_lib import get_all_tasks_from_state
+from paasta_tools.metrics.metastatus_lib import resource_utillizations_from_resource_info
+from paasta_tools.utils import paasta_print
+from paasta_tools.utils import PaastaColors
+
+
+def main(hostnames):
+    master = get_mesos_master()
+    try:
+        mesos_state = master.state
+    except MasterNotAvailableException as e:
+        paasta_print(PaastaColors.red("CRITICAL:  %s" % e.message))
+        sys.exit(2)
+    slaves = [slave for slave in mesos_state.get('slaves', []) if slave['hostname'] in hostnames]
+    tasks = get_all_tasks_from_state(mesos_state, include_orphans=True)
+    filtered_tasks = filter_tasks_for_slaves(slaves, tasks)
+    resource_info_dict = calculate_resource_utilization_for_slaves(slaves, filtered_tasks)
+    resource_utilizations = resource_utillizations_from_resource_info(
+        total=resource_info_dict['total'],
+        free=resource_info_dict['free'],
+    )
+    output = {}
+    for metric in resource_utilizations:
+        utilization = metric.total - metric.free
+        if int(metric.total) == 0:
+            utilization_perc = 100
+        else:
+            utilization_perc = utilization / float(metric.total) * 100
+        output[metric.metric] = {
+            'total': metric.total,
+            'used': utilization,
+            'perc': utilization_perc,
+        }
+    print(json.dumps(output))
+
+
+if __name__ == "__main__":
+    hostnames = reduce(lambda x, y: x + [y.strip()], sys.stdin, [])
+    main(hostnames)


### PR DESCRIPTION
I wanted a script that gave me an easier entrypoint for finding
utilization data of arbitrary sets of hosts in the cluster than
metastatus can provide. This is pretty simple: reads a list of hosts
from stdin and prints a json dump of total, used, perc for the list
of inputs. I can put this behind the api next, but this'll do for now

@mattmb this is a first pass of what we spoke about in meat-space. lmk
what you think.

Here's it working

```
(paasta-tools) robj@paasta1-uswest1adevc:~/dev_paasta  % mco find -F "paasta_pool=default" -F "paasta_cluster=norcal-devc" | python paasta_tools/contrib/utilization_check.py
{"mem": {"perc": 47.72612940201327, "total": 2369484.0, "used": 1130863.0}, "disk": {"perc": 7.5974465585857285, "total": 9745906.0, "used": 740440.0}, "cpus": {"perc": 54.94285714400156, "total": 525.0, "used": 288.45000000600817}}
```