### PR TITLE
gevent proof of concept for the service autoscaling

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+concurrency = gevent
 branch = True
 source = .
 omit =

--- a/paasta_tools/mesos/task.py
+++ b/paasta_tools/mesos/task.py
@@ -72,6 +72,9 @@ class Task(object):
         except exceptions.MissingExecutor:
             return {}
 
+    def stats_callable(self):
+        return self.stats
+
     @property
     def cpu_time(self):
         st = self.stats

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -206,11 +206,11 @@ def test_mesos_cpu_metrics_provider_no_previous_cpu_data():
         branch_dict={},
     )
     fake_mesos_task = mock.MagicMock(
-        stats={
+        stats_callable=mock.MagicMock(return_value={
             'cpus_limit': 1.1,
             'cpus_system_time_secs': 240,
             'cpus_user_time_secs': 240,
-        },
+        })
     )
     fake_mesos_task.__getitem__.return_value = 'fake-service.fake-instance'
 
@@ -240,11 +240,11 @@ def test_mesos_cpu_metrics_provider():
         branch_dict={},
     )
     fake_mesos_task = mock.MagicMock(
-        stats={
+        stats_callable=mock.MagicMock(return_value={
             'cpus_limit': 1.1,
             'cpus_system_time_secs': 240,
             'cpus_user_time_secs': 240,
-        },
+        })
     )
     fake_mesos_task.__getitem__.return_value = 'fake-service.fake-instance'
 

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -41,7 +41,7 @@ class fake_args:
     verbose = False
 
 
-def mock_status_instance_side_effect(service, instance):
+def mock_status_instance_side_effect(service, instance):  # pragma: no cover (gevent)
     if instance in ['instance1', 'instance6', 'notaninstance', 'api_error']:
         # valid completed instance
         mock_mstatus = Mock(app_count=1, deploy_status='Running',
@@ -184,7 +184,7 @@ def test_instances_deployed(mock_get_paasta_api_client, mock__log):
     assert instances_out.empty()
 
 
-def instances_deployed_side_effect(cluster_data, instances_out, green_light):
+def instances_deployed_side_effect(cluster_data, instances_out, green_light):  # pragma: no cover (gevent)
     while not cluster_data.instances_queue.empty():
         instance = cluster_data.instances_queue.get()
         if instance not in ['instance1', 'instance2']:


### PR DESCRIPTION
A very quick optimization of the mesos cpu metrics provider to get stats asynchronously.
It shows 12% improvement in dev, which is a quite good result because dev services don't have enough instances to leverage gevent.

The next steps will be:
1. to support all provider
2. to query each mesos slave only once
3. will not query /slave(1)/state.json on every slave when collecting stats, because we probably don't need it.
3. (optional) to upgrade gevent
