### PR TITLE
Use Mesos 1.2.0 in itests

### DIFF
--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get -y install apt-transport-https
 RUN echo "deb https://dl.bintray.com/yelp/paasta trusty main" > /etc/apt/sources.list.d/paasta.list
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install libsasl2-modules mesos=1.1.0-2.0.107.ubuntu1404
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=1.2.0-2.0.2
 
 RUN apt-get install -y software-properties-common
 RUN add-apt-repository ppa:webupd8team/java

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get -y install apt-transport-https
 RUN echo "deb https://dl.bintray.com/yelp/paasta trusty main" > /etc/apt/sources.list.d/paasta.list
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install libsasl2-modules mesos=1.1.0-2.0.107.ubuntu1404
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=1.2.0-2.0.2
 
 # Install Java 8 PPA
 RUN apt-get install -y software-properties-common

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources
 RUN echo "deb http://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 58118E89F3A912897C070ADBF76221572C52609D
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install libsasl2-modules mesos=1.1.0-2.0.107.ubuntu1404 zip python-pip
+RUN apt-get update && apt-get -y install libsasl2-modules mesos=1.2.0-2.0.2 zip python-pip
 RUN cd /usr/lib/python2.7/site-packages && \
 	zip -r /root/mesos.native-1.1.0-cp27-none-linux_x86_64.whl mesos/native mesos.native-1.1.0.dist-info && \
 	zip -r /root/mesos.executor-1.1.0-cp27-none-linux_x86_64.whl mesos/executor mesos.executor-1.1.0.dist-info && \

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -19,12 +19,12 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 58118E89F3A912897C070ADB
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
 RUN apt-get update && apt-get -y install libsasl2-modules mesos=1.2.0-2.0.2 zip python-pip
 RUN cd /usr/lib/python2.7/site-packages && \
-	zip -r /root/mesos.native-1.1.0-cp27-none-linux_x86_64.whl mesos/native mesos.native-1.1.0.dist-info && \
-	zip -r /root/mesos.executor-1.1.0-cp27-none-linux_x86_64.whl mesos/executor mesos.executor-1.1.0.dist-info && \
-	zip -r /root/mesos.scheduler-1.1.0-cp27-none-linux_x86_64.whl mesos/scheduler mesos.scheduler-1.1.0.dist-info && \
-  pip install /root/mesos.executor-1.1.0-cp27-none-linux_x86_64.whl &&\
-  pip install /root/mesos.scheduler-1.1.0-cp27-none-linux_x86_64.whl &&\
-  pip install /root/mesos.native-1.1.0-cp27-none-linux_x86_64.whl
+	zip -r /root/mesos.native-1.2.0-cp27-none-linux_x86_64.whl mesos/native mesos.native-1.2.0.dist-info && \
+	zip -r /root/mesos.executor-1.2.0-cp27-none-linux_x86_64.whl mesos/executor mesos.executor-1.2.0.dist-info && \
+	zip -r /root/mesos.scheduler-1.2.0-cp27-none-linux_x86_64.whl mesos/scheduler mesos.scheduler-1.2.0.dist-info && \
+  pip install /root/mesos.executor-1.2.0-cp27-none-linux_x86_64.whl &&\
+  pip install /root/mesos.scheduler-1.2.0-cp27-none-linux_x86_64.whl &&\
+  pip install /root/mesos.native-1.2.0-cp27-none-linux_x86_64.whl
 
 RUN apt-get -y install docker-engine=1.10.3-0~trusty
 ADD mesos-secrets /etc/mesos-secrets

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -22,6 +22,8 @@ RUN cd /usr/lib/python2.7/site-packages && \
 	zip -r /root/mesos.native-1.2.0-cp27-none-linux_x86_64.whl mesos/native mesos.native-1.2.0.dist-info && \
 	zip -r /root/mesos.executor-1.2.0-cp27-none-linux_x86_64.whl mesos/executor mesos.executor-1.2.0.dist-info && \
 	zip -r /root/mesos.scheduler-1.2.0-cp27-none-linux_x86_64.whl mesos/scheduler mesos.scheduler-1.2.0.dist-info && \
+	zip -r /root/mesos.interface-1.2.0-cp27-none-linux_x86_64.whl mesos/interface mesos.interface-1.2.0.dist-info && \
+  pip install /root/mesos.interface-1.2.0-cp27-none-linux_x86_64.whl &&\
   pip install /root/mesos.executor-1.2.0-cp27-none-linux_x86_64.whl &&\
   pip install /root/mesos.scheduler-1.2.0-cp27-none-linux_x86_64.whl &&\
   pip install /root/mesos.native-1.2.0-cp27-none-linux_x86_64.whl


### PR DESCRIPTION
Mesos 1.2.0 has been released. This change updates our itests to use this new version.

Changelog: https://github.com/apache/mesos/blob/1.2.0/CHANGELOG

This relates to internal ticket PAASTA-9514