### PR TITLE
Make the drain lib handle the situation where a task is UNKNOWN and has no ports

### DIFF
--- a/tests/test_drain_lib.py
+++ b/tests/test_drain_lib.py
@@ -40,6 +40,11 @@ class TestHacheckDrainMethod(object):
         expected = 'http://fake_host:12345/spool/srv.ns/54321/status'
         assert actual == expected
 
+    def test_spool_url_handles_tasks_with_no_ports(self):
+        fake_task = mock.Mock(host="fake_host", ports=[])
+        actual = self.drain_method.spool_url(fake_task)
+        assert actual is None
+
     def test_get_spool(self):
         fake_response = mock.Mock(
             status_code=503,
@@ -57,6 +62,11 @@ class TestHacheckDrainMethod(object):
             'until': 1435694178.780000,
         }
         assert actual == expected
+
+    def test_get_spool_handles_no_ports(self):
+        fake_task = mock.Mock(host="fake_host", ports=[])
+        actual = self.drain_method.get_spool(fake_task)
+        assert actual is None
 
     def test_is_draining_yes(self):
         fake_response = mock.Mock(


### PR DESCRIPTION
These are the tasks we were crashing on:

    MarathonTask::{'started_at': None, 'staged_at': None, 'state': u'TASK_UNKNOWN', 'ip_addresses': [], 'app_id': u'/geocoder.main.gitbae12aef.configa5d0ae8b', 'id': u'geocoder.main.gitbae12aef.configa5d0ae8b.cda16aec-0e80-11e7-a1c8-aef0de6ab313', 'local_volumes': [], 'service_ports': [], 'host': u'10-40-18-14-uswest1cdevc.dev.yelpcorp.com', 'version': None, 'health_check_results': [], 'slave_id': u'650b33b1-1997-415b-83b5-ed5ac440562c-S996', 'ports': []}

So I made all the draining stuff just return `None` if there is no port to talk to and drain.