### PR TITLE
Only update deployments.json if changed

### DIFF
--- a/paasta_tools/generate_all_deployments
+++ b/paasta_tools/generate_all_deployments
@@ -1,19 +1,7 @@
 #!/bin/bash
 #
 # Generates all the per-service deployments.json files
-# and cleans up any leftovers
 #
 
-function delete_old_deployments {
-    # Delete any deployments.json file that is older than an hour
-    for service in $(comm -2 -3 <(find /nail/etc/services/ -maxdepth 1 -type d -printf %f\\n|tail -n +2|sort) <(paasta list|sort)); do
-        if [ -f /nail/etc/services/$service/deployments.json ]; then
-	    echo "Removing $service deployment.json as no instances found by paasta list"
-	    rm -f /nail/etc/services/$service/deployments.json
-        fi
-    done
-}
-
-delete_old_deployments
 # xargs will return 0 if everything went ok, but 12X if something else went wrong
 paasta list | shuf | xargs -n 1 -r -P 4 generate_deployments_for_service -s

--- a/paasta_tools/generate_all_deployments
+++ b/paasta_tools/generate_all_deployments
@@ -6,18 +6,14 @@
 
 function delete_old_deployments {
     # Delete any deployments.json file that is older than an hour
-    find /nail/etc/services -iname deployments.json  -mmin +60 -delete
+    for service in $(comm -2 -3 <(find /nail/etc/services/ -maxdepth 1 -type d -printf %f\\n|tail -n +2|sort) <(paasta list|sort)); do
+        if [ -f /nail/etc/services/$service/deployments.json ]; then
+	    echo "Removing $service deployment.json as no instances found by paasta list"
+	    rm -f /nail/etc/services/$service/deployments.json
+        fi
+    done
 }
 
+delete_old_deployments
 # xargs will return 0 if everything went ok, but 12X if something else went wrong
 paasta list | shuf | xargs -n 1 -r -P 4 generate_deployments_for_service -s
-ret=$?
-
-if [[ $ret -eq 0 ]]; then
-    # Only delete old files if we are confident than everything went ok
-    delete_old_deployments
-else
-    # Otherwise return whatever exit code xargs gives us, so we can
-    # get alerted
-    exit $ret
-fi

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -244,6 +244,7 @@ def generate_deployments_for_service(service, soa_dir):
             old_mappings = get_deploy_group_mappings_from_deployments_dict(old_deployments_dict)
     except (IOError, ValueError):
         old_mappings = {}
+        old_deployments_dict = {}
     mappings, v2_mappings = get_deploy_group_mappings(
         soa_dir=soa_dir,
         service=service,
@@ -251,9 +252,9 @@ def generate_deployments_for_service(service, soa_dir):
     )
 
     deployments_dict = get_deployments_dict_from_deploy_group_mappings(mappings, v2_mappings)
-
-    with atomic_file_write(os.path.join(soa_dir, service, TARGET_FILE)) as f:
-        json.dump(deployments_dict, f)
+    if deployments_dict != old_deployments_dict:
+        with atomic_file_write(os.path.join(soa_dir, service, TARGET_FILE)) as f:
+            json.dump(deployments_dict, f)
 
 
 def main():

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -193,6 +193,22 @@ def test_main():
         )
         json_load_patch.assert_called_once_with(file_mock.return_value.__enter__.return_value)
 
+        # test no update to file if content unchanged
+        json_load_patch.return_value = {
+            'v1': {
+                'MAP': {'docker_image': 'PINGS', 'desired_state': 'start'}
+            },
+            'v2': mock.sentinel.v2_mappings,
+        }
+        json_dump_patch.reset_mock()
+        generate_deployments_for_service.main()
+        assert not json_dump_patch.called
+
+        # test IOError path
+        open_patch.side_effect = IOError
+        generate_deployments_for_service.main()
+        assert json_dump_patch.called
+
 
 def test_get_deployments_dict():
     branch_mappings = {


### PR DESCRIPTION
This is a precursor to the work on paasta-deployd. It means that
deployments.json files will only be written to if they are being
updated. This makes it possible to watch for inotify updates to that
file and perform a bounce based on inotify events.

Note that this will probably change the behaviour of:
https://github.com/Yelp/paasta/blob/master/paasta_tools/generate_all_deployments#L9

In fact, we definitely need to do something or it will be deleting things that haven't changed in a while. Do we really need that cleanup? I guess if a folder removes all it's marathon-* files then we need to remove the deployents.json...