### PR TITLE
Use proper quoting and a newer PyStaticConfiguration to fix manpages

### DIFF
--- a/build-manpages.sh
+++ b/build-manpages.sh
@@ -20,7 +20,9 @@ set -euxo pipefail
 mkdir -p /nail/etc/services
 
 mkdir -p docs/man/
+set +u
 . .tox/manpages/bin/activate
+set -u
 
 VERSION=`paasta --version 2>&1 | cut -f 2 -d ' '`
 

--- a/build-manpages.sh
+++ b/build-manpages.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Copyright 2015-2016 Yelp Inc.
+set -euxo pipefail
+# Copyright 2015-2017 Yelp Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +27,7 @@ VERSION=`paasta --version 2>&1 | cut -f 2 -d ' '`
 function build_man() {
     COMMAND=$1
     echo "paasta $COMMAND --help"
-    help2man --name=$COMMAND --version-string=$VERSION "paasta $COMMAND" > docs/man/paasta-$COMMAND.1
+    help2man --name="$COMMAND" --version-string="$VERSION" "paasta $COMMAND" > "docs/man/paasta-$COMMAND.1"
 }
 
 for FILE in paasta_tools/cli/cmds/*.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ Pygments==2.0.2
 pyramid==1.7
 pyramid-swagger==2.2.3
 pysensu-yelp==0.3.3
-PyStaticConfiguration==0.9.0
+PyStaticConfiguration==0.10.3
 python-crontab==2.1.1
 python-dateutil==2.4.2
 pytimeparse==1.1.5


### PR DESCRIPTION
This relates to #1118 . The issue was that `paasta --version` was resulting in a traceback with the error, `pkg_resources.DistributionNotFound: The 'PyStaticConfiguration>=0.10.3' distribution was not found and is required by yelp-clog`. This got passed to `help2man`'s `--version-string` unquoted, causing problems. I've bumped up the version of `PyStaticConfiguration`, added some extra quoting, and tried to make the manpage script fail in a more obvious manner.