### PR TITLE
Send "A deployment could not be found" to stderr

### DIFF
--- a/paasta_tools/cli/cmds/get_latest_deployment.py
+++ b/paasta_tools/cli/cmds/get_latest_deployment.py
@@ -15,6 +15,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import sys
+
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import list_services
@@ -57,7 +59,10 @@ def paasta_get_latest_deployment(args):
 
     git_sha = get_currently_deployed_sha(service=service, deploy_group=deploy_group, soa_dir=soa_dir)
     if not git_sha:
-        paasta_print(PaastaColors.red("A deployment could not be found for %s in %s" % (deploy_group, service)))
+        paasta_print(
+            PaastaColors.red("A deployment could not be found for %s in %s" % (deploy_group, service)),
+            file=sys.stderr,
+        )
         return 1
     else:
         paasta_print(git_sha)

--- a/tests/cli/test_cmds_get_latest_deployment.py
+++ b/tests/cli/test_cmds_get_latest_deployment.py
@@ -50,4 +50,4 @@ def test_get_latest_deployment_no_deployment_tag(capfd):
     ):
         assert get_latest_deployment.paasta_get_latest_deployment(mock_args) == 1
         assert "A deployment could not be found for fake_deploy_group in fake_service" in \
-            capfd.readouterr()[0]
+            capfd.readouterr()[1]


### PR DESCRIPTION
I'm trying to do `THING=$(paasta get-latest-deployment || other thing)` but I end up with `A deployment could not be found for super-production in example_happyhour` and red ansi color codes in my variable :)