### PR TITLE
better verbosity levels for cluster autoscaler

### DIFF
--- a/paasta_tools/autoscale_cluster.py
+++ b/paasta_tools/autoscale_cluster.py
@@ -39,14 +39,22 @@ def parse_args(argv):
 def main(argv=None):
     args = parse_args(argv)
     log_format = '%(asctime)s:%(levelname)s:%(name)s:%(message)s'
-    if args.verbose >= 2:
+    log_level = None
+    if args.verbose >= 3:
         logging.basicConfig(level=logging.DEBUG, format=log_format)
+    elif args.verbose == 2:
+        logging.basicConfig(level=logging.INFO, format=log_format)
+        log_level = logging.DEBUG
     elif args.verbose == 1:
         logging.basicConfig(level=logging.INFO, format=log_format)
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    autoscale_local_cluster(dry_run=args.dry_run, config_folder=args.autoscaler_configs)
+    autoscale_local_cluster(
+        dry_run=args.dry_run,
+        config_folder=args.autoscaler_configs,
+        log_level=log_level,
+    )
 
 
 if __name__ == '__main__':

--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -70,11 +70,13 @@ class ResourceLogMixin(object):
 
 class ClusterAutoscaler(ResourceLogMixin):
 
-    def __init__(self, resource, pool_settings, config_folder, dry_run):
+    def __init__(self, resource, pool_settings, config_folder, dry_run, log_level=None):
         self.resource = resource
         self.pool_settings = pool_settings
         self.config_folder = config_folder
         self.dry_run = dry_run
+        if log_level is not None:
+            self.log.setLevel(log_level)
 
     def set_capacity(self, capacity):
         pass
@@ -708,7 +710,7 @@ class PaastaAwsSlave(object):
             return 1
 
 
-def autoscale_local_cluster(config_folder, dry_run=False):
+def autoscale_local_cluster(config_folder, dry_run=False, log_level=None):
     log.debug("Sleep 20s to throttle AWS API calls")
     time.sleep(20)
     if dry_run:
@@ -723,7 +725,8 @@ def autoscale_local_cluster(config_folder, dry_run=False):
             autoscaling_scalers.append(get_scaler(resource['type'])(resource=resource,
                                                                     pool_settings=pool_settings,
                                                                     config_folder=config_folder,
-                                                                    dry_run=dry_run))
+                                                                    dry_run=dry_run,
+                                                                    log_level=log_level))
         except KeyError:
             log.warning("Couldn't find a metric provider for resource of type: {}".format(resource['type']))
             continue

--- a/tests/test_autoscale_cluster.py
+++ b/tests/test_autoscale_cluster.py
@@ -24,4 +24,4 @@ from paasta_tools.autoscale_cluster import main
 @mock.patch('paasta_tools.autoscale_cluster.autoscale_local_cluster', autospec=True)
 def test_main(mock_autoscale_local_cluster, logging):
     main(('--dry-run', '--autoscaler-configs=/nail/blah'))
-    mock_autoscale_local_cluster.assert_called_with(dry_run=True, config_folder='/nail/blah')
+    mock_autoscale_local_cluster.assert_called_with(dry_run=True, config_folder='/nail/blah', log_level=None)


### PR DESCRIPTION
Current behavior in cluster autoscaler is that with ```-vv``` all logging is set to level=DEBUG.

Turns out it's too verbose - this includes debug output of not only autoscaler but also all underlying libraries like boto and kazoo.

In this CR, we preserve current behavior at ```-vvv``` but at ```-vv``` we have underlying libs log at INFO while autoscaler logs at DEBUG.