### PR TITLE
Watcher for deployd for autoscaling

### DIFF
--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -6,9 +6,13 @@ import time
 from functools import reduce
 
 import pyinotify
+from kazoo.protocol.states import EventType
+from kazoo.recipe.watchers import ChildrenWatch
+from kazoo.recipe.watchers import DataWatch
 
 from paasta_tools.deployd.common import PaastaThread
 from paasta_tools.deployd.common import ServiceInstance
+from paasta_tools.long_running_service_tools import AUTOSCALING_ZK_ROOT
 from paasta_tools.marathon_tools import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_all_instances_for_service
 
@@ -21,6 +25,59 @@ class PaastaWatcher(PaastaThread):
         self.inbox_q = inbox_q
         self.cluster = cluster
         self.is_ready = False
+
+
+class AutoscalerWatcher(PaastaWatcher):
+
+    def __init__(self, inbox_q, cluster, **kwargs):
+        super(AutoscalerWatcher, self).__init__(inbox_q, cluster)
+        self.zk = kwargs.pop('zookeeper_client')
+        self.watchers = {}
+
+    def watch_folder(self, path):
+        """recursive nonsense"""
+        if "autoscaling.lock" in path:
+            return
+        self.log.debug("Adding watch on {}".format(path))
+        watcher = ChildrenWatch(self.zk, path, func=self.process_folder_event, send_event=True)
+        self.watchers[path] = watcher
+        children = watcher._prior_children
+        if children and ('instances' in children):
+            self.watch_node("{}/instances".format(path))
+        elif children:
+            for child in children:
+                self.watch_folder("{}/{}".format(path, child))
+
+    def watch_node(self, path):
+        self.log.debug("Adding watch on {}".format(path))
+        DataWatch(self.zk, path, func=self.process_node_event, send_event=True)
+
+    def process_node_event(self, data, stat, event):
+        self.log.debug("Node change: {}".format(event))
+        if event and (event.type == EventType.CREATED or event.type == EventType.CHANGED):
+            service, instance = event.path.split('/')[-3:-1]
+            self.log.info("Number of instances changed or autoscaling enabled for first time"
+                          " for {}.{}".format(service, instance))
+            service_instance = ServiceInstance(service=service,
+                                               instance=instance,
+                                               bounce_by=int(time.time()),
+                                               bounce_timers=None,
+                                               watcher=self.__class__.__name__)
+            self.inbox_q.put(service_instance)
+
+    def process_folder_event(self, children, event):
+        self.log.debug("Folder change: {}".format(event))
+        if event and (event.type == EventType.CHILD):
+            fq_children = ["{}/{}".format(event.path, child) for child in children]
+            for child in fq_children:
+                if child not in self.watchers:
+                    self.watch_folder(child)
+
+    def run(self):
+        self.watchers[AUTOSCALING_ZK_ROOT] = self.watch_folder(AUTOSCALING_ZK_ROOT)
+        self.is_ready = True
+        while True:
+            time.sleep(0.1)
 
 
 class FileWatcher(PaastaWatcher):

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -18,6 +18,8 @@ from paasta_tools.utils import ZookeeperPool
 log = logging.getLogger(__name__)
 logging.getLogger('marathon').setLevel(logging.WARNING)
 
+AUTOSCALING_ZK_ROOT = '/autoscaling'
+
 
 class LongRunningServiceConfig(InstanceConfig):
     def __init__(self, service, cluster, instance, config_dict, branch_dict):
@@ -320,7 +322,7 @@ def get_instances_from_zookeeper(service, instance):
 
 
 def compose_autoscaling_zookeeper_root(service, instance):
-    return '/autoscaling/%s/%s' % (service, instance)
+    return '%s/%s/%s' % (AUTOSCALING_ZK_ROOT, service, instance)
 
 
 def set_instances_for_marathon_service(service, instance, instance_count, soa_dir=DEFAULT_SOA_DIR):


### PR DESCRIPTION
First stab at watching zookeeper for changes to the number of instances.

I'll add some itests + unit tests before I merge this but it works for me in the example cluster.