### PR TITLE
Add another itest for deployd file watcher

### DIFF
--- a/paasta_itests/paasta_deployd.feature
+++ b/paasta_itests/paasta_deployd.feature
@@ -18,7 +18,21 @@ Feature: paasta-deployd deploys apps
      Then we can run get_app
      Then we set a new command for our service instance to "/bin/bash -c 'echo deploy-all-the-things'"
     Given I have yelpsoa-configs for the marathon job "test-service.main"
-     Then the config sha for "test-service.main" should have changed
+     Then the appid for "test-service.main" should have changed
+     Then we should not see the old version listed in marathon after 60 seconds
+     Then we should see "test-service.main" listed in marathon after 60 seconds
+     Then we can run get_app
+     Then paasta-deployd can be stopped
+
+  Scenario: deployd will re-deploy an app if its deployment.json is updated
+    Given a working paasta cluster
+      And paasta-deployd is running
+      And I have yelpsoa-configs for the marathon job "test-service.main"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
+     Then we should see "test-service.main" listed in marathon after 30 seconds
+     Then we can run get_app
+    Given we have a deployments.json for the service "test-service" with enabled instance "main" image "test-image-foobar1"
+     Then the appid for "test-service.main" should have changed
      Then we should not see the old version listed in marathon after 60 seconds
      Then we should see "test-service.main" listed in marathon after 60 seconds
      Then we can run get_app

--- a/paasta_itests/steps/paasta_deployd_steps.py
+++ b/paasta_itests/steps/paasta_deployd_steps.py
@@ -113,7 +113,7 @@ def set_cmd(context, cmd):
     context.cmd = cmd
 
 
-@then('the config sha for "{service_instance}" should have changed')
+@then('the appid for "{service_instance}" should have changed')
 def check_sha_changed(context, service_instance):
     service, instance, _, _ = decompose_job_id(service_instance)
     service_configuration_lib._yaml_cache = {}


### PR DESCRIPTION
This checks that we spot changes to deployments.json and bounce
successfully.