### PR TITLE
Update schema to require that 0 < bounce_margin_factor <= 1

### DIFF
--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -139,7 +139,11 @@
                 },
                 "bounce_margin_factor": {
                     "type": "number",
-                    "default": 1
+                    "default": 1,
+                    "minimum": 0,
+                    "maximum": 1,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
                 },
                 "deploy_group": {
                     "type": "string"


### PR DESCRIPTION
From the docs (https://paasta.readthedocs.io/en/latest/yelpsoa_configs.html#marathon-clustername-yaml):

```
bounce_margin_factor: proportionally increase the number of old instances to be drained when the crossover bounce method is used. 0 < bounce_margin_factor <= 1. Defaults to 1 (no influence). This allows bounces to proceed in the face of a percentage of failures. It doesn’t affect any other bounce method but crossover.
```