### PR TITLE
More caching for paasta status

### DIFF
--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -47,6 +47,7 @@ from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import PaastaNotConfiguredError
+from paasta_tools.utils import time_cache
 from paasta_tools.utils import timeout
 
 
@@ -128,14 +129,30 @@ def load_chronos_config():
         raise ChronosNotConfigured("Could not find chronos_config in configuration directory")
 
 
-def get_chronos_client(config):
+class CachingChronosClient(chronos.ChronosClient):
+
+    @time_cache(ttl=20)
+    def list(self):
+        return super(CachingChronosClient, self).list()
+
+    @time_cache(ttl=20)
+    def scheduler_graph(self):
+        return super(CachingChronosClient, self).scheduler_graph()
+
+
+def get_chronos_client(config, cached=False):
     """Returns a chronos client object for interacting with the API"""
     chronos_hosts = config.get_url()
     chronos_hostnames = [urlsplit(hostname).netloc for hostname in chronos_hosts]
     log.info("Attempting to connect to Chronos servers: %s" % chronos_hosts)
-    return chronos.connect(servers=chronos_hostnames,
-                           username=config.get_username(),
-                           password=config.get_password())
+    if cached:
+        return CachingChronosClient(servers=chronos_hostnames,
+                                    username=config.get_username(),
+                                    password=config.get_password())
+    else:
+        return chronos.connect(servers=chronos_hostnames,
+                               username=config.get_username(),
+                               password=config.get_password())
 
 
 def compose_job_id(service, instance):

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -23,8 +23,9 @@ import isodate
 
 from paasta_tools import marathon_tools
 from paasta_tools.mesos_tools import get_all_slaves_for_blacklist_whitelist
+from paasta_tools.mesos_tools import get_cached_list_of_running_tasks_from_frameworks
 from paasta_tools.mesos_tools import get_mesos_slaves_grouped_by_attribute
-from paasta_tools.mesos_tools import get_running_tasks_from_frameworks
+from paasta_tools.mesos_tools import select_tasks_by_id
 from paasta_tools.mesos_tools import status_mesos_tasks_verbose
 from paasta_tools.smartstack_tools import backend_is_up
 from paasta_tools.smartstack_tools import get_backends
@@ -371,8 +372,7 @@ def status_mesos_tasks(service, instance, normal_instance_count):
     # We have to add a spacer at the end to make sure we only return
     # things for service.main and not service.main_foo
     filter_string = "%s%s" % (job_id, marathon_tools.MESOS_TASK_SPACER)
-    running_and_active_tasks = get_running_tasks_from_frameworks(filter_string)
-    count = len(running_and_active_tasks)
+    count = len(select_tasks_by_id(get_cached_list_of_running_tasks_from_frameworks(), filter_string))
     if count >= normal_instance_count:
         status = PaastaColors.green("Healthy")
         count = PaastaColors.green("(%d/%d)" % (count, normal_instance_count))
@@ -393,7 +393,7 @@ def perform_command(command, service, instance, cluster, verbose, soa_dir, app_i
     :param instance: instance name, like "main" or "canary"
     :param cluster: cluster name
     :param verbose: int verbosity level
-    :param client: MarathonClient or CachedMarathonClient
+    :param client: MarathonClient or CachingMarathonClient
     :returns: A unix-style return code
     """
     system_config = load_system_paasta_config()

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -24,7 +24,6 @@ import json
 import logging
 import os
 import re
-import time
 from math import ceil
 
 import requests
@@ -117,26 +116,7 @@ class MarathonConfig(dict):
             raise MarathonNotConfigured('Could not find marathon password in system marathon config')
 
 
-class cached_marathon_service_config():
-    def __init__(self, *args, **kwargs):
-        self.configs = {}
-        self.ttl = kwargs.get("ttl", 0.0)
-
-    def __call__(self, f):
-        def cache(*args, **kwargs):
-            if 'ttl' in kwargs:
-                ttl = kwargs['ttl']
-                del kwargs['ttl']
-            else:
-                ttl = self.ttl
-            key = (args, ''.join("%s%s" % (k, v) for (k, v) in kwargs.items()))
-            if (not ttl) or (key not in self.configs) or (time.time() - self.configs[key]['fetch_time'] > ttl):
-                self.configs[key] = {'data': f(*args, **kwargs), 'fetch_time': time.time()}
-            return self.configs[key]['data']
-        return cache
-
-
-@cached_marathon_service_config(ttl=5)
+@time_cache(ttl=5)
 def load_marathon_service_config(service, instance, cluster, load_deployments=True, soa_dir=DEFAULT_SOA_DIR):
     """Read a service instance's configuration for marathon.
 

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -23,6 +23,7 @@ import traceback
 import requests_cache
 
 from paasta_tools import chronos_serviceinit
+from paasta_tools import chronos_tools
 from paasta_tools import marathon_serviceinit
 from paasta_tools import marathon_tools
 from paasta_tools import paasta_native_serviceinit
@@ -34,7 +35,6 @@ from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import validate_service_instance
-
 
 log = logging.getLogger(__name__)
 # kazoo can be really noisy - turn it down
@@ -82,6 +82,7 @@ class PaastaClients():
     def __init__(self, cached=False):
         self._cached = cached
         self._marathon = None
+        self._chronos = None
 
     def marathon(self):
         if self._marathon is None:
@@ -91,6 +92,12 @@ class PaastaClients():
                                                                 marathon_config.get_password(),
                                                                 cached=self._cached)
         return self._marathon
+
+    def chronos(self):
+        if self._chronos is None:
+            chronos_config = chronos_tools.load_chronos_config()
+            self._chronos = chronos_tools.get_chronos_client(chronos_config, cached=self._cached)
+        return self._chronos
 
 
 def main():
@@ -151,6 +158,7 @@ def main():
                     cluster=cluster,
                     verbose=args.verbose,
                     soa_dir=args.soa_dir,
+                    client=clients.chronos(),
                 )
             elif instance_type == 'paasta_native':
                 return_code = paasta_native_serviceinit.perform_command(

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -940,10 +940,10 @@ def test_get_short_task_id():
 
 def test_status_mesos_tasks_working():
     with mock.patch(
-            'paasta_tools.marathon_serviceinit.get_running_tasks_from_frameworks', autospec=True) as mock_tasks:
-        mock_tasks.return_value = [
-            {'id': 1}, {'id': 2}
-        ]
+            'paasta_tools.marathon_serviceinit.get_cached_list_of_running_tasks_from_frameworks',
+            autospec=True) as mock_tasks:
+        mock_tasks.return_value = [{'id': 'unused{0}unused{0}'.format(marathon_tools.MESOS_TASK_SPACER)}
+                                   for _ in xrange(2)]
         normal_count = 2
         actual = marathon_serviceinit.status_mesos_tasks('unused', 'unused', normal_count)
         assert 'Healthy' in actual
@@ -951,18 +951,19 @@ def test_status_mesos_tasks_working():
 
 def test_status_mesos_tasks_warning():
     with mock.patch(
-            'paasta_tools.marathon_serviceinit.get_running_tasks_from_frameworks', autospec=True) as mock_tasks:
-        mock_tasks.return_value = [
-            {'id': 1}, {'id': 2}
-        ]
+            'paasta_tools.marathon_serviceinit.get_cached_list_of_running_tasks_from_frameworks',
+            autospec=True) as mock_tasks:
+        mock_tasks.return_value = [{'id': 'fake{0}fake{0}'.format(marathon_tools.MESOS_TASK_SPACER)}
+                                   for _ in xrange(2)]
         normal_count = 4
-        actual = marathon_serviceinit.status_mesos_tasks('unused', 'unused', normal_count)
+        actual = marathon_serviceinit.status_mesos_tasks('fake', 'fake', normal_count)
         assert 'Warning' in actual
 
 
 def test_status_mesos_tasks_critical():
     with mock.patch(
-            'paasta_tools.marathon_serviceinit.get_running_tasks_from_frameworks', autospec=True) as mock_tasks:
+            'paasta_tools.marathon_serviceinit.get_cached_list_of_running_tasks_from_frameworks',
+            autospec=True) as mock_tasks:
         mock_tasks.return_value = []
         normal_count = 10
         actual = marathon_serviceinit.status_mesos_tasks('unused', 'unused', normal_count)

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -943,7 +943,7 @@ def test_status_mesos_tasks_working():
             'paasta_tools.marathon_serviceinit.get_cached_list_of_running_tasks_from_frameworks',
             autospec=True) as mock_tasks:
         mock_tasks.return_value = [{'id': 'unused{0}unused{0}'.format(marathon_tools.MESOS_TASK_SPACER)}
-                                   for _ in xrange(2)]
+                                   for _ in range(2)]
         normal_count = 2
         actual = marathon_serviceinit.status_mesos_tasks('unused', 'unused', normal_count)
         assert 'Healthy' in actual
@@ -954,7 +954,7 @@ def test_status_mesos_tasks_warning():
             'paasta_tools.marathon_serviceinit.get_cached_list_of_running_tasks_from_frameworks',
             autospec=True) as mock_tasks:
         mock_tasks.return_value = [{'id': 'fake{0}fake{0}'.format(marathon_tools.MESOS_TASK_SPACER)}
-                                   for _ in xrange(2)]
+                                   for _ in range(2)]
         normal_count = 4
         actual = marathon_serviceinit.status_mesos_tasks('fake', 'fake', normal_count)
         assert 'Warning' in actual


### PR DESCRIPTION
 * cache get_current_tasks() for paasta status explicitly
 * cache cronos.client for paasta status
 * always cache get_service_instance_list for 5 seconds

'paasta status -s yelp-main -c norcal-prod' takes 20 seconds.
'paasta status -s yelp-main -c norcal-prod -v' takes 3m20s. 