### PR TITLE
Make setup_marathon_job return bounce_again var

### DIFF
--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -211,7 +211,7 @@ def when_setup_service_initiated(context):
         for _ in range(120):
             try:
                 marathon_apps = marathon_tools.get_all_marathon_apps(context.marathon_client, embed_failures=True)
-                (code, message) = setup_marathon_job.setup_service(
+                (code, message, bounce_again) = setup_marathon_job.setup_service(
                     service=context.service,
                     instance=context.instance,
                     client=context.marathon_client,

--- a/paasta_tools/deployd/workers.py
+++ b/paasta_tools/deployd/workers.py
@@ -5,6 +5,7 @@ import time
 
 from paasta_tools import marathon_tools
 from paasta_tools.deployd.common import PaastaThread
+from paasta_tools.deployd.common import ServiceInstance
 from paasta_tools.setup_marathon_job import deploy_marathon_service
 
 
@@ -29,11 +30,21 @@ class PaastaDeployWorker(PaastaThread):
             service_instance = self.bounce_q.get()
             self.log.info("{} processing {}".format(self.name, service_instance))
             marathon_apps = marathon_tools.get_all_marathon_apps(self.marathon_client, embed_failures=True)
-            deploy_marathon_service(service=service_instance.service,
-                                    instance=service_instance.instance,
-                                    client=self.marathon_client,
-                                    soa_dir=marathon_tools.DEFAULT_SOA_DIR,
-                                    marathon_config=self.marathon_config,
-                                    marathon_apps=marathon_apps)
-            # TODO: make this return a time to wait for bounce and re-add to inbox_q
+            return_code, bounce_again_in_seconds = deploy_marathon_service(service=service_instance.service,
+                                                                           instance=service_instance.instance,
+                                                                           client=self.marathon_client,
+                                                                           soa_dir=marathon_tools.DEFAULT_SOA_DIR,
+                                                                           marathon_config=self.marathon_config,
+                                                                           marathon_apps=marathon_apps)
+            self.log.info("setup marathon completed with exit code {} for {}".format(return_code, service_instance))
+            if bounce_again_in_seconds:
+                self.log.info("{} not in steady state so bouncing again in {} seconds".format(service_instance,
+                                                                                              bounce_again_in_seconds))
+                service_instance = ServiceInstance(service=service_instance.service,
+                                                   instance=service_instance.instance,
+                                                   bounce_by=int(time.time()) + bounce_again_in_seconds,
+                                                   watcher=self.name)
+                self.inbox_q.put(service_instance)
+            else:
+                self.log.info("{} in steady state".format(service_instance))
             time.sleep(0.1)

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -86,7 +86,7 @@ class TestSetupMarathonJob:
             autospec=True,
         ) as read_service_conf_patch, mock.patch(
             'paasta_tools.setup_marathon_job.setup_service',
-            return_value=(0, 'it_is_finished'),
+            return_value=(0, 'it_is_finished', None),
             autospec=True,
         ) as setup_service_patch, mock.patch(
             'paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True,
@@ -148,7 +148,7 @@ class TestSetupMarathonJob:
             autospec=True,
         ) as read_service_conf_patch, mock.patch(
             'paasta_tools.setup_marathon_job.setup_service',
-            return_value=(1, 'NEVER'),
+            return_value=(1, 'NEVER', None),
             autospec=True,
         ) as setup_service_patch, mock.patch(
             'paasta_tools.setup_marathon_job.load_system_paasta_config', autospec=True,
@@ -681,7 +681,7 @@ class TestSetupMarathonJob:
                 client=fake_client,
                 soa_dir='fake_soa_dir',
             )
-            assert mock_log.call_count == 0
+            assert mock_log.call_count == 1
             assert mock_create_marathon_app.call_count == 0
             assert fake_drain_method.drain.call_count == 0
             assert mock_kill_old_ids.call_count == 0
@@ -1146,7 +1146,7 @@ class TestSetupMarathonJob:
             'format_marathon_app_dict',
             side_effect=NoDockerImageError,
         ):
-            status, output = setup_marathon_job.setup_service(
+            status, output, bounce_again = setup_marathon_job.setup_service(
                 service=fake_name,
                 instance=fake_instance,
                 client=None,
@@ -1157,6 +1157,7 @@ class TestSetupMarathonJob:
             assert status == 1
             expected = 'Docker image for test_service.test_instance not in'
             assert expected in output
+            assert bounce_again is None
 
     def test_setup_service_nerve_ns(self):
         fake_service = 'fake_service'
@@ -1215,7 +1216,7 @@ class TestSetupMarathonJob:
         fake_config = {'id': fake_id, 'instances': 2}
 
         errormsg = 'ERROR: drain_method not recognized: doesntexist. Must be one of (exists1, exists2)'
-        expected = (1, errormsg)
+        expected = (1, errormsg, None)
 
         with mock.patch(
             'paasta_tools.setup_marathon_job._log', autospec=True,
@@ -1258,7 +1259,7 @@ class TestSetupMarathonJob:
 
         errormsg = 'ERROR: bounce_method not recognized: %s. Must be one of (%s)' % \
             (fake_bounce, ', '.join(list_bounce_methods()))
-        expected = (1, errormsg)
+        expected = (1, errormsg, None)
 
         with mock.patch(
             'paasta_tools.setup_marathon_job._log', autospec=True,
@@ -1497,7 +1498,7 @@ class TestSetupMarathonJob:
                                                              mock_marathon_config,
                                                              mock_marathon_apps)
             assert not mock_setup_service.called
-            assert ret == 0
+            assert ret == (0, None)
 
 
 class TestGetOldHappyUnhappyDrainingTasks(object):


### PR DESCRIPTION
This adds an extra return variable to setup_marathon_job with a time in
which the service instance it is deploying should be bounced again. To
start with this aims to be simple and naive. If it thinks everything is
steady state it returns -1, if it thinks more work needs to be done it
returns 60 (seconds). This can be further nuanced in the future.

This extra return variable is consumed by the paasta deployd workers
which can then re-add services to the bounce queue. For the existing
cron jobs the extra variable is just ignored.