### PR TITLE
Use wheels in non yelp env

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,7 @@
 # -*- makefile -*-
 
 ifeq ($(PAASTA_ENV),YELP)
-	EXTRA_PYPI="--extra-index-url 'https://pypi.yelpcorp.com/simple'"
+	EXTRA_PYPI="--extra-index-url 'https://pypi.yelpcorp.com/simple' --preinstall no-manylinux1"
 endif
 
 %:
@@ -23,4 +23,4 @@ override_dh_auto_test:
 	true
 
 override_dh_virtualenv:
-	dh_virtualenv $EXTRA_PYPI --python=/usr/bin/python2.7 --preinstall no-manylinux1 --preinstall pip-custom-platform --pip-tool pip-custom-platform
+	dh_virtualenv $EXTRA_PYPI --python=/usr/bin/python2.7 --preinstall pip-custom-platform --pip-tool pip-custom-platform

--- a/yelp_package/dockerfiles/itest/hacheck/Dockerfile
+++ b/yelp_package/dockerfiles/itest/hacheck/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM ubuntu:trusty
 
-RUN apt-get update && apt-get -y install git python2.7 python2.7-dev libyaml-dev python-virtualenv python-pkg-resources
+RUN apt-get update && apt-get -y install git python2.7 python-virtualenv python-pkg-resources
 
 RUN git clone --branch=yelp git://github.com/Yelp/hacheck
 WORKDIR /hacheck

--- a/yelp_package/dockerfiles/itest/itest/Dockerfile
+++ b/yelp_package/dockerfiles/itest/itest/Dockerfile
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 FROM ubuntu:trusty
-RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools python-dev debhelper
+RUN apt-get update && apt-get -y install python-tox python-setuptools debhelper

--- a/yelp_package/dockerfiles/lucid/Dockerfile
+++ b/yelp_package/dockerfiles/lucid/Dockerfile
@@ -18,7 +18,7 @@ MAINTAINER Kyle Anderson <kwa@yelp.com>
 # Make sure we get a package suitable for building this package correctly.
 # Per dnephin we need https://github.com/spotify/dh-virtualenv/pull/20
 # Which at this time is in this package
-RUN apt-get update && apt-get -y install dpkg-dev python-pip python-setuptools python-dev libssl-dev libffi-dev debhelper dh-virtualenv python-yaml libyaml-dev python-pytest pyflakes python2.7 python2.7-dev help2man zsh git
+RUN apt-get update && apt-get -y install python-pip python-setuptools debhelper dh-virtualenv python-yaml python-pytest pyflakes python2.7 help2man zsh git
 
 RUN pip install -U virtualenv==15.1.0 tox==2.6.0
 

--- a/yelp_package/dockerfiles/mesos-paasta/Dockerfile
+++ b/yelp_package/dockerfiles/mesos-paasta/Dockerfile
@@ -1,6 +1,6 @@
 FROM examplecluster_mesosbase
 RUN apt-get update && apt-get -y install python-tox python-setuptools \
-  python-dev libyaml-dev openssh-server libffi-dev libssl-dev
+  openssh-server
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 RUN mkdir -p /var/log/paasta_logs 
 RUN mkdir /var/run/sshd

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -19,16 +19,11 @@ RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         debhelper \
-        dpkg-dev \
         gcc \
         gdebi-core \
         git \
         help2man \
-        libffi-dev \
-        libssl-dev \
-        libyaml-dev \
         pyflakes \
-        python-dev \
         python-pip \
         python-pytest \
         python-setuptools \

--- a/yelp_package/dockerfiles/xenial/Dockerfile
+++ b/yelp_package/dockerfiles/xenial/Dockerfile
@@ -19,16 +19,11 @@ RUN echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         debhelper \
-        dpkg-dev \
         gcc \
         gdebi-core \
         git \
         help2man \
-        libffi-dev \
-        libssl-dev \
-        libyaml-dev \
         pyflakes \
-        python-dev \
         python-pytest \
         python-setuptools \
         python-tox \


### PR DESCRIPTION
We've were getting some Travis build failures in compiling tornado. With this change we can use wheels for that when outside of the Yelp env.  This way we also don't need all the -dev packages