### PR TITLE
A new version of pyOpenSSL requires this upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ choice==0.1
 chronos-python==0.37.0
 cookiecutter==1.4.0
 croniter==0.3.14
-cryptography==1.4
+cryptography==1.7
 docker-py==1.2.3
 dulwich==0.16.3
 ephemeral-port-reserve==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'choice == 0.1',
         'chronos-python == 0.37.0',
         'cookiecutter == 1.4.0',
-        'cryptography == 1.4',
+        'cryptography == 1.7',
         # Don't update this unless you have confirmed the client works with
         # the Docker version deployed on PaaSTA servers
         'docker-py == 1.2.3',


### PR DESCRIPTION
There was a new release https://pypi.python.org/pypi/pyOpenSSL today
that breaks our build because we've pinned cryptography. This upgrades
it to see if we get a clean build.