### PR TITLE
Fix threaded timeout decorator

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1829,6 +1829,7 @@ class _Timeout(object):
         self.func_thread = threading.Thread(target=self.run,
                                             args=args,
                                             kwargs=kwargs)
+        self.func_thread.daemon = True
         self.timeout = self.seconds + time.time()
         self.func_thread.start()
         return self.get_and_raise()


### PR DESCRIPTION
Currently the TimeoutError is thrown but the main thread will still
continue to wait for the function thread to finish before it exits
itself. Setting the daemon flag means that the child thread will be
killed if the main thread dies, which it does on receiving the timeout
exception.

Internally: PAASTA-10556