### PR TITLE
Remove cryptography exact pin from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'choice == 0.1',
         'chronos-python == 0.37.0',
         'cookiecutter == 1.4.0',
-        'cryptography == 1.7',
         # Don't update this unless you have confirmed the client works with
         # the Docker version deployed on PaaSTA servers
         'docker-py == 1.2.3',


### PR DESCRIPTION
The previous fix which changed the exact pin of 1.4 to 1.7 is not the right fix. Paasta doesn't even import cryptography, it shouldn't be enforcing an == relationship. Let's see if we can pass tests without the pin.

@mattmb 