### PR TITLE
Remove create_app_lock when creating marathon apps

### DIFF
--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -131,8 +131,7 @@ def given_an_old_app_to_be_destroyed_constraints(context, constraints):
         'backoff_factor': 1,
         'constraints': constraints,
     }
-    with mock.patch('paasta_tools.bounce_lib.create_app_lock'):
-        bounce_lib.create_marathon_app(old_app_name, context.old_app_config, context.marathon_client)
+    bounce_lib.create_marathon_app(old_app_name, context.old_app_config, context.marathon_client)
 
 
 @when('there are exactly {num:d} {which} {state} tasks')
@@ -184,8 +183,6 @@ def when_setup_service_initiated(context):
             app, context.service, "fake_nerve_ns", context.system_paasta_config)[:context.max_tasks],
     ), mock.patch(
         'paasta_tools.bounce_lib.bounce_lock_zookeeper', autospec=True,
-    ), mock.patch(
-        'paasta_tools.bounce_lib.create_app_lock', autospec=True,
     ), mock.patch(
         'paasta_tools.bounce_lib.time.sleep', autospec=True,
     ), mock.patch(

--- a/paasta_itests/steps/marathon_steps.py
+++ b/paasta_itests/steps/marathon_steps.py
@@ -41,8 +41,7 @@ def create_trivial_marathon_app(context):
         'instances': 3,
         'constraints': [["hostname", "UNIQUE"]],
     }
-    with mock.patch('paasta_tools.bounce_lib.create_app_lock'):
-        paasta_tools.bounce_lib.create_marathon_app(app_config['id'], app_config, context.marathon_client)
+    paasta_tools.bounce_lib.create_marathon_app(app_config['id'], app_config, context.marathon_client)
 
 
 @then('we should see it running in marathon')

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -48,8 +48,7 @@ def run_marathon_app(context, job_id, instances):
         'instances': instances,
         'constraints': [["hostname", "UNIQUE"]],
     }
-    with mock.patch('paasta_tools.bounce_lib.create_app_lock'):
-        paasta_tools.bounce_lib.create_marathon_app(app_id, app_config, context.marathon_client)
+    paasta_tools.bounce_lib.create_marathon_app(app_id, app_config, context.marathon_client)
 
 
 @then('marathon_serviceinit status_marathon_job should return "{status}" for "{job_id}"')

--- a/tests/test_bounce_lib.py
+++ b/tests/test_bounce_lib.py
@@ -14,7 +14,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import contextlib
 import datetime
 
 import marathon
@@ -72,12 +71,9 @@ class TestBounceLib:
         fake_client = marathon_client_mock
         fake_config = {'id': 'fake_creation'}
         with mock.patch(
-            'paasta_tools.bounce_lib.create_app_lock', spec=contextlib.contextmanager, autospec=None,
-        ) as lock_patch, mock.patch(
             'paasta_tools.bounce_lib.wait_for_create', autospec=True,
         ) as wait_patch:
             bounce_lib.create_marathon_app('fake_creation', fake_config, fake_client)
-            assert lock_patch.called
             assert fake_client.create_app.call_count == 1
             actual_call_args = fake_client.create_app.call_args
             actual_config = actual_call_args[0][1]
@@ -88,8 +84,6 @@ class TestBounceLib:
         fake_client = mock.Mock(delete_app=mock.Mock())
         fake_id = 'fake_deletion'
         with mock.patch(
-            'paasta_tools.bounce_lib.create_app_lock', spec=contextlib.contextmanager, autospec=None,
-        ) as lock_patch, mock.patch(
             'paasta_tools.bounce_lib.wait_for_delete', autospec=True,
         ) as wait_patch, mock.patch(
             'time.sleep', autospec=True,
@@ -98,7 +92,6 @@ class TestBounceLib:
             fake_client.scale_app.assert_called_once_with(fake_id, instances=0, force=True)
             fake_client.delete_app.assert_called_once_with(fake_id, force=True)
             wait_patch.assert_called_once_with(fake_id, fake_client)
-            assert lock_patch.called
 
     def test_kill_old_ids(self):
         old_ids = ['mmm.whatcha.say', 'that.you', 'only.meant.well']


### PR DESCRIPTION
This was added because we were overwhelming marathon. However, the
problem was with a pretty old version of marathon so we're hoping we no
longer need to be so conservative!