### PR TITLE
remote-run start/stop/list, --detach for background mode, optional --run-id for naming your runs

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -81,7 +81,7 @@ def add_common_args_to_parser(parser):
         help='Show Docker commands output',
         action='store_true',
         required=False,
-        default=True,
+        default=False,
     )
     parser.add_argument(
         '-R', '--run-id',

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -35,7 +35,7 @@ from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
 
 
-def start_args(parser):
+def add_start_args_to_parser(parser):
     parser.add_argument(
         '-C', '--cmd',
         help=('Run Docker container with particular command, '
@@ -60,7 +60,7 @@ def start_args(parser):
     )
 
 
-def common_args(parser):
+def add_common_args_to_parser(parser):
     parser.add_argument(
         '-s', '--service',
         help='The name of the service you wish to inspect',
@@ -125,8 +125,8 @@ def add_subparser(subparsers):
         'start',
         help="Start task subcommand"
     )
-    start_args(start_parser)
-    common_args(start_parser)
+    add_start_args_to_parser(start_parser)
+    add_common_args_to_parser(start_parser)
     start_parser.add_argument(
         '-X', '--constraint',
         help='Constraint option, format: <attr>,OP[,<value>], OP can be one of '
@@ -142,7 +142,7 @@ def add_subparser(subparsers):
         'stop',
         help="Stop task subcommand"
     )
-    common_args(stop_parser)
+    add_common_args_to_parser(stop_parser)
     stop_parser.add_argument(
         '-F', '--framework-id',
         help='ID of framework to stop. Must belong to remote-run of selected service instance.',
@@ -154,7 +154,7 @@ def add_subparser(subparsers):
         'list',
         help="Stop task subcommand"
     )
-    common_args(list_parser)
+    add_common_args_to_parser(list_parser)
 
     main_parser.set_defaults(command=paasta_remote_run)
 

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -209,9 +209,10 @@ def paasta_remote_run(args):
     if len(constraints) > 0:
         cmd_parts.extend(['--constraints-json', quote(json.dumps(constraints))])
 
+    graceful_exit = (args.action == 'start' and not args.detach)
     return_code, status = run_on_master(
         args.cluster, system_paasta_config, cmd_parts,
-        graceful_exit=args.action == 'start' and not args.detach)
+        graceful_exit=graceful_exit)
 
     # Status results are streamed. This print is for possible error messages.
     if status is not None:

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -93,9 +93,9 @@ def add_common_args_to_parser(parser):
     parser.add_argument(
         '-d', '--dry-run',
         help='Don\'t launch the task',
-        action='count',
+        action='store_true',
         required=False,
-        default=0,
+        default=False,
     )
     parser.add_argument(
         '-i', '--instance',
@@ -181,6 +181,7 @@ def paasta_remote_run(args):
         'yelpsoa_config_root': DEFAULT_SOA_DIR,
         'cmd': None,
         'verbose': True,
+        'dry_run': False,
         'staging_timeout': None,
         'detach': False,
         'run_id': None,
@@ -208,13 +209,8 @@ def paasta_remote_run(args):
     if len(constraints) > 0:
         cmd_parts.extend(['--constraints-json', quote(json.dumps(constraints))])
 
-    if args.dry_run > 0:
-        cmd_parts.append('--dry-run')
-
-    paasta_print('Running on master: %s' % ' '.join(cmd_parts))
     return_code, status = run_on_master(
         args.cluster, system_paasta_config, cmd_parts,
-        dry=args.dry_run > 1,
         graceful_exit=args.action == 'start' and not args.detach)
 
     # Status results are streamed. This print is for possible error messages.

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -35,7 +35,45 @@ from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
 
 
-def add_remote_run_args(parser):
+def start_args(parser):
+    parser.add_argument(
+        '-C', '--cmd',
+        help=('Run Docker container with particular command, '
+              'for example: "bash". By default will use the command or args specified by the '
+              'soa-configs or what was specified in the Dockerfile'),
+        required=False,
+        default=None,
+    )
+    parser.add_argument(
+        '-D', '--detach',
+        help='Launch in background',
+        action='store_true',
+        required=False,
+        default=False,
+    )
+    parser.add_argument(
+        '-t', '--staging-timeout',
+        help='A timeout for the task to be launching before killed',
+        required=False,
+        default=60,
+        type=float,
+    )
+    parser.add_argument(
+        '-i', '--instance',
+        help=("Simulate a docker run for a particular instance of the service, like 'main' or 'canary'"),
+        required=False,
+        default=None,
+    ).completer = lazy_choices_completer(list_instances)
+    parser.add_argument(
+        '-d', '--dry-run',
+        help='Don\'t launch the task',
+        action='count',
+        required=False,
+        default=0,
+    )
+
+
+def common_args(parser):
     parser.add_argument(
         '-s', '--service',
         help='The name of the service you wish to inspect',
@@ -52,26 +90,6 @@ def add_remote_run_args(parser):
         default=DEFAULT_SOA_DIR,
     )
     parser.add_argument(
-        '--json-dict',
-        help='When running dry run, output the arguments as a json dict',
-        action='store_true',
-        dest='dry_run_json_dict',
-    )
-    parser.add_argument(
-        '-C', '--cmd',
-        help=('Run Docker container with particular command, '
-              'for example: "bash". By default will use the command or args specified by the '
-              'soa-configs or what was specified in the Dockerfile'),
-        required=False,
-        default=None,
-    )
-    parser.add_argument(
-        '-i', '--instance',
-        help=("Simulate a docker run for a particular instance of the service, like 'main' or 'canary'"),
-        required=False,
-        default=None,
-    ).completer = lazy_choices_completer(list_instances)
-    parser.add_argument(
         '-v', '--verbose',
         help='Show Docker commands output',
         action='store_true',
@@ -79,23 +97,16 @@ def add_remote_run_args(parser):
         default=True,
     )
     parser.add_argument(
-        '-d', '--dry-run',
-        help='Don\'t launch the task',
-        action='store_true',
+        '-R', '--run-id',
+        help='Identifier to assign/refer to individual task runs',
+        action='store',
         required=False,
-        default=False,
-    )
-    parser.add_argument(
-        '-t', '--staging-timeout',
-        help='A timeout for the task to be launching before killed',
-        required=False,
-        default=60,
-        type=float,
+        default=None,
     )
 
 
 def add_subparser(subparsers):
-    list_parser = subparsers.add_parser(
+    main_parser = subparsers.add_parser(
         'remote-run',
         help="Schedule Mesos to run adhoc command in context of a service",
         description=(
@@ -107,15 +118,16 @@ def add_subparser(subparsers):
             "Note: 'paasta remote-run' Mesos API that may require authentication."
         ),
     )
-    add_remote_run_args(list_parser)
-    list_parser.add_argument(
-        '-D', '--very-dry-run',
-        help='Don\'t ssh into mesos-master',
-        action='store_true',
-        required=False,
-        default=False,
+
+    main_subs = main_parser.add_subparsers(dest='action', help='Subcommands of remote-run')
+
+    start_parser = main_subs.add_parser(
+        'start',
+        help="Start task subcommand"
     )
-    list_parser.add_argument(
+    start_args(start_parser)
+    common_args(start_parser)
+    start_parser.add_argument(
         '-X', '--constraint',
         help='Constraint option, format: <attr>,OP[,<value>], OP can be one of '
         'the following: EQUALS matches attribute value exactly, LIKE and '
@@ -125,10 +137,25 @@ def add_subparser(subparsers):
         action='append',
         default=[]
     )
-    list_parser.set_defaults(command=paasta_remote_run)
+
+    stop_parser = main_subs.add_parser(
+        'stop',
+        help="Stop task subcommand"
+    )
+    common_args(stop_parser)
+
+    list_parser = main_subs.add_parser(
+        'list',
+        help="Stop task subcommand"
+    )
+    common_args(list_parser)
+
+    main_parser.set_defaults(command=paasta_remote_run)
 
 
 def paasta_remote_run(args):
+    print(args)
+
     try:
         system_paasta_config = load_system_paasta_config()
     except PaastaNotConfiguredError:
@@ -142,17 +169,17 @@ def paasta_remote_run(args):
         )
         system_paasta_config = SystemPaastaConfig({"volumes": []}, '/etc/paasta')
 
-    cmd_parts = ['/usr/bin/paasta_remote_run']
+    cmd_parts = ['/usr/bin/paasta_remote_run', args.action]
     args_vars = vars(args)
     args_keys = {
         'service': None,
         'cluster': None,
         'yelpsoa_config_root': DEFAULT_SOA_DIR,
-        'json_dict': False,
         'cmd': None,
         'verbose': True,
-        'dry_run': False,
         'staging_timeout': None,
+        'detach': False,
+        'run_id': None,
     }
     for key in args_vars:
         # skip args we don't know about
@@ -176,10 +203,14 @@ def paasta_remote_run(args):
     if len(constraints) > 0:
         cmd_parts.extend(['--constraints-json', quote(json.dumps(constraints))])
 
+    if args.dry_run > 0:
+        cmd_parts.append('--dry-run')
+
     paasta_print('Running on master: %s' % ' '.join(cmd_parts))
     return_code, status = run_on_master(
         args.cluster, system_paasta_config, cmd_parts,
-        dry=args.very_dry_run)
+        dry=args.dry_run > 1,
+        graceful_exit=not args.detach)
 
     # Status results are streamed. This print is for possible error messages.
     if status is not None:

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -615,7 +615,7 @@ def run_on_master(cluster, system_paasta_config, cmd_parts,
         popen_kwargs = {}
 
     cmd_parts = [
-        'ssh', '-q', '-o', 'StrictHostKeyChecking no', '-t', '-t', '-A',
+        'ssh', '-q', '-t', '-t', '-A',
         master, "/bin/bash", "-c", quote(' '.join(cmd_parts))
     ]
 

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -606,14 +606,7 @@ def run_on_master(cluster, system_paasta_config, cmd_parts,
         return (err_code, str(e))
 
     if graceful_exit:
-        cmd_parts.append(
-            # send target cmd to background
-            "& script=$$; target=$!; " +
-            # wait for stdin and kill target cmd
-            "read; kill $target & " +
-            # wait for target cmd to die and kill current script
-            "while kill -0 $target 2>/dev/null; do sleep 1; done; kill $script; wait"
-        )
+        cmd_parts.append("; kill $$ & read; kill $!; wait")
         stdin = subprocess.PIPE
         stdin_interrupt = True
         popen_kwargs = {'preexec_fn': os.setsid}

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -582,7 +582,7 @@ def execute_chronos_rerun_on_remote_master(service, instancename, cluster, syste
 
 
 def run_on_master(cluster, system_paasta_config, cmd_parts,
-                  timeout=None, shell=False, dry=False, err_code=-1,
+                  timeout=None, shell=False, err_code=-1,
                   graceful_exit=True, stdin=None):
     """Find connectable master for :cluster: and :system_paasta_config: args and
     invoke command from :cmd_parts:, wrapping it in ssh call.
@@ -619,12 +619,11 @@ def run_on_master(cluster, system_paasta_config, cmd_parts,
         master, "/bin/bash", "-c", quote(' '.join(cmd_parts))
     ]
 
-    if dry:
-        return (0, "Would have run: %s" % ' '.join(cmd_parts))
-    else:
-        return _run(cmd_parts, timeout=timeout, stream=True,
-                    stdin=stdin, stdin_interrupt=stdin_interrupt,
-                    popen_kwargs=popen_kwargs)
+    log.debug("Running %s" % ' '.join(cmd_parts))
+
+    return _run(cmd_parts, timeout=timeout, stream=True,
+                stdin=stdin, stdin_interrupt=stdin_interrupt,
+                popen_kwargs=popen_kwargs)
 
 
 def lazy_choices_completer(list_func):

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -614,8 +614,10 @@ def run_on_master(cluster, system_paasta_config, cmd_parts,
         stdin_interrupt = False
         popen_kwargs = {}
 
-    cmd_parts = ['ssh', '-t', '-t', '-A', master, "/bin/bash", "-c", quote(' '.join(cmd_parts))]
-    paasta_print(' '.join(cmd_parts))
+    cmd_parts = [
+        'ssh', '-q', '-o', 'StrictHostKeyChecking no', '-t', '-t', '-A',
+        master, "/bin/bash", "-c", quote(' '.join(cmd_parts))
+    ]
 
     if dry:
         return (0, "Would have run: %s" % ' '.join(cmd_parts))

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -619,9 +619,8 @@ def run_on_master(cluster, system_paasta_config, cmd_parts,
     else:
         stdin_interrupt = False
         popen_kwargs = {}
-        cmd = ' '.join(cmd_parts)
 
-    cmd_parts = ['ssh', '-q', '-t', '-t', '-A', master, "/bin/bash -c %s" % quote(cmd)]
+    cmd_parts = ['ssh', '-q', '-t', '-t', '-A', master, "/bin/bash -c %s" % quote(' '.join(cmd_parts))]
 
     log.debug("Running %s" % ' '.join(cmd_parts))
 

--- a/paasta_tools/frameworks/adhoc_scheduler.py
+++ b/paasta_tools/frameworks/adhoc_scheduler.py
@@ -51,7 +51,7 @@ class AdhocScheduler(NativeScheduler):
                     tasks_and_state_for_offer(driver, offer, state)
                 paasta_print("Would have launched: ", tasks)
             driver.stop()
-            return None, state
+            return [], state
 
         return super(AdhocScheduler, self). \
             tasks_and_state_for_offer(driver, offer, state)

--- a/paasta_tools/frameworks/native_scheduler.py
+++ b/paasta_tools/frameworks/native_scheduler.py
@@ -163,7 +163,7 @@ class NativeScheduler(mesos.interface.Scheduler):
                     tasks, new_state = self.tasks_and_state_for_offer(
                         driver, offer, self.constraint_state)
 
-                    if len(tasks) > 0:
+                    if tasks is not None and len(tasks) > 0:
                         operation = mesos_pb2.Offer.Operation()
                         operation.type = mesos_pb2.Offer.Operation.LAUNCH
                         operation.launch.task_infos.extend(tasks)

--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -69,14 +69,20 @@ class MesosMaster(object):
         return "{}://{}".format(self.config["scheme"], self.resolve(self.config["master"]))
 
     @log.duration
-    def fetch(self, url, **kwargs):
+    def request(self, url, method=requests.get, **kwargs):
         try:
-            return requests.get(
+            return method(
                 urljoin(self.host, url),
                 timeout=self.config["response_timeout"],
                 **kwargs)
         except requests.exceptions.ConnectionError:
             raise exceptions.MasterNotAvailableException(MISSING_MASTER.format(self.host))
+
+    def fetch(self, url, **kwargs):
+        return self.request(url, **kwargs)
+
+    def post(self, url, **kwargs):
+        return self.request(url, method=requests.post, **kwargs)
 
     def _file_resolver(self, cfg):
         return self.resolve(open(cfg[6:], "r+").read().strip())
@@ -217,6 +223,9 @@ class MesosMaster(object):
 
     def frameworks(self, active_only=False):
         return [framework.Framework(f) for f in self._framework_list(active_only)]
+
+    def teardown(self, framework_id):
+        return self.post("/master/teardown", data="frameworkId=%s" % framework_id)
 
     def metrics_snapshot(self):
         return self.fetch("/metrics/snapshot").json()

--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -69,7 +69,7 @@ class MesosMaster(object):
         return "{}://{}".format(self.config["scheme"], self.resolve(self.config["master"]))
 
     @log.duration
-    def request(self, url, method=requests.get, **kwargs):
+    def _request(self, url, method=requests.get, **kwargs):
         try:
             return method(
                 urljoin(self.host, url),
@@ -79,10 +79,10 @@ class MesosMaster(object):
             raise exceptions.MasterNotAvailableException(MISSING_MASTER.format(self.host))
 
     def fetch(self, url, **kwargs):
-        return self.request(url, **kwargs)
+        return self._request(url, **kwargs)
 
     def post(self, url, **kwargs):
-        return self.request(url, method=requests.post, **kwargs)
+        return self._request(url, method=requests.post, **kwargs)
 
     def _file_resolver(self, cfg):
         return self.resolve(open(cfg[6:], "r+").read().strip())

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -28,8 +28,8 @@ from datetime import datetime
 
 import requests
 
-from paasta_tools.cli.cmds.remote_run import common_args
-from paasta_tools.cli.cmds.remote_run import start_args
+from paasta_tools.cli.cmds.remote_run import add_common_args_to_parser
+from paasta_tools.cli.cmds.remote_run import add_start_args_to_parser
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.frameworks.adhoc_scheduler import AdhocScheduler
 from paasta_tools.frameworks.native_scheduler import create_driver
@@ -47,8 +47,8 @@ def parse_args(argv):
     subs = parser.add_subparsers(dest='action', help='Subcommands of paasta_remote_run')
 
     start_parser = subs.add_parser('start', help='Start task')
-    start_args(start_parser)
-    common_args(start_parser)
+    add_start_args_to_parser(start_parser)
+    add_common_args_to_parser(start_parser)
     start_parser.add_argument(
         '-X', '--constraints-json',
         help=('Mesos constraints JSON'),
@@ -57,7 +57,7 @@ def parse_args(argv):
     )
 
     stop_parser = subs.add_parser('stop', help='Stop task')
-    common_args(stop_parser)
+    add_common_args_to_parser(stop_parser)
     stop_parser.add_argument(
         '-F', '--framework-id',
         help=('ID of framework to stop'),
@@ -66,7 +66,7 @@ def parse_args(argv):
     )
 
     list_parser = subs.add_parser('list', help='List tasks')
-    common_args(list_parser)
+    add_common_args_to_parser(list_parser)
 
     return parser.parse_args(argv)
 

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -196,7 +196,7 @@ def remote_run_stop(args):
                 os._exit(1)
 
             frameworks = requests.get('http://localhost:5050/frameworks').json()['frameworks']
-            found = [f for f in frameworks if re.search('%s$' % args.run_id, f['name']) is not None]
+            found = [f for f in frameworks if re.search(' %s$' % args.run_id, f['name']) is not None]
             if len(found) > 0:
                 framework_id = found[0]['id']
             else:
@@ -208,7 +208,7 @@ def remote_run_stop(args):
     else:
         frameworks = requests.get('http://localhost:5050/frameworks').json()['frameworks']
         found = [f for f in frameworks if f['id'] == framework_id]
-        if len(found) > 0 and re.search('^paasta-remote %s.%s' % (service, instance), found[0]['name']) is None:
+        if len(found) > 0 and re.search('^paasta-remote %s.%s ' % (service, instance), found[0]['name']) is None:
             paasta_print(
                 PaastaColors.red(
                     "Framework name %s does not match remote-run service instance %s.%s" %
@@ -218,7 +218,7 @@ def remote_run_stop(args):
     paasta_print("Tearing down framework %s." % framework_id)
     teardown = requests.post('http://localhost:5050/teardown', data="frameworkId=%s" % framework_id)
     if teardown.status_code == 200:
-        paasta_print("OK")
+        paasta_print(PaastaColors.green("OK"))
     else:
         paasta_print(teardown.text)
 

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -187,7 +187,11 @@ def remote_run_stop(args):
         paasta_print(PaastaColors.red("Must provide either run id or framework id to stop."))
         os._exit(1)
 
-    frameworks = get_all_frameworks(active_only=True)
+    frameworks = [
+        f
+        for f in get_all_frameworks(active_only=True)
+        if re.search('^paasta-remote %s.%s' % (service, instance), f.name)
+    ]
     framework_id = args.framework_id
     if framework_id is None:
         if re.match('\s', args.run_id):
@@ -202,11 +206,11 @@ def remote_run_stop(args):
             os._exit(1)
     else:
         found = [f for f in frameworks if f.id == framework_id]
-        if len(found) > 0 and re.search('^paasta-remote %s.%s ' % (service, instance), found[0].name) is None:
+        if len(found) == 0:
             paasta_print(
                 PaastaColors.red(
-                    "Framework name %s does not match remote-run service instance %s.%s" %
-                    (found[0].name, service, instance)))
+                    "Framework id %s does not match any %s.%s remote-run. Check status to find the correct id." %
+                    (framework_id, service, instance)))
             os._exit(1)
 
     paasta_print("Tearing down framework %s." % framework_id)


### PR DESCRIPTION
paasta remote-run gets subcommands: start / stop / list

paasta remote-run start:
- fix dry-run on master
- run in background with --detach
- optionally name your run with --run-id <blah>

paasta remote-run list: lists all active frameworks for specific cluster/service/instance with their respective run ids and framework ids

paasta remote-run stop: stop remote-run of cluster/service/instance by it's run id (-R) or framework id (-F)