### PR TITLE
Send length of inbox as gauge

### DIFF
--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -101,7 +101,7 @@ class DeployDaemon(PaastaThread):
         self.is_leader = True
         self.log.debug("This node is elected as leader {}".format(socket.getfqdn()))
         self.metrics = get_metrics_interface(self.config.get_deployd_metrics_provider())
-        QueueMetrics(self.inbox_q, self.bounce_q, self.metrics).start()
+        QueueMetrics(self.inbox, self.bounce_q, self.metrics).start()
         self.inbox.start()
         self.log.info("Starting all watcher threads")
         self.start_watchers()

--- a/tests/deployd/test_metrics.py
+++ b/tests/deployd/test_metrics.py
@@ -54,17 +54,17 @@ class TestQueueMetrics(unittest.TestCase):
     def setUp(self):
         mock_metrics_provider = mock.Mock()
         self.mock_gauge = mock.Mock()
-        self.mock_inbox_q = mock.Mock()
+        self.mock_inbox = mock.Mock(inbox_q=mock.Mock(), to_bounce={})
         self.mock_bounce_q = mock.Mock()
         mock_create_gauge = mock.Mock(return_value=self.mock_gauge)
         mock_metrics_provider.create_gauge = mock_create_gauge
-        self.q_metrics = metrics.QueueMetrics(self.mock_inbox_q, self.mock_bounce_q, mock_metrics_provider)
+        self.q_metrics = metrics.QueueMetrics(self.mock_inbox, self.mock_bounce_q, mock_metrics_provider)
 
     def test_run(self):
         with mock.patch('time.sleep', autospec=True, side_effect=LoopBreak):
             with raises(LoopBreak):
                 self.q_metrics.run()
-            assert self.mock_gauge.set.call_count == 2
+            assert self.mock_gauge.set.call_count == 3
 
 
 class LoopBreak(Exception):


### PR DESCRIPTION
Before we just sent the q length. The size of the dict is really the
more interesting thing. This also logs debug entries on the NoMetrics
provider so you can see what's going on when developing without having a
real metrics cluster.