### PR TITLE
Optimize list_marathon_service_instances -m

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -35,7 +35,6 @@ from paasta_tools.long_running_service_tools import InvalidHealthcheckMode
 from paasta_tools.long_running_service_tools import load_service_namespace_config
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
 from paasta_tools.mesos.exceptions import NoSlavesAvailableError
-from paasta_tools.mesos_maintenance import get_draining_hosts
 from paasta_tools.mesos_tools import filter_mesos_slaves_by_blacklist
 from paasta_tools.mesos_tools import get_mesos_network_for_net
 from paasta_tools.mesos_tools import get_mesos_slaves_grouped_by_attribute
@@ -999,16 +998,16 @@ def is_old_task_missing_healthchecks(task, marathon_client):
     return False
 
 
-def get_num_at_risk_tasks(app, draining_hosts=None):
+def get_num_at_risk_tasks(app, draining_hosts):
     """Determine how many of an application's tasks are running on
     at-risk (Mesos Maintenance Draining) hosts.
 
     :param app: A marathon application
+    :param draining_hosts: A list of hostnames that are marked as draining.
+                           See paasta_tools.mesos_maintenance.get_draining_hosts
     :returns: An integer representing the number of tasks running on at-risk hosts
     """
     hosts_tasks_running_on = [task.host for task in app.tasks]
-    if draining_hosts is None:
-        draining_hosts = get_draining_hosts()
     num_at_risk_tasks = 0
     for host in hosts_tasks_running_on:
         if host in draining_hosts:

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -999,7 +999,7 @@ def is_old_task_missing_healthchecks(task, marathon_client):
     return False
 
 
-def get_num_at_risk_tasks(app):
+def get_num_at_risk_tasks(app, draining_hosts=None):
     """Determine how many of an application's tasks are running on
     at-risk (Mesos Maintenance Draining) hosts.
 
@@ -1007,7 +1007,8 @@ def get_num_at_risk_tasks(app):
     :returns: An integer representing the number of tasks running on at-risk hosts
     """
     hosts_tasks_running_on = [task.host for task in app.tasks]
-    draining_hosts = get_draining_hosts()
+    if draining_hosts is None:
+        draining_hosts = get_draining_hosts()
     num_at_risk_tasks = 0
     for host in hosts_tasks_running_on:
         if host in draining_hosts:

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -477,7 +477,7 @@ def deploy_service(
     )
 
     if new_app_running:
-        num_at_risk_tasks = get_num_at_risk_tasks(new_app)
+        num_at_risk_tasks = get_num_at_risk_tasks(new_app, draining_hosts=get_draining_hosts())
         if new_app.instances < config['instances'] + num_at_risk_tasks:
             log.info("Scaling %s from %d to %d instances." %
                      (new_app.id, new_app.instances, config['instances'] + num_at_risk_tasks))

--- a/tests/test_list_marathon_service_instances.py
+++ b/tests/test_list_marathon_service_instances.py
@@ -41,7 +41,9 @@ def test_get_service_instances_that_need_bouncing():
         'paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True,
     ) as mock_get_desired_marathon_configs, mock.patch(
         'paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True,
-    ) as mock_get_num_at_risk_tasks:
+    ) as mock_get_num_at_risk_tasks, mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_draining_hosts', autospec=True,
+    ):
         mock_get_desired_marathon_configs.return_value = {
             'fake--service.fake--instance.sha.config': {'instances': 5},
             'fake--service2.fake--instance.sha.config': {'instances': 5},
@@ -61,7 +63,9 @@ def test_get_service_instances_that_need_bouncing_two_existing_services():
         'paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True,
     ) as mock_get_desired_marathon_configs, mock.patch(
         'paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True,
-    ) as mock_get_num_at_risk_tasks:
+    ) as mock_get_num_at_risk_tasks, mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_draining_hosts', autospec=True,
+    ):
         mock_get_desired_marathon_configs.return_value = {
             'fake--service.fake--instance.sha.config': {'instances': 5},
         }
@@ -80,7 +84,9 @@ def test_get_service_instances_that_need_bouncing_no_difference():
         'paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True,
     ) as mock_get_desired_marathon_configs, mock.patch(
         'paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True,
-    ) as mock_get_num_at_risk_tasks:
+    ) as mock_get_num_at_risk_tasks, mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_draining_hosts', autospec=True,
+    ):
         mock_get_desired_marathon_configs.return_value = {'fake--service.fake--instance.sha.config': {'instances': 5}}
         fake_apps = [mock.MagicMock(instances=5, id='/fake--service.fake--instance.sha.config')]
         mock_client = mock.MagicMock(list_apps=mock.MagicMock(return_value=fake_apps))
@@ -94,7 +100,9 @@ def test_get_service_instances_that_need_bouncing_instances_difference():
         'paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True,
     ) as mock_get_desired_marathon_configs, mock.patch(
         'paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True,
-    ) as mock_get_num_at_risk_tasks:
+    ) as mock_get_num_at_risk_tasks, mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_draining_hosts', autospec=True,
+    ):
         mock_get_desired_marathon_configs.return_value = {'fake--service.fake--instance.sha.config': {'instances': 5}}
         fake_apps = [mock.MagicMock(instances=4, id='/fake--service.fake--instance.sha.config')]
         mock_client = mock.MagicMock(list_apps=mock.MagicMock(return_value=fake_apps))
@@ -108,7 +116,9 @@ def test_get_service_instances_that_need_bouncing_at_risk():
         'paasta_tools.list_marathon_service_instances.get_desired_marathon_configs', autospec=True,
     ) as mock_get_desired_marathon_configs, mock.patch(
         'paasta_tools.list_marathon_service_instances.get_num_at_risk_tasks', autospec=True,
-    ) as mock_get_num_at_risk_tasks:
+    ) as mock_get_num_at_risk_tasks, mock.patch(
+        'paasta_tools.list_marathon_service_instances.get_draining_hosts', autospec=True,
+    ):
         mock_get_desired_marathon_configs.return_value = {'fake--service.fake--instance.sha.config': {'instances': 5}}
         fake_apps = [mock.MagicMock(instances=5, id='/fake--service.fake--instance.sha.config')]
         mock_client = mock.MagicMock(list_apps=mock.MagicMock(return_value=fake_apps))

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -775,7 +775,7 @@ class TestSetupMarathonJob:
         ) as mock_get_drain_method, mock.patch(
             'paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True,
         ), mock.patch(
-            'paasta_tools.marathon_tools.get_draining_hosts', autospec=True,
+            'paasta_tools.mesos_maintenance.get_draining_hosts', autospec=True,
         ):
             mock_load_system_paasta_config.return_value = mock.MagicMock(
                 get_cluster=mock.Mock(return_value='fake_cluster'))
@@ -832,7 +832,7 @@ class TestSetupMarathonJob:
         ) as mock_get_drain_method, mock.patch(
             'paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True,
         ) as mock_get_draining_hosts, mock.patch(
-            'paasta_tools.marathon_tools.get_draining_hosts', autospec=True,
+            'paasta_tools.mesos_maintenance.get_draining_hosts', autospec=True,
         ) as mock_mt_get_draining_hosts:
             mock_load_system_paasta_config.return_value = mock.MagicMock(
                 get_cluster=mock.Mock(return_value='fake_cluster'))
@@ -901,7 +901,7 @@ class TestSetupMarathonJob:
         ) as mock_do_bounce, mock.patch(
             'paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True,
         ), mock.patch(
-            'paasta_tools.marathon_tools.get_draining_hosts', autospec=True,
+            'paasta_tools.mesos_maintenance.get_draining_hosts', autospec=True,
         ):
             mock_load_system_paasta_config.return_value = mock.MagicMock(
                 get_cluster=mock.Mock(return_value='fake_cluster'))
@@ -965,7 +965,7 @@ class TestSetupMarathonJob:
         ) as mock_do_bounce, mock.patch(
             'paasta_tools.setup_marathon_job.get_draining_hosts', autospec=True,
         ), mock.patch(
-            'paasta_tools.marathon_tools.get_draining_hosts', autospec=True,
+            'paasta_tools.mesos_maintenance.get_draining_hosts', autospec=True,
         ):
             mock_stop_draining = mock.MagicMock()
 


### PR DESCRIPTION
Optimize the time it takes to run 'list_marathon_service_instances -m' by calling get_draining_hosts() only once.

Internal ticket: PAASTA-7989

With this change it takes ~30 seconds to run it in norcal-prod.