### PR TITLE
remote-run -j | --instances <number>

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -58,6 +58,13 @@ def add_start_args_to_parser(parser):
         default=60,
         type=float,
     )
+    parser.add_argument(
+        '-j', '--instances',
+        help='Number of copies of the task to launch',
+        required=False,
+        default=None,
+        type=int,
+    )
 
 
 def add_common_args_to_parser(parser):
@@ -186,6 +193,7 @@ def paasta_remote_run(args):
         'detach': False,
         'run_id': None,
         'framework_id': None,
+        'instances': None,
     }
     for key in args_vars:
         # skip args we don't know about

--- a/paasta_tools/frameworks/adhoc_scheduler.py
+++ b/paasta_tools/frameworks/adhoc_scheduler.py
@@ -26,7 +26,7 @@ class AdhocScheduler(NativeScheduler):
 
         if kwargs.get('service_config_overrides') is None:
             kwargs['service_config_overrides'] = {}
-        kwargs['service_config_overrides']['instances'] = 1
+        kwargs['service_config_overrides'].setdefault('instances', 1)
 
         super(AdhocScheduler, self).__init__(*args, **kwargs)
 

--- a/paasta_tools/frameworks/adhoc_scheduler.py
+++ b/paasta_tools/frameworks/adhoc_scheduler.py
@@ -27,18 +27,20 @@ class AdhocScheduler(NativeScheduler):
         if kwargs.get('service_config_overrides') is None:
             kwargs['service_config_overrides'] = {}
         kwargs['service_config_overrides'].setdefault('instances', 1)
+        self.finished_countdown = kwargs['service_config_overrides']['instances']
 
         super(AdhocScheduler, self).__init__(*args, **kwargs)
 
     def need_to_stop(self):
         # Is used to decide whether to stop the driver or try to start more tasks.
-        for task, params in self.tasks_with_flags.items():
-            if params.mesos_task_state not in LIVE_TASK_STATES:
-                return True
-        return False
+        return self.finished_countdown == 0
 
     def statusUpdate(self, driver, update):
         super(AdhocScheduler, self).statusUpdate(driver, update)
+
+        if update.state not in LIVE_TASK_STATES:
+            self.finished_countdown -= 1
+
         # Stop if task ran and finished
         if self.need_to_stop():
             driver.stop()

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -111,8 +111,6 @@ def extract_args(args):
 
 def remote_run_start(args):
     system_paasta_config, service, cluster, soa_dir, instance, instance_type = extract_args(args)
-    dry_run = args.dry_run
-    command = args.cmd
 
     overrides_dict = {}
 
@@ -126,8 +124,11 @@ def remote_run_start(args):
         if constraints:
             overrides_dict['constraints'] = constraints
 
-    if command:
-        overrides_dict['cmd'] = command
+    if args.cmd:
+        overrides_dict['cmd'] = args.cmd
+
+    if args.instances:
+        overrides_dict['instances'] = args.instances
 
     run_id = args.run_id
     if run_id is None:
@@ -154,7 +155,7 @@ def remote_run_start(args):
         system_paasta_config=system_paasta_config,
         soa_dir=soa_dir,
         reconcile_backoff=0,
-        dry_run=dry_run,
+        dry_run=args.dry_run,
         staging_timeout=args.staging_timeout,
         service_config_overrides=overrides_dict,
     )


### PR DESCRIPTION
run multiple copies of remote-run task when -j (--instances) flag passed. default to 1.