### PR TITLE
Fix flappy deployd test

### DIFF
--- a/tests/deployd/test_leader.py
+++ b/tests/deployd/test_leader.py
@@ -31,11 +31,11 @@ class TestPaastaLeaderElection(unittest.TestCase):
 
     def test_connection_listener(self):
         with mock.patch(
-            'paasta_tools.deployd.leader.PaastaLeaderElection.reconnection_listener', autospec=True
-        ) as mock_reconnection_listener:
+            'paasta_tools.deployd.leader.PaastaThread', autospec=True
+        ) as mock_paasta_thread:
             self.election.connection_listener(KazooState.CONNECTED)
             self.election.connection_listener(KazooState.SUSPENDED)
-            assert mock_reconnection_listener.called
+            mock_paasta_thread.assert_called_with(target=self.election.reconnection_listener)
             assert self.election.waiting_for_reconnect
             self.election.connection_listener(KazooState.LOST)
             self.mock_control.put.assert_called_with("ABORT")


### PR DESCRIPTION
This test was flapping ~10% of the time. I guess it was relying on the
thread it was calling to actually have started and run something. This
mocks away the threading and seems to be reliable.