### PR TITLE
Fix tags being null when checking registry

### DIFF
--- a/paasta_tools/cli/cmds/push_to_registry.py
+++ b/paasta_tools/cli/cmds/push_to_registry.py
@@ -172,7 +172,11 @@ def is_docker_image_already_in_registry(service, sha):
     with requests.Session() as s:
         r = s.get(url, timeout=30) if creds[0] is None else s.get(url, auth=creds, timeout=30)
         if r.status_code == 200:
-            return tag in r.json()['tags']
+            tags_resp = r.json()
+            if tags_resp['tags']:
+                return tag in tags_resp['tags']
+            else:
+                return False
         elif r.status_code == 404:
             return False  # No Such Repository Error
         r.raise_for_status()

--- a/tests/cli/test_cmds_push_to_registry.py
+++ b/tests/cli/test_cmds_push_to_registry.py
@@ -192,6 +192,22 @@ def test_is_docker_image_already_in_registry_404_no_such_service_yet(
 @patch('paasta_tools.cli.cmds.push_to_registry.load_system_paasta_config', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.requests.Session.get', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.read_docker_registy_creds', autospec=True)
+def test_is_docker_image_already_in_registry_tags_are_null(
+        mock_read_docker_registy_creds,
+        mock_request_get,
+        mock_load_system_paasta_config,
+):
+    mock_read_docker_registy_creds.return_value = (None, None)
+    mock_load_system_paasta_config.get_docker_registry = MagicMock(return_value='fake_registry')
+    mock_request_get.return_value = MagicMock(status_code=200,
+                                              json=MagicMock(return_value={'tags': None}))
+    assert not is_docker_image_already_in_registry('fake_service', 'fake_sha')
+    assert mock_load_system_paasta_config.called
+
+
+@patch('paasta_tools.cli.cmds.push_to_registry.load_system_paasta_config', autospec=True)
+@patch('paasta_tools.cli.cmds.push_to_registry.requests.Session.get', autospec=True)
+@patch('paasta_tools.cli.cmds.push_to_registry.read_docker_registy_creds', autospec=True)
 def test_is_docker_image_already_in_registry_401_unauthorized(
         mock_read_docker_registy_creds,
         mock_request_get,


### PR DESCRIPTION
If the image isn't in the registry docker returns something like:
``{"name":"hello-world","tags":null}``

This was causing an exception when `is_docker_image_already_in_registry`
should be returning False. This affects new services and blocks them
from being able to push-to-registry.