### PR TITLE
ensure adhoc scheduler service config has cmd

### DIFF
--- a/paasta_tools/frameworks/adhoc_scheduler.py
+++ b/paasta_tools/frameworks/adhoc_scheduler.py
@@ -17,6 +17,7 @@ from __future__ import unicode_literals
 
 from paasta_tools.frameworks.native_scheduler import LIVE_TASK_STATES
 from paasta_tools.frameworks.native_scheduler import NativeScheduler
+from paasta_tools.frameworks.native_scheduler import UnknownNativeServiceError
 from paasta_tools.utils import paasta_print
 
 
@@ -60,3 +61,7 @@ class AdhocScheduler(NativeScheduler):
 
     def kill_tasks_if_necessary(self, *args, **kwargs):
         return
+
+    def validate_config(self):
+        if self.service_config.get_cmd() is None:
+            raise UnknownNativeServiceError("missing cmd in service config")

--- a/paasta_tools/frameworks/native_scheduler.py
+++ b/paasta_tools/frameworks/native_scheduler.py
@@ -125,6 +125,7 @@ class NativeScheduler(mesos.interface.Scheduler):
             self.service_config.config_dict.update(self.service_config_overrides)
             self.recreate_drain_method()
             self.reload_constraints()
+            self.validate_config()
         else:
             self.load_config()
 
@@ -496,6 +497,10 @@ class NativeScheduler(mesos.interface.Scheduler):
         )
         self.recreate_drain_method()
         self.reload_constraints()
+        self.validate_config()
+
+    def validate_config(self):
+        pass
 
     def recreate_drain_method(self):
         """Re-instantiate self.drain_method. Should be called after self.service_config changes."""
@@ -634,9 +639,6 @@ def load_paasta_native_job_config(
         soa_dir=soa_dir
     )
     service_config.service_namespace_config = service_namespace_config
-
-    if service_config.get_cmd() is None:
-        raise UnknownNativeServiceError("missing cmd in service config")
 
     return service_config
 

--- a/paasta_tools/frameworks/native_scheduler.py
+++ b/paasta_tools/frameworks/native_scheduler.py
@@ -635,6 +635,9 @@ def load_paasta_native_job_config(
     )
     service_config.service_namespace_config = service_namespace_config
 
+    if service_config.get_cmd() is None:
+        raise UnknownNativeServiceError("missing cmd in service config")
+
     return service_config
 
 

--- a/tests/frameworks/test_adhoc_scheduler.py
+++ b/tests/frameworks/test_adhoc_scheduler.py
@@ -45,6 +45,41 @@ def make_fake_offer(cpu=50000, mem=50000, port_begin=31000, port_end=32000, pool
 
 
 class TestAdhocScheduler(object):
+    def test_raise_error_when_cmd_missing(self, system_paasta_config):
+        service_name = "service_name"
+        instance_name = "instance_name"
+        cluster = "cluster"
+
+        service_configs = [
+            native_scheduler.NativeServiceConfig(
+                service=service_name,
+                instance=instance_name,
+                cluster=cluster,
+                config_dict={
+                    "cpus": 0.1,
+                    "mem": 50,
+                    "instances": 3,
+                    "drain_method": "test"
+                },
+                branch_dict={
+                    'docker_image': 'busybox',
+                    'desired_state': 'start',
+                },
+            )
+        ]
+
+        with pytest.raises(native_scheduler.UnknownNativeServiceError):
+            adhoc_scheduler.AdhocScheduler(
+                service_name=service_name,
+                instance_name=instance_name,
+                cluster=cluster,
+                system_paasta_config=system_paasta_config,
+                service_config=service_configs[0],
+                dry_run=False,
+                reconcile_start_time=0,
+                staging_timeout=30,
+            )
+
     def test_can_only_launch_task_once(self, system_paasta_config):
         service_name = "service_name"
         instance_name = "instance_name"


### PR DESCRIPTION
lets fail fast, when trying to load config rather than after registering the framework and building a task