### PR TITLE
Create interface for subscribing to task events

### DIFF
--- a/task_processing/events/event.py
+++ b/task_processing/events/event.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+
+class TaskProcessingEvent(object):
+    def __init__(self, original_event):
+        self._original_event = original_event
+
+
+class TaskRunningEvent(TaskProcessingEvent):
+    def __init__(self, *args, **kwargs):
+        super(TaskRunningEvent, self).__init__(*args, **kwargs)
+
+
+def mesos_status_to_event(mesos_status):
+    # DRIVER_NOT_STARTED = 1
+    # DRIVER_RUNNING = 2
+    # DRIVER_ABORTED = 3
+    # DRIVER_STOPPED = 4
+    # TASK_STAGING = 6
+    # TASK_STARTING = 0
+    # TASK_RUNNING = 1
+    # TASK_FINISHED = 2
+    # TASK_FAILED = 3
+    # TASK_KILLED = 4
+    # TASK_LOST = 5
+    translation = {
+        1: TaskRunningEvent
+    }
+    match = translation.get(mesos_status.state, TaskProcessingEvent)
+    return match(original_event=mesos_status)

--- a/task_processing/events/event_processor.py
+++ b/task_processing/events/event_processor.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from task_processing.events.event import mesos_status_to_event
+
+
+class EventProcessor():
+    def __init__(self, publish_queue):
+        self.publish_queue = publish_queue
+
+    def publish_event(self, status):
+        translated = mesos_status_to_event(status)
+        self.publish_queue.put(translated, timeout=1)

--- a/task_processing/executors/mesos_executor.py
+++ b/task_processing/executors/mesos_executor.py
@@ -91,6 +91,13 @@ class MesosExecutor(TaskExecutor, Promiseable, Asyncable, Subscribable):
         """ Stop the instance of the task """
         pass
 
+    def subscribe(self, queue):
+        """Subscribe to TaskProcessingEvent updates.
+
+        :param queue: a threading.Queue object, onto which events will be pushed
+        """
+        self.subscribe_queue = queue
+
     def status(self, task_id=None):
         """ Get the status of this instance of the task.
             What return type here?? we do not know yet

--- a/task_processing/executors/task_executor.py
+++ b/task_processing/executors/task_executor.py
@@ -65,5 +65,5 @@ class Asyncable(object):
 class Subscribable(object):
 
     @abc.abstractmethod
-    def subscribable(self, task_config, success=None, failure=None, status=None):
+    def subscribe(self, queue):
         pass

--- a/task_processing/mesos/execution_framework.py
+++ b/task_processing/mesos/execution_framework.py
@@ -75,7 +75,8 @@ class ExecutionFramework(mesos.interface.Scheduler):
                  system_paasta_config, staging_timeout, soa_dir=DEFAULT_SOA_DIR,
                  service_config=None, reconcile_backoff=30,
                  instance_type='paasta_native', service_config_overrides=None,
-                 reconcile_start_time=float('inf')):
+                 reconcile_start_time=float('inf'), event_processor=None):
+        self.event_processor = event_processor
         self.service_name = service_name
         self.instance_name = instance_name
         self.instance_type = instance_type
@@ -525,6 +526,8 @@ class ExecutionFramework(mesos.interface.Scheduler):
             self.launch_tasks_for_offers(driver, offers)
 
     def statusUpdate(self, driver, update):
+        if self.event_processor:
+            self.event_processor.publish_event(update)
         if self.frozen:
             return
 

--- a/task_processing/tests/events/test_event_processor.py
+++ b/task_processing/tests/events/test_event_processor.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from mesos.interface import mesos_pb2
+from six.moves import queue
+
+from task_processing.events.event_processor import EventProcessor
+
+
+def test_event_processor_e2e():
+    test_queue = queue.Queue(10)
+    processor = EventProcessor(test_queue)
+    fake_status_update = mesos_pb2.TaskStatus()
+    fake_status_update.state = mesos_pb2.TASK_RUNNING
+    processor.publish_event(fake_status_update)
+    event = test_queue.get(block=False, timeout=0)
+    test_queue.task_done()
+    assert event is not None
+    test_queue.join()


### PR DESCRIPTION
first implementation of the event bus idea, that allows users to subscribe to events. Creates a ``TaskProcessingEvent`` abstraction around Mesos's ``StatusUpdate``, but exposes it via the ``_original_event`` var.