### PR TITLE
Don't pingpong with sys.modules for __file__

### DIFF
--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -21,7 +21,6 @@ from __future__ import unicode_literals
 import argparse
 import logging
 import os
-import sys
 
 import requests_cache
 import service_configuration_lib
@@ -29,6 +28,7 @@ from gevent.wsgi import WSGIServer
 from pyramid.config import Configurator
 from pyramid.scripts.pserve import watch_file
 
+import paasta_tools.api
 from paasta_tools import marathon_tools
 from paasta_tools.api import settings
 from paasta_tools.utils import load_system_paasta_config
@@ -58,7 +58,7 @@ def parse_paasta_api_args():
 
 
 def make_app(global_config=None):
-    paasta_api_path = os.path.dirname(sys.modules['paasta_tools.api'].__file__)
+    paasta_api_path = os.path.dirname(paasta_tools.api.__file__)
     setup_paasta_api()
     watch_file(os.path.join(paasta_api_path, 'api_docs/swagger.json'))
 
@@ -117,7 +117,7 @@ def main(argv=None):
     try:
         server.serve_forever()
     except KeyboardInterrupt:
-        sys.exit(0)
+        exit(0)
 
 
 if __name__ == '__main__':

--- a/paasta_tools/api/client.py
+++ b/paasta_tools/api/client.py
@@ -21,11 +21,11 @@ from __future__ import unicode_literals
 import json
 import logging
 import os
-import sys
 
 from bravado.client import SwaggerClient
 from six.moves.urllib_parse import urlparse
 
+import paasta_tools.api
 from paasta_tools.utils import load_system_paasta_config
 
 
@@ -52,7 +52,7 @@ def get_paasta_api_client(cluster=None, system_paasta_config=None):
     api_server = parsed.netloc
 
     # Get swagger spec from file system instead of the api server
-    paasta_api_path = os.path.dirname(sys.modules['paasta_tools.api'].__file__)
+    paasta_api_path = os.path.dirname(paasta_tools.api.__file__)
     swagger_file = os.path.join(paasta_api_path, 'api_docs/swagger.json')
     if not os.path.isfile(swagger_file):
         log.error('paasta-api swagger spec %s does not exist', swagger_file)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -52,7 +52,7 @@ from docker import Client
 from docker.utils import kwargs_from_env
 from kazoo.client import KazooClient
 
-import paasta_tools
+import paasta_tools.cli.fsm
 
 
 # DO NOT CHANGE SPACER, UNLESS YOU'RE PREPARED TO CHANGE ALL INSTANCES
@@ -924,7 +924,7 @@ class SystemPaastaConfig(dict):
         return self['api_endpoints']
 
     def get_fsm_template(self):
-        fsm_path = os.path.dirname(sys.modules['paasta_tools.cli.fsm'].__file__)
+        fsm_path = os.path.dirname(paasta_tools.cli.fsm.__file__)
         template_path = os.path.join(fsm_path, "template")
         return self.get('fsm_template', template_path)
 


### PR DESCRIPTION
`sys.modules` usually means one of two things:
- hacks
- bugs

I changed these to *explicitly* import their dependencies for checking `__file__` (I imagine this was originally copypaste from stackoverflow and then spread to other places in the codebase?)