### PR TITLE
executor_id is always equal to task_id

### DIFF
--- a/paasta_tools/mesos/slave.py
+++ b/paasta_tools/mesos/slave.py
@@ -96,9 +96,8 @@ class MesosSlave(object):
         return list(filter(lambda x: x["executor_id"]))
 
     def task_stats(self, _id):
-        eid = self.task_executor(_id)["id"]
         stats = list(filter(
-            lambda x: x["executor_id"] == eid,
+            lambda x: x["executor_id"] == _id,
             self.stats
         ))
 


### PR DESCRIPTION
Every mesos.task.stats call initiates 2 HTTP requests to mesos slaves.

The first request (/slave(1)/state.json) is used to find correlation between task_id and executor_id.
And the second one (/monitor/statistics.json) is used to get stats for the executor_id.

I used this script to confirm that executor_id is equal to task_id in paasta so that we can skip querying /slave(1)/state.json.


```
from paasta_tools.marathon_tools import get_marathon_client
from paasta_tools.marathon_tools import load_marathon_config
from paasta_tools.mesos_tools import get_all_running_tasks

marathon_config = load_marathon_config()
marathon_client = get_marathon_client(
    url=marathon_config.get_url(),
    user=marathon_config.get_username(),
    passwd=marathon_config.get_password())

all_mesos_tasks = get_all_running_tasks()

for task in all_mesos_tasks:
    task_id = task['id']
    if task_id != task.slave.task_executor(task_id)['id']:
        print(task_id, task.slave.task_executor(task_id)['id'])
```

