### PR TITLE
Add a timeout for when git server cannot be reached

### DIFF
--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -17,7 +17,6 @@ from __future__ import unicode_literals
 
 import datetime
 import socket
-import time
 
 from paasta_tools import remote_git
 from paasta_tools import utils
@@ -35,8 +34,6 @@ from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import paasta_print
-from paasta_tools.utils import Timeout
-from paasta_tools.utils import TimeoutError
 
 
 def add_subparser(subparsers):
@@ -201,31 +198,16 @@ def paasta_start_or_stop(args, desired_state):
     else:
         clusters = valid_clusters
 
-    git_timeout = 10
-
     try:
-        with Timeout(seconds=git_timeout):
-            try:
-                time.sleep(15)
-                remote_refs = remote_git.list_remote_refs(utils.get_git_url(service, soa_dir))
-            except remote_git.LSRemoteException as e:
-                msg = (
-                    "Error talking to the git server: %s\n"
-                    "This PaaSTA command requires access to the git server to operate.\n"
-                    "The git server may be down or not reachable from here.\n"
-                    "Try again from somewhere where the git server can be reached, "
-                    "like your developer environment."
-                ) % str(e)
-                paasta_print(msg)
-                return 1
-    except TimeoutError:
+        remote_refs = remote_git.list_remote_refs(utils.get_git_url(service, soa_dir))
+    except remote_git.LSRemoteException as e:
         msg = (
-            "Timed out after waiting %s seconds trying to talk to the git server.\n"
+            "Error talking to the git server: %s\n"
             "This PaaSTA command requires access to the git server to operate.\n"
             "The git server may be down or not reachable from here.\n"
             "Try again from somewhere where the git server can be reached, "
             "like your developer environment."
-        ) % str(git_timeout)
+        ) % str(e)
         paasta_print(msg)
         return 1
 

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -17,6 +17,7 @@ from __future__ import unicode_literals
 
 import datetime
 import socket
+import time
 
 from paasta_tools import remote_git
 from paasta_tools import utils
@@ -205,6 +206,7 @@ def paasta_start_or_stop(args, desired_state):
     try:
         with Timeout(seconds=git_timeout):
             try:
+                time.sleep(15)
                 remote_refs = remote_git.list_remote_refs(utils.get_git_url(service, soa_dir))
             except remote_git.LSRemoteException as e:
                 msg = (

--- a/paasta_tools/remote_git.py
+++ b/paasta_tools/remote_git.py
@@ -78,7 +78,9 @@ class LSRemoteException(Exception):
     pass
 
 
-@timeout(error_message="Timed out connecting to git server, is it reachable from where you are?", use_signals=False)
+@timeout(seconds=20,
+         error_message="Timed out connecting to git server, is it reachable from where you are?",
+         use_signals=False)
 def list_remote_refs(git_url):
     """Get the refs from a remote git repo as a dictionary of name->hash."""
     client, path = dulwich.client.get_transport_and_path(git_url)

--- a/paasta_tools/remote_git.py
+++ b/paasta_tools/remote_git.py
@@ -14,8 +14,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import time
-
 import dulwich.client
 import dulwich.errors
 
@@ -80,10 +78,9 @@ class LSRemoteException(Exception):
     pass
 
 
-@timeout()
+@timeout(error_message="Timed out connecting to git server, is it reachable from where you are?", use_signals=False)
 def list_remote_refs(git_url):
     """Get the refs from a remote git repo as a dictionary of name->hash."""
-    time.sleep(15)
     client, path = dulwich.client.get_transport_and_path(git_url)
     try:
         refs = client.fetch_pack(path, lambda refs: [], None, lambda data: None)

--- a/paasta_tools/remote_git.py
+++ b/paasta_tools/remote_git.py
@@ -14,8 +14,12 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import time
+
 import dulwich.client
 import dulwich.errors
+
+from paasta_tools.utils import timeout
 
 
 def _make_determine_wants_func(ref_mutator):
@@ -76,8 +80,10 @@ class LSRemoteException(Exception):
     pass
 
 
+@timeout()
 def list_remote_refs(git_url):
     """Get the refs from a remote git repo as a dictionary of name->hash."""
+    time.sleep(15)
     client, path = dulwich.client.get_transport_and_path(git_url)
     try:
         refs = client.fetch_pack(path, lambda refs: [], None, lambda data: None)


### PR DESCRIPTION
This uses the default timeout of 10 seconds for the "timeout" decorator

```
jgl@prod-machine:~$ time paasta start -s example_happyhour -c norcal-stageg -i main
Traceback (most recent call last):
  File "/usr/bin/paasta", line 11, in <module>
    load_entry_point('paasta-tools==0.62.3', 'console_scripts', 'paasta')()
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/cli/cli.py", line 122, in main
    return_code = args.command(args)
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/cli/cmds/start_stop_restart.py", line 266, in paasta_start
    return paasta_start_or_stop(args, 'start')
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/cli/cmds/start_stop_restart.py", line 202, in paasta_start_or_stop
    remote_refs = remote_git.list_remote_refs(utils.get_git_url(service, soa_dir))
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/utils.py", line 1887, in __call__
    return self.get_and_raise()
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/utils.py", line 1899, in get_and_raise
    raise TimeoutError(self.error_message)
paasta_tools.utils.TimeoutError: Timed out connecting to git server, is it reachable from where you are?

real    0m11.202s
user    0m1.128s
sys     0m0.076s
```