### PR TITLE
Move instance type to be a class function of our configs

### DIFF
--- a/paasta_tools/adhoc_tools.py
+++ b/paasta_tools/adhoc_tools.py
@@ -18,10 +18,10 @@ import logging
 
 import service_configuration_lib
 
-from paasta_tools.long_running_service_tools import LongRunningServiceConfig
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_paasta_branch
+from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
@@ -67,7 +67,7 @@ def load_adhoc_job_config(service, instance, cluster, load_deployments=True, soa
     )
 
 
-class AdhocJobConfig(LongRunningServiceConfig):
+class AdhocJobConfig(InstanceConfig):
 
     def __init__(self, service, instance, cluster, config_dict, branch_dict):
         super(AdhocJobConfig, self).__init__(
@@ -77,6 +77,9 @@ class AdhocJobConfig(LongRunningServiceConfig):
             config_dict=config_dict,
             branch_dict=branch_dict,
         )
+
+    def instance_type(self):
+        return "adhoc"
 
 
 def get_default_interactive_config(service, cluster, soa_dir, load_deployments=False):

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -219,8 +219,8 @@ class ChronosJobConfig(InstanceConfig):
             branch_dict=branch_dict,
         )
 
-    def get_service(self):
-        return self.service
+    def instance_type(self):
+        return "chronos"
 
     def get_job_name(self):
         return self.instance

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -59,7 +59,6 @@ from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import Timeout
 from paasta_tools.utils import TimeoutError
-from paasta_tools.utils import validate_service_instance
 
 
 pick_random_port = functools.partial(ephemeral_port_reserve.reserve, '0.0.0.0')
@@ -727,7 +726,6 @@ def configure_and_run_docker_container(
 
     try:
         if instance is None:
-            instance_type = 'adhoc'
             instance = 'interactive'
             instance_config = get_default_interactive_config(
                 service=service,
@@ -737,7 +735,6 @@ def configure_and_run_docker_container(
             )
             interactive = True
         else:
-            instance_type = validate_service_instance(service, instance, cluster, soa_dir)
             instance_config = get_instance_config(
                 service=service,
                 instance=instance,
@@ -796,7 +793,7 @@ def configure_and_run_docker_container(
     else:
         command_from_config = instance_config.get_cmd()
         if command_from_config:
-            command_modifier = command_function_for_framework(instance_type)
+            command_modifier = command_function_for_framework(instance_config.instance_type())
             command = command_modifier(command_from_config)
         else:
             command = instance_config.get_args()
@@ -816,7 +813,7 @@ def configure_and_run_docker_container(
         soa_dir=args.yelpsoa_config_root,
         dry_run=dry_run,
         json_dict=args.dry_run_json_dict,
-        framework=instance_type,
+        framework=instance_config.instance_type(),
     )
 
 

--- a/paasta_tools/frameworks/native_service_config.py
+++ b/paasta_tools/frameworks/native_service_config.py
@@ -42,6 +42,9 @@ class NativeServiceConfig(LongRunningServiceConfig):
         else:
             self.service_namespace_config = ServiceNamespaceConfig()
 
+    def instance_type(self):
+        return "paasta_native"
+
     def task_name(self, base_task):
         code_sha = get_code_sha_from_dockerurl(base_task.container.docker.image)
 
@@ -115,9 +118,6 @@ class NativeServiceConfig(LongRunningServiceConfig):
 
     def get_mesos_network_mode(self):
         return getattr(mesos_pb2.ContainerInfo.DockerInfo, self.get_net().upper())
-
-    def get_constraints(self):
-        return self.config_dict.get('constraints', None)
 
 
 def load_paasta_native_job_config(

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -179,6 +179,9 @@ class MarathonServiceConfig(LongRunningServiceConfig):
             branch_dict=branch_dict,
         )
 
+    def instance_type(self):
+        return "marathon"
+
     def __repr__(self):
         return "MarathonServiceConfig(%r, %r, %r, %r, %r)" % (
             self.service,

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -29,6 +29,7 @@ from datetime import datetime
 from paasta_tools.cli.cmds.remote_run import add_common_args_to_parser
 from paasta_tools.cli.cmds.remote_run import add_start_args_to_parser
 from paasta_tools.cli.utils import figure_out_service_name
+from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.frameworks.adhoc_scheduler import AdhocScheduler
 from paasta_tools.frameworks.native_scheduler import create_driver
 from paasta_tools.mesos_tools import get_all_frameworks
@@ -39,7 +40,6 @@ from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
-from paasta_tools.utils import validate_service_instance
 
 
 def parse_args(argv):
@@ -104,7 +104,8 @@ def extract_args(args):
         instance_type = 'adhoc'
         instance = 'remote'
     else:
-        instance_type = validate_service_instance(service, instance, cluster, soa_dir)
+        instance_config = get_instance_config(service, instance, cluster, soa_dir)
+        instance_type = instance_config.instance_type()
 
     return (system_paasta_config, service, cluster, soa_dir, instance, instance_type)
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -131,6 +131,9 @@ class InstanceConfig(dict):
             if key in self.config_dict:
                 self.config_dict[key] = self.config_dict[key].format(**interpolation_facts)
 
+    def instance_type(self):
+        raise NotImplementedError("Unknown instance type")
+
     def __get_interpolation_facts(self):
         return {
             'cluster': self.cluster,


### PR DESCRIPTION
The paasta codebase isn't very conducive to adding new instance types.

I would like slowly begin to help answer the question of "how would someone add a new instance_type to paasta"? be something like "implement this interface". One of the first interfaces to meet might be the "what kind of instance are you".

Right now we do a kinda awkward thing where we use this validate_service_instance function that happens to return the type. I think it will be more obvious if if we can just make that part of the class.

In the future I would like to move *more* things into the class object to make it easier for people to add new things for local-run, validate, status, etc. 