### PR TITLE
Allow `paasta rerun` of dependent jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ branches:
   only:
     - master
     - /^v[0-9.]+$/
+    - /^maci-.*$/
 language: python
 cache: pip
 env:

--- a/paasta_itests/chronos_rerun.feature
+++ b/paasta_itests/chronos_rerun.feature
@@ -4,7 +4,7 @@ Feature: chronos_rerun can rerun old jobs
     Given a working paasta cluster
       And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
       And we have a deployments.json for the service "testservice" with enabled chronos instance "testinstance"
-     When we run chronos_rerun for service_instance testservice testinstance
+     When we run chronos_rerun for service_instance "testservice testinstance"
      Then we should get exit code 0
      And there is a temporary job for the service testservice and instance testinstance
 
@@ -17,7 +17,7 @@ Feature: chronos_rerun can rerun old jobs
 
     Given we have yelpsoa-configs for the service "testservice" with enabled dependent chronos instance "dependentjob" and parent "testservice.testinstance"
       And we have a deployments.json for the service "testservice" with enabled chronos instance "dependentjob"
-     When we run chronos_rerun for service_instance testservice dependentjob
+     When we run chronos_rerun for service_instance "testservice dependentjob"
      Then we should get exit code 0
      And there is a temporary job for the service testservice and instance dependentjob
 
@@ -27,9 +27,24 @@ Feature: chronos_rerun can rerun old jobs
       And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
       And we have a deployments.json for the service "testservice" with enabled chronos instance "testinstance"
      When we set the "cmd" field of the chronos config for service "testservice" and instance "testinstance" to "echo '%(shortdate)s'"
-     When we run chronos_rerun for service_instance testservice testinstance
+     When we run chronos_rerun for service_instance "testservice testinstance"
      Then we should get exit code 0
      When we store the name of the job for the service testservice and instance testinstance as myjob
      Then the field "disabled" for the job stored as "myjob" is set to "False"
       And the field "command" for the job stored as "myjob" is set to "echo '2016-03-13'"
      And there is a temporary job for the service testservice and instance testinstance
+
+
+  Scenario: a dependent job is rerun with all his graph
+    Given a working paasta cluster
+      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
+      And we have a deployments.json for the service "testservice" with enabled chronos instance "testinstance"
+     When we run setup_chronos_job for service_instance "testservice.testinstance"
+     Then we should get exit code 0
+
+    Given we have yelpsoa-configs for the service "testservice" with enabled dependent chronos instance "dependentjob" and parent "testservice.testinstance"
+      And we have a deployments.json for the service "testservice" with enabled chronos instance "dependentjob,testinstance"
+     When we run chronos_rerun for service_instance "testservice dependentjob" with --run-all-related-jobs
+     Then we should get exit code 0
+     And there is a temporary job for the service testservice and instance testinstance
+     And there is a temporary job for the service testservice and instance dependentjob

--- a/paasta_itests/chronos_rerun.feature
+++ b/paasta_itests/chronos_rerun.feature
@@ -44,7 +44,7 @@ Feature: chronos_rerun can rerun old jobs
 
     Given we have yelpsoa-configs for the service "testservice" with enabled dependent chronos instance "dependentjob" and parent "testservice.testinstance"
       And we have a deployments.json for the service "testservice" with enabled chronos instance "dependentjob,testinstance"
-     When we run chronos_rerun for service_instance "testservice dependentjob" with --run-all-related-jobs
+     When we run chronos_rerun for service_instance "testservice dependentjob" with args --run-all-related-jobs
      Then we should get exit code 0
      And there is a temporary job for the service testservice and instance testinstance
      And there is a temporary job for the service testservice and instance dependentjob

--- a/paasta_itests/cleanup_chronos_jobs.feature
+++ b/paasta_itests/cleanup_chronos_jobs.feature
@@ -15,7 +15,7 @@ Feature: cleanup_chronos_jobs removes chronos jobs no longer in the config
    Given a working paasta cluster
      And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
      And we have a deployments.json for the service "testservice" with enabled instance "testinstance"
-    When we run chronos_rerun for service_instance testservice testinstance
+    When we run chronos_rerun for service_instance "testservice testinstance"
      And we store the name of the job for the service testservice and instance testinstance as myjob
      And we run cleanup_chronos_jobs
     Then we should get exit code 0

--- a/paasta_itests/paasta_serviceinit.feature
+++ b/paasta_itests/paasta_serviceinit.feature
@@ -73,7 +73,7 @@ Feature: paasta_serviceinit
      Then we should get exit code 0
      When we store the name of the job for the service testservice and instance testinstance as myjob
       And we wait for the chronos job stored as "myjob" to appear in the job list
-     When we run chronos_rerun for service_instance testservice testinstance
+     When we run chronos_rerun for service_instance "testservice testinstance"
      Then we should get exit code 0
       And there is a temporary job for the service testservice and instance testinstance
      When we store the name of the rerun job for the service testservice and instance testinstance as rerunjob

--- a/paasta_itests/steps/chronos_rerun_steps.py
+++ b/paasta_itests/steps/chronos_rerun_steps.py
@@ -23,10 +23,20 @@ from paasta_tools import chronos_tools
 from paasta_tools.utils import _run
 
 
-@when('we run chronos_rerun for service_instance {service_instance}')
+@when('we run chronos_rerun for service_instance "{service_instance}"')
 def run_chronos_rerun(context, service_instance):
     cmd = (
         "python ../paasta_tools/chronos_rerun.py -d %s '%s' "
+        "2016-03-13T04:50:31"
+    ) % (context.soa_dir, service_instance)
+    exit_code, output = _run(cmd)
+    context.exit_code, context.output = exit_code, output
+
+
+@when('we run chronos_rerun for service_instance "{service_instance}" with --run-all-related-jobs')
+def run_chronos_rerun_all_related_jobs(context, service_instance):
+    cmd = (
+        "python ../paasta_tools/chronos_rerun.py -d %s --run-all-related-jobs '%s' "
         "2016-03-13T04:50:31"
     ) % (context.soa_dir, service_instance)
     exit_code, output = _run(cmd)

--- a/paasta_itests/steps/chronos_rerun_steps.py
+++ b/paasta_itests/steps/chronos_rerun_steps.py
@@ -33,12 +33,12 @@ def run_chronos_rerun(context, service_instance):
     context.exit_code, context.output = exit_code, output
 
 
-@when('we run chronos_rerun for service_instance "{service_instance}" with --run-all-related-jobs')
-def run_chronos_rerun_all_related_jobs(context, service_instance):
+@when('we run chronos_rerun for service_instance "{service_instance}" with args {cli_args}')
+def run_chronos_rerun_all_related_jobs(context, service_instance, cli_args):
     cmd = (
-        "python ../paasta_tools/chronos_rerun.py -d %s --run-all-related-jobs '%s' "
+        "python ../paasta_tools/chronos_rerun.py -d %s %s '%s' "
         "2016-03-13T04:50:31"
-    ) % (context.soa_dir, service_instance)
+    ) % (context.soa_dir, cli_args, service_instance)
     exit_code, output = _run(cmd)
     context.exit_code, context.output = exit_code, output
 

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -267,7 +267,7 @@ def call_load_paasta_native_job_config(context):
 
 
 @given('we have a deployments.json for the service "{service}" with {disabled} instance '
-       '"{csv_instancs}" image "{image}"')
+       '"{csv_instances}" image "{image}"')
 def write_soa_dir_deployments(context, service, disabled, csv_instances, image):
     if disabled == 'disabled':
         desired_state = 'stop'

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -196,7 +196,14 @@ def write_soa_dir_dependent_chronos_instance(context, service, disabled, instanc
     if not os.path.exists(os.path.join(soa_dir, service)):
         os.makedirs(os.path.join(soa_dir, service))
     with open(os.path.join(soa_dir, service, 'chronos-%s.yaml' % context.cluster), 'w') as f:
+        (_, parent_instance, _, __) = decompose_job_id(parent)
         f.write(yaml.safe_dump({
+            parent_instance: {
+                'schedule': 'R0/2000-01-01T16:20:00Z/PT60S',  # R0 prevents the job from being scheduled automatically
+                'cmd': 'echo "Taking a nap..." && sleep 60m && echo "Nap time over, back to work"',
+                'monitoring': {'team': 'fake_team'},
+                'disabled': desired_disabled,
+            },
             instance: {
                 'parents': [parent],
                 'cmd': 'echo "Taking a nap..." && sleep 1m && echo "Nap time over, back to work"',
@@ -259,8 +266,9 @@ def call_load_paasta_native_job_config(context):
     )
 
 
-@given('we have a deployments.json for the service "{service}" with {disabled} instance "{instance}" image "{image}"')
-def write_soa_dir_deployments(context, service, disabled, instance, image):
+@given('we have a deployments.json for the service "{service}" with {disabled} instance '
+       '"{csv_instancs}" image "{image}"')
+def write_soa_dir_deployments(context, service, disabled, csv_instances, image):
     if disabled == 'disabled':
         desired_state = 'stop'
     else:
@@ -275,13 +283,14 @@ def write_soa_dir_deployments(context, service, disabled, instance, image):
                     'docker_image': image,
                     'desired_state': desired_state,
                 }
+                for instance in csv_instances.split(',')
             }
         }))
 
 
-@given('we have a deployments.json for the service "{service}" with {disabled} instance "{instance}"')
-def write_soa_dir_deployments_default_image(context, service, disabled, instance):
-    write_soa_dir_deployments(context, service, disabled, instance, 'test-image-foobar%d' % context.tag_version)
+@given('we have a deployments.json for the service "{service}" with {disabled} instance "{csv_instance}"')
+def write_soa_dir_deployments_default_image(context, service, disabled, csv_instance):
+    write_soa_dir_deployments(context, service, disabled, csv_instance, 'test-image-foobar%d' % context.tag_version)
 
 
 @when(('we set the "{field}" field of the {framework} config for service "{service}"'

--- a/paasta_tools/cli/cmds/rerun.py
+++ b/paasta_tools/cli/cmds/rerun.py
@@ -16,8 +16,10 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import datetime
+from argparse import RawTextHelpFormatter
 
 from paasta_tools import chronos_tools
+from paasta_tools.chronos_tools import get_related_jobs_configs
 from paasta_tools.cli.cmds.status import get_actual_deployments
 from paasta_tools.cli.cmds.status import get_planned_deployments
 from paasta_tools.cli.cmds.status import list_deployed_clusters
@@ -51,6 +53,7 @@ def add_subparser(subparsers):
             "Note: This command requires SSH and sudo privileges on the remote PaaSTA "
             "masters."
         ),
+        formatter_class=RawTextHelpFormatter,
     )
     rerun_parser.add_argument(
         '-v', '--verbose',
@@ -84,6 +87,21 @@ def add_subparser(subparsers):
         metavar="SOA_DIR",
         default=DEFAULT_SOA_DIR,
         help="define a different soa config directory",
+    )
+    rerun_parser.add_argument(
+        '-t', '--rerun-type',
+        dest="rerun_type",
+        choices=['instance', 'graph'],
+        help="Specify how to rerun jobs that have parent-dependencies.\n"
+             "  - instance: rerun, as soon as possible, the required instance ONLY\n"
+             "  - graph: will rerun, as soon as possible, ALL the instances related to the required instance.\n"
+             "    NOTE: it could be expensive in terms of resources and of time. Use it carefully.\n"
+             "\n"
+             "Example: Assume that we have 4 jobs (j1, j2, j3 and j4) with the following relations\n"
+             "    j1 -> j2, j1 -> j3, j2 -> j3, j2 -> j4\n"
+             "\n"
+             "    Rerunning j2 wih --rerun-type=instance will rerun ONLY j2, j3 and j4 will not be re-ran\n"
+             "    Rerunning j2 wih --rerun-type=graph will rerun j1, j2, j3 and j4\n"
     )
     rerun_parser.set_defaults(command=paasta_rerun)
 
@@ -150,16 +168,41 @@ def paasta_rerun(args):
         if execution_date is None:
             execution_date = _get_default_execution_date()
 
-        rc, output = execute_chronos_rerun_on_remote_master(
-            service=service,
-            instancename=args.instance,
-            cluster=cluster,
-            verbose=args.verbose,
-            execution_date=execution_date.strftime(chronos_tools.EXECUTION_DATE_FORMAT),
-            system_paasta_config=system_paasta_config,
-        )
-        if rc == 0:
-            paasta_print(PaastaColors.green('  successfully created job'))
-        else:
+        related_job_configs = get_related_jobs_configs(cluster, service, args.instance)
+
+        if not args.rerun_type and len(related_job_configs) > 1:
+            instance_names = sorted([
+                '- {}{}{}'.format(srv, chronos_tools.INTERNAL_SPACER, inst)
+                for srv, inst in related_job_configs
+                if srv != service or inst != args.instance
+            ])
             paasta_print(PaastaColors.red('  error'))
-            paasta_print(output)
+            paasta_print(
+                'Instance {instance} has dependency relations with the following jobs:\n'
+                '{relations}\n'
+                '\n'
+                'Please specify the rerun policy via --rerun-type argument'.format(
+                    instance=args.instance,
+                    relations='\n'.join(instance_names),
+                ),
+            )
+            return
+
+        if args.rerun_type in ('instance', None):
+            rc, output = execute_chronos_rerun_on_remote_master(
+                service=service,
+                instancename=args.instance,
+                cluster=cluster,
+                verbose=args.verbose,
+                execution_date=execution_date.strftime(chronos_tools.EXECUTION_DATE_FORMAT),
+                system_paasta_config=system_paasta_config,
+            )
+            if rc == 0:
+                paasta_print(PaastaColors.green('  successfully created job'))
+            else:
+                paasta_print(PaastaColors.red('  error'))
+                paasta_print(output)
+        elif args.rerun_type == 'graph':
+            # TODO: implement this section
+            paasta_print(PaastaColors.red('  not implemented yet'))
+            pass

--- a/paasta_tools/cli/cmds/rerun.py
+++ b/paasta_tools/cli/cmds/rerun.py
@@ -94,14 +94,15 @@ def add_subparser(subparsers):
         choices=['instance', 'graph'],
         help="Specify how to rerun jobs that have parent-dependencies.\n"
              "  - instance: rerun, as soon as possible, the required instance ONLY\n"
-             "  - graph: will rerun, as soon as possible, ALL the instances related to the required instance.\n"
-             "    NOTE: it could be expensive in terms of resources and of time. Use it carefully.\n"
+             "  - graph: will rerun, as soon as possible, ALL the instances related to the required instance\n"
+             "    NOTE: the jobs rerun will respect the parents dependencies (topological order).\n"
+             "    WARNING: it could be expensive in terms of resources and of time. Use it carefully.\n"
              "\n"
              "Example: Assume that we have 4 jobs (j1, j2, j3 and j4) with the following relations\n"
              "    j1 -> j2, j1 -> j3, j2 -> j3, j2 -> j4\n"
              "\n"
              "    Rerunning j2 wih --rerun-type=instance will rerun ONLY j2, j3 and j4 will not be re-ran\n"
-             "    Rerunning j2 wih --rerun-type=graph will rerun j1, j2, j3 and j4\n"
+             "    Rerunning j2 wih --rerun-type=graph will rerun j1, j2, j3 and j4 respecting the dependency order\n",
     )
     rerun_parser.set_defaults(command=paasta_rerun)
 

--- a/paasta_tools/cli/cmds/rerun.py
+++ b/paasta_tools/cli/cmds/rerun.py
@@ -188,21 +188,17 @@ def paasta_rerun(args):
             )
             return
 
-        if args.rerun_type in ('instance', None):
-            rc, output = execute_chronos_rerun_on_remote_master(
-                service=service,
-                instancename=args.instance,
-                cluster=cluster,
-                verbose=args.verbose,
-                execution_date=execution_date.strftime(chronos_tools.EXECUTION_DATE_FORMAT),
-                system_paasta_config=system_paasta_config,
-            )
-            if rc == 0:
-                paasta_print(PaastaColors.green('  successfully created job'))
-            else:
-                paasta_print(PaastaColors.red('  error'))
-                paasta_print(output)
-        elif args.rerun_type == 'graph':
-            # TODO: implement this section
-            paasta_print(PaastaColors.red('  not implemented yet'))
-            pass
+        rc, output = execute_chronos_rerun_on_remote_master(
+            service=service,
+            instancename=args.instance,
+            cluster=cluster,
+            verbose=args.verbose,
+            execution_date=execution_date.strftime(chronos_tools.EXECUTION_DATE_FORMAT),
+            system_paasta_config=system_paasta_config,
+            run_all_related_jobs=args.rerun_type == 'graph',
+        )
+        if rc == 0:
+            paasta_print(PaastaColors.green('  successfully created job'))
+        else:
+            paasta_print(PaastaColors.red('  error'))
+            paasta_print(output)

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -564,8 +564,10 @@ def execute_paasta_metastatus_on_remote_master(cluster, system_paasta_config, hu
 def run_chronos_rerun(master, service, instancename, **kwargs):
     timeout = 60
     verbose_flags = '-v ' * kwargs['verbose']
-    command = 'ssh -A -n -o StrictHostKeyChecking=no %s \'sudo chronos_rerun %s"%s %s" "%s"\'' % (
+    run_all_related_jobs_flag = '--run-all-related-jobs' if kwargs.get('run_all_related_jobs', False) else ''
+    command = 'ssh -A -n -o StrictHostKeyChecking=no %s \'sudo chronos_rerun %s%s"%s %s" "%s"\'' % (
         master,
+        run_all_related_jobs_flag,
         verbose_flags,
         service,
         instancename,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -507,6 +507,16 @@ class InstanceConfig(object):
             return None
         return security.get('outbound_firewall')
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.config_dict == other.config_dict and \
+                self.branch_dict == other.branch_dict and \
+                self.cluster == other.cluster and \
+                self.instance == other.instance and \
+                self.service == other.service
+        else:
+            return False
+
 
 def validate_service_instance(service, instance, cluster, soa_dir):
     for instance_type in INSTANCE_TYPES:

--- a/tests/test_chronos_rerun.py
+++ b/tests/test_chronos_rerun.py
@@ -16,8 +16,10 @@ from __future__ import unicode_literals
 
 import datetime
 import re
+import sys
 
 import mock
+import pytest
 
 from paasta_tools import chronos_rerun
 from paasta_tools import chronos_tools
@@ -60,21 +62,104 @@ def test_set_tmp_naming_scheme():
     assert name_pattern.match(chronos_rerun.set_tmp_naming_scheme(fake_chronos_job_config)['name']) is not None
 
 
-@mock.patch('paasta_tools.chronos_rerun.remove_parents', autospec=True)
-@mock.patch('paasta_tools.chronos_rerun.set_default_schedule', autospec=True)
-@mock.patch('paasta_tools.chronos_rerun.modify_command_for_date', autospec=True)
 @mock.patch('paasta_tools.chronos_rerun.set_tmp_naming_scheme', autospec=True)
-def test_clone_job_dependent(
+@mock.patch('paasta_tools.chronos_rerun.chronos_tools.get_job_type', autospec=True)
+def test_clone_job(
+    mock_get_job_type,
     mock_set_tmp_naming_scheme,
-    mock_modify_command_for_date,
-    mock_set_default_schedule,
-    mock_remove_parents,
 ):
     fake_chronos_job_config = {
         'parents': ['foo', 'bar']
     }
+    mock_get_job_type.return_value = chronos_tools.JobType.Dependent
     chronos_rerun.clone_job(fake_chronos_job_config, '2016-03-2016T04:40:31')
-    assert mock_remove_parents.call_count == 1
-    assert mock_set_default_schedule.call_count == 2
-    assert mock_modify_command_for_date.call_count == 1
+    assert mock_get_job_type.call_count == 1
     assert mock_set_tmp_naming_scheme.call_count == 1
+
+
+@pytest.mark.parametrize(
+    'cluster, service, instance, run_all_related_jobs, is_dependent_job',
+    (
+        ('testcluster', 'testservice', 'test_independent_instance_1', False, False,),
+        ('testcluster', 'testservice', 'test_dependent_instance_2', False, True,),
+        ('testcluster', 'testservice', 'test_dependent_instance_2', True, True,),
+    )
+)
+@mock.patch('paasta_tools.chronos_rerun.clone_job', autospec=True)
+@mock.patch('paasta_tools.chronos_rerun.chronos_tools.get_job_type', autospec=True)
+@mock.patch('paasta_tools.chronos_rerun.remove_parents', autospec=True)
+@mock.patch('paasta_tools.chronos_tools.create_complete_config', autospec=True)
+@mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True)
+@mock.patch('service_configuration_lib.read_services_configuration', autospec=True)
+@mock.patch('paasta_tools.chronos_tools.read_chronos_jobs_for_service', autospec=True)
+@mock.patch('paasta_tools.chronos_tools.get_chronos_client', autospec=True)
+@mock.patch('paasta_tools.chronos_tools.load_chronos_config', autospec=True)
+@mock.patch('paasta_tools.chronos_rerun.load_system_paasta_config', autospec=True)
+def test_chronos_rerun_main_with_independent_job(
+    mock_load_system_paasta_config,
+    mock_load_chronos_config,
+    mock_get_chronos_client,
+    mock_read_chronos_jobs_for_service,
+    mock_read_services_configuration,
+    mock_load_deployments_json,
+    mock_create_complete_config,
+    mock_remove_parents,
+    mock_get_job_type,
+    mock_clone_job,
+    cluster, service, instance, run_all_related_jobs, is_dependent_job,
+):
+    mock_load_system_paasta_config.return_value.get_cluster.return_value = cluster
+
+    generic_config_dict = {
+        'bounce_method': 'graceful',
+        'cmd': '/bin/sleep 40',
+        'epsilon': 'PT30M',
+        'retries': 5,
+        'cpus': 5.5,
+        'mem': 1024.4,
+        'disk': 1234.5,
+        'disabled': False,
+        'schedule_time_zone': 'Zulu',
+        'monitoring': {'fake_monitoring_info': 'fake_monitoring_value'},
+    }
+
+    def gen_scheduled_job():
+        return dict(schedule='R/2015-03-25T19:36:35Z/PT5M', **generic_config_dict)
+
+    def gen_dependent_job(service, instance):
+        return dict(parents='{}.{}'.format(service, instance), **generic_config_dict)
+
+    mock_read_services_configuration.return_value = [service]
+    mock_read_chronos_jobs_for_service.return_value = {
+        'test_independent_instance_1': gen_scheduled_job(),
+        'test_dependent_instance_1': gen_scheduled_job(),
+        'test_dependent_instance_2': gen_dependent_job(service, 'test_dependent_instance_1'),
+    }
+
+    mock_load_deployments_json.return_value.get_branch_dict.side_effect = lambda service, *args, **kwargs: {
+        'desired_state': 'start',
+        'docker_image': 'paasta-{}-{}'.format(service, cluster),
+    }
+
+    if is_dependent_job:
+        mock_get_job_type.return_value = chronos_tools.JobType.Dependent
+    else:
+        mock_get_job_type.return_value = chronos_tools.JobType.Scheduled
+
+    execution_date = datetime.datetime.now().replace(microsecond=0)
+
+    testargs = ['chronos_rerun']
+    if run_all_related_jobs:
+        testargs.append('--run-all-related-jobs')
+    testargs.extend(['{} {}'.format(service, instance), execution_date.isoformat()])
+
+    with mock.patch.object(sys, 'argv', testargs):
+        chronos_rerun.main()
+
+    if not run_all_related_jobs:
+        # remove_parents should not be called if the job is not a dependent job
+        assert mock_remove_parents.call_count == (1 if is_dependent_job else 0)
+        assert mock_get_chronos_client.return_value.add.call_count == 1
+    else:
+        assert mock_remove_parents.call_count == 0
+        assert mock_get_chronos_client.return_value.add.call_count == 2

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -82,7 +82,16 @@ class TestChronosTools:
         'disk': 'all of it',
         'schedule': 'forever/now/5 min',
         'schedule_time_zone': '+0200',
+        'lb_extras': {},
+        'monitoring': {},
+        'deploy': {},
+        'vip': None,
+        'smartstack': {},
+        'dependencies': {},
+        'data': {},
+        'port': None,
     }
+
     fake_invalid_chronos_job_config = chronos_tools.ChronosJobConfig(service=fake_service,
                                                                      cluster=fake_cluster,
                                                                      instance=fake_job_name,

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -22,6 +22,9 @@ from mock import Mock
 from pytest import raises
 
 from paasta_tools import chronos_tools
+from paasta_tools.chronos_tools import _get_related_jobs_and_configs
+from paasta_tools.chronos_tools import ChronosJobConfig
+from paasta_tools.chronos_tools import get_related_jobs_configs
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import sort_dicts
 from paasta_tools.utils import SystemPaastaConfig
@@ -67,6 +70,8 @@ class TestChronosTools:
         branch_dict=fake_branch_dict,
     )
 
+    fake_invalid_job_name = 'bad_job'
+
     fake_invalid_config_dict = {
         'bounce_method': 'crossover',
         'epsilon': 'nolispe',
@@ -86,12 +91,13 @@ class TestChronosTools:
                                                                      )
     fake_config_file = {
         fake_job_name: fake_config_dict,
-        'bad_job': fake_invalid_config_dict,
+        fake_invalid_job_name: fake_invalid_config_dict,
     }
 
+    fake_dependent_job_name = 'test_dependent'
     fake_dependent_job_config_dict = copy.deepcopy(fake_config_dict)
     fake_dependent_job_config_dict.pop("schedule")
-    fake_dependent_job_config_dict["parents"] = ["test-service.parent1", "test-service.parent2"]
+    fake_dependent_job_config_dict["parents"] = ["{}.{}".format(fake_service, fake_job_name)]
     fake_dependent_chronos_job_config = chronos_tools.ChronosJobConfig(
         service=fake_service,
         cluster=fake_cluster,
@@ -1358,7 +1364,7 @@ class TestChronosTools:
             load_system_paasta_config_patch.return_value.get_dockercfg_location = \
                 mock.Mock(return_value='file:///root/.dockercfg')
             actual = chronos_tools.create_complete_config('fake-service', 'fake-job')
-            assert actual["parents"] == ['test-service parent1', 'test-service parent2']
+            assert actual["parents"] == ["{} {}".format(self.fake_service, self.fake_job_name)]
             assert "schedule" not in actual
 
     def test_create_complete_config_considers_disabled(self):
@@ -1855,3 +1861,133 @@ class TestChronosTools:
         actual = chronos_tools.chronos_services_running_here()
         mock_get_local_slave_state.assert_called_once_with(hostname=None)
         assert expected == actual
+
+    @mock.patch('service_configuration_lib.read_services_configuration', autospec=True)
+    @mock.patch('paasta_tools.chronos_tools.read_chronos_jobs_for_service', autospec=True)
+    @mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True)
+    def test__get_related_jobs_and_configs_only_independent_jobs(
+        self, mock_load_deployments_json, mock_read_chronos_jobs_for_service, mock_read_services_configuration,
+    ):
+        mock_load_deployments_json.return_value.get_branch_dict.return_value = self.fake_branch_dict
+        mock_read_chronos_jobs_for_service.return_value = self.fake_config_file
+        mock_read_services_configuration.return_value = [self.fake_service]
+        jobs, configs = _get_related_jobs_and_configs(cluster=self.fake_cluster, ttl=-1)  # ttl=-1 to disable cache
+
+        expected_jobs = {
+            (self.fake_service, self.fake_job_name): {(self.fake_service, self.fake_job_name)},
+            (self.fake_service, self.fake_invalid_job_name): {(self.fake_service, self.fake_invalid_job_name)},
+        }
+        expected_configs = {}
+        expected_configs[(self.fake_service, self.fake_job_name)] = ChronosJobConfig(
+            service=self.fake_service,
+            cluster=self.fake_cluster,
+            instance=self.fake_job_name,
+            config_dict=self.fake_config_dict,
+            branch_dict=self.fake_branch_dict,
+        )
+        expected_configs[(self.fake_service, self.fake_invalid_job_name)] = ChronosJobConfig(
+            service=self.fake_service,
+            cluster=self.fake_cluster,
+            instance=self.fake_invalid_job_name,
+            config_dict=self.fake_invalid_config_dict,
+            branch_dict=self.fake_branch_dict,
+        )
+        assert jobs == expected_jobs
+        assert configs == expected_configs
+
+    @mock.patch('service_configuration_lib.read_services_configuration', autospec=True)
+    @mock.patch('paasta_tools.chronos_tools.read_chronos_jobs_for_service', autospec=True)
+    @mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True)
+    def test__get_related_jobs_and_configs_with_dependent_jobs(
+        self, mock_load_deployments_json, mock_read_chronos_jobs_for_service, mock_read_services_configuration,
+    ):
+        mock_load_deployments_json.return_value.get_branch_dict.return_value = self.fake_branch_dict
+        mock_read_chronos_jobs_for_service.return_value = {
+            self.fake_job_name: self.fake_config_dict,
+            self.fake_dependent_job_name: self.fake_dependent_job_config_dict,
+        }
+        mock_read_services_configuration.return_value = [self.fake_service]
+
+        jobs, configs = _get_related_jobs_and_configs(cluster=self.fake_cluster, ttl=-1)  # ttl=-1 to disable cache
+
+        related_jobs = {(self.fake_service, self.fake_job_name), (self.fake_service, self.fake_dependent_job_name)}
+        expected_jobs = {
+            (self.fake_service, self.fake_job_name): related_jobs,
+            (self.fake_service, self.fake_dependent_job_name): related_jobs,
+        }
+        expected_configs = {}
+        expected_configs[(self.fake_service, self.fake_job_name)] = ChronosJobConfig(
+            service=self.fake_service,
+            cluster=self.fake_cluster,
+            instance=self.fake_job_name,
+            config_dict=self.fake_config_dict,
+            branch_dict=self.fake_branch_dict,
+        )
+        expected_configs[(self.fake_service, self.fake_dependent_job_name)] = ChronosJobConfig(
+            service=self.fake_service,
+            cluster=self.fake_cluster,
+            instance=self.fake_dependent_job_name,
+            config_dict=self.fake_dependent_job_config_dict,
+            branch_dict=self.fake_branch_dict,
+        )
+
+        assert jobs == expected_jobs
+        assert configs == expected_configs
+
+    @mock.patch('service_configuration_lib.read_services_configuration', autospec=True)
+    @mock.patch('paasta_tools.chronos_tools.read_chronos_jobs_for_service', autospec=True)
+    @mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True)
+    def test_get_related_jobs_configs_only_independent_jobs(
+        self, mock_load_deployments_json, mock_read_chronos_jobs_for_service, mock_read_services_configuration,
+    ):
+        mock_load_deployments_json.return_value.get_branch_dict.return_value = self.fake_branch_dict
+        mock_read_chronos_jobs_for_service.return_value = self.fake_config_file
+        mock_read_services_configuration.return_value = [self.fake_service]
+        related_jobs_configs = get_related_jobs_configs(
+            cluster=self.fake_cluster, service=self.fake_service, instance=self.fake_job_name, use_cache=False,
+        )
+
+        expected_related_jobs_configs = {}
+        expected_related_jobs_configs[(self.fake_service, self.fake_job_name)] = ChronosJobConfig(
+            service=self.fake_service,
+            cluster=self.fake_cluster,
+            instance=self.fake_job_name,
+            config_dict=self.fake_config_dict,
+            branch_dict=self.fake_branch_dict,
+        )
+
+        assert related_jobs_configs == expected_related_jobs_configs
+
+    @mock.patch('service_configuration_lib.read_services_configuration', autospec=True)
+    @mock.patch('paasta_tools.chronos_tools.read_chronos_jobs_for_service', autospec=True)
+    @mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True)
+    def test_get_related_jobs_configs_with_dependent_jobs(
+        self, mock_load_deployments_json, mock_read_chronos_jobs_for_service, mock_read_services_configuration,
+    ):
+        mock_load_deployments_json.return_value.get_branch_dict.return_value = self.fake_branch_dict
+        mock_read_chronos_jobs_for_service.return_value = {
+            self.fake_job_name: self.fake_config_dict,
+            self.fake_dependent_job_name: self.fake_dependent_job_config_dict,
+        }
+        mock_read_services_configuration.return_value = [self.fake_service]
+        related_jobs_configs = get_related_jobs_configs(
+            cluster=self.fake_cluster, service=self.fake_service, instance=self.fake_job_name, use_cache=False,
+        )
+
+        expected_related_jobs_configs = {}
+        expected_related_jobs_configs[(self.fake_service, self.fake_job_name)] = ChronosJobConfig(
+            service=self.fake_service,
+            cluster=self.fake_cluster,
+            instance=self.fake_job_name,
+            config_dict=self.fake_config_dict,
+            branch_dict=self.fake_branch_dict,
+        )
+        expected_related_jobs_configs[(self.fake_service, self.fake_dependent_job_name)] = ChronosJobConfig(
+            service=self.fake_service,
+            cluster=self.fake_cluster,
+            instance=self.fake_dependent_job_name,
+            config_dict=self.fake_dependent_job_config_dict,
+            branch_dict=self.fake_branch_dict,
+        )
+
+        assert related_jobs_configs == expected_related_jobs_configs

--- a/tests/test_mac_address.py
+++ b/tests/test_mac_address.py
@@ -17,6 +17,9 @@ import six
 from paasta_tools import mac_address
 
 
+skip_if_osx = pytest.mark.skipif(sys.platform == 'darwin', reason='Flock is not present on OS X')
+
+
 def test_simple(tmpdir):
     mac, lock_file = mac_address.reserve_unique_mac_address(str(tmpdir))
     with contextlib.closing(lock_file):
@@ -58,6 +61,7 @@ def _flock_process(path):
     return child_pid
 
 
+@skip_if_osx
 def test_file_exists_flock(tmpdir):
     # it doesn't count if this process has the flock, so we need to spawn a different one to hold it
     flock_process = _flock_process(str(tmpdir.join('02:52:00:00:00:00')))
@@ -70,6 +74,7 @@ def test_file_exists_flock(tmpdir):
         os.kill(flock_process, signal.SIGKILL)
 
 
+@skip_if_osx
 def test_file_exists_exhaustion(tmpdir):
     flock_processes = []
     try:

--- a/tox.ini
+++ b/tox.ini
@@ -103,6 +103,9 @@ deps =
     /root/mesos.executor-1.0.1-cp27-none-linux_x86_64.whl
     /root/mesos.scheduler-1.0.1-cp27-none-linux_x86_64.whl
     /root/mesos.native-1.0.1-cp27-none-linux_x86_64.whl
+whitelist_externals =
+    /bin/mkdir
+    /bin/ln
 commands =
     mkdir -p /nail/etc
     ln -s /etc/mesos-slave-secret /nail/etc/mesos-slave-secret


### PR DESCRIPTION
## Pre-PR
paasta rerun will re-execute only the job identified by ``(cluster, service, instance)`` from the command line arguments. It implicitly [removes all the references to the parents](https://github.com/Yelp/paasta/blob/master/paasta_tools/chronos_rerun.py#L145) and [schedules the job to start as soon as possible](https://github.com/Yelp/paasta/blob/master/paasta_tools/chronos_rerun.py#L148).
> 'paasta rerun' creates a copy of the specified PaaSTA scheduled job and
executes it immediately. Parent-dependent relationships are ignored: 'pasta
rerun' only executes individual jobs.

## Post-PR
This PR introduces a new command line argument to the ``rerun`` command. The new argument, ``--rerun-type``, will allow the user to customize the rerun policy used for a specific ``(cluster, service, instance)``:
  * ``--rerun-type instance``: same behaviour of Pre-PR (execute the job stripping out parents and scheduling ASAP)
 * ``--rerun-type graph``: rerun all the dependency graph containing the required job. It will schedule the "scheduled" jobs to start ASAP.

### Example:
<img src="http://i.imgur.com/cumodpH.png"></img>
``paasta rerun -s ... -c ... -i D --rerun-type instance`` will rerun only ``D``
``paasta rerun -s ... -c ... -i D --rerun-type graph`` will rerun **all** the nodes (``A`` will start ASAP)

## Tests
 * Added integration tests on ``chronos_rerun.feature```
 * Unittests for ``chronos_tools``, ``chronos_rerun`` and ``cmd/rerun``
 * skipif OSX tests requiring flock

### NOTE
I have updated ``travis.yaml`` file to let travis run tests, most probably that commit should be reverted before merge!

### FUTURE EXPANSION
To avoid a huge Code Review (since it is already quite big) I'll introduce as a follow-up PR the possibility to run only child jobs.
Using the example of before
``paasta rerun -s ... -c ... -i D --rerun-type childs`` will rerun ``D`` and ``F`` (``D`` will start ASAP)