### PR TITLE
InstanceConfig is not a dict

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -117,7 +117,7 @@ class InvalidInstanceConfig(Exception):
     pass
 
 
-class InstanceConfig(dict):
+class InstanceConfig(object):
 
     def __init__(self, cluster, instance, service, config_dict, branch_dict):
         self.config_dict = config_dict

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -190,7 +190,7 @@ class TestChronosTools:
             mock_read_chronos_jobs_for_service.assert_called_once_with(self.fake_service,
                                                                        self.fake_cluster,
                                                                        soa_dir=fake_soa_dir)
-            assert actual == self.fake_chronos_job_config
+            assert actual.config_dict == self.fake_chronos_job_config.config_dict
 
     def test_load_chronos_job_config_can_ignore_deployments(self):
         fake_soa_dir = '/tmp/'
@@ -209,7 +209,7 @@ class TestChronosTools:
                                                                        self.fake_cluster,
                                                                        soa_dir=fake_soa_dir)
             assert not mock_load_deployments_json.called
-            assert dict(actual) == dict(self.fake_chronos_job_config)
+            assert actual.config_dict == self.fake_chronos_job_config.config_dict
 
     def test_load_chronos_job_config_unknown_job(self):
         with mock.patch(

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -2234,7 +2234,7 @@ def test_marathon_service_config_copy():
     )
     fake_marathon_service_config_2 = fake_marathon_service_config.copy()
     assert fake_marathon_service_config is not fake_marathon_service_config_2
-    assert fake_marathon_service_config == fake_marathon_service_config_2
+    assert fake_marathon_service_config.config_dict == fake_marathon_service_config_2.config_dict
 
 
 def test_marathon_service_config_get_healthchecks_invalid_type():


### PR DESCRIPTION
InstanceConfig should not be a dict object. It's not used as a dict - there's nothing stored directly in it. A few tests were relying on this and incorrectly not actually testing what they meant to test.