### PR TITLE
Make paasta check -y look at the correct git_url

### DIFF
--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -174,8 +174,8 @@ def makefile_check():
         paasta_print(PaastaCheckMessages.MAKEFILE_MISSING)
 
 
-def git_repo_check(service):
-    git_url = get_git_url(service)
+def git_repo_check(service, soa_dir):
+    git_url = get_git_url(service, soa_dir)
     cmd = 'git ls-remote %s' % git_url
     returncode, _ = _run(cmd, timeout=5)
     if returncode == 0:
@@ -351,7 +351,7 @@ def paasta_check(args):
     deploy_check(service_path)
     deploy_has_security_check(service, soa_dir)
     deploy_has_performance_check(service, soa_dir)
-    git_repo_check(service)
+    git_repo_check(service, soa_dir)
     docker_check()
     makefile_check()
     yaml_check(service_path)


### PR DESCRIPTION
We currently are not passing the path to yelpsoa-configs to the function that checks the `git_url` field in `service.yaml`. This makes it hard to check that a new service with a custom `git_url` is configured correctly prior to pushing. This change fixes that.

This is internal ticket PAASTA-11129