### PR TITLE
Dependency & security support, and inotify-based synapse file watcher

### DIFF
--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -223,7 +223,7 @@ def write_soa_dir_marathon_job(context, job_id):
     if hasattr(context, "cmd"):
         soa[instance]['cmd'] = context.cmd
     with open(os.path.join(soa_dir, service, 'marathon-%s.yaml' % context.cluster), 'w') as f:
-        f.write(yaml.dump(soa))
+        f.write(yaml.safe_dump(soa))
     context.soa_dir = soa_dir
 
 
@@ -237,7 +237,7 @@ def write_soa_dir_native_service(context, job_id):
     if not os.path.exists(os.path.join(soa_dir, service)):
         os.makedirs(os.path.join(soa_dir, service))
     with open(os.path.join(soa_dir, service, 'paasta_native-%s.yaml' % context.cluster), 'w') as f:
-        f.write(yaml.dump({
+        f.write(yaml.safe_dump({
             "%s" % instance: {
                 'cpus': 0.1,
                 'mem': 100,

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -32,7 +32,9 @@ from six.moves.urllib_parse import urlsplit
 
 from paasta_tools import monitoring_tools
 from paasta_tools.mesos_tools import get_mesos_network_for_net
+from paasta_tools.mesos_tools import mesos_services_running_here
 from paasta_tools.tron import tron_command_context
+from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_docker_url
@@ -182,7 +184,6 @@ class InvalidChronosConfigError(Exception):
 def read_chronos_jobs_for_service(service, cluster, soa_dir=DEFAULT_SOA_DIR):
     chronos_conf_file = 'chronos-%s' % cluster
     log.info("Reading Chronos configuration file: %s/%s/chronos-%s.yaml" % (soa_dir, service, cluster))
-
     return service_configuration_lib.read_extra_service_information(
         service,
         chronos_conf_file,
@@ -191,6 +192,12 @@ def read_chronos_jobs_for_service(service, cluster, soa_dir=DEFAULT_SOA_DIR):
 
 
 def load_chronos_job_config(service, instance, cluster, load_deployments=True, soa_dir=DEFAULT_SOA_DIR):
+    log.info("Reading general configuration file: service.yaml")
+    general_config = service_configuration_lib.read_service_configuration(
+        service,
+        soa_dir=soa_dir,
+    )
+
     service_chronos_jobs = read_chronos_jobs_for_service(service, cluster, soa_dir=soa_dir)
     if instance not in service_chronos_jobs:
         raise NoConfigurationForServiceError('No job named "%s" in config file chronos-%s.yaml' % (instance, cluster))
@@ -199,11 +206,14 @@ def load_chronos_job_config(service, instance, cluster, load_deployments=True, s
         deployments_json = load_deployments_json(service, soa_dir=soa_dir)
         branch = get_paasta_branch(cluster=cluster, instance=instance)
         branch_dict = deployments_json.get_branch_dict(service, branch)
+
+    general_config = deep_merge_dictionaries(overrides=service_chronos_jobs[instance], defaults=general_config)
+
     return ChronosJobConfig(
         service=service,
         cluster=cluster,
         instance=instance,
-        config_dict=service_chronos_jobs[instance],
+        config_dict=general_config,
         branch_dict=branch_dict,
     )
 
@@ -447,6 +457,8 @@ class ChronosJobConfig(InstanceConfig):
             'disk': self.check_disk,
             'schedule': self.check_schedule,
             'scheduleTimeZone': self.check_schedule_time_zone,
+            'security': self.check_security,
+            'dependencies_reference': self.check_dependencies_reference,
             'parents': self.check_parents,
             'cmd': self.check_cmd,
         }
@@ -505,7 +517,8 @@ class ChronosJobConfig(InstanceConfig):
         error_msgs.extend(super(ChronosJobConfig, self).validate())
 
         for param in ['epsilon', 'retries', 'cpus', 'mem', 'disk',
-                      'schedule', 'scheduleTimeZone', 'parents', 'cmd']:
+                      'schedule', 'scheduleTimeZone', 'parents', 'cmd',
+                      'security', 'dependencies_reference']:
             check_passed, check_msg = self.check(param)
             if not check_passed:
                 error_msgs.append(check_msg)
@@ -956,3 +969,13 @@ def is_temporary_job(job):
     :returns: a boolean indicating if a job is a temporary job
     """
     return job['name'].startswith(TMP_JOB_IDENTIFIER)
+
+
+def chronos_services_running_here():
+    """See what chronos services are being run by a mesos-slave on this host.
+    :returns: A list of triples of (service, instance, port)"""
+
+    return mesos_services_running_here(
+        framework_filter=lambda fw: fw['name'].startswith('chronos'),
+        parse_service_instance_from_executor_id=lambda task_id: decompose_job_id(task_id.split(MESOS_TASK_SPACER)[3])
+    )

--- a/paasta_tools/firewall_update.py
+++ b/paasta_tools/firewall_update.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import logging
+import os.path
+import time
+from collections import defaultdict
+
+from inotify.adapters import Inotify
+from inotify.constants import IN_MODIFY
+from inotify.constants import IN_MOVED_TO
+
+from paasta_tools.chronos_tools import chronos_services_running_here
+from paasta_tools.chronos_tools import load_chronos_job_config
+from paasta_tools.marathon_tools import load_marathon_service_config
+from paasta_tools.marathon_tools import marathon_services_running_here
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import load_system_paasta_config
+
+log = logging.getLogger(__name__)
+
+DEFAULT_UPDATE_SECS = 5
+DEFAULT_SYNAPSE_SERVICE_DIR = b'/var/run/synapse/services'
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(description='Monitor synapse changes and update service firewall rules')
+    parser.add_argument('--synapse-service-dir', dest="synapse_service_dir",
+                        default=DEFAULT_SYNAPSE_SERVICE_DIR,
+                        help="Path to synapse service dir (default %(default)s)")
+    parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="soa_dir",
+                        default=DEFAULT_SOA_DIR,
+                        help="define a different soa config directory (default %(default)s)")
+    parser.add_argument('-u', '--update-secs', dest="update_secs",
+                        default=DEFAULT_UPDATE_SECS, type=int,
+                        help="Poll for new containers every N secs (default %(default)s)")
+    parser.add_argument('-v', '--verbose', dest='verbose', action='store_true')
+
+    args = parser.parse_args(argv)
+    return args
+
+
+def setup_logging(verbose):
+    level = logging.DEBUG if verbose else logging.WARNING
+    logging.basicConfig(level=level)
+
+
+def run(args):
+    # Main loop waiting on inotify file events
+    inotify = Inotify(block_duration_s=1)  # event_gen blocks for 1 second
+    inotify.add_watch(args.synapse_service_dir.encode(), IN_MOVED_TO | IN_MODIFY)
+    services_by_dependencies_time = 0
+
+    for event in inotify.event_gen():  # blocks for only up to 1 second at a time
+        if services_by_dependencies_time + args.update_secs < time.time():
+            services_by_dependencies = smartstack_dependencies_of_running_firewalled_services(
+                soa_dir=args.soa_dir)
+            services_by_dependencies_time = time.time()
+
+        if event is None:
+            continue
+
+        process_inotify_event(event, services_by_dependencies)
+
+
+def process_inotify_event(event, services_by_dependencies):
+    filename = event[3]
+    service_instance, suffix = os.path.splitext(filename)
+    if suffix != '.json':
+        return
+
+    services_to_update = services_by_dependencies.get(service_instance, ())
+    for service_to_update in services_to_update:
+        log.debug('Update ', service_to_update)
+        pass  # TODO: iptables added and removed here! :o)
+
+
+def services_running_here(soa_dir):
+    # Generator helper that yields (service, instance, config) of both marathon and chronos tasks
+    cluster = load_system_paasta_config().get_cluster()
+
+    for service, instance, port in marathon_services_running_here():
+        config = load_marathon_service_config(service, instance, cluster, load_deployments=False, soa_dir=soa_dir)
+        yield service, instance, config
+
+    for service, instance, port in chronos_services_running_here():
+        config = load_chronos_job_config(service, instance, cluster, load_deployments=False, soa_dir=soa_dir)
+        yield service, instance, config
+
+
+def smartstack_dependencies_of_running_firewalled_services(soa_dir=DEFAULT_SOA_DIR):
+    dependencies_to_services = defaultdict(set)
+    for service, instance, config in services_running_here(soa_dir):
+        outbound_firewall = config.get_outbound_firewall()
+        if not outbound_firewall:
+            continue
+
+        dependencies = config.get_dependencies()
+
+        smartstack_dependencies = [d['smartstack'] for d in dependencies if d.get('smartstack')]
+        for smartstack_dependency in smartstack_dependencies:
+            # TODO: filter down to only services that have no proxy_port
+            dependencies_to_services[smartstack_dependency].add((service, instance))
+
+    return dependencies_to_services
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    setup_logging(args.verbose)
+    run(args)

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -783,6 +783,9 @@ def mesos_services_running_here(framework_filter, parse_service_instance_from_ex
     srv_list = []
     for executor in executors:
         srv_name, srv_instance = parse_service_instance_from_executor_id(executor['id'])
-        srv_port = int(re.findall('[0-9]+', executor['resources']['ports'])[0])
+        if 'ports' in executor['resources']:
+            srv_port = int(re.findall('[0-9]+', executor['resources']['ports'])[0])
+        else:
+            srv_port = None
         srv_list.append((srv_name, srv_instance, srv_port))
     return srv_list

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -384,19 +384,54 @@ class InstanceConfig(object):
                 return False, 'The specified disk value "%s" is not a valid float or int.' % disk
         return True, ''
 
+    def check_security(self):
+        security = self.config_dict.get('security')
+        if security is None:
+            return True, ''
+
+        outbound_firewall = security.get('outbound_firewall')
+        if outbound_firewall is None:
+            return True, ''
+
+        if outbound_firewall not in ('block', 'monitor'):
+            return False, 'Unrecognized outbound_firewall value "%s"' % outbound_firewall
+
+        unknown_keys = set(security.keys()) - {'outbound_firewall'}
+        if unknown_keys:
+            return False, 'Unrecognized items in security dict of service config: "%s"' % ','.join(unknown_keys)
+
+        return True, ''
+
+    def check_dependencies_reference(self):
+        dependencies_reference = self.config_dict.get('dependencies_reference')
+        if dependencies_reference is None:
+            return True, ''
+
+        dependencies = self.config_dict.get('dependencies')
+        if dependencies is None:
+            return False, 'dependencies_reference "%s" declared but no dependencies found' % dependencies_reference
+
+        if dependencies_reference not in dependencies:
+            return False, 'dependencies_reference "%s" not found in dependencies dictionary' % dependencies_reference
+
+        return True, ''
+
     def check(self, param):
         check_methods = {
             'cpus': self.check_cpus,
             'mem': self.check_mem,
+            'security': self.check_security,
+            'dependencies_reference': self.check_dependencies_reference,
         }
-        if param in check_methods:
-            return check_methods[param]()
+        check_method = check_methods.get(param)
+        if check_method is not None:
+            return check_method()
         else:
-            return False, 'Your Chronos config specifies "%s", an unsupported parameter.' % param
+            return False, 'Your service config specifies "%s", an unsupported parameter.' % param
 
     def validate(self):
         error_msgs = []
-        for param in ['cpus', 'mem']:
+        for param in ['cpus', 'mem', 'security', 'dependencies_reference']:
             check_passed, check_msg = self.check(param)
             if not check_passed:
                 error_msgs.append(check_msg)
@@ -441,6 +476,36 @@ class InstanceConfig(object):
         volumes = system_volumes + self.get_extra_volumes()
         deduped = {v['containerPath'] + v['hostPath']: v for v in volumes}.values()
         return sort_dicts(deduped)
+
+    def get_dependencies_reference(self):
+        """Get the reference to an entry in dependencies.yaml
+
+        Defaults to None if not specified in the config.
+
+        :returns: A string specified in the config, None if not specified"""
+        return self.config_dict.get('dependencies_reference')
+
+    def get_dependencies(self):
+        """Get the contents of the dependencies_dict pointed to by the dependency_reference
+
+        Defaults to None if not specified in the config.
+
+        :returns: A list of dictionaries specified in the dependencies_dict, None if not specified"""
+        dependencies = self.config_dict.get('dependencies')
+        if not dependencies:
+            return None
+        return dependencies.get(self.get_dependencies_reference())
+
+    def get_outbound_firewall(self):
+        """Return 'block', 'monitor', or None as configured in security->outbound_firewall
+
+        Defaults to None if not specified in the config
+
+        :returns: A string specified in the config, None if not specified"""
+        security = self.config_dict.get('security')
+        if not security:
+            return None
+        return security.get('outbound_firewall')
 
 
 def validate_service_instance(service, instance, cluster, soa_dir):

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ git+git://github.com/sensu/sensu-plugin-python@bf00ac33
 git+git://github.com/thefactory/marathon-python@e70307e
 httplib2==0.9
 humanize==0.5.1
+inotify==0.2.8
 isodate==0.5.1
 jsonschema[format]==2.5.1
 kazoo==2.2
@@ -43,7 +44,7 @@ PyYAML==3.11
 requests==2.6.2
 requests-cache==0.4.10
 retry==0.9.2
-service-configuration-lib==0.10.1
+service-configuration-lib==0.12.0
 simplejson==3.10.0
 six>=1.9.0
 thriftpy==0.1.15

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'gevent == 1.1.1',
         'humanize >= 0.5.1',
         'httplib2 >= 0.9,<= 1.0',
+        'inotify >= 0.2.8',
         'isodate >= 0.5.0',
         'jsonschema[format]',
         'kazoo >= 2.0.0',
@@ -67,7 +68,7 @@ setup(
         'requests-cache >= 0.4.10,<= 0.5.0',
         # We install this from git
         # 'sensu-plugin >= 0.2.0',
-        'service-configuration-lib >= 0.10.1',
+        'service-configuration-lib >= 0.12.0',
         'ujson == 1.35',
         'yelp-clog >= 2.7.2',
     ],
@@ -110,6 +111,7 @@ setup(
             'paasta_chronos_rerun=paasta_tools.chronos_rerun:main',
             'paasta_cleanup_maintenance=paasta_tools.cleanup_maintenance:main',
             'paasta_docker_wrapper=paasta_tools.docker_wrapper:main',
+            'paasta_firewall_update=paasta_tools.firewall_update:main',
         ],
         'paste.app_factory': [
             'paasta-api-config=paasta_tools.api.api:make_app'

--- a/tests/test_firewall_update.py
+++ b/tests/test_firewall_update.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-2017 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import subprocess
+
+import mock
+import pytest
+import yaml
+
+from paasta_tools import firewall_update
+
+
+def test_parse_args():
+    args = firewall_update.parse_args([
+        '--synapse-service-dir', 'myservicedir',
+        '-d', 'mysoadir',
+        '-u', '123',
+        '-v'
+    ])
+    assert args.synapse_service_dir == 'myservicedir'
+    assert args.soa_dir == 'mysoadir'
+    assert args.update_secs == 123
+    assert args.verbose
+
+
+def test_parse_args_default():
+    args = firewall_update.parse_args([])
+    assert args.synapse_service_dir == firewall_update.DEFAULT_SYNAPSE_SERVICE_DIR
+    assert args.soa_dir == firewall_update.DEFAULT_SOA_DIR
+    assert args.update_secs == firewall_update.DEFAULT_UPDATE_SECS
+    assert not args.verbose
+
+
+@mock.patch.object(firewall_update, 'load_system_paasta_config', autospec=True)
+@mock.patch.object(firewall_update, 'marathon_services_running_here', autospec=True)
+@mock.patch.object(firewall_update, 'chronos_services_running_here', autospec=True)
+def test_smartstack_dependencies_of_running_firewalled_services(
+        chronos_services_running_mock,
+        marathon_services_running_mock,
+        paasta_config_mock,
+        tmpdir):
+    paasta_config_mock.return_value.get_cluster.return_value = 'mycluster'
+    soa_dir = tmpdir.mkdir('yelpsoa')
+    myservice_dir = soa_dir.mkdir('myservice')
+
+    marathon_config = {
+        'hassecurity': {
+            'dependencies_reference': 'my_ref',
+            'security': {
+                'outbound_firewall': 'block'
+            }
+        },
+        'nosecurity': {
+            'dependencies_reference': 'my_ref',
+        }
+    }
+    myservice_dir.join('marathon-mycluster.yaml').write(yaml.safe_dump(marathon_config))
+
+    chronos_config = {
+        'chronoswithsecurity': {
+            'dependencies_reference': 'my_ref',
+            'security': {
+                'outbound_firewall': 'block'
+            }
+        },
+    }
+    myservice_dir.join('chronos-mycluster.yaml').write(yaml.safe_dump(chronos_config))
+
+    dependencies_config = {
+        'my_ref': [
+            {'well-known': 'internet'},
+            {'smartstack': 'mydependency.depinstance'},
+            {'smartstack': 'another.one'},
+        ]
+    }
+    myservice_dir.join('dependencies.yaml').write(yaml.safe_dump(dependencies_config))
+
+    marathon_services_running_mock.return_value = [
+        ('myservice', 'hassecurity', 0),
+        ('myservice', 'hassecurity', 0),
+        ('myservice', 'nosecurity', 0),
+    ]
+
+    chronos_services_running_mock.return_value = [
+        ('myservice', 'chronoswithsecurity', 0),
+    ]
+
+    result = firewall_update.smartstack_dependencies_of_running_firewalled_services(soa_dir=str(soa_dir))
+    assert dict(result) == {
+        'mydependency.depinstance': {('myservice', 'hassecurity'), ('myservice', 'chronoswithsecurity')},
+        'another.one': {('myservice', 'hassecurity'), ('myservice', 'chronoswithsecurity')},
+    }
+
+
+@mock.patch.object(firewall_update, 'smartstack_dependencies_of_running_firewalled_services', autospec=True)
+@mock.patch.object(firewall_update, 'process_inotify_event', side_effect=StopIteration, autospec=True)
+def test_run(process_inotify_mock, smartstack_deps_mock, mock_args):
+    class kill_after_too_long(object):
+        def __init__(self):
+            self.count = 0
+
+        def __call__(self, *args, **kwargs):
+            self.count += 1
+            assert self.count <= 5, 'Took too long to detect file change'
+            return {}
+
+    smartstack_deps_mock.side_effect = kill_after_too_long()
+    subprocess.Popen(['bash', '-c', 'sleep 2; echo > %s/mydep.depinstance.json' % mock_args.synapse_service_dir])
+    with pytest.raises(StopIteration):
+        firewall_update.run(mock_args)
+    assert smartstack_deps_mock.call_count > 0
+    assert process_inotify_mock.call_args[0][0][3] == b'mydep.depinstance.json'
+    assert process_inotify_mock.call_args[0][1] == {}
+
+
+@mock.patch.object(firewall_update, 'log', autospec=True)
+def test_process_inotify_event(log_mock):
+    # TODO: test something more meaningful than the log function once we have actual iptables
+    services_by_dependencies = {
+        'mydep.depinstance': {('myservice', 'myinstance'), ('anotherservice', 'instance')}
+    }
+    firewall_update.process_inotify_event((None, None, None, 'mydep.depinstance.json'), services_by_dependencies)
+    assert log_mock.debug.call_count == 2
+    log_mock.debug.assert_any_call('Update ', ('myservice', 'myinstance'))
+    log_mock.debug.assert_any_call('Update ', ('anotherservice', 'instance'))
+
+    # Verify that tmp writes do not apply
+    log_mock.reset_mock()
+    firewall_update.process_inotify_event((None, None, None, 'mydep.depinstance.tmp'), services_by_dependencies)
+    assert log_mock.debug.call_count == 0
+
+
+@pytest.fixture
+def mock_args(tmpdir):
+    return firewall_update.parse_args([
+        '--synapse-service-dir', str(tmpdir.mkdir('synapse')),
+        '-d', str(tmpdir.mkdir('yelpsoa')),
+    ])


### PR DESCRIPTION
(I need to squash this before I actually merge)

This introduces support into paasta-tools InstanceConfig for the 'dependencies.yaml' file, and the 'security' dictionary within marathon-* and chronos-*.yaml files. 

Perhaps the biggest impacting change is to the chronos config loading. I make load_chronos_job_config to be more consistent with load_marathon_job_config - it now loads (and merges) the full general_config.

Using these changes I also introduce paasta_firewall_update, a CLI command that will watch the synapse services directory for changes to dependencies that occur on services that are running on this box. There are some TODOs in this file - all it does right now is log. Later we'll hook this up to something that updates iptable rules.

Internal ticket PAASTA-10896