### PR TITLE
Speed up processing inbox loop

### DIFF
--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -50,7 +50,7 @@ class Inbox(PaastaThread):
             self.process_service_instance(service_instance)
         if self.inbox_q.empty() and self.to_bounce:
             self.process_to_bounce()
-        time.sleep(1)
+        time.sleep(0.1)
 
     def process_service_instance(self, service_instance):
         service_instance_key = "{}.{}".format(service_instance.service, service_instance.instance)


### PR DESCRIPTION
Sleeping 1 here is pretty slow on startup if you have a large number of
service instances as we do. This should speed up the startup a lot.