### PR TITLE
Add code for working with iptables

### DIFF
--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -1,94 +1,117 @@
-#!/usr/bin/env python2.7
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import collections
+import hashlib
 
-import re
-import shlex
-import subprocess
-
-
-class ChainDoesNotExist(Exception):
-    pass
+from paasta_tools import iptables
 
 
-def ensure_chain(chain, rules):
-    """Idempotently ensure a chain exists and has a set of rules.
+PRIVATE_IP_RANGES = (
+    '127.0.0.0/8',
+    '10.0.0.0/8',
+    '172.16.0.0/12',
+    '192.168.0.0/16',
+    '169.254.0.0/16',
+)
 
-    This function creates or updates an existing chain to match the rules
-    passed in.
 
-    This function will not reorder existing rules, but any new rules are always
-    inserted at the front of the chain.
+class ServiceGroup(collections.namedtuple('ServiceGroup', (
+    'service',
+    'dependency_group',
+    'mode',
+))):
+    """A service group.
+
+    :param service: the name of a service
+    :param dependency_group: the name of a dependency group
+    :param mode: either 'monitor' or 'block'
     """
-    try:
-        current_rules = list_chain(chain)
-    except ChainDoesNotExist:
-        create_chain(chain)
-        current_rules = set()
 
-    for rule in rules:
-        if rule not in current_rules:
-            print('adding rule: {}'.format(rule))
-            add_rule(chain, rule)
+    __slots__ = ()
 
-    for rule in current_rules:
-        if rule not in rules:
-            print('deleting rule: {}'.format(rule))
-            delete_rule(chain, rule)
+    @property
+    def chain_name(self):
+        """Return iptables chain name.
+
+        Chain names are limited to 28 characters, so we have to trim quite a
+        bit. To attempt to ensure we don't have collisions due to shortening,
+        we append a hash to the end.
+        """
+        chain = 'PAASTA.{}'.format(self.service[:10])
+        chain += '.' + hashlib.sha256(str(tuple(self))).hexdigest()[:10]
+        assert len(chain) <= 28, len(chain)
+        return chain
+
+    @property
+    def rules(self):
+        # TODO: actually read these from somewhere
+        return (
+            '-j REJECT --reject-with icmp-port-unreachable',
+            '-d 169.254.255.254/32 -p tcp -m tcp --dport 20666 -j ACCEPT',
+        )
+
+    def update_rules(self):
+        iptables.ensure_chain(self.chain_name, self.rules)
 
 
-def add_rule(chain, rule):
-    subprocess.check_call(['iptables', '-t', 'filter', '-I', chain] + shlex.split(rule))
+def active_service_groups():
+    """Return active service groups."""
+    # TODO: actually read these from somewhere
+    return {
+        ServiceGroup('cool-service', 'main', 'block'): {
+            '02:42:a9:fe:00:02',
+            'fe:a3:a3:da:2d:51',
+            'fe:a3:a3:da:2d:50',
+        },
+        ServiceGroup('cool-service', 'main', 'monitor'): {
+            'fe:a3:a3:da:2d:40',
+        },
+        ServiceGroup('dumb-service', 'other', 'block'): {
+            'fe:a3:a3:da:2d:30',
+            'fe:a3:a3:da:2d:31',
+        },
+    }
 
 
-def delete_rule(chain, rule):
-    subprocess.check_call(['iptables', '-t', 'filter', '-I', chain] + shlex.split(rule))
-
-
-def create_chain(chain):
-    subprocess.check_call(('iptables', '-t', 'filter', '-N', chain))
-
-
-def list_chain(chain):
-    """List rules in a chain.
-
-    Returns a list of iptables rules, or raises ChainDoesNotExist.
-    """
-    cmd = ('iptables', '-t', 'filter', '--list-rules', chain)
-    proc = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+def general_update():
+    """Update iptables to match the current PaaSTA state."""
+    # Create the "internet" special chain.
+    iptables.ensure_chain(
+        'PAASTA-INTERNET',
+        (
+            '-j ACCEPT',
+        ) + tuple(
+            '-d {} -j RETURN'.format(ip_range)
+            for ip_range in PRIVATE_IP_RANGES
+        )
     )
-    out, err = proc.communicate()
-    if proc.returncode != 0:
-        if b'No chain/target/match by that name.\n' in err:
-            raise ChainDoesNotExist(chain)
-        else:
-            raise subprocess.CalledProcessError(proc.returncode, cmd, output=(out, err))
 
-    # Parse rules into something usable
-    rule_regex = re.compile(b'-A {chain} (.+)$'.format(chain=re.escape(chain)))
-    rules = out.splitlines()
-    parsed = set()
-    for rule in rules:
-        if rule == '-N {}'.format(chain):
-            continue
-        m = rule_regex.match(rule)
-        if not m:
-            raise ValueError(
-                'Unable to parse iptables rule: {}'.format(rule),
-            )
-        else:
-            parsed.add(m.group(1))
+    # Create/update service group chains.
+    paasta_rules = []
+    active_chains = set()
+    for service, macs in active_service_groups().items():
+        service.update_rules()
+        active_chains.add(service.chain_name)
+        for mac in macs:
+            paasta_rules.append('-m mac --mac-source {} -j {}'.format(
+                mac.upper(), service.chain_name,
+            ))
 
-    return parsed
+    # Create/update the PAASTA dispatch chain.
+    iptables.ensure_chain('PAASTA', paasta_rules)
+    iptables.ensure_rule('INPUT', '-j PAASTA')
+    iptables.ensure_rule('FORWARD', '-j PAASTA')
+
+    # Garbage collect any no-longer-needed service group chains.
+    paasta_chains = {
+        chain
+        for chain in iptables.all_chains()
+        if chain.startswith('PAASTA.')
+    }
+    for chain in paasta_chains - active_chains:
+        iptables.delete_chain(chain)
 
 
-
-ensure_chain('ckuehl-test-service', [
-    '-j REJECT --reject-with icmp-port-unreachable',
-    '-d 169.254.255.254/32 -p tcp -m tcp --dport 20666 -j ACCEPT',
-    '-d 169.254.255.254/32 -p tcp -m tcp --dport 20641 -j ACCEPT',
-])
+# TODO: remove this
+general_update()

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import collections
 import hashlib
 import itertools
+import json
 
 from paasta_tools import iptables
 
@@ -42,7 +43,9 @@ class ServiceGroup(collections.namedtuple('ServiceGroup', (
         we append a hash to the end.
         """
         chain = 'PAASTA.{}'.format(self.service[:10])
-        chain += '.' + hashlib.sha256(str(tuple(self))).hexdigest()[:10]
+        chain += '.' + hashlib.sha256(
+            json.dumps(self).encode('utf8'),
+        ).hexdigest()[:10]
         assert len(chain) <= 28, len(chain)
         return chain
 
@@ -76,15 +79,15 @@ def active_service_groups():
     """Return active service groups."""
     # TODO: actually read these from somewhere
     return {
-        ServiceGroup('cool-service', 'main', 'block'): {
+        ServiceGroup('cool_service', 'main', 'block'): {
             '02:42:a9:fe:00:02',
             'fe:a3:a3:da:2d:51',
             'fe:a3:a3:da:2d:50',
         },
-        ServiceGroup('cool-service', 'main', 'monitor'): {
+        ServiceGroup('cool_service', 'main', 'monitor'): {
             'fe:a3:a3:da:2d:40',
         },
-        ServiceGroup('dumb-service', 'other', 'block'): {
+        ServiceGroup('dumb_service', 'other', 'block'): {
             'fe:a3:a3:da:2d:30',
             'fe:a3:a3:da:2d:31',
         },

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -151,7 +151,3 @@ def general_update():
     }
     for chain in paasta_chains - active_chains:
         iptables.delete_chain(chain)
-
-
-# TODO: remove this
-general_update()

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python2.7
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+
+import re
+import shlex
+import subprocess
+
+
+class ChainDoesNotExist(Exception):
+    pass
+
+
+def ensure_chain(chain, rules):
+    """Idempotently ensure a chain exists and has a set of rules.
+
+    This function creates or updates an existing chain to match the rules
+    passed in.
+
+    This function will not reorder existing rules, but any new rules are always
+    inserted at the front of the chain.
+    """
+    try:
+        current_rules = list_chain(chain)
+    except ChainDoesNotExist:
+        create_chain(chain)
+        current_rules = set()
+
+    for rule in rules:
+        if rule not in current_rules:
+            print('adding rule: {}'.format(rule))
+            add_rule(chain, rule)
+
+    for rule in current_rules:
+        if rule not in rules:
+            print('deleting rule: {}'.format(rule))
+            delete_rule(chain, rule)
+
+
+def add_rule(chain, rule):
+    subprocess.check_call(['iptables', '-t', 'filter', '-I', chain] + shlex.split(rule))
+
+
+def delete_rule(chain, rule):
+    subprocess.check_call(['iptables', '-t', 'filter', '-I', chain] + shlex.split(rule))
+
+
+def create_chain(chain):
+    subprocess.check_call(('iptables', '-t', 'filter', '-N', chain))
+
+
+def list_chain(chain):
+    """List rules in a chain.
+
+    Returns a list of iptables rules, or raises ChainDoesNotExist.
+    """
+    cmd = ('iptables', '-t', 'filter', '--list-rules', chain)
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    out, err = proc.communicate()
+    if proc.returncode != 0:
+        if b'No chain/target/match by that name.\n' in err:
+            raise ChainDoesNotExist(chain)
+        else:
+            raise subprocess.CalledProcessError(proc.returncode, cmd, output=(out, err))
+
+    # Parse rules into something usable
+    rule_regex = re.compile(b'-A {chain} (.+)$'.format(chain=re.escape(chain)))
+    rules = out.splitlines()
+    parsed = set()
+    for rule in rules:
+        if rule == '-N {}'.format(chain):
+            continue
+        m = rule_regex.match(rule)
+        if not m:
+            raise ValueError(
+                'Unable to parse iptables rule: {}'.format(rule),
+            )
+        else:
+            parsed.add(m.group(1))
+
+    return parsed
+
+
+
+ensure_chain('ckuehl-test-service', [
+    '-j REJECT --reject-with icmp-port-unreachable',
+    '-d 169.254.255.254/32 -p tcp -m tcp --dport 20666 -j ACCEPT',
+    '-d 169.254.255.254/32 -p tcp -m tcp --dport 20641 -j ACCEPT',
+])

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -24,7 +24,8 @@ class ServiceGroup(collections.namedtuple('ServiceGroup', (
     """A service group.
 
     :param service: the name of a service
-    :param dependency_group: the name of a dependency group
+    :param dependency_group: the name of a set of dependencies
+                             (the key in dependencies.yaml)
     :param mode: either 'monitor' or 'block'
     """
 

--- a/paasta_tools/iptables.py
+++ b/paasta_tools/iptables.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """iptables helper functions.
 
 Unlike the `firewall` module, these functions know nothing about PaaSTA and

--- a/paasta_tools/iptables.py
+++ b/paasta_tools/iptables.py
@@ -1,0 +1,113 @@
+"""iptables helper functions.
+
+Unlike the `firewall` module, these functions know nothing about PaaSTA and
+could effectively be a third-party library. They just make working with
+iptables a little bit easier.
+"""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import re
+import shlex
+import subprocess
+
+
+class ChainDoesNotExist(Exception):
+    pass
+
+
+def all_chains():
+    output = subprocess.check_output(
+        ('iptables', '-t', 'filter', '--list-rules'),
+    )
+    chain_regex = re.compile('-N ([^ ]+)$')
+    chains = set()
+    for line in output.splitlines():
+        m = chain_regex.match(line)
+        if m:
+            chains.add(m.group(1))
+    return chains
+
+
+def ensure_chain(chain, rules=None):
+    """Idempotently ensure a chain exists and has an exact set of rules.
+
+    This function creates or updates an existing chain to match the rules
+    passed in.
+
+    This function will not reorder existing rules, but any new rules are always
+    inserted at the front of the chain.
+    """
+    try:
+        current_rules = list_chain(chain)
+    except ChainDoesNotExist:
+        create_chain(chain)
+        current_rules = set()
+
+    if rules is not None:
+        for rule in rules:
+            if rule not in current_rules:
+                add_rule(chain, rule)
+
+        for rule in current_rules:
+            if rule not in rules:
+                delete_rule(chain, rule)
+
+
+def ensure_rule(chain, rule):
+    rules = list_chain(chain)
+    if rule not in rules:
+        add_rule(chain, rule)
+
+
+def add_rule(chain, rule):
+    print('adding rule to {}: {}'.format(chain, rule))
+    subprocess.check_call(['iptables', '-t', 'filter', '-I', chain] + shlex.split(rule))
+
+
+def delete_rule(chain, rule):
+    print('deleting rule from {}: {}'.format(chain, rule))
+    subprocess.check_call(['iptables', '-t', 'filter', '-D', chain] + shlex.split(rule))
+
+
+def create_chain(chain):
+    print('creating chain: {}'.format(chain))
+    subprocess.check_call(('iptables', '-t', 'filter', '-N', chain))
+
+
+def delete_chain(chain):
+    print('deleting chain: {}'.format(chain))
+    # remove rules from the chain
+    subprocess.check_call(('iptables', '-t', 'filter', '-F', chain))
+    # delete the chain
+    subprocess.check_call(('iptables', '-t', 'filter', '-X', chain))
+
+
+def list_chain(chain):
+    """List rules in a chain.
+
+    Returns a list of iptables rules, or raises ChainDoesNotExist.
+    """
+    cmd = ('iptables', '-t', 'filter', '--list-rules', chain)
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    out, err = proc.communicate()
+    if proc.returncode != 0:
+        if b'No chain/target/match by that name.\n' in err:
+            raise ChainDoesNotExist(chain)
+        else:
+            raise subprocess.CalledProcessError(proc.returncode, cmd, output=(out, err))
+
+    # Parse rules into something usable
+    rule_regex = re.compile(b'-A {chain} (.+)$'.format(chain=re.escape(chain)))
+    rules = out.splitlines()
+    parsed = set()
+    for rule in rules:
+        m = rule_regex.match(rule)
+        if m:
+            parsed.add(m.group(1))
+
+    return parsed

--- a/paasta_tools/iptables.py
+++ b/paasta_tools/iptables.py
@@ -10,12 +10,8 @@ from __future__ import unicode_literals
 
 import collections
 import contextlib
-import re
 
 import iptc
-
-
-CHAIN_REGEX = re.compile('-N ([^ ]+)$')
 
 
 class Rule(collections.namedtuple('Rule', (
@@ -129,8 +125,7 @@ def insert_rule(chain_name, rule):
 
 
 def delete_rules(chain_name, rules):
-    for rule in rules:
-        print('deleting rule from {}: {}'.format(chain_name, rule))
+    print('deleting rules from {}: {}'.format(chain_name, rules))
     table = iptc.Table(iptc.Table.FILTER)
     with iptables_txn(table):
         chain = iptc.Chain(table, chain_name)

--- a/paasta_tools/iptables.py
+++ b/paasta_tools/iptables.py
@@ -10,8 +10,11 @@ from __future__ import unicode_literals
 
 import collections
 import contextlib
+import logging
 
 import iptc
+
+log = logging.getLogger(__name__)
 
 
 class Rule(collections.namedtuple('Rule', (
@@ -119,13 +122,13 @@ def ensure_rule(chain, rule):
 
 
 def insert_rule(chain_name, rule):
-    print('adding rule to {}: {}'.format(chain_name, rule))
+    log.debug('adding rule to {}: {}'.format(chain_name, rule))
     chain = iptc.Chain(iptc.Table(iptc.Table.FILTER), chain_name)
     chain.insert_rule(rule.to_iptc())
 
 
 def delete_rules(chain_name, rules):
-    print('deleting rules from {}: {}'.format(chain_name, rules))
+    log.debug('deleting rules from {}: {}'.format(chain_name, rules))
     table = iptc.Table(iptc.Table.FILTER)
     with iptables_txn(table):
         chain = iptc.Chain(table, chain_name)
@@ -135,12 +138,12 @@ def delete_rules(chain_name, rules):
 
 
 def create_chain(chain_name):
-    print('creating chain: {}'.format(chain_name))
+    log.debug('creating chain: {}'.format(chain_name))
     iptc.Table(iptc.Table.FILTER).create_chain(chain_name)
 
 
 def delete_chain(chain_name):
-    print('deleting chain: {}'.format(chain_name))
+    log.debug('deleting chain: {}'.format(chain_name))
     chain = iptc.Chain(iptc.Table(iptc.Table.FILTER), chain_name)
     chain.flush()
     chain.delete()

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'pytz >= 2014.10',
         'python-crontab>=2.1.1',
         'python-dateutil >= 2.4.0',
+        'python-iptables',
         'retry',
         'requests == 2.6.2',
         'requests-cache >= 0.4.10,<= 0.5.0',

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from paasta_tools import firewall
+from paasta_tools import iptables
+
+
+EMPTY_RULE = iptables.Rule(
+    protocol='ip',
+    src='0.0.0.0/0.0.0.0',
+    dst='0.0.0.0/0.0.0.0',
+    target=None,
+    matches=(),
+)
+
+
+@pytest.fixture
+def service_group():
+    return firewall.ServiceGroup(
+        service='my-cool-service',
+        dependency_group='web',
+        mode='block',
+    )
+
+
+def test_service_group_chain_name(service_group):
+    """The chain name must be stable, unique, and short."""
+    assert service_group.chain_name == 'PAASTA.my-cool-se.40e30b4600'
+    assert len(service_group.chain_name) <= 28
+
+
+def test_service_group_rules(service_group):
+    # TODO: this is a useless test right now
+    assert len(service_group.rules) == 2
+
+
+def test_service_group_update_rules(service_group):
+    with mock.patch.object(iptables, 'ensure_chain', autospec=True) as m:
+        service_group.update_rules()
+    m.assert_called_once_with(
+        service_group.chain_name,
+        service_group.rules,
+    )
+
+
+def test_active_service_groups():
+    # TODO: this is a useless test right now
+    assert len(firewall.active_service_groups()) == 3
+
+
+def test_ensure_internet_chain():
+    with mock.patch.object(iptables, 'ensure_chain', autospec=True) as m:
+        firewall.ensure_internet_chain()
+    call, = m.call_args_list
+    args, _ = call
+    assert args[0] == 'PAASTA-INTERNET'
+    assert args[1] == (
+        EMPTY_RULE._replace(target='ACCEPT'),
+        EMPTY_RULE._replace(dst='127.0.0.0/255.0.0.0', target='RETURN'),
+        EMPTY_RULE._replace(dst='10.0.0.0/255.0.0.0', target='RETURN'),
+        EMPTY_RULE._replace(dst='172.16.0.0/255.240.0.0', target='RETURN'),
+        EMPTY_RULE._replace(dst='192.168.0.0/255.255.0.0', target='RETURN'),
+        EMPTY_RULE._replace(dst='169.254.0.0/255.255.0.0', target='RETURN'),
+    )
+
+
+@pytest.yield_fixture
+def mock_active_service_groups():
+    groups = {
+        firewall.ServiceGroup('cool-service', 'main', 'block'): {
+            '02:42:a9:fe:00:02',
+            'fe:a3:a3:da:2d:51',
+            'fe:a3:a3:da:2d:50',
+        },
+        firewall.ServiceGroup('cool-service', 'main', 'monitor'): {
+            'fe:a3:a3:da:2d:40',
+        },
+        firewall.ServiceGroup('dumb-service', 'other', 'block'): {
+            'fe:a3:a3:da:2d:30',
+            'fe:a3:a3:da:2d:31',
+        },
+    }
+    with mock.patch.object(
+            firewall,
+            'active_service_groups',
+            return_value=groups,
+    ):
+        yield
+
+
+def test_ensure_service_chains(mock_active_service_groups):
+    with mock.patch.object(iptables, 'ensure_chain', autospec=True) as m:
+        assert firewall.ensure_service_chains() == {
+            'PAASTA.cool-servi.003bae64d2': {
+                '02:42:a9:fe:00:02',
+                'fe:a3:a3:da:2d:51',
+                'fe:a3:a3:da:2d:50',
+            },
+            'PAASTA.cool-servi.ccd68729b4': {
+                'fe:a3:a3:da:2d:40',
+            },
+            'PAASTA.dumb-servi.bcc6a6f4b1': {
+                'fe:a3:a3:da:2d:30',
+                'fe:a3:a3:da:2d:31',
+            },
+        }
+    assert len(m.mock_calls) == 3
+    assert mock.call('PAASTA.cool-servi.003bae64d2', mock.ANY) in m.mock_calls
+    assert mock.call('PAASTA.cool-servi.ccd68729b4', mock.ANY) in m.mock_calls
+    assert mock.call('PAASTA.dumb-servi.bcc6a6f4b1', mock.ANY) in m.mock_calls
+
+
+def test_ensure_dispatch_chains():
+    with mock.patch.object(
+        iptables, 'ensure_rule', autospec=True,
+    ) as mock_ensure_rule, mock.patch.object(
+        iptables, 'ensure_chain', autospec=True,
+    ) as mock_ensure_chain:
+        firewall.ensure_dispatch_chains({
+            'chain1': {'mac1', 'mac2'},
+            'chain2': {'mac3'},
+        })
+
+    assert mock_ensure_chain.mock_calls == [mock.call(
+        'PAASTA', {
+            EMPTY_RULE._replace(
+                target='chain1', matches=(('mac', (('mac_source', 'MAC1'),)),),
+            ),
+            EMPTY_RULE._replace(
+                target='chain1', matches=(('mac', (('mac_source', 'MAC2'),)),),
+            ),
+            EMPTY_RULE._replace(
+                target='chain2', matches=(('mac', (('mac_source', 'MAC3'),)),),
+            ),
+        },
+    )]
+
+    assert mock_ensure_rule.mock_calls == [
+        mock.call('INPUT', EMPTY_RULE._replace(target='PAASTA')),
+        mock.call('FORWARD', EMPTY_RULE._replace(target='PAASTA')),
+    ]
+
+
+def test_garbage_collect_old_service_chains():
+    with mock.patch.object(
+        iptables, 'delete_chain', autospec=True,
+    ) as mock_delete_chain, mock.patch.object(
+        iptables, 'all_chains', autospec=True, return_value={
+            'INPUT',
+            'OUTPUT',
+            'FORWARD',
+            'DOCKER',
+            'PAASTA',
+            'PAASTA-INTERNET',
+            'PAASTA.chain1',
+            'PAASTA.chain3',
+        }
+    ):
+        firewall.garbage_collect_old_service_chains({
+            'PAASTA.chain1': {'mac1', 'mac2'},
+            'PAASTA.chain2': {'mac3'},
+        })
+
+    assert mock_delete_chain.mock_calls == [
+        mock.call('PAASTA.chain3'),
+    ]

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -21,7 +21,7 @@ EMPTY_RULE = iptables.Rule(
 @pytest.fixture
 def service_group():
     return firewall.ServiceGroup(
-        service='my-cool-service',
+        service='my_cool_service',
         dependency_group='web',
         mode='block',
     )
@@ -29,7 +29,7 @@ def service_group():
 
 def test_service_group_chain_name(service_group):
     """The chain name must be stable, unique, and short."""
-    assert service_group.chain_name == 'PAASTA.my-cool-se.40e30b4600'
+    assert service_group.chain_name == 'PAASTA.my_cool_se.7693eadc05'
     assert len(service_group.chain_name) <= 28
 
 
@@ -71,15 +71,15 @@ def test_ensure_internet_chain():
 @pytest.yield_fixture
 def mock_active_service_groups():
     groups = {
-        firewall.ServiceGroup('cool-service', 'main', 'block'): {
+        firewall.ServiceGroup('cool_service', 'main', 'block'): {
             '02:42:a9:fe:00:02',
             'fe:a3:a3:da:2d:51',
             'fe:a3:a3:da:2d:50',
         },
-        firewall.ServiceGroup('cool-service', 'main', 'monitor'): {
+        firewall.ServiceGroup('cool_service', 'main', 'monitor'): {
             'fe:a3:a3:da:2d:40',
         },
-        firewall.ServiceGroup('dumb-service', 'other', 'block'): {
+        firewall.ServiceGroup('dumb_service', 'other', 'block'): {
             'fe:a3:a3:da:2d:30',
             'fe:a3:a3:da:2d:31',
         },
@@ -95,23 +95,23 @@ def mock_active_service_groups():
 def test_ensure_service_chains(mock_active_service_groups):
     with mock.patch.object(iptables, 'ensure_chain', autospec=True) as m:
         assert firewall.ensure_service_chains() == {
-            'PAASTA.cool-servi.003bae64d2': {
+            'PAASTA.cool_servi.130d5afc9f': {
                 '02:42:a9:fe:00:02',
                 'fe:a3:a3:da:2d:51',
                 'fe:a3:a3:da:2d:50',
             },
-            'PAASTA.cool-servi.ccd68729b4': {
+            'PAASTA.cool_servi.0d2d779529': {
                 'fe:a3:a3:da:2d:40',
             },
-            'PAASTA.dumb-servi.bcc6a6f4b1': {
+            'PAASTA.dumb_servi.06f185ab16': {
                 'fe:a3:a3:da:2d:30',
                 'fe:a3:a3:da:2d:31',
             },
         }
     assert len(m.mock_calls) == 3
-    assert mock.call('PAASTA.cool-servi.003bae64d2', mock.ANY) in m.mock_calls
-    assert mock.call('PAASTA.cool-servi.ccd68729b4', mock.ANY) in m.mock_calls
-    assert mock.call('PAASTA.dumb-servi.bcc6a6f4b1', mock.ANY) in m.mock_calls
+    assert mock.call('PAASTA.cool_servi.130d5afc9f', mock.ANY) in m.mock_calls
+    assert mock.call('PAASTA.cool_servi.0d2d779529', mock.ANY) in m.mock_calls
+    assert mock.call('PAASTA.dumb_servi.06f185ab16', mock.ANY) in m.mock_calls
 
 
 def test_ensure_dispatch_chains():

--- a/tests/test_iptables.py
+++ b/tests/test_iptables.py
@@ -1,0 +1,264 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import iptc
+import mock
+import pytest
+
+from paasta_tools import iptables
+
+
+EMPTY_RULE = iptables.Rule(
+    protocol='ip',
+    src='0.0.0.0/0.0.0.0',
+    dst='0.0.0.0/0.0.0.0',
+    target=None,
+    matches=(),
+)
+
+
+@pytest.yield_fixture
+def mock_Table():
+    with mock.patch.object(
+        iptc, 'Table', autospec=True,
+    ) as m:
+        m.return_value.autocommit = True
+        yield m
+
+
+@pytest.yield_fixture
+def mock_Chain():
+    with mock.patch.object(
+        iptc, 'Chain', autospec=True,
+    ) as m:
+        yield m
+
+
+def test_rule_from_iptc_simple():
+    rule = iptc.Rule()
+    rule.create_target('DROP')
+    rule.src = '169.229.226.0/255.255.255.0'
+
+    assert iptables.Rule.from_iptc(rule) == EMPTY_RULE._replace(
+        src='169.229.226.0/255.255.255.0',
+        target='DROP',
+    )
+
+
+def test_rule_from_iptc_mac_match():
+    rule = iptc.Rule()
+    rule.create_target('DROP')
+    rule.create_match('mac')
+    rule.matches[0].mac_source = '20:C9:D0:2B:6F:F3'
+
+    assert iptables.Rule.from_iptc(rule) == EMPTY_RULE._replace(
+        target='DROP',
+        matches=(
+            ('mac', (
+                ('mac_source', '20:C9:D0:2B:6F:F3'),
+            )),
+        ),
+    )
+
+
+def test_rule_tcp_to_iptc():
+    rule = EMPTY_RULE._replace(
+        protocol='tcp',
+        target='ACCEPT',
+        matches=(
+            ('tcp', (
+                ('dport', '443'),
+            )),
+        ),
+    ).to_iptc()
+    assert rule.protocol == 'tcp'
+    assert rule.target.name == 'ACCEPT'
+    assert len(rule.matches) == 1
+    assert rule.matches[0].name == 'tcp'
+    assert rule.matches[0].parameters['dport'] == '443'
+
+
+def test_mac_src_to_iptc():
+    rule = EMPTY_RULE._replace(
+        target='ACCEPT',
+        matches=(
+            ('mac', (
+                ('mac_source', '20:C9:D0:2B:6F:F3'),
+            )),
+        ),
+    ).to_iptc()
+    assert rule.protocol == 'ip'
+    assert rule.target.name == 'ACCEPT'
+    assert len(rule.matches) == 1
+    assert rule.matches[0].name == 'mac'
+    assert rule.matches[0].parameters['mac_source'] == '20:C9:D0:2B:6F:F3'
+
+
+def test_iptables_txn_normal():
+    table = mock.Mock(autocommit=True)
+    with iptables.iptables_txn(table):
+        assert table.autocommit is False
+        assert table.commit.called is False
+        assert table.refresh.called is False
+    assert table.commit.called is True
+    assert table.refresh.called is True
+    assert table.autocommit is True
+
+
+def test_iptables_txn_with_exception():
+    table = mock.Mock(autocommit=True)
+    with pytest.raises(ValueError):
+        with iptables.iptables_txn(table):
+            raise ValueError('just testing lol')
+    assert table.commit.called is False
+    assert table.refresh.called is True
+    assert table.autocommit is True
+
+
+def test_all_chains(mock_Table):
+    chain1 = mock.Mock()
+    chain1.name = 'INPUT'
+    chain2 = mock.Mock()
+    chain2.name = 'OUTPUT'
+    mock_Table.return_value = mock.Mock(chains=[
+        chain1, chain2,
+    ])
+    assert iptables.all_chains() == {'INPUT', 'OUTPUT'}
+
+
+def test_ensure_chain():
+    with mock.patch.object(
+        iptables, 'list_chain', autospec=True, return_value={
+            EMPTY_RULE._replace(target='DROP'),
+            EMPTY_RULE._replace(target='ACCEPT', src='1.0.0.0/255.255.255.0'),
+        },
+    ), mock.patch.object(
+        iptables, 'insert_rule', autospec=True,
+    ) as mock_insert_rule, mock.patch.object(
+        iptables, 'delete_rules', autospec=True,
+    ) as mock_delete_rules:
+        iptables.ensure_chain('PAASTA.service', (
+            EMPTY_RULE._replace(target='DROP'),
+            EMPTY_RULE._replace(target='ACCEPT', src='2.0.0.0/255.255.255.0'),
+        ))
+
+    # It should add the missing rule
+    assert mock_insert_rule.mock_calls == [
+        mock.call(
+            'PAASTA.service',
+            EMPTY_RULE._replace(target='ACCEPT', src='2.0.0.0/255.255.255.0'),
+        ),
+    ]
+
+    # It should delete the extra rule
+    assert mock_delete_rules.mock_calls == [
+        mock.call(
+            'PAASTA.service',
+            {EMPTY_RULE._replace(target='ACCEPT', src='1.0.0.0/255.255.255.0')},
+        ),
+    ]
+
+
+def test_ensure_chain_creates_chain_if_doesnt_exist():
+    with mock.patch.object(
+        iptables, 'list_chain',
+        side_effect=iptables.ChainDoesNotExist('PAASTA.service')
+    ), mock.patch.object(
+        iptables, 'create_chain', autospec=True,
+    ) as mock_create_chain:
+        iptables.ensure_chain('PAASTA.service', ())
+
+    assert mock_create_chain.mock_calls == [
+        mock.call('PAASTA.service'),
+    ]
+
+
+def test_ensure_rule_does_not_exist():
+    with mock.patch.object(
+        iptables, 'list_chain', return_value=(
+            EMPTY_RULE._replace(target='ACCEPT'),
+            EMPTY_RULE._replace(src='10.0.0.0/255.255.255.0'),
+        ),
+    ), mock.patch.object(
+        iptables, 'insert_rule', autospec=True,
+    ) as mock_insert_rule:
+        iptables.ensure_rule(
+            'PAASTA.service', EMPTY_RULE._replace(target='DROP'),
+        )
+
+    assert mock_insert_rule.mock_calls == [
+        mock.call('PAASTA.service', EMPTY_RULE._replace(target='DROP')),
+    ]
+
+
+def test_ensure_rule_already_exists():
+    with mock.patch.object(
+        iptables, 'list_chain', return_value=(
+            EMPTY_RULE._replace(target='DROP'),
+            EMPTY_RULE._replace(src='10.0.0.0/255.255.255.0'),
+        ),
+    ), mock.patch.object(
+        iptables, 'insert_rule', autospec=True,
+    ) as mock_insert_rule:
+        iptables.ensure_rule(
+            'PAASTA.service', EMPTY_RULE._replace(target='DROP'),
+        )
+
+    assert mock_insert_rule.called is False
+
+
+def test_insert_rule(mock_Table, mock_Chain):
+    iptables.insert_rule(
+        'PAASTA.service', EMPTY_RULE._replace(target='DROP'),
+    )
+
+    call, = mock_Chain('filter', 'PAASTA.service').insert_rule.call_args_list
+    args, kwargs = call
+    rule, = args
+    assert iptables.Rule.from_iptc(rule) == EMPTY_RULE._replace(target='DROP')
+
+
+def test_delete_rules(mock_Table, mock_Chain):
+    mock_Chain.return_value.rules = (
+        EMPTY_RULE._replace(target='DROP').to_iptc(),
+        EMPTY_RULE._replace(target='ACCEPT').to_iptc(),
+        EMPTY_RULE._replace(target='REJECT').to_iptc(),
+    )
+    iptables.delete_rules('PAASTA.service', (
+        EMPTY_RULE._replace(target='ACCEPT'),
+        EMPTY_RULE._replace(target='REJECT'),
+    ))
+    assert mock_Chain('filter', 'PAASTA.service').delete_rule.mock_calls == [
+        mock.call(mock_Chain.return_value.rules[1]),
+        mock.call(mock_Chain.return_value.rules[2]),
+    ]
+
+
+def test_create_chain(mock_Table):
+    iptables.create_chain('PAASTA.service')
+    mock_Table('filter').create_chain.assert_called_once_with('PAASTA.service')
+
+
+def test_delete_chain(mock_Table, mock_Chain):
+    iptables.delete_chain('PAASTA.service')
+    chain = mock_Chain('filter', 'PAASTA.service')
+    assert chain.flush.called is True
+    assert chain.delete.called is True
+
+
+def test_list_chain_simple(mock_Table, mock_Chain):
+    chain = mock_Chain('PAASTA.internet', mock_Table.return_value)
+    rule = iptc.Rule()
+    rule.create_target('DROP')
+    chain.rules = [rule]
+    mock_Table.return_value.chains = [chain]
+    assert iptables.list_chain('PAASTA.internet') == {
+        EMPTY_RULE._replace(target='DROP'),
+    }
+
+
+def test_list_chain_does_not_exist(mock_Table, mock_Chain):
+    mock_Table.return_value.chains = []
+    with pytest.raises(iptables.ChainDoesNotExist):
+        iptables.list_chain('PAASTA.internet')


### PR DESCRIPTION
This adds code to create and manage iptables rules as part of the PaaSTA firewalls CEP.

The only public entrypoint right now is one function `general_update`, which could be run from a cronjob. It sets up standard rules (such as the `PAASTA` chain), then generates a list of desired rules, diffs them against existing rules, and makes any necessary adjustments. Currently it uses fake data for "list of service instances on this host" and "desired rules for the service".

In the future, we'll need to figure out the integration points between this code and other processes (e.g. the docker wrapper and the inotify watcher).

Some things that need to be done before merge:
* [x] tests
* [x] fix python3 tests
* [x] clean up `print` statements, add logging where appropriate
* [ ] (maybe) make it stop using fake data?

### Example usage

For now I'm just running the function manually and modifying the hard-coded test data.

#### Starting from a box with no iptables rules

It sets up the `PAASTA-INTERNET` chain, populates it, sets up an empty `PAASTA` chain, and sets up jumps to it in the appropriate locations. This is all a fancy noop.

```
$ sudo venv/bin/python -c 'from paasta_tools.firewall import general_update; general_update()'
creating chain: PAASTA-INTERNET
adding rule to PAASTA-INTERNET: Rule(protocol=u'ip', src=u'0.0.0.0/0.0.0.0', dst=u'0.0.0.0/0.0.0.0', target=u'ACCEPT', matches=())
adding rule to PAASTA-INTERNET: Rule(protocol=u'ip', src=u'0.0.0.0/0.0.0.0', dst=u'127.0.0.0/255.0.0.0', target=u'RETURN', matches=())
adding rule to PAASTA-INTERNET: Rule(protocol=u'ip', src=u'0.0.0.0/0.0.0.0', dst=u'10.0.0.0/255.0.0.0', target=u'RETURN', matches=())
adding rule to PAASTA-INTERNET: Rule(protocol=u'ip', src=u'0.0.0.0/0.0.0.0', dst=u'172.16.0.0/255.240.0.0', target=u'RETURN', matches=())
adding rule to PAASTA-INTERNET: Rule(protocol=u'ip', src=u'0.0.0.0/0.0.0.0', dst=u'192.168.0.0/255.255.0.0', target=u'RETURN', matches=())
adding rule to PAASTA-INTERNET: Rule(protocol=u'ip', src=u'0.0.0.0/0.0.0.0', dst=u'169.254.0.0/255.255.0.0', target=u'RETURN', matches=())
creating chain: PAASTA
adding rule to INPUT: Rule(protocol=u'ip', src=u'0.0.0.0/0.0.0.0', dst=u'0.0.0.0/0.0.0.0', target=u'PAASTA', matches=())
adding rule to FORWARD: Rule(protocol=u'ip', src=u'0.0.0.0/0.0.0.0', dst=u'0.0.0.0/0.0.0.0', target=u'PAASTA', matches=())
```

#### Launching a service instance

This creates a new chain for that service and populates it, then adds a jump on the `PAASTA` chain to that service's chain.

```
$ sudo venv/bin/python -c 'from paasta_tools.firewall import general_update; general_update()'
creating chain: PAASTA.cool-servi.003bae64d2
adding rule to PAASTA.cool-servi.003bae64d2: Rule(protocol=u'ip', src=u'0.0.0.0/0.0.0.0', dst=u'0.0.0.0/0.0.0.0', target=u'REJECT', matches=())
adding rule to PAASTA.cool-servi.003bae64d2: Rule(protocol=u'tcp', src=u'0.0.0.0/0.0.0.0', dst=u'169.254.255.254/255.255.255.255', target=u'ACCEPT', matches=((u'tcp', ((u'dport', u'20668'),)),))
adding rule to PAASTA: Rule(protocol=u'ip', src=u'0.0.0.0/0.0.0.0', dst=u'0.0.0.0/0.0.0.0', target=u'PAASTA.cool-servi.003bae64d2', matches=((u'mac', ((u'mac_source', u'02:42:A9:FE:00:02'),)),))
```

#### Adding another instance of that same service

It doesn't need to add another chain since it already has one for this service. Instead it just adds another jump for this new MAC address.

```
$ sudo venv/bin/python -c 'from paasta_tools.firewall import general_update; general_update()'
adding rule to PAASTA: Rule(protocol=u'ip', src=u'0.0.0.0/0.0.0.0', dst=u'0.0.0.0/0.0.0.0', target=u'PAASTA.cool-servi.003bae64d2', matches=((u'mac', ((u'mac_source', u'FE:A3:A3:DA:2D:50'),)),))
```

#### Other things

They pretty much work like you expect, so I didn't include example output.

## Future plans

* Add/improve integration points
* Locking of some kind around iptables updating
* Consider making some flows more efficient

(This PR started as https://github.com/chriskuehl/paasta/pull/1)