### PR TITLE
Split startup vs big bounce rate

### DIFF
--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -149,7 +149,7 @@ class DeployDaemon(PaastaThread):
                                              instance_type='marathon',
                                              soa_dir=DEFAULT_SOA_DIR)
         instances_to_add = rate_limit_instances(instances=instances,
-                                                number_per_minute=self.config.get_deployd_big_bounce_rate(),
+                                                number_per_minute=self.config.get_deployd_startup_bounce_rate(),
                                                 watcher_name='daemon_start')
         for service_instance in instances_to_add:
             self.inbox_q.put(service_instance)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1079,6 +1079,13 @@ class SystemPaastaConfig(dict):
         """
         return self.get("deployd_big_bounce_rate", 2)
 
+    def get_deployd_startup_bounce_rate(self):
+        """Get the number of deploys to do per minute when deployd starts
+
+        :return: integer
+        """
+        return self.get("deployd_startup_bounce_rate", 5)
+
     def get_deployd_log_level(self):
         """Get the log level for paasta-deployd
 


### PR DESCRIPTION
We want to configure these rates separately since you want to check all
services quickly but maybe don't need to bounce all services quickly
when public config changes.