### PR TITLE
Make deployd check marathon ID before bouncing

### DIFF
--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -9,6 +9,7 @@ import os
 import socket
 import time
 
+import service_configuration_lib
 from six.moves.queue import Empty
 
 from paasta_tools.deployd import watchers
@@ -83,6 +84,7 @@ class DeployDaemon(PaastaThread):
         super(DeployDaemon, self).__init__()
         self.started = False
         self.daemon = True
+        service_configuration_lib.disable_yaml_cache()
         self.config = load_system_paasta_config()
         root_logger = logging.getLogger()
         root_logger.setLevel(getattr(logging, self.config.get_deployd_log_level()))

--- a/paasta_tools/deployd/workers.py
+++ b/paasta_tools/deployd/workers.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals
 
 import time
 
-import service_configuration_lib
-
 from paasta_tools import marathon_tools
 from paasta_tools.deployd.common import BounceTimers
 from paasta_tools.deployd.common import PaastaThread
@@ -60,7 +58,6 @@ class PaastaDeployWorker(PaastaThread):
             self.log.info("{} processing {}.{}".format(self.name, service_instance.service, service_instance.instance))
             marathon_apps = marathon_tools.get_all_marathon_apps(self.marathon_client, embed_failures=True)
             bounce_timers.setup_marathon.start()
-            service_configuration_lib._yaml_cache = {}
             return_code, bounce_again_in_seconds = deploy_marathon_service(service=service_instance.service,
                                                                            instance=service_instance.instance,
                                                                            client=self.marathon_client,


### PR DESCRIPTION
As with the public config it doesn't make much sense to add things to
the bounce queue if their sha has not changed. This adds the same check
to changes to marathon-* files and deployments.json.

In addition I have disabled the yaml cache on the service configuration
lib since it was interfering with checking the sha. I'm pretty sure
we're not reading the configs frequently enough to need a cache.