### PR TITLE
Remove quotes around environment variables in local-run

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -376,7 +376,8 @@ def get_docker_run_cmd(memory, chosen_port, container_port, container_name, volu
                        docker_hash, command, net, docker_params):
     cmd = ['paasta_docker_wrapper', 'run']
     for k, v in env.items():
-        cmd.append("--env='%s=%s'" % (k, v))
+        cmd.append('--env')
+        cmd.append('%s=%s' % (k, v))
     cmd.append('--memory=%dm' % memory)
     for i in docker_params:
         cmd.append('--%s=%s' % (i['key'], i['value']))

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -633,8 +633,8 @@ def test_get_docker_run_cmd_with_env_vars():
     docker_params = []
     actual = get_docker_run_cmd(memory, chosen_port, container_port, container_name, volumes, env,
                                 interactive, docker_hash, command, net, docker_params)
-    assert "--env='foo=bar'" in actual
-    assert "--env='baz=qux'" in actual
+    assert actual[actual.index('foo=bar') - 1] == '--env'
+    assert actual[actual.index('baz=qux') - 1] == '--env'
 
 
 def test_get_docker_run_cmd_interactive_false():


### PR DESCRIPTION
They are redundant since we don't use any shell to execute 'docker run'.
They cause a problem with xenial images in new docker versions.

Internal ticket: OPS-11477