### PR TITLE
Use tox-pip-extensions when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=1.13.1-0~ubuntu-trusty devscripts --force-yes
   - 'if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" -a "$DOCKER_USERNAME" != "" ]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi'
-install: pip install coveralls tox
+install: pip install coveralls tox tox-pip-extensions
 script: if [[ -n "$MAKE_TARGET" ]]; then make "$MAKE_TARGET"; else tox; fi
 after_success:
   - coveralls

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ test: .paasta/bin/activate
 	.paasta/bin/pip install -U pip==9.0.1
 	.paasta/bin/pip install -U virtualenv==15.1.0
 	.paasta/bin/pip install -U tox==2.6.0
+	.paasta/bin/pip install -U tox-pip-extensions==1.0.1
 	touch .paasta/bin/activate
 
 itest: test .paasta/bin/activate

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist = py27
 indexserver =
     default = https://pypi.python.org/simple
     private = https://pypi.yelpcorp.com/simple
+tox_pip_extensions_ext_pip_custom_platform = true
+tox_pip_extensions_ext_venv_update = true
 
 [testenv]
 basepython = /usr/bin/python2.7


### PR DESCRIPTION
This enables the use of [tox-pip-extensions](https://github.com/asottile/tox-pip-extensions) when they're available. For users who haven't added tox-pip-extensions, there is no change.

At Yelp, this means we'll be able to take advantage of [pip-custom-platform](https://github.com/asottile/pip-custom-platform) in order to install binary deps from platform-specific wheels, and [venv-update](https://github.com/Yelp/venv-update) to speed up tox.

To actually use the private index server, you'll have to use `tox -i https://pypi.yelpcorp.com/simple`:

```
$ rm -rf .tox && time tox -i https://pypi.yelpcorp.com/simple --notest
[...]
tox -i https://pypi.yelpcorp.com/simple --notest  32.04s user 3.14s system 91% cpu 38.238 total
$ rm -rf .tox && time tox --notest
[... it fails with some build error, but still takes forever ...]
tox --notest  73.60s user 9.07s system 82% cpu 1:40.42 total
```