### PR TITLE
Add cron option to paasta_firewall_update

### DIFF
--- a/paasta_tools/firewall_update.py
+++ b/paasta_tools/firewall_update.py
@@ -13,6 +13,7 @@ from inotify.adapters import Inotify
 from inotify.constants import IN_MODIFY
 from inotify.constants import IN_MOVED_TO
 
+from paasta_tools import firewall
 from paasta_tools.chronos_tools import chronos_services_running_here
 from paasta_tools.chronos_tools import load_chronos_job_config
 from paasta_tools.marathon_tools import load_marathon_service_config
@@ -28,16 +29,27 @@ DEFAULT_SYNAPSE_SERVICE_DIR = b'/var/run/synapse/services'
 
 def parse_args(argv):
     parser = argparse.ArgumentParser(description='Monitor synapse changes and update service firewall rules')
-    parser.add_argument('--synapse-service-dir', dest="synapse_service_dir",
-                        default=DEFAULT_SYNAPSE_SERVICE_DIR,
-                        help="Path to synapse service dir (default %(default)s)")
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="soa_dir",
                         default=DEFAULT_SOA_DIR,
                         help="define a different soa config directory (default %(default)s)")
-    parser.add_argument('-u', '--update-secs', dest="update_secs",
-                        default=DEFAULT_UPDATE_SECS, type=int,
-                        help="Poll for new containers every N secs (default %(default)s)")
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true')
+
+    subparsers = parser.add_subparsers(help='mode to run firewall update in', dest='mode')
+    subparsers.required = True
+
+    daemon_parser = subparsers.add_parser('daemon', description=(
+        'Run a daemon which watches updates to synapse backends and updates iptables rules.'
+    ))
+    daemon_parser.add_argument('--synapse-service-dir', dest="synapse_service_dir",
+                               default=DEFAULT_SYNAPSE_SERVICE_DIR,
+                               help="Path to synapse service dir (default %(default)s)")
+    daemon_parser.add_argument('-u', '--update-secs', dest="update_secs",
+                               default=DEFAULT_UPDATE_SECS, type=int,
+                               help="Poll for new containers every N secs (default %(default)s)")
+
+    subparsers.add_parser('cron', description=(
+        'Do a one-time update of iptables rules to match the current running services.'
+    ))
 
     args = parser.parse_args(argv)
     return args
@@ -48,7 +60,7 @@ def setup_logging(verbose):
     logging.basicConfig(level=level)
 
 
-def run(args):
+def run_daemon(args):
     # Main loop waiting on inotify file events
     inotify = Inotify(block_duration_s=1)  # event_gen blocks for 1 second
     inotify.add_watch(args.synapse_service_dir.encode(), IN_MOVED_TO | IN_MODIFY)
@@ -64,6 +76,10 @@ def run(args):
             continue
 
         process_inotify_event(event, services_by_dependencies)
+
+
+def run_cron(args):
+    firewall.general_update()
 
 
 def process_inotify_event(event, services_by_dependencies):
@@ -111,4 +127,7 @@ def smartstack_dependencies_of_running_firewalled_services(soa_dir=DEFAULT_SOA_D
 def main(argv=None):
     args = parse_args(argv)
     setup_logging(args.verbose)
-    run(args)
+    {
+        'daemon': run_daemon,
+        'cron': run_cron,
+    }[args.mode](args)


### PR DESCRIPTION
This makes turns `paasta_firewall_update` have two modes:
* `paasta_firewall_update cron`
* `paasta_firewall_update daemon`

They share a few options (soa_dir, verbose), but the inotify one has some of its own options (like max update frequency) which don't apply to the cron command.

```
ckuehl@mesos1-uswest1cdevc:~/paasta$ .tox/py27/bin/paasta_firewall_update --help
usage: paasta_firewall_update [-h] [-d soa_dir] [-v] {daemon,cron} ...

Monitor synapse changes and update service firewall rules

positional arguments:
  {daemon,cron}         mode to run firewall update in

optional arguments:
  -h, --help            show this help message and exit
  -d soa_dir, --soa-dir soa_dir
                        define a different soa config directory (default
                        /nail/etc/services)
  -v, --verbose
```
```
ckuehl@mesos1-uswest1cdevc:~/paasta$ .tox/py27/bin/paasta_firewall_update cron --help
usage: paasta_firewall_update cron [-h]

Do a one-time update of iptables rules to match the current running services.

optional arguments:
  -h, --help  show this help message and exit
```
```
ckuehl@mesos1-uswest1cdevc:~/paasta$ .tox/py27/bin/paasta_firewall_update daemon --help
usage: paasta_firewall_update daemon [-h]
                                     [--synapse-service-dir SYNAPSE_SERVICE_DIR]
                                     [-u UPDATE_SECS]

Run a daemon which watches updates to synapse backends and updates iptables
rules.

optional arguments:
  -h, --help            show this help message and exit
  --synapse-service-dir SYNAPSE_SERVICE_DIR
                        Path to synapse service dir (default
                        /var/run/synapse/services)
  -u UPDATE_SECS, --update-secs UPDATE_SECS
                        Poll for new containers every N secs (default 5)
```

Currently specifying `--soa-dir` for `cron` does nothing (since the cronjob doesn't actually look at real data yet), but eventually it will thread that through.