### PR TITLE
Add firewall-related keys to schema validation for Marathon and Chronos

### DIFF
--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -27,6 +27,7 @@ opt/venvs/paasta-tools/bin/paasta_deploy_chronos_jobs usr/bin/paasta_deploy_chro
 opt/venvs/paasta-tools/bin/paasta-deployd usr/bin/paasta-deployd
 opt/venvs/paasta-tools/bin/paasta_docker_wrapper usr/bin/paasta_docker_wrapper
 opt/venvs/paasta-tools/bin/paasta_execute_docker_command.py usr/bin/paasta_execute_docker_command
+opt/venvs/paasta-tools/bin/paasta_firewall_update usr/bin/paasta_firewall_update
 opt/venvs/paasta-tools/bin/paasta_list_chronos_jobs usr/bin/list_chronos_jobs
 opt/venvs/paasta-tools/bin/paasta_list_chronos_jobs usr/bin/paasta_list_chronos_jobs
 opt/venvs/paasta-tools/bin/paasta_maintenance.py usr/bin/paasta_maintenance

--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -121,6 +121,17 @@
                 "type": "integer",
                 "minimum": 0,
                 "exclusiveMinimum": false
+            },
+            "dependencies_reference": {
+                "type": "string"
+            },
+            "security": {
+                "type": "object",
+                "properties": {
+                    "outbound_firewall": {
+                        "enum": ["block", "monitor"]
+                    }
+                }
             }
         },
         "oneOf": [

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -276,6 +276,17 @@
                     "minimum": 0,
                     "maximum": 65535,
                     "exclusiveMinimum": false
+                },
+                "dependencies_reference": {
+                    "type": "string"
+                },
+                "security": {
+                    "type": "object",
+                    "properties": {
+                        "outbound_firewall": {
+                            "enum": ["block", "monitor"]
+                        }
+                    }
                 }
             }
         }

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -327,6 +327,38 @@ def test_marathon_validate_schema_keys_outside_instance_blocks_bad(
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
+def test_marathon_validate_schema_security_good(
+    mock_get_file_contents, capfd,
+):
+    mock_get_file_contents.return_value = """
+main:
+    dependencies_reference: main
+    security:
+        outbound_firewall: block
+"""
+    assert validate_schema('unused_service_path.yaml', 'marathon')
+
+    output, _ = capfd.readouterr()
+    assert SCHEMA_VALID in output
+
+
+@patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
+def test_marathon_validate_schema_security_bad(
+    mock_get_file_contents, capfd,
+):
+    mock_get_file_contents.return_value = """
+main:
+    dependencies_reference: main
+    security:
+        outbound_firewall: bblock
+"""
+    assert not validate_schema('unused_service_path.yaml', 'marathon')
+
+    output, _ = capfd.readouterr()
+    assert SCHEMA_INVALID in output
+
+
+@patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_invalid_key_bad(
     mock_get_file_contents, capfd,
 ):
@@ -376,6 +408,40 @@ def test_chronos_validate_schema_keys_outside_instance_blocks_bad(
 }
 """
     assert not validate_schema('unused_service_path.json', 'chronos')
+
+    output, _ = capfd.readouterr()
+    assert SCHEMA_INVALID in output
+
+
+@patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
+def test_chronos_validate_schema_security_good(
+    mock_get_file_contents, capfd,
+):
+    mock_get_file_contents.return_value = """
+some_batch:
+    schedule: foo
+    dependencies_reference: main
+    security:
+        outbound_firewall: block
+"""
+    assert validate_schema('unused_service_path.yaml', 'chronos')
+
+    output, _ = capfd.readouterr()
+    assert SCHEMA_VALID in output
+
+
+@patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
+def test_chronos_validate_schema_security_bad(
+    mock_get_file_contents, capfd,
+):
+    mock_get_file_contents.return_value = """
+some_batch:
+    schedule: foo
+    dependencies_reference: main
+    security:
+        outbound_firewall: bblock
+"""
+    assert not validate_schema('unused_service_path.yaml', 'chronos')
 
     output, _ = capfd.readouterr()
     assert SCHEMA_INVALID in output


### PR DESCRIPTION
Before:
```
$ /nail/sys/bin/paasta validate -y ~/proj/yelpsoa-configs -s example_happyhour
✓ Successfully validated schema: marathon-STAGE.yaml
✗ Failed to validate schema. More info: http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html: /nail/home/ckuehl/proj/yelpsoa-configs/example_happyhour/marathon-mesosstage.yaml
  Validation Message: Additional properties are not allowed ('security', 'dependencies_reference' were unexpected)
✓ Successfully validated schema: marathon-DEV.yaml
✓ Successfully validated schema: chronos-PROD.yaml
✓ Successfully validated schema: adhoc-norcal-prod.yaml
✓ Successfully validated schema: marathon-pnw-devc.yaml
✓ Successfully validated schema: marathon-PROD.yaml
✓ chronos-mesosstage.yaml has a valid instance: example_child_job.
✓ chronos-mesosstage.yaml has a valid instance: example_chronos_job.

```

After:
```
$ .tox/py27/bin/paasta validate -y ~/proj/yelpsoa-configs -s example_happyhour
✓ Successfully validated schema: marathon-STAGE.yaml
✓ Successfully validated schema: marathon-mesosstage.yaml
✓ Successfully validated schema: marathon-DEV.yaml
✓ Successfully validated schema: chronos-PROD.yaml
✓ Successfully validated schema: adhoc-norcal-prod.yaml
✓ Successfully validated schema: marathon-pnw-devc.yaml
✓ Successfully validated schema: marathon-PROD.yaml
✓ chronos-mesosstage.yaml has a valid instance: example_child_job.
✓ chronos-mesosstage.yaml has a valid instance: example_chronos_job.
```