### PR TITLE
Start to hook up iptables rules with real world state

### DIFF
--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -143,11 +143,8 @@ def active_service_groups(soa_dir):
     """Return active service groups."""
     from paasta_tools import firewall_update
     service_groups = collections.defaultdict(set)
-    for service, instance, framework in firewall_update.services_running_here(soa_dir):
-        service_groups[ServiceGroup(service, instance, framework, soa_dir)].add(
-            # TODO: how to get the mac address of this container?
-            '02:42:a9:fe:00:02',
-        )
+    for service, instance, framework, mac in firewall_update.services_running_here(soa_dir):
+        service_groups[ServiceGroup(service, instance, framework, soa_dir)].add(mac)
     return service_groups
 
 

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -7,7 +7,13 @@ import hashlib
 import itertools
 import json
 
+import six
+
 from paasta_tools import iptables
+from paasta_tools.chronos_tools import load_chronos_job_config
+from paasta_tools.marathon_tools import get_all_namespaces_for_service
+from paasta_tools.marathon_tools import load_marathon_service_config
+from paasta_tools.utils import load_system_paasta_config
 
 
 PRIVATE_IP_RANGES = (
@@ -21,15 +27,16 @@ PRIVATE_IP_RANGES = (
 
 class ServiceGroup(collections.namedtuple('ServiceGroup', (
     'service',
-    'dependency_group',
-    'mode',
+    'instance',
+    'framework',
+    'soa_dir',
 ))):
     """A service group.
 
-    :param service: the name of a service
-    :param dependency_group: the name of a set of dependencies
-                             (the key in dependencies.yaml)
-    :param mode: either 'monitor' or 'block'
+    :param service: service name
+    :param instance: instance name
+    :param framework: Mesos framework (e.g. marathon or chronos)
+    :param soa_dir: path to yelpsoa-configs
     """
 
     __slots__ = ()
@@ -50,48 +57,98 @@ class ServiceGroup(collections.namedtuple('ServiceGroup', (
         return chain
 
     @property
-    def rules(self):
-        # TODO: actually read these from somewhere
-        return (
-            iptables.Rule(
-                protocol='ip',
-                src='0.0.0.0/0.0.0.0',
-                dst='0.0.0.0/0.0.0.0',
-                target='REJECT',
-                matches=(),
-            ),
-            iptables.Rule(
-                protocol='tcp',
-                src='0.0.0.0/0.0.0.0',
-                dst='169.254.255.254/255.255.255.255',
-                target='ACCEPT',
-                matches=(
-                    ('tcp', (('dport', '20668'),)),
-                )
-            ),
+    def config(self):
+        load_fn = {
+            'chronos': load_chronos_job_config,
+            'marathon': load_marathon_service_config,
+        }[self.framework]
+        return load_fn(
+            self.service, self.instance,
+            load_system_paasta_config().get_cluster(),
+            load_deployments=False,
+            soa_dir=self.soa_dir,
         )
+
+    @property
+    def rules(self):
+        conf = self.config
+
+        rules = [_default_rule(conf)]
+        rules.extend(_well_known_rules(conf))
+        rules.extend(_smartstack_rules(conf, self.soa_dir))
+        return tuple(rules)
 
     def update_rules(self):
         iptables.ensure_chain(self.chain_name, self.rules)
 
 
-def active_service_groups():
+def _default_rule(conf):
+    policy = conf.get_outbound_firewall()
+    if policy == 'block':
+        return iptables.Rule(
+            protocol='ip',
+            src='0.0.0.0/0.0.0.0',
+            dst='0.0.0.0/0.0.0.0',
+            target='REJECT',
+            matches=(),
+        )
+    elif policy == 'monitor':
+        # TODO: log-prefix
+        return iptables.Rule(
+            protocol='ip',
+            src='0.0.0.0/0.0.0.0',
+            dst='0.0.0.0/0.0.0.0',
+            target='LOG',
+            matches=(),
+        )
+    else:
+        raise AssertionError(policy)
+
+
+def _well_known_rules(conf):
+    for resource in conf.get_dependencies().get('well-known', ()):
+        if resource == 'internet':
+            yield iptables.Rule(
+                protocol='ip',
+                src='0.0.0.0/0.0.0.0',
+                dst='0.0.0.0/0.0.0.0',
+                target='PAASTA-INTERNET',
+                matches=(),
+            )
+        else:
+            # TODO: handle better
+            raise KeyError(resource)
+
+
+def _smartstack_rules(conf, soa_dir):
+    for namespace in conf.get_dependencies().get('smartstack', ()):
+        # TODO: handle non-synapse-haproxy services
+        # TODO: support wildcards?
+        service, _ = namespace.split('.', 1)
+        service_namespaces = get_all_namespaces_for_service(service, soa_dir=soa_dir)
+        port = dict(service_namespaces)[namespace]['proxy_port']
+
+        yield iptables.Rule(
+            protocol='tcp',
+            src='0.0.0.0/0.0.0.0',
+            dst='169.254.255.254/255.255.255.255',
+            target='ACCEPT',
+            matches=(
+                ('tcp', (('dport', six.text_type(port)),)),
+            )
+        )
+
+
+def active_service_groups(soa_dir):
     """Return active service groups."""
-    # TODO: actually read these from somewhere
-    return {
-        ServiceGroup('cool_service', 'main', 'block'): {
+    from paasta_tools import firewall_update
+    service_groups = collections.defaultdict(set)
+    for service, instance, framework in firewall_update.services_running_here(soa_dir):
+        service_groups[ServiceGroup(service, instance, framework, soa_dir)].add(
+            # TODO: how to get the mac address of this container?
             '02:42:a9:fe:00:02',
-            'fe:a3:a3:da:2d:51',
-            'fe:a3:a3:da:2d:50',
-        },
-        ServiceGroup('cool_service', 'main', 'monitor'): {
-            'fe:a3:a3:da:2d:40',
-        },
-        ServiceGroup('dumb_service', 'other', 'block'): {
-            'fe:a3:a3:da:2d:30',
-            'fe:a3:a3:da:2d:31',
-        },
-    }
+        )
+    return service_groups
 
 
 def ensure_internet_chain():
@@ -118,13 +175,13 @@ def ensure_internet_chain():
     )
 
 
-def ensure_service_chains():
+def ensure_service_chains(soa_dir):
     """Ensure service chains exist and have the right rules.
 
     Returns dictionary {[service chain] => [list of mac addresses]}.
     """
     chains = {}
-    for service, macs in active_service_groups().items():
+    for service, macs in active_service_groups(soa_dir).items():
         service.update_rules()
         chains[service.chain_name] = macs
     return chains
@@ -171,9 +228,9 @@ def garbage_collect_old_service_chains(desired_chains):
         iptables.delete_chain(chain)
 
 
-def general_update():
+def general_update(soa_dir):
     """Update iptables to match the current PaaSTA state."""
     ensure_internet_chain()
-    service_chains = ensure_service_chains()
+    service_chains = ensure_service_chains(soa_dir)
     ensure_dispatch_chains(service_chains)
     garbage_collect_old_service_chains(service_chains)

--- a/paasta_tools/firewall_update.py
+++ b/paasta_tools/firewall_update.py
@@ -15,11 +15,8 @@ from inotify.constants import IN_MOVED_TO
 
 from paasta_tools import firewall
 from paasta_tools.chronos_tools import chronos_services_running_here
-from paasta_tools.chronos_tools import load_chronos_job_config
-from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.marathon_tools import marathon_services_running_here
 from paasta_tools.utils import DEFAULT_SOA_DIR
-from paasta_tools.utils import load_system_paasta_config
 
 log = logging.getLogger(__name__)
 
@@ -79,7 +76,7 @@ def run_daemon(args):
 
 
 def run_cron(args):
-    firewall.general_update()
+    firewall.general_update(args.soa_dir)
 
 
 def process_inotify_event(event, services_by_dependencies):
@@ -95,16 +92,12 @@ def process_inotify_event(event, services_by_dependencies):
 
 
 def services_running_here(soa_dir):
-    # Generator helper that yields (service, instance, config) of both marathon and chronos tasks
-    cluster = load_system_paasta_config().get_cluster()
-
+    # Generator helper that yields (service, instance, framework) of both marathon and chronos tasks
     for service, instance, port in marathon_services_running_here():
-        config = load_marathon_service_config(service, instance, cluster, load_deployments=False, soa_dir=soa_dir)
-        yield service, instance, config
+        yield service, instance, 'marathon'
 
     for service, instance, port in chronos_services_running_here():
-        config = load_chronos_job_config(service, instance, cluster, load_deployments=False, soa_dir=soa_dir)
-        yield service, instance, config
+        yield service, instance, 'chronos'
 
 
 def smartstack_dependencies_of_running_firewalled_services(soa_dir=DEFAULT_SOA_DIR):

--- a/paasta_tools/smartstack_tools.py
+++ b/paasta_tools/smartstack_tools.py
@@ -182,7 +182,7 @@ def get_replication_for_services(synapse_host, synapse_port, synapse_haproxy_url
     This check is intended to be used with an haproxy load balancer, and
     relies on the implementation details of that choice.
 
-    :param synapse_host: The hose that this check should contact for replication information.
+    :param synapse_host: The host that this check should contact for replication information.
     :param synapse_port: The port number that this check should contact for replication information.
     :param synapse_haproxy_url_format: The format of the synapse haproxy URL.
     :param services: A list of strings that are the service names

--- a/tests/test_firewall_update.py
+++ b/tests/test_firewall_update.py
@@ -67,15 +67,66 @@ def test_parse_args_default_cron():
     assert not args.verbose
 
 
-@mock.patch.object(firewall_update, 'load_system_paasta_config', autospec=True)
-@mock.patch.object(firewall_update, 'marathon_services_running_here', autospec=True)
-@mock.patch.object(firewall_update, 'chronos_services_running_here', autospec=True)
-def test_smartstack_dependencies_of_running_firewalled_services(
-        chronos_services_running_mock,
-        marathon_services_running_mock,
-        paasta_config_mock,
-        tmpdir):
-    paasta_config_mock.return_value.get_cluster.return_value = 'mycluster'
+@pytest.yield_fixture
+def mock_get_running_mesos_docker_containers():
+    with mock.patch.object(
+        firewall_update, 'get_running_mesos_docker_containers', autospec=True,
+        return_value=[
+            {
+                'HostConfig': {'NetworkMode': 'bridge'},
+                'Labels': {
+                    'paasta_service': 'myservice',
+                    'paasta_instance': 'hassecurity',
+                },
+                'NetworkSettings': {
+                    'Networks': {
+                        'bridge': {'MacAddress': '02:42:a9:fe:00:0a'},
+                    },
+                },
+            },
+            {
+                'HostConfig': {'NetworkMode': 'bridge'},
+                'Labels': {
+                    'paasta_service': 'myservice',
+                    'paasta_instance': 'chronoswithsecurity',
+                },
+                'NetworkSettings': {
+                    'Networks': {
+                        'bridge': {'MacAddress': '02:42:a9:fe:00:0b'},
+                    },
+                },
+            },
+            # host networking
+            {
+                'HostConfig': {'NetworkMode': 'host'},
+                'Labels': {
+                    'paasta_service': 'myservice',
+                    'paasta_instance': 'batch',
+                },
+            },
+            # no labels
+            {
+                'HostConfig': {'NetworkMode': 'bridge'},
+                'Labels': {},
+            },
+        ],
+    ):
+        yield
+
+
+@pytest.mark.usefixtures('mock_get_running_mesos_docker_containers')
+def test_services_running_here():
+    assert tuple(firewall_update.services_running_here()) == (
+        ('myservice', 'hassecurity', '02:42:a9:fe:00:0a'),
+        ('myservice', 'chronoswithsecurity', '02:42:a9:fe:00:0b'),
+    )
+
+
+@pytest.mark.usefixtures('mock_get_running_mesos_docker_containers')
+@mock.patch.object(firewall_update, 'load_system_paasta_config', return_value=mock.Mock(**{
+    'get_cluster.return_value': 'mycluster',
+}))
+def test_smartstack_dependencies_of_running_firewalled_services(_, tmpdir):
     soa_dir = tmpdir.mkdir('yelpsoa')
     myservice_dir = soa_dir.mkdir('myservice')
 
@@ -110,16 +161,6 @@ def test_smartstack_dependencies_of_running_firewalled_services(
         ]
     }
     myservice_dir.join('dependencies.yaml').write(yaml.safe_dump(dependencies_config))
-
-    marathon_services_running_mock.return_value = [
-        ('myservice', 'hassecurity', 0),
-        ('myservice', 'hassecurity', 0),
-        ('myservice', 'nosecurity', 0),
-    ]
-
-    chronos_services_running_mock.return_value = [
-        ('myservice', 'chronoswithsecurity', 0),
-    ]
 
     result = firewall_update.smartstack_dependencies_of_running_firewalled_services(soa_dir=str(soa_dir))
     assert dict(result) == {


### PR DESCRIPTION
This gets the cronjob correctly applying rules, with the exception of still using fake mac addresses. You can see it in action on `mesos1-uswest1cdevc`, where I'm running instances of `example_happyhour` and `robj-test-service` in both monitor and block mode. (Try e.g. `sudo iptables-save` to see the rules it's set.)

It supports the `internet` well-known name, allowing access to smartstack (but currently only via yocalhost), and monitor/block mode.

#### todo
* [x] use real MAC addresses for instances
* [x] fix/write tests