### PR TITLE
Fix deployd watcher NoDockerImage exception

### DIFF
--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -25,6 +25,7 @@ from paasta_tools.mesos_maintenance import get_draining_hosts
 from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import list_all_instances_for_service
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import PATH_TO_SYSTEM_PAASTA_CONFIG_DIR
 
 
@@ -242,7 +243,11 @@ def get_service_instances_with_changed_id(marathon_client, instances, cluster):
                                               instance=instance,
                                               cluster=cluster,
                                               soa_dir=DEFAULT_SOA_DIR)
-        if config.format_marathon_app_dict()['id'] not in marathon_app_ids:
+        try:
+            config_app_id = config.format_marathon_app_dict()['id']
+        except NoDockerImageError:
+            config_app_id = None
+        if not config_app_id or (config_app_id not in marathon_app_ids):
             service_instances.append((service, instance))
     return service_instances
 

--- a/tests/deployd/test_watchers.py
+++ b/tests/deployd/test_watchers.py
@@ -9,6 +9,7 @@ from pytest import raises
 
 from paasta_tools.deployd.common import ServiceInstance
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import NoDockerImageError
 
 
 class FakePyinotify(object):  # pragma: no cover
@@ -423,6 +424,12 @@ def test_get_service_instances_with_changed_id():
                            soa_dir=DEFAULT_SOA_DIR)]
         mock_load_marathon_service_config.assert_has_calls(calls)
         assert ret == [('universe', 'c138')]
+
+        mock_configs = [mock.Mock(format_marathon_app_dict=mock.Mock(side_effect=NoDockerImageError)),
+                        mock.Mock(format_marathon_app_dict=mock.Mock(return_value={'id': 'universe.c138.c2.g2'}))]
+        mock_load_marathon_service_config.side_effect = mock_configs
+        ret = get_service_instances_with_changed_id(mock.Mock(), mock_service_instances, 'westeros-prod')
+        assert ret == [('universe', 'c137'), ('universe', 'c138')]
 
 
 class TestYelpSoaEventHandler(unittest.TestCase):


### PR DESCRIPTION
Catch this exception when checking the marathon app id.