### PR TITLE
Fix paasta labels from being removed from marathon config

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -19,6 +19,7 @@ make the PaaSTA stack work.
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import copy
 import datetime
 import json
 import logging
@@ -412,7 +413,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         :param config: complete_config hash to sanitize
         :returns: sanitized copy of complete_config hash
         """
-        ahash = {key: value for key, value in config.items() if key not in CONFIG_HASH_BLACKLIST}
+        ahash = {key: copy.deepcopy(value) for key, value in config.items() if key not in CONFIG_HASH_BLACKLIST}
         ahash['container']['docker']['parameters'] = self.format_docker_parameters(with_labels=False)
         return ahash
 

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -878,6 +878,8 @@ class TestMarathonTools:
                         {'key': 'memory-swap', 'value': "%sm" % int(fake_mem)},
                         {"key": "cpu-period", "value": "%s" % int(fake_period)},
                         {"key": "cpu-quota", "value": "%s" % int(fake_cpu_quota)},
+                        {"key": "label", "value": "paasta_service=can_you_dig_it"},
+                        {"key": "label", "value": "paasta_instance=yes_i_can"},
                     ]
                 },
                 'type': 'DOCKER',
@@ -1946,6 +1948,8 @@ def test_format_marathon_app_dict_no_smartstack():
                         {'key': 'memory-swap', 'value': '1024m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '250000'},
+                        {"key": "label", "value": 'paasta_service=service'},
+                        {"key": "label", "value": 'paasta_instance=instance'},
                     ]
                 },
                 'type': 'DOCKER',
@@ -2011,6 +2015,8 @@ def test_format_marathon_app_dict_with_smartstack():
                         {'key': 'memory-swap', 'value': '1024m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '250000'},
+                        {"key": "label", "value": 'paasta_service=service'},
+                        {"key": "label", "value": 'paasta_instance=instance'},
                     ]
                 },
                 'type': 'DOCKER',
@@ -2138,6 +2144,8 @@ def test_format_marathon_app_dict_utilizes_extra_volumes():
                         {'key': 'memory-swap', 'value': '1024m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '250000'},
+                        {"key": "label", "value": 'paasta_service=service'},
+                        {"key": "label", "value": 'paasta_instance=instance'},
                     ]
                 },
                 'type': 'DOCKER',


### PR DESCRIPTION
sanitize_for_config_hash() accidentally modifies the input dictionary, resulting in paasta labels being stripped from marathon configs