### PR TITLE
Catch ValueErrors in processing {white,black}lists

### DIFF
--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -597,9 +597,14 @@ def slave_passes_blacklist(slave, blacklist):
     :returns: boolean, True if the slave gets passed the blacklist
     """
     attributes = slave['attributes']
-    for location_type, location in blacklist:
-        if attributes.get(location_type) == location:
-            return False
+    try:
+        for location_type, location in blacklist:
+            if attributes.get(location_type) == location:
+                return False
+    except ValueError as e:
+        log.error("Slave %s had errors processing the following blacklist: %s" % (slave, blacklist))
+        log.error("I will assume the slave does not pass\nError was: %s" % e)
+        return False
     return True
 
 
@@ -612,10 +617,15 @@ def slave_passes_whitelist(slave, whitelist):
     # No whitelist, so disable whitelisting behaviour.
     if len(whitelist) == 0:
         return True
-    attributes = slave["attributes"]
-    (location_type, locations) = whitelist
-    if attributes.get(location_type) in locations:
-        return True
+    try:
+        attributes = slave["attributes"]
+        (location_type, locations) = whitelist
+        if attributes.get(location_type) in locations:
+            return True
+    except ValueError as e:
+        log.error("Slave %s had errors processing the following whitelist: %s" % (slave, whitelist))
+        log.error("I will assume the slave does not pass\nError was: %s" % e)
+        return False
     return False
 
 


### PR DESCRIPTION
Currently, passing a bad {white,black}list will cause the autoscaler to crash. This PR will catch this kind of ValueError, assume the slave does NOT pass, logs, and continues.

Question: is this assumption sound? Or would it be better to assume it passes the lists?