### PR TITLE
Refactor get_draining_hosts

### DIFF
--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -53,6 +53,7 @@ import pysensu_yelp
 import requests_cache
 from marathon.exceptions import MarathonHttpError
 from requests.exceptions import HTTPError
+from requests.exceptions import ReadTimeout
 
 from paasta_tools import bounce_lib
 from paasta_tools import drain_lib
@@ -314,7 +315,7 @@ def do_bounce(
 
 
 def get_tasks_by_state_for_app(app, drain_method, service, nerve_ns, bounce_health_params,
-                               system_paasta_config, log_deploy_error):
+                               system_paasta_config, log_deploy_error, draining_hosts):
     tasks_by_state = {
         'happy': set(),
         'unhappy': set(),
@@ -323,7 +324,6 @@ def get_tasks_by_state_for_app(app, drain_method, service, nerve_ns, bounce_heal
     }
 
     happy_tasks = bounce_lib.get_happy_tasks(app, service, nerve_ns, system_paasta_config, **bounce_health_params)
-    draining_hosts = get_draining_hosts()
     for task in app.tasks:
         try:
             is_draining = drain_method.is_draining(task)
@@ -349,7 +349,7 @@ def get_tasks_by_state_for_app(app, drain_method, service, nerve_ns, bounce_heal
 
 
 def get_tasks_by_state(other_apps, drain_method, service, nerve_ns, bounce_health_params,
-                       system_paasta_config, log_deploy_error):
+                       system_paasta_config, log_deploy_error, draining_hosts):
     """Split tasks from old apps into 4 categories:
       - live (not draining) and happy (according to get_happy_tasks)
       - live (not draining) and unhappy
@@ -372,6 +372,7 @@ def get_tasks_by_state(other_apps, drain_method, service, nerve_ns, bounce_healt
             bounce_health_params=bounce_health_params,
             system_paasta_config=system_paasta_config,
             log_deploy_error=log_deploy_error,
+            draining_hosts=draining_hosts,
         )
 
         old_app_live_happy_tasks[app.id] = tasks_by_state['happy']
@@ -465,6 +466,12 @@ def deploy_service(
         log_deploy_error(errormsg)
         return (1, errormsg, None)
 
+    try:
+        draining_hosts = get_draining_hosts()
+    except ReadTimeout as e:
+        errormsg = "ReadTimeout encountered trying to get draining hosts: %s" % e
+        return (1, errormsg, 60)
+
     (old_app_live_happy_tasks,
      old_app_live_unhappy_tasks,
      old_app_draining_tasks,
@@ -477,11 +484,12 @@ def deploy_service(
         bounce_health_params=bounce_health_params,
         system_paasta_config=system_paasta_config,
         log_deploy_error=log_deploy_error,
+        draining_hosts=draining_hosts,
     )
 
     num_at_risk_tasks = 0
     if new_app_running:
-        num_at_risk_tasks = get_num_at_risk_tasks(new_app, draining_hosts=get_draining_hosts())
+        num_at_risk_tasks = get_num_at_risk_tasks(new_app, draining_hosts=draining_hosts)
         if new_app.instances < config['instances'] + num_at_risk_tasks:
             log.info("Scaling %s from %d to %d instances." %
                      (new_app.id, new_app.instances, config['instances'] + num_at_risk_tasks))
@@ -498,6 +506,7 @@ def deploy_service(
                 bounce_health_params=bounce_health_params,
                 system_paasta_config=system_paasta_config,
                 log_deploy_error=log_deploy_error,
+                draining_hosts=draining_hosts,
             )
             scaling_app_happy_tasks = list(task_dict['happy'])
             scaling_app_unhappy_tasks = list(task_dict['unhappy'])

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -1552,6 +1552,7 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
                 bounce_health_params={},
                 system_paasta_config=fake_system_paasta_config,
                 log_deploy_error=None,
+                draining_hosts=[],
             )
         actual_live_happy_tasks, actual_live_unhappy_tasks, actual_draining_tasks, actual_at_risk_tasks = actual
         assert actual_live_happy_tasks == expected_live_happy_tasks
@@ -1615,6 +1616,7 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
                 bounce_health_params={},
                 system_paasta_config=fake_system_paasta_config,
                 log_deploy_error=None,
+                draining_hosts=[],
             )
         actual_live_happy_tasks, actual_live_unhappy_tasks, actual_draining_tasks, actual_at_risk_tasks = actual
         assert actual_live_happy_tasks == expected_live_happy_tasks


### PR DESCRIPTION
Only call get_draining_hosts once per bounce, and handle a potential ReadTimeout exception by failing out with an error message, and retrying the bounce again in 60 seconds