### PR TITLE
Skip check for existing image in example cluster

### DIFF
--- a/docs/source/installation/example_cluster.rst
+++ b/docs/source/installation/example_cluster.rst
@@ -37,7 +37,7 @@ the playground container:
     git clone root@git:dockercloud-hello-world
     cd dockercloud-hello-world
     paasta itest -s hello-world -c `git rev-parse HEAD`
-    paasta push-to-registry -s hello-world -c `git rev-parse HEAD`
+    paasta push-to-registry -s hello-world -c `git rev-parse HEAD` --force
     paasta mark-for-deployment --git-url root@git:dockercloud-hello-world --commit `git rev-parse HEAD` --clusterinstance testcluster.everything --service hello-world
 
 This mimics what jenkins would do to deploy a PaaSTA service. If you end

--- a/example_cluster/tests/start-new-service.sh
+++ b/example_cluster/tests/start-new-service.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 paasta itest -s hello-world -c `git rev-parse HEAD`
-paasta push-to-registry -s hello-world -c `git rev-parse HEAD`
+paasta push-to-registry -s hello-world -c `git rev-parse HEAD` --force
 paasta mark-for-deployment --git-url root@git:dockercloud-hello-world --commit `git rev-parse HEAD` --clusterinstance testcluster.everything --service hello-world


### PR DESCRIPTION
We can't do this check in the example cluster because the registry URL
is "wrong". The registry has to be listed as localhost because it is
local to where the daemon is running. However localhost from the cli
tools does not resolve to the docker host and so we get a connection
error. Skipping the check with --force works fine.

@philipmulcahy: @Rob-Johnson and I worked out all we need to do is add `--force`!