### PR TITLE
let autoscaler measure capacity at region level instead of superregion

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -196,14 +196,14 @@ class ClusterAutoscaler(ResourceLogMixin):
                     current_instances, expected_instances, MISSING_SLAVE_PANIC_THRESHOLD)
                 raise ClusterAutoscalingError(error_message)
 
-        pool_utilization_dict = get_resource_utilization_by_grouping(
-            lambda slave: slave['attributes']['pool'],
+        region_pool_utilization_dict = get_resource_utilization_by_grouping(
+            lambda slave: (slave['attributes']['pool'], slave['attributes']['datacenter'],),
             mesos_state
-        )[self.resource['pool']]
+        )[(self.resource['pool'], self.resource['region'],)]
 
-        self.log.debug(pool_utilization_dict)
-        free_pool_resources = pool_utilization_dict['free']
-        total_pool_resources = pool_utilization_dict['total']
+        self.log.debug(region_pool_utilization_dict)
+        free_pool_resources = region_pool_utilization_dict['free']
+        total_pool_resources = region_pool_utilization_dict['total']
         utilization = 1.0 - min([
             float(float(pair[0]) / float(pair[1]))
             for pair in zip(free_pool_resources, total_pool_resources)

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -1226,7 +1226,7 @@ class TestClusterAutoscaler(unittest.TestCase):
                                            {'attributes': {'pool': 'default'}}]}
             mock_utilization = {'free': ResourceInfo(cpus=7.0, mem=2048.0, disk=30.0),
                                 'total': ResourceInfo(cpus=10.0, mem=4096.0, disk=40.0)}
-            mock_get_resource_utilization_by_grouping.return_value = {'default': mock_utilization}
+            mock_get_resource_utilization_by_grouping.return_value = {('default','westeros-1'): mock_utilization}
             self.autoscaler.pool_settings = {'target_utilization': 0.8}
 
             ret = self.autoscaler.get_mesos_utilization_error(

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -1226,7 +1226,7 @@ class TestClusterAutoscaler(unittest.TestCase):
                                            {'attributes': {'pool': 'default'}}]}
             mock_utilization = {'free': ResourceInfo(cpus=7.0, mem=2048.0, disk=30.0),
                                 'total': ResourceInfo(cpus=10.0, mem=4096.0, disk=40.0)}
-            mock_get_resource_utilization_by_grouping.return_value = {('default','westeros-1'): mock_utilization}
+            mock_get_resource_utilization_by_grouping.return_value = {('default', 'westeros-1'): mock_utilization}
             self.autoscaler.pool_settings = {'target_utilization': 0.8}
 
             ret = self.autoscaler.get_mesos_utilization_error(


### PR DESCRIPTION
PAASTA-7692

Could it be as simple as this? 'region' vs 'datacenter' confusion is because slave attributes have datacenter=us-west-1, while autoscaler config (from S3) has region=us-west-1.

@solarkennedy @mattmb 