### PR TITLE
Make firewall cronjob parse dependencies correctly

### DIFF
--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -113,12 +113,10 @@ def mock_service_config():
         return_value={'example_happyhour.main': {'proxy_port': '20000'}},
     ):
         m.return_value = mock.Mock()
-        m.return_value.get_dependencies.return_value = {
-            'well-known': ('internet',),
-            'smartstack': (
-                'example_happyhour.main',
-            ),
-        }
+        m.return_value.get_dependencies.return_value = [
+            {'well-known': 'internet'},
+            {'smartstack': 'example_happyhour.main'},
+        ]
         m.return_value.get_outbound_firewall.return_value = 'monitor'
         yield
 


### PR DESCRIPTION
It was expecting a format like this:

```yaml
main:
    smartstack: ['npm.main', 'pypi.main']
    well-known: ['internet']
```

instead we're using this format:

```yaml
main:
    - smartstack: npm.main
    - smartstack: pypi.main
    - well-known: internet
```