### PR TITLE
Add support for logging with prefix and limits

### DIFF
--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -170,14 +170,17 @@ def services_running_here():
         if service is None or instance is None:
             continue
 
-        mac = container['NetworkSettings']['Networks']['bridge']['MacAddress']
-        yield service, instance, mac
+        network_info = container['NetworkSettings']['Networks']['bridge']
+
+        mac = network_info['MacAddress']
+        ip = network_info['IPAddress']
+        yield service, instance, mac, ip
 
 
 def active_service_groups(soa_dir):
     """Return active service groups."""
     service_groups = collections.defaultdict(set)
-    for service, instance, mac in services_running_here():
+    for service, instance, mac, ip in services_running_here():
         service_groups[ServiceGroup(service, instance, soa_dir)].add(mac)
     return service_groups
 

--- a/paasta_tools/firewall_logging.py
+++ b/paasta_tools/firewall_logging.py
@@ -57,7 +57,7 @@ def syslog_to_paasta_log(data, cluster):
 
 def parse_syslog(data):
     parsed_data = syslogmp.parse(data)
-    full_message = parsed_data.message
+    full_message = parsed_data.message.decode()
 
     if not full_message.startswith('kernel: ['):
         # Not a kernel message

--- a/paasta_tools/firewall_logging.py
+++ b/paasta_tools/firewall_logging.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import logging
+
+import syslogmp
+from six.moves import socketserver
+
+from paasta_tools.firewall import services_running_here
+from paasta_tools.utils import _log
+from paasta_tools.utils import configure_log
+from paasta_tools.utils import load_system_paasta_config
+
+
+log = logging.getLogger(__name__)
+
+
+class SyslogUDPHandler(socketserver.BaseRequestHandler):
+    def setup(self):
+        configure_log()
+        self.cluster = load_system_paasta_config().get_cluster()
+
+    def handle(self):
+        data, socket = self.request
+        syslog_to_paasta_log(data, self.cluster)
+
+
+def syslog_to_paasta_log(data, cluster):
+    iptables_log = parse_syslog(data)
+    if iptables_log is None:
+        return
+
+    service, instance = lookup_service_instance_by_ip(iptables_log['SRC'])
+    if service is None or instance is None:
+        return
+
+    # prepend hostname
+    log_line = iptables_log['hostname'] + ': ' + iptables_log['message']
+
+    _log(
+        service=service,
+        component='security',
+        level='debug',
+        cluster=cluster,
+        instance=instance,
+        line=log_line,
+    )
+
+
+def parse_syslog(data):
+    parsed_data = syslogmp.parse(data)
+    full_message = parsed_data.message
+
+    if not full_message.startswith('kernel: ['):
+        # Not a kernel message
+        return None
+
+    close_bracket = full_message.find(']')
+    if close_bracket == -1:
+        return None
+
+    iptables_message = full_message[close_bracket + 1:].strip()
+    parts = iptables_message.split(' ')
+
+    # parts[0] is the log-prefix
+    # parts[1..] is either KEY=VALUE or just KEY
+    if not parts[1].startswith('IN='):
+        # not an iptables message
+        return None
+
+    fields = {k: v for k, _, v in (field.partition('=') for field in parts[1:])}
+
+    fields['hostname'] = parsed_data.hostname
+    fields['message'] = iptables_message
+    return fields
+
+
+def lookup_service_instance_by_ip(ip_lookup):
+    for service, instance, mac, ip in services_running_here():
+        if ip == ip_lookup:
+            return (service, instance)
+    log.info('Unable to find container for ip {}'.format(ip_lookup))
+    return (None, None)
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description='Adapts iptables syslog messages into scribe')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        dest="verbose", default=False)
+    parser.add_argument('-l', '--listen-host', help='Default %(default)s', default='127.0.0.1')
+    parser.add_argument('-p', '--listen-port', type=int, help='Default %(default)s', default=1516)
+    args = parser.parse_args(argv)
+    return args
+
+
+def setup_logging(verbose):
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
+
+def run_server(listen_host, listen_port):
+    server = socketserver.UDPServer((listen_host, listen_port), SyslogUDPHandler)
+    server.serve_forever()
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    setup_logging(args.verbose)
+    run_server(args.listen_host, args.listen_port)

--- a/paasta_tools/firewall_logging.py
+++ b/paasta_tools/firewall_logging.py
@@ -57,7 +57,10 @@ def syslog_to_paasta_log(data, cluster):
 
 def parse_syslog(data):
     parsed_data = syslogmp.parse(data)
-    full_message = parsed_data.message.decode()
+    try:
+        full_message = parsed_data.message.decode()
+    except UnicodeDecodeError:
+        return None
 
     if not full_message.startswith('kernel: ['):
         # Not a kernel message

--- a/paasta_tools/firewall_update.py
+++ b/paasta_tools/firewall_update.py
@@ -93,7 +93,7 @@ def process_inotify_event(event, services_by_dependencies):
 
 def smartstack_dependencies_of_running_firewalled_services(soa_dir=DEFAULT_SOA_DIR):
     dependencies_to_services = defaultdict(set)
-    for service, instance, _ in firewall.services_running_here():
+    for service, instance, _, _ in firewall.services_running_here():
         config = get_instance_config(
             service, instance,
             load_system_paasta_config().get_cluster(),

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -664,6 +664,10 @@ LOG_COMPONENTS = OrderedDict([
         'color': PaastaColors.yellow,
         'help': 'Stderr from the process spawned by Mesos.',
     }),
+    ('security', {
+        'color': PaastaColors.red,
+        'help': 'Logs from security-related services such as firewall monitoring',
+    }),
     # I'm leaving these planned components here since they provide some hints
     # about where we want to go. See PAASTA-78.
     #

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ retry==0.9.2
 service-configuration-lib==0.12.0
 simplejson==3.10.0
 six>=1.9.0
+syslogmp==0.2.2
 thriftpy==0.1.15
 ujson==1.35
 websocket-client==0.32.0

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         # We install this from git
         # 'sensu-plugin >= 0.2.0',
         'service-configuration-lib >= 0.12.0',
+        'syslogmp',
         'ujson == 1.35',
         'yelp-clog >= 2.7.2',
     ],
@@ -114,6 +115,7 @@ setup(
             'paasta_cleanup_maintenance=paasta_tools.cleanup_maintenance:main',
             'paasta_docker_wrapper=paasta_tools.docker_wrapper:main',
             'paasta_firewall_update=paasta_tools.firewall_update:main',
+            'paasta_firewall_logging=paasta_tools.firewall_logging:main',
         ],
         'paste.app_factory': [
             'paasta-api-config=paasta_tools.api.api:make_app'

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -42,7 +42,10 @@ def mock_get_running_mesos_docker_containers():
                 },
                 'NetworkSettings': {
                     'Networks': {
-                        'bridge': {'MacAddress': '02:42:a9:fe:00:0a'},
+                        'bridge': {
+                            'MacAddress': '02:42:a9:fe:00:0a',
+                            'IPAddress': '1.1.1.1'
+                        },
                     },
                 },
             },
@@ -54,7 +57,10 @@ def mock_get_running_mesos_docker_containers():
                 },
                 'NetworkSettings': {
                     'Networks': {
-                        'bridge': {'MacAddress': '02:42:a9:fe:00:0b'},
+                        'bridge': {
+                            'MacAddress': '02:42:a9:fe:00:0b',
+                            'IPAddress': '2.2.2.2'
+                        },
                     },
                 },
             },
@@ -79,8 +85,8 @@ def mock_get_running_mesos_docker_containers():
 @pytest.mark.usefixtures('mock_get_running_mesos_docker_containers')
 def test_services_running_here():
     assert tuple(firewall.services_running_here()) == (
-        ('myservice', 'hassecurity', '02:42:a9:fe:00:0a'),
-        ('myservice', 'chronoswithsecurity', '02:42:a9:fe:00:0b'),
+        ('myservice', 'hassecurity', '02:42:a9:fe:00:0a', '1.1.1.1'),
+        ('myservice', 'chronoswithsecurity', '02:42:a9:fe:00:0b', '2.2.2.2'),
     )
 
 
@@ -89,11 +95,11 @@ def mock_services_running_here():
     with mock.patch.object(
         firewall, 'services_running_here', autospec=True,
         side_effect=lambda: iter((
-            ('example_happyhour', 'main', '02:42:a9:fe:00:00'),
-            ('example_happyhour', 'main', '02:42:a9:fe:00:01'),
-            ('example_happyhour', 'batch', '02:42:a9:fe:00:02'),
-            ('my_cool_service', 'web', '02:42:a9:fe:00:03'),
-            ('my_cool_service', 'web', '02:42:a9:fe:00:04'),
+            ('example_happyhour', 'main', '02:42:a9:fe:00:00', '1.1.1.1'),
+            ('example_happyhour', 'main', '02:42:a9:fe:00:01', '2.2.2.2'),
+            ('example_happyhour', 'batch', '02:42:a9:fe:00:02', '3.3.3.3'),
+            ('my_cool_service', 'web', '02:42:a9:fe:00:03', '4.4.4.4'),
+            ('my_cool_service', 'web', '02:42:a9:fe:00:04', '5.5.5.5'),
         )),
     ):
         yield

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -16,6 +16,7 @@ EMPTY_RULE = iptables.Rule(
     dst='0.0.0.0/0.0.0.0',
     target=None,
     matches=(),
+    target_parameters=(),
 )
 
 
@@ -118,12 +119,21 @@ def mock_service_config():
             {'smartstack': 'example_happyhour.main'},
         ]
         m.return_value.get_outbound_firewall.return_value = 'monitor'
+        m.return_value.log_prefix = 'my-log-prefix '
         yield
 
 
 def test_service_group_rules(mock_service_config, service_group):
     assert service_group.rules == (
-        EMPTY_RULE._replace(target='LOG'),
+        EMPTY_RULE._replace(
+            target='LOG',
+            matches=(
+                ('limit', (('limit', '1/sec'),)),
+            ),
+            target_parameters=(
+                ('log-prefix', ('my-log-prefix ',)),
+            ),
+        ),
         EMPTY_RULE._replace(target='PAASTA-INTERNET'),
         EMPTY_RULE._replace(
             protocol='tcp',

--- a/tests/test_firewall_logging.py
+++ b/tests/test_firewall_logging.py
@@ -35,6 +35,10 @@ def test_syslog_to_paasta_log_no_container(mock_lookup_service_instance_by_ip, m
     assert mock_log.mock_calls == []
 
 
+def test_parse_syslog_undecodable():
+    assert firewall_logging.parse_syslog(b'<4>Jun  6 07:52:38 myhost \xba~\xa6r') is None
+
+
 @pytest.mark.parametrize('syslog_data', [
     '<4>Jun  6 07:52:38 myhost someothermessage: hello world',
     '<4>Jun  6 07:52:38 myhost kernel: hello world',

--- a/tests/test_firewall_logging.py
+++ b/tests/test_firewall_logging.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from paasta_tools import firewall_logging
+
+
+@mock.patch.object(firewall_logging, 'lookup_service_instance_by_ip')
+def test_syslog_to_paasta_log(mock_lookup_service_instance_by_ip, mock_log):
+    syslog_data = fake_syslog_data('my-hostname', SRC='1.2.3.4')
+    mock_lookup_service_instance_by_ip.return_value = ('myservice', 'myinstance')
+
+    firewall_logging.syslog_to_paasta_log(syslog_data, 'my-cluster')
+
+    assert mock_log.mock_calls == [
+        mock.call(
+            service='myservice',
+            component='security',
+            level='debug',
+            cluster='my-cluster',
+            instance='myinstance',
+            line='my-hostname: my-prefix IN=docker0 SRC=1.2.3.4'
+        )
+    ]
+
+
+@mock.patch.object(firewall_logging, 'lookup_service_instance_by_ip')
+def test_syslog_to_paasta_log_no_container(mock_lookup_service_instance_by_ip, mock_log):
+    syslog_data = fake_syslog_data('my-hostname', SRC='1.2.3.4')
+    mock_lookup_service_instance_by_ip.return_value = (None, None)
+    firewall_logging.syslog_to_paasta_log(syslog_data, 'my-cluster')
+    assert mock_log.mock_calls == []
+
+
+@pytest.mark.parametrize('syslog_data', [
+    '<4>Jun  6 07:52:38 myhost someothermessage: hello world',
+    '<4>Jun  6 07:52:38 myhost kernel: hello world',
+    '<4>Jun  6 07:52:38 myhost kernel [0.0]: hello world',
+])
+@mock.patch.object(firewall_logging, 'lookup_service_instance_by_ip')
+def test_syslog_to_paasta_log_bad_message(mock_lookup_service_instance_by_ip, syslog_data, mock_log):
+    firewall_logging.syslog_to_paasta_log(syslog_data.encode(), 'my-cluster')
+    assert mock_lookup_service_instance_by_ip.mock_calls == []
+    assert mock_log.mock_calls == []
+
+
+@mock.patch.object(firewall_logging, 'services_running_here', return_value=[
+    ('service1', 'instance1', '00:00:00:00:00', '1.1.1.1'),
+    ('service1', 'instance2', '00:00:00:00:00', '2.2.2.2'),
+])
+@mock.patch.object(firewall_logging, 'log')
+def test_lookup_service_instance_by_ip(my_mock_log, mock_services_running_here):
+    assert firewall_logging.lookup_service_instance_by_ip('1.1.1.1') == ('service1', 'instance1')
+    assert firewall_logging.lookup_service_instance_by_ip('2.2.2.2') == ('service1', 'instance2')
+    assert firewall_logging.lookup_service_instance_by_ip('3.3.3.3') == (None, None)
+    assert my_mock_log.info.mock_calls == [
+        mock.call('Unable to find container for ip 3.3.3.3')
+    ]
+
+
+def test_parse_args():
+    assert firewall_logging.parse_args([]).listen_host == '127.0.0.1'
+    assert firewall_logging.parse_args([]).listen_port == 1516
+    assert firewall_logging.parse_args([]).verbose is False
+    assert firewall_logging.parse_args(['-v']).verbose is True
+    assert firewall_logging.parse_args(['-p', '1234']).listen_port == 1234
+    assert firewall_logging.parse_args(['-l', '0.0.0.0']).listen_host == '0.0.0.0'
+
+
+@mock.patch.object(firewall_logging, 'logging')
+def test_setup_logging(logging_mock):
+    firewall_logging.setup_logging(True)
+    assert logging_mock.basicConfig.mock_calls == [mock.call(level=logging_mock.DEBUG)]
+
+
+@mock.patch.object(firewall_logging, 'socketserver')
+def test_run_server(socketserver_mock):
+    firewall_logging.run_server('myhost', 1234)
+    assert socketserver_mock.UDPServer.mock_calls == [
+        mock.call(('myhost', 1234), firewall_logging.SyslogUDPHandler),
+        mock.call().serve_forever()
+    ]
+
+
+@mock.patch.object(firewall_logging, 'logging')
+@mock.patch.object(firewall_logging, 'socketserver')
+def test_main(socketserver_mock, logging_mock):
+    firewall_logging.main([])
+    assert logging_mock.basicConfig.mock_calls == [mock.call(level=logging_mock.WARNING)]
+    assert socketserver_mock.UDPServer.mock_calls == [
+        mock.call(('127.0.0.1', 1516), firewall_logging.SyslogUDPHandler),
+        mock.call().serve_forever()
+    ]
+
+
+def fake_syslog_data(hostname, **kwargs):
+    prefix = '<4>Jun  6 07:52:38 {} kernel: [2736265.340132] my-prefix IN=docker0 '.format(hostname)
+    fields_str = ' '.join(map('='.join, kwargs.items()))
+    return (prefix + fields_str + ' \n').encode()
+
+
+@pytest.yield_fixture
+def mock_log():
+    with mock.patch.object(firewall_logging, '_log', autospec=True) as mock_log:
+        yield mock_log

--- a/tests/test_firewall_update.py
+++ b/tests/test_firewall_update.py
@@ -76,8 +76,8 @@ def test_parse_args_default_cron():
 @mock.patch.object(
     firewall, 'services_running_here', autospec=True,
     return_value=(
-        ('myservice', 'hassecurity', '02:42:a9:fe:00:0a'),
-        ('myservice', 'chronoswithsecurity', '02:42:a9:fe:00:0b'),
+        ('myservice', 'hassecurity', '02:42:a9:fe:00:0a', '1.1.1.1'),
+        ('myservice', 'chronoswithsecurity', '02:42:a9:fe:00:0b', '2.2.2.2'),
     ),
 )
 def test_smartstack_dependencies_of_running_firewalled_services(_, __, tmpdir):


### PR DESCRIPTION
This adds log-prefix and limit to monitor mode.

target_parameters ended up being a bit trickier than expected because adding a REJECT rule will cause iptables to automatically imply a "--reject-with icmp-port-unreachable" rule. This ends up causing comparison problems when loaded back in. To fix, I require that reject-with always be specified in the case of REJECT.