### PR TITLE
Add soa_dir as field in InstanceConfig and subclasses

### DIFF
--- a/paasta_itests/steps/paasta_native_steps.py
+++ b/paasta_itests/steps/paasta_native_steps.py
@@ -72,6 +72,7 @@ def new_paasta_native_config(context, num):
             'desired_state': 'start',
             'force_bounce': None,
         },
+        soa_dir='/fake/etc/services',
         service_namespace_config=None,
     )
 

--- a/paasta_tools/adhoc_tools.py
+++ b/paasta_tools/adhoc_tools.py
@@ -64,18 +64,20 @@ def load_adhoc_job_config(service, instance, cluster, load_deployments=True, soa
         instance=instance,
         config_dict=general_config,
         branch_dict=branch_dict,
+        soa_dir=soa_dir,
     )
 
 
 class AdhocJobConfig(LongRunningServiceConfig):
 
-    def __init__(self, service, instance, cluster, config_dict, branch_dict):
+    def __init__(self, service, instance, cluster, config_dict, branch_dict, soa_dir=DEFAULT_SOA_DIR):
         super(AdhocJobConfig, self).__init__(
             cluster=cluster,
             instance=instance,
             service=service,
             config_dict=config_dict,
             branch_dict=branch_dict,
+            soa_dir=soa_dir,
         )
 
 
@@ -95,6 +97,7 @@ def get_default_interactive_config(service, cluster, soa_dir, load_deployments=F
             cluster=cluster,
             config_dict={},
             branch_dict={},
+            soa_dir=soa_dir,
         )
     except NoDeploymentsAvailable:
         job_config = load_adhoc_job_config(

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -223,18 +223,20 @@ def load_chronos_job_config(service, instance, cluster, load_deployments=True, s
         instance=instance,
         config_dict=general_config,
         branch_dict=branch_dict,
+        soa_dir=soa_dir,
     )
 
 
 class ChronosJobConfig(InstanceConfig):
 
-    def __init__(self, service, instance, cluster, config_dict, branch_dict):
+    def __init__(self, service, instance, cluster, config_dict, branch_dict, soa_dir=DEFAULT_SOA_DIR):
         super(ChronosJobConfig, self).__init__(
             cluster=cluster,
             instance=instance,
             service=service,
             config_dict=config_dict,
             branch_dict=branch_dict,
+            soa_dir=soa_dir,
         )
 
     def get_service(self):

--- a/paasta_tools/frameworks/native_service_config.py
+++ b/paasta_tools/frameworks/native_service_config.py
@@ -24,7 +24,7 @@ MESOS_TASK_SPACER = '.'
 
 
 class NativeServiceConfig(LongRunningServiceConfig):
-    def __init__(self, service, instance, cluster, config_dict, branch_dict,
+    def __init__(self, service, instance, cluster, config_dict, branch_dict, soa_dir,
                  service_namespace_config=None):
         super(NativeServiceConfig, self).__init__(
             cluster=cluster,
@@ -32,6 +32,7 @@ class NativeServiceConfig(LongRunningServiceConfig):
             service=service,
             config_dict=config_dict,
             branch_dict=branch_dict,
+            soa_dir=soa_dir,
         )
         # service_namespace_config may be omitted/set to None at first, then set
         # after initializing. e.g. we do this in load_paasta_native_job_config
@@ -154,6 +155,7 @@ def load_paasta_native_job_config(
         instance=instance,
         config_dict=instance_config_dict,
         branch_dict=branch_dict,
+        soa_dir=soa_dir,
     )
 
     service_namespace_config = load_service_namespace_config(

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -24,13 +24,14 @@ AUTOSCALING_ZK_ROOT = '/autoscaling'
 
 
 class LongRunningServiceConfig(InstanceConfig):
-    def __init__(self, service, cluster, instance, config_dict, branch_dict):
+    def __init__(self, service, cluster, instance, config_dict, branch_dict, soa_dir=DEFAULT_SOA_DIR):
         super(LongRunningServiceConfig, self).__init__(
             cluster=cluster,
             instance=instance,
             service=service,
             config_dict=config_dict,
             branch_dict=branch_dict,
+            soa_dir=soa_dir,
         )
 
     def get_drain_method(self, service_namespace_config):

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -161,6 +161,7 @@ def load_marathon_service_config(service, instance, cluster, load_deployments=Tr
         instance=instance,
         config_dict=general_config,
         branch_dict=branch_dict,
+        soa_dir=soa_dir,
     )
 
 
@@ -170,22 +171,24 @@ class InvalidMarathonConfig(Exception):
 
 class MarathonServiceConfig(LongRunningServiceConfig):
 
-    def __init__(self, service, cluster, instance, config_dict, branch_dict):
+    def __init__(self, service, cluster, instance, config_dict, branch_dict, soa_dir=DEFAULT_SOA_DIR):
         super(MarathonServiceConfig, self).__init__(
             cluster=cluster,
             instance=instance,
             service=service,
             config_dict=config_dict,
             branch_dict=branch_dict,
+            soa_dir=soa_dir,
         )
 
     def __repr__(self):
-        return "MarathonServiceConfig(%r, %r, %r, %r, %r)" % (
+        return "MarathonServiceConfig(%r, %r, %r, %r, %r, %r)" % (
             self.service,
             self.cluster,
             self.instance,
             self.config_dict,
-            self.branch_dict
+            self.branch_dict,
+            self.soa_dir
         )
 
     def copy(self):
@@ -195,6 +198,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
             cluster=self.cluster,
             config_dict=dict(self.config_dict),
             branch_dict=dict(self.branch_dict),
+            soa_dir=self.soa_dir
         )
 
     def get_autoscaling_params(self):

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -119,12 +119,13 @@ class InvalidInstanceConfig(Exception):
 
 class InstanceConfig(object):
 
-    def __init__(self, cluster, instance, service, config_dict, branch_dict):
+    def __init__(self, cluster, instance, service, config_dict, branch_dict, soa_dir=DEFAULT_SOA_DIR):
         self.config_dict = config_dict
         self.branch_dict = branch_dict
         self.cluster = cluster
         self.instance = instance
         self.service = service
+        self.soa_dir = soa_dir
         config_interpolation_keys = ('deploy_group',)
         interpolation_facts = self.__get_interpolation_facts()
         for key in config_interpolation_keys:

--- a/tests/frameworks/test_adhoc_scheduler.py
+++ b/tests/frameworks/test_adhoc_scheduler.py
@@ -67,6 +67,7 @@ class TestAdhocScheduler(object):
                     'docker_image': 'busybox',
                     'desired_state': 'start',
                 },
+                soa_dir='/nail/etc/services',
             )
         ]
 
@@ -103,6 +104,7 @@ class TestAdhocScheduler(object):
                     'docker_image': 'busybox',
                     'desired_state': 'start',
                 },
+                soa_dir='/nail/etc/services',
             )
         ]
 
@@ -169,6 +171,7 @@ class TestAdhocScheduler(object):
                     'docker_image': 'busybox',
                     'desired_state': 'start',
                 },
+                soa_dir='/nail/etc/services',
             )
         ]
 

--- a/tests/frameworks/test_native_scheduler.py
+++ b/tests/frameworks/test_native_scheduler.py
@@ -71,6 +71,7 @@ class TestNativeScheduler(object):
                     'desired_state': 'start',
                     'force_bounce': str(force_bounce),
                 },
+                soa_dir='/nail/etc/services',
             ))
 
         scheduler = native_scheduler.NativeScheduler(
@@ -181,6 +182,7 @@ class TestNativeScheduler(object):
                 'desired_state': 'start',
                 'force_bounce': '0',
             },
+            soa_dir='/nail/etc/services',
         ))
 
         scheduler = native_scheduler.NativeScheduler(
@@ -228,7 +230,7 @@ class TestNativeScheduler(object):
                 'desired_state': 'start',
                 'force_bounce': '0',
             },
-
+            soa_dir='/nail/etc/services',
         )
 
         scheduler = native_scheduler.NativeScheduler(
@@ -268,6 +270,7 @@ class TestNativeServiceConfig(object):
                 'desired_state': 'start',
                 'force_bounce': '0',
             },
+            soa_dir='/nail/etc/services',
         )
 
         task = service_config.base_task(system_paasta_config)
@@ -334,6 +337,7 @@ class TestNativeServiceConfig(object):
                     'docker_image': 'busybox',
                     'desired_state': 'start',
                 },
+                soa_dir='/nail/etc/services',
             )
         ]
 

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1613,8 +1613,8 @@ class TestMarathonServiceConfig(object):
             str('foo'), str('bar'), str(''),
             {str('baz'): str('baz')}, {str('bubble'): str('gum')}
         ))
-        expected = """MarathonServiceConfig('foo', 'bar', '', {'baz': 'baz'}, {'bubble': 'gum'})"""
-        assert actual == expected
+        expect = """MarathonServiceConfig('foo', 'bar', '', {'baz': 'baz'}, {'bubble': 'gum'}, '/nail/etc/services')"""
+        assert actual == expect
 
     def test_get_healthcheck_mode_default(self):
         namespace_config = long_running_service_tools.ServiceNamespaceConfig({})


### PR DESCRIPTION
While working on allowing per-service docker registries, we noticed that we were missing the soa_dir in some places. This change adds soa_dir as a field in our InstanceConfig objects