### PR TITLE
inotify actually does updates, and include backends in iptables rules

### DIFF
--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -6,6 +6,8 @@ import collections
 import hashlib
 import itertools
 import json
+import logging
+import os.path
 
 import six
 
@@ -23,18 +25,20 @@ PRIVATE_IP_RANGES = (
     '192.168.0.0/255.255.0.0',
     '169.254.0.0/255.255.0.0',
 )
+DEFAULT_SYNAPSE_SERVICE_DIR = b'/var/run/synapse/services'
+
+
+log = logging.getLogger(__name__)
 
 
 class ServiceGroup(collections.namedtuple('ServiceGroup', (
     'service',
     'instance',
-    'soa_dir',
 ))):
     """A service group.
 
     :param service: service name
     :param instance: instance name
-    :param soa_dir: path to yelpsoa-configs
     """
     __slots__ = ()
 
@@ -53,29 +57,24 @@ class ServiceGroup(collections.namedtuple('ServiceGroup', (
         assert len(chain) <= 28, len(chain)
         return chain
 
-    @property
-    def config(self):
-        return get_instance_config(
+    def get_rules(self, soa_dir, synapse_service_dir):
+        conf = get_instance_config(
             self.service, self.instance,
             load_system_paasta_config().get_cluster(),
             load_deployments=False,
-            soa_dir=self.soa_dir,
+            soa_dir=soa_dir,
         )
-
-    @property
-    def rules(self):
-        conf = self.config
 
         if conf.get_dependencies() is None:
             return ()
 
         rules = [_default_rule(conf)]
         rules.extend(_well_known_rules(conf))
-        rules.extend(_smartstack_rules(conf, self.soa_dir))
+        rules.extend(_smartstack_rules(conf, soa_dir, synapse_service_dir))
         return tuple(rules)
 
-    def update_rules(self):
-        iptables.ensure_chain(self.chain_name, self.rules)
+    def update_rules(self, soa_dir, synapse_service_dir):
+        iptables.ensure_chain(self.chain_name, self.get_rules(soa_dir, synapse_service_dir))
 
 
 def _default_rule(conf):
@@ -117,14 +116,42 @@ def _well_known_rules(conf):
             raise AssertionError(resource)
 
 
-def _smartstack_rules(conf, soa_dir):
+def _synapse_backends(synapse_service_dir, namespace):
+    # Return the contents of the synapse JSON file for a particular service namespace
+    # e.g. /var/run/synapse/services/example_happyhour.main.json
+    with open(os.path.join(synapse_service_dir, namespace + '.json')) as synapse_backend_file:
+        synapse_backend_json = json.load(synapse_backend_file)
+        return synapse_backend_json
+
+
+def _smartstack_rules(conf, soa_dir, synapse_service_dir):
     for dep in conf.get_dependencies():
         namespace = dep.get('smartstack')
         if namespace is None:
             continue
 
-        # TODO: handle non-synapse-haproxy services
-        # TODO: support wildcards?
+        # TODO: support wildcards
+
+        # synapse backends
+        try:
+            backends = _synapse_backends(synapse_service_dir, namespace)
+        except (OSError, IOError, ValueError):
+            # Don't fatal if something goes wrong loading the synapse files
+            log.exception('Unable to load backend {}'.format(namespace))
+            backends = ()
+
+        for backend in backends:
+            yield iptables.Rule(
+                protocol='tcp',
+                src='0.0.0.0/0.0.0.0',
+                dst='{}/255.255.255.255'.format(backend['host']),
+                target='ACCEPT',
+                matches=(
+                    ('tcp', (('dport', six.text_type(backend['port'])),)),
+                )
+            )
+
+        # synapse-haproxy proxy_port
         service, _ = namespace.split('.', 1)
         service_namespaces = get_all_namespaces_for_service(service, soa_dir=soa_dir)
         port = dict(service_namespaces)[namespace]['proxy_port']
@@ -158,11 +185,11 @@ def services_running_here():
         yield service, instance, mac
 
 
-def active_service_groups(soa_dir):
+def active_service_groups():
     """Return active service groups."""
     service_groups = collections.defaultdict(set)
     for service, instance, mac in services_running_here():
-        service_groups[ServiceGroup(service, instance, soa_dir)].add(mac)
+        service_groups[ServiceGroup(service, instance)].add(mac)
     return service_groups
 
 
@@ -190,7 +217,7 @@ def ensure_internet_chain():
     )
 
 
-def ensure_service_chains(soa_dir, only_services=None):
+def ensure_service_chains(soa_dir, synapse_service_dir, only_services=None):
     """Ensure service chains exist and have the right rules.
 
     only_services is either None or a set of (service,instance) tuples. If it's
@@ -199,10 +226,10 @@ def ensure_service_chains(soa_dir, only_services=None):
     Returns dictionary {[service chain] => [list of mac addresses]}.
     """
     chains = {}
-    for service, macs in active_service_groups(soa_dir).items():
+    for service, macs in active_service_groups().items():
         if only_services is not None and (service.service, service.instance) not in only_services:
             continue
-        service.update_rules()
+        service.update_rules(soa_dir, synapse_service_dir)
         chains[service.chain_name] = macs
     return chains
 
@@ -248,9 +275,9 @@ def garbage_collect_old_service_chains(desired_chains):
         iptables.delete_chain(chain)
 
 
-def general_update(soa_dir):
+def general_update(soa_dir, synapse_service_dir):
     """Update iptables to match the current PaaSTA state."""
     ensure_internet_chain()
-    service_chains = ensure_service_chains(soa_dir)
+    service_chains = ensure_service_chains(soa_dir, synapse_service_dir)
     ensure_dispatch_chains(service_chains)
     garbage_collect_old_service_chains(service_chains)

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -190,13 +190,18 @@ def ensure_internet_chain():
     )
 
 
-def ensure_service_chains(soa_dir):
+def ensure_service_chains(soa_dir, only_services=None):
     """Ensure service chains exist and have the right rules.
+
+    only_services is either None or a set of (service,instance) tuples. If it's
+    set, only act on things in that set.
 
     Returns dictionary {[service chain] => [list of mac addresses]}.
     """
     chains = {}
     for service, macs in active_service_groups(soa_dir).items():
+        if only_services is not None and (service.service, service.instance) not in only_services:
+            continue
         service.update_rules()
         chains[service.chain_name] = macs
     return chains

--- a/paasta_tools/firewall_update.py
+++ b/paasta_tools/firewall_update.py
@@ -21,7 +21,6 @@ from paasta_tools.utils import load_system_paasta_config
 log = logging.getLogger(__name__)
 
 DEFAULT_UPDATE_SECS = 5
-DEFAULT_SYNAPSE_SERVICE_DIR = b'/var/run/synapse/services'
 
 
 def parse_args(argv):
@@ -29,6 +28,9 @@ def parse_args(argv):
     parser.add_argument('-d', '--soa-dir', dest="soa_dir", metavar="soa_dir",
                         default=DEFAULT_SOA_DIR,
                         help="define a different soa config directory (default %(default)s)")
+    parser.add_argument('--synapse-service-dir', dest="synapse_service_dir",
+                        default=firewall.DEFAULT_SYNAPSE_SERVICE_DIR,
+                        help="Path to synapse service dir (default %(default)s)")
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true')
 
     subparsers = parser.add_subparsers(help='mode to run firewall update in', dest='mode')
@@ -37,9 +39,6 @@ def parse_args(argv):
     daemon_parser = subparsers.add_parser('daemon', description=(
         'Run a daemon which watches updates to synapse backends and updates iptables rules.'
     ))
-    daemon_parser.add_argument('--synapse-service-dir', dest="synapse_service_dir",
-                               default=DEFAULT_SYNAPSE_SERVICE_DIR,
-                               help="Path to synapse service dir (default %(default)s)")
     daemon_parser.add_argument('-u', '--update-secs', dest="update_secs",
                                default=DEFAULT_UPDATE_SECS, type=int,
                                help="Poll for new containers every N secs (default %(default)s)")
@@ -76,7 +75,7 @@ def run_daemon(args):
 
 
 def run_cron(args):
-    firewall.general_update(args.soa_dir)
+    firewall.general_update(args.soa_dir, args.synapse_service_dir)
 
 
 def process_inotify_event(event, services_by_dependencies, soa_dir):

--- a/paasta_tools/firewall_update.py
+++ b/paasta_tools/firewall_update.py
@@ -72,23 +72,26 @@ def run_daemon(args):
         if event is None:
             continue
 
-        process_inotify_event(event, services_by_dependencies)
+        process_inotify_event(event, services_by_dependencies, args.soa_dir)
 
 
 def run_cron(args):
     firewall.general_update(args.soa_dir)
 
 
-def process_inotify_event(event, services_by_dependencies):
+def process_inotify_event(event, services_by_dependencies, soa_dir):
     filename = event[3]
     service_instance, suffix = os.path.splitext(filename)
     if suffix != '.json':
         return
 
     services_to_update = services_by_dependencies.get(service_instance, ())
+    if not services_to_update:
+        return
+
+    firewall.ensure_service_chains(soa_dir, services_to_update)
     for service_to_update in services_to_update:
-        log.debug('Update ', service_to_update)
-        pass  # TODO: iptables added and removed here! :o)
+        log.debug('Updated ', service_to_update)
 
 
 def smartstack_dependencies_of_running_firewalled_services(soa_dir=DEFAULT_SOA_DIR):

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -24,7 +24,6 @@ def service_group():
     return firewall.ServiceGroup(
         service='my_cool_service',
         instance='web',
-        soa_dir=DEFAULT_SOA_DIR,
     )
 
 
@@ -100,29 +99,73 @@ def mock_services_running_here():
 
 def test_service_group_chain_name(service_group):
     """The chain name must be stable, unique, and short."""
-    assert service_group.chain_name == 'PAASTA.my_cool_se.da964afae9'
+    assert service_group.chain_name == 'PAASTA.my_cool_se.f031797563'
     assert len(service_group.chain_name) <= 28
 
 
 @pytest.yield_fixture
 def mock_service_config():
     with mock.patch.object(
-        firewall.ServiceGroup, 'config', new_callable=mock.PropertyMock,
-    ) as m, mock.patch.object(
+        firewall, 'get_instance_config', autospec=True,
+    ) as mock_instance_config, mock.patch.object(
         firewall, 'get_all_namespaces_for_service', autospec=True,
         return_value={'example_happyhour.main': {'proxy_port': '20000'}},
-    ):
-        m.return_value = mock.Mock()
-        m.return_value.get_dependencies.return_value = [
+    ), mock.patch.object(
+        firewall, 'load_system_paasta_config', autospec=True
+    ) as mock_system_paasta_config, mock.patch.object(
+        firewall, '_synapse_backends', autospec=True
+    ) as mock_synapse_backends:
+
+        mock_system_paasta_config.return_value.get_cluster.return_value = 'mycluster'
+
+        mock_instance_config.return_value = mock.Mock()
+        mock_instance_config.return_value.get_dependencies.return_value = [
             {'well-known': 'internet'},
             {'smartstack': 'example_happyhour.main'},
         ]
-        m.return_value.get_outbound_firewall.return_value = 'monitor'
+        mock_instance_config.return_value.get_outbound_firewall.return_value = 'monitor'
+
+        mock_synapse_backends.return_value = [
+            {'host': '1.2.3.4', 'port': 123},
+            {'host': '5.6.7.8', 'port': 567}
+        ]
         yield
 
 
 def test_service_group_rules(mock_service_config, service_group):
-    assert service_group.rules == (
+    assert service_group.get_rules(DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR) == (
+        EMPTY_RULE._replace(target='LOG'),
+        EMPTY_RULE._replace(target='PAASTA-INTERNET'),
+        EMPTY_RULE._replace(
+            protocol='tcp',
+            target='ACCEPT',
+            dst='1.2.3.4/255.255.255.255',
+            matches=(
+                ('tcp', (('dport', '123'),)),
+            ),
+        ),
+        EMPTY_RULE._replace(
+            protocol='tcp',
+            target='ACCEPT',
+            dst='5.6.7.8/255.255.255.255',
+            matches=(
+                ('tcp', (('dport', '567'),)),
+            ),
+        ),
+        EMPTY_RULE._replace(
+            protocol='tcp',
+            target='ACCEPT',
+            dst='169.254.255.254/255.255.255.255',
+            matches=(
+                ('tcp', (('dport', '20000'),)),
+            ),
+        ),
+    )
+
+
+def test_service_group_rules_synapse_backend_error(mock_service_config, service_group):
+    firewall._synapse_backends.side_effect = IOError('Error loading file')
+    assert service_group.get_rules(DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR) == (
         EMPTY_RULE._replace(target='LOG'),
         EMPTY_RULE._replace(target='PAASTA-INTERNET'),
         EMPTY_RULE._replace(
@@ -138,8 +181,8 @@ def test_service_group_rules(mock_service_config, service_group):
 
 def test_service_group_update_rules(service_group):
     with mock.patch.object(iptables, 'ensure_chain', autospec=True) as m:
-        with mock.patch.object(type(service_group), 'rules', mock.sentinel.RULES):
-            service_group.update_rules()
+        with mock.patch.object(type(service_group), 'get_rules', return_value=mock.sentinel.RULES):
+            service_group.update_rules(DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR)
     m.assert_called_once_with(
         service_group.chain_name,
         mock.sentinel.RULES,
@@ -147,15 +190,15 @@ def test_service_group_update_rules(service_group):
 
 
 def test_active_service_groups(mock_service_config, mock_services_running_here):
-    assert firewall.active_service_groups(DEFAULT_SOA_DIR) == {
-        firewall.ServiceGroup('example_happyhour', 'main', DEFAULT_SOA_DIR): {
+    assert firewall.active_service_groups() == {
+        firewall.ServiceGroup('example_happyhour', 'main'): {
             '02:42:a9:fe:00:00',
             '02:42:a9:fe:00:01',
         },
-        firewall.ServiceGroup('example_happyhour', 'batch', DEFAULT_SOA_DIR): {
+        firewall.ServiceGroup('example_happyhour', 'batch'): {
             '02:42:a9:fe:00:02',
         },
-        firewall.ServiceGroup('my_cool_service', 'web', DEFAULT_SOA_DIR): {
+        firewall.ServiceGroup('my_cool_service', 'web'): {
             '02:42:a9:fe:00:03',
             '02:42:a9:fe:00:04',
         },
@@ -181,15 +224,15 @@ def test_ensure_internet_chain():
 @pytest.yield_fixture
 def mock_active_service_groups():
     groups = {
-        firewall.ServiceGroup('cool_service', 'main', DEFAULT_SOA_DIR): {
+        firewall.ServiceGroup('cool_service', 'main'): {
             '02:42:a9:fe:00:02',
             'fe:a3:a3:da:2d:51',
             'fe:a3:a3:da:2d:50',
         },
-        firewall.ServiceGroup('cool_service', 'main', DEFAULT_SOA_DIR): {
+        firewall.ServiceGroup('cool_service', 'main'): {
             'fe:a3:a3:da:2d:40',
         },
-        firewall.ServiceGroup('dumb_service', 'other', DEFAULT_SOA_DIR): {
+        firewall.ServiceGroup('dumb_service', 'other'): {
             'fe:a3:a3:da:2d:30',
             'fe:a3:a3:da:2d:31',
         },
@@ -205,28 +248,32 @@ def mock_active_service_groups():
 
 def test_ensure_service_chains(mock_active_service_groups, mock_service_config):
     with mock.patch.object(iptables, 'ensure_chain', autospec=True) as m:
-        assert firewall.ensure_service_chains(DEFAULT_SOA_DIR) == {
-            'PAASTA.cool_servi.771bae24b0': {
+        assert firewall.ensure_service_chains(DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR) == {
+            'PAASTA.cool_servi.397dba3c1f': {
                 'fe:a3:a3:da:2d:40',
             },
-            'PAASTA.dumb_servi.b3e0fd962a': {
+            'PAASTA.dumb_servi.8fb64b4f63': {
                 'fe:a3:a3:da:2d:30',
                 'fe:a3:a3:da:2d:31',
             },
         }
     assert len(m.mock_calls) == 2
-    assert mock.call('PAASTA.cool_servi.771bae24b0', mock.ANY) in m.mock_calls
-    assert mock.call('PAASTA.dumb_servi.b3e0fd962a', mock.ANY) in m.mock_calls
+    assert mock.call('PAASTA.cool_servi.397dba3c1f', mock.ANY) in m.mock_calls
+    assert mock.call('PAASTA.dumb_servi.8fb64b4f63', mock.ANY) in m.mock_calls
 
 
 def test_ensure_service_chains_only_services(mock_active_service_groups, mock_service_config):
     with mock.patch.object(iptables, 'ensure_chain', autospec=True) as m:
-        assert firewall.ensure_service_chains(DEFAULT_SOA_DIR, only_services={('cool_service', 'main')}) == {
-            'PAASTA.cool_servi.771bae24b0': {
+        assert firewall.ensure_service_chains(
+            DEFAULT_SOA_DIR,
+            firewall.DEFAULT_SYNAPSE_SERVICE_DIR,
+            only_services={('cool_service', 'main')}
+        ) == {
+            'PAASTA.cool_servi.397dba3c1f': {
                 'fe:a3:a3:da:2d:40',
             },
         }
-    assert m.mock_calls == [mock.call('PAASTA.cool_servi.771bae24b0', mock.ANY)]
+    assert m.mock_calls == [mock.call('PAASTA.cool_servi.397dba3c1f', mock.ANY)]
 
 
 def test_ensure_dispatch_chains():

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -219,6 +219,16 @@ def test_ensure_service_chains(mock_active_service_groups, mock_service_config):
     assert mock.call('PAASTA.dumb_servi.b3e0fd962a', mock.ANY) in m.mock_calls
 
 
+def test_ensure_service_chains_only_services(mock_active_service_groups, mock_service_config):
+    with mock.patch.object(iptables, 'ensure_chain', autospec=True) as m:
+        assert firewall.ensure_service_chains(DEFAULT_SOA_DIR, only_services={('cool_service', 'main')}) == {
+            'PAASTA.cool_servi.771bae24b0': {
+                'fe:a3:a3:da:2d:40',
+            },
+        }
+    assert m.mock_calls == [mock.call('PAASTA.cool_servi.771bae24b0', mock.ANY)]
+
+
 def test_ensure_dispatch_chains():
     with mock.patch.object(
         iptables, 'ensure_rule', autospec=True,

--- a/tests/test_firewall_update.py
+++ b/tests/test_firewall_update.py
@@ -29,8 +29,8 @@ def test_parse_args_daemon():
     args = firewall_update.parse_args([
         '-d', 'mysoadir',
         '-v',
-        'daemon',
         '--synapse-service-dir', 'myservicedir',
+        'daemon',
         '-u', '123',
     ])
     assert args.mode == 'daemon'
@@ -43,7 +43,7 @@ def test_parse_args_daemon():
 def test_parse_args_default_daemon():
     args = firewall_update.parse_args(['daemon'])
     assert args.mode == 'daemon'
-    assert args.synapse_service_dir == firewall_update.DEFAULT_SYNAPSE_SERVICE_DIR
+    assert args.synapse_service_dir == firewall.DEFAULT_SYNAPSE_SERVICE_DIR
     assert args.soa_dir == firewall_update.DEFAULT_SOA_DIR
     assert args.update_secs == firewall_update.DEFAULT_UPDATE_SECS
     assert not args.verbose
@@ -184,8 +184,8 @@ def test_process_inotify_event(ensure_service_chains_mock, log_mock):
 def mock_daemon_args(tmpdir):
     return firewall_update.parse_args([
         '-d', str(tmpdir.mkdir('yelpsoa')),
-        'daemon',
         '--synapse-service-dir', str(tmpdir.mkdir('synapse')),
+        'daemon',
     ])
 
 
@@ -193,5 +193,6 @@ def mock_daemon_args(tmpdir):
 def mock_cron_args(tmpdir):
     return firewall_update.parse_args([
         '-d', str(tmpdir.mkdir('yelpsoa')),
+        '--synapse-service-dir', str(tmpdir.mkdir('synapse')),
         'cron',
     ])


### PR DESCRIPTION
Sorry for making this one PR - it may be easier to read the commits independently.

The first one was pretty straightforward - modify ensure_service_chains() to take an optional filter kwarg, and then have firewall_update pass in the services it cares about via that kwarg.

Second change was to add support for the synapse backends in the iptables rules. This got a little more involved because we needed a new config_dir to be passed around (the synapse_service_dir) and I didn't like having to add it to the ServiceGroup namedtuple. So instead I refactored ServiceGroup to eliminate storing soa_dir, and made "rules" a method instead of a property. So there are definitely some style differences. The only material thing I can think this affects is that the chain_name() sha no longer factors in the soa_dir. I don't think that matters? but feel free to correct me. :)