### PR TITLE
Catch OSError watching new folder

### DIFF
--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -272,7 +272,11 @@ class YelpSoaEventHandler(pyinotify.ProcessEvent):
     def watch_new_folder(self, event):
         if event.maskname == 'IN_CREATE|IN_ISDIR':
             self.filewatcher.wm.add_watch(event.pathname, self.filewatcher.mask, rec=True)
-            if any(['marathon-' in file_name for file_name in os.listdir(event.pathname)]):
+            try:
+                file_names = os.listdir(event.pathname)
+            except OSError:
+                return
+            if any(['marathon-' in file_name for file_name in file_names]):
                 self.log.info("New folder with marathon files: {}".format(event.name))
                 self.bounce_service(event.name)
 

--- a/tests/deployd/test_watchers.py
+++ b/tests/deployd/test_watchers.py
@@ -485,6 +485,12 @@ class TestYelpSoaEventHandler(unittest.TestCase):
             assert self.mock_filewatcher.wm.add_watch.called
             mock_bounce_service.assert_called_with(self.handler, 'universe')
 
+            mock_os_list.side_effect = OSError
+            mock_bounce_service.reset_mock()
+            self.handler.watch_new_folder(mock_event)
+            assert self.mock_filewatcher.wm.add_watch.called
+            assert not mock_bounce_service.called
+
     def test_process_default(self):
         mock_event = mock.Mock(path='/folder/universe')
         with mock.patch(


### PR DESCRIPTION
listdir can fail, if there's nothing in the folder or listdir fails then
we don't need to proactively bounce so just return from that function