### PR TITLE
docker_wrapper inserts firewall rules in preparation of running

### DIFF
--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -24,7 +24,10 @@ import re
 import socket
 import sys
 
-import paasta_tools.mac_address
+from paasta_tools.firewall import DEFAULT_SYNAPSE_SERVICE_DIR
+from paasta_tools.firewall import prepare_new_container
+from paasta_tools.mac_address import reserve_unique_mac_address
+from paasta_tools.utils import DEFAULT_SOA_DIR
 
 
 LOCK_DIRECTORY = '/var/run/paasta/mac-address'
@@ -287,10 +290,17 @@ def main(argv=None):
     paasta_firewall = env_args.get('PAASTA_FIREWALL')
     if paasta_firewall and can_add_mac_address(argv):
         try:
-            mac_address, lockfile = paasta_tools.mac_address.reserve_unique_mac_address(LOCK_DIRECTORY)
+            mac_address, lockfile = reserve_unique_mac_address(LOCK_DIRECTORY)
         except Exception as e:
             print('Unable to add mac address: {}'.format(e), file=sys.stderr)
         else:
             argv = add_argument(argv, '--mac-address={}'.format(mac_address))
+
+            prepare_new_container(
+                DEFAULT_SOA_DIR,
+                DEFAULT_SYNAPSE_SERVICE_DIR,
+                env_args['PAASTA_SERVICE'],
+                env_args['PAASTA_INSTANCE'],
+                mac_address)
 
     os.execlp('docker', 'docker', *argv[1:])

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -243,8 +243,7 @@ def ensure_internet_chain():
 def ensure_service_chains(service_groups, soa_dir, synapse_service_dir):
     """Ensure service chains exist and have the right rules.
 
-    only_services is either None or a set of (service,instance) tuples. If it's
-    set, only act on things in that set.
+    service_groups is a dict {ServiceGroup: set([mac_address..])}
 
     Returns dictionary {[service chain] => [list of mac addresses]}.
     """

--- a/paasta_tools/firewall_update.py
+++ b/paasta_tools/firewall_update.py
@@ -88,7 +88,13 @@ def process_inotify_event(event, services_by_dependencies, soa_dir, synapse_serv
     if not services_to_update:
         return
 
-    firewall.ensure_service_chains(soa_dir, synapse_service_dir, services_to_update)
+    # filter active_service_groups() down to just the names in services_to_update
+    service_groups = {
+        service_group: macs
+        for service_group, macs in firewall.active_service_groups().items()
+        if service_group in services_to_update
+    }
+    firewall.ensure_service_chains(service_groups, soa_dir, synapse_service_dir)
     for service_to_update in services_to_update:
         log.debug('Updated ', service_to_update)
 
@@ -111,7 +117,7 @@ def smartstack_dependencies_of_running_firewalled_services(soa_dir=DEFAULT_SOA_D
         smartstack_dependencies = [d['smartstack'] for d in dependencies if d.get('smartstack')]
         for smartstack_dependency in smartstack_dependencies:
             # TODO: filter down to only services that have no proxy_port
-            dependencies_to_services[smartstack_dependency].add((service, instance))
+            dependencies_to_services[smartstack_dependency].add(firewall.ServiceGroup(service, instance))
 
     return dependencies_to_services
 

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -245,7 +245,7 @@ def test_ensure_internet_chain():
     )
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_active_service_groups():
     groups = {
         firewall.ServiceGroup('cool_service', 'main'): {
@@ -261,18 +261,16 @@ def mock_active_service_groups():
             'fe:a3:a3:da:2d:31',
         },
     }
-    with mock.patch.object(
-            firewall,
-            'active_service_groups',
-            autospec=True,
-            return_value=groups,
-    ):
-        yield
+    return groups
 
 
 def test_ensure_service_chains(mock_active_service_groups, mock_service_config):
     with mock.patch.object(iptables, 'ensure_chain', autospec=True) as m:
-        assert firewall.ensure_service_chains(DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR) == {
+        assert firewall.ensure_service_chains(
+            mock_active_service_groups,
+            DEFAULT_SOA_DIR,
+            firewall.DEFAULT_SYNAPSE_SERVICE_DIR
+        ) == {
             'PAASTA.cool_servi.397dba3c1f': {
                 'fe:a3:a3:da:2d:40',
             },
@@ -284,20 +282,6 @@ def test_ensure_service_chains(mock_active_service_groups, mock_service_config):
     assert len(m.mock_calls) == 2
     assert mock.call('PAASTA.cool_servi.397dba3c1f', mock.ANY) in m.mock_calls
     assert mock.call('PAASTA.dumb_servi.8fb64b4f63', mock.ANY) in m.mock_calls
-
-
-def test_ensure_service_chains_only_services(mock_active_service_groups, mock_service_config):
-    with mock.patch.object(iptables, 'ensure_chain', autospec=True) as m:
-        assert firewall.ensure_service_chains(
-            DEFAULT_SOA_DIR,
-            firewall.DEFAULT_SYNAPSE_SERVICE_DIR,
-            only_services={('cool_service', 'main')}
-        ) == {
-            'PAASTA.cool_servi.397dba3c1f': {
-                'fe:a3:a3:da:2d:40',
-            },
-        }
-    assert m.mock_calls == [mock.call('PAASTA.cool_servi.397dba3c1f', mock.ANY)]
 
 
 def test_ensure_dispatch_chains():
@@ -353,4 +337,30 @@ def test_garbage_collect_old_service_chains():
 
     assert mock_delete_chain.mock_calls == [
         mock.call('PAASTA.chain3'),
+    ]
+
+
+@mock.patch.object(firewall.ServiceGroup, 'get_rules', return_value=mock.sentinel.RULES)
+@mock.patch.object(iptables, 'ensure_chain', autospec=True)
+@mock.patch.object(iptables, 'insert_rule', autospec=True)
+def test_prepare_new_container(insert_rule_mock, ensure_chain_mock, get_rules_mock):
+    firewall.prepare_new_container(
+        DEFAULT_SOA_DIR,
+        firewall.DEFAULT_SYNAPSE_SERVICE_DIR,
+        'myservice',
+        'myinstance',
+        '00:00:00:00:00:00'
+    )
+    assert ensure_chain_mock.mock_calls == [
+        mock.call('PAASTA-INTERNET', mock.ANY),
+        mock.call('PAASTA.myservice.7e8522249a', mock.sentinel.RULES)
+    ]
+    assert insert_rule_mock.mock_calls == [
+        mock.call(
+            'PAASTA',
+            EMPTY_RULE._replace(
+                target='PAASTA.myservice.7e8522249a',
+                matches=(('mac', (('mac_source', '00:00:00:00:00:00'),)),),
+            ),
+        )
     ]


### PR DESCRIPTION
Integration!

Refactored ensure_service_chains() again - rather than reading all running services and taking an optional filter kwarg, you just pass in the ones that you want in the first place.

prepare_new_container() is a new function that ensures the right rules and chains are in place to allow access with a particular MAC.

I left a TODO: currently we're setting up iptables rules for all containers with security settings, regardless of mac address. We may want to only affect mac addresses that have the prefix that indicates they were generated from docker_wrapper... not sure if it really matters though? Either way you're opting-in via your soa-configs settings.