### PR TITLE
Revert "Revert "Revert "default healthcheck type to MESOS_HTTP"""

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -470,7 +470,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
             http_path = self.get_healthcheck_uri(service_namespace_config)
             healthchecks = [
                 {
-                    "protocol": "MESOS_HTTP",
+                    "protocol": "HTTP",
                     "path": http_path,
                     "gracePeriodSeconds": graceperiodseconds,
                     "intervalSeconds": intervalseconds,

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -851,7 +851,7 @@ class TestMarathonTools:
         })
         fake_healthchecks = [
             {
-                "protocol": "MESOS_HTTP",
+                "protocol": "HTTP",
                 "path": "/health",
                 "gracePeriodSeconds": 3,
                 "intervalSeconds": 10,
@@ -1694,7 +1694,7 @@ class TestMarathonServiceConfig(object):
         })
         expected = [
             {
-                "protocol": "MESOS_HTTP",
+                "protocol": "HTTP",
                 "path": fake_path,
                 "gracePeriodSeconds": 70,
                 "intervalSeconds": 12,
@@ -1719,7 +1719,7 @@ class TestMarathonServiceConfig(object):
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({'mode': 'http'})
         expected = [
             {
-                "protocol": "MESOS_HTTP",
+                "protocol": "HTTP",
                 "path": '/status',
                 "gracePeriodSeconds": 60,
                 "intervalSeconds": 10,
@@ -2038,7 +2038,7 @@ def test_format_marathon_app_dict_with_smartstack():
             'health_checks': [
                 {
                     'portIndex': 0,
-                    'protocol': 'MESOS_HTTP',
+                    'protocol': 'HTTP',
                     'timeoutSeconds': 10,
                     'intervalSeconds': 10,
                     'gracePeriodSeconds': 60,


### PR DESCRIPTION
This reverts commit e4ebd16b8dc67b5b023f592f12e7beeb9e31edb0.

To be clear this is *disabling* MESOS_HTTP checks again

cc @Rob-Johnson 