### PR TITLE
batch calls to describe_instance_status

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -383,9 +383,22 @@ class ClusterAutoscaler(ResourceLogMixin):
         return paasta_aws_slaves
 
     def instance_status_for_instance_ids(self, instance_ids):
-        return self.describe_instance_status(
-            instance_ids=instance_ids,
-            region=self.resource['region'],
+        """
+        Return a list of instance statuses. Batch the API calls into
+        groups of 99, since AWS limit it.
+        """
+        partitions = [
+            instance_ids[partition: partition+99]
+            for partition in
+            range(0, len(instance_ids), 99)
+        ]
+        return reduce(
+            lambda x, y: x + y,
+            [self.describe_instance_status(
+                instance_ids=subgroup,
+                region=self.resource['region']
+            ) for subgroup in partitions],
+            []
         )
 
     def instance_descriptions_for_ips(self, ips):

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -956,6 +956,16 @@ class TestClusterAutoscaler(unittest.TestCase):
         )
         assert actual == [fake_status['InstanceStatuses'][0]]
 
+    def test_instance_status_for_instance_ids_batches_calls(self):
+        instance_ids = map(lambda i: {'foo': i}, range(0,100))
+        with mock.patch(
+            'paasta_tools.autoscaling.autoscaling_cluster_lib.ClusterAutoscaler.describe_instance_status',
+        ) as mock_describe_instance_status:
+            mock_describe_instance_status.return_value = [{'foo': 'bar'}]
+
+            res = self.autoscaler.instance_status_for_instance_ids(instance_ids=instance_ids)
+            assert len(res) == 2
+
     def test_gracefully_terminate_slave(self):
         with mock.patch(
             'time.time', autospec=True,


### PR DESCRIPTION
amazon sets limits of 100 instances ids in the filter - batch the call
into sets of 99