### PR TITLE
Catch SlaveDoesNotExist exception in autoscaler

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -27,7 +27,6 @@ from botocore.exceptions import ClientError
 from requests.exceptions import HTTPError
 
 from paasta_tools.autoscaling import ec2_fitness
-from paasta_tools.mesos.exceptions import SlaveDoesNotExist
 from paasta_tools.mesos_maintenance import drain
 from paasta_tools.mesos_maintenance import undrain
 from paasta_tools.mesos_tools import get_mesos_master
@@ -251,9 +250,6 @@ class ClusterAutoscaler(ResourceLogMixin):
                         self.log.info("Instance {}: NOT ready to kill".format(instance_id))
                     self.log.debug("Waiting 5 seconds and then checking again")
                     time.sleep(5)
-        except SlaveDoesNotExist:
-            self.log.error("Tried to terminate slave {}, but it did not exist. Continuing.".format(slave))
-            pass
         except TimeoutError:
             self.log.error("Timed out after {} waiting to drain {}, now terminating anyway".format(drain_timeout,
                                                                                                    slave.pid))

--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -27,6 +27,7 @@ from botocore.exceptions import ClientError
 from requests.exceptions import HTTPError
 
 from paasta_tools.autoscaling import ec2_fitness
+from paasta_tools.mesos.exceptions import SlaveDoesNotExist
 from paasta_tools.mesos_maintenance import drain
 from paasta_tools.mesos_maintenance import undrain
 from paasta_tools.mesos_tools import get_mesos_master
@@ -250,6 +251,9 @@ class ClusterAutoscaler(ResourceLogMixin):
                         self.log.info("Instance {}: NOT ready to kill".format(instance_id))
                     self.log.debug("Waiting 5 seconds and then checking again")
                     time.sleep(5)
+        except SlaveDoesNotExist:
+            self.log.error("Tried to terminate slave {}, but it did not exist. Continuing.".format(slave))
+            pass
         except TimeoutError:
             self.log.error("Timed out after {} waiting to drain {}, now terminating anyway".format(drain_timeout,
                                                                                                    slave.pid))

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -678,13 +678,9 @@ def get_mesos_task_count_by_slave(mesos_state, slaves_list=None, pool=None):
     :returns: list of slave dicts {'task_count': SlaveTaskCount}
     """
     all_mesos_tasks = get_all_running_tasks()  # empty string = all app ids
-    try:
-        slaves = {
-            slave['id']: {'count': 0, 'slave': slave, 'chronos_count': 0} for slave in mesos_state.get('slaves', [])
-        }
-    except SlaveDoesNotExist:
-        log.debug("Tried to get mesos slaves for id {}, but none existed.".format(mesos_state.get('id'), ''))
-        return {}
+    slaves = {
+        slave['id']: {'count': 0, 'slave': slave, 'chronos_count': 0} for slave in mesos_state.get('slaves', [])
+    }
     for task in all_mesos_tasks:
         if task.slave['id'] not in slaves:
             log.debug("Slave {} not found for task".format(task.slave['id']))

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -678,9 +678,13 @@ def get_mesos_task_count_by_slave(mesos_state, slaves_list=None, pool=None):
     :returns: list of slave dicts {'task_count': SlaveTaskCount}
     """
     all_mesos_tasks = get_all_running_tasks()  # empty string = all app ids
-    slaves = {
-        slave['id']: {'count': 0, 'slave': slave, 'chronos_count': 0} for slave in mesos_state.get('slaves', [])
-    }
+    try:
+        slaves = {
+            slave['id']: {'count': 0, 'slave': slave, 'chronos_count': 0} for slave in mesos_state.get('slaves', [])
+        }
+    except SlaveDoesNotExist:
+        log.debug("Tried to get mesos slaves for id {}, but none existed.".format(mesos_state.get('id'), ''))
+        return {}
     for task in all_mesos_tasks:
         if task.slave['id'] not in slaves:
             log.debug("Slave {} not found for task".format(task.slave['id']))


### PR DESCRIPTION
To address the issue in this stack trace:
```
{u'slaveId': '8f86d7a7-210c-4def-a439-d39baf6f0eb3-S2576', u'resources': '[{"role": "maintenance", "scalar": {"value": 239776.0}, "type": "SCALAR", "name": "disk", "reservation"
: {"principal": "mesos_slave"}}, {"role": "maintenance", "scalar": {"value": 113628.0}, "type": "SCALAR", "name": "mem", "reservation": {"principal": "mesos_slave"}}, {"role": "
maintenance", "scalar": {"value": 1.5}, "type": "SCALAR", "name": "cpus", "reservation": {"principal": "mesos_slave"}}]'}
Traceback (most recent call last):
  File "/usr/bin/paasta_autoscale_cluster", line 11, in <module>
    load_entry_point('paasta-tools==0.65.16', 'console_scripts', 'paasta_autoscale_cluster')()
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/autoscale_cluster.py", line 56, in main
    log_level=log_level,
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/autoscaling/autoscaling_cluster_lib.py", line 818, in autoscale_local_cluster
    autoscale_cluster_resource(scaler)
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/autoscaling/autoscaling_cluster_lib.py", line 834, in autoscale_cluster_resource
    scaler.scale_resource(current, target)
2017-06-12 00:32:37,229:INFO:kazoo.client:Zookeeper connection established, state: CONNECTED
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/autoscaling/autoscaling_cluster_lib.py", line 297, in scale_resource
2017-06-12 00:32:37,223:INFO:kazoo.client:Connecting to 10.69.17.53:22181
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/autoscaling/autoscaling_cluster_lib.py", line 443, in downscale_aws_resource
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/autoscaling/autoscaling_cluster_lib.py", line 331, in gracefully_terminate_slave
    self.wait_and_terminate(slave_to_kill, drain_timeout, self.dry_run, region=self.resource['region'])
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/autoscaling/autoscaling_cluster_lib.py", line 235, in wait_and_terminate
    if is_safe_to_kill(slave.hostname) or dry_run:
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/paasta_maintenance.py", line 98, in is_safe_to_kill
    return mesos_maintenance.is_host_drained(hostname) or \
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/mesos_maintenance.py", line 681, in is_host_drained
    return is_host_draining(hostname=hostname) and get_count_running_tasks_on_slave(hostname) == 0
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/mesos_tools.py", line 716, in get_count_running_tasks_on_slave
    task_counts = get_mesos_task_count_by_slave(mesos_state)
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/mesos_tools.py", line 685, in get_mesos_task_count_by_slave
    if task.slave['id'] not in slaves:
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/mesos/util.py", line 56, in __get__
    value = self.fget(inst)
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/mesos/task.py", line 60, in slave
    return self.master.slave(self["slave_id"])
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/mesos/util.py", line 72, in memoizer
    cache[key] = obj(*args, **kwargs)
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/mesos/master.py", line 157, in slave
    "Slave {} no longer exists.".format(fltr))
paasta_tools.mesos.exceptions.SlaveDoesNotExist: Slave 8f86d7a7-210c-4def-a439-d39baf6f0eb3-S2560 no longer exists.
```