### PR TITLE
Allow for per-service docker registry

### DIFF
--- a/docs/source/system_configs.rst
+++ b/docs/source/system_configs.rst
@@ -29,7 +29,8 @@ These are the keys that may exist in system configs:
   * ``zookeeper``: A zookeeper connection url, used for discovering where the Mesos leader is, and some locks.
     Example: ``"zookeeper": "zk://zookeeper1:2181,zookeeper2:2181,zookeeper3:2181/mesos"``.
 
-  * ``docker_registry``: The name of the docker registry where paasta images will be stored.
+  * ``docker_registry``: The name of the docker registry where paasta images will be stored. This can optionally
+    be set on a per-service level as well, see `yelpsoa_configs <generated/yelpsoa_configs.html#service-yaml>`_
     Example: ``"docker_registry": "docker-paasta.yelpcorp.com:443"``
 
   * ``volumes``: The list of volumes that should be bind-mounted into application containers by default.

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -798,6 +798,7 @@ Various PaaSTA utilities look at the following keys from service.yaml
  * ``git_url``
  * ``description``
  * ``external_link``
+ * ``docker_registry`` This is optional. Set this to override the `system-wide docker registry <generated/system_configs.html#configuration-options>`_, and specify an alternate docker registry for your service.
 
 Where does paasta_tools look for yelpsoa-configs?
 -------------------------------------------------------------

--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -194,7 +194,7 @@ def when_setup_service_initiated(context):
     ), mock.patch(
         'paasta_tools.marathon_tools.get_code_sha_from_dockerurl', autospec=True, return_value='newapp',
     ), mock.patch(
-        'paasta_tools.marathon_tools.get_docker_url', autospec=True, return_value='busybox',
+        'paasta_tools.utils.InstanceConfig.get_docker_url', autospec=True, return_value='busybox',
     ), mock.patch(
         'paasta_tools.mesos_maintenance.get_principal', autospec=True,
     ) as mock_get_principal, mock.patch(

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -40,7 +40,6 @@ from paasta_tools.tron import tron_command_context
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_config_hash
-from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_paasta_branch
 from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import get_services_for_cluster
@@ -585,7 +584,7 @@ def create_complete_config(service, job_name, soa_dir=DEFAULT_SOA_DIR):
     system_paasta_config = load_system_paasta_config()
     chronos_job_config = load_chronos_job_config(
         service, job_name, system_paasta_config.get_cluster(), soa_dir=soa_dir)
-    docker_url = get_docker_url(chronos_job_config.get_docker_registry(), chronos_job_config.get_docker_image())
+    docker_url = chronos_job_config.get_docker_url()
     docker_volumes = chronos_job_config.get_volumes(system_volumes=system_paasta_config.get_volumes())
 
     constraints = chronos_job_config.get_calculated_constraints(

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -585,8 +585,7 @@ def create_complete_config(service, job_name, soa_dir=DEFAULT_SOA_DIR):
     system_paasta_config = load_system_paasta_config()
     chronos_job_config = load_chronos_job_config(
         service, job_name, system_paasta_config.get_cluster(), soa_dir=soa_dir)
-    docker_url = get_docker_url(
-        system_paasta_config.get_docker_registry(), chronos_job_config.get_docker_image())
+    docker_url = get_docker_url(chronos_job_config.get_docker_registry(), chronos_job_config.get_docker_image())
     docker_volumes = chronos_job_config.get_volumes(system_volumes=system_paasta_config.get_volumes())
 
     constraints = chronos_job_config.get_calculated_constraints(

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -773,7 +773,7 @@ def configure_and_run_docker_container(
     if docker_hash is None:
         try:
             docker_url = get_docker_url(
-                system_paasta_config.get_docker_registry(), instance_config.get_docker_image())
+                instance_config.get_docker_registry(), instance_config.get_docker_image())
         except NoDockerImageError:
             paasta_print(PaastaColors.red(
                 "Error: No sha has been marked for deployment for the %s deploy group.\n"

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -45,7 +45,6 @@ from paasta_tools.paasta_execute_docker_command import execute_in_container
 from paasta_tools.utils import _run
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_docker_client
-from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_username
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import load_system_paasta_config
@@ -772,8 +771,7 @@ def configure_and_run_docker_container(
 
     if docker_hash is None:
         try:
-            docker_url = get_docker_url(
-                instance_config.get_docker_registry(), instance_config.get_docker_image())
+            docker_url = instance_config.get_docker_url()
         except NoDockerImageError:
             paasta_print(PaastaColors.red(
                 "Error: No sha has been marked for deployment for the %s deploy group.\n"

--- a/paasta_tools/cli/cmds/push_to_registry.py
+++ b/paasta_tools/cli/cmds/push_to_registry.py
@@ -33,7 +33,7 @@ from paasta_tools.utils import _log
 from paasta_tools.utils import _run
 from paasta_tools.utils import build_docker_tag
 from paasta_tools.utils import DEFAULT_SOA_DIR
-from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import get_service_docker_registry
 from paasta_tools.utils import paasta_print
 
 
@@ -101,7 +101,7 @@ def paasta_push_to_registry(args):
 
     if not args.force:
         try:
-            if is_docker_image_already_in_registry(service, args.commit):
+            if is_docker_image_already_in_registry(service, args.soa_dir, args.commit):
                 paasta_print("The docker image is already in the PaaSTA docker registry. "
                              "I'm NOT overriding the existing image. "
                              "Add --force to override the image in the registry if you are sure what you are doing.")
@@ -156,14 +156,14 @@ def read_docker_registy_creds(registry_uri):
     return (None, None)
 
 
-def is_docker_image_already_in_registry(service, sha):
+def is_docker_image_already_in_registry(service, soa_dir, sha):
     """Verifies that docker image exists in the paasta registry.
 
     :param service: name of the service
     :param sha: git sha
     :returns: True, False or raises requests.exceptions.RequestException
     """
-    registry_uri = load_system_paasta_config().get_docker_registry()
+    registry_uri = get_service_docker_registry(service, soa_dir)
     repository, tag = build_docker_image_name(service, sha).split(':')
     url = 'https://%s/v2/%s/tags/list' % (registry_uri, repository)
 

--- a/paasta_tools/cli/cmds/push_to_registry.py
+++ b/paasta_tools/cli/cmds/push_to_registry.py
@@ -107,8 +107,9 @@ def paasta_push_to_registry(args):
                              "Add --force to override the image in the registry if you are sure what you are doing.")
                 return 0
         except RequestException as e:
-            paasta_print("Can not connect to the PaaSTA docker registry to verify if this image exists.\n"
-                         "%s" % str(e))
+            registry_uri = get_service_docker_registry(service, args.soa_dir)
+            paasta_print("Can not connect to the PaaSTA docker registry '%s' to verify if this image exists.\n"
+                         "%s" % (registry_uri, str(e)))
             return 1
 
     cmd = build_command(service, args.commit)

--- a/paasta_tools/frameworks/native_service_config.py
+++ b/paasta_tools/frameworks/native_service_config.py
@@ -15,9 +15,7 @@ from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_code_sha_from_dockerurl
 from paasta_tools.utils import get_config_hash
-from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_paasta_branch
-from paasta_tools.utils import get_service_docker_registry
 from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import paasta_print
 
@@ -71,11 +69,7 @@ class NativeServiceConfig(LongRunningServiceConfig):
         include task.slave_id or a task.id; those need to be computed separately."""
         task = mesos_pb2.TaskInfo()
         task.container.type = mesos_pb2.ContainerInfo.DOCKER
-        task.container.docker.image = get_docker_url(get_service_docker_registry(self.service,
-                                                                                 self.soa_dir,
-                                                                                 system_paasta_config),  # should i pass
-                                                     # this ^^ thru? done to make test pass...
-                                                     self.get_docker_image())
+        task.container.docker.image = self.get_docker_url()
 
         for param in self.format_docker_parameters():
             p = task.container.docker.parameters.add()

--- a/paasta_tools/frameworks/native_service_config.py
+++ b/paasta_tools/frameworks/native_service_config.py
@@ -17,6 +17,7 @@ from paasta_tools.utils import get_code_sha_from_dockerurl
 from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_paasta_branch
+from paasta_tools.utils import get_service_docker_registry
 from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import paasta_print
 
@@ -70,7 +71,10 @@ class NativeServiceConfig(LongRunningServiceConfig):
         include task.slave_id or a task.id; those need to be computed separately."""
         task = mesos_pb2.TaskInfo()
         task.container.type = mesos_pb2.ContainerInfo.DOCKER
-        task.container.docker.image = get_docker_url(system_paasta_config.get_docker_registry(),
+        task.container.docker.image = get_docker_url(get_service_docker_registry(self.service,
+                                                                                 self.soa_dir,
+                                                                                 system_paasta_config),  # should i pass
+                                                     # this ^^ thru? done to make test pass...
                                                      self.get_docker_image())
 
         for param in self.format_docker_parameters():

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -46,7 +46,6 @@ from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_code_sha_from_dockerurl
 from paasta_tools.utils import get_config_hash
-from paasta_tools.utils import get_docker_url
 from paasta_tools.utils import get_paasta_branch
 from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import get_user_agent
@@ -340,7 +339,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         :returns: A dict containing all of the keys listed above"""
 
         system_paasta_config = load_system_paasta_config()
-        docker_url = get_docker_url(self.get_docker_registry(), self.get_docker_image())
+        docker_url = self.get_docker_url()
         service_namespace_config = load_service_namespace_config(
             service=self.service,
             namespace=self.get_nerve_namespace(),

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -340,7 +340,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         :returns: A dict containing all of the keys listed above"""
 
         system_paasta_config = load_system_paasta_config()
-        docker_url = get_docker_url(system_paasta_config.get_docker_registry(), self.get_docker_image())
+        docker_url = get_docker_url(self.get_docker_registry(), self.get_docker_image())
         service_namespace_config = load_service_namespace_config(
             service=self.service,
             namespace=self.get_nerve_namespace(),

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1371,31 +1371,27 @@ def decompose_job_id(job_id, spacer=SPACER):
     return (decomposed[0], decomposed[1], git_hash, config_hash)
 
 
-def build_docker_image_name(upstream_job_name):
+def build_docker_image_name(service):
     """docker-paasta.yelpcorp.com:443 is the URL for the Registry where PaaSTA
     will look for your images.
 
-    upstream_job_name is a sanitized-for-Jenkins (s,/,-,g) version of the
+    :returns: a sanitized-for-Jenkins (s,/,-,g) version of the
     service's path in git. E.g. For git.yelpcorp.com:services/foo the
-    upstream_job_name is services-foo.
+    docker image name is docker_registry/services-foo.
     """
-    docker_registry_url = load_system_paasta_config().get_docker_registry()  # jgl TODO: fix, try service one first
-    name = '%s/services-%s' % (docker_registry_url, upstream_job_name)
+    docker_registry_url = get_service_docker_registry(service)
+    name = '%s/services-%s' % (docker_registry_url, service)
     return name
 
 
-def build_docker_tag(upstream_job_name, upstream_git_commit):
+def build_docker_tag(service, upstream_git_commit):
     """Builds the DOCKER_TAG string
-
-    upstream_job_name is a sanitized-for-Jenkins (s,/,-,g) version of the
-    service's path in git. E.g. For git.yelpcorp.com:services/foo the
-    upstream_job_name is services-foo.
 
     upstream_git_commit is the SHA that we're building. Usually this is the
     tip of origin/master.
     """
     tag = '%s:paasta-%s' % (
-        build_docker_image_name(upstream_job_name),
+        build_docker_image_name(service),
         upstream_git_commit,
     )
     return tag

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -353,6 +353,17 @@ class InstanceConfig(object):
         a generated deployments.json file."""
         return self.branch_dict.get('docker_image', '')
 
+    def get_docker_url(self):
+        """Compose the docker url.
+        :returns: '<registry_uri>/<docker_image>'
+        """
+        registry_uri = self.get_docker_registry()
+        docker_image = self.get_docker_image()
+        if not docker_image:
+            raise NoDockerImageError('Docker url not available because there is no docker_image')
+        docker_url = '%s/%s' % (registry_uri, docker_image)
+        return docker_url
+
     def get_desired_state(self):
         """Get the desired state (either 'start' or 'stop') for a given service
         branch from a generated deployments.json file."""
@@ -1666,18 +1677,6 @@ def format_tag(tag):
 
 class NoDockerImageError(Exception):
     pass
-
-
-def get_docker_url(registry_uri, docker_image):
-    """Compose the docker url.
-    :param registry_uri: The URI of the docker registry
-    :param docker_image: The docker image name, with tag if desired
-    :returns: '<registry_uri>/<docker_image>'
-    """
-    if not docker_image:
-        raise NoDockerImageError('Docker url not available because there is no docker_image')
-    docker_url = '%s/%s' % (registry_uri, docker_image)
-    return docker_url
 
 
 def get_config_hash(config, force_bounce=None):

--- a/tests/cli/test_cmds_itest.py
+++ b/tests/cli/test_cmds_itest.py
@@ -54,7 +54,6 @@ def test_itest_success(
     mock_build_docker_tag.return_value = 'fake-registry/services-foo:paasta-bar'
     mock_docker_image.return_value = True
     mock_run.return_value = (0, 'Yeeehaaa')
-
     args = MagicMock()
     assert paasta_itest(args) is 0
 

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -98,6 +98,7 @@ def test_dry_run_json_dict(
     mock_get_instance_config.return_value.get_cpu.return_value = 123
     mock_get_instance_config.return_value.get_net.return_value = 'fake_net'
     mock_get_instance_config.return_value.get_docker_image.return_value = 'fake_docker_image'
+    mock_get_instance_config.return_value.get_docker_url.return_value = 'fake_registry/fake_docker_image'
     mock_get_instance_config.return_value.get_container_port.return_value = 8888
     mock_validate_service_instance.return_value = 'marathon'
     mock_paasta_cook_image.return_value = 0
@@ -448,6 +449,7 @@ def test_configure_and_run_pulls_image_when_asked(
     fake_instance_config = mock.MagicMock(InstanceConfig)
     fake_instance_config.get_docker_registry.return_value = 'fake_registry'
     fake_instance_config.get_docker_image.return_value = 'fake_image'
+    fake_instance_config.get_docker_url.return_value = 'fake_registry/fake_image'
     mock_get_instance_config.return_value = fake_instance_config
     fake_service = 'fake_service'
     args = mock.MagicMock()

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -446,6 +446,7 @@ def test_configure_and_run_pulls_image_when_asked(
     mock_system_paasta_config = SystemPaastaConfig(
         {'cluster': 'fake_cluster', 'volumes': [], 'docker_registry': 'fake_registry'}, '/fake_dir/')
     fake_instance_config = mock.MagicMock(InstanceConfig)
+    fake_instance_config.get_docker_registry.return_value = 'fake_registry'
     fake_instance_config.get_docker_image.return_value = 'fake_image'
     mock_get_instance_config.return_value = fake_instance_config
     fake_service = 'fake_service'

--- a/tests/cli/test_cmds_push_to_registry.py
+++ b/tests/cli/test_cmds_push_to_registry.py
@@ -158,63 +158,48 @@ def test_push_to_registry_works_when_service_name_starts_with_services_dash(
     mock_build_command.assert_called_once_with('foo', 'abcd' * 10)
 
 
-@patch('paasta_tools.cli.cmds.push_to_registry.load_system_paasta_config', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.requests.Session.get', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.read_docker_registy_creds', autospec=True)
 def test_is_docker_image_already_in_registry_success(
         mock_read_docker_registy_creds,
         mock_request_get,
-        mock_load_system_paasta_config,
 ):
     mock_read_docker_registy_creds.return_value = (None, None)
-    mock_load_system_paasta_config.get_docker_registry = MagicMock(return_value='fake_registry')
     mock_request_get.return_value = MagicMock(status_code=200,
                                               json=MagicMock(return_value={'tags': ['paasta-fake_sha']}))
-    assert is_docker_image_already_in_registry('fake_service', 'fake_sha')
-    assert mock_load_system_paasta_config.called
+    assert is_docker_image_already_in_registry('fake_service', 'fake_soa_dir', 'fake_sha')
 
 
-@patch('paasta_tools.cli.cmds.push_to_registry.load_system_paasta_config', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.requests.Session.get', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.read_docker_registy_creds', autospec=True)
 def test_is_docker_image_already_in_registry_404_no_such_service_yet(
         mock_read_docker_registy_creds,
         mock_request_get,
-        mock_load_system_paasta_config,
 ):
     mock_read_docker_registy_creds.return_value = (None, None)
-    mock_load_system_paasta_config.get_docker_registry = MagicMock(return_value='fake_registry')
     mock_request_get.return_value = MagicMock(status_code=404)  # No Such Repository Error
-    assert not is_docker_image_already_in_registry('fake_service', 'fake_sha')
-    assert mock_load_system_paasta_config.called
+    assert not is_docker_image_already_in_registry('fake_service', 'fake_soa_dir', 'fake_sha')
 
 
-@patch('paasta_tools.cli.cmds.push_to_registry.load_system_paasta_config', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.requests.Session.get', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.read_docker_registy_creds', autospec=True)
 def test_is_docker_image_already_in_registry_tags_are_null(
         mock_read_docker_registy_creds,
         mock_request_get,
-        mock_load_system_paasta_config,
 ):
     mock_read_docker_registy_creds.return_value = (None, None)
-    mock_load_system_paasta_config.get_docker_registry = MagicMock(return_value='fake_registry')
     mock_request_get.return_value = MagicMock(status_code=200,
                                               json=MagicMock(return_value={'tags': None}))
-    assert not is_docker_image_already_in_registry('fake_service', 'fake_sha')
-    assert mock_load_system_paasta_config.called
+    assert not is_docker_image_already_in_registry('fake_service', 'fake_soa_dir', 'fake_sha')
 
 
-@patch('paasta_tools.cli.cmds.push_to_registry.load_system_paasta_config', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.requests.Session.get', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.read_docker_registy_creds', autospec=True)
 def test_is_docker_image_already_in_registry_401_unauthorized(
         mock_read_docker_registy_creds,
         mock_request_get,
-        mock_load_system_paasta_config,
 ):
     mock_read_docker_registy_creds.return_value = (None, None)
-    mock_load_system_paasta_config.get_docker_registry = MagicMock(return_value='fake_registry')
     mock_request_get.side_effect = RequestException()
     with raises(RequestException):
-        is_docker_image_already_in_registry('fake_service', 'fake_sha')
+        is_docker_image_already_in_registry('fake_service', 'fake_soa_dir', 'fake_sha')

--- a/tests/cli/test_cmds_push_to_registry.py
+++ b/tests/cli/test_cmds_push_to_registry.py
@@ -119,6 +119,7 @@ def test_push_to_registry_does_not_override_existing_image(
     assert not mock_run.called
 
 
+@patch('paasta_tools.utils.load_system_paasta_config', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.is_docker_image_already_in_registry', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.build_command', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.validate_service_name', autospec=True)
@@ -130,6 +131,7 @@ def test_push_to_registry_does_not_override_when_cant_check_status(
     mock_validate_service_name,
     mock_build_command,
     mock_is_docker_image_already_in_registry,
+    mock_load_system_paasta_config,
 ):
     args, _ = parse_args(['push-to-registry', '-s', 'foo', '-c', 'abcd' * 10])
     mock_run.return_value = (0, 'Success')

--- a/tests/cli/test_cmds_push_to_registry.py
+++ b/tests/cli/test_cmds_push_to_registry.py
@@ -158,11 +158,13 @@ def test_push_to_registry_works_when_service_name_starts_with_services_dash(
     mock_build_command.assert_called_once_with('foo', 'abcd' * 10)
 
 
+@patch('paasta_tools.utils.load_system_paasta_config', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.requests.Session.get', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.read_docker_registy_creds', autospec=True)
 def test_is_docker_image_already_in_registry_success(
         mock_read_docker_registy_creds,
         mock_request_get,
+        mock_load_system_paasta_config,
 ):
     mock_read_docker_registy_creds.return_value = (None, None)
     mock_request_get.return_value = MagicMock(status_code=200,
@@ -170,22 +172,26 @@ def test_is_docker_image_already_in_registry_success(
     assert is_docker_image_already_in_registry('fake_service', 'fake_soa_dir', 'fake_sha')
 
 
+@patch('paasta_tools.utils.load_system_paasta_config', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.requests.Session.get', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.read_docker_registy_creds', autospec=True)
 def test_is_docker_image_already_in_registry_404_no_such_service_yet(
         mock_read_docker_registy_creds,
         mock_request_get,
+        mock_load_system_paasta_config,
 ):
     mock_read_docker_registy_creds.return_value = (None, None)
     mock_request_get.return_value = MagicMock(status_code=404)  # No Such Repository Error
     assert not is_docker_image_already_in_registry('fake_service', 'fake_soa_dir', 'fake_sha')
 
 
+@patch('paasta_tools.utils.load_system_paasta_config', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.requests.Session.get', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.read_docker_registy_creds', autospec=True)
 def test_is_docker_image_already_in_registry_tags_are_null(
         mock_read_docker_registy_creds,
         mock_request_get,
+        mock_load_system_paasta_config,
 ):
     mock_read_docker_registy_creds.return_value = (None, None)
     mock_request_get.return_value = MagicMock(status_code=200,
@@ -193,11 +199,13 @@ def test_is_docker_image_already_in_registry_tags_are_null(
     assert not is_docker_image_already_in_registry('fake_service', 'fake_soa_dir', 'fake_sha')
 
 
+@patch('paasta_tools.utils.load_system_paasta_config', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.requests.Session.get', autospec=True)
 @patch('paasta_tools.cli.cmds.push_to_registry.read_docker_registy_creds', autospec=True)
 def test_is_docker_image_already_in_registry_401_unauthorized(
         mock_read_docker_registy_creds,
         mock_request_get,
+        mock_load_system_paasta_config,
 ):
     mock_read_docker_registy_creds.return_value = (None, None)
     mock_request_get.side_effect = RequestException()

--- a/tests/frameworks/test_native_scheduler.py
+++ b/tests/frameworks/test_native_scheduler.py
@@ -273,7 +273,10 @@ class TestNativeServiceConfig(object):
             soa_dir='/nail/etc/services',
         )
 
-        task = service_config.base_task(system_paasta_config)
+        with mock.patch('paasta_tools.utils.load_system_paasta_config', autospec=True,
+                        return_value=system_paasta_config
+                        ):
+            task = service_config.base_task(system_paasta_config)
 
         assert task.container.type == mesos_pb2.ContainerInfo.DOCKER
         assert task.container.docker.image == "fake/busybox"

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1305,18 +1305,20 @@ class TestChronosTools:
     def test_create_complete_config(self):
         fake_owner = 'test_team'
         fake_config_hash = 'fake_config_hash'
+        fake_registry = 'fake_registry'
         with mock.patch(
             'paasta_tools.chronos_tools.load_system_paasta_config', autospec=True,
         ) as load_system_paasta_config_patch, mock.patch(
             'paasta_tools.chronos_tools.load_chronos_job_config',
             autospec=True, return_value=self.fake_chronos_job_config,
         ), mock.patch(
+            'paasta_tools.utils.get_service_docker_registry', return_value=fake_registry, autospec=True,
+        ), mock.patch(
             'paasta_tools.monitoring_tools.get_team', return_value=fake_owner, autospec=True,
         ), mock.patch(
             'paasta_tools.chronos_tools.get_config_hash', return_value=fake_config_hash, autospec=True,
         ):
             load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=[])
-            load_system_paasta_config_patch.return_value.get_docker_registry = mock.Mock(return_value='fake_registry')
             load_system_paasta_config_patch.return_value.get_dockercfg_location = \
                 mock.Mock(return_value='file:///root/.dockercfg')
             actual = chronos_tools.create_complete_config('fake-service', 'fake-job')
@@ -1358,18 +1360,20 @@ class TestChronosTools:
     def test_create_complete_config_understands_parents(self):
         fake_owner = 'test_team'
         fake_config_hash = 'fake_config_hash'
+        fake_registry = 'fake_registry'
         with mock.patch(
             'paasta_tools.chronos_tools.load_system_paasta_config', autospec=True,
         ) as load_system_paasta_config_patch, mock.patch(
             'paasta_tools.chronos_tools.load_chronos_job_config',
             autospec=True, return_value=self.fake_dependent_chronos_job_config,
         ), mock.patch(
+            'paasta_tools.utils.get_service_docker_registry', return_value=fake_registry, autospec=True,
+        ), mock.patch(
             'paasta_tools.monitoring_tools.get_team', return_value=fake_owner, autospec=True,
         ), mock.patch(
             'paasta_tools.chronos_tools.get_config_hash', return_value=fake_config_hash, autospec=True,
         ):
             load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=[])
-            load_system_paasta_config_patch.return_value.get_docker_registry = mock.Mock(return_value='fake_registry')
             load_system_paasta_config_patch.return_value.get_dockercfg_location = \
                 mock.Mock(return_value='file:///root/.dockercfg')
             actual = chronos_tools.create_complete_config('fake-service', 'fake-job')
@@ -1387,7 +1391,6 @@ class TestChronosTools:
             'paasta_tools.monitoring_tools.get_team', return_value=fake_owner, autospec=True,
         ):
             load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=[])
-            load_system_paasta_config_patch.return_value.get_docker_registry = mock.Mock(return_value='fake_registry')
             load_system_paasta_config_patch.return_value.get_dockercfg_location = \
                 mock.Mock(return_value='file:///root/.dockercfg')
             first_description = chronos_tools.create_complete_config('fake-service', 'fake-job')['description']
@@ -1420,18 +1423,20 @@ class TestChronosTools:
             },
         )
         fake_config_hash = 'fake_config_hash'
+        fake_registry = 'fake_registry'
         with mock.patch(
             'paasta_tools.chronos_tools.load_system_paasta_config', autospec=True,
         ) as load_system_paasta_config_patch, mock.patch(
             'paasta_tools.chronos_tools.load_chronos_job_config',
             autospec=True, return_value=fake_chronos_job_config,
         ), mock.patch(
+            'paasta_tools.utils.get_service_docker_registry', return_value=fake_registry, autospec=True,
+        ), mock.patch(
             'paasta_tools.monitoring_tools.get_team', return_value=fake_owner, autospec=True,
         ), mock.patch(
             'paasta_tools.chronos_tools.get_config_hash', return_value=fake_config_hash, autospec=True,
         ):
             load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=[])
-            load_system_paasta_config_patch.return_value.get_docker_registry = mock.Mock(return_value='fake_registry')
             load_system_paasta_config_patch.return_value.get_dockercfg_location = \
                 mock.Mock(return_value='file:///root/.dockercfg')
             actual = chronos_tools.create_complete_config('fake_service', 'fake_job')
@@ -1483,18 +1488,20 @@ class TestChronosTools:
             },
         )
         fake_config_hash = 'fake_config_hash'
+        fake_registry = 'fake_registry'
         with mock.patch(
             'paasta_tools.chronos_tools.load_system_paasta_config', autospec=True,
         ) as load_system_paasta_config_patch, mock.patch(
             'paasta_tools.chronos_tools.load_chronos_job_config',
             autospec=True, return_value=fake_chronos_job_config,
         ), mock.patch(
+            'paasta_tools.utils.get_service_docker_registry', return_value=fake_registry, autospec=True,
+        ), mock.patch(
             'paasta_tools.monitoring_tools.get_team', return_value=fake_owner, autospec=True,
         ), mock.patch(
             'paasta_tools.chronos_tools.get_config_hash', return_value=fake_config_hash, autospec=True,
         ):
             load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=[])
-            load_system_paasta_config_patch.return_value.get_docker_registry = mock.Mock(return_value='fake_registry')
             load_system_paasta_config_patch.return_value.get_dockercfg_location = \
                 mock.Mock(return_value='file:///root/.dockercfg')
             actual = chronos_tools.create_complete_config('fake_service', 'fake_job')
@@ -1562,18 +1569,20 @@ class TestChronosTools:
             },
         )
         fake_config_hash = 'fake_config_hash'
+        fake_registry = 'fake_registry'
         with mock.patch(
             'paasta_tools.chronos_tools.load_system_paasta_config', autospec=True,
         ) as load_system_paasta_config_patch, mock.patch(
             'paasta_tools.chronos_tools.load_chronos_job_config',
             autospec=True, return_value=fake_chronos_job_config,
         ), mock.patch(
+            'paasta_tools.utils.get_service_docker_registry', return_value=fake_registry, autospec=True,
+        ), mock.patch(
             'paasta_tools.monitoring_tools.get_team', return_value=fake_owner, autospec=True,
         ), mock.patch(
             'paasta_tools.chronos_tools.get_config_hash', return_value=fake_config_hash, autospec=True,
         ):
             load_system_paasta_config_patch.return_value.get_volumes = mock.Mock(return_value=fake_system_volumes)
-            load_system_paasta_config_patch.return_value.get_docker_registry = mock.Mock(return_value='fake_registry')
             load_system_paasta_config_patch.return_value.get_dockercfg_location = \
                 mock.Mock(return_value='file:///root/.dockercfg')
             actual = chronos_tools.create_complete_config('fake_service', 'fake_job')

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1385,6 +1385,8 @@ class TestChronosTools:
         with mock.patch(
             'paasta_tools.chronos_tools.load_system_paasta_config', autospec=True,
         ) as load_system_paasta_config_patch, mock.patch(
+            'paasta_tools.utils.load_system_paasta_config', autospec=True,
+        ), mock.patch(
             'paasta_tools.chronos_tools.load_chronos_job_config',
             autospec=True, return_value=self.fake_chronos_job_config,
         ) as load_chronos_job_config_patch, mock.patch(

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -2092,6 +2092,9 @@ def test_format_marathon_app_dict_utilizes_net():
     ), mock.patch(
         'paasta_tools.marathon_tools.format_job_id', return_value=fake_job_id, autospec=True,
     ), mock.patch(
+        'paasta_tools.utils.load_system_paasta_config',
+        return_value=fake_system_paasta_config, autospec=True,
+    ), mock.patch(
         'paasta_tools.marathon_tools.load_system_paasta_config',
         return_value=fake_system_paasta_config, autospec=True,
     ):

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1925,15 +1925,17 @@ def test_format_marathon_app_dict_no_smartstack():
     )
     fake_system_paasta_config = SystemPaastaConfig({
         'volumes': [],
-        'docker_registry': 'fake_docker_registry:443',
         'expected_slave_attributes': [{"region": "blah"}],
     }, '/fake/dir/')
     fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig()
+    fake_docker_registry = 'fake_docker_registry:443'
 
     with mock.patch(
         'paasta_tools.marathon_tools.load_service_namespace_config',
         return_value=fake_service_namespace_config,
         autospec=True,
+    ), mock.patch(
+        'paasta_tools.utils.get_service_docker_registry', return_value=fake_docker_registry, autospec=True,
     ), mock.patch(
         'paasta_tools.marathon_tools.format_job_id', return_value=fake_job_id, autospec=True,
     ), mock.patch(
@@ -1992,15 +1994,17 @@ def test_format_marathon_app_dict_with_smartstack():
     )
     fake_system_paasta_config = SystemPaastaConfig({
         'volumes': [],
-        'docker_registry': 'fake_docker_registry:443',
         'expected_slave_attributes': [{"region": "blah"}],
     }, '/fake/dir/')
     fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({'proxy_port': 9001})
+    fake_docker_registry = 'fake_docker_registry:443'
 
     with mock.patch(
         'paasta_tools.marathon_tools.load_service_namespace_config',
         return_value=fake_service_namespace_config,
         autospec=True,
+    ), mock.patch(
+        'paasta_tools.utils.get_service_docker_registry', return_value=fake_docker_registry, autospec=True,
     ), mock.patch(
         'paasta_tools.marathon_tools.format_job_id', return_value=fake_job_id, autospec=True,
     ), mock.patch(
@@ -2121,15 +2125,17 @@ def test_format_marathon_app_dict_utilizes_extra_volumes():
     )
     fake_system_paasta_config = SystemPaastaConfig({
         'volumes': fake_system_volumes,
-        'docker_registry': 'fake_docker_registry:443',
         'expected_slave_attributes': [{"region": "blah"}],
     }, '/fake/dir/')
     fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig()
+    fake_docker_registry = 'fake_docker_registry:443'
 
     with mock.patch(
         'paasta_tools.marathon_tools.load_service_namespace_config',
         return_value=fake_service_namespace_config,
         autospec=True,
+    ), mock.patch(
+        'paasta_tools.utils.get_service_docker_registry', return_value=fake_docker_registry, autospec=True,
     ), mock.patch(
         'paasta_tools.marathon_tools.format_job_id', return_value=fake_job_id, autospec=True,
     ), mock.patch(

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -926,7 +926,7 @@ class TestMarathonTools:
             branch_dict={'desired_state': 'start'}
         )
         with mock.patch(
-            'paasta_tools.marathon_tools.get_docker_url', autospec=True, return_value=fake_url,
+            'paasta_tools.utils.InstanceConfig.get_docker_url', autospec=True, return_value=fake_url,
         ), mock.patch(
             'paasta_tools.marathon_tools.load_service_namespace_config', autospec=True,
             return_value=fake_service_namespace_config,
@@ -1466,7 +1466,7 @@ class TestMarathonTools:
             'paasta_tools.marathon_tools.load_system_paasta_config',
             autospec=True, return_value=fake_system_paasta_config,
         ) as load_system_paasta_config_patch, mock.patch(
-            'paasta_tools.marathon_tools.get_docker_url', autospec=True, return_value=fake_url,
+            'paasta_tools.utils.InstanceConfig.get_docker_url', autospec=True, return_value=fake_url,
         ), mock.patch(
             'paasta_tools.marathon_tools.load_service_namespace_config', autospec=True,
             return_value=self.fake_service_namespace_config,

--- a/tests/test_setup_chronos_job.py
+++ b/tests/test_setup_chronos_job.py
@@ -253,6 +253,8 @@ class TestSetupChronosJob:
             autospec=True,
             return_value=fake_existing_jobs,
         ), mock.patch(
+            'paasta_tools.utils.load_system_paasta_config', autospec=True,
+        ), mock.patch(
             'paasta_tools.chronos_tools.load_system_paasta_config', autospec=True,
         ) as load_system_paasta_config_patch, mock.patch(
             'paasta_tools.chronos_tools.load_chronos_job_config',
@@ -298,6 +300,8 @@ class TestSetupChronosJob:
             'paasta_tools.chronos_tools.sort_jobs',
             autospec=True,
             return_value=[fake_existing_job],
+        ), mock.patch(
+            'paasta_tools.utils.load_system_paasta_config', autospec=True,
         ), mock.patch(
             'paasta_tools.chronos_tools.load_system_paasta_config', autospec=True,
         ) as load_system_paasta_config_patch, mock.patch(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -715,18 +715,6 @@ def test_DeploymentsJson_read():
         assert actual == fake_json['v1']
 
 
-def test_get_docker_url_no_error():
-    fake_registry = "im.a-real.vm"
-    fake_image = "and-i-can-run:1.0"
-    expected = "%s/%s" % (fake_registry, fake_image)
-    assert utils.get_docker_url(fake_registry, fake_image) == expected
-
-
-def test_get_docker_url_with_no_docker_image():
-    with raises(utils.NoDockerImageError):
-        utils.get_docker_url('fake_registry', None)
-
-
 def test_get_running_mesos_docker_containers():
 
     fake_container_data = [
@@ -1333,6 +1321,28 @@ class TestInstanceConfig:
         assert fake_conf.get_volumes(system_volumes) == [
             {"containerPath": "/a", "hostPath": "/a", "mode": "RW"},
         ]
+
+    def test_get_docker_url_no_error(self):
+        fake_registry = "im.a-real.vm"
+        fake_image = "and-i-can-run:1.0"
+
+        fake_conf = utils.InstanceConfig(
+            service='',
+            cluster='',
+            instance='',
+            config_dict={},
+            branch_dict={},
+        )
+
+        with mock.patch(
+            'paasta_tools.utils.InstanceConfig.get_docker_registry', autospec=True,
+            return_value=fake_registry
+        ), mock.patch(
+            'paasta_tools.utils.InstanceConfig.get_docker_image', autospec=True,
+            return_value=fake_image
+        ):
+            expected_url = "%s/%s" % (fake_registry, fake_image)
+            assert fake_conf.get_docker_url() == expected_url
 
     @pytest.mark.parametrize(('dependencies_reference', 'dependencies', 'expected'), [
         (None, None, None),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -287,19 +287,37 @@ def test_SystemPaastaConfig_get_zk_dne():
         fake_config.get_zk_hosts()
 
 
-def test_SystemPaastaConfig_get_registry():
-    fake_config = utils.SystemPaastaConfig({
-        'docker_registry': 'fake_registry'
+def test_get_service_registry():
+    fake_registry = 'fake_registry'
+    fake_service_config = {
+        "description": "This service is fake",
+        "external_link": "www.yelp.com",
+        "git_url": "git@mercurial-scm.org:fake-service",
+        "docker_registry": fake_registry,
+    }
+    with mock.patch('service_configuration_lib.read_service_configuration',
+                    return_value=fake_service_config, autospec=True):
+        actual = utils.get_service_docker_registry('fake_service', 'fake_soa_dir')
+        assert actual == fake_registry
+
+
+def test_get_service_registry_dne():
+    fake_registry = 'fake_registry'
+    fake_service_config = {
+        "description": "This service is fake",
+        "external_link": "www.yelp.com",
+        "git_url": "git@mercurial-scm.org:fake-service",
+        # no docker_registry configured for this service
+    }
+    fake_system_config = utils.SystemPaastaConfig({
+        "docker_registry": fake_registry,
     }, '/some/fake/dir')
-    expected = 'fake_registry'
-    actual = fake_config.get_docker_registry()
-    assert actual == expected
-
-
-def test_SystemPaastaConfig_get_registry_dne():
-    fake_config = utils.SystemPaastaConfig({}, '/some/fake/dir')
-    with raises(utils.PaastaNotConfiguredError):
-        fake_config.get_docker_registry()
+    with mock.patch('service_configuration_lib.read_service_configuration',
+                    return_value=fake_service_config, autospec=True):
+        with mock.patch('paasta_tools.utils.load_system_paasta_config',
+                        return_value=fake_system_config, autospec=True):
+            actual = utils.get_service_docker_registry('fake_service', 'fake_soa_dir')
+            assert actual == fake_registry
 
 
 def test_SystemPaastaConfig_get_sensu_host_default():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -491,6 +491,16 @@ def test_decompose_job_id_with_hashes():
     assert actual == expected
 
 
+def test_build_docker_image_name():
+    registry_url = "fake_registry"
+    upstream_job_name = "a_really_neat_service"
+    expected = "%s/services-%s" % (registry_url, upstream_job_name)
+    with mock.patch('paasta_tools.utils.get_service_docker_registry', autospec=True,
+                    return_value=registry_url):
+        actual = utils.build_docker_image_name(upstream_job_name)
+    assert actual == expected
+
+
 @mock.patch('paasta_tools.utils.build_docker_image_name', autospec=True)
 def test_build_docker_tag(mock_build_docker_image_name):
     upstream_job_name = 'foo'


### PR DESCRIPTION
This PR allows service owners to specify their own docker registry to use.

Currently, the docker registry is set at a system-wide level in the system config.  This system-wide docker registry will still be the default, but service owners can optionally specify a different registry by setting the "docker_registry" key in their service configuration file.