### PR TITLE
stricter handling of iptables parameters

### DIFF
--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -94,7 +94,7 @@ def _default_rule(conf, log_prefix):
             target='REJECT',
             matches=(),
             target_parameters=(
-                (('reject-with', ('icmp-port-unreachable',))),
+                ('reject-with', ('icmp-port-unreachable',)),
             ),
         )
     elif policy == 'monitor':
@@ -104,13 +104,13 @@ def _default_rule(conf, log_prefix):
             dst='0.0.0.0/0.0.0.0',
             target='LOG',
             target_parameters=(
-                ('log-prefix', ((log_prefix),)),
+                ('log-prefix', (log_prefix,)),
             ),
             matches=(
                 (
                     'limit', (
-                        ('limit', '1/sec'),
-                        ('limit-burst', '1'),
+                        ('limit', ('1/sec',)),
+                        ('limit-burst', ('1',)),
                     )
                 ),
             )
@@ -167,7 +167,12 @@ def _smartstack_rules(conf, soa_dir, synapse_service_dir):
                 dst='{}/255.255.255.255'.format(backend['host']),
                 target='ACCEPT',
                 matches=(
-                    ('tcp', (('dport', six.text_type(backend['port'])),)),
+                    (
+                        'tcp',
+                        (
+                            ('dport', (six.text_type(backend['port']),)),
+                        )
+                    ),
                 ),
                 target_parameters=(),
             )
@@ -183,7 +188,12 @@ def _smartstack_rules(conf, soa_dir, synapse_service_dir):
             dst='169.254.255.254/255.255.255.255',
             target='ACCEPT',
             matches=(
-                ('tcp', (('dport', six.text_type(port)),)),
+                (
+                    'tcp',
+                    (
+                        ('dport', (six.text_type(port),)),
+                    )
+                ),
             ),
             target_parameters=(),
         )
@@ -266,7 +276,7 @@ def dispatch_rule(chain, mac):
         dst='0.0.0.0/0.0.0.0',
         target=chain,
         matches=(
-            ('mac', (('mac_source', mac.upper()),)),
+            ('mac', (('mac-source', (mac.upper(),)),)),
         ),
         target_parameters=(),
     )

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -145,8 +145,8 @@ def test_service_group_rules(mock_service_config, service_group):
             target='LOG',
             matches=(
                 ('limit', (
-                    ('limit', '1/sec'),
-                    ('limit-burst', '1'),
+                    ('limit', ('1/sec',)),
+                    ('limit-burst', ('1',)),
                 )),
             ),
             target_parameters=(
@@ -159,7 +159,7 @@ def test_service_group_rules(mock_service_config, service_group):
             target='ACCEPT',
             dst='1.2.3.4/255.255.255.255',
             matches=(
-                ('tcp', (('dport', '123'),)),
+                ('tcp', (('dport', ('123',)),)),
             ),
         ),
         EMPTY_RULE._replace(
@@ -167,7 +167,7 @@ def test_service_group_rules(mock_service_config, service_group):
             target='ACCEPT',
             dst='5.6.7.8/255.255.255.255',
             matches=(
-                ('tcp', (('dport', '567'),)),
+                ('tcp', (('dport', ('567',)),)),
             ),
         ),
         EMPTY_RULE._replace(
@@ -175,7 +175,7 @@ def test_service_group_rules(mock_service_config, service_group):
             target='ACCEPT',
             dst='169.254.255.254/255.255.255.255',
             matches=(
-                ('tcp', (('dport', '20000'),)),
+                ('tcp', (('dport', ('20000',)),)),
             ),
         ),
     )
@@ -188,8 +188,8 @@ def test_service_group_rules_synapse_backend_error(mock_service_config, service_
             target='LOG',
             matches=(
                 ('limit', (
-                    ('limit', '1/sec'),
-                    ('limit-burst', '1'),
+                    ('limit', ('1/sec',)),
+                    ('limit-burst', ('1',)),
                 )),
             ),
             target_parameters=(
@@ -202,7 +202,7 @@ def test_service_group_rules_synapse_backend_error(mock_service_config, service_
             target='ACCEPT',
             dst='169.254.255.254/255.255.255.255',
             matches=(
-                ('tcp', (('dport', '20000'),)),
+                ('tcp', (('dport', ('20000',)),)),
             ),
         ),
     )
@@ -303,13 +303,13 @@ def test_ensure_dispatch_chains():
     assert mock_ensure_chain.mock_calls == [mock.call(
         'PAASTA', {
             EMPTY_RULE._replace(
-                target='chain1', matches=(('mac', (('mac_source', 'MAC1'),)),),
+                target='chain1', matches=(('mac', (('mac-source', ('MAC1',)),)),),
             ),
             EMPTY_RULE._replace(
-                target='chain1', matches=(('mac', (('mac_source', 'MAC2'),)),),
+                target='chain1', matches=(('mac', (('mac-source', ('MAC2',)),)),),
             ),
             EMPTY_RULE._replace(
-                target='chain2', matches=(('mac', (('mac_source', 'MAC3'),)),),
+                target='chain2', matches=(('mac', (('mac-source', ('MAC3',)),)),),
             ),
         },
     )]
@@ -365,7 +365,7 @@ def test_prepare_new_container(insert_rule_mock, ensure_chain_mock, get_rules_mo
             'PAASTA',
             EMPTY_RULE._replace(
                 target='PAASTA.myservice.7e8522249a',
-                matches=(('mac', (('mac_source', '00:00:00:00:00:00'),)),),
+                matches=(('mac', (('mac-source', ('00:00:00:00:00:00',)),)),),
             ),
         )
     ]

--- a/tests/test_iptables.py
+++ b/tests/test_iptables.py
@@ -57,7 +57,7 @@ def test_rule_from_iptc_mac_match():
         target='DROP',
         matches=(
             ('mac', (
-                ('mac_source', '20:C9:D0:2B:6F:F3'),
+                ('mac-source', ('20:C9:D0:2B:6F:F3',)),
             )),
         ),
     )
@@ -80,7 +80,7 @@ def test_rule_tcp_to_iptc():
         target='ACCEPT',
         matches=(
             ('tcp', (
-                ('dport', '443'),
+                ('dport', ('443',)),
             )),
         ),
     ).to_iptc()
@@ -96,7 +96,7 @@ def test_mac_src_to_iptc():
         target='ACCEPT',
         matches=(
             ('mac', (
-                ('mac_source', '20:C9:D0:2B:6F:F3'),
+                ('mac-source', ('20:C9:D0:2B:6F:F3',)),
             )),
         ),
     ).to_iptc()


### PR DESCRIPTION
stricter handling of iptables parameters to preserve symmetry with how they're read back out of iptables:
- parameter values must always be tuples
- must use dashes instead of underscores