### PR TITLE
Enforce ordering on iptables rules

### DIFF
--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -75,6 +75,7 @@ class ServiceGroup(collections.namedtuple('ServiceGroup', (
 
     def update_rules(self, soa_dir, synapse_service_dir):
         iptables.ensure_chain(self.chain_name, self.get_rules(soa_dir, synapse_service_dir))
+        iptables.reorder_chain(self.chain_name)
 
     @property
     def log_prefix(self):

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -68,7 +68,7 @@ class ServiceGroup(collections.namedtuple('ServiceGroup', (
         if conf.get_dependencies() is None:
             return ()
 
-        rules = [_default_rule(conf, self.log_prefix)]
+        rules = list(_default_rules(conf, self.log_prefix))
         rules.extend(_well_known_rules(conf))
         rules.extend(_smartstack_rules(conf, soa_dir, synapse_service_dir))
         return tuple(rules)
@@ -85,37 +85,42 @@ class ServiceGroup(collections.namedtuple('ServiceGroup', (
         return 'paasta.{}'.format(self.service)[:28] + ' '
 
 
-def _default_rule(conf, log_prefix):
+def _default_rules(conf, log_prefix):
+    log_rule = iptables.Rule(
+        protocol='ip',
+        src='0.0.0.0/0.0.0.0',
+        dst='0.0.0.0/0.0.0.0',
+        target='LOG',
+        target_parameters=(
+            ('log-prefix', (log_prefix,)),
+        ),
+        matches=(
+            (
+                'limit', (
+                    ('limit', ('1/sec',)),
+                    ('limit-burst', ('1',)),
+                )
+            ),
+        )
+    )
+
     policy = conf.get_outbound_firewall()
     if policy == 'block':
-        return iptables.Rule(
-            protocol='ip',
-            src='0.0.0.0/0.0.0.0',
-            dst='0.0.0.0/0.0.0.0',
-            target='REJECT',
-            matches=(),
-            target_parameters=(
-                ('reject-with', ('icmp-port-unreachable',)),
+        return (
+            iptables.Rule(
+                protocol='ip',
+                src='0.0.0.0/0.0.0.0',
+                dst='0.0.0.0/0.0.0.0',
+                target='REJECT',
+                matches=(),
+                target_parameters=(
+                    (('reject-with', ('icmp-port-unreachable',))),
+                ),
             ),
+            log_rule
         )
     elif policy == 'monitor':
-        return iptables.Rule(
-            protocol='ip',
-            src='0.0.0.0/0.0.0.0',
-            dst='0.0.0.0/0.0.0.0',
-            target='LOG',
-            target_parameters=(
-                ('log-prefix', (log_prefix,)),
-            ),
-            matches=(
-                (
-                    'limit', (
-                        ('limit', ('1/sec',)),
-                        ('limit-burst', ('1',)),
-                    )
-                ),
-            )
-        )
+        return (log_rule,)
     else:
         raise AssertionError(policy)
 


### PR DESCRIPTION
This adds a function called reorder_chain() that ensures that all rules of a chain have REJECT being last, and LOG being second-last.

I have admittedly mixed feelings about it. Changing the existing behavior of ensure_chain() is pretty complex - it'd require a diff algo. So instead this is its own separate function. This way the code is reasonably simple to follow IMHO. I also wanted something that will fix existing chains, like if we introduce a bug with ordering at any point, or a failure results in inconsistent state. This is a straightforward way to fix any existing chain.

It doesn't cause any unnecessary reordering - it preserves order of existing ACCEPT rules. There's probably a way to do it with fewer operations, I'd need to break out my sorting algorithms. OTOH, it doesn't do any operations if things are already sorted, so in the overwhelming common case this incurs no additional iptables operations.

I also add LOG rules to 'block' situations (the second commit).

internal ticket PAASTA-11763