### PR TITLE
Remove mesos.interface now that we use pymesos.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,12 +27,10 @@ jsonschema[format]==2.5.1
 kazoo==2.2
 lockfile==0.9.1
 mccabe==0.3.1
-mesos.interface==1.1.0
 path.py==8.1
 ply==3.4
 prettytable==0.7.2
 progressbar2==3.10.1
-protobuf==2.6.1
 pyasn1==0.1.8
 pycrypto==2.6.1
 Pygments==2.0.2

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         'jsonschema[format]',
         'kazoo >= 2.0.0',
         'marathon >= 0.8.1',
-        'mesos.interface == 1.1.0',
         'path.py >= 8.1',
         'progressbar2 >= 3.10.0',
         'pyramid == 1.7',


### PR DESCRIPTION
@jglukasik is having dependency version conflicts with protobuf -- mesos.interface needs < 3, signalform needs >3.5.