### PR TITLE
Add comments on iptables ACCEPT lines

### DIFF
--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -168,6 +168,12 @@ def _smartstack_rules(conf, soa_dir, synapse_service_dir):
                 target='ACCEPT',
                 matches=(
                     (
+                        'comment',
+                        (
+                            ('comment', ('backend ' + namespace,)),
+                        )
+                    ),
+                    (
                         'tcp',
                         (
                             ('dport', (six.text_type(backend['port']),)),
@@ -188,6 +194,12 @@ def _smartstack_rules(conf, soa_dir, synapse_service_dir):
             dst='169.254.255.254/255.255.255.255',
             target='ACCEPT',
             matches=(
+                (
+                    'comment',
+                    (
+                        ('comment', ('proxy_port ' + namespace,)),
+                    )
+                ),
                 (
                     'tcp',
                     (

--- a/paasta_tools/iptables.py
+++ b/paasta_tools/iptables.py
@@ -74,11 +74,14 @@ class Rule(_RuleBase):
         for param_name, param_value in sorted(rule.target.get_all_parameters().items()):
             fields['target_parameters'] += ((param_name, tuple(param_value)),)
 
+        matches = []
         for match in rule.matches:
-            fields['matches'] += ((
+            matches.append((
                 match.name,
                 tuple((param, tuple(value)) for param, value in sorted(match.get_all_parameters().items()))
-            ),)
+            ))
+        # ensure that matches are sorted for consistency with matching
+        fields['matches'] = tuple(sorted(matches))
 
         return cls(**fields)
 

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -159,6 +159,7 @@ def test_service_group_rules(mock_service_config, service_group):
             target='ACCEPT',
             dst='1.2.3.4/255.255.255.255',
             matches=(
+                ('comment', (('comment', ('backend example_happyhour.main',)),)),
                 ('tcp', (('dport', ('123',)),)),
             ),
         ),
@@ -167,6 +168,7 @@ def test_service_group_rules(mock_service_config, service_group):
             target='ACCEPT',
             dst='5.6.7.8/255.255.255.255',
             matches=(
+                ('comment', (('comment', ('backend example_happyhour.main',)),)),
                 ('tcp', (('dport', ('567',)),)),
             ),
         ),
@@ -175,6 +177,7 @@ def test_service_group_rules(mock_service_config, service_group):
             target='ACCEPT',
             dst='169.254.255.254/255.255.255.255',
             matches=(
+                ('comment', (('comment', ('proxy_port example_happyhour.main',)),)),
                 ('tcp', (('dport', ('20000',)),)),
             ),
         ),
@@ -202,6 +205,7 @@ def test_service_group_rules_synapse_backend_error(mock_service_config, service_
             target='ACCEPT',
             dst='169.254.255.254/255.255.255.255',
             matches=(
+                ('comment', (('comment', ('proxy_port example_happyhour.main',)),)),
                 ('tcp', (('dport', ('20000',)),)),
             ),
         ),


### PR DESCRIPTION
..  to help identify what they refer to.

Example iptables -S output:

```
-A PAASTA.example_ha.8891d16afc -d 169.254.255.254/32 -p tcp -m comment --comment "proxy_port yelp-main.internalapi" -m tcp --dport 20666 -j ACCEPT
-A PAASTA.example_ha.8891d16afc -d 10.40.10.88/32 -p tcp -m comment --comment "backend yelp-main.internalapi" -m tcp --dport 31719 -j ACCEPT
-A PAASTA.example_ha.8891d16afc -d 10.40.24.254/32 -p tcp -m comment --comment "backend yelp-main.internalapi" -m tcp --dport 31918 -j ACCEPT
-A PAASTA.example_ha.8891d16afc -d 10.40.22.153/32 -p tcp -m comment --comment "backend yelp-main.internalapi" -m tcp --dport 31063 -j ACCEPT
-A PAASTA.example_ha.8891d16afc -d 169.254.255.254/32 -p tcp -m comment --comment "proxy_port pypi.main" -m tcp --dport 20641 -j ACCEPT
-A PAASTA.example_ha.8891d16afc -d 10.40.11.209/32 -p tcp -m comment --comment "backend pypi.main" -m tcp --dport 31703 -j ACCEPT
-A PAASTA.example_ha.8891d16afc -d 10.40.11.234/32 -p tcp -m comment --comment "backend pypi.main" -m tcp --dport 31517 -j ACCEPT
-A PAASTA.example_ha.8891d16afc -d 10.40.30.223/32 -p tcp -m comment --comment "backend pypi.main" -m tcp --dport 31186 -j ACCEPT
-A PAASTA.example_ha.8891d16afc -d 169.254.255.254/32 -p tcp -m comment --comment "proxy_port npm.main" -m tcp --dport 20493 -j ACCEPT
-A PAASTA.example_ha.8891d16afc -d 10.40.18.159/32 -p tcp -m comment --comment "backend npm.main" -m tcp --dport 31454 -j ACCEPT
-A PAASTA.example_ha.8891d16afc -d 10.40.11.5/32 -p tcp -m comment --comment "backend npm.main" -m tcp --dport 31852 -j ACCEPT
-A PAASTA.example_ha.8891d16afc -d 10.40.11.209/32 -p tcp -m comment --comment "backend npm.main" -m tcp --dport 31939 -j ACCEPT
-A PAASTA.example_ha.8891d16afc -m limit --limit 1/sec --limit-burst 1 -j LOG --log-prefix "paasta.example_happyhour "
-A PAASTA.example_ha.8891d16afc -j PAASTA-INTERNET
```

Internal ticket PAASTA-11760