### PR TITLE
Add timeout to HTTP draining requests

### DIFF
--- a/paasta_tools/drain_lib.py
+++ b/paasta_tools/drain_lib.py
@@ -284,7 +284,11 @@ class HTTPDrainMethod(DrainMethod):
             'HEAD': requests.head,
         }[method]
 
-        resp = requests_func(url, headers={'User-Agent': get_user_agent()},)
+        resp = requests_func(
+            url,
+            headers={'User-Agent': get_user_agent()},
+            timeout=15,
+        )
         self.check_response_code(resp.status_code, url_spec['success_codes'])
 
     def drain(self, task):

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -448,7 +448,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         (/status currently)
 
         Otherwise these do *not* use the same thresholds as smartstack in order to not
-        produce a negative feedback loop, where mesos agressivly kills tasks because they
+        produce a negative feedback loop, where mesos aggressively kills tasks because they
         are slow, which causes other things to be slow, etc.
 
         If the mode of the service is None, indicating that it was not specified in the service config

--- a/tests/test_drain_lib.py
+++ b/tests/test_drain_lib.py
@@ -139,4 +139,4 @@ class TestHTTPDrainMethod(object):
                 task=fake_task,
             )
 
-        mock_get.assert_called_once_with('http://localhost:654321/fake/fake_host', headers=mock.ANY)
+        mock_get.assert_called_once_with('http://localhost:654321/fake/fake_host', headers=mock.ANY, timeout=15)


### PR DESCRIPTION
Fixes #1287

@EvanKrall Is a timeout of 15 seconds enough time? Do we want to catch the timeout and proceed anyway when in `stop_draining`?