### PR TITLE
Tolerate weird instance types in firewall update

### DIFF
--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -64,12 +64,17 @@ class ServiceGroup(collections.namedtuple('ServiceGroup', (
         return chain
 
     def get_rules(self, soa_dir, synapse_service_dir):
-        conf = get_instance_config(
-            self.service, self.instance,
-            load_system_paasta_config().get_cluster(),
-            load_deployments=False,
-            soa_dir=soa_dir,
-        )
+        try:
+            conf = get_instance_config(
+                self.service, self.instance,
+                load_system_paasta_config().get_cluster(),
+                load_deployments=False,
+                soa_dir=soa_dir,
+            )
+        except NotImplementedError:
+            # PAASTA-11414: new instance types may not provide this configuration information;
+            # we don't want to break all of the firewall infrastructure when that happens
+            return ()
 
         if conf.get_dependencies() is None:
             return ()

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -268,7 +268,7 @@ def test_service_group_rules_synapse_backend_error(mock_service_config, service_
     )
 
 
-def test_service_group_rules_empty_when_invalid_instance_type(service_group):
+def test_service_group_rules_empty_when_invalid_instance_type(service_group, mock_service_config):
     with mock.patch.object(firewall, 'get_instance_config', side_effect=NotImplementedError()):
         assert service_group.get_rules(DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR) == ()
 

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -268,6 +268,11 @@ def test_service_group_rules_synapse_backend_error(mock_service_config, service_
     )
 
 
+def test_service_group_rules_empty_when_invalid_instance_type(service_group):
+    with mock.patch.object(firewall, 'get_instance_config', side_effect=NotImplementedError()):
+        assert service_group.get_rules(DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR) == ()
+
+
 @mock.patch.object(iptables, 'ensure_chain', autospec=True)
 @mock.patch.object(iptables, 'reorder_chain', autospec=True)
 def test_service_group_update_rules(reorder_mock, ensure_mock, service_group):


### PR DESCRIPTION
Internal ticket: PAASTA-11414

If we can't get configuration for an instance type, just ignore it instead of breaking all of the firewall infrastructure.