### PR TITLE
Upgrade itests to use Marathon 1.4.5

### DIFF
--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -32,7 +32,7 @@ RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set
 RUN echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections
 RUN apt-get update > /dev/null && apt-get -y install lsb-release oracle-java8-installer > /dev/null
 
-RUN apt-get update > /dev/null && apt-get -y install marathon=1.4.3-1.0.649.ubuntu1404 > /dev/null
+RUN apt-get update > /dev/null && apt-get -y install marathon=1.4.5-1.0.654.ubuntu1404 > /dev/null
 
 RUN echo -n "secret2" > /etc/marathon_framework_secret
 


### PR DESCRIPTION
Marathon 1.4.5 is released.

https://github.com/mesosphere/marathon/releases/tag/v1.4.5

The only change in this release is:
```
MARATHON-7479 Fixes major deployment plan computation performance regression for Marathon instances containing a large number of apps (500+).
```

This is internal ticket: PAASTA-11880