### PR TITLE
Adding a timed flock to firewall operations

### DIFF
--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -24,13 +24,10 @@ import re
 import socket
 import sys
 
-import pysensu_yelp
-
 from paasta_tools.firewall import DEFAULT_SYNAPSE_SERVICE_DIR
 from paasta_tools.firewall import firewall_flock
 from paasta_tools.firewall import prepare_new_container
 from paasta_tools.mac_address import reserve_unique_mac_address
-from paasta_tools.monitoring_tools import send_event
 from paasta_tools.utils import DEFAULT_SOA_DIR
 
 
@@ -278,13 +275,10 @@ def append_cpuset_args(argv, env_args):
 
 def add_firewall(argv, service, instance):
     output = ''
-    sensu_status = pysensu_yelp.Status.OK
-
     try:
         mac_address, lockfile = reserve_unique_mac_address(LOCK_DIRECTORY)
     except Exception as e:
         output = 'Unable to add mac address: {}'.format(e)
-        sensu_status = pysensu_yelp.Status.CRITICAL
     else:
         argv = add_argument(argv, '--mac-address={}'.format(mac_address))
         try:
@@ -298,19 +292,10 @@ def add_firewall(argv, service, instance):
                     mac_address)
         except Exception as e:
             output = 'Unable to add firewall rules: {}'.format(e)
-            sensu_status = pysensu_yelp.Status.CRITICAL
 
     if output:
         print(output, file=sys.stderr)
 
-    send_event(
-        service=service,
-        check_name='apply_firewall',
-        overrides={},
-        status=sensu_status,
-        output=output,
-        soa_dir=DEFAULT_SOA_DIR
-    )
     return argv
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ import datetime
 import json
 import os
 import stat
+import time
 
 import mock
 import pytest
@@ -1823,5 +1824,19 @@ def test_timed_flock_timeout(mock_flock, mock_timeout, tmpdir):
     with open(str(my_file), 'w') as f:
         with pytest.raises(utils.TimeoutError):
             with utils.timed_flock(f):
-                assert False
+                assert False  # pragma: no cover
         assert mock_flock.mock_calls == []
+
+
+@mock.patch("paasta_tools.utils.fcntl.flock", autospec=True, wraps=utils.fcntl.flock)
+def test_timed_flock_inner_timeout_ok(mock_flock, tmpdir):
+    # Doing something slow inside the 'with' context of timed_flock doesn't cause a timeout
+    # (the timeout should only apply to the flock operation itself)
+    my_file = tmpdir.join('my-file')
+    with open(str(my_file), 'w') as f:
+        with utils.timed_flock(f, seconds=1):
+            time.sleep(2)
+        assert mock_flock.mock_calls == [
+            mock.call(f, utils.fcntl.LOCK_EX),
+            mock.call(f, utils.fcntl.LOCK_UN),
+        ]


### PR DESCRIPTION
Introduce a `timed_flock` contextmanager to utils, and use it in the paasta_firewall stuff:
- firewall_update cron will flock upon calling general_update(). Exceptions are not caught, causing the cron to fail.
- firewall_update inotify daemon will flock upon calling ensure_service_chains(). Exceptions will log an error but not propagate, allowing the daemon to continue running.
- docker_wrapper will flock upon calling prepare_new_container(). Exceptions will print to stderr but not propagate. The underlying docker command will still be executed.

This presumes that /var/run/paasta is writable. /var/run/paasta/mac-address is already required for use by the docker_wrapper, so this shouldn't really be anything new.

Internal ticket PAASTA-11247