### PR TITLE
Upgrade to mesos 1.3.0

### DIFF
--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update > /dev/null && apt-get -y install apt-transport-https > /dev/
 RUN echo "deb https://dl.bintray.com/yelp/paasta trusty main" > /etc/apt/sources.list.d/paasta.list
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update > /dev/null && apt-get -y install libsasl2-modules mesos=1.2.0-2.0.2 > /dev/null
+RUN apt-get update > /dev/null && apt-get -y install libsasl2-modules mesos=1.3.0-2.0.3 > /dev/null
 
 RUN apt-get install -y software-properties-common > /dev/null
 RUN add-apt-repository ppa:webupd8team/java

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update > /dev/null && apt-get -y install apt-transport-https > /dev/
 RUN echo "deb https://dl.bintray.com/yelp/paasta trusty main" > /etc/apt/sources.list.d/paasta.list
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update > /dev/null && apt-get -y install libsasl2-modules mesos=1.2.0-2.0.2 > /dev/null
+RUN apt-get update > /dev/null && apt-get -y install libsasl2-modules mesos=1.3.0-2.0.3 > /dev/null
 
 # Install Java 8 PPA
 RUN apt-get install -y software-properties-common > /dev/null

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -20,7 +20,7 @@ RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources
 RUN echo "deb http://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 58118E89F3A912897C070ADBF76221572C52609D
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update > /dev/null && apt-get -y install libsasl2-modules mesos=1.2.0-2.0.2 zip python-pip > /dev/null
+RUN apt-get update > /dev/null && apt-get -y install libsasl2-modules mesos=1.3.0-2.0.3 zip python-pip > /dev/null
 
 RUN apt-get -y install docker-engine=1.10.3-0~trusty > /dev/null
 ADD mesos-secrets /etc/mesos-secrets


### PR DESCRIPTION
Mesos 1.3.0 has been released. It appears to fix the issues we noticed while testing 1.2.0. Let's start evaluating it.

This is internal ticket PAASTA-9514