### PR TITLE
fix fitness evaluation of mesos slaves

### DIFF
--- a/paasta_tools/autoscaling/ec2_fitness.py
+++ b/paasta_tools/autoscaling/ec2_fitness.py
@@ -26,11 +26,11 @@ def sort_by_upcoming_events(instances):
 
 
 def sort_by_total_tasks(instances):
-    return sorted(instances, key=lambda i: i.task_counts.count)
+    return sorted(instances, key=lambda i: i.task_counts.count, reverse=True)
 
 
 def sort_by_running_batch_count(instances):
-    return sorted(instances, key=lambda i: i.task_counts.chronos_count)
+    return sorted(instances, key=lambda i: i.task_counts.chronos_count, reverse=True)
 
 
 def sort_by_ec2_fitness(instances):
@@ -44,9 +44,10 @@ def sort_by_ec2_fitness(instances):
           considered to be least healthy
         - next, instances are ranked according to whether they have events planned. an event
           planned marks against your fitness.
-        - next, instances are sorted according to the number of total tasks they have. those with
+        - next, instances are sorted according to the number of chronos tasks running on them.
+          we can't drain chronos tasks, so make an effort to avoid disrupting them.
+        - finally, instances are sorted according to the number of total tasks they have. those with
           the hightest total task are considered fittest, because it's painful to drain them.
-        - finally, instances are sorted according to the number of chronos tasks running on them.
     """
     return sort_by_system_instance_health(
         sort_by_upcoming_events(

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -957,9 +957,10 @@ class TestClusterAutoscaler(unittest.TestCase):
         assert actual == [fake_status['InstanceStatuses'][0]]
 
     def test_instance_status_for_instance_ids_batches_calls(self):
-        instance_ids = map(lambda i: {'foo': i}, range(0,100))
+        instance_ids = [{'foo': i} for i in range(0, 100)]
         with mock.patch(
             'paasta_tools.autoscaling.autoscaling_cluster_lib.ClusterAutoscaler.describe_instance_status',
+            autospec=True
         ) as mock_describe_instance_status:
             mock_describe_instance_status.return_value = {'InstanceStatuses': [{'foo': 'bar'}]}
             res = self.autoscaler.instance_status_for_instance_ids(instance_ids=instance_ids)
@@ -1331,4 +1332,3 @@ class TestPaastaAwsSlave(unittest.TestCase):
     def test_instance_weight(self):
         assert self.mock_slave.instance_weight == 2
         assert self.mock_asg_slave.instance_weight == 1
-

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -956,6 +956,15 @@ class TestClusterAutoscaler(unittest.TestCase):
         )
         assert actual == [fake_status['InstanceStatuses'][0]]
 
+    def test_instance_status_for_instance_ids_batches_calls(self):
+        instance_ids = map(lambda i: {'foo': i}, range(0,100))
+        with mock.patch(
+            'paasta_tools.autoscaling.autoscaling_cluster_lib.ClusterAutoscaler.describe_instance_status',
+        ) as mock_describe_instance_status:
+            mock_describe_instance_status.return_value = {'InstanceStatuses': [{'foo': 'bar'}]}
+            res = self.autoscaler.instance_status_for_instance_ids(instance_ids=instance_ids)
+            assert len(res['InstanceStatuses']) == 2
+
     def test_gracefully_terminate_slave(self):
         with mock.patch(
             'time.time', autospec=True,
@@ -1322,3 +1331,4 @@ class TestPaastaAwsSlave(unittest.TestCase):
     def test_instance_weight(self):
         assert self.mock_slave.instance_weight == 2
         assert self.mock_asg_slave.instance_weight == 1
+

--- a/tests/autoscaling/test_ec2_fitness.py
+++ b/tests/autoscaling/test_ec2_fitness.py
@@ -15,7 +15,7 @@ def test_sort_by_total_tasks():
     mock_slave_2 = Mock(task_counts=SlaveTaskCount(count=2, slave=Mock(), chronos_count=1))
     mock_slave_3 = Mock(task_counts=SlaveTaskCount(count=5, slave=Mock(), chronos_count=0))
     ret = ec2_fitness.sort_by_total_tasks([mock_slave_1, mock_slave_2, mock_slave_3])
-    assert ret == [mock_slave_2, mock_slave_1, mock_slave_3]
+    assert ret == [mock_slave_3, mock_slave_1, mock_slave_2]
 
 
 def test_sort_by_running_batch_count():
@@ -23,101 +23,96 @@ def test_sort_by_running_batch_count():
     mock_slave_2 = Mock(task_counts=SlaveTaskCount(count=2, slave=Mock(), chronos_count=2))
     mock_slave_3 = Mock(task_counts=SlaveTaskCount(count=5, slave=Mock(), chronos_count=3))
     ret = ec2_fitness.sort_by_running_batch_count([mock_slave_1, mock_slave_2, mock_slave_3])
-    assert ret == [mock_slave_1, mock_slave_2, mock_slave_3]
+    assert ret == [mock_slave_3, mock_slave_2, mock_slave_1]
 
 
 def test_sort_by_health_system_instance_health_system_status_failed():
-    mock_slave_1 = Mock(
-        task_counts=SlaveTaskCount(
-            count=3,
-            slave=Mock(),
-            chronos_count=1,
-        ),
-        instance_status={
-            'Events': [
-                {
-                    'Code': 'instance-reboot',
-                    'Description': 'string',
-                    'NotBefore': datetime(2015, 1, 1),
-                    'NotAfter': datetime(2015, 1, 1)
-                },
-            ],
-            'SystemStatus': {
-                'Status': 'impaired',
-            },
-            'InstanceStatus': {
-                'Status': 'ok',
-            }
-        },
+    mock_slave_1 = Mock(name='slave1')
+    mock_slave_1.task_counts=SlaveTaskCount(
+        count=3,
+        slave=Mock(),
+        chronos_count=1,
     )
-    mock_slave_2 = Mock(
-        task_counts=SlaveTaskCount(
-            count=3,
-            slave=Mock(),
-            chronos_count=1,
-        ),
-        instance_status={
-            'Events': [
-                {
-                    'Code': 'instance-reboot',
-                    'Description': 'string',
-                    'NotBefore': datetime(2015, 1, 1),
-                    'NotAfter': datetime(2015, 1, 1)
-                },
-            ],
-            'SystemStatus': {
-                'Status': 'ok',
+    mock_slave_1.instance_status = {
+        'Events': [
+            {
+                'Code': 'instance-reboot',
+                'Description': 'string',
+                'NotBefore': datetime(2015, 1, 1),
+                'NotAfter': datetime(2015, 1, 1)
             },
-            'InstanceStatus': {
-                'Status': 'ok',
-            }
+        ],
+        'SystemStatus': {
+            'Status': 'impaired',
         },
-    )
-    mock_slave_2 = Mock(task_counts=SlaveTaskCount(count=2, slave=Mock(), chronos_count=2))
-    ret = ec2_fitness.sort_by_running_batch_count([mock_slave_1, mock_slave_2])
-    assert ret == [mock_slave_1, mock_slave_2]
+        'InstanceStatus': {
+            'Status': 'ok',
+        }
+    }
+    mock_slave_2 = Mock(name='slave2')
+    mock_slave_2.task_counts=SlaveTaskCount(
+        count=3,
+        slave=Mock(),
+        chronos_count=1,
+    ),
+    mock_slave_2.instance_status={
+        'Events': [
+            {
+                'Code': 'instance-reboot',
+                'Description': 'string',
+                'NotBefore': datetime(2015, 1, 1),
+                'NotAfter': datetime(2015, 1, 1)
+            },
+        ],
+        'SystemStatus': {
+            'Status': 'ok',
+        },
+        'InstanceStatus': {
+            'Status': 'ok',
+        }
+    }
+    ret = ec2_fitness.sort_by_system_instance_health([mock_slave_1, mock_slave_2])
+    assert ret == [mock_slave_2, mock_slave_1]
 
 
 def test_sort_by_upcoming_events():
-    mock_slave_1 = Mock(
-        task_counts=SlaveTaskCount(
+    mock_slave_1 = Mock()
+    mock_slave_1.task_counts=SlaveTaskCount(
             count=3,
             slave=Mock(),
             chronos_count=1,
-        ),
-        instance_status={
-            'Events': [],
-            'SystemStatus': {
-                'Status': 'ok',
-            },
-            'InstanceStatus': {
-                'Status': 'ok',
-            }
-        },
     )
-    mock_slave_2 = Mock(
-        task_counts=SlaveTaskCount(
-            count=3,
-            slave=Mock(),
-            chronos_count=1,
-        ),
-        instance_status={
-            'Events': [
-                {
-                    'Code': 'instance-reboot',
-                    'Description': 'string',
-                    'NotBefore': datetime(2015, 1, 1),
-                    'NotAfter': datetime(2015, 1, 1)
-                },
-            ],
-            'SystemStatus': {
-                'Status': 'ok',
-            },
-            'InstanceStatus': {
-                'Status': 'ok',
-            }
+    mock_slave_1.instance_status={
+        'Events': [],
+        'SystemStatus': {
+            'Status': 'ok',
         },
+        'InstanceStatus': {
+            'Status': 'ok',
+        }
+    }
+    mock_slave_2 = Mock()
+    mock_slave_2. task_counts= SlaveTaskCount(
+        count=3,
+        slave=Mock(),
+        chronos_count=1,
     )
+    mock_slave_2.instance_status={
+        'Events': [
+            {
+                'Code': 'instance-reboot',
+                'Description': 'string',
+                'NotBefore': datetime(2015, 1, 1),
+                'NotAfter': datetime(2015, 1, 1)
+            },
+        ],
+        'SystemStatus': {
+            'Status': 'ok',
+        },
+        'InstanceStatus': {
+            'Status': 'ok',
+        }
+    }
     ret = ec2_fitness.sort_by_upcoming_events([mock_slave_1, mock_slave_2])
     assert ret == [mock_slave_1, mock_slave_2]
 
@@ -145,72 +140,74 @@ def test_sort_by_fitness_calls_all_sorting_funcs():
 
 
 def test_sort_by_fitness():
-    mock_slave_1 = Mock(
-        task_counts=SlaveTaskCount(
+    mock_slave_1 = Mock(name='slave1')
+    mock_slave_1.task_counts=SlaveTaskCount(
             count=3,
             slave=Mock(),
             chronos_count=1,
-        ),
-        instance_status={
+    )
+    mock_slave_1.instance_status={
             'Events': [],
             'SystemStatus': {'Status': 'impaired', },
             'InstanceStatus': {'Status': 'ok', }
-        },
+    }
+    mock_slave_2 = Mock(name='slave2')
+    mock_slave_2.task_counts=SlaveTaskCount(
+        count=3,
+        slave=Mock(),
+        chronos_count=1,
     )
-    mock_slave_2 = Mock(
-        task_counts=SlaveTaskCount(
-            count=3,
-            slave=Mock(),
-            chronos_count=1,
-        ),
-        instance_status={
-            'Events': [
-                {
-                    'Code': 'instance-reboot',
-                    'Description': 'foo',
-                    'NotBefore': datetime(2015, 1, 1),
-                    'NotAfter': datetime(2015, 1, 1)
-                },
-            ],
-            'SystemStatus': {'Status': 'ok', },
-            'InstanceStatus': {'Status': 'ok', }
-        },
+    mock_slave_2.instance_status={
+        'Events': [
+            {
+                'Code': 'instance-reboot',
+                'Description': 'foo',
+                'NotBefore': datetime(2015, 1, 1),
+                'NotAfter': datetime(2015, 1, 1)
+            },
+        ],
+        'SystemStatus': {'Status': 'ok', },
+        'InstanceStatus': {'Status': 'ok', }
+    }
+    mock_slave_3 = Mock(name='slave3')
+    mock_slave_3.task_counts=SlaveTaskCount(
+        count=2,
+        slave=Mock(),
+        chronos_count=3,
     )
-    mock_slave_3 = Mock(
-        task_counts=SlaveTaskCount(
-            count=2,
-            slave=Mock(),
-            chronos_count=3,
-        ),
-        instance_status={
-            'Events': [],
-            'SystemStatus': {'Status': 'ok', },
-            'InstanceStatus': {'Status': 'ok', }
-        },
+    mock_slave_3.instance_status={
+        'Events': [],
+        'SystemStatus': {'Status': 'ok', },
+        'InstanceStatus': {'Status': 'ok', }
+    }
+    mock_slave_4 = Mock(name='slave4')
+    mock_slave_4.task_counts=SlaveTaskCount(
+        count=3,
+        slave=Mock(),
+        chronos_count=1,
     )
-    mock_slave_4 = Mock(
-        task_counts=SlaveTaskCount(
-            count=3,
-            slave=Mock(),
-            chronos_count=1,
-        ),
-        instance_status={
-            'Events': [],
-            'SystemStatus': {'Status': 'ok', },
-            'InstanceStatus': {'Status': 'ok', }
-        },
+    mock_slave_4.instance_status={
+        'Events': [],
+        'SystemStatus': {'Status': 'ok', },
+        'InstanceStatus': {'Status': 'ok', }
+    }
+    mock_slave_5 = Mock(name='slave5')
+    mock_slave_5.task_counts=SlaveTaskCount(
+        count=1,
+        slave=Mock(),
+        chronos_count=1,
     )
-    mock_slave_5 = Mock(
-        task_counts=SlaveTaskCount(
-            count=1,
-            slave=Mock(),
-            chronos_count=1,
-        ),
-        instance_status={
-            'Events': [],
-            'SystemStatus': {'Status': 'ok', },
-            'InstanceStatus': {'Status': 'ok', }
-        },
-    )
+    mock_slave_5.instance_status={
+        'Events': [],
+        'SystemStatus': {'Status': 'ok', },
+        'InstanceStatus': {'Status': 'ok', }
+    }
     ret = ec2_fitness.sort_by_ec2_fitness([mock_slave_1, mock_slave_2, mock_slave_3, mock_slave_4, mock_slave_5])
-    assert ret == [mock_slave_5, mock_slave_4, mock_slave_3, mock_slave_2, mock_slave_1]
+
+    # we expect this order for the following reason:
+    # mock_slave_1 is impaired and so should be killed asap
+    # mock_slave_2 has an upcoming event
+    # mock_slave_5 and mock_slave_4 have the fewest chronos tasks, and so should be killed before
+    # mock_slave_3 (we cant drain chronos tasks, so try and save them)
+    # mock_slave_5 has fewer tasks than mock_slave_4, and so is a better candidate for killing
+    assert ret == [mock_slave_3, mock_slave_4, mock_slave_5, mock_slave_2, mock_slave_1]

--- a/tests/autoscaling/test_ec2_fitness.py
+++ b/tests/autoscaling/test_ec2_fitness.py
@@ -28,7 +28,7 @@ def test_sort_by_running_batch_count():
 
 def test_sort_by_health_system_instance_health_system_status_failed():
     mock_slave_1 = Mock(name='slave1')
-    mock_slave_1.task_counts=SlaveTaskCount(
+    mock_slave_1.task_counts = SlaveTaskCount(
         count=3,
         slave=Mock(),
         chronos_count=1,
@@ -50,12 +50,12 @@ def test_sort_by_health_system_instance_health_system_status_failed():
         }
     }
     mock_slave_2 = Mock(name='slave2')
-    mock_slave_2.task_counts=SlaveTaskCount(
+    mock_slave_2.task_counts = SlaveTaskCount(
         count=3,
         slave=Mock(),
         chronos_count=1,
     ),
-    mock_slave_2.instance_status={
+    mock_slave_2.instance_status = {
         'Events': [
             {
                 'Code': 'instance-reboot',
@@ -77,12 +77,12 @@ def test_sort_by_health_system_instance_health_system_status_failed():
 
 def test_sort_by_upcoming_events():
     mock_slave_1 = Mock()
-    mock_slave_1.task_counts=SlaveTaskCount(
-            count=3,
-            slave=Mock(),
-            chronos_count=1,
+    mock_slave_1.task_counts = SlaveTaskCount(
+        count=3,
+        slave=Mock(),
+        chronos_count=1,
     )
-    mock_slave_1.instance_status={
+    mock_slave_1.instance_status = {
         'Events': [],
         'SystemStatus': {
             'Status': 'ok',
@@ -92,12 +92,12 @@ def test_sort_by_upcoming_events():
         }
     }
     mock_slave_2 = Mock()
-    mock_slave_2. task_counts= SlaveTaskCount(
+    mock_slave_2. task_counts = SlaveTaskCount(
         count=3,
         slave=Mock(),
         chronos_count=1,
     )
-    mock_slave_2.instance_status={
+    mock_slave_2.instance_status = {
         'Events': [
             {
                 'Code': 'instance-reboot',
@@ -141,23 +141,23 @@ def test_sort_by_fitness_calls_all_sorting_funcs():
 
 def test_sort_by_fitness():
     mock_slave_1 = Mock(name='slave1')
-    mock_slave_1.task_counts=SlaveTaskCount(
-            count=3,
-            slave=Mock(),
-            chronos_count=1,
-    )
-    mock_slave_1.instance_status={
-            'Events': [],
-            'SystemStatus': {'Status': 'impaired', },
-            'InstanceStatus': {'Status': 'ok', }
-    }
-    mock_slave_2 = Mock(name='slave2')
-    mock_slave_2.task_counts=SlaveTaskCount(
+    mock_slave_1.task_counts = SlaveTaskCount(
         count=3,
         slave=Mock(),
         chronos_count=1,
     )
-    mock_slave_2.instance_status={
+    mock_slave_1.instance_status = {
+        'Events': [],
+        'SystemStatus': {'Status': 'impaired', },
+        'InstanceStatus': {'Status': 'ok', }
+    }
+    mock_slave_2 = Mock(name='slave2')
+    mock_slave_2.task_counts = SlaveTaskCount(
+        count=3,
+        slave=Mock(),
+        chronos_count=1,
+    )
+    mock_slave_2.instance_status = {
         'Events': [
             {
                 'Code': 'instance-reboot',
@@ -170,34 +170,34 @@ def test_sort_by_fitness():
         'InstanceStatus': {'Status': 'ok', }
     }
     mock_slave_3 = Mock(name='slave3')
-    mock_slave_3.task_counts=SlaveTaskCount(
+    mock_slave_3.task_counts = SlaveTaskCount(
         count=2,
         slave=Mock(),
         chronos_count=3,
     )
-    mock_slave_3.instance_status={
+    mock_slave_3.instance_status = {
         'Events': [],
         'SystemStatus': {'Status': 'ok', },
         'InstanceStatus': {'Status': 'ok', }
     }
     mock_slave_4 = Mock(name='slave4')
-    mock_slave_4.task_counts=SlaveTaskCount(
+    mock_slave_4.task_counts = SlaveTaskCount(
         count=3,
         slave=Mock(),
         chronos_count=1,
     )
-    mock_slave_4.instance_status={
+    mock_slave_4.instance_status = {
         'Events': [],
         'SystemStatus': {'Status': 'ok', },
         'InstanceStatus': {'Status': 'ok', }
     }
     mock_slave_5 = Mock(name='slave5')
-    mock_slave_5.task_counts=SlaveTaskCount(
+    mock_slave_5.task_counts = SlaveTaskCount(
         count=1,
         slave=Mock(),
         chronos_count=1,
     )
-    mock_slave_5.instance_status={
+    mock_slave_5.instance_status = {
         'Events': [],
         'SystemStatus': {'Status': 'ok', },
         'InstanceStatus': {'Status': 'ok', }


### PR DESCRIPTION
we need to sort chronos_tasks and tasks in descending order, since we
want to save those instances which have the most tasks attached.