### PR TITLE
Switch from package_data to manifest file to fix missing package data in internal wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include paasta_tools/cli/fsm/template *
+include paasta_tools/cli/schemas/*.json
+include paasta_tools/api/api_docs/*.json

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,6 @@ setup(
         'paasta_tools/setup_marathon_job.py',
         'paasta_tools/synapse_srv_namespaces_fact.py',
     ] + glob.glob('paasta_tools/contrib/*'),
-    package_data={str(''): [str('cli/fsm/template/*/*'), str('cli/schemas/*.json'), str('api/api_docs/*.json')]},
     entry_points={
         'console_scripts': [
             'paasta=paasta_tools.cli.cli:main',


### PR DESCRIPTION
`package_data` is used only for binary distributions (like doing `python setup.py bdist_wheel`) and not source distributions. The way we build our wheels (since 2016-12-13) is by taking the source distribution (which is missing the package data) and turning it into wheels.

Using `MANIFEST.in` will put the package data in both source and binary distributions.

#### testing

I ran `setup.py bdist_wheel` and `setup.py sdist` both before and after this change, and diffed the list of files:

```diff
--- before/before       2017-06-20 11:58:56.633670501 -0700
+++ after/after 2017-06-20 11:58:51.137596501 -0700
@@ -69,10 +69,23 @@
 ./sdist/paasta-tools-0.65.26/paasta_tools/cli/cmds/__init__.py
 ./sdist/paasta-tools-0.65.26/paasta_tools/cli/cmds/rerun.py
 ./sdist/paasta-tools-0.65.26/paasta_tools/cli/cmds/info.py
+./sdist/paasta-tools-0.65.26/paasta_tools/cli/schemas
+./sdist/paasta-tools-0.65.26/paasta_tools/cli/schemas/marathon_schema.json
+./sdist/paasta-tools-0.65.26/paasta_tools/cli/schemas/chronos_schema.json
+./sdist/paasta-tools-0.65.26/paasta_tools/cli/schemas/adhoc_schema.json
 ./sdist/paasta-tools-0.65.26/paasta_tools/cli/paasta_tabcomplete.sh
 ./sdist/paasta-tools-0.65.26/paasta_tools/cli/utils.py
 ./sdist/paasta-tools-0.65.26/paasta_tools/cli/cli.py
 ./sdist/paasta-tools-0.65.26/paasta_tools/cli/fsm
+./sdist/paasta-tools-0.65.26/paasta_tools/cli/fsm/template
+./sdist/paasta-tools-0.65.26/paasta_tools/cli/fsm/template/{{cookiecutter.service}}
+./sdist/paasta-tools-0.65.26/paasta_tools/cli/fsm/template/{{cookiecutter.service}}/chronos-PROD.yaml
+./sdist/paasta-tools-0.65.26/paasta_tools/cli/fsm/template/{{cookiecutter.service}}/service.yaml
+./sdist/paasta-tools-0.65.26/paasta_tools/cli/fsm/template/{{cookiecutter.service}}/smartstack.yaml
+./sdist/paasta-tools-0.65.26/paasta_tools/cli/fsm/template/{{cookiecutter.service}}/marathon-PROD.yaml
+./sdist/paasta-tools-0.65.26/paasta_tools/cli/fsm/template/{{cookiecutter.service}}/monitoring.yaml
+./sdist/paasta-tools-0.65.26/paasta_tools/cli/fsm/template/README.md
+./sdist/paasta-tools-0.65.26/paasta_tools/cli/fsm/template/cookiecutter.json
 ./sdist/paasta-tools-0.65.26/paasta_tools/cli/fsm/autosuggest.py
 ./sdist/paasta-tools-0.65.26/paasta_tools/cli/fsm/__init__.py
 ./sdist/paasta-tools-0.65.26/paasta_tools/cli/__init__.py
@@ -131,6 +144,8 @@
 ./sdist/paasta-tools-0.65.26/paasta_tools/api
 ./sdist/paasta-tools-0.65.26/paasta_tools/api/client.py
 ./sdist/paasta-tools-0.65.26/paasta_tools/api/api.py
+./sdist/paasta-tools-0.65.26/paasta_tools/api/api_docs
+./sdist/paasta-tools-0.65.26/paasta_tools/api/api_docs/swagger.json
 ./sdist/paasta-tools-0.65.26/paasta_tools/api/settings.py
 ./sdist/paasta-tools-0.65.26/paasta_tools/api/views
 ./sdist/paasta-tools-0.65.26/paasta_tools/api/views/autoscaler.py
@@ -167,6 +182,7 @@
 ./sdist/paasta-tools-0.65.26/paasta_tools/deploy_marathon_services
 ./sdist/paasta-tools-0.65.26/paasta_tools/firewall.py
 ./sdist/paasta-tools-0.65.26/PKG-INFO
+./sdist/paasta-tools-0.65.26/MANIFEST.in
 ./sdist/paasta-tools-0.65.26/paasta_tools.egg-info
 ./sdist/paasta-tools-0.65.26/paasta_tools.egg-info/entry_points.txt
 ./sdist/paasta-tools-0.65.26/paasta_tools.egg-info/requires.txt
@@ -258,6 +274,8 @@
 ./wheel/paasta_tools/cli/fsm/template/{{cookiecutter.service}}/smartstack.yaml
 ./wheel/paasta_tools/cli/fsm/template/{{cookiecutter.service}}/marathon-PROD.yaml
 ./wheel/paasta_tools/cli/fsm/template/{{cookiecutter.service}}/monitoring.yaml
+./wheel/paasta_tools/cli/fsm/template/README.md
+./wheel/paasta_tools/cli/fsm/template/cookiecutter.json
 ./wheel/paasta_tools/cli/fsm/autosuggest.py
 ./wheel/paasta_tools/cli/fsm/__init__.py
 ./wheel/paasta_tools/cli/__init__.py
```

So, the sdist has the package data files as expected, and the wheel has a couple more files (`paasta_tools/cli/fsm/template/README.md` and `wheel/paasta_tools/cli/fsm/template/cookiecutter.json`) which weren't previously included because they're in the root (the pattern was `cli/fsm/template/*/*`) which is probably fine.

More info: https://stackoverflow.com/a/14159430
Internal ticket: PAASTA-11932