### PR TITLE
Fix paasta local-run port argument

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -360,7 +360,6 @@ def add_subparser(subparsers):
         '-o', '--port',
         help='Specify a port number to use. If not set, a random non-conflicting port will be found.',
         dest='user_port',
-        action='store_true',
         required=False,
         default=False,
     )


### PR DESCRIPTION
'action=store_true' means this argument will ony be a true/false flag.
Right now paasta local-run errors out if you run it with '--port 9999',
because it's not expecting the 9999 option.