### PR TITLE
Better error message telling you which cluster the problem was with

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -347,8 +347,8 @@ def _run_instance_worker(cluster_data, instances_out, green_light):
                             .format(instance, cluster_data.service,
                                     cluster_data.cluster))
             else:
-                log.warning("Error getting service status from PaaSTA API: {}:"
-                            "{}".format(e.response.status_code,
+                log.warning("Error getting service status from PaaSTA API for {}: {}"
+                            "{}".format(cluster_data.cluster, e.response.status_code,
                                         e.response.text))
         except ConnectionError as e:
             log.warning("Error getting service status from PaaSTA API for {}:"


### PR DESCRIPTION
Another case where the error message would be a lot more helpful if it told you what it was actually trying to talk to.