### PR TITLE
Restore old signal handler on exit

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1627,11 +1627,12 @@ class Timeout:
         raise TimeoutError(self.error_message)
 
     def __enter__(self):
-        signal.signal(signal.SIGALRM, self.handle_timeout)
+        self.old_handler = signal.signal(signal.SIGALRM, self.handle_timeout)
         signal.alarm(self.seconds)
 
     def __exit__(self, type, value, traceback):
         signal.alarm(0)
+        signal.signal(signal.SIGALRM, self.old_handler)
 
 
 def print_with_indent(line, indent=2):


### PR DESCRIPTION
Very minor change. I was reading through @bchess's PR #1314 and noticed the Timeout context manager is not restoring existing signal handlers should they exist. Most likely this is not and never will be an issue, but it's probably better safe than sorry.