### PR TITLE
Make mark and wait for deployment commands accept a short git sha

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -211,7 +211,9 @@ def paasta_mark_for_deployment(args):
         refs = remote_git.list_remote_refs(args.git_url)
         commits = short_to_full_git_sha(short=args.commit, refs=refs)
         if len(commits) != 1:
-            raise ValueError("%s matched %d git shas. Must match exactly 1." % (args.commit, len(commits)))
+            raise ValueError(
+                "%s matched %d git shas (with refs pointing at them). Must match exactly 1." %
+                (args.commit, len(commits)))
         args.commit = commits[0]
 
     old_git_sha = get_currently_deployed_sha(service=service, deploy_group=args.deploy_group)

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -209,7 +209,10 @@ def paasta_mark_for_deployment(args):
         validate_full_git_sha(args.commit)
     except ArgumentTypeError:
         refs = remote_git.list_remote_refs(args.git_url)
-        args.commit = short_to_full_git_sha(short=args.commit, refs=refs)
+        commits = short_to_full_git_sha(short=args.commit, refs=refs)
+        if len(commits) != 1:
+            raise ValueError("%s matched %d git shas. Must match exactly 1." % (args.commit, len(commits)))
+        args.commit = commits[0]
 
     old_git_sha = get_currently_deployed_sha(service=service, deploy_group=args.deploy_group)
     if old_git_sha == args.commit:

--- a/paasta_tools/cli/cmds/wait_for_deployment.py
+++ b/paasta_tools/cli/cmds/wait_for_deployment.py
@@ -199,7 +199,9 @@ def paasta_wait_for_deployment(args):
         refs = remote_git.list_remote_refs(args.git_url)
         commits = short_to_full_git_sha(short=args.commit, refs=refs)
         if len(commits) != 1:
-            raise ValueError("%s matched %d git shas. Must match exactly 1." % (args.commit, len(commits)))
+            raise ValueError(
+                "%s matched %d git shas (with refs pointing at them). Must match exactly 1." %
+                (args.commit, len(commits)))
         args.commit = commits[0]
 
     try:

--- a/paasta_tools/cli/cmds/wait_for_deployment.py
+++ b/paasta_tools/cli/cmds/wait_for_deployment.py
@@ -197,7 +197,10 @@ def paasta_wait_for_deployment(args):
         validate_full_git_sha(args.commit)
     except ArgumentTypeError:
         refs = remote_git.list_remote_refs(args.git_url)
-        args.commit = short_to_full_git_sha(short=args.commit, refs=refs)
+        commits = short_to_full_git_sha(short=args.commit, refs=refs)
+        if len(commits) != 1:
+            raise ValueError("%s matched %d git shas. Must match exactly 1." % (args.commit, len(commits)))
+        args.commit = commits[0]
 
     try:
         validate_service_name(service, soa_dir=args.soa_dir)

--- a/paasta_tools/cli/cmds/wait_for_deployment.py
+++ b/paasta_tools/cli/cmds/wait_for_deployment.py
@@ -19,16 +19,20 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import logging
+from argparse import ArgumentTypeError
 
+from paasta_tools import remote_git
 from paasta_tools.cli.cmds.mark_for_deployment import NoInstancesFound
 from paasta_tools.cli.cmds.mark_for_deployment import wait_for_deployment
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import NoSuchService
+from paasta_tools.cli.utils import short_to_full_git_sha
 from paasta_tools.cli.utils import validate_full_git_sha
 from paasta_tools.cli.utils import validate_given_deploy_groups
 from paasta_tools.cli.utils import validate_service_name
+from paasta_tools.cli.utils import validate_short_git_sha
 from paasta_tools.remote_git import list_remote_refs
 from paasta_tools.remote_git import LSRemoteException
 from paasta_tools.utils import _log
@@ -76,7 +80,7 @@ def add_subparser(subparsers):
         '-c', '-k', '--commit',
         help='Git sha to wait for deployment',
         required=True,
-        type=validate_full_git_sha
+        type=validate_short_git_sha
     )
     list_parser.add_argument(
         '-l', '--deploy-group',
@@ -188,6 +192,12 @@ def paasta_wait_for_deployment(args):
 
     if args.git_url is None:
         args.git_url = get_git_url(service=service, soa_dir=args.soa_dir)
+
+    try:
+        validate_full_git_sha(args.commit)
+    except ArgumentTypeError:
+        refs = remote_git.list_remote_refs(args.git_url)
+        args.commit = short_to_full_git_sha(short=args.commit, refs=refs)
 
     try:
         validate_service_name(service, soa_dir=args.soa_dir)

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -738,10 +738,7 @@ def short_to_full_git_sha(short, refs):
     :param refs: A list of refs in the git repository
     :return: The full git sha or None if one can't be found
     """
-    for sha in list(set(refs.values())):
-        if sha.startswith(short):
-            return sha
-    return None
+    return [sha for sha in set(refs.values()) if sha.startswith(short)]
 
 
 def validate_short_git_sha(value):

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -731,6 +731,27 @@ def validate_given_deploy_groups(all_deploy_groups, args_deploy_groups):
     return valid_deploy_groups, invalid_deploy_groups
 
 
+def short_to_full_git_sha(short, refs):
+    """Converts a short git sha to a full sha
+
+    :param short: A short git sha represented as a string
+    :param refs: A list of refs in the git repository
+    :return: The full git sha or None if one can't be found
+    """
+    for sha in list(set(refs.values())):
+        if sha.startswith(short):
+            return sha
+    return None
+
+
+def validate_short_git_sha(value):
+    pattern = re.compile('[a-f0-9]{4,40}')
+    if not pattern.match(value):
+        raise argparse.ArgumentTypeError(
+            "%s is not a valid git sha" % value)
+    return value
+
+
 def validate_full_git_sha(value):
     pattern = re.compile('[a-f0-9]{40}')
     if not pattern.match(value):

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -25,7 +25,7 @@ class fake_args:
     deploy_group = 'test_deploy_group'
     service = 'test_service'
     git_url = 'git://false.repo/services/test_services'
-    commit = 'fake-hash'
+    commit = 'd670460b4b4aece5915caf5c68d12f560a9fe3e4'
     soa_dir = 'fake_soa_dir'
     block = False
     verbose = False
@@ -45,7 +45,7 @@ def test_paasta_mark_for_deployment_acts_like_main(
     mock_mark_for_deployment.assert_called_once_with(
         service='test_service',
         deploy_group='test_deploy_group',
-        commit='fake-hash',
+        commit='d670460b4b4aece5915caf5c68d12f560a9fe3e4',
         git_url='git://false.repo/services/test_services',
     )
     assert mock_validate_service_name.called
@@ -107,7 +107,7 @@ def test_paasta_mark_for_deployment_with_good_rollback(
     mock_mark_for_deployment.assert_any_call(
         service='test_service',
         deploy_group='test_deploy_group',
-        commit='fake-hash',
+        commit='d670460b4b4aece5915caf5c68d12f560a9fe3e4',
         git_url='git://false.repo/services/test_services',
     )
     mock_mark_for_deployment.assert_any_call(
@@ -135,11 +135,11 @@ def test_paasta_mark_for_deployment_with_skips_rollback_when_same_sha(
         timeout = 600
 
     mock_wait_for_deployment.side_effect = TimeoutError
-    mock_get_currently_deployed_sha.return_value = "fake-hash"
+    mock_get_currently_deployed_sha.return_value = "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
     assert mark_for_deployment.paasta_mark_for_deployment(fake_args_rollback) == 1
     mock_mark_for_deployment.assert_called_once_with(
         service='test_service',
         deploy_group='test_deploy_group',
-        commit='fake-hash',
+        commit='d670460b4b4aece5915caf5c68d12f560a9fe3e4',
         git_url='git://false.repo/services/test_services',
     )

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -35,7 +35,7 @@ class fake_args:
     deploy_group = 'test_deploy_group'
     service = 'test_service'
     git_url = ''
-    commit = 'fake-hash'
+    commit = 'd670460b4b4aece5915caf5c68d12f560a9fe3e4'
     soa_dir = 'fake_soa_dir'
     timeout = 0
     verbose = False

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -687,6 +687,9 @@ def test_git_sha_validation():
         '060ce8bc10efe0030c048a4711ad5dd85de5adac') == '060ce8bc10efe0030c048a4711ad5dd85de5adac'
     with raises(argparse.ArgumentTypeError):
         utils.validate_full_git_sha('BAD')
+    assert utils.validate_short_git_sha('060c') == '060c'
+    with raises(argparse.ArgumentTypeError):
+        utils.validate_short_git_sha('BAD')
 
 
 @patch('paasta_tools.cli.utils.get_instance_configs_for_service', autospec=True)


### PR DESCRIPTION
It is rather frustrating not being able to simply copy/paste a short git sha displayed in other tools into `paasta wait-for-deployment`. This PR attempts to fix that. It modifies `mark-for-deployment` and `wait-for-deployment` to accept a short git sha as an argument. It will then attempt to convert this to a full sha and pass that full sha around internally.

This is internal ticket PAASTA-10534