### PR TITLE
Fix rounding error: cluster autoscaler

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -284,7 +284,7 @@ class ClusterAutoscaler(ResourceLogMixin):
             mesos_state = get_mesos_master().state_summary()
             slaves_list = get_mesos_task_count_by_slave(mesos_state, pool=self.resource['pool'])
             filtered_slaves = self.filter_aws_slaves(slaves_list)
-            killable_capacity = sum([slave.instance_weight for slave in filtered_slaves])
+            killable_capacity = round(sum([slave.instance_weight for slave in filtered_slaves]), 2)
             amount_to_decrease = delta * -1
             if amount_to_decrease > killable_capacity:
                 self.log.error(

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -784,19 +784,19 @@ class TestClusterAutoscaler(unittest.TestCase):
             mock_set_capacity.assert_called_with(self.autoscaler, 4)
 
             # test scale down
-            mock_slave_1 = mock.Mock(instance_weight=1)
-            mock_slave_2 = mock.Mock(instance_weight=2)
+            mock_slave_1 = mock.Mock(instance_weight=1.099999999)
+            mock_slave_2 = mock.Mock(instance_weight=2.2)
             mock_sfr_sorted_slaves_1 = [mock_slave_1, mock_slave_2]
             mock_filter_aws_slaves.return_value = mock_sfr_sorted_slaves_1
-            self.autoscaler.scale_resource(5, 2)
+            self.autoscaler.scale_resource(3.3, 0)
             assert mock_get_mesos_master.called
             mock_get_mesos_task_count_by_slave.assert_called_with(mock_mesos_state,
                                                                   pool='default')
             mock_filter_aws_slaves.assert_called_with(self.autoscaler, mock_get_mesos_task_count_by_slave.return_value)
             mock_downscale_aws_resource.assert_called_with(self.autoscaler,
                                                            filtered_slaves=mock_filter_aws_slaves.return_value,
-                                                           current_capacity=5,
-                                                           target_capacity=2)
+                                                           current_capacity=3.3,
+                                                           target_capacity=0)
 
     def test_downscale_aws_resource(self):
         with mock.patch(


### PR DESCRIPTION
Currently we get the weight of each instance from AWS and then we sum
those weights. Due to floating point arithmetic we can end up with a
killable capacity that is slightly less than the desired change. This
additional rounding should stop the autoscaler getting wedged.