### PR TITLE
Fix issue in handling SlaveDoesNotExist exception

### DIFF
--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -692,7 +692,7 @@ def get_mesos_task_count_by_slave(mesos_state, slaves_list=None, pool=None):
                 if task.framework.name == CHRONOS_FRAMEWORK_NAME:
                     slaves[task.slave['id']]['chronos_count'] += 1
         except SlaveDoesNotExist:
-            log.debug("Tried to get mesos slaves for task {}, but none existed.".format(task))
+            log.debug("Tried to get mesos slaves for task {}, but none existed.".format(task['id']))
             continue
     if slaves_list:
         for slave in slaves_list:

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -632,6 +632,7 @@ def test_get_mesos_task_count_by_slave():
         assert len(ret) == len(expected) and utils.sort_dicts(ret) == utils.sort_dicts(expected)
 
         # test SlaveDoesNotExist exception handling
+        mock_task2.__getitem__ = mock.Mock(side_effect="fakeid")
         mock_task2.slave = mock.Mock()
         mock_task2.slave.__getitem__ = mock.Mock()
         mock_task2.slave.__getitem__.side_effect = mesos.exceptions.SlaveDoesNotExist


### PR DESCRIPTION
Inside the debug line for handling this exception, I print the task.
Well, the __str__ method of task, calls task.slave, which then throws
another SlaveDNE exception within the handler, so it doesnt get caught

Now, just print the task id, instead of the whole task (id + slave)