### PR TITLE
Add exponential back off deployd

### DIFF
--- a/paasta_tools/deployd/common.py
+++ b/paasta_tools/deployd/common.py
@@ -9,7 +9,12 @@ from threading import Thread
 from six.moves.queue import Queue
 
 BounceTimers = namedtuple('BounceTimers', ['processed_by_worker', 'setup_marathon', 'bounce_length'])
-ServiceInstance = namedtuple('ServiceInstance', ['service', 'instance', 'bounce_by', 'watcher', 'bounce_timers'])
+ServiceInstance = namedtuple('ServiceInstance', ['service',
+                                                 'instance',
+                                                 'bounce_by',
+                                                 'watcher',
+                                                 'bounce_timers',
+                                                 'failures'])
 
 
 class PaastaThread(Thread):
@@ -48,6 +53,12 @@ def rate_limit_instances(instances, number_per_minute, watcher_name):
                                                  instance=instance,
                                                  watcher=watcher_name,
                                                  bounce_by=bounce_time,
-                                                 bounce_timers=None))
+                                                 bounce_timers=None,
+                                                 failures=0))
         bounce_time += time_step
     return service_instances
+
+
+def exponential_back_off(failures, factor, base, max_time):
+    seconds = factor * base ** failures
+    return seconds if seconds < max_time else max_time

--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -180,7 +180,7 @@ class DeployDaemon(PaastaThread):
         number_of_dead_workers = self.config.get_deployd_number_workers() - live_workers
         for i in range(number_of_dead_workers):
             worker_no = len(self.workers) + 1
-            worker = PaastaDeployWorker(worker_no, self.inbox_q, self.bounce_q, self.config.get_cluster(), self.metrics)
+            worker = PaastaDeployWorker(worker_no, self.inbox_q, self.bounce_q, self.config, self.metrics)
             worker.start()
             self.workers.append(worker)
 
@@ -190,7 +190,7 @@ class DeployDaemon(PaastaThread):
     def start_workers(self):
         self.workers = []
         for i in range(self.config.get_deployd_number_workers()):
-            worker = PaastaDeployWorker(i, self.inbox_q, self.bounce_q, self.config.get_cluster(), self.metrics)
+            worker = PaastaDeployWorker(i, self.inbox_q, self.bounce_q, self.config, self.metrics)
             worker.start()
             self.workers.append(worker)
 

--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -75,7 +75,8 @@ class AutoscalerWatcher(PaastaWatcher):
                                                instance=instance,
                                                bounce_by=int(time.time()),
                                                bounce_timers=None,
-                                               watcher=self.__class__.__name__)
+                                               watcher=self.__class__.__name__,
+                                               failures=0)
             self.inbox_q.put(service_instance)
 
     def process_folder_event(self, children, event):
@@ -180,7 +181,8 @@ class MaintenanceWatcher(PaastaWatcher):
                                                          instance=instance,
                                                          bounce_by=int(time.time()),
                                                          watcher=self.__class__.__name__,
-                                                         bounce_timers=None))
+                                                         bounce_timers=None,
+                                                         failures=0))
         return service_instances
 
 
@@ -306,7 +308,8 @@ class YelpSoaEventHandler(pyinotify.ProcessEvent):
                                              instance=instance,
                                              bounce_by=int(time.time()),
                                              watcher=self.__class__.__name__,
-                                             bounce_timers=None)
+                                             bounce_timers=None,
+                                             failures=0)
                              for service, instance in service_instances]
         for service_instance in service_instances:
             self.filewatcher.inbox_q.put(service_instance)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1087,6 +1087,14 @@ class SystemPaastaConfig(dict):
         """
         return self.get('deployd_metrics_provider')
 
+    def get_deployd_worker_failure_backoff_factor(self):
+        """Get the factor for calculating exponential backoff when a deployd worker
+        fails to bounce a service
+
+        :returns: An integer
+        """
+        return self.get('deployd_worker_failure_backoff_factor', 30)
+
     def get_sensu_host(self):
         """Get the host that we should send sensu events to.
 

--- a/tests/deployd/test_common.py
+++ b/tests/deployd/test_common.py
@@ -5,6 +5,7 @@ import unittest
 
 import mock
 
+from paasta_tools.deployd.common import exponential_back_off
 from paasta_tools.deployd.common import PaastaQueue
 from paasta_tools.deployd.common import PaastaThread
 from paasta_tools.deployd.common import rate_limit_instances
@@ -46,10 +47,18 @@ def test_rate_limit_instances():
                                     instance='c137',
                                     watcher='Custos',
                                     bounce_by=1,
-                                    bounce_timers=None),
+                                    bounce_timers=None,
+                                    failures=0),
                     ServiceInstance(service='universe',
                                     instance='c138',
                                     watcher='Custos',
                                     bounce_by=31,
-                                    bounce_timers=None)]
+                                    bounce_timers=None,
+                                    failures=0)]
         assert ret == expected
+
+
+def test_exponential_back_off():
+    assert exponential_back_off(0, 60, 2, 6000) == 60
+    assert exponential_back_off(2, 60, 2, 6000) == 240
+    assert exponential_back_off(99, 60, 2, 6000) == 6000

--- a/tests/deployd/test_watchers.py
+++ b/tests/deployd/test_watchers.py
@@ -129,7 +129,8 @@ class TestAutoscalerWatcher(unittest.TestCase):
                                                                      instance='instance',
                                                                      bounce_by=1,
                                                                      bounce_timers=None,
-                                                                     watcher=self.watcher.__class__.__name__))
+                                                                     watcher=self.watcher.__class__.__name__,
+                                                                     failures=0))
 
             mock_event_changed = mock_event_type.CHANGED
             mock_event = mock.Mock(type=mock_event_changed,
@@ -139,7 +140,8 @@ class TestAutoscalerWatcher(unittest.TestCase):
                                                                      instance='instance',
                                                                      bounce_by=1,
                                                                      bounce_timers=None,
-                                                                     watcher=self.watcher.__class__.__name__))
+                                                                     watcher=self.watcher.__class__.__name__,
+                                                                     failures=0))
 
     def test_process_folder_event(self):
         with mock.patch(
@@ -312,12 +314,14 @@ class TestMaintenanceWatcher(unittest.TestCase):
                                         instance='c137',
                                         bounce_by=1,
                                         watcher=self.watcher.__class__.__name__,
-                                        bounce_timers=None),
+                                        bounce_timers=None,
+                                        failures=0),
                         ServiceInstance(service='universe',
                                         instance='c139',
                                         bounce_by=1,
                                         watcher=self.watcher.__class__.__name__,
-                                        bounce_timers=None)]
+                                        bounce_timers=None,
+                                        failures=0)]
             assert ret == expected
 
 
@@ -529,6 +533,7 @@ class TestYelpSoaEventHandler(unittest.TestCase):
                                           instance='c137',
                                           bounce_by=1,
                                           watcher='YelpSoaEventHandler',
-                                          bounce_timers=None)
+                                          bounce_timers=None,
+                                          failures=0)
             self.mock_filewatcher.inbox_q.put.assert_called_with(expected_si)
             assert self.mock_filewatcher.inbox_q.put.call_count == 1

--- a/tests/deployd/test_workers.py
+++ b/tests/deployd/test_workers.py
@@ -74,7 +74,8 @@ class TestPaastaDeployWorker(unittest.TestCase):
             self.worker.marathon_config = mock.Mock()
             mock_deploy_marathon_service.return_value = (0, None)
             mock_si = mock.Mock(service='universe',
-                                instance='c137')
+                                instance='c137',
+                                failures=0)
             self.mock_bounce_q.get.return_value = mock_si
             with raises(LoopBreak):
                 self.worker.run()
@@ -109,7 +110,8 @@ class TestPaastaDeployWorker(unittest.TestCase):
                                                                      instance='c137',
                                                                      bounce_by=61,
                                                                      watcher='Worker1',
-                                                                     bounce_timers=mock_setup_timers.return_value))
+                                                                     bounce_timers=mock_setup_timers.return_value,
+                                                                     failures=0))
             assert not mock_setup_timers.return_value.bounce_length.stop.called
 
             mock_deploy_marathon_service.side_effect = Exception()
@@ -128,9 +130,10 @@ class TestPaastaDeployWorker(unittest.TestCase):
             assert mock_setup_timers.return_value.processed_by_worker.start.called
             self.mock_inbox_q.put.assert_called_with(ServiceInstance(service='universe',
                                                                      instance='c137',
-                                                                     bounce_by=61,
+                                                                     bounce_by=121,
                                                                      watcher='Worker1',
-                                                                     bounce_timers=mock_setup_timers.return_value))
+                                                                     bounce_timers=mock_setup_timers.return_value,
+                                                                     failures=1))
             assert not mock_setup_timers.return_value.bounce_length.stop.called
 
 

--- a/tests/deployd/test_workers.py
+++ b/tests/deployd/test_workers.py
@@ -17,13 +17,17 @@ class TestPaastaDeployWorker(unittest.TestCase):
         self.mock_inbox_q = mock.Mock()
         self.mock_bounce_q = mock.Mock()
         self.mock_metrics = mock.Mock()
+        mock_config = mock.Mock(
+            get_cluster=mock.Mock(return_value='westeros-prod'),
+            get_deployd_worker_failure_backoff_factor=mock.Mock(return_value=30)
+        )
         with mock.patch(
             'paasta_tools.deployd.workers.PaastaDeployWorker.setup', autospec=True
         ):
             self.worker = PaastaDeployWorker(1,
                                              self.mock_inbox_q,
                                              self.mock_bounce_q,
-                                             "westeros-prod",
+                                             mock_config,
                                              self.mock_metrics)
 
     def test_setup(self):
@@ -130,7 +134,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
             assert mock_setup_timers.return_value.processed_by_worker.start.called
             self.mock_inbox_q.put.assert_called_with(ServiceInstance(service='universe',
                                                                      instance='c137',
-                                                                     bounce_by=121,
+                                                                     bounce_by=61,
                                                                      watcher='Worker1',
                                                                      bounce_timers=mock_setup_timers.return_value,
                                                                      failures=1))


### PR DESCRIPTION
If a worker fails to bounce a service due to an exception then it will
back off trying exponentially. This is especially to be kind to Marathon
incase it is overwhelmed and causing the bounces to fail.

cc @solarkennedy 