### PR TITLE
Make deployd prioritise bouncing services on start

### DIFF
--- a/paasta_itests/steps/paasta_deployd_steps.py
+++ b/paasta_itests/steps/paasta_deployd_steps.py
@@ -15,7 +15,7 @@ from itest_utils import get_service_connection_string
 from kazoo.exceptions import NodeExistsError
 
 from paasta_tools.marathon_tools import list_all_marathon_app_ids
-from paasta_tools.marathon_tools import load_marathon_service_config
+from paasta_tools.marathon_tools import load_marathon_service_config_no_cache
 from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import ZookeeperPool
 
@@ -88,7 +88,7 @@ def second_deployd_is_leader(context):
 def check_app_running(context, service_instance, seconds):
     service, instance, _, _ = decompose_job_id(service_instance)
     service_configuration_lib._yaml_cache = {}
-    context.marathon_config = load_marathon_service_config(service, instance, context.cluster)
+    context.marathon_config = load_marathon_service_config_no_cache(service, instance, context.cluster)
     context.app_id = context.marathon_config.format_marathon_app_dict()['id']
     step = 5
     attempts = 0
@@ -122,5 +122,5 @@ def set_cmd(context, cmd):
 def check_sha_changed(context, service_instance):
     service, instance, _, _ = decompose_job_id(service_instance)
     service_configuration_lib._yaml_cache = {}
-    context.marathon_config = load_marathon_service_config(service, instance, context.cluster)
+    context.marathon_config = load_marathon_service_config_no_cache(service, instance, context.cluster)
     assert context.app_id != context.marathon_config.format_marathon_app_dict()['id']

--- a/tests/deployd/test_common.py
+++ b/tests/deployd/test_common.py
@@ -6,10 +6,14 @@ import unittest
 import mock
 
 from paasta_tools.deployd.common import exponential_back_off
+from paasta_tools.deployd.common import get_marathon_client_from_config
+from paasta_tools.deployd.common import get_service_instances_with_changed_id
 from paasta_tools.deployd.common import PaastaQueue
 from paasta_tools.deployd.common import PaastaThread
 from paasta_tools.deployd.common import rate_limit_instances
 from paasta_tools.deployd.common import ServiceInstance
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import NoDockerImageError
 
 
 class TestPaastaThread(unittest.TestCase):
@@ -62,3 +66,44 @@ def test_exponential_back_off():
     assert exponential_back_off(0, 60, 2, 6000) == 60
     assert exponential_back_off(2, 60, 2, 6000) == 240
     assert exponential_back_off(99, 60, 2, 6000) == 6000
+
+
+def test_get_service_instances_with_changed_id():
+    with mock.patch(
+        'paasta_tools.deployd.common.list_all_marathon_app_ids', autospec=True
+    ) as mock_get_marathon_apps, mock.patch(
+        'paasta_tools.deployd.common.load_marathon_service_config_no_cache', autospec=True
+    ) as mock_load_marathon_service_config:
+        mock_get_marathon_apps.return_value = ['universe.c137.c1.g1',
+                                               'universe.c138.c1.g1']
+        mock_service_instances = [('universe', 'c137'), ('universe', 'c138')]
+        mock_configs = [mock.Mock(format_marathon_app_dict=mock.Mock(return_value={'id': 'universe.c137.c1.g1'})),
+                        mock.Mock(format_marathon_app_dict=mock.Mock(return_value={'id': 'universe.c138.c2.g2'}))]
+        mock_load_marathon_service_config.side_effect = mock_configs
+        ret = get_service_instances_with_changed_id(mock.Mock(), mock_service_instances, 'westeros-prod')
+        assert mock_get_marathon_apps.called
+        calls = [mock.call(service='universe',
+                           instance='c137',
+                           cluster='westeros-prod',
+                           soa_dir=DEFAULT_SOA_DIR),
+                 mock.call(service='universe',
+                           instance='c138',
+                           cluster='westeros-prod',
+                           soa_dir=DEFAULT_SOA_DIR)]
+        mock_load_marathon_service_config.assert_has_calls(calls)
+        assert ret == [('universe', 'c138')]
+
+        mock_configs = [mock.Mock(format_marathon_app_dict=mock.Mock(side_effect=NoDockerImageError)),
+                        mock.Mock(format_marathon_app_dict=mock.Mock(return_value={'id': 'universe.c138.c2.g2'}))]
+        mock_load_marathon_service_config.side_effect = mock_configs
+        ret = get_service_instances_with_changed_id(mock.Mock(), mock_service_instances, 'westeros-prod')
+        assert ret == [('universe', 'c137'), ('universe', 'c138')]
+
+
+def test_get_marathon_client_from_config():
+    with mock.patch(
+        'paasta_tools.deployd.common.load_marathon_config', autospec=True
+    ), mock.patch(
+        'paasta_tools.deployd.common.get_marathon_client', autospec=True
+    ) as mock_marathon_client:
+        assert get_marathon_client_from_config() == mock_marathon_client.return_value

--- a/tests/deployd/test_watchers.py
+++ b/tests/deployd/test_watchers.py
@@ -8,8 +8,6 @@ import mock
 from pytest import raises
 
 from paasta_tools.deployd.common import ServiceInstance
-from paasta_tools.utils import DEFAULT_SOA_DIR
-from paasta_tools.utils import NoDockerImageError
 
 
 class FakePyinotify(object):  # pragma: no cover
@@ -248,15 +246,6 @@ class TestPublicConfigWatcher(unittest.TestCase):
         assert self.watcher.is_ready
 
 
-def test_get_marathon_client_from_config():
-    with mock.patch(
-        'paasta_tools.deployd.watchers.load_marathon_config', autospec=True
-    ), mock.patch(
-        'paasta_tools.deployd.watchers.get_marathon_client', autospec=True
-    ) as mock_marathon_client:
-        assert get_marathon_client_from_config() == mock_marathon_client.return_value
-
-
 class TestMaintenanceWatcher(unittest.TestCase):
     def setUp(self):
         self.mock_inbox_q = mock.Mock()
@@ -408,38 +397,6 @@ class TestPublicConfigEventHandler(unittest.TestCase):
             assert mock_get_service_instances_with_changed_id.called
             assert mock_rate_limit_instances.called
             self.mock_filewatcher.inbox_q.put.assert_called_with(mock_si)
-
-
-def test_get_service_instances_with_changed_id():
-    with mock.patch(
-        'paasta_tools.deployd.watchers.list_all_marathon_app_ids', autospec=True
-    ) as mock_get_marathon_apps, mock.patch(
-        'paasta_tools.deployd.watchers.load_marathon_service_config_no_cache', autospec=True
-    ) as mock_load_marathon_service_config:
-        mock_get_marathon_apps.return_value = ['universe.c137.c1.g1',
-                                               'universe.c138.c1.g1']
-        mock_service_instances = [('universe', 'c137'), ('universe', 'c138')]
-        mock_configs = [mock.Mock(format_marathon_app_dict=mock.Mock(return_value={'id': 'universe.c137.c1.g1'})),
-                        mock.Mock(format_marathon_app_dict=mock.Mock(return_value={'id': 'universe.c138.c2.g2'}))]
-        mock_load_marathon_service_config.side_effect = mock_configs
-        ret = get_service_instances_with_changed_id(mock.Mock(), mock_service_instances, 'westeros-prod')
-        assert mock_get_marathon_apps.called
-        calls = [mock.call(service='universe',
-                           instance='c137',
-                           cluster='westeros-prod',
-                           soa_dir=DEFAULT_SOA_DIR),
-                 mock.call(service='universe',
-                           instance='c138',
-                           cluster='westeros-prod',
-                           soa_dir=DEFAULT_SOA_DIR)]
-        mock_load_marathon_service_config.assert_has_calls(calls)
-        assert ret == [('universe', 'c138')]
-
-        mock_configs = [mock.Mock(format_marathon_app_dict=mock.Mock(side_effect=NoDockerImageError)),
-                        mock.Mock(format_marathon_app_dict=mock.Mock(return_value={'id': 'universe.c138.c2.g2'}))]
-        mock_load_marathon_service_config.side_effect = mock_configs
-        ret = get_service_instances_with_changed_id(mock.Mock(), mock_service_instances, 'westeros-prod')
-        assert ret == [('universe', 'c137'), ('universe', 'c138')]
 
 
 class TestYelpSoaEventHandler(unittest.TestCase):


### PR DESCRIPTION
When deployd starts it must evaluate every service with a run of setup
marathon job to ensure it hasn't "missed" an event (e.g. autoscaling or
deployment). However, when we start we can prioritise services that we
know are deploying becuase their app ID has changed. This way if there
is a leader election or restart of deployd: bouncing/deploying services
will be at the front of the queue when it starts up.

Note the bulk of this is just moving stuff around. `prioritise_bouncing_services` is the new bit.