### PR TITLE
Don't fail firewall updates when a deleted service still has running containers

### DIFF
--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -19,6 +19,7 @@ from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.marathon_tools import get_all_namespaces_for_service
 from paasta_tools.utils import get_running_mesos_docker_containers
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import timed_flock
 
 
@@ -78,6 +79,10 @@ class ServiceGroup(collections.namedtuple('ServiceGroup', (
         except NotImplementedError:
             # PAASTA-11414: new instance types may not provide this configuration information;
             # we don't want to break all of the firewall infrastructure when that happens
+            return ()
+        except NoConfigurationForServiceError:
+            # PAASTA-12050: a deleted service may still have containers running on PaaSTA hosts
+            # for several minutes after the directory disappears from soa-configs.
             return ()
 
         if conf.get_dependencies() is None:

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -8,6 +8,7 @@ import pytest
 from paasta_tools import firewall
 from paasta_tools import iptables
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import NoConfigurationForServiceError
 
 
 EMPTY_RULE = iptables.Rule(
@@ -270,6 +271,12 @@ def test_service_group_rules_synapse_backend_error(mock_service_config, service_
 
 def test_service_group_rules_empty_when_invalid_instance_type(service_group, mock_service_config):
     with mock.patch.object(firewall, 'get_instance_config', side_effect=NotImplementedError()):
+        assert service_group.get_rules(DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR) == ()
+
+
+def test_service_group_rules_empty_when_service_is_deleted(service_group, mock_service_config):
+    """A deleted service which still has running containers shouldn't cause exceptions."""
+    with mock.patch.object(firewall, 'get_instance_config', side_effect=NoConfigurationForServiceError()):
         assert service_group.get_rules(DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR) == ()
 
 


### PR DESCRIPTION
Internal ticket: PAASTA-12050