### PR TITLE
Make maintenance polling frequency configurable

### DIFF
--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -216,7 +216,8 @@ class DeployDaemon(PaastaThread):
                            obj[1].__bases__[0] == watchers.PaastaWatcher]
         self.watcher_threads = [watcher(inbox_q=self.inbox_q,
                                         cluster=self.config.get_cluster(),
-                                        zookeeper_client=self.zk)
+                                        zookeeper_client=self.zk,
+                                        config=self.config)
                                 for watcher in watcher_classes]
         self.log.info("Starting the following watchers {}".format(self.watcher_threads))
         for watcher in self.watcher_threads:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1095,6 +1095,14 @@ class SystemPaastaConfig(dict):
         """
         return self.get('deployd_worker_failure_backoff_factor', 30)
 
+    def get_deployd_maintenance_polling_frequency(self):
+        """Get the frequency in seconds that the deployd maintenance watcher should
+        poll mesos's api for new draining hosts
+
+        :returns: An integer
+        """
+        return self.get('deployd_maintenance_polling_frequency', 30)
+
     def get_sensu_host(self):
         """Get the host that we should send sensu events to.
 

--- a/tests/deployd/test_watchers.py
+++ b/tests/deployd/test_watchers.py
@@ -47,14 +47,17 @@ from paasta_tools.deployd.watchers import MaintenanceWatcher  # noqa
 class TestPaastaWatcher(unittest.TestCase):
     def test_init(self):
         mock_inbox_q = mock.Mock()
-        PaastaWatcher(mock_inbox_q, 'westeros-prod')
+        PaastaWatcher(mock_inbox_q, 'westeros-prod', config=mock.Mock())
 
 
 class TestAutoscalerWatcher(unittest.TestCase):
     def setUp(self):
         self.mock_zk = mock.Mock()
         self.mock_inbox_q = mock.Mock()
-        self.watcher = AutoscalerWatcher(self.mock_inbox_q, "westeros-prod", zookeeper_client=self.mock_zk)
+        self.watcher = AutoscalerWatcher(self.mock_inbox_q,
+                                         "westeros-prod",
+                                         zookeeper_client=self.mock_zk,
+                                         config=mock.Mock())
 
     def test_watch_folder(self):
         with mock.patch(
@@ -193,7 +196,7 @@ class TestSoaFileWatcher(unittest.TestCase):
         ):
             self.mock_notifier = mock.Mock()
             mock_notifier_class.return_value = self.mock_notifier
-            self.watcher = SoaFileWatcher(mock_inbox_q, 'westeros-prod')
+            self.watcher = SoaFileWatcher(mock_inbox_q, 'westeros-prod', config=mock.Mock())
             assert mock_notifier_class.called
 
     def test_mask(self):
@@ -227,7 +230,7 @@ class TestPublicConfigWatcher(unittest.TestCase):
         ):
             self.mock_notifier = mock.Mock()
             mock_notifier_class.return_value = self.mock_notifier
-            self.watcher = PublicConfigFileWatcher(mock_inbox_q, 'westeros-prod')
+            self.watcher = PublicConfigFileWatcher(mock_inbox_q, 'westeros-prod', config=mock.Mock())
             assert mock_notifier_class.called
 
     def test_mask(self):
@@ -251,10 +254,11 @@ class TestMaintenanceWatcher(unittest.TestCase):
     def setUp(self):
         self.mock_inbox_q = mock.Mock()
         self.mock_marathon_client = mock.Mock()
+        mock_config = mock.Mock(get_deployd_maintenance_polling_frequency=mock.Mock(return_value=20))
         with mock.patch(
             'paasta_tools.deployd.watchers.get_marathon_client_from_config', autospec=True
         ):
-            self.watcher = MaintenanceWatcher(self.mock_inbox_q, "westeros-prod")
+            self.watcher = MaintenanceWatcher(self.mock_inbox_q, "westeros-prod", config=mock_config)
 
     def test_get_new_draining_hosts(self):
         with mock.patch(


### PR DESCRIPTION
This makes the frequency at which we poll mesos's maintenance API from
deployd configurable. The motivation is so we can throttle load against
the mesos master by polling less frequently.

I've also increased the default from 20 to 30 seconds

cc @solarkennedy we may need to bump higher in our biggest cluster but I suspect 30 is okay elsewhere.