### PR TITLE
Changing firewall-related paths to be /var/lib/paasta instead of /var/run/paasta

### DIFF
--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -31,7 +31,7 @@ from paasta_tools.mac_address import reserve_unique_mac_address
 from paasta_tools.utils import DEFAULT_SOA_DIR
 
 
-LOCK_DIRECTORY = '/var/run/paasta/mac-address'
+LOCK_DIRECTORY = '/var/lib/paasta/mac-address'
 ENV_MATCH_RE = re.compile('^(-\w*e\w*|--env(?P<file>-file)?)(=(?P<arg>\S.*))?$')
 MAX_HOSTNAME_LENGTH = 63
 

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -30,7 +30,7 @@ PRIVATE_IP_RANGES = (
     '169.254.0.0/255.255.0.0',
 )
 DEFAULT_SYNAPSE_SERVICE_DIR = b'/var/run/synapse/services'
-DEFAULT_FIREWALL_FLOCK_PATH = '/var/run/paasta/firewall.flock'
+DEFAULT_FIREWALL_FLOCK_PATH = '/var/lib/paasta/firewall.flock'
 DEFAULT_FIREWALL_FLOCK_TIMEOUT_SECS = 5
 
 RESOLV_CONF = '/etc/resolv.conf'


### PR DESCRIPTION
Because /var/run is a tmpfs so is empty upon boot/reboot. Internal ticket PAASTA-12034