### PR TITLE
Fix deployd prioritising bouncing services

### DIFF
--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -200,8 +200,8 @@ class DeployDaemon(PaastaThread):
     def prioritise_bouncing_services(self):
         service_instances = get_service_instances_that_need_bouncing(self.marathon_client,
                                                                      DEFAULT_SOA_DIR)
-        self.log.info("Found the following services that need bouncing now: {}".format(list(service_instances)))
         for service_instance in service_instances:
+            self.log.info("Prioritising {} to be bounced immediately".format(service_instance))
             service, instance = service_instance.split('.')
             self.inbox_q.put(ServiceInstance(service=service,
                                              instance=instance,

--- a/tests/deployd/test_deployd_master.py
+++ b/tests/deployd/test_deployd_master.py
@@ -302,7 +302,7 @@ class TestDeployDaemon(unittest.TestCase):
         ) as mock_get_service_instances_that_need_bouncing, mock.patch(
             'time.time', autospec=True, return_value=1
         ):
-            mock_changed_instances = ('universe.c137', 'universe.c138')
+            mock_changed_instances = (x for x in {'universe.c137', 'universe.c138'})
             mock_get_service_instances_that_need_bouncing.return_value = mock_changed_instances
 
             self.deployd.prioritise_bouncing_services()


### PR DESCRIPTION
The log line was "consuming" the generator :-( so this was not working
and my test wasn't catching it because it wasn't using a mock of what
the output actually would have been.