### PR TITLE
Ask marathon to embed tasks not failures

### DIFF
--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -216,7 +216,7 @@ def when_setup_service_initiated(context):
         # 120 * 0.5 = 60 seconds
         for _ in range(120):
             try:
-                marathon_apps = marathon_tools.get_all_marathon_apps(context.marathon_client, embed_failures=True)
+                marathon_apps = marathon_tools.get_all_marathon_apps(context.marathon_client, embed_tasks=True)
                 (code, message, bounce_again) = setup_marathon_job.setup_service(
                     service=context.service,
                     instance=context.instance,

--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -180,7 +180,7 @@ class MaintenanceWatcher(PaastaWatcher):
             time.sleep(self.config.get_deployd_maintenance_polling_frequency())
 
     def get_at_risk_service_instances(self, draining_hosts):
-        marathon_apps = get_all_marathon_apps(self.marathon_client, embed_failures=True)
+        marathon_apps = get_all_marathon_apps(self.marathon_client, embed_tasks=True)
         at_risk_tasks = [task for app in marathon_apps for task in app.tasks if task.host in draining_hosts]
         self.log.info("At risk tasks: {}".format(at_risk_tasks))
         service_instances = []

--- a/paasta_tools/deployd/workers.py
+++ b/paasta_tools/deployd/workers.py
@@ -69,7 +69,7 @@ class PaastaDeployWorker(PaastaThread):
             failures = service_instance.failures
             bounce_timers = self.setup_timers(service_instance)
             self.log.info("{} processing {}.{}".format(self.name, service_instance.service, service_instance.instance))
-            marathon_apps = marathon_tools.get_all_marathon_apps(self.marathon_client, embed_failures=True)
+            marathon_apps = marathon_tools.get_all_marathon_apps(self.marathon_client, embed_tasks=True)
             bounce_timers.setup_marathon.start()
             try:
                 return_code, bounce_again_in_seconds = deploy_marathon_service(

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -954,8 +954,8 @@ def get_matching_apps(servicename, instance, marathon_apps):
     return [app for app in marathon_apps if app.id.startswith(expected_prefix)]
 
 
-def get_all_marathon_apps(client, embed_failures=False):
-    return client.list_apps(embed_failures=embed_failures)
+def get_all_marathon_apps(client, embed_tasks=False):
+    return client.list_apps(embed_tasks=embed_tasks)
 
 
 def kill_task(client, app_id, task_id, scale):

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -685,7 +685,7 @@ def main():
         marathon_config.get_url(), marathon_config.get_username(),
         marathon_config.get_password(),
     )
-    marathon_apps = marathon_tools.get_all_marathon_apps(client, embed_failures=True)
+    marathon_apps = marathon_tools.get_all_marathon_apps(client, embed_tasks=True)
 
     num_failed_deployments = 0
     for service_instance in args.service_instance_list:


### PR DESCRIPTION
For some calls to /v2/apps we need to embed the tasks in the results. I
don't think we need the task failures and embedding them is deprecated
because it implies embedding everything else. See:
https://mesosphere.github.io/marathon/docs/rest-api.html#get-v2apps

Unfortunately embedding tasks still implies embedding deployments which
I think we also don't need. However, this is supposed to change at some
point in the future.

If the itests pass then I think this is safe and it should reduce the
load on marathon slightly.