### PR TITLE
Catch InvalidJobNameError in deployd

### DIFF
--- a/paasta_tools/deployd/common.py
+++ b/paasta_tools/deployd/common.py
@@ -13,6 +13,7 @@ from paasta_tools.marathon_tools import get_all_marathon_apps
 from paasta_tools.marathon_tools import get_marathon_client
 from paasta_tools.marathon_tools import load_marathon_config
 from paasta_tools.marathon_tools import load_marathon_service_config_no_cache
+from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import NoDockerImageError
 
 BounceTimers = namedtuple('BounceTimers', ['processed_by_worker', 'setup_marathon', 'bounce_length'])
@@ -83,7 +84,7 @@ def get_service_instances_needing_update(marathon_client, instances, cluster):
         try:
             config_app = config.format_marathon_app_dict()
             app_id = '/{}'.format(config_app['id'])
-        except NoDockerImageError:
+        except (NoDockerImageError, InvalidJobNameError):
             config_app = None
         if not config_app:
             service_instances.append((service, instance))

--- a/tests/deployd/test_common.py
+++ b/tests/deployd/test_common.py
@@ -13,6 +13,7 @@ from paasta_tools.deployd.common import PaastaThread
 from paasta_tools.deployd.common import rate_limit_instances
 from paasta_tools.deployd.common import ServiceInstance
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import NoDockerImageError
 
 
@@ -105,6 +106,13 @@ def test_get_service_instances_needing_update():
         assert ret == [('universe', 'c137'), ('universe', 'c138')]
 
         mock_configs = [mock.Mock(format_marathon_app_dict=mock.Mock(side_effect=NoDockerImageError)),
+                        mock.Mock(format_marathon_app_dict=mock.Mock(return_value={'id': 'universe.c138.c2.g2',
+                                                                                         'instances': 2}))]
+        mock_load_marathon_service_config.side_effect = mock_configs
+        ret = get_service_instances_needing_update(mock.Mock(), mock_service_instances, 'westeros-prod')
+        assert ret == [('universe', 'c137'), ('universe', 'c138')]
+
+        mock_configs = [mock.Mock(format_marathon_app_dict=mock.Mock(side_effect=InvalidJobNameError)),
                         mock.Mock(format_marathon_app_dict=mock.Mock(return_value={'id': 'universe.c138.c2.g2',
                                                                                          'instances': 2}))]
         mock_load_marathon_service_config.side_effect = mock_configs


### PR DESCRIPTION
I'm not 100% on the root cause of this exception but the deploy daemons
file watcher certainly shouldn't die as a result. The safest thing is to
catch it and assume the service needs a bounce. Then it will be up to
the worker to have a go at deploying the service and back off it sees
the same error.