### PR TITLE
Pysensu is not py36 compatible until 0.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ Pygments==2.0.2
 pymesos==0.2.13
 pyramid==1.8.4
 pyramid-swagger==2.4.1
-pysensu-yelp==0.3.3
+pysensu-yelp==0.3.4
 PyStaticConfiguration==0.10.3
 python-crontab==2.1.1
 python-dateutil==2.4.2

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'pyramid >= 1.8',
         'pymesos >= 0.2.0',
         'pyramid-swagger >= 2.3.0',
-        'pysensu-yelp >= 0.2.2',
+        'pysensu-yelp >= 0.3.4',
         'pytimeparse >= 1.1.0',
         'pytz >= 2014.10',
         'python-crontab>=2.1.1',


### PR DESCRIPTION
Got errors like:

```
Jul 12 17:27:05 mesos1-uswest1cdevc cron_check_chronos_jobs: soa_dir=soa_dir,
Jul 12 17:27:05 mesos1-uswest1cdevc cron_check_chronos_jobs: File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/check_chronos_jobs.py", line 99, in send_event
Jul 12 17:27:05 mesos1-uswest1cdevc cron_check_chronos_jobs: soa_dir=soa_dir,
Jul 12 17:27:05 mesos1-uswest1cdevc cron_check_chronos_jobs: File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/monitoring_tools.py", line 203, in send_event
Jul 12 17:27:05 mesos1-uswest1cdevc cron_check_chronos_jobs: **result_dict)
Jul 12 17:27:05 mesos1-uswest1cdevc cron_check_chronos_jobs: File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/pysensu_yelp/__init__.py", line 324, in send_event
Jul 12 17:27:05 mesos1-uswest1cdevc cron_check_chronos_jobs: sock.sendall(json_hash + '\n')
Jul 12 17:27:05 mesos1-uswest1cdevc cron_check_chronos_jobs: TypeError: a bytes-like object is required, not 'str'
```

looks like https://github.com/Yelp/pysensu-yelp/pull/22

Solution is to bump from 0.3.3 to 0.3.4