### PR TITLE
Fix the type of user_port to avoid TypeError in socket.socket

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -359,6 +359,7 @@ def add_subparser(subparsers):
     list_parser.add_argument(
         '-o', '--port',
         help='Specify a port number to use. If not set, a random non-conflicting port will be found.',
+        type=int,
         dest='user_port',
         required=False,
         default=False,


### PR DESCRIPTION
Otherwise, when --port=5000 is provided, one gets,

```
Traceback (most recent call last):
  File "/usr/bin/paasta", line 11, in <module>
    load_entry_point('paasta-tools==0.65.38', 'console_scripts', 'paasta')()
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/cli/cli.py", line 122, in main
    return_code = args.command(args)
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/cli/cmds/local_run.py", line 892, in paasta_local_run
    dry_run=args.action == 'dry_run',
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/cli/cmds/local_run.py", line 824, in configure_and_run_docker_container
    framework=instance_type,
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/cli/cmds/local_run.py", line 538, in run_docker_container
    if check_if_port_free(user_port):
  File "/opt/venvs/paasta-tools/local/lib/python2.7/site-packages/paasta_tools/cli/cmds/local_run.py", line 505, in check_if_port_free
    temp_socket.bind(("127.0.0.1", port))
  File "/usr/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
TypeError: an integer is required
```

This fixes that.  Tested with run of local-run with this fix.