### PR TITLE
Add haproxy support for mesos leader discovery

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ croniter==0.3.14
 docker-py==1.2.3
 dulwich==0.17.3
 enum34==1.1.6
+environment-tools==1.1.3
 ephemeral-port-reserve==1.0.1
 futures==3.0.1
 gevent==1.1.1


### PR DESCRIPTION
Previous request: https://github.com/Yelp/task_processing/pull/36
## Summary:
- Added get_mesos_proxy to mesos_tools
- Added accompanying tests
## Testing done:
- Manually called get_mesos_proxy to ensure it works with services.yaml
- make test
## Notes:
- Initially wanted to do a plugin for taskproc, but concluded that it would be too roundabout because in TaskProcessor, we would need to pass the class MesosExecutor and have the would-be plugin initialize it with the smartstack address. Paasta never loads the mesos plugin itself, which is confusing.
- I did not modify remote-run because we do not yet have a taskproc cluster in prod, so remote-run still uses Zookeeper via get_mesos_leader, also in mesos_tools. However, with the new function, we can test more easily without having to manually get the address ourselves.
- I looked around Paasta's smartstack_tools to find a way to access services in a more Paasta-like way, but couldn't find anything. If anyone has any idea better than looking at services.yaml, please comment!
