### PR TITLE
Scribereader was not py3 compatible until 0.2.6

### DIFF
--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -1,5 +1,5 @@
 --extra-index-url=https://pypi.yelpcorp.com/simple
-scribereader==0.1.30
+scribereader==0.2.6
 yelp-cgeom==1.3.1
 yelp-logging==1.0.37
 yelp_meteorite


### PR DESCRIPTION
Found by acoover, paasta logs doesn't work because scribereader had non absolute imports until 0.2.6 ...

I've upgraded to 0.2.6 and am testing paasta logs locally from the lucid package.