### PR TITLE
Fix remote run signal handler

### DIFF
--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -283,6 +283,10 @@ def remote_run_start(args):
         paasta_print(
             PaastaColors.red("Signal received, shutting down scheduler."))
         runner.stop()
+        if _signum == signal.SIGTERM:
+            sys.exit(143)
+        else:
+            sys.exit(1)
     signal.signal(signal.SIGINT, handle_interrupt)
     signal.signal(signal.SIGTERM, handle_interrupt)
 


### PR DESCRIPTION
Previously Ctrl+C doesn't work. The patch was tested with kill -SIGINT|SIGTERM pid.