### PR TITLE
Manually resolved add-trailing-comma changes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -176,8 +176,10 @@ htmlhelp_basename = 'paasta_toolsdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ('index', 'paasta_tools.tex', 'service\\_deployment\\_tools Documentation',
-     'Yelp Inc', 'manual'),
+    (
+        'index', 'paasta_tools.tex', 'service\\_deployment\\_tools Documentation',
+        'Yelp Inc', 'manual',
+    ),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -82,7 +82,8 @@ def perform_http_healthcheck(url, timeout):
     if 'content-type' in res.headers and ',' in res.headers['content-type']:
         paasta_print(PaastaColors.yellow(
             "Multiple content-type headers detected in response."
-            " The Mesos healthcheck system will treat this as a failure!"))
+            " The Mesos healthcheck system will treat this as a failure!",
+        ))
         return (False, "http request succeeded, code %d" % res.status_code)
     # check if response code is valid per https://mesosphere.github.io/marathon/docs/health-checks.html
     elif res.status_code >= 200 and res.status_code < 400:
@@ -149,7 +150,8 @@ def run_healthcheck_on_container(
         healthcheck_result = perform_tcp_healthcheck(healthcheck_data, timeout)
     else:
         paasta_print(PaastaColors.yellow(
-            "Healthcheck mode '%s' is not currently supported!" % healthcheck_mode))
+            "Healthcheck mode '%s' is not currently supported!" % healthcheck_mode,
+        ))
         sys.exit(1)
     return healthcheck_result
 
@@ -267,8 +269,10 @@ def add_subparser(subparsers):
     ).completer = lazy_choices_completer(list_services)
     list_parser.add_argument(
         '-c', '--cluster',
-        help=("The name of the cluster you wish to simulate. "
-              "If omitted, uses the default cluster defined in the paasta local-run configs"),
+        help=(
+            "The name of the cluster you wish to simulate. "
+            "If omitted, uses the default cluster defined in the paasta local-run configs"
+        ),
     ).completer = lazy_choices_completer(list_clusters)
     list_parser.add_argument(
         '-y', '--yelpsoa-config-root',
@@ -313,9 +317,11 @@ def add_subparser(subparsers):
     )
     list_parser.add_argument(
         '-C', '--cmd',
-        help=('Run Docker container with particular command, '
-              'for example: "bash". By default will use the command or args specified by the '
-              'soa-configs or what was specified in the Dockerfile'),
+        help=(
+            'Run Docker container with particular command, '
+            'for example: "bash". By default will use the command or args specified by the '
+            'soa-configs or what was specified in the Dockerfile'
+        ),
         required=False,
         default=None,
     )
@@ -334,8 +340,10 @@ def add_subparser(subparsers):
     )
     list_parser.add_argument(
         '-I', '--interactive',
-        help=('Run container in interactive mode. If interactive is set the default command will be "bash" '
-              'unless otherwise set by the "--cmd" flag'),
+        help=(
+            'Run container in interactive mode. If interactive is set the default command will be "bash" '
+            'unless otherwise set by the "--cmd" flag'
+        ),
         action='store_true',
         required=False,
         default=False,
@@ -370,8 +378,10 @@ def get_container_name():
     return 'paasta_local_run_%s_%s' % (get_username(), randint(1, 999999))
 
 
-def get_docker_run_cmd(memory, chosen_port, container_port, container_name, volumes, env, interactive,
-                       docker_hash, command, net, docker_params):
+def get_docker_run_cmd(
+    memory, chosen_port, container_port, container_name, volumes, env, interactive,
+    docker_hash, command, net, docker_params,
+):
     cmd = ['paasta_docker_wrapper', 'run']
     for k, v in env.items():
         cmd.append('--env')
@@ -454,7 +464,8 @@ def _cleanup_container(docker_client, container_id):
         paasta_print("...done")
     except errors.APIError:
         paasta_print(PaastaColors.yellow(
-            "Could not clean up container! You should stop and remove container '%s' manually." % container_id))
+            "Could not clean up container! You should stop and remove container '%s' manually." % container_id,
+        ))
 
 
 def get_local_run_environment_vars(instance_config, port0, framework):
@@ -580,7 +591,8 @@ def run_docker_container(
     docker_run_cmd = get_docker_run_cmd(**docker_run_args)
     joined_docker_run_cmd = ' '.join(docker_run_cmd)
     healthcheck_mode, healthcheck_data = get_healthcheck_for_instance(
-        service, instance, instance_config, chosen_port, soa_dir=soa_dir)
+        service, instance, instance_config, chosen_port, soa_dir=soa_dir,
+    )
 
     if dry_run:
         if json_dict:
@@ -772,10 +784,14 @@ def configure_and_run_docker_container(
         try:
             docker_url = instance_config.get_docker_url()
         except NoDockerImageError:
-            paasta_print(PaastaColors.red(
-                "Error: No sha has been marked for deployment for the %s deploy group.\n"
-                "Please ensure this service has either run through a jenkins pipeline "
-                "or paasta mark-for-deployment has been run for %s\n" % (instance_config.get_deploy_group(), service)),
+            paasta_print(
+                PaastaColors.red(
+                    "Error: No sha has been marked for deployment for the %s deploy group.\n"
+                    "Please ensure this service has either run through a jenkins pipeline "
+                    "or paasta mark-for-deployment has been run for %s\n" % (
+                        instance_config.get_deploy_group(), service,
+                    ),
+                ),
                 sep='',
                 file=sys.stderr,
             )
@@ -855,7 +871,8 @@ def paasta_local_run(args):
             paasta_print(
                 PaastaColors.red(
                     "PaaSTA on this machine has not been configured with a default cluster."
-                    "Please pass one to local-run using '-c'."),
+                    "Please pass one to local-run using '-c'.",
+                ),
                 sep='\n',
                 file=sys.stderr,
             )

--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -240,7 +240,8 @@ def append_cpuset_args(argv, env_args):
         pinned_numa_node = int(env_args.get('PIN_TO_NUMA_NODE'))
     except (ValueError, TypeError):
         logging.error('Could not read PIN_TO_NUMA_NODE value as an int: {}'.format(
-            env_args.get('PIN_TO_NUMA_NODE')))
+            env_args.get('PIN_TO_NUMA_NODE'),
+        ))
         return argv
 
     cpumap = get_cpumap()
@@ -250,7 +251,8 @@ def append_cpuset_args(argv, env_args):
         return argv
     if pinned_numa_node not in cpumap:
         logging.error('Specified NUMA node: {} does not exist on this system'.format(
-            pinned_numa_node))
+            pinned_numa_node,
+        ))
         return argv
     if arg_collision(['--cpuset-cpus', '--cpuset-mems'], argv):
         logging.error('--cpuset options are already set. Not overriding')
@@ -263,12 +265,16 @@ def append_cpuset_args(argv, env_args):
         return argv
     if get_numa_memsize(len(cpumap)) <= get_mem_requierements(env_args):
         logging.error('Requested memory:{} MB does not fit in one NUMA node: {} MB'.format(
-            get_mem_requierements(env_args), get_numa_memsize(len(cpumap))))
+            get_mem_requierements(env_args), get_numa_memsize(len(cpumap)),
+        ))
         return argv
 
     logging.info('Binding container to NUMA node {}'.format(pinned_numa_node))
-    argv = add_argument(argv, ('--cpuset-cpus=' + ','.join(
-        str(c) for c in cpumap[pinned_numa_node])))
+    argv = add_argument(
+        argv, ('--cpuset-cpus=' + ','.join(
+            str(c) for c in cpumap[pinned_numa_node]
+        )),
+    )
     argv = add_argument(argv, ('--cpuset-mems=' + str(pinned_numa_node)))
     return argv
 
@@ -289,7 +295,8 @@ def add_firewall(argv, service, instance):
                     DEFAULT_SYNAPSE_SERVICE_DIR,
                     service,
                     instance,
-                    mac_address)
+                    mac_address,
+                )
         except Exception as e:
             output = 'Unable to add firewall rules: {}'.format(e)
 

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -127,7 +127,8 @@ class LongRunningServiceConfig(InstanceConfig):
                 limited_instances = self.limit_instance_count(zk_instances)
                 if limited_instances != zk_instances:
                     log.warning("Returning limited instance count %d. (zk had %d)" % (
-                                limited_instances, zk_instances))
+                        limited_instances, zk_instances,
+                    ))
                 return limited_instances
         else:
             instances = self.config_dict.get('instances', 1)
@@ -234,7 +235,8 @@ def load_service_namespace_config(service, namespace, soa_dir=DEFAULT_SOA_DIR):
     """
 
     service_config = service_configuration_lib.read_service_configuration(
-        service_name=service, soa_dir=soa_dir)
+        service_name=service, soa_dir=soa_dir,
+    )
     smartstack_config = service_config.get('smartstack', {})
     namespace_config_from_file = smartstack_config.get(namespace, {})
 

--- a/paasta_tools/mesos/slave.py
+++ b/paasta_tools/mesos/slave.py
@@ -46,16 +46,21 @@ class MesosSlave(object):
         return "{}://{}:{}".format(
             self.config["scheme"],
             self["hostname"],
-            self["pid"].split(":")[-1])
+            self["pid"].split(":")[-1],
+        )
 
     @log.duration
     def fetch(self, url, **kwargs):
         try:
-            return requests.get(urljoin(
-                self.host, url), timeout=self.config["response_timeout"], **kwargs)
+            return requests.get(
+                urljoin(
+                    self.host, url,
+                ), timeout=self.config["response_timeout"], **kwargs
+            )
         except requests.exceptions.ConnectionError:
             raise exceptions.SlaveDoesNotExist(
-                "Unable to connect to the slave at {}".format(self.host))
+                "Unable to connect to the slave at {}".format(self.host),
+            )
 
     @util.CachedProperty(ttl=5)
     def state(self):
@@ -71,7 +76,9 @@ class MesosSlave(object):
                 if task_id in list(map(
                         lambda x: x["id"],
                         util.merge(
-                            exc, "completed_tasks", "tasks", "queued_tasks"))):
+                            exc, "completed_tasks", "tasks", "queued_tasks",
+                        ),
+                )):
                     return exc
         raise exceptions.MissingExecutor("No executor has a task by that id")
 

--- a/paasta_tools/metrics/metastatus_lib.py
+++ b/paasta_tools/metrics/metastatus_lib.py
@@ -128,17 +128,23 @@ def assert_cpu_health(metrics, mesos_state, threshold=10):
     try:
         perc_used = percent_used(total, used)
     except ZeroDivisionError:
-        return HealthCheckResult(message="Error reading total available cpu from mesos!",
-                                 healthy=False)
+        return HealthCheckResult(
+            message="Error reading total available cpu from mesos!",
+            healthy=False,
+        )
 
     if check_threshold(perc_used, threshold):
-        return HealthCheckResult(message="CPUs: %.2f / %d in use (%s)"
-                                 % (used, total, PaastaColors.green("%.2f%%" % perc_used)),
-                                 healthy=True)
+        return HealthCheckResult(
+            message="CPUs: %.2f / %d in use (%s)"
+            % (used, total, PaastaColors.green("%.2f%%" % perc_used)),
+            healthy=True,
+        )
     else:
-        return HealthCheckResult(message="CRITICAL: Less than %d%% CPUs available. (Currently using %.2f%% of %d)"
-                                 % (threshold, perc_used, total),
-                                 healthy=False)
+        return HealthCheckResult(
+            message="CRITICAL: Less than %d%% CPUs available. (Currently using %.2f%% of %d)"
+            % (threshold, perc_used, total),
+            healthy=False,
+        )
 
 
 def assert_memory_health(metrics, mesos_state, threshold=10):
@@ -154,8 +160,10 @@ def assert_memory_health(metrics, mesos_state, threshold=10):
     try:
         perc_used = percent_used(total, used)
     except ZeroDivisionError:
-        return HealthCheckResult(message="Error reading total available memory from mesos!",
-                                 healthy=False)
+        return HealthCheckResult(
+            message="Error reading total available memory from mesos!",
+            healthy=False,
+        )
 
     if check_threshold(perc_used, threshold):
         return HealthCheckResult(
@@ -184,8 +192,10 @@ def assert_disk_health(metrics, mesos_state, threshold=10):
     try:
         perc_used = percent_used(total, used)
     except ZeroDivisionError:
-        return HealthCheckResult(message="Error reading total available disk from mesos!",
-                                 healthy=False)
+        return HealthCheckResult(
+            message="Error reading total available disk from mesos!",
+            healthy=False,
+        )
 
     if check_threshold(perc_used, threshold):
         return HealthCheckResult(
@@ -501,8 +511,10 @@ def run_healthchecks_with_param(param, healthcheck_functions, format_options={})
 def assert_marathon_apps(client):
     num_apps = len(client.list_apps())
     if num_apps < 1:
-        return HealthCheckResult(message="CRITICAL: No marathon apps running",
-                                 healthy=False)
+        return HealthCheckResult(
+            message="CRITICAL: No marathon apps running",
+            healthy=False,
+        )
     else:
         return HealthCheckResult(message="marathon apps: %d" % num_apps, healthy=True)
 
@@ -520,10 +532,13 @@ def assert_marathon_deployments(client):
 def get_marathon_status(client):
     """ Gathers information about marathon.
     :return: string containing the status.  """
-    return run_healthchecks_with_param(client, [
-        assert_marathon_apps,
-        assert_marathon_tasks,
-        assert_marathon_deployments])
+    return run_healthchecks_with_param(
+        client, [
+            assert_marathon_apps,
+            assert_marathon_tasks,
+            assert_marathon_deployments,
+        ],
+    )
 
 
 def assert_chronos_scheduled_jobs(client):
@@ -554,10 +569,12 @@ def get_chronos_status(chronos_client):
     """Gather information about chronos.
     :return: string containing the status
     """
-    return run_healthchecks_with_param(chronos_client, [
-        assert_chronos_scheduled_jobs,
-        assert_chronos_queued_jobs,
-    ])
+    return run_healthchecks_with_param(
+        chronos_client, [
+            assert_chronos_scheduled_jobs,
+            assert_chronos_queued_jobs,
+        ],
+    )
 
 
 def get_marathon_client(marathon_config):

--- a/tests/api/test_resources.py
+++ b/tests/api/test_resources.py
@@ -68,60 +68,67 @@ def test_resources_utilization_nothing_special(mock_get_mesos_master, mock_get_r
 
 
 mock_mesos_state = {
-    'slaves': [{
-        'id': 'foo1',
-        'resources': {
-            'disk': 100,
-            'cpus': 10,
-            'mem': 50,
-        },
-        'attributes': {'pool': 'default', 'region': 'top'},
-        'reserved_resources': []},
+    'slaves': [
         {
-        'id': 'bar1',
-        'resources': {
-            'disk': 100,
-            'cpus': 10,
-            'mem': 50,
+            'id': 'foo1',
+            'resources': {
+                'disk': 100,
+                'cpus': 10,
+                'mem': 50,
+            },
+            'attributes': {'pool': 'default', 'region': 'top'},
+            'reserved_resources': [],
         },
-        'attributes': {'pool': 'default', 'region': 'bottom'},
-        'reserved_resources': []},
         {
-        'id': 'foo2',
-        'resources': {
-            'disk': 100,
-            'cpus': 10,
-            'mem': 50,
+            'id': 'bar1',
+            'resources': {
+                'disk': 100,
+                'cpus': 10,
+                'mem': 50,
+            },
+            'attributes': {'pool': 'default', 'region': 'bottom'},
+            'reserved_resources': [],
         },
-        'attributes': {'pool': 'other', 'region': 'top'},
-        'reserved_resources': []},
         {
-        'id': 'bar2',
-        'resources': {
-            'disk': 100,
-            'cpus': 10,
-            'mem': 50,
+            'id': 'foo2',
+            'resources': {
+                'disk': 100,
+                'cpus': 10,
+                'mem': 50,
+            },
+            'attributes': {'pool': 'other', 'region': 'top'},
+            'reserved_resources': [],
         },
-        'attributes': {'pool': 'other', 'region': 'bottom'},
-        'reserved_resources': []},
         {
-        'id': 'foo3',
-        'resources': {
-            'disk': 100,
-            'cpus': 10,
-            'mem': 50,
+            'id': 'bar2',
+            'resources': {
+                'disk': 100,
+                'cpus': 10,
+                'mem': 50,
+            },
+            'attributes': {'pool': 'other', 'region': 'bottom'},
+            'reserved_resources': [],
         },
-        'attributes': {'pool': 'other', 'region': 'top'},
-        'reserved_resources': []},
         {
-        'id': 'bar2',
-        'resources': {
-            'disk': 100,
-            'cpus': 10,
-            'mem': 50,
+            'id': 'foo3',
+            'resources': {
+                'disk': 100,
+                'cpus': 10,
+                'mem': 50,
+            },
+            'attributes': {'pool': 'other', 'region': 'top'},
+            'reserved_resources': [],
         },
-        'attributes': {'pool': 'other', 'region': 'bottom'},
-        'reserved_resources': []},
+        {
+            'id': 'bar2',
+            'resources': {
+                'disk': 100,
+                'cpus': 10,
+                'mem': 50,
+            },
+            'attributes': {'pool': 'other', 'region': 'bottom'},
+            'reserved_resources': [],
+        },
     ],
     'frameworks': [
         {'tasks': [

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -639,22 +639,25 @@ def test_get_resource_utilization_by_grouping(
 
 def test_get_resource_utilization_by_grouping_correctly_groups():
     fake_state = {
-        'slaves': [{
-            'id': 'foo',
-            'resources': {
-                'disk': 100,
-                'cpus': 10,
-                'mem': 50,
-            },
-            'reserved_resources': []},
+        'slaves': [
             {
-            'id': 'bar',
-            'resources': {
-                'disk': 100,
-                'cpus': 10,
-                'mem': 50,
+                'id': 'foo',
+                'resources': {
+                    'disk': 100,
+                    'cpus': 10,
+                    'mem': 50,
+                },
+                'reserved_resources': [],
             },
-            'reserved_resources': []},
+            {
+                'id': 'bar',
+                'resources': {
+                    'disk': 100,
+                    'cpus': 10,
+                    'mem': 50,
+                },
+                'reserved_resources': [],
+            },
         ],
         'frameworks': [
             {'tasks': [
@@ -682,42 +685,47 @@ def test_get_resource_utilization_by_grouping_correctly_groups():
 
 def test_get_resource_utilization_by_grouping_correctly_multi_groups():
     fake_state = {
-        'slaves': [{
-            'id': 'foo1',
-            'resources': {
-                'disk': 100,
-                'cpus': 10,
-                'mem': 50,
-            },
-            'attributes': {'one': 'yes', 'two': 'yes'},
-            'reserved_resources': []},
+        'slaves': [
             {
-            'id': 'bar1',
-            'resources': {
-                'disk': 100,
-                'cpus': 10,
-                'mem': 50,
+                'id': 'foo1',
+                'resources': {
+                    'disk': 100,
+                    'cpus': 10,
+                    'mem': 50,
+                },
+                'attributes': {'one': 'yes', 'two': 'yes'},
+                'reserved_resources': [],
             },
-            'attributes': {'one': 'yes', 'two': 'no'},
-            'reserved_resources': []},
             {
-            'id': 'foo2',
-            'resources': {
-                'disk': 100,
-                'cpus': 10,
-                'mem': 50,
+                'id': 'bar1',
+                'resources': {
+                    'disk': 100,
+                    'cpus': 10,
+                    'mem': 50,
+                },
+                'attributes': {'one': 'yes', 'two': 'no'},
+                'reserved_resources': [],
             },
-            'attributes': {'one': 'no', 'two': 'yes'},
-            'reserved_resources': []},
             {
-            'id': 'bar2',
-            'resources': {
-                'disk': 100,
-                'cpus': 10,
-                'mem': 50,
+                'id': 'foo2',
+                'resources': {
+                    'disk': 100,
+                    'cpus': 10,
+                    'mem': 50,
+                },
+                'attributes': {'one': 'no', 'two': 'yes'},
+                'reserved_resources': [],
             },
-            'attributes': {'one': 'no', 'two': 'no'},
-            'reserved_resources': []},
+            {
+                'id': 'bar2',
+                'resources': {
+                    'disk': 100,
+                    'cpus': 10,
+                    'mem': 50,
+                },
+                'attributes': {'one': 'no', 'two': 'no'},
+                'reserved_resources': [],
+            },
         ],
         'frameworks': [
             {'tasks': [
@@ -994,8 +1002,10 @@ def test_format_table_column_for_healthcheck_resource_utilization_pair_zero_huma
     ) == expected
 
 
-@patch('paasta_tools.metrics.metastatus_lib.format_table_column_for_healthcheck_resource_utilization_pair',
-       autospec=True)
+@patch(
+    'paasta_tools.metrics.metastatus_lib.format_table_column_for_healthcheck_resource_utilization_pair',
+    autospec=True,
+)
 def test_format_row_for_resource_utilization_checks(mock_format_row):
     fake_pairs = [
         (Mock(), Mock()),

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -51,10 +51,12 @@ def test_filter_not_running_tasks():
     assert not_running[0]['id'] == 2
 
 
-@mark.parametrize('test_case', [
-    [0, 0],
-    [10, 1 + 10],  # 1 running task, 10 non-running taks (truncated)
-])
+@mark.parametrize(
+    'test_case', [
+        [0, 0],
+        [10, 1 + 10],  # 1 running task, 10 non-running taks (truncated)
+    ],
+)
 def test_status_mesos_tasks_verbose(test_case):
     tail_lines, expected_format_tail_call_count = test_case
     job_id = format_job_id('fake_service', 'fake_instance')
@@ -473,16 +475,25 @@ def test_get_paasta_execute_docker_healthcheck_when_not_found():
     assert mesos_tools.get_container_id_for_mesos_id(mock_docker_client, fake_mesos_id) is None
 
 
-@mark.parametrize('test_case', [
-    [['taska', 'taskb'],  # test_case0 - OK
-     [['outlna1', 'outlna2', 'errlna1'],
-      ['outlnb1', 'errlnb1', 'errlnb2']],
-     ['taska', 'outlna1', 'outlna2', 'errlna1', 'taskb', 'outlnb1', 'errlnb1', 'errlnb2'],
-     False],
-    [['a'],  # test_case1 - can't zip different length lists
-     [1, 2],
-     None,
-     True]])
+@mark.parametrize(
+    'test_case', [
+        [
+            ['taska', 'taskb'],  # test_case0 - OK
+            [
+                ['outlna1', 'outlna2', 'errlna1'],
+                ['outlnb1', 'errlnb1', 'errlnb2'],
+            ],
+            ['taska', 'outlna1', 'outlna2', 'errlna1', 'taskb', 'outlnb1', 'errlnb1', 'errlnb2'],
+            False,
+        ],
+        [
+            ['a'],  # test_case1 - can't zip different length lists
+            [1, 2],
+            None,
+            True,
+        ],
+    ],
+)
 def test_zip_tasks_verbose_output(test_case):
     table, stdstreams, expected, should_raise = test_case
     result = None
@@ -496,24 +507,30 @@ def test_zip_tasks_verbose_output(test_case):
     assert result == expected
 
 
-@mark.parametrize('test_case', [
-    # task_id, file1, file2, nlines, raise_what
-    ['a_task',  # test_case0 - OK
-     ['stdout', [str(x) for x in range(20)]],
-     ['stderr', [str(x) for x in range(30)]],
-     10,
-     None],
-    ['a_task',  # test_case1 - OK, short stdout, swapped stdout/stderr
-     ['stderr', [str(x) for x in range(30)]],
-     ['stdout', ['1', '2']],
-     10,
-     None],
-    ['a_task', None, None, 10, mesos.exceptions.MasterNotAvailableException],
-    ['a_task', None, None, 10, mesos.exceptions.SlaveDoesNotExist],
-    ['a_task', None, None, 10, mesos.exceptions.TaskNotFoundException],
-    ['a_task', None, None, 10, mesos.exceptions.FileNotFoundForTaskException],
-    ['a_task', None, None, 10, utils.TimeoutError],
-])
+@mark.parametrize(
+    'test_case', [
+        # task_id, file1, file2, nlines, raise_what
+        [
+            'a_task',  # test_case0 - OK
+            ['stdout', [str(x) for x in range(20)]],
+            ['stderr', [str(x) for x in range(30)]],
+            10,
+            None,
+        ],
+        [
+            'a_task',  # test_case1 - OK, short stdout, swapped stdout/stderr
+            ['stderr', [str(x) for x in range(30)]],
+            ['stdout', ['1', '2']],
+            10,
+            None,
+        ],
+        ['a_task', None, None, 10, mesos.exceptions.MasterNotAvailableException],
+        ['a_task', None, None, 10, mesos.exceptions.SlaveDoesNotExist],
+        ['a_task', None, None, 10, mesos.exceptions.TaskNotFoundException],
+        ['a_task', None, None, 10, mesos.exceptions.FileNotFoundForTaskException],
+        ['a_task', None, None, 10, utils.TimeoutError],
+    ],
+)
 def test_format_stdstreams_tail_for_task(
     test_case,
 ):
@@ -605,14 +622,18 @@ def test_get_mesos_task_count_by_slave():
         mock_mesos_state = {'slaves': [mock_slave_1, mock_slave_2, mock_slave_3]}
         ret = mesos_tools.get_mesos_task_count_by_slave(mock_mesos_state, pool='default')
         assert mock_get_all_running_tasks.called
-        expected = [{'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=1, slave=mock_slave_1)},
-                    {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=0, slave=mock_slave_2)}]
+        expected = [
+            {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=1, slave=mock_slave_1)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=0, slave=mock_slave_2)},
+        ]
         assert len(ret) == len(expected) and utils.sort_dicts(ret) == utils.sort_dicts(expected)
         ret = mesos_tools.get_mesos_task_count_by_slave(mock_mesos_state, pool=None)
         assert mock_get_all_running_tasks.called
-        expected = [{'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=1, slave=mock_slave_1)},
-                    {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=0, slave=mock_slave_2)},
-                    {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)}]
+        expected = [
+            {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=1, slave=mock_slave_1)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=0, slave=mock_slave_2)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)},
+        ]
         assert len(ret) == len(expected) and utils.sort_dicts(ret) == utils.sort_dicts(expected)
 
         # test slaves_list override
@@ -621,14 +642,20 @@ def test_get_mesos_task_count_by_slave():
         mock_task2.framework = mock_marathon
         mock_tasks = [mock_task1, mock_task2, mock_task3, mock_task4]
         mock_get_all_running_tasks.return_value = mock_tasks
-        mock_slaves_list = [{'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_1)},
-                            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_2)},
-                            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)}]
-        ret = mesos_tools.get_mesos_task_count_by_slave(mock_mesos_state,
-                                                        slaves_list=mock_slaves_list)
-        expected = [{'task_counts': mesos_tools.SlaveTaskCount(count=1, chronos_count=1, slave=mock_slave_1)},
-                    {'task_counts': mesos_tools.SlaveTaskCount(count=3, chronos_count=0, slave=mock_slave_2)},
-                    {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)}]
+        mock_slaves_list = [
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_1)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_2)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)},
+        ]
+        ret = mesos_tools.get_mesos_task_count_by_slave(
+            mock_mesos_state,
+            slaves_list=mock_slaves_list,
+        )
+        expected = [
+            {'task_counts': mesos_tools.SlaveTaskCount(count=1, chronos_count=1, slave=mock_slave_1)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=3, chronos_count=0, slave=mock_slave_2)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)},
+        ]
         assert len(ret) == len(expected) and utils.sort_dicts(ret) == utils.sort_dicts(expected)
 
         # test SlaveDoesNotExist exception handling
@@ -639,15 +666,21 @@ def test_get_mesos_task_count_by_slave():
         # we expect to handle this SlaveDoesNotExist exception gracefully, and continue on to handle other tasks
         mock_tasks = [mock_task1, mock_task2, mock_task3, mock_task4]
         mock_get_all_running_tasks.return_value = mock_tasks
-        mock_slaves_list = [{'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_1)},
-                            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_2)},
-                            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)}]
-        ret = mesos_tools.get_mesos_task_count_by_slave(mock_mesos_state,
-                                                        slaves_list=mock_slaves_list)
+        mock_slaves_list = [
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_1)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_2)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)},
+        ]
+        ret = mesos_tools.get_mesos_task_count_by_slave(
+            mock_mesos_state,
+            slaves_list=mock_slaves_list,
+        )
         # we expect mock_slave_2 to only count 2 tasks, as one of them returned a SlaveDoesNotExist exception
-        expected = [{'task_counts': mesos_tools.SlaveTaskCount(count=1, chronos_count=1, slave=mock_slave_1)},
-                    {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=0, slave=mock_slave_2)},
-                    {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)}]
+        expected = [
+            {'task_counts': mesos_tools.SlaveTaskCount(count=1, chronos_count=1, slave=mock_slave_1)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=0, slave=mock_slave_2)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)},
+        ]
         assert len(ret) == len(expected) and utils.sort_dicts(ret) == utils.sort_dicts(expected)
 
 
@@ -662,8 +695,10 @@ def test_get_count_running_tasks_on_slave():
         mock_master.state_summary.return_value = mock_mesos_state
         mock_get_master.return_value = mock_master
 
-        mock_slave_counts = [{'task_counts': mock.Mock(count=3, slave={'hostname': 'host1'})},
-                             {'task_counts': mock.Mock(count=0, slave={'hostname': 'host2'})}]
+        mock_slave_counts = [
+            {'task_counts': mock.Mock(count=3, slave={'hostname': 'host1'})},
+            {'task_counts': mock.Mock(count=0, slave={'hostname': 'host2'})},
+        ]
         mock_get_mesos_task_count_by_slave.return_value = mock_slave_counts
 
         assert mesos_tools.get_count_running_tasks_on_slave('host1') == 3
@@ -733,9 +768,13 @@ def test_get_all_tasks_from_state():
     mock_task_2 = mock.Mock()
     mock_task_3 = mock.Mock()
     mock_task_4 = mock.Mock()
-    mock_state = {'frameworks': [{'tasks': [mock_task_1, mock_task_2]},
-                                 {'tasks': [mock_task_3]}],
-                  'orphan_tasks': [mock_task_4]}
+    mock_state = {
+        'frameworks': [
+            {'tasks': [mock_task_1, mock_task_2]},
+            {'tasks': [mock_task_3]},
+        ],
+        'orphan_tasks': [mock_task_4],
+    }
     ret = mesos_tools.get_all_tasks_from_state(mock_state)
     expected = [mock_task_1, mock_task_2, mock_task_3]
     assert len(ret) == len(expected) and ret == expected


### PR DESCRIPTION
This was almost entirely automated
- ran `add-trailing-comma` twice (there's an oddity where a refold of a long string literal will later trigger a trailing comma to be added in a function call, I'm going to try and fix this before adding the hook here)
- ran `autopep8-wrapper` - there are some *really strange* indentation patterns in paasta that `add-trailing-comma` simply can't fix 100% correctly (or they were incorrect to begin with and erroneously not flagged by `pycodestyle` (formerly `pep8`))

I needed a few manual changes:

- One line became too long after refolding
- One instance where add-trailing-comma applied this fix:

```diff
--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -128,7 +128,7 @@ class LongRunningServiceConfig(InstanceConfig):
                 if limited_instances != zk_instances:
                     log.warning("Returning limited instance count %d. (zk had %d)" % (
                                 limited_instances, zk_instances,
-                                ))
+                    ))
                 return limited_instances
         else:
             instances = self.config_dict.get('instances', 1)
```

and then autopep8-wrapper would come by and apply this fix:

```diff
--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -128,7 +128,7 @@ class LongRunningServiceConfig(InstanceConfig):
                 if limited_instances != zk_instances:
                     log.warning("Returning limited instance count %d. (zk had %d)" % (
                                 limited_instances, zk_instances,
-                    ))
+                                ))
                 return limited_instances
         else:
             instances = self.config_dict.get('instances', 1)
```

(I resolved this by correcting the indentation of the arguments)