### PR TITLE
Python3 bytes

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -140,9 +140,9 @@ def pid_decision_policy(zookeeper_path, current_instances, min_instances, max_in
 
     with ZookeeperPool() as zk:
         try:
-            iterm, _ = zk.get(zk_iterm_path)
-            last_error, _ = zk.get(zk_last_error_path)
-            last_time, _ = zk.get(zk_last_time_path)
+            iterm = zk.get(zk_iterm_path)[0].decode('utf8')
+            last_error = zk.get(zk_last_error_path)[0].decode('utf8')
+            last_time = zk.get(zk_last_time_path)[0].decode('utf8')
             iterm = float(iterm)
             last_error = float(last_error)
             last_time = float(last_time)
@@ -412,8 +412,8 @@ def mesos_cpu_metrics_provider(
 
     with ZookeeperPool() as zk:
         try:
-            last_time, _ = zk.get(zk_last_time_path)
-            last_cpu_data, _ = zk.get(zk_last_cpu_data)
+            last_time = zk.get(zk_last_time_path)[0].decode('utf8')
+            last_cpu_data = zk.get(zk_last_cpu_data)[0].decode('utf8')
             log_utilization_data[last_time] = last_cpu_data
             last_time = float(last_time)
             last_cpu_data = (datum for datum in last_cpu_data.split(',') if datum)

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -111,9 +111,12 @@ def get_git_shas_for_service(service, deploy_groups, soa_dir):
         except KeyError:
             pass
         else:
-            # note that all strings are greater than ''
-            if deploy_group in deploy_groups and tstamp > previously_deployed_shas.get(sha, ''):
-                previously_deployed_shas[sha] = (tstamp, deploy_group)
+            # Now we filter and dedup by picking the most recent sha for a deploy group
+            # Note that all strings are greater than ''
+            if deploy_group in deploy_groups:
+                tstamp_so_far = previously_deployed_shas.get(sha, ('all', ''))[1]
+                if tstamp > tstamp_so_far:
+                    previously_deployed_shas[sha] = (tstamp, deploy_group)
     return previously_deployed_shas
 
 

--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -110,6 +110,8 @@ class MesosMaster(object):
 
             if not data:
                 exceptions.MasterNotAvailableException("Cannot retrieve valid MasterInfo data from ZooKeeper")
+            else:
+                data = data.decode('utf8')
 
             try:
                 parsed = json.loads(data)

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -159,11 +159,10 @@ def test_pid_decision_policy():
     }
 
     with mock.patch(
-        'paasta_tools.utils.KazooClient', autospec=True,
-        return_value=mock.Mock(
+        'paasta_tools.utils.KazooClient', autospec=True, return_value=mock.Mock(
             get=mock.Mock(
-                side_effect=lambda x: (zookeeper_get_payload[x.split('/')[-1]], None),
-            ),
+                side_effect=lambda x: (str(zookeeper_get_payload[x.split('/')[-1]]).encode('utf-8'), None)
+	    ),
         ),
     ) as mock_zk_client, mock.patch(
         'paasta_tools.autoscaling.autoscaling_service_lib.datetime', autospec=True,
@@ -305,7 +304,7 @@ def test_mesos_cpu_metrics_provider():
     with mock.patch(
         'paasta_tools.utils.KazooClient', autospec=True,
         return_value=mock.Mock(get=mock.Mock(
-            side_effect=lambda x: (zookeeper_get_payload[x.split('/')[-1]], None),
+            side_effect=lambda x: (str(zookeeper_get_payload[x.split('/')[-1]]).encode('utf-8'), None),
         )),
     ) as mock_zk_client, mock.patch(
         'paasta_tools.autoscaling.autoscaling_service_lib.datetime', autospec=True,
@@ -464,7 +463,7 @@ def test_mesos_cpu_metrics_provider_no_data_mesos():
     with mock.patch(
         'paasta_tools.utils.KazooClient', autospec=True,
         return_value=mock.Mock(get=mock.Mock(
-            side_effect=lambda x: (zookeeper_get_payload[x.split('/')[-1]], None),
+            side_effect=lambda x: (str(zookeeper_get_payload[x.split('/')[-1]]).encode('utf-8'), None),
         )),
     ), mock.patch(
         'paasta_tools.utils.load_system_paasta_config', autospec=True,


### PR DESCRIPTION
* fixes bytes handling from zk by explicitly decoding
* fixes a bug in paasta rollback that deals with tuple comparison instead of string comparison 