### PR TITLE
Fix bug where paasta fsm was suggesting ports that were already in use

### DIFF
--- a/paasta_tools/cli/fsm/autosuggest.py
+++ b/paasta_tools/cli/fsm/autosuggest.py
@@ -21,24 +21,24 @@ import random
 import yaml
 
 
-def _get_smartstack_proxy_port_from_file(root, file):
+def _get_smartstack_proxy_ports_from_file(root, file):
     """Given a root and file (as from os.walk), attempt to return the highest
     smartstack proxy port number (int) from that file. Returns 0 if there is no
     smartstack proxy_port.
     """
-    port = 0
+    ports = set()
     with open(os.path.join(root, file)) as f:
         data = yaml.safe_load(f)
 
     if file.endswith('service.yaml') and 'smartstack' in data:
         # Specifying this in service.yaml is old and deprecated and doesn't
         # support multiple namespaces.
-        port = data['smartstack'].get('proxy_port', 0)
+        ports = {int(data['smartstack'].get('proxy_port', 0))}
     elif file.endswith('smartstack.yaml'):
         for namespace in data.keys():
-            port = max(port, data[namespace].get('proxy_port', 0))
+            ports.add(data[namespace].get('proxy_port', 0))
 
-    return int(port)
+    return ports
 
 
 def suggest_smartstack_proxy_port(yelpsoa_config_root, range_min=20000, range_max=21000):
@@ -48,8 +48,9 @@ def suggest_smartstack_proxy_port(yelpsoa_config_root, range_min=20000, range_ma
         for f in files:
             if f.endswith('smartstack.yaml'):
                 try:
-                    proxy_port = _get_smartstack_proxy_port_from_file(root, f)
-                    available_proxy_ports.discard(proxy_port)
+                    used_ports = _get_smartstack_proxy_ports_from_file(root, f)
+                    for used_port in used_ports:
+                        available_proxy_ports.discard(used_port)
                 except Exception:
                     pass
 


### PR DESCRIPTION
We used to allocate proxy_port sequentially, so the assumption was that all ports were compacted at the bottom of the port range. Under that assumption, max() was sufficient. Now, we allocate randomly, so we need to consider the set of all ports from each file.