### PR TITLE
Call flush() in paasta_print

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2032,6 +2032,7 @@ def paasta_print(*args, **kwargs):
     assert not kwargs, kwargs
     to_print = sep.join(to_bytes(x) for x in args) + end
     f.write(to_print)
+    f.flush()
 
 
 def timeout(seconds=10, error_message=os.strerror(errno.ETIME), use_signals=True):


### PR DESCRIPTION
After the Python 3 upgrade, I noticed I didn't get all of the output in paasta local-run (including the URL) until after I hit ^C. Flushing explicitly fixes that.