### PR TITLE
Upgrade add-trailing-comma to 0.6.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@
     hooks:
     -   id: pyupgrade
 -   repo: https://github.com/asottile/add-trailing-comma
-    sha: v0.5.1
+    sha: v0.6.1
     hooks:
     -   id: add-trailing-comma
 -   repo: local


### PR DESCRIPTION
trivial upgrade, just wanted to make sure this repo doesn't get hit by some not-so-good bugs in 0.6.0