### PR TITLE
Add agent count to paasta metastatus -vv

### DIFF
--- a/paasta_tools/metrics/metastatus_lib.py
+++ b/paasta_tools/metrics/metastatus_lib.py
@@ -381,6 +381,7 @@ def calculate_resource_utilization_for_slaves(slaves, tasks):
             disk=resource_total_dict['disk'],
             mem=resource_total_dict['mem'],
         ),
+        "slave_count": len(slaves),
     }
 
 

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -156,7 +156,9 @@ def main(argv=None):
                 grouping_function,
                 mesos_state,
             )
-            all_rows = [[grouping.capitalize(), 'CPU (used/total)', 'RAM (used/total)', 'Disk (used/total)']]
+            all_rows = [[
+                grouping.capitalize(), 'CPU (used/total)', 'RAM (used/total)', 'Disk (used/total)', 'Agent count',
+            ]]
             table_rows = []
             for attribute_value, resource_info_dict in resource_info_dict.items():
                 resource_utilizations = metastatus_lib.resource_utillizations_from_resource_info(
@@ -175,7 +177,7 @@ def main(argv=None):
                     attribute_value,
                     healthcheck_utilization_pairs,
                     args.humanize,
-                ))
+                ) + [str(resource_info_dict['slave_count'])])
             table_rows = sorted(table_rows, key=lambda x: x[0])
             all_rows.extend(table_rows)
             for line in format_table(all_rows):

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -815,7 +815,7 @@ def test_get_resource_utilization_per_slave():
         slaves=slaves,
         tasks=tasks,
     )
-    assert sorted(actual.keys()) == sorted(['total', 'free'])
+    assert sorted(actual.keys()) == sorted(['total', 'free', 'slave_count'])
     assert actual['total'] == metastatus_lib.ResourceInfo(
         cpus=575,
         disk=450,
@@ -826,6 +826,7 @@ def test_get_resource_utilization_per_slave():
         disk=430,
         mem=680,
     )
+    assert actual['slave_count'] == 2
 
 
 def test_calculate_resource_utilization_for_slaves():


### PR DESCRIPTION
```
  Resources Grouped by region
    Region      CPU (used/total)   RAM (used/total)        Disk (used/total)      Agent count
    fakeregion  2.0/10.0 (20.00%)  200.0M/512.0M (39.06%)  80.0M/100.0M (80.00%)  1
  Resources Grouped by pool
    Pool     CPU (used/total)   RAM (used/total)        Disk (used/total)      Agent count
    default  2.0/10.0 (20.00%)  200.0M/512.0M (39.06%)  80.0M/100.0M (80.00%)  1
```