### PR TITLE
Only get slave data from the paasta api on verbose mode

### DIFF
--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -45,7 +45,7 @@ def adhoc_instance_status(instance_status, service, instance, verbose):
     return cstatus
 
 
-def marathon_job_status(mstatus, client, job_config):
+def marathon_job_status(mstatus, client, job_config, verbose):
     try:
         app_id = job_config.format_marathon_app_dict()['id']
     except NoDockerImageError:
@@ -54,7 +54,8 @@ def marathon_job_status(mstatus, client, job_config):
         return
 
     mstatus['app_id'] = app_id
-    mstatus['slaves'] = list({task.slave['hostname'] for task in get_running_tasks_from_frameworks(app_id)})
+    if verbose is True:
+        mstatus['slaves'] = list({task.slave['hostname'] for task in get_running_tasks_from_frameworks(app_id)})
     mstatus['expected_instance_count'] = job_config.get_instances()
 
     deploy_status = marathon_tools.get_marathon_app_deploy_status(client, app_id)
@@ -83,7 +84,7 @@ def marathon_instance_status(instance_status, service, instance, verbose):
     mstatus['app_count'] = len(apps)
     mstatus['desired_state'] = job_config.get_desired_state()
     mstatus['bounce_method'] = job_config.get_bounce_method()
-    marathon_job_status(mstatus, settings.marathon_client, job_config)
+    marathon_job_status(mstatus, settings.marathon_client, job_config, verbose)
     return mstatus
 
 

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -107,7 +107,7 @@ def test_instances_status_adhoc(
 
 @mock.patch('paasta_tools.api.views.instance.get_running_tasks_from_frameworks', autospec=True)
 @mock.patch('paasta_tools.api.views.instance.marathon_tools.is_app_id_running', autospec=True)
-def test_marathon_job_status(
+def test_marathon_job_status_verbose(
     mock_is_app_id_running,
     mock_get_running_tasks_from_frameworks,
 ):
@@ -132,7 +132,7 @@ def test_marathon_job_status(
     job_config.get_instances.return_value = 5
 
     mstatus = {}
-    instance.marathon_job_status(mstatus, client, job_config)
+    instance.marathon_job_status(mstatus, client, job_config, verbose=True)
     expected = {
         'deploy_status': 'Running',
         'running_instance_count': 5,


### PR DESCRIPTION
The paasta api needs to be "cheap" for wait for deployment.
We can't afford fetching state.json on the non-verbose mode of this, especially with the heavy load of wait-for-deployment polling constantly.