### PR TITLE
Fix example_cluster

### DIFF
--- a/yelp_package/dockerfiles/mesos-paasta/Dockerfile
+++ b/yelp_package/dockerfiles/mesos-paasta/Dockerfile
@@ -14,6 +14,7 @@ ADD ./requirements-dev.txt /paasta/requirements-dev.txt
 ADD ./requirements.txt /paasta/requirements.txt
 RUN pip install --upgrade pip==9.0.1
 RUN pip install --upgrade virtualenv==15.1.0
+RUN pip install --upgrade setuptools==36.2.0
 RUN pip install -r /paasta/requirements-dev.txt
 ADD ./yelp_package/dockerfiles/mesos-paasta/start.sh /start.sh
 ADD ./yelp_package/dockerfiles/mesos-paasta/start-slave.sh /start-slave.sh

--- a/yelp_package/dockerfiles/playground/Dockerfile
+++ b/yelp_package/dockerfiles/playground/Dockerfile
@@ -10,5 +10,6 @@ ADD ./requirements-dev.txt /paasta/requirements-dev.txt
 ADD ./requirements.txt /paasta/requirements.txt
 RUN pip install --upgrade pip==9.0.1
 RUN pip install --upgrade virtualenv==15.1.0
+RUN pip install --upgrade setuptools==36.2.0
 RUN pip install -r /paasta/requirements-dev.txt
 ADD ./yelp_package/dockerfiles/playground/start.sh /start.sh

--- a/yelp_package/dockerfiles/playground/start.sh
+++ b/yelp_package/dockerfiles/playground/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-pip install ./extra-linux-requirements.txt
+pip install -r ./extra-linux-requirements.txt
 pip install -e .
 # This is a hack because we're not creating a real package which would create symlinks for the .py scripts
 while read link; do echo $link|sed -e 's/opt\/venvs\/paasta-tools\//\/usr\/local\//'| sed -e 's/\ usr/\ \/usr/'| xargs ln -s; done < /work/debian/paasta-tools.links


### PR DESCRIPTION
The pip step was hanging for me. Seemed to be a setuptools bug of some
sort. This should upgrade and pin setuptools in the container.