### PR TITLE
Add capacity_check health check

### DIFF
--- a/paasta_itests/capacity_check.feature
+++ b/paasta_itests/capacity_check.feature
@@ -36,4 +36,18 @@ Feature: capacity_check
       And 3 tasks belonging to the app with id "cputest" are in the task list
      Then capacity_check "cpus" --crit "99" --warn "90" should return "WARNING" with code "1"
 
+  Scenario: High cpu usage crit empty overrides
+    Given a working paasta cluster
+      And a capacity check overrides file with contents "{}"
+     When an app with id "cputest" using high cpu is launched
+      And 3 tasks belonging to the app with id "cputest" are in the task list
+     Then capacity_check with override file "cpus" should return "CRITICAL" with code "2"
+
+  Scenario: High cpu usage warn real overrides
+    Given a working paasta cluster
+      And a capacity check overrides file with contents "[{"groupings": {"notreal": "unknown"}, "crit": {"cpus": 99, "mem": 99, "disk": 99}, "warn": {"cpus": 80, "disk": 80, "mem": 80}}]"
+     When an app with id "cputest" using high cpu is launched
+      And 3 tasks belonging to the app with id "cputest" are in the task list
+     Then capacity_check with override file "cpus" and attributes "notreal" should return "WARNING" with code "1"
+
 # vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2

--- a/paasta_itests/capacity_check.feature
+++ b/paasta_itests/capacity_check.feature
@@ -1,0 +1,39 @@
+Feature: capacity_check
+
+  Scenario: High disk usage crit
+   Given a working paasta cluster
+    When an app with id "disktest" using high disk is launched
+     And 3 tasks belonging to the app with id "disktest" are in the task list
+    Then capacity_check "disk" should return "CRITICAL" with code "2"
+
+  Scenario: High memory usage crit
+    Given a working paasta cluster
+     When an app with id "memtest" using high memory is launched
+      And 3 tasks belonging to the app with id "memtest" are in the task list
+     Then capacity_check "mem" should return "CRITICAL" with code "2"
+
+  Scenario: High cpu usage crit
+    Given a working paasta cluster
+     When an app with id "cputest" using high cpu is launched
+      And 3 tasks belonging to the app with id "cputest" are in the task list
+     Then capacity_check "cpus" should return "CRITICAL" with code "2"
+
+  Scenario: High disk usage warn
+   Given a working paasta cluster
+    When an app with id "disktest" using high disk is launched
+     And 3 tasks belonging to the app with id "disktest" are in the task list
+    Then capacity_check "disk" --crit "99" --warn "90" should return "WARNING" with code "1"
+
+  Scenario: High memory usage warn
+    Given a working paasta cluster
+     When an app with id "memtest" using high memory is launched
+      And 3 tasks belonging to the app with id "memtest" are in the task list
+     Then capacity_check "mem" --crit "99" --warn "90" should return "WARNING" with code "1"
+
+  Scenario: High cpu usage warn
+    Given a working paasta cluster
+     When an app with id "cputest" using high cpu is launched
+      And 3 tasks belonging to the app with id "cputest" are in the task list
+     Then capacity_check "cpus" --crit "99" --warn "90" should return "WARNING" with code "1"
+
+# vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2

--- a/paasta_itests/capacity_check.feature
+++ b/paasta_itests/capacity_check.feature
@@ -38,10 +38,10 @@ Feature: capacity_check
 
   Scenario: High cpu usage crit empty overrides
     Given a working paasta cluster
-      And a capacity check overrides file with contents "{}"
+      And a capacity check overrides file with contents "[]"
      When an app with id "cputest" using high cpu is launched
       And 3 tasks belonging to the app with id "cputest" are in the task list
-     Then capacity_check with override file "cpus" should return "CRITICAL" with code "2"
+     Then capacity_check with override file "cpus" and attributes "notreal" should return "CRITICAL" with code "2"
 
   Scenario: High cpu usage warn real overrides
     Given a working paasta cluster

--- a/paasta_itests/paasta_api.feature
+++ b/paasta_itests/paasta_api.feature
@@ -25,7 +25,7 @@ Feature: paasta_api
     Given a working paasta cluster
      When an app with id "cputest" using high cpu is launched
       And 3 tasks belonging to the app with id "cputest" are in the task list
-     Then resources GET should show "cpus" has 27 used
+     Then resources GET should show "cpus" has 27.3 used
 
   # Note that the following tests depend on the configuration of docker-compose.yml
   #  in paasta_itests.  This is unfortunate, but seems to be the easiest way to launch

--- a/paasta_itests/steps/paasta_api_steps.py
+++ b/paasta_itests/steps/paasta_api_steps.py
@@ -48,8 +48,9 @@ def service_instance_status_error(context, error_code, job_id):
     assert not response
 
 
-@then('resources GET should show "{resource}" has {used:d} used')
+@then('resources GET should show "{resource}" has {used} used')
 def resources_resource_used(context, resource, used):
+    used = float(used)
     response = context.paasta_api_client.resources.resources().result()
     assert response[0][resource]['used'] == used, response
 

--- a/paasta_itests/steps/paasta_metastatus_steps.py
+++ b/paasta_itests/steps/paasta_metastatus_steps.py
@@ -75,7 +75,7 @@ def chronos_job_launched(context, job_name):
 def run_paasta_metastatus_high_cpu(context, app_id):
     context.marathon_client.create_app(
         app_id, MarathonApp(
-            cmd='/bin/sleep 100000', cpus=9, instances=3,
+            cmd='/bin/sleep 100000', cpus=9.1, instances=3,
             container=CONTAINER,
         ),
     )

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -16,10 +16,12 @@ from __future__ import unicode_literals
 
 import re
 import time
+from tempfile import NamedTemporaryFile
 
 import itest_utils
 import mock
 import requests_cache
+from behave import given
 from behave import then
 from behave import when
 
@@ -277,6 +279,13 @@ def wait_launch_tasks_native(context, task_count):
         time.sleep(0.5)
 
 
+@given('a capacity check overrides file with contents "{contents}"')
+def write_overrides_file(context, contents):
+    with NamedTemporaryFile(mode='w', delete=False) as f:
+        f.write(contents)
+        context.overridefile = f.name
+
+
 @then('"{job_id}" has exactly {task_count:d} requested tasks in marathon')
 def marathon_app_task_count(context, job_id, task_count):
     (service, instance, _, __) = decompose_job_id(job_id)
@@ -300,6 +309,21 @@ def capacity_check_status_crit_warn(context, check_type, crit, warn, status, cod
 @then('capacity_check "{check_type}" should return "{status}" with code "{code:d}"')
 def capacity_check_type_status(context, check_type, status, code):
     cmd = '../paasta_tools/monitoring/check_capacity.py %s' % check_type
+    paasta_print('Running cmd %s' % cmd)
+    exit_code, output = _run(cmd)
+    paasta_print(output)
+    assert exit_code == code
+    assert status in output
+
+
+@then(
+    'capacity_check with override file "{check_type}" and attributes "{attrs}" '
+    'should return "{status}" with code "{code:d}"',
+)
+def capacity_check_type_status_overrides(context, check_type, attrs, status, code):
+    cmd = '../paasta_tools/monitoring/check_capacity.py %s --overrides %s --attributes %s' % (
+        check_type, context.overridefile, attrs,
+    )
     paasta_print('Running cmd %s' % cmd)
     exit_code, output = _run(cmd)
     paasta_print(output)

--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -286,4 +286,25 @@ def marathon_app_task_count(context, job_id, task_count):
     assert len(tasks) == task_count
 
 
+@then('capacity_check "{check_type}" --crit "{crit:d}" --warn "{warn:d}" should return "{status}" with code "{code:d}"')
+def capacity_check_status_crit_warn(context, check_type, crit, warn, status, code):
+    paasta_print(check_type, crit, warn)
+    cmd = '../paasta_tools/monitoring/check_capacity.py %s --crit %s --warn %s' % (check_type, crit, warn)
+    paasta_print('Running cmd %s' % cmd)
+    exit_code, output = _run(cmd)
+    paasta_print(output)
+    assert exit_code == code
+    assert status in output
+
+
+@then('capacity_check "{check_type}" should return "{status}" with code "{code:d}"')
+def capacity_check_type_status(context, check_type, status, code):
+    cmd = '../paasta_tools/monitoring/check_capacity.py %s' % check_type
+    paasta_print('Running cmd %s' % cmd)
+    exit_code, output = _run(cmd)
+    paasta_print(output)
+    assert exit_code == code
+    assert status in output
+
+
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -93,8 +93,12 @@ def setup_chronos_config():
     return chronos_config
 
 
+def get_paasta_api_url():
+    return "http://%s/%s" % (get_service_connection_string('api'), 'swagger.json')
+
+
 def setup_paasta_api_client():
-    return SwaggerClient.from_url("http://%s/%s" % (get_service_connection_string('api'), 'swagger.json'))
+    return SwaggerClient.from_url(get_paasta_api_url())
 
 
 def _generate_mesos_cli_config(zk_host_and_port):
@@ -200,6 +204,13 @@ def working_paasta_cluster_with_registry(context, docker_registry):
                 "path": mesos_cli_config_filename,
             },
         }, 'mesos.json',
+    )
+    write_etc_paasta(
+        context, {
+            'api_endpoints': {
+                'testcluster': get_paasta_api_url(),
+            },
+        }, 'api_endpoints.json',
     )
 
 

--- a/paasta_tools/monitoring/check_capacity.py
+++ b/paasta_tools/monitoring/check_capacity.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import argparse
+import json
+import sys
+
+from paasta_tools.api.client import get_paasta_api_client
+from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import paasta_print
+
+
+def parse_capacity_check_options():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '--cpus', dest='cpus_default', type=float,
+        help='Default maximum cpu capacity before critical.',
+    )
+    parser.add_argument(
+        '--mem', dest='mem_default', type=float,
+        help='Default maximum memory capacity before critical.',
+    )
+    parser.add_argument(
+        '--disk', dest='disk_default', type=float,
+        help='Default maximum disk capacity before critical.',
+    )
+    parser.add_argument(
+        '--overrides', dest='overrides', type=str,
+        help='json file of per-attribute overrides.',
+    )
+    parser.add_argument(
+        '--cluster', dest='cluster', type=str,
+        help='Cluster to check. Defaults to looking for the current cluster.\n'
+        'In the format {attribute_name: {value: {cpus: num, disk: num, mem: num}}}',
+    )
+    parser.add_argument(
+        '--attributes', dest='attributes', type=str,
+        help='Comma separated list of attributes to check. If not specified, '
+        'these will be infered from the contents of the overrides file. '
+        'If overrides is also not specified, just check the whole cluster.\n'
+        'By default, only checks attributes individually; see --cross-product-check',
+    )
+    parser.add_argument(
+        '--cross-product-check', dest='cpc', action='store_true',
+        help='When specified, --cross-product-check will check combinations of '
+        'attributes instead of individual attributes. \n'
+        'eg if attributes is \'pool,region\', this will cause the check to fail '
+        'if any region-pool combination is below the threashold, or either\'s override',
+    )
+    options = parser.parse_args()
+
+    return options
+
+
+def calc_percent_usage(resource_item, value_to_check):
+    values = resource_item[value_to_check]
+    if values['total'] == 0:
+        return 0
+    return 100 * (values['used'] / values['total'])
+
+
+def run_capacity_check():
+    options = parse_capacity_check_options()
+    system_paasta_config = load_system_paasta_config()
+    cluster = options.cluster if options.cluster is not None else system_paasta_config.get_cluster()
+    to_check = filter(
+        lambda x: x[0] is not None,
+        [(options.disk_default, 'disk'), (options.cpus_default, 'cpus'), (options.mem_default, 'mem')],
+    )
+    if len(to_check) != 1:
+        paasta_print('UNKNOWN exactly one of --cpus, --mem, or --disk must be specified to capacity check')
+        sys.exit(3)
+    value_to_check = to_check[0][1]
+
+    client = get_paasta_api_client(cluster=options.cluster)
+    if client is None:
+        paasta_print('UNKNOWN Failed to load paasta api client')
+        sys.exit(3)
+
+    if options.overrides:
+        with open(options.overrides, 'r') as f:
+            overrides = json.loads(f.read())
+        attributes = overrides.keys()
+    else:
+        attributes = []
+        overrides = {}
+
+    if options.attributes:
+        attributes = options.attributes.split(',')
+
+    if options.cpc or attributes == []:
+        resource_use = {'superregion': client.resources.resources(groupings=attributes + ['superregion']).result()}
+    else:
+        resource_use = {a: client.resources.resources(groupings=[a]).result() for a in attributes}
+
+    default_check = {
+        'cpus': options.cpus_default,
+        'mem': options.mem_default,
+        'disk': options.disk_default,
+    }
+
+    failures = []
+    for attribute, values in resource_use.items():
+        for usage_value in values:
+            attribute_value = usage_value['groupings'].get(attribute, 'unknown')
+            check = overrides.get('attribute', {}).get(attribute_value, default_check)
+            usage_percent = calc_percent_usage(usage_value, value_to_check)
+            if usage_percent > check[value_to_check]:
+                failures.append({
+                    'attrs': [{'attr': a, 'value': v} for a, v in usage_value['groupings'].items()],
+                    'maximum': check[value_to_check], 'current': usage_percent,
+                })
+
+    if len(failures) > 0:
+        result = "CRITICAL cluster %s %s usage: " % (cluster, value_to_check)
+        results = []
+        for f in failures:
+            attrs = ", ".join(["%s: %s" % (e['attr'], e['value']) for e in f['attrs']])
+            results.append(
+                "%s is at %s percent %s, maximum %s percent" % (
+                    attrs, f['current'], value_to_check,
+                    f['maximum'],
+                ),
+            )
+
+        result += "; ".join(results)
+        paasta_print(result)
+        sys.exit(2)
+
+    paasta_print("OK cluster %s is below critical capacity" % cluster)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    run_capacity_check()

--- a/paasta_tools/monitoring/check_capacity.py
+++ b/paasta_tools/monitoring/check_capacity.py
@@ -89,7 +89,7 @@ def error_message(failures, level, cluster, value_to_check):
 def get_check_from_overrides(overrides, default_check, groupings):
     """Get the overrides dict from overrides with the same groupings as groupings,
     or return the default"""
-    checks = [o for o in overrides if o == groupings]
+    checks = [o for o in overrides if o['groupings'] == groupings]
     if len(checks) == 0:
         return default_check
     elif len(checks) == 1:
@@ -100,22 +100,26 @@ def get_check_from_overrides(overrides, default_check, groupings):
         sys.exit(3)
 
 
+def read_overrides(override_file):
+    if override_file:
+        with open(override_file, 'r') as f:
+            return json.loads(f.read())
+    else:
+        return {}
+
+
 def run_capacity_check():
     options = parse_capacity_check_options()
     system_paasta_config = load_system_paasta_config()
     cluster = options.cluster if options.cluster is not None else system_paasta_config.get_cluster()
     value_to_check = options.type
 
-    client = get_paasta_api_client(cluster=options.cluster)
+    client = get_paasta_api_client(cluster=cluster)
     if client is None:
         paasta_print('UNKNOWN Failed to load paasta api client')
         sys.exit(3)
 
-    if options.overrides:
-        with open(options.overrides, 'r') as f:
-            overrides = json.loads(f.read())
-    else:
-        overrides = {}
+    overrides = read_overrides(options.overrides)
 
     attributes = options.attributes.split(',')
 

--- a/paasta_tools/monitoring/check_capacity.py
+++ b/paasta_tools/monitoring/check_capacity.py
@@ -18,6 +18,7 @@ from __future__ import unicode_literals
 import argparse
 import json
 import sys
+from collections import defaultdict
 
 from paasta_tools.api.client import get_paasta_api_client
 from paasta_tools.utils import load_system_paasta_config
@@ -25,19 +26,21 @@ from paasta_tools.utils import paasta_print
 
 
 def parse_capacity_check_options():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
     parser.add_argument(
-        '--cpus', dest='cpus_default', type=float,
-        help='Default maximum cpu capacity before critical.',
+        'type', choices=['cpus', 'mem', 'disk'], type=str,
+        help='The resource to check.',
     )
     parser.add_argument(
-        '--mem', dest='mem_default', type=float,
-        help='Default maximum memory capacity before critical.',
+        '--warn', '-w', dest='warn', type=float, default=90,
+        help='Level to emit a warning status.',
     )
     parser.add_argument(
-        '--disk', dest='disk_default', type=float,
-        help='Default maximum disk capacity before critical.',
+        '--crit', '-c', dest='crit', type=float, default=90,
+        help='Level to emit a critical status.',
     )
     parser.add_argument(
         '--overrides', dest='overrides', type=str,
@@ -49,10 +52,8 @@ def parse_capacity_check_options():
         help='Cluster to check. Defaults to looking for the current cluster.',
     )
     parser.add_argument(
-        '--attributes', dest='attributes', type=str,
-        help='Comma separated list of attributes to check. If not specified, '
-        'these will be infered from the contents of the overrides file. '
-        'If overrides is also not specified, just check the whole cluster.\n'
+        '--attributes', dest='attributes', type=str, default='pool',
+        help='Comma separated list of attributes to check.\n'
         'By default, only checks attributes individually; see --cross-product-check',
     )
     parser.add_argument(
@@ -74,18 +75,28 @@ def calc_percent_usage(resource_item, value_to_check):
     return 100 * (values['used'] / values['total'])
 
 
+def error_message(failures, level, cluster, value_to_check):
+    result = "%s cluster %s %s usage:\n" % (level, cluster, value_to_check)
+    results = []
+    for f in failures:
+        attrs = ", ".join(["%s: %s" % (e['attr'], e['value']) for e in f['attrs']])
+        results.append(
+            "    %s is at %s percent %s, maximum %s percent" % (
+                attrs, f['current'], value_to_check,
+                f['maximum'],
+            ),
+        )
+
+    result += "\n".join(results)
+
+    return result
+
+
 def run_capacity_check():
     options = parse_capacity_check_options()
     system_paasta_config = load_system_paasta_config()
     cluster = options.cluster if options.cluster is not None else system_paasta_config.get_cluster()
-    to_check = filter(
-        lambda x: x[0] is not None,
-        [(options.disk_default, 'disk'), (options.cpus_default, 'cpus'), (options.mem_default, 'mem')],
-    )
-    if len(to_check) != 1:
-        paasta_print('UNKNOWN exactly one of --cpus, --mem, or --disk must be specified to capacity check')
-        sys.exit(3)
-    value_to_check = to_check[0][1]
+    value_to_check = options.type
 
     client = get_paasta_api_client(cluster=options.cluster)
     if client is None:
@@ -95,55 +106,57 @@ def run_capacity_check():
     if options.overrides:
         with open(options.overrides, 'r') as f:
             overrides = json.loads(f.read())
-        attributes = overrides.keys()
     else:
-        attributes = []
         overrides = {}
 
-    if options.attributes:
-        attributes = options.attributes.split(',')
+    attributes = options.attributes.split(',')
 
-    if options.cpc or attributes == []:
-        resource_use = {'superregion': client.resources.resources(groupings=attributes + ['superregion']).result()}
+    if options.cpc:
+        resource_use = {'all': client.resources.resources(groupings=attributes).result()}
     else:
         resource_use = {a: client.resources.resources(groupings=[a]).result() for a in attributes}
 
     default_check = {
-        'cpus': options.cpus_default,
-        'mem': options.mem_default,
-        'disk': options.disk_default,
+        'warn': {
+            'cpus': options.warn,
+            'mem': options.warn,
+            'disk': options.warn,
+        },
+        'crit': {
+            'cpus': options.crit,
+            'mem': options.crit,
+            'disk': options.crit,
+        },
     }
 
-    failures = []
+    failures = defaultdict(list)
     for attribute, values in resource_use.items():
         for usage_value in values:
             attribute_value = usage_value['groupings'].get(attribute, 'unknown')
             check = overrides.get('attribute', {}).get(attribute_value, default_check)
             usage_percent = calc_percent_usage(usage_value, value_to_check)
-            if usage_percent > check[value_to_check]:
-                failures.append({
-                    'attrs': [{'attr': a, 'value': v} for a, v in usage_value['groupings'].items()],
-                    'maximum': check[value_to_check], 'current': usage_percent,
-                })
+            for c in ['crit', 'warn']:
+                if usage_percent > check[c][value_to_check]:
+                    failures[c].append({
+                        'attrs': [{'attr': a, 'value': v} for a, v in usage_value['groupings'].items()],
+                        'maximum': check[c][value_to_check], 'current': usage_percent,
+                    })
+                    break
 
-    if len(failures) > 0:
-        result = "CRITICAL cluster %s %s usage: " % (cluster, value_to_check)
-        results = []
-        for f in failures:
-            attrs = ", ".join(["%s: %s" % (e['attr'], e['value']) for e in f['attrs']])
-            results.append(
-                "%s is at %s percent %s, maximum %s percent" % (
-                    attrs, f['current'], value_to_check,
-                    f['maximum'],
-                ),
-            )
-
-        result += "; ".join(results)
+    return_value = [0]
+    if len(failures['crit']) > 0:
+        result = error_message(failures['crit'], 'CRITICAL', cluster, value_to_check)
         paasta_print(result)
-        sys.exit(2)
+        return_value.append(2)
+    if len(failures['warn']) > 0:
+        result = error_message(failures['warn'], 'WARNING', cluster, value_to_check)
+        paasta_print(result)
+        return_value.append(1)
 
-    paasta_print("OK cluster %s is below critical capacity in %s" % (cluster, value_to_check))
-    sys.exit(0)
+    if max(return_value) == 0:
+        paasta_print("OK cluster %s is below critical capacity in %s" % (cluster, value_to_check))
+
+    sys.exit(max(return_value))
 
 
 if __name__ == "__main__":

--- a/paasta_tools/monitoring/check_capacity.py
+++ b/paasta_tools/monitoring/check_capacity.py
@@ -142,7 +142,7 @@ def run_capacity_check():
         paasta_print(result)
         sys.exit(2)
 
-    paasta_print("OK cluster %s is below critical capacity" % cluster)
+    paasta_print("OK cluster %s is below critical capacity in %s" % (cluster, value_to_check))
     sys.exit(0)
 
 

--- a/paasta_tools/monitoring/check_capacity.py
+++ b/paasta_tools/monitoring/check_capacity.py
@@ -41,12 +41,12 @@ def parse_capacity_check_options():
     )
     parser.add_argument(
         '--overrides', dest='overrides', type=str,
-        help='json file of per-attribute overrides.',
+        help='json file of per-attribute overrides.\n'
+        'In the format {attribute_name: {value: {cpus: num, disk: num, mem: num}}}',
     )
     parser.add_argument(
         '--cluster', dest='cluster', type=str,
-        help='Cluster to check. Defaults to looking for the current cluster.\n'
-        'In the format {attribute_name: {value: {cpus: num, disk: num, mem: num}}}',
+        help='Cluster to check. Defaults to looking for the current cluster.',
     )
     parser.add_argument(
         '--attributes', dest='attributes', type=str,

--- a/paasta_tools/monitoring/check_capacity.py
+++ b/paasta_tools/monitoring/check_capacity.py
@@ -35,7 +35,7 @@ def parse_capacity_check_options():
         help='The resource to check.',
     )
     parser.add_argument(
-        '--warn', '-w', dest='warn', type=float, default=90,
+        '--warn', '-w', dest='warn', type=float, default=80,
         help='Level to emit a warning status.',
     )
     parser.add_argument(
@@ -45,7 +45,8 @@ def parse_capacity_check_options():
     parser.add_argument(
         '--overrides', dest='overrides', type=str,
         help='json file of per-attribute overrides.\n'
-        'In the format {attribute_name: {value: {cpus: num, disk: num, mem: num}}}',
+        'In the format {attribute_name: {value: {warn: {cpus: num, disk: num, mem: num}, '
+        'crit: {cpus: num, disk: num, mem: num}}}}',
     )
     parser.add_argument(
         '--cluster', dest='cluster', type=str,

--- a/tests/monitoring/test_check_capacity.py
+++ b/tests/monitoring/test_check_capacity.py
@@ -1,0 +1,270 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import mock
+import pytest
+from mock import sentinel
+
+from paasta_tools.monitoring.check_capacity import calc_percent_usage
+from paasta_tools.monitoring.check_capacity import get_check_from_overrides
+from paasta_tools.monitoring.check_capacity import run_capacity_check
+
+
+overrides = [{
+    'groupings': {
+        'foo': 'bar',
+    },
+    'crit': {
+        'cpus': 90,
+        'mem': 95,
+        'disk': 99,
+    },
+    'warn': {
+        'cpus': 80,
+        'mem': 85,
+        'disk': 89,
+    },
+}]
+
+check_types = ['cpus', 'mem', 'disk']
+
+
+def test_calc_percent_usage():
+    item = {
+        'cpus': {
+            'free': 10,
+            'total': 20,
+            'used': 10,
+        },
+        'mem': {
+            'free': 100,
+            'total': 200,
+            'used': 100,
+        },
+        'disk': {
+            'free': 1000,
+            'total': 2000,
+            'used': 1000,
+        },
+    }
+
+    for v in check_types:
+        assert calc_percent_usage(item, v) == 50
+
+    item = {
+        'cpus': {
+            'free': 0,
+            'total': 0,
+            'used': 0,
+        },
+    }
+
+    assert calc_percent_usage(item, 'cpus') == 0
+
+
+def test_get_check_from_overrides_default():
+    default_check = sentinel.default
+    groupings = {'foo': 'baz'}
+
+    assert get_check_from_overrides(overrides, default_check, groupings) == default_check
+
+
+def test_get_check_from_overrides_override():
+    default_check = sentinel.default
+    groupings = {'foo': 'bar'}
+
+    assert get_check_from_overrides(overrides, default_check, groupings) == overrides[0]
+
+
+def test_get_check_from_overrides_error():
+    default_check = sentinel.default_check
+    bad_overrides = overrides + [{
+        'groupings': {
+            'foo': 'bar',
+        },
+    }]
+    groupings = {'foo': 'bar'}
+
+    with pytest.raises(SystemExit) as error:
+        get_check_from_overrides(bad_overrides, default_check, groupings)
+    assert error.value.code == 3
+
+
+def test_capacity_check_ok(capfd):
+    mock_api_client = mock.MagicMock()
+    mock_api_client.resources.resources.result.return_value = [{
+        'groupings': {'foo', 'baz'},
+        'cpus': {'total': 2, 'free': 1, 'used': 1},
+        'mem': {'total': 2, 'free': 1, 'used': 1},
+        'disk': {'total': 2, 'free': 1, 'used': 1},
+    }]
+
+    for t in check_types:
+        options = mock.MagicMock()
+        options.type = t
+        options.overrides = None
+        options.cluster = 'fake_cluster'
+        options.attributes = 'foo'
+        options.warn = 80
+        options.crit = 90
+
+        with mock.patch(
+            'paasta_tools.monitoring.check_capacity.parse_capacity_check_options', autospec=True,
+            return_value=options,
+        ), mock.patch(
+            'paasta_tools.monitoring.check_capacity.load_system_paasta_config', autospec=True,
+        ), mock.patch(
+            'paasta_tools.monitoring.check_capacity.get_paasta_api_client', autospec=True,
+            return_value=mock_api_client,
+        ):
+            with pytest.raises(SystemExit) as error:
+                run_capacity_check()
+            out, err = capfd.readouterr()
+            assert error.value.code == 0
+            assert 'OK' in out
+            assert 'fake_cluster' in out
+            assert t in out
+
+
+def test_capacity_check_warn(capfd):
+    mock_result = mock.MagicMock()
+    mock_result.result = lambda: [{
+        'groupings': {'foo': 'baz'},
+        'cpus': {'total': 2, 'free': 1, 'used': 1},
+        'mem': {'total': 2, 'free': 1, 'used': 1},
+        'disk': {'total': 2, 'free': 1, 'used': 1},
+    }]
+    mock_api_client = mock.MagicMock()
+    mock_api_client.resources.resources = lambda groupings: mock_result
+
+    for t in check_types:
+        options = mock.MagicMock()
+        options.type = t
+        options.overrides = None
+        options.cluster = 'fake_cluster'
+        options.attributes = 'foo'
+        options.warn = 45
+        options.crit = 80
+
+        with mock.patch(
+            'paasta_tools.monitoring.check_capacity.parse_capacity_check_options', autospec=True,
+            return_value=options,
+        ), mock.patch(
+            'paasta_tools.monitoring.check_capacity.load_system_paasta_config', autospec=True,
+        ), mock.patch(
+            'paasta_tools.monitoring.check_capacity.get_paasta_api_client', autospec=True,
+            return_value=mock_api_client,
+        ):
+            with pytest.raises(SystemExit) as error:
+                run_capacity_check()
+            out, err = capfd.readouterr()
+            assert error.value.code == 1, out
+            assert 'WARNING' in out
+            assert 'fake_cluster' in out
+            assert t in out
+
+
+def test_capacity_check_crit(capfd):
+    mock_result = mock.MagicMock()
+    mock_result.result = lambda: [{
+        'groupings': {'foo': 'baz'},
+        'cpus': {'total': 2, 'free': 1, 'used': 1},
+        'mem': {'total': 2, 'free': 1, 'used': 1},
+        'disk': {'total': 2, 'free': 1, 'used': 1},
+    }]
+    mock_api_client = mock.MagicMock()
+    mock_api_client.resources.resources = lambda groupings: mock_result
+
+    for t in check_types:
+        options = mock.MagicMock()
+        options.type = t
+        options.overrides = None
+        options.cluster = 'fake_cluster'
+        options.attributes = 'foo'
+        options.warn = 45
+        options.crit = 49
+
+        with mock.patch(
+            'paasta_tools.monitoring.check_capacity.parse_capacity_check_options', autospec=True,
+            return_value=options,
+        ), mock.patch(
+            'paasta_tools.monitoring.check_capacity.load_system_paasta_config', autospec=True,
+        ), mock.patch(
+            'paasta_tools.monitoring.check_capacity.get_paasta_api_client', autospec=True,
+            return_value=mock_api_client,
+        ):
+            with pytest.raises(SystemExit) as error:
+                run_capacity_check()
+            out, err = capfd.readouterr()
+            assert error.value.code == 2, out
+            assert 'CRITICAL' in out
+            assert 'fake_cluster' in out
+            assert t in out
+
+
+def test_capacity_check_overrides(capfd):
+    mock_result = mock.MagicMock()
+    mock_result.result = lambda: [
+        {
+            'groupings': {'foo': 'bar'},
+            'cpus': {'total': 2, 'free': 1, 'used': 1},
+            'mem': {'total': 2, 'free': 1, 'used': 1},
+            'disk': {'total': 2, 'free': 1, 'used': 1},
+        }, {
+            'groupings': {'foo': 'baz'},
+            'cpus': {'total': 2, 'free': 1, 'used': 1},
+            'mem': {'total': 2, 'free': 1, 'used': 1},
+            'disk': {'total': 2, 'free': 1, 'used': 1},
+        },
+    ]
+    mock_api_client = mock.MagicMock()
+    mock_api_client.resources.resources = lambda groupings: mock_result
+
+    mock_overrides = [{
+        'groupings': {'foo': 'bar'},
+        'warn': {'cpus': 99, 'mem': 99, 'disk': 99},
+        'crit': {'cpus': 10, 'mem': 10, 'disk': 10},
+    }]
+
+    for t in check_types:
+        options = mock.MagicMock()
+        options.type = t
+        options.overrides = '/fake/file.json'
+        options.cluster = 'fake_cluster'
+        options.attributes = 'foo'
+        options.warn = 99
+        options.crit = 99
+
+        with mock.patch(
+            'paasta_tools.monitoring.check_capacity.parse_capacity_check_options', autospec=True,
+            return_value=options,
+        ), mock.patch(
+            'paasta_tools.monitoring.check_capacity.load_system_paasta_config', autospec=True,
+        ), mock.patch(
+            'paasta_tools.monitoring.check_capacity.get_paasta_api_client', autospec=True,
+            return_value=mock_api_client,
+        ), mock.patch(
+            'paasta_tools.monitoring.check_capacity.read_overrides', autospec=True,
+            return_value=mock_overrides,
+        ):
+            with pytest.raises(SystemExit) as error:
+                run_capacity_check()
+            out, err = capfd.readouterr()
+            assert error.value.code == 2, out
+            assert 'CRITICAL' in out
+            assert 'fake_cluster' in out
+            assert t in out
+            assert 'baz' not in out


### PR DESCRIPTION
Allows to specify attributes and override the defaults per attribute value.  Also allows checking each attribute individually or by the combination of different attributes.

RFC: is this a sensible way to do this?

(Still needs tests, itests)

Examples:
```
root@0fdabc955099:/work/paasta_tools# ./monitoring/check_capacity.py --disk 79
CRITICAL cluster testcluster disk usage: superregion: unknown is at 80.0 percent disk, maximum 79.0 percent
```
```
root@0fdabc955099:/work/paasta_tools# ./monitoring/check_capacity.py --disk 79 --attributes region,pool --cross-product-check
CRITICAL cluster testcluster disk usage: superregion: unknown, region: fakeregion, pool: default is at 80.0 percent disk, maximum 79.0 percent
```
```
root@0fdabc955099:/work/paasta_tools# ./monitoring/check_capacity.py --disk 79 --attributes region,pool
CRITICAL cluster testcluster disk usage: region: fakeregion is at 80.0 percent disk, maximum 79.0 percent; pool: default is at 80.0 percent disk, maximum 79.0 percent
```
```
root@0fdabc955099:/work/paasta_tools# ./monitoring/check_capacity.py --disk 81
OK cluster testcluster is below critical capacity
```