### PR TITLE
CI test branches prefixed with `travis-ci-`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ branches:
   only:
     - master
     - /^v[0-9.]+$/
-    - /^maci-.*$/
+    - /^travis-ci-.*$/
 language: python
 cache:
   pip: true


### PR DESCRIPTION
This is useful for "interactive" debugging against travis-ci without making a pull request.

It seems @macisamuele already had this set up, this makes it more generic