### PR TITLE
Handle NoSlavesException from list_marathon_service_instances

### DIFF
--- a/paasta_tools/list_marathon_service_instances.py
+++ b/paasta_tools/list_marathon_service_instances.py
@@ -40,6 +40,7 @@ from paasta_tools.marathon_tools import load_marathon_config
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.mesos.exceptions import NoSlavesAvailableError
 from paasta_tools.mesos_maintenance import get_draining_hosts
+from paasta_tools.utils import _log
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import load_system_paasta_config
@@ -90,7 +91,16 @@ def get_desired_marathon_configs(soa_dir):
                 soa_dir=soa_dir,
             ).format_marathon_app_dict()
             marathon_configs[marathon_config['id'].lstrip('/')] = marathon_config
-        except (NoDeploymentsAvailable, NoDockerImageError, NoSlavesAvailableError):
+        except NoSlavesAvailableError as errormsg:
+            _log(
+                service=service,
+                line=errormsg,
+                component='deploy',
+                level='event',
+                cluster=cluster,
+                instance=instance,
+            )
+        except (NoDeploymentsAvailable, NoDockerImageError):
             pass
     return marathon_configs
 

--- a/paasta_tools/list_marathon_service_instances.py
+++ b/paasta_tools/list_marathon_service_instances.py
@@ -38,6 +38,7 @@ from paasta_tools.marathon_tools import get_marathon_client
 from paasta_tools.marathon_tools import get_num_at_risk_tasks
 from paasta_tools.marathon_tools import load_marathon_config
 from paasta_tools.marathon_tools import load_marathon_service_config
+from paasta_tools.mesos.exceptions import NoSlavesAvailableError
 from paasta_tools.mesos_maintenance import get_draining_hosts
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import get_services_for_cluster
@@ -89,7 +90,7 @@ def get_desired_marathon_configs(soa_dir):
                 soa_dir=soa_dir,
             ).format_marathon_app_dict()
             marathon_configs[marathon_config['id'].lstrip('/')] = marathon_config
-        except (NoDeploymentsAvailable, NoDockerImageError):
+        except (NoDeploymentsAvailable, NoDockerImageError, NoSlavesAvailableError):
             pass
     return marathon_configs
 


### PR DESCRIPTION
Closing https://github.com/Yelp/paasta/pull/1389 in favor of this new approach.

Turns out this was a much simpler fix than I realized, and just requires adding NoSlavesAvailableError as an except in a try block in `get_desired_marathon_configs`. I added a test in `test_list_marathon_service_instance`, it fails without the NoSlaves catch, passes with it.

I started this by digging a lot into setup_marathon_job. I ended up writing a test to ensure `deploy_marathon_service` handled the NoSlavesAvailableError correctly. I was surprised to find the test pass, before I ever added code to `setup_marathon_job`. It was then that I took a closer look at the stack trace, and realized that `list_marathon_service_instances` was the real culprit. I think I'll leave the test to check against regressions though, if no one objects.