### PR TITLE
Bug fixes to firewall_update related to py3 upgrade

### DIFF
--- a/paasta_tools/firewall_update.py
+++ b/paasta_tools/firewall_update.py
@@ -92,7 +92,9 @@ def run_cron(args):
 
 
 def process_inotify_event(event, services_by_dependencies, soa_dir, synapse_service_dir):
-    filename = event[3]
+    filename = event[3].decode()
+    log.debug('process_inotify_event on {}'.format(filename))
+
     service_instance, suffix = os.path.splitext(filename)
     if suffix != '.json':
         return
@@ -113,7 +115,7 @@ def process_inotify_event(event, services_by_dependencies, soa_dir, synapse_serv
             firewall.ensure_service_chains(service_groups, soa_dir, synapse_service_dir)
 
         for service_to_update in services_to_update:
-            log.debug('Updated ', service_to_update)
+            log.debug('Updated {}'.format(service_to_update))
     except TimeoutError as e:
         log.error(
             'Unable to update firewalls for {} because time-out obtaining flock: {}'.format(

--- a/tests/test_firewall_update.py
+++ b/tests/test_firewall_update.py
@@ -177,14 +177,14 @@ def test_process_inotify_event(firewall_flock_mock, active_service_groups_mock, 
     soa_dir = mock.Mock()
     synapse_service_dir = mock.Mock()
     firewall_update.process_inotify_event(
-        (None, None, None, 'mydep.depinstance.json'),
+        (None, None, None, b'mydep.depinstance.json'),
         services_by_dependencies,
         soa_dir,
         synapse_service_dir,
     )
-    assert log_mock.debug.call_count == 2
-    log_mock.debug.assert_any_call('Updated ', ('myservice', 'myinstance'))
-    log_mock.debug.assert_any_call('Updated ', ('anotherservice', 'instance'))
+    assert log_mock.debug.call_count == 3
+    log_mock.debug.assert_any_call("Updated ('myservice', 'myinstance')")
+    log_mock.debug.assert_any_call("Updated ('anotherservice', 'instance')")
     assert ensure_service_chains_mock.mock_calls == [
         mock.call(
             {
@@ -202,12 +202,12 @@ def test_process_inotify_event(firewall_flock_mock, active_service_groups_mock, 
     log_mock.reset_mock()
     ensure_service_chains_mock.reset_mock()
     firewall_update.process_inotify_event(
-        (None, None, None, 'mydep.depinstance.tmp'),
+        (None, None, None, b'mydep.depinstance.tmp'),
         services_by_dependencies,
         soa_dir,
         synapse_service_dir,
     )
-    assert log_mock.debug.call_count == 0
+    assert log_mock.debug.call_count == 1
     assert ensure_service_chains_mock.call_count == 0
 
 
@@ -233,12 +233,12 @@ def test_process_inotify_event_flock_error(
     soa_dir = mock.Mock()
     synapse_service_dir = mock.Mock()
     firewall_update.process_inotify_event(
-        (None, None, None, 'mydep.depinstance.json'),
+        (None, None, None, b'mydep.depinstance.json'),
         services_by_dependencies,
         soa_dir,
         synapse_service_dir,
     )
-    assert log_mock.debug.call_count == 0
+    assert log_mock.debug.call_count == 1
     assert log_mock.error.call_count == 1
 
 


### PR DESCRIPTION
inotify filenames were bytestrings so the `suffix == '.json'` test was failing :(
