### PR TITLE
Bump task-proc and fix a unit test.

### DIFF
--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -47,6 +47,8 @@ from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import validate_service_instance
+from task_processing.runners.sync import Sync
+from task_processing.task_processor import TaskProcessor
 
 MESOS_TASK_SPACER = '.'
 

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -25,8 +25,11 @@ import string
 import sys
 from datetime import datetime
 
+<<<<<<< 2c350cc0d5ea9a01bbd3451efb74935d54ce02c5
 from boto3.session import Session
 from task_processing.plugins.persistence.dynamodb_persistence import DynamoDBPersister
+=======
+>>>>>>> Make pre-commit happy
 from task_processing.runners.sync import Sync
 from task_processing.task_processor import TaskProcessor
 
@@ -47,8 +50,6 @@ from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import validate_service_instance
-from task_processing.runners.sync import Sync
-from task_processing.task_processor import TaskProcessor
 
 MESOS_TASK_SPACER = '.'
 

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -25,11 +25,8 @@ import string
 import sys
 from datetime import datetime
 
-<<<<<<< 2c350cc0d5ea9a01bbd3451efb74935d54ce02c5
 from boto3.session import Session
 from task_processing.plugins.persistence.dynamodb_persistence import DynamoDBPersister
-=======
->>>>>>> Make pre-commit happy
 from task_processing.runners.sync import Sync
 from task_processing.task_processor import TaskProcessor
 

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -1177,6 +1177,7 @@ def test_run_docker_container_terminates_with_healthcheck_only_fail(
 @mock.patch('paasta_tools.cli.cmds.local_run.execlp', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.local_run._run', autospec=True, return_value=(0, 'fake _run output'))
 @mock.patch('paasta_tools.cli.cmds.local_run.get_container_id', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.local_run.check_if_port_free', autospec=True)
 @mock.patch(
     'paasta_tools.cli.cmds.local_run.get_healthcheck_for_instance',
     autospec=True,
@@ -1185,6 +1186,7 @@ def test_run_docker_container_terminates_with_healthcheck_only_fail(
 def test_run_docker_container_with_user_specified_port(
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
+    mock_check_if_port_free,
     mock_run,
     mock_execlp,
     mock_pick_random_port,
@@ -1209,6 +1211,7 @@ def test_run_docker_container_with_user_specified_port(
         instance_config=mock_service_manifest,
     )
     mock_service_manifest.get_mem.assert_called_once_with()
+    assert mock_check_if_port_free.call_count == 1
     mock_pick_random_port.assert_not_called()  # Don't pick a random port, use the user chosen one
     docker_run_args = mock_run.call_args[0][0]
     assert "--publish=1234:8888" in docker_run_args


### PR DESCRIPTION
Bumped task-proc to latest.

test_run_docker_container_with_user_specified_port test was failing on master because check_if_port_free is not mocked out. So, if port 1234 is taken on the box where these tests are running, then this unit test fails. Mocked it out to fix the test.