### PR TITLE
add a note describing Yelp's fork of Chronos.

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -314,9 +314,14 @@ Notes:
 
 The yaml where Chronos jobs are defined. Top-level keys are the job names.
 
-Most of the descriptions below are taken directly from the Chronos API docs,
-which can be found here:
-https://mesos.github.io/chronos/docs/api.html#job-configuration
+NB: Yelp maintains its own fork of Chronos at https://github.com/Yelp/chronos,
+and this is the version deployed in the paasta clusters at Yelp. The fork is
+based off the 2.4 release of upstream Chronos. The most notable change is the
+support for specifying schedules in crontab format, but also contains various
+stability fixes. We have not backported any of the new features to hit 3.0.
+Consequently, the list shown here is the most accurate documentation of
+supported fields; the docs upstream may describe keys that are not supported or
+have different behaviour to those mentioned here.
 
 Each job configuration MUST specify the following options:
 


### PR DESCRIPTION
This was confusing for users of paasta expecting 3.0 features to be
available in Yelp's infrastructure, and not knowing about the features we've added to 2.4