### PR TITLE
Use xenial for more dockerfiles

### DIFF
--- a/general_itests/fake_simple_service/Dockerfile
+++ b/general_itests/fake_simple_service/Dockerfile
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:trusty
+FROM ubuntu:xenial

--- a/yelp_package/dockerfiles/gitremote/Dockerfile
+++ b/yelp_package/dockerfiles/gitremote/Dockerfile
@@ -1,6 +1,9 @@
-FROM ubuntu:trusty
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update > /dev/null && apt-get install -y openssh-server git > /dev/null
+FROM ubuntu:xenial
+RUN apt-get update > /dev/null && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        git \
+        openssh-server > /dev/null && \
+    apt-get clean
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 RUN mkdir /var/run/sshd
 RUN cd /root/ && git clone --bare https://github.com/mattmb/dockercloud-hello-world

--- a/yelp_package/dockerfiles/itest/zookeeper/Dockerfile
+++ b/yelp_package/dockerfiles/itest/zookeeper/Dockerfile
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update > /dev/null && apt-get -y install zookeeper > /dev/null
+RUN apt-get update > /dev/null && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+         zookeeper > /dev/null && \
+    apt-get clean
 
 EXPOSE 2181
-CMD /usr/share/zookeeper/bin/zkServer.sh start-foreground
+CMD ["/usr/share/zookeeper/bin/zkServer.sh", "start-foreground"]


### PR DESCRIPTION
I'll eventually follow up with more of these, this makes it easier to get all of the compose containers running python3.6