### PR TITLE
Convert more dockerfiles to xenial

### DIFF
--- a/yelp_package/dockerfiles/itest/hacheck/Dockerfile
+++ b/yelp_package/dockerfiles/itest/hacheck/Dockerfile
@@ -12,23 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
-ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update > /dev/null && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        git \
+        python2.7-dev \
+        libyaml-dev \
+        virtualenv > /dev/null && \
+    apt-get clean
 
-
-RUN apt-get update > /dev/null && apt-get -y install git python2.7 python2.7-dev libyaml-dev python-virtualenv > /dev/null
-
-RUN git clone --branch=yelp git://github.com/Yelp/hacheck
+RUN git clone git://github.com/Yelp/hacheck
 WORKDIR /hacheck
-# Until my remote_maint branch gets merged in to our fork, we'll need to merge it here.
-# git complains when making merge commits unless you have user.email/user.name defined
-RUN git config --global user.email "docker@docker.docker"; git config --global user.name "Docker Docker"
-RUN git pull git://github.com/EvanKrall/hacheck remote_maint
 
-RUN virtualenv --python=python2.7 --no-site-packages venv && . venv/bin/activate && pip install -e .
+RUN virtualenv --python=python2.7 venv && venv/bin/pip install -e .
 
 RUN echo 'allow_remote_spool_changes: yes' > /etc/hacheck.yaml
 
-CMD venv/bin/hacheck -p 6666 --config-file /etc/hacheck.yaml
+CMD ["venv/bin/hacheck", "-p", "6666", "--config-file", "/etc/hacheck.yaml"]
 EXPOSE 6666


### PR DESCRIPTION
This branch:
- upgrades `hacheck` to use yelp's master branch
- uses xenial instead of trusty
- some docker best practices

previous passing run: https://travis-ci.org/asottile/paasta/builds/260310790?utm_source=email&utm_medium=notification