### PR TITLE
Add process name to the oom log

### DIFF
--- a/paasta_tools/oom_logger.py
+++ b/paasta_tools/oom_logger.py
@@ -24,7 +24,7 @@ destination paasta_oom_logger {
 };
 
 filter f_cgroup_oom {
-  match("killed as a result of limit of");
+  match(" killed as a result of limit of ") or match(" invoked oom-killer: ");
 };
 
 log {
@@ -49,16 +49,31 @@ from paasta_tools.utils import get_docker_client
 from paasta_tools.utils import load_system_paasta_config
 
 
+LogLine = namedtuple(
+    'LogLine', [
+        'timestamp', 'hostname', 'container_id',
+        'cluster', 'service', 'instance', 'process_name',
+    ],
+)
+
+
 def capture_oom_events_from_stdin():
+    process_name_regex = re.compile('^\d+\s[a-zA-Z0-9\-]+\s.*\]\s(\w+) invoked oom-killer:')
     oom_regex = re.compile('^(\d+)\s([a-zA-Z0-9\-]+)\s.*Task in /docker/(\w{12})\w+ killed as a')
+    process_name = ''
 
     while True:
         syslog = sys.stdin.readline()
         if not syslog:
             break
+        print(syslog)
+        r = process_name_regex.search(syslog)
+        if r:
+            process_name = r.group(1)
         r = oom_regex.search(syslog)
         if r:
-            yield (int(r.group(1)), r.group(2), r.group(3))
+            yield (int(r.group(1)), r.group(2), r.group(3), process_name)
+            process_name = ''
 
 
 def get_container_env_as_dict(docker_inspect):
@@ -75,17 +90,21 @@ def get_container_env_as_dict(docker_inspect):
 def log_to_scribe(logger, log_line):
     """Send the event to 'tmp_paasta_oom_events'."""
     line = ('{"timestamp": %d, "hostname": "%s", "container_id": "%s", "cluster": "%s", '
-            '"service": "%s", "instance": "%s"}' % (
-                log_line.timestamp, log_line.hostname,
-                log_line.container_id, log_line.cluster, log_line.service, log_line.instance,
+            '"service": "%s", "instance": "%s", "process_name": "%s"}' % (
+                log_line.timestamp, log_line.hostname, log_line.container_id,
+                log_line.cluster, log_line.service, log_line.instance,
+                log_line.process_name,
             ))
     logger.log_line('tmp_paasta_oom_events', line)
 
 
 def log_to_paasta(log_line):
     """Add the event to the standard PaaSTA logging backend."""
-    line = ('A process in the container %s on %s killed by OOM.'
-            % (log_line.container_id, log_line.hostname))
+    line = ('oom-killer killed %s on %s (container_id: %s).'
+            % (
+                'a %s process' % log_line.process_name if log_line.process_name else 'a process',
+                log_line.hostname, log_line.container_id,
+            ))
     _log(
         service=log_line.service, instance=log_line.instance, component='oom',
         cluster=log_line.cluster, level=DEFAULT_LOGLEVEL, line=line,
@@ -93,17 +112,10 @@ def log_to_paasta(log_line):
 
 
 def main():
-    LogLine = namedtuple(
-        'LogLine', [
-            'timestamp', 'hostname', 'container_id',
-            'cluster', 'service', 'instance',
-        ],
-    )
-
     scribe_logger = ScribeLogger(host='169.254.255.254', port=1463, retry_interval=5)
     cluster = load_system_paasta_config().get_cluster()
     client = get_docker_client()
-    for timestamp, hostname, container_id in capture_oom_events_from_stdin():
+    for timestamp, hostname, container_id, process_name in capture_oom_events_from_stdin():
         try:
             docker_inspect = client.inspect_container(resource_id=container_id)
         except (APIError):
@@ -116,6 +128,7 @@ def main():
             cluster=cluster,
             service=env_vars.get('PAASTA_SERVICE', 'unknown'),
             instance=env_vars.get('PAASTA_INSTANCE', 'unknown'),
+            process_name=process_name,
         )
         log_to_scribe(scribe_logger, log_line)
         log_to_paasta(log_line)

--- a/tests/test_oom_logger.py
+++ b/tests/test_oom_logger.py
@@ -14,10 +14,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import io
 import json
-import sys
-from collections import namedtuple
 
 import pytest
 from mock import Mock
@@ -25,17 +22,38 @@ from mock import patch
 
 from paasta_tools.oom_logger import capture_oom_events_from_stdin
 from paasta_tools.oom_logger import log_to_scribe
+from paasta_tools.oom_logger import LogLine
 from paasta_tools.oom_logger import main
 
 
 @pytest.fixture
 def sys_stdin():
-    return io.StringIO(
+    return [
+        'some ramdom line1\n',
+        '1500316299 dev37-devc [30533610.306528] apache2 invoked oom-killer: '
+        'gfp_mask=0x24000c0, order=0, oom_score_adj=0\n,'
+        'some ramdom line2\n',
         '1500316300 dev37-devc [30533610.306529] Task in '
         '/docker/a687af92e281725daf5b4cda0b487f20d2055d2bb6814b76d0e39c18a52a4e79 '
         'killed as a result of limit of '
-        '/docker/a687af92e281725daf5b4cda0b487f20d2055d2bb6814b76d0e39c18a52a4e79',
-    )
+        '/docker/a687af92e281725daf5b4cda0b487f20d2055d2bb6814b76d0e39c18a52a4e79\n',
+    ]
+
+
+@pytest.fixture
+def sys_stdin_without_process_name():
+    return [
+        'some ramdom line1\n',
+        '1500216300 dev37-devc [1140036.678311] Task in '
+        '/docker/e3a1057fdd485f5dffe48f1584e6f30c2bf6d30107d95518aea32bbb8bb29560 '
+        'killed as a result of limit of '
+        '/docker/e3a1057fdd485f5dffe48f1584e6f30c2bf6d30107d95518aea32bbb8bb29560\n,'
+        'some ramdom line2\n',
+        '1500316300 dev37-devc [30533610.306529] Task in '
+        '/docker/a687af92e281725daf5b4cda0b487f20d2055d2bb6814b76d0e39c18a52a4e79 '
+        'killed as a result of limit of '
+        '/docker/a687af92e281725daf5b4cda0b487f20d2055d2bb6814b76d0e39c18a52a4e79\n',
+    ]
 
 
 @pytest.fixture
@@ -45,12 +63,6 @@ def docker_inspect():
 
 @pytest.fixture
 def log_line():
-    LogLine = namedtuple(
-        'LogLine', [
-            'timestamp', 'hostname', 'container_id',
-            'cluster', 'service', 'instance',
-        ],
-    )
     return LogLine(
         timestamp=1500316300,
         hostname='dev37-devc',
@@ -58,16 +70,34 @@ def log_line():
         cluster='fake_cluster',
         service='fake_service',
         instance='fake_instance',
+        process_name='apache2',
     )
 
 
-def test_capture_oom_events_from_stdin(sys_stdin):
-    sys.stdin = sys_stdin
+@patch('paasta_tools.oom_logger.sys.stdin', autospec=True)
+def test_capture_oom_events_from_stdin(mock_sys_stdin, sys_stdin):
+    mock_sys_stdin.readline.side_effect = sys_stdin
     test_output = []
     for a_tuple in capture_oom_events_from_stdin():
         test_output.append(a_tuple)
 
-    assert test_output == [(1500316300, 'dev37-devc', 'a687af92e281')]
+    assert test_output == [(1500316300, 'dev37-devc', 'a687af92e281', 'apache2')]
+
+
+@patch('paasta_tools.oom_logger.sys.stdin', autospec=True)
+def test_capture_oom_events_from_stdin_without_process_name(
+        mock_sys_stdin,
+        sys_stdin_without_process_name,
+):
+    mock_sys_stdin.readline.side_effect = sys_stdin_without_process_name
+    test_output = []
+    for a_tuple in capture_oom_events_from_stdin():
+        test_output.append(a_tuple)
+
+    assert test_output == [
+        (1500216300, 'dev37-devc', 'e3a1057fdd48', ''),
+        (1500316300, 'dev37-devc', 'a687af92e281', ''),
+    ]
 
 
 def test_log_to_scribe(log_line):
@@ -82,10 +112,12 @@ def test_log_to_scribe(log_line):
             'cluster': log_line.cluster,
             'service': log_line.service,
             'instance': log_line.instance,
+            'process_name': log_line.process_name,
         }),
     )
 
 
+@patch('paasta_tools.oom_logger.sys.stdin', autospec=True)
 @patch('paasta_tools.oom_logger.ScribeLogger', autospec=True)
 @patch('paasta_tools.oom_logger.load_system_paasta_config', autospec=True)
 @patch('paasta_tools.oom_logger.log_to_scribe', autospec=True)
@@ -97,12 +129,13 @@ def test_main(
     mock_log_to_scribe,
     mock_load_system_paasta_config,
     mock_scribelogger,
+    mock_sys_stdin,
     sys_stdin,
     docker_inspect,
     log_line,
 ):
 
-    sys.stdin = sys_stdin
+    mock_sys_stdin.readline.side_effect = sys_stdin
     docker_client = Mock(inspect_container=Mock(return_value=docker_inspect))
     mock_get_docker_client.return_value = docker_client
     mock_load_system_paasta_config.return_value.get_cluster.return_value = 'fake_cluster'


### PR DESCRIPTION
This change should add name of the process invoked OOM killer to the log.