### PR TITLE
Add support for whitelisting CIDR/port combinations

### DIFF
--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -130,6 +130,8 @@ def mock_service_config():
         mock_instance_config.return_value.get_dependencies.return_value = [
             {'well-known': 'internet'},
             {'smartstack': 'example_happyhour.main'},
+            {'cidr': '169.229.226.0/24'},
+            {'cidr': '8.8.8.8', 'port': 53},
         ]
         mock_instance_config.return_value.get_outbound_firewall.return_value = 'monitor'
 
@@ -206,6 +208,32 @@ def test_service_group_rules_monitor(mock_service_config, service_group):
                 ('tcp', (('dport', ('20000',)),)),
             ),
         ),
+        EMPTY_RULE._replace(
+            protocol='ip',
+            target='ACCEPT',
+            dst='169.229.226.0/255.255.255.0',
+            matches=(
+                ('comment', (('comment', ('allow 169.229.226.0/24:*',)),)),
+            ),
+        ),
+        EMPTY_RULE._replace(
+            protocol='tcp',
+            target='ACCEPT',
+            dst='8.8.8.8/255.255.255.255',
+            matches=(
+                ('comment', (('comment', ('allow 8.8.8.8/32:53',)),)),
+                ('tcp', (('dport', ('53',)),)),
+            ),
+        ),
+        EMPTY_RULE._replace(
+            protocol='udp',
+            target='ACCEPT',
+            dst='8.8.8.8/255.255.255.255',
+            matches=(
+                ('comment', (('comment', ('allow 8.8.8.8/32:53',)),)),
+                ('udp', (('dport', ('53',)),)),
+            ),
+        ),
     )
 
 
@@ -262,10 +290,39 @@ def test_service_group_rules_block(mock_service_config, service_group):
                 ('tcp', (('dport', ('20000',)),)),
             ),
         ),
+        EMPTY_RULE._replace(
+            protocol='ip',
+            target='ACCEPT',
+            dst='169.229.226.0/255.255.255.0',
+            matches=(
+                ('comment', (('comment', ('allow 169.229.226.0/24:*',)),)),
+            ),
+        ),
+        EMPTY_RULE._replace(
+            protocol='tcp',
+            target='ACCEPT',
+            dst='8.8.8.8/255.255.255.255',
+            matches=(
+                ('comment', (('comment', ('allow 8.8.8.8/32:53',)),)),
+                ('tcp', (('dport', ('53',)),)),
+            ),
+        ),
+        EMPTY_RULE._replace(
+            protocol='udp',
+            target='ACCEPT',
+            dst='8.8.8.8/255.255.255.255',
+            matches=(
+                ('comment', (('comment', ('allow 8.8.8.8/32:53',)),)),
+                ('udp', (('dport', ('53',)),)),
+            ),
+        ),
     )
 
 
 def test_service_group_rules_synapse_backend_error(mock_service_config, service_group):
+    mock_service_config.return_value.get_dependencies.return_value = [
+        {'smartstack': 'example_happyhour.main'},
+    ]
     firewall._synapse_backends.side_effect = IOError('Error loading file')
     assert service_group.get_rules(DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR) == (
         EMPTY_RULE._replace(
@@ -283,7 +340,6 @@ def test_service_group_rules_synapse_backend_error(mock_service_config, service_
             ),
         ),
         EMPTY_RULE._replace(target='PAASTA-COMMON'),
-        EMPTY_RULE._replace(target='PAASTA-INTERNET'),
         EMPTY_RULE._replace(
             protocol='tcp',
             target='ACCEPT',


### PR DESCRIPTION
The yelpsoa-configs look like this:

```yaml
 main:
    - cidr: '169.229.226.0/25'
      port: 80

    - cidr: '169.229.226.0/25'
      port: 443

    # subnet without port allows all ports
    - cidr: '169.229.226.128/25'

    # you can omit the netmask to target a single ip
    - cidr: '169.229.226.12'
```