### PR TITLE
Make deployd skip deploys on broken instances

### DIFF
--- a/paasta_tools/deployd/common.py
+++ b/paasta_tools/deployd/common.py
@@ -14,6 +14,7 @@ from paasta_tools.marathon_tools import get_marathon_client
 from paasta_tools.marathon_tools import load_marathon_config
 from paasta_tools.marathon_tools import load_marathon_service_config_no_cache
 from paasta_tools.utils import InvalidJobNameError
+from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import NoDockerImageError
 
 BounceTimers = namedtuple('BounceTimers', ['processed_by_worker', 'setup_marathon', 'bounce_length'])
@@ -83,20 +84,19 @@ def get_service_instances_needing_update(marathon_client, instances, cluster):
     marathon_app_ids = marathon_apps.keys()
     service_instances = []
     for service, instance in instances:
-        config = load_marathon_service_config_no_cache(
-            service=service,
-            instance=instance,
-            cluster=cluster,
-            soa_dir=DEFAULT_SOA_DIR,
-        )
         try:
+            config = load_marathon_service_config_no_cache(
+                service=service,
+                instance=instance,
+                cluster=cluster,
+                soa_dir=DEFAULT_SOA_DIR,
+            )
             config_app = config.format_marathon_app_dict()
             app_id = '/{}'.format(config_app['id'])
-        except (NoDockerImageError, InvalidJobNameError):
-            config_app = None
-        if not config_app:
-            service_instances.append((service, instance))
-        elif app_id not in marathon_app_ids:
+        except (NoDockerImageError, InvalidJobNameError, NoDeploymentsAvailable) as e:
+            print("DEBUG: Skipping %s.%s because: '%s'" % (service, instance, str(e)))
+            continue
+        if app_id not in marathon_app_ids:
             service_instances.append((service, instance))
         elif marathon_apps[app_id].instances != config_app['instances']:
             service_instances.append((service, instance))

--- a/tests/deployd/test_common.py
+++ b/tests/deployd/test_common.py
@@ -14,6 +14,7 @@ from paasta_tools.deployd.common import rate_limit_instances
 from paasta_tools.deployd.common import ServiceInstance
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import InvalidJobNameError
+from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import NoDockerImageError
 
 
@@ -140,7 +141,7 @@ def test_get_service_instances_needing_update():
         ]
         mock_load_marathon_service_config.side_effect = mock_configs
         ret = get_service_instances_needing_update(mock.Mock(), mock_service_instances, 'westeros-prod')
-        assert ret == [('universe', 'c137'), ('universe', 'c138')]
+        assert ret == [('universe', 'c138')]
 
         mock_configs = [
             mock.Mock(format_marathon_app_dict=mock.Mock(side_effect=InvalidJobNameError)),
@@ -151,7 +152,18 @@ def test_get_service_instances_needing_update():
         ]
         mock_load_marathon_service_config.side_effect = mock_configs
         ret = get_service_instances_needing_update(mock.Mock(), mock_service_instances, 'westeros-prod')
-        assert ret == [('universe', 'c137'), ('universe', 'c138')]
+        assert ret == [('universe', 'c138')]
+
+        mock_configs = [
+            mock.Mock(format_marathon_app_dict=mock.Mock(side_effect=NoDeploymentsAvailable)),
+            mock.Mock(format_marathon_app_dict=mock.Mock(return_value={
+                'id': 'universe.c138.c2.g2',
+                'instances': 2,
+            })),
+        ]
+        mock_load_marathon_service_config.side_effect = mock_configs
+        ret = get_service_instances_needing_update(mock.Mock(), mock_service_instances, 'westeros-prod')
+        assert ret == [('universe', 'c138')]
 
 
 def test_get_marathon_client_from_config():


### PR DESCRIPTION
1. I'm deciding *not* to list service.instances that are not ready for some reason (broken deployments, image, etc)
2. I'm caching NoDeployments, as it was crashing deployd and causing it to start over.