### PR TITLE
Add b prefix to fix type errors

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -269,17 +269,17 @@ def extract_utc_timestamp_from_log_line(line):
     or None if it could not parse the line
     """
     # Extract ISO 8601 date per http://www.pelagodesign.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/
-    iso_re = r'^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|' \
-        r'(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+' \
-        r'(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)? '
-
+    iso_re = br'^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|' \
+        br'(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+' \
+        br'(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)? '
+    line = line if type(line) is bytes else line.encode() 
     tokens = re.match(iso_re, line)
 
     if not tokens:
         # Could not parse line
         return None
     timestamp = tokens.group(0).strip()
-    dt = isodate.parse_datetime(timestamp)
+    dt = isodate.parse_datetime(timestamp.decode())
     utc_timestamp = datetime_convert_timezone(dt, dt.tzinfo, dateutil.tz.tzutc())
     return utc_timestamp
 

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -272,7 +272,7 @@ def extract_utc_timestamp_from_log_line(line):
     iso_re = br'^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|' \
         br'(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+' \
         br'(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)? '
-    line = line if type(line) is bytes else line.encode() 
+    line = line if type(line) is bytes else line.encode()
     tokens = re.match(iso_re, line)
 
     if not tokens:

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -281,7 +281,7 @@ def format_haproxy_backend_row(backend, is_correct_instance):
     if is_correct_instance:
         return row
     else:
-        return tuple(PaastaColors.grey(remove_ansi_escape_sequences(col)) for col in row)
+        return tuple(PaastaColors.grey(remove_ansi_escape_sequences(col.encode()).decode()) for col in row)
 
 
 def status_smartstack_backends(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -73,8 +73,7 @@ DEPLOY_PIPELINE_NON_DEPLOY_STEPS = (
 ANY_CLUSTER = 'N/A'
 ANY_INSTANCE = 'N/A'
 DEFAULT_LOGLEVEL = 'event'
-no_escape = re.compile('\x1B\[[0-9;]*[mK]')
-no_escape_b = re.compile(b'\x1B\[[0-9;]*[mK]')
+no_escape = re.compile(b'\x1B\[[0-9;]*[mK]')
 
 DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT = "http://{host:s}:{port:d}/;csv;norefresh"
 
@@ -842,7 +841,7 @@ def _now():
 
 def remove_ansi_escape_sequences(line):
     """Removes ansi escape sequences from the given line."""
-    return no_escape.sub('', line) if type(line) is str else no_escape_b.sub(b'', line)
+    return no_escape.sub(b'', line)
 
 
 def format_log_line(level, cluster, service, instance, component, line, timestamp=None):
@@ -854,7 +853,7 @@ def format_log_line(level, cluster, service, instance, component, line, timestam
     validate_log_component(component)
     if not timestamp:
         timestamp = _now()
-    line = remove_ansi_escape_sequences(line)
+    line = remove_ansi_escape_sequences(line.encode())
     message = json.dumps(
         {
             'timestamp': timestamp,
@@ -863,7 +862,7 @@ def format_log_line(level, cluster, service, instance, component, line, timestam
             'service': service,
             'instance': instance,
             'component': component,
-            'message': str(line),
+            'message': line.decode(),
         }, sort_keys=True,
     )
     return message
@@ -1876,7 +1875,7 @@ def deploy_whitelist_to_constraints(deploy_whitelist):
 
 def terminal_len(text):
     """Return the number of characters that text will take up on a terminal. """
-    return len(remove_ansi_escape_sequences(text))
+    return len(remove_ansi_escape_sequences(text.encode()))
 
 
 def format_table(rows, min_spacing=2):

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -842,7 +842,7 @@ def _now():
 
 def remove_ansi_escape_sequences(line):
     """Removes ansi escape sequences from the given line."""
-    return no_escape.sub('', line) if type(line) is str else no_escape_b.sub('', line)
+    return no_escape.sub('', line) if type(line) is str else no_escape_b.sub(b'', line)
 
 
 def format_log_line(level, cluster, service, instance, component, line, timestamp=None):

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -74,6 +74,7 @@ ANY_CLUSTER = 'N/A'
 ANY_INSTANCE = 'N/A'
 DEFAULT_LOGLEVEL = 'event'
 no_escape = re.compile('\x1B\[[0-9;]*[mK]')
+no_escape_b = re.compile(b'\x1B\[[0-9;]*[mK]')
 
 DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT = "http://{host:s}:{port:d}/;csv;norefresh"
 
@@ -841,7 +842,7 @@ def _now():
 
 def remove_ansi_escape_sequences(line):
     """Removes ansi escape sequences from the given line."""
-    return no_escape.sub('', line)
+    return no_escape.sub('', line) if type(line) is str else no_escape_b.sub('', line)
 
 
 def format_log_line(level, cluster, service, instance, component, line, timestamp=None):
@@ -862,7 +863,7 @@ def format_log_line(level, cluster, service, instance, component, line, timestam
             'service': service,
             'instance': instance,
             'component': component,
-            'message': line,
+            'message': str(line),
         }, sort_keys=True,
     )
     return message

--- a/tests/cli/test_cmds_logs.py
+++ b/tests/cli/test_cmds_logs.py
@@ -325,11 +325,13 @@ def test_extract_utc_timestamp_from_log_line_ok():
     line = '%s this is a fake syslog test message' % fake_timestamp
     assert logs.extract_utc_timestamp_from_log_line(line) == fake_utc_timestamp
 
-
 def test_extract_utc_timestamp_from_log_line_when_missing_date():
     line = 'this is a fake invalid syslog message'
     assert not logs.extract_utc_timestamp_from_log_line(line)
 
+def test_extract_utc_timestamp_from_log_line_when_missing_date_with_bytes_object():
+    line = 'this is a fake invalid syslog message'
+    assert not logs.extract_utc_timestamp_from_log_line(line)
 
 def test_extract_utc_timestamp_from_log_line_when_invalid_date_format():
     line = 'Jul 22 10:39:08 this is a fake invalid syslog message'

--- a/tests/cli/test_cmds_logs.py
+++ b/tests/cli/test_cmds_logs.py
@@ -325,13 +325,16 @@ def test_extract_utc_timestamp_from_log_line_ok():
     line = '%s this is a fake syslog test message' % fake_timestamp
     assert logs.extract_utc_timestamp_from_log_line(line) == fake_utc_timestamp
 
+
 def test_extract_utc_timestamp_from_log_line_when_missing_date():
     line = 'this is a fake invalid syslog message'
     assert not logs.extract_utc_timestamp_from_log_line(line)
 
+
 def test_extract_utc_timestamp_from_log_line_when_missing_date_with_bytes_object():
     line = 'this is a fake invalid syslog message'
     assert not logs.extract_utc_timestamp_from_log_line(line)
+
 
 def test_extract_utc_timestamp_from_log_line_when_invalid_date_format():
     line = 'Jul 22 10:39:08 this is a fake invalid syslog message'

--- a/tests/cli/test_cmds_logs.py
+++ b/tests/cli/test_cmds_logs.py
@@ -331,11 +331,6 @@ def test_extract_utc_timestamp_from_log_line_when_missing_date():
     assert not logs.extract_utc_timestamp_from_log_line(line)
 
 
-def test_extract_utc_timestamp_from_log_line_when_missing_date_with_bytes_object():
-    line = 'this is a fake invalid syslog message'
-    assert not logs.extract_utc_timestamp_from_log_line(line)
-
-
 def test_extract_utc_timestamp_from_log_line_when_invalid_date_format():
     line = 'Jul 22 10:39:08 this is a fake invalid syslog message'
     assert not logs.extract_utc_timestamp_from_log_line(line)

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -1147,7 +1147,7 @@ def test_pretty_print_smartstack_backends_for_locations_verbose():
             synapse_haproxy_url_format=DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT,
         )
 
-        colorstripped_actual = [remove_ansi_escape_sequences(l) for l in actual]
+        colorstripped_actual = [remove_ansi_escape_sequences(l.encode()).decode() for l in actual]
         assert colorstripped_actual == [
             '      Name        LastCheck        LastChange  Status',
             '    place1 - Healthy - in haproxy with (1/1) total backends UP in this namespace.',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -582,6 +582,11 @@ def test_remove_ansi_escape_sequences():
     colored_string = '\033[34m' + plain_string + '\033[0m'
     assert utils.remove_ansi_escape_sequences(colored_string) == plain_string
 
+def test_remove_ansi_escape_sequences_with_bytes_object():
+    plain_string = 'blackandwhite'
+    colored_string = '\033[34m' + plain_string + '\033[0m'
+    assert utils.remove_ansi_escape_sequences(colored_string.encode()) == plain_string.encode()
+
 
 def test_list_clusters_no_service_given_lists_all_of_them():
     fake_soa_dir = '/nail/etc/services'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -578,15 +578,9 @@ def test_check_docker_image_true(mock_build_docker_image_name):
 
 
 def test_remove_ansi_escape_sequences():
-    plain_string = 'blackandwhite'
-    colored_string = '\033[34m' + plain_string + '\033[0m'
+    plain_string = b'blackandwhite'
+    colored_string = b'\033[34m' + plain_string + b'\033[0m'
     assert utils.remove_ansi_escape_sequences(colored_string) == plain_string
-
-
-def test_remove_ansi_escape_sequences_with_bytes_object():
-    plain_string = 'blackandwhite'
-    colored_string = '\033[34m' + plain_string + '\033[0m'
-    assert utils.remove_ansi_escape_sequences(colored_string.encode()) == plain_string.encode()
 
 
 def test_list_clusters_no_service_given_lists_all_of_them():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -582,6 +582,7 @@ def test_remove_ansi_escape_sequences():
     colored_string = '\033[34m' + plain_string + '\033[0m'
     assert utils.remove_ansi_escape_sequences(colored_string) == plain_string
 
+
 def test_remove_ansi_escape_sequences_with_bytes_object():
     plain_string = 'blackandwhite'
     colored_string = '\033[34m' + plain_string + '\033[0m'


### PR DESCRIPTION
When running `paasta status -s service-name -C chronos` I see the following stack trace

```
[36mFetching the last 100 lines and applying filters...[0m
Traceback (most recent call last):
  File "/usr/bin/paasta", line 11, in <module>
    load_entry_point('paasta-tools==0.66.19', 'console_scripts', 'paasta')()
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cli.py", line 122, in main
    return_code = args.command(args)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cmds/logs.py", line 1106, in paasta_logs
    return pick_default_log_mode(args, log_reader, service, levels, components, clusters, instances)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cmds/logs.py", line 1033, in pick_default_log_mode
    raw_mode=args.raw_mode,
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cmds/logs.py", line 771, in print_last_n_logs
    self.run_code_over_scribe_envs(clusters=clusters, components=components, callback=callback)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cmds/logs.py", line 566, in run_code_over_scribe_envs
    callback(component, stream_info, scribe_env, cluster=cluster)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cmds/logs.py", line 768, in callback
    parser_fn=stream_info.parse_fn,
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cmds/logs.py", line 786, in filter_and_aggregate_scribe_logs
    line = parser_fn(line, clusters, service)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cmds/logs.py", line 304, in parse_chronos_log_line
    utc_timestamp = extract_utc_timestamp_from_log_line(line)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cmds/logs.py", line 276, in extract_utc_timestamp_from_log_line
    tokens = re.match(iso_re, line)
  File "/opt/venvs/paasta-tools/lib/python3.6/re.py", line 172, in match
    return _compile(pattern, flags).match(string)
TypeError: cannot use a string pattern on a bytes-like object
```