### PR TITLE
Add script to generate HAProxy map file

### DIFF
--- a/paasta_tools/contrib/get_containers_and_ips.py
+++ b/paasta_tools/contrib/get_containers_and_ips.py
@@ -3,9 +3,39 @@ import argparse
 import os
 import socket
 
+from paasta_tools.utils import atomic_file_write
 from paasta_tools.utils import get_docker_client
 
 HAPROXY_STATS_SOCKET = '/var/run/synapse/haproxy.sock'
+
+
+def get_prev_file_contents(filename):
+    if os.path.isfile(filename):
+        with open(filename, 'r') as fp:
+            prev_lines = [
+                # Remove any empty strings, since split could leave empty
+                # strings if there is any extra whitespace in the file
+                list(filter(None, line.strip().split(' ')))
+                for line
+                in fp.readlines()
+            ]
+            return {line[0]: line[1] for line in prev_lines}
+    return {}
+
+
+def extract_taskid_and_ip(docker_client):
+    service_ips_and_ids = []
+    for container in docker_client.containers():
+        networks = container['NetworkSettings']['Networks']
+        labels = container['Labels']
+
+        # Only add containers that are using bridged networking and are
+        # running as Mesos tasks
+        if 'bridge' in networks and 'MESOS_TASK_ID' in labels:
+            ip_addr = networks['bridge']['IPAddress']
+            task_id = labels['MESOS_TASK_ID']
+            service_ips_and_ids.append((ip_addr, task_id))
+    return service_ips_and_ids
 
 
 def send_to_haproxy(command):
@@ -13,12 +43,40 @@ def send_to_haproxy(command):
     # 1 seconds should be more than enough of a timeout since HAProxy is local
     s.settimeout(1)
     s.connect(HAPROXY_STATS_SOCKET)
-    print("Sending {} to HAProxy stats socket".format(command))
     s.send((command + '\n').encode())
-    file_handle = s.makefile()
-    response = file_handle.read().splitlines()
-    print("Response: {}".format(response))
     s.close()
+
+
+def update_haproxy_mapping(ip_addr, task_id, prev_ip_to_task_id, filename):
+    # Check if this IP was in the file previously, if so, we want
+    # to send an update to the HAProxy map instead of adding a new
+    # entry (new additions to the map don't overwrite old entries
+    # and instead create duplicate keys with different values).
+    if ip_addr in prev_ip_to_task_id:
+        if prev_ip_to_task_id[ip_addr] != task_id:
+            method = 'set'
+        else:
+            method = None
+    else:
+        # The IP was not added previously, add it as a new entry
+        method = 'add'
+
+    if method:
+        send_to_haproxy('{} map {} {} {}'.format(
+            method,
+            filename,
+            ip_addr,
+            task_id,
+        ))
+
+
+def remove_stopped_container_entries(prev_ips, curr_ips, filename):
+    for ip in prev_ips:
+        if ip not in curr_ips:
+            send_to_haproxy('del map {} {}'.format(
+                filename,
+                ip,
+            ))
 
 
 def main():
@@ -33,72 +91,22 @@ def main():
     )
     args = parser.parse_args()
 
-    client = get_docker_client()
+    prev_ip_to_task_id = get_prev_file_contents(args.map_file)
 
-    file_exists = os.path.isfile(args.map_file)
-    if file_exists:
-        mode = 'r+'
-    else:
-        mode = 'w'
+    new_lines = []
+    ip_addrs = []
+    service_ips_and_ids = extract_taskid_and_ip(get_docker_client())
 
-    with open(args.map_file, mode) as f:
-        if file_exists:
-            prev_lines = [line.strip().split(' ') for line in f.readlines()]
-            prev_ip_to_task_id = {line[0]: line[1] for line in prev_lines}
-        else:
-            prev_ip_to_task_id = {}
+    for ip_addr, task_id in service_ips_and_ids:
+        ip_addrs.append(ip_addr)
+        update_haproxy_mapping(ip_addr, task_id, prev_ip_to_task_id, args.map_file)
+        new_lines.append('{} {}'.format(ip_addr, task_id))
 
-        print("Previous file: {}".format(prev_ip_to_task_id))
+    remove_stopped_container_entries(prev_ip_to_task_id.keys(), ip_addrs, args.map_file)
 
-        new_lines = []
-        ip_addrs = []
-        for container in client.containers():
-            networks = container['NetworkSettings']['Networks']
-            labels = container['Labels']
-
-            # Only add containers that are using bridged networking and are
-            # running in Mesos
-            if 'bridge' in networks and 'MESOS_TASK_ID' in labels:
-                ip_addr = networks['bridge']['IPAddress']
-                task_id = labels['MESOS_TASK_ID']
-                ip_addrs.append(ip_addr)
-
-                # Check if this IP was in the file previously, if so, we want
-                # to send an update to the HAProxy map instead of adding a new
-                # entry (new additions to the map don't overwrite old entries
-                # and instead create duplicate keys with different values).
-                if ip_addr in prev_ip_to_task_id:
-                    if prev_ip_to_task_id[ip_addr] != task_id:
-                        method = 'set'
-                    else:
-                        method = None
-                else:
-                    # The IP was not added previously, add it as a new entry
-                    method = 'add'
-
-                if method:
-                    send_to_haproxy('{} map {} {} {}'.format(
-                        method,
-                        args.map_file,
-                        ip_addr,
-                        task_id,
-                    ))
-
-                new_lines.append('{} {}'.format(ip_addr, task_id))
-
-        for ip_addr in prev_ip_to_task_id.keys():
-            # Remove any keys for containers that are no longer running
-            if ip_addr not in ip_addrs:
-                send_to_haproxy('del map {} {}'.format(
-                    args.map_file,
-                    ip_addr,
-                ))
-
-        # Replace the file contents with the new map
-        if file_exists:
-            f.seek(0)
-            f.truncate()
-        f.write('\n'.join(new_lines))
+    # Replace the file contents with the new map
+    with atomic_file_write(args.map_file) as fp:
+        fp.write('\n'.join(new_lines))
 
 
 if __name__ == "__main__":

--- a/paasta_tools/contrib/get_containers_and_ips.py
+++ b/paasta_tools/contrib/get_containers_and_ips.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+import argparse
+import os
+import socket
+
+from paasta_tools.utils import get_docker_client
+
+HAPROXY_STATS_SOCKET = '/var/run/synapse/haproxy.sock'
+
+
+def send_to_haproxy(command):
+    s = socket.socket(socket.AF_UNIX)
+    # 1 seconds should be more than enough of a timeout since HAProxy is local
+    s.settimeout(1)
+    s.connect(HAPROXY_STATS_SOCKET)
+    print("Sending {} to HAProxy stats socket".format(command))
+    s.send((command + '\n').encode())
+    file_handle = s.makefile()
+    response = file_handle.read().splitlines()
+    print("Response: {}".format(response))
+    s.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            'Script to dump a HAProxy map between container IPs and task IDs.'
+        ),
+    )
+    parser.add_argument(
+        'map_file', nargs='?', default='/var/run/synapse/maps/ip_to_service.map',
+        help='Where to write the output map file',
+    )
+    args = parser.parse_args()
+
+    client = get_docker_client()
+
+    file_exists = os.path.isfile(args.map_file)
+    if file_exists:
+        mode = 'r+'
+    else:
+        mode = 'w'
+
+    with open(args.map_file, mode) as f:
+        if file_exists:
+            prev_lines = [line.strip().split(' ') for line in f.readlines()]
+            prev_ip_to_task_id = {line[0]: line[1] for line in prev_lines}
+        else:
+            prev_ip_to_task_id = {}
+
+        print("Previous file: {}".format(prev_ip_to_task_id))
+
+        new_lines = []
+        ip_addrs = []
+        for container in client.containers():
+            networks = container['NetworkSettings']['Networks']
+            labels = container['Labels']
+
+            # Only add containers that are using bridged networking and are
+            # running in Mesos
+            if 'bridge' in networks and 'MESOS_TASK_ID' in labels:
+                ip_addr = networks['bridge']['IPAddress']
+                task_id = labels['MESOS_TASK_ID']
+                ip_addrs.append(ip_addr)
+
+                # Check if this IP was in the file previously, if so, we want
+                # to send an update to the HAProxy map instead of adding a new
+                # entry (new additions to the map don't overwrite old entries
+                # and instead create duplicate keys with different values).
+                if ip_addr in prev_ip_to_task_id:
+                    if prev_ip_to_task_id[ip_addr] != task_id:
+                        method = 'set'
+                    else:
+                        method = None
+                else:
+                    # The IP was not added previously, add it as a new entry
+                    method = 'add'
+
+                if method:
+                    send_to_haproxy('{} map {} {} {}'.format(
+                        method,
+                        args.map_file,
+                        ip_addr,
+                        task_id,
+                    ))
+
+                new_lines.append('{} {}'.format(ip_addr, task_id))
+
+        for ip_addr in prev_ip_to_task_id.keys():
+            # Remove any keys for containers that are no longer running
+            if ip_addr not in ip_addrs:
+                send_to_haproxy('del map {} {}'.format(
+                    args.map_file,
+                    ip_addr,
+                ))
+
+        # Replace the file contents with the new map
+        if file_exists:
+            f.seek(0)
+            f.truncate()
+        f.write('\n'.join(new_lines))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
It also sends commands via the HAProxy socket file to add and remove entries from the map without requiring HAProxy to reload. It'll just run via cron for now, but later on it would be better to use docker [pre and post hooks](https://github.com/moby/moby/issues/28837) for this instead of cron.