### PR TITLE
Make deployd startup oracle optional

### DIFF
--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -170,7 +170,8 @@ class DeployDaemon(PaastaThread):
         self.log.info("All watchers started, now adding all services for initial bounce")
         self.add_all_services()
         self.log.info("Prioritising services that we know need a bounce...")
-        self.prioritise_bouncing_services()
+        if self.config.get_deployd_startup_oracle_enabled():
+            self.prioritise_bouncing_services()
         self.log.info("Starting worker threads")
         self.start_workers()
         self.started = True

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1146,6 +1146,15 @@ class SystemPaastaConfig(dict):
         """
         return self.get('deployd_maintenance_polling_frequency', 30)
 
+    def get_deployd_startup_oracle_enabled(self):
+        """This controls whether deployd will add all services that need a bounce on
+        startup. Generally this is desirable behaviour. If you are performing a bounce
+        of *all* services you will want to disable this.
+
+        :returns: A boolean
+        """
+        return self.get('deployd_startup_oracle_enabled', True)
+
     def get_sensu_host(self):
         """Get the host that we should send sensu events to.
 

--- a/tests/deployd/test_deployd_master.py
+++ b/tests/deployd/test_deployd_master.py
@@ -191,6 +191,7 @@ class TestDeployDaemon(unittest.TestCase):
                 get_deployd_big_bounce_rate=mock.Mock(return_value=10),
                 get_cluster=mock.Mock(return_value='westeros-prod'),
                 get_log_writer=mock.Mock(return_value={'driver': None}),
+                get_deployd_startup_oracle_enabled=mock.Mock(return_value=False),
             )
             mock_config_getter.return_value = mock_config
             self.deployd = DeployDaemon()
@@ -242,9 +243,13 @@ class TestDeployDaemon(unittest.TestCase):
             assert mock_q_metrics.return_value.start.called
             assert mock_start_watchers.called
             assert mock_add_all_services.called
-            assert mock_prioritise_bouncing_services.called
+            assert not mock_prioritise_bouncing_services.called
             assert mock_start_workers.called
             assert mock_main_loop.called
+
+            self.deployd.config.get_deployd_startup_oracle_enabled = mock.Mock(return_value=True)
+            self.deployd.startup()
+            assert mock_prioritise_bouncing_services.called
 
     def test_main_loop(self):
         with mock.patch(


### PR DESCRIPTION
In order to gradually bounce all services it is important to have the
option to disable the oracle like behaviour on startup. In other words
if we know we need to bounce all services gradually we don't want
deployd to bounce everything right away when it starts up.