### PR TITLE
paasta status reports remote runs

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -177,23 +177,24 @@ def add_subparser(subparsers):
     main_parser.set_defaults(command=paasta_remote_run)
 
 
-def paasta_remote_run(args):
-    try:
-        system_paasta_config = load_system_paasta_config()
-    except PaastaNotConfiguredError:
-        paasta_print(
-            PaastaColors.yellow(
-                "Warning: Couldn't load config files from '/etc/paasta'. This "
-                "indicates PaaSTA is not configured locally on this host, and "
-                "remote-run may not behave the same way it would behave on a "
-                "server configured for PaaSTA.",
-            ),
-            sep='\n',
-        )
-        system_paasta_config = SystemPaastaConfig(
-            {"volumes": []},
-            '/etc/paasta',
-        )
+def paasta_remote_run(args, system_paasta_config=None):
+    if system_paasta_config is None:
+        try:
+            system_paasta_config = load_system_paasta_config()
+        except PaastaNotConfiguredError:
+            paasta_print(
+                PaastaColors.yellow(
+                    "Warning: Couldn't load config files from '/etc/paasta'. This "
+                    "indicates PaaSTA is not configured locally on this host, and "
+                    "remote-run may not behave the same way it would behave on a "
+                    "server configured for PaaSTA.",
+                ),
+                sep='\n',
+            )
+            system_paasta_config = SystemPaastaConfig(
+                {"volumes": []},
+                '/etc/paasta',
+            )
 
     cmd_parts = ['/usr/bin/paasta_remote_run', args.action]
     args_vars = vars(args)

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import difflib
 import os
 import sys
@@ -22,6 +23,7 @@ from bravado.exception import HTTPError
 from service_configuration_lib import read_deploy
 
 from paasta_tools.api.client import get_paasta_api_client
+from paasta_tools.cli.cmds.remote_run import paasta_remote_run
 from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
@@ -259,7 +261,24 @@ def report_status_for_cluster(
                 for line in status.rstrip().split('\n'):
                     paasta_print('    %s' % line)
 
-    paasta_print(report_invalid_whitelist_values(instance_whitelist, seen_instances, 'instance'))
+            paasta_print('Remote runs:')
+            remote_run_args = argparse.Namespace(
+                action='list',
+                service=service,
+                cluster=cluster,
+                instance=','.join(deployed_instances),
+                verbose=True,
+            )
+            paasta_remote_run(
+                remote_run_args,
+                system_paasta_config=system_paasta_config,
+            )
+
+    report_invalid = report_invalid_whitelist_values(
+        instance_whitelist, seen_instances, 'instance',
+    )
+    if report_invalid != '':
+        paasta_print(report_invalid)
 
     return return_code
 
@@ -395,7 +414,7 @@ def paasta_args_mixer(args, service):
 
 
 def paasta_status(args):
-    """Print the status of a Yelp service running on PaaSTA.
+    """Print the status of a service running on PaaSTA.
     :param args: argparse.Namespace obj created from sys.args by cli"""
     soa_dir = args.soa_dir
     service = figure_out_service_name(args, soa_dir)

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -410,7 +410,7 @@ def remote_run_list(args):
         ).groups()
         paasta_print(
             "Instance: %s, Launch time: %s, run id: %s, framework id: %s" %
-            (instance, launch_time, run_id, f.id),
+            (instance, launch_time[0:13], run_id, f.id),
         )
 
     if len(filtered) > 0:

--- a/yelp_package/dockerfiles/mesos-paasta/Dockerfile
+++ b/yelp_package/dockerfiles/mesos-paasta/Dockerfile
@@ -22,6 +22,7 @@ ADD requirements.txt requirements-dev.txt /paasta/
 RUN pip install virtualenv==15.1.0
 RUN virtualenv /venv -ppython3.6
 ENV PATH=/venv/bin:$PATH
+RUN pip install -r /paasta/requirements.txt
 RUN pip install -r /paasta/requirements-dev.txt
 
 ADD ./yelp_package/dockerfiles/mesos-paasta/start.sh /start.sh

--- a/yelp_package/dockerfiles/playground/Dockerfile
+++ b/yelp_package/dockerfiles/playground/Dockerfile
@@ -17,5 +17,6 @@ ADD requirements.txt requirements-dev.txt /paasta/
 RUN virtualenv /venv -ppython3.6
 ENV PATH=/venv/bin:$PATH
 RUN pip install -r /paasta/requirements-dev.txt
+RUN pip install -r /paasta/requirements.txt
 
 ADD ./yelp_package/dockerfiles/playground/start.sh /start.sh


### PR DESCRIPTION
- change `remote-run list` to handle comma-separated instances
- install requirements.txt in mesosmaster and playground images