### PR TITLE
only consider maintenance role for utilization

### DIFF
--- a/paasta_tools/mesos_maintenance.py
+++ b/paasta_tools/mesos_maintenance.py
@@ -37,6 +37,7 @@ log = logging.getLogger(__name__)
 Hostname = namedtuple('Hostname', ['host', 'ip'])
 Credentials = namedtuple('Credentials', ['file', 'principal', 'secret'])
 Resource = namedtuple('Resource', ['name', 'amount'])
+MAINTENANCE_ROLE = 'maintenance'
 
 
 def base_api():
@@ -378,7 +379,7 @@ def build_reservation_payload(resources):
                 'scalar': {
                     'value': resource.amount,
                 },
-                'role': 'maintenance',
+                'role': MAINTENANCE_ROLE,
                 'reservation': {
                     'principal': get_principal(),
                 },

--- a/paasta_tools/metrics/metastatus_lib.py
+++ b/paasta_tools/metrics/metastatus_lib.py
@@ -22,6 +22,7 @@ from humanize import naturalsize
 
 from paasta_tools import chronos_tools
 from paasta_tools import marathon_tools
+from paasta_tools.mesos_maintenance import MAINTENANCE_ROLE
 from paasta_tools.mesos_tools import get_all_tasks_from_state
 from paasta_tools.mesos_tools import get_mesos_quorum
 from paasta_tools.mesos_tools import get_number_of_mesos_masters
@@ -39,7 +40,6 @@ ResourceUtilization = namedtuple('ResourceUtilization', ['metric', 'total', 'fre
 EXPECTED_HEALTHY_FRAMEWORKS = 2
 HIGH_QUEUE_GAUGE = 'org.apache.mesos.chronos.scheduler.jobs.TaskManager.highQueueSize'
 QUEUE_GAUGE = 'org.apache.mesos.chronos.scheduler.jobs.TaskManager.queueSize'
-MAINTENANCE_RESOURCE = 'maintenance'
 
 
 def get_num_masters():
@@ -711,7 +711,7 @@ def get_table_rows_for_resource_info_dict(attribute_value, healthcheck_utilizati
 
 def reserved_maintenence_resources(resources):
     return resources.get(
-        MAINTENANCE_RESOURCE, {
+        MAINTENANCE_ROLE, {
             'cpus': 0,
             'mem': 0,
             'disk': 0,

--- a/tests/api/test_resources.py
+++ b/tests/api/test_resources.py
@@ -74,7 +74,7 @@ mock_mesos_state = {
                 'mem': 50,
             },
             'attributes': {'pool': 'default', 'region': 'top'},
-            'reserved_resources': [],
+            'reserved_resources': {},
         },
         {
             'id': 'bar1',
@@ -84,7 +84,7 @@ mock_mesos_state = {
                 'mem': 50,
             },
             'attributes': {'pool': 'default', 'region': 'bottom'},
-            'reserved_resources': [],
+            'reserved_resources': {},
         },
         {
             'id': 'foo2',
@@ -94,7 +94,7 @@ mock_mesos_state = {
                 'mem': 50,
             },
             'attributes': {'pool': 'other', 'region': 'top'},
-            'reserved_resources': [],
+            'reserved_resources': {},
         },
         {
             'id': 'bar2',
@@ -104,7 +104,7 @@ mock_mesos_state = {
                 'mem': 50,
             },
             'attributes': {'pool': 'other', 'region': 'bottom'},
-            'reserved_resources': [],
+            'reserved_resources': {},
         },
         {
             'id': 'foo3',
@@ -114,7 +114,7 @@ mock_mesos_state = {
                 'mem': 50,
             },
             'attributes': {'pool': 'other', 'region': 'top'},
-            'reserved_resources': [],
+            'reserved_resources': {},
         },
         {
             'id': 'bar2',
@@ -124,7 +124,7 @@ mock_mesos_state = {
                 'mem': 50,
             },
             'attributes': {'pool': 'other', 'region': 'bottom'},
-            'reserved_resources': [],
+            'reserved_resources': {},
         },
     ],
     'frameworks': [

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -1053,3 +1053,19 @@ def test_reserved_maintenence_resources():
         },
     })
     assert all([actual[x] == 5 for x in ['cpus', 'mem', 'disk']])
+
+
+def test_reserved_maintenence_resources_ignores_non_maintenance():
+    actual = metastatus_lib.reserved_maintenence_resources({
+        'maintenance': {
+            'cpus': 5,
+            'mem': 5,
+            'disk': 5,
+        },
+        'myotherole': {
+            'cpus': 5,
+            'mem': 5,
+            'disk': 5,
+        },
+    })
+    assert all([actual[x] == 5 for x in ['cpus', 'mem', 'disk']])

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -41,7 +41,7 @@ def test_get_mesos_cpu_status():
         'slaves': [
             {
                 'reserved_resources': {
-                    'some-role': {
+                    'maintenance': {
                         'cpus': 1,
                     },
                 },
@@ -63,7 +63,7 @@ def test_ok_cpu_health():
         'slaves': [
             {
                 'reserved_resources': {
-                    'some-role': {
+                    'maintenance': {
                         'cpus': 0.5,
                     },
                 },
@@ -84,7 +84,7 @@ def test_bad_cpu_health():
         'slaves': [
             {
                 'reserved_resources': {
-                    'some-role': {
+                    'maintenance': {
                         'cpus': 1,
                     },
                 },
@@ -105,7 +105,7 @@ def test_assert_memory_health():
         'slaves': [
             {
                 'reserved_resources': {
-                    'some-role': {
+                    'maintenance': {
                         'mem': 256,
                     },
                 },
@@ -126,7 +126,7 @@ def test_failing_memory_health():
         'slaves': [
             {
                 'reserved_resources': {
-                    'some-role': {
+                    'maintenance': {
                         'mem': 500,
                     },
                 },
@@ -147,7 +147,7 @@ def test_assert_disk_health():
         'slaves': [
             {
                 'reserved_resources': {
-                    'some-role': {
+                    'maintenance': {
                         'disk': 256,
                     },
                 },
@@ -168,7 +168,7 @@ def test_failing_disk_health():
         'slaves': [
             {
                 'reserved_resources': {
-                    'some-role': {
+                    'maintenance': {
                         'disk': 500,
                     },
                 },
@@ -644,7 +644,7 @@ def test_get_resource_utilization_by_grouping_correctly_groups():
                     'cpus': 10,
                     'mem': 50,
                 },
-                'reserved_resources': [],
+                'reserved_resources': {},
             },
             {
                 'id': 'bar',
@@ -653,7 +653,7 @@ def test_get_resource_utilization_by_grouping_correctly_groups():
                     'cpus': 10,
                     'mem': 50,
                 },
-                'reserved_resources': [],
+                'reserved_resources': {},
             },
         ],
         'frameworks': [
@@ -691,7 +691,7 @@ def test_get_resource_utilization_by_grouping_correctly_multi_groups():
                     'mem': 50,
                 },
                 'attributes': {'one': 'yes', 'two': 'yes'},
-                'reserved_resources': [],
+                'reserved_resources': {},
             },
             {
                 'id': 'bar1',
@@ -701,7 +701,7 @@ def test_get_resource_utilization_by_grouping_correctly_multi_groups():
                     'mem': 50,
                 },
                 'attributes': {'one': 'yes', 'two': 'no'},
-                'reserved_resources': [],
+                'reserved_resources': {},
             },
             {
                 'id': 'foo2',
@@ -711,7 +711,7 @@ def test_get_resource_utilization_by_grouping_correctly_multi_groups():
                     'mem': 50,
                 },
                 'attributes': {'one': 'no', 'two': 'yes'},
-                'reserved_resources': [],
+                'reserved_resources': {},
             },
             {
                 'id': 'bar2',
@@ -721,7 +721,7 @@ def test_get_resource_utilization_by_grouping_correctly_multi_groups():
                     'mem': 50,
                 },
                 'attributes': {'one': 'no', 'two': 'no'},
-                'reserved_resources': [],
+                'reserved_resources': {},
             },
         ],
         'frameworks': [
@@ -797,7 +797,7 @@ def test_get_resource_utilization_per_slave():
                 'mem': 750,
             },
             'reserved_resources': {
-                'some-role': {
+                'maintenance': {
                     'cpus': 10,
                     'disk': 0,
                     'mem': 150,
@@ -1037,3 +1037,19 @@ def test_get_mesos_disk_status():
     }
     actual = metastatus_lib.get_mesos_disk_status(metrics)
     assert actual == (100, 50, 50)
+
+
+def test_reserved_maintenence_resources_no_maintenenance():
+    actual = metastatus_lib.reserved_maintenence_resources({})
+    assert all([actual[x] == 0 for x in ['cpus', 'mem', 'disk']])
+
+
+def test_reserved_maintenence_resources():
+    actual = metastatus_lib.reserved_maintenence_resources({
+        'maintenance': {
+            'cpus': 5,
+            'mem': 5,
+            'disk': 5,
+        },
+    })
+    assert all([actual[x] == 5 for x in ['cpus', 'mem', 'disk']])


### PR DESCRIPTION
closes JIRA PAASTA-12410

rather than counting *all* reserved resources as used, only count the
resources reserved by the maintenance mode