### PR TITLE
install paasta dependencies in relevant containers

### DIFF
--- a/yelp_package/dockerfiles/mesos-paasta/Dockerfile
+++ b/yelp_package/dockerfiles/mesos-paasta/Dockerfile
@@ -22,6 +22,7 @@ ADD requirements.txt requirements-dev.txt /paasta/
 RUN pip install virtualenv==15.1.0
 RUN virtualenv /venv -ppython3.6
 ENV PATH=/venv/bin:$PATH
+RUN pip install -r /paasta/requirements.txt
 RUN pip install -r /paasta/requirements-dev.txt
 
 ADD ./yelp_package/dockerfiles/mesos-paasta/start.sh /start.sh

--- a/yelp_package/dockerfiles/playground/Dockerfile
+++ b/yelp_package/dockerfiles/playground/Dockerfile
@@ -17,5 +17,6 @@ ADD requirements.txt requirements-dev.txt /paasta/
 RUN virtualenv /venv -ppython3.6
 ENV PATH=/venv/bin:$PATH
 RUN pip install -r /paasta/requirements-dev.txt
+RUN pip install -r /paasta/requirements.txt
 
 ADD ./yelp_package/dockerfiles/playground/start.sh /start.sh


### PR DESCRIPTION
install dependencies in mesosmaster and playground dockerfiles, otherwise we don't have things like task_processing lib in example cluster