### PR TITLE
Add gpu resource for remote-run and cli (for hook validation)

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import math
 import os
 import time
 from collections import namedtuple
@@ -213,10 +214,13 @@ class ClusterAutoscaler(ResourceLogMixin):
         self.log.debug(region_pool_utilization_dict)
         free_pool_resources = region_pool_utilization_dict['free']
         total_pool_resources = region_pool_utilization_dict['total']
-        utilization = 1.0 - min([
-            float(float(pair[0]) / float(pair[1]))
-            for pair in zip(free_pool_resources, total_pool_resources)
-        ])
+        free_percs = []
+        for pair in zip(free_pool_resources, total_pool_resources):
+            free, total = pair[0], pair[1]
+            if math.isclose(total, 0):
+                continue
+            free_percs.append(float(free) / float(total))
+        utilization = 1.0 - min(free_percs)
         target_utilization = self.pool_settings.get('target_utilization', DEFAULT_TARGET_UTILIZATION)
         return utilization - target_utilization
 

--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -27,7 +27,7 @@
                 "default": 1024
             },
             "gpus": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0,
                 "exclusiveMinimum": true,
                 "default": 0

--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -26,6 +26,12 @@
                 "exclusiveMinimum": true,
                 "default": 1024
             },
+            "gpus": {
+                "type": "number",
+                "minimum": 0,
+                "exclusiveMinimum": true,
+                "default": 0
+            },
             "cmd": {
                 "type": "string"
             },

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -157,6 +157,7 @@ def paasta_to_task_config_kwargs(
     cpus = native_job_config.get_cpus()
     mem = native_job_config.get_mem()
     disk = native_job_config.get_disk(10)
+    gpus = native_job_config.get_gpus()
 
     kwargs = {
         'image': str(image),
@@ -171,6 +172,8 @@ def paasta_to_task_config_kwargs(
         'uris': [uris],
         'docker_parameters': docker_parameters,
     }
+    if gpus > 0:
+        kwargs['gpus'] = float(gpus)
 
     config_hash = get_config_hash(
         kwargs,

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -171,9 +171,11 @@ def paasta_to_task_config_kwargs(
         # 'ulimit'
         'uris': [uris],
         'docker_parameters': docker_parameters,
+        'containerizer': 'DOCKER',
     }
     if gpus > 0:
-        kwargs['gpus'] = float(gpus)
+        kwargs['gpus'] = int(gpus)
+        kwargs['containerizer'] = 'MESOS'
 
     config_hash = get_config_hash(
         kwargs,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -272,6 +272,15 @@ class InstanceConfig(object):
         disk = self.config_dict.get('disk', default)
         return disk
 
+    def get_gpus(self, default=0):
+        """Gets the number of gpus required from the service's configuration.
+
+        Default to 0 if no value is specified in the config.
+
+        :returns: The number of gpus specified by the config, 0 if not specified"""
+        gpus = self.config_dict.get('gpus', default)
+        return gpus
+
     def get_cmd(self):
         """Get the docker cmd specified in the service's configuration.
 
@@ -408,6 +417,12 @@ class InstanceConfig(object):
         if disk is not None:
             if not isinstance(disk, (float, int)):
                 return False, 'The specified disk value "%s" is not a valid float or int.' % disk
+        return True, ''
+
+    def check_gpus(self):
+        gpus = self.get_gpus()
+        if gpus is not None and not isinstance(gpus, (float, int)):
+            return False, 'The specified gpus value "%s" is not a valid float or int.' % gpus
         return True, ''
 
     def check_security(self):

--- a/tests/api/test_resources.py
+++ b/tests/api/test_resources.py
@@ -61,7 +61,7 @@ def test_resources_utilization_nothing_special(mock_get_mesos_master, mock_get_r
 
     assert(resp.status_int == 200)
     assert(len(body) == 1)
-    assert(set(body[0].keys()) == {"disk", "mem", "groupings", "cpus"})
+    assert(set(body[0].keys()) == {"disk", "mem", "groupings", "cpus", "gpus"})
 
 
 mock_mesos_state = {

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -180,6 +180,36 @@ def test_failing_disk_health():
     assert "CRITICAL: Less than 10% disk available. (Currently using 97.66%)" in failure_output
 
 
+def test_assert_gpu_health():
+    ok_metrics = {
+        'master/gpus_total': 3,
+        'master/gpus_used': 1,
+    }
+    ok_output, ok_health = metastatus_lib.assert_gpu_health(ok_metrics)
+    assert ok_health
+    assert "GPUs: 1 / 3 in use (%s)" % PaastaColors.green("33.33%") in ok_output
+
+
+def test_assert_no_gpu_health():
+    zero_metrics = {
+        'master/gpus_total': 0,
+        'master/gpus_used': 0,
+    }
+    zero_output, zero_health = metastatus_lib.assert_gpu_health(zero_metrics)
+    assert zero_health
+    assert "No gpus found from mesos!" in zero_output
+
+
+def test_assert_bad_gpu_health():
+    bad_metrics = {
+        'master/gpus_total': 4,
+        'master/gpus_used': 3,
+    }
+    bad_output, bad_health = metastatus_lib.assert_gpu_health(bad_metrics, threshold=50)
+    assert not bad_health
+    assert "CRITICAL: Less than 50% GPUs available. (Currently using 75.00% of 4)" in bad_output
+
+
 def test_cpu_health_mesos_reports_zero():
     mesos_metrics = {
         'master/cpus_total': 0,
@@ -525,10 +555,14 @@ def test_filter_mesos_state_metrics():
         'mem': 1,
         'MEM': 2,
         'garbage_data': 3,
+        'disk': 4,
+        'gpus': 5,
     }
     expected = {
         'cpus': 0,
         'mem': 1,
+        'disk': 4,
+        'gpus': 5,
     }
     assert metastatus_lib.filter_mesos_state_metrics(test_resource_dictionary) == expected
 
@@ -835,6 +869,7 @@ def test_calculate_resource_utilization_for_slaves():
                 'cpus': 500,
                 'disk': 200,
                 'mem': 750,
+                'gpus': 5,
             },
             'reserved_resources': {},
             'attributes': {
@@ -848,6 +883,7 @@ def test_calculate_resource_utilization_for_slaves():
                 'cpus': 10,
                 'mem': 10,
                 'disk': 10,
+                'gpus': 1,
             },
             'state': 'TASK_RUNNING',
         },
@@ -856,14 +892,20 @@ def test_calculate_resource_utilization_for_slaves():
                 'cpus': 10,
                 'mem': 10,
                 'disk': 10,
+                'gpus': 2,
             },
             'state': 'TASK_RUNNING',
         },
     ]
-    assert metastatus_lib.calculate_resource_utilization_for_slaves(
+    free = metastatus_lib.calculate_resource_utilization_for_slaves(
         slaves=fake_slaves,
         tasks=tasks,
-    )['free'].cpus == 480
+    )['free']
+
+    assert free.cpus == 480
+    assert free.mem == 730
+    assert free.disk == 180
+    assert free.gpus == 2
 
 
 def test_healthcheck_result_for_resource_utilization_ok():
@@ -1037,6 +1079,15 @@ def test_get_mesos_disk_status():
     }
     actual = metastatus_lib.get_mesos_disk_status(metrics)
     assert actual == (100, 50, 50)
+
+
+def test_get_mesos_gpu_status():
+    metrics = {
+        'master/gpus_total': 3,
+        'master/gpus_used': 1,
+    }
+    actual = metastatus_lib.get_mesos_gpu_status(metrics)
+    assert actual == (3, 1, 2)
 
 
 def test_reserved_maintenence_resources_no_maintenenance():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -995,6 +995,26 @@ class TestInstanceConfig:
         )
         assert fake_conf.get_disk() == 1024
 
+    def test_get_gpus_in_config(self):
+        fake_conf = utils.InstanceConfig(
+            service='',
+            instance='',
+            cluster='',
+            config_dict={'gpus': -123},
+            branch_dict={},
+        )
+        assert fake_conf.get_gpus() == -123
+
+    def test_get_gpus_default(self):
+        fake_conf = utils.InstanceConfig(
+            service='',
+            instance='',
+            cluster='',
+            config_dict={},
+            branch_dict={},
+        )
+        assert fake_conf.get_gpus() == 0
+
     def test_get_ulimit_in_config(self):
         fake_conf = utils.InstanceConfig(
             service='',


### PR DESCRIPTION
## Summary
- add gpus resource to remote-run and basic instance config (in utils)
- add gpus functions for basic instance config
- add gpus to adhoc service schema (used by py-gitolite hooks to check yelpsoa-configs)
- add tests for gpus in utils; none for remote-run since no tests yet
- add gpus to paasta metastatus as another resource
- modify the ResourceInfo namedtuple to have gpus default to 0
## Testing
- tox
- manual testing for instance gpus
- manual testing for adhoc service schema - added a gpus instance in yelpsoa-config's taskproc-canary service and ran it against my schema using cli.cmds.validate
## Notes
- I will run an end-to-end test once I have updated yelpsoa-configs - validation hooks should use paasta's updated gpus schema
- Does anyone know if I need to update any version numbers or what the deployment path is to guarantee the hooks will use my changes?
- Not sure if metastatus for gpus is strictly necessary since we don't care about its threshold and we never reserve any