### PR TITLE
Add https healthcheck option to get_healthchecks()

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -481,6 +481,19 @@ class MarathonServiceConfig(LongRunningServiceConfig):
                     "maxConsecutiveFailures": maxconsecutivefailures,
                 },
             ]
+        elif mode == 'https':
+            http_path = self.get_healthcheck_uri(service_namespace_config)
+            healthchecks = [
+                {
+                    "protocol": "HTTPS",
+                    "path": http_path,
+                    "gracePeriodSeconds": graceperiodseconds,
+                    "intervalSeconds": intervalseconds,
+                    "portIndex": 0,
+                    "timeoutSeconds": timeoutseconds,
+                    "maxConsecutiveFailures": maxconsecutivefailures,
+                },
+            ]
         elif mode == 'tcp':
             healthchecks = [
                 {
@@ -507,7 +520,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
             healthchecks = []
         else:
             raise InvalidHealthcheckMode(
-                "Unknown mode: %s. Only acceptable healthcheck modes are http/tcp/cmd" % mode,
+                "Unknown mode: %s. Only acceptable healthcheck modes are http/https/tcp/cmd" % mode,
             )
         return healthchecks
 

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1776,6 +1776,29 @@ class TestMarathonServiceConfig(object):
         actual = fake_marathon_service_config.get_healthchecks(fake_service_namespace_config)
         assert actual == expected
 
+    def test_get_healthchecks_https(self):
+        fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
+            service='service',
+            cluster='cluster',
+            instance='instance',
+            config_dict={},
+            branch_dict={},
+        )
+        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({'mode': 'https'})
+        expected = [
+            {
+                "protocol": "HTTPS",
+                "path": "/status",
+                "gracePeriodSeconds": 60,
+                "intervalSeconds": 10,
+                "portIndex": 0,
+                "timeoutSeconds": 10,
+                "maxConsecutiveFailures": 30,
+            },
+        ]
+        actual = fake_marathon_service_config.get_healthchecks(fake_service_namespace_config)
+        assert actual == expected
+
     def test_get_healthchecks_tcp(self):
         fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
             service='service',


### PR DESCRIPTION
Wrote the test, it failed. Wrote the extra elif in marathon_tools.py, the test passes.

Looking at the [marathon docs](https://mesosphere.github.io/marathon/docs/rest-api.html#post-/v2/apps), HTTPS protocol is a valid option on their end.