### PR TITLE
Fix scaling SFRs to less than 1

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -465,6 +465,13 @@ class ClusterAutoscaler(ResourceLogMixin):
                         "This is a SFR so we must kill at least one slave to prevent the autoscaler "
                         "getting stuck whilst scaling down gradually",
                     )
+                    if new_capacity < 1 and self.sfr['SpotFleetRequestState'] == 'active':
+                        self.log.info(
+                            "Can't set target capacity to less than 1 for SFRs. No further "
+                            "action for this SFR",
+
+                        )
+                        break
                 else:
                     break
             try:


### PR DESCRIPTION
When scaling SFRs we have to always kill one instance when down scaling.
This prevents us getting stuck when the non integer value of capacity
would take us below our integer target.

However, we can't set a capacity of 0 because it is not allowed by AWS
so we still need to prevent the autoscaler attempting to set a target of
0 even when it means it kills 0 instances. In addition, we must kill the
instance if the SFR is cancelled, it is safe to do so because we don't
need to set a target capacity on a cancelled SFR.