### PR TITLE
Make deployd bounce queue a priority queue

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -114,6 +114,13 @@ instance MAY have:
     This allows bounces to proceed in the face of a percentage of failures.
     It doesn’t affect any other bounce method but crossover.
 
+  * ``bounce_priority``: an integer priority that informs paasta-deployd which service
+    instances should take priority over each other. The default priority is 0 and higher numbers
+    are considered higher priority. For example: if there are three service instances that need
+    bouncing: the first with a ``bounce_prioirty`` -1, the second with no ``bounce_priority`` and the
+    third with ``bounce_priority`` 1. Then paasta-deployd will prioritise the bounce of the third
+    service instance, then the second service instance and finally the first service instance.
+
   * ``drain_method``: Controls the drain method; see `drain_lib
     <generated/paasta_tools.drain_lib.html>`_. Defaults to ``noop`` for
     instances that are not in Smartstack, or ``hacheck`` if they are.

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -145,6 +145,9 @@
                     "exclusiveMinimum": true,
                     "exclusiveMaximum": false
                 },
+                "bounce_priority": {
+                    "type": "integer"
+                },
                 "deploy_group": {
                     "type": "string"
                 },

--- a/paasta_tools/deployd/common.py
+++ b/paasta_tools/deployd/common.py
@@ -1,6 +1,7 @@
 import logging
 import time
 from collections import namedtuple
+from queue import PriorityQueue
 from queue import Queue
 from threading import Thread
 
@@ -8,13 +9,14 @@ from paasta_tools.marathon_tools import DEFAULT_SOA_DIR
 from paasta_tools.marathon_tools import get_all_marathon_apps
 from paasta_tools.marathon_tools import get_marathon_client
 from paasta_tools.marathon_tools import load_marathon_config
+from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.marathon_tools import load_marathon_service_config_no_cache
 from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import NoDockerImageError
 
 BounceTimers = namedtuple('BounceTimers', ['processed_by_worker', 'setup_marathon', 'bounce_length'])
-ServiceInstance = namedtuple(
+BaseServiceInstance = namedtuple(
     'ServiceInstance', [
         'service',
         'instance',
@@ -22,15 +24,46 @@ ServiceInstance = namedtuple(
         'watcher',
         'bounce_timers',
         'failures',
+        'priority',
     ],
 )
+
+
+class ServiceInstance(BaseServiceInstance):
+    __slots__ = ()
+
+    def __new__(cls, service, instance, watcher, cluster, bounce_by, failures=0, bounce_timers=None, priority=None):
+        if priority is None:
+            priority = cls.get_priority(service, instance, cluster)
+        return super().__new__(
+            _cls=cls,
+            service=service,
+            instance=instance,
+            watcher=watcher,
+            bounce_by=bounce_by,
+            failures=failures,
+            bounce_timers=bounce_timers,
+            priority=priority,
+        )
+
+    def get_priority(service, instance, cluster):
+        try:
+            config = load_marathon_service_config(
+                service=service,
+                instance=instance,
+                cluster=cluster,
+                soa_dir=DEFAULT_SOA_DIR,
+            )
+        except (NoDockerImageError, InvalidJobNameError, NoDeploymentsAvailable) as e:
+            return 0
+        return config.get_bounce_priority()
 
 
 class PaastaThread(Thread):
 
     @property
     def log(self):
-        name = '.'.join([self.__class__.__module__, self.__class__.__name__])
+        name = '.'.join([type(self).__module__, type(self).__name__])
         return logging.getLogger(name)
 
 
@@ -42,7 +75,7 @@ class PaastaQueue(Queue):
 
     @property
     def log(self):
-        name = '.'.join([self.__class__.__module__, self.__class__.__name__])
+        name = '.'.join([type(self).__module__, type(self).__name__])
         return logging.getLogger(name)
 
     def put(self, item, *args, **kwargs):
@@ -50,7 +83,32 @@ class PaastaQueue(Queue):
         Queue.put(self, item, *args, **kwargs)
 
 
-def rate_limit_instances(instances, number_per_minute, watcher_name):
+class PaastaPriorityQueue(PriorityQueue):
+
+    def __init__(self, name, *args, **kwargs):
+        self.name = name
+        PriorityQueue.__init__(self, *args, **kwargs)
+        self.counter = 0
+
+    @property
+    def log(self):
+        name = '.'.join([type(self).__module__, type(self).__name__])
+        return logging.getLogger(name)
+
+    def put(self, priority, item, *args, **kwargs):
+        self.log.debug("Adding {} to {} queue with priority {}".format(item, self.name, priority))
+        # this counter is to preserve the FIFO nature of the queue, it increments on every put
+        # and the python PriorityQueue sorts based on the first item in the tuple (priority)
+        # and then the second item in the tuple (counter). This way all items with the same
+        # priority come out in the order they were entered.
+        self.counter += 1
+        PriorityQueue.put(self, (priority, self.counter, item), *args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        return PriorityQueue.get(self, *args, **kwargs)[2]
+
+
+def rate_limit_instances(instances, cluster, number_per_minute, watcher_name):
     service_instances = []
     if not instances:
         return []
@@ -62,6 +120,7 @@ def rate_limit_instances(instances, number_per_minute, watcher_name):
             service=service,
             instance=instance,
             watcher=watcher_name,
+            cluster=cluster,
             bounce_by=bounce_time,
             bounce_timers=None,
             failures=0,

--- a/paasta_tools/deployd/common.py
+++ b/paasta_tools/deployd/common.py
@@ -71,7 +71,7 @@ class PaastaQueue(Queue):
 
     def __init__(self, name, *args, **kwargs):
         self.name = name
-        Queue.__init__(self, *args, **kwargs)
+        super(PaastaQueue, self).__init__(*args, **kwargs)
 
     @property
     def log(self):
@@ -80,14 +80,14 @@ class PaastaQueue(Queue):
 
     def put(self, item, *args, **kwargs):
         self.log.debug("Adding {} to {} queue".format(item, self.name))
-        Queue.put(self, item, *args, **kwargs)
+        super(PaastaQueue, self).put(item, *args, **kwargs)
 
 
 class PaastaPriorityQueue(PriorityQueue):
 
     def __init__(self, name, *args, **kwargs):
         self.name = name
-        PriorityQueue.__init__(self, *args, **kwargs)
+        super(PaastaPriorityQueue, self).__init__(*args, **kwargs)
         self.counter = 0
 
     @property
@@ -102,10 +102,10 @@ class PaastaPriorityQueue(PriorityQueue):
         # and then the second item in the tuple (counter). This way all items with the same
         # priority come out in the order they were entered.
         self.counter += 1
-        PriorityQueue.put(self, (priority, self.counter, item), *args, **kwargs)
+        super(PaastaPriorityQueue, self).put((priority, self.counter, item), *args, **kwargs)
 
     def get(self, *args, **kwargs):
-        return PriorityQueue.get(self, *args, **kwargs)[2]
+        return super(PaastaPriorityQueue, self).get(*args, **kwargs)[2]
 
 
 def rate_limit_instances(instances, cluster, number_per_minute, watcher_name):

--- a/paasta_tools/deployd/leader.py
+++ b/paasta_tools/deployd/leader.py
@@ -19,7 +19,7 @@ class PaastaLeaderElection(Election):
 
     @property
     def log(self):
-        name = '.'.join([__name__, self.__class__.__name__])
+        name = '.'.join([__name__, type(self).__name__])
         return logging.getLogger(name)
 
     def run(self, func, *args, **kwargs):

--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -11,6 +11,7 @@ import service_configuration_lib
 
 from paasta_tools.deployd import watchers
 from paasta_tools.deployd.common import get_marathon_client_from_config
+from paasta_tools.deployd.common import PaastaPriorityQueue
 from paasta_tools.deployd.common import PaastaQueue
 from paasta_tools.deployd.common import PaastaThread
 from paasta_tools.deployd.common import rate_limit_instances
@@ -26,29 +27,29 @@ from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import ZookeeperPool
 
 
-class DedupedQueue(PaastaQueue):
+class DedupedPriorityQueue(PaastaPriorityQueue):
     """This class extends the python Queue class so that the Queue is
     deduplicated. i.e. there can be only one copy of each service instance
     in the queue at any one time
     """
 
     def __init__(self, name, *args, **kwargs):
-        PaastaQueue.__init__(self, name, *args, **kwargs)
+        PaastaPriorityQueue.__init__(self, name, *args, **kwargs)
         self.bouncing = set()
 
-    def put(self, service_instance, *args, **kwargs):
+    def put(self, priority, service_instance, *args, **kwargs):
         service_instance_key = "{}.{}".format(
             service_instance.service,
             service_instance.instance,
         )
         if service_instance_key not in self.bouncing:
             self.bouncing.add(service_instance_key)
-            PaastaQueue.put(self, service_instance, *args, **kwargs)
+            PaastaPriorityQueue.put(self, priority, service_instance, *args, **kwargs)
         else:
             self.log.debug("{} already present in {}, dropping extra message".format(service_instance_key, self.name))
 
     def get(self, *args, **kwargs):
-        service_instance = PaastaQueue.get(self, *args, **kwargs)
+        service_instance = PaastaPriorityQueue.get(self, *args, **kwargs)
         service_instance_key = "{}.{}".format(
             service_instance.service,
             service_instance.instance,
@@ -105,7 +106,7 @@ class Inbox(PaastaThread):
             if self.to_bounce[service_instance_key].bounce_by < int(time.time()):
                 service_instance = self.to_bounce[service_instance_key]
                 bounced.append(service_instance_key)
-                self.bounce_q.put(service_instance)
+                self.bounce_q.put(service_instance.priority, service_instance)
         for service_instance_key in bounced:
             self.to_bounce.pop(service_instance_key)
         # TODO: if the bounceq is empty we could probably start adding SIs from
@@ -129,7 +130,7 @@ class DeployDaemon(PaastaThread):
         service_configuration_lib.disable_yaml_cache()
         self.config = load_system_paasta_config()
         self.setup_logging()
-        self.bounce_q = DedupedQueue("BounceQueue")
+        self.bounce_q = DedupedPriorityQueue("BounceQueue")
         self.inbox_q = PaastaQueue("InboxQueue")
         self.control = PaastaQueue("ControlQueue")
         self.inbox = Inbox(self.inbox_q, self.bounce_q)
@@ -228,6 +229,7 @@ class DeployDaemon(PaastaThread):
         )
         instances_to_add = rate_limit_instances(
             instances=instances,
+            cluster=self.config.get_cluster(),
             number_per_minute=self.config.get_deployd_startup_bounce_rate(),
             watcher_name='daemon_start',
         )
@@ -245,7 +247,8 @@ class DeployDaemon(PaastaThread):
             self.inbox_q.put(ServiceInstance(
                 service=service,
                 instance=instance,
-                watcher=self.__class__.__name__,
+                cluster=self.config.get_cluster(),
+                watcher=type(self).__name__,
                 bounce_by=int(time.time()),
                 bounce_timers=None,
                 failures=0,

--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -34,7 +34,7 @@ class DedupedPriorityQueue(PaastaPriorityQueue):
     """
 
     def __init__(self, name, *args, **kwargs):
-        PaastaPriorityQueue.__init__(self, name, *args, **kwargs)
+        super(DedupedPriorityQueue, self).__init__(name, *args, **kwargs)
         self.bouncing = set()
 
     def put(self, priority, service_instance, *args, **kwargs):
@@ -44,12 +44,12 @@ class DedupedPriorityQueue(PaastaPriorityQueue):
         )
         if service_instance_key not in self.bouncing:
             self.bouncing.add(service_instance_key)
-            PaastaPriorityQueue.put(self, priority, service_instance, *args, **kwargs)
+            super(DedupedPriorityQueue, self).put(priority, service_instance, *args, **kwargs)
         else:
             self.log.debug("{} already present in {}, dropping extra message".format(service_instance_key, self.name))
 
     def get(self, *args, **kwargs):
-        service_instance = PaastaPriorityQueue.get(self, *args, **kwargs)
+        service_instance = super(DedupedPriorityQueue, self).get(*args, **kwargs)
         service_instance_key = "{}.{}".format(
             service_instance.service,
             service_instance.instance,

--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -70,9 +70,10 @@ class AutoscalerWatcher(PaastaWatcher):
             service_instance = ServiceInstance(
                 service=service,
                 instance=instance,
+                cluster=self.config.get_cluster(),
                 bounce_by=int(time.time()),
                 bounce_timers=None,
-                watcher=self.__class__.__name__,
+                watcher=type(self).__name__,
                 failures=0,
             )
             self.inbox_q.put(service_instance)
@@ -191,8 +192,9 @@ class MaintenanceWatcher(PaastaWatcher):
                 service_instances.append(ServiceInstance(
                     service=service,
                     instance=instance,
+                    cluster=self.config.get_cluster(),
                     bounce_by=int(time.time()),
-                    watcher=self.__class__.__name__,
+                    watcher=type(self).__name__,
                     bounce_timers=None,
                     failures=0,
                 ))
@@ -208,7 +210,7 @@ class PublicConfigEventHandler(pyinotify.ProcessEvent):
 
     @property
     def log(self):
-        name = '.'.join([__name__, self.__class__.__name__])
+        name = '.'.join([__name__, type(self).__name__])
         return logging.getLogger(name)
 
     def filter_event(self, event):
@@ -250,8 +252,9 @@ class PublicConfigEventHandler(pyinotify.ProcessEvent):
                 bounce_rate = self.public_config.get_deployd_big_bounce_rate()
                 service_instances = rate_limit_instances(
                     instances=service_instances,
+                    cluster=self.public_config.get_cluster(),
                     number_per_minute=bounce_rate,
-                    watcher_name=self.__class__.__name__,
+                    watcher_name=type(self).__name__,
                 )
             for service_instance in service_instances:
                 self.filewatcher.inbox_q.put(service_instance)
@@ -265,7 +268,7 @@ class YelpSoaEventHandler(pyinotify.ProcessEvent):
 
     @property
     def log(self):
-        name = '.'.join([__name__, self.__class__.__name__])
+        name = '.'.join([__name__, type(self).__name__])
         return logging.getLogger(name)
 
     def filter_event(self, event):
@@ -314,8 +317,9 @@ class YelpSoaEventHandler(pyinotify.ProcessEvent):
             ServiceInstance(
                 service=service,
                 instance=instance,
+                cluster=self.filewatcher.cluster,
                 bounce_by=int(time.time()),
-                watcher=self.__class__.__name__,
+                watcher=type(self).__name__,
                 bounce_timers=None,
                 failures=0,
             )

--- a/paasta_tools/deployd/workers.py
+++ b/paasta_tools/deployd/workers.py
@@ -86,9 +86,11 @@ class PaastaDeployWorker(PaastaThread):
                 service_instance = ServiceInstance(
                     service=service_instance.service,
                     instance=service_instance.instance,
+                    cluster=self.config.get_cluster(),
                     bounce_by=int(time.time()) + bounce_again_in_seconds,
                     watcher=self.name,
                     bounce_timers=bounce_timers,
+                    priority=service_instance.priority,
                     failures=failures,
                 )
                 self.inbox_q.put(service_instance)

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -107,6 +107,15 @@ class LongRunningServiceConfig(InstanceConfig):
             raise InvalidHealthcheckMode("Unknown mode: %s" % mode)
         return mode
 
+    def get_bounce_priority(self):
+        """Gives a priority to each service instance which deployd will use to prioritise services.
+        Higher numbers are higher priority. This affects the order in which deployd workers pick
+        instances from the bounce queue.
+
+        NB: we multiply by -1 here because *internally* lower numbers are higher priority.
+        """
+        return self.config_dict.get('bounce_priority', 0) * -1
+
     def get_instances(self):
         """Gets the number of instances for a service, ignoring whether the user has requested
         the service to be started or stopped"""

--- a/tests/deployd/test_common.py
+++ b/tests/deployd/test_common.py
@@ -34,10 +34,10 @@ class TestPaastaQueue(unittest.TestCase):
 
     def test_put(self):
         with mock.patch(
-            'paasta_tools.deployd.common.Queue', autospec=True,
-        ) as mock_q:
+            'paasta_tools.deployd.common.Queue.put', autospec=True,
+        ) as mock_q_put:
             self.queue.put("human")
-            mock_q.put.assert_called_with(self.queue, "human")
+            mock_q_put.assert_called_with(self.queue, "human")
 
 
 class TestPaastaPriorityQueue(unittest.TestCase):
@@ -49,19 +49,19 @@ class TestPaastaPriorityQueue(unittest.TestCase):
 
     def test_put(self):
         with mock.patch(
-            'paasta_tools.deployd.common.PriorityQueue', autospec=True,
-        ) as mock_q:
+            'paasta_tools.deployd.common.PriorityQueue.put', autospec=True,
+        ) as mock_q_put:
             self.queue.put(3, "human")
-            mock_q.put.assert_called_with(self.queue, (3, 1, "human"))
+            mock_q_put.assert_called_with(self.queue, (3, 1, "human"))
 
             self.queue.put(3, "human")
-            mock_q.put.assert_called_with(self.queue, (3, 2, "human"))
+            mock_q_put.assert_called_with(self.queue, (3, 2, "human"))
 
     def test_get(self):
         with mock.patch(
-            'paasta_tools.deployd.common.PriorityQueue', autospec=True,
-        ) as mock_q:
-            mock_q.get.return_value = (3, 2, "human")
+            'paasta_tools.deployd.common.PriorityQueue.get', autospec=True,
+        ) as mock_q_get:
+            mock_q_get.return_value = (3, 2, "human")
             assert self.queue.get() == "human"
 
 

--- a/tests/deployd/test_common.py
+++ b/tests/deployd/test_common.py
@@ -2,9 +2,11 @@ import unittest
 
 import mock
 
+from paasta_tools.deployd.common import BaseServiceInstance
 from paasta_tools.deployd.common import exponential_back_off
 from paasta_tools.deployd.common import get_marathon_client_from_config
 from paasta_tools.deployd.common import get_service_instances_needing_update
+from paasta_tools.deployd.common import PaastaPriorityQueue
 from paasta_tools.deployd.common import PaastaQueue
 from paasta_tools.deployd.common import PaastaThread
 from paasta_tools.deployd.common import rate_limit_instances
@@ -38,27 +40,126 @@ class TestPaastaQueue(unittest.TestCase):
             mock_q.put.assert_called_with(self.queue, "human")
 
 
+class TestPaastaPriorityQueue(unittest.TestCase):
+    def setUp(self):
+        self.queue = PaastaPriorityQueue("AtThePostOffice")
+
+    def test_log(self):
+        self.queue.log.info("HAAAALP ME")
+
+    def test_put(self):
+        with mock.patch(
+            'paasta_tools.deployd.common.PriorityQueue', autospec=True,
+        ) as mock_q:
+            self.queue.put(3, "human")
+            mock_q.put.assert_called_with(self.queue, (3, 1, "human"))
+
+            self.queue.put(3, "human")
+            mock_q.put.assert_called_with(self.queue, (3, 2, "human"))
+
+    def test_get(self):
+        with mock.patch(
+            'paasta_tools.deployd.common.PriorityQueue', autospec=True,
+        ) as mock_q:
+            mock_q.get.return_value = (3, 2, "human")
+            assert self.queue.get() == "human"
+
+
+class TestServiceInstance(unittest.TestCase):
+    def setUp(self):
+        with mock.patch(
+            'paasta_tools.deployd.common.ServiceInstance.get_priority', autospec=True,
+        ) as mock_get_priority:
+            mock_get_priority.return_value = 1
+            self.service_instance = ServiceInstance(
+                service='universe',
+                instance='c137',
+                watcher='mywatcher',
+                cluster='westeros-prod',
+                bounce_by=0,
+            )
+
+    def test___new__(self):
+        with mock.patch(
+            'paasta_tools.deployd.common.ServiceInstance.get_priority', autospec=True,
+        ):
+            expected = BaseServiceInstance(
+                service='universe',
+                instance='c137',
+                watcher='mywatcher',
+                bounce_by=0,
+                failures=0,
+                bounce_timers=None,
+                priority=1,
+            )
+            assert self.service_instance == expected
+
+            expected = BaseServiceInstance(
+                service='universe',
+                instance='c137',
+                watcher='mywatcher',
+                bounce_by=0,
+                failures=0,
+                bounce_timers=None,
+                priority=2,
+            )
+            assert ServiceInstance(
+                service='universe',
+                instance='c137',
+                watcher='mywatcher',
+                cluster='westeros-prod',
+                bounce_by=0,
+                priority=2,
+            ) == expected
+
+    def test_get_priority(self):
+        with mock.patch(
+            'paasta_tools.deployd.common.load_marathon_service_config', autospec=True,
+        ) as mock_load_marathon_service_config:
+            mock_load_marathon_service_config.return_value = mock.Mock(get_bounce_priority=mock.Mock(return_value=1))
+            assert type(self.service_instance).get_priority('universe', 'c137', 'westeros-prod') == 1
+            mock_load_marathon_service_config.assert_called_with(
+                service='universe',
+                instance='c137',
+                cluster='westeros-prod',
+                soa_dir='/nail/etc/services',
+            )
+
+            mock_load_marathon_service_config.side_effect = NoDockerImageError()
+            assert type(self.service_instance).get_priority('universe', 'c137', 'westeros-prod') == 0
+
+            mock_load_marathon_service_config.side_effect = InvalidJobNameError()
+            assert type(self.service_instance).get_priority('universe', 'c137', 'westeros-prod') == 0
+
+            mock_load_marathon_service_config.side_effect = NoDeploymentsAvailable()
+            assert type(self.service_instance).get_priority('universe', 'c137', 'westeros-prod') == 0
+
+
 def test_rate_limit_instances():
     with mock.patch(
+        'paasta_tools.deployd.common.ServiceInstance.get_priority', autospec=True, return_value=0,
+    ), mock.patch(
         'time.time', autospec=True,
     ) as mock_time:
         mock_time.return_value = 1
         mock_si_1 = ('universe', 'c137')
         mock_si_2 = ('universe', 'c138')
-        ret = rate_limit_instances([mock_si_1, mock_si_2], 2, "Custos")
+        ret = rate_limit_instances([mock_si_1, mock_si_2], "westeros-prod", 2, "Custos")
         expected = [
-            ServiceInstance(
+            BaseServiceInstance(
                 service='universe',
                 instance='c137',
                 watcher='Custos',
+                priority=0,
                 bounce_by=1,
                 bounce_timers=None,
                 failures=0,
             ),
-            ServiceInstance(
+            BaseServiceInstance(
                 service='universe',
                 instance='c138',
                 watcher='Custos',
+                priority=0,
                 bounce_by=31,
                 bounce_timers=None,
                 failures=0,

--- a/tests/deployd/test_deployd_master.py
+++ b/tests/deployd/test_deployd_master.py
@@ -53,22 +53,22 @@ class TestDedupedPriorityQueue(unittest.TestCase):
 
     def test_put(self):
         with mock.patch(
-            'paasta_tools.deployd.master.PaastaPriorityQueue', autospec=True,
-        ) as mock_paasta_queue:
+            'paasta_tools.deployd.master.PaastaPriorityQueue.put', autospec=True,
+        ) as mock_paasta_queue_put:
 
             self.queue.put(0, self.mock_service_instance)
-            mock_paasta_queue.put.assert_called_with(self.queue, 0, self.mock_service_instance)
+            mock_paasta_queue_put.assert_called_with(self.queue, 0, self.mock_service_instance)
             assert 'universe.c137' in self.queue.bouncing
 
-            mock_paasta_queue.reset_mock()
+            mock_paasta_queue_put.reset_mock()
             self.queue.put(0, self.mock_service_instance)
-            assert not mock_paasta_queue.called
+            assert not mock_paasta_queue_put.called
             assert 'universe.c137' in self.queue.bouncing
 
     def test_get(self):
         with mock.patch(
-            'paasta_tools.deployd.master.PaastaPriorityQueue', autospec=True,
-        ) as mock_paasta_queue:
+            'paasta_tools.deployd.master.PaastaPriorityQueue.get', autospec=True,
+        ) as mock_paasta_queue_get:
 
             self.mock_service_instance = BaseServiceInstance(
                 service='universe',
@@ -80,10 +80,10 @@ class TestDedupedPriorityQueue(unittest.TestCase):
                 failures=0,
             )
             self.queue.bouncing.add('universe.c137')
-            mock_paasta_queue.get.return_value = self.mock_service_instance
+            mock_paasta_queue_get.return_value = self.mock_service_instance
 
             assert self.queue.get() is self.mock_service_instance
-            assert mock_paasta_queue.get.called
+            assert mock_paasta_queue_get.called
             assert 'universe.c137' not in self.queue.bouncing
 
 

--- a/tests/deployd/test_deployd_master.py
+++ b/tests/deployd/test_deployd_master.py
@@ -5,7 +5,7 @@ from queue import Empty
 import mock
 from pytest import raises
 
-from paasta_tools.deployd.common import ServiceInstance
+from paasta_tools.deployd.common import BaseServiceInstance
 
 
 class FakePyinotify(object):  # pragma: no cover
@@ -33,18 +33,19 @@ sys.modules['pyinotify'] = FakePyinotify
 
 from paasta_tools.deployd.master import Inbox  # noqa
 from paasta_tools.deployd.master import DeployDaemon  # noqa
-from paasta_tools.deployd.master import DedupedQueue  # noqa
+from paasta_tools.deployd.master import DedupedPriorityQueue  # noqa
 from paasta_tools.deployd.master import main  # noqa
 
 
-class TestDedupedQueue(unittest.TestCase):
+class TestDedupedPriorityQueue(unittest.TestCase):
     def setUp(self):
-        self.queue = DedupedQueue("BounceQueue")
+        self.queue = DedupedPriorityQueue("BounceQueue")
         assert not self.queue.bouncing
-        self.mock_service_instance = ServiceInstance(
+        self.mock_service_instance = BaseServiceInstance(
             service='universe',
             instance='c137',
             watcher='tests',
+            priority=0,
             bounce_by=1,
             bounce_timers=None,
             failures=0,
@@ -52,27 +53,28 @@ class TestDedupedQueue(unittest.TestCase):
 
     def test_put(self):
         with mock.patch(
-            'paasta_tools.deployd.master.PaastaQueue', autospec=True,
+            'paasta_tools.deployd.master.PaastaPriorityQueue', autospec=True,
         ) as mock_paasta_queue:
 
-            self.queue.put(self.mock_service_instance)
-            mock_paasta_queue.put.assert_called_with(self.queue, self.mock_service_instance)
+            self.queue.put(0, self.mock_service_instance)
+            mock_paasta_queue.put.assert_called_with(self.queue, 0, self.mock_service_instance)
             assert 'universe.c137' in self.queue.bouncing
 
             mock_paasta_queue.reset_mock()
-            self.queue.put(self.mock_service_instance)
+            self.queue.put(0, self.mock_service_instance)
             assert not mock_paasta_queue.called
             assert 'universe.c137' in self.queue.bouncing
 
     def test_get(self):
         with mock.patch(
-            'paasta_tools.deployd.master.PaastaQueue', autospec=True,
+            'paasta_tools.deployd.master.PaastaPriorityQueue', autospec=True,
         ) as mock_paasta_queue:
 
-            self.mock_service_instance = ServiceInstance(
+            self.mock_service_instance = BaseServiceInstance(
                 service='universe',
                 instance='c137',
                 watcher='tests',
+                priority=0,
                 bounce_by=1,
                 bounce_timers=None,
                 failures=0,
@@ -165,7 +167,7 @@ class TestInbox(unittest.TestCase):
                 'universe.c138': mock_service_instance_2,
             }
             self.inbox.process_to_bounce()
-            self.mock_bounce_q.put.assert_called_with(mock_service_instance_1)
+            self.mock_bounce_q.put.assert_called_with(mock_service_instance_1.priority, mock_service_instance_1)
             assert self.mock_bounce_q.put.call_count == 1
 
     def tearDown(self):
@@ -177,7 +179,7 @@ class TestDeployDaemon(unittest.TestCase):
         with mock.patch(
             'paasta_tools.deployd.master.PaastaQueue', autospec=True,
         ), mock.patch(
-            'paasta_tools.deployd.master.DedupedQueue', autospec=True,
+            'paasta_tools.deployd.master.DedupedPriorityQueue', autospec=True,
         ), mock.patch(
             'paasta_tools.deployd.master.Inbox', autospec=True,
         ) as self.mock_inbox, mock.patch(
@@ -369,6 +371,8 @@ class TestDeployDaemon(unittest.TestCase):
 
     def test_prioritise_bouncing_services(self):
         with mock.patch(
+            'paasta_tools.deployd.common.ServiceInstance.get_priority', autospec=True, return_value=0,
+        ), mock.patch(
             'paasta_tools.deployd.master.get_service_instances_that_need_bouncing', autospec=True,
         ) as mock_get_service_instances_that_need_bouncing, mock.patch(
             'time.time', autospec=True, return_value=1,
@@ -382,18 +386,20 @@ class TestDeployDaemon(unittest.TestCase):
                 '/nail/etc/services',
             )
             calls = [
-                mock.call(ServiceInstance(
+                mock.call(BaseServiceInstance(
                     service='universe',
                     instance='c138',
                     watcher='DeployDaemon',
+                    priority=0,
                     bounce_by=1,
                     bounce_timers=None,
                     failures=0,
                 )),
-                mock.call(ServiceInstance(
+                mock.call(BaseServiceInstance(
                     service='universe',
                     instance='c137',
                     watcher='DeployDaemon',
+                    priority=0,
                     bounce_by=1,
                     bounce_timers=None,
                     failures=0,

--- a/tests/deployd/test_watchers.py
+++ b/tests/deployd/test_watchers.py
@@ -5,7 +5,7 @@ import mock
 from pytest import raises
 from requests.exceptions import RequestException
 
-from paasta_tools.deployd.common import ServiceInstance
+from paasta_tools.deployd.common import BaseServiceInstance
 
 
 class FakePyinotify(object):  # pragma: no cover
@@ -125,6 +125,8 @@ class TestAutoscalerWatcher(unittest.TestCase):
 
     def test_process_node_event(self):
         with mock.patch(
+            'paasta_tools.deployd.common.ServiceInstance.get_priority', autospec=True, return_value=0,
+        ), mock.patch(
             'paasta_tools.deployd.watchers.EventType', autospec=True,
         ) as mock_event_type, mock.patch(
             'time.time', autospec=True, return_value=1,
@@ -142,12 +144,13 @@ class TestAutoscalerWatcher(unittest.TestCase):
                 path='/autoscaling/service/instance/instances',
             )
             self.watcher.process_node_event(mock.Mock(), mock.Mock(), mock_event)
-            self.mock_inbox_q.put.assert_called_with(ServiceInstance(
+            self.mock_inbox_q.put.assert_called_with(BaseServiceInstance(
                 service='service',
                 instance='instance',
                 bounce_by=1,
                 bounce_timers=None,
                 watcher=self.watcher.__class__.__name__,
+                priority=0,
                 failures=0,
             ))
 
@@ -157,12 +160,13 @@ class TestAutoscalerWatcher(unittest.TestCase):
                 path='/autoscaling/service/instance/instances',
             )
             self.watcher.process_node_event(mock.Mock(), mock.Mock(), mock_event)
-            self.mock_inbox_q.put.assert_called_with(ServiceInstance(
+            self.mock_inbox_q.put.assert_called_with(BaseServiceInstance(
                 service='service',
                 instance='instance',
                 bounce_by=1,
                 bounce_timers=None,
                 watcher=self.watcher.__class__.__name__,
+                priority=0,
                 failures=0,
             ))
 
@@ -341,6 +345,8 @@ class TestMaintenanceWatcher(unittest.TestCase):
 
     def test_get_at_risk_service_instances(self):
         with mock.patch(
+            'paasta_tools.deployd.common.ServiceInstance.get_priority', autospec=True, return_value=0,
+        ), mock.patch(
             'paasta_tools.deployd.watchers.get_all_marathon_apps', autospec=True,
         ) as mock_get_marathon_apps, mock.patch(
             'time.time', autospec=True, return_value=1,
@@ -368,19 +374,21 @@ class TestMaintenanceWatcher(unittest.TestCase):
             mock_get_marathon_apps.return_value = mock_marathon_apps
             ret = self.watcher.get_at_risk_service_instances(['host1'])
             expected = [
-                ServiceInstance(
+                BaseServiceInstance(
                     service='universe',
                     instance='c137',
                     bounce_by=1,
                     watcher=self.watcher.__class__.__name__,
+                    priority=0,
                     bounce_timers=None,
                     failures=0,
                 ),
-                ServiceInstance(
+                BaseServiceInstance(
                     service='universe',
                     instance='c139',
                     bounce_by=1,
                     watcher=self.watcher.__class__.__name__,
+                    priority=0,
                     bounce_timers=None,
                     failures=0,
                 ),
@@ -543,6 +551,8 @@ class TestYelpSoaEventHandler(unittest.TestCase):
 
     def test_bounce_service(self):
         with mock.patch(
+            'paasta_tools.deployd.common.ServiceInstance.get_priority', autospec=True, return_value=0,
+        ), mock.patch(
             'paasta_tools.deployd.watchers.list_all_instances_for_service', autospec=True,
         ) as mock_list_instances, mock.patch(
             'paasta_tools.deployd.watchers.get_service_instances_needing_update', autospec=True,
@@ -566,12 +576,13 @@ class TestYelpSoaEventHandler(unittest.TestCase):
                 ],
                 self.handler.filewatcher.cluster,
             )
-            expected_si = ServiceInstance(
+            expected_si = BaseServiceInstance(
                 service='universe',
                 instance='c137',
                 bounce_by=1,
                 watcher='YelpSoaEventHandler',
                 bounce_timers=None,
+                priority=0,
                 failures=0,
             )
             self.mock_filewatcher.inbox_q.put.assert_called_with(expected_si)

--- a/tests/deployd/test_workers.py
+++ b/tests/deployd/test_workers.py
@@ -3,8 +3,8 @@ import unittest
 import mock
 from pytest import raises
 
+from paasta_tools.deployd.common import BaseServiceInstance
 from paasta_tools.deployd.common import BounceTimers
-from paasta_tools.deployd.common import ServiceInstance
 from paasta_tools.deployd.workers import BounceResults
 from paasta_tools.deployd.workers import PaastaDeployWorker
 from paasta_tools.marathon_tools import DEFAULT_SOA_DIR
@@ -93,6 +93,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 service='universe',
                 instance='c137',
                 failures=0,
+                priority=0,
             )
             self.mock_bounce_q.get.return_value = mock_si
             with raises(LoopBreak):
@@ -106,13 +107,14 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 bounce_timers=mock_timers,
             )
             mock_process_service_instance.return_value = mock_bounce_results
-            mock_queued_si = ServiceInstance(
+            mock_queued_si = BaseServiceInstance(
                 service='universe',
                 instance='c137',
                 bounce_by=61,
                 watcher='Worker1',
                 bounce_timers=mock_timers,
                 failures=1,
+                priority=0,
             )
             with raises(LoopBreak):
                 self.worker.run()
@@ -123,16 +125,18 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 service='universe',
                 instance='c137',
                 failures=0,
+                priority=0,
             )
             self.mock_bounce_q.get.return_value = mock_si
             mock_process_service_instance.side_effect = Exception
-            mock_queued_si = ServiceInstance(
+            mock_queued_si = BaseServiceInstance(
                 service='universe',
                 instance='c137',
                 bounce_by=61,
                 watcher='Worker1',
                 bounce_timers=mock_si.bounce_timers,
                 failures=1,
+                priority=0,
             )
             with raises(LoopBreak):
                 self.worker.run()


### PR DESCRIPTION
This changes the bounce queue to a python PriorityQueue. It adds
everything with priority 0 by default but lets you give a service
instance a higher or lower priority. Workers will fetch higher priority
instances first and fall back to FIFO if there is a tie.