### PR TITLE
Remove validation that prevents github remotes

### DIFF
--- a/paasta_tools/cli/cmds/generate_pipeline.py
+++ b/paasta_tools/cli/cmds/generate_pipeline.py
@@ -61,23 +61,11 @@ def paasta_generate_pipeline(args):
     generate_pipeline(service=service, soa_dir=soa_dir)
 
 
-def validate_git_url_for_fab_repo(git_url):
-    """fab_repo can only accept certain git urls, so this function will raise an
-    exception if the git_url is not something fab_repo can handle."""
-    if not git_url.startswith('git@git.yelpcorp.com:'):
-        raise NotImplementedError(
-            "fab_repo cannot currently handle git urls that look like: '%s'.\n"
-            "They must start with 'git@git.yelpcorp.com:'" % git_url,
-        )
-    return True
-
-
 def get_git_repo_for_fab_repo(service, soa_dir):
     """Returns the 'repo' in fab_repo terms. fab_repo just wants the trailing
     section of the git_url, after the colon.
     """
     git_url = get_git_url(service, soa_dir=soa_dir)
-    validate_git_url_for_fab_repo(git_url)
     repo = git_url.split(':')[1]
     return repo
 

--- a/tests/cli/test_cmds_generate_pipeline.py
+++ b/tests/cli/test_cmds_generate_pipeline.py
@@ -14,12 +14,10 @@
 from mock import ANY
 from mock import MagicMock
 from mock import patch
-from pytest import raises
 
 from paasta_tools.cli.cmds.generate_pipeline import generate_pipeline
 from paasta_tools.cli.cmds.generate_pipeline import get_git_repo_for_fab_repo
 from paasta_tools.cli.cmds.generate_pipeline import paasta_generate_pipeline
-from paasta_tools.cli.cmds.generate_pipeline import validate_git_url_for_fab_repo
 from paasta_tools.cli.utils import NoSuchService
 
 
@@ -168,17 +166,3 @@ def test_get_git_repo_for_fab_repo_handles_services(mock_get_git_url):
     mock_get_git_url.return_value = 'git@git.yelpcorp.com:services/fake_service'
     actual = get_git_repo_for_fab_repo('unused', '/fake/soa/dir')
     assert actual == 'services/fake_service'
-
-
-def test_validate_git_url_for_fab_repo_happy():
-    good_git_url = 'git@git.yelpcorp.com:foobar'
-    actual = validate_git_url_for_fab_repo(good_git_url)
-    assert actual is True
-
-
-def test_validate_git_url_for_fab_repo_invalid():
-    bad_git_url = 'git@github.com:foobar'
-    with raises(NotImplementedError) as exc:
-        validate_git_url_for_fab_repo(bad_git_url)
-    assert 'cannot currently handle' in str(exc.value)
-    assert bad_git_url in str(exc.value)


### PR DESCRIPTION
fab_repo has been updated to work with GitHub remotes and Nowait's pipelines are now taking advantage of this.  PAASTA-12492 is the internal ticket that has the other relevant changes that have already been submitted.