### PR TITLE
Fix condition within PyPI deploy step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ deploy:
       secure: r9zzkDhFF/aMhId26nVuyk91t0uMLFd80ZWIXpOdGL36AvOKTj90l2Usb9ipxJeIBdiccQ5rFtX7r2RnFC9Q3cP83A0c5p1jacpb7OyNRVDaYqr/+iDVp83SQKF9l2PnKyIXeLpIbVi6x7s0L+gJ7Ex+6ck0X9V1MA1zFtFxOyhGRAPxjPhywLAIsWd7RdclD/Bg79YtZ9pZGg0QK0hm9S3RZL+e2kdM+9rNpfhmyI6Bcf6ZBMoJtsCWWRRg8JgI/StfrXs1VpJfjWmy+XApsOWTWWfjdLO3IpuDhQrAfrCwM8n7AHv8MCfxt8yPlRKA4OEg2TGOm7U+VSIubV64hgFdSt7fazYh+uttUxGE8cz8Jt/rRCYmrYmWPzm7MIoFOwBfrK7QEQDxSN9gWUbL3eWgPGQMVZC06hb0pdLog/8piNrC5DBwywlPy24ChVlt+0UMA8rzIepwX1//Bcc4a9lIxbLFg8P/1JtS7Tkfag9p2Y1Z943GU1JAHhPLktdxMxFlZ4qTfaaxz7fYU+Kr/47noNLWKtnNejVEgy4bYAR9NxDET/vnpeJ7MacefYL0zvXBWO6MCbVDCUbM8fQWrZUAjeFzMCk8kXgA1qkkQ0Lm/7ACbUUECiZ1qclZh2du6Cvt6xRsBJXDXjzYwm2ECKGS8GQ4pJ6h3DypdHgHrMM=
     on:
       tags: true
-      condition: $TOXENV == py36
+      condition: $TOXENV == "py36,coverage,docs"
       repo: Yelp/paasta
   - provider: bintray
     file: "yelp_package/bintray.json"


### PR DESCRIPTION
I was looking at the published packages on PyPI and noticed that the last published version of `paasta-tools` is 0.66.6: https://pypi.python.org/pypi/paasta-tools

It looks like when build time improvements were made as part of #1337, the conditional wasn't updated too, so the deploy step has been skipped for any tagged versions since.