### PR TITLE
Make paasta status show the service name

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -211,6 +211,7 @@ def report_status_for_cluster(
     """With a given service and cluster, prints the status of the instances
     in that cluster"""
     paasta_print()
+    paasta_print("service: %s" % service)
     paasta_print("cluster: %s" % cluster)
     seen_instances = []
     deployed_instances = []


### PR DESCRIPTION
Previously, you had to determine the service name from the app id. This causes `paasta status` to explicitly specify the service name.

This is PAASTA-12553