### PR TITLE
remove --memory-swap option from docker run

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -21,7 +21,6 @@ import hashlib
 import io
 import json
 import logging
-import math
 import os
 import pwd
 import queue
@@ -165,16 +164,6 @@ class InstanceConfig(object):
         mem = self.config_dict.get('mem', 1024)
         return mem
 
-    def get_mem_swap(self):
-        """Gets the memory-swap value. This value is passed to the docker
-        container to ensure that the total memory limit (memory + swap) is the
-        same value as the 'mem' key in soa-configs. Note - this value *has* to
-        be >= to the mem key, so we always round up to the closest MB.
-        """
-        mem = self.get_mem()
-        mem_swap = int(math.ceil(mem))
-        return "%sm" % mem_swap
-
     def get_cpus(self):
         """Gets the number of cpus required from the service's configuration.
 
@@ -246,7 +235,6 @@ class InstanceConfig(object):
         :param with_labels: Whether to build docker parameters with or without labels
         :returns: A list of parameters to be added to docker run"""
         parameters = [
-            {"key": "memory-swap", "value": self.get_mem_swap()},
             {"key": "cpu-period", "value": "%s" % int(self.get_cpu_period())},
             {"key": "cpu-quota", "value": "%s" % int(self.get_cpu_quota())},
         ]

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1084,7 +1084,6 @@ class TestChronosTools:
                 'image': fake_docker_url,
                 'type': 'DOCKER',
                 'parameters': [
-                    {'key': 'memory-swap', 'value': "1024m"},
                     {"key": "cpu-period", "value": "%s" % int(fake_period)},
                     {"key": "cpu-quota", "value": "%s" % int(fake_cpu_quota)},
                     {"key": "label", "value": "paasta_service=test_service"},
@@ -1383,7 +1382,6 @@ class TestChronosTools:
                     'image': "fake_registry/paasta-test-service-penguin",
                     'type': 'DOCKER',
                     'parameters': [
-                        {'key': 'memory-swap', 'value': '1025m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '5500000'},
                         {"key": "label", "value": "paasta_service=test-service"},
@@ -1503,7 +1501,6 @@ class TestChronosTools:
                     'image': "fake_registry/fake_image",
                     'type': 'DOCKER',
                     'parameters': [
-                        {'key': 'memory-swap', 'value': '1025m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '5500000'},
                         {"key": "label", "value": "paasta_service=test-service"},
@@ -1568,7 +1565,6 @@ class TestChronosTools:
                     'image': "fake_registry/fake_image",
                     'type': 'DOCKER',
                     'parameters': [
-                        {'key': 'memory-swap', 'value': '1025m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '5500000'},
                         {"key": "label", "value": "paasta_service=test-service"},
@@ -1649,7 +1645,6 @@ class TestChronosTools:
                     'image': "fake_registry/fake_image",
                     'type': 'DOCKER',
                     'parameters': [
-                        {'key': 'memory-swap', 'value': '1025m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '5500000'},
                         {"key": "label", "value": "paasta_service=test-service"},

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -908,7 +908,6 @@ class TestMarathonTools:
                         },
                     ],
                     'parameters': [
-                        {'key': 'memory-swap', 'value': "%sm" % int(fake_mem)},
                         {"key": "cpu-period", "value": "%s" % int(fake_period)},
                         {"key": "cpu-quota", "value": "%s" % int(fake_cpu_quota)},
                         {"key": "label", "value": "paasta_service=can_you_dig_it"},
@@ -2020,7 +2019,6 @@ def test_format_marathon_app_dict_no_smartstack():
                     'image': 'fake_docker_registry:443/abcdef',
                     'network': 'BRIDGE',
                     'parameters': [
-                        {'key': 'memory-swap', 'value': '1024m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '250000'},
                         {"key": "label", "value": 'paasta_service=service'},
@@ -2091,7 +2089,6 @@ def test_format_marathon_app_dict_with_smartstack():
                     'image': 'fake_docker_registry:443/abcdef',
                     'network': 'BRIDGE',
                     'parameters': [
-                        {'key': 'memory-swap', 'value': '1024m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '250000'},
                         {"key": "label", "value": 'paasta_service=service'},
@@ -2229,7 +2226,6 @@ def test_format_marathon_app_dict_utilizes_extra_volumes():
                     'image': 'fake_docker_registry:443/abcdef',
                     'network': 'BRIDGE',
                     'parameters': [
-                        {'key': 'memory-swap', 'value': '1024m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '250000'},
                         {"key": "label", "value": 'paasta_service=service'},

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -904,7 +904,6 @@ class TestInstanceConfig:
             branch_dict={},
         )
         assert fake_conf.format_docker_parameters() == [
-            {"key": "memory-swap", "value": '1024m'},
             {"key": "cpu-period", "value": "100000"},
             {"key": "cpu-quota", "value": "1000000"},
             {"key": "label", "value": "paasta_service=fake_name"},
@@ -930,7 +929,6 @@ class TestInstanceConfig:
             branch_dict={},
         )
         assert fake_conf.format_docker_parameters() == [
-            {"key": "memory-swap", "value": '1024m'},
             {"key": "cpu-period", "value": "200000"},
             {"key": "cpu-quota", "value": "600000"},
             {"key": "label", "value": "paasta_service=fake_name"},
@@ -950,30 +948,6 @@ class TestInstanceConfig:
             branch_dict={},
         )
         assert fake_conf.get_cpu_quota() == 200000
-
-    def test_get_mem_swap_int(self):
-        fake_conf = utils.InstanceConfig(
-            service='',
-            instance='',
-            cluster='',
-            config_dict={
-                'mem': 50,
-            },
-            branch_dict={},
-        )
-        assert fake_conf.get_mem_swap() == "50m"
-
-    def test_get_mem_swap_float_rounds_up(self):
-        fake_conf = utils.InstanceConfig(
-            service='',
-            instance='',
-            cluster='',
-            config_dict={
-                'mem': 50.4,
-            },
-            branch_dict={},
-        )
-        assert fake_conf.get_mem_swap() == "51m"
 
     def test_get_disk_in_config(self):
         fake_conf = utils.InstanceConfig(


### PR DESCRIPTION
remove --memory-swap option from docker run so that mesos can manage this value.

Internal ticket: PAASTA-12450