### PR TITLE
Add 64MB to memory-swap to work around PAASTA-12450

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -169,10 +169,11 @@ class InstanceConfig(object):
         """Gets the memory-swap value. This value is passed to the docker
         container to ensure that the total memory limit (memory + swap) is the
         same value as the 'mem' key in soa-configs. Note - this value *has* to
-        be >= to the mem key, so we always round up to the closest MB.
+        be >= to the mem key, so we always round up to the closest MB and add
+        additional 64MB for the docker executor (See PAASTA-12450).
         """
         mem = self.get_mem()
-        mem_swap = int(math.ceil(mem))
+        mem_swap = int(math.ceil(mem + 64))
         return "%sm" % mem_swap
 
     def get_cpus(self):

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1084,7 +1084,7 @@ class TestChronosTools:
                 'image': fake_docker_url,
                 'type': 'DOCKER',
                 'parameters': [
-                    {'key': 'memory-swap', 'value': "1024m"},
+                    {'key': 'memory-swap', 'value': "1088m"},
                     {"key": "cpu-period", "value": "%s" % int(fake_period)},
                     {"key": "cpu-quota", "value": "%s" % int(fake_cpu_quota)},
                     {"key": "label", "value": "paasta_service=test_service"},
@@ -1383,7 +1383,7 @@ class TestChronosTools:
                     'image': "fake_registry/paasta-test-service-penguin",
                     'type': 'DOCKER',
                     'parameters': [
-                        {'key': 'memory-swap', 'value': '1025m'},
+                        {'key': 'memory-swap', 'value': '1089m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '5500000'},
                         {"key": "label", "value": "paasta_service=test-service"},
@@ -1503,7 +1503,7 @@ class TestChronosTools:
                     'image': "fake_registry/fake_image",
                     'type': 'DOCKER',
                     'parameters': [
-                        {'key': 'memory-swap', 'value': '1025m'},
+                        {'key': 'memory-swap', 'value': '1089m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '5500000'},
                         {"key": "label", "value": "paasta_service=test-service"},
@@ -1568,7 +1568,7 @@ class TestChronosTools:
                     'image': "fake_registry/fake_image",
                     'type': 'DOCKER',
                     'parameters': [
-                        {'key': 'memory-swap', 'value': '1025m'},
+                        {'key': 'memory-swap', 'value': '1089m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '5500000'},
                         {"key": "label", "value": "paasta_service=test-service"},
@@ -1649,7 +1649,7 @@ class TestChronosTools:
                     'image': "fake_registry/fake_image",
                     'type': 'DOCKER',
                     'parameters': [
-                        {'key': 'memory-swap', 'value': '1025m'},
+                        {'key': 'memory-swap', 'value': '1089m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '5500000'},
                         {"key": "label", "value": "paasta_service=test-service"},

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -908,7 +908,7 @@ class TestMarathonTools:
                         },
                     ],
                     'parameters': [
-                        {'key': 'memory-swap', 'value': "%sm" % int(fake_mem)},
+                        {'key': 'memory-swap', 'value': "%sm" % int(fake_mem + 64)},
                         {"key": "cpu-period", "value": "%s" % int(fake_period)},
                         {"key": "cpu-quota", "value": "%s" % int(fake_cpu_quota)},
                         {"key": "label", "value": "paasta_service=can_you_dig_it"},
@@ -2020,7 +2020,7 @@ def test_format_marathon_app_dict_no_smartstack():
                     'image': 'fake_docker_registry:443/abcdef',
                     'network': 'BRIDGE',
                     'parameters': [
-                        {'key': 'memory-swap', 'value': '1024m'},
+                        {'key': 'memory-swap', 'value': '1088m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '250000'},
                         {"key": "label", "value": 'paasta_service=service'},
@@ -2091,7 +2091,7 @@ def test_format_marathon_app_dict_with_smartstack():
                     'image': 'fake_docker_registry:443/abcdef',
                     'network': 'BRIDGE',
                     'parameters': [
-                        {'key': 'memory-swap', 'value': '1024m'},
+                        {'key': 'memory-swap', 'value': '1088m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '250000'},
                         {"key": "label", "value": 'paasta_service=service'},
@@ -2229,7 +2229,7 @@ def test_format_marathon_app_dict_utilizes_extra_volumes():
                     'image': 'fake_docker_registry:443/abcdef',
                     'network': 'BRIDGE',
                     'parameters': [
-                        {'key': 'memory-swap', 'value': '1024m'},
+                        {'key': 'memory-swap', 'value': '1088m'},
                         {"key": "cpu-period", "value": '100000'},
                         {"key": "cpu-quota", "value": '250000'},
                         {"key": "label", "value": 'paasta_service=service'},

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -904,7 +904,7 @@ class TestInstanceConfig:
             branch_dict={},
         )
         assert fake_conf.format_docker_parameters() == [
-            {"key": "memory-swap", "value": '1024m'},
+            {"key": "memory-swap", "value": '1088m'},
             {"key": "cpu-period", "value": "100000"},
             {"key": "cpu-quota", "value": "1000000"},
             {"key": "label", "value": "paasta_service=fake_name"},
@@ -930,7 +930,7 @@ class TestInstanceConfig:
             branch_dict={},
         )
         assert fake_conf.format_docker_parameters() == [
-            {"key": "memory-swap", "value": '1024m'},
+            {"key": "memory-swap", "value": '1088m'},
             {"key": "cpu-period", "value": "200000"},
             {"key": "cpu-quota", "value": "600000"},
             {"key": "label", "value": "paasta_service=fake_name"},
@@ -961,7 +961,7 @@ class TestInstanceConfig:
             },
             branch_dict={},
         )
-        assert fake_conf.get_mem_swap() == "50m"
+        assert fake_conf.get_mem_swap() == "114m"
 
     def test_get_mem_swap_float_rounds_up(self):
         fake_conf = utils.InstanceConfig(
@@ -973,7 +973,7 @@ class TestInstanceConfig:
             },
             branch_dict={},
         )
-        assert fake_conf.get_mem_swap() == "51m"
+        assert fake_conf.get_mem_swap() == "115m"
 
     def test_get_disk_in_config(self):
         fake_conf = utils.InstanceConfig(


### PR DESCRIPTION
Internal ticket: PAASTA-12450

Add 64MB to memory-swap to work around PAASTA-12450 and to be able to test mesos-slave with --cgroups_limit_swap.

If --cgroups_limit_swap works as intended mesos-slave should reduce memory.memsw.limit_in_bytes from x + 64MB to x + 32MB.