### PR TITLE
Match process names with spaces and slashes in oom-logger

### DIFF
--- a/paasta_tools/oom_logger.py
+++ b/paasta_tools/oom_logger.py
@@ -55,7 +55,7 @@ LogLine = namedtuple(
 
 
 def capture_oom_events_from_stdin():
-    process_name_regex = re.compile('^\d+\s[a-zA-Z0-9\-]+\s.*\]\s(\w+) invoked oom-killer:')
+    process_name_regex = re.compile('^\d+\s[a-zA-Z0-9\-]+\s.*\]\s(.+)\sinvoked\soom-killer:')
     oom_regex = re.compile('^(\d+)\s([a-zA-Z0-9\-]+)\s.*Task in /docker/(\w{12})\w+ killed as a')
     process_name = ''
 
@@ -63,7 +63,6 @@ def capture_oom_events_from_stdin():
         syslog = sys.stdin.readline()
         if not syslog:
             break
-        print(syslog)
         r = process_name_regex.search(syslog)
         if r:
             process_name = r.group(1)

--- a/tests/test_oom_logger.py
+++ b/tests/test_oom_logger.py
@@ -38,6 +38,34 @@ def sys_stdin():
 
 
 @pytest.fixture
+def sys_stdin_process_name_with_slashes():
+    return [
+        'some ramdom line1\n',
+        '1500316299 dev37-devc [30533610.306528] /nail/live/yelp invoked oom-killer: '
+        'gfp_mask=0x24000c0, order=0, oom_score_adj=0\n,'
+        'some ramdom line2\n',
+        '1500316300 dev37-devc [30533610.306529] Task in '
+        '/docker/a687af92e281725daf5b4cda0b487f20d2055d2bb6814b76d0e39c18a52a4e79 '
+        'killed as a result of limit of '
+        '/docker/a687af92e281725daf5b4cda0b487f20d2055d2bb6814b76d0e39c18a52a4e79\n',
+    ]
+
+
+@pytest.fixture
+def sys_stdin_process_name_with_spaces():
+    return [
+        'some ramdom line1\n',
+        '1500316299 dev37-devc [30533610.306528] python batch/ke invoked oom-killer: '
+        'gfp_mask=0x24000c0, order=0, oom_score_adj=0\n,'
+        'some ramdom line2\n',
+        '1500316300 dev37-devc [30533610.306529] Task in '
+        '/docker/a687af92e281725daf5b4cda0b487f20d2055d2bb6814b76d0e39c18a52a4e79 '
+        'killed as a result of limit of '
+        '/docker/a687af92e281725daf5b4cda0b487f20d2055d2bb6814b76d0e39c18a52a4e79\n',
+    ]
+
+
+@pytest.fixture
 def sys_stdin_without_process_name():
     return [
         'some ramdom line1\n',
@@ -79,6 +107,26 @@ def test_capture_oom_events_from_stdin(mock_sys_stdin, sys_stdin):
         test_output.append(a_tuple)
 
     assert test_output == [(1500316300, 'dev37-devc', 'a687af92e281', 'apache2')]
+
+
+@patch('paasta_tools.oom_logger.sys.stdin', autospec=True)
+def test_capture_oom_events_from_stdin_with_slashes(mock_sys_stdin, sys_stdin_process_name_with_slashes):
+    mock_sys_stdin.readline.side_effect = sys_stdin_process_name_with_slashes
+    test_output = []
+    for a_tuple in capture_oom_events_from_stdin():
+        test_output.append(a_tuple)
+
+    assert test_output == [(1500316300, 'dev37-devc', 'a687af92e281', '/nail/live/yelp')]
+
+
+@patch('paasta_tools.oom_logger.sys.stdin', autospec=True)
+def test_capture_oom_events_from_stdin_with_spaces(mock_sys_stdin, sys_stdin_process_name_with_spaces):
+    mock_sys_stdin.readline.side_effect = sys_stdin_process_name_with_spaces
+    test_output = []
+    for a_tuple in capture_oom_events_from_stdin():
+        test_output.append(a_tuple)
+
+    assert test_output == [(1500316300, 'dev37-devc', 'a687af92e281', 'python batch/ke')]
 
 
 @patch('paasta_tools.oom_logger.sys.stdin', autospec=True)


### PR DESCRIPTION
To recognize such process names as "/nail/live/yelp" and "python batch/ke"