### PR TITLE
adjusts get_marathon_services_for_nerve to handle missing marathon files

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -769,8 +769,9 @@ def get_marathon_services_running_here_for_nerve(cluster, soa_dir):
                     continue
                 nerve_dict['port'] = port
                 nerve_list.append((registration, nerve_dict))
-        except KeyError:
+        except (KeyError, NoConfigurationForServiceError):
             continue  # SOA configs got deleted for this app, it'll get cleaned up
+
     return nerve_list
 
 


### PR DESCRIPTION
As per SMTSTK-192 - configure_nerve shouldn't crash when a marathon file is not found for a container still running. 

get_marathon_services_for_nerve is called [here](https://github.com/yelp/nerve-tools/blob/master/src/nerve_tools/configure_nerve.py#L289)