### PR TITLE
Add a prefilter before reading service configuration files

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -338,15 +338,10 @@ def get_filters(args):
     :param args: args object
     :returns: list of functions that take an instance config and returns if the instance conf matches the filter
     """
-    if args.service is None and args.owner is None:
-        service = figure_out_service_name(args, soa_dir=args.soa_dir)
-    else:
-        service = args.service
-
     filters = []
 
-    if service:
-        filters.append(lambda conf: conf.get_service() in service.split(','))
+    if args.service:
+        filters.append(lambda conf: conf.get_service() in args.service.split(','))
 
     if args.clusters:
         filters.append(lambda conf: conf.get_cluster() in args.clusters.split(','))
@@ -384,11 +379,14 @@ def apply_args_filters(args):
     """
     clusters_services_instances = defaultdict(lambda: defaultdict(set))
 
+    if args.service is None and args.owner is None:
+        args.service = figure_out_service_name(args, soa_dir=args.soa_dir)
+
     filters = get_filters(args)
 
     i_count = 0
     for service in list_services(soa_dir=args.soa_dir):
-        if service != args.service:
+        if args.service and service != args.service:
             continue
 
         for instance_conf in get_instance_configs_for_service(service, soa_dir=args.soa_dir):

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -388,6 +388,9 @@ def apply_args_filters(args):
 
     i_count = 0
     for service in list_services(soa_dir=args.soa_dir):
+        if service != args.service:
+            continue
+
         for instance_conf in get_instance_configs_for_service(service, soa_dir=args.soa_dir):
             if all([f(instance_conf) for f in filters]):
                 clusters_services_instances[instance_conf.get_cluster()][service].add(instance_conf.get_instance())


### PR DESCRIPTION
Right now `paasta status` will read every service configuration and then filter. This can take a good 15 seconds as it parses everything. We can skip listing services that do not match the service filter.