### PR TITLE
remote runs in paasta_serviceinit

### DIFF
--- a/example_cluster/docker-compose.override.yml
+++ b/example_cluster/docker-compose.override.yml
@@ -20,6 +20,7 @@ services:
     volumes:
       - ../:/work:rw
       - ./paasta:/etc/paasta:rw
+      - ./boto:/etc/boto:rw
       - ./example-services:/nail/etc/services:rw
       - /var/run/docker.sock:/var/run/docker.sock
       - ssh-data:/root/.ssh

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -112,21 +112,24 @@ def get_latest_deployment_tag(refs, deploy_group):
     return most_recent_ref, most_recent_sha
 
 
-def get_deploy_group_mappings(soa_dir, service, old_mappings):
+def get_deploy_group_mappings(soa_dir, service, old_mappings=None):
     """Gets mappings from service:deploy_group to services-service:paasta-hash,
     where hash is the current SHA at the HEAD of branch_name.
     This is done for all services in soa_dir.
 
     :param soa_dir: The SOA configuration directory to read from
-    :param old_mappings: A dictionary like the return dictionary. Used for fallback if there is a problem with a new
-                         mapping.
-    :returns: A dictionary mapping service:deploy_group to a dictionary containing:
+    :param old_mappings_DEPRECATED: A dictionary like the return dictionary.
+      Used for fallback if there is a problem with a new mapping.
+    :returns: A dictionary mapping service:deploy_group to a dictionary
+      containing:
 
-    - 'docker_image': something like "services-service:paasta-hash". This is relative to the paasta docker
-      registry.
-    - 'desired_state': either 'start' or 'stop'. Says whether this branch should be running.
-    - 'force_bounce': An arbitrary value, which may be None. A change in this value should trigger a bounce, even if
-      the other properties of this app have not changed.
+    - 'docker_image': something like "services-service:paasta-hash". This is
+      relative to the paasta docker registry.
+    - 'desired_state': either 'start' or 'stop'. Says whether this branch
+      should be running.
+    - 'force_bounce': An arbitrary value, which may be None. A change in this
+      value should trigger a bounce, even if the other properties of this app
+      have not changed.
     """
     mappings = {}
     v2_mappings = {
@@ -139,7 +142,10 @@ def get_deploy_group_mappings(soa_dir, service, old_mappings):
         service=service,
     )
 
-    deploy_group_branch_mappings = {config.get_branch(): config.get_deploy_group() for config in service_configs}
+    deploy_group_branch_mappings = {
+        config.get_branch(): config.get_deploy_group()
+        for config in service_configs
+    }
     if not deploy_group_branch_mappings:
         log.info('Service %s has no valid deploy groups. Skipping.', service)
         return {}

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -412,20 +412,22 @@ def remote_run_stop(args):
         paasta_print(teardown.text)
 
 
-frameworks = None
-def remote_run_list(args, reset_frameworks=False):
-    _, service, cluster, _, instance, _ = extract_args(args)
+def remote_run_frameworks():
+    return get_all_frameworks(active_only=True)
 
-    global frameworks
 
-    if reset_frameworks:
-        frameworks = None
-
+def remote_run_filter_frameworks(service, instance, frameworks=None):
     if frameworks is None:
-        frameworks = get_all_frameworks(active_only=True)
+        frameworks = remote_run_frameworks()
 
     prefix = "paasta-remote %s.%s" % (service, instance)
-    filtered = [f for f in frameworks if f.name.startswith(prefix)]
+    return [f for f in frameworks if f.name.startswith(prefix)]
+
+
+def remote_run_list(args, frameworks=None):
+    _, service, cluster, _, instance, _ = extract_args(args)
+    filtered = remote_run_frameworks_for(
+        service, instance, frameworks=frameworks)
     filtered.sort(key=lambda x: x.name)
     for f in filtered:
         launch_time, run_id = re.match(

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -424,8 +424,7 @@ def remote_run_filter_frameworks(service, instance, frameworks=None):
     return [f for f in frameworks if f.name.startswith(prefix)]
 
 
-def remote_run_list(args, frameworks=None):
-    _, service, cluster, _, instance, _ = extract_args(args)
+def remote_run_list_report(service, instance, cluster, frameworks=None):
     filtered = remote_run_filter_frameworks(
         service, instance, frameworks=frameworks,
     )
@@ -445,6 +444,16 @@ def remote_run_list(args, frameworks=None):
         )
     else:
         paasta_print("Nothing found.")
+
+
+def remote_run_list(args, frameworks=None):
+    _, service, cluster, _, instance, _ = extract_args(args)
+    return remote_run_list_report(
+        service=service,
+        instance=instance,
+        cluster=cluster,
+        frameworks=frameworks,
+    )
 
 
 def main(argv):

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -409,29 +409,20 @@ def remote_run_list(args, reset_frameworks=False):
     filtered = [f for f in frameworks if f.name.startswith(prefix)]
     filtered.sort(key=lambda x: x.name)
     for f in filtered:
-        launch_time, run_id = re.match('paasta-remote [^\s]+ (\w+) (\w+)', f.name).groups()
+        launch_time, run_id = re.match(
+            'paasta-remote [^\s]+ (\w+) (\w+)', f.name
+        ).groups()
         paasta_print("Launch time: %s, run id: %s, framework id: %s" %
                      (launch_time, run_id, f.id))
     if len(filtered) > 0:
         paasta_print(
-            "Use `paasta remote-run stop -s %s -c %s -i %s [-R <run id> | -F <framework id>]` to stop." %
-            (service, cluster, instance),
+            (
+                "Use `paasta remote-run stop -s {} -c {} -i {} [-R <run id> "
+                "| -F <framework id>]` to stop."
+            ).format(service, cluster, instance),
         )
     else:
         paasta_print("Nothing found.")
-
-
-def perform_command(command, service, instance, cluster, verbose, soa_dir):
-    if command != 'status':
-        return 0
-
-    try:
-        remote_run_list(
-            **{'service': service, 'cluster': cluster, 'instance': instance}
-        )
-        return 0
-    except:
-        return 1
 
 
 def main(argv):

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -103,7 +103,7 @@ def extract_args(args):
             sep='\n',
             file=sys.stderr,
         )
-        os._exit(1)
+        sys.exit(1)
 
     soa_dir = args.yelpsoa_config_root
     instance = args.instance
@@ -123,7 +123,7 @@ def extract_args(args):
                     ).format(instance, instance_type)
                 )
             )
-            os._exit(1)
+            sys.exit(1)
 
     return (
         system_paasta_config,
@@ -373,7 +373,7 @@ def remote_run_stop(args):
     _, service, cluster, _, instance, _ = extract_args(args)
     if args.framework_id is None and args.run_id is None:
         paasta_print(PaastaColors.red("Must provide either run id or framework id to stop."))
-        os._exit(1)
+        sys.exit(1)
 
     frameworks = [
         f
@@ -384,14 +384,14 @@ def remote_run_stop(args):
     if framework_id is None:
         if re.match('\s', args.run_id):
             paasta_print(PaastaColors.red("Run id must not contain whitespace."))
-            os._exit(1)
+            sys.exit(1)
 
         found = [f for f in frameworks if re.search(' %s$' % args.run_id, f.name) is not None]
         if len(found) > 0:
             framework_id = found[0].id
         else:
             paasta_print(PaastaColors.red("Framework with run id %s not found." % args.run_id))
-            os._exit(1)
+            sys.exit(1)
     else:
         found = [f for f in frameworks if f.id == framework_id]
         if len(found) == 0:
@@ -401,7 +401,7 @@ def remote_run_stop(args):
                     (framework_id, service, instance),
                 ),
             )
-            os._exit(1)
+            sys.exit(1)
 
     paasta_print("Tearing down framework %s." % framework_id)
     mesos_master = get_mesos_master()
@@ -426,7 +426,7 @@ def remote_run_filter_frameworks(service, instance, frameworks=None):
 
 def remote_run_list(args, frameworks=None):
     _, service, cluster, _, instance, _ = extract_args(args)
-    filtered = remote_run_frameworks_for(
+    filtered = remote_run_filter_frameworks(
         service, instance, frameworks=frameworks)
     filtered.sort(key=lambda x: x.name)
     for f in filtered:

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -393,9 +393,18 @@ def remote_run_stop(args):
         paasta_print(teardown.text)
 
 
-def remote_run_list(args):
+frameworks = None
+def remote_run_list(args, reset_frameworks=False):
     _, service, cluster, _, instance, _ = extract_args(args)
-    frameworks = get_all_frameworks(active_only=True)
+
+    global frameworks
+
+    if reset_frameworks:
+        frameworks = None
+
+    if frameworks is None:
+        frameworks = get_all_frameworks(active_only=True)
+
     prefix = "paasta-remote %s.%s" % (service, instance)
     filtered = [f for f in frameworks if f.name.startswith(prefix)]
     filtered.sort(key=lambda x: x.name)
@@ -410,6 +419,19 @@ def remote_run_list(args):
         )
     else:
         paasta_print("Nothing found.")
+
+
+def perform_command(command, service, instance, cluster, verbose, soa_dir):
+    if command != 'status':
+        return 0
+
+    try:
+        remote_run_list(
+            **{'service': service, 'cluster': cluster, 'instance': instance}
+        )
+        return 0
+    except:
+        return 1
 
 
 def main(argv):

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -112,7 +112,7 @@ def extract_args(args):
         instance = 'remote'
     else:
         instance_type = validate_service_instance(
-            service, instance, cluster, soa_dir
+            service, instance, cluster, soa_dir,
         )
         if instance_type != 'adhoc':
             paasta_print(
@@ -120,8 +120,8 @@ def extract_args(args):
                     (
                         "Please use instance declared in adhoc.yaml for use "
                         "with remote-run, {} is declared as {}"
-                    ).format(instance, instance_type)
-                )
+                    ).format(instance, instance_type),
+                ),
             )
             sys.exit(1)
 
@@ -131,7 +131,7 @@ def extract_args(args):
         cluster,
         soa_dir,
         instance,
-        instance_type
+        instance_type,
     )
 
 
@@ -427,11 +427,12 @@ def remote_run_filter_frameworks(service, instance, frameworks=None):
 def remote_run_list(args, frameworks=None):
     _, service, cluster, _, instance, _ = extract_args(args)
     filtered = remote_run_filter_frameworks(
-        service, instance, frameworks=frameworks)
+        service, instance, frameworks=frameworks,
+    )
     filtered.sort(key=lambda x: x.name)
     for f in filtered:
         launch_time, run_id = re.match(
-            'paasta-remote [^\s]+ (\w+) (\w+)', f.name
+            'paasta-remote [^\s]+ (\w+) (\w+)', f.name,
         ).groups()
         paasta_print("Launch time: %s, run id: %s, framework id: %s" %
                      (launch_time, run_id, f.id))

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -111,9 +111,28 @@ def extract_args(args):
         instance_type = 'adhoc'
         instance = 'remote'
     else:
-        instance_type = validate_service_instance(service, instance, cluster, soa_dir)
+        instance_type = validate_service_instance(
+            service, instance, cluster, soa_dir
+        )
+        if instance_type != 'adhoc':
+            paasta_print(
+                PaastaColors.red(
+                    (
+                        "Please use instance declared in adhoc.yaml for use "
+                        "with remote-run, {} is declared as {}"
+                    ).format(instance, instance_type)
+                )
+            )
+            os._exit(1)
 
-    return (system_paasta_config, service, cluster, soa_dir, instance, instance_type)
+    return (
+        system_paasta_config,
+        service,
+        cluster,
+        soa_dir,
+        instance,
+        instance_type
+    )
 
 
 def paasta_to_task_config_kwargs(
@@ -121,7 +140,7 @@ def paasta_to_task_config_kwargs(
         instance,
         cluster,
         system_paasta_config,
-        instance_type='paasta_native',
+        instance_type,
         soa_dir=DEFAULT_SOA_DIR,
         config_overrides=None,
 ):
@@ -308,7 +327,7 @@ def remote_run_start(args):
             instance,
             cluster,
             system_paasta_config,
-            instance_type=instance_type,
+            instance_type,
             soa_dir=soa_dir,
             config_overrides=overrides_dict,
         ),

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -224,15 +224,10 @@ def main():
                     if command != 'status':
                         raise NotImplementedError
 
-                    paasta_remote_run.remote_run_list(
-                        argparse.Namespace(
-                            **{
-                                'service': service,
-                                'cluster': cluster,
-                                'instance': instance,
-                                'yelpsoa_config_root': args.soa_dir,
-                            },
-                        ),
+                    paasta_remote_run.remote_run_list_report(
+                        service=service,
+                        instance=instance,
+                        cluster=cluster,
                         frameworks=remote_run_frameworks,
                     )
                     return_code = 0

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -24,6 +24,7 @@ from paasta_tools import chronos_tools
 from paasta_tools import marathon_serviceinit
 from paasta_tools import marathon_tools
 from paasta_tools import paasta_native_serviceinit
+from paasta_tools import remote_run
 from paasta_tools.cli.cmds.status import get_actual_deployments
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import decompose_job_id
@@ -146,9 +147,6 @@ def main():
     for instance in instances:
         try:
             instance_type = validate_service_instance(service, instance, cluster, args.soa_dir)
-            if instance_type == 'adhoc':
-                continue
-
             version = get_deployment_version(actual_deployments, cluster, instance)
             paasta_print('instance: %s' % PaastaColors.blue(instance))
             paasta_print('Git sha:    %s (desired)' % version)
@@ -177,6 +175,18 @@ def main():
                 )
             elif instance_type == 'paasta_native':
                 return_code = paasta_native_serviceinit.perform_command(
+                    command=command,
+                    service=service,
+                    instance=instance,
+                    cluster=cluster,
+                    verbose=args.verbose,
+                    soa_dir=args.soa_dir,
+                )
+            elif instance_type == 'adhoc':
+                if instance == 'interactive':
+                    continue
+
+                return_code = paasta_remote_run.perform_command(
                     command=command,
                     service=service,
                     instance=instance,

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -16,7 +16,6 @@ import argparse
 import logging
 import sys
 import traceback
-from addict import Dict
 
 import requests_cache
 
@@ -222,16 +221,18 @@ def main():
                     )
                 elif instance_type == 'adhoc':
                     if instance == 'interactive':
-                        continue
+                        raise NotImplementedError
                     if command != 'status':
-                        continue
+                        raise NotImplementedError
 
                     paasta_remote_run.remote_run_list(
-                        Dict(
-                            service=service,
-                            cluster=cluster,
-                            instance=instance,
-                            yelpsoa_config_root=args.soa_dir,
+                        argparse.Namespace(
+                            **{
+                                'service': service,
+                                'cluster': cluster,
+                                'instance': instance,
+                                'yelpsoa_config_root': args.soa_dir,
+                            }
                         ),
                         frameworks=remote_run_frameworks,
                     )

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -149,13 +149,13 @@ def main():
     for instance in instances:
         try:
             instance_type = validate_service_instance(
-                service, instance, cluster, args.soa_dir
+                service, instance, cluster, args.soa_dir,
             )
         except Exception:
             log.error(
                 (
                     'Exception raised while looking at service %s instance %s:'
-                ).format(service, instance)
+                ).format(service, instance),
             )
             log.error(traceback.format_exc())
             return_codes.append(1)
@@ -167,13 +167,12 @@ def main():
                     "I calculated an instance_type of {} for {} which I don't "
                     "know how to handle."
                 ).format(
-                    instance_type, compose_job_id(service, instance)
-                )
+                    instance_type, compose_job_id(service, instance),
+                ),
             )
             return_codes.append(1)
         else:
             instance_types_map[instance_type].append(instance)
-
 
     remote_run_frameworks = None
     if len(instance_types_map['adhoc']) > 0:
@@ -183,7 +182,7 @@ def main():
         for instance in instance_types_map[instance_type]:
             try:
                 version = get_deployment_version(
-                    actual_deployments, cluster, instance
+                    actual_deployments, cluster, instance,
                 )
                 paasta_print('instance: %s' % PaastaColors.blue(instance))
                 paasta_print('Git sha:    %s (desired)' % version)
@@ -232,7 +231,7 @@ def main():
                                 'cluster': cluster,
                                 'instance': instance,
                                 'yelpsoa_config_root': args.soa_dir,
-                            }
+                            },
                         ),
                         frameworks=remote_run_frameworks,
                     )
@@ -242,7 +241,8 @@ def main():
                     (
                         'Exception raised while looking at service {} '
                         'instance {}:'
-                    ).format(service, instance))
+                    ).format(service, instance),
+                )
                 log.error(traceback.format_exc())
                 return_code = 1
 

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -176,6 +176,10 @@ def main():
             instance_types_map[instance_type].append(instance)
 
 
+    remote_run_frameworks = None
+    if len(instance_types_map['adhoc']) > 0:
+        remote_run_frameworks = paasta_remote_run.remote_run_frameworks()
+
     for instance_type in instance_types:
         for instance in instance_types_map[instance_type]:
             try:
@@ -228,7 +232,8 @@ def main():
                             cluster=cluster,
                             instance=instance,
                             yelpsoa_config_root=args.soa_dir,
-                        )
+                        ),
+                        frameworks=remote_run_frameworks,
                     )
                     return_code = 0
             except Exception:


### PR DESCRIPTION
adhoc instances are now sort of adopted by remote-run cmd, except the "interactive" one because we don't care about it?

also only status command is handled for now.