### PR TITLE
De-prioritise startup/public config bounces

### DIFF
--- a/paasta_tools/deployd/common.py
+++ b/paasta_tools/deployd/common.py
@@ -108,7 +108,7 @@ class PaastaPriorityQueue(PriorityQueue):
         return super(PaastaPriorityQueue, self).get(*args, **kwargs)[2]
 
 
-def rate_limit_instances(instances, cluster, number_per_minute, watcher_name):
+def rate_limit_instances(instances, cluster, number_per_minute, watcher_name, priority=None):
     service_instances = []
     if not instances:
         return []
@@ -124,6 +124,7 @@ def rate_limit_instances(instances, cluster, number_per_minute, watcher_name):
             bounce_by=bounce_time,
             bounce_timers=None,
             failures=0,
+            priority=priority,
         ))
         bounce_time += time_step
     return service_instances

--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -232,6 +232,7 @@ class DeployDaemon(PaastaThread):
             cluster=self.config.get_cluster(),
             number_per_minute=self.config.get_deployd_startup_bounce_rate(),
             watcher_name='daemon_start',
+            priority=99,
         )
         for service_instance in instances_to_add:
             self.inbox_q.put(service_instance)

--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -255,6 +255,7 @@ class PublicConfigEventHandler(pyinotify.ProcessEvent):
                     cluster=self.public_config.get_cluster(),
                     number_per_minute=bounce_rate,
                     watcher_name=type(self).__name__,
+                    priority=99,
                 )
             for service_instance in service_instances:
                 self.filewatcher.inbox_q.put(service_instance)

--- a/tests/deployd/test_common.py
+++ b/tests/deployd/test_common.py
@@ -167,6 +167,29 @@ def test_rate_limit_instances():
         ]
         assert ret == expected
 
+        ret = rate_limit_instances([mock_si_1, mock_si_2], "westeros-prod", 2, "Custos", priority=99)
+        expected = [
+            BaseServiceInstance(
+                service='universe',
+                instance='c137',
+                watcher='Custos',
+                priority=99,
+                bounce_by=1,
+                bounce_timers=None,
+                failures=0,
+            ),
+            BaseServiceInstance(
+                service='universe',
+                instance='c138',
+                watcher='Custos',
+                priority=99,
+                bounce_by=31,
+                bounce_timers=None,
+                failures=0,
+            ),
+        ]
+        assert ret == expected
+
 
 def test_exponential_back_off():
     assert exponential_back_off(0, 60, 2, 6000) == 60


### PR DESCRIPTION
This makes deployd workers pick bounces triggered on startup of deployd
or on changes to public config after all other bounces are done.

The motivation is to stop "big bounces" tying up workers that could be
dealing with real service pushes or autoscaling events. A "big bounce"
is one in which a config change or a code change in paasta_tools means
that we need to recreate every marathon app.