### PR TITLE
Instance configs experiments

### DIFF
--- a/docs/source/generated/paasta_tools.paasta_service_config.rst
+++ b/docs/source/generated/paasta_tools.paasta_service_config.rst
@@ -1,0 +1,7 @@
+paasta_tools.paasta_service_config module
+=========================================
+
+.. automodule:: paasta_tools.paasta_service_config
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/generated/paasta_tools.rst
+++ b/docs/source/generated/paasta_tools.rst
@@ -65,6 +65,7 @@ Submodules
    paasta_tools.paasta_metastatus
    paasta_tools.paasta_native_serviceinit
    paasta_tools.paasta_remote_run
+   paasta_tools.paasta_service_config
    paasta_tools.paasta_serviceinit
    paasta_tools.remote_git
    paasta_tools.secret_tools

--- a/paasta_tools/adhoc_tools.py
+++ b/paasta_tools/adhoc_tools.py
@@ -76,6 +76,16 @@ class AdhocJobConfig(LongRunningServiceConfig):
             soa_dir=soa_dir,
         )
 
+    def __repr__(self):
+        return "AdhocJobConfig(%r, %r, %r, %r, %r, %r)" % (
+            self.service,
+            self.cluster,
+            self.instance,
+            self.config_dict,
+            self.branch_dict,
+            self.soa_dir,
+        )
+
 
 def get_default_interactive_config(service, cluster, soa_dir, load_deployments=False):
     default_job_config = {

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -32,6 +32,7 @@ instance then it will be used instead.
 """
 import argparse
 import logging
+import os
 from datetime import datetime
 from datetime import timedelta
 
@@ -41,50 +42,54 @@ from paasta_tools import marathon_tools
 from paasta_tools import monitoring_tools
 from paasta_tools.marathon_tools import format_job_id
 from paasta_tools.mesos_tools import get_slaves
+from paasta_tools.paasta_service_config import PaastaServiceConfig
 from paasta_tools.smartstack_tools import SmartstackReplicationChecker
 from paasta_tools.utils import _log
-from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import DEFAULT_SOA_DIR
-from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import is_under_replicated
 from paasta_tools.utils import load_system_paasta_config
-from paasta_tools.utils import NoDeploymentsAvailable
 
 
 log = logging.getLogger(__name__)
 
 
-def send_event(service, namespace, cluster, soa_dir, status, output):
+def send_event(instance_config, status, output):
     """Send an event to sensu via pysensu_yelp with the given information.
 
-    :param service: The service name the event is about
-    :param namespace: The namespace of the service the event is about
-    :param soa_dir: The service directory to read monitoring information from
+    :param instance_config: an instance of MarathonServiceConfig
     :param status: The status to emit for this event
     :param output: The output to emit for this event"""
     # This function assumes the input is a string like "mumble.main"
-    monitoring_overrides = marathon_tools.load_marathon_service_config(
-        service=service,
-        instance=namespace,
-        cluster=cluster,
-        soa_dir=soa_dir,
-        load_deployments=False,
-    ).get_monitoring()
+    monitoring_overrides = instance_config.get_monitoring()
     if 'alert_after' not in monitoring_overrides:
         monitoring_overrides['alert_after'] = '2m'
     monitoring_overrides['check_every'] = '1m'
-    monitoring_overrides['runbook'] = monitoring_tools.get_runbook(monitoring_overrides, service, soa_dir=soa_dir)
+    monitoring_overrides['runbook'] = monitoring_tools.get_runbook(
+        monitoring_overrides,
+        instance_config.service, soa_dir=instance_config.soa_dir,
+    )
 
-    check_name = 'check_marathon_services_replication.%s' % compose_job_id(service, namespace)
-    monitoring_tools.send_event(service, check_name, monitoring_overrides, status, output, soa_dir, cluster=cluster)
+    check_name = (
+        'check_marathon_services_replication.%s' %
+        instance_config.job_id
+    )
+    monitoring_tools.send_event(
+        service=instance_config.service,
+        check_name=check_name,
+        overrides=monitoring_overrides,
+        status=status,
+        output=output,
+        soa_dir=instance_config.soa_dir,
+        cluster=instance_config.cluster,
+    )
     _log(
-        service=service,
+        service=instance_config.service,
         line='Replication: %s' % output,
         component='monitoring',
         level='debug',
-        cluster=cluster,
-        instance=namespace,
+        cluster=instance_config.cluster,
+        instance=instance_config.instance,
     )
 
 
@@ -107,10 +112,7 @@ def parse_args():
 
 
 def check_smartstack_replication_for_instance(
-    service,
-    instance,
-    cluster,
-    soa_dir,
+    instance_config,
     expected_count,
     smartstack_replication_checker,
 ):
@@ -118,39 +120,33 @@ def check_smartstack_replication_for_instance(
     emitting events to Sensu based on the fraction available and the thresholds defined in
     the corresponding yelpsoa config.
 
-    :param service: A string like example_service
-    :param instance: A PaaSTA instance, like "main"
-    :param cluster: name of the cluster
-    :param soa_dir: The SOA configuration directory to read from
+    :param instance_config: an instance of MarathonServiceConfig
     :param smartstack_replication_checker: an instance of SmartstackReplicationChecker
     """
-    full_name = compose_job_id(service, instance)
+    primary_registration = instance_config.get_registrations()[0]
 
-    primary_registration = marathon_tools.read_registration_for_service_instance(
-        service, instance, soa_dir=soa_dir, cluster=cluster,
-    )
-
-    if primary_registration != full_name:
+    if primary_registration != instance_config.job_id:
         log.debug(
             '%s is announced under: %s. '
-            'Not checking replication for it' % (full_name, primary_registration),
+            'Not checking replication for it' % (instance_config.job_id, primary_registration),
         )
         return
 
-    job_config = marathon_tools.load_marathon_service_config(service, instance, cluster)
-    crit_threshold = job_config.get_replication_crit_percentage()
+    crit_threshold = instance_config.get_replication_crit_percentage()
 
-    log.info('Checking instance %s in smartstack', full_name)
-    smartstack_replication_info = smartstack_replication_checker.get_replication_for_instance(job_config)
+    log.info('Checking instance %s in smartstack', instance_config.job_id)
+    smartstack_replication_info = \
+        smartstack_replication_checker.get_replication_for_instance(instance_config)
 
-    log.debug('Got smartstack replication info for %s: %s' % (full_name, smartstack_replication_info))
+    log.debug('Got smartstack replication info for %s: %s' %
+              (instance_config.job_id, smartstack_replication_info))
 
     if len(smartstack_replication_info) == 0:
         status = pysensu_yelp.Status.CRITICAL
         output = (
             'Service %s has no Smartstack replication info. Make sure the discover key in your smartstack.yaml '
             'is valid!\n'
-        ) % full_name
+        ) % instance_config.job_id
         log.error(output)
     else:
         expected_count_per_location = int(expected_count / len(smartstack_replication_info))
@@ -160,17 +156,17 @@ def check_smartstack_replication_for_instance(
         under_replication_per_location = []
 
         for location, available_backends in sorted(smartstack_replication_info.items()):
-            num_available_in_location = available_backends.get(full_name, 0)
+            num_available_in_location = available_backends.get(instance_config.job_id, 0)
             under_replicated, ratio = is_under_replicated(
                 num_available_in_location, expected_count_per_location, crit_threshold,
             )
             if under_replicated:
                 output_critical += '- Service %s has %d out of %d expected instances in %s (CRITICAL: %d%%)\n' % (
-                    full_name, num_available_in_location, expected_count_per_location, location, ratio,
+                    instance_config.job_id, num_available_in_location, expected_count_per_location, location, ratio,
                 )
             else:
                 output_ok += '- Service %s has %d out of %d expected instances in %s (OK: %d%%)\n' % (
-                    full_name, num_available_in_location, expected_count_per_location, location, ratio,
+                    instance_config.job_id, num_available_in_location, expected_count_per_location, location, ratio,
                 )
             under_replication_per_location.append(under_replicated)
 
@@ -210,15 +206,15 @@ def check_smartstack_replication_for_instance(
                 "  * Increase the instance count\n"
                 "\n"
             ) % {
-                'service': service,
-                'instance': instance,
-                'cluster': cluster,
+                'service': instance_config.service,
+                'instance': instance_config.instance,
+                'cluster': instance_config.cluster,
             }
             log.error(output)
         else:
             status = pysensu_yelp.Status.OK
             log.info(output)
-    send_event(service=service, namespace=instance, cluster=cluster, soa_dir=soa_dir, status=status, output=output)
+    send_event(instance_config=instance_config, status=status, output=output)
 
 
 def filter_healthy_marathon_instances_for_short_app_id(all_tasks, app_id):
@@ -235,40 +231,33 @@ def filter_healthy_marathon_instances_for_short_app_id(all_tasks, app_id):
 
 
 def check_healthy_marathon_tasks_for_service_instance(
-    service, instance, cluster,
-    soa_dir, expected_count, all_tasks,
+    instance_config,
+    expected_count,
+    all_tasks,
 ):
-    app_id = format_job_id(service, instance)
+    app_id = format_job_id(instance_config.service, instance_config.instance)
     num_healthy_tasks = filter_healthy_marathon_instances_for_short_app_id(
         all_tasks=all_tasks,
         app_id=app_id,
     )
     log.info("Checking %s in marathon as it is not in smartstack" % app_id)
     send_event_if_under_replication(
-        service=service,
-        instance=instance,
-        cluster=cluster,
+        instance_config=instance_config,
         expected_count=expected_count,
         num_available=num_healthy_tasks,
-        soa_dir=soa_dir,
     )
 
 
 def send_event_if_under_replication(
-    service,
-    instance,
-    cluster,
+    instance_config,
     expected_count,
     num_available,
-    soa_dir,
 ):
-    full_name = compose_job_id(service, instance)
-    job_config = marathon_tools.load_marathon_service_config(service, instance, cluster)
-    crit_threshold = job_config.get_replication_crit_percentage()
+    crit_threshold = instance_config.get_replication_crit_percentage()
     output = (
         'Service %s has %d out of %d expected instances available!\n' +
         '(threshold: %d%%)'
-    ) % (full_name, num_available, expected_count, crit_threshold)
+    ) % (instance_config.job_id, num_available, expected_count, crit_threshold)
     under_replicated, _ = is_under_replicated(num_available, expected_count, crit_threshold)
     if under_replicated:
         output += (
@@ -290,9 +279,9 @@ def send_event_if_under_replication(
             "\n"
             "      paasta status -s %(service)s -i %(instance)s -c %(cluster)s -vv\n"
         ) % {
-            'service': service,
-            'instance': instance,
-            'cluster': cluster,
+            'service': instance_config.service,
+            'instance': instance_config.instance,
+            'cluster': instance_config.cluster,
         }
         log.error(output)
         status = pysensu_yelp.Status.CRITICAL
@@ -300,61 +289,48 @@ def send_event_if_under_replication(
         log.info(output)
         status = pysensu_yelp.Status.OK
     send_event(
-        service=service,
-        namespace=instance,
-        cluster=cluster,
-        soa_dir=soa_dir,
+        instance_config=instance_config,
         status=status,
         output=output,
     )
 
 
 def check_service_replication(
-    service, instance, all_tasks, cluster, soa_dir,
+    instance_config,
+    all_tasks,
     smartstack_replication_checker,
 ):
     """Checks a service's replication levels based on how the service's replication
     should be monitored. (smartstack or mesos)
 
-    :param service: Service name, like "example_service"
-    :param instance: Instance name, like "main" or "canary"
-    :param cluster: name of the cluster
-    :param soa_dir: The SOA configuration directory to read from
+    :param instance_config: an instance of MarathonServiceConfig
     :param smartstack_replication_checker: an instance of SmartstackReplicationChecker
     """
-    job_id = compose_job_id(service, instance)
-    try:
-        expected_count = marathon_tools.get_expected_instance_count_for_namespace(
-            service=service, namespace=instance,
-            cluster=cluster, soa_dir=soa_dir,
-        )
-    except NoDeploymentsAvailable:
-        log.debug('deployments.json missing for %s. Skipping replication monitoring.' % job_id)
-        return
-    if expected_count is None:
-        return
-    log.info("Expecting %d total tasks for %s" % (expected_count, job_id))
+    expected_count = instance_config.get_instances()
+    log.info("Expecting %d total tasks for %s" % (expected_count, instance_config.job_id))
     proxy_port = marathon_tools.get_proxy_port_for_instance(
-        name=service, instance=instance, cluster=cluster, soa_dir=soa_dir,
+        name=instance_config.service,
+        instance=instance_config.instance,
+        cluster=instance_config.cluster,
+        soa_dir=instance_config.soa_dir,
     )
     if proxy_port is not None:
         check_smartstack_replication_for_instance(
-            service=service,
-            instance=instance,
-            cluster=cluster,
-            soa_dir=soa_dir,
+            instance_config=instance_config,
             expected_count=expected_count,
             smartstack_replication_checker=smartstack_replication_checker,
         )
     else:
         check_healthy_marathon_tasks_for_service_instance(
-            service=service,
-            instance=instance,
-            cluster=cluster,
-            soa_dir=soa_dir,
+            instance_config=instance_config,
             expected_count=expected_count,
             all_tasks=all_tasks,
         )
+
+
+def list_services(soa_dir):
+    rootdir = os.path.abspath(soa_dir)
+    return os.listdir(rootdir)
 
 
 def main():
@@ -367,9 +343,6 @@ def main():
 
     system_paasta_config = load_system_paasta_config()
     cluster = system_paasta_config.get_cluster()
-    service_instances = get_services_for_cluster(
-        cluster=cluster, instance_type='marathon', soa_dir=args.soa_dir,
-    )
 
     clients = marathon_tools.get_marathon_clients(marathon_tools.get_marathon_servers(system_paasta_config))
     all_clients = clients.get_all_clients()
@@ -378,16 +351,21 @@ def main():
         all_tasks.extend(client.list_tasks())
     mesos_slaves = get_slaves()
     smartstack_replication_checker = SmartstackReplicationChecker(mesos_slaves, system_paasta_config)
-    for service, instance in service_instances:
 
-        check_service_replication(
-            service=service,
-            instance=instance,
-            cluster=cluster,
-            all_tasks=all_tasks,
-            soa_dir=args.soa_dir,
-            smartstack_replication_checker=smartstack_replication_checker,
-        )
+    for service in list_services(soa_dir=args.soa_dir):
+        service_config = PaastaServiceConfig(service=service, soa_dir=args.soa_dir)
+        for instance_config in service_config.instance_configs(cluster=cluster, instance_type='marathon'):
+            if instance_config.get_docker_image():
+                check_service_replication(
+                    instance_config=instance_config,
+                    all_tasks=all_tasks,
+                    smartstack_replication_checker=smartstack_replication_checker,
+                )
+            else:
+                log.debug(
+                    '%s is not deployed. Skipping replication monitoring.' %
+                    instance_config.job_id,
+                )
 
 
 if __name__ == "__main__":

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -241,6 +241,16 @@ class ChronosJobConfig(InstanceConfig):
             soa_dir=soa_dir,
         )
 
+    def __repr__(self):
+        return "ChronosJobConfig(%r, %r, %r, %r, %r, %r)" % (
+            self.service,
+            self.cluster,
+            self.instance,
+            self.config_dict,
+            self.branch_dict,
+            self.soa_dir,
+        )
+
     def get_service(self):
         return self.service
 

--- a/paasta_tools/paasta_service_config.py
+++ b/paasta_tools/paasta_service_config.py
@@ -161,7 +161,8 @@ class PaastaServiceConfig():
             if self._deployments_json is None:
                 self._deployments_json = load_v2_deployments_json(self._service, soa_dir=self._soa_dir)
             branch = config.get('branch', get_paasta_branch(cluster, instance))
-            return self._deployments_json.get_branch_dict_v2(self._service, branch)
+            deploy_group = config.get('deploy_group', branch)
+            return self._deployments_json.get_branch_dict_v2(self._service, branch, deploy_group)
         else:
             return {}
 

--- a/paasta_tools/paasta_service_config.py
+++ b/paasta_tools/paasta_service_config.py
@@ -33,43 +33,28 @@ log.addHandler(logging.NullHandler())
 
 
 class PaastaServiceConfig():
-    """PaastaServiceConfig provides the public methods described below.
-
-    .. method:: PaastaServiceConfig.clusters
-
-        Returns an iterator that yields cluster names for the service.
-
-    .. method:: PaastaServiceConfig.instances(cluster, instance_type)
-
-        Returns an iterator that yields instance names as strings.
-
-    .. method:: PaastaServiceConfig.instance_configs(cluster, instance_type)
-
-        Returns an iterator that yields InstanceConfig objects.
-
-    .. method:: PaastaServiceConfig.instance_config(cluster, instance)
-
-        Returns an InstanceConfig object for whatever type of instance it is.
+    """PaastaServiceConfig provides useful methods for reading soa-configs and
+    iterating instance names or InstanceConfigs objects.
 
     :Example:
 
-        >>> from paasta_tools.paasta_service_config import PaastaServiceConfig
-        >>> from paasta_tools.utils import DEFAULT_SOA_DIR
-        >>>
-        >>> sc = PaastaServiceConfig(service='fake_service', soa_dir=DEFAULT_SOA_DIR)
-        >>>
-        >>> for instance in sc.instances(cluster='fake_cluster', instance_type='marathon'):
-        ...     print(instance)
-        ...
-        main
-        canary
-        >>>
-        >>> for instance_config in sc.instance_configs(cluster='fake_cluster', instance_type='marathon'):
-        ...     print(instance_config.get_instance())
-        ...
-        main
-        canary
-        >>>
+    >>> from paasta_tools.paasta_service_config import PaastaServiceConfig
+    >>> from paasta_tools.utils import DEFAULT_SOA_DIR
+    >>>
+    >>> sc = PaastaServiceConfig(service='fake_service', soa_dir=DEFAULT_SOA_DIR)
+    >>>
+    >>> for instance in sc.instances(cluster='fake_cluster', instance_type='marathon'):
+    ...     print(instance)
+    ...
+    main
+    canary
+    >>>
+    >>> for instance_config in sc.instance_configs(cluster='fake_cluster', instance_type='marathon'):
+    ...     print(instance_config.get_instance())
+    ...
+    main
+    canary
+    >>>
     """
 
     def __init__(self, service: str, soa_dir: str=DEFAULT_SOA_DIR, load_deployments: bool=True):
@@ -98,7 +83,7 @@ class PaastaServiceConfig():
 
         :param cluster: The cluster name
         :param instance_type: One of paasta_tools.utils.INSTANCE_TYPES
-        :returns: yields instance names
+        :returns: an iterator that yields instance names
         """
         if (cluster, instance_type) not in self._framework_configs:
             self._refresh_framework_config(cluster, instance_type)
@@ -110,7 +95,7 @@ class PaastaServiceConfig():
 
         :param cluster: The cluster name
         :param instance_type: One of paasta_tools.utils.INSTANCE_TYPES
-        :returns: yields instances of MarathonServiceConfig, ChronosJobConfig and etc.
+        :returns: an iterator that yields instances of MarathonServiceConfig, ChronosJobConfig and etc.
         :raises NotImplementedError: when it doesn't know how to create a config for instance_type
         """
         create_config_function = self._get_create_config_function(instance_type)

--- a/paasta_tools/paasta_service_config.py
+++ b/paasta_tools/paasta_service_config.py
@@ -1,0 +1,237 @@
+# Copyright 2015-2017 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+from service_configuration_lib import read_extra_service_information
+from service_configuration_lib import read_service_configuration
+
+from paasta_tools.adhoc_tools import AdhocJobConfig
+from paasta_tools.chronos_tools import ChronosJobConfig
+from paasta_tools.marathon_tools import MarathonServiceConfig
+from paasta_tools.utils import deep_merge_dictionaries
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import get_paasta_branch
+from paasta_tools.utils import INSTANCE_TYPES
+from paasta_tools.utils import list_clusters
+from paasta_tools.utils import load_deployments_json
+from paasta_tools.utils import load_v2_deployments_json
+
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class PaastaServiceConfig():
+    """
+
+    :Example:
+
+        >>> from paasta_tools.paasta_service_config import PaastaServiceConfig
+        >>> from paasta_tools.utils import DEFAULT_SOA_DIR
+        >>>
+        >>> sc = PaastaServiceConfig(service='fake_service', soa_dir=DEFAULT_SOA_DIR)
+        >>>
+        >>> for instance in sc.instances(cluster='fake_cluster', instance_type='marathon'):
+        ...     print(instance)
+        ...
+        main
+        canary
+        >>>
+        >>> for instance_config in sc.instance_configs(cluster='fake_cluster', instance_type='marathon'):
+        ...     print(instance_config.get_instance())
+        ...
+        main
+        canary
+        >>>
+    """
+
+    def __init__(self, service: str, soa_dir: str=DEFAULT_SOA_DIR, load_deployments: bool=True):
+        self._service = service
+        self._soa_dir = soa_dir
+        self._load_deployments = load_deployments
+        self._clusters = None
+        self._general_config = None
+        self._deployments_json = None
+        self._framework_configs = {}
+        self._deployments_json = None
+
+    @property
+    def clusters(self):
+        """Yield cluster names for the service.
+
+        :returns: yields cluster names
+        """
+        if self._clusters is None:
+            self._clusters = list_clusters(service=self._service, soa_dir=self._soa_dir)
+        for cluster in self._clusters:
+            yield cluster
+
+    def instances(self, cluster: str, instance_type: str):
+        """Yield instance names as a string.
+
+        :param cluster: The cluster name
+        :param instance_type: One of paasta_tools.utils.INSTANCE_TYPES
+        :returns: yields instance names
+        """
+        if (cluster, instance_type) not in self._framework_configs:
+            self._refresh_framework_config(cluster, instance_type)
+        for instance in self._framework_configs.get((cluster, instance_type), []):
+            yield instance
+
+    def instance_configs(self, cluster: str, instance_type: str):
+        """Yield instance configs.
+
+        :param cluster: The cluster name
+        :param instance_type: One of paasta_tools.utils.INSTANCE_TYPES
+        :returns: yields instances of MarathonServiceConfig, ChronosJobConfig and etc.
+        :raises NotImplementedError: when it doesn't know how to create a config for instance_type
+        """
+        create_config_function = self._get_create_config_function(instance_type)
+        if (cluster, instance_type) not in self._framework_configs:
+            self._refresh_framework_config(cluster, instance_type)
+        for instance, config in self._framework_configs.get((cluster, instance_type), []).items():
+            yield create_config_function(cluster, instance, config)
+
+    def instance_config(self, cluster: str, instance: str):
+        """Return an InstanceConfig object for whatever type of instance it is.
+
+        :param cluster: The cluster name
+        :param instance: The instance name
+        :returns: instance of MarathonServiceConfig, ChronosJobConfig or None
+        """
+        for instance_type in INSTANCE_TYPES:
+            if (cluster, instance_type) not in self._framework_configs:
+                self._refresh_framework_config(cluster, instance_type)
+            if instance in self._framework_configs:
+                create_config_function = self._get_create_config_function(instance_type)
+                return create_config_function(
+                    cluster=cluster,
+                    instance=instance,
+                    config=self._framework_configs[instance],
+                )
+
+    def _get_create_config_function(self, instance_type: str):
+        f = {
+            'marathon': self._create_marathon_service_config,
+            'chronos': self._create_chronos_service_config,
+            'adhoc': self._create_adhoc_service_config,
+        }.get(instance_type)
+        if f is None:
+            raise NotImplementedError(
+                "instance type %s is not supported by PaastaServiceConfig."
+                % instance_type,
+            )
+        return f
+
+    def _framework_config_filename(self, cluster: str, instance_type: str):
+        return "%s-%s" % (instance_type, cluster)
+
+    def _refresh_framework_config(self, cluster: str, instance_type: str):
+        conf_name = self._framework_config_filename(cluster, instance_type)
+        log.info("Reading configuration file: %s.yaml", conf_name)
+        instances = read_extra_service_information(
+            service_name=self._service,
+            extra_info=conf_name,
+            soa_dir=self._soa_dir,
+        )
+        self._framework_configs[(cluster, instance_type)] = instances
+
+    def _get_branch_dict(self, cluster: str, instance: str, config: dict):
+        if self._load_deployments:
+            if self._deployments_json is None:
+                self._deployments_json = load_deployments_json(self._service, soa_dir=self._soa_dir)
+            branch = config.get('branch', get_paasta_branch(cluster, instance))
+            return self._deployments_json.get_branch_dict(self._service, branch)
+        else:
+            return {}
+
+    def _get_branch_dict_v2(self, cluster: str, instance: str, config: dict):
+        if self._load_deployments:
+            if self._deployments_json is None:
+                self._deployments_json = load_v2_deployments_json(self._service, soa_dir=self._soa_dir)
+            branch = config.get('branch', get_paasta_branch(cluster, instance))
+            return self._deployments_json.get_branch_dict_v2(self._service, branch)
+        else:
+            return {}
+
+    def _get_merged_config(self, config):
+        if self._general_config is None:
+            self._general_config = read_service_configuration(
+                service_name=self._service,
+                soa_dir=self._soa_dir,
+            )
+        return deep_merge_dictionaries(
+            overrides=config,
+            defaults=self._general_config,
+        )
+
+    def _create_marathon_service_config(self, cluster, instance, config):
+        """Create a service instance's configuration for marathon.
+
+        :param cluster: The cluster to read the configuration for
+        :param instance: The instance of the service to retrieve
+        :param config: the framework instance config.
+        :returns: An instance of MarathonServiceConfig
+        """
+        merged_config = self._get_merged_config(config)
+        branch_dict = self._get_branch_dict(cluster, instance, merged_config)
+
+        return MarathonServiceConfig(
+            service=self._service,
+            cluster=cluster,
+            instance=instance,
+            config_dict=merged_config,
+            branch_dict=branch_dict,
+            soa_dir=self._soa_dir,
+        )
+
+    def _create_chronos_service_config(self, cluster, instance, config):
+        """Create a service instance's configuration for chronos.
+
+        :param cluster: The cluster to read the configuration for
+        :param instance: The instance of the service to retrieve
+        :param config:
+        :returns: An instance of ChronosJobConfig
+        """
+        merged_config = self._get_merged_config(config)
+        branch_dict = self._get_branch_dict(cluster, instance, merged_config)
+
+        return ChronosJobConfig(
+            service=self._service,
+            cluster=cluster,
+            instance=instance,
+            config_dict=merged_config,
+            branch_dict=branch_dict,
+            soa_dir=self._soa_dir,
+        )
+
+    def _create_adhoc_service_config(self, cluster, instance, config):
+        """Create a service instance's configuration for the adhoc instance type.
+
+        :param cluster: The cluster to read the configuration for
+        :param instance: The instance of the service to retrieve
+        :param config:
+        :returns: An instance of AdhocJobConfig
+        """
+        merged_config = self._get_merged_config(config)
+        branch_dict = self._get_branch_dict_v2(cluster, instance, merged_config)
+
+        return AdhocJobConfig(
+            service=self._service,
+            cluster=cluster,
+            instance=instance,
+            config_dict=merged_config,
+            branch_dict=branch_dict,
+            soa_dir=self._soa_dir,
+        )

--- a/paasta_tools/paasta_service_config.py
+++ b/paasta_tools/paasta_service_config.py
@@ -33,7 +33,23 @@ log.addHandler(logging.NullHandler())
 
 
 class PaastaServiceConfig():
-    """
+    """PaastaServiceConfig provides the public methods described below.
+
+    .. method:: PaastaServiceConfig.clusters
+
+        Returns an iterator that yields cluster names for the service.
+
+    .. method:: PaastaServiceConfig.instances(cluster, instance_type)
+
+        Returns an iterator that yields instance names as strings.
+
+    .. method:: PaastaServiceConfig.instance_configs(cluster, instance_type)
+
+        Returns an iterator that yields InstanceConfig objects.
+
+    .. method:: PaastaServiceConfig.instance_config(cluster, instance)
+
+        Returns an InstanceConfig object for whatever type of instance it is.
 
     :Example:
 
@@ -68,9 +84,9 @@ class PaastaServiceConfig():
 
     @property
     def clusters(self):
-        """Yield cluster names for the service.
+        """Returns an iterator that yields cluster names for the service.
 
-        :returns: yields cluster names
+        :returns: iterator that yields cluster names.
         """
         if self._clusters is None:
             self._clusters = list_clusters(service=self._service, soa_dir=self._soa_dir)
@@ -78,7 +94,7 @@ class PaastaServiceConfig():
             yield cluster
 
     def instances(self, cluster: str, instance_type: str):
-        """Yield instance names as a string.
+        """Returns an iterator that yields instance names as strings.
 
         :param cluster: The cluster name
         :param instance_type: One of paasta_tools.utils.INSTANCE_TYPES
@@ -90,7 +106,7 @@ class PaastaServiceConfig():
             yield instance
 
     def instance_configs(self, cluster: str, instance_type: str):
-        """Yield instance configs.
+        """Returns an iterator that yields InstanceConfig objects.
 
         :param cluster: The cluster name
         :param instance_type: One of paasta_tools.utils.INSTANCE_TYPES
@@ -104,7 +120,7 @@ class PaastaServiceConfig():
             yield create_config_function(cluster, instance, config)
 
     def instance_config(self, cluster: str, instance: str):
-        """Return an InstanceConfig object for whatever type of instance it is.
+        """Returns an InstanceConfig object for whatever type of instance it is.
 
         :param cluster: The cluster name
         :param instance: The instance name
@@ -113,12 +129,12 @@ class PaastaServiceConfig():
         for instance_type in INSTANCE_TYPES:
             if (cluster, instance_type) not in self._framework_configs:
                 self._refresh_framework_config(cluster, instance_type)
-            if instance in self._framework_configs:
+            if instance in self._framework_configs[(cluster, instance_type)]:
                 create_config_function = self._get_create_config_function(instance_type)
                 return create_config_function(
                     cluster=cluster,
                     instance=instance,
-                    config=self._framework_configs[instance],
+                    config=self._framework_configs[(cluster, instance_type)][instance],
                 )
 
     def _get_create_config_function(self, instance_type: str):

--- a/paasta_tools/paasta_service_config.py
+++ b/paasta_tools/paasta_service_config.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+from typing import Any
+from typing import Dict
+from typing import no_type_check
 
 from service_configuration_lib import read_extra_service_information
 from service_configuration_lib import read_service_configuration
@@ -57,14 +60,14 @@ class PaastaServiceConfig():
     >>>
     """
 
-    def __init__(self, service: str, soa_dir: str=DEFAULT_SOA_DIR, load_deployments: bool=True):
+    def __init__(self, service: str, soa_dir: str=DEFAULT_SOA_DIR, load_deployments: bool=True) -> None:
         self._service = service
         self._soa_dir = soa_dir
         self._load_deployments = load_deployments
         self._clusters = None
         self._general_config = None
         self._deployments_json = None
-        self._framework_configs = {}
+        self._framework_configs: Dict[Any, Any] = {}
         self._deployments_json = None
 
     @property
@@ -148,7 +151,8 @@ class PaastaServiceConfig():
         )
         self._framework_configs[(cluster, instance_type)] = instances
 
-    def _get_branch_dict(self, cluster: str, instance: str, config: dict):
+    @no_type_check
+    def _get_branch_dict(self, cluster: str, instance: str, config: Dict[Any, Any]):
         if self._load_deployments:
             if self._deployments_json is None:
                 self._deployments_json = load_deployments_json(self._service, soa_dir=self._soa_dir)
@@ -157,7 +161,8 @@ class PaastaServiceConfig():
         else:
             return {}
 
-    def _get_branch_dict_v2(self, cluster: str, instance: str, config: dict):
+    @no_type_check
+    def _get_branch_dict_v2(self, cluster: str, instance: str, config: Dict[Any, Any]):
         if self._load_deployments:
             if self._deployments_json is None:
                 self._deployments_json = load_v2_deployments_json(self._service, soa_dir=self._soa_dir)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -249,6 +249,7 @@ class InstanceConfig(object):
         self.instance = instance
         self.service = service
         self.soa_dir = soa_dir
+        self._job_id = compose_job_id(service, instance)
         config_interpolation_keys = ('deploy_group',)
         interpolation_facts = self.__get_interpolation_facts()
         for key in config_interpolation_keys:
@@ -270,6 +271,10 @@ class InstanceConfig(object):
 
     def get_service(self) -> str:
         return self.service
+
+    @property
+    def job_id(self) -> str:
+        return self._job_id
 
     def get_docker_registry(self) -> str:
         return get_service_docker_registry(self.service, self.soa_dir)

--- a/tests/test_paasta_service_config.py
+++ b/tests/test_paasta_service_config.py
@@ -1,0 +1,177 @@
+# Copyright 2015-2017 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from mock import patch
+
+from paasta_tools.chronos_tools import load_chronos_job_config
+from paasta_tools.marathon_tools import load_marathon_service_config
+from paasta_tools.marathon_tools import MarathonServiceConfig
+from paasta_tools.paasta_service_config import PaastaServiceConfig
+from paasta_tools.utils import DeploymentsJson
+
+
+TEST_SERVICE_NAME = 'example_happyhour'
+TEST_SOA_DIR = 'fake_soa_dir'
+TEST_CLUSTER_NAME = 'cluster'
+
+
+def create_test_service():
+    return PaastaServiceConfig(
+        service=TEST_SERVICE_NAME,
+        soa_dir=TEST_SOA_DIR,
+        load_deployments=True,
+    )
+
+
+def deployment_json():
+    return DeploymentsJson({'example_happyhour:paasta-norcal-prod2.main': {
+        'docker_image': 'services-example_happyhour:paasta-ff682c43d474155d708cf751a63d63abb9788b5e',
+        'desired_state': 'start',
+        'force_bounce': None,
+    }})
+
+
+def marathon_cluster_config():
+    """Return a sample dict to mock service_configuration_lib.read_extra_service_information"""
+    return {
+        'main': {
+            'instances': 3, 'deploy_group': 'fake.non_canary',
+            'cpus': 0.1, 'mem': 1000,
+        },
+        'canary': {
+            'instances': 1, 'deploy_group': 'fake.canary',
+            'cpus': 0.1, 'mem': 1000,
+        },
+    }
+
+
+def chronos_cluster_config():
+    """Return a sample dict to mock service_configuration_lib.read_extra_service_information"""
+    return {
+        'example_chronos_job': {
+            'deploy_group': 'prod.non_canary', 'cpus': 0.1, 'mem': 200,
+            'cmd': '/code/virtualenv_run/bin/python -m timeit',
+            'schedule': 'R/2016-04-15T06:00:00Z/PT24H',
+            'schedule_time_zone': 'America/Los_Angeles',
+        },
+        'example_child_job': {
+            'parents': ['example_happyhour.example_chronos_job'],
+            'deploy_group': 'prod.non_canary',
+            'cmd': '/code/virtualenv_run/bin/python -m timeit',
+        },
+    }
+
+
+@patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
+def test_marathon_instances(mock_read_extra_service_information):
+    mock_read_extra_service_information.return_value = marathon_cluster_config()
+    s = create_test_service()
+    assert [i for i in s.instances(TEST_CLUSTER_NAME, 'marathon')] == ['main', 'canary']
+    mock_read_extra_service_information.assert_called_once_with(
+        extra_info='marathon-%s' % TEST_CLUSTER_NAME,
+        service_name=TEST_SERVICE_NAME, soa_dir=TEST_SOA_DIR,
+    )
+
+
+@patch('paasta_tools.paasta_service_config.load_deployments_json', autospec=True)
+@patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
+def test_marathon_instances_configs(
+        mock_read_extra_service_information,
+        mock_load_deployments_json,
+):
+    mock_read_extra_service_information.return_value = marathon_cluster_config()
+    mock_load_deployments_json.return_value = deployment_json()
+    s = create_test_service()
+    expected = [
+        MarathonServiceConfig(
+            TEST_SERVICE_NAME, TEST_CLUSTER_NAME, 'main', {
+                'port': None, 'vip': None,
+                'lb_extras': {}, 'monitoring': {}, 'deploy': {}, 'data': {},
+                'smartstack': {}, 'dependencies': {}, 'instances': 3,
+                'deploy_group': 'fake.non_canary', 'cpus': 0.1, 'mem': 1000,
+            }, {}, TEST_SOA_DIR,
+        ),
+        MarathonServiceConfig(
+            TEST_SERVICE_NAME, TEST_CLUSTER_NAME, 'canary', {
+                'port': None, 'vip': None,
+                'lb_extras': {}, 'monitoring': {}, 'deploy': {}, 'data': {},
+                'smartstack': {}, 'dependencies': {}, 'instances': 1,
+                'deploy_group': 'fake.canary', 'cpus': 0.1, 'mem': 1000,
+            }, {}, TEST_SOA_DIR,
+        ),
+    ]
+    assert [i for i in s.instance_configs(TEST_CLUSTER_NAME, 'marathon')] == expected
+    mock_read_extra_service_information.assert_called_once_with(
+        extra_info='marathon-%s' % TEST_CLUSTER_NAME,
+        service_name=TEST_SERVICE_NAME, soa_dir=TEST_SOA_DIR,
+    )
+    mock_load_deployments_json.assert_called_once_with(
+        TEST_SERVICE_NAME,
+        soa_dir=TEST_SOA_DIR,
+    )
+
+
+@patch('paasta_tools.paasta_service_config.load_deployments_json', autospec=True)
+@patch('paasta_tools.marathon_tools.load_deployments_json', autospec=True)
+@patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
+@patch('paasta_tools.marathon_tools.service_configuration_lib.read_extra_service_information', autospec=True)
+def test_old_and_new_ways_load_the_same_marathon_configs(
+        mock_marathon_tools_read_extra_service_information,
+        mock_read_extra_service_information,
+        mock_marathon_tools_load_deployments_json,
+        mock_load_deployments_json,
+):
+    mock_read_extra_service_information.return_value = marathon_cluster_config()
+    mock_marathon_tools_read_extra_service_information.return_value = marathon_cluster_config()
+    mock_load_deployments_json.return_value = deployment_json()
+    mock_marathon_tools_load_deployments_json.return_value = deployment_json()
+    s = create_test_service()
+    expected = [
+        load_marathon_service_config(
+            service=TEST_SERVICE_NAME, instance='main',
+            cluster=TEST_CLUSTER_NAME, load_deployments=True, soa_dir=TEST_SOA_DIR,
+        ),
+        load_marathon_service_config(
+            service=TEST_SERVICE_NAME, instance='canary',
+            cluster=TEST_CLUSTER_NAME, load_deployments=True, soa_dir=TEST_SOA_DIR,
+        ),
+    ]
+    assert [i for i in s.instance_configs(TEST_CLUSTER_NAME, 'marathon')] == expected
+
+
+@patch('paasta_tools.paasta_service_config.load_deployments_json', autospec=True)
+@patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True)
+@patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
+@patch('paasta_tools.chronos_tools.service_configuration_lib.read_extra_service_information', autospec=True)
+def test_old_and_new_ways_load_the_same_chronos_configs(
+        mock_chronos_tools_read_extra_service_information,
+        mock_read_extra_service_information,
+        mock_chronos_tools_load_deployments_json,
+        mock_load_deployments_json,
+):
+    mock_read_extra_service_information.return_value = chronos_cluster_config()
+    mock_chronos_tools_read_extra_service_information.return_value = chronos_cluster_config()
+    mock_load_deployments_json.return_value = deployment_json()
+    mock_chronos_tools_load_deployments_json.return_value = deployment_json()
+    s = create_test_service()
+    expected = [
+        load_chronos_job_config(
+            service=TEST_SERVICE_NAME, instance='example_chronos_job',
+            cluster=TEST_CLUSTER_NAME, load_deployments=True, soa_dir=TEST_SOA_DIR,
+        ),
+        load_chronos_job_config(
+            service=TEST_SERVICE_NAME, instance='example_child_job',
+            cluster=TEST_CLUSTER_NAME, load_deployments=True, soa_dir=TEST_SOA_DIR,
+        ),
+    ]
+    assert [i for i in s.instance_configs(TEST_CLUSTER_NAME, 'chronos')] == expected


### PR DESCRIPTION
TLDR; An idea of a new way to work with yelpsoa-configs, so that to only read them once and to not use any caches.

Right now to iterate over instances of MarathonServiceConfig, we usually read yelpsoa-configs once  to get the service-instance pairs (get_services_for_cluster), and then we read the same files many times to create MarathonServiceConfig objects (load_marathon_service_config).
Moreover we implemented cache https://github.com/Yelp/paasta/blob/master/paasta_tools/marathon_tools.py#L160 to solve some performance issues caused by this approach.

The idea is to get rid of all the complexity by introducing a new class (PaastaServiceConfig ) which is capable of creating instance configs without re-reading yaml files.
I adjusted check_marathon_services_replication to show how it would look like after switching to PaastaServiceConfig.