### PR TITLE
Rename the bounce_queue to pending_bounces

### DIFF
--- a/paasta_tools/deployd/metrics.py
+++ b/paasta_tools/deployd/metrics.py
@@ -69,20 +69,20 @@ class MeteoriteMetrics(object):
 
 
 class QueueMetrics(PaastaThread):
-    def __init__(self, inbox, bounce_q, cluster, metrics_provider):
+    def __init__(self, inbox, pending_bounces, cluster, metrics_provider):
         super(QueueMetrics, self).__init__()
         self.daemon = True
         self.inbox_q = inbox.inbox_q
         self.inbox = inbox.to_bounce
-        self.bounce_q = bounce_q
+        self.pending_bounces = pending_bounces
         self.metrics = metrics_provider
         self.inbox_q_gauge = self.metrics.create_gauge("inbox_queue", paasta_cluster=cluster)
         self.inbox_gauge = self.metrics.create_gauge("inbox", paasta_cluster=cluster)
-        self.bounce_q_gauge = self.metrics.create_gauge("bounce_queue", paasta_cluster=cluster)
+        self.pending_bounces_gauge = self.metrics.create_gauge("pending_bounces", paasta_cluster=cluster)
 
     def run(self):
         while True:
             self.inbox_q_gauge.set(self.inbox_q.qsize())
             self.inbox_gauge.set(len(self.inbox.keys()))
-            self.bounce_q_gauge.set(self.bounce_q.qsize())
+            self.pending_bounces_gauge.set(self.pending_bounces.qsize())
             time.sleep(20)

--- a/paasta_tools/deployd/workers.py
+++ b/paasta_tools/deployd/workers.py
@@ -12,12 +12,12 @@ BounceResults = namedtuple('BounceResults', ['bounce_again_in_seconds', 'return_
 
 
 class PaastaDeployWorker(PaastaThread):
-    def __init__(self, worker_number, inbox_q, bounce_q, config, metrics_provider):
+    def __init__(self, worker_number, inbox_q, pending_bounces, config, metrics_provider):
         super(PaastaDeployWorker, self).__init__()
         self.daemon = True
         self.name = "Worker{}".format(worker_number)
         self.inbox_q = inbox_q
-        self.bounce_q = bounce_q
+        self.pending_bounces = pending_bounces
         self.metrics = metrics_provider
         self.config = config
         self.cluster = self.config.get_cluster()
@@ -65,7 +65,7 @@ class PaastaDeployWorker(PaastaThread):
     def run(self):
         self.log.info("{} starting up".format(self.name))
         while True:
-            service_instance = self.bounce_q.get()
+            service_instance = self.pending_bounces.get()
             try:
                 bounce_again_in_seconds, return_code, bounce_timers = self.process_service_instance(service_instance)
             except Exception as e:

--- a/tests/deployd/test_deployd_master.py
+++ b/tests/deployd/test_deployd_master.py
@@ -89,9 +89,9 @@ class TestDedupedPriorityQueue(unittest.TestCase):
 
 class TestInbox(unittest.TestCase):
     def setUp(self):
-        self.mock_bounce_q = mock.Mock()
+        self.mock_pending_bounces = mock.Mock()
         self.mock_inbox_q = mock.Mock()
-        self.inbox = Inbox(self.mock_inbox_q, self.mock_bounce_q)
+        self.inbox = Inbox(self.mock_inbox_q, self.mock_pending_bounces)
 
     def test_run(self):
         with mock.patch(
@@ -167,8 +167,8 @@ class TestInbox(unittest.TestCase):
                 'universe.c138': mock_service_instance_2,
             }
             self.inbox.process_to_bounce()
-            self.mock_bounce_q.put.assert_called_with(mock_service_instance_1.priority, mock_service_instance_1)
-            assert self.mock_bounce_q.put.call_count == 1
+            self.mock_pending_bounces.put.assert_called_with(mock_service_instance_1.priority, mock_service_instance_1)
+            assert self.mock_pending_bounces.put.call_count == 1
 
     def tearDown(self):
         self.inbox.to_bounce = {}
@@ -238,7 +238,7 @@ class TestDeployDaemon(unittest.TestCase):
             assert self.deployd.is_leader
             mock_q_metrics.assert_called_with(
                 self.deployd.inbox,
-                self.deployd.bounce_q,
+                self.deployd.pending_bounces,
                 'westeros-prod',
                 mock_get_metrics_interface.return_value,
             )

--- a/tests/deployd/test_metrics.py
+++ b/tests/deployd/test_metrics.py
@@ -52,10 +52,12 @@ class TestQueueMetrics(unittest.TestCase):
         mock_metrics_provider = mock.Mock()
         self.mock_gauge = mock.Mock()
         self.mock_inbox = mock.Mock(inbox_q=mock.Mock(), to_bounce={})
-        self.mock_bounce_q = mock.Mock()
+        self.mock_pending_bounces = mock.Mock()
         mock_create_gauge = mock.Mock(return_value=self.mock_gauge)
         mock_metrics_provider.create_gauge = mock_create_gauge
-        self.metrics = metrics.QueueMetrics(self.mock_inbox, self.mock_bounce_q, "mock-cluster", mock_metrics_provider)
+        self.metrics = metrics.QueueMetrics(
+            self.mock_inbox, self.mock_pending_bounces, "mock-cluster", mock_metrics_provider,
+        )
 
     def test_run(self):
         with mock.patch('time.sleep', autospec=True, side_effect=LoopBreak):

--- a/tests/deployd/test_workers.py
+++ b/tests/deployd/test_workers.py
@@ -13,7 +13,7 @@ from paasta_tools.marathon_tools import DEFAULT_SOA_DIR
 class TestPaastaDeployWorker(unittest.TestCase):
     def setUp(self):
         self.mock_inbox_q = mock.Mock()
-        self.mock_bounce_q = mock.Mock()
+        self.mock_pending_bounces = mock.Mock()
         self.mock_metrics = mock.Mock()
         mock_config = mock.Mock(
             get_cluster=mock.Mock(return_value='westeros-prod'),
@@ -25,7 +25,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
             self.worker = PaastaDeployWorker(
                 1,
                 self.mock_inbox_q,
-                self.mock_bounce_q,
+                self.mock_pending_bounces,
                 mock_config,
                 self.mock_metrics,
             )
@@ -95,7 +95,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 failures=0,
                 priority=0,
             )
-            self.mock_bounce_q.get.return_value = mock_si
+            self.mock_pending_bounces.get.return_value = mock_si
             with raises(LoopBreak):
                 self.worker.run()
             mock_process_service_instance.assert_called_with(self.worker, mock_si)
@@ -127,7 +127,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 failures=0,
                 priority=0,
             )
-            self.mock_bounce_q.get.return_value = mock_si
+            self.mock_pending_bounces.get.return_value = mock_si
             mock_process_service_instance.side_effect = Exception
             mock_queued_si = BaseServiceInstance(
                 service='universe',


### PR DESCRIPTION
I'm going to try renaming things one thing at a time.

Does "pending_bounces" better describe what the bounce_q currently is?