### PR TITLE
PAASTA-12576: Optimize check_marathon_service runtime.

### DIFF
--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -317,7 +317,7 @@ def send_event_if_under_replication(
     )
 
 
-def check_service_replication(client, service, instance, all_tasks, cluster, soa_dir, system_paasta_config):
+def check_service_replication(service, instance, all_tasks, cluster, soa_dir, system_paasta_config):
     """Checks a service's replication levels based on how the service's replication
     should be monitored. (smartstack or mesos)
 
@@ -329,7 +329,10 @@ def check_service_replication(client, service, instance, all_tasks, cluster, soa
     """
     job_id = compose_job_id(service, instance)
     try:
-        expected_count = marathon_tools.get_expected_instance_count_for_namespace(service, instance, soa_dir=soa_dir)
+        expected_count = marathon_tools.get_expected_instance_count_for_namespace(
+            service=service, namespace=instance,
+            cluster=cluster, soa_dir=soa_dir,
+        )
     except NoDeploymentsAvailable:
         log.debug('deployments.json missing for %s. Skipping replication monitoring.' % job_id)
         return
@@ -379,7 +382,6 @@ def main():
     for service, instance in service_instances:
 
         check_service_replication(
-            client=client,
             service=service,
             instance=instance,
             cluster=cluster,

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -129,7 +129,7 @@ def check_smartstack_replication_for_instance(
     full_name = compose_job_id(service, instance)
 
     primary_registration = marathon_tools.read_registration_for_service_instance(
-        service, instance, soa_dir=soa_dir,
+        service, instance, soa_dir=soa_dir, cluster=cluster,
     )
 
     if primary_registration != full_name:
@@ -347,7 +347,9 @@ def check_service_replication(
     if expected_count is None:
         return
     log.info("Expecting %d total tasks for %s" % (expected_count, job_id))
-    proxy_port = marathon_tools.get_proxy_port_for_instance(service, instance, soa_dir=soa_dir)
+    proxy_port = marathon_tools.get_proxy_port_for_instance(
+        name=service, instance=instance, cluster=cluster, soa_dir=soa_dir,
+    )
     if proxy_port is not None:
         check_smartstack_replication_for_instance(
             service=service,

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -77,7 +77,7 @@ def send_event(service, namespace, cluster, soa_dir, status, output):
     monitoring_overrides['runbook'] = monitoring_tools.get_runbook(monitoring_overrides, service, soa_dir=soa_dir)
 
     check_name = 'check_marathon_services_replication.%s' % compose_job_id(service, namespace)
-    monitoring_tools.send_event(service, check_name, monitoring_overrides, status, output, soa_dir)
+    monitoring_tools.send_event(service, check_name, monitoring_overrides, status, output, soa_dir, cluster=cluster)
     _log(
         service=service,
         line='Replication: %s' % output,

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -122,8 +122,7 @@ def check_smartstack_replication_for_instance(
     :param instance: A PaaSTA instance, like "main"
     :param cluster: name of the cluster
     :param soa_dir: The SOA configuration directory to read from
-    :param mesos_slaves: A list of Mesos slaves (see mesos_tools.get_slaves)
-    :param system_paasta_config: A SystemPaastaConfig object representing the system configuration.
+    :param smartstack_replication_checker: an instance of SmartstackReplicationChecker
     """
     full_name = compose_job_id(service, instance)
 
@@ -321,7 +320,7 @@ def check_service_replication(
     :param instance: Instance name, like "main" or "canary"
     :param cluster: name of the cluster
     :param soa_dir: The SOA configuration directory to read from
-        :param smartstack_replication_checker: an instance of SmartstackReplicationChecker
+    :param smartstack_replication_checker: an instance of SmartstackReplicationChecker
     """
     job_id = compose_job_id(service, instance)
     try:
@@ -359,9 +358,7 @@ def check_service_replication(
 
 
 def main():
-
     args = parse_args()
-    soa_dir = args.soa_dir
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
@@ -386,7 +383,7 @@ def main():
             instance=instance,
             cluster=cluster,
             all_tasks=all_tasks,
-            soa_dir=soa_dir,
+            soa_dir=args.soa_dir,
             smartstack_replication_checker=smartstack_replication_checker,
         )
 

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -572,7 +572,6 @@ def get_mesos_slaves_grouped_by_attribute(slaves, attribute):
     }
 
 
-@time_cache(ttl=10)
 def get_slaves():
     return get_mesos_master().fetch("/master/slaves").json()['slaves']
 

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -572,6 +572,7 @@ def get_mesos_slaves_grouped_by_attribute(slaves, attribute):
     }
 
 
+@time_cache(ttl=10)
 def get_slaves():
     return get_mesos_master().fetch("/master/slaves").json()['slaves']
 

--- a/paasta_tools/smartstack_tools.py
+++ b/paasta_tools/smartstack_tools.py
@@ -119,18 +119,13 @@ def get_multiple_backends(services, synapse_host, synapse_port, synapse_haproxy_
     return backends
 
 
-def load_smartstack_info_for_service(
-    service, namespace, blacklist, system_paasta_config,
-    soa_dir=DEFAULT_SOA_DIR, mesos_slaves=None,
-):
+def load_smartstack_info_for_service(service, namespace, blacklist, system_paasta_config, soa_dir=DEFAULT_SOA_DIR):
     """Retrives number of available backends for given services
 
     :param service_instances: A list of tuples of (service, instance)
     :param namespaces: list of Smartstack namespaces
     :param blacklist: A list of blacklisted location tuples in the form (location, value)
-    :param system_paasta_config: A SystemPaastaConfig object representing the system configuration
-    :param mesos_slaves: A list of Mesos slaves (see mesos_tools.get_slaves)
-
+    :param system_paasta_config: A SystemPaastaConfig object representing the system configuration.
     :returns: a dictionary of the form
 
     ::
@@ -155,14 +150,10 @@ def load_smartstack_info_for_service(
         namespace=namespace,
         blacklist=blacklist,
         system_paasta_config=system_paasta_config,
-        mesos_slaves=mesos_slaves,
     )
 
 
-def get_smartstack_replication_for_attribute(
-    attribute, service, namespace, blacklist,
-    system_paasta_config, mesos_slaves=None,
-):
+def get_smartstack_replication_for_attribute(attribute, service, namespace, blacklist, system_paasta_config):
     """Loads smartstack replication from a host with the specified attribute
 
     :param attribute: a Mesos attribute
@@ -171,22 +162,14 @@ def get_smartstack_replication_for_attribute(
     :param constraints: A list of Marathon constraints to restrict which synapse hosts to query
     :param blacklist: A list of blacklisted location tuples in the form of (location, value)
     :param system_paasta_config: A SystemPaastaConfig object representing the system configuration.
-    :param mesos_slaves: A list of Mesos slaves (see mesos_tools.get_slaves)
     :returns: a dictionary of the form {'<unique_attribute_value>': <smartstack replication hash>}
               (the dictionary will contain keys for unique all attribute values)
     """
     replication_info = {}
-    if mesos_slaves is not None:
-        filtered_slaves = mesos_tools.filter_mesos_slaves_by_blacklist(
-            slaves=mesos_slaves,
-            blacklist=blacklist,
-            whitelist=None,
-        )
-    else:
-        filtered_slaves = mesos_tools.get_all_slaves_for_blacklist_whitelist(
-            blacklist=blacklist,
-            whitelist=None,
-        )
+    filtered_slaves = mesos_tools.get_all_slaves_for_blacklist_whitelist(
+        blacklist=blacklist,
+        whitelist=None,
+    )
     if not filtered_slaves:
         raise mesos_tools.NoSlavesAvailableError
 

--- a/paasta_tools/smartstack_tools.py
+++ b/paasta_tools/smartstack_tools.py
@@ -119,13 +119,18 @@ def get_multiple_backends(services, synapse_host, synapse_port, synapse_haproxy_
     return backends
 
 
-def load_smartstack_info_for_service(service, namespace, blacklist, system_paasta_config, soa_dir=DEFAULT_SOA_DIR):
+def load_smartstack_info_for_service(
+    service, namespace, blacklist, system_paasta_config,
+    soa_dir=DEFAULT_SOA_DIR, mesos_slaves=None,
+):
     """Retrives number of available backends for given services
 
     :param service_instances: A list of tuples of (service, instance)
     :param namespaces: list of Smartstack namespaces
     :param blacklist: A list of blacklisted location tuples in the form (location, value)
-    :param system_paasta_config: A SystemPaastaConfig object representing the system configuration.
+    :param system_paasta_config: A SystemPaastaConfig object representing the system configuration
+    :param mesos_slaves: A list of Mesos slaves (see mesos_tools.get_slaves)
+
     :returns: a dictionary of the form
 
     ::
@@ -150,10 +155,14 @@ def load_smartstack_info_for_service(service, namespace, blacklist, system_paast
         namespace=namespace,
         blacklist=blacklist,
         system_paasta_config=system_paasta_config,
+        mesos_slaves=mesos_slaves,
     )
 
 
-def get_smartstack_replication_for_attribute(attribute, service, namespace, blacklist, system_paasta_config):
+def get_smartstack_replication_for_attribute(
+    attribute, service, namespace, blacklist,
+    system_paasta_config, mesos_slaves=None,
+):
     """Loads smartstack replication from a host with the specified attribute
 
     :param attribute: a Mesos attribute
@@ -162,14 +171,22 @@ def get_smartstack_replication_for_attribute(attribute, service, namespace, blac
     :param constraints: A list of Marathon constraints to restrict which synapse hosts to query
     :param blacklist: A list of blacklisted location tuples in the form of (location, value)
     :param system_paasta_config: A SystemPaastaConfig object representing the system configuration.
+    :param mesos_slaves: A list of Mesos slaves (see mesos_tools.get_slaves)
     :returns: a dictionary of the form {'<unique_attribute_value>': <smartstack replication hash>}
               (the dictionary will contain keys for unique all attribute values)
     """
     replication_info = {}
-    filtered_slaves = mesos_tools.get_all_slaves_for_blacklist_whitelist(
-        blacklist=blacklist,
-        whitelist=None,
-    )
+    if mesos_slaves is not None:
+        filtered_slaves = mesos_tools.filter_mesos_slaves_by_blacklist(
+            slaves=mesos_slaves,
+            blacklist=blacklist,
+            whitelist=None,
+        )
+    else:
+        filtered_slaves = mesos_tools.get_all_slaves_for_blacklist_whitelist(
+            blacklist=blacklist,
+            whitelist=None,
+        )
     if not filtered_slaves:
         raise mesos_tools.NoSlavesAvailableError
 

--- a/paasta_tools/smartstack_tools.py
+++ b/paasta_tools/smartstack_tools.py
@@ -194,7 +194,7 @@ def get_smartstack_replication_for_attribute(attribute, service, namespace, blac
     return replication_info
 
 
-def get_replication_for_all_services_from_synapse_haproxy(
+def get_replication_for_all_services(
         synapse_host: str,
         synapse_port: int,
         synapse_haproxy_url_format: str,
@@ -339,7 +339,7 @@ def match_backends_and_tasks(backends, tasks):
 
 
 class SmartstackReplicationChecker:
-    """Retrives the number of regestered instances in each discoverable location.
+    """Retrives the number of registered instances in each discoverable location.
 
     Optimized for multiple queries. Gets the list of backends from synapse-haproxy
     only once per location and reuse it in all subsequent calls of
@@ -371,7 +371,7 @@ class SmartstackReplicationChecker:
         self._cache = {}
 
     def get_replication_for_instance(self, instance_config):
-        """Returns the number of regestered instances in each discoverable location.
+        """Returns the number of registered instances in each discoverable location.
 
         :param instance_config: An instance of MarathonServiceConfig.
         :returns: a dict {'location_type': {'service.instance': int}}
@@ -379,22 +379,22 @@ class SmartstackReplicationChecker:
         replication_info = {}
         attribute_slave_dict = self._get_allowed_locations_and_hostnames(instance_config)
         for location, hosts in attribute_slave_dict.items():
-            replication_info[location] = self._get_replication_info(location, hosts, instance_config)
+            replication_info[location] = self._get_replication_info(location, hosts[0], instance_config)
         return replication_info
 
-    def _get_replication_info(self, location, hosts, instance_config) -> Dict[str, int]:
+    def _get_replication_info(self, location, hostname, instance_config) -> Dict[str, int]:
         """Returns service.instance and the number of instances registered in smartstack
         at the location as a dict.
 
         :param location: A string that identifies a habitat, a region and etc.
-        :param hosts: A list of mesos slave hostnames in this location.
+        :param hostname: A mesos slave hostname to read replication information from.
         :param instance_config: An instance of MarathonServiceConfig.
         :returns: A dict {"service.instance": number_of_instances}.
         """
         full_name = compose_job_id(instance_config.service, instance_config.instance)
         if location not in self._cache:
-            self._cache[location] = get_replication_for_all_services_from_synapse_haproxy(
-                synapse_host=hosts[0],
+            self._cache[location] = get_replication_for_all_services(
+                synapse_host=hostname,
                 synapse_port=self._synapse_port,
                 synapse_haproxy_url_format=self._synapse_haproxy_url_format,
             )

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -555,9 +555,8 @@ def test_check_service_replication_for_normal_smartstack():
         'paasta_tools.check_marathon_services_replication.check_smartstack_replication_for_instance',
         autospec=True,
     ) as mock_check_smartstack_replication_for_service:
-        mock_client = mock.Mock()
         check_marathon_services_replication.check_service_replication(
-            client=mock_client, service=service, instance=instance, cluster=cluster, soa_dir=None,
+            service=service, instance=instance, cluster=cluster, soa_dir=None,
             system_paasta_config=fake_system_paasta_config, all_tasks=all_tasks,
         )
         mock_check_smartstack_replication_for_service.assert_called_once_with(
@@ -584,9 +583,7 @@ def test_check_service_replication_for_non_smartstack():
         'paasta_tools.check_marathon_services_replication.check_healthy_marathon_tasks_for_service_instance',
         autospec=True,
     ) as mock_check_healthy_marathon_tasks:
-        mock_client = mock.Mock()
         check_marathon_services_replication.check_service_replication(
-            client=mock_client,
             all_tasks=[],
             service=service,
             instance=instance,
@@ -698,10 +695,9 @@ def test_check_service_replication_for_namespace_with_no_deployments():
         'paasta_tools.marathon_tools.get_expected_instance_count_for_namespace',
         autospec=True,
     ) as mock_get_expected_count:
-        mock_client = mock.Mock()
         mock_get_expected_count.side_effect = check_marathon_services_replication.NoDeploymentsAvailable
         check_marathon_services_replication.check_service_replication(
-            client=mock_client, service=service, instance=instance, cluster=cluster, soa_dir=None,
+            service=service, instance=instance, cluster=cluster, soa_dir=None,
             system_paasta_config=fake_system_paasta_config, all_tasks=[],
         )
         assert mock_get_proxy_port_for_instance.call_count == 0

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -54,12 +54,13 @@ def test_send_event_users_monitoring_tools_send_event_properly():
             fake_output,
         )
         send_event_patch.assert_called_once_with(
-            fake_service_name,
-            expected_check_name,
-            mock.ANY,
-            fake_status,
-            fake_output,
-            fake_soa_dir,
+            service=fake_service_name,
+            check_name=expected_check_name,
+            overrides=mock.ANY,
+            status=fake_status,
+            output=fake_output,
+            soa_dir=fake_soa_dir,
+            cluster=fake_cluster,
         )
         # The overrides dictionary is mutated in the function under test, so
         # we expect the send_event_patch to be called with something that is a
@@ -105,6 +106,7 @@ def test_send_event_users_monitoring_tools_send_event_respects_alert_after():
             fake_status,
             fake_output,
             fake_soa_dir,
+            cluster=fake_cluster,
         )
         # The overrides dictionary is mutated in the function under test, so
         # we expect the send_event_patch to be called with something that is a

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -125,7 +125,6 @@ def test_check_smartstack_replication_for_instance_ok_when_expecting_zero():
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
-    mesos_slaves = []
 
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
@@ -145,7 +144,6 @@ def test_check_smartstack_replication_for_instance_ok_when_expecting_zero():
 
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
-            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -166,7 +164,6 @@ def test_check_smartstack_replication_for_instance_crit_when_absent():
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
-    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -183,7 +180,6 @@ def test_check_smartstack_replication_for_instance_crit_when_absent():
         mock_load_marathon_service_config.return_value = mock_service_job_config
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
-            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -204,7 +200,6 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication():
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
-    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -221,7 +216,6 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication():
         mock_load_marathon_service_config.return_value = mock_service_job_config
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
-            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -246,7 +240,6 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication():
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
-    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -263,7 +256,6 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication():
         mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
-            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -288,7 +280,6 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication():
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
-    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -305,7 +296,6 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication():
         mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
-            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -330,7 +320,6 @@ def test_check_smartstack_replication_for_instance_ignores_things_under_a_differ
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
-    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event_if_under_replication', autospec=True,
     ) as mock_send_event_if_under_replication, mock.patch(
@@ -347,7 +336,6 @@ def test_check_smartstack_replication_for_instance_ignores_things_under_a_differ
         mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
-            mesos_slaves=mesos_slaves,
         )
         mock_send_event_if_under_replication.call_count == 0
 
@@ -361,7 +349,6 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication_mu
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
-    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -378,7 +365,6 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication_mu
         mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
-            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -403,7 +389,6 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication_mul
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
-    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -420,7 +405,6 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication_mul
         mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
-            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -446,7 +430,6 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication_mu
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
-    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -463,7 +446,6 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication_mu
         mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
-            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -489,7 +471,6 @@ def test_check_smartstack_replication_for_instance_crit_when_missing_replication
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
-    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -506,7 +487,6 @@ def test_check_smartstack_replication_for_instance_crit_when_missing_replication
         mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
-            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -530,7 +510,6 @@ def test_check_smartstack_replication_for_instance_crit_when_no_smartstack_info(
     expected_replication_count = 2
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
-    mesos_slaves = []
     crit = 90
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
@@ -548,7 +527,6 @@ def test_check_smartstack_replication_for_instance_crit_when_no_smartstack_info(
         mock_load_marathon_service_config.return_value = mock_service_job_config
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
-            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -569,7 +547,6 @@ def test_check_service_replication_for_normal_smartstack():
     cluster = 'fake_cluster'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     all_tasks = []
-    mesos_slaves = []
     with mock.patch(
         'paasta_tools.marathon_tools.get_proxy_port_for_instance',
         autospec=True, return_value=666,
@@ -583,7 +560,6 @@ def test_check_service_replication_for_normal_smartstack():
         check_marathon_services_replication.check_service_replication(
             service=service, instance=instance, cluster=cluster, soa_dir=None,
             system_paasta_config=fake_system_paasta_config, all_tasks=all_tasks,
-            mesos_slaves=mesos_slaves,
         )
         mock_check_smartstack_replication_for_service.assert_called_once_with(
             service=service,
@@ -592,7 +568,6 @@ def test_check_service_replication_for_normal_smartstack():
             soa_dir=None,
             expected_count=100,
             system_paasta_config=fake_system_paasta_config,
-            mesos_slaves=mesos_slaves,
         )
 
 
@@ -617,7 +592,6 @@ def test_check_service_replication_for_non_smartstack():
             cluster=cluster,
             soa_dir=None,
             system_paasta_config=fake_system_paasta_config,
-            mesos_slaves=[],
         )
 
         mock_check_healthy_marathon_tasks.assert_called_once_with(
@@ -726,7 +700,7 @@ def test_check_service_replication_for_namespace_with_no_deployments():
         mock_get_expected_count.side_effect = check_marathon_services_replication.NoDeploymentsAvailable
         check_marathon_services_replication.check_service_replication(
             service=service, instance=instance, cluster=cluster, soa_dir=None,
-            system_paasta_config=fake_system_paasta_config, all_tasks=[], mesos_slaves=[],
+            system_paasta_config=fake_system_paasta_config, all_tasks=[],
         )
         assert mock_get_proxy_port_for_instance.call_count == 0
 
@@ -859,10 +833,7 @@ def test_main():
     ) as mock_load_marathon_config, mock.patch(
         'paasta_tools.check_marathon_services_replication.marathon_tools.get_marathon_client',
         autospec=True,
-    ) as mock_get_marathon_client, mock.patch(
-        'paasta_tools.check_marathon_services_replication.get_slaves',
-        autospec=True,
-    ) as mock_get_slaves:
+    ) as mock_get_marathon_client:
         mock_client = mock.Mock()
         mock_client.list_tasks.return_value = []
         mock_get_marathon_client.return_value = mock_client
@@ -874,4 +845,3 @@ def test_main():
         mock_get_services_for_cluster.assert_called_once_with(
             cluster='fake_cluster', instance_type='marathon', soa_dir=soa_dir,
         )
-        assert mock_get_slaves.called

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -123,6 +123,7 @@ def test_check_smartstack_replication_for_instance_ok_when_expecting_zero():
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mesos_slaves = []
 
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
@@ -142,6 +143,7 @@ def test_check_smartstack_replication_for_instance_ok_when_expecting_zero():
 
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -162,6 +164,7 @@ def test_check_smartstack_replication_for_instance_crit_when_absent():
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -178,6 +181,7 @@ def test_check_smartstack_replication_for_instance_crit_when_absent():
         mock_load_marathon_service_config.return_value = mock_service_job_config
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -198,6 +202,7 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication():
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -214,6 +219,7 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication():
         mock_load_marathon_service_config.return_value = mock_service_job_config
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -238,6 +244,7 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication():
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -254,6 +261,7 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication():
         mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -278,6 +286,7 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication():
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -294,6 +303,7 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication():
         mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -318,6 +328,7 @@ def test_check_smartstack_replication_for_instance_ignores_things_under_a_differ
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event_if_under_replication', autospec=True,
     ) as mock_send_event_if_under_replication, mock.patch(
@@ -334,6 +345,7 @@ def test_check_smartstack_replication_for_instance_ignores_things_under_a_differ
         mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            mesos_slaves=mesos_slaves,
         )
         mock_send_event_if_under_replication.call_count == 0
 
@@ -347,6 +359,7 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication_mu
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -363,6 +376,7 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication_mu
         mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -387,6 +401,7 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication_mul
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -403,6 +418,7 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication_mul
         mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -428,6 +444,7 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication_mu
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -444,6 +461,7 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication_mu
         mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -469,6 +487,7 @@ def test_check_smartstack_replication_for_instance_crit_when_missing_replication
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mesos_slaves = []
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
@@ -485,6 +504,7 @@ def test_check_smartstack_replication_for_instance_crit_when_missing_replication
         mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -508,6 +528,7 @@ def test_check_smartstack_replication_for_instance_crit_when_no_smartstack_info(
     expected_replication_count = 2
     soa_dir = 'test_dir'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
+    mesos_slaves = []
     crit = 90
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
@@ -525,6 +546,7 @@ def test_check_smartstack_replication_for_instance_crit_when_no_smartstack_info(
         mock_load_marathon_service_config.return_value = mock_service_job_config
         check_marathon_services_replication.check_smartstack_replication_for_instance(
             service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            mesos_slaves=mesos_slaves,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -545,6 +567,7 @@ def test_check_service_replication_for_normal_smartstack():
     cluster = 'fake_cluster'
     fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     all_tasks = []
+    mesos_slaves = []
     with mock.patch(
         'paasta_tools.marathon_tools.get_proxy_port_for_instance',
         autospec=True, return_value=666,
@@ -558,6 +581,7 @@ def test_check_service_replication_for_normal_smartstack():
         check_marathon_services_replication.check_service_replication(
             service=service, instance=instance, cluster=cluster, soa_dir=None,
             system_paasta_config=fake_system_paasta_config, all_tasks=all_tasks,
+            mesos_slaves=mesos_slaves,
         )
         mock_check_smartstack_replication_for_service.assert_called_once_with(
             service=service,
@@ -566,6 +590,7 @@ def test_check_service_replication_for_normal_smartstack():
             soa_dir=None,
             expected_count=100,
             system_paasta_config=fake_system_paasta_config,
+            mesos_slaves=mesos_slaves,
         )
 
 
@@ -590,6 +615,7 @@ def test_check_service_replication_for_non_smartstack():
             cluster=cluster,
             soa_dir=None,
             system_paasta_config=fake_system_paasta_config,
+            mesos_slaves=[],
         )
 
         mock_check_healthy_marathon_tasks.assert_called_once_with(
@@ -698,7 +724,7 @@ def test_check_service_replication_for_namespace_with_no_deployments():
         mock_get_expected_count.side_effect = check_marathon_services_replication.NoDeploymentsAvailable
         check_marathon_services_replication.check_service_replication(
             service=service, instance=instance, cluster=cluster, soa_dir=None,
-            system_paasta_config=fake_system_paasta_config, all_tasks=[],
+            system_paasta_config=fake_system_paasta_config, all_tasks=[], mesos_slaves=[],
         )
         assert mock_get_proxy_port_for_instance.call_count == 0
 
@@ -831,7 +857,10 @@ def test_main():
     ) as mock_load_marathon_config, mock.patch(
         'paasta_tools.check_marathon_services_replication.marathon_tools.get_marathon_client',
         autospec=True,
-    ) as mock_get_marathon_client:
+    ) as mock_get_marathon_client, mock.patch(
+        'paasta_tools.check_marathon_services_replication.get_slaves',
+        autospec=True,
+    ) as mock_get_slaves:
         mock_client = mock.Mock()
         mock_client.list_tasks.return_value = []
         mock_get_marathon_client.return_value = mock_client
@@ -843,3 +872,4 @@ def test_main():
         mock_get_services_for_cluster.assert_called_once_with(
             cluster='fake_cluster', instance_type='marathon', soa_dir=soa_dir,
         )
+        assert mock_get_slaves.called

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -20,7 +20,6 @@ import pysensu_yelp
 from paasta_tools import check_marathon_services_replication
 from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.utils import compose_job_id
-from paasta_tools.utils import SystemPaastaConfig
 
 check_marathon_services_replication.log = mock.Mock()
 
@@ -120,11 +119,12 @@ def test_check_smartstack_replication_for_instance_ok_when_expecting_zero():
     service = 'test'
     instance = 'main'
     cluster = 'fake_cluster'
-    available = {'fake_region': {'test.main': 1, 'test.three': 4, 'test.four': 8}}
     expected_replication_count = 0
     soa_dir = 'test_dir'
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mock_smartstack_replication_checker = mock.Mock()
+    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
+        {'fake_region': {'test.main': 1, 'test.three': 4, 'test.four': 8}}
 
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
@@ -132,18 +132,16 @@ def test_check_smartstack_replication_for_instance_ok_when_expecting_zero():
         'paasta_tools.marathon_tools.read_registration_for_service_instance',
         autospec=True, return_value=compose_job_id(service, instance),
     ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True,
-    ) as mock_load_smartstack_info_for_service, mock.patch(
         'paasta_tools.marathon_tools.load_marathon_service_config', autospec=True,
     ) as mock_load_marathon_service_config:
-        mock_load_smartstack_info_for_service.return_value = available
 
         mock_service_job_config = mock.MagicMock(spec_set=MarathonServiceConfig)
         mock_service_job_config.get_replication_crit_percentage.return_value = crit
         mock_load_marathon_service_config.return_value = mock_service_job_config
 
         check_marathon_services_replication.check_smartstack_replication_for_instance(
-            service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            service, instance, cluster, soa_dir, expected_replication_count,
+            smartstack_replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -159,27 +157,26 @@ def test_check_smartstack_replication_for_instance_crit_when_absent():
     service = 'test'
     instance = 'some_absent_instance'
     cluster = 'fake_cluster'
-    available = {'fake_region': {'test.two': 1, 'test.three': 4, 'test.four': 8}}
     expected_replication_count = 8
     soa_dir = 'test_dir'
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mock_smartstack_replication_checker = mock.Mock()
+    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
+        {'fake_region': {'test.two': 1, 'test.three': 4, 'test.four': 8}}
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
         'paasta_tools.marathon_tools.read_registration_for_service_instance',
         autospec=True, return_value=compose_job_id(service, instance),
     ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True,
-    ) as mock_load_smartstack_info_for_service, mock.patch(
         'paasta_tools.marathon_tools.load_marathon_service_config', autospec=True,
     ) as mock_load_marathon_service_config:
-        mock_load_smartstack_info_for_service.return_value = available
         mock_service_job_config = mock.MagicMock(spec_set=MarathonServiceConfig)
         mock_service_job_config.get_replication_crit_percentage.return_value = crit
         mock_load_marathon_service_config.return_value = mock_service_job_config
         check_marathon_services_replication.check_smartstack_replication_for_instance(
-            service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            service, instance, cluster, soa_dir, expected_replication_count,
+            smartstack_replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -195,27 +192,26 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication():
     service = 'test'
     instance = 'zero_running'
     cluster = 'fake_cluster'
-    available = {'fake_region': {'test.zero_running': 0, 'test.main': 8, 'test.fully_replicated': 8}}
     expected_replication_count = 8
     soa_dir = 'test_dir'
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mock_smartstack_replication_checker = mock.Mock()
+    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
+        {'fake_region': {'test.zero_running': 0, 'test.main': 8, 'test.fully_replicated': 8}}
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
         'paasta_tools.marathon_tools.read_registration_for_service_instance',
         autospec=True, return_value=compose_job_id(service, instance),
     ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True,
-    ) as mock_load_smartstack_info_for_service, mock.patch(
         'paasta_tools.marathon_tools.load_marathon_service_config', autospec=True,
     ) as mock_load_marathon_service_config:
-        mock_load_smartstack_info_for_service.return_value = available
         mock_service_job_config = mock.MagicMock(spec_set=MarathonServiceConfig)
         mock_service_job_config.get_replication_crit_percentage.return_value = crit
         mock_load_marathon_service_config.return_value = mock_service_job_config
         check_marathon_services_replication.check_smartstack_replication_for_instance(
-            service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            service, instance, cluster, soa_dir, expected_replication_count,
+            smartstack_replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -235,27 +231,26 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication():
     service = 'test'
     instance = 'not_enough'
     cluster = 'fake_cluster'
-    available = {'fake_region': {'test.canary': 1, 'test.not_enough': 4, 'test.fully_replicated': 8}}
     expected_replication_count = 8
     soa_dir = 'test_dir'
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mock_smartstack_replication_checker = mock.Mock()
+    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
+        {'fake_region': {'test.canary': 1, 'test.not_enough': 4, 'test.fully_replicated': 8}}
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
         'paasta_tools.marathon_tools.read_registration_for_service_instance',
         autospec=True, return_value=compose_job_id(service, instance),
     ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True,
-    ) as mock_load_smartstack_info_for_service, mock.patch(
         'paasta_tools.marathon_tools.load_marathon_service_config', autospec=True,
     ) as mock_load_marathon_service_config:
         mock_service_job_config = mock.MagicMock(spec_set=MarathonServiceConfig)
         mock_service_job_config.get_replication_crit_percentage.return_value = crit
         mock_load_marathon_service_config.return_value = mock_service_job_config
-        mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
-            service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            service, instance, cluster, soa_dir, expected_replication_count,
+            smartstack_replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -275,27 +270,26 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication():
     service = 'test'
     instance = 'everything_up'
     cluster = 'fake_cluster'
-    available = {'fake_region': {'test.canary': 1, 'test.low_replication': 4, 'test.everything_up': 8}}
     expected_replication_count = 8
     soa_dir = 'test_dir'
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mock_smartstack_replication_checker = mock.Mock()
+    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
+        {'fake_region': {'test.canary': 1, 'test.low_replication': 4, 'test.everything_up': 8}}
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
         'paasta_tools.marathon_tools.read_registration_for_service_instance',
         autospec=True, return_value=compose_job_id(service, instance),
     ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True,
-    ) as mock_load_smartstack_info_for_service, mock.patch(
         'paasta_tools.marathon_tools.load_marathon_service_config', autospec=True,
     ) as mock_load_marathon_service_config:
         mock_service_job_config = mock.MagicMock(spec_set=MarathonServiceConfig)
         mock_service_job_config.get_replication_crit_percentage.return_value = crit
         mock_load_marathon_service_config.return_value = mock_service_job_config
-        mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
-            service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            service, instance, cluster, soa_dir, expected_replication_count,
+            smartstack_replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -315,27 +309,26 @@ def test_check_smartstack_replication_for_instance_ignores_things_under_a_differ
     instance = 'main'
     namespace = 'canary'
     cluster = 'fake_cluster'
-    available = {'fake_region': {'test.canary': 1, 'test.main': 4, 'test.fully_replicated': 8}}
     expected_replication_count = 8
     soa_dir = 'test_dir'
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mock_smartstack_replication_checker = mock.Mock()
+    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
+        {'fake_region': {'test.canary': 1, 'test.main': 4, 'test.fully_replicated': 8}}
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event_if_under_replication', autospec=True,
     ) as mock_send_event_if_under_replication, mock.patch(
         'paasta_tools.marathon_tools.read_registration_for_service_instance',
         autospec=True, return_value=namespace,
     ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True,
-    ) as mock_load_smartstack_info_for_service, mock.patch(
         'paasta_tools.marathon_tools.load_marathon_service_config', autospec=True,
     ) as mock_load_marathon_service_config:
         mock_service_job_config = mock.MagicMock(spec_set=MarathonServiceConfig)
         mock_service_job_config.get_replication_crit_percentage.return_value = crit
         mock_load_marathon_service_config.return_value = mock_service_job_config
-        mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
-            service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            service, instance, cluster, soa_dir, expected_replication_count,
+            smartstack_replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_event_if_under_replication.call_count == 0
 
@@ -344,27 +337,29 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication_mu
     service = 'test'
     instance = 'everything_up'
     cluster = 'fake_cluster'
-    available = {'fake_region': {'test.everything_up': 1}, 'fake_other_region': {'test.everything_up': 1}}
     expected_replication_count = 2
     soa_dir = 'test_dir'
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mock_smartstack_replication_checker = mock.Mock()
+    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
+        {
+            'fake_region': {'test.everything_up': 1}, 'fake_other_region':
+            {'test.everything_up': 1},
+        }
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
         'paasta_tools.marathon_tools.read_registration_for_service_instance',
         autospec=True, return_value=compose_job_id(service, instance),
     ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True,
-    ) as mock_load_smartstack_info_for_service, mock.patch(
         'paasta_tools.marathon_tools.load_marathon_service_config', autospec=True,
     ) as mock_load_marathon_service_config:
         mock_service_job_config = mock.MagicMock(spec_set=MarathonServiceConfig)
         mock_service_job_config.get_replication_crit_percentage.return_value = crit
         mock_load_marathon_service_config.return_value = mock_service_job_config
-        mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
-            service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            service, instance, cluster, soa_dir, expected_replication_count,
+            smartstack_replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -384,27 +379,29 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication_mul
     service = 'test'
     instance = 'low_replication'
     cluster = 'fake_cluster'
-    available = {'fake_region': {'test.low_replication': 1}, 'fake_other_region': {'test.low_replication': 0}}
     expected_replication_count = 2
     soa_dir = 'test_dir'
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mock_smartstack_replication_checker = mock.Mock()
+    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
+        {
+            'fake_region': {'test.low_replication': 1}, 'fake_other_region':
+            {'test.low_replication': 0},
+        }
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
         'paasta_tools.marathon_tools.read_registration_for_service_instance',
         autospec=True, return_value=compose_job_id(service, instance),
     ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True,
-    ) as mock_load_smartstack_info_for_service, mock.patch(
         'paasta_tools.marathon_tools.load_marathon_service_config', autospec=True,
     ) as mock_load_marathon_service_config:
         mock_service_job_config = mock.MagicMock(spec_set=MarathonServiceConfig)
         mock_service_job_config.get_replication_crit_percentage.return_value = crit
         mock_load_marathon_service_config.return_value = mock_service_job_config
-        mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
-            service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            service, instance, cluster, soa_dir, expected_replication_count,
+            smartstack_replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -425,27 +422,29 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication_mu
     service = 'test'
     instance = 'zero_running'
     cluster = 'fake_cluster'
-    available = {'fake_region': {'test.zero_running': 0}, 'fake_other_region': {'test.zero_running': 0}}
     expected_replication_count = 2
     soa_dir = 'test_dir'
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mock_smartstack_replication_checker = mock.Mock()
+    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
+        {
+            'fake_region': {'test.zero_running': 0}, 'fake_other_region':
+            {'test.zero_running': 0},
+        }
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
         'paasta_tools.marathon_tools.read_registration_for_service_instance',
         autospec=True, return_value=compose_job_id(service, instance),
     ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True,
-    ) as mock_load_smartstack_info_for_service, mock.patch(
         'paasta_tools.marathon_tools.load_marathon_service_config', autospec=True,
     ) as mock_load_marathon_service_config:
         mock_service_job_config = mock.MagicMock(spec_set=MarathonServiceConfig)
         mock_service_job_config.get_replication_crit_percentage.return_value = crit
         mock_load_marathon_service_config.return_value = mock_service_job_config
-        mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
-            service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            service, instance, cluster, soa_dir, expected_replication_count,
+            smartstack_replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -466,27 +465,26 @@ def test_check_smartstack_replication_for_instance_crit_when_missing_replication
     service = 'test'
     instance = 'missing_instance'
     cluster = 'fake_cluster'
-    available = {'fake_region': {'test.main': 0}, 'fake_other_region': {'test.main': 0}}
     expected_replication_count = 2
     soa_dir = 'test_dir'
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mock_smartstack_replication_checker = mock.Mock()
+    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
+        {'fake_region': {'test.main': 0}, 'fake_other_region': {'test.main': 0}}
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
         'paasta_tools.marathon_tools.read_registration_for_service_instance',
         autospec=True, return_value=compose_job_id(service, instance),
     ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True,
-    ) as mock_load_smartstack_info_for_service, mock.patch(
         'paasta_tools.marathon_tools.load_marathon_service_config', autospec=True,
     ) as mock_load_marathon_service_config:
         mock_service_job_config = mock.MagicMock(spec_set=MarathonServiceConfig)
         mock_service_job_config.get_replication_crit_percentage.return_value = crit
         mock_load_marathon_service_config.return_value = mock_service_job_config
-        mock_load_smartstack_info_for_service.return_value = available
         check_marathon_services_replication.check_smartstack_replication_for_instance(
-            service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            service, instance, cluster, soa_dir, expected_replication_count,
+            smartstack_replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -506,27 +504,25 @@ def test_check_smartstack_replication_for_instance_crit_when_no_smartstack_info(
     service = 'test'
     instance = 'some_instance'
     cluster = 'fake_cluster'
-    available = {}
     expected_replication_count = 2
     soa_dir = 'test_dir'
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     crit = 90
+    mock_smartstack_replication_checker = mock.Mock()
+    mock_smartstack_replication_checker.get_replication_for_instance.return_value = {}
     with mock.patch(
         'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
     ) as mock_send_event, mock.patch(
         'paasta_tools.marathon_tools.read_registration_for_service_instance',
         autospec=True, return_value=compose_job_id(service, instance),
     ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.load_smartstack_info_for_service', autospec=True,
-    ) as mock_load_smartstack_info_for_service, mock.patch(
         'paasta_tools.marathon_tools.load_marathon_service_config', autospec=True,
     ) as mock_load_marathon_service_config:
-        mock_load_smartstack_info_for_service.return_value = available
         mock_service_job_config = mock.MagicMock(spec_set=MarathonServiceConfig)
         mock_service_job_config.get_replication_crit_percentage.return_value = crit
         mock_load_marathon_service_config.return_value = mock_service_job_config
         check_marathon_services_replication.check_smartstack_replication_for_instance(
-            service, instance, cluster, soa_dir, expected_replication_count, fake_system_paasta_config,
+            service, instance, cluster, soa_dir, expected_replication_count,
+            smartstack_replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_event.assert_called_once_with(
             service=service,
@@ -545,7 +541,6 @@ def test_check_service_replication_for_normal_smartstack():
     service = 'test_service'
     instance = 'test_instance'
     cluster = 'fake_cluster'
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     all_tasks = []
     with mock.patch(
         'paasta_tools.marathon_tools.get_proxy_port_for_instance',
@@ -559,7 +554,7 @@ def test_check_service_replication_for_normal_smartstack():
     ) as mock_check_smartstack_replication_for_service:
         check_marathon_services_replication.check_service_replication(
             service=service, instance=instance, cluster=cluster, soa_dir=None,
-            system_paasta_config=fake_system_paasta_config, all_tasks=all_tasks,
+            all_tasks=all_tasks, smartstack_replication_checker=None,
         )
         mock_check_smartstack_replication_for_service.assert_called_once_with(
             service=service,
@@ -567,7 +562,7 @@ def test_check_service_replication_for_normal_smartstack():
             cluster=cluster,
             soa_dir=None,
             expected_count=100,
-            system_paasta_config=fake_system_paasta_config,
+            smartstack_replication_checker=None,
         )
 
 
@@ -575,7 +570,7 @@ def test_check_service_replication_for_non_smartstack():
     service = 'test_service'
     instance = 'worker'
     cluster = 'fake_cluster'
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
+
     with mock.patch(
         'paasta_tools.marathon_tools.get_proxy_port_for_instance', autospec=True, return_value=None,
     ), mock.patch(
@@ -591,7 +586,7 @@ def test_check_service_replication_for_non_smartstack():
             instance=instance,
             cluster=cluster,
             soa_dir=None,
-            system_paasta_config=fake_system_paasta_config,
+            smartstack_replication_checker=None,
         )
 
         mock_check_healthy_marathon_tasks.assert_called_once_with(
@@ -689,7 +684,6 @@ def test_check_service_replication_for_namespace_with_no_deployments():
     service = 'test_service'
     instance = 'worker'
     cluster = 'fake_cluster'
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
 
     with mock.patch(
         'paasta_tools.marathon_tools.get_proxy_port_for_instance', autospec=True, return_value=None,
@@ -700,7 +694,7 @@ def test_check_service_replication_for_namespace_with_no_deployments():
         mock_get_expected_count.side_effect = check_marathon_services_replication.NoDeploymentsAvailable
         check_marathon_services_replication.check_service_replication(
             service=service, instance=instance, cluster=cluster, soa_dir=None,
-            system_paasta_config=fake_system_paasta_config, all_tasks=[],
+            all_tasks=[], smartstack_replication_checker=None,
         )
         assert mock_get_proxy_port_for_instance.call_count == 0
 
@@ -833,7 +827,10 @@ def test_main():
     ) as mock_load_marathon_config, mock.patch(
         'paasta_tools.check_marathon_services_replication.marathon_tools.get_marathon_client',
         autospec=True,
-    ) as mock_get_marathon_client:
+    ) as mock_get_marathon_client, mock.patch(
+        'paasta_tools.check_marathon_services_replication.get_slaves',
+        autospec=True,
+    ):
         mock_client = mock.Mock()
         mock_client.list_tasks.return_value = []
         mock_get_marathon_client.return_value = mock_client

--- a/tests/test_smartstack_tools.py
+++ b/tests/test_smartstack_tools.py
@@ -234,3 +234,40 @@ def test_match_backends_and_tasks():
         def keyfunc(t):
             return tuple(sorted((t[0] or {}).items())), t[1]
         assert sorted(actual, key=keyfunc) == sorted(expected, key=keyfunc)
+
+
+@mock.patch('paasta_tools.smartstack_tools.get_multiple_backends', autospec=True)
+def test_get_replication_for_all_services_from_synapse_haproxy(mock_get_multiple_backends):
+    mock_get_multiple_backends.return_value = [
+        {"pxname": "servicename.main", "svname": "10.50.2.4:31000_box4", "status": "UP"},
+        {"pxname": "servicename.main", "svname": "10.50.2.5:31001_box5", "status": "UP"},
+        {"pxname": "servicename.main", "svname": "10.50.2.6:31001_box6", "status": "UP"},
+        {"pxname": "servicename.main", "svname": "10.50.2.6:31002_box7", "status": "UP"},
+        {"pxname": "servicename.main", "svname": "10.50.2.8:31000_box8", "status": "UP"},
+    ]
+    assert {'servicename.main': 5} == \
+        smartstack_tools.get_replication_for_all_services_from_synapse_haproxy('', 8888, '')
+
+
+@mock.patch('paasta_tools.smartstack_tools.marathon_tools.load_service_namespace_config', autospec=True)
+@mock.patch('paasta_tools.smartstack_tools.get_replication_for_all_services_from_synapse_haproxy', autospec=True)
+def test_get_replication_for_instance(
+    mock_get_replication_for_all_services_from_synapse_haproxy,
+    mock_load_service_namespace_config,
+):
+    mock_mesos_slaves = [
+        {'hostname': 'host1', 'attributes': {'region': 'fake_region1'}},
+        {'hostname': 'host2', 'attributes': {'region': 'fake_region1'}},
+    ]
+    mock_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
+    instance_config = mock.Mock(service='fake_service', instance='fake_instance')
+    instance_config.get_monitoring_blacklist.return_value = []
+    mock_get_replication_for_all_services_from_synapse_haproxy.return_value = \
+        {'fake_service.fake_instance': 20}
+    mock_load_service_namespace_config.return_value.get_discover.return_value = 'region'
+    checker = smartstack_tools.SmartstackReplicationChecker(
+        mesos_slaves=mock_mesos_slaves,
+        system_paasta_config=mock_system_paasta_config,
+    )
+    assert checker.get_replication_for_instance(instance_config) == \
+        {'fake_region1': {'fake_service.fake_instance': 20}}

--- a/tests/test_smartstack_tools.py
+++ b/tests/test_smartstack_tools.py
@@ -96,62 +96,6 @@ def test_get_smartstack_replication_for_attribute():
         )
 
 
-@mock.patch('paasta_tools.mesos_tools.get_all_slaves_for_blacklist_whitelist', autospec=True)
-@mock.patch('paasta_tools.mesos_tools.filter_mesos_slaves_by_blacklist', autospec=True)
-@mock.patch('paasta_tools.smartstack_tools.get_replication_for_services', autospec=True)
-def test_get_smartstack_replication_for_attribute_when_mesos_slave_is_specified(
-        mock_get_replication_for_services,
-        mock_filter_mesos_slaves_by_blacklist,
-        mock_get_all_slaves_for_blacklist_whitelist,
-):
-    fake_namespace = 'fake_main'
-    fake_service = 'fake_service'
-    mock_filtered_slaves = [
-        {
-            'hostname': 'hostone',
-            'attributes': {
-                'fake_attribute': 'foo',
-            },
-        },
-        {
-            'hostname': 'hostone',
-            'attributes': {
-                'fake_attribute': 'bar',
-            },
-        },
-    ]
-
-    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
-    mock_filter_mesos_slaves_by_blacklist.return_value = mock_filtered_slaves
-    mock_get_replication_for_services.return_value = {}
-    expected = {'foo': {}, 'bar': {}}
-    mesos_slaves = mock.Mock()
-
-    actual = smartstack_tools.get_smartstack_replication_for_attribute(
-        attribute='fake_attribute',
-        service=fake_service,
-        namespace=fake_namespace,
-        blacklist=[],
-        system_paasta_config=fake_system_paasta_config,
-        mesos_slaves=mesos_slaves,
-    )
-    assert not mock_get_all_slaves_for_blacklist_whitelist.called
-    mock_filter_mesos_slaves_by_blacklist.assert_called_once_with(
-        slaves=mesos_slaves,
-        blacklist=[],
-        whitelist=None,
-    )
-    assert actual == expected
-    assert mock_get_replication_for_services.call_count == 2
-
-    mock_get_replication_for_services.assert_any_call(
-        synapse_host='hostone',
-        synapse_port=fake_system_paasta_config.get_synapse_port(),
-        synapse_haproxy_url_format=fake_system_paasta_config.get_synapse_haproxy_url_format(),
-        services=['fake_service.fake_main'],
-    )
-
-
 def test_get_replication_for_service():
     testdir = os.path.dirname(os.path.realpath(__file__))
     testdata = os.path.join(testdir, 'haproxy_snapshot.txt')

--- a/tests/test_smartstack_tools.py
+++ b/tests/test_smartstack_tools.py
@@ -96,6 +96,62 @@ def test_get_smartstack_replication_for_attribute():
         )
 
 
+@mock.patch('paasta_tools.mesos_tools.get_all_slaves_for_blacklist_whitelist', autospec=True)
+@mock.patch('paasta_tools.mesos_tools.filter_mesos_slaves_by_blacklist', autospec=True)
+@mock.patch('paasta_tools.smartstack_tools.get_replication_for_services', autospec=True)
+def test_get_smartstack_replication_for_attribute_when_mesos_slave_is_specified(
+        mock_get_replication_for_services,
+        mock_filter_mesos_slaves_by_blacklist,
+        mock_get_all_slaves_for_blacklist_whitelist,
+):
+    fake_namespace = 'fake_main'
+    fake_service = 'fake_service'
+    mock_filtered_slaves = [
+        {
+            'hostname': 'hostone',
+            'attributes': {
+                'fake_attribute': 'foo',
+            },
+        },
+        {
+            'hostname': 'hostone',
+            'attributes': {
+                'fake_attribute': 'bar',
+            },
+        },
+    ]
+
+    fake_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
+    mock_filter_mesos_slaves_by_blacklist.return_value = mock_filtered_slaves
+    mock_get_replication_for_services.return_value = {}
+    expected = {'foo': {}, 'bar': {}}
+    mesos_slaves = mock.Mock()
+
+    actual = smartstack_tools.get_smartstack_replication_for_attribute(
+        attribute='fake_attribute',
+        service=fake_service,
+        namespace=fake_namespace,
+        blacklist=[],
+        system_paasta_config=fake_system_paasta_config,
+        mesos_slaves=mesos_slaves,
+    )
+    assert not mock_get_all_slaves_for_blacklist_whitelist.called
+    mock_filter_mesos_slaves_by_blacklist.assert_called_once_with(
+        slaves=mesos_slaves,
+        blacklist=[],
+        whitelist=None,
+    )
+    assert actual == expected
+    assert mock_get_replication_for_services.call_count == 2
+
+    mock_get_replication_for_services.assert_any_call(
+        synapse_host='hostone',
+        synapse_port=fake_system_paasta_config.get_synapse_port(),
+        synapse_haproxy_url_format=fake_system_paasta_config.get_synapse_haproxy_url_format(),
+        services=['fake_service.fake_main'],
+    )
+
+
 def test_get_replication_for_service():
     testdir = os.path.dirname(os.path.realpath(__file__))
     testdata = os.path.join(testdir, 'haproxy_snapshot.txt')

--- a/tests/test_smartstack_tools.py
+++ b/tests/test_smartstack_tools.py
@@ -237,7 +237,7 @@ def test_match_backends_and_tasks():
 
 
 @mock.patch('paasta_tools.smartstack_tools.get_multiple_backends', autospec=True)
-def test_get_replication_for_all_services_from_synapse_haproxy(mock_get_multiple_backends):
+def test_get_replication_for_all_services(mock_get_multiple_backends):
     mock_get_multiple_backends.return_value = [
         {"pxname": "servicename.main", "svname": "10.50.2.4:31000_box4", "status": "UP"},
         {"pxname": "servicename.main", "svname": "10.50.2.5:31001_box5", "status": "UP"},
@@ -246,13 +246,13 @@ def test_get_replication_for_all_services_from_synapse_haproxy(mock_get_multiple
         {"pxname": "servicename.main", "svname": "10.50.2.8:31000_box8", "status": "UP"},
     ]
     assert {'servicename.main': 5} == \
-        smartstack_tools.get_replication_for_all_services_from_synapse_haproxy('', 8888, '')
+        smartstack_tools.get_replication_for_all_services('', 8888, '')
 
 
 @mock.patch('paasta_tools.smartstack_tools.marathon_tools.load_service_namespace_config', autospec=True)
-@mock.patch('paasta_tools.smartstack_tools.get_replication_for_all_services_from_synapse_haproxy', autospec=True)
+@mock.patch('paasta_tools.smartstack_tools.get_replication_for_all_services', autospec=True)
 def test_get_replication_for_instance(
-    mock_get_replication_for_all_services_from_synapse_haproxy,
+    mock_get_replication_for_all_services,
     mock_load_service_namespace_config,
 ):
     mock_mesos_slaves = [
@@ -262,7 +262,7 @@ def test_get_replication_for_instance(
     mock_system_paasta_config = SystemPaastaConfig({}, '/fake/config')
     instance_config = mock.Mock(service='fake_service', instance='fake_instance')
     instance_config.get_monitoring_blacklist.return_value = []
-    mock_get_replication_for_all_services_from_synapse_haproxy.return_value = \
+    mock_get_replication_for_all_services.return_value = \
         {'fake_service.fake_instance': 20}
     mock_load_service_namespace_config.return_value.get_discover.return_value = 'region'
     checker = smartstack_tools.SmartstackReplicationChecker(


### PR DESCRIPTION
* Remove unused 'client' from check_service_replication
* Pass cluster to marathon_tools.get_expected_instance_count_for_namespace() to avoid calling load_system_paasta_config() at https://github.com/Yelp/paasta/blob/master/paasta_tools/marathon_tools.py#L927
* Cache mesos_tools.get_slaves for 10 seconds. This reduces the number of calls to mesos-master from 105 (76 seconds) to 9 (11 seconds) on norcal-prod.