### PR TITLE
Async scale down cluster resource (ie parallel draining+killing of slaves in an sfr/asg)

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -1028,5 +1028,9 @@ def get_mesos_utilization_error(
         if math.isclose(total, 0):
             continue
         free_percs.append(float(free) / float(total))
+
+    if len(free_percs) == 0:  # If all resource totals are close to 0 for some reason
+        return 0
+
     utilization = 1.0 - min(free_percs)
     return utilization - target_utilization

--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -294,7 +294,7 @@ class ClusterAutoscaler(ResourceLogMixin):
                 await asyncio.sleep(5)
         except TimeoutError:
             self.log.error("Timed out after {} waiting to drain {}, now terminating anyway".format(
-                drain_timeout,
+                timer.timeout,
                 slave.pid,
             ))
             try:

--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -319,12 +319,10 @@ class ClusterAutoscaler(ResourceLogMixin):
         delta = target_capacity - current_capacity
         if delta == 0:
             self.log.info("Already at target capacity: {}".format(target_capacity))
-            await asyncio.sleep(1)
             return
         elif delta > 0:
             self.log.info("Increasing resource capacity to: {}".format(target_capacity))
             self.set_capacity(target_capacity)
-            await asyncio.sleep(1)
             return
         elif delta < 0:
             mesos_state = get_mesos_master().state_summary()
@@ -565,9 +563,6 @@ class ClusterAutoscaler(ResourceLogMixin):
                 await task
             except (HTTPError, FailSetResourceCapacity):
                 continue
-
-        # In case there's nothing to kill, we'll get a RuntimeWarning unless we await on something
-        await asyncio.sleep(1)
 
 
 class SpotAutoscaler(ClusterAutoscaler):
@@ -977,7 +972,6 @@ async def run_parallel_scalers(sorted_autoscaling_scalers):
         if task.cancelled() or task.done():
             continue
         await task
-    await asyncio.sleep(0.1)
 
 
 def get_scaler(scaler_type):
@@ -989,7 +983,6 @@ def get_scaler(scaler_type):
 
 
 async def autoscale_cluster_resource(scaler):
-    await asyncio.sleep(0.1)
     log.info("Autoscaling {} in pool, {}".format(scaler.resource['id'], scaler.resource['pool']))
     try:
         current, target = scaler.metrics_provider()

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -28,10 +28,12 @@ from paasta_tools.utils import TimeoutError
 
 
 warnings.filterwarnings("error", category=RuntimeWarning)
+asyncio.get_event_loop().set_debug(True)
 
 
 def _run(coro):
     asyncio.set_event_loop(asyncio.new_event_loop())
+    asyncio.get_event_loop().set_debug(True)
     return asyncio.get_event_loop().run_until_complete(coro)
 
 

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import asyncio
 import unittest
+import warnings
 from math import floor
 
 import mock
@@ -26,6 +27,9 @@ from paasta_tools.metrics.metastatus_lib import ResourceInfo
 from paasta_tools.utils import TimeoutError
 
 
+warnings.filterwarnings("error", category=RuntimeWarning)
+
+
 def _run(coro):
     asyncio.set_event_loop(asyncio.new_event_loop())
     return asyncio.get_event_loop().run_until_complete(coro)
@@ -33,7 +37,7 @@ def _run(coro):
 
 def get_coro_with_exception(error):
     async def f(*args, **kwargs):
-        asyncio.sleep(0.01)
+        await asyncio.sleep(0.01)
         raise error
     return f
 

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -925,8 +925,6 @@ class TestClusterAutoscaler(unittest.TestCase):
 
     def test_downscale_aws_resource(self):
         with mock.patch(
-            'paasta_tools.autoscaling.autoscaling_cluster_lib.get_mesos_master', autospec=True,
-        ) as mock_get_mesos_master, mock.patch(
             'paasta_tools.autoscaling.autoscaling_cluster_lib.get_mesos_task_count_by_slave', autospec=True,
         ) as mock_get_mesos_task_count_by_slave, mock.patch(
             'paasta_tools.autoscaling.ec2_fitness.sort_by_ec2_fitness',
@@ -941,11 +939,6 @@ class TestClusterAutoscaler(unittest.TestCase):
             mock_timer.return_value = mock_timer_value
 
             mock_gracefully_terminate_slave.side_effect = just_sleep
-            mock_master = mock.Mock()
-            mock_mesos_state = mock.Mock()
-            mock_mesos_state.get = lambda _, __: [{'id': 'i-blah123'}, {'id': 'i-blah456'}]
-            mock_master.state_summary.return_value = mock_mesos_state
-            mock_get_mesos_master.return_value = mock_master
             mock_task_counts = mock.Mock()
             mock_slave_1 = mock.Mock(
                 hostname='host1',


### PR DESCRIPTION
This changes the cluster autosclaler so that within one resource, it will attempt to kill multiple slaves at once.

Basically, it creates a coroutine per slave to kill, and then runs that until it hits `await asyncio.sleep(5)`.  At which point the execution will be suspended, and the `downscale_aws_resource` will resume, going on to the next slave.  At the end of `downscale_aws_resource`, we wait until all coroutines have completed (or been canceled) before returning.

The logic in `downscale_aws_resource` is a bit iffy, but I'm confident in the proper interactions between having multiple `gracefully_terminate_slave`s and `wait_and_terminate`s running at at time.

This is not actually multithreaded, as only one coroutine will run at once, but there is a bit of difficulty around setting the capacity correctly (and then resetting in case of failure).

Addresses (but not totally) #1495