### PR TITLE
Cluster autoscaler ignore unfufilled sfr

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -572,12 +572,6 @@ class SpotAutoscaler(ClusterAutoscaler):
                 self.resource['id'],
             ))
             raise ClusterAutoscalingError
-        if self.is_aws_launching_instances() and self.sfr['SpotFleetRequestState'] == 'active':
-            self.log.warning(
-                "AWS hasn't reached the TargetCapacity that is currently set. We won't make any "
-                "changes this time as we should wait for AWS to launch more instances first.",
-            )
-            return 0, 0
         current, target = self.get_spot_fleet_delta(error)
         if self.sfr['SpotFleetRequestState'] == 'cancelled_running':
             self.resource['min_capacity'] = 0

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -737,8 +737,8 @@ class TestSpotAutoscaler(unittest.TestCase):
             self.autoscaler.sfr = {'SpotFleetRequestState': 'active'}
             mock_is_aws_launching_sfr_instances.return_value = True
             ret = self.autoscaler.metrics_provider()
-            assert ret == (0, 0)
-            assert not mock_get_spot_fleet_delta.called
+            assert ret == (1, 2)
+            assert mock_get_spot_fleet_delta.called
 
             # cancelled_running SFR
             mock_cleanup_cancelled_config.reset_mock()


### PR DESCRIPTION
This check can prevent us to scale up or down. I don't see the use case where it protects us.
Let's just remove it!?