### PR TITLE
Chunk calls to aws describe instances to 199 at a time

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -420,16 +420,19 @@ class ClusterAutoscaler(ResourceLogMixin):
         return accumulated
 
     def instance_descriptions_for_ips(self, ips):
-        return self.describe_instances(
-            instance_ids=[],
-            region=self.resource['region'],
-            instance_filters=[
-                {
-                    'Name': 'private-ip-address',
-                    'Values': ips,
-                },
-            ],
-        )
+        all_instances = []
+        for start, stop in zip(range(0, len(ips), 199), range(199, len(ips) + 199, 199)):
+            all_instances += self.describe_instances(
+                instance_ids=[],
+                region=self.resource['region'],
+                instance_filters=[
+                    {
+                        'Name': 'private-ip-address',
+                        'Values': ips[start:stop],
+                    },
+                ],
+            )
+        return all_instances
 
     def filter_instance_description_for_ip(self, ip, instance_descriptions):
         return [

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -1460,6 +1460,21 @@ class TestClusterAutoscaler(unittest.TestCase):
         ret = self.autoscaler.get_pool_slaves(mock_mesos_state)
         assert ret == {'id1': mock_mesos_state['slaves'][0]}
 
+    def test_instace_descriptions_for_ips_splits_ips(self):
+        with mock.patch(
+            'paasta_tools.autoscaling.autoscaling_cluster_lib.ClusterAutoscaler.describe_instances',
+            autospec=True,
+        ) as mock_describe_instances:
+            ips = list(range(567))
+
+            def mock_describe_instance(self, instance_ids, region, instance_filters):
+                return instance_filters[0]['Values']
+            mock_describe_instances.side_effect = mock_describe_instance
+
+            ret = self.autoscaler.instance_descriptions_for_ips(ips)
+            assert len(ret) == 567
+            assert ret == ips
+
 
 class TestPaastaAwsSlave(unittest.TestCase):
 

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -1474,6 +1474,7 @@ class TestClusterAutoscaler(unittest.TestCase):
             ret = self.autoscaler.instance_descriptions_for_ips(ips)
             assert len(ret) == 567
             assert ret == ips
+            assert mock_describe_instances.call_count == 3
 
 
 class TestPaastaAwsSlave(unittest.TestCase):


### PR DESCRIPTION
describe instances has a limit of 200 at a time from aws, so we should call it with 199 ips at a time.

Fixes #1501