### PR TITLE
Make cluster autoscaler gracefully handle a mesos leader election

### DIFF
--- a/paasta_tools/mesos/exceptions.py
+++ b/paasta_tools/mesos/exceptions.py
@@ -19,6 +19,10 @@ class MasterNotAvailableException(Exception):
     pass
 
 
+class MasterTemporarilyNotAvailableException(Exception):
+    pass
+
+
 class NoSlavesAvailableError(Exception):
     pass
 

--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -75,6 +75,10 @@ class MesosMaster(object):
             )
         except requests.exceptions.ConnectionError:
             raise exceptions.MasterNotAvailableException(MISSING_MASTER.format(self.host))
+        except requests.exceptions.TooManyRedirects:
+            raise exceptions.MasterTemporarilyNotAvailableException(
+                "Unable to connect to master at %s, likely due to an ongoing leader election" % self.host,
+            )
 
     def fetch(self, url, **kwargs):
         return self._request(url, **kwargs)


### PR DESCRIPTION
I am, however, unsure whether we should continue in the face of a leader election.  It could produce a state where two cluster autoscalers are running at once.

Fixes #1503