### PR TITLE
MesosMaster.orphan_tasks should return a list of Task objects

### DIFF
--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -198,7 +198,11 @@ class MesosMaster(object):
         return lst[0]
 
     def orphan_tasks(self):
-        return self.state["orphan_tasks"]
+        return [
+            task.Task(self, x)
+            for x in self._task_list(False)
+            if x['id'] in self.state["orphan_tasks"]
+        ]
 
     # XXX - need to filter on task state as well as id
     def tasks(self, fltr="", active_only=False):


### PR DESCRIPTION
PAASTA-11595

I am relatively confident this or something like this in spirit is required to fix this ticket. It looks like orphan_tasks() method returns data straight out of state (which is a giant dict), instead of converting it to a list of Task objects.

This probably needs tests? And ideally I'd like to observe this in the wild to ensure data structures in mesos api look like what we expect? Mesos docs are lacking - http://mesos.apache.org/documentation/latest/endpoints/master/state/

cc @bobtfish as fyi

This is probably not yet ready to be merged.