### PR TITLE
Added sharded marathon servers to the paasta_itests and example_cluster

### DIFF
--- a/example_cluster/docker-compose.override.yml
+++ b/example_cluster/docker-compose.override.yml
@@ -42,8 +42,12 @@ services:
   marathon:
     ports:
       - '8080:8080'
-    depends_on:
-      - zookeeper
+  marathon1:
+    ports:
+      - '8080:8080'
+  marathon2:
+    ports:
+      - '8080:8080'
   itest_trusty:
     build: ../yelp_package/dockerfiles/trusty/
   playground:
@@ -66,6 +70,8 @@ services:
       - git
       - mesosslave
       - marathon
+      - marathon1
+      - marathon2
       - dynamodb
       - paasta_api
   chronos:

--- a/example_cluster/paasta/marathon.json
+++ b/example_cluster/paasta/marathon.json
@@ -5,5 +5,22 @@
     "url": [
       "http://marathon:8080"
     ]
-  }
+  },
+  "marathon_servers": [
+    {
+      "user": "admin",
+      "password": "secret2",
+      "url": ["http://marathon:8080"]
+    },
+    {
+      "user": "admin",
+      "password": "secret2",
+      "url": ["http://marathon1:8080"]
+    },
+    {
+      "user": "admin",
+      "password": "secret2",
+      "url": ["http://marathon2:8080"]
+    }
+  ]
 }

--- a/paasta_itests/docker-compose.yml
+++ b/paasta_itests/docker-compose.yml
@@ -83,7 +83,27 @@ services:
       - 8080
     environment:
       CLUSTER: testcluster
-    command: 'marathon --zk zk://zookeeper:2181/marathon --master zk://zookeeper:2181/mesos-testcluster --no-logger --mesos_authentication --env_vars_prefix MARATHON_ --mesos_authentication_principal marathon --mesos_authentication_secret_file /etc/marathon_framework_secret'
+    command: 'marathon --zk zk://zookeeper:2181/marathon --master zk://zookeeper:2181/mesos-testcluster --no-logger --mesos_authentication --env_vars_prefix MARATHON_ --mesos_authentication_principal marathon --mesos_authentication_secret_file /etc/marathon_framework_secret --framework_name marathon'
+    depends_on:
+      - zookeeper
+
+  marathon1:
+    build: ../yelp_package/dockerfiles/itest/marathon/
+    ports:
+      - 8080
+    environment:
+      CLUSTER: testcluster
+    command: 'marathon --zk zk://zookeeper:2181/marathon1 --master zk://zookeeper:2181/mesos-testcluster --no-logger --mesos_authentication --env_vars_prefix MARATHON_ --mesos_authentication_principal marathon --mesos_authentication_secret_file /etc/marathon_framework_secret --framework_name marathon1'
+    depends_on:
+      - zookeeper
+
+  marathon2:
+    build: ../yelp_package/dockerfiles/itest/marathon/
+    ports:
+      - 8080
+    environment:
+      CLUSTER: testcluster
+    command: 'marathon --zk zk://zookeeper:2181/marathon2 --master zk://zookeeper:2181/mesos-testcluster --no-logger --mesos_authentication --env_vars_prefix MARATHON_ --mesos_authentication_principal marathon --mesos_authentication_secret_file /etc/marathon_framework_secret --framework_name marathon2'
     depends_on:
       - zookeeper
 
@@ -91,6 +111,8 @@ services:
     build: ../yelp_package/dockerfiles/trusty/
     environment:
       MARATHON_PORT: 'http://marathon:8080'
+      MARATHON1_PORT: 'http://marathon1:8080'
+      MARATHON2_PORT: 'http://marathon2:8080'
       MESOSMASTER_PORT: 'http://mesosmaster:5050'
       HACHECK_PORT: 'http://hacheck:6666'
       ZOOKEEPER_PORT: 'zk://zookeeper:2181'

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -645,18 +645,18 @@ def get_marathon_clients(marathon_servers, cached=False):
     current_clients = []
     for current_server in current_servers:
         current_clients.append(get_marathon_client(
-            url=current_server.url,
-            user=current_server.user,
-            passwd=current_server.passwd,
+            url=current_server.get_url(),
+            user=current_server.get_username(),
+            passwd=current_server.get_password(),
             cached=cached,
         ))
     previous_servers = marathon_servers.previous
     previous_clients = []
     for previous_server in previous_servers:
         previous_clients.append(get_marathon_client(
-            url=previous_server.url,
-            user=previous_server.user,
-            passwd=previous_server.passwd,
+            url=previous_server.get_url(),
+            user=previous_server.get_username(),
+            passwd=previous_server.get_password(),
             cached=cached,
         ))
     return MarathonClients(current=current_clients, previous=previous_clients)

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
     docker-compose pull
     docker-compose --verbose build
     # Fire up the marathon cluster in background
-    docker-compose up -d mesosmaster mesosslave marathon chronos hacheck mesosslave2 mesosslave3 mesosslave4 mesosslave5
+    docker-compose up -d mesosmaster mesosslave marathon marathon1 marathon2 chronos hacheck mesosslave2 mesosslave3 mesosslave4 mesosslave5
     docker-compose scale mesosslave=3
     # Run the paastatools container in foreground to catch the output
     # the `docker-compose run` vs `docker-compose up` is important here, as docker-compose run will


### PR DESCRIPTION
This is not a shard-only config, this is still in hybrid mode, like our real infrastructure.

However, it allows itest-specific room so you could make assertions about an individual shard, like:
```
  marathon shard N should have appid foo
```
with the raw clients available in the paasta_itests context with this PR.