### PR TITLE
temporarily ignore orphan_tasks in mesos_tools.get_all_running_tasks

### DIFF
--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -154,8 +154,6 @@ def get_all_running_tasks():
     """ Will include all running tasks, including orphans
     """
     framework_tasks = get_current_tasks('')
-    mesos_master = get_mesos_master()
-    framework_tasks += mesos_master.orphan_tasks()
     running_tasks = filter_running_tasks(framework_tasks)
     return running_tasks
 

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -151,7 +151,7 @@ def get_running_tasks_from_frameworks(job_id=''):
 
 
 def get_all_running_tasks():
-    """ Will include all running tasks, including orphans
+    """ Will include all running tasks; for now orphans are not included
     """
     framework_tasks = get_current_tasks('')
     running_tasks = filter_running_tasks(framework_tasks)

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -803,16 +803,15 @@ def test_get_all_running_tasks():
     ) as mock_get_mesos_master:
         mock_task_1 = mock.Mock()
         mock_task_2 = mock.Mock()
-        mock_task_3 = mock.Mock()
 
         mock_get_current_tasks.return_value = [mock_task_1, mock_task_2]
-        mock_orphan_tasks = mock.Mock(return_value=[mock_task_3])
+        mock_orphan_tasks = mock.Mock(return_value=[])
         mock_mesos_master = mock.Mock(orphan_tasks=mock_orphan_tasks)
         mock_get_mesos_master.return_value = mock_mesos_master
 
         ret = mesos_tools.get_all_running_tasks()
         mock_get_current_tasks.assert_called_with('')
-        mock_filter_running_tasks.assert_called_with([mock_task_1, mock_task_2, mock_task_3])
+        mock_filter_running_tasks.assert_called_with([mock_task_1, mock_task_2])
         assert ret == mock_filter_running_tasks.return_value
 
 


### PR DESCRIPTION
PAASTA-11595

This is a temporary fix that will be eventually undone as part of https://github.com/Yelp/paasta/pull/1528.