### PR TITLE
Make paasta status ignore adhoc instances again

### DIFF
--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -220,10 +220,9 @@ def main():
                     )
                 elif instance_type == 'adhoc':
                     if instance == 'interactive':
-                        raise NotImplementedError
+                        continue
                     if command != 'status':
                         raise NotImplementedError
-
                     paasta_remote_run.remote_run_list_report(
                         service=service,
                         instance=instance,


### PR DESCRIPTION
We used to ignore adhoc things in paasta status, but now we don't and it raises a NotImplementedError for users. 

While "technically" correct, I think it is a bad developer experience and I think it would be better if we just skipped past them.