### PR TITLE
Paasta 13123 ignore remote run frameworks in metastatus

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -77,10 +77,13 @@ def load_marathon_config():
     return MarathonConfig(load_system_paasta_config().get_marathon_config())
 
 
-def get_marathon_servers():
-    system_config = load_system_paasta_config()
-    current = [MarathonConfig(x) for x in system_config.get_marathon_servers()]
-    previous = [MarathonConfig(x) for x in system_config.get_previous_marathon_servers()]
+def get_marathon_servers(system_paasta_config):
+    """
+    :param system_paasta_config: A SystemPaastaConfig object representing the system
+                                 configuration.
+    """
+    current = [MarathonConfig(x) for x in system_paasta_config.get_marathon_servers()]
+    previous = [MarathonConfig(x) for x in system_paasta_config.get_previous_marathon_servers()]
     return MarathonServers(current=current, previous=previous)
 
 
@@ -92,6 +95,18 @@ class MarathonConfig(dict):
 
     def __init__(self, config):
         super(MarathonConfig, self).__init__(config)
+
+    @property
+    def url(self):
+        return self.get_url()
+
+    @property
+    def user(self):
+        return self.get_username()
+
+    @property
+    def passwd(self):
+        return self.get_password()
 
     def get_url(self):
         """Get the Marathon API url

--- a/paasta_tools/monitoring/check_mesos_duplicate_frameworks.py
+++ b/paasta_tools/monitoring/check_mesos_duplicate_frameworks.py
@@ -12,28 +12,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import argparse
 import sys
 
+from paasta_tools.marathon_tools import get_marathon_servers
 from paasta_tools.mesos.exceptions import MasterNotAvailableException
 from paasta_tools.mesos_tools import get_mesos_master
-from paasta_tools.metrics.metastatus_lib import assert_no_duplicate_frameworks
+from paasta_tools.metrics.metastatus_lib import assert_framework_count
+from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 
 
-def parse_args():
-    parser = argparse.ArgumentParser()
-
-    parser.add_argument(
-        '--check', '-C', dest='check', type=str, default='',
-        help='Comma separated list of frameworks to check for duplicates',
-    )
-    return parser.parse_args()
-
-
 def check_mesos_no_duplicate_frameworks():
-    options = parse_args()
-    check = options.check.split(',')
     master = get_mesos_master()
     try:
         state = master.state
@@ -41,12 +30,16 @@ def check_mesos_no_duplicate_frameworks():
         paasta_print("CRITICAL: %s" % e.message)
         sys.exit(2)
 
-    result = assert_no_duplicate_frameworks(state, check)
+    system_paasta_config = load_system_paasta_config()
+    marathon_servers = get_marathon_servers(system_paasta_config)
+    configured_framework_count = len(marathon_servers.current) + len(marathon_servers.previous) + 1
+
+    result = assert_framework_count(state, configured_framework_count)
     if result.healthy:
         paasta_print("OK: " + result.message)
         sys.exit(0)
     else:
-        paasta_print(result.message)
+        paasta_print("CRITICAL: %s" % result.message)
         sys.exit(2)
 
 

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -27,10 +27,12 @@ from paasta_tools.autoscaling.autoscaling_cluster_lib import AutoscalingInfo
 from paasta_tools.autoscaling.autoscaling_cluster_lib import get_autoscaling_info_for_all_resources
 from paasta_tools.chronos_tools import get_chronos_client
 from paasta_tools.chronos_tools import load_chronos_config
+from paasta_tools.marathon_tools import get_marathon_servers
 from paasta_tools.mesos.exceptions import MasterNotAvailableException
 from paasta_tools.mesos_tools import get_mesos_master
 from paasta_tools.metrics import metastatus_lib
 from paasta_tools.utils import format_table
+from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import print_with_indent
@@ -77,6 +79,8 @@ def main(argv=None):
     chronos_config = None
     args = parse_args(argv)
 
+    system_paasta_config = load_system_paasta_config()
+
     master = get_mesos_master()
     try:
         mesos_state = master.state
@@ -86,8 +90,11 @@ def main(argv=None):
         paasta_print(PaastaColors.red("CRITICAL:  %s" % e.message))
         sys.exit(2)
 
+    marathon_servers = get_marathon_servers(system_paasta_config)
+    configured_framework_count = len(marathon_servers.current) + len(marathon_servers.previous) + 1
     mesos_state_status = metastatus_lib.get_mesos_state_status(
         mesos_state=mesos_state,
+        configured_framework_count=configured_framework_count,
     )
 
     metrics = master.metrics_snapshot()
@@ -95,9 +102,8 @@ def main(argv=None):
         mesos_metrics=metrics,
         mesos_state=mesos_state,
     )
-    framework_metrics_healthchecks = metastatus_lib.get_framework_metrics_status(metrics=metrics)
 
-    all_mesos_results = mesos_state_status + mesos_metrics_status + framework_metrics_healthchecks
+    all_mesos_results = mesos_state_status + mesos_metrics_status
 
     # Check to see if Marathon should be running here by checking for config
     marathon_config = marathon_tools.load_marathon_config()

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -243,120 +243,55 @@ def test_disk_health_mesos_reports_zero():
     assert failure_health is False
 
 
-def test_assert_no_duplicate_frameworks():
+def test_assert_framework_count_not_ok():
     state = {
         'frameworks': [
             {
-                'name': 'test_framework1',
+                'name': 'marathon',
             },
             {
-                'name': 'test_framework2',
+                'name': 'marathon1',
             },
             {
-                'name': 'test_framework3',
+                'name': 'marathon2',
             },
             {
-                'name': 'test_framework4',
+                'name': 'test_framework',
             },
         ],
     }
-    output, ok = metastatus_lib.assert_no_duplicate_frameworks(
+    output, ok = metastatus_lib.assert_framework_count(
         state,
-        ['test_framework1', 'test_framework2', 'test_framework3', 'test_framework4'],
+        configured_framework_count=4,
     )
 
-    expected_output = "\n".join(
-        ["Frameworks:"] +
-        ['    Framework: %s count: 1' % x['name'] for x in state['frameworks']],
-    )
-    assert output == expected_output
-    assert ok
-
-
-def test_duplicate_frameworks():
-    state = {
-        'frameworks': [
-            {
-                'name': 'test_framework1',
-            },
-            {
-                'name': 'test_framework1',
-            },
-            {
-                'name': 'test_framework1',
-            },
-            {
-                'name': 'test_framework2',
-            },
-        ],
-    }
-    output, ok = metastatus_lib.assert_no_duplicate_frameworks(
-        state,
-        ['test_framework1', 'test_framework2', 'test_framework3', 'test_framework4'],
-    )
-    assert "    CRITICAL: Framework test_framework1 has 3 instances running--expected no more than 1." in output
+    assert "Frameworks (configured 4, connected 3):" in output
     assert not ok
 
 
-def test_duplicate_frameworks_not_checked():
+def test_assert_framework_count_ok():
     state = {
         'frameworks': [
             {
-                'name': 'test_framework1',
+                'name': 'chronos',
             },
             {
-                'name': 'test_framework1',
+                'name': 'marathon',
             },
             {
-                'name': 'test_framework1',
+                'name': 'marathon1',
             },
             {
-                'name': 'test_framework2',
+                'name': 'test_framework',
             },
         ],
     }
-    output, ok = metastatus_lib.assert_no_duplicate_frameworks(
+    output, ok = metastatus_lib.assert_framework_count(
         state,
-        ['test_framework2', 'test_framework3', 'test_framework4'],
+        configured_framework_count=3,
     )
-    assert "test_framework2" in output
+    assert "Frameworks (configured 3, connected 3):" in output
     assert ok
-
-
-def test_connected_frameworks():
-    metrics = {
-        'master/frameworks_connected': 2,
-    }
-    hcr = metastatus_lib.assert_connected_frameworks(metrics)
-    assert hcr.healthy
-    assert "Connected Frameworks: expected: 2 actual: 2" in hcr.message
-
-
-def test_disconnected_frameworks():
-    metrics = {
-        'master/frameworks_disconnected': 1,
-    }
-    hcr = metastatus_lib.assert_disconnected_frameworks(metrics)
-    assert not hcr.healthy
-    assert "Disconnected Frameworks: expected: 0 actual: 1" in hcr.message
-
-
-def test_assert_active_frameworks():
-    metrics = {
-        'master/frameworks_active': 2,
-    }
-    hcr = metastatus_lib.assert_active_frameworks(metrics)
-    assert hcr.healthy
-    assert "Active Frameworks: expected: 2 actual: 2" in hcr.message
-
-
-def test_assert_inactive_frameworks():
-    metrics = {
-        'master/frameworks_inactive': 0,
-    }
-    hcr = metastatus_lib.assert_inactive_frameworks(metrics)
-    assert hcr.healthy
-    assert "Inactive Frameworks: expected: 0 actual: 0" in hcr.message
 
 
 @patch('paasta_tools.marathon_tools.get_marathon_client', autospec=True)

--- a/tests/monitoring/test_check_mesos_duplicate_frameworks.py
+++ b/tests/monitoring/test_check_mesos_duplicate_frameworks.py
@@ -19,13 +19,14 @@ from paasta_tools.monitoring.check_mesos_duplicate_frameworks import check_mesos
 
 def test_check_mesos_no_duplicate_frameworks_ok(capfd):
     with mock.patch(
-        'paasta_tools.monitoring.check_mesos_duplicate_frameworks.parse_args', autospec=True,
-    ) as mock_parse_args, mock.patch(
+        'paasta_tools.monitoring.check_mesos_duplicate_frameworks.load_system_paasta_config', autospec=True,
+    ), mock.patch(
+        'paasta_tools.monitoring.check_mesos_duplicate_frameworks.get_marathon_servers',
+        autospec=True,
+        return_value=mock.Mock(current=[1], previous=[]),
+    ), mock.patch(
         'paasta_tools.monitoring.check_mesos_duplicate_frameworks.get_mesos_master', autospec=True,
     ) as mock_get_mesos_master:
-        mock_opts = mock.MagicMock()
-        mock_opts.check = 'marathon,chronos'
-        mock_parse_args.return_value = mock_opts
         mock_master = mock.MagicMock()
         mock_master.state = {
             'frameworks': [
@@ -49,13 +50,14 @@ def test_check_mesos_no_duplicate_frameworks_ok(capfd):
 
 def test_check_mesos_no_duplicate_frameworks_critical(capfd):
     with mock.patch(
-        'paasta_tools.monitoring.check_mesos_duplicate_frameworks.parse_args', autospec=True,
-    ) as mock_parse_args, mock.patch(
+        'paasta_tools.monitoring.check_mesos_duplicate_frameworks.load_system_paasta_config', autospec=True,
+    ), mock.patch(
+        'paasta_tools.monitoring.check_mesos_duplicate_frameworks.get_marathon_servers',
+        autospec=True,
+        return_value=mock.Mock(current=[1], previous=[]),
+    ), mock.patch(
         'paasta_tools.monitoring.check_mesos_duplicate_frameworks.get_mesos_master', autospec=True,
     ) as mock_get_mesos_master:
-        mock_opts = mock.MagicMock()
-        mock_opts.check = 'marathon,chronos'
-        mock_parse_args.return_value = mock_opts
         mock_master = mock.MagicMock()
         mock_master.state = {
             'frameworks': [

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -21,6 +21,8 @@ from paasta_tools import paasta_metastatus
 
 def test_main_no_marathon_config():
     with patch(
+        'paasta_tools.paasta_metastatus.load_system_paasta_config', autospec=True,
+    ), patch(
         'paasta_tools.marathon_tools.load_marathon_config', autospec=True,
     ) as load_marathon_config_patch, patch(
         'paasta_tools.paasta_metastatus.load_chronos_config', autospec=True,
@@ -58,6 +60,8 @@ def test_main_no_marathon_config():
 
 def test_main_no_chronos_config():
     with patch(
+        'paasta_tools.paasta_metastatus.load_system_paasta_config', autospec=True,
+    ), patch(
         'paasta_tools.marathon_tools.load_marathon_config', autospec=True,
     ) as load_marathon_config_patch, patch(
         'paasta_tools.paasta_metastatus.load_chronos_config', autospec=True,
@@ -95,6 +99,8 @@ def test_main_no_chronos_config():
 
 def test_main_marathon_jsondecode_error():
     with patch(
+        'paasta_tools.paasta_metastatus.load_system_paasta_config', autospec=True,
+    ), patch(
         'paasta_tools.marathon_tools.load_marathon_config', autospec=True,
     ) as load_marathon_config_patch, patch(
         'paasta_tools.paasta_metastatus.load_chronos_config', autospec=True,


### PR DESCRIPTION
internal ticket: PAASTA-13123

before:
```
Mesos Status: CRITICAL
  Quorum: masters: 3 configured quorum: 2
  Frameworks:
    Framework: chronos count: 1
    Framework: marathon count: 1
  CPUs: 1.61 / 309 in use (0.52%)
  Memory: 8.63 / 548.10GB in use (1.58%)
  Disk: 16.00 / 3064.37GB in use (0.52%)
  No gpus found from mesos!
  Tasks: running: 17 staging: 0 starting: 0
  Slaves: active: 15 inactive: 0
  Connected Frameworks: expected: 2 actual: 4
  Disconnected Frameworks: expected: 0 actual: 0
  Inactive Frameworks: expected: 0 actual: 0
```

after:
```
Mesos Status: OK
  Quorum: masters: 3 configured quorum: 2
  Frameworks (configured 4, connected 4):
    Framework: chronos count: 1
    Framework: marathon count: 3
  CPUs: 1.61 / 309 in use (0.52%)
  Memory: 8.63 / 548.10GB in use (1.58%)
  Disk: 16.00 / 3064.37GB in use (0.52%)
  No gpus found from mesos!
  Tasks: running: 17 staging: 0 starting: 0
  Slaves: active: 15 inactive: 0
```

Also I added system_paasta_config as a mandatory parameter to get_marathon_servers().
load_system_paasta_config is a heavy operation. It reads, parses and merges many json files.
We should read it once and pass everywhere we need this information.