### PR TITLE
Make wait-for-deployment only inspect marathon instances

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -536,7 +536,11 @@ def _run_cluster_worker(cluster_data, green_light):
 
 
 def wait_for_deployment(service, deploy_group, git_sha, soa_dir, timeout):
-    cluster_map = get_cluster_instance_map_for_service(soa_dir=soa_dir, service=service, deploy_group=deploy_group)
+    # Currently only 'marathon' instances are supported for wait_for_deployment because they
+    # are the only thing that are worth waiting on.
+    cluster_map = get_cluster_instance_map_for_service(
+        soa_dir=soa_dir, service=service, deploy_group=deploy_group, type_filter='marathon',
+    )
     if not cluster_map:
         _log(
             service=service,

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -849,50 +849,55 @@ def pick_slave_from_status(status, host=None):
         return slaves[0]
 
 
-def get_instance_configs_for_service(service, soa_dir):
+def get_instance_configs_for_service(service, soa_dir, type_filter=None):
     for cluster in list_clusters(
         service=service,
         soa_dir=soa_dir,
     ):
-        for _, instance in get_service_instance_list(
-            service=service,
-            cluster=cluster,
-            instance_type='marathon',
-            soa_dir=soa_dir,
-        ):
-            yield load_marathon_service_config(
+        if type_filter is None:
+            type_filter = ['marathon', 'chronos', 'adhoc']
+        if 'marathon' in type_filter:
+            for _, instance in get_service_instance_list(
                 service=service,
-                instance=instance,
                 cluster=cluster,
+                instance_type='marathon',
                 soa_dir=soa_dir,
-                load_deployments=False,
-            )
-        for _, instance in get_service_instance_list(
-            service=service,
-            cluster=cluster,
-            instance_type='chronos',
-            soa_dir=soa_dir,
-        ):
-            yield load_chronos_job_config(
+            ):
+                yield load_marathon_service_config(
+                    service=service,
+                    instance=instance,
+                    cluster=cluster,
+                    soa_dir=soa_dir,
+                    load_deployments=False,
+                )
+        if 'chronos' in type_filter:
+            for _, instance in get_service_instance_list(
                 service=service,
-                instance=instance,
                 cluster=cluster,
+                instance_type='chronos',
                 soa_dir=soa_dir,
-                load_deployments=False,
-            )
-        for _, instance in get_service_instance_list(
-            service=service,
-            cluster=cluster,
-            instance_type='adhoc',
-            soa_dir=soa_dir,
-        ):
-            yield load_adhoc_job_config(
+            ):
+                yield load_chronos_job_config(
+                    service=service,
+                    instance=instance,
+                    cluster=cluster,
+                    soa_dir=soa_dir,
+                    load_deployments=False,
+                )
+        if 'adhoc' in type_filter:
+            for _, instance in get_service_instance_list(
                 service=service,
-                instance=instance,
                 cluster=cluster,
+                instance_type='adhoc',
                 soa_dir=soa_dir,
-                load_deployments=False,
-            )
+            ):
+                yield load_adhoc_job_config(
+                    service=service,
+                    instance=instance,
+                    cluster=cluster,
+                    soa_dir=soa_dir,
+                    load_deployments=False,
+                )
 
 
 class PaastaTaskNotFound(Exception):

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -73,14 +73,16 @@ def parse_args():
     return args
 
 
-def get_cluster_instance_map_for_service(soa_dir, service, deploy_group=None):
+def get_cluster_instance_map_for_service(soa_dir, service, deploy_group=None, type_filter=None):
     if deploy_group:
         instances = [
-            config for config in get_instance_configs_for_service(soa_dir=soa_dir, service=service)
+            config for config in get_instance_configs_for_service(
+                soa_dir=soa_dir, service=service, type_filter=type_filter,
+            )
             if config.get_deploy_group() == deploy_group
         ]
     else:
-        instances = get_instance_configs_for_service(soa_dir=soa_dir, service=service)
+        instances = get_instance_configs_for_service(soa_dir=soa_dir, service=service, type_filter=type_filter)
     cluster_map = defaultdict(lambda: defaultdict(list))
     for instance_config in instances:
         cluster_map[instance_config.get_cluster()]['instances'].append(instance_config.get_instance())

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -244,7 +244,6 @@ def test_wait_for_deployment(
         with patch('time.time', side_effect=[0, 0, 2], autospec=True):
             with patch('time.sleep', autospec=True):
                 mark_for_deployment.wait_for_deployment('service', 'deploy_group_1', 'somesha', '/nail/soa', 1)
-    mock_get_cluster_instance_map_for_service.assert_called_with('/nail/soa', 'service', 'deploy_group_1')
 
     mock_cluster_map = {
         'cluster1': {'instances': ['instance1', 'instance2']},

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -125,9 +125,8 @@ def test_get_cluster_instance_map_for_service():
     with mock.patch(
         'paasta_tools.generate_deployments_for_service.get_instance_configs_for_service',
         return_value=fake_service_configs, autospec=True,
-    ) as mock_get_instance_configs_for_service:
+    ):
         ret = generate_deployments_for_service.get_cluster_instance_map_for_service('/nail/blah', 'service1', 'try_me')
-        mock_get_instance_configs_for_service.assert_called_with(soa_dir='/nail/blah', service='service1')
         expected = {'clusterA': {'instances': ['canary']}, 'clusterB': {'instances': ['main']}}
         assert ret == expected
 


### PR DESCRIPTION
I want to reduce the scope of what wait-for-deployment does, to prevent future issues where we add something and it has the potential for breaking w-f-d. 

