### PR TITLE
Add type annotations to marathon-related things

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -17,3 +17,6 @@ disallow_untyped_defs = True
 
 [mypy-paasta_tools.marathon_tools]
 disallow_untyped_defs = True
+
+[mypy-paasta_tools.setup_marathon_job]
+disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -14,3 +14,6 @@ disallow_untyped_defs = True
 
 [mypy-paasta_tools.long_running_service_tools]
 disallow_untyped_defs = True
+
+[mypy-paasta_tools.marathon_tools]
+disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,3 +11,6 @@ ignore_missing_imports = False
 [mypy-paasta_tools.utils]
 # utils.py is imported all over the place, so it's good to have type annotations on everything in it.
 disallow_untyped_defs = True
+
+[mypy-paasta_tools.long_running_service_tools]
+disallow_untyped_defs = True

--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -20,8 +20,10 @@ import os
 import time
 from contextlib import contextmanager
 from typing import Callable
+from typing import Collection
 from typing import Dict
 from typing import List
+from typing import Mapping
 
 from kazoo.client import KazooClient
 from kazoo.exceptions import LockTimeout
@@ -33,6 +35,7 @@ from requests.exceptions import ConnectionError
 from requests.exceptions import RequestException
 
 from paasta_tools import marathon_tools
+from paasta_tools.long_running_service_tools import BounceMethodConfigDict
 from paasta_tools.smartstack_tools import get_registered_marathon_tasks
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import load_system_paasta_config
@@ -57,15 +60,13 @@ BounceMethodResult = TypedDict(
     },
 )
 
-NewConfig = TypedDict('NewConfig', {"instances": int})
-
 BounceMethod = Callable[
     [
-        Arg(NewConfig, 'new_config'),
+        Arg(BounceMethodConfigDict, 'new_config'),
         Arg(bool, 'new_app_running'),
-        Arg(List, 'happy_new_tasks'),
-        Arg(Dict[str, List], 'old_app_live_happy_tasks'),
-        Arg(Dict[str, List], 'old_app_live_unhappy_tasks'),
+        Arg(Collection, 'happy_new_tasks'),
+        Arg(Mapping[str, Collection], 'old_app_live_happy_tasks'),
+        Arg(Mapping[str, Collection], 'old_app_live_unhappy_tasks'),
         DefaultArg(float, 'margin_factor'),
     ],
     BounceMethodResult
@@ -269,11 +270,11 @@ def flatten_tasks(tasks_by_app_id):
 
 @register_bounce_method('brutal')
 def brutal_bounce(
-    new_config: NewConfig,
+    new_config: BounceMethodConfigDict,
     new_app_running: bool,
-    happy_new_tasks: List,
-    old_app_live_happy_tasks: Dict[str, List],
-    old_app_live_unhappy_tasks: Dict[str, List],
+    happy_new_tasks: Collection,
+    old_app_live_happy_tasks: Mapping[str, Collection],
+    old_app_live_unhappy_tasks: Mapping[str, Collection],
     margin_factor=1.0,
 ):
     """Pays no regard to safety. Starts the new app if necessary, and kills any
@@ -300,11 +301,11 @@ def brutal_bounce(
 
 @register_bounce_method('upthendown')
 def upthendown_bounce(
-    new_config: NewConfig,
+    new_config: BounceMethodConfigDict,
     new_app_running: bool,
-    happy_new_tasks: List,
-    old_app_live_happy_tasks: Dict[str, List],
-    old_app_live_unhappy_tasks: Dict[str, List],
+    happy_new_tasks: Collection,
+    old_app_live_happy_tasks: Mapping[str, Collection],
+    old_app_live_unhappy_tasks: Mapping[str, Collection],
     margin_factor=1.0,
 ):
     """Starts a new app if necessary; only kills old apps once all the requested tasks for the new version are running.
@@ -326,11 +327,11 @@ def upthendown_bounce(
 
 @register_bounce_method('crossover')
 def crossover_bounce(
-    new_config: NewConfig,
+    new_config: BounceMethodConfigDict,
     new_app_running: bool,
-    happy_new_tasks: List,
-    old_app_live_happy_tasks: Dict[str, List],
-    old_app_live_unhappy_tasks: Dict[str, List],
+    happy_new_tasks: Collection,
+    old_app_live_happy_tasks: Mapping[str, Collection],
+    old_app_live_unhappy_tasks: Mapping[str, Collection],
     margin_factor=1.0,
 ):
     """Starts a new app if necessary; slowly kills old apps as instances of the new app become happy.
@@ -363,11 +364,11 @@ def crossover_bounce(
 
 @register_bounce_method('downthenup')
 def downthenup_bounce(
-    new_config: NewConfig,
+    new_config: BounceMethodConfigDict,
     new_app_running: bool,
-    happy_new_tasks: List,
-    old_app_live_happy_tasks: Dict[str, List],
-    old_app_live_unhappy_tasks: Dict[str, List],
+    happy_new_tasks: Collection,
+    old_app_live_happy_tasks: Mapping[str, Collection],
+    old_app_live_unhappy_tasks: Mapping[str, Collection],
     margin_factor=1.0,
 ):
     """Stops any old apps and waits for them to die before starting a new one.
@@ -383,11 +384,11 @@ def downthenup_bounce(
 
 @register_bounce_method('down')
 def down_bounce(
-    new_config: NewConfig,
+    new_config: BounceMethodConfigDict,
     new_app_running: bool,
-    happy_new_tasks: List,
-    old_app_live_happy_tasks: Dict[str, List],
-    old_app_live_unhappy_tasks: Dict[str, List],
+    happy_new_tasks: Collection,
+    old_app_live_happy_tasks: Mapping[str, Collection],
+    old_app_live_unhappy_tasks: Mapping[str, Collection],
     margin_factor=1.0,
 ):
     """

--- a/paasta_tools/deployd/workers.py
+++ b/paasta_tools/deployd/workers.py
@@ -106,7 +106,6 @@ class PaastaDeployWorker(PaastaThread):
             instance=service_instance.instance,
             client=self.marathon_client,
             soa_dir=marathon_tools.DEFAULT_SOA_DIR,
-            marathon_config=self.marathon_config,
             marathon_apps=marathon_apps,
         )
 

--- a/paasta_tools/frameworks/native_scheduler.py
+++ b/paasta_tools/frameworks/native_scheduler.py
@@ -7,8 +7,10 @@ import random
 import threading
 import time
 import uuid
+from typing import Collection
 from typing import Dict
 from typing import List
+from typing import Mapping
 from typing import Optional
 from typing import Tuple
 
@@ -500,7 +502,7 @@ class NativeScheduler(Scheduler):
         driver.killTask({'value': task_id})
         self.task_store.update_task(task_id, mesos_task_state=TASK_KILLING)
 
-    def group_tasks_by_version(self, task_ids: List[str]) -> Dict[str, List[str]]:
+    def group_tasks_by_version(self, task_ids: Collection[str]) -> Mapping[str, Collection[str]]:
         d: Dict[str, List[str]] = {}
         for task_id in task_ids:
             version = task_id.rsplit('.', 1)[0]

--- a/paasta_tools/frameworks/native_service_config.py
+++ b/paasta_tools/frameworks/native_service_config.py
@@ -14,7 +14,7 @@ from paasta_tools.long_running_service_tools import LongRunningServiceConfigDict
 from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
 from paasta_tools.utils import BranchDict  # noqa, imported for typing.
 from paasta_tools.utils import compose_job_id
-from paasta_tools.utils import Constraint
+from paasta_tools.utils import Constraint  # noqa, imported for typing.
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import DockerParameter
 from paasta_tools.utils import get_code_sha_from_dockerurl
@@ -287,9 +287,6 @@ class NativeServiceConfig(LongRunningServiceConfig):
 
     def get_mesos_network_mode(self) -> str:
         return self.get_net().upper()
-
-    def get_constraints(self) -> List[Constraint]:
-        return self.config_dict.get('constraints', [])
 
 
 def load_paasta_native_job_config(

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 import service_configuration_lib
 from kazoo.exceptions import NoNodeError
+from mypy_extensions import TypedDict
 
 from paasta_tools.utils import BranchDict
 from paasta_tools.utils import compose_job_id
@@ -43,6 +44,10 @@ class LongRunningServiceConfigDict(InstanceConfigDict, total=False):
     nerve_ns: str
     registrations: List[str]
     bounce_priority: int
+
+
+# Defined here to avoid import cycles -- this gets used in bounce_lib and subclassed in marathon_tools.
+BounceMethodConfigDict = TypedDict('BounceMethodConfigDict', {"instances": int})
 
 
 class ServiceNamespaceConfig(dict):

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -65,13 +65,13 @@ class ServiceNamespaceConfig(dict):
         else:
             raise InvalidSmartstackMode("Unknown mode: %s" % mode)
 
-    def get_healthcheck_uri(self):
+    def get_healthcheck_uri(self) -> str:
         return self.get('healthcheck_uri', '/status')
 
-    def get_discover(self):
+    def get_discover(self) -> str:
         return self.get('discover', 'region')
 
-    def is_in_smartstack(self):
+    def is_in_smartstack(self) -> bool:
         if self.get('proxy_port') is not None:
             return True
         else:
@@ -83,7 +83,7 @@ class LongRunningServiceConfig(InstanceConfig):
 
     def __init__(
         self, service: str, cluster: str, instance: str, config_dict: LongRunningServiceConfigDict,
-        branch_dict: BranchDict, soa_dir=DEFAULT_SOA_DIR,
+        branch_dict: BranchDict, soa_dir: str=DEFAULT_SOA_DIR,
     ) -> None:
         super(LongRunningServiceConfig, self).__init__(
             cluster=cluster,
@@ -139,7 +139,7 @@ class LongRunningServiceConfig(InstanceConfig):
 
         return registrations or [compose_job_id(self.service, self.instance)]
 
-    def get_healthcheck_uri(self, service_namespace_config) -> str:
+    def get_healthcheck_uri(self, service_namespace_config: ServiceNamespaceConfig) -> str:
         return self.config_dict.get('healthcheck_uri', service_namespace_config.get_healthcheck_uri())
 
     def get_healthcheck_cmd(self) -> str:
@@ -162,7 +162,7 @@ class LongRunningServiceConfig(InstanceConfig):
     def get_healthcheck_max_consecutive_failures(self) -> int:
         return self.config_dict.get('healthcheck_max_consecutive_failures', 30)
 
-    def get_healthcheck_mode(self, service_namespace_config) -> str:
+    def get_healthcheck_mode(self, service_namespace_config: ServiceNamespaceConfig) -> str:
         mode = self.config_dict.get('healthcheck_mode', None)
         if mode is None:
             mode = service_namespace_config.get_mode()

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -23,22 +23,34 @@ import logging
 import os
 from collections import namedtuple
 from math import ceil
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
 
 import requests
 import service_configuration_lib
 from marathon import MarathonClient
 from marathon import MarathonHttpError
 from marathon import NotFoundError
+from marathon.models.app import MarathonApp
+from marathon.models.app import MarathonTask
+from mypy_extensions import TypedDict
 
 from paasta_tools.long_running_service_tools import InvalidHealthcheckMode
 from paasta_tools.long_running_service_tools import load_service_namespace_config
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
+from paasta_tools.long_running_service_tools import LongRunningServiceConfigDict
+from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
 from paasta_tools.mesos.exceptions import NoSlavesAvailableError
 from paasta_tools.mesos_tools import filter_mesos_slaves_by_blacklist
 from paasta_tools.mesos_tools import get_mesos_network_for_net
 from paasta_tools.mesos_tools import get_mesos_slaves_grouped_by_attribute
 from paasta_tools.mesos_tools import mesos_services_running_here
+from paasta_tools.utils import BranchDict
 from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import Constraint
 from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -49,9 +61,11 @@ from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import get_user_agent
 from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import MarathonConfigDict
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaNotConfiguredError
+from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import time_cache
 
 # Marathon creates Mesos tasks with an id composed of the app's full name, a
@@ -73,11 +87,11 @@ MarathonServers = namedtuple('MarathonServers', ['current', 'previous'])
 MarathonClients = namedtuple('MarathonClients', ['current', 'previous'])
 
 
-def load_marathon_config():
+def load_marathon_config() -> "MarathonConfig":
     return MarathonConfig(load_system_paasta_config().get_marathon_config())
 
 
-def get_marathon_servers():
+def get_marathon_servers() -> MarathonServers:
     system_config = load_system_paasta_config()
     current = [MarathonConfig(x) for x in system_config.get_marathon_servers()]
     previous = [MarathonConfig(x) for x in system_config.get_previous_marathon_servers()]
@@ -88,12 +102,47 @@ class MarathonNotConfigured(Exception):
     pass
 
 
+class AutoscalingParamsDict(TypedDict, total=False):
+    metrics_provider: str
+    decision_policy: str
+    setpoint: float
+
+
+class MarathonServiceConfigDict(LongRunningServiceConfigDict, total=False):
+    autoscaling: AutoscalingParamsDict
+    backoff_factor: float
+    max_launch_delay_seconds: float
+    bounce_method: str
+    bounce_health_params: Dict[str, Any]
+    bounce_margin_factor: float
+    accepted_resource_roles: Optional[List[str]]
+    replication_threshold: int
+    host_port: int
+    marathon_shard: int
+    previous_marathon_shards: List[int]
+
+
+class CommandDict(TypedDict):
+    value: str
+
+
+class HealthcheckDict(TypedDict, total=False):
+    protocol: str
+    gracePeriodSeconds: float
+    intervalSeconds: float
+    portIndex: int
+    timeoutSeconds: float
+    maxConsecutiveFailures: int
+    path: str
+    command: CommandDict
+
+
 class MarathonConfig(dict):
 
-    def __init__(self, config):
+    def __init__(self, config: MarathonConfigDict) -> None:
         super(MarathonConfig, self).__init__(config)
 
-    def get_url(self):
+    def get_url(self) -> List[str]:
         """Get the Marathon API url
 
         :returns: The Marathon API endpoint"""
@@ -102,7 +151,7 @@ class MarathonConfig(dict):
         except KeyError:
             raise MarathonNotConfigured('Could not find marathon url in system marathon config')
 
-    def get_username(self):
+    def get_username(self) -> str:
         """Get the Marathon API username
 
         :returns: The Marathon API username"""
@@ -111,7 +160,7 @@ class MarathonConfig(dict):
         except KeyError:
             raise MarathonNotConfigured('Could not find marathon user in system marathon config')
 
-    def get_password(self):
+    def get_password(self) -> str:
         """Get the Marathon API password
 
         :returns: The Marathon API password"""
@@ -121,7 +170,13 @@ class MarathonConfig(dict):
             raise MarathonNotConfigured('Could not find marathon password in system marathon config')
 
 
-def load_marathon_service_config_no_cache(service, instance, cluster, load_deployments=True, soa_dir=DEFAULT_SOA_DIR):
+def load_marathon_service_config_no_cache(
+    service: str,
+    instance: str,
+    cluster: str,
+    load_deployments: bool=True,
+    soa_dir: str=DEFAULT_SOA_DIR,
+) -> "MarathonServiceConfig":
     """Read a service instance's configuration for marathon.
 
     If a branch isn't specified for a config, the 'branch' key defaults to
@@ -152,7 +207,7 @@ def load_marathon_service_config_no_cache(service, instance, cluster, load_deplo
 
     general_config = deep_merge_dictionaries(overrides=instance_configs[instance], defaults=general_config)
 
-    branch_dict = {}
+    branch_dict: BranchDict = {}
     if load_deployments:
         deployments_json = load_deployments_json(service, soa_dir=soa_dir)
         branch = general_config.get('branch', get_paasta_branch(cluster, instance))
@@ -169,7 +224,13 @@ def load_marathon_service_config_no_cache(service, instance, cluster, load_deplo
 
 
 @time_cache(ttl=5)
-def load_marathon_service_config(service, instance, cluster, load_deployments=True, soa_dir=DEFAULT_SOA_DIR):
+def load_marathon_service_config(
+    service: str,
+    instance: str,
+    cluster: str,
+    load_deployments: bool=True,
+    soa_dir: str=DEFAULT_SOA_DIR,
+) -> "MarathonServiceConfig":
     """Read a service instance's configuration for marathon.
 
     If a branch isn't specified for a config, the 'branch' key defaults to
@@ -196,8 +257,17 @@ class InvalidMarathonConfig(Exception):
 
 
 class MarathonServiceConfig(LongRunningServiceConfig):
+    config_dict: MarathonServiceConfigDict
 
-    def __init__(self, service, cluster, instance, config_dict, branch_dict, soa_dir=DEFAULT_SOA_DIR):
+    def __init__(
+        self,
+        service: str,
+        cluster: str,
+        instance: str,
+        config_dict: MarathonServiceConfigDict,
+        branch_dict: BranchDict,
+        soa_dir: str=DEFAULT_SOA_DIR,
+    ) -> None:
         super(MarathonServiceConfig, self).__init__(
             cluster=cluster,
             instance=instance,
@@ -207,7 +277,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
             soa_dir=soa_dir,
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "MarathonServiceConfig(%r, %r, %r, %r, %r, %r)" % (
             self.service,
             self.cluster,
@@ -217,7 +287,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
             self.soa_dir,
         )
 
-    def copy(self):
+    def copy(self) -> "MarathonServiceConfig":
         return self.__class__(
             service=self.service,
             instance=self.instance,
@@ -227,15 +297,18 @@ class MarathonServiceConfig(LongRunningServiceConfig):
             soa_dir=self.soa_dir,
         )
 
-    def get_autoscaling_params(self):
-        default_params = {
+    def get_autoscaling_params(self) -> AutoscalingParamsDict:
+        default_params: AutoscalingParamsDict = {
             'metrics_provider': 'mesos_cpu',
             'decision_policy': 'pid',
             'setpoint': 0.8,
         }
-        return deep_merge_dictionaries(overrides=self.config_dict.get('autoscaling', {}), defaults=default_params)
+        return deep_merge_dictionaries(
+            overrides=self.config_dict.get('autoscaling', AutoscalingParamsDict({})),
+            defaults=default_params,
+        )
 
-    def get_backoff_seconds(self):
+    def get_backoff_seconds(self) -> int:
         """backoff_seconds represents a penalization factor for relaunching failing tasks.
         Every time a task fails, Marathon adds this value multiplied by a backoff_factor.
         In PaaSTA we know how many instances a service has, so we adjust the backoff_seconds
@@ -249,20 +322,24 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         else:
             return int(ceil(10.0 / instances))
 
-    def get_backoff_factor(self):
+    def get_backoff_factor(self) -> float:
         return self.config_dict.get('backoff_factor', 2)
 
-    def get_max_launch_delay_seconds(self):
+    def get_max_launch_delay_seconds(self) -> float:
         return self.config_dict.get('max_launch_delay_seconds', 300)
 
-    def get_bounce_method(self):
+    def get_bounce_method(self) -> str:
         """Get the bounce method specified in the service's marathon configuration.
 
         :param service_config: The service instance's configuration dictionary
         :returns: The bounce method specified in the config, or 'crossover' if not specified"""
         return self.config_dict.get('bounce_method', 'crossover')
 
-    def get_calculated_constraints(self, system_paasta_config, service_namespace_config):
+    def get_calculated_constraints(
+        self,
+        system_paasta_config: SystemPaastaConfig,
+        service_namespace_config: ServiceNamespaceConfig,
+    ) -> List[Constraint]:
         """Gets the calculated constraints for a marathon instance
 
         If ``constraints`` is specified in the config, it will use that regardless.
@@ -290,9 +367,13 @@ class MarathonServiceConfig(LongRunningServiceConfig):
                 ),
             )
             constraints.extend(self.get_pool_constraints())
-        return [[str(val) for val in constraint] for constraint in constraints]
+        return constraints
 
-    def get_routing_constraints(self, service_namespace_config, system_paasta_config):
+    def get_routing_constraints(
+        self,
+        service_namespace_config: ServiceNamespaceConfig,
+        system_paasta_config: SystemPaastaConfig,
+    ) -> List[Constraint]:
         """
         Returns a set of constraints in order to evenly group a marathon
         application amongst instances of a discovery type.
@@ -340,10 +421,10 @@ class MarathonServiceConfig(LongRunningServiceConfig):
             filtered_slaves,
             discover_level,
         )
-        routing_constraints = [[discover_level, "GROUP_BY", str(len(value_dict.keys()))]]
+        routing_constraints: List[Constraint] = [[discover_level, "GROUP_BY", str(len(value_dict.keys()))]]
         return routing_constraints
 
-    def format_marathon_app_dict(self):
+    def format_marathon_app_dict(self) -> Dict[str, Any]:
         """Create the configuration that will be passed to the Marathon REST API.
 
         Currently compiles the following keys into one nice dict:
@@ -380,7 +461,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
 
         net = get_mesos_network_for_net(self.get_net())
 
-        complete_config = {
+        complete_config: Dict[str, Any] = {
             'container': {
                 'docker': {
                     'image': docker_url,
@@ -444,7 +525,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         log.debug("Complete configuration for instance is: %s", complete_config)
         return complete_config
 
-    def sanitize_for_config_hash(self, config):
+    def sanitize_for_config_hash(self, config: Dict[str, Any]) -> Dict[str, Any]:
         """Removes some data from complete_config to make it suitable for
         calculation of config hash.
 
@@ -455,7 +536,11 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         ahash['container']['docker']['parameters'] = self.format_docker_parameters(with_labels=False)
         return ahash
 
-    def get_healthchecks(self, service_namespace_config, use_mesos_healthcheck):
+    def get_healthchecks(
+        self,
+        service_namespace_config: ServiceNamespaceConfig,
+        use_mesos_healthcheck: bool,
+    ) -> List[HealthcheckDict]:
         """Returns a list of healthchecks per `the Marathon docs`_.
 
         If you have an http service, it uses the default endpoint that smartstack uses.
@@ -488,7 +573,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
             http_path = self.get_healthcheck_uri(service_namespace_config)
             protocol = "MESOS_%s" % mode.upper() if use_mesos_healthcheck else mode.upper()
             healthchecks = [
-                {
+                HealthcheckDict({
                     "protocol": protocol,
                     "path": http_path,
                     "gracePeriodSeconds": graceperiodseconds,
@@ -496,29 +581,29 @@ class MarathonServiceConfig(LongRunningServiceConfig):
                     "portIndex": 0,
                     "timeoutSeconds": timeoutseconds,
                     "maxConsecutiveFailures": maxconsecutivefailures,
-                },
+                }),
             ]
         elif mode == 'tcp':
             healthchecks = [
-                {
+                HealthcheckDict({
                     "protocol": "TCP",
                     "gracePeriodSeconds": graceperiodseconds,
                     "intervalSeconds": intervalseconds,
                     "portIndex": 0,
                     "timeoutSeconds": timeoutseconds,
                     "maxConsecutiveFailures": maxconsecutivefailures,
-                },
+                }),
             ]
         elif mode == 'cmd':
             healthchecks = [
-                {
+                HealthcheckDict({
                     "protocol": "COMMAND",
                     "command": {"value": self.get_healthcheck_cmd()},
                     "gracePeriodSeconds": graceperiodseconds,
                     "intervalSeconds": intervalseconds,
                     "timeoutSeconds": timeoutseconds,
                     "maxConsecutiveFailures": maxconsecutivefailures,
-                },
+                }),
             ]
         elif mode is None:
             healthchecks = []
@@ -528,34 +613,35 @@ class MarathonServiceConfig(LongRunningServiceConfig):
             )
         return healthchecks
 
-    def get_bounce_health_params(self, service_namespace_config):
-        default = {}
+    def get_bounce_health_params(self, service_namespace_config: ServiceNamespaceConfig) -> Dict[str, Any]:
+        default: Dict[str, Any] = {}
         if service_namespace_config.is_in_smartstack():
             default = {'check_haproxy': True}
         return self.config_dict.get('bounce_health_params', default)
 
-    def get_bounce_margin_factor(self):
+    def get_bounce_margin_factor(self) -> float:
         return self.config_dict.get('bounce_margin_factor', 1.0)
 
-    def get_accepted_resource_roles(self):
+    def get_accepted_resource_roles(self) -> Optional[List[str]]:
         return self.config_dict.get('accepted_resource_roles', None)
 
-    def get_replication_crit_percentage(self):
+    def get_replication_crit_percentage(self) -> int:
         return self.config_dict.get('replication_threshold', 50)
 
-    def get_host_port(self):
+    def get_host_port(self) -> int:
         '''Map this port on the host to your container's port 8888. Default is 0, which means Marathon picks a port.'''
         return self.config_dict.get('host_port', 0)
 
-    def get_marathon_shard(self):
+    def get_marathon_shard(self) -> Optional[int]:
         """Returns the configued shard of Marathon to use.
-        Defaults to 0 currently as a fail-safe"""
+        Defaults to 0 currently as a fail-safe, but will default to None when we have more confidence in the sharding
+        code."""
         return self.config_dict.get('marathon_shard', 0)
 
-    def get_previous_marathon_shards(self):
+    def get_previous_marathon_shards(self) -> Optional[List[int]]:
         """Returns a list of Marathon shards a service might have been on previously.
-        Useful for graceful shard migrations. Defaults to an empty list"""
-        return self.config_dict.get('previous_marathon_shards', [])
+        Useful for graceful shard migrations. Defaults to None"""
+        return self.config_dict.get('previous_marathon_shards', None)
 
 
 class MarathonDeployStatus:
@@ -565,17 +651,18 @@ class MarathonDeployStatus:
     Running, Deploying, Stopped, Delayed, Waiting, NotRunning = range(0, 6)
 
     @classmethod
-    def tostring(cls, val):
+    def tostring(cls, val: int) -> str:
         for k, v in vars(cls).items():
             if v == val:
                 return k
+        raise ValueError("Unknown Marathon deploy status %d" % val)
 
     @classmethod
-    def fromstring(cls, str):
-        return getattr(cls, str, None)
+    def fromstring(cls, _str: str) -> int:
+        return getattr(cls, _str, None)
 
 
-def get_marathon_app_deploy_status(client, app_id):
+def get_marathon_app_deploy_status(client: MarathonClient, app_id: str) -> int:
     if is_app_id_running(app_id, client):
         app = client.get_app(app_id)
     else:
@@ -602,11 +689,11 @@ def get_marathon_app_deploy_status(client, app_id):
 class CachedMarathonClient(MarathonClient):
 
     @time_cache(ttl=20)
-    def list_apps(self, *args, **kwargs):
+    def list_apps(self, *args: Any, **kwargs: Any) -> Any:
         return super(CachedMarathonClient, self).list_apps(*args, **kwargs)
 
 
-def get_marathon_client(url, user, passwd, cached=False):
+def get_marathon_client(url: List[str], user: str, passwd: str, cached: bool=False) -> MarathonClient:
     """Get a new Marathon client connection in the form of a MarathonClient object.
 
     :param url: The url to connect to Marathon at
@@ -625,7 +712,7 @@ def get_marathon_client(url, user, passwd, cached=False):
         return MarathonClient(url, user, passwd, timeout=30, session=session)
 
 
-def get_marathon_clients(marathon_servers, cached=False):
+def get_marathon_clients(marathon_servers: MarathonServers, cached: bool=False) -> MarathonClients:
     current_servers = marathon_servers.current
     current_clients = []
     for current_server in current_servers:
@@ -647,7 +734,7 @@ def get_marathon_clients(marathon_servers, cached=False):
     return MarathonClients(current=current_clients, previous=previous_clients)
 
 
-def format_job_id(service, instance, git_hash=None, config_hash=None):
+def format_job_id(service: str, instance: str, git_hash: Optional[str]=None, config_hash: Optional[str]=None) -> str:
     """Compose a Marathon app id formatted to meet Marathon's
     `app id requirements <https://mesosphere.github.io/marathon/docs/rest-api.html#id-string>`_
 
@@ -670,12 +757,17 @@ def format_job_id(service, instance, git_hash=None, config_hash=None):
     return formatted
 
 
-def deformat_job_id(job_id):
+def deformat_job_id(job_id: str) -> Tuple[str, str, str, str]:
     job_id = job_id.replace('--', '_')
     return decompose_job_id(job_id)
 
 
-def read_all_registrations_for_service_instance(service, instance, cluster=None, soa_dir=DEFAULT_SOA_DIR):
+def read_all_registrations_for_service_instance(
+    service: str,
+    instance: str,
+    cluster: Optional[str]=None,
+    soa_dir: str=DEFAULT_SOA_DIR,
+) -> List[str]:
     """Retreive all registrations as fully specified name.instance pairs
     for a particular service instance.
 
@@ -694,7 +786,12 @@ def read_all_registrations_for_service_instance(service, instance, cluster=None,
     return marathon_service_config.get_registrations()
 
 
-def read_registration_for_service_instance(service, instance, cluster=None, soa_dir=DEFAULT_SOA_DIR):
+def read_registration_for_service_instance(
+    service: str,
+    instance: str,
+    cluster: Optional[str]=None,
+    soa_dir: str=DEFAULT_SOA_DIR,
+) -> str:
     """Retreive a service instance's primary registration for a particular
     service instance.
 
@@ -712,7 +809,12 @@ def read_registration_for_service_instance(service, instance, cluster=None, soa_
     )[0]
 
 
-def get_proxy_port_for_instance(name, instance, cluster=None, soa_dir=DEFAULT_SOA_DIR):
+def get_proxy_port_for_instance(
+    name: str,
+    instance: str,
+    cluster: Optional[str]=None,
+    soa_dir: str=DEFAULT_SOA_DIR,
+) -> Optional[int]:
     """Get the proxy_port defined in the first namespace configuration for a
     service instance.
 
@@ -733,7 +835,11 @@ def get_proxy_port_for_instance(name, instance, cluster=None, soa_dir=DEFAULT_SO
     return nerve_dict.get('proxy_port')
 
 
-def get_all_namespaces_for_service(service, soa_dir=DEFAULT_SOA_DIR, full_name=True):
+def get_all_namespaces_for_service(
+    service: str,
+    soa_dir: str=DEFAULT_SOA_DIR,
+    full_name: bool=True,
+) -> List[Tuple[str, str]]:
     """Get all the smartstack namespaces listed for a given service name.
 
     :param service: The service name
@@ -755,7 +861,7 @@ def get_all_namespaces_for_service(service, soa_dir=DEFAULT_SOA_DIR, full_name=T
     return namespace_list
 
 
-def get_all_namespaces(soa_dir=DEFAULT_SOA_DIR):
+def get_all_namespaces(soa_dir: str=DEFAULT_SOA_DIR) -> List[Tuple[str, str]]:
     """Get all the smartstack namespaces across all services.
     This is mostly so synapse can get everything it needs in one call.
 
@@ -768,18 +874,19 @@ def get_all_namespaces(soa_dir=DEFAULT_SOA_DIR):
     return namespace_list
 
 
-def get_app_id_and_task_uuid_from_executor_id(executor_id):
+def get_app_id_and_task_uuid_from_executor_id(executor_id: str) -> Tuple[str, str]:
     """Parse the marathon executor ID and return the (app id, task uuid)"""
-    return executor_id.rsplit('.', 1)
+    app_id, task_uuid = executor_id.rsplit('.', 1)
+    return app_id, task_uuid
 
 
-def parse_service_instance_from_executor_id(task_id):
+def parse_service_instance_from_executor_id(task_id: str) -> Tuple[str, str]:
     app_id, task_uuid = get_app_id_and_task_uuid_from_executor_id(task_id)
     (srv_name, srv_instance, _, __) = deformat_job_id(app_id)
     return srv_name, srv_instance
 
 
-def marathon_services_running_here():
+def marathon_services_running_here() -> List[Tuple[str, str, int]]:
     """See what marathon services are being run by a mesos-slave on this host.
     :returns: A list of triples of (service, instance, port)"""
 
@@ -789,7 +896,10 @@ def marathon_services_running_here():
     )
 
 
-def get_marathon_services_running_here_for_nerve(cluster, soa_dir):
+def get_marathon_services_running_here_for_nerve(
+    cluster: str,
+    soa_dir: str,
+) -> List[Tuple[str, ServiceNamespaceConfig]]:
     if not cluster:
         try:
             cluster = load_system_paasta_config().get_cluster()
@@ -822,7 +932,7 @@ def get_marathon_services_running_here_for_nerve(cluster, soa_dir):
     return nerve_list
 
 
-def get_puppet_services_that_run_here():
+def get_puppet_services_that_run_here() -> Dict[str, List[str]]:
     # find all files in the PUPPET_SERVICE_DIR, but discard broken symlinks
     # this allows us to (de)register services on a machine by
     # breaking/healing a symlink placed by Puppet.
@@ -838,7 +948,7 @@ def get_puppet_services_that_run_here():
     return puppet_service_dir_services
 
 
-def get_puppet_services_running_here_for_nerve(soa_dir):
+def get_puppet_services_running_here_for_nerve(soa_dir: str) -> List[Tuple[str, ServiceNamespaceConfig]]:
     puppet_services = []
     for service, namespaces in sorted(get_puppet_services_that_run_here().items()):
         for namespace in namespaces:
@@ -850,11 +960,15 @@ def get_puppet_services_running_here_for_nerve(soa_dir):
     return puppet_services
 
 
-def get_classic_service_information_for_nerve(name, soa_dir):
+def get_classic_service_information_for_nerve(name: str, soa_dir: str) -> Tuple[str, ServiceNamespaceConfig]:
     return _namespaced_get_classic_service_information_for_nerve(name, 'main', soa_dir)
 
 
-def _namespaced_get_classic_service_information_for_nerve(name, namespace, soa_dir):
+def _namespaced_get_classic_service_information_for_nerve(
+    name: str,
+    namespace: str,
+    soa_dir: str,
+) -> Tuple[str, ServiceNamespaceConfig]:
     nerve_dict = load_service_namespace_config(name, namespace, soa_dir)
     port_file = os.path.join(soa_dir, name, 'port')
     # If the namespace defines a port, prefer that, otherwise use the
@@ -867,7 +981,7 @@ def _namespaced_get_classic_service_information_for_nerve(name, namespace, soa_d
     return (nerve_name, nerve_dict)
 
 
-def get_classic_services_running_here_for_nerve(soa_dir):
+def get_classic_services_running_here_for_nerve(soa_dir: str) -> List[Tuple[str, ServiceNamespaceConfig]]:
     classic_services = []
     classic_services_here = service_configuration_lib.services_that_run_here()
     for service in sorted(classic_services_here):
@@ -883,7 +997,7 @@ def get_classic_services_running_here_for_nerve(soa_dir):
     return classic_services
 
 
-def list_all_marathon_app_ids(client):
+def list_all_marathon_app_ids(client: MarathonClient) -> List[str]:
     """List all marathon app_ids, regardless of state
 
     The raw marathon API returns app ids in their URL form, with leading '/'s
@@ -897,7 +1011,7 @@ def list_all_marathon_app_ids(client):
     return [app.id.lstrip('/') for app in get_all_marathon_apps(client)]
 
 
-def is_app_id_running(app_id, client):
+def is_app_id_running(app_id: str, client: MarathonClient) -> bool:
     """Returns a boolean indicating if the app is in the current list
     of marathon apps
 
@@ -908,7 +1022,12 @@ def is_app_id_running(app_id, client):
     return app_id.lstrip('/') in all_app_ids
 
 
-def app_has_tasks(client, app_id, expected_tasks, exact_matches_only=False):
+def app_has_tasks(
+    client: MarathonClient,
+    app_id: str,
+    expected_tasks: int,
+    exact_matches_only: bool=False,
+) -> bool:
     """A predicate function indicating whether an app has launched *at least* expected_tasks
     tasks.
 
@@ -935,7 +1054,7 @@ def app_has_tasks(client, app_id, expected_tasks, exact_matches_only=False):
         return len(tasks) >= expected_tasks
 
 
-def get_app_queue_status(client, app_id):
+def get_app_queue_status(client: MarathonClient, app_id: str) -> Tuple[Optional[bool], Optional[float]]:
     """Returns the status of an application if it exists in Marathon's launch queue
 
     :param client: The marathon client
@@ -953,7 +1072,7 @@ def get_app_queue_status(client, app_id):
     return (None, None)
 
 
-def create_complete_config(service, instance, soa_dir=DEFAULT_SOA_DIR):
+def create_complete_config(service: str, instance: str, soa_dir: str=DEFAULT_SOA_DIR) -> Dict[str, Any]:
     """Generates a complete dictionary to be POST'ed to create an app on Marathon"""
     return load_marathon_service_config(
         service=service,
@@ -963,7 +1082,12 @@ def create_complete_config(service, instance, soa_dir=DEFAULT_SOA_DIR):
     ).format_marathon_app_dict()
 
 
-def get_expected_instance_count_for_namespace(service, namespace, cluster=None, soa_dir=DEFAULT_SOA_DIR):
+def get_expected_instance_count_for_namespace(
+    service: str,
+    namespace: str,
+    cluster: str=None,
+    soa_dir: str=DEFAULT_SOA_DIR,
+) -> int:
     """Get the number of expected instances for a namespace, based on the number
     of instances set to run on that namespace as specified in Marathon service
     configuration files.
@@ -988,7 +1112,7 @@ def get_expected_instance_count_for_namespace(service, namespace, cluster=None, 
     return total_expected
 
 
-def get_matching_appids(servicename, instance, client):
+def get_matching_appids(servicename: str, instance: str, client: MarathonClient) -> List[str]:
     """Returns a list of appids given a service and instance.
     Useful for fuzzy matching if you think there are marathon
     apps running but you don't know the full instance id"""
@@ -996,7 +1120,7 @@ def get_matching_appids(servicename, instance, client):
     return [app.id for app in get_matching_apps(servicename, instance, marathon_apps)]
 
 
-def get_matching_apps(servicename, instance, marathon_apps):
+def get_matching_apps(servicename: str, instance: str, marathon_apps: List[MarathonApp]) -> List[MarathonApp]:
     """Returns a list of appids given a service and instance.
     Useful for fuzzy matching if you think there are marathon
     apps running but you don't know the full instance id"""
@@ -1005,11 +1129,11 @@ def get_matching_apps(servicename, instance, marathon_apps):
     return [app for app in marathon_apps if app.id.startswith(expected_prefix)]
 
 
-def get_all_marathon_apps(client, embed_tasks=False):
+def get_all_marathon_apps(client: MarathonClient, embed_tasks: bool=False) -> List[MarathonApp]:
     return client.list_apps(embed_tasks=embed_tasks)
 
 
-def kill_task(client, app_id, task_id, scale):
+def kill_task(client: MarathonClient, app_id: str, task_id: str, scale: bool) -> Optional[MarathonTask]:
     """Wrapper to the official kill_task method that is tolerant of errors"""
     try:
         return client.kill_task(app_id=app_id, task_id=task_id, scale=True)
@@ -1021,19 +1145,19 @@ def kill_task(client, app_id, task_id, scale):
         # valid" message or a "Bean is not valid" message.
         if 'is not valid' in e.error_message and e.status_code == 422:
             log.warning("Got 'is not valid' when killing task %s. Continuing anyway." % task_id)
-            return []
+            return None
         elif 'does not exist' in e.error_message and e.status_code == 404:
             log.warning("Got 'does not exist' when killing task %s. Continuing anyway." % task_id)
-            return []
+            return None
         else:
             raise
 
 
-def kill_given_tasks(client, task_ids, scale):
+def kill_given_tasks(client: MarathonClient, task_ids: List[str], scale: bool) -> bool:
     """Wrapper to the official kill_given_tasks method that is tolerant of errors"""
     if not task_ids:
         log.debug("No task_ids specified, not killing any tasks")
-        return []
+        return False
     try:
         return client.kill_given_tasks(task_ids=task_ids, scale=scale, force=True)
     except MarathonHttpError as e:
@@ -1043,12 +1167,12 @@ def kill_given_tasks(client, task_ids, scale):
         # swallow this error.
         if 'is not valid' in e.error_message and e.status_code == 422:
             log.debug("Probably tried to kill a task id that didn't exist. Continuing.")
-            return []
+            return False
         else:
             raise
 
 
-def is_task_healthy(task, require_all=True, default_healthy=False):
+def is_task_healthy(task: MarathonTask, require_all: bool=True, default_healthy: bool=False) -> bool:
     """Check that a marathon task is healthy
 
     :param task: the marathon task object
@@ -1066,7 +1190,7 @@ def is_task_healthy(task, require_all=True, default_healthy=False):
     return default_healthy
 
 
-def is_old_task_missing_healthchecks(task, marathon_client):
+def is_old_task_missing_healthchecks(task: MarathonTask, marathon_client: MarathonClient) -> bool:
     """We check this because versions of Marathon (at least up to 1.1)
     sometimes stop healthchecking tasks, leaving no results. We can normally
     assume that an "old" task which has no healthcheck results is still up
@@ -1081,7 +1205,7 @@ def is_old_task_missing_healthchecks(task, marathon_client):
     return False
 
 
-def get_num_at_risk_tasks(app, draining_hosts):
+def get_num_at_risk_tasks(app: MarathonApp, draining_hosts: List[str]) -> int:
     """Determine how many of an application's tasks are running on
     at-risk (Mesos Maintenance Draining) hosts.
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -366,7 +366,7 @@ class InstanceConfig(object):
         for value in self.config_dict.get('cap_add', []):
             yield {"key": "cap-add", "value": "{}".format(value)}
 
-    def format_docker_parameters(self, with_labels: bool=True) -> Iterable[DockerParameter]:
+    def format_docker_parameters(self, with_labels: bool=True) -> List[DockerParameter]:
         """Formats extra flags for running docker.  Will be added in the format
         `["--%s=%s" % (e['key'], e['value']) for e in list]` to the `docker run` command
         Note: values must be strings
@@ -612,7 +612,7 @@ class InstanceConfig(object):
                 error_msgs.append(check_msg)
         return error_msgs
 
-    def get_extra_volumes(self) -> Sequence[DockerVolume]:
+    def get_extra_volumes(self) -> List[DockerVolume]:
         """Extra volumes are a specially formatted list of dictionaries that should
         be bind mounted in a container The format of the dictionaries should
         conform to the `Mesos container volumes spec
@@ -647,7 +647,7 @@ class InstanceConfig(object):
         """
         return self.config_dict.get('net', 'bridge')
 
-    def get_volumes(self, system_volumes: Sequence[DockerVolume]) -> Sequence[DockerVolume]:
+    def get_volumes(self, system_volumes: Sequence[DockerVolume]) -> List[DockerVolume]:
         volumes = list(system_volumes) + list(self.get_extra_volumes())
         deduped = {v['containerPath'].rstrip('/') + v['hostPath'].rstrip('/'): v for v in volumes}.values()
         return sort_dicts(deduped)
@@ -1325,7 +1325,7 @@ SystemPaastaConfigDict = TypedDict(
     {
         'zookeeper': str,
         'docker_registry': str,
-        'volumes': Sequence[DockerVolume],
+        'volumes': List[DockerVolume],
         'cluster': str,
         'dashboard_links': Dict[str, Dict[str, str]],
         'api_endpoints': Dict[str, str],
@@ -1436,7 +1436,7 @@ class SystemPaastaConfig(object):
                 % self.directory,
             )
 
-    def get_volumes(self) -> Sequence[DockerVolume]:
+    def get_volumes(self) -> List[DockerVolume]:
         """Get the volumes defined in this host's volumes config file.
 
         :returns: The list of volumes specified in the paasta configuration

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -149,8 +149,16 @@ class InvalidInstanceConfig(Exception):
 
 DeployBlacklist = List[Tuple[str, str]]
 DeployWhitelist = Optional[Tuple[str, List[str]]]
+# The actual config files will have lists, since tuples are not expressible in base YAML, so we define different types
+# here to represent that. The getter functions will convert to the safe versions above.
+UnsafeDeployBlacklist = Optional[Sequence[Sequence[str]]]
+UnsafeDeployWhitelist = Optional[Sequence[Union[str, Sequence[str]]]]
+
 
 Constraint = Sequence[str]
+
+# e.g. ['GROUP_BY', 'habitat', 2]. Marathon doesn't like that so we'll convert to Constraint later.
+UnstringifiedConstraint = Sequence[Union[str, int, float]]
 
 SecurityConfigDict = Dict  # Todo: define me.
 
@@ -178,16 +186,16 @@ InstanceConfigDict = TypedDict(
         'cap_add': List,
         'env': Dict[str, str],
         'monitoring': Dict[str, str],
-        'deploy_blacklist': DeployBlacklist,
-        'deploy_whitelist': DeployWhitelist,
-        'monitoring_blacklist': DeployBlacklist,
+        'deploy_blacklist': UnsafeDeployBlacklist,
+        'deploy_whitelist': UnsafeDeployWhitelist,
+        'monitoring_blacklist': UnsafeDeployBlacklist,
         'pool': str,
         'extra_volumes': List[DockerVolume],
         'security': SecurityConfigDict,
         'dependencies_reference': str,
         'dependencies': Dict[str, Dict],
-        'constraints': List[Constraint],
-        'extra_constraints': List[Constraint],
+        'constraints': List[UnstringifiedConstraint],
+        'extra_constraints': List[UnstringifiedConstraint],
         'net': str,
         'extra_docker_args': Dict[str, str],
         'gpus': float,
@@ -215,6 +223,18 @@ DockerParameter = TypedDict(
         'value': str,
     },
 )
+
+
+def safe_deploy_blacklist(input: UnsafeDeployBlacklist) -> DeployBlacklist:
+    return [(t, l) for t, l in input]
+
+
+def safe_deploy_whitelist(input: UnsafeDeployWhitelist) -> DeployWhitelist:
+    try:
+        location_type, allowed_values = input
+        return cast(str, location_type), cast(List[str], allowed_values)
+    except TypeError:
+        return None
 
 
 class InstanceConfig(object):
@@ -464,19 +484,20 @@ class InstanceConfig(object):
     def get_deploy_blacklist(self) -> DeployBlacklist:
         """The deploy blacklist is a list of lists, where the lists indicate
         which locations the service should not be deployed"""
-        return self.config_dict.get('deploy_blacklist', [])
+        return safe_deploy_blacklist(self.config_dict.get('deploy_blacklist', []))
 
     def get_deploy_whitelist(self) -> DeployWhitelist:
         """The deploy whitelist is a tuple of (location_type, [allowed value, allowed value, ...]).
         To have tasks scheduled on it, a host must be covered by the deploy whitelist (if present) and not excluded by
         the deploy blacklist."""
-        return self.config_dict.get('deploy_whitelist', None)
+
+        return safe_deploy_whitelist(self.config_dict.get('deploy_whitelist'))
 
     def get_monitoring_blacklist(self, system_deploy_blacklist: DeployBlacklist) -> DeployBlacklist:
         """The monitoring_blacklist is a list of tuples of (location type, location value), where the tuples indicate
         which locations the user doesn't care to be monitored"""
         return (
-            self.config_dict.get('monitoring_blacklist', []) +
+            safe_deploy_blacklist(self.config_dict.get('monitoring_blacklist', [])) +
             self.get_deploy_blacklist() +
             system_deploy_blacklist
         )
@@ -591,7 +612,7 @@ class InstanceConfig(object):
                 error_msgs.append(check_msg)
         return error_msgs
 
-    def get_extra_volumes(self) -> List[DockerVolume]:
+    def get_extra_volumes(self) -> Sequence[DockerVolume]:
         """Extra volumes are a specially formatted list of dictionaries that should
         be bind mounted in a container The format of the dictionaries should
         conform to the `Mesos container volumes spec
@@ -614,11 +635,11 @@ class InstanceConfig(object):
         pool = self.get_pool()
         return [["pool", "LIKE", pool]]
 
-    def get_constraints(self) -> List[Constraint]:
-        return self.config_dict.get('constraints', None)
+    def get_constraints(self) -> Optional[List[Constraint]]:
+        return stringify_constraints(self.config_dict.get('constraints', None))
 
     def get_extra_constraints(self) -> List[Constraint]:
-        return self.config_dict.get('extra_constraints', [])
+        return stringify_constraints(self.config_dict.get('extra_constraints', []))
 
     def get_net(self) -> str:
         """
@@ -626,8 +647,8 @@ class InstanceConfig(object):
         """
         return self.config_dict.get('net', 'bridge')
 
-    def get_volumes(self, system_volumes: List[DockerVolume]) -> List[DockerVolume]:
-        volumes = system_volumes + self.get_extra_volumes()
+    def get_volumes(self, system_volumes: Sequence[DockerVolume]) -> Sequence[DockerVolume]:
+        volumes = list(system_volumes) + list(self.get_extra_volumes())
         deduped = {v['containerPath'].rstrip('/') + v['hostPath'].rstrip('/'): v for v in volumes}.values()
         return sort_dicts(deduped)
 
@@ -670,6 +691,16 @@ class InstanceConfig(object):
                 self.service == other.service
         else:
             return False
+
+
+def stringify_constraint(usc: UnstringifiedConstraint) -> Constraint:
+    return [str(x) for x in usc]
+
+
+def stringify_constraints(uscs: Optional[List[UnstringifiedConstraint]]) -> List[Constraint]:
+    if uscs is None:
+        return None
+    return [stringify_constraint(usc) for usc in uscs]
 
 
 def validate_service_instance(service: str, instance: str, cluster: str, soa_dir: str) -> str:
@@ -1294,7 +1325,7 @@ SystemPaastaConfigDict = TypedDict(
     {
         'zookeeper': str,
         'docker_registry': str,
-        'volumes': List[DockerVolume],
+        'volumes': Sequence[DockerVolume],
         'cluster': str,
         'dashboard_links': Dict[str, Dict[str, str]],
         'api_endpoints': Dict[str, str],
@@ -1321,8 +1352,8 @@ SystemPaastaConfigDict = TypedDict(
         'paasta_native': PaastaNativeConfig,
         'mesos_config': Dict,
         'monitoring_config': Dict,
-        'deploy_blacklist': DeployBlacklist,
-        'deploy_whitelist': DeployWhitelist,
+        'deploy_blacklist': UnsafeDeployBlacklist,
+        'deploy_whitelist': UnsafeDeployWhitelist,
         'expected_slave_attributes': ExpectedSlaveAttributes,
         'security_check_command': str,
         'deployd_number_workers': int,
@@ -1405,7 +1436,7 @@ class SystemPaastaConfig(object):
                 % self.directory,
             )
 
-    def get_volumes(self) -> List[DockerVolume]:
+    def get_volumes(self) -> Sequence[DockerVolume]:
         """Get the volumes defined in this host's volumes config file.
 
         :returns: The list of volumes specified in the paasta configuration
@@ -1594,7 +1625,7 @@ class SystemPaastaConfig(object):
 
         :returns: The blacklist
         """
-        return self.config_dict.get("deploy_blacklist", [])
+        return safe_deploy_blacklist(self.config_dict.get("deploy_blacklist", []))
 
     def get_deploy_whitelist(self) -> DeployWhitelist:
         """Get global whitelist. This applies to all services
@@ -1602,7 +1633,8 @@ class SystemPaastaConfig(object):
 
         :returns: The whitelist
         """
-        return self.config_dict.get("deploy_whitelist", None)
+
+        return safe_deploy_whitelist(self.config_dict.get('deploy_whitelist'))
 
     def get_expected_slave_attributes(self) -> ExpectedSlaveAttributes:
         """Return a list of dictionaries, representing the expected combinations of attributes in this cluster. Used for

--- a/tests/deployd/test_workers.py
+++ b/tests/deployd/test_workers.py
@@ -171,7 +171,6 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 instance='c137',
                 client=self.worker.marathon_client,
                 soa_dir=DEFAULT_SOA_DIR,
-                marathon_config=self.worker.marathon_config,
                 marathon_apps=mock_get_all_marathon_apps.return_value,
             )
             assert mock_setup_timers.return_value.setup_marathon.stop.called
@@ -190,7 +189,6 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 instance='c137',
                 client=self.worker.marathon_client,
                 soa_dir=DEFAULT_SOA_DIR,
-                marathon_config=self.worker.marathon_config,
                 marathon_apps=mock_get_all_marathon_apps.return_value,
             )
             assert mock_setup_timers.return_value.setup_marathon.stop.called

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -12,8 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Any  # noqa: imported for typing
+from typing import Dict  # noqa: imported for typing
+from typing import List  # noqa: imported for typing
+from typing import Set  # noqa: imported for typing
+
 import marathon
 import mock
+from marathon.models.app import MarathonApp  # noqa: imported for typing
+from marathon.models.app import MarathonTask  # noqa: imported for typing
 from pytest import raises
 
 from paasta_tools import bounce_lib
@@ -33,7 +40,6 @@ from paasta_tools.utils import paasta_print
 
 class TestSetupMarathonJob:
 
-    fake_docker_image = 'test_docker:1.0'
     fake_cluster = 'fake_test_cluster'
     fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
         service='servicename',
@@ -43,7 +49,6 @@ class TestSetupMarathonJob:
             'instances': 3,
             'cpus': 1,
             'mem': 100,
-            'docker_image': fake_docker_image,
             'nerve_ns': 'aaaaugh',
             'bounce_method': 'brutal',
         },
@@ -51,7 +56,7 @@ class TestSetupMarathonJob:
     )
     fake_docker_registry = 'remote_registry.com'
     fake_marathon_config = marathon_tools.MarathonConfig({
-        'url': 'http://test_url',
+        'url': ['http://test_url'],
         'user': 'admin',
         'password': 'admin_pass',
     })
@@ -234,7 +239,7 @@ class TestSetupMarathonJob:
     def test_send_event(self):
         fake_service = 'fake_service'
         fake_instance = 'fake_instance'
-        fake_status = '42'
+        fake_status = 42
         fake_output = 'The http port is not open'
         fake_soa_dir = ''
         expected_check_name = 'setup_marathon_job.%s' % compose_job_id(fake_service, fake_instance)
@@ -275,7 +280,7 @@ class TestSetupMarathonJob:
     def test_do_bounce_when_create_app_and_new_app_not_running_but_already_created(self):
         """ Note that this is possible if two bounces are running at the same time
         because we get the list of marathon apps outside of any locking"""
-        fake_bounce_func_return = {
+        fake_bounce_func_return: bounce_lib.BounceMethodResult = {
             'create_app': True,
             'tasks_to_drain': [mock.Mock(app_id='fake_task_to_kill_1')],
         }
@@ -283,13 +288,13 @@ class TestSetupMarathonJob:
             bounce_lib.brutal_bounce,
             return_value=fake_bounce_func_return,
         )
-        fake_config = {'instances': 5}
+        fake_config: marathon_tools.FormattedMarathonAppDict = {'instances': 5}
         fake_new_app_running = False
         fake_happy_new_tasks = ['fake_one', 'fake_two', 'fake_three']
-        fake_old_app_live_happy_tasks = {}
-        fake_old_app_live_unhappy_tasks = {}
-        fake_old_app_draining_tasks = {}
-        fake_old_app_at_risk_tasks = {}
+        fake_old_app_live_happy_tasks: Dict[str, Set[MarathonTask]] = {}
+        fake_old_app_live_unhappy_tasks: Dict[str, Set[MarathonTask]] = {}
+        fake_old_app_draining_tasks: Dict[str, Set[MarathonTask]] = {}
+        fake_old_app_at_risk_tasks: Dict[str, Set[MarathonTask]] = {}
         fake_service = 'fake_service'
         fake_serviceinstance = 'fake_service.fake_instance'
         self.fake_cluster = 'fake_cluster'
@@ -345,7 +350,7 @@ class TestSetupMarathonJob:
             assert mock_kill_old_ids.call_count == 0
 
     def test_do_bounce_when_create_app_and_new_app_not_running(self):
-        fake_bounce_func_return = {
+        fake_bounce_func_return: bounce_lib.BounceMethodResult = {
             'create_app': True,
             'tasks_to_drain': [mock.Mock(app_id='fake_task_to_kill_1')],
         }
@@ -353,13 +358,13 @@ class TestSetupMarathonJob:
             bounce_lib.brutal_bounce,
             return_value=fake_bounce_func_return,
         )
-        fake_config = {'instances': 5}
+        fake_config: marathon_tools.FormattedMarathonAppDict = {'instances': 5}
         fake_new_app_running = False
         fake_happy_new_tasks = ['fake_one', 'fake_two', 'fake_three']
-        fake_old_app_live_happy_tasks = {}
-        fake_old_app_live_unhappy_tasks = {}
-        fake_old_app_draining_tasks = {}
-        fake_old_app_at_risk_tasks = {}
+        fake_old_app_live_happy_tasks: Dict[str, Set[MarathonTask]] = {}
+        fake_old_app_live_unhappy_tasks: Dict[str, Set[MarathonTask]] = {}
+        fake_old_app_draining_tasks: Dict[str, Set[MarathonTask]] = {}
+        fake_old_app_at_risk_tasks: Dict[str, Set[MarathonTask]] = {}
         fake_service = 'fake_service'
         fake_serviceinstance = 'fake_service.fake_instance'
         self.fake_cluster = 'fake_cluster'
@@ -439,7 +444,7 @@ class TestSetupMarathonJob:
 
     def test_do_bounce_when_create_app_and_new_app_running(self):
         fake_task_to_drain = mock.Mock(app_id='fake_app_to_kill_1')
-        fake_bounce_func_return = {
+        fake_bounce_func_return: bounce_lib.BounceMethodResult = {
             'create_app': True,
             'tasks_to_drain': [fake_task_to_drain],
         }
@@ -447,13 +452,13 @@ class TestSetupMarathonJob:
             bounce_lib.brutal_bounce,
             return_value=fake_bounce_func_return,
         )
-        fake_config = {'instances': 5}
+        fake_config: marathon_tools.FormattedMarathonAppDict = {'instances': 5}
         fake_new_app_running = True
         fake_happy_new_tasks = ['fake_one', 'fake_two', 'fake_three']
-        fake_old_app_live_happy_tasks = {'fake_app_to_kill_1': {fake_task_to_drain}}
-        fake_old_app_live_unhappy_tasks = {'fake_app_to_kill_1': set()}
-        fake_old_app_draining_tasks = {'fake_app_to_kill_1': set()}
-        fake_old_app_at_risk_tasks = {'fake_app_to_kill_1': set()}
+        fake_old_app_live_happy_tasks: Dict[str, Set[MarathonTask]] = {'fake_app_to_kill_1': {fake_task_to_drain}}
+        fake_old_app_live_unhappy_tasks: Dict[str, Set[MarathonTask]] = {'fake_app_to_kill_1': set()}
+        fake_old_app_draining_tasks: Dict[str, Set[MarathonTask]] = {'fake_app_to_kill_1': set()}
+        fake_old_app_at_risk_tasks: Dict[str, Set[MarathonTask]] = {'fake_app_to_kill_1': set()}
         fake_service = 'fake_service'
         fake_serviceinstance = 'fake_service.fake_instance'
         self.fake_cluster = 'fake_cluster'
@@ -504,7 +509,7 @@ class TestSetupMarathonJob:
 
     def test_do_bounce_when_tasks_to_drain(self):
         fake_task_to_drain = mock.Mock(app_id='fake_app_to_kill_1')
-        fake_bounce_func_return = {
+        fake_bounce_func_return: bounce_lib.BounceMethodResult = {
             'create_app': False,
             'tasks_to_drain': [fake_task_to_drain],
         }
@@ -512,13 +517,13 @@ class TestSetupMarathonJob:
             bounce_lib.brutal_bounce,
             return_value=fake_bounce_func_return,
         )
-        fake_config = {'instances': 5}
+        fake_config: marathon_tools.FormattedMarathonAppDict = {'instances': 5}
         fake_new_app_running = True
         fake_happy_new_tasks = ['fake_one', 'fake_two', 'fake_three']
-        fake_old_app_live_happy_tasks = {'fake_app_to_kill_1': {fake_task_to_drain}}
-        fake_old_app_live_unhappy_tasks = {'fake_app_to_kill_1': set()}
-        fake_old_app_draining_tasks = {'fake_app_to_kill_1': set()}
-        fake_old_app_at_risk_tasks = {'fake_app_to_kill_1': set()}
+        fake_old_app_live_happy_tasks: Dict[str, Set[MarathonTask]] = {'fake_app_to_kill_1': {fake_task_to_drain}}
+        fake_old_app_live_unhappy_tasks: Dict[str, Set[MarathonTask]] = {'fake_app_to_kill_1': set()}
+        fake_old_app_draining_tasks: Dict[str, Set[MarathonTask]] = {'fake_app_to_kill_1': set()}
+        fake_old_app_at_risk_tasks: Dict[str, Set[MarathonTask]] = {'fake_app_to_kill_1': set()}
         fake_service = 'fake_service'
         fake_serviceinstance = 'fake_service.fake_instance'
         self.fake_cluster = 'fake_cluster'
@@ -569,7 +574,7 @@ class TestSetupMarathonJob:
             assert fake_drain_method.drain.call_count == expected_drain_task_count
 
     def test_do_bounce_when_apps_to_kill(self):
-        fake_bounce_func_return = {
+        fake_bounce_func_return: bounce_lib.BounceMethodResult = {
             'create_app': False,
             'tasks_to_drain': [],
         }
@@ -577,13 +582,13 @@ class TestSetupMarathonJob:
             bounce_lib.brutal_bounce,
             return_value=fake_bounce_func_return,
         )
-        fake_config = {'instances': 5}
+        fake_config: marathon_tools.FormattedMarathonAppDict = {'instances': 5}
         fake_new_app_running = True
         fake_happy_new_tasks = ['fake_one', 'fake_two', 'fake_three']
-        fake_old_app_live_happy_tasks = {'fake_app_to_kill_1': set()}
-        fake_old_app_live_unhappy_tasks = {'fake_app_to_kill_1': set()}
-        fake_old_app_draining_tasks = {'fake_app_to_kill_1': set()}
-        fake_old_app_at_risk_tasks = {'fake_app_to_kill_1': set()}
+        fake_old_app_live_happy_tasks: Dict[str, Set[MarathonTask]] = {'fake_app_to_kill_1': set()}
+        fake_old_app_live_unhappy_tasks: Dict[str, Set[MarathonTask]] = {'fake_app_to_kill_1': set()}
+        fake_old_app_draining_tasks: Dict[str, Set[MarathonTask]] = {'fake_app_to_kill_1': set()}
+        fake_old_app_at_risk_tasks: Dict[str, Set[MarathonTask]] = {'fake_app_to_kill_1': set()}
         fake_service = 'fake_service'
         fake_serviceinstance = 'fake_service.fake_instance'
         self.fake_cluster = 'fake_cluster'
@@ -636,7 +641,7 @@ class TestSetupMarathonJob:
             assert 'Now running %s' % fake_marathon_jobid in third_logged_line
 
     def test_do_bounce_when_nothing_to_do(self):
-        fake_bounce_func_return = {
+        fake_bounce_func_return: bounce_lib.BounceMethodResult = {
             'create_app': False,
             'tasks_to_drain': [],
         }
@@ -645,13 +650,13 @@ class TestSetupMarathonJob:
             return_value=fake_bounce_func_return,
         )
 
-        fake_config = {'instances': 3}
+        fake_config: marathon_tools.FormattedMarathonAppDict = {'instances': 3}
         fake_new_app_running = True
         fake_happy_new_tasks = ['fake_one', 'fake_two', 'fake_three']
-        fake_old_app_live_happy_tasks = {}
-        fake_old_app_live_unhappy_tasks = {}
-        fake_old_app_draining_tasks = {}
-        fake_old_app_at_risk_tasks = {}
+        fake_old_app_live_happy_tasks: Dict[str, Set[MarathonTask]] = {}
+        fake_old_app_live_unhappy_tasks: Dict[str, Set[MarathonTask]] = {}
+        fake_old_app_draining_tasks: Dict[str, Set[MarathonTask]] = {}
+        fake_old_app_at_risk_tasks: Dict[str, Set[MarathonTask]] = {}
         fake_service = 'fake_service'
         fake_serviceinstance = 'fake_service.fake_instance'
         self.fake_cluster = 'fake_cluster'
@@ -694,7 +699,7 @@ class TestSetupMarathonJob:
 
     def test_do_bounce_when_all_old_tasks_are_unhappy(self):
         old_tasks = [mock.Mock(id=id, app_id='old_app') for id in ['old_one', 'old_two', 'old_three']]
-        fake_bounce_func_return = {
+        fake_bounce_func_return: bounce_lib.BounceMethodResult = {
             'create_app': False,
             'tasks_to_drain': old_tasks,
         }
@@ -703,13 +708,13 @@ class TestSetupMarathonJob:
             return_value=fake_bounce_func_return,
         )
 
-        fake_config = {'instances': 3}
+        fake_config: marathon_tools.FormattedMarathonAppDict = {'instances': 3}
         fake_new_app_running = True
         fake_happy_new_tasks = ['fake_one', 'fake_two', 'fake_three']
-        fake_old_app_live_happy_tasks = {'old_app': set()}
-        fake_old_app_live_unhappy_tasks = {'old_app': set(old_tasks)}
-        fake_old_app_draining_tasks = {'old_app': set()}
-        fake_old_app_at_risk_tasks = {'old_app': set()}
+        fake_old_app_live_happy_tasks: Dict[str, Set[MarathonTask]] = {'old_app': set()}
+        fake_old_app_live_unhappy_tasks: Dict[str, Set[MarathonTask]] = {'old_app': set(old_tasks)}
+        fake_old_app_draining_tasks: Dict[str, Set[MarathonTask]] = {'old_app': set()}
+        fake_old_app_at_risk_tasks: Dict[str, Set[MarathonTask]] = {'old_app': set()}
         fake_service = 'fake_service'
         fake_serviceinstance = 'fake_service.fake_instance'
         self.fake_cluster = 'fake_cluster'
@@ -756,16 +761,16 @@ class TestSetupMarathonJob:
         fake_service = 'fake_service'
         fake_instance = 'fake_instance'
         fake_jobid = 'fake_jobid'
-        fake_config = {
+        fake_config: marathon_tools.FormattedMarathonAppDict = {
             'id': 'some_id',
             'instances': 5,
         }
         fake_client = mock.MagicMock(scale_app=mock.Mock())
         fake_bounce_method = 'bounce'
         fake_drain_method_name = 'drain'
-        fake_drain_method_params = {}
+        fake_drain_method_params: Dict[str, Any] = {}
         fake_nerve_ns = 'nerve'
-        fake_bounce_health_params = {}
+        fake_bounce_health_params: Dict[str, Any] = {}
         fake_soa_dir = '/soa/dir'
         fake_marathon_apps = mock.Mock()
         with mock.patch(
@@ -814,16 +819,16 @@ class TestSetupMarathonJob:
         fake_service = 'fake_service'
         fake_instance = 'fake_instance'
         fake_jobid = 'fake_jobid'
-        fake_config = {
+        fake_config: marathon_tools.FormattedMarathonAppDict = {
             'id': 'some_id',
             'instances': 5,
         }
         fake_client = mock.MagicMock(scale_app=mock.Mock())
         fake_bounce_method = 'bounce'
         fake_drain_method_name = 'drain'
-        fake_drain_method_params = {}
+        fake_drain_method_params: Dict[str, Any] = {}
         fake_nerve_ns = 'nerve'
-        fake_bounce_health_params = {}
+        fake_bounce_health_params: Dict[str, Any] = {}
         fake_soa_dir = '/soa/dir'
         fake_marathon_apps = mock.Mock()
         with mock.patch(
@@ -880,16 +885,16 @@ class TestSetupMarathonJob:
         fake_service = 'fake_service'
         fake_instance = 'fake_instance'
         fake_jobid = 'fake_jobid'
-        fake_config = {
+        fake_config: marathon_tools.FormattedMarathonAppDict = {
             'id': 'some_id',
             'instances': 1,
         }
         fake_client = mock.MagicMock()
         fake_bounce_method = 'bounce'
         fake_drain_method_name = 'drain'
-        fake_drain_method_params = {}
+        fake_drain_method_params: Dict[str, Any] = {}
         fake_nerve_ns = 'nerve'
-        fake_bounce_health_params = {}
+        fake_bounce_health_params: Dict[str, Any] = {}
         fake_soa_dir = '/soa/dir'
         fake_marathon_apps = mock.Mock()
         with mock.patch(
@@ -946,16 +951,16 @@ class TestSetupMarathonJob:
         fake_service = 'fake_service'
         fake_instance = 'fake_instance'
         fake_jobid = 'fake_jobid'
-        fake_config = {
+        fake_config: marathon_tools.FormattedMarathonAppDict = {
             'id': 'some_id',
             'instances': 50,
         }
         fake_client = mock.MagicMock()
         fake_bounce_method = 'bounce'
         fake_drain_method_name = 'drain'
-        fake_drain_method_params = {}
+        fake_drain_method_params: Dict[str, Any] = {}
         fake_nerve_ns = 'nerve'
-        fake_bounce_health_params = {}
+        fake_bounce_health_params: Dict[str, Any] = {}
         fake_soa_dir = '/soa/dir'
         fake_marathon_apps = mock.Mock()
         with mock.patch(
@@ -1015,16 +1020,16 @@ class TestSetupMarathonJob:
         fake_service = 'fake_service'
         fake_instance = 'fake_instance'
         fake_jobid = 'fake_jobid'
-        fake_config = {
+        fake_config: marathon_tools.FormattedMarathonAppDict = {
             'id': 'some_id',
             'instances': 3,
         }
         fake_client = mock.MagicMock()
         fake_bounce_method = 'bounce'
         fake_drain_method_name = 'drain'
-        fake_drain_method_params = {}
+        fake_drain_method_params: Dict[str, Any] = {}
         fake_nerve_ns = 'nerve'
-        fake_bounce_health_params = {}
+        fake_bounce_health_params: Dict[str, Any] = {}
         fake_soa_dir = '/soa/dir'
         fake_marathon_apps = mock.Mock()
         with mock.patch(
@@ -1146,11 +1151,11 @@ class TestSetupMarathonJob:
         }
         fake_bounce = 'trampoline'
         fake_drain_method = 'noop'
-        fake_drain_method_params = {}
+        fake_drain_method_params: Dict[str, Any] = {}
         fake_bounce_margin_factor = 0.5
         with mock.patch(
             'paasta_tools.setup_marathon_job.deploy_service',
-            return_value=(111, 'Never'),
+            return_value=(111, 'Never', 63),
             autospec=True,
         ) as deploy_service_patch, mock.patch.object(
             self.fake_marathon_service_config,
@@ -1190,7 +1195,7 @@ class TestSetupMarathonJob:
             autospec=True,
         ):
             mock_marathon_apps = mock.Mock()
-            status, output = setup_marathon_job.setup_service(
+            status, output, bounce_in_seconds = setup_marathon_job.setup_service(
                 service=fake_name,
                 instance=fake_instance,
                 client=fake_client,
@@ -1200,6 +1205,7 @@ class TestSetupMarathonJob:
             )
             assert status == 111
             assert output == 'Never'
+            assert bounce_in_seconds == 63
 
             get_bounce_patch.assert_called_once_with()
             get_bounce_margin_factor_patch.assert_called_once_with()
@@ -1258,7 +1264,6 @@ class TestSetupMarathonJob:
                 'instances': 3,
                 'cpus': 1,
                 'mem': 100,
-                'docker_image': self.fake_docker_image,
                 'nerve_ns': 'fake_nerve_ns',
                 'bounce_method': 'brutal',
             },
@@ -1299,7 +1304,7 @@ class TestSetupMarathonJob:
         fake_client = mock.MagicMock(
             list_apps=mock.Mock(return_value=fake_marathon_apps),
         )
-        fake_config = {'id': fake_id, 'instances': 2}
+        fake_config: marathon_tools.FormattedMarathonAppDict = {'id': fake_id, 'instances': 2}
 
         errormsg = 'ERROR: drain_method not recognized: doesntexist. Must be one of (exists1, exists2)'
         expected = (1, errormsg, None)
@@ -1342,7 +1347,7 @@ class TestSetupMarathonJob:
         fake_client = mock.MagicMock(
             list_apps=mock.Mock(return_value=fake_marathon_apps),
         )
-        fake_config = {'id': fake_id, 'instances': 2}
+        fake_config: marathon_tools.FormattedMarathonAppDict = {'id': fake_id, 'instances': 2}
 
         errormsg = 'ERROR: bounce_method not recognized: %s. Must be one of (%s)' % \
             (fake_bounce, ', '.join(list_bounce_methods()))
@@ -1380,7 +1385,7 @@ class TestSetupMarathonJob:
         fake_name = 'how_many_strings'
         fake_instance = 'will_i_need_to_think_of'
         fake_id = marathon_tools.format_job_id(fake_name, fake_instance, 'git11111111', 'config11111111')
-        fake_config = {'id': fake_id, 'instances': 2}
+        fake_config: marathon_tools.FormattedMarathonAppDict = {'id': fake_id, 'instances': 2}
 
         old_app_id = marathon_tools.format_job_id(fake_name, fake_instance, 'git22222222', 'config22222222')
         old_task_to_drain = mock.Mock(id="old_task_to_drain", app_id=old_app_id)
@@ -1442,7 +1447,7 @@ class TestSetupMarathonJob:
                 bounce_health_params={},
                 soa_dir='fake_soa_dir',
             )
-            assert result[0] == 0, "Expected successful result; got (%d, %s)" % result
+            assert result[0] == 0, "Expected successful result; got (%d, %s, %d)" % result
             assert fake_client.create_app.call_count == 0
             fake_bounce_func.assert_called_once_with(
                 new_config=fake_config,
@@ -1485,7 +1490,7 @@ class TestSetupMarathonJob:
         fake_client = mock.MagicMock(
             list_apps=mock.Mock(return_value=fake_apps),
         )
-        fake_config = {'id': fake_id, 'instances': 2}
+        fake_config: marathon_tools.FormattedMarathonAppDict = {'id': fake_id, 'instances': 2}
 
         with mock.patch(
             'paasta_tools.setup_marathon_job._log', autospec=True,
@@ -1530,7 +1535,7 @@ class TestSetupMarathonJob:
         fake_client = mock.MagicMock(
             list_apps=mock.Mock(return_value=fake_apps),
         )
-        fake_config = {'id': fake_id, 'instances': 2}
+        fake_config: marathon_tools.FormattedMarathonAppDict = {'id': fake_id, 'instances': 2}
 
         with mock.patch(
             'paasta_tools.setup_marathon_job._log', autospec=True,
@@ -1581,14 +1586,12 @@ class TestSetupMarathonJob:
             side_effect=bounce_lib.LockHeldException,
         ):
             mock_client = mock.Mock()
-            mock_marathon_config = {}
-            mock_marathon_apps = []
+            mock_marathon_apps: List[MarathonApp] = []
             ret = setup_marathon_job.deploy_marathon_service(
                 'something',
                 'main',
                 mock_client,
                 'fake_soa',
-                mock_marathon_config,
                 mock_marathon_apps,
             )
             assert not mock_setup_service.called
@@ -1604,15 +1607,13 @@ class TestSetupMarathonJob:
             'paasta_tools.setup_marathon_job.bounce_lib.bounce_lock_zookeeper', autospec=True,
         ):
             load_system_paasta_config_patch.return_value.get_cluster = mock.Mock(return_value=self.fake_cluster)
-            mock_client = mock.Mock()
-            mock_marathon_config = {}
-            mock_marathon_apps = []
+            mock_client: marathon_tools.MarathonClient = mock.Mock()
+            mock_marathon_apps: List[marathon_tools.MarathonApp] = []
             ret = setup_marathon_job.deploy_marathon_service(
                 'something',
                 'main',
                 mock_client,
                 'fake_soa',
-                mock_marathon_config,
                 mock_marathon_apps,
             )
             assert ret == (1, None)
@@ -1639,19 +1640,19 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
         ]
         fake_system_paasta_config = utils.SystemPaastaConfig({}, "/fake/configs")
 
-        expected_live_happy_tasks = {
+        expected_live_happy_tasks: Dict[str, Set[marathon_tools.MarathonTask]] = {
             fake_apps[0].id: set(),
             fake_apps[1].id: set(),
         }
-        expected_live_unhappy_tasks = {
+        expected_live_unhappy_tasks: Dict[str, Set[marathon_tools.MarathonTask]] = {
             fake_apps[0].id: set(),
             fake_apps[1].id: set(),
         }
-        expected_draining_tasks = {
+        expected_draining_tasks: Dict[str, Set[marathon_tools.MarathonTask]] = {
             fake_apps[0].id: set(),
             fake_apps[1].id: set(),
         }
-        expected_at_risk_tasks = {
+        expected_at_risk_tasks: Dict[str, Set[marathon_tools.MarathonTask]] = {
             fake_apps[0].id: set(),
             fake_apps[1].id: set(),
         }
@@ -1703,19 +1704,19 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
 
         fake_system_paasta_config = utils.SystemPaastaConfig({}, "/fake/configs")
 
-        expected_live_happy_tasks = {
+        expected_live_happy_tasks: Dict[str, Set[marathon_tools.MarathonTask]] = {
             fake_apps[0].id: {fake_apps[0].tasks[0]},
             fake_apps[1].id: {fake_apps[1].tasks[0]},
         }
-        expected_live_unhappy_tasks = {
+        expected_live_unhappy_tasks: Dict[str, Set[marathon_tools.MarathonTask]] = {
             fake_apps[0].id: {fake_apps[0].tasks[1]},
             fake_apps[1].id: {fake_apps[1].tasks[1]},
         }
-        expected_draining_tasks = {
+        expected_draining_tasks: Dict[str, Set[marathon_tools.MarathonTask]] = {
             fake_apps[0].id: {fake_apps[0].tasks[2]},
             fake_apps[1].id: {fake_apps[1].tasks[2]},
         }
-        expected_at_risk_tasks = {
+        expected_at_risk_tasks: Dict[str, Set[marathon_tools.MarathonTask]] = {
             fake_apps[0].id: set(),
             fake_apps[1].id: set(),
         }
@@ -1745,8 +1746,8 @@ class TestGetOldHappyUnhappyDrainingTasks(object):
 class TestDrainTasksAndFindTasksToKill(object):
     def test_catches_exception_during_drain(self):
         tasks_to_drain = {mock.Mock(id='to_drain')}
-        already_draining_tasks = set()
-        at_risk_tasks = set()
+        already_draining_tasks: Set[MarathonTask] = set()
+        at_risk_tasks: Set[MarathonTask] = set()
         fake_drain_method = mock.Mock(
             drain=mock.Mock(side_effect=Exception('Hello')),
         )
@@ -1770,8 +1771,8 @@ class TestDrainTasksAndFindTasksToKill(object):
 
     def test_catches_exception_during_is_safe_to_kill(self):
         tasks_to_drain = {mock.Mock(id='to_drain')}
-        already_draining_tasks = set()
-        at_risk_tasks = set()
+        already_draining_tasks: Set[MarathonTask] = set()
+        at_risk_tasks: Set[MarathonTask] = set()
         fake_drain_method = mock.Mock(
             is_safe_to_kill=mock.Mock(side_effect=Exception('Hello')),
         )

--- a/tox.ini
+++ b/tox.ini
@@ -131,9 +131,11 @@ whitelist_externals =
 mypy_paths =
     paasta_tools/frameworks
     paasta_tools/utils.py
+    paasta_tools/marathon_tools.py
     paasta_tools/long_running_service_tools.py
     tests/frameworks
     tests/test_utils.py
+    tests/test_marathon_tools.py
     tests/test_long_running_service_tools.py
 commands =
     mypy {posargs:{[testenv:mypy]mypy_paths}}

--- a/tox.ini
+++ b/tox.ini
@@ -131,8 +131,10 @@ whitelist_externals =
 mypy_paths =
     paasta_tools/frameworks
     paasta_tools/utils.py
+    paasta_tools/long_running_service_tools.py
     tests/frameworks
     tests/test_utils.py
+    tests/test_long_running_service_tools.py
 commands =
     mypy {posargs:{[testenv:mypy]mypy_paths}}
 

--- a/tox.ini
+++ b/tox.ini
@@ -133,10 +133,12 @@ mypy_paths =
     paasta_tools/utils.py
     paasta_tools/marathon_tools.py
     paasta_tools/long_running_service_tools.py
+    paasta_tools/setup_marathon_job.py
     tests/frameworks
     tests/test_utils.py
     tests/test_marathon_tools.py
     tests/test_long_running_service_tools.py
+    tests/test_setup_marathon_job.py
 commands =
     mypy {posargs:{[testenv:mypy]mypy_paths}}
 


### PR DESCRIPTION
This adds type annotations to long_running_service_tools, marathon_tools, setup_marathon_job, and related tests. I did this work to help make sure the sharding change is correct.

#1552 has the actual meat of the sharding change -- this PR is separate so that #1552's diff is cleaner.