### PR TITLE
add broadcast_log_all_services_running_here

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1360,7 +1360,7 @@ def broadcast_log_all_services_running_here(line, component='monitoring'):
     cluster = system_paasta_config.get_cluster()
 
     services = mesos_services_running_here(
-        framework_filter=lambda fw: fw['name'].startswith('marathon') or fw['name'].startswith('chronos'),
+        framework_filter=lambda _: True,
         parse_service_instance_from_executor_id=parse_service_instance_from_executor_id,
     )
     for service, instance, _ in services:

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1359,8 +1359,11 @@ def broadcast_log_all_services_running_here(line, component='monitoring'):
     system_paasta_config = load_system_paasta_config()
     cluster = system_paasta_config.get_cluster()
 
-    services = get_marathon_services_running_here_for_nerve(None, DEFAULT_SOA_DIR)
-    for service, instance in [x[0].split('.') for x in services]:
+    services = mesos_services_running_here(
+        framework_filter=lambda fw: fw['name'].startswith('marathon') or fw['name'].startswith('chronos'),
+        parse_service_instance_from_executor_id=parse_service_instance_from_executor_id,
+    )
+    for service, instance, _ in services:
         _log(
             line=line,
             service=service,

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ setup(
             'paasta_firewall_update=paasta_tools.firewall_update:main',
             'paasta_firewall_logging=paasta_tools.firewall_logging:main',
             'paasta_oom_logger=paasta_tools.oom_logger:main',
+            'paasta_broadcast_log=paasta_tools.marathon_tools:broadcast_log_all_services_running_here_from_stdin',
         ],
         'paste.app_factory': [
             'paasta-api-config=paasta_tools.api.api:make_app',


### PR DESCRIPTION
PAASTA-13173

@solarkennedy - this does not exactly follow the ticket's description but I think it might be easier.

The end result is that we will be able to log to streams of all services running on this host from bash using something like this:

```
echo foo | /path/to/paasta/python -c 'import sys; from paasta_tools.marathon_tools import broadcast_log_all_services_running_here; broadcast_log_all_services_running_here(sys.stdin.read().strip())'
```

I think it's a bit less disruptive than rewriting entire script in python.