### PR TITLE
Add potential reasons for app deployments being stalled to paasta status and api

### DIFF
--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -70,6 +70,7 @@ def make_app(global_config=None):
     config.include('pyramid_swagger')
     config.add_route('resources.utilization', '/v1/resources/utilization')
     config.add_route('service.instance.status', '/v1/services/{service}/{instance}/status')
+    config.add_route('service.instance.delay', '/v1/services/{service}/{instance}/delay')
     config.add_route('service.instance.tasks', '/v1/services/{service}/{instance}/tasks')
     config.add_route('service.instance.tasks.task', '/v1/services/{service}/{instance}/tasks/{task_id}')
     config.add_route('service.list', '/v1/services/{service}')

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -137,6 +137,46 @@
         ]
       }
     },
+    "/services/{service}/{instance}/delay": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "The service is delayed for these possible reasons",
+            "schema": {
+                "$ref":"#/definitions/InstanceDelay"
+            }
+          },
+          "204": {
+            "description": "Could not find any reasons for a delay"
+          },
+          "404": {
+            "description": "Deployment key not found"
+          },
+          "500": {
+            "description": "Instance failure"
+          }
+        },
+        "summary": "Get the possible reasons for a deployment delay for a marathon service.instance",
+        "operationId": "delay_instance",
+        "tags": ["service"],
+        "parameters": [
+          {
+            "in": "path",
+            "description": "Service name",
+            "name": "service",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "description": "Instance name",
+            "name": "instance",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
     "/services/{service}/{instance}/tasks": {
       "get": {
         "responses": {
@@ -369,6 +409,9 @@
           "description": "Chronos specifid instance status"
         }
       }
+    },
+    "InstanceDelay": {
+      "type": "object"
     },
     "InstanceStatusMarathon": {
       "type": "object",

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -220,6 +220,21 @@ def instance_tasks(request):
     return [task._Task__items for task in tasks]
 
 
+@view_config(route_name="service.instance.delay", request_method='GET', renderer='json')
+def instance_delay(request):
+    service = request.swagger_data.get('service')
+    instance = request.swagger_data.get('instance')
+    client = settings.marathon_client
+    job_config = marathon_tools.load_marathon_service_config(
+        service, instance, settings.cluster, soa_dir=settings.soa_dir,
+    )
+    app_id = job_config.format_marathon_app_dict()['id']
+    app_queue = marathon_tools.get_app_queue(client, app_id)
+    unused_offers_summary = marathon_tools.summarize_unused_offers(app_queue)
+
+    return unused_offers_summary
+
+
 def add_executor_info(task):
     task._Task__items['executor'] = task.executor.copy()
     task._Task__items['executor'].pop('tasks', None)

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -17,6 +17,7 @@ PaaSTA service instance status/start/stop etc.
 """
 import traceback
 
+from pyramid.response import Response
 from pyramid.view import view_config
 
 from paasta_tools import chronos_tools
@@ -232,7 +233,12 @@ def instance_delay(request):
     app_queue = marathon_tools.get_app_queue(client, app_id)
     unused_offers_summary = marathon_tools.summarize_unused_offers(app_queue)
 
-    return unused_offers_summary
+    if len(unused_offers_summary) != 0:
+        return unused_offers_summary
+    else:
+        response = Response()
+        response.status_int = 204
+        return response
 
 
 def add_executor_info(task):

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -96,9 +96,14 @@ def status_desired_state(service, instance, client, job_config):
 
 def status_marathon_job_human(
     service, instance, deploy_status, app_id,
-    running_instances, normal_instance_count,
+    running_instances, normal_instance_count, unused_offers_summary=None,
 ):
     name = PaastaColors.cyan(compose_job_id(service, instance))
+    if unused_offers_summary is not None:
+        stalled_str = "\n    ".join(["%s: %s times" % (k, n) for k, n in unused_offers_summary.items()])
+        stalled = "\n  Possibly stalled for:\n    %s" % stalled_str
+    else:
+        stalled = ""
     if deploy_status != 'NotRunning':
         if running_instances >= normal_instance_count:
             status = PaastaColors.green("Healthy")
@@ -109,11 +114,11 @@ def status_marathon_job_human(
         else:
             status = PaastaColors.yellow("Warning")
             instance_count = PaastaColors.yellow("(%d/%d)" % (running_instances, normal_instance_count))
-        return "Marathon:   %s - up with %s instances. Status: %s" % (status, instance_count, deploy_status)
+        return "Marathon:   %s - up with %s instances. Status: %s%s" % (status, instance_count, deploy_status, stalled)
     else:
         status = PaastaColors.yellow("Warning")
-        return "Marathon:   %s - %s (app %s) is not configured in Marathon yet (waiting for bounce)" % (
-            status, name, app_id,
+        return "Marathon:   %s - %s (app %s) is not configured in Marathon yet (waiting for bounce)%s" % (
+            status, name, app_id, stalled,
         )
 
 
@@ -140,8 +145,11 @@ def marathon_app_deploy_status_human(status, backoff_seconds=None):
 
 def status_marathon_job(service, instance, app_id, normal_instance_count, client):
     status = marathon_tools.get_marathon_app_deploy_status(client, app_id)
+    unused_offers_summary = None
     if status == marathon_tools.MarathonDeployStatus.Delayed:
-        _, backoff_seconds = marathon_tools.get_app_queue_status(client, app_id)
+        app_queue = marathon_tools.get_app_queue(client, app_id)
+        _, backoff_seconds = marathon_tools.get_app_queue_status_from_queue(app_queue)
+        unused_offers_summary = marathon_tools.summarize_unused_offers(app_queue)
         deploy_status_human = marathon_app_deploy_status_human(status, backoff_seconds)
     else:
         deploy_status_human = marathon_app_deploy_status_human(status)
@@ -152,7 +160,7 @@ def status_marathon_job(service, instance, app_id, normal_instance_count, client
         running_instances = client.get_app(app_id).tasks_running
     return status_marathon_job_human(
         service, instance, deploy_status_human, app_id,
-        running_instances, normal_instance_count,
+        running_instances, normal_instance_count, unused_offers_summary,
     )
 
 

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -145,11 +145,10 @@ def marathon_app_deploy_status_human(status, backoff_seconds=None):
 
 def status_marathon_job(service, instance, app_id, normal_instance_count, client):
     status = marathon_tools.get_marathon_app_deploy_status(client, app_id)
-    unused_offers_summary = None
+    app_queue = marathon_tools.get_app_queue(client, app_id)
+    unused_offers_summary = marathon_tools.summarize_unused_offers(app_queue)
     if status == marathon_tools.MarathonDeployStatus.Delayed:
-        app_queue = marathon_tools.get_app_queue(client, app_id)
         _, backoff_seconds = marathon_tools.get_app_queue_status_from_queue(app_queue)
-        unused_offers_summary = marathon_tools.summarize_unused_offers(app_queue)
         deploy_status_human = marathon_app_deploy_status_human(status, backoff_seconds)
     else:
         deploy_status_human = marathon_app_deploy_status_human(status)

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -99,7 +99,7 @@ def status_marathon_job_human(
     running_instances, normal_instance_count, unused_offers_summary=None,
 ):
     name = PaastaColors.cyan(compose_job_id(service, instance))
-    if unused_offers_summary is not None:
+    if unused_offers_summary is not None and len(unused_offers_summary) > 0:
         stalled_str = "\n    ".join(["%s: %s times" % (k, n) for k, n in unused_offers_summary.items()])
         stall_reason = "\n  Possibly stalled for:\n    %s" % stalled_str
     else:

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -101,9 +101,9 @@ def status_marathon_job_human(
     name = PaastaColors.cyan(compose_job_id(service, instance))
     if unused_offers_summary is not None:
         stalled_str = "\n    ".join(["%s: %s times" % (k, n) for k, n in unused_offers_summary.items()])
-        stalled = "\n  Possibly stalled for:\n    %s" % stalled_str
+        stall_reason = "\n  Possibly stalled for:\n    %s" % stalled_str
     else:
-        stalled = ""
+        stall_reason = ""
     if deploy_status != 'NotRunning':
         if running_instances >= normal_instance_count:
             status = PaastaColors.green("Healthy")
@@ -114,11 +114,13 @@ def status_marathon_job_human(
         else:
             status = PaastaColors.yellow("Warning")
             instance_count = PaastaColors.yellow("(%d/%d)" % (running_instances, normal_instance_count))
-        return "Marathon:   %s - up with %s instances. Status: %s%s" % (status, instance_count, deploy_status, stalled)
+        return "Marathon:   %s - up with %s instances. Status: %s%s" % (
+            status, instance_count, deploy_status, stall_reason,
+        )
     else:
         status = PaastaColors.yellow("Warning")
         return "Marathon:   %s - %s (app %s) is not configured in Marathon yet (waiting for bounce)%s" % (
-            status, name, app_id, stalled,
+            status, name, app_id, stall_reason,
         )
 
 

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1186,7 +1186,7 @@ def get_app_queue_last_unused_offers(app_queue_item: Optional[MarathonQueueItem]
 def summarize_unused_offers(app_queue: List[Dict]) -> Dict[str, int]:
     """Returns a summary of the reasons marathon rejected offers from mesos
 
-    :param unused_offers: A list of unused offers as returned by get_app_queue_last_unused_offers
+    :param app_queue: An app queue item as returned from get_app_queue
     :returns: A dict of rejection_reason: count
     """
     unused_offers = get_app_queue_last_unused_offers(app_queue)

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -995,7 +995,7 @@ def get_app_queue_last_unused_offers(app_queue_item):
     """
     if app_queue_item is None:
         return []
-    return app_queue_item.lastUnusedOffers
+    return app_queue_item.last_unused_offers
     return []
 
 
@@ -1008,7 +1008,7 @@ def summarize_unused_offers(app_queue):
     unused_offers = get_app_queue_last_unused_offers(app_queue)
     reasons = defaultdict(lambda: 0)
     for offer in unused_offers:
-        for reason in offer.reason:
+        for reason in offer['reason']:
             reasons[reason] += 1
     return reasons
 

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -984,8 +984,6 @@ def get_app_queue_status_from_queue(app_queue_item):
         return (None, None)
     return (app_queue_item.delay.overdue, app_queue_item.delay.time_left_seconds)
 
-    return (None, None)
-
 
 def get_app_queue_last_unused_offers(app_queue_item):
     """Returns the unused offers for an app
@@ -996,7 +994,6 @@ def get_app_queue_last_unused_offers(app_queue_item):
     if app_queue_item is None:
         return []
     return app_queue_item.last_unused_offers
-    return []
 
 
 def summarize_unused_offers(app_queue):

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -39,7 +39,7 @@ from marathon import MarathonHttpError
 from marathon import NotFoundError
 from marathon.models.app import MarathonApp
 from marathon.models.app import MarathonTask
-from marathon.modesl.queue import MarathonQueueItem
+from marathon.models.queue import MarathonQueueItem
 from mypy_extensions import TypedDict
 
 from paasta_tools.long_running_service_tools import BounceMethodConfigDict

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ ephemeral-port-reserve==1.0.1
 gevent==1.1.1
 # We have git commit access to marathon-python but don't have pypi
 # so we pull from git
-git+git://github.com/thefactory/marathon-python@c1e0c341#egg=marathon
+git+git://github.com/thefactory/marathon-python@c8b776d#egg=marathon
 # While task_processing is in rapid development mode, we install it from git
 git+git://github.com/Yelp/task_processing@72fafd9ebdbd0d6165f8b79ba0050dba1009ec31#egg=task_processing[mesos_executor]
 http-parser==0.8.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ ephemeral-port-reserve==1.0.1
 gevent==1.1.1
 # We have git commit access to marathon-python but don't have pypi
 # so we pull from git
-git+git://github.com/thefactory/marathon-python@c8b776d#egg=marathon
+git+git://github.com/thefactory/marathon-python@c8b776dc82e63865b0e3497b26cf7829bbbffb3f#egg=marathon
 # While task_processing is in rapid development mode, we install it from git
 git+git://github.com/Yelp/task_processing@72fafd9ebdbd0d6165f8b79ba0050dba1009ec31#egg=task_processing[mesos_executor]
 http-parser==0.8.3

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -250,6 +250,37 @@ def test_instance_task(mock_get_task, mock_instance_status, mock_add_slave_info,
         ret = instance.instance_task(mock_request)
 
 
+@mock.patch('paasta_tools.api.views.instance.marathon_tools.get_app_queue', autospec=True)
+@mock.patch('paasta_tools.api.views.instance.marathon_tools.load_marathon_service_config', autospec=True)
+def test_instance_delay(mock_load_config, mock_get_app_queue):
+    mock_unused_offers = mock.Mock()
+    mock_unused_offers.last_unused_offers = [
+        {
+            'reason': ['foo', 'bar'],
+        },
+        {
+            'reason': ['bar', 'baz'],
+        },
+        {
+            'reason': [],
+        },
+    ]
+    mock_get_app_queue.return_value = mock_unused_offers
+
+    mock_config = mock.Mock()
+    mock_config.format_marathon_app_dict = lambda: {'id': 'foo'}
+    mock_load_config.return_value = mock_config
+
+    request = testing.DummyRequest()
+    request.swagger_data = {'service': 'fake_service', 'instance': 'fake_instance'}
+
+    response = instance.instance_delay(request)
+    print(response)
+    assert response['foo'] == 1
+    assert response['bar'] == 2
+    assert response['baz'] == 1
+
+
 def test_add_executor_info():
     mock_mesos_task = mock.Mock()
     mock_executor = {


### PR DESCRIPTION
Info is grabbed from /v2/queue in marathon, and if available summarized and printed with paasta status
This may require bumping the marathon-python version?

Fixes #1408