### PR TITLE
Filter out slaves from the slaves list if not in mesos state

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -536,6 +536,8 @@ class ClusterAutoscaler(ResourceLogMixin):
                 # Update the task counts in the slaves list
                 for i, slave in enumerate(updated_filtered_slaves):
                     slave.task_counts = task_counts[i]['task_counts']
+            else:
+                updated_filtered_slaves = filtered_sorted_slaves
             filtered_slaves = updated_filtered_slaves
 
 

--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -524,7 +524,7 @@ class ClusterAutoscaler(ResourceLogMixin):
                 # Filter out slaves no longer in mesos state
                 updated_filtered_slaves = [
                     slave for slave in filtered_sorted_slaves
-                    if slave['id'] in good_ids
+                    if slave.instance_id in good_ids
                 ]
                 # Get updated task counts for slaves from state
                 task_counts = get_mesos_task_count_by_slave(

--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -520,10 +520,11 @@ class ClusterAutoscaler(ResourceLogMixin):
             current_capacity = new_capacity
             mesos_state = get_mesos_master().state_summary()
             if filtered_sorted_slaves:
+                good_ids = [s['id'] for s in mesos_state.get('slaves', [])]
                 # Filter out slaves no longer in mesos state
                 updated_filtered_slaves = [
                     slave for slave in filtered_sorted_slaves
-                    if slave['id'] in [s['id'] for s in mesos_state.get('slaves', [])]
+                    if slave['id'] in good_ids
                 ]
                 # Get updated task counts for slaves from state
                 task_counts = get_mesos_task_count_by_slave(

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -899,6 +899,7 @@ class TestClusterAutoscaler(unittest.TestCase):
         ) as mock_gracefully_terminate_slave:
             mock_master = mock.Mock()
             mock_mesos_state = mock.Mock()
+            mock_mesos_state.get = lambda _, __: [{'id': 'i-blah123'}, {'id': 'i-blah456'}]
             mock_master.state_summary.return_value = mock_mesos_state
             mock_get_mesos_master.return_value = mock_master
             mock_task_counts = mock.Mock()


### PR DESCRIPTION
If an agent disapears from the mesos state while running the cluster
autoscaler, the cluster autoscaler needs to take into account the fact
that it no longer exists.  This updates the autoscaler to only look at
currently existing agents at each loop while scaling down