### PR TITLE
Ignore images where RepoTags is None.

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1919,7 +1919,7 @@ def check_docker_image(service: str, tag: str) -> bool:
     image_name = build_docker_image_name(service)
     docker_tag = build_docker_tag(service, tag)
     images = docker_client.images(name=image_name)
-    result = [image for image in images if docker_tag in image['RepoTags']]
+    result = [image for image in images if docker_tag in (image['RepoTags'] or [])]
     if len(result) > 1:
         raise ValueError('More than one docker image found with tag %s\n%s' % (docker_tag, result))
     return len(result) == 1


### PR DESCRIPTION
Sometimes, RepoTags is None; I'm not sure why. This patch will ignore those images.