### PR TITLE
Make chronos itest use xenial and upate gpg key for bintray

### DIFF
--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         lsb-release \
         chronos=2.5.0-yelp32-1.ubuntu1604 \
+        rsyslog \
         && \
     apt-get clean
 

--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -12,25 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
-ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update > /dev/null && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        software-properties-common > /dev/null && \
+    echo "deb https://dl.bintray.com/yelp/paasta xenial main" > /etc/apt/sources.list.d/paasta.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv 8756C4F765C9AC3CB6B85D62379CE192D401AB61 && \
+    echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF && \
+    apt-get update > /dev/null && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        libsasl2-modules mesos=1.3.0-2.0.3 > /dev/null && \
+    apt-get clean
 
-
-RUN apt-get update > /dev/null && apt-get -y install apt-transport-https > /dev/null
-
-RUN echo "deb https://dl.bintray.com/yelp/paasta trusty main" > /etc/apt/sources.list.d/paasta.list
-RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update > /dev/null && apt-get -y install libsasl2-modules mesos=1.3.0-2.0.3 > /dev/null
-
-RUN apt-get install -y software-properties-common > /dev/null
-RUN add-apt-repository ppa:webupd8team/java
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 7B2C3B0889BF5709A105D03AC2518248EEA14886
-RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
-RUN echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections
-RUN apt-get update > /dev/null && apt-get -y install lsb-release oracle-java8-installer > /dev/null
-RUN apt-get -y --allow-unauthenticated install chronos=2.5.0-yelp19-1.ubuntu1404 > /dev/null
+RUN apt-get update > /dev/null && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        lsb-release \
+        chronos=2.5.0-yelp32-1.ubuntu1604 \
+        && \
+    apt-get clean
 
 # Chronos will look in here for zk config, so we blow away the bogus defaults
 RUN rm -rf /etc/mesos/

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update > /dev/null && \
         apt-transport-https \
         software-properties-common > /dev/null && \
     echo "deb https://dl.bintray.com/yelp/paasta xenial main" > /etc/apt/sources.list.d/paasta.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv 8756C4F765C9AC3CB6B85D62379CE192D401AB61 && \
     echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF && \
     apt-get update > /dev/null && \
@@ -26,15 +27,11 @@ RUN apt-get update > /dev/null && \
         libsasl2-modules mesos=1.3.0-2.0.3 > /dev/null && \
     apt-get clean
 
-RUN add-apt-repository ppa:webupd8team/java && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv 7B2C3B0889BF5709A105D03AC2518248EEA14886 && \
-    echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections && \
-    echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections && \
-    apt-get update > /dev/null && \
+RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         lsb-release \
         marathon=1.4.6-1.0.656.ubuntu1604 \
-        oracle-java8-installer > /dev/null && \
+        && \
     apt-get clean
 
 RUN echo -n "secret2" > /etc/marathon_framework_secret


### PR DESCRIPTION
We were not using the webupd8 java anyway, we were using the java that came from openjdk9-headless as a zookeeper dep (pretty sure).