### PR TITLE
Update setup.py to use marathon >= 0.9.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'isodate >= 0.5.0',
         'jsonschema[format]',
         'kazoo >= 2.0.0',
-        'marathon >= 0.9.0',
+        'marathon >= 0.9.2',
         'progressbar2 >= 3.10.0',
         'pyramid >= 1.8',
         'pymesos >= 0.2.0',


### PR DESCRIPTION
Jenkins doesnt seem to be respecting requirements.txt , its still using 0.9.0