### PR TITLE
reduce hacheck timeout in drain_lib

### DIFF
--- a/paasta_tools/drain_lib.py
+++ b/paasta_tools/drain_lib.py
@@ -19,7 +19,7 @@ import requests
 from paasta_tools.utils import get_user_agent
 
 _drain_methods = {}
-HACHECK_TIMEOUT = 15
+HACHECK_TIMEOUT = (3, 1)  # (connect timeout, read timeout)
 
 
 def register_drain_method(name):


### PR DESCRIPTION
OPS-12282

Current 15 second timeout for both connect and read operations seems too generous to me. Let's reduce it to 3s connect timeout and 1s read timeout? I think these numbers are good even though reduction from 15 to this level might be a bit too aggressive.

requests lib supports passing timeout as int/float or as tuple - https://github.com/requests/requests/blob/master/requests/api.py#L32