### PR TITLE
include expiration only when draining in HacheckDrainMethod

### DIFF
--- a/paasta_tools/drain_lib.py
+++ b/paasta_tools/drain_lib.py
@@ -157,13 +157,15 @@ class HacheckDrainMethod(DrainMethod):
     def post_spool(self, task, status):
         spool_url = self.spool_url(task)
         if spool_url is not None:
-            resp = requests.post(
-                self.spool_url(task),
-                data={
-                    'status': status,
+            data = {'status': status}
+            if status == 'down':
+                data.update({
                     'expiration': time.time() + self.expiration,
                     'reason': 'Drained by Paasta',
-                },
+                })
+            resp = requests.post(
+                self.spool_url(task),
+                data=data,
                 headers={'User-Agent': get_user_agent()},
                 timeout=HACHECK_TIMEOUT,
             )


### PR DESCRIPTION
I think expiration doesn't mean anything when we post 'up' to hacheck.