### PR TITLE
Fix cleanup_chronos_jobs for jobs with no interval

### DIFF
--- a/paasta_tools/cleanup_chronos_jobs.py
+++ b/paasta_tools/cleanup_chronos_jobs.py
@@ -142,7 +142,7 @@ def filter_expired_tmp_jobs(client, job_names, cluster, soa_dir):
                     cluster=cluster,
                     soa_dir=soa_dir,
                 )
-                interval = chronos_job_config.get_schedule_interval_in_seconds()
+                interval = chronos_job_config.get_schedule_interval_in_seconds() or 0
             except NoConfigurationForServiceError:
                 # If we can't get the job's config, default to cleanup after 1 day
                 interval = 0


### PR DESCRIPTION
internal ticket: PAASTA-13323

This method can return None for jobs that have no interval.