### PR TITLE
Set new terminate timeout based on the number of tasks on killed agent

### DIFF
--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -1262,7 +1262,10 @@ class TestClusterAutoscaler(unittest.TestCase):
             'time.sleep', autospec=True,
         ), mock.patch(
             'paasta_tools.autoscaling.autoscaling_cluster_lib.is_safe_to_kill', autospec=True,
-        ) as mock_is_safe_to_kill:
+        ) as mock_is_safe_to_kill, mock.patch(
+            'paasta_tools.autoscaling.autoscaling_cluster_lib.ClusterAutoscaler.get_new_timeout_after_terminate',
+            autospec=True,
+        ):
             mock_terminate_instances = mock.Mock()
             mock_ec2_client.return_value = mock.Mock(terminate_instances=mock_terminate_instances)
             mock_timer = mock.Mock()


### PR DESCRIPTION
When scaling down a cluster, we can set the timout for the next slave
based on the running tasks on the most recently killed slave.  If, on
one terminate, we hit the timeout, this will try to set a lower timeout
for the next terminate based on the running tasks on the just killed
slave.

note: I'm not sure about the 30s + 30s*(running_tasks).  30s + 60s*(running_tasks) might make more sense.