### PR TITLE
Only call state once on the cluster autoscaler

### DIFF
--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -212,7 +212,7 @@ def main(argv=None):
             headers = [field.replace("_", " ").capitalize() for field in AutoscalingInfo._fields]
             table = functools.reduce(
                 lambda x, y: x + [(y)],
-                get_autoscaling_info_for_all_resources(),
+                get_autoscaling_info_for_all_resources(mesos_state),
                 [headers],
             )
 


### PR DESCRIPTION
Also makes metastatus do fewer state calls if you want autoscaling info

fixes #1583 