### PR TITLE
Fix error when a pool isn't ready when the cluster autoscaler tries to run

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -1045,10 +1045,14 @@ def get_mesos_utilization_error(
     pool,
     target_utilization,
 ):
-    region_pool_utilization_dict = get_resource_utilization_by_grouping(
-        lambda slave: (slave['attributes']['pool'], slave['attributes']['datacenter'],),
-        mesos_state,
-    )[(pool, region,)]
+    try:
+        region_pool_utilization_dict = get_resource_utilization_by_grouping(
+            lambda slave: (slave['attributes']['pool'], slave['attributes']['datacenter'],),
+            mesos_state,
+        )[(pool, region,)]
+    except KeyError:
+        log.info("Failed to find utilization for region %s, pool %s, returning 0 error")
+        return 0
 
     log.debug(region_pool_utilization_dict)
     free_pool_resources = region_pool_utilization_dict['free']

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -86,6 +86,14 @@ def test_get_mesos_utilization_error():
         )
         assert ret == 0.5 - 0.8
 
+        ret = autoscaling_cluster_lib.get_mesos_utilization_error(
+            mesos_state=mock_mesos_state,
+            region="westeros-1",
+            pool="fake-pool",
+            target_utilization=0.8,
+        )
+        assert ret == 0
+
 
 def test_get_instances_from_ip():
     mock_instances = []


### PR DESCRIPTION
If the cluster autoscaler can't find utilization for a region/pool, assume error is zero, so that no autoscaling will be attempted for that region/pool