### PR TITLE
Fix autoscaling info for metastatus

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -1019,6 +1019,7 @@ def autoscaling_info_for_resource(resource, pool_settings, mesos_state):
         pool_settings=pool_settings,
         config_folder=None,
         dry_run=True,
+        utilization_error=0,
     )
     if not scaler.exists:
         log.info("no scaler for resource {}. ignoring".format(resource['id']))

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -243,6 +243,7 @@ def test_autoscaling_info_for_resources():
             pool_settings={},
             config_folder=None,
             dry_run=True,
+            utilization_error=0,
         )
         assert ret == autoscaling_cluster_lib.AutoscalingInfo(
             resource_id='sfr-blah',

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -182,8 +182,8 @@ def test_autoscale_cluster_resource():
 
 
 def test_get_autoscaling_info_for_all_resources():
-    mock_resource_1 = mock.Mock()
-    mock_resource_2 = mock.Mock()
+    mock_resource_1 = {'region': 'westeros-1', 'pool': 'default'}
+    mock_resource_2 = {'region': 'westeros-1', 'pool': 'not-default'}
     mock_resources = {
         'id1': mock_resource_1,
         'id2': mock_resource_2,
@@ -196,19 +196,31 @@ def test_get_autoscaling_info_for_all_resources():
 
     mock_autoscaling_info = mock.Mock()
 
-    def mock_autoscaling_info_for_resource_side_effect(resource, pool_settings, state):
-        return {mock_resource_1: None, mock_resource_2: mock_autoscaling_info}[resource]
+    def mock_autoscaling_info_for_resource_side_effect(resource, pool_settings, state, utilization_errors):
+        return {
+            (mock_resource_1['region'], mock_resource_1['pool'],): None,
+            (mock_resource_2['region'], mock_resource_2['pool'],): mock_autoscaling_info,
+        }[(resource['region'], resource['pool'],)]
 
     with mock.patch(
         'paasta_tools.autoscaling.autoscaling_cluster_lib.load_system_paasta_config', autospec=True,
         return_value=mock_system_config,
     ), mock.patch(
         'paasta_tools.autoscaling.autoscaling_cluster_lib.autoscaling_info_for_resource', autospec=True,
-    ) as mock_autoscaling_info_for_resource:
+    ) as mock_autoscaling_info_for_resource, mock.patch(
+        'paasta_tools.autoscaling.autoscaling_cluster_lib.get_mesos_utilization_error', autospec=True,
+    ) as mock_get_utilization_error:
         mock_autoscaling_info_for_resource.side_effect = mock_autoscaling_info_for_resource_side_effect
         mock_state = mock.Mock()
+        mock_get_utilization_error.return_value = 0
         ret = autoscaling_cluster_lib.get_autoscaling_info_for_all_resources(mock_state)
-        calls = [mock.call(mock_resource_1, {}, mock_state), mock.call(mock_resource_2, {}, mock_state)]
+        utilization_errors = autoscaling_cluster_lib.get_all_utilization_errors(
+            mock_resources, {}, mock_state,
+        )
+        calls = [
+            mock.call(mock_resource_1, {}, mock_state, utilization_errors),
+            mock.call(mock_resource_2, {}, mock_state, utilization_errors),
+        ]
         mock_autoscaling_info_for_resource.assert_has_calls(calls, any_order=True)
         assert ret == [mock_autoscaling_info]
 
@@ -220,6 +232,7 @@ def test_autoscaling_info_for_resources():
         'max_capacity': 5,
         'pool': 'default',
         'type': 'sfr',
+        'region': 'westeros-1',
     }}
 
     with mock.patch(
@@ -236,7 +249,10 @@ def test_autoscaling_info_for_resources():
         mock_scaler_class = mock.Mock(return_value=mock_scaler)
         mock_get_scaler.return_value = mock_scaler_class
         mock_state = mock.Mock()
-        ret = autoscaling_cluster_lib.autoscaling_info_for_resource(mock_resources['sfr-blah'], {}, mock_state)
+        mock_utilization_errors = {('westeros-1', 'default',): 0}
+        ret = autoscaling_cluster_lib.autoscaling_info_for_resource(
+            mock_resources['sfr-blah'], {}, mock_state, mock_utilization_errors,
+        )
         assert mock_metrics_provider.called
         mock_scaler_class.assert_called_with(
             resource=mock_resources['sfr-blah'],
@@ -265,7 +281,9 @@ def test_autoscaling_info_for_resources():
         )
         mock_scaler_class = mock.Mock(return_value=mock_scaler)
         mock_get_scaler.return_value = mock_scaler_class
-        ret = autoscaling_cluster_lib.autoscaling_info_for_resource(mock_resources['sfr-blah'], {}, mock_state)
+        ret = autoscaling_cluster_lib.autoscaling_info_for_resource(
+            mock_resources['sfr-blah'], {}, mock_state, mock_utilization_errors,
+        )
         assert ret == autoscaling_cluster_lib.AutoscalingInfo(
             resource_id='sfr-blah',
             pool='default',
@@ -288,7 +306,9 @@ def test_autoscaling_info_for_resources():
         )
         mock_scaler_class = mock.Mock(return_value=mock_scaler)
         mock_get_scaler.return_value = mock_scaler_class
-        ret = autoscaling_cluster_lib.autoscaling_info_for_resource(mock_resources['sfr-blah'], {}, mock_state)
+        ret = autoscaling_cluster_lib.autoscaling_info_for_resource(
+            mock_resources['sfr-blah'], {}, mock_state, mock_utilization_errors,
+        )
         assert ret == autoscaling_cluster_lib.AutoscalingInfo(
             resource_id='sfr-blah',
             pool='default',


### PR DESCRIPTION
Just set the utilization_error to 0, since metastatus won't actually scale anything