### PR TITLE
check_mesos_outdated_tasks

### DIFF
--- a/paasta_tools/monitoring/check_mesos_outdated_tasks.py
+++ b/paasta_tools/monitoring/check_mesos_outdated_tasks.py
@@ -90,7 +90,7 @@ def report_outdated_instances(task_id, gitsha, tasks, slave_id2hostname):
     output = []
     for t in tasks:
         deploy_time = datetime.datetime.fromtimestamp(int(t['statuses'][0]['timestamp'])).strftime('%Y-%m-%d %H:%M:%S')
-        container_name = "{}.{}".format(
+        container_name = "mesos-{}.{}".format(
             t['slave_id'],
             t['statuses'][0]['container_status']['container_id']['value'],
         )

--- a/paasta_tools/monitoring/check_mesos_outdated_tasks.py
+++ b/paasta_tools/monitoring/check_mesos_outdated_tasks.py
@@ -42,7 +42,7 @@ def parse_args():
 
 
 def get_mesos_state():
-    state = get_mesos_master().state
+    state = get_mesos_master(use_mesos_cache=True).state
     return state
 
 

--- a/paasta_tools/monitoring/check_mesos_outdated_tasks.py
+++ b/paasta_tools/monitoring/check_mesos_outdated_tasks.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+# Copyright 2015-2017 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import datetime
+import sys
+import time
+
+from paasta_tools.mesos_tools import get_mesos_master
+from paasta_tools.utils import load_system_paasta_config
+
+
+OUTPUT_FORMAT = "{:<30}  {:<8}  {:<20}  {:<27}  {}"
+
+
+def get_mesos_state():
+    state = get_mesos_master().state
+    return state
+
+
+def marathon_tasks(state):
+    for framework in state.get('frameworks', []):
+        if framework['name'].lower().startswith('marathon'):
+            for task in framework.get('tasks', []):
+                yield task
+
+
+def create_slave_id_to_hostname_dict(state):
+    res = {}
+    for slave in state['slaves']:
+        res[slave['id']] = slave['hostname']
+    return res
+
+
+def group_running_tasks_by_job_id_and_gitsha(state):
+    res = {}
+    for t in marathon_tasks(state):
+        if t['state'] == 'TASK_RUNNING':
+            job_id = t['name'][:t['name'].find('.', t['name'].find('.') + 1)]
+            gitsha = t['name'][len(job_id) + 1:t['name'].find('.', len(job_id) + 1)]
+            res.setdefault(job_id, {}).setdefault(gitsha, []).append(t)
+    return res
+
+
+def detect_outdated_gitshas(versions, max_bounce_time=4 * 3600):
+    """Find versions that should have drained more than bounce_time ago (in seconds)"""
+    deploy_time = {}
+    res = []
+    if len(versions) > 1:
+        latest_deploy = 0
+        for version, tasks in versions.items():
+            deploy_time[version] = sum(t['statuses'][0]['timestamp'] for t in tasks) / len(tasks)
+            if deploy_time[version] > latest_deploy and time.time() - deploy_time[version] > max_bounce_time:
+                latest_deploy = deploy_time[version]
+        for version, dtime in deploy_time.items():
+            if dtime + max_bounce_time < latest_deploy:
+                res.append(version)
+    return res
+
+
+def report_outdated_instances(job_id, gitsha, tasks, slave_id2hostname):
+    output = []
+    for t in tasks:
+        deploy_time = datetime.datetime.fromtimestamp(int(t['statuses'][0]['timestamp'])).strftime('%Y-%m-%d %H:%M:%S')
+        container_name = "{}.{}".format(
+            t['slave_id'],
+            t['statuses'][0]['container_status']['container_id']['value'],
+        )
+        hostname = slave_id2hostname[t['slave_id']]
+        hostname = hostname[:hostname.find('.')]
+        output.append(
+            OUTPUT_FORMAT.format(
+                job_id.replace('--', '_')[:30],
+                gitsha[3:],
+                deploy_time,
+                hostname,
+                container_name,
+            ),
+        )
+    return output
+
+
+def check_mesos_tasks():
+    output = []
+    state = get_mesos_state()
+    aggregated_tasks = group_running_tasks_by_job_id_and_gitsha(state)
+    slave_id2hostname = create_slave_id_to_hostname_dict(state)
+    for job_id, versions in aggregated_tasks.items():
+        for gitsha in detect_outdated_gitshas(versions):
+            output.extend(report_outdated_instances(
+                job_id, gitsha, versions[gitsha],
+                slave_id2hostname,
+            ))
+    return output
+
+
+def main():
+    cluster = load_system_paasta_config().get_cluster()
+    output = check_mesos_tasks()
+    if output:
+        print("CRITICAL - There are {} outdated instances running in {}"
+              .format(len(output), cluster))
+        print(OUTPUT_FORMAT.format('SERVICE.INSTANCE', 'COMMIT', 'CREATED', 'HOSTNAME', 'CONTAINER'))
+        print('\n'.join(output))
+        return 1
+    else:
+        print("OK - There are no outdated instances in {}".format(cluster))
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         'paasta_tools/monitoring/check_mesos_active_frameworks.py',
         'paasta_tools/monitoring/check_mesos_duplicate_frameworks.py',
         'paasta_tools/monitoring/check_mesos_quorum.py',
+        'paasta_tools/monitoring/check_mesos_outdated_tasks.py',
         'paasta_tools/monitoring/check_synapse_replication.py',
         'paasta_tools/monitoring/kill_orphaned_docker_containers.py',
         'paasta_tools/cli/paasta_tabcomplete.sh',

--- a/tests/monitoring/test_check_mesos_outdated_tasks.py
+++ b/tests/monitoring/test_check_mesos_outdated_tasks.py
@@ -1,0 +1,61 @@
+# Copyright 2015-2017 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from mock import patch
+
+from paasta_tools.monitoring import check_mesos_outdated_tasks
+
+
+@patch('paasta_tools.monitoring.check_mesos_outdated_tasks.get_mesos_master', autospec=True)
+def test_check_mesos_tasks(mock_get_mesos_master):
+    mock_get_mesos_master.return_value.state = {
+        'slaves': [
+            {
+                'id': '4abbb181-fd06-4729-815b-6b55cebdf8ee-S2',
+                'hostname': 'mesos-slave1.example.com',
+            },
+        ],
+        'frameworks': [{
+            'name': 'marathon',
+            'tasks': [
+                {
+                    'state': 'TASK_RUNNING',
+                    'name': 'service.instance.gitlast_SHA.config3f15fefe',
+                    'slave_id': '4abbb181-fd06-4729-815b-6b55cebdf8ee-S2',
+                    'statuses': [{
+                        'state': 'TASK_RUNNING',
+                        'timestamp': 1509392500.9267,
+                        'container_status': {
+                             'container_id': {'value': 'a69b426d-f283-4287-9bee-6b8811386e1a'},
+                        },
+                    }],
+                },
+                {
+                    'state': 'TASK_RUNNING',
+                    'name': 'service.instance.gitold_SHA.config3f15fefe',
+                    'slave_id': '4abbb181-fd06-4729-815b-6b55cebdf8ee-S2',
+                    'statuses': [{
+                        'state': 'TASK_RUNNING',
+                        'timestamp': 1509342500.9267,
+                        'container_status': {
+                            'container_id': {'value': 'a69b426d-f283-4287-9bee-6b8811386e1b'},
+                        },
+                    }],
+                },
+            ],
+        }],
+    }
+    output = check_mesos_outdated_tasks.check_mesos_tasks()
+    assert len(output) == 1
+    assert 'a69b426d-f283-4287-9bee-6b8811386e1b' in output[0]
+    assert 'old_SHA' in output[0]


### PR DESCRIPTION
internal ticket: PAASTA-13357

This check looks for containers serving previous versions.

```
./check_mesos_outdated_tasks.py --bounce-time 2
CRITICAL - There are 2 tasks running in norcal-prod that are more than 2h older than their last bounce.
SERVICE.INSTANCE                COMMIT    CREATED               HOSTNAME                     CONTAINER
yelp-main.mobile_alerts_update  addafd00  2017-10-11 15:28:46   paasta23-r6-sfo2             23c11d92-4ad9-467c-98e2-4b5767d6e5af-S1.9e84d80f-64b6-49fb-b609-ff49dd0300c6
yelp-main.elites_csv_kew_worke  1e332c88  2017-10-20 14:21:15   paasta64-r1-sfo2             a3e48ca4-3bb6-463f-af46-7595829d04ff-S39.1ff04304-c7b4-415e-a49c-28d5f7096f47
```
