### PR TITLE
paasta status: fix string interpolation in error message

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -105,7 +105,7 @@ def add_subparser(subparsers):
 
 def missing_deployments_message(service):
     message = (
-        "%s No deployments in deployments.json yet.\n  "
+        f"{service} has no deployments in deployments.json yet.\n  "
         "Has Jenkins run?"
     )
     return message


### PR DESCRIPTION
### before

```
$ paasta status -s fluffy -c norcal-devc -i main -d ~/proj/yelpsoa-configs
Warning: it looks like fluffy has not been deployed anywhere yet!
%s No deployments in deployments.json yet.
  Has Jenkins run?
```

(note the `%s` in the output)

### after

```
$ paasta status -s fluffy -c norcal-devc -i main -d ~/proj/yelpsoa-configs
Warning: it looks like fluffy has not been deployed anywhere yet!
fluffy has no deployments in deployments.json yet.
  Has Jenkins run?
```