### PR TITLE
Initial Support for a Sharded Marathon Dashboard

### DIFF
--- a/example_cluster/paasta/dashboard_links.json
+++ b/example_cluster/paasta/dashboard_links.json
@@ -1,0 +1,7 @@
+{
+  "dashboard_links": {
+    "testcluster": {
+      "Marathon RO": ["http://accessible-marathon", "http://accessible-marathon1", "http://accessible-marathon2"]
+    }
+  }
+}

--- a/paasta_itests/paasta_api.feature
+++ b/paasta_itests/paasta_api.feature
@@ -53,4 +53,11 @@ Feature: paasta_api
       And resources GET with groupings "pool" and filters "region:fakeregion" should return 2 groups
       And resources GET with groupings "pool" and filters "ssd:true|region:fakeregion" should return 1 groups
 
+  Scenario: Marathon Dashboard
+    Given a working paasta cluster
+      And I have yelpsoa-configs for the marathon job "test-service.main"
+      And I have yelpsoa-configs for the marathon job "test-service2.main" on shard 0, previous shard 1
+      Then marathon_dashboard GET should return "test-service.main" in cluster "testcluster" with shard 2
+      Then marathon_dashboard GET should return "service.instance2" in cluster "testcluster" with shard 3
+
 # vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2

--- a/paasta_itests/paasta_api.feature
+++ b/paasta_itests/paasta_api.feature
@@ -53,7 +53,6 @@ Feature: paasta_api
       And resources GET with groupings "pool" and filters "region:fakeregion" should return 2 groups
       And resources GET with groupings "pool" and filters "ssd:true|region:fakeregion" should return 1 groups
 
-  @wip
   Scenario: Marathon Dashboard
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"

--- a/paasta_itests/paasta_api.feature
+++ b/paasta_itests/paasta_api.feature
@@ -53,6 +53,7 @@ Feature: paasta_api
       And resources GET with groupings "pool" and filters "region:fakeregion" should return 2 groups
       And resources GET with groupings "pool" and filters "ssd:true|region:fakeregion" should return 1 groups
 
+  @wip
   Scenario: Marathon Dashboard
     Given a working paasta cluster
       And I have yelpsoa-configs for the marathon job "test-service.main"

--- a/paasta_itests/paasta_api.feature
+++ b/paasta_itests/paasta_api.feature
@@ -59,6 +59,6 @@ Feature: paasta_api
       And I have yelpsoa-configs for the marathon job "test-service.main"
       And I have yelpsoa-configs for the marathon job "test-service2.main" on shard 0, previous shard 1
       Then marathon_dashboard GET should return "test-service.main" in cluster "testcluster" with shard 2
-      Then marathon_dashboard GET should return "service.instance2" in cluster "testcluster" with shard 3
+      Then marathon_dashboard GET should return "service.instance2" in cluster "testcluster" with shard 0
 
 # vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2

--- a/paasta_itests/steps/paasta_api_steps.py
+++ b/paasta_itests/steps/paasta_api_steps.py
@@ -81,6 +81,7 @@ def resources_groupings(context, groupings, num):
 def marathon_dashboard(context, service, instance, cluster, shard):
     response = context.paasta_api_client.marathon_dashboard.marathon_dashboard().result()
     dashboard = response[cluster]
+    shard_url = context.system_paasta_config.get_dashboard_links()[cluster]['Marathon RO'][shard]
     for marathon_dashboard_item in dashboard:
         if marathon_dashboard_item['service'] == service and marathon_dashboard_item['instance'] == instance:
-            assert marathon_dashboard_item['shard_url'] == context.marathon_servers.current[shard].url, response
+            assert marathon_dashboard_item['shard_url'] == shard_url

--- a/paasta_itests/steps/paasta_api_steps.py
+++ b/paasta_itests/steps/paasta_api_steps.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Yelp Inc.
+# Copyright 2015-2017 Yelp Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -75,3 +75,12 @@ def resources_groupings_filters(context, groupings, filters, num):
 @then('resources GET with groupings "{groupings}" should return {num:d} groups')
 def resources_groupings(context, groupings, num):
     return resources_groupings_filters(context, groupings, [], num)
+
+
+@then('marathon_dashboard GET should return "{service}.{instance}" in cluster "{cluster}" with shard {shard:d}')
+def marathon_dashboard(context, service, instance, cluster, shard):
+    response = context.paasta_api_client.marathon_dashboard.marathon_dashboard().result()
+    dashboard = response[cluster]
+    for marathon_dashboard_item in dashboard:
+        if marathon_dashboard_item['service'] == service and marathon_dashboard_item['instance'] == instance:
+            assert marathon_dashboard_item['shard'] == context.marathon_servers.current[shard].url, response

--- a/paasta_itests/steps/paasta_api_steps.py
+++ b/paasta_itests/steps/paasta_api_steps.py
@@ -83,4 +83,4 @@ def marathon_dashboard(context, service, instance, cluster, shard):
     dashboard = response[cluster]
     for marathon_dashboard_item in dashboard:
         if marathon_dashboard_item['service'] == service and marathon_dashboard_item['instance'] == instance:
-            assert marathon_dashboard_item['shard'] == context.marathon_servers.current[shard].url, response
+            assert marathon_dashboard_item['shard_url'] == context.marathon_servers.current[shard].url, response

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -79,9 +79,13 @@ def setup_system_paasta_config():
             },
             'dashboard_links': {
                 'testcluster': {
-                    'Marathon RO': ['http://accessible-marathon', 'http://accessible-marathon1', 'http://accessible-marathon2']
-                }
-            }
+                    'Marathon RO': [
+                        'http://accessible-marathon',
+                        'http://accessible-marathon1',
+                        'http://accessible-marathon2',
+                    ],
+                },
+            },
         }, '/some_fake_path_to_config_dir/',
     )
     return system_paasta_config

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -235,6 +235,19 @@ def working_paasta_cluster_with_registry(context, docker_registry):
             },
         }, 'api_endpoints.json',
     )
+    write_etc_paasta(
+        context, {
+            'dashboard_links': {
+                'testcluster': {
+                    'Marathon RO': [
+                        'http://accessible-marathon',
+                        'http://accessible-marathon1',
+                        'http://accessible-marathon2',
+                    ],
+                },
+            },
+        }, 'dashboard_links.json',
+    )
 
 
 @given('we have yelpsoa-configs for the service "{service}" with {disabled} scheduled chronos instance "{instance}"')

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -77,6 +77,11 @@ def setup_system_paasta_config():
                 'password': None,
                 'url': [chronos_connection_string],
             },
+            'dashboard_links': {
+                'testcluster': {
+                    'Marathon RO': ['http://accessible-marathon', 'http://accessible-marathon1', 'http://accessible-marathon2']
+                }
+            }
         }, '/some_fake_path_to_config_dir/',
     )
     return system_paasta_config

--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -80,6 +80,7 @@ def make_app(global_config=None):
     config.add_route('service_autoscaler.pause.delete', '/v1/service_autoscaler/pause', request_method="DELETE")
     config.add_route('service_autoscaler.pause.get', '/v1/service_autoscaler/pause', request_method="GET")
     config.add_route('version', '/v1/version')
+    config.add_route('marathon_dashboard', '/v1/marathon_dashboard', request_method="GET")
     config.scan()
     return CORS(config.make_wsgi_app(), headers="*", methods="*", maxage="180", origin="*")
 
@@ -93,6 +94,12 @@ def setup_paasta_api():
 
     settings.marathon_clients = marathon_tools.get_marathon_clients(
         marathon_tools.get_marathon_servers(system_paasta_config),
+    )
+
+    settings.marathon_servers = marathon_tools.get_marathon_servers(system_paasta_config=system_paasta_config)
+    settings.marathon_clients = marathon_tools.get_marathon_clients(
+        marathon_servers=settings.marathon_servers,
+        cached=False,
     )
 
     # Set up transparent cache for http API calls. With expire_after, responses

--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -89,14 +89,14 @@ def setup_paasta_api():
     # pyinotify is a better solution than turning off file caching completely
     service_configuration_lib.disable_yaml_cache()
 
-    system_paasta_config = load_system_paasta_config()
-    settings.cluster = system_paasta_config.get_cluster()
+    settings.system_paasta_config = load_system_paasta_config()
+    settings.cluster = settings.system_paasta_config.get_cluster()
 
     settings.marathon_clients = marathon_tools.get_marathon_clients(
-        marathon_tools.get_marathon_servers(system_paasta_config),
+        marathon_tools.get_marathon_servers(settings.system_paasta_config),
     )
 
-    settings.marathon_servers = marathon_tools.get_marathon_servers(system_paasta_config=system_paasta_config)
+    settings.marathon_servers = marathon_tools.get_marathon_servers(system_paasta_config=settings.system_paasta_config)
     settings.marathon_clients = marathon_tools.get_marathon_clients(
         marathon_servers=settings.marathon_servers,
         cached=False,

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -702,7 +702,7 @@
           "type": "string",
           "description": "Instance name"
         },
-        "shard": {
+        "shard_url": {
           "type": "string",
           "description": "Marathon Shard URL"
         }

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -678,7 +678,7 @@
     },
     "MarathonDashboard": {
       "type": "object",
-      "description": "A list of Marathon service, instance, and shard number for one or more clusters",
+      "description": "A list of Marathon service, instance, and shard url for one or more clusters",
       "additionalProperties": {
         "$ref": "#/definitions/MarathonDashboardCluster"
       }
@@ -692,7 +692,7 @@
     },
     "MarathonDashboardItem": {
       "type": "object",
-      "description": "Marathon service, instance, and shard number",
+      "description": "Marathon service, instance, and shard url",
       "properties": {
         "service": {
           "type": "string",

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -5,9 +5,15 @@
     "version": "1.0.0"
   },
   "basePath": "/v1",
-  "schemes": ["http"],
-  "consumes": ["application/x-www-form-urlencoded"],
-  "produces": ["application/json"],
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/x-www-form-urlencoded"
+  ],
+  "produces": [
+    "application/json"
+  ],
   "tags": [
     {
       "name": "service",
@@ -84,13 +90,30 @@
         "operationId": "delete_service_autoscaler_pause"
       }
     },
+    "/marathon_dashboard": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "List of service instances and information on their Marathon shard",
+            "schema": {
+              "$ref": "#/definitions/MarathonDashboard"
+            }
+          }
+        },
+        "summary": "Get marathon service instances and their shards",
+        "operationId": "marathon_dashboard",
+        "tags": [
+          "marathon_dashboard"
+        ]
+      }
+    },
     "/resources/utilization": {
       "get": {
         "responses": {
           "200": {
             "description": "Resources in the cluster, filtered and grouped by parameters",
             "schema": {
-              "$ref":"#/definitions/Resource"
+              "$ref": "#/definitions/Resource"
             }
           },
           "400": {
@@ -99,7 +122,9 @@
         },
         "summary": "Get resources in the cluster",
         "operationId": "resources",
-        "tags": ["resources"],
+        "tags": [
+          "resources"
+        ],
         "parameters": [
           {
             "in": "query",
@@ -108,7 +133,9 @@
             "required": false,
             "type": "array",
             "collectionFormat": "csv",
-            "items": {"type": "string"}
+            "items": {
+              "type": "string"
+            }
           },
           {
             "in": "query",
@@ -135,7 +162,9 @@
               "properties": {
                 "instances": {
                   "type": "array",
-                  "items": {"type": "string"}
+                  "items": {
+                    "type": "string"
+                  }
                 }
               }
             }
@@ -143,7 +172,9 @@
         },
         "summary": "List instances of service_name",
         "operationId": "list_instances",
-        "tags": ["service"],
+        "tags": [
+          "service"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -161,7 +192,7 @@
           "200": {
             "description": "Detailed status of an instance",
             "schema": {
-                "$ref":"#/definitions/InstanceStatus"
+              "$ref": "#/definitions/InstanceStatus"
             }
           },
           "404": {
@@ -173,7 +204,9 @@
         },
         "summary": "Get status of service_name.instance_name",
         "operationId": "status_instance",
-        "tags": ["service"],
+        "tags": [
+          "service"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -238,14 +271,14 @@
           "200": {
             "description": "List of tasks associated with an instance",
             "schema": {
-                "$ref":"#/definitions/InstanceTasks"
+              "$ref": "#/definitions/InstanceTasks"
             }
-          },
-          "404": {
-            "description": "Deployment key not found"
           },
           "400": {
             "description": "Bad request"
+          },
+          "404": {
+            "description": "Deployment key not found"
           },
           "500": {
             "description": "Instance failure"
@@ -253,7 +286,9 @@
         },
         "summary": "Get mesos tasks of service_name.instance_name",
         "operationId": "tasks_instance",
-        "tags": ["service"],
+        "tags": [
+          "service"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -275,14 +310,14 @@
             "name": "slave_hostname",
             "required": false,
             "type": "string"
-	  },
+          },
           {
             "in": "query",
             "description": "Return slave and executor for task",
             "name": "verbose",
             "required": false,
             "type": "boolean"
-	  }
+          }
         ]
       }
     },
@@ -292,14 +327,14 @@
           "200": {
             "description": "Task associated with an instance with specified ID",
             "schema": {
-                "$ref":"#/definitions/InstanceTask"
+              "$ref": "#/definitions/InstanceTask"
             }
-          },
-          "404": {
-            "description": "Task with ID not found"
           },
           "400": {
             "description": "Bad request"
+          },
+          "404": {
+            "description": "Task with ID not found"
           },
           "500": {
             "description": "Instance failure"
@@ -307,7 +342,9 @@
         },
         "summary": "Get mesos task of service_name.instance_name by task_id",
         "operationId": "task_instance",
-        "tags": ["service"],
+        "tags": [
+          "service"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -329,14 +366,14 @@
             "name": "task_id",
             "required": true,
             "type": "string"
-	  },
+          },
           {
             "in": "query",
             "description": "Return slave and executor for task",
             "name": "verbose",
             "required": false,
             "type": "boolean"
-	  }
+          }
         ]
       }
     },
@@ -363,7 +400,9 @@
         },
         "summary": "Get status of service_name.instance_name",
         "operationId": "get_autoscaler_count",
-        "tags": ["autoscaler"],
+        "tags": [
+          "autoscaler"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -406,7 +445,9 @@
         },
         "summary": "Get status of service_name.instance_name",
         "operationId": "update_autoscaler_count",
-        "tags": ["autoscaler"],
+        "tags": [
+          "autoscaler"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -474,7 +515,10 @@
         "desired_state": {
           "type": "string",
           "description": "Desired state of a service, for both Marathon and Chronos",
-          "enum": ["start", "stop"]
+          "enum": [
+            "start",
+            "stop"
+          ]
         },
         "app_count": {
           "type": "integer",
@@ -488,12 +532,24 @@
         "bounce_method": {
           "type": "string",
           "description": "Method to transit between new and old versions of a service",
-          "enum": ["brutal", "upthendown", "downthenup", "crossover"]
+          "enum": [
+            "brutal",
+            "upthendown",
+            "downthenup",
+            "crossover"
+          ]
         },
         "deploy_status": {
           "type": "string",
           "description": "Deploy status of a marathon service",
-          "enum": ["Running", "Deploying", "Stopped", "Delayed", "Waiting", "NotRunning"]
+          "enum": [
+            "Running",
+            "Deploying",
+            "Stopped",
+            "Delayed",
+            "Waiting",
+            "NotRunning"
+          ]
         },
         "backoff_seconds": {
           "type": "integer",
@@ -527,12 +583,18 @@
         "desired_state": {
           "type": "string",
           "description": "Desired state of a service, for both Marathon and Chronos",
-          "enum": ["start", "stop"]
+          "enum": [
+            "start",
+            "stop"
+          ]
         },
         "schedule_type": {
           "type": "string",
           "description": "The type of schedule, dependent or shceduled",
-          "enum": ["parents", "schedule"]
+          "enum": [
+            "parents",
+            "schedule"
+          ]
         },
         "schedule_parents": {
           "type": "array",
@@ -562,7 +624,10 @@
           "properties": {
             "disabled_state": {
               "type": "string",
-              "enum": ["not_scheduled", "scheduled"]
+              "enum": [
+                "not_scheduled",
+                "scheduled"
+              ]
             },
             "chronos_state": {
               "type": "string"
@@ -570,7 +635,10 @@
             "mesos_state": {
               "type": "string",
               "description": "The status in mesos",
-              "enum": ["running", "not_running"]
+              "enum": [
+                "running",
+                "not_running"
+              ]
             }
           }
         },
@@ -601,14 +669,50 @@
     "InstanceTasks": {
       "type": "array",
       "description": "List of tasks associated with instance",
-      "items": {"$ref": "#/definitions/InstanceTask"}
+      "items": {
+        "$ref": "#/definitions/InstanceTask"
+      }
     },
     "InstanceTask": {
       "type": "object"
     },
+    "MarathonDashboard": {
+      "type": "object",
+      "description": "A list of Marathon service, instance, and shard number for one or more clusters",
+      "additionalProperties": {
+        "$ref": "#/definitions/MarathonDashboardCluster"
+      }
+    },
+    "MarathonDashboardCluster": {
+      "type": "array",
+      "description": "List of all the MarathonDashboardItems for a cluster",
+      "items": {
+        "$ref": "#/definitions/MarathonDashboardItem"
+      }
+    },
+    "MarathonDashboardItem": {
+      "type": "object",
+      "description": "Marathon service, instance, and shard number",
+      "properties": {
+        "service": {
+          "type": "string",
+          "description": "Service name"
+        },
+        "instance": {
+          "type": "string",
+          "description": "Instance name"
+        },
+        "shard": {
+          "type": "string",
+          "description": "Marathon Shard URL"
+        }
+      }
+    },
     "Resource": {
       "type": "array",
-      "items": {"$ref": "#/definitions/ResourceItem"}
+      "items": {
+        "$ref": "#/definitions/ResourceItem"
+      }
     },
     "ResourceItem": {
       "type": "object",
@@ -630,9 +734,15 @@
     "ResourceValue": {
       "type": "object",
       "properties": {
-        "free": {"type": "number"},
-        "used": {"type": "number"},
-        "total": {"type": "number"}
+        "free": {
+          "type": "number"
+        },
+        "used": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        }
       }
     }
   }

--- a/paasta_tools/api/views/marathon_dashboard.py
+++ b/paasta_tools/api/views/marathon_dashboard.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# Copyright 2017 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Marathon Dashboard
+"""
+from pyramid.view import view_config
+
+from paasta_tools.api import settings
+from paasta_tools.marathon_dashboard import create_marathon_dashboard
+
+
+@view_config(route_name='marathon_dashboard', request_method='GET', renderer='json')
+def marathon_dashboard(request):
+    return create_marathon_dashboard(
+        cluster=settings.cluster,
+        soa_dir=settings.soa_dir,
+        marathon_clients=settings.marathon_clients,
+    )

--- a/paasta_tools/api/views/marathon_dashboard.py
+++ b/paasta_tools/api/views/marathon_dashboard.py
@@ -27,4 +27,5 @@ def marathon_dashboard(request):
         cluster=settings.cluster,
         soa_dir=settings.soa_dir,
         marathon_clients=settings.marathon_clients,
+        system_paasta_config=settings.system_paasta_config,
     )

--- a/paasta_tools/api/views/marathon_dashboard.py
+++ b/paasta_tools/api/views/marathon_dashboard.py
@@ -23,6 +23,7 @@ from paasta_tools.marathon_dashboard import create_marathon_dashboard
 
 @view_config(route_name='marathon_dashboard', request_method='GET', renderer='json')
 def marathon_dashboard(request):
+    print("marathon_dashboard view")
     return create_marathon_dashboard(
         cluster=settings.cluster,
         soa_dir=settings.soa_dir,

--- a/paasta_tools/marathon_dashboard.py
+++ b/paasta_tools/marathon_dashboard.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# Copyright 2017 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import json
+import logging
+
+from paasta_tools.marathon_tools import get_marathon_clients
+from paasta_tools.marathon_tools import get_marathon_servers
+from paasta_tools.marathon_tools import load_marathon_service_config
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import get_services_for_cluster
+from paasta_tools.utils import load_system_paasta_config
+
+
+log = logging.getLogger(__name__)
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description='Generates links from marathon instances to their respective web dashboard.',
+    )
+    parser.add_argument(
+        '-c', '--cluster', dest="cluster", metavar="CLUSTER",
+        default=None,
+        help="define a specific cluster to read from",
+    )
+    parser.add_argument(
+        '-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
+        default=DEFAULT_SOA_DIR,
+        help="define a different soa config directory",
+    )
+    args = parser.parse_args(argv)
+    return args
+
+
+def create_marathon_dashboard(cluster, soa_dir=DEFAULT_SOA_DIR, marathon_clients=None):
+    try:
+        instances = get_services_for_cluster(
+            cluster=cluster,
+            instance_type='marathon',
+            soa_dir=soa_dir,
+        )
+    except FileNotFoundError:
+        instances = []
+    dashboard = {cluster: []}
+    system_paasta_config = load_system_paasta_config()
+    if marathon_clients is None:
+        marathon_servers = get_marathon_servers(system_paasta_config=system_paasta_config)
+        marathon_clients = get_marathon_clients(marathon_servers=marathon_servers, cached=False)
+    for service_instance in instances:
+        service = service_instance[0]
+        instance = service_instance[1]
+        service_config = load_marathon_service_config(
+            service=service,
+            instance=instance,
+            cluster=cluster,
+            load_deployments=False,
+            soa_dir=soa_dir,
+        )
+        client = marathon_clients.get_current_client_for_service(job_config=service_config)
+        shard = client.servers[0]
+        service_info = {
+            'service': service,
+            'instance': instance,
+            'shard': shard,
+        }
+        dashboard[cluster].append(service_info)
+    return dashboard
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    dashboard = create_marathon_dashboard(cluster=args.cluster, soa_dir=args.soa_dir)
+    print(json.dumps(dashboard))
+
+
+if __name__ == "__main__":
+    main()

--- a/paasta_tools/marathon_dashboard.py
+++ b/paasta_tools/marathon_dashboard.py
@@ -70,11 +70,11 @@ def create_marathon_dashboard(cluster, soa_dir=DEFAULT_SOA_DIR, marathon_clients
             soa_dir=soa_dir,
         )
         client = marathon_clients.get_current_client_for_service(job_config=service_config)
-        shard = client.servers[0]
+        shard_url = client.servers[0]
         service_info = {
             'service': service,
             'instance': instance,
-            'shard': shard,
+            'shard_url': shard_url,
         }
         dashboard[cluster].append(service_info)
     return dashboard

--- a/paasta_tools/marathon_dashboard.py
+++ b/paasta_tools/marathon_dashboard.py
@@ -72,9 +72,9 @@ def create_marathon_dashboard(cluster, soa_dir=DEFAULT_SOA_DIR, marathon_clients
         client = marathon_clients.get_current_client_for_service(job_config=service_config)
         dashboard_links = system_paasta_config.get_dashboard_links()
         shard_url = client.servers[0]
-        for shard_number in marathon_servers.current:
-            if marathon_servers.current[shard_number].url == shard_url:
-                shard_url = dashboard_links[shard_number]
+        for shard_number, shard in enumerate(marathon_servers.current):
+            if shard.url[0] == shard_url:
+                shard_url = dashboard_links[cluster]['Marathon RO'][shard_number]
         service_info = {
             'service': service,
             'instance': instance,

--- a/paasta_tools/marathon_dashboard.py
+++ b/paasta_tools/marathon_dashboard.py
@@ -56,8 +56,8 @@ def create_marathon_dashboard(cluster, soa_dir=DEFAULT_SOA_DIR, marathon_clients
         instances = []
     dashboard = {cluster: []}
     system_paasta_config = load_system_paasta_config()
+    marathon_servers = get_marathon_servers(system_paasta_config=system_paasta_config)
     if marathon_clients is None:
-        marathon_servers = get_marathon_servers(system_paasta_config=system_paasta_config)
         marathon_clients = get_marathon_clients(marathon_servers=marathon_servers, cached=False)
     for service_instance in instances:
         service = service_instance[0]

--- a/paasta_tools/marathon_dashboard.py
+++ b/paasta_tools/marathon_dashboard.py
@@ -70,7 +70,11 @@ def create_marathon_dashboard(cluster, soa_dir=DEFAULT_SOA_DIR, marathon_clients
             soa_dir=soa_dir,
         )
         client = marathon_clients.get_current_client_for_service(job_config=service_config)
+        dashboard_links = system_paasta_config.get_dashboard_links()
         shard_url = client.servers[0]
+        for shard_number in marathon_servers.current:
+            if marathon_servers.current[shard_number].url == shard_url:
+                shard_url = dashboard_links[shard_number]
         service_info = {
             'service': service,
             'instance': instance,

--- a/paasta_tools/marathon_dashboard.py
+++ b/paasta_tools/marathon_dashboard.py
@@ -49,7 +49,7 @@ def create_marathon_dashboard(
         cluster,
         soa_dir=DEFAULT_SOA_DIR,
         marathon_clients=None,
-        system_paasta_config=load_system_paasta_config(),
+        system_paasta_config=None,
 ):
     try:
         instances = get_services_for_cluster(
@@ -60,6 +60,8 @@ def create_marathon_dashboard(
     except FileNotFoundError:
         instances = []
     dashboard = {cluster: []}
+    if system_paasta_config is None:
+        system_paasta_config = load_system_paasta_config()
     marathon_servers = get_marathon_servers(system_paasta_config=system_paasta_config)
     if marathon_clients is None:
         marathon_clients = get_marathon_clients(marathon_servers=marathon_servers, cached=False)

--- a/paasta_tools/marathon_dashboard.py
+++ b/paasta_tools/marathon_dashboard.py
@@ -45,7 +45,12 @@ def parse_args(argv):
     return args
 
 
-def create_marathon_dashboard(cluster, soa_dir=DEFAULT_SOA_DIR, marathon_clients=None):
+def create_marathon_dashboard(
+        cluster,
+        soa_dir=DEFAULT_SOA_DIR,
+        marathon_clients=None,
+        system_paasta_config=load_system_paasta_config(),
+):
     try:
         instances = get_services_for_cluster(
             cluster=cluster,
@@ -55,7 +60,6 @@ def create_marathon_dashboard(cluster, soa_dir=DEFAULT_SOA_DIR, marathon_clients
     except FileNotFoundError:
         instances = []
     dashboard = {cluster: []}
-    system_paasta_config = load_system_paasta_config()
     marathon_servers = get_marathon_servers(system_paasta_config=system_paasta_config)
     if marathon_clients is None:
         marathon_clients = get_marathon_clients(marathon_servers=marathon_servers, cached=False)

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -135,7 +135,7 @@ class MarathonClients(object):
         self.current = current
         self.previous = previous
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'Current: %s | Previous: %s' % (self.current, self.previous)
 
     def get_current_client_for_service(self, job_config: 'MarathonServiceConfig') -> MarathonClient:

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -135,6 +135,9 @@ class MarathonClients(object):
         self.current = current
         self.previous = previous
 
+    def __repr__(self):
+        return 'Current: %s | Previous: %s' % (self.current, self.previous)
+
     def get_current_client_for_service(self, job_config: 'MarathonServiceConfig') -> MarathonClient:
         service_instance = compose_job_id(job_config.service, job_config.instance)
         if job_config.get_marathon_shard() is not None:

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -136,7 +136,7 @@ class MarathonClients(object):
         self.previous = previous
 
     def __repr__(self) -> str:
-        return 'Current: %s | Previous: %s' % (self.current, self.previous)
+        return 'MarathonClients(current=%r, previous=%r' % (self.current, self.previous)
 
     def get_current_client_for_service(self, job_config: 'MarathonServiceConfig') -> MarathonClient:
         service_instance = compose_job_id(job_config.service, job_config.instance)

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         'paasta_tools/generate_services_yaml.py',
         'paasta_tools/get_mesos_leader.py',
         'paasta_tools/list_marathon_service_instances.py',
+        'paasta_tools/marathon_dashboard.py',
         'paasta_tools/monitoring/check_capacity.py',
         'paasta_tools/monitoring/check_chronos_has_jobs.py',
         'paasta_tools/monitoring/check_classic_service_replication.py',

--- a/tests/api/test_marathon_dashboard_api.py
+++ b/tests/api/test_marathon_dashboard_api.py
@@ -1,0 +1,59 @@
+# Copyright 2017 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pyramid import testing
+
+from paasta_tools import marathon_tools
+from paasta_tools.api import settings
+from paasta_tools.api.views.marathon_dashboard import marathon_dashboard
+from paasta_tools.utils import SystemPaastaConfig
+
+
+def test_list_instances():
+    settings.cluster = 'fake_cluster'
+    system_paasta_config_dict = {
+        "marathon_servers": [
+            {
+                "user": "fake_user",
+                "password": "fake_password",
+                "url": [
+                    "http://marathon:8080",
+                ],
+            },
+            {
+                "user": "fake_user",
+                "password": "fake_password",
+                "url": [
+                    "http://marathon1:8080",
+                ],
+            },
+            {
+                "user": "fake_user",
+                "password": "fake_password",
+                "url": [
+                    "http://marathon2:8080",
+                ],
+            },
+        ],
+    }
+    system_paasta_config = SystemPaastaConfig(config=system_paasta_config_dict, directory='unused')
+    marathon_servers = marathon_tools.get_marathon_servers(system_paasta_config)
+    settings.marathon_clients = marathon_tools.get_marathon_clients(
+        marathon_servers=marathon_servers,
+        cached=False,
+    )
+    request = testing.DummyRequest()
+
+    response = marathon_dashboard(request)
+    expected_output = {settings.cluster: []}
+    assert response == expected_output

--- a/tests/api/test_marathon_dashboard_api.py
+++ b/tests/api/test_marathon_dashboard_api.py
@@ -47,6 +47,11 @@ def test_list_instances(mock_load_system_paasta_config):
                 ],
             },
         ],
+        "dashboard_links": {
+            "testcluster": {
+                "Marathon RO": ["http://accessible-marathon", "http://accessible-marathon1", "http://accessible-marathon2"]
+            }
+        }
     }
     system_paasta_config = SystemPaastaConfig(config=system_paasta_config_dict, directory='unused')
     marathon_servers = marathon_tools.get_marathon_servers(system_paasta_config)

--- a/tests/api/test_marathon_dashboard_api.py
+++ b/tests/api/test_marathon_dashboard_api.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import mock
 from pyramid import testing
 
 from paasta_tools import marathon_tools
@@ -19,7 +20,8 @@ from paasta_tools.api.views.marathon_dashboard import marathon_dashboard
 from paasta_tools.utils import SystemPaastaConfig
 
 
-def test_list_instances():
+@mock.patch('paasta_tools.marathon_dashboard.load_system_paasta_config', autospec=True)
+def test_list_instances(mock_load_system_paasta_config):
     settings.cluster = 'fake_cluster'
     system_paasta_config_dict = {
         "marathon_servers": [
@@ -54,6 +56,7 @@ def test_list_instances():
     )
     request = testing.DummyRequest()
 
+    mock_load_system_paasta_config.return_value = SystemPaastaConfig({}, 'fake_directory')
     response = marathon_dashboard(request)
     expected_output = {settings.cluster: []}
     assert response == expected_output

--- a/tests/api/test_marathon_dashboard_api.py
+++ b/tests/api/test_marathon_dashboard_api.py
@@ -49,7 +49,11 @@ def test_list_instances(mock_load_system_paasta_config):
         ],
         "dashboard_links": {
             "testcluster": {
-                "Marathon RO": ["http://accessible-marathon", "http://accessible-marathon1", "http://accessible-marathon2"]
+                "Marathon RO": [
+                    "http://accessible-marathon",
+                    "http://accessible-marathon1",
+                    "http://accessible-marathon2",
+                ]
             }
         }
     }

--- a/tests/api/test_marathon_dashboard_api.py
+++ b/tests/api/test_marathon_dashboard_api.py
@@ -53,9 +53,9 @@ def test_list_instances(mock_load_system_paasta_config):
                     "http://accessible-marathon",
                     "http://accessible-marathon1",
                     "http://accessible-marathon2",
-                ]
-            }
-        }
+                ],
+            },
+        },
     }
     system_paasta_config = SystemPaastaConfig(config=system_paasta_config_dict, directory='unused')
     marathon_servers = marathon_tools.get_marathon_servers(system_paasta_config)

--- a/tests/api/test_marathon_dashboard_api.py
+++ b/tests/api/test_marathon_dashboard_api.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import mock
 from pyramid import testing
 
 from paasta_tools import marathon_tools
@@ -20,8 +19,7 @@ from paasta_tools.api.views.marathon_dashboard import marathon_dashboard
 from paasta_tools.utils import SystemPaastaConfig
 
 
-@mock.patch('paasta_tools.marathon_dashboard.load_system_paasta_config', autospec=True)
-def test_list_instances(mock_load_system_paasta_config):
+def test_list_instances():
     settings.cluster = 'fake_cluster'
     system_paasta_config_dict = {
         "marathon_servers": [
@@ -66,7 +64,6 @@ def test_list_instances(mock_load_system_paasta_config):
     request = testing.DummyRequest()
 
     settings.system_paasta_config = system_paasta_config
-    mock_load_system_paasta_config.return_value = SystemPaastaConfig({}, 'fake_directory')
     response = marathon_dashboard(request)
     expected_output = {settings.cluster: []}
     assert response == expected_output

--- a/tests/api/test_marathon_dashboard_api.py
+++ b/tests/api/test_marathon_dashboard_api.py
@@ -65,6 +65,7 @@ def test_list_instances(mock_load_system_paasta_config):
     )
     request = testing.DummyRequest()
 
+    settings.system_paasta_config = system_paasta_config
     mock_load_system_paasta_config.return_value = SystemPaastaConfig({}, 'fake_directory')
     response = marathon_dashboard(request)
     expected_output = {settings.cluster: []}

--- a/tests/test_marathon_dashboard.py
+++ b/tests/test_marathon_dashboard.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# Copyright 2017 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+
+from paasta_tools import marathon_dashboard
+
+
+def test_main():
+    soa_dir = '/fake/soa/dir'
+    cluster = 'fake_cluster'
+    with mock.patch(
+        'paasta_tools.marathon_dashboard.create_marathon_dashboard',
+        autospec=True,
+        return_value={},
+    ) as create_marathon_dashboard:
+        marathon_dashboard.main(('--soa-dir', soa_dir, '--cluster', cluster))
+        create_marathon_dashboard.assert_called_once_with(
+            cluster=cluster,
+            soa_dir=soa_dir,
+        )
+
+
+def test_create_marathon_dashboard():
+    soa_dir = '/fake/soa/dir'
+    cluster = 'fake_cluster'
+    expected_output = {'fake_cluster': []}
+    assert(marathon_dashboard.create_marathon_dashboard(cluster=cluster, soa_dir=soa_dir) == expected_output)

--- a/tests/test_marathon_dashboard.py
+++ b/tests/test_marathon_dashboard.py
@@ -15,6 +15,7 @@
 import mock
 
 from paasta_tools import marathon_dashboard
+from paasta_tools.utils import SystemPaastaConfig
 
 
 def test_main():
@@ -32,8 +33,10 @@ def test_main():
         )
 
 
-def test_create_marathon_dashboard():
+@mock.patch('paasta_tools.marathon_dashboard.load_system_paasta_config', autospec=True)
+def test_create_marathon_dashboard(mock_load_system_paasta_config):
     soa_dir = '/fake/soa/dir'
     cluster = 'fake_cluster'
     expected_output = {'fake_cluster': []}
+    mock_load_system_paasta_config.return_value = SystemPaastaConfig({}, 'fake_directory')
     assert(marathon_dashboard.create_marathon_dashboard(cluster=cluster, soa_dir=soa_dir) == expected_output)

--- a/tests/test_marathon_dashboard.py
+++ b/tests/test_marathon_dashboard.py
@@ -18,9 +18,11 @@ from paasta_tools import marathon_dashboard
 from paasta_tools.utils import SystemPaastaConfig
 
 
-def test_main():
+@mock.patch('paasta_tools.marathon_dashboard.load_system_paasta_config', autospec=True)
+def test_main(mock_load_system_paasta_config):
     soa_dir = '/fake/soa/dir'
     cluster = 'fake_cluster'
+    mock_load_system_paasta_config.return_value = SystemPaastaConfig({}, 'fake_directory')
     with mock.patch(
         'paasta_tools.marathon_dashboard.create_marathon_dashboard',
         autospec=True,

--- a/yelp_package/dockerfiles/itest/api/dashboard_links.json
+++ b/yelp_package/dockerfiles/itest/api/dashboard_links.json
@@ -1,0 +1,7 @@
+{
+  "dashboard_links": {
+    "testcluster": {
+      "Marathon RO": ["http://accessible-marathon", "http://accessible-marathon1", "http://accessible-marathon2"]
+    }
+  }
+}

--- a/yelp_package/dockerfiles/itest/api/marathon.json
+++ b/yelp_package/dockerfiles/itest/api/marathon.json
@@ -1,7 +1,25 @@
 {
   "marathon_servers": [
-    {"user": null, "password": null, "url": ["http://marathon:8080"]},
-    {"user": null, "password": null, "url": ["http://marathon1:8080"]},
-    {"user": null, "password": null, "url": ["http://marathon2:8080"]}
+    {
+      "url": [
+        "http://marathon:8080"
+      ],
+      "user": null,
+      "password": null
+    },
+    {
+      "url": [
+        "http://marathon1:8080"
+      ],
+      "user": null,
+      "password": null
+    },
+    {
+      "url": [
+        "http://marathon2:8080"
+      ],
+      "user": null,
+      "password": null
+    }
   ]
 }


### PR DESCRIPTION
This is a first pass at adding a script to spit out information about the service instances in a cluster and their associated marathon shard. The API will ultimately get queries and displayed as a nice dashboard by an external service.

TODO:

* Add a real unit test
* Add type annotations