### PR TITLE
Always fix the slack of old marathon apps when bouncing

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1484,3 +1484,11 @@ def broadcast_log_all_services_running_here(line: str, component: str='monitorin
 
 def broadcast_log_all_services_running_here_from_stdin(component: str='monitoring') -> None:
     broadcast_log_all_services_running_here(sys.stdin.read().strip())
+
+
+def take_up_slack(client: MarathonClient, app: MarathonApp) -> None:
+    slack = max(app.instances - len(app.tasks), 0)
+    if slack > 0:
+        log.info("Scaling %s down from %d to %d instances to remove slack." %
+                 (app.id, app.instances, app.instances - slack))
+        client.scale_app(app_id=app.id, instances=(app.instances - slack), force=True)

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -1432,7 +1432,7 @@ class TestSetupMarathonJob:
         fake_name = 'whoa'
         fake_instance = 'the_earth_is_tiny'
         fake_id = marathon_tools.format_job_id(fake_name, fake_instance)
-        fake_marathon_apps = [mock.Mock(id=fake_id, tasks=[]), mock.Mock(id=('%s2' % fake_id), tasks=[])]
+        fake_marathon_apps = [mock.Mock(id=fake_id, tasks=[], instances=2), mock.Mock(id=('%s2' % fake_id), tasks=[])]
         fake_client = mock.MagicMock(
             list_apps=mock.Mock(return_value=fake_marathon_apps),
         )
@@ -1486,7 +1486,10 @@ class TestSetupMarathonJob:
         old_task_is_draining = mock.Mock(id="old_task_is_draining", app_id=old_app_id)
         old_task_dont_drain = mock.Mock(id="old_task_dont_drain", app_id=old_app_id)
 
-        old_app = mock.Mock(id="/%s" % old_app_id, tasks=[old_task_to_drain, old_task_is_draining, old_task_dont_drain])
+        old_app = mock.Mock(
+            id="/%s" % old_app_id, tasks=[old_task_to_drain, old_task_is_draining, old_task_dont_drain],
+            instances=2,
+        )
 
         fake_client = mock.MagicMock(  # pragma: no branch (only used for interface)
             list_apps=mock.Mock(return_value=[old_app]),


### PR DESCRIPTION
I noticed this was happening during big bounces and lucy bounces. Here is what happens:

* paasta restart (or other signal) is initiated more than 1 time, like run paasta restart 100 times
* 100 apps are created, all waiting, 1 "new app" is the desired one
* The bounce never tries to scaled down those old apps, so they have to launch, then it drains, etc.

This same "take in the slack" technique was already being applied to the new_app on scaledown. Now it will also be applied to all the other old apps, because we are also scaling those down too.