### PR TITLE
Add bounce logic for json secret files

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -30,3 +30,6 @@ disallow_untyped_defs = True
 
 [mypy-paasta_tools.autoscaling.autoscaling_cluster_lib]
 disallow_untyped_defs = True
+
+[mypy-paasta_tools.secret_tools]
+disallow_untyped_defs = True

--- a/paasta_itests/paasta_deployd.feature
+++ b/paasta_itests/paasta_deployd.feature
@@ -35,6 +35,21 @@ Feature: paasta-deployd deploys apps
      Then we should see "test-service.main" listed in marathon after 60 seconds
      Then we can run get_app
 
+  Scenario: deployd will re-deploy an app if a secret json file is updated and the secret's HMAC changes
+    Given a working paasta cluster
+      And paasta-deployd is running
+      And we have a secret called "test-secret" for the service "test-service" with signature "notArealHMAC"
+      And I have yelpsoa-configs for the marathon job "test-service.main"
+      And we set the an environment variable called "SOME_SECRET" to "SECRET(test-secret)" for service "test-service" and instance "main" for framework "marathon"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
+     Then we should see "test-service.main" listed in marathon after 60 seconds
+     Then we can run get_app
+    Given we have a secret called "test-secret" for the service "test-service" with signature "StillNotArealHMAC"
+     Then the appid for "test-service.main" should have changed
+     Then we should not see the old version listed in marathon after 70 seconds
+     Then we should see "test-service.main" listed in marathon after 60 seconds
+     Then we can run get_app
+
   Scenario: deployd will re-deploy an app if the public config changes
     Given a working paasta cluster
       And paasta-deployd is running

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -205,6 +205,7 @@ def working_paasta_cluster_with_registry(context, docker_registry):
         context, {
             "cluster": "testcluster",
             "zookeeper": "zk://zookeeper/mesos-testcluster",
+            "vault_environment": 'devc',
             "docker_registry": docker_registry,
         }, 'cluster.json',
     )

--- a/paasta_tools/secret_tools.py
+++ b/paasta_tools/secret_tools.py
@@ -1,0 +1,56 @@
+# Copyright 2015-2017 Yelp Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import os
+import re
+from typing import Optional
+
+SECRET_REGEX = "^SECRET\([A-Za-z0-9_-]*\)$"
+
+
+def is_secret_ref(env_var_val: str) -> bool:
+    pattern = re.compile(SECRET_REGEX)
+    return pattern.match(env_var_val) is not None
+
+
+def get_hmac_for_secret(
+    env_var_val: str,
+    service: str,
+    soa_dir: str,
+    vault_environment: str,
+) -> Optional[str]:
+    secret_name = _get_secret_name_from_ref(env_var_val)
+    secret_path = os.path.join(
+        soa_dir,
+        service,
+        "secrets", "{}.json".format(secret_name),
+    )
+    try:
+        with open(secret_path, 'r') as json_secret_file:
+            secret_file = json.load(json_secret_file)
+            try:
+                return secret_file['environments'][vault_environment]['signature']
+            except KeyError:
+                print("Failed to get secret signature at environments:{}:signature in json"
+                      " file".format(vault_environment))
+                return None
+    except IOError as e:
+        print("Failed to open json secret at {}".format(secret_path))
+        return None
+    except json.decoder.JSONDecodeError as e:
+        print("Failed to deserialise json secret at {}".format(secret_path))
+        return None
+
+
+def _get_secret_name_from_ref(env_var_val: str) -> str:
+    return env_var_val.split('(')[1][:-1]

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1365,6 +1365,7 @@ SystemPaastaConfigDict = TypedDict(
         'use_mesos_healthchecks': bool,
         'taskproc': Dict,
         'disabled_watchers': List,
+        'vault_environment': str,
     },
     total=False,
 )
@@ -1693,6 +1694,12 @@ class SystemPaastaConfig(object):
 
     def get_disabled_watchers(self) -> List:
         return self.config_dict.get('disabled_watchers', [])
+
+    def get_vault_environment(self) -> Optional[str]:
+        """ Get the environment name for the vault cluster
+        This must match the environment keys in the secret json files
+        used by all services in this cluster"""
+        return self.config_dict.get('vault_environment')
 
 
 def _run(

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -25,10 +25,13 @@ from pytest import raises
 from paasta_tools import long_running_service_tools
 from paasta_tools import marathon_tools
 from paasta_tools.marathon_serviceinit import desired_state_human
-from paasta_tools.marathon_tools import MarathonServiceConfigDict
+from paasta_tools.marathon_tools import FormattedMarathonAppDict  # noqa, imported for typing.
+from paasta_tools.marathon_tools import MarathonContainerInfo  # noqa, imported for typing.
+from paasta_tools.marathon_tools import MarathonServiceConfigDict  # noqa, imported for typing.
 from paasta_tools.mesos.exceptions import NoSlavesAvailableError
 from paasta_tools.utils import BranchDict
 from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import DeploymentsJson
 from paasta_tools.utils import DockerVolume
 from paasta_tools.utils import SystemPaastaConfig
@@ -1713,6 +1716,101 @@ class TestMarathonServiceConfig(object):
             branch_dict={},
         )
         assert marathon_config.get_healthcheck_mode(namespace_config) is None
+
+    def test_sanitize_for_config_hash(self):
+        with mock.patch(
+            'paasta_tools.marathon_tools.MarathonServiceConfig.format_docker_parameters', autospec=True,
+        ) as mock_format_docker_parameters, mock.patch(
+            'paasta_tools.marathon_tools.MarathonServiceConfig.get_secret_hashes', autospec=True,
+        ) as mock_get_secret_hashes:
+            mock_get_secret_hashes.return_value = {}
+            mock_system_config = mock.Mock()
+            marathon_conf: MarathonServiceConfigDict = {
+                'env': {'SOME_VAR': 'SOME_VAL'},
+                'instances': 1,
+            }
+            container_dict: MarathonContainerInfo = {
+                'docker': {
+                    'parameters': None,
+                    'image': 'blah',
+                    'network': 'blah',
+                    'portMappings': [],
+                },
+                'type': 'blah',
+                'volumes': [],
+            }
+            f_marathon_conf: FormattedMarathonAppDict = {
+                'env': {'SOME_VAR': 'SOME_VAL'},
+                'container': container_dict,
+                'instances': 1,
+            }
+            marathon_config = marathon_tools.MarathonServiceConfig(
+                service='service',
+                cluster='cluster',
+                instance='instance',
+                config_dict=marathon_conf,
+                branch_dict={},
+            )
+            expected = {
+                'env': {'SOME_VAR': 'SOME_VAL'},
+                'container': {
+                    'docker': {
+                        'parameters': mock_format_docker_parameters.return_value,
+                        'image': 'blah',
+                        'network': 'blah',
+                        'portMappings': [],
+                    },
+                    'type': 'blah',
+                    'volumes': [],
+                },
+            }
+            assert marathon_config.sanitize_for_config_hash(f_marathon_conf, mock_system_config) == expected
+
+            mock_get_secret_hashes.return_value = {'some': 'thing'}
+            expected = {
+                'env': {'SOME_VAR': 'SOME_VAL'},
+                'container': {
+                    'docker': {
+                        'parameters': mock_format_docker_parameters.return_value,
+                        'image': 'blah',
+                        'network': 'blah',
+                        'portMappings': [],
+                    },
+                    'type': 'blah',
+                    'volumes': [],
+                },
+                'paasta_secrets': {'some': 'thing'},
+            }
+            assert marathon_config.sanitize_for_config_hash(f_marathon_conf, mock_system_config) == expected
+
+    def test_get_secret_hashes(self):
+        with mock.patch(
+            'paasta_tools.marathon_tools.is_secret_ref', autospec=True, return_value=False,
+        ) as mock_is_secret_ref, mock.patch(
+            'paasta_tools.marathon_tools.get_hmac_for_secret', autospec=True,
+        ) as mock_get_hmac_for_secret:
+            conf: MarathonServiceConfigDict = {'env': {'SOME_VAR': 'SOME_VAL'}}
+            marathon_config = marathon_tools.MarathonServiceConfig(
+                service='service',
+                cluster='cluster',
+                instance='instance',
+                config_dict=conf,
+                branch_dict={},
+            )
+            assert marathon_config.get_secret_hashes(conf['env'], 'dev') == {}
+            mock_is_secret_ref.assert_called_with("SOME_VAL")
+            assert not mock_get_hmac_for_secret.called
+
+            mock_is_secret_ref.return_value = True
+            expected = {"SOME_VAL": mock_get_hmac_for_secret.return_value}
+            assert marathon_config.get_secret_hashes(conf['env'], 'dev') == expected
+            mock_is_secret_ref.assert_called_with("SOME_VAL")
+            mock_get_hmac_for_secret.assert_called_with(
+                env_var_val="SOME_VAL",
+                service="service",
+                soa_dir=DEFAULT_SOA_DIR,
+                vault_environment='dev',
+            )
 
     def test_get_healthchecks_http_overrides(self):
         fake_path = '/mycoolstatus'

--- a/tests/test_secret_tools.py
+++ b/tests/test_secret_tools.py
@@ -1,0 +1,67 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from json.decoder import JSONDecodeError
+
+import mock
+
+from paasta_tools.secret_tools import _get_secret_name_from_ref
+from paasta_tools.secret_tools import get_hmac_for_secret
+from paasta_tools.secret_tools import is_secret_ref
+
+
+def test_is_secret_ref():
+    assert is_secret_ref('SECRET(aaa-bbb-222_111)')
+    assert not is_secret_ref('SECRET(#!$)')
+    # herein is a lesson on how tests are hard:
+    assert not is_secret_ref('anything_else')
+
+
+def test__get_secret_name_from_ref():
+    assert _get_secret_name_from_ref('SECRET(aaa-bbb-222_111)') == 'aaa-bbb-222_111'
+
+
+def test_get_hmac_for_secret():
+    with mock.patch(
+        'paasta_tools.secret_tools.open', autospec=False,
+    ) as mock_open, mock.patch(
+        'json.load', autospec=True,
+    ) as mock_json_load, mock.patch(
+        'paasta_tools.secret_tools._get_secret_name_from_ref', autospec=True,
+    ) as mock_get_secret_name_from_ref:
+        mock_json_load.return_value = {
+            'environments': {
+                'dev': {'signature': 'notArealHMAC'},
+            },
+        }
+        mock_get_secret_name_from_ref.return_value = 'secretsquirrel'
+
+        ret = get_hmac_for_secret("SECRET(secretsquirrel)", "service-name", "/nail/blah", 'dev')
+        mock_get_secret_name_from_ref.assert_called_with("SECRET(secretsquirrel)")
+        mock_open.assert_called_with("/nail/blah/service-name/secrets/secretsquirrel.json", "r")
+        assert ret == 'notArealHMAC'
+
+        ret = get_hmac_for_secret("SECRET(secretsquirrel)", "service-name", "/nail/blah", 'dev-what')
+        assert ret is None
+
+        mock_open.side_effect = IOError
+        ret = get_hmac_for_secret("SECRET(secretsquirrel)", "service-name", "/nail/blah", 'dev')
+        assert ret is None
+
+        ret = get_hmac_for_secret("SECRET(secretsquirrel)", "service-name", "/nail/blah", 'dev')
+        assert ret is None
+
+        mock_open.side_effect = None
+        mock_json_load.side_effect = JSONDecodeError('', '', 1)
+        ret = get_hmac_for_secret("SECRET(secretsquirrel)", "service-name", "/nail/blah", 'dev')
+        assert ret is None

--- a/tox.ini
+++ b/tox.ini
@@ -138,6 +138,7 @@ mypy_paths =
     paasta_tools/paasta_serviceinit.py
     paasta_tools/setup_marathon_job.py
     paasta_tools/autoscaling/autoscaling_cluster_lib.py
+    paasta_tools/secret_tools.py
     paasta_tools/utils.py
     tests/deployd/test_common.py
     tests/deployd/test_watchers.py
@@ -145,6 +146,7 @@ mypy_paths =
     tests/test_long_running_service_tools.py
     tests/test_marathon_tools.py
     tests/test_setup_marathon_job.py
+    tests/test_secret_tools.py
     tests/test_utils.py
 commands =
     mypy {posargs:{[testenv:mypy]mypy_paths}}


### PR DESCRIPTION
This adds the neccessary logic to the bounce code so that services will
be bounced when the related json files containing a secret are updated
*and* the signature of a secret used by that service changes.

* Make deployd aware of json files in secrets subdir and get it to
check if marathon app id has changed
* Check env vars in marathon config for SECRET(my-secret) format and
retreive signature for inclusion in config hash
* itest to check it works