### PR TITLE
Make service autoscaler work with multiple marathon shards.

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -37,10 +37,11 @@ from paasta_tools.bounce_lib import ZK_LOCK_CONNECT_TIMEOUT_S
 from paasta_tools.long_running_service_tools import compose_autoscaling_zookeeper_root
 from paasta_tools.long_running_service_tools import set_instances_for_marathon_service
 from paasta_tools.marathon_tools import format_job_id
-from paasta_tools.marathon_tools import get_marathon_client
+from paasta_tools.marathon_tools import get_marathon_apps_with_clients
+from paasta_tools.marathon_tools import get_marathon_clients
+from paasta_tools.marathon_tools import get_marathon_servers
 from paasta_tools.marathon_tools import is_old_task_missing_healthchecks
 from paasta_tools.marathon_tools import is_task_healthy
-from paasta_tools.marathon_tools import load_marathon_config
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.marathon_tools import MESOS_TASK_SPACER
 from paasta_tools.mesos_tools import get_all_running_tasks
@@ -492,21 +493,15 @@ def get_error_from_utilization(utilization, setpoint, current_instances):
         return 0.0
 
 
-def get_autoscaling_info(marathon_client, service, instance, cluster, soa_dir):
-    service_config = load_marathon_service_config(
-        service=service,
-        instance=instance,
-        cluster=cluster,
-        soa_dir=soa_dir,
-    )
+def get_autoscaling_info(marathon_clients, service_config):
     if service_config.get_max_instances() and service_config.get_desired_state() == 'start':
-        all_marathon_tasks, all_mesos_tasks = get_all_marathon_mesos_tasks(marathon_client)
+        apps_with_clients = get_marathon_apps_with_clients(marathon_clients, embed_tasks=True)
+        all_mesos_tasks = get_all_running_tasks()
         autoscaling_params = service_config.get_autoscaling_params()
         autoscaling_params.update({'noop': True})
         try:
             marathon_tasks, mesos_tasks = filter_autoscaling_tasks(
-                marathon_client,
-                all_marathon_tasks,
+                [app for (app, client) in apps_with_clients],
                 all_mesos_tasks,
                 service_config,
             )
@@ -704,22 +699,19 @@ def get_configs_of_services_to_scale(cluster, soa_dir=DEFAULT_SOA_DIR):
 def autoscale_services(soa_dir=DEFAULT_SOA_DIR):
     try:
         with create_autoscaling_lock():
-            cluster = load_system_paasta_config().get_cluster()
+            system_paasta_config = load_system_paasta_config()
+            cluster = system_paasta_config.get_cluster()
             configs = get_configs_of_services_to_scale(cluster=cluster, soa_dir=soa_dir)
-            marathon_config = load_marathon_config()
-            marathon_client = get_marathon_client(
-                url=marathon_config.get_url(),
-                user=marathon_config.get_username(),
-                passwd=marathon_config.get_password(),
-            )
-            all_marathon_tasks, all_mesos_tasks = get_all_marathon_mesos_tasks(marathon_client)
+
+            marathon_clients = get_marathon_clients(get_marathon_servers(system_paasta_config))
+            apps_with_clients = get_marathon_apps_with_clients(marathon_clients, embed_tasks=True)
+            all_mesos_tasks = get_all_running_tasks()
             if configs:
                 with ZookeeperPool():
                     for config in configs:
                         try:
                             marathon_tasks, mesos_tasks = filter_autoscaling_tasks(
-                                marathon_client,
-                                all_marathon_tasks,
+                                [app for (app, client) in apps_with_clients],
                                 all_mesos_tasks,
                                 config,
                             )
@@ -730,13 +722,7 @@ def autoscale_services(soa_dir=DEFAULT_SOA_DIR):
         log.warning("Skipping autoscaling run for services because the lock is held")
 
 
-def get_all_marathon_mesos_tasks(marathon_client):
-    all_marathon_tasks = marathon_client.list_tasks()
-    all_mesos_tasks = get_all_running_tasks()
-    return all_marathon_tasks, all_mesos_tasks
-
-
-def filter_autoscaling_tasks(marathon_client, all_marathon_tasks, all_mesos_tasks, config):
+def filter_autoscaling_tasks(marathon_apps, all_mesos_tasks, config):
     job_id_prefix = "%s%s" % (format_job_id(service=config.service, instance=config.instance), MESOS_TASK_SPACER)
 
     # Get a dict of healthy tasks, we assume tasks with no healthcheck defined
@@ -745,11 +731,16 @@ def filter_autoscaling_tasks(marathon_client, all_marathon_tasks, all_mesos_task
     # assume that marathon has screwed up and stopped healthchecking but that
     # they are healthy
     log.info("Inspecting %s for autoscaling" % job_id_prefix)
-    marathon_tasks = {task.id: task for task in all_marathon_tasks
-                      if task.id.startswith(job_id_prefix) and
-                      (is_task_healthy(task) or not
-                       marathon_client.get_app(task.app_id).health_checks or
-                       is_old_task_missing_healthchecks(task, marathon_client))}
+    marathon_tasks = {}
+    for app in marathon_apps:
+        for task in app.tasks:
+            if task.id.startswith(job_id_prefix) and (
+                is_task_healthy(task) or not
+                app.health_checks or
+                is_old_task_missing_healthchecks(task, app)
+            ):
+                marathon_tasks[task.id] = task
+
     if not marathon_tasks:
         raise MetricsProviderNoDataError("Couldn't find any healthy marathon tasks")
     mesos_tasks = [task for task in all_mesos_tasks if task['id'] in marathon_tasks]

--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -173,13 +173,6 @@ def get_verbose_status_of_marathon_app(marathon_client, app, service, instance, 
     output.append("  Marathon app ID: %s" % PaastaColors.bold(app.id))
     output.append("    App created: %s (%s)" % (str(create_datetime), humanize.naturaltime(create_datetime)))
 
-    autoscaling_info = get_autoscaling_info(marathon_client, service, instance, cluster, soa_dir)
-    if autoscaling_info:
-        output.append("    Autoscaling Info:")
-        headers = [field.replace("_", " ").capitalize() for field in ServiceAutoscalingInfo._fields]
-        table = [headers, autoscaling_info]
-        output.append('\n'.join(["      %s" % line for line in format_table(table)]))
-
     output.append("    Tasks:")
     rows = [("Mesos Task ID", "Host deployed to", "Deployed at what localtime", "Health")]
     for task in app.tasks:
@@ -223,6 +216,14 @@ def status_marathon_job_verbose(service, instance, clients, cluster, soa_dir, jo
 
     relevant_clients = clients.get_all_clients_for_service(job_config)
     marathon_apps_with_clients = marathon_tools.get_marathon_apps_with_clients(relevant_clients, embed_tasks=True)
+
+    autoscaling_info = get_autoscaling_info(clients, job_config)
+    if autoscaling_info:
+        all_output.append("  Autoscaling Info:")
+        headers = [field.replace("_", " ").capitalize() for field in ServiceAutoscalingInfo._fields]
+        table = [headers, autoscaling_info]
+        all_output.append('\n'.join(["    %s" % line for line in format_table(table)]))
+
     for app, client in marathon_tools.get_matching_apps_with_clients(service, instance, marathon_apps_with_clients):
         tasks, output = get_verbose_status_of_marathon_app(
             marathon_client=client,

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1426,13 +1426,13 @@ def is_task_healthy(task: MarathonTask, require_all: bool=True, default_healthy:
     return default_healthy
 
 
-def is_old_task_missing_healthchecks(task: MarathonTask, marathon_client: MarathonClient) -> bool:
+def is_old_task_missing_healthchecks(task: MarathonTask, app: MarathonApp) -> bool:
     """We check this because versions of Marathon (at least up to 1.1)
     sometimes stop healthchecking tasks, leaving no results. We can normally
     assume that an "old" task which has no healthcheck results is still up
     and healthy but marathon has simply decided to stop healthchecking it.
     """
-    health_checks = marathon_client.get_app(task.app_id).health_checks
+    health_checks = app.health_checks
     if not task.health_check_results and health_checks and task.started_at:
         healthcheck_startup_time = datetime.timedelta(seconds=health_checks[0].grace_period_seconds) + \
             datetime.timedelta(seconds=health_checks[0].interval_seconds * 5)

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -115,6 +115,10 @@ def rendezvous_hash(
     :param choices: A sequence of arbitrary values. The "winning" value will be returned."""
     max_hash_value = None
     max_hash_choice = None
+
+    if len(choices) == 0:
+        raise ValueError("Must pass at least one choice to rendezvous_hash")
+
     for i, choice in enumerate(choices):
         str_to_hash = MESOS_TASK_SPACER.join([str(i), key, salt])
         hash_value = hash_func(str_to_hash)
@@ -142,7 +146,10 @@ class MarathonClients(object):
         if job_config.get_previous_marathon_shards() is not None:
             return [self.previous[i] for i in job_config.get_previous_marathon_shards()]
         else:
-            return [rendezvous_hash(choices=self.previous, key=service_instance)]
+            try:
+                return [rendezvous_hash(choices=self.previous, key=service_instance)]
+            except ValueError:
+                return []
 
     def get_all_clients_for_service(self, job_config: 'MarathonServiceConfig') -> Sequence[MarathonClient]:
         """Return the set of all clients that a service might have apps on, with no duplicate clients."""

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -99,7 +99,15 @@ def test_status_marathon_job_verbose():
         'paasta_tools.marathon_serviceinit.marathon_tools.get_matching_apps_with_clients', autospec=True,
     ) as mock_get_matching_apps_with_clients, mock.patch(
         'paasta_tools.marathon_serviceinit.get_verbose_status_of_marathon_app', autospec=True,
-    ) as mock_get_verbose_app:
+    ) as mock_get_verbose_app, mock.patch(
+        'paasta_tools.marathon_serviceinit.get_autoscaling_info', autospec=True, return_value=ServiceAutoscalingInfo(
+            current_instances='1',
+            max_instances='2',
+            min_instances='3',
+            current_utilization='4',
+            target_instances='5',
+        ),
+    ):
         mock_get_matching_apps_with_clients.return_value = [(app, client)]
         mock_get_verbose_app.return_value = ([task], 'fake_return')
         tasks, out = marathon_serviceinit.status_marathon_job_verbose(
@@ -129,6 +137,7 @@ def test_status_marathon_job_verbose():
         )
         assert tasks == [task]
         assert 'fake_return' in out
+        assert '  Autoscaling Info:' in out
 
 
 def test_get_verbose_status_of_marathon_app():
@@ -166,7 +175,6 @@ def test_get_verbose_status_of_marathon_app():
         assert '/fake--service' in out
         assert 'App created: 2015-01-15 05:30:49' in out
         assert 'fake_deployed_host:6666' in out
-        assert 'Autoscaling Info' in out
         assert tasks == [fake_task]
 
 

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -2475,42 +2475,38 @@ def test_is_old_task_missing_healthchecks():
         interval_seconds=10,
     )
     mock_marathon_app = mock.Mock(health_checks=[mock_health_check])
-    mock_get_app = mock.Mock(return_value=mock_marathon_app)
-    mock_marathon_client = mock.Mock(get_app=mock_get_app)
     mock_task = mock.Mock(
         health_check_results=[],
         started_at=datetime.datetime(year=1990, month=1, day=1),
     )
 
     # test old task missing hcrs
-    assert marathon_tools.is_old_task_missing_healthchecks(mock_task, mock_marathon_client)
+    assert marathon_tools.is_old_task_missing_healthchecks(mock_task, mock_marathon_app)
 
     # test new task missing hcrs
     mock_task = mock.Mock(
         health_check_results=[],
         started_at=datetime.datetime.now(),
     )
-    assert not marathon_tools.is_old_task_missing_healthchecks(mock_task, mock_marathon_client)
+    assert not marathon_tools.is_old_task_missing_healthchecks(mock_task, mock_marathon_app)
 
     # test new task with hcrs
     mock_task = mock.Mock(
         health_check_results=["SOMERESULTS"],
         started_at=datetime.datetime.now(),
     )
-    assert not marathon_tools.is_old_task_missing_healthchecks(mock_task, mock_marathon_client)
+    assert not marathon_tools.is_old_task_missing_healthchecks(mock_task, mock_marathon_app)
 
     # test missing started at time
     mock_task = mock.Mock(
         health_check_results=[],
         started_at=None,
     )
-    assert not marathon_tools.is_old_task_missing_healthchecks(mock_task, mock_marathon_client)
+    assert not marathon_tools.is_old_task_missing_healthchecks(mock_task, mock_marathon_app)
 
     # test no health checks
     mock_marathon_app = mock.Mock(health_checks=[])
-    mock_get_app = mock.Mock(return_value=mock_marathon_app)
-    mock_marathon_client = mock.Mock(get_app=mock_get_app)
-    assert not marathon_tools.is_old_task_missing_healthchecks(mock_task, mock_marathon_client)
+    assert not marathon_tools.is_old_task_missing_healthchecks(mock_task, mock_marathon_app)
 
 
 def test_kill_given_tasks():


### PR DESCRIPTION
Notable change: This moves the "Autoscaling Info" section of verbose status out of the per-app section and into the per-job section, which seems like the correct thing to do -- get_autoscaling_info queries information about all running apps, instead of just the particular app in question. (Bonus! this might reduce calls to Mesos's /master/state.)