### PR TITLE
Reuse paasta_itest images

### DIFF
--- a/paasta_itests/docker-compose.yml
+++ b/paasta_itests/docker-compose.yml
@@ -11,6 +11,7 @@ services:
 
   mesosmaster:
     build: ../yelp_package/dockerfiles/itest/mesos/
+    image: paasta_itest_mesos:latest
     ports:
       - 5050
     command: 'mesos-master --zk=zk://zookeeper:2181/mesos-testcluster --registry=in_memory --quorum=1 --authenticate --authenticate_slaves --work_dir=/tmp/mesos --credentials=/etc/mesos-secrets'
@@ -18,7 +19,7 @@ services:
       - zookeeper
 
   mesosslave:
-    build: ../yelp_package/dockerfiles/itest/mesos/
+    image: paasta_itest_mesos:latest
     ports:
       - 5051
     environment:
@@ -30,7 +31,7 @@ services:
       - zookeeper
 
   mesosslave2:
-    build: ../yelp_package/dockerfiles/itest/mesos/
+    image: paasta_itest_mesos:latest
     ports:
       - 5051
     environment:
@@ -42,7 +43,7 @@ services:
       - zookeeper
 
   mesosslave3:
-    build: ../yelp_package/dockerfiles/itest/mesos/
+    image: paasta_itest_mesos:latest
     ports:
       - 5051
     environment:
@@ -54,7 +55,7 @@ services:
       - zookeeper
 
   mesosslave4:
-    build: ../yelp_package/dockerfiles/itest/mesos/
+    image: paasta_itest_mesos:latest
     ports:
       - 5051
     environment:
@@ -66,7 +67,7 @@ services:
       - zookeeper
 
   mesosslave5:
-    build: ../yelp_package/dockerfiles/itest/mesos/
+    image: paasta_itest_mesos:latest
     ports:
       - 5051
     environment:
@@ -79,6 +80,7 @@ services:
 
   marathon:
     build: ../yelp_package/dockerfiles/itest/marathon/
+    image: paasta_itest_marathon:latest
     ports:
       - 8080
     environment:
@@ -88,7 +90,7 @@ services:
       - zookeeper
 
   marathon1:
-    build: ../yelp_package/dockerfiles/itest/marathon/
+    image: paasta_itest_marathon:latest
     ports:
       - 8080
     environment:
@@ -98,7 +100,7 @@ services:
       - zookeeper
 
   marathon2:
-    build: ../yelp_package/dockerfiles/itest/marathon/
+    image: paasta_itest_marathon:latest
     ports:
       - 8080
     environment:

--- a/tox.ini
+++ b/tox.ini
@@ -41,10 +41,9 @@ commands = ./build-manpages.sh
 changedir=paasta_itests/
 passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
 deps =
-    docker-compose==1.7.1
+    docker-compose==1.17.1
 commands =
     docker-compose down
-    docker-compose pull
     docker-compose --verbose build
     # Fire up the marathon cluster in background
     docker-compose up -d mesosmaster mesosslave marathon marathon1 marathon2 chronos hacheck mesosslave2 mesosslave3 mesosslave4 mesosslave5
@@ -64,7 +63,7 @@ commands =
 changedir=example_cluster/
 passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
 deps =
-    docker-compose==1.7.1
+    docker-compose==1.17.1
 commands =
     docker-compose down
     docker-compose pull

--- a/yelp_package/dockerfiles/itest/api/Dockerfile
+++ b/yelp_package/dockerfiles/itest/api/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Yelp Inc.
+# Copyright 2015-2017 Yelp Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,10 +37,9 @@ RUN virtualenv /venv -ppython3.6
 ENV PATH=/venv/bin:$PATH
 RUN pip install -r requirements.txt
 
-ADD yelp_package/dockerfiles/itest/api/mesos-cli.json /nail/etc/
-ADD yelp_package/dockerfiles/trusty/mesos-slave-secret /etc/
-ADD yelp_package/dockerfiles/trusty/mesos-slave-secret /nail/etc/
-ADD yelp_package/dockerfiles/itest/api/*.json /etc/paasta/
+COPY yelp_package/dockerfiles/trusty/mesos-slave-secret /etc/
+COPY yelp_package/dockerfiles/itest/api/mesos-cli.json yelp_package/dockerfiles/trusty/mesos-slave-secret /nail/etc/
+COPY yelp_package/dockerfiles/itest/api/*.json /etc/paasta/
 
 ADD . /work/
 RUN pip install -e /work/

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Yelp Inc.
+# Copyright 2015-2017 Yelp Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,23 +14,25 @@
 
 FROM ubuntu:trusty
 
-# Need python3.6
-RUN apt-get update > /dev/null && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
+# Install packages to allow apt to use a repository over HTTPS
+# https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#trusty-1404
+RUN apt-get update > /dev/null && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common
 
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list && \
-    echo "deb http://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv 58118E89F3A912897C070ADBF76221572C52609D && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv 9DC858229FC7DD38854AE2D88D81803C0EBFCD88 && \
     apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        docker-engine=1.10.3-0~trusty \
+        docker-ce=17.03.2~ce-0~ubuntu-trusty \
         libsasl2-modules \
         mesos=1.3.0-2.0.3 > /dev/null && \
     apt-get clean
 
-ADD mesos-secrets /etc/mesos-secrets
-ADD mesos-slave-secret /etc/mesos-slave-secret
+COPY mesos-secrets mesos-slave-secret /etc/
 RUN echo '{}' > /root/.dockercfg
 RUN chmod 600 /etc/mesos-secrets


### PR DESCRIPTION
* bump docker-compose to 1.17.1
* reuse paasta_Itests images when it is possible instead of rebuilding them
* docker-ce 17.03.2 in paasta_itests