### PR TITLE
Support arrays in dashboard_links.json

### DIFF
--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -138,8 +138,10 @@ def get_cluster_dashboards(cluster):
     else:
         output = ['Dashboards:']
         spacing = max((len(label) for label in dashboards.keys())) + 1
-        for label, url in dashboards.items():
-            output.append('  %s:%s%s' % (label, SPACER * (spacing - len(label)), PaastaColors.cyan(url)))
+        for label, urls in dashboards.items():
+            if isinstance(urls, list):
+                urls = "\n    %s" % '\n    '.join(urls)
+            output.append('  %s:%s%s' % (label, SPACER * (spacing - len(label)), PaastaColors.cyan(urls)))
     return '\n'.join(output)
 
 

--- a/tests/cli/test_cmds_metastatus.py
+++ b/tests/cli/test_cmds_metastatus.py
@@ -84,6 +84,26 @@ def test_get_cluster_dashboards():
         assert 'URL: ' in output_text
 
 
+def test_get_cluster_dashboards_for_sharded_frameworks():
+    with mock.patch(
+        'paasta_tools.cli.cmds.metastatus.load_system_paasta_config',
+        autospec=True,
+    ) as mock_load_system_paasta_config:
+        mock_load_system_paasta_config.return_value = SystemPaastaConfig(
+            {
+                'dashboard_links': {
+                    'fake_cluster': {
+                        'URL': ['http://paasta-fake_cluster.yelp:5050', 'http://paasta-fake_cluster1.yelp:5050'],
+                    },
+                },
+            }, 'fake_directory',
+        )
+        output_text = metastatus.get_cluster_dashboards('fake_cluster')
+        assert 'http://paasta-fake_cluster.yelp:5050' in output_text
+        assert 'http://paasta-fake_cluster1.yelp:5050' in output_text
+        assert 'URL: ' in output_text
+
+
 def test_get_cluster_no_dashboards():
     with mock.patch(
         'paasta_tools.cli.cmds.metastatus.load_system_paasta_config',


### PR DESCRIPTION
internal ticket: PAASTA-13069

It allows us to define 'Marathon RO' as a list that contains URLs for each configured shard.
If this is OK, I'm going to update dashboard_links.json and to use these links in paasta status as well.