### PR TITLE
Fix TypeError in status_marathon_job_verbose

### DIFF
--- a/paasta_tools/marathon_serviceinit.py
+++ b/paasta_tools/marathon_serviceinit.py
@@ -217,7 +217,7 @@ def status_marathon_job_verbose(service, instance, clients, cluster, soa_dir, jo
     relevant_clients = clients.get_all_clients_for_service(job_config)
     marathon_apps_with_clients = marathon_tools.get_marathon_apps_with_clients(relevant_clients, embed_tasks=True)
 
-    autoscaling_info = get_autoscaling_info(clients, job_config)
+    autoscaling_info = get_autoscaling_info(relevant_clients, job_config)
     if autoscaling_info:
         all_output.append("  Autoscaling Info:")
         headers = [field.replace("_", " ").capitalize() for field in ServiceAutoscalingInfo._fields]


### PR DESCRIPTION
It should fix the following exception in paasta status.

```
ERROR:__main__:Traceback (most recent call last):
  File "/usr/bin/paasta_serviceinit", line 203, in main
    clients=clients.marathon(),
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/marathon_serviceinit.py", line 459, in perform_command
    tasks, out = status_marathon_job_verbose(service, instance, clients, cluster, soa_dir, job_config)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/marathon_serviceinit.py", line 220, in status_marathon_job_verbose
    autoscaling_info = get_autoscaling_info(clients, job_config)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/autoscaling/autoscaling_service_lib.py", line 498, in get_autoscaling_info
    apps_with_clients = get_marathon_apps_with_clients(marathon_clients, embed_tasks=True)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/marathon_tools.py", line 1398, in get_marathon_apps_with_clients
    for client in clients:
TypeError: 'MarathonClients' object is not iterable
```