### PR TITLE
RFC: create spot_bid_creator script

### DIFF
--- a/paasta_tools/contrib/spot_bid_creator.py
+++ b/paasta_tools/contrib/spot_bid_creator.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python
+import argparse
+import csv
+import json
+
+
+def parse_ecu_per_vcpu(s):
+    s = s.strip(' units')
+    try:
+        s = float(s)
+    except ValueError:
+        s = 0
+    return s
+
+
+def parse_instance_storage(s):
+    s = s.split(' ')[0]
+    try:
+        s = int(s)
+    except ValueError:
+        s = 0
+    return s
+
+
+def parse_vcpus(s):
+    s = s.strip(' vCPUs')
+    try:
+        s = int(s)
+    except ValueError:
+        s = 0
+    return s
+
+
+def parse_cost(s):
+    s = s.strip('$').strip(' hourly')
+    try:
+        s = float(s)
+    except ValueError:
+        s = 0
+    return s
+
+
+parsers = {
+    'Memory': lambda s: float(s.strip(' GiB')),
+    'vCPUs': parse_vcpus,
+    'ECU per vCPU': parse_ecu_per_vcpu,
+    'Instance Storage': parse_instance_storage,
+}
+
+for h in [
+    'Linux On Demand cost', 'Linux Reserved cost', 'RHEL On Demand cost', 'RHEL Reserved cost',
+    'SLES On Demand cost', 'SLES Reserved cost', 'Windows On Demand cost', 'Windows Reserved cost',
+    'Windows SQL Web On Demand cost', 'Windows SQL Web Reserved cost', 'Windows SQL Std On Demand cost',
+    'Windows SQL Std Reserved cost', 'Windows SQL Ent On Demand cost', 'Windows SQL Ent Reserved cost',
+]:
+    parsers[h] = parse_cost
+
+
+def parse_headers_and_lines(headers, lines):
+    instances = []
+    for line in lines:
+        d = {}
+        zipped = zip(headers, line)
+        for header, value in zipped:
+            if header in parsers.keys():
+                d[header] = parsers[header](value)
+            else:
+                d[header] = value
+        instances.append(d)
+
+    return instances
+
+
+def check_cpu_cores(args, instance):
+    return instance['vCPUs'] >= args.min_cores
+
+
+def check_mem(args, instance):
+    return instance['Memory'] >= args.min_memory
+
+
+def check_ecu_per_core(args, instance):
+    return instance['ECU per vCPU'] >= args.min_ecu_per_core
+
+
+def check_instance_type(args, instance):
+    if args.skip_instance_types is None:
+        return True
+    skip = args.skip_instance_types.split(",")
+    for s in skip:
+        if instance['API Name'].startswith(s):
+            return False
+    return True
+
+
+instance_checks = [check_cpu_cores, check_mem, check_ecu_per_core, check_instance_type]
+
+
+def calculate_root_ebs_size(args, instance):
+    if instance['Instance Storage'] >= args.min_instance_storage:
+        return args.small_ebs
+    else:
+        return args.big_ebs
+
+
+def calculate_bid(args, instance):
+    on_demand_cost_per_core = instance['Linux On Demand cost'] / instance['vCPUs']
+    bid_per_core = on_demand_cost_per_core * 2
+    if bid_per_core > args.max_bid_per_core:
+        return args.max_bid_per_core * instance['vCPUs']
+    else:
+        return 2 * on_demand_cost_per_core * instance['vCPUs']
+
+
+def make_one_instance_data(args, instance):
+    data = {}
+    data['ebs_size'] = calculate_root_ebs_size(args, instance)
+    data['price'] = calculate_bid(args, instance)
+    data['type'] = instance['API Name']
+    data['weight'] = instance['vCPUs'] / 100.0
+
+    return data
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--instance-data", help="csv file of instance data, as returned by ec2instances.info",
+        required=True,
+    )
+    parser.add_argument(
+        "--min-memory", help="minimum memory, in GiB", type=float, required=True,
+    )
+    parser.add_argument(
+        "--min-cores", help="minimum cores aka vCPUs", type=int, required=True,
+    )
+    parser.add_argument(
+        "--min-ecu-per-core", help="minimum ecu per core", type=float, required=True,
+    )
+    parser.add_argument(
+        "--max-bid-per-core", help="maximum bid per core, in $", type=float, required=True,
+    )
+    parser.add_argument(
+        "--min-instance-storage", help="minimum instance storage to use small ebs root, in GiB",
+        type=float, required=True,
+    )
+    parser.add_argument(
+        "--small-ebs", help="size of root ebs when instance storage is enough, in GiB",
+        type=float, required=True,
+    )
+    parser.add_argument(
+        "--big-ebs", help="size of root ebs when instance storage is not enough, in GiB",
+        type=float, required=True,
+    )
+    parser.add_argument(
+        "--max-returned", help="maximum number of instances to return", type=int,
+    )
+    parser.add_argument(
+        "--skip-instance-types", help="comma separated list of instance types to skip",
+        type=str,
+    )
+
+    args = parser.parse_args()
+
+    headers = []
+    lines = []
+    with open(args.instance_data, 'r', newline='') as f:
+        reader = csv.reader(f)
+        headers += reader.__next__()
+        for row in reader:
+            lines.append(row)
+
+    instances = parse_headers_and_lines(headers, lines)
+
+    good_instances = []
+    for instance in instances:
+        if all([f(args, instance) for f in instance_checks]):
+            good_instances.append(instance)
+
+    good_instances = sorted(good_instances, key=lambda i: i['ECU per vCPU'])
+
+    if args.max_returned:
+        good_instances = good_instances[:args.max_returned]
+
+    instance_datas = []
+    for instance in good_instances:
+        instance_datas.append(make_one_instance_data(args, instance))
+
+    print(json.dumps({'instance_data': instance_datas}))
+
+
+if __name__ == '__main__':
+    main()

--- a/paasta_tools/contrib/spot_bid_creator.py
+++ b/paasta_tools/contrib/spot_bid_creator.py
@@ -177,7 +177,7 @@ def main():
         if all([f(args, instance) for f in instance_checks]):
             good_instances.append(instance)
 
-    good_instances = sorted(good_instances, key=lambda i: i['ECU per vCPU'])
+    good_instances = sorted(good_instances, key=lambda i: i['ECU per vCPU'], reverse=True)
 
     if args.max_returned:
         good_instances = good_instances[:args.max_returned]

--- a/paasta_tools/contrib/spot_bid_graph.py
+++ b/paasta_tools/contrib/spot_bid_graph.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+import argparse
+import json
+import time
+from collections import defaultdict
+from datetime import datetime
+
+import boto3
+import matplotlib.pyplot as plt
+
+
+region_names = {
+    'us-east-1': 'US East (N. Virginia)',
+    'us-east-2': 'US East (Ohio)',
+    'us-west-1': 'US West (N. California)',
+    'us-west-2': 'US West (Oregon)',
+}
+
+
+def get_on_demand_price(pricing, region, instance_type):
+    r = pricing.get_products(
+        ServiceCode='AmazonEC2',
+        Filters=[
+            {
+                'Type': 'TERM_MATCH',
+                'Field': 'instanceType',
+                'Value': instance_type,
+            }, {
+                'Type': "TERM_MATCH",
+                'Field': "operatingSystem",
+                'Value': "Linux",
+            }, {
+                'Type': 'TERM_MATCH',
+                'Field': 'location',
+                'Value': region_names[region],
+            }, {
+                'Type': "TERM_MATCH",
+                'Field': "tenancy",
+                "Value": "Shared",
+            },
+        ],
+    )
+    print(instance_type)
+    if len(r['PriceList']) == 0:
+        return None
+    assert len(r['PriceList']) == 1, r
+    p = json.loads(r['PriceList'][0])
+    price = float(list(list(p['terms']['OnDemand'].values())[0]['priceDimensions'].values())[0]['pricePerUnit']['USD'])
+    vcpu = int(p['product']['attributes']['vcpu'])
+    return {'price': price, 'vcpu': vcpu}
+
+
+def get_spot_price_history(ec2, instance_types, ts, bid_per_core, on_demand_prices, azs):
+    ret = ec2.describe_spot_price_history(
+        InstanceTypes=instance_types,
+        ProductDescriptions=['Linux/UNIX (Amazon VPC)'],
+        StartTime=ts,
+        EndTime=ts,
+    )
+    history = ret['SpotPriceHistory']
+    price_history = defaultdict(dict)
+
+    for item in history:
+        item['Timestamp'] = str(item['Timestamp'])
+        item['SpotPrice'] = float(item['SpotPrice'])
+        item['Bid'] = bid_per_core * on_demand_prices[item['InstanceType']]['vcpu']
+        item['Price'] = on_demand_prices[item['InstanceType']]['price']
+        if item['AvailabilityZone'] not in azs:
+            continue
+        price_history[item['InstanceType']][item['AvailabilityZone']] = item
+
+    return price_history
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--availability-zones", type=str, required=True)
+    parser.add_argument("--instance-types", type=str, required=True)
+    parser.add_argument("--bid-per-core", type=float, required=True)
+    parser.add_argument("--days", type=int, default=5)
+
+    args = parser.parse_args()
+    azs = args.availability_zones.split(',')
+    region = azs[0][:-1]
+    instance_types = args.instance_types.split(',')
+    bid_per_core = args.bid_per_core
+
+    pricing = boto3.client('pricing', region_name='us-east-1')
+
+    on_demand_prices = {i_type: get_on_demand_price(pricing, region, i_type) for i_type in instance_types}
+
+    ec2 = boto3.client('ec2', region_name=region)
+
+    spot_histories = {}
+    ts = int(time.time())
+    end = ts - 60 * 60 * 24 * args.days
+    while ts > end:
+        print(ts)
+        spot_histories[ts] = get_spot_price_history(ec2, instance_types, ts, bid_per_core, on_demand_prices, azs)
+        ts -= 3600
+
+    x = []
+    oks = []
+    no_launches = []
+    terminates = []
+    for ts, item in spot_histories.items():
+        x.append(datetime.fromtimestamp(ts))
+        ok = 0
+        no_launch = 0
+        terminate = 0
+        for itype, az_data in item.items():
+            for az, data in az_data.items():
+                if data['SpotPrice'] < data['Price'] and data['SpotPrice'] < data['Bid']:
+                    ok += 1
+                elif data['SpotPrice'] < data['Bid']:
+                    no_launch += 1
+                else:
+                    terminate += 1
+        oks.append(ok)
+        no_launches.append(no_launch)
+        terminates.append(terminate)
+
+    fig, ax = plt.subplots()
+    ax.stackplot(
+        x, oks, no_launches, terminates,
+        baseline='zero',
+        labels=['OK', 'No launch', 'Terminate'],
+        colors=['green', 'yellow', 'red'],
+        step='mid',
+    )
+    handles, labels = ax.get_legend_handles_labels()
+    ax.legend(handles, labels)
+    plt.title("%s bid status" % region)
+    plt.ylabel("Number of instances in each state")
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 addict==2.1.0
 argcomplete==0.8.1
 backports.ssl-match-hostname==3.4.0.2
-boto3==1.3.0
+boto3==1.4.8
 bravado==8.4.0
 choice==0.1
 chronos-python==1.2.1


### PR DESCRIPTION
This takes a csv from https://ec2instances.info, and returns a dict in then format:
```
{
  "instance_data": [instance-data],
}
```

where instance-data is in the format:
```
{
    "ebs_size": 60,
    "price": 12.8,
    "type": "x1e.32xlarge",
    "weight": 1.28
}
```

This is useful for creating instance data definitions for aws spot fleet.

It needs to be organized a bit better, and maybe a better name.

This also hard-codes some assumptions about bids, like we should bid 2 times the on demand price (unless the instance is too expensive, then we bid the price per core as set on the command line).

TODO: add a region flag, check whether instances are available on spot in that region.

also adds a script to create graphs like this: 
![us-west-1-spot](https://user-images.githubusercontent.com/1930163/33183724-e7b23fe2-d070-11e7-8d40-84f05c9cb7e7.png) to analyze the spot market.

Also TODO: don't use the ec2instances.info info, instead get it from the api, and then combine the functionality of the 2 scripts (so we can analyze what vcpu/mem/ecu combinations would look like over the past n days).