### PR TITLE
Make metastatus able to group by multiple values properly

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -1267,7 +1267,7 @@ def get_mesos_utilization_error(
         log.info("Failed to find utilization for region %s, pool %s, returning 0 error")
         return 0
 
-    log.debug(region_pool_utilization_dict)
+    log.debug(repr(region_pool_utilization_dict))
     free_pool_resources = region_pool_utilization_dict['free']
     total_pool_resources = region_pool_utilization_dict['total']
     free_percs = []

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
-import functools
 import itertools
 import logging
 import sys
+from typing import List
+from typing import Optional
 
 import chronos
 from marathon.exceptions import MarathonError
@@ -103,7 +104,7 @@ def all_marathon_clients(marathon_clients):
     return [c for c in itertools.chain(marathon_clients.current, marathon_clients.previous)]
 
 
-def main(argv=None):
+def main(argv: Optional[List[str]]=None) -> None:
     chronos_config = None
     args = parse_args(argv)
 
@@ -128,7 +129,7 @@ def main(argv=None):
     except MasterNotAvailableException as e:
         # if we can't connect to master at all,
         # then bomb out early
-        paasta_print(PaastaColors.red("CRITICAL:  %s" % e.message))
+        paasta_print(PaastaColors.red("CRITICAL:  %s" % '\n'.join(e.args)))
         sys.exit(2)
 
     # Check to see if Chronos should be running here by checking for config
@@ -200,11 +201,7 @@ def main(argv=None):
         if args.autoscaling_info:
             print_with_indent("Autoscaling resources:", 2)
             headers = [field.replace("_", " ").capitalize() for field in AutoscalingInfo._fields]
-            table = functools.reduce(
-                lambda x, y: x + [(y)],
-                get_autoscaling_info_for_all_resources(mesos_state),
-                [headers],
-            )
+            table = [headers] + [[str(x) for x in asi] for asi in get_autoscaling_info_for_all_resources(mesos_state)]
 
             for line in format_table(table):
                 print_with_indent(line, 4)

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -16,8 +16,11 @@ import argparse
 import itertools
 import logging
 import sys
+from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
+from typing import Tuple
 
 import chronos
 from marathon.exceptions import MarathonError
@@ -53,7 +56,7 @@ def parse_args(argv):
         '-g',
         '--groupings',
         nargs='+',
-        default=['region'],
+        default=['pool', 'region'],
         help=(
             'Group resource information of slaves grouped by attribute.'
             'Note: This is only effective with -vv'
@@ -102,6 +105,58 @@ def _run_marathon_checks(marathon_clients):
 
 def all_marathon_clients(marathon_clients):
     return [c for c in itertools.chain(marathon_clients.current, marathon_clients.previous)]
+
+
+def utilization_table_by_grouping_from_mesos_state(
+    groupings: Sequence[str],
+    threshold: float,
+    humanize: bool,
+    mesos_state: Dict,
+) -> Tuple[
+    List[List[str]],
+    bool,
+]:
+    grouping_function = metastatus_lib.key_func_for_attribute_multi(groupings)
+    resource_info_dict_grouped = metastatus_lib.get_resource_utilization_by_grouping(
+        grouping_function,
+        mesos_state,
+    )
+
+    static_headers = [
+        'CPU (used/total)',
+        'RAM (used/total)',
+        'Disk (used/total)',
+        'GPU (used/total)',
+        'Agent count',
+    ]
+
+    all_rows = [
+        [grouping.capitalize() for grouping in groupings] + static_headers,
+    ]
+    table_rows = []
+
+    for grouping_values, resource_info_dict in resource_info_dict_grouped.items():
+        resource_utilizations = metastatus_lib.resource_utillizations_from_resource_info(
+            total=resource_info_dict['total'],
+            free=resource_info_dict['free'],
+        )
+        healthcheck_utilization_pairs = [
+            metastatus_lib.healthcheck_result_resource_utilization_pair_for_resource_utilization(
+                utilization,
+                threshold,
+            )
+            for utilization in resource_utilizations
+        ]
+        healthy_exit = all(pair[0].healthy for pair in healthcheck_utilization_pairs)
+        table_rows.append(metastatus_lib.get_table_rows_for_resource_info_dict(
+            [v for g, v in grouping_values],
+            healthcheck_utilization_pairs,
+            humanize,
+        ) + [str(resource_info_dict['slave_count'])])
+    table_rows = sorted(table_rows, key=lambda x: x[0:len(groupings)])
+    all_rows.extend(table_rows)
+
+    return all_rows, healthy_exit
 
 
 def main(argv: Optional[List[str]]=None) -> None:
@@ -163,40 +218,15 @@ def main(argv: Optional[List[str]]=None) -> None:
     paasta_print("Master paasta_tools version: {}".format(__version__))
     metastatus_lib.print_results_for_healthchecks(mesos_summary, mesos_ok, all_mesos_results, args.verbose)
     if args.verbose > 1:
-        for grouping in args.groupings:
-            print_with_indent('Resources Grouped by %s' % grouping, 2)
-            grouping_function = metastatus_lib.key_func_for_attribute(grouping)
-            resource_info_dict = metastatus_lib.get_resource_utilization_by_grouping(
-                grouping_function,
-                mesos_state,
-            )
-            all_rows = [[
-                grouping.capitalize(), 'CPU (used/total)', 'RAM (used/total)', 'Disk (used/total)',
-                'GPU (used/total)', 'Agent count',
-            ]]
-            table_rows = []
-            for attribute_value, resource_info_dict in resource_info_dict.items():
-                resource_utilizations = metastatus_lib.resource_utillizations_from_resource_info(
-                    total=resource_info_dict['total'],
-                    free=resource_info_dict['free'],
-                )
-                healthcheck_utilization_pairs = [
-                    metastatus_lib.healthcheck_result_resource_utilization_pair_for_resource_utilization(
-                        utilization,
-                        args.threshold,
-                    )
-                    for utilization in resource_utilizations
-                ]
-                healthy_exit = all(pair[0].healthy for pair in healthcheck_utilization_pairs)
-                table_rows.append(metastatus_lib.get_table_rows_for_resource_info_dict(
-                    attribute_value,
-                    healthcheck_utilization_pairs,
-                    args.humanize,
-                ) + [str(resource_info_dict['slave_count'])])
-            table_rows = sorted(table_rows, key=lambda x: x[0])
-            all_rows.extend(table_rows)
-            for line in format_table(all_rows):
-                print_with_indent(line, 4)
+        print_with_indent('Resources Grouped by %s' % ", ".join(args.groupings), 2)
+        all_rows, healthy_exit = utilization_table_by_grouping_from_mesos_state(
+            groupings=args.groupings,
+            threshold=args.threshold,
+            humanize=args.humanize,
+            mesos_state=mesos_state,
+        )
+        for line in format_table(all_rows):
+            print_with_indent(line, 4)
 
         if args.autoscaling_info:
             print_with_indent("Autoscaling resources:", 2)
@@ -208,35 +238,20 @@ def main(argv: Optional[List[str]]=None) -> None:
 
         if args.verbose >= 3:
             print_with_indent('Per Slave Utilization', 2)
-            slave_resource_dict = metastatus_lib.get_resource_utilization_by_grouping(
-                lambda slave: slave['hostname'],
-                mesos_state,
-            )
-            all_rows = [['Hostname', 'CPU (used/total)', 'RAM (used//total)', 'Disk (used//total)', 'GPU (used/total)']]
-
             # print info about slaves here. Note that we don't make modifications to
             # the healthy_exit variable here, because we don't care about a single slave
             # having high usage.
-            for attribute_value, resource_info_dict in slave_resource_dict.items():
-                table_rows = []
-                resource_utilizations = metastatus_lib.resource_utillizations_from_resource_info(
-                    total=resource_info_dict['total'],
-                    free=resource_info_dict['free'],
-                )
-                healthcheck_utilization_pairs = [
-                    metastatus_lib.healthcheck_result_resource_utilization_pair_for_resource_utilization(
-                        utilization,
-                        args.threshold,
-                    )
-                    for utilization in resource_utilizations
-                ]
-                table_rows.append(metastatus_lib.get_table_rows_for_resource_info_dict(
-                    attribute_value,
-                    healthcheck_utilization_pairs,
-                    args.humanize,
-                ))
-                table_rows = sorted(table_rows, key=lambda x: x[0])
-                all_rows.extend(table_rows)
+            all_rows, _ = utilization_table_by_grouping_from_mesos_state(
+                groupings=args.groupings + ["hostname"],
+                threshold=args.threshold,
+                humanize=args.humanize,
+                mesos_state=mesos_state,
+            )
+            # The last column from utilization_table_by_grouping_from_mesos_state is "Agent count", which will always be
+            # 1 for per-slave resources, so delete it.
+            for row in all_rows:
+                row.pop()
+
             for line in format_table(all_rows):
                 print_with_indent(line, 4)
     metastatus_lib.print_results_for_healthchecks(marathon_summary, marathon_ok, marathon_results, args.verbose)

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -1033,7 +1033,7 @@ def test_get_table_rows_for_resource_usage_dict(mock_format_row):
         (Mock(), Mock()),
     ]
     mock_format_row.return_value = ['10/10', '10/10', '10/10']
-    actual = metastatus_lib.get_table_rows_for_resource_info_dict('myhabitat', fake_pairs, False)
+    actual = metastatus_lib.get_table_rows_for_resource_info_dict(['myhabitat'], fake_pairs, False)
     assert actual == ['myhabitat', '10/10', '10/10', '10/10']
 
 


### PR DESCRIPTION
This fixes something that's been bothering me for a while, which is that there's no easy way to see resource utilization for a pool broken down by region. You currently either get region or pool, but can't distinguish default/uswest1-prod and default/sfo12-prod.

Example output: https://fluffy.yelpcorp.com/i/tdFCpRCrnWRHpF0p1HQLtmXhXthj5VSg.html

One thing I expect to be somewhat controversial, and am not very tied to: This adds the groupings (region and pool by default) before the hostname in the `-vvv` output. I think this will be useful, as currently with `-vvv` it's impossible to know what pool a host is in.
