### PR TITLE
paasta local-run --no-healthcheck shouldn't publish a container's ports

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -589,6 +589,8 @@ def run_docker_container(
     if healthcheck_mode is None:
         container_port = None
         interactive = True
+    elif not user_port and not healthcheck and not healthcheck_only:
+        container_port = None
     else:
         try:
             container_port = instance_config.get_container_port()
@@ -651,7 +653,7 @@ def run_docker_container(
         paasta_print('Found our container running with CID %s' % container_id)
 
         # If the service has a healthcheck, simulate it
-        if healthcheck_mode is not None:
+        if healthcheck and healthcheck_mode is not None:
             healthcheck_result = simulate_healthcheck_on_service(
                 instance_config=instance_config,
                 docker_client=docker_client,

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -1076,7 +1076,7 @@ def test_run_docker_container_with_custom_soadir_uses_healthcheck(
             volumes=[],
             interactive=False,
             command='fake_command',
-            healthcheck=False,
+            healthcheck=True,
             healthcheck_only=True,
             user_port=None,
             instance_config=mock_service_manifest,


### PR DESCRIPTION
Internal ticket: OPS-12441

paasta local-run shouldn't publish a container's port(s) for non-http (--no-healthcheck) batches.