### PR TITLE
Make marathon_dashboard work for non-sharded clusters

### DIFF
--- a/paasta_tools/marathon_dashboard.py
+++ b/paasta_tools/marathon_dashboard.py
@@ -90,12 +90,14 @@ def create_marathon_dashboard(
         client: MarathonClient = marathon_clients.get_current_client_for_service(job_config=service_config)
         dashboard_links: Dict = system_paasta_config.get_dashboard_links()
         shard_url: str = client.servers[0]
-        if isinstance(dashboard_links[cluster]['Marathon RO'], list):
-            for shard_number, shard in enumerate(marathon_servers.current):
-                if shard.url[0] == shard_url:
-                    shard_url = dashboard_links[cluster]['Marathon RO'][shard_number]
-        else:
-            shard_url = dashboard_links[cluster]['Marathon RO'].split(' ')[0]
+        if 'Marathon RO' in dashboard_links[cluster]:
+            marathon_links = dashboard_links[cluster]['Marathon RO']
+            if isinstance(marathon_links, list):
+                for shard_number, shard in enumerate(marathon_servers.current):
+                    if shard.url[0] == shard_url:
+                        shard_url = marathon_links[shard_number]
+            elif isinstance(marathon_links, str):
+                shard_url = marathon_links.split(' ')[0]
         service_info: Marathon_Dashboard_Item = {
             'service': service,
             'instance': instance,

--- a/paasta_tools/marathon_dashboard.py
+++ b/paasta_tools/marathon_dashboard.py
@@ -90,9 +90,12 @@ def create_marathon_dashboard(
         client: MarathonClient = marathon_clients.get_current_client_for_service(job_config=service_config)
         dashboard_links: Dict = system_paasta_config.get_dashboard_links()
         shard_url: str = client.servers[0]
-        for shard_number, shard in enumerate(marathon_servers.current):
-            if shard.url[0] == shard_url:
-                shard_url = dashboard_links[cluster]['Marathon RO'][shard_number]
+        if isinstance(dashboard_links[cluster]['Marathon RO'], list):
+            for shard_number, shard in enumerate(marathon_servers.current):
+                if shard.url[0] == shard_url:
+                    shard_url = dashboard_links[cluster]['Marathon RO'][shard_number]
+        else:
+            shard_url = dashboard_links[cluster]['Marathon RO'].split(' ')[0]
         service_info: Marathon_Dashboard_Item = {
             'service': service,
             'instance': instance,


### PR DESCRIPTION
The code was producing broken shard_urls for non-sharded clusters. This should make it work properly.