### PR TITLE
RFC: Automatically add ['hostname', 'UNIQUE'] to small services

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -549,9 +549,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         """
         if 'prod' in self.cluster:
             auto_hostname_unique_size = system_paasta_config.get_auto_hostname_unique_size()
-            app_size = self.get_max_instances()
-            if app_size is None:
-                app_size = self.get_desired_instances()
+            app_size = self.get_max_instances() or self.get_desired_instances() 
             if app_size <= auto_hostname_unique_size:
                 return [["hostname", "UNIQUE"]]
         return []

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -549,7 +549,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         """
         if 'prod' in self.cluster:
             auto_hostname_unique_size = system_paasta_config.get_auto_hostname_unique_size()
-            app_size = self.get_max_instances() or self.get_desired_instances() 
+            app_size = self.get_max_instances() or self.get_desired_instances()
             if app_size <= auto_hostname_unique_size:
                 return [["hostname", "UNIQUE"]]
         return []

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -531,7 +531,30 @@ class MarathonServiceConfig(LongRunningServiceConfig):
                 ),
             )
             constraints.extend(self.get_pool_constraints())
+            constraints.extend(self.get_hostname_unique_constraint(system_paasta_config=system_paasta_config))
         return constraints
+
+    def get_hostname_unique_constraint(
+            self,
+            system_paasta_config: SystemPaastaConfig,
+    ) -> List[Constraint]:
+        """
+        "Small" services running in a production cluster automatically receive a running
+        in a production cluster automatically receive a hostname UNIQUE constraint to reduce
+        the risk of all tasks getting launched on the same agent, which might then be lost.
+
+        :param system_paasta_config: A SystemPaastaConfig object representing the system
+                                 configuration.
+        :returns: a set of constraints for marathon
+        """
+        if 'prod' in self.cluster:
+            auto_hostname_unique_size = system_paasta_config.get_auto_hostname_unique_size()
+            app_size = self.get_max_instances()
+            if app_size is None:
+                app_size = self.get_desired_instances()
+            if app_size <= auto_hostname_unique_size:
+                return [["hostname", "UNIQUE"]]
+        return []
 
     def get_routing_constraints(
         self,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1471,11 +1471,11 @@ class SystemPaastaConfig(object):
         """
         We automatically add a ["hostname", "UNIQUE"] constraint to "small" services running in production clusters.
         If there are less than or equal to this number of instances, we consider it small.
-        We fail safe and return 0 to avoid adding the ['hostname', 'UNIQUE'] constraint if this value is not defined
+        We fail safe and return -1 to avoid adding the ['hostname', 'UNIQUE'] constraint if this value is not defined
 
         :returns: The integer size of a small service
         """
-        return self.config_dict.get('auto_hostname_unique_size', 0)
+        return self.config_dict.get('auto_hostname_unique_size', -1)
 
     def get_api_endpoints(self) -> Dict[str, str]:
         return self.config_dict['api_endpoints']

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1328,6 +1328,7 @@ ExpectedSlaveAttributes = List[Dict[str, Any]]
 SystemPaastaConfigDict = TypedDict(
     'SystemPaastaConfigDict',
     {
+        'auto_hostname_unique_size': int,
         'zookeeper': str,
         'docker_registry': str,
         'volumes': List[DockerVolume],
@@ -1465,6 +1466,16 @@ class SystemPaastaConfig(object):
 
     def get_dashboard_links(self) -> Dict[str, Dict[str, str]]:
         return self.config_dict['dashboard_links']
+
+    def get_auto_hostname_unique_size(self) -> int:
+        """
+        We automatically add a ["hostname", "UNIQUE"] constraint to "small" services running in production clusters.
+        If there are less than or equal to this number of instances, we consider it small.
+        We fail safe and return 0 to avoid adding the ['hostname', 'UNIQUE'] constraint if this value is not defined
+
+        :returns: The integer size of a small service
+        """
+        return self.config_dict.get('auto_hostname_unique_size', 0)
 
     def get_api_endpoints(self) -> Dict[str, str]:
         return self.config_dict['api_endpoints']

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1116,6 +1116,95 @@ class TestMarathonTools:
         )
         assert actual == [['something', 'GROUP_BY']]
 
+    def test_get_calculated_constraints_small_hostname_unique(self):
+        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig()
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_prod_cluster',
+            instance='fake_instance',
+            config_dict={'instances': 3},
+            branch_dict={},
+        )
+        fake_system_paasta_config = SystemPaastaConfig(
+            {
+                "auto_hostname_unique_size": 3,
+            }, "/foo",
+        )
+        expected_constraints = [
+            ["pool", "LIKE", "default"],
+            ["hostname", "UNIQUE"],
+        ]
+        actual = fake_conf.get_calculated_constraints(
+            service_namespace_config=fake_service_namespace_config,
+            system_paasta_config=fake_system_paasta_config,
+        )
+        assert actual == expected_constraints
+
+    def test_get_calculated_constraints_non_prod_no_hostname_unique(self):
+        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig()
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_dev_cluster',
+            instance='fake_instance',
+            config_dict={'instances': 3},
+            branch_dict={},
+        )
+        fake_system_paasta_config = SystemPaastaConfig(
+            {
+                "auto_hostname_unique_size": 3,
+            }, "/foo",
+        )
+        expected_constraints = [
+            ["pool", "LIKE", "default"],
+        ]
+        actual = fake_conf.get_calculated_constraints(
+            service_namespace_config=fake_service_namespace_config,
+            system_paasta_config=fake_system_paasta_config,
+        )
+        assert actual == expected_constraints
+
+    def test_get_calculated_constraints_no_config_no_hostname_unique(self):
+        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig()
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_dev_cluster',
+            instance='fake_instance',
+            config_dict={'instances': 3},
+            branch_dict={},
+        )
+        fake_system_paasta_config = SystemPaastaConfig({}, "/foo")
+        expected_constraints = [
+            ["pool", "LIKE", "default"],
+        ]
+        actual = fake_conf.get_calculated_constraints(
+            service_namespace_config=fake_service_namespace_config,
+            system_paasta_config=fake_system_paasta_config,
+        )
+        assert actual == expected_constraints
+
+    def test_get_calculated_constraints_large_no_hostname_unique(self):
+        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig()
+        fake_conf = marathon_tools.MarathonServiceConfig(
+            service='fake_name',
+            cluster='fake_prod_cluster',
+            instance='fake_instance',
+            config_dict={'instances': 10},
+            branch_dict={},
+        )
+        fake_system_paasta_config = SystemPaastaConfig(
+            {
+                "auto_hostname_unique_size": 3,
+            }, "/foo",
+        )
+        expected_constraints = [
+            ["pool", "LIKE", "default"],
+        ]
+        actual = fake_conf.get_calculated_constraints(
+            service_namespace_config=fake_service_namespace_config,
+            system_paasta_config=fake_system_paasta_config,
+        )
+        assert actual == expected_constraints
+
     def test_get_calculated_constraints_default_no_expected_slave_attributes(self, system_paasta_config):
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig()
         fake_conf = marathon_tools.MarathonServiceConfig(


### PR DESCRIPTION
We briefly discussed the idea of automatically adding a `['hostname', 'UNIQUE']` constraint to small services running in production. This would avoid situations where all of their tasks end up running on the same agent, which might then go away and cause replication issues.