### PR TITLE
Passing boost arguments only when action is set

### DIFF
--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -29,7 +29,7 @@ opt/venvs/paasta-tools/bin/paasta_chronos_rerun usr/bin/paasta_chronos_rerun
 opt/venvs/paasta-tools/bin/paasta_cleanup_chronos_jobs usr/bin/cleanup_chronos_jobs
 opt/venvs/paasta-tools/bin/paasta_cleanup_chronos_jobs usr/bin/paasta_cleanup_chronos_jobs
 opt/venvs/paasta-tools/bin/paasta_cleanup_maintenance usr/bin/paasta_cleanup_maintenance
-opt/venvs/paasta-tools/bin/paasta_cluster_boost usr/bin/paasta_cluster_boost
+opt/venvs/paasta-tools/bin/paasta_cluster_boost.py usr/bin/paasta_cluster_boost
 opt/venvs/paasta-tools/bin/paasta_deploy_chronos_jobs usr/bin/deploy_chronos_jobs
 opt/venvs/paasta-tools/bin/paasta_deploy_chronos_jobs usr/bin/paasta_deploy_chronos_jobs
 opt/venvs/paasta-tools/bin/paasta-deployd usr/bin/paasta-deployd

--- a/paasta_tools/paasta_cluster_boost.py
+++ b/paasta_tools/paasta_cluster_boost.py
@@ -61,7 +61,7 @@ def parse_args():
         'action',
         choices=[
             'set',
-            'status',
+            'get',
             'clear',
         ],
         help="You can set, get or clear a boost.",
@@ -121,7 +121,7 @@ def paasta_cluster_boost():
             region=region,
             pool=pool,
             factor=args.boost,
-            duration_minutes=args.duration_minutes,
+            duration_minutes=args.duration,
             override=args.override,
         ):
             paasta_print('Failed! Check the logs.')


### PR DESCRIPTION
Plus minor cli fixes.


Ideally I'd like to add integration tests:
get, set, get, clear, get

to make sure that this toolchain is working properly