### PR TITLE
Fix tail discovery, date handling and upgrade yelp_clog

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -823,11 +823,14 @@ class ScribeLogReader(LogReader):
         if end_time > warning_end_time:
             log.warn("Recent logs might be incomplete. Consider tailing instead.")
 
-        start_time_yst = start_time .replace(tzinfo=timezone.utc).astimezone(tz=None)
-        end_time_yst = end_time.replace(tzinfo=timezone.utc).astimezone(tz=None)
+        # scribeerader, sadly, is not based on UTC timestamps. It uses YST
+        # dates instead.
+        start_date_yst = (start_time - datetime.timedelta(hours=8)).date()
+        end_date_yst = (end_time - datetime.timedelta(hours=8)).date()
 
-        log.info("Running the equivalent of 'scribereader -e %s %s" % (scribe_env, stream_name))
-        return scribereader.get_stream_reader(stream_name, host, port, start_time_yst, end_time_yst)
+        log.info("Running the equivalent of 'scribereader -e %s %s --min-date %s --max-date %s" \
+                 % (scribe_env, stream_name, start_date_yst, end_date_yst))
+        return scribereader.get_stream_reader(stream_name, host, port, start_date_yst, end_date_yst)
 
     def scribe_get_last_n_lines(self, scribe_env, stream_name, line_count):
         # Scribe connection details

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -225,7 +225,6 @@ def paasta_log_line_passes_filter(
         return False
 
     timestamp = isodate.parse_datetime(parsed_line.get('timestamp'))
-    timestamp = pytz.utc.localize(timestamp)
     if not check_timestamp_in_range(timestamp, start_time, end_time):
         return False
     return (

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -20,7 +20,6 @@ import re
 import sys
 from collections import namedtuple
 from contextlib import contextmanager
-from datetime import timezone
 from multiprocessing import Process
 from multiprocessing import Queue
 from queue import Empty

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,5 +46,5 @@ typing_extensions==3.6.2.1
 tzlocal==1.2
 ujson==1.35
 wsgicors==0.7.0
-yelp-clog==2.7.2
+yelp-clog==2.12.1
 zope.interface==4.1.2

--- a/tests/cli/test_cmds_logs.py
+++ b/tests/cli/test_cmds_logs.py
@@ -722,7 +722,7 @@ def test_scribereader_print_logs_by_time():
         )
 
         # Please see comment in test_scribereader_print_last_n_logs for where this number comes from
-        assert mock_scribereader.get_stream_tailer.call_count == 14
+        assert mock_scribereader.get_stream_reader.call_count == 14
 
         start_time, end_time = logs.generate_start_end_time("3d", "2d")
         logs.ScribeLogReader(cluster_map={}).print_logs_by_time(
@@ -732,7 +732,7 @@ def test_scribereader_print_logs_by_time():
         )
 
         # Please see comment in test_scribereader_print_last_n_logs for where this number comes from
-        assert mock_scribereader.get_stream_reader.call_count == 14
+        assert mock_scribereader.get_stream_reader.call_count == 14 * 2
 
 
 def test_tail_paasta_logs_ctrl_c_in_queue_get():


### PR DESCRIPTION
- Fix log tailer discovery
- Fix date handling for range logs (timezone issues + fetching today's logs)
- Upgrade to new yelp_clog version with gzip decompression working in python3

I run different tests and they all seem to return the correct results.