### PR TITLE
Avoid using default event loop on secondary threads.

### DIFF
--- a/paasta_tools/frameworks/constraints.py
+++ b/paasta_tools/frameworks/constraints.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# Without this, the import of mesos.interface breaks because paasta_tools.mesos exists
 import re
 from typing import Any
 from typing import Callable

--- a/paasta_tools/frameworks/native_scheduler.py
+++ b/paasta_tools/frameworks/native_scheduler.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# Without this, the import of mesos.interface breaks because paasta_tools.mesos exists
 import asyncio
 import copy
 import getpass

--- a/paasta_tools/frameworks/native_service_config.py
+++ b/paasta_tools/frameworks/native_service_config.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# Without this, the import of mesos.interface breaks because paasta_tools.mesos exists
 import copy
 from typing import Any
 from typing import List

--- a/paasta_tools/native_mesos_scheduler.py
+++ b/paasta_tools/native_mesos_scheduler.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# Without this, the import of mesos.interface breaks because paasta_tools.mesos exists
 import argparse
 import sys
 import time

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+a_sync==0.5.0
 addict==2.1.0
 aiohttp==2.3.3
 argcomplete==0.8.1
@@ -46,6 +47,7 @@ thriftpy==0.1.15
 typing_extensions==3.6.2.1
 tzlocal==1.2
 ujson==1.35
+utaw==0.2.0
 wsgicors==0.7.0
 yelp-clog==2.7.2
 zope.interface==4.1.2

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     packages=find_packages(exclude=("tests*", "scripts*")),
     include_package_data=True,
     install_requires=[
+        'a_sync >= 0.5.0',
         'argcomplete >= 0.8.1',
         'aiohttp >= 2.3.3',
         'bravado == 8.4.0',


### PR DESCRIPTION
Deployd broke after #1653 was merged, because of errors like `There is no current event loop in thread 'Worker6'.`

This should fix that, by creating event loops where necessary. It also cleans up some boilerplate using the https://github.com/notion/a_sync library.