### PR TITLE
Add jira dependency that was missed in #1663

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ httplib2==0.9.2
 humanize==0.5.1
 inotify==0.2.8
 isodate==0.5.1
+jira==0.50
 jsonschema[format]==2.5.1
 kazoo==2.2
 marathon==0.9.3


### PR DESCRIPTION
I was trying to use the paasta_update_soa_memcpu script for some Nowait services and I received the following error when running the script

```
(.paasta)ddelnano@dev7-uswest1cdevc:~/pg/paasta (master) $ paasta_tools/contrib/paasta_update_soa_memcpu.py
Traceback (most recent call last):
  File "paasta_tools/contrib/paasta_update_soa_memcpu.py", line 12, in <module>
    from jira.client import JIRA
ModuleNotFoundError: No module named 'jira'
```

Looks like the dependency was not added to the requirements.txt when the import was added in #1663.  Since there are no tests this was missed.  I opted to use jira 0.50 because 1.0.10 requires updating the requests version to >= 2.10.0