### PR TITLE
Allow the most recent tag to take precedence over a deploy tag.

### DIFF
--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -260,16 +260,13 @@ def get_desired_state(branch: str, remote_refs: Dict[str, str], deploy_group: st
     # (?:paasta-){1,2} supports a previous mistake where some tags would be called
     # paasta-paasta-cluster.instance
     tag_pattern = r'^refs/tags/(?:paasta-){0,2}%s-(?P<force_bounce>[^-]+)-(?P<state>(start|stop))$' % branch
-
     states = []
-    (_, head_sha) = get_latest_deployment_tag(remote_refs, deploy_group)
 
     for ref_name, sha in remote_refs.items():
-        if sha == head_sha:
-            match = re.match(tag_pattern, ref_name)
-            if match:
-                gd = match.groupdict()
-                states.append((gd['state'], gd['force_bounce']))
+        match = re.match(tag_pattern, ref_name)
+        if match:
+            gd = match.groupdict()
+            states.append((gd['state'], gd['force_bounce']))
 
     if states:
         # there may be more than one that matches, so take the one that sorts

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -267,3 +267,36 @@ def test_get_desired_state_fails_gracefully_with_start():
     actual = generate_deployments_for_service.get_desired_state(branch, remote_refs, deploy_group)
 
     assert actual == expected_desired_state
+
+
+def test_get_desired_state_respects_stop_before_deploy():
+    remote_refs = {
+        'refs/heads/master': '7894E99E6805E9DC8C1D8EB26229E3E2243878C9',
+        'refs/remotes/origin/HEAD': 'EE8796C4E4295B7D4087E3EB73662B99218DAD94',
+        'refs/remotes/origin/master': '5F7C10B320A4EDBC4773C5FEFB1CD7B7A84FCB69',
+        'refs/tags/paasta-cluster.instance-20160202T233805-stop': 'BE68473F98F619F26FD7824B8F56F9A7ABAEB860',
+        'refs/tags/paasta-cluster.instance-20160308T053933-deploy': '4EF01B5A574B519AB546309E89F72972A33B6B75',
+    }
+    branch = 'cluster.instance'
+    deploy_group = branch
+    expected_desired_state = ('stop', '20160202T233805')
+    actual = generate_deployments_for_service.get_desired_state(branch, remote_refs, deploy_group)
+
+    assert actual == expected_desired_state
+
+
+def test_get_desired_state_respects_start_after_stop():
+    remote_refs = {
+        'refs/heads/master': '7894E99E6805E9DC8C1D8EB26229E3E2243878C9',
+        'refs/remotes/origin/HEAD': 'EE8796C4E4295B7D4087E3EB73662B99218DAD94',
+        'refs/remotes/origin/master': '5F7C10B320A4EDBC4773C5FEFB1CD7B7A84FCB69',
+        'refs/tags/paasta-cluster.instance-20160202T233805-stop': 'BE68473F98F619F26FD7824B8F56F9A7ABAEB860',
+        'refs/tags/paasta-cluster.instance-20160308T053933-deploy': '4EF01B5A574B519AB546309E89F72972A33B6B75',
+        'refs/tags/paasta-cluster.instance-20160402T233805-start': 'STARTA473F98F619F26FD7824B8F56F9A7ABAEB860',
+    }
+    branch = 'cluster.instance'
+    deploy_group = branch
+    expected_desired_state = ('start', '20160402T233805')
+    actual = generate_deployments_for_service.get_desired_state(branch, remote_refs, deploy_group)
+
+    assert actual == expected_desired_state


### PR DESCRIPTION
Honestly I'm surprised at this. I'm kinda skeptical this works. We don't even need to run `get_latest_deployment_tag`? Is it really OK to look at all the tags and just sort by date?

This is a seriously iffy change. Obv I would run generate_deployments manually and see a diff.

Amazingly, a diff shows nothing on yelp-main. I should probably do a manual stop + deploy and test this for real?