### PR TITLE
Added a script to emit additional paasta metrics

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -609,6 +609,10 @@ def autoscale_marathon_instance(marathon_service_config, marathon_tasks, mesos_t
     if yelp_meteorite:
         gauge = yelp_meteorite.create_gauge('paasta.service.autoscaler', meteorite_dims)
         gauge.set(new_instance_count)
+        gauge = yelp_meteorite.create_gauge('paasta.service.max_instances', meteorite_dims)
+        gauge.set(marathon_service_config.get_max_instances())
+        gauge = yelp_meteorite.create_gauge('paasta.service.min_instances', meteorite_dims)
+        gauge.set(marathon_service_config.get_min_instances())
 
 
 def humanize_error(error):

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -784,7 +784,10 @@ def get_jenkins_build_output_url():
     return build_output
 
 
-def get_instance_config(service, instance, cluster, soa_dir, load_deployments=False, instance_type=None):
+def get_instance_config(
+    service, instance, cluster, soa_dir=DEFAULT_SOA_DIR,
+    load_deployments=False, instance_type=None,
+):
     """ Returns the InstanceConfig object for whatever type of instance
     it is. (chronos or marathon) """
     if instance_type is None:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -708,6 +708,7 @@ def stringify_constraints(uscs: Optional[List[UnstringifiedConstraint]]) -> List
     return [stringify_constraint(usc) for usc in uscs]
 
 
+@time_cache(ttl=60)
 def validate_service_instance(service: str, instance: str, cluster: str, soa_dir: str) -> str:
     for instance_type in INSTANCE_TYPES:
         services = get_services_for_cluster(cluster=cluster, instance_type=instance_type, soa_dir=soa_dir)
@@ -2126,7 +2127,7 @@ def get_services_for_cluster(
     if not cluster:
         cluster = load_system_paasta_config().get_cluster()
     rootdir = os.path.abspath(soa_dir)
-    log.info("Retrieving all service instance names from %s for cluster %s", rootdir, cluster)
+    log.debug("Retrieving all service instance names from %s for cluster %s", rootdir, cluster)
     instance_list: List[Tuple[str, str]] = []
     for srv_dir in os.listdir(rootdir):
         service_instance_list = get_service_instance_list(srv_dir, cluster, instance_type, soa_dir)

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -541,13 +541,7 @@ def test_autoscale_marathon_instance():
         mock_set_instances_for_marathon_service.assert_called_once_with(
             service='fake-service', instance='fake-instance', instance_count=2,
         )
-        meteorite_dims = {
-            'service_name': 'fake-service',
-            'paasta_cluster': 'fake-cluster',
-            'decision_policy': 'proportional',
-            'instance_name': 'fake-instance',
-        }
-        mock_meteorite.create_gauge.assert_called_once_with('paasta.service.autoscaler', meteorite_dims)
+        mock_meteorite.create_gauge.call_count == 3
 
 
 def test_autoscale_marathon_instance_up_to_min_instances():


### PR DESCRIPTION
Although ideally this number would be available "for free", mts's are expensive, and we don't need to emit this "constant" for every docker container at yelp.

To that end, I made this script that emits the metric directly. It doesn't change that much, so I'm think of running every 5m or so on masters. 