### PR TITLE
Better cluster boost

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -1112,7 +1112,7 @@ def autoscale_local_cluster(
     utilization_errors = get_all_utilization_errors(
         autoscaling_resources=autoscaling_resources,
         all_pool_settings=all_pool_settings,
-        mesos_state=MesosState,
+        mesos_state=mesos_state,
         system_config=system_config,
     )
     autoscaling_scalers: Dict[Tuple[str, str], List[ClusterAutoscaler]] = defaultdict(list)
@@ -1224,7 +1224,7 @@ def get_autoscaling_info_for_all_resources(mesos_state: MesosState) -> List[Auto
     utilization_errors = get_all_utilization_errors(
         autoscaling_resources=autoscaling_resources,
         all_pool_settings=all_pool_settings,
-        mesos_state=MesosState,
+        mesos_state=mesos_state,
         system_config=system_config,
     )
     vals = [

--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -1267,6 +1267,7 @@ def get_mesos_utilization_error(
     When the boost feature is enabled, the current_load will be artifically increased
     and stored into boosted_load. If the boost is disabled, boosted_load = current_load
     """
+    system_config = load_system_paasta_config()
     try:
         region_pool_utilization_dict = get_resource_utilization_by_grouping(
             lambda slave: (slave['attributes']['pool'], slave['attributes']['datacenter'],),
@@ -1291,7 +1292,7 @@ def get_mesos_utilization_error(
         current_load = total - free
 
         # We apply the boost only on the cpu resource.
-        if resource == 'cpus':
+        if resource == 'cpus'and system_config.get_cluster_boost_enabled():
             boosted_load = cluster_boost.get_boosted_load(region=region, pool=pool, current_load=current_load)
         else:
             boosted_load = current_load

--- a/paasta_tools/autoscaling/cluster_boost.py
+++ b/paasta_tools/autoscaling/cluster_boost.py
@@ -89,8 +89,8 @@ def get_boosted_load(region: str, pool: str, current_load: float) -> float:
         return current_load
 
 
-def print_boost_value(region: str, pool: str) -> float:
-    """THis function prints the boost value if a boost is active
+def get_boost_factor(region: str, pool: str) -> float:
+    """This function returns the boost factor value if a boost is active
     """
     current_time = get_time()
 

--- a/paasta_tools/autoscaling/cluster_boost.py
+++ b/paasta_tools/autoscaling/cluster_boost.py
@@ -89,6 +89,19 @@ def get_boosted_load(region: str, pool: str, current_load: float) -> float:
         return current_load
 
 
+def print_boost_value(region: str, pool: str) -> float:
+    """THis function prints the boost value if a boost is active
+    """
+    current_time = get_time()
+
+    with ZookeeperPool() as zk:
+        boost_values = get_boost_values(region, pool, zk)
+        if current_time < boost_values.end_time:
+            return boost_values.boost_factor
+        else:
+            return 1.0
+
+
 def get_boost_values(
     region: str,
     pool: str,

--- a/paasta_tools/cli/cmds/boost.py
+++ b/paasta_tools/cli/cmds/boost.py
@@ -24,7 +24,7 @@ from paasta_tools.utils import paasta_print
 def add_subparser(subparsers):
     boost_parser = subparsers.add_parser(
         'boost',
-        help="Set, get, or clear a capacity boost for a given region in a PaaSTA cluster",
+        help="Set, print the status, or clear a capacity boost for a given region in a PaaSTA cluster",
         description=(
             "'paasta boost' is used to temporary provision more capacity in a given cluster "
             "It operates by ssh'ing to a Mesos master of a remote cluster, and "
@@ -98,7 +98,8 @@ def paasta_boost(args):
     soa_dir = args.soa_dir
     system_paasta_config = load_system_paasta_config()
     all_clusters = list_clusters(soa_dir=soa_dir)
-    for cluster in args.cluster.split(','):
+    clusters = args.cluster.split(',')
+    for cluster in clusters:
         if cluster not in all_clusters:
             paasta_print(
                 "Error: {} doesn't look like a valid cluster. ".format(cluster) +
@@ -107,7 +108,7 @@ def paasta_boost(args):
             return 1
 
     return_code, output = execute_paasta_cluster_boost_on_remote_master(
-        clusters=args.cluster,
+        clusters=clusters,
         system_paasta_config=system_paasta_config,
         action=args.action,
         pool=args.pool,

--- a/paasta_tools/cli/cmds/boost.py
+++ b/paasta_tools/cli/cmds/boost.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 from paasta_tools.autoscaling import cluster_boost
 from paasta_tools.cli.utils import execute_paasta_cluster_boost_on_remote_master
+from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import load_system_paasta_config
@@ -46,10 +47,10 @@ def add_subparser(subparsers):
     boost_parser.add_argument(
         '-c', '--cluster',
         type=str,
-        action='append',
         required=True,
-        help="Cluster to boost. ex: nova-prod .This option can be specified multiple times.",
-    )
+        help="""Paasta cluster(s) to boost. This option can take comma separated values.
+        If auto-completion doesn't work, you can get a list of cluster with `paasta list-clusters'""",
+    ).completer = lazy_choices_completer(list_clusters)
     boost_parser.add_argument(
         '-d', '--soa-dir',
         dest="soa_dir",
@@ -97,7 +98,7 @@ def paasta_boost(args):
     soa_dir = args.soa_dir
     system_paasta_config = load_system_paasta_config()
     all_clusters = list_clusters(soa_dir=soa_dir)
-    for cluster in args.cluster:
+    for cluster in args.cluster.split(','):
         if cluster not in all_clusters:
             paasta_print(
                 "Error: {} doesn't look like a valid cluster. ".format(cluster) +

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -646,14 +646,14 @@ def execute_paasta_cluster_boost_on_remote_master(
     """Returns a string containing an error message if an error occurred.
     Otherwise returns the output of run_paasta_cluster_boost().
     """
-    output = {}
+    result = {}
     for cluster in clusters:
         try:
             master = connectable_master(cluster, system_paasta_config)
         except NoMasterError as e:
-            output[cluster] = (255, str(e))
+            result[cluster] = (255, str(e))
 
-        output[cluster] = run_paasta_cluster_boost(
+        result[cluster] = run_paasta_cluster_boost(
             master=master,
             action=action,
             pool=pool,
@@ -664,14 +664,14 @@ def execute_paasta_cluster_boost_on_remote_master(
         )
 
     aggregated_code = 0
-    aggregated_stdout = ""
-    for cluster in output:
-        code = output[cluster][0]
-        stdout = output[cluster][1]
+    aggregated_output = ""
+    for cluster in result:
+        code = result[cluster][0]
+        output = result[cluster][1]
         if not code == 0:
-            aggregated_code = code
-        aggregated_stdout += "\n{}: \n{}\n".format(cluster, stdout)
-    return (aggregated_code, aggregated_stdout)
+            aggregated_code = 1
+        aggregated_output += "\n{}: \n{}\n".format(cluster, output)
+    return (aggregated_code, aggregated_output)
 
 
 def run_chronos_rerun(master, service, instancename, **kwargs):

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -625,7 +625,7 @@ def run_paasta_cluster_boost(
             ],
         ),
     )
-    command = ('ssh -A -n -o StrictHostKeyChecking=no %s sudo paasta_cluster_boost %s' % (
+    command = ('ssh -A -n -o StrictHostKeyChecking=no %s paasta_cluster_boost %s' % (
         master,
         cmd_args,
     )).strip()

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -595,21 +595,19 @@ def execute_paasta_metastatus_on_remote_master(
 def run_paasta_cluster_boost(
     master,
     action,
-    region,
     pool,
     duration,
     override,
     boost,
     verbose,
 ):
-    if verbose > 0:
-        verbose_flag = '{}'.format('v' * verbose)
-        timeout = 120
-    else:
-        verbose_flag = ''
-        timeout = 20
+    timeout = 20
 
-    region_flag = '--region {}'.format(region)
+    if verbose > 0:
+        verbose_flag = '-{}'.format('v' * verbose)
+    else:
+        verbose_flag = None
+
     pool_flag = '--pool {}'.format(pool)
     duration_flag = '--duration {}'.format(duration) if duration is not None else ''
     boost_flag = '--boost {}'.format(boost) if boost is not None else ''
@@ -618,7 +616,7 @@ def run_paasta_cluster_boost(
     cmd_args = " ".join(
         filter(
             None, [
-                region_flag,
+                action,
                 pool_flag,
                 duration_flag,
                 boost_flag,
@@ -636,10 +634,9 @@ def run_paasta_cluster_boost(
 
 
 def execute_paasta_cluster_boost_on_remote_master(
-    cluster,
+    clusters,
     system_paasta_config,
     action,
-    region,
     pool,
     duration=None,
     override=None,
@@ -647,23 +644,34 @@ def execute_paasta_cluster_boost_on_remote_master(
     verbose=0,
 ):
     """Returns a string containing an error message if an error occurred.
-    Otherwise returns the output of run_paasta_metastatus().
+    Otherwise returns the output of run_paasta_cluster_boost().
     """
-    try:
-        master = connectable_master(cluster, system_paasta_config)
-    except NoMasterError as e:
-        return (255, str(e))
+    output = {}
+    for cluster in clusters:
+        try:
+            master = connectable_master(cluster, system_paasta_config)
+        except NoMasterError as e:
+            output[cluster] = (255, str(e))
 
-    return run_paasta_cluster_boost(
-        master=master,
-        action=action,
-        region=region,
-        pool=pool,
-        duration=duration,
-        override=override,
-        boost=boost,
-        verbose=verbose,
-    )
+        output[cluster] = run_paasta_cluster_boost(
+            master=master,
+            action=action,
+            pool=pool,
+            duration=duration,
+            override=override,
+            boost=boost,
+            verbose=verbose,
+        )
+
+    aggregated_code = 0
+    aggregated_stdout = ""
+    for cluster in output:
+        code = output[cluster][0]
+        stdout = output[cluster][1]
+        if not code == 0:
+            aggregated_code = code
+        aggregated_stdout += "\n{}: \n{}\n".format(cluster, stdout)
+    return (aggregated_code, aggregated_stdout)
 
 
 def run_chronos_rerun(master, service, instancename, **kwargs):

--- a/paasta_tools/paasta_cluster_boost.py
+++ b/paasta_tools/paasta_cluster_boost.py
@@ -15,7 +15,6 @@
 import argparse
 import logging
 import sys
-from typing import List
 
 from paasta_tools.autoscaling import cluster_boost
 from paasta_tools.utils import load_system_paasta_config

--- a/paasta_tools/paasta_cluster_boost.py
+++ b/paasta_tools/paasta_cluster_boost.py
@@ -69,7 +69,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def get_regions(pool: str):
+def get_regions(pool: str) -> list:
     """ Return the regions where we have slaves running for a given pool
     """
     system_paasta_config = load_system_paasta_config()

--- a/paasta_tools/paasta_cluster_boost.py
+++ b/paasta_tools/paasta_cluster_boost.py
@@ -91,6 +91,7 @@ def paasta_cluster_boost():
     """ Set, Get or clear a boost on a paasta cluster for a given pool in a given region
     :returns: None
     """
+    system_config = load_system_paasta_config()
     args = parse_args()
 
     if args.verbose >= 2:
@@ -102,6 +103,11 @@ def paasta_cluster_boost():
 
     action = args.action
     pool = args.pool
+
+    if not system_config.get_cluster_boost_enabled():
+        paasta_print('ERROR: cluster_boost feature is not enabled.')
+        return False
+
     regions = get_regions(pool)
 
     if len(regions) == 0:

--- a/paasta_tools/paasta_cluster_boost.py
+++ b/paasta_tools/paasta_cluster_boost.py
@@ -77,7 +77,7 @@ def get_regions(pool: str) -> list:
     if expected_slave_attributes is None:
         return []
 
-    regions = []
+    regions = []  # type: list
     for slave in expected_slave_attributes:
         slave_region = slave['datacenter']
         if slave['pool'] == pool:

--- a/paasta_tools/paasta_cluster_boost.py
+++ b/paasta_tools/paasta_cluster_boost.py
@@ -110,7 +110,7 @@ def paasta_cluster_boost():
     regions = get_regions(pool)
 
     if len(regions) == 0:
-        paasta_print('Error, no slaves found in pool {}'.format(pool))
+        paasta_print('ERROR: no slaves found in pool {}'.format(pool))
         return False
 
     for region in regions:
@@ -122,19 +122,19 @@ def paasta_cluster_boost():
                 duration_minutes=args.duration,
                 override=args.override,
             ):
-                paasta_print('Failed to set the boost for pool {}, region {}.'.format(pool, region))
+                paasta_print('ERROR: Failed to set the boost for pool {}, region {}.'.format(pool, region))
                 return False
 
         elif action == 'status':
             paasta_print('Current boost value for pool: {}, region: {}: {}'.format(
-                pool, region, cluster_boost.print_boost_value(
+                pool, region, cluster_boost.get_boost_factor(
                     region=region, pool=pool,
                 ),
             ))
 
         elif action == 'clear':
             if not cluster_boost.clear_boost(pool=pool, region=region):
-                paasta_print('Failed to clear the boost for pool {}, region {}.')
+                paasta_print('ERROR: Failed to clear the boost for pool {}, region {}.')
                 return False
 
         else:

--- a/paasta_tools/paasta_cluster_boost.py
+++ b/paasta_tools/paasta_cluster_boost.py
@@ -69,7 +69,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def get_regions(pool: str) -> list:
+def get_regions(pool: str):
     """ Return the regions where we have slaves running for a given pool
     """
     system_paasta_config = load_system_paasta_config()

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1372,6 +1372,7 @@ SystemPaastaConfigDict = TypedDict(
         'taskproc': Dict,
         'disabled_watchers': List,
         'vault_environment': str,
+        'cluster_boost_enabled': bool,
     },
     total=False,
 )
@@ -1589,6 +1590,13 @@ class SystemPaastaConfig(object):
 
         :returns A bool"""
         return self.config_dict.get('cluster_autoscaling_draining_enabled', True)
+
+    def get_cluster_boost_enabled(self) -> bool:
+        """ Enable the cluster boost. Note boost that applies only to the resource cpus anyway.
+        If the boost is toggle on here but not configured, it will be transparent.
+
+        :returns A bool"""
+        return self.config_dict.get('cluster_boost_enabled', False)
 
     def get_resource_pool_settings(self) -> ResourcePoolSettings:
         return self.config_dict.get('resource_pool_settings', {})

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1592,10 +1592,10 @@ class SystemPaastaConfig(object):
         return self.config_dict.get('cluster_autoscaling_draining_enabled', True)
 
     def get_cluster_boost_enabled(self) -> bool:
-        """ Enable the cluster boost. Note boost that applies only to the resource cpus anyway.
-        If the boost is toggle on here but not configured, it will be transparent.
+        """ Enable the cluster boost. Note that the boost only applies to the CPUs.
+        If the boost is toggled on here but not configured, it will be transparent.
 
-        :returns A bool"""
+        :returns A bool: True means cluster boost is enabled."""
         return self.config_dict.get('cluster_boost_enabled', False)
 
     def get_resource_pool_settings(self) -> ResourcePoolSettings:

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -71,6 +71,7 @@ def is_resource_cancelled_sideeffect(self):
 
 
 def test_get_mesos_utilization_error():
+    mock_system_config = mock.Mock(return_value={})
     with mock.patch(
         'paasta_tools.autoscaling.autoscaling_cluster_lib.get_resource_utilization_by_grouping',
         autospec=True,
@@ -87,6 +88,7 @@ def test_get_mesos_utilization_error():
 
         ret = autoscaling_cluster_lib.get_mesos_utilization_error(
             mesos_state=mock_mesos_state,
+            system_config=mock_system_config,
             region="westeros-1",
             pool="default",
             target_utilization=0.8,
@@ -95,6 +97,7 @@ def test_get_mesos_utilization_error():
 
         ret = autoscaling_cluster_lib.get_mesos_utilization_error(
             mesos_state=mock_mesos_state,
+            system_config=mock_system_config,
             region="westeros-1",
             pool="fake-pool",
             target_utilization=0.8,
@@ -329,7 +332,7 @@ def test_get_autoscaling_info_for_all_resources():
         mock_get_utilization_error.return_value = 0
         ret = autoscaling_cluster_lib.get_autoscaling_info_for_all_resources(mock_state)
         utilization_errors = autoscaling_cluster_lib.get_all_utilization_errors(
-            mock_resources, {}, mock_state,
+            mock_resources, {}, mock_state, mock_system_config,
         )
         calls = [
             mock.call(mock_resource_1, {}, mock_state, utilization_errors),

--- a/tests/test_paasta_cluster_boost.py
+++ b/tests/test_paasta_cluster_boost.py
@@ -22,7 +22,7 @@ FAKE_SLAVE_DATA = [
         'habitat': 'uswest1cstagef',
         'instance_type': 'c3.4xlarge',
         'kwatest': 'foo',
-        'pool': 'piscine',
+        'pool': 'default',
         'region': 'uswest1-stagef',
         'role': 'taskproc',
         'runtimeenv': 'stage',
@@ -45,7 +45,7 @@ FAKE_SLAVE_DATA = [
 ]
 
 
-def test_check_pool_exist():
+def test_get_regions():
     with mock.patch(
         'paasta_tools.paasta_cluster_boost.load_system_paasta_config',
         autospec=True,
@@ -53,10 +53,10 @@ def test_check_pool_exist():
         load_system_paasta_config_patch.return_value.get_expected_slave_attributes = mock.Mock(
             return_value=FAKE_SLAVE_DATA,
         )
-        assert paasta_cluster_boost.check_pool_exist(pool='piscine', region='westeros-1')
+        assert paasta_cluster_boost.get_regions('default') == ['westeros-1']
 
 
-def test_check_pool_exist_bad_pool():
+def test_get_regions_wrong_pool():
     with mock.patch(
         'paasta_tools.paasta_cluster_boost.load_system_paasta_config',
         autospec=True,
@@ -64,24 +64,4 @@ def test_check_pool_exist_bad_pool():
         load_system_paasta_config_patch.return_value.get_expected_slave_attributes = mock.Mock(
             return_value=FAKE_SLAVE_DATA,
         )
-        assert not paasta_cluster_boost.check_pool_exist(pool='big_pond', region='westeros-1')
-
-
-def test_check_pool_exist_bad_region():
-    with mock.patch(
-        'paasta_tools.paasta_cluster_boost.load_system_paasta_config',
-        autospec=True,
-    ) as load_system_paasta_config_patch:
-        load_system_paasta_config_patch.return_value.get_expected_slave_attributes = mock.Mock(
-            return_value=FAKE_SLAVE_DATA,
-        )
-        assert not paasta_cluster_boost.check_pool_exist(pool='piscine', region='the-north')
-
-
-def test_check_pool_exist_no_data():
-    with mock.patch(
-        'paasta_tools.paasta_cluster_boost.load_system_paasta_config',
-        autospec=True,
-    ) as load_system_paasta_config_patch:
-        load_system_paasta_config_patch.return_value.get_expected_slave_attributes = mock.Mock(return_value=None)
-        assert not paasta_cluster_boost.check_pool_exist(pool='piscine', region='westeros-1')
+        assert paasta_cluster_boost.get_regions('piscine') == []


### PR DESCRIPTION
* Apply the cluster boost only on CPU resource
* Fix the call from a paasta boost
* Figure out the region(s) automatically
* Replaced get by status to remove confusion:
  - get is for the autoscaler
  - status is for a human to check