### PR TITLE
Perform paasta status ssh in parallel

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import difflib
+import concurrent.futures
 import os
 import sys
 from collections import defaultdict
@@ -216,9 +217,7 @@ def report_status_for_cluster(
 ):
     """With a given service and cluster, prints the status of the instances
     in that cluster"""
-    paasta_print()
-    paasta_print("service: %s" % service)
-    paasta_print("cluster: %s" % cluster)
+    output = ['', 'service: %s' % service, 'cluster: %s' % cluster]
     seen_instances = []
     deployed_instances = []
 
@@ -237,8 +236,8 @@ def report_status_for_cluster(
 
         # Case: service NOT deployed to cluster.instance
         else:
-            paasta_print('  instance: %s' % PaastaColors.red(instance))
-            paasta_print('    Git sha:    None (not deployed yet)')
+            output.append('  instance: %s' % PaastaColors.red(instance))
+            output.append('    Git sha:    None (not deployed yet)')
 
     return_code = 0
     if len(deployed_instances) > 0:
@@ -258,17 +257,17 @@ def report_status_for_cluster(
         else:
             return_code, status = execute_paasta_serviceinit_on_remote_master(
                 'status', cluster, service, ','.join(deployed_instances),
-                system_paasta_config, stream=True, verbose=verbose,
+                system_paasta_config, stream=False, verbose=verbose,
                 ignore_ssh_output=True,
             )
             # Status results are streamed. This print is for possible error messages.
             if status is not None:
                 for line in status.rstrip().split('\n'):
-                    paasta_print('    %s' % line)
+                    output.append('    %s' % line)
 
-    paasta_print(report_invalid_whitelist_values(instance_whitelist, seen_instances, 'instance'))
+    output.append(report_invalid_whitelist_values(instance_whitelist, seen_instances, 'instance'))
 
-    return return_code
+    return return_code, output
 
 
 def report_invalid_whitelist_values(whitelist, items, item_type):
@@ -416,13 +415,14 @@ def paasta_status(args):
         use_api_endpoint = False
 
     return_codes = [0]
+    tasks = []
     clusters_services_instances = apply_args_filters(args)
     for cluster, service_instances in clusters_services_instances.items():
         for service, instances in service_instances.items():
             actual_deployments = get_actual_deployments(service, soa_dir)
             if actual_deployments:
                 deploy_pipeline = list(get_planned_deployments(service, soa_dir))
-                return_code = report_status_for_cluster(
+                tasks.append((report_status_for_cluster, dict(
                     service=service,
                     cluster=cluster,
                     deploy_pipeline=deploy_pipeline,
@@ -431,10 +431,16 @@ def paasta_status(args):
                     system_paasta_config=load_system_paasta_config(),
                     verbose=args.verbose,
                     use_api_endpoint=use_api_endpoint,
-                )
-                return_codes.append(return_code)
+                )))
             else:
                 paasta_print(missing_deployments_message(service))
                 return_codes.append(1)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
+        tasks = [executor.submit(t[0], **t[1]) for t in tasks]
+        for future in concurrent.futures.as_completed(tasks):
+            return_code, output = future.result()
+            paasta_print('\n'.join(output))
+            return_codes.append(return_code)
 
     return max(return_codes)

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -12,8 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import difflib
 import concurrent.futures
+import difflib
 import os
 import sys
 from collections import defaultdict
@@ -422,16 +422,18 @@ def paasta_status(args):
             actual_deployments = get_actual_deployments(service, soa_dir)
             if actual_deployments:
                 deploy_pipeline = list(get_planned_deployments(service, soa_dir))
-                tasks.append((report_status_for_cluster, dict(
-                    service=service,
-                    cluster=cluster,
-                    deploy_pipeline=deploy_pipeline,
-                    actual_deployments=actual_deployments,
-                    instance_whitelist=instances,
-                    system_paasta_config=load_system_paasta_config(),
-                    verbose=args.verbose,
-                    use_api_endpoint=use_api_endpoint,
-                )))
+                tasks.append((
+                    report_status_for_cluster, dict(
+                        service=service,
+                        cluster=cluster,
+                        deploy_pipeline=deploy_pipeline,
+                        actual_deployments=actual_deployments,
+                        instance_whitelist=instances,
+                        system_paasta_config=load_system_paasta_config(),
+                        verbose=args.verbose,
+                        use_api_endpoint=use_api_endpoint,
+                    ),
+                ))
             else:
                 paasta_print(missing_deployments_message(service))
                 return_codes.append(1)

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -408,6 +408,7 @@ def paasta_status(args):
     """Print the status of a Yelp service running on PaaSTA.
     :param args: argparse.Namespace obj created from sys.args by cli"""
     soa_dir = args.soa_dir
+    system_paasta_config = load_system_paasta_config()
 
     if 'USE_API_ENDPOINT' in os.environ:
         use_api_endpoint = strtobool(os.environ.get('USE_API_ENDPOINT'))
@@ -429,7 +430,7 @@ def paasta_status(args):
                         deploy_pipeline=deploy_pipeline,
                         actual_deployments=actual_deployments,
                         instance_whitelist=instances,
-                        system_paasta_config=load_system_paasta_config(),
+                        system_paasta_config=system_paasta_config,
                         verbose=args.verbose,
                         use_api_endpoint=use_api_endpoint,
                     ),

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -26,7 +26,6 @@ from socket import gethostbyname_ex
 
 from bravado.exception import HTTPError
 from bravado.exception import HTTPNotFound
-from service_configuration_lib import read_services_configuration
 
 from paasta_tools.adhoc_tools import load_adhoc_job_config
 from paasta_tools.api import client

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -341,7 +341,8 @@ def validate_service_name(service, soa_dir=DEFAULT_SOA_DIR):
 
 def list_services(**kwargs):
     """Returns a sorted list of all services"""
-    return sorted(read_services_configuration().keys())
+    soa_dir = kwargs.get('soa_dir', DEFAULT_SOA_DIR)
+    return sorted(os.listdir(os.path.abspath(soa_dir)))
 
 
 def list_paasta_services():

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -64,10 +64,12 @@ def test_figure_out_service_name_not_found(
 
 
 @patch('paasta_tools.cli.cmds.status.list_clusters', autospec=True)
+@patch('paasta_tools.cli.cmds.status.load_system_paasta_config', autospec=True)
 @patch('paasta_tools.cli.utils.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.utils.guess_service_name', autospec=True)
 def test_status_arg_service_not_found(
-    mock_guess_service_name, mock_validate_service_name, mock_list_clusters, capfd,
+    mock_guess_service_name, mock_validate_service_name,
+    mock_load_system_paasta_config, mock_list_clusters, capfd,
     system_paasta_config,
 ):
     # paasta_status with no args and non-service directory results in error
@@ -75,6 +77,7 @@ def test_status_arg_service_not_found(
     error = NoSuchService('fake_service')
     mock_validate_service_name.side_effect = error
     mock_list_clusters.return_value = ['cluster1']
+    mock_load_system_paasta_config.return_value = system_paasta_config
     expected_output = str(error) + "\n"
 
     args = MagicMock()

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -101,7 +101,6 @@ def test_status_arg_service_not_found(
 def test_report_status_for_cluster_displays_deployed_service(
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
-    capfd,
     system_paasta_config,
 ):
     # paasta_status with no args displays deploy info - vanilla case
@@ -144,7 +143,6 @@ def test_report_status_for_cluster_displays_deployed_service(
 def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_serviceinit_on_remote_master(
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
-    capfd,
     system_paasta_config,
 ):
     # paasta_status with no args displays deploy info - vanilla case
@@ -182,7 +180,6 @@ def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_s
 def test_report_status_for_cluster_instance_sorts_in_deploy_order(
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
-    capfd,
     system_paasta_config,
 ):
     # paasta_status with no args displays deploy info
@@ -229,7 +226,6 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
 def test_print_cluster_status_missing_deploys_in_red(
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
-    capfd,
     system_paasta_config,
 ):
     # paasta_status displays missing deploys in red
@@ -279,7 +275,6 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
     verbosity_level,
-    capfd,
     system_paasta_config,
 ):
     service = 'fake_service'
@@ -322,7 +317,6 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
 def test_report_status_for_cluster_obeys_instance_whitelist(
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
-    capfd,
     system_paasta_config,
 ):
     service = 'fake_service'
@@ -357,7 +351,6 @@ def test_report_status_for_cluster_obeys_instance_whitelist(
 def test_report_status_calls_report_invalid_whitelist_values(
     mock_report_invalid_whitelist_values,
     mock_execute_paasta_serviceinit_on_remote_master,
-    capfd,
     system_paasta_config,
 ):
     service = 'fake_service'
@@ -472,7 +465,6 @@ def test_status_calls_sergeants(
     mock_load_system_paasta_config,
     mock_list_services,
     mock_get_instance_configs_for_service,
-    capfd,
     system_paasta_config,
 ):
     service = 'fake_service'
@@ -757,7 +749,7 @@ def test_verify_instances_with_clusters(mock_paasta_print, mock_list_all_instanc
 def test_status_with_owner(
         mock_report_status, mock_load_system_paasta_config, mock_get_actual_deployments,
         mock_figure_out_service_name, mock_list_services,
-        mock_get_instance_configs_for_service, capfd,
+        mock_get_instance_configs_for_service,
         system_paasta_config,
 ):
     mock_load_system_paasta_config.return_value = system_paasta_config

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -68,6 +68,7 @@ def test_figure_out_service_name_not_found(
 @patch('paasta_tools.cli.utils.guess_service_name', autospec=True)
 def test_status_arg_service_not_found(
     mock_guess_service_name, mock_validate_service_name, mock_list_clusters, capfd,
+    system_paasta_config
 ):
     # paasta_status with no args and non-service directory results in error
     mock_guess_service_name.return_value = 'not_a_service'

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -119,7 +119,7 @@ def test_report_status_for_cluster_displays_deployed_service(
         % (fake_status)
     )
 
-    status.report_status_for_cluster(
+    _, output = status.report_status_for_cluster(
         service=service,
         cluster='fake_cluster',
         deploy_pipeline=planned_deployments,
@@ -127,11 +127,11 @@ def test_report_status_for_cluster_displays_deployed_service(
         instance_whitelist=instance_whitelist,
         system_paasta_config=system_paasta_config,
     )
-    output, _ = capfd.readouterr()
+    output = '\n'.join(str(line) for line in output)
     assert expected_output in output
     mock_execute_paasta_serviceinit_on_remote_master.assert_called_once_with(
         'status', 'fake_cluster', 'fake_service', 'fake_instance',
-        system_paasta_config, stream=True, verbose=0, ignore_ssh_output=True,
+        system_paasta_config, stream=False, verbose=0, ignore_ssh_output=True,
     )
 
 
@@ -161,7 +161,7 @@ def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_s
         "    on another line!\n"
     )
 
-    status.report_status_for_cluster(
+    _, output = status.report_status_for_cluster(
         service=service,
         cluster='cluster',
         deploy_pipeline=planned_deployments,
@@ -169,7 +169,7 @@ def test_report_status_for_cluster_displays_multiple_lines_from_execute_paasta_s
         instance_whitelist=instance_whitelist,
         system_paasta_config=system_paasta_config,
     )
-    output, _ = capfd.readouterr()
+    output = '\n'.join(str(line) for line in output)
     assert expected_output in output
 
 
@@ -204,7 +204,7 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
         % (fake_status)
     )
 
-    status.report_status_for_cluster(
+    _, output = status.report_status_for_cluster(
         service=service,
         cluster='fake_cluster',
         deploy_pipeline=planned_deployments,
@@ -212,11 +212,11 @@ def test_report_status_for_cluster_instance_sorts_in_deploy_order(
         instance_whitelist=instance_whitelist,
         system_paasta_config=system_paasta_config,
     )
-    output, _ = capfd.readouterr()
+    output = '\n'.join(str(line) for line in output)
     assert expected_output in output
     mock_execute_paasta_serviceinit_on_remote_master.assert_called_once_with(
         'status', 'fake_cluster', 'fake_service', 'fake_instance_a,fake_instance_b',
-        system_paasta_config, stream=True, verbose=0, ignore_ssh_output=True,
+        system_paasta_config, stream=False, verbose=0, ignore_ssh_output=True,
     )
 
 
@@ -255,7 +255,7 @@ def test_print_cluster_status_missing_deploys_in_red(
         )
     )
 
-    status.report_status_for_cluster(
+    _, output = status.report_status_for_cluster(
         service=service,
         cluster='a_cluster',
         deploy_pipeline=planned_deployments,
@@ -263,7 +263,8 @@ def test_print_cluster_status_missing_deploys_in_red(
         instance_whitelist=instance_whitelist,
         system_paasta_config=system_paasta_config,
     )
-    output, _ = capfd.readouterr()
+
+    output = '\n'.join(str(line) for line in output)
     assert expected_output in output
 
 
@@ -293,7 +294,7 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
         fake_output,
     )
     expected_output = "    %s\n" % fake_output
-    status.report_status_for_cluster(
+    _, output = status.report_status_for_cluster(
         service=service,
         cluster='a_cluster',
         deploy_pipeline=planned_deployments,
@@ -305,10 +306,10 @@ def test_print_cluster_status_calls_execute_paasta_serviceinit_on_remote_master(
     assert mock_execute_paasta_serviceinit_on_remote_master.call_count == 1
     mock_execute_paasta_serviceinit_on_remote_master.assert_any_call(
         'status', 'a_cluster', service, 'a_instance', system_paasta_config,
-        stream=True, verbose=verbosity_level, ignore_ssh_output=True,
+        stream=False, verbose=verbosity_level, ignore_ssh_output=True,
     )
 
-    output, _ = capfd.readouterr()
+    output = '\n'.join(str(line) for line in output)
     assert expected_output in output
 
 
@@ -343,7 +344,7 @@ def test_report_status_for_cluster_obeys_instance_whitelist(
     )
     mock_execute_paasta_serviceinit_on_remote_master.assert_called_once_with(
         'status', 'fake_cluster', 'fake_service', 'fake_instance_a',
-        system_paasta_config, stream=True, verbose=0, ignore_ssh_output=True,
+        system_paasta_config, stream=False, verbose=0, ignore_ssh_output=True,
     )
 
 
@@ -490,7 +491,7 @@ def test_status_calls_sergeants(
     }
     mock_get_actual_deployments.return_value = actual_deployments
     mock_load_system_paasta_config.return_value = system_paasta_config
-    mock_report_status.return_value = 1776
+    mock_report_status.return_value = 1776, ['dummy', 'output']
 
     args = MagicMock()
     args.service = service
@@ -771,7 +772,7 @@ def test_status_with_owner(
         'otherservice.instance3': 'sha3',
         'otherservice.instance1': 'sha4',
     }
-    mock_report_status.return_value = 0
+    mock_report_status.return_value = 0, ['dummy', 'output']
 
     args = MagicMock()
     args.service = None

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -68,7 +68,7 @@ def test_figure_out_service_name_not_found(
 @patch('paasta_tools.cli.utils.guess_service_name', autospec=True)
 def test_status_arg_service_not_found(
     mock_guess_service_name, mock_validate_service_name, mock_list_clusters, capfd,
-    system_paasta_config
+    system_paasta_config,
 ):
     # paasta_status with no args and non-service directory results in error
     mock_guess_service_name.return_value = 'not_a_service'


### PR DESCRIPTION
This makes paasta status take max(latencies) instead of sum(latencies), with respect to paasta_serviceinit time to complete.