### PR TITLE
Enabled paasta_remote_run to connect to diffferent mesos clusters

### DIFF
--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -97,6 +97,9 @@
             },
             "pool": {
                 "type": "string"
+            },
+            "role": {
+                "type": "string"
             }
         }
     }

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -116,6 +116,17 @@ def is_mesos_leader(hostname=MY_HOSTNAME):
     return get_mesos_leader() == hostname
 
 
+def find_mesos_leader(master):
+    """ Find the leader with redirect given one mesos master.
+    """
+    if master is None:
+        raise ValueError("Mesos master is required to find leader")
+
+    url = "http://%s:%s/redirect" % (master, MESOS_MASTER_PORT)
+    response = requests.get(url)
+    return urlparse(response.url).hostname
+
+
 def get_current_tasks(job_id):
     """ Returns a list of all the tasks with a given job id.
     :param job_id: the job id of the tasks.

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -190,6 +190,7 @@ InstanceConfigDict = TypedDict(
         'deploy_whitelist': UnsafeDeployWhitelist,
         'monitoring_blacklist': UnsafeDeployBlacklist,
         'pool': str,
+        'role': str,
         'extra_volumes': List[DockerVolume],
         'security': SecurityConfigDict,
         'dependencies_reference': str,
@@ -623,6 +624,11 @@ class InstanceConfig(object):
         conform to the `Mesos container volumes spec
         <https://mesosphere.github.io/marathon/docs/native-docker.html>`_"""
         return self.config_dict.get('extra_volumes', [])
+
+    def get_role(self) -> Optional[str]:
+        """Which mesos role of nodes this job should run on.
+        """
+        return self.config_dict.get('role')
 
     def get_pool(self) -> str:
         """Which pool of nodes this job should run on. This can be used to mitigate noisy neighbors, by putting
@@ -1315,6 +1321,13 @@ LocalRunConfig = TypedDict(
     },
     total=False,
 )
+RemoteRunConfig = TypedDict(
+    'RemoteRunConfig',
+    {
+        'default_role': str,
+    },
+    total=False,
+)
 PaastaNativeConfig = TypedDict(
     'PaastaNativeConfig',
     {
@@ -1356,6 +1369,7 @@ SystemPaastaConfigDict = TypedDict(
         'marathon_servers': List[MarathonConfigDict],
         'previous_marathon_servers': List[MarathonConfigDict],
         'local_run_config': LocalRunConfig,
+        'remote_run_config': RemoteRunConfig,
         'paasta_native': PaastaNativeConfig,
         'mesos_config': Dict,
         'monitoring_config': Dict,
@@ -1626,6 +1640,12 @@ class SystemPaastaConfig(object):
 
         :returns: The local-run job config dictionary"""
         return self.config_dict.get('local_run_config', {})
+
+    def get_remote_run_config(self) -> RemoteRunConfig:
+        """Get the remote-run config
+
+        :returns: The remote-run system_paasta_config dictionary"""
+        return self.config_dict.get('remote_run_config', {})
 
     def get_paasta_native_config(self) -> PaastaNativeConfig:
         return self.config_dict.get('paasta_native', {})


### PR DESCRIPTION
This is for TASKPROC-166 to enable paasta_remote_run schedule tasks on more than one mesos clusters. Note that "role" is added to adhoc schema so that resources with non-taskproc role can be used. This also helps TASKPROC-169 where "paasta remote_run" was stuck because resources with "*" role do not match the default taskproc role.

The change is tested on devc:
tronplayground-uswest1adevc: $ sudo .tox/py36/bin/paasta_remote_run.py start --service taskproc_canary --instance remote --cluster norcal-stageg --verbose
tronplayground-uswest1adevc: $ sudo .tox/py36/bin/paasta_remote_run.py start --service taskproc_canary --instance remote --cluster norcal-devc --verbose
