### PR TITLE
Allow auto hostname unique in non-prod clusters

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -544,19 +544,17 @@ class MarathonServiceConfig(LongRunningServiceConfig):
             system_paasta_config: SystemPaastaConfig,
     ) -> List[Constraint]:
         """
-        "Small" services running in a production cluster automatically receive a running
-        in a production cluster automatically receive a hostname UNIQUE constraint to reduce
+        "Small" services automatically receive a hostname UNIQUE constraint to reduce
         the risk of all tasks getting launched on the same agent, which might then be lost.
 
         :param system_paasta_config: A SystemPaastaConfig object representing the system
                                  configuration.
         :returns: a set of constraints for marathon
         """
-        if 'prod' in self.cluster:
-            auto_hostname_unique_size = system_paasta_config.get_auto_hostname_unique_size()
-            app_size = self.get_max_instances() or self.get_desired_instances()
-            if app_size <= auto_hostname_unique_size:
-                return [["hostname", "UNIQUE"]]
+        auto_hostname_unique_size = system_paasta_config.get_auto_hostname_unique_size()
+        app_size = self.get_max_instances() or self.get_desired_instances()
+        if app_size <= auto_hostname_unique_size:
+            return [["hostname", "UNIQUE"]]
         return []
 
     def get_routing_constraints(

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1162,29 +1162,6 @@ class TestMarathonTools:
         )
         assert actual == expected_constraints
 
-    def test_get_calculated_constraints_non_prod_no_hostname_unique(self):
-        fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig()
-        fake_conf = marathon_tools.MarathonServiceConfig(
-            service='fake_name',
-            cluster='fake_dev_cluster',
-            instance='fake_instance',
-            config_dict={'instances': 3},
-            branch_dict={},
-        )
-        fake_system_paasta_config = SystemPaastaConfig(
-            {
-                "auto_hostname_unique_size": 3,
-            }, "/foo",
-        )
-        expected_constraints = [
-            ["pool", "LIKE", "default"],
-        ]
-        actual = fake_conf.get_calculated_constraints(
-            service_namespace_config=fake_service_namespace_config,
-            system_paasta_config=fake_system_paasta_config,
-        )
-        assert actual == expected_constraints
-
     def test_get_calculated_constraints_no_config_no_hostname_unique(self):
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig()
         fake_conf = marathon_tools.MarathonServiceConfig(


### PR DESCRIPTION
I originally made paasta only add the hostname unique constraint to small services running in production clusters. Enforcing this in code was rather stupid. We have the system paasta config setting. Simply omitting it from our non-production clusters will be sufficient. This will also give us the ability to test this feature more in non-prod clusters.