### PR TITLE
Enable yaml-cache in deployd

### DIFF
--- a/paasta_tools/deployd/common.py
+++ b/paasta_tools/deployd/common.py
@@ -10,6 +10,8 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
+import service_configuration_lib
+
 from paasta_tools.marathon_tools import DEFAULT_SOA_DIR
 from paasta_tools.marathon_tools import get_all_marathon_apps
 from paasta_tools.marathon_tools import get_marathon_clients
@@ -198,3 +200,17 @@ def get_marathon_clients_from_config() -> MarathonClients:
     marathon_servers = get_marathon_servers(system_paasta_config)
     marathon_clients = get_marathon_clients(marathon_servers)
     return marathon_clients
+
+
+def clear_yaml_cache(service_name=None):
+    if not service_name:
+        print("Deleting all from yaml cache")
+        service_configuration_lib._yaml_cache = {}
+        return
+    keys_to_delete = []
+    for key in service_configuration_lib._yaml_cache.keys():
+        if service_name in key.split('/'):
+            keys_to_delete.append(key)
+    for key in keys_to_delete:
+        print("Deleting {} from cache".format(key))
+        service_configuration_lib._yaml_cache.pop(key)

--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -7,8 +7,6 @@ import sys
 import time
 from queue import Empty
 
-import service_configuration_lib
-
 from paasta_tools.deployd import watchers
 from paasta_tools.deployd.common import get_marathon_clients_from_config
 from paasta_tools.deployd.common import PaastaPriorityQueue
@@ -128,7 +126,6 @@ class DeployDaemon(PaastaThread):
         super(DeployDaemon, self).__init__()
         self.started = False
         self.daemon = True
-        service_configuration_lib.disable_yaml_cache()
         self.config = load_system_paasta_config()
         self.setup_logging()
         self.bounce_q = DedupedPriorityQueue("BounceQueue")

--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -13,6 +13,7 @@ from kazoo.recipe.watchers import ChildrenWatch
 from kazoo.recipe.watchers import DataWatch
 from requests.exceptions import RequestException
 
+from paasta_tools.deployd.common import clear_yaml_cache
 from paasta_tools.deployd.common import get_marathon_clients_from_config
 from paasta_tools.deployd.common import get_service_instances_needing_update
 from paasta_tools.deployd.common import PaastaThread
@@ -247,6 +248,7 @@ class PublicConfigEventHandler(pyinotify.ProcessEvent):
                 return
             service_instances: List[Tuple[str, str]] = []
             if new_config != self.public_config:
+                clear_yaml_cache()
                 self.log.info("Public config has changed, now checking if it affects any services config shas")
                 self.public_config = new_config
                 all_service_instances = get_services_for_cluster(
@@ -319,6 +321,7 @@ class YelpSoaEventHandler(pyinotify.ProcessEvent):
 
     def bounce_service(self, service_name):
         self.log.info("Checking if any instances for {} need bouncing".format(service_name))
+        clear_yaml_cache(service_name)
         instances = list_all_instances_for_service(
             service=service_name,
             clusters=[self.filewatcher.cluster],

--- a/paasta_tools/deployd/workers.py
+++ b/paasta_tools/deployd/workers.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 
 from paasta_tools import marathon_tools
 from paasta_tools.deployd.common import BounceTimers
+from paasta_tools.deployd.common import clear_yaml_cache
 from paasta_tools.deployd.common import exponential_back_off
 from paasta_tools.deployd.common import PaastaThread
 from paasta_tools.deployd.common import ServiceInstance
@@ -97,6 +98,7 @@ class PaastaDeployWorker(PaastaThread):
     def process_service_instance(self, service_instance):
         bounce_timers = self.setup_timers(service_instance)
         self.log.info("{} processing {}.{}".format(self.name, service_instance.service, service_instance.instance))
+        clear_yaml_cache(service_instance.service)
 
         bounce_timers.setup_marathon.start()
         return_code, bounce_again_in_seconds = deploy_marathon_service(

--- a/tests/deployd/test_common.py
+++ b/tests/deployd/test_common.py
@@ -3,6 +3,7 @@ import unittest
 import mock
 
 from paasta_tools.deployd.common import BaseServiceInstance
+from paasta_tools.deployd.common import clear_yaml_cache
 from paasta_tools.deployd.common import exponential_back_off
 from paasta_tools.deployd.common import get_marathon_clients_from_config
 from paasta_tools.deployd.common import get_priority
@@ -310,3 +311,26 @@ def test_get_marathon_clients_from_config():
         'paasta_tools.deployd.common.get_marathon_clients', autospec=True,
     ) as mock_marathon_clients:
         assert get_marathon_clients_from_config() == mock_marathon_clients.return_value
+
+
+def test_clear_yaml_cache():
+    with mock.patch(
+        'paasta_tools.deployd.common.service_configuration_lib', autospec=True,
+    ) as mock_config_lib:
+        mock_config_lib._yaml_cache = {}
+        assert clear_yaml_cache('universe') is None
+        assert mock_config_lib._yaml_cache == {}
+
+        mock_config_lib._yaml_cache = {
+            '/some/universe/blah.yaml': 'data',
+            '/some/multiverse/blah.yaml': 'moredata',
+        }
+        assert clear_yaml_cache('universe') is None
+        assert mock_config_lib._yaml_cache == {'/some/multiverse/blah.yaml': 'moredata'}
+
+        mock_config_lib._yaml_cache = {
+            '/some/universe/blah.yaml': 'data',
+            '/some/multiverse/blah.yaml': 'moredata',
+        }
+        assert clear_yaml_cache() is None
+        assert mock_config_lib._yaml_cache == {}


### PR DESCRIPTION
This re-enables the yaml cache in deployd whilst strategically clearing
the cache when deployd needs to be sure it is reading the latest data
from disk.

I'm pretty sure I caught all the places where I need to clear this
cache. Specifically, I've done anywhere in a watcher where the watcher
is using those yaml files to make a decision. I've also cleared it in
the worker before the worker runs SMJ for that service.