### PR TITLE
Close connections to Zookeeper properly

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -756,3 +756,4 @@ def create_autoscaling_lock():
         lock.release()
     finally:
         zk.stop()
+        zk.close()

--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -139,6 +139,7 @@ def bounce_lock_zookeeper(name):
         lock.release()
     finally:
         zk.stop()
+        zk.close()
 
 
 def wait_for_create(app_id, client):

--- a/paasta_tools/frameworks/native_scheduler.py
+++ b/paasta_tools/frameworks/native_scheduler.py
@@ -137,6 +137,7 @@ class NativeScheduler(Scheduler):
         for task, parameters in self.task_store.get_all_tasks().items():
             if parameters.mesos_task_state in LIVE_TASK_STATES:
                 self.kill_task(driver, task)
+        self.task_store.close()
 
     def registered(self, driver: MesosSchedulerDriver, frameworkId, masterInfo):
         self.framework_id = frameworkId['value']

--- a/paasta_tools/frameworks/task_store.py
+++ b/paasta_tools/frameworks/task_store.py
@@ -154,7 +154,10 @@ class ZKTaskStore(TaskStore):
         self.zk_client = KazooClient(hosts='%s/%s' % (self.zk_hosts, chroot))
         self.zk_client.start()
         self.zk_client.ensure_path('/')
-        # TODO: call self.zk_client.stop() and .close()
+
+    def close(self):
+        self.zk_client.stop()
+        self.zk_client.close()
 
     def get_task(self, task_id: str) -> MesosTaskParameters:
         params, stat = self._get_task(task_id)

--- a/paasta_tools/frameworks/task_store.py
+++ b/paasta_tools/frameworks/task_store.py
@@ -115,6 +115,9 @@ class TaskStore(object):
         # TODO: implement in base class.
         raise NotImplementedError()
 
+    def close(self):
+        pass
+
 
 class DictTaskStore(TaskStore):
     def __init__(self, service_name, instance_name, framework_id, system_paasta_config):

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -536,10 +536,17 @@ def get_number_of_mesos_masters(host, path):
     """
     zk = KazooClient(hosts=host, read_only=True)
     zk.start()
-    root_entries = zk.get_children(path)
-    result = [info for info in root_entries if info.startswith('json.info_') or info.startswith('info_')]
-    zk.stop()
-    return len(result)
+    try:
+        root_entries = zk.get_children(path)
+        result = [
+            info
+            for info in root_entries
+            if info.startswith('json.info_') or info.startswith('info_')
+        ]
+        return len(result)
+    finally:
+        zk.stop()
+        zk.close()
 
 
 def get_all_slaves_for_blacklist_whitelist(blacklist: DeployBlacklist, whitelist: DeployWhitelist):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ humanize==0.5.1
 inotify==0.2.8
 isodate==0.5.1
 jsonschema[format]==2.5.1
-kazoo==2.2
+kazoo==2.4
 marathon==0.9.3
 mypy_extensions
 ply==3.4


### PR DESCRIPTION
We seem to be leaking file descriptors of ZK clients. Calling `zk.stop()` is not enough so add a bunch of `zk.close()` calls where appropriate.