### PR TITLE
validate error message improvement

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -102,15 +102,15 @@ def validate_schema(file_path, file_type):
     extension = os.path.splitext(basename)[1]
     try:
         config_file = get_file_contents(file_path)
-    except IOError:
+        if extension == '.yaml':
+            config_file_object = yaml.safe_load(config_file)
+        elif extension == '.json':
+            config_file_object = json.loads(config_file)
+        else:
+            config_file_object = config_file
+    except Exception:
         paasta_print('%s: %s' % (FAILED_READING_FILE, file_path))
-        return False
-    if extension == '.yaml':
-        config_file_object = yaml.safe_load(config_file)
-    elif extension == '.json':
-        config_file_object = json.loads(config_file)
-    else:
-        config_file_object = config_file
+        raise
     try:
         validator.validate(config_file_object)
     except ValidationError:


### PR DESCRIPTION
Here is the new error message looks like:

✓ Successfully validated schema: chronos-nova-prod.yaml
✓ Successfully validated schema: adhoc-norcal-prod.yaml
✓ Successfully validated schema: chronos-norcal-prod.yaml
✓ Successfully validated schema: marathon-pnw-prod.yaml
✗ Failed to load file. More info: http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html: /nail/home/chl/git/yelpsoa-configs/yelp-main/marathon-norcal-stagef.yaml
Traceback (most recent call last):
  File "/nail/home/chl/paasta/.tox/py36/bin/paasta", line 11, in <module>
    load_entry_point('paasta-tools', 'console_scripts', 'paasta')()
  File "/nail/home/chl/paasta/paasta_tools/cli/cli.py", line 121, in main
    return_code = args.command(args)
  File "/nail/home/chl/paasta/paasta_tools/cli/cmds/validate.py", line 295, in paasta_validate
    if not paasta_validate_soa_configs(service_path):
  File "/nail/home/chl/paasta/paasta_tools/cli/cmds/validate.py", line 277, in paasta_validate_soa_configs
    if not validate_all_schemas(service_path):
  File "/nail/home/chl/paasta/paasta_tools/cli/cmds/validate.py", line 151, in validate_all_schemas
    if not validate_schema(file_name, file_type):
  File "/nail/home/chl/paasta/paasta_tools/cli/cmds/validate.py", line 115, in validate_schema
    config_file_object = yaml.safe_load(config_file)
  File "/nail/home/chl/paasta/.tox/py36/lib/python3.6/site-packages/yaml/__init__.py", line 94, in safe_load
    return load(stream, SafeLoader)
  File "/nail/home/chl/paasta/.tox/py36/lib/python3.6/site-packages/yaml/__init__.py", line 72, in load
    return loader.get_single_data()
  File "/nail/home/chl/paasta/.tox/py36/lib/python3.6/site-packages/yaml/constructor.py", line 35, in get_single_data
    node = self.get_single_node()
  File "/nail/home/chl/paasta/.tox/py36/lib/python3.6/site-packages/yaml/composer.py", line 36, in get_single_node
    document = self.compose_document()
  File "/nail/home/chl/paasta/.tox/py36/lib/python3.6/site-packages/yaml/composer.py", line 55, in compose_document
    node = self.compose_node(None, None)
  File "/nail/home/chl/paasta/.tox/py36/lib/python3.6/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/nail/home/chl/paasta/.tox/py36/lib/python3.6/site-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "/nail/home/chl/paasta/.tox/py36/lib/python3.6/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/nail/home/chl/paasta/.tox/py36/lib/python3.6/site-packages/yaml/composer.py", line 127, in compose_mapping_node
    while not self.check_event(MappingEndEvent):
  File "/nail/home/chl/paasta/.tox/py36/lib/python3.6/site-packages/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
  File "/nail/home/chl/paasta/.tox/py36/lib/python3.6/site-packages/yaml/parser.py", line 428, in parse_block_mapping_key
    if self.check_token(KeyToken):
  File "/nail/home/chl/paasta/.tox/py36/lib/python3.6/site-packages/yaml/scanner.py", line 116, in check_token
    self.fetch_more_tokens()
  File "/nail/home/chl/paasta/.tox/py36/lib/python3.6/site-packages/yaml/scanner.py", line 220, in fetch_more_tokens
    return self.fetch_value()
  File "/nail/home/chl/paasta/.tox/py36/lib/python3.6/site-packages/yaml/scanner.py", line 580, in fetch_value
    self.get_mark())
yaml.scanner.ScannerError: mapping values are not allowed here
  in "<unicode string>", line 1499, column 8:
        env:
           ^