### PR TITLE
Opinions welcome: Convert service autoscaler to use asyncio

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-concurrency = gevent
+concurrency = thread
 branch = True
 source = .
 omit =

--- a/paasta_itests/steps/autoscaling_service_steps.py
+++ b/paasta_itests/steps/autoscaling_service_steps.py
@@ -1,3 +1,4 @@
+import a_sync
 from behave import given
 from behave import then
 from behave import when
@@ -17,11 +18,15 @@ def make_fake_historical_load_data(context):
 
 @when('I save the fake historical load data')
 def save_fake_historical_load_data(context):
-    autoscaling_service_lib.save_historical_load(context.fake_historical_load_data, '/itest/fake_historical_load_data')
+    a_sync.block(
+        autoscaling_service_lib.save_historical_load,
+        context.fake_historical_load_data,
+        '/itest/fake_historical_load_data',
+    )
 
 
 @then('I should get the same fake historical load data back when I fetch it')
 def load_fake_historical_load_data(context):
-    actual = autoscaling_service_lib.fetch_historical_load('/itest/fake_historical_load_data')
+    actual = a_sync.block(autoscaling_service_lib.fetch_historical_load, '/itest/fake_historical_load_data')
     expected = context.fake_historical_load_data
     assert actual == expected

--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -231,7 +231,6 @@ async def get_json_body_from_service(host, port, endpoint, session, timeout=2):
         'http://%s:%s/%s' % (host, port, endpoint),
         headers={'User-Agent': get_user_agent()}, timeout=timeout,
     ) as resp:
-        print(f"resp = {resp!r}")
         return await resp.json()
 
 
@@ -721,7 +720,7 @@ def autoscale_services(soa_dir=DEFAULT_SOA_DIR):
                                 all_mesos_tasks,
                                 config,
                             )
-                            autoscale_marathon_instance(
+                            await autoscale_marathon_instance(
                                 config,
                                 system_paasta_config,
                                 list(marathon_tasks.values()),


### PR DESCRIPTION
This changes the interface of several autoscaling_service_lib functions to be coroutines instead.