### PR TITLE
Make paasta status display information about all marathon apps, even without -v.

### DIFF
--- a/paasta_itests/steps/paasta_serviceinit_steps.py
+++ b/paasta_itests/steps/paasta_serviceinit_steps.py
@@ -74,14 +74,19 @@ def status_marathon_job(context, status, job_id):
     app_id = job_config.format_marathon_app_dict()['id']
 
     with requests_cache.disabled():
-        output = marathon_serviceinit.status_marathon_job(
-            service,
-            instance,
-            app_id,
-            normal_instance_count,
-            context.marathon_clients.get_current_client_for_service(job_config),
+        tasks, output = marathon_serviceinit.status_marathon_job(
+            service=service,
+            instance=instance,
+            cluster=load_system_paasta_config().get_cluster(),
+            soa_dir=context.soa_dir,
+            dashboards=None,
+            normal_instance_count=normal_instance_count,
+            clients=context.marathon_clients,
+            job_config=job_config,
+            desired_app_id=app_id,
+            verbose=0,
         )
-    assert status in output
+    assert status in output, f"{status!r} not found in {output!r}"
 
 
 @then('marathon_serviceinit restart should get new task_ids for "{job_id}"')

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -17,6 +17,7 @@ PaaSTA service instance status/start/stop etc.
 """
 import traceback
 
+import marathon
 from pyramid.response import Response
 from pyramid.view import view_config
 
@@ -105,26 +106,29 @@ def marathon_job_status(mstatus, client, job_config, verbose):
         error_msg = "Docker image is not in deployments.json."
         mstatus['error_message'] = error_msg
         return
-    app = client.get_app(app_id)
 
     mstatus['app_id'] = app_id
     if verbose is True:
         mstatus['slaves'] = list({task.slave['hostname'] for task in get_running_tasks_from_frameworks(app_id)})
     mstatus['expected_instance_count'] = job_config.get_instances()
 
-    deploy_status = marathon_tools.get_marathon_app_deploy_status(client, app)
-    mstatus['deploy_status'] = marathon_tools.MarathonDeployStatus.tostring(deploy_status)
-
-    # by comparing running count with expected count, callers can figure
-    # out if the instance is in Healthy, Warning or Critical state.
-    if deploy_status == marathon_tools.MarathonDeployStatus.NotRunning:
+    try:
+        app = client.get_app(app_id)
+    except marathon.exceptions.NotFoundError:
+        mstatus['deploy_status'] = marathon_tools.MarathonDeployStatus.tostring(
+            marathon_tools.MarathonDeployStatus.NotRunning,
+        )
         mstatus['running_instance_count'] = 0
     else:
+        deploy_status = marathon_tools.get_marathon_app_deploy_status(client, app)
+        mstatus['deploy_status'] = marathon_tools.MarathonDeployStatus.tostring(deploy_status)
+        # by comparing running count with expected count, callers can figure
+        # out if the instance is in Healthy, Warning or Critical state.
         mstatus['running_instance_count'] = app.tasks_running
 
-    if deploy_status == marathon_tools.MarathonDeployStatus.Delayed:
-        _, backoff_seconds = marathon_tools.get_app_queue_status(client, app_id)
-        mstatus['backoff_seconds'] = backoff_seconds
+        if deploy_status == marathon_tools.MarathonDeployStatus.Delayed:
+            _, backoff_seconds = marathon_tools.get_app_queue_status(client, app_id)
+            mstatus['backoff_seconds'] = backoff_seconds
 
 
 def marathon_instance_status(instance_status, service, instance, verbose):

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -105,13 +105,14 @@ def marathon_job_status(mstatus, client, job_config, verbose):
         error_msg = "Docker image is not in deployments.json."
         mstatus['error_message'] = error_msg
         return
+    app = client.get_app(app_id)
 
     mstatus['app_id'] = app_id
     if verbose is True:
         mstatus['slaves'] = list({task.slave['hostname'] for task in get_running_tasks_from_frameworks(app_id)})
     mstatus['expected_instance_count'] = job_config.get_instances()
 
-    deploy_status = marathon_tools.get_marathon_app_deploy_status(client, app_id)
+    deploy_status = marathon_tools.get_marathon_app_deploy_status(client, app)
     mstatus['deploy_status'] = marathon_tools.MarathonDeployStatus.tostring(deploy_status)
 
     # by comparing running count with expected count, callers can figure
@@ -119,7 +120,7 @@ def marathon_job_status(mstatus, client, job_config, verbose):
     if deploy_status == marathon_tools.MarathonDeployStatus.NotRunning:
         mstatus['running_instance_count'] = 0
     else:
-        mstatus['running_instance_count'] = client.get_app(app_id).tasks_running
+        mstatus['running_instance_count'] = app.tasks_running
 
     if deploy_status == marathon_tools.MarathonDeployStatus.Delayed:
         _, backoff_seconds = marathon_tools.get_app_queue_status(client, app_id)

--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -46,6 +46,7 @@ from paasta_tools.marathon_tools import is_task_healthy
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.marathon_tools import MESOS_TASK_SPACER
 from paasta_tools.mesos_tools import get_all_running_tasks
+from paasta_tools.mesos_tools import get_cached_list_of_running_tasks_from_frameworks
 from paasta_tools.utils import _log
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -454,10 +455,9 @@ def get_error_from_utilization(utilization, setpoint, current_instances):
         return 0.0
 
 
-def get_autoscaling_info(marathon_clients, service_config):
+def get_autoscaling_info(apps_with_clients, service_config):
     if service_config.get_max_instances() and service_config.get_desired_state() == 'start':
-        apps_with_clients = get_marathon_apps_with_clients(marathon_clients.get_all_clients(), embed_tasks=True)
-        all_mesos_tasks = get_all_running_tasks()
+        all_mesos_tasks = get_cached_list_of_running_tasks_from_frameworks()
         autoscaling_params = service_config.get_autoscaling_params()
         autoscaling_params.update({'noop': True})
         system_paasta_config = load_system_paasta_config()

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -200,12 +200,13 @@ def paasta_status_on_api_endpoint(cluster, service, instance, system_paasta_conf
 
     paasta_print(
         status_marathon_job_human(
-            service,
-            instance,
-            deploy_status,
-            marathon_status.app_id,
-            marathon_status.running_instance_count,
-            marathon_status.expected_instance_count,
+            service=service,
+            instance=instance,
+            deploy_status=deploy_status,
+            desired_app_id=marathon_status.app_id,
+            app_count=marathon_status.app_count,
+            running_instances=marathon_status.running_instance_count,
+            normal_instance_count=marathon_status.expected_instance_count,
         ),
     )
     return 0

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -877,14 +877,9 @@ class MarathonDeployStatus:
         return getattr(cls, _str, None)
 
 
-def get_marathon_app_deploy_status(client: MarathonClient, app_id: str) -> int:
-    if is_app_id_running(app_id, client):
-        app = client.get_app(app_id)
-    else:
-        return MarathonDeployStatus.NotRunning
-
+def get_marathon_app_deploy_status(client: MarathonClient, app: MarathonApp=None) -> int:
     # Check the launch queue to see if an app is blocked
-    is_overdue, backoff_seconds = get_app_queue_status(client, app_id)
+    is_overdue, backoff_seconds = get_app_queue_status(client, app.id)
 
     # Based on conditions at https://mesosphere.github.io/marathon/docs/marathon-ui.html
     if is_overdue:

--- a/paasta_tools/paasta_serviceinit.py
+++ b/paasta_tools/paasta_serviceinit.py
@@ -199,7 +199,6 @@ def main() -> None:
                         verbose=args.verbose,
                         soa_dir=args.soa_dir,
                         app_id=args.app_id,
-                        delta=args.delta,
                         clients=clients.marathon(),
                     )
                 elif instance_type == 'chronos':

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2395,7 +2395,7 @@ def terminal_len(text: str) -> int:
     return len(remove_ansi_escape_sequences(text))
 
 
-def format_table(rows: Iterable[Union[str, List[str]]], min_spacing: int=2) -> List[str]:
+def format_table(rows: Iterable[Union[str, Sequence[str]]], min_spacing: int=2) -> List[str]:
     """Formats a table for use on the command line.
 
     :param rows: List of rows, each of which can either be a tuple of strings containing the row's values, or a string

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -158,6 +158,7 @@ def test_marathon_job_status_verbose(
     app.instances = 5
     app.tasks_running = 5
     app.deployments = []
+    app.id = 'mock_app_id'
 
     client = mock.create_autospec(marathon.MarathonClient)
     client.get_app.return_value = app

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -1087,6 +1087,7 @@ def test_perform_command_handles_no_docker_and_doesnt_raise():
     ):
         actual = marathon_serviceinit.perform_command(
             'start', fake_service, fake_instance, fake_cluster, False, soa_dir,
+            clients=mock.Mock(),
         )
         assert actual == 1
 


### PR DESCRIPTION
I'm tired of having to do paasta status -v to see information relevant to the bounce.
Most of the time I don't actually care about the individual tasks, so I don't need to see that; I just need the numbers and statuses.