### PR TITLE
Stop allowing nerve_ns in marathon files

### DIFF
--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -95,9 +95,6 @@
                     "minimum": 0,
                     "exclusiveMinimum": false
                 },
-                "nerve_ns": {
-                    "type": "string"
-                },
                 "backoff_factor": {
                     "type": "integer",
                     "default": 2


### PR DESCRIPTION
We no longer have any services using `nerve_ns` in their marathon configs. It has been deprecated for quite some time. Let's remove it from the schema to prevent its use going forward. Unfortunately, removing the Python logic surrounding nerve_ns will require a bit more work since we never fully updated all of the codebase to handle registrations and the multiple namespaces.