### PR TITLE
Do a huge refactor to make get_expected_instance_count_for_service a lot faster

### DIFF
--- a/docs/source/generated/paasta_tools.paasta_service_config.rst
+++ b/docs/source/generated/paasta_tools.paasta_service_config.rst
@@ -1,7 +1,7 @@
-paasta_tools.paasta_service_config module
+paasta_tools.paasta_service_config_loader module
 =========================================
 
-.. automodule:: paasta_tools.paasta_service_config
+.. automodule:: paasta_tools.paasta_service_config_loader
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/generated/paasta_tools.rst
+++ b/docs/source/generated/paasta_tools.rst
@@ -65,7 +65,7 @@ Submodules
    paasta_tools.paasta_metastatus
    paasta_tools.paasta_native_serviceinit
    paasta_tools.paasta_remote_run
-   paasta_tools.paasta_service_config
+   paasta_tools.paasta_service_config_loader
    paasta_tools.paasta_serviceinit
    paasta_tools.remote_git
    paasta_tools.secret_tools

--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -29,6 +29,7 @@ from dulwich.repo import Repo
 from paasta_tools import generate_deployments_for_service
 from paasta_tools.cli.cmds.mark_for_deployment import paasta_mark_for_deployment
 from paasta_tools.cli.cmds.start_stop_restart import paasta_stop
+from paasta_tools.utils import DeploymentsJsonV1
 from paasta_tools.utils import format_tag
 from paasta_tools.utils import format_timestamp
 from paasta_tools.utils import get_paasta_tag_from_deploy_group
@@ -138,7 +139,7 @@ def step_impl_when(context):
 @then('that deployments.json can be read back correctly')
 def step_impl_then(context):
     deployments = load_deployments_json('fake_deployments_json_service', soa_dir='fake_soa_configs')
-    expected_deployments = {
+    expected_deployments = DeploymentsJsonV1({
         'fake_deployments_json_service:paasta-test_cluster.test_instance': {
             'force_bounce': context.force_bounce_timestamp,
             'desired_state': 'stop',
@@ -149,14 +150,14 @@ def step_impl_then(context):
             'desired_state': 'start',
             'docker_image': 'services-fake_deployments_json_service:paasta-%s' % context.expected_commit,
         },
-    }
+    })
     assert expected_deployments == deployments, "actual: %s\nexpected:%s" % (deployments, expected_deployments)
 
 
 @then('that deployments.json has a desired_state of "{expected_state}"')
 def step_impl_then_desired_state(context, expected_state):
     deployments = load_deployments_json('fake_deployments_json_service', soa_dir='fake_soa_configs')
-    latest = sorted(deployments.items(), key=lambda kv: kv[1]['force_bounce'] or '', reverse=True)[0][1]
+    latest = sorted(deployments.config_dict.items(), key=lambda kv: kv[1]['force_bounce'] or '', reverse=True)[0][1]
     desired_state = latest['desired_state']
     assert desired_state == expected_state, "actual: %s\nexpected: %s" % (desired_state, expected_state)
 

--- a/paasta_itests/chronos_rerun.feature
+++ b/paasta_itests/chronos_rerun.feature
@@ -16,7 +16,7 @@ Feature: chronos_rerun can rerun old jobs
      Then we should get exit code 0
 
     Given we have yelpsoa-configs for the service "testservice" with enabled dependent chronos instance "dependentjob" and parent "testservice.testinstance"
-      And we have a deployments.json for the service "testservice" with enabled chronos instance "dependentjob"
+      And we have a deployments.json for the service "testservice" with enabled chronos instance "dependentjob,testinstance"
      When we run chronos_rerun for service_instance "testservice dependentjob"
      Then we should get exit code 0
       And there is a temporary job for the service "testservice" and instance "dependentjob"

--- a/paasta_itests/steps/paasta_native_steps.py
+++ b/paasta_itests/steps/paasta_native_steps.py
@@ -164,6 +164,20 @@ def write_paasta_native_cluster_yaml_files(context, service, instance):
                         'force_bounce': None,
                     },
                 },
+                'v2': {
+                    'deployments': {
+                        f"{context.cluster}.{instance}": {
+                            'docker_image': 'busybox',
+                            'git_sha': 'deadbeef',
+                        },
+                    },
+                    'controls': {
+                        f"{service}:{context.cluster}.{instance}": {
+                            'desired_state': 'start',
+                            'force_bounce': None,
+                        },
+                    },
+                },
             }, f,
         )
 

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -378,6 +378,22 @@ def write_soa_dir_deployments(context, service, disabled, csv_instances, image):
                 }
                 for instance in csv_instances.split(',')
             },
+            'v2': {
+                'deployments': {
+                    f"{context.cluster}.{instance}": {
+                        'docker_image': image,
+                        'git_sha': 'deadbeef',
+                    }
+                    for instance in csv_instances.split(',')
+                },
+                'controls': {
+                    f"{service}:{context.cluster}.{instance}": {
+                        'desired_state': desired_state,
+                        'force_bounce': None,
+                    }
+                    for instance in csv_instances.split(',')
+                },
+            },
         }))
 
 

--- a/paasta_tools/adhoc_tools.py
+++ b/paasta_tools/adhoc_tools.py
@@ -49,7 +49,7 @@ def load_adhoc_job_config(service, instance, cluster, load_deployments=True, soa
 
     general_config = deep_merge_dictionaries(overrides=instance_configs[instance], defaults=general_config)
 
-    branch_dict = {}
+    branch_dict = None
     if load_deployments:
         deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
         branch = general_config.get('branch', get_paasta_branch(cluster, instance))

--- a/paasta_tools/adhoc_tools.py
+++ b/paasta_tools/adhoc_tools.py
@@ -16,6 +16,8 @@ import logging
 import service_configuration_lib
 
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
+from paasta_tools.long_running_service_tools import LongRunningServiceConfigDict
+from paasta_tools.utils import BranchDictV2
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_paasta_branch
@@ -52,7 +54,7 @@ def load_adhoc_job_config(service, instance, cluster, load_deployments=True, soa
         deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
         branch = general_config.get('branch', get_paasta_branch(cluster, instance))
         deploy_group = general_config.get('deploy_group', branch)
-        branch_dict = deployments_json.get_branch_dict_v2(service, branch, deploy_group)
+        branch_dict = deployments_json.get_branch_dict(service, branch, deploy_group)
 
     return AdhocJobConfig(
         service=service,
@@ -65,8 +67,17 @@ def load_adhoc_job_config(service, instance, cluster, load_deployments=True, soa
 
 
 class AdhocJobConfig(LongRunningServiceConfig):
+    config_filename_prefix = 'adhoc'
 
-    def __init__(self, service, instance, cluster, config_dict, branch_dict, soa_dir=DEFAULT_SOA_DIR):
+    def __init__(
+        self,
+        service: str,
+        instance: str,
+        cluster: str,
+        config_dict: LongRunningServiceConfigDict,
+        branch_dict: BranchDictV2,
+        soa_dir: str=DEFAULT_SOA_DIR,
+    ) -> None:
         super(AdhocJobConfig, self).__init__(
             cluster=cluster,
             instance=instance,
@@ -76,7 +87,7 @@ class AdhocJobConfig(LongRunningServiceConfig):
             soa_dir=soa_dir,
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "AdhocJobConfig(%r, %r, %r, %r, %r, %r)" % (
             self.service,
             self.cluster,
@@ -87,7 +98,12 @@ class AdhocJobConfig(LongRunningServiceConfig):
         )
 
 
-def get_default_interactive_config(service, cluster, soa_dir, load_deployments=False):
+def get_default_interactive_config(
+    service: str,
+    cluster: str,
+    soa_dir: str,
+    load_deployments: bool=False,
+) -> AdhocJobConfig:
     default_job_config = {
         'cpus': 4,
         'mem': 10240,
@@ -102,7 +118,7 @@ def get_default_interactive_config(service, cluster, soa_dir, load_deployments=F
             instance='interactive',
             cluster=cluster,
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
             soa_dir=soa_dir,
         )
     except NoDeploymentsAvailable:
@@ -113,14 +129,16 @@ def get_default_interactive_config(service, cluster, soa_dir, load_deployments=F
     if not job_config.branch_dict and load_deployments:
         deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
         deploy_group = prompt_pick_one(
-            (
-                deployment
-                for deployment in deployments_json['deployments'].keys()
-            ),
+            deployments_json.get_deploy_groups(),
             choosing='deploy group',
         )
         job_config.config_dict['deploy_group'] = deploy_group
-        job_config.branch_dict['docker_image'] = deployments_json.get_docker_image_for_deploy_group(deploy_group)
+        job_config.branch_dict = {
+            'docker_image': deployments_json.get_docker_image_for_deploy_group(deploy_group),
+            'git_sha': deployments_json.get_git_sha_for_deploy_group(deploy_group),
+            'force_bounce': None,
+            'desired_state': 'start',
+        }
 
     for key, value in default_job_config.items():
         job_config.config_dict.setdefault(key, value)

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -350,7 +350,10 @@ def main():
 
     for service in list_services(soa_dir=args.soa_dir):
         service_config = PaastaServiceConfig(service=service, soa_dir=args.soa_dir)
-        for instance_config in service_config.instance_configs(cluster=cluster, instance_type='marathon'):
+        for instance_config in service_config.instance_configs(
+            cluster=cluster,
+            instance_type_class=marathon_tools.MarathonServiceConfig,
+        ):
             if instance_config.get_docker_image():
                 check_service_replication(
                     instance_config=instance_config,

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -42,7 +42,7 @@ from paasta_tools import marathon_tools
 from paasta_tools import monitoring_tools
 from paasta_tools.marathon_tools import format_job_id
 from paasta_tools.mesos_tools import get_slaves
-from paasta_tools.paasta_service_config import PaastaServiceConfig
+from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.smartstack_tools import SmartstackReplicationChecker
 from paasta_tools.utils import _log
 from paasta_tools.utils import datetime_from_utc_to_local
@@ -349,7 +349,7 @@ def main():
     smartstack_replication_checker = SmartstackReplicationChecker(mesos_slaves, system_paasta_config)
 
     for service in list_services(soa_dir=args.soa_dir):
-        service_config = PaastaServiceConfig(service=service, soa_dir=args.soa_dir)
+        service_config = PaastaServiceConfigLoader(service=service, soa_dir=args.soa_dir)
         for instance_config in service_config.instance_configs(
             cluster=cluster,
             instance_type_class=marathon_tools.MarathonServiceConfig,

--- a/paasta_tools/cli/cmds/info.py
+++ b/paasta_tools/cli/cmds/info.py
@@ -12,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Collection
+from typing import List
+
 from service_configuration_lib import read_service_configuration
 
 from paasta_tools.cli.cmds.status import get_actual_deployments
@@ -61,7 +64,7 @@ def add_subparser(subparsers):
     list_parser.set_defaults(command=paasta_info)
 
 
-def deployments_to_clusters(deployments):
+def deployments_to_clusters(deployments: Collection[str]) -> Collection[str]:
     clusters = []
     for deployment in deployments:
         cluster, _ = deployment.split('.')
@@ -80,7 +83,7 @@ def get_smartstack_endpoints(service, soa_dir):
     return endpoints
 
 
-def get_deployments_strings(service, soa_dir):
+def get_deployments_strings(service: str, soa_dir: str) -> List[str]:
     output = []
     try:
         deployments = get_actual_deployments(service, soa_dir)

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -40,6 +40,7 @@ from paasta_tools.cli.utils import validate_given_deploy_groups
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.cli.utils import validate_short_git_sha
 from paasta_tools.deployment_utils import get_currently_deployed_sha
+from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.paasta_service_config import PaastaServiceConfig
 from paasta_tools.utils import _log
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -541,7 +542,10 @@ def wait_for_deployment(service, deploy_group, git_sha, soa_dir, timeout):
             raise NoSuchCluster
 
         instances_queue = Queue()
-        for instance_config in service_configs.instance_configs(cluster=cluster, instance_type='marathon'):
+        for instance_config in service_configs.instance_configs(
+            cluster=cluster,
+            instance_type_class=MarathonServiceConfig,
+        ):
             if instance_config.get_deploy_group() == deploy_group:
                 instances_queue.put(instance_config)
                 total_instances += 1

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -41,7 +41,7 @@ from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.cli.utils import validate_short_git_sha
 from paasta_tools.deployment_utils import get_currently_deployed_sha
 from paasta_tools.marathon_tools import MarathonServiceConfig
-from paasta_tools.paasta_service_config import PaastaServiceConfig
+from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.utils import _log
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import format_tag
@@ -528,7 +528,7 @@ def _run_cluster_worker(cluster_data, green_light):
 def wait_for_deployment(service, deploy_group, git_sha, soa_dir, timeout):
     # Currently only 'marathon' instances are supported for wait_for_deployment because they
     # are the only thing that are worth waiting on.
-    service_configs = PaastaServiceConfig(service=service, soa_dir=soa_dir, load_deployments=False)
+    service_configs = PaastaServiceConfigLoader(service=service, soa_dir=soa_dir, load_deployments=False)
 
     total_instances = 0
     clusters_data = []

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -18,6 +18,7 @@ import os
 import sys
 from collections import defaultdict
 from distutils.util import strtobool
+from typing import Dict
 
 from bravado.exception import HTTPError
 from service_configuration_lib import read_deploy
@@ -35,13 +36,13 @@ from paasta_tools.marathon_serviceinit import bouncing_status_human
 from paasta_tools.marathon_serviceinit import desired_state_human
 from paasta_tools.marathon_serviceinit import marathon_app_deploy_status_human
 from paasta_tools.marathon_serviceinit import status_marathon_job_human
-from paasta_tools.marathon_tools import load_deployments_json
 from paasta_tools.marathon_tools import MarathonDeployStatus
 from paasta_tools.monitoring_tools import get_team
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_soa_cluster_deploy_files
 from paasta_tools.utils import list_all_instances_for_service
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
@@ -141,16 +142,16 @@ def list_deployed_clusters(pipeline, actual_deployments):
     return deployed_clusters
 
 
-def get_actual_deployments(service, soa_dir):
+def get_actual_deployments(service: str, soa_dir: str) -> Dict[str, str]:
     deployments_json = load_deployments_json(service, soa_dir)
     if not deployments_json:
         paasta_print("Warning: it looks like %s has not been deployed anywhere yet!" % service, file=sys.stderr)
     # Create a dictionary of actual $service Jenkins deployments
     actual_deployments = {}
-    for key in deployments_json:
+    for key, branch_dict in deployments_json.config_dict.items():
         service, namespace = key.split(':')
         if service == service:
-            value = deployments_json[key]['docker_image']
+            value = branch_dict['docker_image']
             sha = value[value.rfind('-') + 1:]
             actual_deployments[namespace.replace('paasta-', '', 1)] = sha
     return actual_deployments

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -9,7 +9,7 @@ import service_configuration_lib
 from kazoo.exceptions import NoNodeError
 from mypy_extensions import TypedDict
 
-from paasta_tools.utils import BranchDict
+from paasta_tools.utils import BranchDictV2
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -89,7 +89,7 @@ class LongRunningServiceConfig(InstanceConfig):
 
     def __init__(
         self, service: str, cluster: str, instance: str, config_dict: LongRunningServiceConfigDict,
-        branch_dict: BranchDict, soa_dir: str=DEFAULT_SOA_DIR,
+        branch_dict: Optional[BranchDictV2], soa_dir: str=DEFAULT_SOA_DIR,
     ) -> None:
         super(LongRunningServiceConfig, self).__init__(
             cluster=cluster,

--- a/paasta_tools/paasta_service_config.py
+++ b/paasta_tools/paasta_service_config.py
@@ -12,27 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from typing import Any
 from typing import Dict
-from typing import no_type_check
+from typing import Iterable
+from typing import List
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
 
 from service_configuration_lib import read_extra_service_information
 from service_configuration_lib import read_service_configuration
 
-from paasta_tools.adhoc_tools import AdhocJobConfig
-from paasta_tools.chronos_tools import ChronosJobConfig
-from paasta_tools.marathon_tools import MarathonServiceConfig
+from paasta_tools import utils
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_paasta_branch
-from paasta_tools.utils import INSTANCE_TYPES
+from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import list_clusters
-from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_v2_deployments_json
 
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
+
+
+_InstanceConfig_T = TypeVar('_InstanceConfig_T', bound=InstanceConfig)
 
 
 class PaastaServiceConfig():
@@ -59,6 +62,12 @@ class PaastaServiceConfig():
     canary
     >>>
     """
+    _framework_configs: Dict[
+        Tuple[str, type],
+        Dict[str, utils.InstanceConfigDict],
+    ]
+    _clusters: List[str]
+    _deployments_json: utils.DeploymentsJsonV2
 
     def __init__(self, service: str, soa_dir: str=DEFAULT_SOA_DIR, load_deployments: bool=True) -> None:
         self._service = service
@@ -67,11 +76,10 @@ class PaastaServiceConfig():
         self._clusters = None
         self._general_config = None
         self._deployments_json = None
-        self._framework_configs: Dict[Any, Any] = {}
-        self._deployments_json = None
+        self._framework_configs = {}
 
     @property
-    def clusters(self):
+    def clusters(self) -> Iterable[str]:
         """Returns an iterator that yields cluster names for the service.
 
         :returns: iterator that yields cluster names.
@@ -81,19 +89,23 @@ class PaastaServiceConfig():
         for cluster in self._clusters:
             yield cluster
 
-    def instances(self, cluster: str, instance_type: str):
+    def instances(self, cluster: str, instance_type_class: Type[_InstanceConfig_T]) -> Iterable[str]:
         """Returns an iterator that yields instance names as strings.
 
         :param cluster: The cluster name
         :param instance_type: One of paasta_tools.utils.INSTANCE_TYPES
         :returns: an iterator that yields instance names
         """
-        if (cluster, instance_type) not in self._framework_configs:
-            self._refresh_framework_config(cluster, instance_type)
-        for instance in self._framework_configs.get((cluster, instance_type), []):
+        if (cluster, instance_type_class) not in self._framework_configs:
+            self._refresh_framework_config(cluster, instance_type_class)
+        for instance in self._framework_configs.get((cluster, instance_type_class), []):
             yield instance
 
-    def instance_configs(self, cluster: str, instance_type: str):
+    def instance_configs(
+        self,
+        cluster: str,
+        instance_type_class: Type[_InstanceConfig_T],
+    ) -> Iterable[_InstanceConfig_T]:
         """Returns an iterator that yields InstanceConfig objects.
 
         :param cluster: The cluster name
@@ -101,78 +113,32 @@ class PaastaServiceConfig():
         :returns: an iterator that yields instances of MarathonServiceConfig, ChronosJobConfig and etc.
         :raises NotImplementedError: when it doesn't know how to create a config for instance_type
         """
-        create_config_function = self._get_create_config_function(instance_type)
-        if (cluster, instance_type) not in self._framework_configs:
-            self._refresh_framework_config(cluster, instance_type)
-        for instance, config in self._framework_configs.get((cluster, instance_type), []).items():
-            yield create_config_function(cluster, instance, config)
+        if (cluster, instance_type_class) not in self._framework_configs:
+            self._refresh_framework_config(cluster, instance_type_class)
+        for instance, config in self._framework_configs.get((cluster, instance_type_class), {}).items():
+            yield self._create_service_config(cluster, instance, config, instance_type_class)
 
-    def instance_config(self, cluster: str, instance: str):
-        """Returns an InstanceConfig object for whatever type of instance it is.
+    def _framework_config_filename(self, cluster: str, instance_type_class: Type[_InstanceConfig_T]):
+        return "%s-%s" % (instance_type_class.config_filename_prefix, cluster)
 
-        :param cluster: The cluster name
-        :param instance: The instance name
-        :returns: instance of MarathonServiceConfig, ChronosJobConfig or None
-        """
-        for instance_type in INSTANCE_TYPES:
-            if (cluster, instance_type) not in self._framework_configs:
-                self._refresh_framework_config(cluster, instance_type)
-            if instance in self._framework_configs[(cluster, instance_type)]:
-                create_config_function = self._get_create_config_function(instance_type)
-                return create_config_function(
-                    cluster=cluster,
-                    instance=instance,
-                    config=self._framework_configs[(cluster, instance_type)][instance],
-                )
-
-    def _get_create_config_function(self, instance_type: str):
-        f = {
-            'marathon': self._create_marathon_service_config,
-            'chronos': self._create_chronos_service_config,
-            'adhoc': self._create_adhoc_service_config,
-        }.get(instance_type)
-        if f is None:
-            raise NotImplementedError(
-                "instance type %s is not supported by PaastaServiceConfig."
-                % instance_type,
-            )
-        return f
-
-    def _framework_config_filename(self, cluster: str, instance_type: str):
-        return "%s-%s" % (instance_type, cluster)
-
-    def _refresh_framework_config(self, cluster: str, instance_type: str):
-        conf_name = self._framework_config_filename(cluster, instance_type)
+    def _refresh_framework_config(self, cluster: str, instance_type_class: Type[_InstanceConfig_T]):
+        conf_name = self._framework_config_filename(cluster, instance_type_class)
         log.info("Reading configuration file: %s.yaml", conf_name)
         instances = read_extra_service_information(
             service_name=self._service,
             extra_info=conf_name,
             soa_dir=self._soa_dir,
         )
-        self._framework_configs[(cluster, instance_type)] = instances
+        self._framework_configs[(cluster, instance_type_class)] = instances
 
-    @no_type_check
-    def _get_branch_dict(self, cluster: str, instance: str, config: Dict[Any, Any]):
-        if self._load_deployments:
-            if self._deployments_json is None:
-                self._deployments_json = load_deployments_json(self._service, soa_dir=self._soa_dir)
-            branch = config.get('branch', get_paasta_branch(cluster, instance))
-            return self._deployments_json.get_branch_dict(self._service, branch)
-        else:
-            return {}
+    def _get_branch_dict(self, cluster: str, instance: str, config: utils.InstanceConfigDict) -> utils.BranchDictV2:
+        if self._deployments_json is None:
+            self._deployments_json = load_v2_deployments_json(self._service, soa_dir=self._soa_dir)
+        branch = config.get('branch', get_paasta_branch(cluster, instance))
+        deploy_group = config.get('deploy_group', branch)
+        return self._deployments_json.get_branch_dict(self._service, branch, deploy_group)
 
-    @no_type_check
-    def _get_branch_dict_v2(self, cluster: str, instance: str, config: Dict[Any, Any]):
-        if self._load_deployments:
-            if self._deployments_json is None:
-                self._deployments_json = load_v2_deployments_json(self._service, soa_dir=self._soa_dir)
-            branch = config.get('branch', get_paasta_branch(cluster, instance))
-            deploy_group = config.get('deploy_group', branch)
-            return self._deployments_json.get_branch_dict_v2(self._service, branch, deploy_group)
-        else:
-            return {}
-
-    def _get_merged_config(self, config):
+    def _get_merged_config(self, config: utils.InstanceConfigDict) -> utils.InstanceConfigDict:
         if self._general_config is None:
             self._general_config = read_service_configuration(
                 service_name=self._service,
@@ -183,58 +149,24 @@ class PaastaServiceConfig():
             defaults=self._general_config,
         )
 
-    def _create_marathon_service_config(self, cluster, instance, config):
+    def _create_service_config(
+        self,
+        cluster: str,
+        instance: str,
+        config: utils.InstanceConfigDict,
+        config_class: Type[_InstanceConfig_T],
+    ) -> _InstanceConfig_T:
         """Create a service instance's configuration for marathon.
 
         :param cluster: The cluster to read the configuration for
         :param instance: The instance of the service to retrieve
         :param config: the framework instance config.
-        :returns: An instance of MarathonServiceConfig
+        :returns: An instance of config_class
         """
         merged_config = self._get_merged_config(config)
         branch_dict = self._get_branch_dict(cluster, instance, merged_config)
 
-        return MarathonServiceConfig(
-            service=self._service,
-            cluster=cluster,
-            instance=instance,
-            config_dict=merged_config,
-            branch_dict=branch_dict,
-            soa_dir=self._soa_dir,
-        )
-
-    def _create_chronos_service_config(self, cluster, instance, config):
-        """Create a service instance's configuration for chronos.
-
-        :param cluster: The cluster to read the configuration for
-        :param instance: The instance of the service to retrieve
-        :param config:
-        :returns: An instance of ChronosJobConfig
-        """
-        merged_config = self._get_merged_config(config)
-        branch_dict = self._get_branch_dict(cluster, instance, merged_config)
-
-        return ChronosJobConfig(
-            service=self._service,
-            cluster=cluster,
-            instance=instance,
-            config_dict=merged_config,
-            branch_dict=branch_dict,
-            soa_dir=self._soa_dir,
-        )
-
-    def _create_adhoc_service_config(self, cluster, instance, config):
-        """Create a service instance's configuration for the adhoc instance type.
-
-        :param cluster: The cluster to read the configuration for
-        :param instance: The instance of the service to retrieve
-        :param config:
-        :returns: An instance of AdhocJobConfig
-        """
-        merged_config = self._get_merged_config(config)
-        branch_dict = self._get_branch_dict_v2(cluster, instance, merged_config)
-
-        return AdhocJobConfig(
+        return config_class(
             service=self._service,
             cluster=cluster,
             instance=instance,

--- a/paasta_tools/paasta_service_config_loader.py
+++ b/paasta_tools/paasta_service_config_loader.py
@@ -38,16 +38,16 @@ log.addHandler(logging.NullHandler())
 _InstanceConfig_T = TypeVar('_InstanceConfig_T', bound=InstanceConfig)
 
 
-class PaastaServiceConfig():
-    """PaastaServiceConfig provides useful methods for reading soa-configs and
+class PaastaServiceConfigLoader():
+    """PaastaServiceConfigLoader provides useful methods for reading soa-configs and
     iterating instance names or InstanceConfigs objects.
 
     :Example:
 
-    >>> from paasta_tools.paasta_service_config import PaastaServiceConfig
+    >>> from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
     >>> from paasta_tools.utils import DEFAULT_SOA_DIR
     >>>
-    >>> sc = PaastaServiceConfig(service='fake_service', soa_dir=DEFAULT_SOA_DIR)
+    >>> sc = PaastaServiceConfigLoader(service='fake_service', soa_dir=DEFAULT_SOA_DIR)
     >>>
     >>> for instance in sc.instances(cluster='fake_cluster', instance_type='marathon'):
     ...     print(instance)

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -52,7 +52,7 @@ def test_instances_status_marathon(
         cluster='fake_cluster',
         instance='fake_instance',
         config_dict={'bounce_method': 'fake_bounce'},
-        branch_dict={},
+        branch_dict=None,
     )
     mock_load_marathon_service_config.return_value = mock_service_config
     mock_marathon_job_status.return_value = 'fake_marathon_status'
@@ -98,7 +98,7 @@ def test_chronos_instance_status(
         {
             'schedule': 'always',
         },
-        {},
+        None,
     )
 
     request = testing.DummyRequest()

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -37,7 +37,7 @@ def test_get_zookeeper_instances():
             'instances': 5,
             'max_instances': 10,
         },
-        branch_dict={},
+        branch_dict=None,
     )
     with mock.patch(
         'paasta_tools.utils.KazooClient', autospec=True,
@@ -75,7 +75,7 @@ def test_get_zookeeper_instances_defaults_to_max_instances_when_no_zk_node():
             'min_instances': 5,
             'max_instances': 10,
         },
-        branch_dict={},
+        branch_dict=None,
     )
     with mock.patch(
         'paasta_tools.utils.KazooClient', autospec=True,
@@ -95,7 +95,7 @@ def test_get_zookeeper_instances_defaults_to_config_out_of_bounds():
             'min_instances': 5,
             'max_instances': 10,
         },
-        branch_dict={},
+        branch_dict=None,
     )
     with mock.patch(
         'paasta_tools.utils.KazooClient', autospec=True,
@@ -126,7 +126,7 @@ def test_update_instances_for_marathon_service():
                 'min_instances': 5,
                 'max_instances': 10,
             },
-            branch_dict={},
+            branch_dict=None,
         )
         autoscaling_service_lib.set_instances_for_marathon_service('service', 'instance', instance_count=8)
         zk_client.set.assert_called_once_with('/autoscaling/service/instance/instances', '8'.encode('utf8'))
@@ -170,7 +170,7 @@ def test_mesos_cpu_metrics_provider_no_previous_cpu_data():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={},
-        branch_dict={},
+        branch_dict=None,
     )
     fake_mesos_task = mock.MagicMock(
         stats_callable=mock.MagicMock(return_value={
@@ -211,7 +211,7 @@ def test_mesos_cpu_metrics_provider():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={},
-        branch_dict={},
+        branch_dict=None,
     )
     fake_system_paasta_config = mock.MagicMock()
     fake_system_paasta_config.get_filter_bogus_mesos_cputime_enabled.return_value = False
@@ -308,7 +308,7 @@ def test_mesos_cpu_metrics_provider_filter_bogus_values():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={},
-        branch_dict={},
+        branch_dict=None,
     )
     fake_system_paasta_config = mock.MagicMock()
     fake_system_paasta_config.get_filter_bogus_mesos_cputime_enabled.return_value = True
@@ -436,7 +436,7 @@ def test_get_http_utilization_for_all_tasks_no_data():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={},
-        branch_dict={},
+        branch_dict=None,
     )
     fake_marathon_tasks = [mock.Mock(id='fake-service.fake-instance', host='fake_host', ports=[30101])]
     # KeyError simulates an invalid response
@@ -500,7 +500,7 @@ def test_mesos_cpu_metrics_provider_no_data_mesos():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={},
-        branch_dict={},
+        branch_dict=None,
     )
     fake_system_paasta_config = mock.MagicMock()
     fake_marathon_tasks = [mock.Mock(id='fake-service.fake-instance')]
@@ -532,7 +532,7 @@ def test_autoscale_marathon_instance():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={'min_instances': 1, 'max_instances': 10},
-        branch_dict={},
+        branch_dict=None,
     )
     fake_system_paasta_config = mock.MagicMock()
     with mock.patch(
@@ -570,7 +570,7 @@ def test_autoscale_marathon_instance_up_to_min_instances():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={'min_instances': 10, 'max_instances': 100},
-        branch_dict={},
+        branch_dict=None,
     )
     fake_system_paasta_config = mock.MagicMock()
     with mock.patch(
@@ -620,7 +620,7 @@ def test_autoscale_marathon_instance_below_min_instances():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={'min_instances': 5, 'max_instances': 10},
-        branch_dict={},
+        branch_dict=None,
     )
     fake_system_paasta_config = mock.MagicMock()
     with mock.patch(
@@ -658,7 +658,7 @@ def test_autoscale_marathon_instance_above_max_instances():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={'min_instances': 5, 'max_instances': 10},
-        branch_dict={},
+        branch_dict=None,
     )
     fake_system_paasta_config = mock.MagicMock()
     with mock.patch(
@@ -696,7 +696,7 @@ def test_autoscale_marathon_instance_drastic_downscaling():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={'min_instances': 5, 'max_instances': 100},
-        branch_dict={},
+        branch_dict=None,
     )
     fake_system_paasta_config = mock.MagicMock()
     with mock.patch(
@@ -740,7 +740,7 @@ def test_autoscale_marathon_with_http_stuff():
                 'endpoint': '/bogus',
             },
         },
-        branch_dict={},
+        branch_dict=None,
     )
     fake_system_paasta_config = mock.MagicMock()
     with mock.patch(
@@ -776,7 +776,7 @@ def test_is_task_data_insufficient():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={'min_instances': 1, 'max_instances': 100},
-        branch_dict={},
+        branch_dict=None,
     )
     # Test all running
     ret = autoscaling_service_lib.is_task_data_insufficient(
@@ -833,7 +833,7 @@ def test_autoscale_marathon_instance_aborts_when_wrong_number_tasks():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={'min_instances': 1, 'max_instances': 100},
-        branch_dict={},
+        branch_dict=None,
     )
     fake_system_paasta_config = mock.MagicMock()
     mock_autoscaling_decision = mock.Mock()
@@ -912,7 +912,7 @@ def test_autoscale_services_happy_path():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={'min_instances': 1, 'max_instances': 10, 'desired_state': 'start'},
-        branch_dict={},
+        branch_dict=None,
     )
     mock_mesos_tasks = [{'id': 'fake-service.fake-instance.sha123.sha456'}]
     mock_healthcheck_results = mock.Mock(alive=True)
@@ -976,7 +976,7 @@ def test_autoscale_services_not_healthy():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={'min_instances': 1, 'max_instances': 10, 'desired_state': 'start'},
-        branch_dict={},
+        branch_dict=None,
     )
     mock_mesos_tasks = [{'id': 'fake-service.fake-instance.sha123.sha456.uuid'}]
     with mock.patch(
@@ -1078,7 +1078,7 @@ def test_autoscale_services_bespoke_doesnt_autoscale():
             'min_instances': 1, 'max_instances': 10, 'desired_state': 'start',
             'autoscaling': {'decision_policy': 'bespoke'},
         },
-        branch_dict={},
+        branch_dict=None,
     )
     mock_mesos_tasks = [{'id': 'fake-service.fake-instance'}]
     with mock.patch(
@@ -1175,7 +1175,7 @@ def test_filter_autoscaling_tasks():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={'min_instances': 1, 'max_instances': 10, 'desired_state': 'start'},
-        branch_dict={},
+        branch_dict=None,
     )
     mock_mesos_tasks = [{'id': 'fake-service.fake-instance.sha123.sha456.uuid'}]
     with mock.patch(
@@ -1654,7 +1654,7 @@ def test_filter_autoscaling_tasks_considers_old_versions():
         cluster='cluster',
         instance='instance',
         config_dict={},
-        branch_dict={},
+        branch_dict=None,
         soa_dir='/soa/dir',
     )
 

--- a/tests/cli/test_cmds_check.py
+++ b/tests/cli/test_cmds_check.py
@@ -476,7 +476,7 @@ def test_get_deploy_groups_used_by_framework(
             instance=instance,
             cluster=cluster,
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
     expected = ['cluster1.instance1', 'cluster1.instance2']
     actual = get_deploy_groups_used_by_framework('marathon', service='unused', soa_dir='/fake/path')

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -1228,7 +1228,7 @@ def test_simulate_healthcheck_on_service_enabled_success(mock_run_healthcheck_on
         config_dict={
             'healthcheck_grace_period_seconds': 0,
         },
-        branch_dict={},
+        branch_dict=None,
     )
     fake_container_id = 'fake_container_id'
     fake_mode = 'http'
@@ -1250,7 +1250,7 @@ def test_simulate_healthcheck_on_service_enabled_failure(mock_run_healthcheck_on
         config_dict={
             'healthcheck_grace_period_seconds': 0,
         },
-        branch_dict={},
+        branch_dict=None,
     )
     mock_service_manifest
 
@@ -1276,7 +1276,7 @@ def test_simulate_healthcheck_on_service_enabled_partial_failure(mock_run_health
         config_dict={
             'healthcheck_grace_period_seconds': 0,
         },
-        branch_dict={},
+        branch_dict=None,
     )
 
     fake_container_id = 'fake_container_id'
@@ -1311,7 +1311,7 @@ def test_simulate_healthcheck_on_service_enabled_during_grace_period(
         config_dict={
             'healthcheck_grace_period_seconds': 1,
         },
-        branch_dict={},
+        branch_dict=None,
     )
 
     fake_container_id = 'fake_container_id'
@@ -1346,7 +1346,7 @@ def test_simulate_healthcheck_on_service_enabled_honors_grace_period(
             # only one healthcheck will be performed silently
             'healthcheck_grace_period_seconds': 2,
         },
-        branch_dict={},
+        branch_dict=None,
     )
 
     fake_container_id = 'fake_container_id'
@@ -1380,7 +1380,7 @@ def test_simulate_healthcheck_on_service_dead_container_exits_immediately(capfd)
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         ret = simulate_healthcheck_on_service(
             fake_service_manifest, mock_client, mock.sentinel.container_id,
@@ -1522,7 +1522,7 @@ def test_volumes_are_deduped(mock_exists):
                     "mode": "RO",
                 }],
             },
-            branch_dict={},
+            branch_dict=None,
         )
 
         configure_and_run_docker_container(
@@ -1574,7 +1574,7 @@ def test_missing_volumes_skipped(mock_exists):
                     "mode": "RO",
                 }],
             },
-            branch_dict={},
+            branch_dict=None,
         )
 
         configure_and_run_docker_container(

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -47,7 +47,7 @@ def test_issue_state_change_for_service(mock_log_event, get_transport_and_path, 
             instance='fake_instance',
             service='fake_service',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         ),
         '0',
         'stop',
@@ -68,7 +68,7 @@ def test_make_mutate_refs_func():
             instance='fake_instance',
             service='fake_service',
             config_dict={'deploy_group': 'a'},
-            branch_dict={},
+            branch_dict=None,
         ),
         force_bounce='FORCEBOUNCE',
         desired_state='stop',
@@ -103,7 +103,7 @@ def test_log_event():
             instance='fake_instance',
             service='fake_service',
             config_dict={'deploy_group': 'fake_deploy_group'},
-            branch_dict={},
+            branch_dict=None,
         )
         start_stop_restart.log_event(service_config, 'stopped')
         mock_log.assert_called_once_with(
@@ -388,7 +388,7 @@ def test_start_or_stop_bad_refs(
         instance='fake_instance',
         service='fake_service',
         config_dict={},
-        branch_dict={},
+        branch_dict=None,
     )
     mock_list_remote_refs.return_value = {
         "refs/tags/paasta-deliberatelyinvalidref-20160304T053919-deploy": "70f7245ccf039d778c7e527af04eac00d261d783",

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -414,7 +414,7 @@ def test_status_pending_pipeline_build_message(
 
 @patch('paasta_tools.cli.cmds.status.load_deployments_json', autospec=True)
 def test_get_actual_deployments(mock_get_deployments,):
-    mock_get_deployments.return_value = utils.DeploymentsJson({
+    mock_get_deployments.return_value = utils.DeploymentsJsonV1({
         'fake_service:paasta-b_cluster.b_instance': {
             'docker_image': 'this_is_a_sha',
         },

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -222,17 +222,17 @@ def instances_deployed_side_effect(cluster_data, instances_out, green_light):  #
 
 
 @patch('paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config', autospec=True)
-@patch('paasta_tools.cli.cmds.mark_for_deployment.PaastaServiceConfig', autospec=True)
+@patch('paasta_tools.cli.cmds.mark_for_deployment.PaastaServiceConfigLoader', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment._log', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment.instances_deployed', autospec=True)
 def test_wait_for_deployment(
     mock_instances_deployed,
     mock__log,
-    mock_paasta_service_config,
+    mock_paasta_service_config_loader,
     mock_load_system_paasta_config,
 ):
-    mock_paasta_service_config.return_value.clusters = ['cluster1']
-    mock_paasta_service_config.return_value.instance_configs.return_value = [
+    mock_paasta_service_config_loader.return_value.clusters = ['cluster1']
+    mock_paasta_service_config_loader.return_value.instance_configs.return_value = [
         mock_marathon_instance_config('instance1'),
         mock_marathon_instance_config('instance2'),
         mock_marathon_instance_config('instance3'),
@@ -247,16 +247,16 @@ def test_wait_for_deployment(
             with patch('time.sleep', autospec=True):
                 mark_for_deployment.wait_for_deployment('service', 'fake_deploy_group', 'somesha', '/nail/soa', 1)
 
-    mock_paasta_service_config.return_value.clusters = ['cluster1', 'cluster2']
-    mock_paasta_service_config.return_value.instance_configs.side_effect = [
+    mock_paasta_service_config_loader.return_value.clusters = ['cluster1', 'cluster2']
+    mock_paasta_service_config_loader.return_value.instance_configs.side_effect = [
         [mock_marathon_instance_config('instance1'), mock_marathon_instance_config('instance2')],
         [mock_marathon_instance_config('instance1'), mock_marathon_instance_config('instance2')],
     ]
     with patch('sys.stdout', autospec=True, flush=Mock()):
         assert mark_for_deployment.wait_for_deployment('service', 'fake_deploy_group', 'somesha', '/nail/soa', 5) == 0
 
-    mock_paasta_service_config.return_value.clusters = ['cluster1', 'cluster2']
-    mock_paasta_service_config.return_value.instance_configs.side_effect = [
+    mock_paasta_service_config_loader.return_value.clusters = ['cluster1', 'cluster2']
+    mock_paasta_service_config_loader.return_value.instance_configs.side_effect = [
         [mock_marathon_instance_config('instance1'), mock_marathon_instance_config('instance2')],
         [mock_marathon_instance_config('instance1'), mock_marathon_instance_config('instance3')],
     ]
@@ -265,19 +265,19 @@ def test_wait_for_deployment(
 
 
 @patch('paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config', autospec=True)
-@patch('paasta_tools.cli.cmds.mark_for_deployment.PaastaServiceConfig', autospec=True)
+@patch('paasta_tools.cli.cmds.mark_for_deployment.PaastaServiceConfigLoader', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment._log', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment.instances_deployed', autospec=True)
 def test_wait_for_deployment_raise_no_such_cluster(
     mock_instances_deployed,
     mock__log,
-    mock_paasta_service_config,
+    mock_paasta_service_config_loader,
     mock_load_system_paasta_config,
 ):
     mock_load_system_paasta_config.return_value.get_api_endpoints.return_value = \
         {'cluster1': 'some_url_1', 'cluster2': 'some_url_2'}
 
-    mock_paasta_service_config.return_value.clusters = ['cluster3']
+    mock_paasta_service_config_loader.return_value.clusters = ['cluster3']
     with raises(NoSuchCluster):
         mark_for_deployment.wait_for_deployment('service', 'deploy_group_3', 'somesha', '/nail/soa', 0)
 
@@ -309,7 +309,7 @@ def test_paasta_wait_for_deployment_return_1_when_deploy_group_not_found(
 
 
 @patch('paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config', autospec=True)
-@patch('paasta_tools.cli.cmds.mark_for_deployment.PaastaServiceConfig', autospec=True)
+@patch('paasta_tools.cli.cmds.mark_for_deployment.PaastaServiceConfigLoader', autospec=True)
 @patch('paasta_tools.cli.cmds.wait_for_deployment.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.wait_for_deployment.validate_git_sha', autospec=True)
 @patch('paasta_tools.cli.cmds.wait_for_deployment.list_deploy_groups', autospec=True)
@@ -317,12 +317,12 @@ def test_paasta_wait_for_deployment_return_0_when_no_instances_in_deploy_group(
     mock_list_deploy_groups,
     mock_validate_service_name,
     mock_validate_git_sha,
-    mock_paasta_service_config,
+    mock_paasta_service_config_loader,
     mock_load_system_paasta_config,
     system_paasta_config,
 ):
     mock_load_system_paasta_config.return_value = system_paasta_config
-    mock_paasta_service_config.return_value.instance_configs.return_value = \
+    mock_paasta_service_config_loader.return_value.instance_configs.return_value = \
         [mock_marathon_instance_config('some_instance')]
     mock_list_deploy_groups.return_value = {'test_deploy_group'}
     assert paasta_wait_for_deployment(fake_args) == 0

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -370,7 +370,7 @@ def mock_marathon_instance_config(fake_name) -> "MarathonServiceConfig":
         cluster='fake_cluster',
         instance=fake_name,
         config_dict={'deploy_group': 'fake_deploy_group'},
-        branch_dict={},
+        branch_dict=None,
         soa_dir='fake_soa_dir',
     )
 

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -723,14 +723,14 @@ def test_list_deploy_groups_parses_configs(
             cluster='',
             instance='',
             config_dict={'deploy_group': 'fake_deploy_group'},
-            branch_dict={},
+            branch_dict=None,
         ),
         MarathonServiceConfig(
             service='foo',
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         ),
     ]
     actual = utils.list_deploy_groups(service="foo")

--- a/tests/frameworks/test_adhoc_scheduler.py
+++ b/tests/frameworks/test_adhoc_scheduler.py
@@ -109,6 +109,7 @@ class TestAdhocScheduler(object):
                 branch_dict={
                     'docker_image': 'busybox',
                     'desired_state': 'start',
+                    'force_bounce': None,
                 },
                 soa_dir='/nail/etc/services',
             ),
@@ -190,6 +191,7 @@ class TestAdhocScheduler(object):
                 branch_dict={
                     'docker_image': 'busybox',
                     'desired_state': 'start',
+                    'force_bounce': None,
                 },
                 soa_dir='/nail/etc/services',
             ),

--- a/tests/test_adhoc_tools.py
+++ b/tests/test_adhoc_tools.py
@@ -14,7 +14,7 @@
 import mock
 
 from paasta_tools import adhoc_tools
-from paasta_tools.utils import DeploymentsJson
+from paasta_tools.utils import DeploymentsJsonV2
 from paasta_tools.utils import NoConfigurationForServiceError
 
 
@@ -50,12 +50,14 @@ def test_get_default_interactive_config_reads_from_tty():
     ) as mock_load_deployments_json:
         mock_prompt_pick_one.return_value = 'fake_deploygroup'
         mock_load_adhoc_job_config.side_effect = NoConfigurationForServiceError
-        mock_load_deployments_json.return_value = DeploymentsJson({
+        mock_load_deployments_json.return_value = DeploymentsJsonV2({
             'deployments': {
                 'fake_deploygroup': {
                     'docker_image': mock.sentinel.docker_image,
+                    'git_sha': mock.sentinel.git_sha,
                 },
             },
+            'controls': {},
         })
         result = adhoc_tools.get_default_interactive_config(
             'fake_serivce',

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -650,17 +650,17 @@ def test_main(instance_config):
         'paasta_tools.check_marathon_services_replication.get_slaves',
         autospec=True,
     ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.PaastaServiceConfig',
+        'paasta_tools.check_marathon_services_replication.PaastaServiceConfigLoader',
         autospec=True,
-    ) as mock_paasta_service_config:
-        mock_paasta_service_config.return_value.instance_configs.return_value = [instance_config]
+    ) as mock_paasta_service_config_loader:
+        mock_paasta_service_config_loader.return_value.instance_configs.return_value = [instance_config]
         mock_client = mock.Mock()
         mock_client.list_tasks.return_value = []
         mock_get_marathon_clients.return_value = mock.Mock(get_all_clients=mock.Mock(return_value=[mock_client]))
         mock_load_system_paasta_config.return_value.get_cluster = mock.Mock(return_value='fake_cluster')
         check_marathon_services_replication.main()
         mock_parse_args.assert_called_once_with()
-        mock_paasta_service_config.assert_called_once_with(
+        mock_paasta_service_config_loader.assert_called_once_with(
             service='a',
             soa_dir=soa_dir,
         )

--- a/tests/test_chronos_rerun.py
+++ b/tests/test_chronos_rerun.py
@@ -128,7 +128,7 @@ def test_clone_job_dependent_jobs(
 @mock.patch('paasta_tools.chronos_rerun.chronos_tools.get_job_type', autospec=True)
 @mock.patch('paasta_tools.chronos_rerun.remove_parents', autospec=True)
 @mock.patch('paasta_tools.chronos_tools.create_complete_config', autospec=True)
-@mock.patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True)
+@mock.patch('paasta_tools.chronos_tools.load_v2_deployments_json', autospec=True)
 @mock.patch('service_configuration_lib.read_services_configuration', autospec=True)
 @mock.patch('paasta_tools.chronos_tools.read_chronos_jobs_for_service', autospec=True)
 @mock.patch('paasta_tools.chronos_tools.get_chronos_client', autospec=True)
@@ -140,7 +140,7 @@ def test_chronos_rerun_main_with_independent_job(
     mock_get_chronos_client,
     mock_read_chronos_jobs_for_service,
     mock_read_services_configuration,
-    mock_load_deployments_json,
+    mock_load_v2_deployments_json,
     mock_create_complete_config,
     mock_remove_parents,
     mock_get_job_type,
@@ -175,7 +175,7 @@ def test_chronos_rerun_main_with_independent_job(
         'test_dependent_instance_2': gen_dependent_job(service, 'test_dependent_instance_1'),
     }
 
-    mock_load_deployments_json.return_value.get_branch_dict.side_effect = lambda service, *args, **kwargs: {
+    mock_load_v2_deployments_json.return_value.get_branch_dict.side_effect = lambda service, *args, **kwargs: {
         'desired_state': 'start',
         'docker_image': 'paasta-{}-{}'.format(service, cluster),
     }

--- a/tests/test_deployment_utils.py
+++ b/tests/test_deployment_utils.py
@@ -14,14 +14,14 @@
 import mock
 
 from paasta_tools import deployment_utils
-from paasta_tools.utils import DeploymentsJson
+from paasta_tools.utils import DeploymentsJsonV2
 
 
 @mock.patch('paasta_tools.deployment_utils.load_v2_deployments_json', autospec=True)
 def test_get_currently_deployed_sha(
     mock_load_v2_deployments_json,
 ):
-    mock_load_v2_deployments_json.return_value = DeploymentsJson({
+    mock_load_v2_deployments_json.return_value = DeploymentsJsonV2({
         "controls": {},
         "deployments": {
             "everything": {

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -26,14 +26,14 @@ def test_get_deploy_group_mappings():
             service=fake_service,
             cluster='clusterA',
             instance='main',
-            branch_dict={},
+            branch_dict=None,
             config_dict={'deploy_group': 'no_thanks'},
         ),
         MarathonServiceConfig(
             service=fake_service,
             cluster='clusterB',
             instance='main',
-            branch_dict={},
+            branch_dict=None,
             config_dict={'deploy_group': 'try_me'},
         ),
     ]

--- a/tests/test_long_running_service_tools.py
+++ b/tests/test_long_running_service_tools.py
@@ -26,7 +26,7 @@ class TestLongRunningServiceConfig(object):
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={'healthcheck_cmd': 'test_cmd'},
-            branch_dict={},
+            branch_dict=None,
         )
         actual = fake_conf.get_healthcheck_cmd()
         assert actual == 'test_cmd'
@@ -37,7 +37,7 @@ class TestLongRunningServiceConfig(object):
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         with raises(InvalidInstanceConfig) as exc:
             fake_conf.get_healthcheck_cmd()
@@ -55,7 +55,7 @@ class TestLongRunningServiceConfig(object):
             cluster='fake_cluster',
             instance=fake_namespace,
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({
             'mode': 'http',
@@ -85,7 +85,7 @@ class TestLongRunningServiceConfig(object):
             cluster='fake_cluster',
             instance=fake_namespace,
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({
             'mode': 'tcp',
@@ -118,7 +118,7 @@ class TestLongRunningServiceConfig(object):
                 'healthcheck_mode': 'cmd',
                 'healthcheck_cmd': fake_cmd,
             },
-            branch_dict={},
+            branch_dict=None,
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
         with mock.patch(
@@ -146,7 +146,7 @@ class TestLongRunningServiceConfig(object):
             config_dict={
                 'healthcheck_mode': None,
             },
-            branch_dict={},
+            branch_dict=None,
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
         with mock.patch(
@@ -175,7 +175,7 @@ class TestLongRunningServiceConfig(object):
             config_dict={
                 'healthcheck_mode': None,
             },
-            branch_dict={},
+            branch_dict=None,
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
         with mock.patch(
@@ -208,7 +208,7 @@ class TestLongRunningServiceConfig(object):
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_instances() == 1
 

--- a/tests/test_marathon_serviceinit.py
+++ b/tests/test_marathon_serviceinit.py
@@ -58,7 +58,7 @@ def test_get_bouncing_status():
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={'bounce_method': 'fake_bounce'},
-            branch_dict={},
+            branch_dict=None,
         )
         actual = marathon_serviceinit.get_bouncing_status('fake_service', 'fake_instance', 'unused', mock_config)
         assert 'fake_bounce' in actual

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -29,10 +29,10 @@ from paasta_tools.marathon_tools import FormattedMarathonAppDict
 from paasta_tools.marathon_tools import MarathonContainerInfo
 from paasta_tools.marathon_tools import MarathonServiceConfigDict
 from paasta_tools.mesos.exceptions import NoSlavesAvailableError
-from paasta_tools.utils import BranchDict
+from paasta_tools.utils import BranchDictV2
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
-from paasta_tools.utils import DeploymentsJson
+from paasta_tools.utils import DeploymentsJsonV2
 from paasta_tools.utils import DockerVolume
 from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import SystemPaastaConfig
@@ -54,6 +54,7 @@ class TestMarathonTools:
             'docker_image': 'test_docker:1.0',
             'desired_state': 'start',
             'force_bounce': None,
+            'git_sha': 'deadbeef',
         },
     )
     fake_srv_config = {
@@ -76,7 +77,7 @@ class TestMarathonTools:
         fake_cluster = 'amnesia'
         fake_dir = '/nail/home/sanfran'
         with mock.patch(
-            'paasta_tools.marathon_tools.load_deployments_json', autospec=True,
+            'paasta_tools.marathon_tools.load_v2_deployments_json', autospec=True,
         ) as mock_load_deployments_json, mock.patch(
             'service_configuration_lib.read_service_configuration', autospec=True,
         ) as mock_read_service_configuration, mock.patch(
@@ -101,7 +102,7 @@ class TestMarathonTools:
         fake_cluster = 'amnesia'
         fake_dir = '/nail/home/sanfran'
         with mock.patch(
-            'paasta_tools.marathon_tools.load_deployments_json', autospec=True,
+            'paasta_tools.marathon_tools.load_v2_deployments_json', autospec=True,
         ), mock.patch(
             'service_configuration_lib.read_service_configuration', autospec=True,
         ), mock.patch(
@@ -122,7 +123,7 @@ class TestMarathonTools:
         fake_cluster = 'amnesia'
         fake_dir = '/nail/home/sanfran'
         with mock.patch(
-            'paasta_tools.marathon_tools.load_deployments_json', autospec=True,
+            'paasta_tools.marathon_tools.load_v2_deployments_json', autospec=True,
         ), mock.patch(
             'service_configuration_lib.read_service_configuration', autospec=True,
         ), mock.patch(
@@ -154,7 +155,7 @@ class TestMarathonTools:
                     **self.fake_marathon_app_config.config_dict,
                 ),
             ),
-            branch_dict={},
+            branch_dict=None,
         )
 
         with mock.patch(
@@ -191,9 +192,14 @@ class TestMarathonTools:
         fake_docker = 'no_docker:9.9'
         config_copy = self.fake_marathon_app_config.config_dict.copy()
 
-        fake_branch_dict = BranchDict({'desired_state': 'stop', 'force_bounce': '12345', 'docker_image': fake_docker})
+        fake_branch_dict = BranchDictV2({
+            'desired_state': 'stop',
+            'force_bounce': '12345',
+            'docker_image': fake_docker,
+            'git_sha': '9',
+        })
         deployments_json_mock = mock.Mock(
-            spec=DeploymentsJson,
+            spec=DeploymentsJsonV2,
             get_branch_dict=mock.Mock(return_value=fake_branch_dict),
         )
 
@@ -206,7 +212,7 @@ class TestMarathonTools:
             autospec=True,
             return_value={fake_instance: config_copy},
         ) as read_extra_info_patch, mock.patch(
-            'paasta_tools.marathon_tools.load_deployments_json',
+            'paasta_tools.marathon_tools.load_v2_deployments_json',
             autospec=True,
             return_value=deployments_json_mock,
         ):
@@ -234,7 +240,7 @@ class TestMarathonTools:
             assert expected.config_dict == actual.config_dict
             assert expected.branch_dict == actual.branch_dict
 
-            deployments_json_mock.get_branch_dict.assert_called_once_with(fake_name, 'amnesia.solo')
+            deployments_json_mock.get_branch_dict.assert_called_once_with(fake_name, 'amnesia.solo', 'amnesia.solo')
             assert read_service_configuration_patch.call_count == 1
             read_service_configuration_patch.assert_any_call(fake_name, soa_dir=fake_dir)
             assert read_extra_info_patch.call_count == 1
@@ -467,7 +473,7 @@ class TestMarathonTools:
             cluster=cluster,
             instance=instance,
             config_dict={'nerve_ns': namespace},
-            branch_dict={},
+            branch_dict=None,
         )
         actual = marathon_tools.read_registration_for_service_instance(name, instance, cluster, soa_dir)
         assert actual == compose_job_id(name, namespace)
@@ -489,7 +495,7 @@ class TestMarathonTools:
                     compose_job_id(name, 'something else'),
                 ],
             },
-            branch_dict={},
+            branch_dict=None,
         )
         actual = marathon_tools.read_registration_for_service_instance(name, instance, cluster, soa_dir)
         assert actual == compose_job_id(name, instance)
@@ -508,7 +514,7 @@ class TestMarathonTools:
             cluster=cluster,
             instance=instance,
             config_dict={'registrations': registrations},
-            branch_dict={},
+            branch_dict=None,
         )
         actual_registrations = marathon_tools.read_all_registrations_for_service_instance(
             name, instance, cluster, soa_dir,
@@ -527,7 +533,7 @@ class TestMarathonTools:
             cluster=cluster,
             instance=instance,
             config_dict={'bounce_method': 'fakefakefake'},
-            branch_dict={},
+            branch_dict=None,
         )
 
         actual = marathon_tools.read_registration_for_service_instance(name, instance, cluster, soa_dir)
@@ -830,7 +836,7 @@ class TestMarathonTools:
             ]
 
     def test_format_marathon_app_dict(self):
-        fake_url = 'dockervania_from_konami'
+        fake_url = 'docker-registry/dockervania_from_konami'
         fake_volumes = [
             DockerVolume({
                 'hostPath': '/var/data/a',
@@ -851,7 +857,7 @@ class TestMarathonTools:
             'PAASTA_INSTANCE': 'yes_i_can',
             'PAASTA_SERVICE': 'can_you_dig_it',
             'PAASTA_DEPLOY_GROUP': 'fake_cluster.yes_i_can',
-            'PAASTA_DOCKER_IMAGE': '',
+            'PAASTA_DOCKER_IMAGE': 'dockervania_from_konami',
         }
         fake_cpus = .42
         fake_disk = 1234.5
@@ -937,7 +943,12 @@ class TestMarathonTools:
                 'healthcheck_max_consecutive_failures': 3,
                 'accepted_resource_roles': ['ads'],
             },
-            branch_dict={'desired_state': 'start'},
+            branch_dict={
+                'desired_state': 'start',
+                'docker_image': 'dockervania_from_konami',
+                'force_bounce': None,
+                'git_sha': 'deadbeef',
+            },
         )
         with mock.patch(
             'paasta_tools.utils.InstanceConfig.get_docker_url', autospec=True, return_value=fake_url,
@@ -980,7 +991,7 @@ class TestMarathonTools:
             cluster='',
             instance='fake_instance',
             config_dict={'bounce_method': 'aaargh'},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_bounce_method() == 'aaargh'
 
@@ -990,7 +1001,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_bounce_method() == 'crossover'
 
@@ -1001,7 +1012,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={'bounce_health_params': fake_param},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_bounce_health_params(mock.Mock()) == fake_param
 
@@ -1012,7 +1023,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_bounce_health_params(fake_service_namespace_config) == {}
 
@@ -1023,7 +1034,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_bounce_health_params(fake_service_namespace_config) == {'check_haproxy': True}
 
@@ -1034,7 +1045,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={'drain_method': fake_param},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_drain_method(mock.Mock()) == fake_param
 
@@ -1045,7 +1056,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_drain_method(fake_service_namespace_config) == 'noop'
 
@@ -1056,7 +1067,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_drain_method(fake_service_namespace_config) == 'hacheck'
 
@@ -1067,7 +1078,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={'drain_method_params': fake_param},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_drain_method_params(mock.Mock()) == fake_param
 
@@ -1078,7 +1089,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_drain_method_params(fake_service_namespace_config) == {}
 
@@ -1089,7 +1100,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_drain_method_params(fake_service_namespace_config) == {'delay': 60}
 
@@ -1109,7 +1120,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_instances() == 1
 
@@ -1130,7 +1141,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={'constraints': [['something', 'GROUP_BY']], 'extra_constraints': [['ignore', 'this']]},
-            branch_dict={},
+            branch_dict=None,
         )
         actual = fake_conf.get_calculated_constraints(
             service_namespace_config=fake_service_namespace_config,
@@ -1145,7 +1156,7 @@ class TestMarathonTools:
             cluster='fake_prod_cluster',
             instance='fake_instance',
             config_dict={'instances': 3},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_system_paasta_config = SystemPaastaConfig(
             {
@@ -1169,7 +1180,7 @@ class TestMarathonTools:
             cluster='fake_dev_cluster',
             instance='fake_instance',
             config_dict={'instances': 3},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_system_paasta_config = SystemPaastaConfig({}, "/foo")
         expected_constraints = [
@@ -1188,7 +1199,7 @@ class TestMarathonTools:
             cluster='fake_prod_cluster',
             instance='fake_instance',
             config_dict={'instances': 10},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_system_paasta_config = SystemPaastaConfig(
             {
@@ -1211,7 +1222,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
 
         expected_constraints = [
@@ -1230,7 +1241,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_system_paasta_config = SystemPaastaConfig(
             {
@@ -1255,7 +1266,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={'extra_constraints': [['foo', 1]]},
-            branch_dict={},
+            branch_dict=None,
         )
 
         expected_constraints = [
@@ -1275,7 +1286,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={'extra_constraints': [['extra', 'constraint']]},
-            branch_dict={},
+            branch_dict=None,
         )
 
         expected_constraints = [
@@ -1299,7 +1310,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_system_paasta_config = SystemPaastaConfig(
             {
@@ -1324,7 +1335,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={'deploy_blacklist': fake_deploy_blacklist},
-            branch_dict={},
+            branch_dict=None,
         )
         expected_constraints = [
             ["region", "UNLIKE", "fake_blacklisted_region"],
@@ -1344,7 +1355,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={'deploy_whitelist': fake_deploy_whitelist},
-            branch_dict={},
+            branch_dict=None,
         )
         expected_constraints = [
             ["region", "LIKE", "fake_whitelisted_region"],
@@ -1369,7 +1380,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         expected_constraints = [
             ["region", "GROUP_BY", "1"],
@@ -1395,7 +1406,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         expected_constraints = [
             ["region", "GROUP_BY", "1"],
@@ -1414,7 +1425,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={'monitoring': {'test': 'foo'}},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_monitoring() == {'test': 'foo'}
 
@@ -1522,6 +1533,8 @@ class TestMarathonTools:
             branch_dict={
                 'desired_state': 'start',
                 'force_bounce': '88888',
+                'git_sha': 'deadbeef',
+                'docker_image': 'doesntmatter',
             },
         )
 
@@ -1533,6 +1546,8 @@ class TestMarathonTools:
             branch_dict={
                 'desired_state': 'start',
                 'force_bounce': '99999',
+                'git_sha': 'deadbeef',
+                'docker_image': 'doesntmatter',
             },
         )
 
@@ -1544,6 +1559,8 @@ class TestMarathonTools:
             branch_dict={
                 'desired_state': 'stop',
                 'force_bounce': '99999',
+                'git_sha': 'deadbeef',
+                'docker_image': 'doesntmatter',
             },
         )
 
@@ -1612,7 +1629,7 @@ class TestMarathonTools:
             cluster='fake_cluster',
             instance='blue',
             config_dict={'nerve_ns': 'rojo', 'instances': 11},
-            branch_dict={},
+            branch_dict=None,
         )
 
         def config_helper(name, inst, cluster, soa_dir=None):
@@ -1624,7 +1641,7 @@ class TestMarathonTools:
                     cluster='fake_cluster',
                     instance='green',
                     config_dict={'nerve_ns': 'amarillo'},
-                    branch_dict={},
+                    branch_dict=None,
                 )
 
         with mock.patch(
@@ -1713,7 +1730,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert marathon_config.get_healthcheck_mode(namespace_config) is None
 
@@ -1724,7 +1741,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert marathon_config.get_healthcheck_mode(namespace_config) == 'http'
 
@@ -1735,7 +1752,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={'healthcheck_mode': 'tcp'},
-            branch_dict={},
+            branch_dict=None,
         )
         assert marathon_config.get_healthcheck_mode(namespace_config) == 'tcp'
 
@@ -1746,7 +1763,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={'healthcheck_mode': 'udp'},
-            branch_dict={},
+            branch_dict=None,
         )
         with raises(long_running_service_tools.InvalidHealthcheckMode):
             marathon_config.get_healthcheck_mode(namespace_config)
@@ -1758,7 +1775,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={'healthcheck_mode': None},
-            branch_dict={},
+            branch_dict=None,
         )
         assert marathon_config.get_healthcheck_mode(namespace_config) is None
 
@@ -1794,7 +1811,7 @@ class TestMarathonServiceConfig(object):
                 cluster='cluster',
                 instance='instance',
                 config_dict=marathon_conf,
-                branch_dict={},
+                branch_dict=None,
             )
             expected = {
                 'env': {'SOME_VAR': 'SOME_VAL'},
@@ -1840,7 +1857,7 @@ class TestMarathonServiceConfig(object):
                 cluster='cluster',
                 instance='instance',
                 config_dict=conf,
-                branch_dict={},
+                branch_dict=None,
             )
             assert marathon_config.get_secret_hashes(conf['env'], 'dev') == {}
             mock_is_secret_ref.assert_called_with("SOME_VAL")
@@ -1871,7 +1888,7 @@ class TestMarathonServiceConfig(object):
                 "healthcheck_timeout_seconds": 13,
                 "healthcheck_max_consecutive_failures": 7,
             },
-            branch_dict={},
+            branch_dict=None,
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({
             'mode': 'http',
@@ -1901,7 +1918,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({'mode': 'http'})
         expected = [
@@ -1927,7 +1944,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({'mode': 'http'})
         expected = [
@@ -1953,7 +1970,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({'mode': 'https'})
         expected = [
@@ -1979,7 +1996,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({'mode': 'tcp'})
         expected = [
@@ -2005,7 +2022,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={'healthcheck_mode': 'cmd', 'healthcheck_cmd': fake_command},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig()
         expected = [
@@ -2036,7 +2053,7 @@ class TestMarathonServiceConfig(object):
                 'healthcheck_timeout_seconds': fake_timeout,
                 'healthcheck_cmd': fake_command,
             },
-            branch_dict={},
+            branch_dict=None,
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig()
         expected = [
@@ -2061,7 +2078,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
         assert fake_marathon_service_config.get_healthchecks(
@@ -2075,7 +2092,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={'healthcheck_mode': 'none'},
-            branch_dict={},
+            branch_dict=None,
         )
         namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
         with raises(long_running_service_tools.InvalidHealthcheckMode):
@@ -2087,7 +2104,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={'instances': 100},
-            branch_dict={},
+            branch_dict=None,
         )
         assert marathon_config.get_backoff_seconds() == 1
 
@@ -2097,7 +2114,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={'instances': 1},
-            branch_dict={},
+            branch_dict=None,
         )
         assert marathon_config.get_backoff_seconds() == 10
 
@@ -2107,7 +2124,7 @@ class TestMarathonServiceConfig(object):
             cluster='cluster',
             instance='instance',
             config_dict={'instances': 0},
-            branch_dict={},
+            branch_dict=None,
         )
         assert marathon_config.get_backoff_seconds() == 1
 
@@ -2117,7 +2134,7 @@ class TestMarathonServiceConfig(object):
             instance='instance',
             cluster='cluster',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert marathon_config.get_accepted_resource_roles() is None
 
@@ -2127,7 +2144,7 @@ class TestMarathonServiceConfig(object):
             instance='instance',
             cluster='cluster',
             config_dict={"accepted_resource_roles": ["ads"]},
-            branch_dict={},
+            branch_dict=None,
         )
         assert marathon_config.get_accepted_resource_roles() == ["ads"]
 
@@ -2176,7 +2193,12 @@ def test_format_marathon_app_dict_no_smartstack():
         cluster='clustername',
         instance=instance,
         config_dict={},
-        branch_dict={'docker_image': 'abcdef'},
+        branch_dict={
+            'docker_image': 'abcdef',
+            'git_sha': 'deadbeef',
+            'force_bounce': None,
+            'desired_state': 'start',
+        },
     )
     fake_system_paasta_config = SystemPaastaConfig(
         {
@@ -2247,7 +2269,12 @@ def test_format_marathon_app_dict_with_smartstack():
         cluster='clustername',
         instance=instance,
         config_dict={},
-        branch_dict={'docker_image': 'abcdef'},
+        branch_dict={
+            'docker_image': 'abcdef',
+            'git_sha': 'deadbeef',
+            'force_bounce': None,
+            'desired_state': 'start',
+        },
     )
     fake_system_paasta_config = SystemPaastaConfig(
         {
@@ -2335,7 +2362,12 @@ def test_format_marathon_app_dict_utilizes_net():
         cluster='clustername',
         instance=instance_name,
         config_dict={'net': 'host'},
-        branch_dict={'docker_image': 'abcdef'},
+        branch_dict={
+            'docker_image': 'abcdef',
+            'git_sha': 'deadbeef',
+            'force_bounce': None,
+            'desired_state': 'start',
+        },
     )
     fake_system_paasta_config = SystemPaastaConfig(
         {
@@ -2385,7 +2417,12 @@ def test_format_marathon_app_dict_utilizes_extra_volumes():
         cluster='clustername',
         instance=instance_name,
         config_dict={'extra_volumes': fake_extra_volumes},
-        branch_dict={'docker_image': 'abcdef'},
+        branch_dict={
+            'docker_image': 'abcdef',
+            'git_sha': 'deadbeef',
+            'force_bounce': None,
+            'desired_state': 'start',
+        },
     )
     fake_system_paasta_config = SystemPaastaConfig(
         {
@@ -2526,7 +2563,7 @@ def test_marathon_service_config_get_healthchecks_invalid_type():
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={},
-        branch_dict={},
+        branch_dict=None,
     )
     with mock.patch.object(
         marathon_tools.MarathonServiceConfig, 'get_healthcheck_mode', autospec=True,
@@ -2542,7 +2579,7 @@ def test_marathon_service_config_get_desired_state_human_invalid_desired_state()
         instance='fake-instance',
         cluster='fake-cluster',
         config_dict={},
-        branch_dict={},
+        branch_dict=None,
     )
     with mock.patch.object(
         marathon_tools.MarathonServiceConfig, 'get_desired_state', autospec=True,

--- a/tests/test_monitoring_tools.py
+++ b/tests/test_monitoring_tools.py
@@ -34,7 +34,7 @@ class TestMonitoring_Tools:
         cluster='mycluster',
         instance='myinstance',
         config_dict={},
-        branch_dict={},
+        branch_dict=None,
     )
     job_page = False
     fake_marathon_job_config = marathon_tools.MarathonServiceConfig(
@@ -48,7 +48,7 @@ class TestMonitoring_Tools:
             'notification_email': 'job_test_notification_email',
             'page': job_page,
         },
-        branch_dict={},
+        branch_dict=None,
     )
     fake_chronos_job_config = chronos_tools.ChronosJobConfig(
         service='myservicename',
@@ -61,7 +61,7 @@ class TestMonitoring_Tools:
             'notification_email': 'job_test_notification_email',
             'page': job_page,
         },
-        branch_dict={},
+        branch_dict=None,
     )
     empty_job_config = {}
     monitor_page = True

--- a/tests/test_paasta_service_config.py
+++ b/tests/test_paasta_service_config.py
@@ -20,7 +20,7 @@ from paasta_tools.chronos_tools import load_chronos_job_config
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.paasta_service_config import PaastaServiceConfig
-from paasta_tools.utils import DeploymentsJson
+from paasta_tools.utils import DeploymentsJsonV2
 
 
 TEST_SERVICE_NAME = 'example_happyhour'
@@ -37,28 +37,38 @@ def create_test_service():
 
 
 def deployment_json():
-    return DeploymentsJson({
-        '%s:paasta-%s.main' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
-            'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
-        },
-        '%s:paasta-%s.canary' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
-            'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
-        },
-        '%s:paasta-%s.example_chronos_job' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
-            'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
-        },
-        '%s:paasta-%s.example_child_job' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
-            'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
-        },
-    })
+    # return DeploymentsJsonV2({
+    #     '%s:paasta-%s.main' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
+    #         'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
+    #     },
+    #     '%s:paasta-%s.canary' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
+    #         'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
+    #     },
+    #     '%s:paasta-%s.example_chronos_job' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
+    #         'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
+    #     },
+    #     '%s:paasta-%s.example_child_job' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
+    #         'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
+    #     },
+    #     '%s:paasta-%s.sample_batch' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
+    #         'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
+    #     },
+    #     '%s:paasta-%s.interactive' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
+    #         'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
+    #     },
+    # })
 
-
-def deployment_json_v2():
-    return DeploymentsJson({
-        'deployments': {'fake.non_canary': {
-            'docker_image': 'some_image',
-            'git_sha': 'some_sha',
-        }},
+    return DeploymentsJsonV2({
+        'deployments': {
+            'fake.non_canary': {
+                'docker_image': 'some_image',
+                'git_sha': 'some_sha',
+            },
+            'fake.canary': {
+                'docker_image': 'some_image',
+                'git_sha': 'some_sha',
+            },
+        },
         'controls': {
             'example_happyhour:%s.sample_batch' % TEST_CLUSTER_NAME: {
                 'desired_state': 'start',
@@ -67,6 +77,24 @@ def deployment_json_v2():
             'example_happyhour:%s.interactive' % TEST_CLUSTER_NAME: {
                 'desired_state': 'start',
                 'force_bounce': None,
+            },
+            '%s:%s.main' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
+                'desired_state': 'start', 'force_bounce': None,
+            },
+            '%s:%s.canary' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
+                'desired_state': 'start', 'force_bounce': None,
+            },
+            '%s:%s.example_chronos_job' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
+                'desired_state': 'start', 'force_bounce': None,
+            },
+            '%s:%s.example_child_job' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
+                'desired_state': 'start', 'force_bounce': None,
+            },
+            '%s:%s.sample_batch' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
+                'desired_state': 'start', 'force_bounce': None,
+            },
+            '%s:%s.interactive' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
+                'desired_state': 'start', 'force_bounce': None,
             },
         },
     })
@@ -117,14 +145,14 @@ def adhoc_cluster_config():
 def test_marathon_instances(mock_read_extra_service_information):
     mock_read_extra_service_information.return_value = marathon_cluster_config()
     s = create_test_service()
-    assert [i for i in s.instances(TEST_CLUSTER_NAME, 'marathon')] == ['main', 'canary']
+    assert list(s.instances(TEST_CLUSTER_NAME, MarathonServiceConfig)) == ['main', 'canary']
     mock_read_extra_service_information.assert_called_once_with(
         extra_info='marathon-%s' % TEST_CLUSTER_NAME,
         service_name=TEST_SERVICE_NAME, soa_dir=TEST_SOA_DIR,
     )
 
 
-@patch('paasta_tools.paasta_service_config.load_deployments_json', autospec=True)
+@patch('paasta_tools.paasta_service_config.load_v2_deployments_json', autospec=True)
 @patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
 def test_marathon_instances_configs(
         mock_read_extra_service_information,
@@ -145,8 +173,10 @@ def test_marathon_instances_configs(
                 'deploy_group': 'fake.non_canary', 'cpus': 0.1, 'mem': 1000,
             },
             branch_dict={
-                'docker_image': 'some_image', 'desired_state': 'start',
+                'docker_image': 'some_image',
+                'desired_state': 'start',
                 'force_bounce': None,
+                'git_sha': 'some_sha',
             },
             soa_dir=TEST_SOA_DIR,
         ),
@@ -161,13 +191,15 @@ def test_marathon_instances_configs(
                 'deploy_group': 'fake.canary', 'cpus': 0.1, 'mem': 1000,
             },
             branch_dict={
-                'docker_image': 'some_image', 'desired_state': 'start',
+                'docker_image': 'some_image',
+                'desired_state': 'start',
                 'force_bounce': None,
+                'git_sha': 'some_sha',
             },
             soa_dir=TEST_SOA_DIR,
         ),
     ]
-    assert [i for i in s.instance_configs(TEST_CLUSTER_NAME, 'marathon')] == expected
+    assert list(s.instance_configs(TEST_CLUSTER_NAME, MarathonServiceConfig)) == expected
     mock_read_extra_service_information.assert_called_once_with(
         extra_info='marathon-%s' % TEST_CLUSTER_NAME,
         service_name=TEST_SERVICE_NAME, soa_dir=TEST_SOA_DIR,
@@ -178,7 +210,7 @@ def test_marathon_instances_configs(
     )
 
 
-@patch('paasta_tools.paasta_service_config.load_deployments_json', autospec=True)
+@patch('paasta_tools.paasta_service_config.load_v2_deployments_json', autospec=True)
 @patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
 def test_chronos_instances_configs(
         mock_read_extra_service_information,
@@ -201,8 +233,10 @@ def test_chronos_instances_configs(
                 'schedule_time_zone': 'America/Los_Angeles',
             },
             branch_dict={
-                'docker_image': 'some_image', 'desired_state': 'start',
+                'docker_image': 'some_image',
+                'desired_state': 'start',
                 'force_bounce': None,
+                'git_sha': 'some_sha',
             },
             soa_dir=TEST_SOA_DIR,
         ),
@@ -218,13 +252,15 @@ def test_chronos_instances_configs(
                 'deploy_group': 'fake.non_canary', 'cmd': '/bin/sleep 5s',
             },
             branch_dict={
-                'docker_image': 'some_image', 'desired_state': 'start',
+                'docker_image': 'some_image',
+                'desired_state': 'start',
                 'force_bounce': None,
+                'git_sha': 'some_sha',
             },
             soa_dir=TEST_SOA_DIR,
         ),
     ]
-    assert [i for i in s.instance_configs(TEST_CLUSTER_NAME, 'chronos')] == expected
+    assert list(s.instance_configs(TEST_CLUSTER_NAME, ChronosJobConfig)) == expected
     mock_read_extra_service_information.assert_called_once_with(
         extra_info='chronos-%s' % TEST_CLUSTER_NAME,
         service_name=TEST_SERVICE_NAME, soa_dir=TEST_SOA_DIR,
@@ -242,7 +278,7 @@ def test_adhoc_instances_configs(
         mock_load_deployments_json,
 ):
     mock_read_extra_service_information.return_value = adhoc_cluster_config()
-    mock_load_deployments_json.return_value = deployment_json_v2()
+    mock_load_deployments_json.return_value = deployment_json()
     s = create_test_service()
     expected = [
         AdhocJobConfig(
@@ -256,8 +292,10 @@ def test_adhoc_instances_configs(
                 'deploy_group': 'fake.non_canary', 'cpus': 0.1, 'mem': 1000,
             },
             branch_dict={
-                'docker_image': 'some_image', 'git_sha': 'some_sha',
-                'desired_state': 'start', 'force_bounce': None,
+                'docker_image': 'some_image',
+                'desired_state': 'start',
+                'force_bounce': None,
+                'git_sha': 'some_sha',
             },
             soa_dir=TEST_SOA_DIR,
         ),
@@ -271,15 +309,17 @@ def test_adhoc_instances_configs(
                 'deploy_group': 'fake.non_canary', 'mem': 1000,
             },
             branch_dict={
-                'docker_image': 'some_image', 'git_sha': 'some_sha',
-                'desired_state': 'start', 'force_bounce': None,
+                'docker_image': 'some_image',
+                'desired_state': 'start',
+                'force_bounce': None,
+                'git_sha': 'some_sha',
             },
             soa_dir=TEST_SOA_DIR,
         ),
     ]
-    for i in s.instance_configs(TEST_CLUSTER_NAME, 'adhoc'):
+    for i in s.instance_configs(TEST_CLUSTER_NAME, AdhocJobConfig):
         print(i, i.cluster)
-    assert [i for i in s.instance_configs(TEST_CLUSTER_NAME, 'adhoc')] == expected
+    assert list(s.instance_configs(TEST_CLUSTER_NAME, AdhocJobConfig)) == expected
     mock_read_extra_service_information.assert_called_once_with(
         extra_info='adhoc-%s' % TEST_CLUSTER_NAME,
         service_name=TEST_SERVICE_NAME, soa_dir=TEST_SOA_DIR,
@@ -290,8 +330,8 @@ def test_adhoc_instances_configs(
     )
 
 
-@patch('paasta_tools.paasta_service_config.load_deployments_json', autospec=True)
-@patch('paasta_tools.marathon_tools.load_deployments_json', autospec=True)
+@patch('paasta_tools.paasta_service_config.load_v2_deployments_json', autospec=True)
+@patch('paasta_tools.marathon_tools.load_v2_deployments_json', autospec=True)
 @patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
 @patch('paasta_tools.marathon_tools.service_configuration_lib.read_extra_service_information', autospec=True)
 def test_old_and_new_ways_load_the_same_marathon_configs(
@@ -315,11 +355,11 @@ def test_old_and_new_ways_load_the_same_marathon_configs(
             cluster=TEST_CLUSTER_NAME, load_deployments=True, soa_dir=TEST_SOA_DIR,
         ),
     ]
-    assert [i for i in s.instance_configs(TEST_CLUSTER_NAME, 'marathon')] == expected
+    assert list(s.instance_configs(TEST_CLUSTER_NAME, MarathonServiceConfig)) == expected
 
 
-@patch('paasta_tools.paasta_service_config.load_deployments_json', autospec=True)
-@patch('paasta_tools.chronos_tools.load_deployments_json', autospec=True)
+@patch('paasta_tools.paasta_service_config.load_v2_deployments_json', autospec=True)
+@patch('paasta_tools.chronos_tools.load_v2_deployments_json', autospec=True)
 @patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
 @patch('paasta_tools.chronos_tools.service_configuration_lib.read_extra_service_information', autospec=True)
 def test_old_and_new_ways_load_the_same_chronos_configs(
@@ -343,7 +383,7 @@ def test_old_and_new_ways_load_the_same_chronos_configs(
             cluster=TEST_CLUSTER_NAME, load_deployments=True, soa_dir=TEST_SOA_DIR,
         ),
     ]
-    assert [i for i in s.instance_configs(TEST_CLUSTER_NAME, 'chronos')] == expected
+    assert list(s.instance_configs(TEST_CLUSTER_NAME, ChronosJobConfig)) == expected
 
 
 @patch('paasta_tools.paasta_service_config.load_v2_deployments_json', autospec=True)
@@ -358,8 +398,8 @@ def test_old_and_new_ways_load_the_same_adhoc_configs(
 ):
     mock_read_extra_service_information.return_value = adhoc_cluster_config()
     mock_adhoc_tools_read_extra_service_information.return_value = adhoc_cluster_config()
-    mock_load_deployments_json.return_value = deployment_json_v2()
-    mock_adhoc_tools_load_deployments_json.return_value = deployment_json_v2()
+    mock_load_deployments_json.return_value = deployment_json()
+    mock_adhoc_tools_load_deployments_json.return_value = deployment_json()
     s = create_test_service()
     expected = [
         load_adhoc_job_config(
@@ -371,33 +411,4 @@ def test_old_and_new_ways_load_the_same_adhoc_configs(
             cluster=TEST_CLUSTER_NAME, load_deployments=True, soa_dir=TEST_SOA_DIR,
         ),
     ]
-    assert [i for i in s.instance_configs(TEST_CLUSTER_NAME, 'adhoc')] == expected
-
-
-@patch('paasta_tools.paasta_service_config.load_deployments_json', autospec=True)
-@patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
-def test_instance_config(
-        mock_read_extra_service_information,
-        mock_load_deployments_json,
-):
-    mock_read_extra_service_information.return_value = marathon_cluster_config()
-    mock_load_deployments_json.return_value = deployment_json()
-    expected_instance_config = MarathonServiceConfig(
-        service=TEST_SERVICE_NAME,
-        cluster=TEST_CLUSTER_NAME,
-        instance='main',
-        config_dict={
-            'port': None, 'vip': None,
-            'lb_extras': {}, 'monitoring': {}, 'deploy': {}, 'data': {},
-            'smartstack': {}, 'dependencies': {}, 'instances': 3,
-            'deploy_group': 'fake.non_canary', 'cpus': 0.1, 'mem': 1000,
-        },
-        branch_dict={
-            'docker_image': 'some_image', 'desired_state': 'start',
-            'force_bounce': None,
-        },
-        soa_dir=TEST_SOA_DIR,
-    )
-    s = create_test_service()
-    instance_config = s.instance_config(TEST_CLUSTER_NAME, 'main')
-    assert instance_config == expected_instance_config
+    assert list(s.instance_configs(TEST_CLUSTER_NAME, AdhocJobConfig)) == expected

--- a/tests/test_paasta_service_config_loader.py
+++ b/tests/test_paasta_service_config_loader.py
@@ -37,27 +37,6 @@ def create_test_service():
 
 
 def deployment_json():
-    # return DeploymentsJsonV2({
-    #     '%s:paasta-%s.main' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
-    #         'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
-    #     },
-    #     '%s:paasta-%s.canary' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
-    #         'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
-    #     },
-    #     '%s:paasta-%s.example_chronos_job' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
-    #         'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
-    #     },
-    #     '%s:paasta-%s.example_child_job' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
-    #         'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
-    #     },
-    #     '%s:paasta-%s.sample_batch' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
-    #         'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
-    #     },
-    #     '%s:paasta-%s.interactive' % (TEST_SERVICE_NAME, TEST_CLUSTER_NAME): {
-    #         'docker_image': 'some_image', 'desired_state': 'start', 'force_bounce': None,
-    #     },
-    # })
-
     return DeploymentsJsonV2({
         'deployments': {
             'fake.non_canary': {

--- a/tests/test_paasta_service_config_loader.py
+++ b/tests/test_paasta_service_config_loader.py
@@ -19,7 +19,7 @@ from paasta_tools.chronos_tools import ChronosJobConfig
 from paasta_tools.chronos_tools import load_chronos_job_config
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.marathon_tools import MarathonServiceConfig
-from paasta_tools.paasta_service_config import PaastaServiceConfig
+from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.utils import DeploymentsJsonV2
 
 
@@ -29,7 +29,7 @@ TEST_CLUSTER_NAME = 'cluster'
 
 
 def create_test_service():
-    return PaastaServiceConfig(
+    return PaastaServiceConfigLoader(
         service=TEST_SERVICE_NAME,
         soa_dir=TEST_SOA_DIR,
         load_deployments=True,
@@ -141,7 +141,7 @@ def adhoc_cluster_config():
     }
 
 
-@patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
+@patch('paasta_tools.paasta_service_config_loader.read_extra_service_information', autospec=True)
 def test_marathon_instances(mock_read_extra_service_information):
     mock_read_extra_service_information.return_value = marathon_cluster_config()
     s = create_test_service()
@@ -152,8 +152,8 @@ def test_marathon_instances(mock_read_extra_service_information):
     )
 
 
-@patch('paasta_tools.paasta_service_config.load_v2_deployments_json', autospec=True)
-@patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
+@patch('paasta_tools.paasta_service_config_loader.load_v2_deployments_json', autospec=True)
+@patch('paasta_tools.paasta_service_config_loader.read_extra_service_information', autospec=True)
 def test_marathon_instances_configs(
         mock_read_extra_service_information,
         mock_load_deployments_json,
@@ -210,8 +210,8 @@ def test_marathon_instances_configs(
     )
 
 
-@patch('paasta_tools.paasta_service_config.load_v2_deployments_json', autospec=True)
-@patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
+@patch('paasta_tools.paasta_service_config_loader.load_v2_deployments_json', autospec=True)
+@patch('paasta_tools.paasta_service_config_loader.read_extra_service_information', autospec=True)
 def test_chronos_instances_configs(
         mock_read_extra_service_information,
         mock_load_deployments_json,
@@ -271,8 +271,8 @@ def test_chronos_instances_configs(
     )
 
 
-@patch('paasta_tools.paasta_service_config.load_v2_deployments_json', autospec=True)
-@patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
+@patch('paasta_tools.paasta_service_config_loader.load_v2_deployments_json', autospec=True)
+@patch('paasta_tools.paasta_service_config_loader.read_extra_service_information', autospec=True)
 def test_adhoc_instances_configs(
         mock_read_extra_service_information,
         mock_load_deployments_json,
@@ -330,9 +330,9 @@ def test_adhoc_instances_configs(
     )
 
 
-@patch('paasta_tools.paasta_service_config.load_v2_deployments_json', autospec=True)
+@patch('paasta_tools.paasta_service_config_loader.load_v2_deployments_json', autospec=True)
 @patch('paasta_tools.marathon_tools.load_v2_deployments_json', autospec=True)
-@patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
+@patch('paasta_tools.paasta_service_config_loader.read_extra_service_information', autospec=True)
 @patch('paasta_tools.marathon_tools.service_configuration_lib.read_extra_service_information', autospec=True)
 def test_old_and_new_ways_load_the_same_marathon_configs(
         mock_marathon_tools_read_extra_service_information,
@@ -358,9 +358,9 @@ def test_old_and_new_ways_load_the_same_marathon_configs(
     assert list(s.instance_configs(TEST_CLUSTER_NAME, MarathonServiceConfig)) == expected
 
 
-@patch('paasta_tools.paasta_service_config.load_v2_deployments_json', autospec=True)
+@patch('paasta_tools.paasta_service_config_loader.load_v2_deployments_json', autospec=True)
 @patch('paasta_tools.chronos_tools.load_v2_deployments_json', autospec=True)
-@patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
+@patch('paasta_tools.paasta_service_config_loader.read_extra_service_information', autospec=True)
 @patch('paasta_tools.chronos_tools.service_configuration_lib.read_extra_service_information', autospec=True)
 def test_old_and_new_ways_load_the_same_chronos_configs(
         mock_chronos_tools_read_extra_service_information,
@@ -386,9 +386,9 @@ def test_old_and_new_ways_load_the_same_chronos_configs(
     assert list(s.instance_configs(TEST_CLUSTER_NAME, ChronosJobConfig)) == expected
 
 
-@patch('paasta_tools.paasta_service_config.load_v2_deployments_json', autospec=True)
+@patch('paasta_tools.paasta_service_config_loader.load_v2_deployments_json', autospec=True)
 @patch('paasta_tools.adhoc_tools.load_v2_deployments_json', autospec=True)
-@patch('paasta_tools.paasta_service_config.read_extra_service_information', autospec=True)
+@patch('paasta_tools.paasta_service_config_loader.read_extra_service_information', autospec=True)
 @patch('paasta_tools.adhoc_tools.service_configuration_lib.read_extra_service_information', autospec=True)
 def test_old_and_new_ways_load_the_same_adhoc_configs(
         mock_adhoc_tools_read_extra_service_information,

--- a/tests/test_setup_chronos_job.py
+++ b/tests/test_setup_chronos_job.py
@@ -51,6 +51,9 @@ class TestSetupChronosJob:
     }
     fake_branch_dict = {
         'docker_image': 'paasta-%s-%s' % (fake_service, fake_cluster),
+        'git_sha': 'fake_sha',
+        'force_bounce': None,
+        'desired_state': 'start',
     }
     fake_chronos_job_config = chronos_tools.ChronosJobConfig(
         service=fake_service,

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -55,7 +55,7 @@ class TestSetupMarathonJob:
             'nerve_ns': 'aaaaugh',
             'bounce_method': 'brutal',
         },
-        branch_dict={},
+        branch_dict=None,
     )
     fake_docker_registry = 'remote_registry.com'
     fake_marathon_config = marathon_tools.MarathonConfig({
@@ -1402,7 +1402,7 @@ class TestSetupMarathonJob:
                 'nerve_ns': 'fake_nerve_ns',
                 'bounce_method': 'brutal',
             },
-            branch_dict={},
+            branch_dict=None,
         )
 
         with mock.patch(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -821,7 +821,7 @@ def test_DeploymentsJson_read():
         actual = utils.load_deployments_json('fake_service', fake_dir)
         open_patch.assert_called_once_with(fake_path)
         json_patch.assert_called_once_with(file_mock.return_value.__enter__.return_value)
-        assert actual == fake_json['v1']
+        assert actual == utils.DeploymentsJsonV1(fake_json['v1'])
 
 
 def test_get_running_mesos_docker_containers():
@@ -897,7 +897,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={'monitoring': fake_info},
-            branch_dict={},
+            branch_dict=None,
         ).get_monitoring() == fake_info
 
     def test_get_cpus_in_config(self):
@@ -906,7 +906,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={'cpus': -5},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_cpus() == -5
 
@@ -916,7 +916,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={'cpus': .66},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_cpus() == .66
 
@@ -926,7 +926,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_cpus() == .25
 
@@ -936,7 +936,7 @@ class TestInstanceConfig:
             instance='',
             cluster='',
             config_dict={'mem': -999},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_mem() == -999
 
@@ -946,7 +946,7 @@ class TestInstanceConfig:
             instance='',
             cluster='',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_mem() == 1024
 
@@ -956,7 +956,7 @@ class TestInstanceConfig:
             cluster='',
             instance='fake_instance',
             config_dict={'cpu_burst_pct': 0, 'cpus': 1},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_cpu_quota() == 100000
 
@@ -969,7 +969,7 @@ class TestInstanceConfig:
                 'cpus': 1,
                 'mem': 1024,
             },
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.format_docker_parameters() == [
             {"key": "memory-swap", "value": '1088m'},
@@ -995,7 +995,7 @@ class TestInstanceConfig:
                 },
                 'cap_add': ['IPC_LOCK', 'SYS_PTRACE'],
             },
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.format_docker_parameters() == [
             {"key": "memory-swap", "value": '1088m'},
@@ -1015,7 +1015,7 @@ class TestInstanceConfig:
             cluster='',
             instance='fake_instance',
             config_dict={'cpu_burst_pct': 100, 'cpus': 1},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_cpu_quota() == 200000
 
@@ -1027,7 +1027,7 @@ class TestInstanceConfig:
             config_dict={
                 'mem': 50,
             },
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_mem_swap() == "114m"
 
@@ -1039,7 +1039,7 @@ class TestInstanceConfig:
             config_dict={
                 'mem': 50.4,
             },
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_mem_swap() == "115m"
 
@@ -1049,7 +1049,7 @@ class TestInstanceConfig:
             instance='',
             cluster='',
             config_dict={'disk': -999},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_disk() == -999
 
@@ -1059,7 +1059,7 @@ class TestInstanceConfig:
             instance='',
             cluster='',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_disk() == 1024
 
@@ -1069,7 +1069,7 @@ class TestInstanceConfig:
             instance='',
             cluster='',
             config_dict={'gpus': -123},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_gpus() == -123
 
@@ -1079,7 +1079,7 @@ class TestInstanceConfig:
             instance='',
             cluster='',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_gpus() == 0
 
@@ -1094,7 +1094,7 @@ class TestInstanceConfig:
                     'nice': {'soft': 20},
                 },
             },
-            branch_dict={},
+            branch_dict=None,
         )
         assert list(fake_conf.get_ulimit()) == [
             {"key": "ulimit", "value": "nice=20"},
@@ -1107,7 +1107,7 @@ class TestInstanceConfig:
             instance='',
             cluster='',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert list(fake_conf.get_ulimit()) == []
 
@@ -1119,7 +1119,7 @@ class TestInstanceConfig:
             config_dict={
                 'cap_add': ['IPC_LOCK', 'SYS_PTRACE'],
             },
-            branch_dict={},
+            branch_dict=None,
         )
         assert list(fake_conf.get_cap_add()) == [
             {"key": "cap-add", "value": "IPC_LOCK"},
@@ -1132,7 +1132,7 @@ class TestInstanceConfig:
             instance='',
             cluster='',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert list(fake_conf.get_cap_add()) == []
 
@@ -1142,7 +1142,7 @@ class TestInstanceConfig:
             instance='fake_instance',
             cluster='fake_cluster',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_deploy_group() == 'fake_cluster.fake_instance'
 
@@ -1152,7 +1152,7 @@ class TestInstanceConfig:
             instance='',
             cluster='',
             config_dict={'deploy_group': 'fake_deploy_group'},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_deploy_group() == 'fake_deploy_group'
 
@@ -1162,7 +1162,7 @@ class TestInstanceConfig:
             instance='',
             cluster='fake_cluster',
             config_dict={'deploy_group': 'cluster_is_{cluster}'},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_deploy_group() == 'cluster_is_fake_cluster'
 
@@ -1172,7 +1172,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_cmd() is None
 
@@ -1182,7 +1182,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={'cmd': 'FAKECMD'},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_cmd() == 'FAKECMD'
 
@@ -1192,7 +1192,7 @@ class TestInstanceConfig:
             cluster='fake_cluster',
             instance='fake_instance',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_env() == {
             'PAASTA_SERVICE': 'fake_service',
@@ -1225,7 +1225,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_args() == []
 
@@ -1235,7 +1235,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={'cmd': 'FAKECMD'},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_args() is None
 
@@ -1245,7 +1245,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={'args': ['arg1', 'arg2']},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_args() == ['arg1', 'arg2']
 
@@ -1255,7 +1255,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={'args': ['A'], 'cmd': 'C'},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_conf.get_cmd()
         with raises(utils.InvalidInstanceConfig):
@@ -1287,7 +1287,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_monitoring_blacklist(system_deploy_blacklist=[]) == []
 
@@ -1298,7 +1298,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={'deploy_blacklist': fake_deploy_blacklist},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_monitoring_blacklist(system_deploy_blacklist=[]) == fake_deploy_blacklist
 
@@ -1308,7 +1308,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_deploy_blacklist() == []
 
@@ -1319,7 +1319,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={'deploy_blacklist': fake_deploy_blacklist},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_deploy_blacklist() == fake_deploy_blacklist
 
@@ -1329,7 +1329,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_extra_volumes() == []
 
@@ -1346,7 +1346,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={'extra_volumes': fake_extra_volumes},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_extra_volumes() == fake_extra_volumes
 
@@ -1357,7 +1357,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={'pool': pool},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_pool() == pool
 
@@ -1367,7 +1367,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.get_pool() == 'default'
 
@@ -1382,7 +1382,7 @@ class TestInstanceConfig:
                     {"containerPath": "/a", "hostPath": "/a", "mode": "RO"},
                 ],
             },
-            branch_dict={},
+            branch_dict=None,
         )
         system_volumes: List[utils.DockerVolume] = []
         assert fake_conf.get_volumes(system_volumes) == [
@@ -1400,7 +1400,7 @@ class TestInstanceConfig:
                     {"containerPath": "/a", "hostPath": "/other_a", "mode": "RO"},
                 ],
             },
-            branch_dict={},
+            branch_dict=None,
         )
         system_volumes: List[utils.DockerVolume] = [{"containerPath": "/a", "hostPath": "/a", "mode": "RO"}]
         assert fake_conf.get_volumes(system_volumes) == [
@@ -1420,7 +1420,7 @@ class TestInstanceConfig:
                     {"containerPath": "/c", "hostPath": "/c", "mode": "RO"},
                 ],
             },
-            branch_dict={},
+            branch_dict=None,
         )
         system_volumes: List[utils.DockerVolume] = [
             {"containerPath": "/a", "hostPath": "/a", "mode": "RO"},
@@ -1444,7 +1444,7 @@ class TestInstanceConfig:
                     {"containerPath": "/a", "hostPath": "/a", "mode": "RW"},
                 ],
             },
-            branch_dict={},
+            branch_dict=None,
         )
         system_volumes: List[utils.DockerVolume] = [
             {"containerPath": "/a", "hostPath": "/a", "mode": "RO"},
@@ -1464,7 +1464,7 @@ class TestInstanceConfig:
                     {"containerPath": "/b", "hostPath": "/b", "mode": "RO"},
                 ],
             },
-            branch_dict={},
+            branch_dict=None,
         )
         system_volumes: List[utils.DockerVolume] = [
             {"containerPath": "/a", "hostPath": "/a", "mode": "RO"},
@@ -1486,7 +1486,7 @@ class TestInstanceConfig:
                     {"containerPath": "/a/", "hostPath": "/a/", "mode": "RW"},
                 ],
             },
-            branch_dict={},
+            branch_dict=None,
         )
         system_volumes: List[utils.DockerVolume] = [
             {"containerPath": "/b/", "hostPath": "/b/", "mode": "RW"},
@@ -1505,7 +1505,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={},
-            branch_dict={},
+            branch_dict=None,
         )
 
         with mock.patch(
@@ -1536,7 +1536,7 @@ class TestInstanceConfig:
                 'dependencies_reference': dependencies_reference,
                 'dependencies': dependencies,
             },
-            branch_dict={},
+            branch_dict=None,
         )
         fake_conf.get_dependencies() == expected
 
@@ -1554,7 +1554,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={'security': security},
-            branch_dict={},
+            branch_dict=None,
         )
         fake_conf.get_outbound_firewall() == expected
 
@@ -1576,7 +1576,7 @@ class TestInstanceConfig:
             cluster='',
             instance='',
             config_dict={'security': security},
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.check_security() == expected
 
@@ -1597,7 +1597,7 @@ class TestInstanceConfig:
                 'dependencies_reference': dependencies_reference,
                 'dependencies': dependencies,
             },
-            branch_dict={},
+            branch_dict=None,
         )
         assert fake_conf.check_dependencies_reference() == expected
 


### PR DESCRIPTION
I recommend reviewing this per-commit, going backwards (last commit first).

- The raison d'être of this branch is the [third commit](https://github.com/Yelp/paasta/pull/1722/commits/d25962855ca6fa8adf5ca90c906d639d8c792ba2). Currently, `get_expected_instance_count_for_namespace` calls `load_marathon_service_config` once per instance. This ends up calling into service_configuration_lib.read_extra_service_information each time, which then does a copy.deepcopy on the cached parsed yaml. (At least we aren't loading the yaml N times.) This amounts to an O(N^2) running time based on the number of instances defined in your marathon.yaml: for each instance, copy a dict including each of the instances. This commit should change that into an O(N) algorithm, by using PaastaServiceConfigLoader, which produces many MarathonServiceConfigs from one copy of that dict. For yelp-main in prod, this currently takes about 4-5 seconds; this branch takes that to ~80ms.
- The [second commit](https://github.com/Yelp/paasta/pull/1722/commits/d28ecdfb8473f33a0c332abe6541ddbabdc5e529) renames PaastaServiceConfig to PaastaServiceConfigLoader, which I think is a better name -- the object loads configs, it is not itself a config.
- The [first commit](https://github.com/Yelp/paasta/pull/1722/commits/3b7b0705e7a95e98f759b6b4be0ca9cf45278732) makes several refactors (I probably should have done these in separate commits, but did not, and teasing that out after the fact would likely be very difficult. Sorry.):
  1. It changes the PaastaServiceConfig(Loader) code so that the user passes an InstanceConfig subclass (e.g. MarathonServiceConfig); this way, paasta_service_config(_loader).py does not need to import marathon_tools, and therefore marathon_tools can import paasta_service_config(_loader). So that PaastaServiceConfig can know what filename to look up for the particular config type specified, this commit makes the filename prefix a class variable.
  2. Because the AdhocJobConfig was using the v2 version of branch_dict, and PaastaServiceConfig no longer knows which version of branch_dict is appropriate, this commit changes all the other InstanceConfig types to also use the v2 style. (It's been ~15 months, it's time to finish this change.)
  3. Because a DeploymentsJson object either contained v1 or v2 information (never both), depending on whether `load_deployments_json` or `load_v2_deployments_json` was called, this commit also splits those into two different types.
  4. It makes all the keys of DeploymentsJsonV2 / BranchDictV2 required, so mypy will yell at you if you try to use an incomplete BranchDictV2. As part of this, the InstanceConfig interface changes, so that e.g. `load_marathon_service_config(..., load_deployments=False)` passes `branch_dict=None` instead of  `branch_dict={}`. This part of the change probably touched the most lines, particularly in tests.
  5. It makes DeploymentsJsonV{1,2} not subclass dict.
