### PR TITLE
Update marathon schema to allow instance names to begin with an underscore

### DIFF
--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -5,7 +5,7 @@
     "additionalProperties": false,
     "minProperties": 1,
     "patternProperties": {
-        "^([a-z0-9]|[a-z0-9][a-z0-9_-]*[a-z0-9])*$": {
+        "^([a-z0-9_]|[a-z0-9_][a-z0-9_-]*[a-z0-9])*$": {
             "type": "object",
             "additionalProperties": false,
             "minProperties": 1,

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -149,7 +149,7 @@ main_worker:
   cmd: virtualenv_run/bin/python adindexer/adindex_worker.py
   healthcheck_mode: cmd
   healthcheck_cmd: '/bin/true'
-main_http:
+_main_http:
   cpus: 0.1
   instances: 2
   mem: 250


### PR DESCRIPTION
We added support in the code to treat instances whose name begins with an underscore (`_`) as templates. This was to assist with dealing with yaml anchors/templating. However, we never updated our marathon schema file to support this.

This is PAASTA-13886