### PR TITLE
Have PaastaServiceConfigLoader.get_instances() skip instances which have no version marked for deployment.

### DIFF
--- a/paasta_tools/paasta_service_config_loader.py
+++ b/paasta_tools/paasta_service_config_loader.py
@@ -28,6 +28,7 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import load_v2_deployments_json
+from paasta_tools.utils import NoDeploymentsAvailable
 
 
 log = logging.getLogger(__name__)
@@ -115,7 +116,10 @@ class PaastaServiceConfigLoader():
         if (cluster, instance_type_class) not in self._framework_configs:
             self._refresh_framework_config(cluster, instance_type_class)
         for instance, config in self._framework_configs.get((cluster, instance_type_class), {}).items():
-            yield self._create_service_config(cluster, instance, config, instance_type_class)
+            try:
+                yield self._create_service_config(cluster, instance, config, instance_type_class)
+            except NoDeploymentsAvailable:
+                pass
 
     def _framework_config_filename(self, cluster: str, instance_type_class: Type[_InstanceConfig_T]):
         return "%s-%s" % (instance_type_class.config_filename_prefix, cluster)

--- a/tests/test_paasta_service_config_loader.py
+++ b/tests/test_paasta_service_config_loader.py
@@ -90,6 +90,10 @@ def marathon_cluster_config():
             'instances': 1, 'deploy_group': '{cluster}.canary',
             'cpus': 0.1, 'mem': 1000,
         },
+        'not_deployed': {
+            'instances': 1, 'deploy_group': 'not_deployed',
+            'cpus': 0.1, 'mem': 1000,
+        },
     }
 
 
@@ -107,6 +111,13 @@ def chronos_cluster_config():
             'deploy_group': '{cluster}.non_canary',
             'cmd': '/bin/sleep 5s',
         },
+        'not_deployed': {
+            'deploy_group': 'not_deployed',
+            'cpus': 0.1,
+            'mem': 1000,
+            'schedule': 'R/2016-04-15T06:00:00Z/PT24H',
+            'schedule_time_zone': 'America/Los_Angeles',
+        },
     }
 
 
@@ -117,6 +128,7 @@ def adhoc_cluster_config():
             'cmd': '/bin/sleep 5s',
         },
         'interactive': {'deploy_group': '{cluster}.non_canary', 'mem': 1000},
+        'not_deployed': {'deploy_group': 'not_deployed'},
     }
 
 
@@ -124,7 +136,7 @@ def adhoc_cluster_config():
 def test_marathon_instances(mock_read_extra_service_information):
     mock_read_extra_service_information.return_value = marathon_cluster_config()
     s = create_test_service()
-    assert list(s.instances(TEST_CLUSTER_NAME, MarathonServiceConfig)) == ['main', 'canary']
+    assert list(s.instances(TEST_CLUSTER_NAME, MarathonServiceConfig)) == ['main', 'canary', 'not_deployed']
     mock_read_extra_service_information.assert_called_once_with(
         extra_info='marathon-%s' % TEST_CLUSTER_NAME,
         service_name=TEST_SERVICE_NAME, soa_dir=TEST_SOA_DIR,


### PR DESCRIPTION
Another breakage from #1722: anything that calls `PaastaServiceConfigLoader.instance_configs()` (including `check_marathon_services_replication`) now gets a `NoDeploymentsAvailable` exception if there's any instances for the service/cluster in question that do not have a corresponding entry in deployments.json. The v1 deployments json object (which we used to use in PaastaServiceConfigLoader for marathon configs) returns an empty branch dict instead of raising an error.

This has `instance_configs` simply skip over any instances where `NoDeploymentsAvailable` gets raised. This does mean that the set of instances returned will be different depending on whether `PaastaServiceConfigLoader` is initialized with `load_deployments=True` or `False`.