### PR TITLE
Slightly better "paasta status" output for a bad service name

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -385,8 +385,19 @@ def apply_args_filters(args):
 
     filters = get_filters(args)
 
+    all_services = list_services(soa_dir=args.soa_dir)
+
+    if args.service and args.service not in all_services:
+        paasta_print(PaastaColors.red(f'The service "{args.service}" does not exist.'))
+        suggestions = difflib.get_close_matches(args.service, all_services, n=5, cutoff=0.5)
+        if suggestions:
+            paasta_print(PaastaColors.red(f'Did you mean any of these?'))
+            for suggestion in suggestions:
+                paasta_print(PaastaColors.red(f'  {suggestion}'))
+        return {}
+
     i_count = 0
-    for service in list_services(soa_dir=args.soa_dir):
+    for service in all_services:
         if args.service and service != args.service:
             continue
 

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -670,6 +670,26 @@ def test_apply_args_filters_clusters_and_instances(
     assert pargs['cluster1']['fake_service'] == {'instance1', 'instance3'}
 
 
+@patch('paasta_tools.cli.cmds.status.list_services', autospec=True)
+def test_apply_args_filters_bad_service_name(mock_list_services, capfd):
+    PaastaArgs = namedtuple('PaastaArgs', ['service', 'soa_dir', 'clusters', 'instances', 'deploy_group', 'owner'])
+    args = PaastaArgs(
+        service='fake-service',
+        soa_dir='/fake/soa/dir',
+        deploy_group=None,
+        clusters='cluster1',
+        instances='instance4,instance5',
+        owner=None,
+    )
+    mock_list_services.return_value = ['fake_service']
+    pargs = apply_args_filters(args)
+    output, _ = capfd.readouterr()
+    assert len(pargs) == 0
+    assert 'The service "fake-service" does not exist.' in output
+    assert 'Did you mean any of these?' in output
+    assert '  fake_service' in output
+
+
 @patch('paasta_tools.cli.cmds.status.list_all_instances_for_service', autospec=True)
 @patch('paasta_tools.cli.cmds.status.get_instance_configs_for_service', autospec=True)
 @patch('paasta_tools.cli.cmds.status.list_services', autospec=True)


### PR DESCRIPTION
This confused someone a bit earlier.

### Before:

```
$ paasta status -c norcal-prod -s yelp_main -i my_important_kew_worker
yelp_main doesn't have any instances matching my_important_kew_worker on norcal-prod.
```

(This makes it look like you misspelled the instance rather than the service.)

### After:

```
$ paasta status -c norcal-prod -s yelp_main -i my_important_kew_worker
The service "yelp_main" does not exist.
Did you mean any of these?
  yelp-main
  [another suggestion]
  [another suggestion]
  [another suggestion]
  [another suggestion]
```