### PR TITLE
Add libgpgme as a dependency

### DIFF
--- a/yelp_package/dockerfiles/lucid/Dockerfile
+++ b/yelp_package/dockerfiles/lucid/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update > /dev/null && apt-get -y install \
         help2man \
         libssl-dev \
         libffi-dev \
+        libgpgme11 \
         libyaml-dev \
         python-pip \
         python-setuptools \

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update > /dev/null && \
         git \
         help2man \
         libffi-dev \
+        libgpgme11 \
         libssl-dev \
         libyaml-dev \
         python3.6-dev \

--- a/yelp_package/dockerfiles/xenial/Dockerfile
+++ b/yelp_package/dockerfiles/xenial/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update > /dev/null && \
         git \
         help2man \
         libffi-dev \
+        libgpgme11 \
         libssl-dev \
         libyaml-dev \
         python3.6-dev \


### PR DESCRIPTION
This is needed by vault_tools -> crypto_lib -> pygpgme.

It's really only needed for the yelp internal build which is why Travis
passed.