### PR TITLE
Added the jars option for spark-run

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -72,6 +72,11 @@ def add_subparser(subparsers):
     )
 
     list_parser.add_argument(
+        '-j', '--jars',
+        help="Comma-separated list of local jars to include on the driver and executor classpaths.",
+    )
+
+    list_parser.add_argument(
         '-p', '--pool',
         help="Name of the resource pool to run the Spark job.",
         default='default',
@@ -219,6 +224,9 @@ def get_spark_conf_str(
     spark_conf.append('--conf spark.mesos.executor.docker.image=%s' % docker_img)
     if not args.build:
         spark_conf.append('--conf spark.mesos.uris=file:///root/.dockercfg')
+
+    if args.jars:
+        spark_conf.append('--conf spark.jars=%s' % args.jars)
 
     # TODO PAASTA-13815
     # spark_conf.append('--conf spark.mesos.secret=')


### PR DESCRIPTION
pyspark, spark-shell and spark-submit already have this option. jupyter users also want this option. However, due to https://issues.apache.org/jira/browse/TOREE-427, the %AddJar magic is broken. As a workaround, this PR adds --jars as a spark-run option, to satisfy needs from both sides.

~/paasta/.tox/py36/bin/paasta spark-run --cluster pnw-devc --jars /spark_client/target/data_pipeline_spark-0.1.0-SNAPSHOT.jar --cmd "spark-submit /spark_client/python_example.py"