### PR TITLE
Bump vault_tools version

### DIFF
--- a/paasta_tools/secret_providers/vault.py
+++ b/paasta_tools/secret_providers/vault.py
@@ -56,6 +56,6 @@ class SecretProvider(BaseSecretProvider):
                 cache_dir=None,
                 cache_key=None,
                 context=self.service_name,
-            )[0]
+            ).decode('utf-8')
             secret_environment[k] = secret
         return secret_environment

--- a/tests/secret_providers/test_vault.py
+++ b/tests/secret_providers/test_vault.py
@@ -20,7 +20,7 @@ def test_decrypt_environment():
     ) as mock_get_secret_name_from_ref, mock.patch(
         'paasta_tools.secret_providers.vault.get_plaintext', autospec=False,
     ) as mock_get_plaintext:
-        mock_get_plaintext.return_value = ('SECRETSQUIRREL',)
+        mock_get_plaintext.return_value = b'SECRETSQUIRREL'
         sp = SecretProvider(
             soa_dir='/nail/blah',
             service_name='universe',

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -1,7 +1,7 @@
 --extra-index-url=https://pypi.yelpcorp.com/simple
 crypto_lib==4.0.0
 scribereader==0.2.6
-vault-tools==0.6.6
+vault-tools==0.6.10
 yelp-cgeom==1.3.1
 yelp-logging==1.0.37
 yelp_meteorite


### PR DESCRIPTION
This version has:
* saner string encoding
* support for SUDO_USER which will make paasta local-run --pull work
with vault

cc @filipposc5