### PR TITLE
Moved SPARK_OPTS out from jupyter

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -182,9 +182,10 @@ def get_spark_env(
 
     # Run spark (and mesos framework) as root.
     spark_env['SPARK_USER'] = 'root'
+    spark_env['SPARK_OPTS'] = spark_conf
 
+    # Default configs to start the jupyter notebook server
     if cmd == 'jupyter':
-        spark_env['SPARK_OPTS'] = spark_conf
         spark_env['JUPYTER_RUNTIME_DIR'] = DEFAULT_SPARK_WORK_DIR + '/.jupyter'
         spark_env['JUPYTER_DATA_DIR'] = DEFAULT_SPARK_WORK_DIR + '/.jupyter'
 
@@ -314,12 +315,13 @@ def configure_and_run_docker_container(
         paasta_print("A command is required, pyspark, spark-shell, spark-submit or jupyter", file=sys.stderr)
         return 1
 
-    # Spark options are passed as options to pyspark and spark-shell.
-    # For jupyter, environment variable SPARK_OPTS is set instead.
+    # Default cli options to start the jupyter notebook server.
     if docker_cmd == 'jupyter':
         docker_cmd = 'jupyter notebook -y --ip=%s --notebook-dir=%s' % (
             socket.getfqdn(), DEFAULT_SPARK_WORK_DIR,
         )
+    # Spark options are passed as options to pyspark and spark-shell.
+    # For jupyter, environment variable SPARK_OPTS is set instead.
     elif docker_cmd in ['pyspark', 'spark-shell']:
         docker_cmd = docker_cmd + ' ' + spark_conf_str
     elif docker_cmd.startswith('spark-submit'):

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -151,6 +151,7 @@ def test_configure_and_run_docker_container(
             'AWS_ACCESS_KEY_ID': 'id',
             'AWS_SECRET_ACCESS_KEY': 'secret',
             'SPARK_USER': 'root',
+            'SPARK_OPTS': '--conf spark.app.name=fake_app',
         },
         docker_img='fake-registry/fake-service',
         docker_cmd='pyspark --conf spark.app.name=fake_app',


### PR DESCRIPTION
yelp-dm has a different way of launching a jupyter notebook server. It becomes a general use case when spark-run is used on a service other than the default services/spark. This change is to make SPARK_OPTS available for non-default jupyter commands.