### PR TITLE
Add --verify-image-exists flag for PAASTA-14050

### DIFF
--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -73,6 +73,7 @@ def step_paasta_mark_for_deployments_when(context):
         commit=context.expected_commit,
         soa_dir='fake_soa_configs',
         block=False,
+        verify_image=False,
     )
     context.force_bounce_timestamp = format_timestamp(datetime.utcnow())
     with mock.patch(
@@ -96,6 +97,7 @@ def step_paasta_stop_when(context):
         soa_dir='fake_soa_configs',
         service='fake_deployments_json_service',
         deploy_group=None,
+        verify_image=False,
     )
     context.force_bounce_timestamp = format_timestamp(datetime.utcnow())
     with mock.patch(

--- a/paasta_tools/cli/cmds/push_to_registry.py
+++ b/paasta_tools/cli/cmds/push_to_registry.py
@@ -22,7 +22,6 @@ import os
 
 import requests
 from requests.exceptions import RequestException
-from requests.exceptions import SSLError
 
 from paasta_tools.cli.utils import get_jenkins_build_output_url
 from paasta_tools.cli.utils import validate_full_git_sha
@@ -170,26 +169,13 @@ def is_docker_image_already_in_registry(service, soa_dir, sha):
     registry_uri = get_service_docker_registry(service, soa_dir)
     repository, tag = build_docker_image_name(service, sha).split(':')
 
-    creds = read_docker_registy_creds(registry_uri)
-    uri = '%s/v2/%s/tags/list' % (registry_uri, repository)
+    uri = '%s/v2/%s/manifests/paasta-%s' % (registry_uri, repository, sha)
 
-    with requests.Session() as s:
-        try:
-            url = 'https://' + uri
-            r = s.get(url, timeout=30) if creds[0] is None else s.get(url, auth=creds, timeout=30)
-        except SSLError:
-            # If no auth creds, fallback to trying http
-            if creds[0] is not None:
-                raise
-            url = 'http://' + uri
-            r = s.get(url, timeout=30)
+    url = 'https://' + uri
+    r = requests.head(url, timeout=30)
 
-        if r.status_code == 200:
-            tags_resp = r.json()
-            if tags_resp['tags']:
-                return tag in tags_resp['tags']
-            else:
-                return False
-        elif r.status_code == 404:
-            return False  # No Such Repository Error
-        r.raise_for_status()
+    if r.status_code == 200:
+        return True
+    elif r.status_code == 404:
+        return False
+    r.raise_for_status()


### PR DESCRIPTION
See internal ticket for details.

## Todo
- [x] Put back auth code in `is_docker_image_already_in_registry` (otherwise this change is not backwards compatible with docker registry that enforces auth on all endpoints)
- [x] Fix build