### PR TITLE
Fix docker_ commands container name

### DIFF
--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -1054,7 +1054,7 @@ def get_task_from_instance(cluster, service, instance, slave_hostname=None, task
 
 
 def get_container_name(task):
-    container_name = "mesos-{}.{}".format(task.slave_id, task.executor['container'])
+    container_name = "mesos-{}".format(task.executor['container'])
     return container_name
 
 

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -800,9 +800,9 @@ def test_get_task_from_instance(mock_client):
 
 
 def test_get_container_name():
-    mock_task = mock.Mock(slave_id='slave1', executor={'container': 'container1'})
+    mock_task = mock.Mock(executor={'container': 'container1'})
     ret = utils.get_container_name(mock_task)
-    assert ret == 'mesos-slave1.container1'
+    assert ret == 'mesos-container1'
 
 
 def test_pick_random_port():


### PR DESCRIPTION
The format mesos uses for the container name they pass to docker seems to
have changed in a recent version of mesos. This fixes our docker_
commands which rely on using the container name.