### PR TITLE
Fix chronos interval detection on weekly jobs

### DIFF
--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -349,8 +349,9 @@ class ChronosJobConfig(InstanceConfig):
             except (pytz.exceptions.UnknownTimeZoneError, AttributeError):
                 job_tz = pytz.utc
             c = croniter(schedule, datetime.datetime.now(job_tz) - datetime.timedelta(seconds=seconds_ago))
-            # For some reason, croniter's iterator has trouble with monthly jobs that have a time-zone attached
+            # For some reason, croniter's iterator has trouble with weekly/monthly jobs that have a time-zone attached
             # So we pretend we are in the future a bit in order to get a sane interval.
+            c.get_next()
             c.get_next()
             return c.get_next() - c.get_prev()
         else:

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -577,6 +577,17 @@ class TestChronosTools:
         )
         assert 60 * 60 * 24 * 28 <= fake_conf.get_schedule_interval_in_seconds() <= 60 * 60 * 24 * 31
 
+    def test_get_schedule_interval_in_seconds_if_weekly_crontab_format(self):
+        fake_schedule = '0 14 * * 4'
+        fake_conf = chronos_tools.ChronosJobConfig(
+            service='fake_name',
+            cluster='fake_cluster',
+            instance='fake_instance',
+            config_dict={'schedule': fake_schedule, 'schedule_time_zone': 'America/Los_Angeles'},
+            branch_dict=None,
+        )
+        assert 60 * 60 * 24 * 7 == fake_conf.get_schedule_interval_in_seconds()
+
     def test_get_schedule_interval_in_seconds_if_no_interval(self):
         fake_schedule = '2016-10-21T00:30:00Z'
         fake_conf = chronos_tools.ChronosJobConfig(


### PR DESCRIPTION
I don't really understand why croniter thinks the interval is only an hour.
But if we look forward enough into the future (`next()` twice the interval is "correct").