### PR TITLE
Always return http response with bravado client, bump bravado

### DIFF
--- a/paasta_tools/api/client.py
+++ b/paasta_tools/api/client.py
@@ -29,7 +29,7 @@ from paasta_tools.utils import load_system_paasta_config
 log = logging.getLogger(__name__)
 
 
-def get_paasta_api_client(cluster=None, system_paasta_config=None, http_res=False):
+def get_paasta_api_client(cluster=None, system_paasta_config=None):
     if not system_paasta_config:
         system_paasta_config = load_system_paasta_config()
 
@@ -60,9 +60,4 @@ def get_paasta_api_client(cluster=None, system_paasta_config=None, http_res=Fals
     # replace localhost in swagger.json with actual api server
     spec_dict['host'] = api_server
 
-    # sometimes we want the status code
-    if http_res:
-        config = {'also_return_response': True}
-        return SwaggerClient.from_spec(spec_dict=spec_dict, config=config)
-    else:
-        return SwaggerClient.from_spec(spec_dict=spec_dict)
+    return SwaggerClient.from_spec(spec_dict=spec_dict, config={'also_return_response': True})

--- a/paasta_tools/autoscaling/pause_service_autoscaler.py
+++ b/paasta_tools/autoscaling/pause_service_autoscaler.py
@@ -8,7 +8,7 @@ from paasta_tools.utils import paasta_print
 
 
 def get_service_autoscale_pause_time(cluster):
-    api = client.get_paasta_api_client(cluster=cluster, http_res=True)
+    api = client.get_paasta_api_client(cluster=cluster)
     if not api:
         paasta_print('Could not connect to paasta api. Maybe you misspelled the cluster?')
         return 1
@@ -29,7 +29,7 @@ def get_service_autoscale_pause_time(cluster):
 
 
 def update_service_autoscale_pause_time(cluster, mins):
-    api = client.get_paasta_api_client(cluster=cluster, http_res=True)
+    api = client.get_paasta_api_client(cluster=cluster)
     if not api:
         paasta_print('Could not connect to paasta api. Maybe you misspelled the cluster?')
         return 1
@@ -44,7 +44,7 @@ def update_service_autoscale_pause_time(cluster, mins):
 
 
 def delete_service_autoscale_pause_time(cluster):
-    api = client.get_paasta_api_client(cluster=cluster, http_res=True)
+    api = client.get_paasta_api_client(cluster=cluster)
     if not api:
         paasta_print('Could not connect to paasta api. Maybe you misspelled the cluster?')
         return 1

--- a/paasta_tools/cli/cmds/autoscale.py
+++ b/paasta_tools/cli/cmds/autoscale.py
@@ -57,7 +57,7 @@ def add_subparser(subparsers):
 def paasta_autoscale(args):
     log.setLevel(logging.DEBUG)
     service = figure_out_service_name(args)
-    api = client.get_paasta_api_client(cluster=args.cluster, http_res=True)
+    api = client.get_paasta_api_client(cluster=args.cluster)
     if not api:
         paasta_print('Could not connect to paasta api. Maybe you misspelled the cluster?')
         return 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp==2.3.3
 argcomplete==0.8.1
 backports.ssl-match-hostname==3.4.0.2
 boto3==1.3.0
-bravado==8.4.0
+bravado==9.2.2
 choice==0.1
 chronos-python==1.2.1
 cookiecutter==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'a_sync >= 0.5.0',
         'argcomplete >= 0.8.1',
         'aiohttp >= 2.3.3',
-        'bravado == 8.4.0',
+        'bravado == 9.2.2',
         'choice == 0.1',
         'chronos-python >= 1.2.0',
         'cookiecutter == 1.4.0',

--- a/tests/autoscaling/test_pause_service_autoscaler.py
+++ b/tests/autoscaling/test_pause_service_autoscaler.py
@@ -10,7 +10,7 @@ def test_get_service_autoscale_pause_time_error(mock_client):
     mock_client.get_paasta_api_client.return_value = None
     return_code = get_service_autoscale_pause_time('cluster1')
     assert return_code == 1
-    mock_client.get_paasta_api_client.assert_called_with(cluster='cluster1', http_res=True)
+    mock_client.get_paasta_api_client.assert_called_with(cluster='cluster1')
 
     mock_api = mock.Mock()
     mock_client.get_paasta_api_client.return_value = mock_api
@@ -58,7 +58,7 @@ def test_update_service_autoscale_pause_time(mock_client):
     mock_client.get_paasta_api_client.return_value = None
     return_code = update_service_autoscale_pause_time('cluster1', '2')
     assert return_code == 1
-    mock_client.get_paasta_api_client.assert_called_with(cluster='cluster1', http_res=True)
+    mock_client.get_paasta_api_client.assert_called_with(cluster='cluster1')
 
     mock_api = mock.Mock()
     mock_client.get_paasta_api_client.return_value = mock_api
@@ -82,7 +82,7 @@ def test_delete_service_autoscale_pause_time(mock_client):
     mock_client.get_paasta_api_client.return_value = None
     return_code = delete_service_autoscale_pause_time('cluster1')
     assert return_code == 1
-    mock_client.get_paasta_api_client.assert_called_with(cluster='cluster1', http_res=True)
+    mock_client.get_paasta_api_client.assert_called_with(cluster='cluster1')
 
     mock_api = mock.Mock()
     mock_client.get_paasta_api_client.return_value = mock_api


### PR DESCRIPTION
Newer versions of bravado hint that they understand these "extra" arguments and should remove the warning.