### PR TITLE
Add paasta secret cli module

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -554,11 +554,11 @@ def decrypt_secret_environment_variables(
             secret_provider_name=secret_provider_name,
             soa_dir=soa_dir,
             service_name=service_name,
-            cluster_name=cluster_name,
+            cluster_names=[cluster_name],
+            secret_provider_kwargs=secret_provider_kwargs,
         )
         secret_environment = secret_provider.decrypt_environment(
             secret_env_vars,
-            **secret_provider_kwargs,
         )
     return secret_environment
 

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+# Copyright 2015-2018 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+
+from paasta_tools.cli.utils import lazy_choices_completer
+from paasta_tools.cli.utils import list_services
+from paasta_tools.secret_tools import get_secret_provider
+from paasta_tools.utils import list_clusters
+from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import paasta_print
+
+
+def add_subparser(subparsers):
+    secret_parser = subparsers.add_parser(
+        'secret',
+        help="Add/update PaaSTA service secrets",
+        description=(
+            "This script allows you to add secrets to your services "
+            "as environment variables. This script modifies your local "
+            "checkout of yelpsoa-configs and you must then commit and "
+            "push the changes back to git."
+        ),
+    )
+    secret_parser.add_argument(
+        "action",
+        help="should be add/update",
+        choices=["add", "update", "decrypt"],
+    )
+    secret_parser.add_argument(
+        "-n",
+        "--secret-name",
+        required=True,
+        help="The name of the secret to create/update, "
+             "this is the name you will reference in your "
+             "services marathon/chronos yaml files and should "
+             "be unique per service.",
+    )
+    secret_parser.add_argument(
+        '-s', '--service',
+        help='The name of the service on which you wish to act',
+        required=True,
+    ).completer = lazy_choices_completer(list_services)
+    secret_parser.add_argument(
+        '-c', '--clusters',
+        help="A comma-separated list of clusters to create secrets for. "
+             "Note: this is translated to ecosystems because Vault is run "
+             "at an ecosystem level. As a result you can only have different "
+             "secrets per ecosystem. (it is not possible for example to encrypt "
+             "a different value for norcal-prod vs nova-prod. "
+             "Defaults to all clusters in which the service runs. "
+             "For example: --clusters norcal-prod,nova-prod ",
+    ).completer = lazy_choices_completer(list_clusters)
+    secret_parser.add_argument(
+        "-p",
+        "--plain-text",
+        required=False,
+        type=str,
+        help="Optionally specify the secret as a command line argument",
+    )
+    secret_parser.add_argument(
+        "-i",
+        "--stdin",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Optionally pass the plaintext from stdin",
+    )
+    secret_parser.set_defaults(command=paasta_secret)
+
+
+def print_paasta_helper(secret_path, secret_name):
+    print("\nYou have successfully encrypted your new secret and it\n"
+          "has been stored at {}\n"
+          "To use the secret in a service you can add it to your PaaSTA service\n"
+          "as an environment variable.\n"
+          "You do so by referencing it in the env dict in your yaml config:\n\n"
+          "main:\n"
+          "  cpus: 1\n"
+          "  env:\n"
+          "    MY_SECRET_VAR: SECRET({})\n\n"
+          "Once you have referenced the secret you must commit the newly\n"
+          "created/updated json file and your changes to your yaml config. When\n"
+          "you push to master PaaSTA will bounce your service and the new\n"
+          "secrets plaintext will be in the environment variable you have\n"
+          "specified.".format(secret_path, secret_name))
+
+
+def get_plaintext_input(args):
+    if args.stdin:
+        plaintext = sys.stdin.buffer.read()
+    elif args.plain_text:
+        plaintext = args.plain_text.encode('utf-8')
+    else:
+        print("Please enter the plaintext for the secret, press Ctrl-D when done.")
+        lines = []
+        while True:
+            try:
+                line = input()
+            except EOFError:
+                break
+            lines.append(line)
+        plaintext = '\n'.join(lines).encode('utf-8')
+    return plaintext
+
+
+def is_service_folder(soa_dir, service_name):
+    return os.path.isfile(os.path.join(soa_dir, service_name, "service.yaml"))
+
+
+def _get_secret_provider_for_service(service_name, cluster_names=None):
+    if not is_service_folder(os.getcwd(), service_name):
+        paasta_print(
+            "You must run this tool from the root of your local yelpsoa checkout\n"
+            "The tool modifies files in yelpsoa-configs that you must then commit\n"
+            "and push back to git.",
+        )
+        sys.exit(1)
+    system_paasta_config = load_system_paasta_config()
+    secret_provider_kwargs = {
+        'vault_cluster_config': system_paasta_config.get_vault_cluster_config(),
+    }
+    clusters = cluster_names.split(',') if cluster_names else list_clusters(
+        service=service_name,
+        soa_dir=os.getcwd(),
+    )
+    return get_secret_provider(
+        secret_provider_name=system_paasta_config.get_secret_provider_name(),
+        soa_dir=os.getcwd(),
+        service_name=service_name,
+        cluster_names=clusters,
+        secret_provider_kwargs=secret_provider_kwargs,
+    )
+
+
+def paasta_secret(args):
+    secret_provider = _get_secret_provider_for_service(args.service, cluster_names=args.clusters)
+    if args.action in ["add", "update"]:
+        secret_provider.write_secret(
+            action=args.action,
+            secret_name=args.secret_name,
+            plaintext=get_plaintext_input(args),
+        )
+        secret_path = os.path.join(secret_provider.secret_dir, "{}.json".format(args.secret_name))
+        print_paasta_helper(secret_path, args.secret_name)
+    elif args.action == "decrypt":
+        print(decrypt_secret(
+            secret_provider=secret_provider,
+            secret_name=args.secret_name,
+        ))
+    else:
+        print("Unknown action")
+        sys.exit(1)
+
+
+def decrypt_secret(secret_provider, secret_name):
+    if len(secret_provider.cluster_names) > 1:
+        paasta_print(
+            "Can only decrypt for one cluster at a time!\nFor example, try '-c norcal-devc'"
+            " to decrypt the secret for this service in norcal-devc.",
+        )
+        sys.exit(1)
+    return secret_provider.decrypt_secret(secret_name)

--- a/paasta_tools/secret_providers/__init__.py
+++ b/paasta_tools/secret_providers/__init__.py
@@ -1,16 +1,30 @@
 import os
 from typing import Any
 from typing import Dict
+from typing import List
 
 
 class BaseSecretProvider(object):
 
-    def __init__(self, soa_dir: str, service_name: str, cluster_name: str) -> None:
-        self.secret_dir = os.path.join(soa_dir, service_name, "secrets")
+    def __init__(
+        self,
+        soa_dir: str,
+        service_name: str,
+        cluster_names: List[str],
+        **kwargs: Any,
+    ) -> None:
+        self.soa_dir = soa_dir
         self.service_name = service_name
-        self.cluster_name = cluster_name
+        self.secret_dir = os.path.join(self.soa_dir, self.service_name, "secrets")
+        self.cluster_names = cluster_names
 
     def decrypt_environment(self, environment: Dict[str, str], **kwargs: Any) -> Dict[str, str]:
+        raise NotImplementedError
+
+    def write_secret(self, action: str, secret_name: str, plaintext: bytes) -> None:
+        raise NotImplementedError
+
+    def decrypt_secret(self, secret_name: str) -> str:
         raise NotImplementedError
 
 

--- a/paasta_tools/secret_providers/vault.py
+++ b/paasta_tools/secret_providers/vault.py
@@ -1,13 +1,19 @@
+import getpass
 import os
 from typing import Any
 from typing import Dict
+from typing import List
 
 try:
     from vault_tools.client.jsonsecret import get_plaintext
     from vault_tools.paasta_secret import get_vault_client
+    from vault_tools.gpg import TempGpgKeyring
+    from vault_tools.paasta_secret import encrypt_secret
 except ImportError:
     get_plaintext = None
     get_vault_client = None
+    TempGpgKeyring = None
+    encrypt_secret = None
 
 from paasta_tools.secret_providers import BaseSecretProvider
 from paasta_tools.utils import paasta_print
@@ -16,30 +22,32 @@ from paasta_tools.secret_tools import get_secret_name_from_ref
 
 class SecretProvider(BaseSecretProvider):
 
-    def __init__(self, soa_dir: str, service_name: str, cluster_name: str) -> None:
-        super().__init__(soa_dir, service_name, cluster_name)
+    def __init__(
+        self,
+        soa_dir: str,
+        service_name: str,
+        cluster_names: List[str],
+        vault_cluster_config: Dict[str, str]={},
+        vault_auth_method: str='ldap',
+        vault_token_file: str='/root/.vault-token',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(soa_dir, service_name, cluster_names)
+        self.vault_cluster_config = vault_cluster_config
+        self.vault_auth_method = vault_auth_method
+        self.vault_token_file = vault_token_file
 
     def decrypt_environment(
         self,
         environment: Dict[str, str],
-        vault_auth_method: str='ldap',
-        vault_token_file: str='/root/.vault-token',
-        vault_cluster_config: Dict[str, str]={},
         **kwargs: Any,
     ) -> Dict[str, str]:
-        try:
-            self.ecosystem = vault_cluster_config[self.cluster_name]
-        except KeyError:
-            paasta_print(
-                "Cannot find a vault cluster for the %s paasta cluster. A mapping must exist "
-                "in /etc/paasta so we contact the correct vault cluster to get secrets" % self.cluster_name,
-            )
-            raise
+        self.ecosystem = self.get_vault_ecosystems_for_clusters()[0]
         self.client = get_vault_client(
             ecosystem=self.ecosystem,
             num_uses=len(environment),
-            vault_auth_method=vault_auth_method,
-            vault_token_file=vault_token_file,
+            vault_auth_method=self.vault_auth_method,
+            vault_token_file=self.vault_token_file,
         )
         secret_environment = {}
         for k, v in environment.items():
@@ -59,3 +67,65 @@ class SecretProvider(BaseSecretProvider):
             ).decode('utf-8')
             secret_environment[k] = secret
         return secret_environment
+
+    def get_vault_ecosystems_for_clusters(self) -> List[str]:
+        try:
+            return list({self.vault_cluster_config[cluster_name] for cluster_name in self.cluster_names})
+        except KeyError as e:
+            paasta_print(
+                "Cannot find a vault cluster for the %s paasta cluster. A mapping must exist "
+                "in /etc/paasta so we contact the correct vault cluster to get/set secrets" % e,
+            )
+            raise
+
+    def write_secret(self, action: str, secret_name: str, plaintext: bytes) -> None:
+        with TempGpgKeyring(overwrite=True):
+            ecosystems = self.get_vault_ecosystems_for_clusters()
+            if 'VAULT_TOKEN_OVERRIDE' not in os.environ:
+                username = getpass.getuser()
+                password = getpass.getpass("Please enter your LDAP password to auth with Vault\n")
+            else:
+                username = None
+                password = None
+            for ecosystem in ecosystems:
+                client = get_vault_client(
+                    ecosystem=ecosystem,
+                    username=username,
+                    password=password,
+                )
+                encrypt_secret(
+                    client=client,
+                    action=action,
+                    ecosystem=ecosystem,
+                    secret_name=secret_name,
+                    soa_dir=self.soa_dir,
+                    plaintext=plaintext,
+                    service_name=self.service_name,
+                )
+
+    def decrypt_secret(self, secret_name: str) -> str:
+        ecosystem = self.get_vault_ecosystems_for_clusters()[0]
+        if 'VAULT_TOKEN_OVERRIDE' not in os.environ:
+            username = getpass.getuser()
+            password = getpass.getpass("Please enter your LDAP password to auth with Vault\n")
+        else:
+            username = None
+            password = None
+        client = get_vault_client(
+            ecosystem=ecosystem,
+            username=username,
+            password=password,
+        )
+        secret_path = os.path.join(
+            self.secret_dir,
+            "{}.json".format(secret_name),
+        )
+        return get_plaintext(
+            client=client,
+            path=secret_path,
+            env=ecosystem,
+            cache_enabled=False,
+            cache_key=None,
+            cache_dir=None,
+            context=self.service_name,
+        ).decode('utf-8')

--- a/paasta_tools/secret_tools.py
+++ b/paasta_tools/secret_tools.py
@@ -13,6 +13,9 @@
 import json
 import os
 import re
+from typing import Any
+from typing import Dict
+from typing import List
 from typing import Optional
 
 from paasta_tools.secret_providers import SecretProvider
@@ -62,7 +65,13 @@ def get_secret_provider(
     secret_provider_name: str,
     soa_dir: str,
     service_name: str,
-    cluster_name: str,
+    cluster_names: List[str],
+    secret_provider_kwargs: Dict[str, Any],
 ) -> SecretProvider:
     SecretProvider = __import__(secret_provider_name, fromlist=['SecretProvider']).SecretProvider
-    return SecretProvider(soa_dir, service_name, cluster_name)
+    return SecretProvider(
+        soa_dir=soa_dir,
+        service_name=service_name,
+        cluster_names=cluster_names,
+        **secret_provider_kwargs,
+    )

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -1697,11 +1697,11 @@ def test_decrypt_secret_environment_variables():
             secret_provider_name='vault',
             soa_dir='/nail/blah',
             service_name='universe',
-            cluster_name='mesosstage',
+            cluster_names=['mesosstage'],
+            secret_provider_kwargs={'some': 'config'},
         )
         mock_secret_provider.decrypt_environment.assert_called_with(
             {'SECRET': 'SECRET(123)'},
-            some='config',
         )
         assert ret == mock_secret_provider.decrypt_environment.return_value
 

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -1,0 +1,175 @@
+# Copyright 2015-2018 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+from pytest import raises
+
+from paasta_tools.cli.cmds import secret
+
+
+def test_add_subparser():
+    mock_subparsers = mock.Mock()
+    secret.add_subparser(mock_subparsers)
+    assert mock_subparsers.add_parser.called
+    mock_subparsers.add_parser.return_value.set_defaults.assert_called_with(
+        command=secret.paasta_secret,
+    )
+
+
+def test_print_paasta_helper():
+    secret.print_paasta_helper('/blah/what', 'keepithidden')
+
+
+def test_get_plaintext_input():
+    with mock.patch(
+        'sys.stdin', autospec=True,
+    ) as mock_stdin, mock.patch(
+        'paasta_tools.cli.cmds.secret.input', autospec=False,
+    ) as mock_input:
+        mock_args = mock.Mock(plain_text=False, stdin=True)
+        mock_stdin.buffer.read.return_value = b"SECRET_SQUIRREL"
+        assert secret.get_plaintext_input(mock_args) == b"SECRET_SQUIRREL"
+
+        mock_args = mock.Mock(plain_text="SECRET_CAT", stdin=False)
+        assert secret.get_plaintext_input(mock_args) == b"SECRET_CAT"
+
+        mock_args = mock.Mock(plain_text=False, stdin=False)
+        mock_input.side_effect = ["DANGER_DOG", EOFError]
+        assert secret.get_plaintext_input(mock_args) == b"DANGER_DOG"
+
+
+def test_is_service_folder():
+    with mock.patch(
+        "os.path.isfile", autospec=True,
+    ) as mock_is_file:
+        mock_is_file.return_value = True
+        assert secret.is_service_folder(
+            soa_dir='/nail',
+            service_name='universe',
+        )
+        mock_is_file.assert_called_with('/nail/universe/service.yaml')
+
+        mock_is_file.return_value = False
+        assert not secret.is_service_folder(
+            soa_dir='/nail',
+            service_name='universe',
+        )
+
+
+def test__get_secret_provider_for_service():
+    with mock.patch(
+        'os.getcwd', autospec=True,
+    ) as mock_getcwd, mock.patch(
+        'paasta_tools.cli.cmds.secret.is_service_folder', autospec=True,
+    ) as mock_is_service_folder, mock.patch(
+        'paasta_tools.cli.cmds.secret.load_system_paasta_config', autospec=True,
+    ) as mock_load_system_paasta_config, mock.patch(
+        'paasta_tools.cli.cmds.secret.list_clusters', autospec=True,
+    ) as mock_list_clusters, mock.patch(
+        'paasta_tools.cli.cmds.secret.get_secret_provider', autospec=True,
+    ) as mock_get_secret_provider:
+        mock_config = mock.Mock()
+        mock_load_system_paasta_config.return_value = mock_config
+        mock_is_service_folder.return_value = False
+        with raises(SystemExit):
+            secret._get_secret_provider_for_service('universe')
+        mock_is_service_folder.return_value = True
+
+        ret = secret._get_secret_provider_for_service('universe', cluster_names='mesosstage,norcal-devc')
+        assert ret == mock_get_secret_provider.return_value
+        mock_get_secret_provider.assert_called_with(
+            secret_provider_name=mock_config.get_secret_provider_name.return_value,
+            soa_dir=mock_getcwd.return_value,
+            service_name='universe',
+            cluster_names=['mesosstage', 'norcal-devc'],
+            secret_provider_kwargs={
+                'vault_cluster_config': mock_config.get_vault_cluster_config.return_value,
+            },
+        )
+
+        ret = secret._get_secret_provider_for_service('universe', cluster_names=None)
+        assert ret == mock_get_secret_provider.return_value
+        mock_get_secret_provider.assert_called_with(
+            secret_provider_name=mock_config.get_secret_provider_name.return_value,
+            soa_dir=mock_getcwd.return_value,
+            service_name='universe',
+            cluster_names=mock_list_clusters.return_value,
+            secret_provider_kwargs={
+                'vault_cluster_config': mock_config.get_vault_cluster_config.return_value,
+            },
+        )
+
+
+def test_paasta_secret():
+    with mock.patch(
+        'paasta_tools.cli.cmds.secret._get_secret_provider_for_service', autospec=True,
+    ) as mock_get_secret_provider_for_service, mock.patch(
+        'paasta_tools.cli.cmds.secret.decrypt_secret', autospec=True,
+    ) as mock_decrypt_secret, mock.patch(
+        'paasta_tools.cli.cmds.secret.get_plaintext_input', autospec=True,
+    ) as mock_get_plaintext_input:
+        mock_secret_provider = mock.Mock(secret_dir='/nail/blah')
+        mock_get_secret_provider_for_service.return_value = mock_secret_provider
+        mock_args = mock.Mock(
+            action='add',
+            secret_name='theonering',
+            service='middleearth',
+            clusters='mesosstage',
+        )
+        secret.paasta_secret(mock_args)
+        mock_get_secret_provider_for_service.assert_called_with('middleearth', cluster_names='mesosstage')
+        mock_secret_provider.write_secret.assert_called_with(
+            action='add',
+            secret_name='theonering',
+            plaintext=mock_get_plaintext_input.return_value,
+        )
+
+        mock_args = mock.Mock(
+            action='update',
+            secret_name='theonering',
+            service='middleearth',
+            clusters='mesosstage',
+        )
+        secret.paasta_secret(mock_args)
+        mock_get_secret_provider_for_service.assert_called_with('middleearth', cluster_names='mesosstage')
+        mock_secret_provider.write_secret.assert_called_with(
+            action='update',
+            secret_name='theonering',
+            plaintext=mock_get_plaintext_input.return_value,
+        )
+
+        mock_args = mock.Mock(
+            action='decrypt',
+            secret_name='theonering',
+            service='middleearth',
+            clusters='mesosstage',
+        )
+        secret.paasta_secret(mock_args)
+        mock_get_secret_provider_for_service.assert_called_with('middleearth', cluster_names='mesosstage')
+        mock_decrypt_secret.assert_called_with(
+            secret_provider=mock_secret_provider,
+            secret_name='theonering',
+        )
+
+
+def test_decrypt_secret():
+    mock_secret_provider = mock.Mock(
+        cluster_names=['mesosstage', 'devc'],
+    )
+    with raises(SystemExit):
+        secret.decrypt_secret(mock_secret_provider, 'theonering')
+    mock_secret_provider = mock.Mock(
+        cluster_names=['mesosstage'],
+    )
+    assert secret.decrypt_secret(mock_secret_provider, 'theonering') == mock_secret_provider.decrypt_secret.return_value
+    mock_secret_provider.decrypt_secret.assert_called_with('theonering')

--- a/tests/secret_providers/test_secret_providers.py
+++ b/tests/secret_providers/test_secret_providers.py
@@ -7,7 +7,8 @@ def test_secret_provider():
     SecretProvider(
         soa_dir='/nail/blah',
         service_name='universe',
-        cluster_name='mesosstage',
+        cluster_names=['mesosstage'],
+        some='setting',
     )
 
 
@@ -16,5 +17,29 @@ def test_decrypt_environment():
         SecretProvider(
             soa_dir='/nail/blah',
             service_name='universe',
-            cluster_name='mesosstage',
+            cluster_names=['mesosstage'],
         ).decrypt_environment(environment={}, a='kwarg')
+
+
+def test_write_secret():
+    with raises(NotImplementedError):
+        SecretProvider(
+            soa_dir='/nail/blah',
+            service_name='universe',
+            cluster_names=['mesosstage'],
+        ).write_secret(
+            action='update',
+            secret_name='whatididlastsummer',
+            plaintext=b'noybw',
+        )
+
+
+def test_decrypt_secret():
+    with raises(NotImplementedError):
+        SecretProvider(
+            soa_dir='/nail/blah',
+            service_name='universe',
+            cluster_names=['mesosstage'],
+        ).decrypt_secret(
+            secret_name='whatididlastsummer',
+        )

--- a/tests/secret_providers/test_vault.py
+++ b/tests/secret_providers/test_vault.py
@@ -8,7 +8,7 @@ def test_secret_provider():
     SecretProvider(
         soa_dir='/nail/blah',
         service_name='universe',
-        cluster_name='mesosstage',
+        cluster_names=['mesosstage'],
     )
 
 
@@ -24,7 +24,10 @@ def test_decrypt_environment():
         sp = SecretProvider(
             soa_dir='/nail/blah',
             service_name='universe',
-            cluster_name='mesosstage',
+            cluster_names=['mesosstage', ],
+            vault_auth_method='ldap',
+            vault_token_file='/nail/blah',
+            vault_cluster_config={'mesosstage': 'devc'},
         )
         mock_env = {
             'MY_VAR': 'SECRET(test-secret)',
@@ -33,9 +36,6 @@ def test_decrypt_environment():
         mock_get_secret_name_from_ref.return_value = "secret_name"
         ret = sp.decrypt_environment(
             environment=mock_env,
-            vault_auth_method='ldap',
-            vault_token_file='/nail/blah',
-            vault_cluster_config={'mesosstage': 'devc'},
             some='kwarg',
         )
         mock_get_secret_name_from_ref.assert_has_calls(
@@ -54,11 +54,100 @@ def test_decrypt_environment():
         }
         assert ret == expected
 
-        with raises(KeyError):
-            sp.decrypt_environment(
-                environment=mock_env,
-                vault_auth_method='ldap',
-                vault_token_file='/nail/blah',
-                vault_cluster_config={'westeros-prod': 'devc'},
-                some='kwarg',
-            )
+
+def test_get_vault_ecosystems_for_clusters():
+    sp = SecretProvider(
+        soa_dir='/nail/blah',
+        service_name='universe',
+        cluster_names=['mesosstage', 'devc', 'prod'],
+        vault_auth_method='ldap',
+        vault_token_file='/nail/blah',
+        vault_cluster_config={
+            'mesosstage': 'devc',
+            'devc': 'devc',
+            'prod': 'prod',
+        },
+    )
+    assert sorted(sp.get_vault_ecosystems_for_clusters()) == sorted(['devc', 'prod'])
+
+    sp = SecretProvider(
+        soa_dir='/nail/blah',
+        service_name='universe',
+        cluster_names=['mesosstage', 'devc', 'prod1'],
+        vault_auth_method='ldap',
+        vault_token_file='/nail/blah',
+        vault_cluster_config={
+            'mesosstage': 'devc',
+            'devc': 'devc',
+            'prod': 'prod',
+        },
+    )
+    with raises(KeyError):
+        sp.get_vault_ecosystems_for_clusters()
+
+
+def test_write_secret():
+    with mock.patch(
+        'paasta_tools.secret_providers.vault.TempGpgKeyring', autospec=False,
+    ), mock.patch(
+        'paasta_tools.secret_providers.vault.get_vault_client', autospec=False,
+    ) as mock_get_client, mock.patch(
+        'paasta_tools.secret_providers.vault.encrypt_secret', autospec=False,
+    ) as mock_encrypt_secret, mock.patch(
+        'paasta_tools.secret_providers.vault.getpass', autospec=True,
+    ):
+        sp = SecretProvider(
+            soa_dir='/nail/blah',
+            service_name='universe',
+            cluster_names=['mesosstage'],
+            vault_auth_method='ldap',
+            vault_token_file='/nail/blah',
+            vault_cluster_config={
+                'mesosstage': 'devc',
+            },
+        )
+        sp.write_secret(
+            action='add',
+            secret_name='mysecret',
+            plaintext=b"SECRETSQUIRREL",
+        )
+        assert mock_get_client.called
+        mock_encrypt_secret.assert_called_with(
+            client=mock_get_client.return_value,
+            action="add",
+            ecosystem="devc",
+            secret_name="mysecret",
+            plaintext=b"SECRETSQUIRREL",
+            service_name='universe',
+            soa_dir='/nail/blah',
+        )
+
+
+def test_decrypt_secret():
+    with mock.patch(
+        'paasta_tools.secret_providers.vault.get_vault_client', autospec=False,
+    ) as mock_get_vault_client, mock.patch(
+        'paasta_tools.secret_providers.vault.get_plaintext', autospec=False,
+    ) as mock_get_plaintext, mock.patch(
+        'paasta_tools.secret_providers.vault.getpass', autospec=True,
+    ):
+        mock_get_plaintext.return_value = b'SECRETSQUIRREL'
+        sp = SecretProvider(
+            soa_dir='/nail/blah',
+            service_name='universe',
+            cluster_names=['mesosstage', ],
+            vault_auth_method='ldap',
+            vault_token_file='/nail/blah',
+            vault_cluster_config={'mesosstage': 'devc'},
+        )
+        assert sp.decrypt_secret('mysecret') == 'SECRETSQUIRREL'
+        assert mock_get_vault_client.called
+        mock_get_plaintext.assert_called_with(
+            client=mock_get_vault_client.return_value,
+            path='/nail/blah/universe/secrets/mysecret.json',
+            env='devc',
+            cache_enabled=False,
+            cache_key=None,
+            cache_dir=None,
+            context='universe',
+        )

--- a/tests/test_secret_tools.py
+++ b/tests/test_secret_tools.py
@@ -72,6 +72,17 @@ def test_get_secret_provider():
     with mock.patch(
         'paasta_tools.secret_providers.SecretProvider', autospec=True,
     ) as mock_secret_provider:
-        ret = get_secret_provider('paasta_tools.secret_providers', '/nail/blah', 'test-service', 'norcal-devc')
-        mock_secret_provider.assert_called_with('/nail/blah', 'test-service', 'norcal-devc')
+        ret = get_secret_provider(
+            secret_provider_name='paasta_tools.secret_providers',
+            soa_dir='/nail/blah',
+            service_name='test-service',
+            cluster_names=['norcal-devc'],
+            secret_provider_kwargs={'some': 'thing'},
+        )
+        mock_secret_provider.assert_called_with(
+            soa_dir='/nail/blah',
+            service_name='test-service',
+            cluster_names=['norcal-devc'],
+            some='thing',
+        )
         assert ret == mock_secret_provider.return_value

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -1,7 +1,7 @@
 --extra-index-url=https://pypi.yelpcorp.com/simple
 crypto_lib==4.0.0
 scribereader==0.2.6
-vault-tools==0.6.10
+vault-tools==0.6.11
 yelp-cgeom==1.3.1
 yelp-logging==1.0.37
 yelp_meteorite


### PR DESCRIPTION
* Extend secret provider so that it can write secrets to your local
checkout of yelpsoa-configs
* Extend secret provider so it can decrypt secrets (just useful to have)
* Add cli module to call these secret provider methods

the motivation is to deprecate the paasta_secret cli which is in the
internal vault_tools package in favour of this which is generic and
imports the vault_tools package for the vault provider (which is
currently the only one implemented).