### PR TITLE
Add PAASTA_MONITORING_TEAM environment variable

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -447,6 +447,9 @@ class InstanceConfig(object):
             "PAASTA_DEPLOY_GROUP": self.get_deploy_group(),
             "PAASTA_DOCKER_IMAGE": self.get_docker_image(),
         }
+        team = self.get_team()
+        if team:
+            env["PAASTA_MONITORING_TEAM"] = team
         user_env = self.config_dict.get('env', {})
         env.update(user_env)
         return env

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1207,7 +1207,11 @@ class TestInstanceConfig:
             service='',
             cluster='',
             instance='',
-            config_dict={'env': {'SPECIAL_ENV': 'TRUE'}, 'deploy_group': 'fake_deploy_group'},
+            config_dict={
+                'env': {'SPECIAL_ENV': 'TRUE'},
+                'deploy_group': 'fake_deploy_group',
+                'monitoring': {'team': 'generic_team'},
+            },
             branch_dict={'docker_image': 'something'},
         )
         assert fake_conf.get_env() == {
@@ -1217,6 +1221,7 @@ class TestInstanceConfig:
             'PAASTA_CLUSTER': '',
             'PAASTA_DEPLOY_GROUP': 'fake_deploy_group',
             'PAASTA_DOCKER_IMAGE': 'something',
+            'PAASTA_MONITORING_TEAM': 'generic_team',
         }
 
     def test_get_args_default_no_cmd(self):


### PR DESCRIPTION
It gets team from get_team() method. Otherwise if that wasn’t set in the configuration the environment variable won’t be set.