### PR TITLE
Don't add .git to default yelp git urls. Fixes #1756

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -963,7 +963,7 @@ def get_git_url(service: str, soa_dir: str=DEFAULT_SOA_DIR) -> str:
     """Get the git url for a service. Assumes that the service's
     repo matches its name, and that it lives in services- i.e.
     if this is called with the string 'test', the returned
-    url will be git@git.yelpcorp.com:services/test.git.
+    url will be git@git.yelpcorp.com:services/test.
 
     :param service: The service name to get a URL for
     :returns: A git url to the service's repository"""
@@ -971,7 +971,7 @@ def get_git_url(service: str, soa_dir: str=DEFAULT_SOA_DIR) -> str:
         service,
         soa_dir=soa_dir,
     )
-    default_location = 'git@git.yelpcorp.com:services/%s.git' % service
+    default_location = 'git@git.yelpcorp.com:services/%s' % service
     return general_config.get('git_url', default_location)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,7 +40,7 @@ def test_get_git_url_provided_by_serviceyaml():
 
 def test_get_git_url_default():
     service = 'giiiiiiiiiiit'
-    expected = 'git@git.yelpcorp.com:services/%s.git' % service
+    expected = 'git@git.yelpcorp.com:services/%s' % service
     with (
         mock.patch('service_configuration_lib.read_service_configuration', autospec=True)
     ) as mock_read_service_configuration:


### PR DESCRIPTION
cc @acoover