### PR TITLE
Fix TypeError checking for secret_ref

### DIFF
--- a/paasta_tools/secret_tools.py
+++ b/paasta_tools/secret_tools.py
@@ -25,7 +25,12 @@ SECRET_REGEX = "^SECRET\([A-Za-z0-9_-]*\)$"
 
 def is_secret_ref(env_var_val: str) -> bool:
     pattern = re.compile(SECRET_REGEX)
-    return pattern.match(env_var_val) is not None
+    try:
+        match = pattern.match(env_var_val)
+    except TypeError:
+        # it can't be a secret ref if it isn't a string
+        return False
+    return match is not None
 
 
 def get_hmac_for_secret(

--- a/tests/test_secret_tools.py
+++ b/tests/test_secret_tools.py
@@ -26,6 +26,12 @@ def test_is_secret_ref():
     assert not is_secret_ref('SECRET(#!$)')
     # herein is a lesson on how tests are hard:
     assert not is_secret_ref('anything_else')
+    assert not is_secret_ref('')
+    # this is just incase a non string leaks in somewhere
+    # if it is not a string it can't be a secret ref
+    # so this checks that we are catching the TypeError
+    assert not is_secret_ref(None)
+    assert not is_secret_ref(3)
 
 
 def test_get_secret_name_from_ref():


### PR DESCRIPTION
We recently ended up throwing this error when a non-string crept in to
an environment variable. Just as belt and braces we should catch this
TypeError since a bogus env var cannot be a secret ref.