### PR TITLE
Add monitoring schema

### DIFF
--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -60,7 +60,16 @@
                 "default": "graceful"
             },
             "monitoring": {
-                "type": "object"
+                "type": "object",
+                "properties": {
+                    "team": {
+                        "type": "string"
+                    },
+                    "page": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": true
             },
             "env": {
                 "type": "object",

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -196,7 +196,16 @@
                     "uniqueItems": true
                 },
                 "monitoring": {
-                    "type": "object"
+                    "type": "object",
+                    "properties": {
+                        "team": {
+                            "type": "string"
+                        },
+                        "page": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": true
                 },
                 "net": {
                     "type": "string"


### PR DESCRIPTION
Enforce types on fields in monitoring dict of json schema.

This is really to prevent team becoming a non-string which can cause
errors now we pass it into the containers' environment.