### PR TITLE
[RFC] paasta api authentication

### DIFF
--- a/example_cluster/paasta/api.json
+++ b/example_cluster/paasta/api.json
@@ -1,5 +1,5 @@
 {
   "api_endpoints": {
-    "testcluster": "http://mesosmaster:5054"
+    "testcluster": "http://paasta_api:5054"
   }
 }

--- a/paasta_tools/api/auth.py
+++ b/paasta_tools/api/auth.py
@@ -1,0 +1,57 @@
+import json
+
+import hvac
+from hvac.exceptions import Forbidden
+from pyramid.authentication import CallbackAuthenticationPolicy
+from pyramid.interfaces import IAuthenticationPolicy
+from zope.interface import implementer
+
+
+@implementer(IAuthenticationPolicy)
+class VaultAuthAuthenticationPolicy(CallbackAuthenticationPolicy):
+    """
+    """
+
+    def __init__(self, vault_url, vault_ca):
+        self.debug = True
+        self.vault_url = vault_url
+        self.vault_ca = vault_ca
+
+    def get_vault_client(self, token):
+        self.client = hvac.Client(url=self.vault_url, token=token, verify=self.vault_ca)
+
+    def unauthenticated_userid(self, request):
+        """
+        """
+        return 'nobody'
+
+    def remember(self, request, userid, **kw):
+        """ A no-op. Vault authentication does not provide a protocol for
+        remembering the user. Credentials are sent on every request.
+        """
+        return []
+
+    def forget(self, request):
+        return []
+
+    def check(self, token, request):
+        self.get_vault_client(token)
+        try:
+            token = self.client.lookup_token()
+            self.client.renew_token()
+            self.debug and self._log(json.dumps(token), 'check', request)
+        except Forbidden:
+            self.debug and self._log("Vault token expired/invalid", 'check', request)
+            return None
+        except Exception:
+            self.debug and self._log("Failed to communicate with Vault", 'check', request)
+            raise
+        policies = token['data']['policies']
+        username = token['data']['meta']['username']
+        return policies + [username]
+
+    def callback(self, username, request):
+        # Username arg is ignored, we get it later from resolving the token
+        token = request.headers.get('X-Paasta-Token')
+        if token:
+            return self.check(token, request)

--- a/paasta_tools/api/auth_decorator.py
+++ b/paasta_tools/api/auth_decorator.py
@@ -1,0 +1,150 @@
+import functools
+
+from bravado.docstring_property import docstring_property
+from bravado.exception import HTTPForbidden
+
+from paasta_tools.cli.cmds.auth import get_token_from_file
+from paasta_tools.cli.cmds.auth import get_token_from_vault
+from paasta_tools.cli.cmds.auth import write_token_to_disk
+
+# from bravado_decorators.decorate_client import decorate_client
+
+
+class AuthFutureDecorator(object):
+
+    def __init__(self, future, cluster_name):
+        self.future = future
+        self.attempts = 0
+        self.cluster_name = cluster_name
+
+    def result(self, *args, **kwargs):
+        """ Wraps a Future's result method with a timer. """
+        try:
+            result = self.future.result(*args, **kwargs)
+        except HTTPForbidden:
+            if self.attempts >= 3:
+                raise
+            self.attempts += 1
+            token = get_token_from_file(self.cluster_name)
+            if not token or self.future.future.request.headers['X-Paasta-Token'] == token:
+                # the token we sent matches on disk but we failed auth anyway
+                # so lets try and get a fresh one!
+                token = get_token_from_vault(self.cluster_name)
+                write_token_to_disk(self.cluster_name, token)
+            self.future.future.request.headers['X-Paasta-Token'] = token
+            result = self.result(*args, **kwargs)
+        return result
+
+
+class AuthResourceDecorator(object):
+
+    def __init__(self, resource, cluster_name):
+        self.resource = resource
+        self.cluster_name = cluster_name
+
+    def __getattr__(self, name):
+        return decorate_client(self.resource, self._with_auth_check, name)
+
+    def _with_auth_check(self, call_name, *args, **kwargs):
+        return AuthFutureDecorator(
+            getattr(self.resource, call_name)(*args, **kwargs),
+            self.cluster_name,
+        )
+
+
+class AuthClientDecorator(object):
+    """
+    """
+
+    def __init__(self, client, cluster_name):
+        """ Create a auth client decorator.
+        :param client: The client that will have all resource operation calls
+            tracked.
+        :type client: swaggerpy.SwaggerClient
+        :return: A wrapped swagger client that should be used in place of a
+            plain swagger client.
+        """
+        self.client = client
+        self.cluster_name = cluster_name
+
+    def __getattr__(self, name):
+        return AuthResourceDecorator(
+            getattr(self.client, name),
+            self.cluster_name,
+        )
+
+    def __dir__(self):
+        return dir(self.client)
+
+
+# below helpers borrowed from bravado_decorators/decorate_client.py
+# maybe move into one of the open bravado packages?
+
+def decorate_client(api_client, func, name):
+    """A helper for decorating :class:`bravado.client.SwaggerClient`.
+    :class:`bravado.client.SwaggerClient` can be extended by creating a class
+    which wraps all calls to it. This helper is used in a :func:`__getattr__`
+    to check if the attr exists on the api_client. If the attr does not exist
+    raise :class:`AttributeError`, if it exists and is not callable return it,
+    and if it is callable return a partial function calling `func` with `name`.
+
+    Example usage:
+
+    .. code-block:: python
+
+        class SomeClientDecorator(object):
+
+            def __init__(self, api_client, ...):
+                self.api_client = api_client
+
+            # First arg should be suffiently unique to not conflict with any of
+            # the kwargs
+            def wrap_call(self, client_call_name, *args, **kwargs):
+                ...
+
+            def __getattr__(self, name):
+                return decorate_client(self.api_client, self.wrap_call, name)
+
+    :param api_client: the client which is being decorated
+    :type  api_client: :class:`bravado.client.SwaggerClient`
+    :param func: a callable which accepts `name`, `*args`, `**kwargs`
+    :type  func: callable
+    :param name: the attribute being accessed
+    :type  name: string
+    :returns: the attribute from the `api_client` or a partial of `func`
+    :raises: :class:`AttributeError`
+    """
+    client_attr = getattr(api_client, name)
+    if not callable(client_attr):
+        return client_attr
+
+    return OperationDecorator(client_attr, functools.partial(func, name))
+
+
+class OperationDecorator(object):
+    """A helper to preserve attributes of :class:`swaggerpy.client.Operation`
+    and :class:`bravado.client.CallableOperation` while decorating their
+    __call__() methods
+
+    :param operation: callable operation, e.g., attributes of
+        :class:`swaggerpy.client.Resource` or
+        :class:`bravado_core.resource.Resource`
+    :type  operation: :class:`swaggerpy.client.Operation` or
+        :class:`bravado.client.CallableOperation`
+    :param func: a callable which accepts `*args`, `**kwargs`
+    :type  func: callable
+    """
+
+    @docstring_property(__doc__)
+    def __doc__(self):
+        return self.operation.__doc__
+
+    def __init__(self, operation, func):
+        self.operation = operation
+        self.func = func
+
+    def __getattr__(self, name):
+        return getattr(self.operation, name)
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)

--- a/paasta_tools/api/settings.py
+++ b/paasta_tools/api/settings.py
@@ -19,3 +19,6 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 soa_dir = DEFAULT_SOA_DIR
 cluster = None
 marathon_clients = None
+auth_enabled = False
+vault_ca = None
+vault_url = None

--- a/paasta_tools/api/views/autoscaler.py
+++ b/paasta_tools/api/views/autoscaler.py
@@ -24,7 +24,7 @@ from paasta_tools.long_running_service_tools import set_instances_for_marathon_s
 from paasta_tools.marathon_tools import load_marathon_service_config
 
 
-@view_config(route_name='service.autoscaler.get', request_method='GET', renderer='json')
+@view_config(route_name='service.autoscaler.get', request_method='GET', renderer='json', permission='view')
 def get_autoscaler_count(request):
     service = request.swagger_data.get('service')
     instance = request.swagger_data.get('instance')

--- a/paasta_tools/api/views/version.py
+++ b/paasta_tools/api/views/version.py
@@ -20,6 +20,6 @@ from pyramid.view import view_config
 from paasta_tools import __version__
 
 
-@view_config(route_name='version', request_method='GET', renderer='json')
+@view_config(route_name='version', request_method='GET', renderer='json', permission='view')
 def version(request):
     return __version__

--- a/paasta_tools/cli/cmds/auth.py
+++ b/paasta_tools/cli/cmds/auth.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# Copyright 2015-2018 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import getpass
+import json
+import os
+from pathlib import Path
+
+import hvac
+
+from paasta_tools.utils import load_system_paasta_config
+
+
+def add_subparser(subparsers):
+    auth_parser = subparsers.add_parser(
+        'auth',
+        help="",
+        description=(
+            ""
+        ),
+    )
+    auth_parser.add_argument(
+        '-c', '--cluster',
+        help="",
+        required=True,
+    )
+    auth_parser.set_defaults(command=paasta_auth)
+
+
+def paasta_auth(args):
+    get_token(cluster=args.cluster)
+
+
+def get_token(cluster):
+    token = get_token_from_file(cluster)
+    if token:
+        return token
+    else:
+        token = get_token_from_vault(cluster)
+        write_token_to_disk(cluster, token)
+
+
+def write_token_to_disk(cluster, token):
+    if not os.path.isfile(os.path.join(str(Path.home()), ".paasta_token.json")):
+        with open(os.path.join(str(Path.home()), ".paasta_token.json"), 'w') as token_file:
+            json.dump({}, token_file)
+    with open(os.path.join(str(Path.home()), ".paasta_token.json"), 'r+') as token_file:
+        tokens = json.load(token_file)
+        tokens[cluster] = token
+        token_file.seek(0)
+        json.dump(tokens, token_file)
+
+
+def get_token_from_vault(cluster):
+    system_paasta_config = load_system_paasta_config()
+    vault_cluster_map = system_paasta_config.get_vault_cluster_config()
+    vault_url = system_paasta_config.get_vault_host_template().format(vault_cluster_map[cluster])
+    vault_ca = system_paasta_config.get_vault_ca_template().format(vault_cluster_map[cluster])
+    client = hvac.Client(url=vault_url, verify=vault_ca)
+    username = getpass.getuser()
+    client.auth_ldap(username, getpass.getpass())
+    # token_data = client.create_token()
+    # token = token_data['auth']['client_token']
+    # print(token_data)
+    # client = hvac.Client(url=vault_url, verify=vault_ca, token=token)
+    token_data = client.create_token(
+        meta={'username': username},
+        # period='120s',
+        ttl='120s',
+        # no_parent=False,
+        orphan=False,
+        role='paasta_api',
+        renewable=True,
+    )
+    print(token_data)
+    token = token_data['auth']['client_token']
+    return token
+
+
+def get_token_from_file(cluster):
+    try:
+        with open(os.path.join(str(Path.home()), ".paasta_token.json")) as token_file:
+            tokens = json.load(token_file)
+            return tokens.get(cluster, None)
+    except IOError:
+        return None

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1778,10 +1778,26 @@ class SystemPaastaConfig(object):
         used by all services in this cluster"""
         return self.config_dict.get('vault_environment')
 
+    def get_vault_local_url(self) -> str:
+        """ a url to resolve the local vault cluster"""
+        return self.config_dict.get('vault_local_url')
+
+    def get_api_auth_enabled(self) -> bool:
+        """ enable auth on paasta_api"""
+        return self.config_dict.get('api_auth_enabled', False)
+
     def get_vault_cluster_config(self) -> dict:
         """ Get a map from paasta_cluster to vault ecosystem. We need
         this because not every ecosystem will have its own vault cluster"""
         return self.config_dict.get('vault_cluster_map', {})
+
+    def get_vault_host_template(self) -> str:
+        """ get string template for vault host"""
+        return self.config_dict.get('vault_host_template', "https://{}.example.com:8200")
+
+    def get_vault_ca_template(self) -> str:
+        """ get vault_ca certificate path template"""
+        return self.config_dict.get('vault_ca_template', '/path/{}/ca.crt')
 
     def get_secret_provider_name(self) -> str:
         """ Get the name for the configured secret_provider, used to


### PR DESCRIPTION
This is quite rough around the edges (or in other words I'm not super
happy about the implementation in its current form). Lacking tests etc.
I'm just opening this to get some opinions and see if anyone thinks it
is worth tidying up/working on for real.

The rough idea is to include a vault token in requests to the paasta API
as a header. The server then validates that the token is legit with
Vault and checks what policies are attached to the token. These vault
policies are then mappped to permissions on each api view.

I've also wrapped the client to generate + send the correct token in
response to 403s.