### PR TITLE
Prevent autoscalerwatcher adding services on start

### DIFF
--- a/paasta_itests/paasta_deployd.feature
+++ b/paasta_itests/paasta_deployd.feature
@@ -63,7 +63,6 @@ Feature: paasta-deployd deploys apps
      Then we should see "test-service.main" listed in marathon after 60 seconds
      Then we can run get_app
 
-  @skip
   Scenario: deployd will scale up an app if the instance count changes in zk
     Given a working paasta cluster
       And paasta-deployd is running
@@ -78,7 +77,6 @@ Feature: paasta-deployd deploys apps
      When we set the instance count in zookeeper for service "test-service" instance "main" to 4
      Then we should see the number of instances become 4
 
-  @skip
   Scenario: deployd will scale down an app if the instance count changes in zk
     Given a working paasta cluster
       And paasta-deployd is running

--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -47,19 +47,19 @@ class AutoscalerWatcher(PaastaWatcher):
         self.zk = kwargs.pop('zookeeper_client')
         self.watchers: Dict[str, PaastaWatcher] = {}
 
-    def watch_folder(self, path):
+    def watch_folder(self, path, enqueue_children=False):
         """recursive nonsense"""
         if "autoscaling.lock" in path:
             return
-        self.log.debug("Adding folder watch on {}".format(path))
+        self.log.info("Adding folder watch on {}".format(path))
         watcher = ChildrenWatch(self.zk, path, func=self.process_folder_event, send_event=True)
         self.watchers[path] = watcher
         children = watcher._prior_children
         if children and ('instances' in children):
-            self.watch_node("{}/instances".format(path))
+            self.watch_node("{}/instances".format(path), enqueue=enqueue_children)
         elif children:
             for child in children:
-                self.watch_folder("{}/{}".format(path, child))
+                self.watch_folder("{}/{}".format(path, child), enqueue_children=enqueue_children)
 
     def _enqueue_service_instance(self, path):
         service, instance = path.split('/')[-3:-1]
@@ -77,10 +77,11 @@ class AutoscalerWatcher(PaastaWatcher):
         )
         self.inbox_q.put(service_instance)
 
-    def watch_node(self, path):
-        self.log.debug("Adding node watch on {}".format(path))
+    def watch_node(self, path, enqueue=False):
+        self.log.info("Adding node watch on {}".format(path))
         DataWatch(self.zk, path, func=self.process_node_event, send_event=True)
-        self._enqueue_service_instance(path)
+        if enqueue:
+            self._enqueue_service_instance(path)
 
     def process_node_event(self, data, stat, event):
         self.log.debug("Node change: {}".format(event))
@@ -93,7 +94,7 @@ class AutoscalerWatcher(PaastaWatcher):
             fq_children = ["{}/{}".format(event.path, child) for child in children]
             for child in fq_children:
                 if child not in self.watchers:
-                    self.watch_folder(child)
+                    self.watch_folder(child, enqueue_children=True)
 
     def run(self):
         self.watchers[AUTOSCALING_ZK_ROOT] = self.watch_folder(AUTOSCALING_ZK_ROOT)

--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -54,7 +54,7 @@ class AutoscalerWatcher(PaastaWatcher):
         self.log.info("Adding folder watch on {}".format(path))
         watcher = ChildrenWatch(self.zk, path, func=self.process_folder_event, send_event=True)
         self.watchers[path] = watcher
-        children = watcher._prior_children
+        children = watcher._client.get_children(watcher._path)
         if children and ('instances' in children):
             self.watch_node("{}/instances".format(path), enqueue=enqueue_children)
         elif children:

--- a/tests/deployd/test_watchers.py
+++ b/tests/deployd/test_watchers.py
@@ -67,7 +67,7 @@ class TestAutoscalerWatcher(unittest.TestCase):
             self.watcher.watch_folder('/path/autoscaling.lock')
             assert not mock_children_watch.called
 
-            mock_watcher = mock.Mock(_prior_children=[])
+            mock_watcher = mock.Mock(_client=mock.Mock(get_children=mock.Mock(return_value=[])))
             mock_children_watch.return_value = mock_watcher
             self.watcher.watch_folder('/rick/beth')
             mock_children_watch.assert_called_with(
@@ -78,9 +78,8 @@ class TestAutoscalerWatcher(unittest.TestCase):
             )
             assert not mock_watch_node.called
 
-            mock_children = mock.PropertyMock(side_effect=[['morty', 'summer'], [], []])
-            mock_watcher = mock.Mock()
-            type(mock_watcher)._prior_children = mock_children
+            mock_children = mock.Mock(side_effect=[['morty', 'summer'], [], []])
+            mock_watcher = mock.Mock(_client=mock.Mock(get_children=mock_children))
             mock_children_watch.return_value = mock_watcher
             self.watcher.watch_folder('/rick/beth')
             assert not mock_watch_node.called
@@ -104,14 +103,17 @@ class TestAutoscalerWatcher(unittest.TestCase):
                     send_event=True,
                 ),
             ]
-            mock_children_watch.assert_has_calls(calls)
+            for call in calls:
+                # this is a bit nasty because the calls to _client get lumped in too
+                # this just checks about the calls we really care happened
+                assert call in mock_children_watch.mock_calls
 
-            mock_watcher = mock.Mock(_prior_children=['instances'])
+            mock_watcher = mock.Mock(_client=mock.Mock(get_children=mock.Mock(return_value=['instances'])))
             mock_children_watch.return_value = mock_watcher
             self.watcher.watch_folder('/rick/beth')
             mock_watch_node.assert_called_with(self.watcher, '/rick/beth/instances', enqueue=False)
 
-            mock_watcher = mock.Mock(_prior_children=['instances'])
+            mock_watcher = mock.Mock(_client=mock.Mock(get_children=mock.Mock(return_value=['instances'])))
             mock_children_watch.return_value = mock_watcher
             self.watcher.watch_folder('/rick/beth', enqueue_children=True)
             mock_watch_node.assert_called_with(self.watcher, '/rick/beth/instances', enqueue=True)

--- a/tests/deployd/test_watchers.py
+++ b/tests/deployd/test_watchers.py
@@ -109,7 +109,12 @@ class TestAutoscalerWatcher(unittest.TestCase):
             mock_watcher = mock.Mock(_prior_children=['instances'])
             mock_children_watch.return_value = mock_watcher
             self.watcher.watch_folder('/rick/beth')
-            mock_watch_node.assert_called_with(self.watcher, '/rick/beth/instances')
+            mock_watch_node.assert_called_with(self.watcher, '/rick/beth/instances', enqueue=False)
+
+            mock_watcher = mock.Mock(_prior_children=['instances'])
+            mock_children_watch.return_value = mock_watcher
+            self.watcher.watch_folder('/rick/beth', enqueue_children=True)
+            mock_watch_node.assert_called_with(self.watcher, '/rick/beth/instances', enqueue=True)
 
     def test_watch_node(self):
         with mock.patch(
@@ -191,8 +196,8 @@ class TestAutoscalerWatcher(unittest.TestCase):
             )
             self.watcher.process_folder_event(['morty', 'summer'], mock_event)
             calls = [
-                mock.call(self.watcher, '/rick/beth/morty'),
-                mock.call(self.watcher, '/rick/beth/summer'),
+                mock.call(self.watcher, '/rick/beth/morty', enqueue_children=True),
+                mock.call(self.watcher, '/rick/beth/summer', enqueue_children=True),
             ]
             mock_watch_folder.assert_has_calls(calls)
 


### PR DESCRIPTION
When deployd starts it must add watches to all the zookeeper nodes for
autoscaled services. This also enqueues the services. This is normally
fine except in a "big bounce" scenario in which we don't want all
autoscaled services enqueued at startup.

This change passes an enqueue paramater to the watcher functions so that
new nodes that are created are enqueued for a bounce but nodes that are
enumerated on startup are not.

Note: I'm also re-enabling some autoscaling tests which used to be flakey but which I think we should be running. I'll run multiple travis builds to hopefully assert they are not flakey.