### PR TITLE
Fix Bogus CPU value filter

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -412,19 +412,14 @@ def mesos_cpu_metrics_provider(
 
             if system_paasta_config.get_filter_bogus_mesos_cputime_enabled():
                 # It is unlikely that the cputime consumed by a task is greater than the CPU limits
-                # that we enforce (plus 10% of margin). This is a bug in Mesos (tracked in PAASTA-13510)
-                cpu_burst_allowance = (
-                    1.10 *
-                    marathon_service_config.get_cpu_quota() /
-                    marathon_service_config.get_cpu_period()
-                )
-                if cputime_delta > time_delta * cpu_burst_allowance:
-                    log.warning('Ignoring potentially bogus cputime values for task {}'.format(str(task_id)))
-                    log.debug(
-                        'Elapsed time: {}, Enforced CPU limit: {}, CPU time consumed: {}'.format(
-                            time_delta,
-                            cpu_burst_allowance,
-                            cputime_delta,
+                # that we enforce. This is a bug in Mesos (tracked in PAASTA-13510)
+                max_cpu_allowed = (100 + marathon_service_config.get_cpu_burst_pct()) / 100
+                task_cpu_usage = cputime_delta / time_delta
+                if task_cpu_usage > max_cpu_allowed:
+                    log.warning(
+                        'Ignoring potentially bogus cpu usage {} for task {}'.format(
+                            task_cpu_usage,
+                            str(task_id),
                         ),
                     )
                     continue

--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -415,7 +415,7 @@ def mesos_cpu_metrics_provider(
                 # that we enforce. This is a bug in Mesos (tracked in PAASTA-13510)
                 max_cpu_allowed = (100 + marathon_service_config.get_cpu_burst_pct()) / 100
                 task_cpu_usage = cputime_delta / time_delta
-                if task_cpu_usage > max_cpu_allowed:
+                if task_cpu_usage > (max_cpu_allowed * 1.1):
                     log.warning(
                         'Ignoring potentially bogus cpu usage {} for task {}'.format(
                             task_cpu_usage,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -330,6 +330,11 @@ class InstanceConfig(object):
         cpus = self.config_dict.get('cpus', .25)
         return cpus
 
+    def get_cpu_burst_pct(self) -> float:
+        """Returns the percent over its declared cpu usage that a container
+        will be allowed to go. Default to DEFAULT_CPU_PERIOD"""
+        return self.config_dict.get('cpu_burst_pct', DEFAULT_CPU_BURST_PCT)
+
     def get_cpu_period(self) -> float:
         """The --cpu-period option to be passed to docker
         Comes from the cfs_period_us configuration option
@@ -339,13 +344,11 @@ class InstanceConfig(object):
 
     def get_cpu_quota(self) -> float:
         """Gets the --cpu-quota option to be passed to docker
-        Calculated from the cpu_burst_pct configuration option, which is the percent
-        over its declared cpu usage that a container will be allowed to go.
 
         Calculation: cpus * cfs_period_us * (100 + cpu_burst_pct) / 100
 
         :returns: The number to be passed to the --cpu-quota docker flag"""
-        cpu_burst_pct = self.config_dict.get('cpu_burst_pct', DEFAULT_CPU_BURST_PCT)
+        cpu_burst_pct = self.get_cpu_burst_pct()
         return self.get_cpus() * self.get_cpu_period() * (100 + cpu_burst_pct) / 100
 
     def get_extra_docker_args(self) -> Dict[str, str]:

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -206,6 +206,17 @@ def test_mesos_cpu_metrics_provider_no_previous_cpu_data():
 
 
 def test_mesos_cpu_metrics_provider():
+    """
+    +------+--------------+--------------+---------+-------+---------------+----------------+
+    | inst | prev cputime | elasped_time | cputime | limit | norm_cputime  |  utilization   |
+    +------+--------------+--------------+---------+-------+---------------+----------------+
+    | 1    |            0 |          600 | 480     | 1.1   | 480/(1.1-0.1) | 480/600 => 0.8 |
+    | 2    |          300 |          600 | None    | None  | N/A           | N/A            |
+    | 3    |       123456 |          600 | {}      | {}    | N/A           | N/A            |
+    | -    |            - |            - | -       | -     | -             | -              |
+    | avg  |              |              |         |       |               | 0.8            |
+    +------+--------------+--------------+---------+-------+---------------+----------------+
+    """
     fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
         service='fake-service',
         instance='fake-instance',
@@ -302,7 +313,18 @@ def test_mesos_cpu_metrics_provider():
         assert not mock_zk_client.return_value.set.called
 
 
-def test_mesos_cpu_metrics_provider_filter_bogus_values():
+def test_mesos_cpu_metrics_provider_filter_bogus_values_big_cpu_limit():
+    """
+    +--------+--------------+--------------+---------+-------+----------------+-----------------------+
+    |  inst  | prev cputime | elasped_time | cputime | limit |  norm_cputime  |      utilization      |
+    +--------+--------------+--------------+---------+-------+----------------+-----------------------+
+    | 1      |          126 |          600 |     480 |   2.1 | 480/(2.1-0.1)  | (240-126)/600 => 0.19 |
+    | 2      |            0 |          600 |    9600 |   2.1 | 9600/(2.1-0.1) | 4800/600 => 8.0       |
+    | 3(bug) |            0 |          600 |  987654 |   2.1 | 9600/(2.1-0.1) | 493827/600 => 823     |
+    | -      |            - |            - |       - |     - | -              | -                     |
+    | avg    |              |              |         |       |                | 4.095                 |
+    +--------+--------------+--------------+---------+-------+----------------+-----------------------+
+    """
     fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
         service='fake-service',
         instance='fake-instance',
@@ -314,31 +336,24 @@ def test_mesos_cpu_metrics_provider_filter_bogus_values():
     fake_system_paasta_config.get_filter_bogus_mesos_cputime_enabled.return_value = True
     fake_mesos_task = mock.MagicMock(
         stats_callable=mock.MagicMock(return_value={
-            'cpus_limit': 1.1,
-            # These values are counter. They can only increment.
-            # This container has been running for 80 minutes at 100% CPU usage of one core
-            # and for the last 10 minutes at 80%
-            # (80 * 60) + 0.8 * (10 * 60) = 4800 + 600 = 5400 cpu seconds consumed
-            # Let's just ignore the system cpu time for the sake of this test
+            'cpus_limit': 2.1,
             'cpus_system_time_secs': 0,
-            'cpus_user_time_secs': 80 * 60 + 0.8 * 10 * 60,
+            'cpus_user_time_secs': 480,
         }),
     )
     fake_mesos_task_2 = mock.MagicMock(
         stats_callable=mock.MagicMock(return_value={
-            'cpus_limit': 1.1,
-            # The CPU Value for this task is wrongly reported by Mesos.
-            # We expect the mean utilization to not take this into account.
+            'cpus_limit': 2.1,
             'cpus_system_time_secs': 0,
-            'cpus_user_time_secs': 948184546,
+            'cpus_user_time_secs': 9600,
         }),
     )
     fake_mesos_task_3 = mock.MagicMock(
         stats_callable=mock.MagicMock(return_value={
-            'cpus_limit': 1.1,
-            # This task has just started 10 minutes and 1 second ago and is using 100% of one CPU
+            'cpus_limit': 2.1,
             'cpus_system_time_secs': 0,
-            'cpus_user_time_secs': 1 + 10 * 60,
+            # Bogus value
+            'cpus_user_time_secs': 987654,
         }),
     )
     fake_mesos_task.__getitem__.return_value = 'fake-service.fake-instance'
@@ -352,14 +367,12 @@ def test_mesos_cpu_metrics_provider_filter_bogus_values():
     ]
 
     current_time = datetime.now()
-    last_time = (current_time - timedelta(seconds=600)).strftime('%s')  # 10 minutes
+    last_time = (current_time - timedelta(seconds=600)).strftime('%s')
 
     fake_old_utilization_data = ','.join([
-        # 80 minutes at 100%
-        '4800:fake-service.fake-instance',
-        '4800:fake-service.fake-instance2',
-        # 1 second at 100% CPU
-        '1:fake-service.fake-instance3',
+        '126:fake-service.fake-instance',
+        '0:fake-service.fake-instance2',
+        '0:fake-service.fake-instance3',
     ])
 
     zookeeper_get_payload = {
@@ -380,13 +393,105 @@ def test_mesos_cpu_metrics_provider_filter_bogus_values():
     ):
         mock_datetime.now.return_value = current_time
         log_utilization_data = {}
-        # We expect an average of 80% and 100% CPU usage == 90%
-        assert 0.9 == autoscaling_service_lib.mesos_cpu_metrics_provider(
-            fake_marathon_service_config,
-            fake_system_paasta_config,
-            fake_marathon_tasks,
-            (fake_mesos_task_2, fake_mesos_task_3, fake_mesos_task),
-            log_utilization_data=log_utilization_data,
+        assert 4.095 == round(
+            autoscaling_service_lib.mesos_cpu_metrics_provider(
+                fake_marathon_service_config,
+                fake_system_paasta_config,
+                fake_marathon_tasks,
+                (fake_mesos_task_2, fake_mesos_task_3, fake_mesos_task),
+                log_utilization_data=log_utilization_data,
+            ), 3,
+        )
+
+
+def test_mesos_cpu_metrics_provider_filter_bogus_values_small_cpu_limit():
+    """
+    +--------+-------------------+--------------+---------+-------+-----------------+----------------------+
+    |  inst  | prev norm_cputime | elasped_time | cputime | limit |  norm_cputime   |     utilization      |
+    +--------+-------------------+--------------+---------+-------+-----------------+----------------------+
+    | 1      |              1234 |          600 |   603.4 |   0.2 | 603.4/(0.2-0.1) | (6034-1234)/600 => 8 |
+    | 2      |                 0 |          600 |      48 |   0.2 | 48/(0.2-0.1)    | 480/600 => 0.8       |
+    | 3(bug) |                 0 |          600 |    1234 |   0.2 | 1234/(0.2-0.1)  | 12340/600 => 20.5    |
+    | -      |                 - |            - |       - |     - | -               | -                    |
+    | avg    |                   |              |         |       |                 | 4.4                  |
+    +--------+-------------------+--------------+---------+-------+-----------------+----------------------+
+    """
+    fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
+        service='fake-service',
+        instance='fake-instance',
+        cluster='fake-cluster',
+        config_dict={},
+        branch_dict=None,
+    )
+    fake_system_paasta_config = mock.MagicMock()
+    fake_system_paasta_config.get_filter_bogus_mesos_cputime_enabled.return_value = True
+    fake_mesos_task = mock.MagicMock(
+        stats_callable=mock.MagicMock(return_value={
+            'cpus_limit': 0.2,
+            'cpus_system_time_secs': 103.4,
+            'cpus_user_time_secs': 500,
+        }),
+    )
+    fake_mesos_task_2 = mock.MagicMock(
+        stats_callable=mock.MagicMock(return_value={
+            'cpus_limit': 0.2,
+            'cpus_system_time_secs': 0,
+            'cpus_user_time_secs': 48,
+        }),
+    )
+    fake_mesos_task_3 = mock.MagicMock(
+        stats_callable=mock.MagicMock(return_value={
+            'cpus_limit': 0.2,
+            'cpus_system_time_secs': 0,
+            # bogus
+            'cpus_user_time_secs': 1234,
+        }),
+    )
+    fake_mesos_task.__getitem__.return_value = 'fake-service.fake-instance'
+    fake_mesos_task_2.__getitem__.return_value = 'fake-service.fake-instance2'
+    fake_mesos_task_3.__getitem__.return_value = 'fake-service.fake-instance3'
+
+    fake_marathon_tasks = [
+        mock.Mock(id='fake-service.fake-instance'),
+        mock.Mock(id='fake-service.fake-instance2'),
+        mock.Mock(id='fake-service.fake-instance3'),
+    ]
+
+    current_time = datetime.now()
+    last_time = (current_time - timedelta(seconds=600)).strftime('%s')
+
+    fake_old_utilization_data = ','.join([
+        '1234:fake-service.fake-instance',
+        '0:fake-service.fake-instance2',
+        '0:fake-service.fake-instance4',
+    ])
+
+    zookeeper_get_payload = {
+        'cpu_last_time': last_time,
+        'cpu_data': fake_old_utilization_data,
+    }
+
+    with mock.patch(
+        'paasta_tools.utils.KazooClient', autospec=True,
+        return_value=mock.Mock(get=mock.Mock(
+            side_effect=lambda x: (str(zookeeper_get_payload[x.split('/')[-1]]).encode('utf-8'), None),
+        )),
+    ), mock.patch(
+        'paasta_tools.autoscaling.autoscaling_service_lib.datetime', autospec=True,
+    ) as mock_datetime, mock.patch(
+        'paasta_tools.utils.load_system_paasta_config', autospec=True,
+        return_value=mock.Mock(get_zk_hosts=mock.Mock()),
+    ):
+        mock_datetime.now.return_value = current_time
+        log_utilization_data = {}
+        assert 4.4 == round(
+            autoscaling_service_lib.mesos_cpu_metrics_provider(
+                fake_marathon_service_config,
+                fake_system_paasta_config,
+                fake_marathon_tasks,
+                (fake_mesos_task_2, fake_mesos_task_3, fake_mesos_task),
+                log_utilization_data=log_utilization_data,
+            ), 1,
         )
 
 


### PR DESCRIPTION
The previous filter only worked properly with service declaring one CPU. It didn't take into account the fact that we use and store a normalized CPU usage

This implementation of the filter compare the CPU usage of tasks according to their own limit with the burst limit that we enforce.
I added tests and detailled tables to make sure the logic works