### PR TITLE
pass pyspark options through to final docker command in spark-run sub…

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -360,10 +360,10 @@ def configure_and_run_docker_container(
         )
     # Spark options are passed as options to pyspark and spark-shell.
     # For jupyter, environment variable SPARK_OPTS is set instead.
-    elif docker_cmd in ['pyspark', 'spark-shell']:
-        docker_cmd = docker_cmd + ' ' + spark_conf_str
-    elif docker_cmd.startswith('spark-submit'):
-        docker_cmd = 'spark-submit ' + spark_conf_str + docker_cmd[len('spark-submit'):]
+    else:
+        base_cmd, remainder = docker_cmd.split(None, 1)
+        if base_cmd in ('pyspark', 'spark-shell', 'spark-submit'):
+            docker_cmd = f'{base_cmd} {spark_conf_str} {remainder}'
 
     environment = instance_config.get_env_dictionary()
     environment.update(

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -98,7 +98,7 @@ def test_configure_and_run_docker_container(
 
     args = mock.MagicMock()
     args.cluster = 'fake_cluster'
-    args.cmd = 'pyspark'
+    args.cmd = 'pyspark -v'
     args.work_dir = '/fake_dir:/spark_driver'
     args.dry_run = True
 
@@ -152,6 +152,6 @@ def test_configure_and_run_docker_container(
             'SPARK_OPTS': '--conf spark.app.name=fake_app',
         },
         docker_img='fake-registry/fake-service',
-        docker_cmd='pyspark --conf spark.app.name=fake_app',
+        docker_cmd='pyspark --conf spark.app.name=fake_app -v',
         dry_run=True,
     )


### PR DESCRIPTION
…command

Currently invocations like `spark-run --cmd "pyspark -v"` are not getting modified to add options telling pyspark how to talk to Mesos.