### PR TITLE
Only use sudo with paasta local-run when there is no docker config available

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -923,8 +923,16 @@ def configure_and_run_docker_container(
     )
 
 
+def docker_config_available():
+    home = os.path.expanduser('~')
+    oldconfig = os.path.join(home, ".dockercfg")
+    newconfig = os.path.join(home, ".docker", "config.json")
+    return (os.path.isfile(oldconfig) and os.access(oldconfig, os.R_OK)) or \
+        (os.path.isfile(newconfig) and os.access(newconfig, os.R_OK))
+
+
 def paasta_local_run(args):
-    if args.action == 'pull' and os.geteuid() != 0:
+    if args.action == 'pull' and os.geteuid() != 0 and not docker_config_available():
         paasta_print("Re-executing paasta local-run --pull with sudo..")
         os.execvp("sudo", ["sudo", "-H"] + sys.argv)
     if args.action == 'build' and not makefile_responds_to('cook-image'):


### PR DESCRIPTION
I don't want people blindly using sudo all the time, so this check only makes it use sudo when we "have to".

Technically you could use paasta without a registry that requires auth.

Hopefully this change will be an ok "compromise" between magic and non-surprising behavior.

But really I don't want auto-sudo so Tron can run this command *and* have the permission to kill it later.

cc @qui cc @bobtfish 