### PR TITLE
Add --registration argument to stop/start/restart by refactoring to use add_instance_filter_arguments.

### DIFF
--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -21,17 +21,12 @@ import choice
 from paasta_tools import remote_git
 from paasta_tools import utils
 from paasta_tools.chronos_tools import ChronosJobConfig
+from paasta_tools.cli.cmds.status import add_instance_filter_arguments
 from paasta_tools.cli.cmds.status import apply_args_filters
 from paasta_tools.cli.utils import get_instance_config
-from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.cli.utils import list_deploy_groups
-from paasta_tools.cli.utils import list_instances
-from paasta_tools.cli.utils import list_services
-from paasta_tools.cli.utils import list_teams
 from paasta_tools.generate_deployments_for_service import get_latest_deployment_tag
 from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.utils import DEFAULT_SOA_DIR
-from paasta_tools.utils import list_clusters
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
 
@@ -53,33 +48,7 @@ def add_subparser(subparsers):
                 "for the service is available."
             ),
         )
-        status_parser.add_argument(
-            '-s', '--service',
-            help='Service that you want to %s. Like example_service.' % lower,
-        ).completer = lazy_choices_completer(list_services)
-        status_parser.add_argument(
-            '-i', '--instances',
-            help='A comma-separated list of instances of the service that you '
-                 'want to %s. Like --instances main,canary. Defaults to all instances for the service.' % lower,
-        ).completer = lazy_choices_completer(list_instances)
-        status_parser.add_argument(
-            '-l', '--deploy-group',
-            help=(
-                'Name of the deploy group which you want to get status for. '
-                'If specified together with --instances and/or --clusters, will %s common instances only.' % lower
-            ),
-        ).completer = lazy_choices_completer(list_deploy_groups)
-        status_parser.add_argument(
-            '-o', '--owner',
-            help='Team to filter instances by.',
-        ).completer = lazy_choices_completer(list_teams)
-        status_parser.add_argument(
-            '-c', '--clusters',
-            help="A comma-separated list of clusters to view. "
-            "For example: --clusters norcal-prod,nova-prod",
-            required=True,
-        ).completer = lazy_choices_completer(list_clusters)
-
+        add_instance_filter_arguments(status_parser, verb=lower)
         status_parser.add_argument(
             '-d', '--soa-dir',
             dest="soa_dir",

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -81,35 +81,35 @@ def add_subparser(subparsers):
     status_parser.set_defaults(command=paasta_status)
 
 
-def add_instance_filter_arguments(status_parser):
+def add_instance_filter_arguments(status_parser, verb='inspect'):
     status_parser.add_argument(
         '-s', '--service',
-        help='The name of the service you wish to inspect',
+        help=f'The name of the service you wish to {verb}',
     ).completer = lazy_choices_completer(list_services)
     status_parser.add_argument(
         '-c', '--clusters',
-        help="A comma-separated list of clusters to view. Defaults to view all clusters.\n"
-             "For example: --clusters norcal-prod,nova-prod",
+        help=f"A comma-separated list of clusters to {verb}. By default, will {verb} all clusters.\n"
+             f"For example: --clusters norcal-prod,nova-prod",
     ).completer = lazy_choices_completer(list_clusters)
     status_parser.add_argument(
         '-i', '--instances',
-        help="A comma-separated list of instances to view. Defaults to view all instances.\n"
-             "For example: --instances canary,main",
+        help=f"A comma-separated list of instances to {verb}. By default, will {verb} all instances.\n"
+             f"For example: --instances canary,main",
     )  # No completer because we need to know service first and we can't until some other stuff has happened
     status_parser.add_argument(
         '-l', '--deploy-group',
         help=(
-            'Name of the deploy group which you want to get status for. '
-            'If specified together with --instances and/or --clusters, will show common instances only.'
+            f'Name of the deploy group which you want to {verb}. '
+            f'If specified together with --instances and/or --clusters, will {verb} common instances only.'
         ),
     ).completer = lazy_choices_completer(list_deploy_groups)
     status_parser.add_argument(
         '-o', '--owner',
-        help='Team to filter instances by.',
+        help=f'Only {verb} instances with this owner specified in soa-configs.',
     ).completer = lazy_choices_completer(list_teams)
     status_parser.add_argument(
         '-r', '--registration',
-        help='Show only instances with this registration.',
+        help='Only {verb} instances with this registration.',
     )
 
 

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -127,7 +127,7 @@ def test_log_event():
 @mock.patch('paasta_tools.utils.InstanceConfig', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.get_instance_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.utils.get_git_url', autospec=True)
-@mock.patch('paasta_tools.cli.cmds.start_stop_restart.list_clusters', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.status.list_clusters', autospec=True)
 def test_paasta_start_or_stop(
     mock_list_clusters,
     mock_get_git_url,
@@ -212,7 +212,7 @@ def test_paasta_start_or_stop(
 @mock.patch('paasta_tools.utils.InstanceConfig', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.get_instance_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.utils.get_git_url', autospec=True)
-@mock.patch('paasta_tools.cli.cmds.start_stop_restart.list_clusters', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.status.list_clusters', autospec=True)
 def test_paasta_start_or_stop_with_deploy_group(
     mock_list_clusters,
     mock_get_git_url,
@@ -267,7 +267,7 @@ def test_paasta_start_or_stop_with_deploy_group(
 @mock.patch('paasta_tools.utils.InstanceConfig', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.get_instance_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.utils.get_git_url', autospec=True)
-@mock.patch('paasta_tools.cli.cmds.start_stop_restart.list_clusters', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.status.list_clusters', autospec=True)
 def test_stop_or_start_figures_out_correct_instances(
     mock_list_clusters,
     mock_get_git_url,
@@ -340,7 +340,7 @@ def test_stop_or_start_figures_out_correct_instances(
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.remote_git.list_remote_refs', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.get_instance_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.utils.get_git_url', autospec=True)
-@mock.patch('paasta_tools.cli.cmds.start_stop_restart.list_clusters', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.status.list_clusters', autospec=True)
 def test_stop_or_start_handle_ls_remote_failures(
     mock_list_clusters,
     mock_get_git_url,
@@ -369,7 +369,7 @@ def test_stop_or_start_handle_ls_remote_failures(
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.apply_args_filters', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.get_instance_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.remote_git.list_remote_refs', autospec=True)
-@mock.patch('paasta_tools.cli.cmds.start_stop_restart.list_clusters', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.status.list_clusters', autospec=True)
 def test_start_or_stop_bad_refs(
     mock_list_clusters,
     mock_list_remote_refs,
@@ -413,7 +413,7 @@ def test_cluster_list_defaults_to_all():
 @mock.patch('paasta_tools.utils.InstanceConfig', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.get_instance_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.utils.get_git_url', autospec=True)
-@mock.patch('paasta_tools.cli.cmds.start_stop_restart.list_clusters', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.status.list_clusters', autospec=True)
 def test_stop_or_start_warn_on_multi_instance(
     mock_list_clusters,
     mock_get_git_url,


### PR DESCRIPTION
Fixes #1774

I had meant to do this refactor when I started #1770 (hence why I pulled the filter-specific arguments into their own function), but didn't follow through.