### PR TITLE
Added PAASTA_SERVICE and PAASTA_INSTANCE to spark executor envs

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -279,6 +279,9 @@ def get_spark_conf_str(
 
     spark_conf.append('--conf spark.mesos.executor.docker.volumes=%s' % ','.join(volumes))
 
+    spark_conf.append('--conf spark.executorEnv.PAASTA_SERVICE=%s' % args.service)
+    spark_conf.append('--conf spark.executorEnv.PAASTA_INSTANCE=%s_%s' % (args.instance, get_username()))
+
     return ' '.join(spark_conf)
 
 


### PR DESCRIPTION
Tests:
1.  docker exec to an executor container and run env to check the variables are there.
2. check signalfx graphs.