### PR TITLE
PAASTA-13077 bogus error on symlink bug fix

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -116,7 +116,8 @@ def missing_deployments_message(service):
 def get_deploy_info(deploy_file_path):
     deploy_info = read_deploy(deploy_file_path)
     if not deploy_info:
-        paasta_print(PaastaCheckMessages.DEPLOY_YAML_MISSING)
+        paasta_print('Error encountered with %s' % deploy_file_path)
+
         exit(1)
     return deploy_info
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -31,7 +31,6 @@ from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import list_teams
-from paasta_tools.cli.utils import PaastaCheckMessages
 from paasta_tools.marathon_serviceinit import bouncing_status_human
 from paasta_tools.marathon_serviceinit import desired_state_human
 from paasta_tools.marathon_serviceinit import marathon_app_deploy_status_human

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2067,7 +2067,7 @@ def get_soa_cluster_deploy_files(
 
     for yaml_file in glob.glob('%s/*.yaml' % service_path):
         try:
-            with open(yaml_file) as fh:
+            with open(yaml_file):
                 cluster_re_match = re.search(search_re, yaml_file)
                 if cluster_re_match is not None:
                     cluster = cluster_re_match.group(2)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2066,10 +2066,14 @@ def get_soa_cluster_deploy_files(
     search_re = r'/.*/(' + instance_types + r')-([0-9a-z-_]*)\.yaml$'
 
     for yaml_file in glob.glob('%s/*.yaml' % service_path):
-        cluster_re_match = re.search(search_re, yaml_file)
-        if cluster_re_match is not None:
-            cluster = cluster_re_match.group(2)
-            yield (cluster, yaml_file)
+        try:
+            with open(yaml_file) as fh:
+                cluster_re_match = re.search(search_re, yaml_file)
+                if cluster_re_match is not None:
+                    cluster = cluster_re_match.group(2)
+                    yield (cluster, yaml_file)
+        except IOError as err:
+            print("Error opening %s: %s" % (yaml_file, err))
 
 
 def list_clusters(service: str=None, soa_dir: str=DEFAULT_SOA_DIR, instance_type: str=None) -> List[str]:

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -29,7 +29,6 @@ from paasta_tools.cli.cmds.status import paasta_status
 from paasta_tools.cli.cmds.status import report_invalid_whitelist_values
 from paasta_tools.cli.cmds.status import verify_instances
 from paasta_tools.cli.utils import NoSuchService
-from paasta_tools.cli.utils import PaastaCheckMessages
 from paasta_tools.cli.utils import PaastaColors
 
 
@@ -442,7 +441,6 @@ def test_get_deploy_info_exists(mock_read_deploy):
 @patch('paasta_tools.cli.cmds.status.read_deploy', autospec=True)
 def test_get_deploy_info_does_not_exist(mock_read_deploy, capfd):
     mock_read_deploy.return_value = False
-    expected_output = '%s\n' % PaastaCheckMessages.DEPLOY_YAML_MISSING
     with raises(SystemExit) as sys_exit:
         status.get_deploy_info('fake_service')
     output, _ = capfd.readouterr()

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -447,7 +447,7 @@ def test_get_deploy_info_does_not_exist(mock_read_deploy, capfd):
         status.get_deploy_info('fake_service')
     output, _ = capfd.readouterr()
     assert sys_exit.value.code == 1
-    assert output == expected_output
+    assert output.startswith('Error encountered with')
 
 
 @patch('paasta_tools.cli.cmds.status.get_instance_configs_for_service', autospec=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -597,35 +597,37 @@ def test_missing_cluster_configs_are_ignored():
         actual = utils.list_clusters(soa_dir=fake_soa_dir)
         assert actual == expected
         mock_join_path.assert_called_once_with(fake_soa_dir, '*')
-        mock_glob.assert_called_once_with('%s/*/*.yaml' % fake_soa_dir)    
+        mock_glob.assert_called_once_with('%s/*/*.yaml' % fake_soa_dir)
 
 
 def test_list_clusters_no_service_given_lists_all_of_them():
     fake_soa_dir = '/nail/etc/services'
     fake_soa_cluster_configs = [
-        ['cluster1','/nail/etc/services/service1/marathon-cluster1.yaml'],
-        ['cluster2','/nail/etc/services/service1/chronos-cluster2.yaml']
+        ['cluster1', '/nail/etc/services/service1/marathon-cluster1.yaml'],
+        ['cluster2', '/nail/etc/services/service1/chronos-cluster2.yaml'],
     ]
     expected = ['cluster1', 'cluster2']
     with mock.patch(
-        'paasta_tools.utils.get_soa_cluster_deploy_files', autospec=True, return_value=fake_soa_cluster_configs
-    ) as mock_get_soa:
+        'paasta_tools.utils.get_soa_cluster_deploy_files', autospec=True, return_value=fake_soa_cluster_configs,
+    ):
         actual = utils.list_clusters(soa_dir=fake_soa_dir)
         assert actual == expected
+
 
 def test_list_clusters_with_service():
     fake_soa_dir = '/nail/etc/services'
     fake_service = 'fake_service'
     fake_soa_cluster_configs = [
-        ['cluster1','/nail/etc/services/service1/marathon-cluster1.yaml'],
-        ['cluster2','/nail/etc/services/service1/chronos-cluster2.yaml']
+        ['cluster1', '/nail/etc/services/service1/marathon-cluster1.yaml'],
+        ['cluster2', '/nail/etc/services/service1/chronos-cluster2.yaml'],
     ]
     expected = ['cluster1', 'cluster2']
     with mock.patch(
-        'paasta_tools.utils.get_soa_cluster_deploy_files', autospec=True, return_value=fake_soa_cluster_configs
-    ) as mock_get_soa:
+        'paasta_tools.utils.get_soa_cluster_deploy_files', autospec=True, return_value=fake_soa_cluster_configs,
+    ):
         actual = utils.list_clusters(fake_service, fake_soa_dir)
         assert actual == expected
+
 
 def test_list_clusters_ignores_bogus_clusters():
     fake_soa_dir = '/nail/etc/services'
@@ -642,7 +644,8 @@ def test_list_clusters_ignores_bogus_clusters():
     ), mock.patch(
         'glob.glob', autospec=True, return_value=fake_cluster_configs,
     ), mock.patch(
-        'builtins.open', mock.mock_open(read_data="fakedata")) as mock_file:
+        'builtins.open', autospec=None, path=mock.mock_open(read_data="fakedata"),
+    ):
         actual = utils.list_clusters(service=fake_service)
         assert actual == expected
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -582,13 +582,13 @@ def test_remove_ansi_escape_sequences():
     assert utils.remove_ansi_escape_sequences(colored_string) == plain_string
 
 
-def test_list_clusters_no_service_given_lists_all_of_them():
+def test_missing_cluster_configs_are_ignored():
     fake_soa_dir = '/nail/etc/services'
     fake_cluster_configs = [
         '/nail/etc/services/service1/marathon-cluster1.yaml',
         '/nail/etc/services/service2/chronos-cluster2.yaml',
     ]
-    expected = ['cluster1', 'cluster2']
+    expected = []
     with mock.patch(
         'os.path.join', autospec=True, return_value='%s/*' % fake_soa_dir,
     ) as mock_join_path, mock.patch(
@@ -597,27 +597,35 @@ def test_list_clusters_no_service_given_lists_all_of_them():
         actual = utils.list_clusters(soa_dir=fake_soa_dir)
         assert actual == expected
         mock_join_path.assert_called_once_with(fake_soa_dir, '*')
-        mock_glob.assert_called_once_with('%s/*/*.yaml' % fake_soa_dir)
+        mock_glob.assert_called_once_with('%s/*/*.yaml' % fake_soa_dir)    
 
+
+def test_list_clusters_no_service_given_lists_all_of_them():
+    fake_soa_dir = '/nail/etc/services'
+    fake_soa_cluster_configs = [
+        ['cluster1','/nail/etc/services/service1/marathon-cluster1.yaml'],
+        ['cluster2','/nail/etc/services/service1/chronos-cluster2.yaml']
+    ]
+    expected = ['cluster1', 'cluster2']
+    with mock.patch(
+        'paasta_tools.utils.get_soa_cluster_deploy_files', autospec=True, return_value=fake_soa_cluster_configs
+    ) as mock_get_soa:
+        actual = utils.list_clusters(soa_dir=fake_soa_dir)
+        assert actual == expected
 
 def test_list_clusters_with_service():
     fake_soa_dir = '/nail/etc/services'
     fake_service = 'fake_service'
-    fake_cluster_configs = [
-        '/nail/etc/services/service1/marathon-cluster1.yaml',
-        '/nail/etc/services/service1/chronos-cluster2.yaml',
+    fake_soa_cluster_configs = [
+        ['cluster1','/nail/etc/services/service1/marathon-cluster1.yaml'],
+        ['cluster2','/nail/etc/services/service1/chronos-cluster2.yaml']
     ]
     expected = ['cluster1', 'cluster2']
     with mock.patch(
-        'os.path.join', autospec=True, return_value='%s/%s' % (fake_soa_dir, fake_service),
-    ) as mock_join_path, mock.patch(
-        'glob.glob', autospec=True, return_value=fake_cluster_configs,
-    ) as mock_glob:
+        'paasta_tools.utils.get_soa_cluster_deploy_files', autospec=True, return_value=fake_soa_cluster_configs
+    ) as mock_get_soa:
         actual = utils.list_clusters(fake_service, fake_soa_dir)
         assert actual == expected
-        mock_join_path.assert_called_once_with(fake_soa_dir, fake_service)
-        mock_glob.assert_called_once_with('%s/%s/*.yaml' % (fake_soa_dir, fake_service))
-
 
 def test_list_clusters_ignores_bogus_clusters():
     fake_soa_dir = '/nail/etc/services'
@@ -633,7 +641,8 @@ def test_list_clusters_ignores_bogus_clusters():
         'os.path.join', autospec=True, return_value='%s/%s' % (fake_soa_dir, fake_service),
     ), mock.patch(
         'glob.glob', autospec=True, return_value=fake_cluster_configs,
-    ):
+    ), mock.patch(
+        'builtins.open', mock.mock_open(read_data="fakedata")) as mock_file:
         actual = utils.list_clusters(service=fake_service)
         assert actual == expected
 


### PR DESCRIPTION
Test procedure:

Step 1 - Create bogus file
~/.../yelpsoa-configs/careers (master)$ ls -la
lrwxrwxrwx   1 bryanp users    28 Mar 26 12:56 adhoc-nova-prod.yaml -> careers/adhoc-nova-prod.yaml
...
~/.../yelpsoa-configs/careers (master)$

Step 2 - Recreate bug
~/.../yelpsoa-configs/careers (master)$ paasta status
✗ No deploy.yaml exists, so your service cannot be deployed.
  Push a deploy.yaml and run `paasta generate-pipeline`.
  More info: http://y/yelpsoa-configs
~/.../yelpsoa-configs/careers (master)$

~/.../yelpsoa-configs/careers (master)$ paasta validate
✓ Successfully validated schema: marathon-nova-prod.yaml
...
~/.../yelpsoa-configs/careers (master)$
<note: no errors mentioned despite having a broken symlink>

Step 3 - Fix and retry
~/.../yelpsoa-configs/careers (master)$ paasta status
Error opening /nail/etc/services/careers/adhoc-nova-prod.yaml: [Errno 2] No such file or directory: '/nail/etc/services/careers/adhoc-nova-prod.yaml'
Error opening /nail/etc/services/careers/adhoc-nova-prod.yaml: [Errno 2] No such file or directory: '/nail/etc/services/careers/adhoc-nova-prod.yaml'
...
service: careers
cluster: norcal-stageg
    instance: main
...
        uswest2-prod - Healthy - in haproxy with (4/0) total backends UP in this namespace.
~/.../yelpsoa-configs/careers (master)$

~/.../yelpsoa-configs/careers (master)$ paasta validate
✓ Successfully validated schema: marathon-nova-prod.yaml
✓ Successfully validated schema: marathon-DEV.yaml
✓ Successfully validated schema: marathon-pnw-prod.yaml
✓ Successfully validated schema: marathon-STAGE.yaml
✓ Successfully validated schema: marathon-norcal-prod.yaml
Error opening /nail/home/bryanp/src-repo/yelpsoa-configs/careers/adhoc-nova-prod.yaml: [Errno 2] No such file or directory: '/nail/home/bryanp/src-repo/yelpsoa-configs/careers/adhoc-nova-prod.yaml'
~/.../yelpsoa-configs/careers (master)$


