### PR TITLE
Change default vault token path

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -383,7 +383,7 @@ def add_subparser(subparsers):
         type=str,
         dest='vault_token_file',
         required=False,
-        default='/root/.vault-token',
+        default='/var/spool/.paasta_vault_token',
     )
     list_parser.add_argument(
         '--skip-secrets',


### PR DESCRIPTION
It makes sense to have the default in a path that is easier to access
for users other than root. This is so that different roles with
different users and token permissions can standardise on the path of the
token they need for local-run.