### PR TITLE
Fix internal build

### DIFF
--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -24,9 +24,8 @@ RUN apt-get update > /dev/null && \
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
         debhelper \
-        dpkg-dev \
-        gcc \
         gdebi-core \
         git \
         help2man \

--- a/yelp_package/dockerfiles/xenial/Dockerfile
+++ b/yelp_package/dockerfiles/xenial/Dockerfile
@@ -24,9 +24,8 @@ RUN apt-get update > /dev/null && \
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
         debhelper \
-        dpkg-dev \
-        gcc \
         gdebi-core \
         git \
         help2man \


### PR DESCRIPTION
itest_trusty and itest_xenial are failing on our internal build servers, due to the extra dependencies that we add in. If I run the commands manually, I get:

```
x86_64-linux-gnu-gcc: error trying to exec 'cc1plus': execvp: No such file or directory
```
when trying to build grpcio, due to a lack of g++.

grpcio comes from:

```
Collecting grpcio>=1.0.0; extra == "grpc" (from googleapis-common-protos[grpc]<2.0dev,>=1.5.2->google-cloud-dataproc->mrjob->yelp-logging==1.0.37->-r ./requirements.txt (line 105))
```

This branch shouldn't really change much on Travis.