### PR TITLE
Fix autoscaler watcher missing new service

### DIFF
--- a/example_cluster/paasta/api.json
+++ b/example_cluster/paasta/api.json
@@ -1,5 +1,5 @@
 {
   "api_endpoints": {
-    "testcluster": "http://mesosmaster:5054"
+    "testcluster": "http://paasta_api:5054"
   }
 }

--- a/paasta_itests/paasta_deployd.feature
+++ b/paasta_itests/paasta_deployd.feature
@@ -92,6 +92,23 @@ Feature: paasta-deployd deploys apps
      When we set the instance count in zookeeper for service "test-service" instance "main" to 2
      Then we should see the number of instances become 2
 
+  Scenario: deployd will scale up an app if the instance count changes in zk even if other keys are created in zk first.
+    # See PAASTA-14172: we had a bug where we fail to instantiate the appropriate watcher
+    Given a working paasta cluster
+      And we remove autoscaling ZK keys for test-service
+      And paasta-deployd is running
+      And I have yelpsoa-configs for the marathon job "test-service.main"
+      And we have a deployments.json for the service "test-service" with enabled instance "main"
+     When we set the "min_instances" field of the marathon config for service "test-service" and instance "main" to the integer 2
+      And we set the "max_instances" field of the marathon config for service "test-service" and instance "main" to the integer 4
+      And we set the "disk" field of the marathon config for service "test-service" and instance "main" to the integer 1
+      And we set some arbitrary data at "/autoscaling/test-service/main/somethingrandom" in ZK
+      And we set the instance count in zookeeper for service "test-service" instance "main" to 3
+     Then we should see "test-service.main" listed in marathon after 45 seconds
+     Then we should see the number of instances become 3
+     When we set the instance count in zookeeper for service "test-service" instance "main" to 4
+     Then we should see the number of instances become 4
+
   Scenario: deployd starts and only one leader
     Given a working paasta cluster
       And paasta-deployd is running

--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -51,13 +51,14 @@ class AutoscalerWatcher(PaastaWatcher):
         """recursive nonsense"""
         if "autoscaling.lock" in path:
             return
+        if path.split('/')[-1] == 'instances':
+            self.watch_node(path, enqueue=enqueue_children)
+            return
         self.log.info("Adding folder watch on {}".format(path))
         watcher = ChildrenWatch(self.zk, path, func=self.process_folder_event, send_event=True)
         self.watchers[path] = watcher
         children = watcher._client.get_children(watcher._path)
-        if children and ('instances' in children):
-            self.watch_node("{}/instances".format(path), enqueue=enqueue_children)
-        elif children:
+        if children:
             for child in children:
                 self.watch_folder("{}/{}".format(path, child), enqueue_children=enqueue_children)
 

--- a/tests/deployd/test_watchers.py
+++ b/tests/deployd/test_watchers.py
@@ -113,6 +113,12 @@ class TestAutoscalerWatcher(unittest.TestCase):
             self.watcher.watch_folder('/rick/beth')
             mock_watch_node.assert_called_with(self.watcher, '/rick/beth/instances', enqueue=False)
 
+            mock_watch_node.reset_mock()
+            mock_watcher = mock.Mock(_client=mock.Mock(get_children=mock.Mock(return_value=[])))
+            mock_children_watch.return_value = mock_watcher
+            self.watcher.watch_folder('/rick/beth/instances')
+            mock_watch_node.assert_called_with(self.watcher, '/rick/beth/instances', enqueue=False)
+
             mock_watcher = mock.Mock(_client=mock.Mock(get_children=mock.Mock(return_value=['instances'])))
             mock_children_watch.return_value = mock_watcher
             self.watcher.watch_folder('/rick/beth', enqueue_children=True)


### PR DESCRIPTION
This makes it so the autoscaler watcher explicitly creates a node watch
on keys called "instances". Before this would only be the case if the
parent folder and instances key were created at nearly the same time.
i.e. the instances child existed by the time the watcher was being
created for the containing folder. Note that the added itest was failing
before I made this change.