### PR TITLE
Make sure spark-run executor_cores is less than max_cores

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -458,6 +458,15 @@ def validate_work_dir(s):
 
 
 def paasta_spark_run(args):
+    if args.max_cores < args.executor_cores:
+        paasta_print(
+            "Total number of cores %d is less than per-executor cores %d" % (
+                args.max_cores,
+                args.executor_cores,
+            ),
+        )
+        sys.exit(1)
+
     # argparse does not work as expected with both default and
     # type=validate_work_dir.
     validate_work_dir(args.work_dir)


### PR DESCRIPTION
Bailing out is preferred over using max() to avoid spark-run with unexpected behavior.