### PR TITLE
Upgrade tox-pip-extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test: .paasta/bin/activate
 	.paasta/bin/pip install -U pip==9.0.1
 	.paasta/bin/pip install -U virtualenv==15.1.0
 	.paasta/bin/pip install -U tox==2.6.0
-	.paasta/bin/pip install -U tox-pip-extensions==1.0.1
+	.paasta/bin/pip install -U tox-pip-extensions==1.2.1
 	touch .paasta/bin/activate
 
 itest: test .paasta/bin/activate


### PR DESCRIPTION
The latest version supports newer versions of pip which for some reason
I need on my laptop where some new versions of the extensions are
getting installed. I've added this version on our internal pypi and it
seems to work...

I guess if travis passes this will be okay