### PR TITLE
Added Docker labels to spark-run executors

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -356,6 +356,11 @@ def get_spark_conf_str(
     spark_conf.append('--conf spark.executorEnv.PAASTA_INSTANCE=%s_%s' % (args.instance, get_username()))
     spark_conf.append('--conf spark.executorEnv.PAASTA_CLUSTER=%s' % (args.cluster))
 
+    # Labels for CloudHealth
+    para_service = 'label=paasta_service=%s' % args.service
+    para_instance = 'label=paasta_instance=%s_%s' % (args.instance, get_username())
+    spark_conf.append('--conf spark.mesos.executor.docker.parameters=%s,%s' % (para_service, para_instance))
+
     return ' '.join(spark_conf)
 
 


### PR DESCRIPTION
CH per instance report is broken. Note that spark.mesos.task.labels in https://spark.apache.org/docs/latest/running-on-mesos.html is not the right config to use. Below is from docker inspect with spark.mesos.executor.docker.parameters.

            "Image": "docker-paasta.yelpcorp.com:443/services-spark:paasta-8a92fdcc9c48026a28d83d0463b7ef7fdaf2ee59",
            "WorkingDir": "/work",
            "Entrypoint": [
                "/bin/sh"
            ],
            "Labels": {
                "paasta_instance": "client_hliu",
                "paasta_service": "spark"
            }