### PR TITLE
TASKPROC-194: increase the default staging timeout for remote-run

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -51,7 +51,7 @@ def add_start_args_to_parser(parser):
         '-t', '--staging-timeout',
         help='A timeout for the task to be launching before killed',
         required=False,
-        default=60,
+        default=240,
         type=float,
     )
     parser.add_argument(


### PR DESCRIPTION
we missed this before.