### PR TITLE
adds timeout cli option for spark-run jupyter

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -169,6 +169,13 @@ def add_subparser(subparsers):
         help='Number of CPU cores for the Spark driver',
     )
 
+    list_parser.add_argument(
+        '-t', '--timeout',
+        type=int,
+        help='Number of seconds to wait before terminating an idle framework.',
+        default=3600,
+    )
+
     aws_group = list_parser.add_argument_group(
         title='AWS credentials options',
         description='If --aws-credentials-yaml is specified, it overrides all '
@@ -457,10 +464,10 @@ def get_docker_cmd(args, instance_config, spark_conf_str):
         return None
 
     # Default cli options to start the jupyter notebook server.
-    if original_docker_cmd == 'jupyter':
-        # Shutdown idle kernels that are not connected after one hour.
+    if original_docker_cmd == 'jupyter' and args.timeout >= 0:
+        # Shutdown idle kernels that are not connected after the timeout period.
         # Shutdown connected kernels if they use more than 32 cores.
-        cull_opts = '--MappingKernelManager.cull_idle_timeout=3600 '
+        cull_opts = '--MappingKernelManager.cull_idle_timeout=%d ' % args.timeout
         if args.max_cores > 32:
             cull_opts += '--MappingKernelManager.cull_connected=True '
 

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -179,6 +179,14 @@ def test_get_docker_cmd_other_cmd():
     assert get_docker_cmd(args, instance_config, spark_conf_str) == 'bash'
 
 
+def test_get_docker_cmd_jupyter_timeout():
+    args = mock.Mock(cmd='jupyter', timeout=3600, max_cores=30, work_dir='test:test')
+    assert 'cull_idle_timeout' in get_docker_cmd(args, None, None)
+
+    args.timeout = -1
+    assert 'cull_idle_timeout' not in get_docker_cmd(args, None, None)
+
+
 def test_load_aws_credentials_from_yaml(tmpdir):
     fake_access_key_id = 'fake_access_key_id'
     fake_secret_access_key = 'fake_secret_access_key'


### PR DESCRIPTION
It seems that `MappingKernelManager.cull_idle_timeout` requires the front end and not just the server to be connected to recognize that a framework is still active. The default timeout has resulted in frameworks being lost for example when the underlying file was automatically reloaded or when the machine running the UI is asleep.