### PR TITLE
Do not use --it for spark-submit and jupyter

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -229,8 +229,11 @@ def get_docker_run_cmd(
     cmd = ['paasta_docker_wrapper', 'run']
     cmd.append('--rm')
     cmd.append('--net=host')
-    cmd.append('--interactive=true')
-    cmd.append('--tty=true')
+
+    if 'spark-submit' not in docker_cmd and 'jupyter' not in docker_cmd:
+        cmd.append('--interactive=true')
+        if sys.stdout.isatty():
+            cmd.append('--tty=true')
 
     cmd.append('--user=%d:%d' % (os.geteuid(), os.getegid()))
     cmd.append('--name=%s' % container_name)

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -48,7 +48,7 @@ def test_get_docker_run_cmd(
         docker_cmd,
     )
 
-    assert actual[6:] == [
+    assert actual[5:] == [
         '--user=1234:100',
         '--name=fake_name',
         '--env', 'k1=v1', '--env', 'k2=v2',


### PR DESCRIPTION
This is to fix "the input device is not a TTY" when running spark-submit with tron.