### PR TITLE
Bump hacheck timeouts to avoid mass-timeouts when draining many tasks at once.

### DIFF
--- a/paasta_tools/drain_lib.py
+++ b/paasta_tools/drain_lib.py
@@ -28,8 +28,8 @@ from mypy_extensions import TypedDict
 from paasta_tools.utils import get_user_agent
 
 _drain_methods: Dict[str, Type["DrainMethod"]] = {}
-HACHECK_CONN_TIMEOUT = 3
-HACHECK_READ_TIMEOUT = 1
+HACHECK_CONN_TIMEOUT = 30
+HACHECK_READ_TIMEOUT = 10
 
 
 _RegisterDrainMethod_T = TypeVar('_RegisterDrainMethod_T', bound=Type["DrainMethod"])


### PR DESCRIPTION
Relates to the 503s found in OPS-13121. Basically, when we bounce larger apps, and drain a large number of tasks at once, we get a bunch of errors like this:

    crossover bounce killing task REDACTED due to exception in is_safe_to_kill: Traceback (most recent call last):
      File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/setup_marathon_job.py", line 195, in add_to_tasks_to_kill_if_safe_to_kill
        if task.state != 'TASK_RUNNING' or await drain_method.is_safe_to_kill(task):
      File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/drain_lib.py", line 279, in is_safe_to_kill
        info = await self.get_spool(task)
      File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/drain_lib.py", line 234, in get_spool
        headers={'User-Agent': get_user_agent()},
      File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/aiohttp/helpers.py", line 104, in __await__
        ret = yield from self._coro
      File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/aiohttp/client.py", line 341, in _request
        break
      File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/aiohttp/helpers.py", line 727, in __exit__
        raise asyncio.TimeoutError from None
    concurrent.futures._base.TimeoutError

This causes the bounce to kill a large number of tasks immediately without draining. haproxy-synapse is configured to redispatch on connection failures, but if enough tasks are killed at the same time, then some requests will be redispatched to tasks that are also dead.


I think what's happening is that setup_marathon_job is making enough requests in parallel that they can't all be processed before their 3 / 1 second timeouts. Bumping the timeouts is kinda lame, but should paper over this for now. Ideally we'd limit the number of concurrent requests to hacheck, retry failed requests, or figure out how to only time-out on connection issues (and not local CPU contention).