### PR TITLE
Add a flag to disable reservation on maint calls

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1423,6 +1423,7 @@ SystemPaastaConfigDict = TypedDict(
         'vault_cluster_map': Dict,
         'secret_provider': str,
         'slack': Dict[str, str],
+        'maintenance_resource_reservation_enabled': bool,
     },
     total=False,
 )
@@ -1647,6 +1648,13 @@ class SystemPaastaConfig(object):
 
         :returns A bool"""
         return self.config_dict.get('cluster_autoscaling_draining_enabled', True)
+
+    def get_maintenance_resource_reservation_enabled(self) -> bool:
+        """ Enable un/reserving of resources when we un/drain a host in mesos maintenance
+        *and* after tasks are killed in setup_marathon_job etc.
+
+        :returns A bool"""
+        return self.config_dict.get('maintenance_resource_reservation_enabled', True)
 
     def get_filter_bogus_mesos_cputime_enabled(self) -> bool:
         """ Filters out mesos cputime values if they are greater than

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -1448,8 +1448,12 @@ class TestClusterAutoscaler(unittest.TestCase):
                 self.capacity = capacity
 
             mock_set_capacity.side_effect = _set_capacity
-
-            mock_drain.assert_called_with(['host1|10.1.1.1'], mock_start, 600 * 1000000000)
+            mock_drain.assert_called_with(
+                hostnames=['host1|10.1.1.1'],
+                start=mock_start,
+                duration=600 * 1000000000,
+                reserve_resources=True,
+            )
             set_call_1 = mock.call(self.autoscaler, 4)
             mock_set_capacity.assert_has_calls([set_call_1])
             mock_wait_and_terminate.assert_called_with(
@@ -1467,13 +1471,21 @@ class TestClusterAutoscaler(unittest.TestCase):
                 capacity_diff=-1,
                 timer=mock_timer,
             ))
-            mock_drain.assert_called_with(['host1|10.1.1.1'], mock_start, 600 * 1000000000)
+            mock_drain.assert_called_with(
+                hostnames=['host1|10.1.1.1'],
+                start=mock_start,
+                duration=600 * 1000000000,
+                reserve_resources=True,
+            )
             mock_set_capacity.assert_has_calls([set_call_1, set_call_2])
             mock_wait_and_terminate.assert_called_with(
                 self.autoscaler, slave=mock_slave, drain_timeout=123, dry_run=False,
                 region='westeros-1', should_drain=True, timer=mock_timer,
             )
-            mock_undrain.assert_called_with(['host1|10.1.1.1'])
+            mock_undrain.assert_called_with(
+                hostnames=['host1|10.1.1.1'],
+                unreserve_resources=True,
+            )
 
             # test we cleanup if a set spot capacity fails
             mock_wait_and_terminate.side_effect = just_sleep
@@ -1486,9 +1498,17 @@ class TestClusterAutoscaler(unittest.TestCase):
                     capacity_diff=-1,
                     timer=mock_timer,
                 ))
-            mock_drain.assert_called_with(['host1|10.1.1.1'], mock_start, 600 * 1000000000)
+            mock_drain.assert_called_with(
+                hostnames=['host1|10.1.1.1'],
+                start=mock_start,
+                duration=600 * 1000000000,
+                reserve_resources=True,
+            )
             mock_set_capacity.assert_has_calls([set_call_1])
-            mock_undrain.assert_called_with(['host1|10.1.1.1'])
+            mock_undrain.assert_called_with(
+                hostnames=['host1|10.1.1.1'],
+                unreserve_resources=True,
+            )
             assert not mock_wait_and_terminate.called
 
             # test we cleanup if a drain fails
@@ -1503,7 +1523,12 @@ class TestClusterAutoscaler(unittest.TestCase):
                     capacity_diff=-1,
                     timer=mock_timer,
                 ))
-            mock_drain.assert_called_with(['host1|10.1.1.1'], mock_start, 600 * 1000000000)
+            mock_drain.assert_called_with(
+                hostnames=['host1|10.1.1.1'],
+                start=mock_start,
+                duration=600 * 1000000000,
+                reserve_resources=True,
+            )
             assert not mock_set_capacity.called
             assert not mock_wait_and_terminate.called
 

--- a/tests/test_mesos_maintenance.py
+++ b/tests/test_mesos_maintenance.py
@@ -520,6 +520,12 @@ def test_drain(
     drain(hostnames=['some-host'], start='some-start', duration='some-duration')
     assert mock_operator_api.call_count == 2
 
+    mock_reserve_all_resources.reset_mock()
+    mock_operator_api.reset_mock()
+    drain(hostnames=['some-host'], start='some-start', duration='some-duration', reserve_resources=False)
+    assert mock_reserve_all_resources.call_count == 0
+    assert mock_operator_api.return_value.call_count == 1
+
 
 @mock.patch('paasta_tools.mesos_maintenance.operator_api', autospec=True)
 @mock.patch('paasta_tools.mesos_maintenance.build_maintenance_schedule_payload', autospec=True)
@@ -549,6 +555,12 @@ def test_undrain(
     mock_unreserve_all_resources.side_effect = HTTPError()
     undrain(hostnames=['some-host'])
     assert mock_operator_api.call_count == 2
+
+    mock_operator_api.reset_mock()
+    mock_unreserve_all_resources.reset_mock()
+    undrain(hostnames=['some-host'], unreserve_resources=False)
+    assert mock_operator_api.call_count == 1
+    assert mock_unreserve_all_resources.call_count == 0
 
 
 @mock.patch(


### PR DESCRIPTION
We are trying a new approach with mesos to not send offers from hosts in
maintenance mode. If this works we should not need to reserve the
resources on an agent to prevent tasks getting launched there. This
commit adds a config flag to disable the reservation in both the bounce
logic and the cluster autoscaler. Doing this behind a config flag to
just enable in the places where we have patched mesos first for testing.
If everything works out okay I can double back and remove the
reservation code.