### PR TITLE
Require the `--cluster` argument when running `paasta remote-run`

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -70,11 +70,8 @@ def add_common_args_to_parser(parser):
     ).completer = lazy_choices_completer(list_services)
     parser.add_argument(
         '-c', '--cluster',
-        help=(
-            'The name of the cluster you wish to run your task on. '
-            'If omitted, uses the default cluster defined in the paasta'
-            'remote-run configs'
-        ),
+        required=True,
+        help=('The name of the cluster you wish to run your task on.'),
     ).completer = lazy_choices_completer(list_clusters)
     parser.add_argument(
         '-y', '--yelpsoa-config-root',


### PR DESCRIPTION
Without this, you get an error like:

```
Traceback (most recent call last):
  File "/usr/bin/paasta", line 11, in <module>
    sys.exit(main())
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cli.py", line 121, in main
    return_code = args.command(args)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cmds/remote_run.py", line 248, in paasta_remote_run
    graceful_exit=graceful_exit,
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/utils.py", line 729, in run_on_master
    master = connectable_master(cluster, system_paasta_config)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/utils.py", line 438, in connectable_master
    masters, output = calculate_remote_masters(cluster, system_paasta_config)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/utils.py", line 402, in calculate_remote_masters
    cluster_fqdn = system_paasta_config.get_cluster_fqdn_format().format(cluster=cluster)
TypeError: unsupported format string passed to NoneType.__format__
```