### PR TITLE
Catch NoSlavesAvailableError in deployd

### DIFF
--- a/paasta_tools/deployd/common.py
+++ b/paasta_tools/deployd/common.py
@@ -17,6 +17,7 @@ from paasta_tools.marathon_tools import get_marathon_servers
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.marathon_tools import load_marathon_service_config_no_cache
 from paasta_tools.marathon_tools import MarathonClients
+from paasta_tools.mesos.exceptions import NoSlavesAvailableError
 from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import NoConfigurationForServiceError
@@ -183,7 +184,7 @@ def get_service_instances_needing_update(
             )
             config_app = config.format_marathon_app_dict()
             app_id = '/{}'.format(config_app['id'])
-        except (NoDockerImageError, InvalidJobNameError, NoDeploymentsAvailable) as e:
+        except (NoDockerImageError, InvalidJobNameError, NoDeploymentsAvailable, NoSlavesAvailableError) as e:
             print("DEBUG: Skipping %s.%s because: '%s'" % (service, instance, str(e)))
             continue
         if app_id not in marathon_app_ids:


### PR DESCRIPTION
This error ocassionally crops up when a service specifies an invalid
constraint. Currently it isn't caught and causes one or more of the
watchers in deployd to die which causes freqeunt leader elections. It
should be safe to catch and log.

NB: by invalid I mean restricting to a set of agents that does not exist.