### PR TITLE
Added a get_authors remote git command for better slack notifications

### DIFF
--- a/paasta_tools/remote_git.py
+++ b/paasta_tools/remote_git.py
@@ -11,9 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
+
 import dulwich.client
 import dulwich.errors
 
+from paasta_tools.utils import _run
 from paasta_tools.utils import timeout
 
 
@@ -88,3 +91,27 @@ def list_remote_refs(git_url):
         return {k.decode('UTF-8'): v.decode('UTF-8') for k, v in refs.items()}
     except dulwich.errors.HangupException as e:
         raise LSRemoteException("Unable to fetch remote refs from %s: %s" % (git_url, e))
+
+
+def get_authors(git_url, from_sha, to_sha):
+    """ Gets the list of authors who contributed to a git changeset.
+    Currently only supports fetching this in a very "yelpy" way by
+    executing a gitolite command """
+    matches = re.match("(?P<git_server>.*):(?P<git_repo>.*)", git_url)
+    if matches is None:
+        return (1, f"could not understand the git url {git_url} for authors detection")
+    git_server = matches.group("git_server")
+    git_repo = matches.group("git_repo")
+    if git_server is None:
+        return 1, f"could not understand the git server in {git_url} for authors detection"
+    if git_repo is None:
+        return 1, f"could not understand the git repo in {git_url} for authors detection"
+
+    if "yelpcorp.com" in git_server:
+        ssh_command = f"ssh {git_server} {git_repo} {from_sha} {to_sha}"
+        return _run(
+            command=ssh_command,
+            timeout=5.0,
+        )
+    else:
+        return 1, f"Fetching authors not supported for {git_server}"

--- a/tests/test_remote_git.py
+++ b/tests/test_remote_git.py
@@ -115,3 +115,24 @@ def test_create_remote_refs_allows_force_and_uses_the_provided_mutator(mock_dulw
     fake_git_client.send_pack.assert_called_once_with(
         'fake_path', mock.sentinel.ref_mutator, mock.ANY,
     )
+
+
+@mock.patch('paasta_tools.remote_git._run', autospec=True)
+def test_get_authors_fails_with_bad_url(mock_run):
+    expected = 1, mock.ANY
+    assert expected == remote_git.get_authors('bad', 'a', 'b')
+
+
+@mock.patch('paasta_tools.remote_git._run', autospec=True)
+def test_get_authors_fails_with_unknown(mock_run):
+    url = 'git@bitbucket.org:something.git'
+    expected = 1, mock.ANY
+    assert expected == remote_git.get_authors(url, 'a', 'b')
+
+
+@mock.patch('paasta_tools.remote_git._run', autospec=True)
+def test_get_authors_works_with_good_url(mock_run):
+    mock_run.return_value = (0, 'it worked')
+    expected = mock_run.return_value
+    assert expected == remote_git.get_authors('git@git.yelpcorp.com:yelp-main', 'a', 'b')
+    mock_run.assert_called_once_with(command='ssh git@git.yelpcorp.com yelp-main a b', timeout=5.0)


### PR DESCRIPTION
This is to (eventually) allow us to ping authors in slack who are part of a push.

It only needs to work on "yelpy" git servers, but leaves room to get authors via other means for different git servers (maybe in the future we can curl bitbucket or something)