### PR TITLE
Encode newlines before sending them to stdin

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1856,7 +1856,7 @@ def _run(
 
         if stdin_interrupt:
             def signal_handler(signum: int, frame: FrameType) -> None:
-                process.stdin.write("\n")
+                process.stdin.write("\n".encode('utf-8'))
                 process.stdin.flush()
                 process.wait()
             signal.signal(signal.SIGINT, signal_handler)


### PR DESCRIPTION
Another remote_run traceback, I think this should fix
```
Traceback (most recent call last):
  File "/usr/bin/paasta", line 11, in <module>
    sys.exit(main())
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cli.py", line 121, in main
    return_code = args.command(args)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cmds/remote_run.py", line 248, in paasta_remote_run
    graceful_exit=graceful_exit,
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/utils.py", line 757, in run_on_master
    popen_kwargs=popen_kwargs,
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/utils.py", line 1856, in _run
    for linestr in iter(process.stdout.readline, b''):
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/utils.py", line 1846, in signal_handler
    process.stdin.write("\n")
TypeError: a bytes-like object is required, not 'str'
```