### PR TITLE
Ping Slack with authors

### DIFF
--- a/paasta_tools/remote_git.py
+++ b/paasta_tools/remote_git.py
@@ -108,7 +108,7 @@ def get_authors(git_url, from_sha, to_sha):
         return 1, f"could not understand the git repo in {git_url} for authors detection"
 
     if "yelpcorp.com" in git_server:
-        ssh_command = f"ssh {git_server} {git_repo} {from_sha} {to_sha}"
+        ssh_command = f"ssh {git_server} authors-of-changeset {git_repo} {from_sha} {to_sha}"
         return _run(
             command=ssh_command,
             timeout=5.0,

--- a/tests/test_remote_git.py
+++ b/tests/test_remote_git.py
@@ -135,4 +135,4 @@ def test_get_authors_works_with_good_url(mock_run):
     mock_run.return_value = (0, 'it worked')
     expected = mock_run.return_value
     assert expected == remote_git.get_authors('git@git.yelpcorp.com:yelp-main', 'a', 'b')
-    mock_run.assert_called_once_with(command='ssh git@git.yelpcorp.com yelp-main a b', timeout=5.0)
+    mock_run.assert_called_once_with(command='ssh git@git.yelpcorp.com authors-of-changeset yelp-main a b', timeout=5.0)


### PR DESCRIPTION
Based on #1829, this connects the two and makes it so we will ping authors when their deploy is ready.

@chriskuehl do you think this approach is "better" (comparing before/after sha) or do I need to go all the way and do exactly what the existing thing does, which is always compare against the "production_deploy_group" ?