### PR TITLE
Don't get header so that config diff is accurate

### DIFF
--- a/paasta_tools/tron/client.py
+++ b/paasta_tools/tron/client.py
@@ -81,7 +81,13 @@ class TronClient:
         :param skip_if_unchanged: boolean. If False, will send the update
             even if the current config matches the new config.
         """
-        current_config = self._get('/api/config', {'name': namespace})
+        current_config = self._get(
+            '/api/config',
+            {
+                'name': namespace,
+                'no_header': 1,
+            },
+        )
         if skip_if_unchanged and new_config == current_config['config']:
             log.info('No change in config, skipping update.')
             return

--- a/tests/tron/test_tron_client.py
+++ b/tests/tron/test_tron_client.py
@@ -70,7 +70,7 @@ class TestTronClient:
         assert mock_requests.get.call_count == 1
         _, kwargs = mock_requests.get.call_args
         assert kwargs['url'] == self.tron_url + '/api/config'
-        assert kwargs['params'] == {'name': 'some_service'}
+        assert kwargs['params'] == {'name': 'some_service', 'no_header': 1}
 
         assert mock_requests.post.call_count == 1
         _, kwargs = mock_requests.post.call_args


### PR DESCRIPTION
Without this, Tron returns the "Named Configuration Template" stuff along with the actual config, so it's always different and the script will update every namespace.