### PR TITLE
Don't load deployments if a docker_image is provided in remote-run

### DIFF
--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -360,6 +360,7 @@ def remote_run_start(args):
         soa_dir=soa_dir,
         instance_type=instance_type,
         config_overrides=overrides_dict,
+        load_deployments=not args.docker_image,
     )
     try:
         task_config = MesosExecutor.TASK_CONFIG_INTERFACE(


### PR DESCRIPTION
Although a special case, locust needs this because they are an "adhoc" service that doesn't have real deployments.