### PR TITLE
Make SpotAutoscaler cleanup cancelled_running SFR with no instances

### DIFF
--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -1001,8 +1001,16 @@ class TestSpotAutoscaler(unittest.TestCase):
             ret = self.autoscaler.metrics_provider(mock_mesos_state)
             assert ret == (0, 0)
 
+            # cancelled_running SFR with no instances
+            mock_cleanup_cancelled_config.reset_mock()
+            self.autoscaler.instances = []
+            ret = self.autoscaler.metrics_provider(mock_mesos_state)
+            assert ret == (0, 0)
+            mock_cleanup_cancelled_config.assert_called_with(self.autoscaler, 'sfr-blah', '/nail/blah', dry_run=False)
+
             # SFR with no instances
             mock_get_mesos_master.reset_mock()
+            self.autoscaler.sfr = {'SpotFleetRequestState': 'active'}
             self.autoscaler.instances = []
             ret = self.autoscaler.metrics_provider(mock_mesos_state)
             assert ret == (0, 0)


### PR DESCRIPTION
More or less treating a cancelled_running SFR with no instances the same way we treat a cancelled SFR.  Let me know if you think that's too aggressive.

Also we've seen SFRs sit in this state more or less indefinitely (until we manually cancel them), and this may make us less likely to notice that.  Is that at all problematic?