### PR TITLE
Don't send slack noifications if the old and new commits are the same

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -251,13 +251,13 @@ class SlackDeployNotifier(object):
 
     def notify_after_mark(self, ret):
         if ret == 0:
-            mes = (
-                f"*{self.service}* - Marked *{self.commit}* for deployment on *{self.deploy_group}*.\n"
-                "Will start deploying soon!\n"
-                f"{self.authors}"
-            )
-            self.post(channels=self.channels, message=mes)
             if self.old_commit is not None and self.commit != self.old_commit:
+                mes = (
+                    f"*{self.service}* - Marked *{self.commit}* for deployment on *{self.deploy_group}*.\n"
+                    "Will start deploying soon!\n"
+                    f"{self.authors}"
+                )
+                self.post(channels=self.channels, message=mes)
                 mes = (
                     "Roll it back at any time with:\n"
                     f"`paasta rollback --service {self.service} --deploy-group {self.deploy_group} "
@@ -265,23 +265,24 @@ class SlackDeployNotifier(object):
                 )
                 self.post(channels=self.channels, message=mes)
         else:
-            message = f"*{self.service}* - mark-for-deployment failed on *{self.deploy_group}* for *{self.commit}*."
-            self.post(channels=self.channels, message=message)
-            build_url = os.environ.get('BUILD_URL')
-            if build_url is not None:
-                message = "Please see the jenkins output: {}/console".format(build_url)
+            if self.old_commit is not None and self.commit != self.old_commit:
+                message = f"*{self.service}* - mark-for-deployment failed on *{self.deploy_group}* for *{self.commit}*."
                 self.post(channels=self.channels, message=message)
-            else:
-                message = "(Run by {} on {})".format(getpass.getuser(), socket.getfqdn())
-                self.post(channels=self.channels, message=message)
+                build_url = os.environ.get('BUILD_URL')
+                if build_url is not None:
+                    message = "Please see the jenkins output: {}/console".format(build_url)
+                    self.post(channels=self.channels, message=message)
+                else:
+                    message = "(Run by {} on {})".format(getpass.getuser(), socket.getfqdn())
+                    self.post(channels=self.channels, message=message)
 
     def notify_after_good_deploy(self):
-        message = (
-            f"*{self.service}* - Finished for deployment of *{self.commit}* on *{self.deploy_group}*.\n"
-            f"{self.authors}"
-        )
-        self.post(channels=self.channels, message=message)
         if self.old_commit is not None and self.commit != self.old_commit:
+            message = (
+                f"*{self.service}* - Finished for deployment of *{self.commit}* on *{self.deploy_group}*.\n"
+                f"{self.authors}"
+            )
+            self.post(channels=self.channels, message=message)
             mes = (
                 "If you need to roll back, run:\n"
                 f"`paasta rollback --service {self.service} --deploy-group {self.deploy_group} "
@@ -290,19 +291,20 @@ class SlackDeployNotifier(object):
             self.post(channels=self.channels, message=mes)
 
     def notify_after_auto_rollback(self):
-        message = (
-            f"*{self.service}* - Deployment of {self.commit} for {self.deploy_group} *failed*!\n"
-            f"Auto-rolling back to {self.old_commit}"
-        )
-        self.post(channels=self.channels, message=message)
+        if self.old_commit is not None and self.commit != self.old_commit:
+            message = (
+                f"*{self.service}* - Deployment of {self.commit} for {self.deploy_group} *failed*!\n"
+                f"Auto-rolling back to {self.old_commit}"
+            )
+            self.post(channels=self.channels, message=message)
 
     def notify_after_abort(self):
-        message = (
-            f"*{self.service}* - Deployment of {self.commit} to {self.deploy_group} *aborted*.\n"
-            "PaaSTA will keep trying to deploy this code until it is healthy."
-        )
-        self.post(channels=self.channels, message=message)
         if self.old_commit is not None and self.commit != self.old_commit:
+            message = (
+                f"*{self.service}* - Deployment of {self.commit} to {self.deploy_group} *aborted*.\n"
+                "PaaSTA will keep trying to deploy this code until it is healthy."
+            )
+            self.post(channels=self.channels, message=message)
             mes = (
                 "If you need to roll back, run:\n"
                 f"`paasta rollback --service {self.service} --deploy-group {self.deploy_group} --commit {self.commit}`"

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -207,7 +207,7 @@ def test_slack_deploy_notifier(mock_get_authors, mock_client):
     assert sdn.notify_after_good_deploy() is None
     assert sdn.notify_after_auto_rollback() is None
     assert sdn.notify_after_abort() is None
-    assert fake_psc.post.call_count >= 0
+    assert fake_psc.post.call_count >= 0, fake_psc.post.call_args
     assert sdn.get_authors_to_be_notified() == "Pinging authors: <@fakeuser1>, <@fakeuser2>"
 
 
@@ -235,4 +235,32 @@ def test_slack_deploy_notifier_on_non_notify_groups(mock_get_authors, mock_clien
     assert sdn.notify_after_good_deploy() is None
     assert sdn.notify_after_auto_rollback() is None
     assert sdn.notify_after_abort() is None
-    assert fake_psc.post.call_count == 0
+    assert fake_psc.post.call_count == 0, fake_psc.post.call_args
+
+
+@patch('paasta_tools.cli.cmds.mark_for_deployment.get_slack_client', autospec=True)
+@patch('paasta_tools.remote_git.get_authors', autospec=True)
+def test_slack_deploy_notifier_doesnt_notify_on_same_commit(mock_get_authors, mock_client):
+    fake_psc = mock.create_autospec(PaastaSlackClient)
+    mock_client.return_value = fake_psc
+    mock_get_authors.return_value = 0, "fakeuser1 fakeuser2"
+    sdn = mark_for_deployment.SlackDeployNotifier(
+        service='testservice',
+        deploy_info={
+            'pipeline':
+            [
+                {'step': 'test_deploy_group', 'slack_notify': True, },
+            ],
+        },
+        deploy_group='test_deploy_group',
+        commit='samecommit',
+        old_commit='samecommit',
+        git_url="foo",
+    )
+    assert sdn.notify_after_mark(ret=1) is None
+    assert sdn.notify_after_mark(ret=0) is None
+    assert sdn.notify_after_good_deploy() is None
+    assert sdn.notify_after_auto_rollback() is None
+    assert sdn.notify_after_abort() is None
+    assert fake_psc.post.call_count == 0, fake_psc.post.call_args
+    assert sdn.get_authors_to_be_notified() == "Pinging authors: <@fakeuser1>, <@fakeuser2>"


### PR DESCRIPTION
Since this situation is idempotent, and we do it every day with daily builds, I think we want to suppress these notifications.

@chriskuehl 