### PR TITLE
[tron tools] error on namespace conflict

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -406,11 +406,11 @@ def get_tron_namespaces_for_cluster(cluster=None, soa_dir=DEFAULT_SOA_DIR):
     namespaces1 = set(_get_tron_namespaces_from_service_dir(cluster, soa_dir))
     namespaces2 = set(_get_tron_namespaces_from_tron_dir(cluster, soa_dir))
 
-    if namespaces1 & namespaces2:
+    if namespaces1.intersection(namespaces2):
         raise ConflictingNamespacesError(
             "namespaces found in both service/*/tron and service/tron/*: {}".
-            format(namespaces1 & namespaces2)
+            format(namespaces1.intersection(namespaces2))
         )
 
-    namespaces = list(namespaces1 + namespaces2)
+    namespaces = list(namespaces1.union(namespaces2))
     return namespaces

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -395,13 +395,22 @@ def _get_tron_namespaces_from_tron_dir(cluster, soa_dir):
     ]
     return namespaces
 
+class ConflictingNamespacesError(RuntimeError):
+    pass
 
 def get_tron_namespaces_for_cluster(cluster=None, soa_dir=DEFAULT_SOA_DIR):
     """Get all the namespaces that are configured in a particular Tron cluster."""
     if not cluster:
         cluster = load_tron_config().get_cluster_name()
 
-    namespaces1 = _get_tron_namespaces_from_service_dir(cluster, soa_dir)
-    namespaces2 = _get_tron_namespaces_from_tron_dir(cluster, soa_dir)
-    namespaces = list(set(namespaces1 + namespaces2))
+    namespaces1 = set(_get_tron_namespaces_from_service_dir(cluster, soa_dir))
+    namespaces2 = set(_get_tron_namespaces_from_tron_dir(cluster, soa_dir))
+
+    if namespaces1 & namespaces2:
+        raise ConflictingNamespacesError(
+            "namespaces found in both service/*/tron and service/tron/*: {}".
+            format(namespaces1 & namespaces2)
+        )
+
+    namespaces = list(namespaces1 + namespaces2)
     return namespaces

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -395,8 +395,10 @@ def _get_tron_namespaces_from_tron_dir(cluster, soa_dir):
     ]
     return namespaces
 
+
 class ConflictingNamespacesError(RuntimeError):
     pass
+
 
 def get_tron_namespaces_for_cluster(cluster=None, soa_dir=DEFAULT_SOA_DIR):
     """Get all the namespaces that are configured in a particular Tron cluster."""
@@ -409,7 +411,7 @@ def get_tron_namespaces_for_cluster(cluster=None, soa_dir=DEFAULT_SOA_DIR):
     if namespaces1.intersection(namespaces2):
         raise ConflictingNamespacesError(
             "namespaces found in both service/*/tron and service/tron/*: {}".
-            format(namespaces1.intersection(namespaces2))
+            format(namespaces1.intersection(namespaces2)),
         )
 
     namespaces = list(namespaces1.union(namespaces2))

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -560,7 +560,6 @@ class TestTronTools:
         )
         assert namespaces == expected_namespaces
 
-
     @mock.patch('os.walk', autospec=True)
     @mock.patch('os.listdir', autospec=True)
     def test_get_tron_namespaces_for_cluster_conflict(self, mock_ls, mock_walk):

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -571,7 +571,7 @@ class TestTronTools:
         soa_dir = '/my_soa_dir'
 
         try:
-            namespaces = tron_tools.get_tron_namespaces_for_cluster(
+            tron_tools.get_tron_namespaces_for_cluster(
                 cluster=cluster_name,
                 soa_dir=soa_dir,
             )

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -570,11 +570,8 @@ class TestTronTools:
         mock_ls.return_value = ['cool.yaml']
         soa_dir = '/my_soa_dir'
 
-        try:
+        with pytest.raises(tron_tools.ConflictingNamespacesError):
             tron_tools.get_tron_namespaces_for_cluster(
                 cluster=cluster_name,
                 soa_dir=soa_dir,
             )
-            assert False, "no exception raised on conflicting namespaces"
-        except tron_tools.ConflictingNamespacesError as e:
-            assert True

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -559,3 +559,23 @@ class TestTronTools:
             soa_dir=soa_dir,
         )
         assert namespaces == expected_namespaces
+
+
+    @mock.patch('os.walk', autospec=True)
+    @mock.patch('os.listdir', autospec=True)
+    def test_get_tron_namespaces_for_cluster_conflict(self, mock_ls, mock_walk):
+        cluster_name = 'stage'
+        mock_walk.return_value = [
+            ('/my_soa_dir/cool', [], ['tron-stage.yaml']),
+        ]
+        mock_ls.return_value = ['cool.yaml']
+        soa_dir = '/my_soa_dir'
+
+        try:
+            namespaces = tron_tools.get_tron_namespaces_for_cluster(
+                cluster=cluster_name,
+                soa_dir=soa_dir,
+            )
+            assert False, "no exception raised on conflicting namespaces"
+        except tron_tools.ConflictingNamespacesError as e:
+            assert True


### PR DESCRIPTION
raise an error if conflicting namespaces are detected during in `get_tron_namespaces_for_cluster`