### PR TITLE
Remove a few unused requirements

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -44,6 +44,5 @@ task-processing
 typing-extensions
 tzlocal
 ujson == 1.35
-websocket-client==0.44.0
 wsgicors
 yelp-clog >= 2.7.2

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -46,5 +46,4 @@ tzlocal
 ujson == 1.35
 websocket-client==0.44.0
 wsgicors
-yelp-bytes
 yelp-clog >= 2.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,8 +94,6 @@ websocket-client==0.44.0
 whichcraft==0.4.0
 wsgicors==0.7.0
 yarl==1.1.1
-yelp-bytes==0.3.0
 yelp-clog==2.12.1
-yelp-encodings==0.1.3
 zope.deprecation==4.2.0
 zope.interface==4.1.2

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ setup(
         'tzlocal',
         'ujson == 1.35',
         'wsgicors',
-        'yelp-bytes',
         'yelp-clog >= 2.7.2',
     ],
     scripts=[


### PR DESCRIPTION
sorry for the drive-by, friends :)

I was testing out https://github.com/asottile/seed-isort-config and wanted to see if I could find any unused requirements.

As far as I can tell the two things I've removed aren't direct dependencies:

```
$ git grep yelp_bytes
$ git grep yelp_encodings
$ git grep websocket
requirements.txt:websocket-client==0.44.0
```