### PR TITLE
Add a custom key for "sfn_autoscaling" to marathon_schema.

### DIFF
--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -151,6 +151,9 @@
                 "autoscaling": {
                     "type": "object"
                 },
+                "sfn_autoscaling": {
+                    "type": "object"
+                },
                 "drain_method": {
                     "enum": [ "noop", "hacheck", "http", "test" ],
                     "default": "noop"


### PR DESCRIPTION
This is required for sfn_autoscaling.

Testing:
Manually tested by creating a virtualenv.