### PR TITLE
check-ast is no longer useful now that paasta is py3+

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@
     -   id: requirements-txt-fixer
     -   id: flake8
         exclude: ^docs/source/conf.py$
-    -   id: check-ast
     -   id: fix-encoding-pragma
         args: [--remove]
 -   repo: https://github.com/asottile/reorder_python_imports


### PR DESCRIPTION
`flake8` (and the other ast-loading hooks) also check this