### PR TITLE
Split out MAX_CLUSTER_DELTA for cluster autoscaler

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1414,6 +1414,8 @@ SystemPaastaConfigDict = TypedDict(
         'deployd_log_level': str,
         'deployd_startup_oracle_enabled': bool,
         'cluster_autoscaling_draining_enabled': bool,
+        'cluster_autoscaler_max_decrease': float,
+        'cluster_autoscaler_max_increase': float,
         'use_mesos_healthchecks': bool,
         'taskproc': Dict,
         'disabled_watchers': List,
@@ -1660,6 +1662,18 @@ class SystemPaastaConfig(object):
 
         :returns A bool"""
         return self.config_dict.get('cluster_autoscaling_draining_enabled', True)
+
+    def get_cluster_autoscaler_max_increase(self) -> float:
+        """ Set the maximum increase that the cluster autoscaler can make in each run
+
+        :returns A float"""
+        return self.config_dict.get('cluster_autoscaler_max_increase', 0.2)
+
+    def get_cluster_autoscaler_max_decrease(self) -> float:
+        """ Set the maximum decrease that the cluster autoscaler can make in each run
+
+        :returns A float"""
+        return self.config_dict.get('cluster_autoscaler_max_decrease', 0.1)
 
     def get_maintenance_resource_reservation_enabled(self) -> bool:
         """ Enable un/reserving of resources when we un/drain a host in mesos maintenance

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -15,6 +15,7 @@ import asyncio
 import contextlib
 import unittest
 import warnings
+from math import ceil
 from math import floor
 
 import mock
@@ -314,7 +315,14 @@ def test_get_autoscaling_info_for_all_resources():
 
     mock_autoscaling_info = mock.Mock()
 
-    def mock_autoscaling_info_for_resource_side_effect(resource, pool_settings, state, utilization_errors):
+    def mock_autoscaling_info_for_resource_side_effect(
+        resource,
+        pool_settings,
+        mesos_state,
+        utilization_errors,
+        max_increase,
+        max_decrease,
+    ):
         return {
             (mock_resource_1['region'], mock_resource_1['pool'],): None,
             (mock_resource_2['region'], mock_resource_2['pool'],): mock_autoscaling_info,
@@ -336,8 +344,22 @@ def test_get_autoscaling_info_for_all_resources():
             mock_resources, {}, mock_state, mock_system_config,
         )
         calls = [
-            mock.call(mock_resource_1, {}, mock_state, utilization_errors),
-            mock.call(mock_resource_2, {}, mock_state, utilization_errors),
+            mock.call(
+                resource=mock_resource_1,
+                pool_settings={},
+                mesos_state=mock_state,
+                utilization_errors=utilization_errors,
+                max_increase=mock_system_config.get_cluster_autoscaler_max_increase(),
+                max_decrease=mock_system_config.get_cluster_autoscaler_max_decrease(),
+            ),
+            mock.call(
+                resource=mock_resource_2,
+                pool_settings={},
+                mesos_state=mock_state,
+                utilization_errors=utilization_errors,
+                max_increase=mock_system_config.get_cluster_autoscaler_max_increase(),
+                max_decrease=mock_system_config.get_cluster_autoscaler_max_decrease(),
+            ),
         ]
         mock_autoscaling_info_for_resource.assert_has_calls(calls, any_order=True)
         assert ret == [mock_autoscaling_info]
@@ -369,7 +391,12 @@ def test_autoscaling_info_for_resources():
         mock_state = mock.Mock()
         mock_utilization_errors = {('westeros-1', 'default',): 0}
         ret = autoscaling_cluster_lib.autoscaling_info_for_resource(
-            mock_resources['sfr-blah'], {}, mock_state, mock_utilization_errors,
+            resource=mock_resources['sfr-blah'],
+            pool_settings={},
+            mesos_state=mock_state,
+            utilization_errors=mock_utilization_errors,
+            max_increase=0.2,
+            max_decrease=0.1,
         )
         assert mock_metrics_provider.called
         mock_scaler_class.assert_called_with(
@@ -378,6 +405,8 @@ def test_autoscaling_info_for_resources():
             config_folder=None,
             dry_run=True,
             utilization_error=0,
+            max_increase=0.2,
+            max_decrease=0.1,
         )
         assert ret == autoscaling_cluster_lib.AutoscalingInfo(
             resource_id='sfr-blah',
@@ -400,7 +429,12 @@ def test_autoscaling_info_for_resources():
         mock_scaler_class = mock.Mock(return_value=mock_scaler)
         mock_get_scaler.return_value = mock_scaler_class
         ret = autoscaling_cluster_lib.autoscaling_info_for_resource(
-            mock_resources['sfr-blah'], {}, mock_state, mock_utilization_errors,
+            resource=mock_resources['sfr-blah'],
+            pool_settings={},
+            mesos_state=mock_state,
+            utilization_errors=mock_utilization_errors,
+            max_increase=0.2,
+            max_decrease=0.1,
         )
         assert ret == autoscaling_cluster_lib.AutoscalingInfo(
             resource_id='sfr-blah',
@@ -425,7 +459,12 @@ def test_autoscaling_info_for_resources():
         mock_scaler_class = mock.Mock(return_value=mock_scaler)
         mock_get_scaler.return_value = mock_scaler_class
         ret = autoscaling_cluster_lib.autoscaling_info_for_resource(
-            mock_resources['sfr-blah'], {}, mock_state, mock_utilization_errors,
+            resource=mock_resources['sfr-blah'],
+            pool_settings={},
+            mesos_state=mock_state,
+            utilization_errors=mock_utilization_errors,
+            max_increase=0.2,
+            max_decrease=0.1,
         )
         assert ret == autoscaling_cluster_lib.AutoscalingInfo(
             resource_id='sfr-blah',
@@ -458,11 +497,13 @@ class TestAsgAutoscaler(unittest.TestCase):
             return_value=asg or {},
         ):
             autoscaler = autoscaling_cluster_lib.AsgAutoscaler(
-                resource or self.mock_resource,
-                self.mock_pool_settings,
-                self.mock_config_folder,
-                False,
-                utilization_error,
+                resource=resource or self.mock_resource,
+                pool_settings=self.mock_pool_settings,
+                config_folder=self.mock_config_folder,
+                dry_run=False,
+                utilization_error=utilization_error,
+                max_increase=0.2,
+                max_decrease=0.1,
             )
             autoscaler.instances = []
             return autoscaler
@@ -571,18 +612,24 @@ class TestAsgAutoscaler(unittest.TestCase):
         assert ret == (0, 1)
 
         resource_big_max = self.create_mock_resource(min_capacity=0, max_capacity=100)
-        bigger_asg = {'Instances': [mock.Mock()] * 20}
+        bigger_asg = {'Instances': [mock.Mock()] * 21}
         autoscaler = self.create_autoscaler(utilization_error=-0.5, resource=resource_big_max, asg=bigger_asg)
         ret = autoscaler.get_asg_delta()
-        assert ret == (20, int(floor(20 * (1.0 - autoscaling_cluster_lib.MAX_CLUSTER_DELTA))))
+        assert ret == (21, int(floor(21 * (1.0 - autoscaler.max_decrease))))
+
+        resource_big_max = self.create_mock_resource(min_capacity=0, max_capacity=100)
+        bigger_asg = {'Instances': [mock.Mock()] * 21}
+        autoscaler = self.create_autoscaler(utilization_error=0.5, resource=resource_big_max, asg=bigger_asg)
+        ret = autoscaler.get_asg_delta()
+        assert ret == (21, int(ceil(21 * (1.0 + autoscaler.max_increase))))
 
         resource_zeroes = self.create_mock_resource(min_capacity=0, max_capacity=0)
         autoscaler = self.create_autoscaler(utilization_error=-0.5, resource=resource_zeroes, asg=bigger_asg)
         ret = autoscaler.get_asg_delta()
-        assert ret == (20, int(floor(20 * (1.0 - autoscaling_cluster_lib.MAX_CLUSTER_DELTA))))
+        assert ret == (21, int(floor(21 * (1.0 - autoscaler.max_decrease))))
 
         resource = self.create_mock_resource(min_capacity=10, max_capacity=40)
-        current_instances = int((10 * (1 - autoscaling_cluster_lib.MAX_CLUSTER_DELTA)) - 1)
+        current_instances = int((10 * (1 - autoscaler.max_decrease)) - 1)
         asg = {'Instances': [mock.Mock()] * current_instances}
         autoscaler = self.create_autoscaler(utilization_error=-1, resource=resource, asg=asg)
         ret = autoscaler.get_asg_delta()
@@ -688,11 +735,13 @@ class TestSpotAutoscaler(unittest.TestCase):
             mock_get_spot_fleet_instances.return_value = []
 
             return autoscaling_cluster_lib.SpotAutoscaler(
-                resource or self.mock_resource,
-                self.mock_pool_settings,
-                self.mock_config_folder,
-                False,
-                utilization_error,
+                resource=resource or self.mock_resource,
+                pool_settings=self.mock_pool_settings,
+                config_folder=self.mock_config_folder,
+                dry_run=False,
+                utilization_error=utilization_error,
+                max_increase=0.2,
+                max_decrease=0.1,
             )
 
     def create_mock_resource(self, **kwargs):
@@ -878,13 +927,19 @@ class TestSpotAutoscaler(unittest.TestCase):
         assert ret == (1, 1)
 
         resource = self.create_mock_resource(min_capacity=0, max_capacity=100)
-        sfr = self.create_mock_sfr(fulfilled_capacity=20)
+        sfr = self.create_mock_sfr(fulfilled_capacity=21)
+        autoscaler = self.create_autoscaler(utilization_error=0.5, resource=resource, sfr=sfr)
+        ret = autoscaler.get_spot_fleet_delta()
+        assert ret == (21, int(ceil(21 * (1.0 + autoscaler.max_increase))))
+
+        resource = self.create_mock_resource(min_capacity=0, max_capacity=100)
+        sfr = self.create_mock_sfr(fulfilled_capacity=21)
         autoscaler = self.create_autoscaler(utilization_error=-0.5, resource=resource, sfr=sfr)
         ret = autoscaler.get_spot_fleet_delta()
-        assert ret == (20, int(floor(20 * (1.0 - autoscaling_cluster_lib.MAX_CLUSTER_DELTA))))
+        assert ret == (21, int(floor(21 * (1.0 - autoscaler.max_decrease))))
 
         resource = self.create_mock_resource(min_capacity=10, max_capacity=100)
-        current_instances = (10 * (1 - autoscaling_cluster_lib.MAX_CLUSTER_DELTA)) - 1
+        current_instances = (10 * (1 - autoscaler.max_decrease)) - 1
         sfr = self.create_mock_sfr(fulfilled_capacity=current_instances)
         autoscaler = self.create_autoscaler(utilization_error=-1, resource=resource, sfr=sfr)
         ret = autoscaler.get_spot_fleet_delta()
@@ -1048,11 +1103,13 @@ class TestClusterAutoscaler(unittest.TestCase):
             autospec=True,
         ):
             self.autoscaler = autoscaling_cluster_lib.ClusterAutoscaler(
-                mock_resource,
-                mock_pool_settings,
-                mock_config_folder,
-                False,
-                mock_utilization_error,
+                resource=mock_resource,
+                pool_settings=mock_pool_settings,
+                config_folder=mock_config_folder,
+                dry_run=False,
+                utilization_error=mock_utilization_error,
+                max_increase=0.2,
+                max_decrease=0.1,
                 enable_metrics=True,
             )
 


### PR DESCRIPTION
I'm splitting this into a maximum increase and maximum decrease so that
I can reduce the maximum decrease without affecting the autoscaler's
ability to scale up.

The motivation is that because we now have multiple SFRs to speed up
scaling down we end up decreasing by 20% on each one and because we
round down to the nearest whole number we are effectively being more
aggressive than before both in speed and amount that we scale down.
So I've reduced the default max decrease to 10% and made it
configurable via /etc/paasta.