### PR TITLE
Added safer passing of credentials to spark

### DIFF
--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -54,7 +54,7 @@ def test_get_docker_run_cmd(
         '--env', 'k1=v1', '--env', 'k2=v2',
         '--volume=v1:v1:rw', '--volume=v2:v2:rw',
         'fake-registry/fake-service',
-        'sh', '-c', 'pyspark', {}
+        'sh', '-c', 'pyspark', {},
     ]
 
 

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -54,7 +54,7 @@ def test_get_docker_run_cmd(
         '--env', 'k1=v1', '--env', 'k2=v2',
         '--volume=v1:v1:rw', '--volume=v2:v2:rw',
         'fake-registry/fake-service',
-        'sh', '-c', 'pyspark',
+        'sh', '-c', 'pyspark', {}
     ]
 
 


### PR DESCRIPTION
Pass aws credentials via the environment rather than as ``--env key=value``. This prevents you from being able to see the keys using ``ps``

Fixes #1851 

To verify this code works:
```
>>> os.execlpe('docker', *['docker', 'run', '-it', '--env', 'foo', 'ubuntu', {'foo': 'bar'}])
root@dd9e6ceafaee:/# echo $foo
bar
```