### PR TITLE
Fix more async problems

### DIFF
--- a/paasta_tools/api/settings.py
+++ b/paasta_tools/api/settings.py
@@ -14,8 +14,10 @@
 """
 Settings of the paasta-api server.
 """
+import os
+
 from paasta_tools.utils import DEFAULT_SOA_DIR
 
-soa_dir = DEFAULT_SOA_DIR
+soa_dir = os.environ.get("PAASTA_API_SOA_DIR", DEFAULT_SOA_DIR)
 cluster = None
 marathon_clients = None

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -114,7 +114,7 @@ def marathon_job_status(mstatus, client, job_config, verbose):
     mstatus['app_id'] = app_id
     if verbose is True:
         mstatus['slaves'] = list(
-            {task.slave['hostname'] for task in a_sync.block(get_running_tasks_from_frameworks, app_id)},
+            {a_sync.block(task.slave)['hostname'] for task in a_sync.block(get_running_tasks_from_frameworks, app_id)},
         )
     mstatus['expected_instance_count'] = job_config.get_instances()
 
@@ -254,7 +254,7 @@ def instance_delay(request):
 
 
 def add_executor_info(task):
-    task._Task__items['executor'] = task.executor.copy()
+    task._Task__items['executor'] = a_sync.block(task.executor).copy()
     task._Task__items['executor'].pop('tasks', None)
     task._Task__items['executor'].pop('completed_tasks', None)
     task._Task__items['executor'].pop('queued_tasks', None)
@@ -262,5 +262,5 @@ def add_executor_info(task):
 
 
 def add_slave_info(task):
-    task._Task__items['slave'] = task.slave._MesosSlave__items.copy()
+    task._Task__items['slave'] = a_sync.block(task.slave)._MesosSlave__items.copy()
     return task

--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -468,7 +468,7 @@ class ClusterAutoscaler(object):
             return
         elif delta < 0:
             mesos_state = get_mesos_master().state_summary()
-            slaves_list = get_mesos_task_count_by_slave(mesos_state, pool=self.resource['pool'])
+            slaves_list = await get_mesos_task_count_by_slave(mesos_state, pool=self.resource['pool'])
             filtered_slaves = self.filter_aws_slaves(slaves_list)
             killable_capacity = round(sum([slave.instance_weight for slave in filtered_slaves]), 2)
             amount_to_decrease = round(delta * -1, 2)

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -746,7 +746,6 @@ def get_mesos_network_for_net(net):
     return docker_mesos_net_mapping.get(net, net)
 
 
-@a_sync.to_blocking
 async def get_mesos_task_count_by_slave(mesos_state, slaves_list=None, pool=None):
     """Get counts of running tasks per mesos slave. Also include separate count of chronos tasks
 
@@ -801,7 +800,7 @@ def get_count_running_tasks_on_slave(hostname):
     :param hostname: hostname of the slave
     :returns: integer count of mesos tasks"""
     mesos_state = a_sync.block(get_mesos_master().state_summary)
-    task_counts = get_mesos_task_count_by_slave(mesos_state)
+    task_counts = a_sync.block(get_mesos_task_count_by_slave, mesos_state)
     counts = [slave['task_counts'].count for slave in task_counts if slave['task_counts'].slave['hostname'] == hostname]
     if counts:
         return counts[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ ephemeral-port-reserve==1.1.0
 future==0.16.0
 gevent==1.1.1
 greenlet==0.4.12
+gunicorn==19.8.1
 http-parser==0.8.3
 httplib2==0.9.2
 humanize==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'dulwich >= 0.17.3',
         'ephemeral-port-reserve >= 1.0.1',
         'gevent == 1.1.1',
+        'gunicorn >= 19.8.1',
         'humanize >= 0.5.1',
         'inotify >= 0.2.8',
         'isodate >= 0.5.0',

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asynctest
 import marathon
 import mock
 from pyramid import testing
@@ -147,9 +148,18 @@ def test_marathon_job_status_verbose(
     mock_get_running_tasks_from_frameworks,
 ):
     mock_tasks = [
-        mock.Mock(slave={'hostname': 'host1'}),
-        mock.Mock(slave={'hostname': 'host1'}),
-        mock.Mock(slave={'hostname': 'host2'}),
+        mock.Mock(slave=asynctest.CoroutineMock(
+            return_value={'hostname': 'host1'},
+            func=asynctest.CoroutineMock(),  # https://github.com/notion/a_sync/pull/40
+        )),
+        mock.Mock(slave=asynctest.CoroutineMock(
+            return_value={'hostname': 'host1'},
+            func=asynctest.CoroutineMock(),  # https://github.com/notion/a_sync/pull/40
+        )),
+        mock.Mock(slave=asynctest.CoroutineMock(
+            return_value={'hostname': 'host2'},
+            func=asynctest.CoroutineMock(),  # https://github.com/notion/a_sync/pull/40
+        )),
     ]
     mock_get_running_tasks_from_frameworks.return_value = mock_tasks
     mock_is_app_id_running.return_value = True
@@ -284,7 +294,10 @@ def test_add_executor_info():
     }
     mock_task = mock.Mock(
         _Task__items={'a': 'thing'},
-        executor=mock_executor,
+        executor=asynctest.CoroutineMock(
+            return_value=mock_executor,
+            func=asynctest.CoroutineMock(),  # https://github.com/notion/a_sync/pull/40
+        ),
     )
     ret = instance.add_executor_info(mock_task)
     expected = {
@@ -301,7 +314,10 @@ def test_add_executor_info():
 
 
 def test_add_slave_info():
-    mock_slave = mock.Mock(_MesosSlave__items={'some': 'thing'})
+    mock_slave = asynctest.CoroutineMock(
+        return_value=mock.Mock(_MesosSlave__items={'some': 'thing'}),
+        func=asynctest.CoroutineMock(),  # https://github.com/notion/a_sync/pull/40
+    )
     mock_task = mock.Mock(
         _Task__items={'a': 'thing'},
         slave=mock_slave,

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -1192,7 +1192,7 @@ class TestClusterAutoscaler(unittest.TestCase):
             autospec=True,
         ) as mock_filter_aws_slaves, mock.patch(
             'paasta_tools.autoscaling.autoscaling_cluster_lib.get_mesos_master', autospec=True,
-        ) as mock_get_mesos_master, mock.patch(
+        ) as mock_get_mesos_master, asynctest.patch(
             'paasta_tools.autoscaling.autoscaling_cluster_lib.get_mesos_task_count_by_slave', autospec=True,
         ) as mock_get_mesos_task_count_by_slave, mock.patch(
             'paasta_tools.autoscaling.autoscaling_cluster_lib.ClusterAutoscaler.downscale_aws_resource',
@@ -1254,7 +1254,7 @@ class TestClusterAutoscaler(unittest.TestCase):
             )
 
     def test_downscale_aws_resource(self):
-        with mock.patch(
+        with asynctest.patch(
             'paasta_tools.autoscaling.autoscaling_cluster_lib.get_mesos_task_count_by_slave', autospec=True,
         ) as mock_get_mesos_task_count_by_slave, mock.patch(
             'paasta_tools.autoscaling.ec2_fitness.sort_by_ec2_fitness',

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -607,7 +607,8 @@ def test_slave_pid_to_ip():
     assert ret == '10.40.31.172'
 
 
-def test_get_mesos_task_count_by_slave():
+@mark.asyncio
+async def test_get_mesos_task_count_by_slave():
     with asynctest.patch('paasta_tools.mesos_tools.get_all_running_tasks', autospec=True) as mock_get_all_running_tasks:
         mock_chronos = mock.Mock()
         mock_chronos.name = 'chronos'
@@ -631,14 +632,14 @@ def test_get_mesos_task_count_by_slave():
         mock_slave_2 = {'id': 'slave2', 'attributes': {'pool': 'default'}, 'hostname': 'host2'}
         mock_slave_3 = {'id': 'slave3', 'attributes': {'pool': 'another'}, 'hostname': 'host3'}
         mock_mesos_state = {'slaves': [mock_slave_1, mock_slave_2, mock_slave_3]}
-        ret = mesos_tools.get_mesos_task_count_by_slave(mock_mesos_state, pool='default')
+        ret = await mesos_tools.get_mesos_task_count_by_slave(mock_mesos_state, pool='default')
         assert mock_get_all_running_tasks.called
         expected = [
             {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=1, slave=mock_slave_1)},
             {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=0, slave=mock_slave_2)},
         ]
         assert len(ret) == len(expected) and utils.sort_dicts(ret) == utils.sort_dicts(expected)
-        ret = mesos_tools.get_mesos_task_count_by_slave(mock_mesos_state, pool=None)
+        ret = await mesos_tools.get_mesos_task_count_by_slave(mock_mesos_state, pool=None)
         assert mock_get_all_running_tasks.called
         expected = [
             {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=1, slave=mock_slave_1)},
@@ -658,7 +659,7 @@ def test_get_mesos_task_count_by_slave():
             {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_2)},
             {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)},
         ]
-        ret = mesos_tools.get_mesos_task_count_by_slave(
+        ret = await mesos_tools.get_mesos_task_count_by_slave(
             mock_mesos_state,
             slaves_list=mock_slaves_list,
         )
@@ -682,7 +683,7 @@ def test_get_mesos_task_count_by_slave():
             {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_2)},
             {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)},
         ]
-        ret = mesos_tools.get_mesos_task_count_by_slave(
+        ret = await mesos_tools.get_mesos_task_count_by_slave(
             mock_mesos_state,
             slaves_list=mock_slaves_list,
         )


### PR DESCRIPTION
- Switch to gunicorn for the API, so that we don't have to use gevent's monkey-patching to get concurrency, since that breaks asyncio.
- Fix some call sites I missed when changing the mesos module to async