### PR TITLE
Even more async fixes.

### DIFF
--- a/paasta_tools/async_utils.py
+++ b/paasta_tools/async_utils.py
@@ -13,7 +13,7 @@ T = TypeVar('T')
 
 
 def async_ttl_cache(
-    ttl: int=300,
+    ttl: float=300,
 ) -> Callable[
     [Callable[..., Awaitable[T]]],  # wrapped
     Callable[..., Awaitable[T]],  # inner

--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -27,7 +27,6 @@ from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List
-from typing import NewType
 from typing import Optional
 from typing import Tuple
 from typing import Union
@@ -39,6 +38,7 @@ from requests.exceptions import HTTPError
 
 from paasta_tools.autoscaling import cluster_boost
 from paasta_tools.autoscaling import ec2_fitness
+from paasta_tools.mesos.master import MesosState
 from paasta_tools.mesos_maintenance import drain
 from paasta_tools.mesos_maintenance import undrain
 from paasta_tools.mesos_tools import get_mesos_master
@@ -88,8 +88,6 @@ ResourcePoolSetting = TypedDict(
         'drain_timeout': int,
     },
 )
-
-MesosState = NewType('MesosState', Dict)
 
 CLUSTER_METRICS_PROVIDER_KEY = 'cluster_metrics_provider'
 DEFAULT_TARGET_UTILIZATION = 0.8  # decimal fraction
@@ -467,7 +465,7 @@ class ClusterAutoscaler(object):
             self.set_capacity(target_capacity)
             return
         elif delta < 0:
-            mesos_state = get_mesos_master().state_summary()
+            mesos_state = await get_mesos_master().state_summary()
             slaves_list = await get_mesos_task_count_by_slave(mesos_state, pool=self.resource['pool'])
             filtered_slaves = self.filter_aws_slaves(slaves_list)
             killable_capacity = round(sum([slave.instance_weight for slave in filtered_slaves]), 2)

--- a/paasta_tools/mesos/cluster.py
+++ b/paasta_tools/mesos/cluster.py
@@ -13,23 +13,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import itertools
 from typing import Set
 
 from . import exceptions
-from . import parallel
 from paasta_tools.utils import paasta_print
 
 missing_slave: Set[str] = set()
 
 
-def get_files_for_tasks(task_list, file_list, max_workers):
+async def get_files_for_tasks(task_list, file_list, max_workers):
     no_files_found = True
 
-    def process(task_fname):
+    async def process(task_fname):
         task, fname = task_fname
         try:
-            fobj = task.file(fname)
+            fobj = await task.file(fname)
         except exceptions.SlaveDoesNotExist:
             if task["id"] not in missing_slave:
                 paasta_print("{}:{}".format(task["id"], fname))
@@ -38,17 +38,24 @@ def get_files_for_tasks(task_list, file_list, max_workers):
             missing_slave.add(task["id"])
             raise exceptions.SkipResult
 
-        if fobj.exists():
+        if await fobj.exists():
             return fobj
 
     elements = itertools.chain(
         *[[(task, fname) for fname in file_list] for task in task_list],
     )
 
-    for result in parallel.stream(process, elements, max_workers):
-        if result:
-            no_files_found = False
-            yield result
+    futures = [asyncio.ensure_future(process(element)) for element in elements]
+
+    if futures:
+        for result in asyncio.as_completed(futures):
+            try:
+                result = await result
+                if result:
+                    no_files_found = False
+                    yield result
+            except exceptions.SkipResult:
+                pass
 
     if no_files_found:
         raise exceptions.FileNotFoundForTaskException(

--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -19,12 +19,14 @@ import json
 import logging
 import os
 import re
+from typing import List
 from urllib.parse import urljoin
 from urllib.parse import urlparse
 
 import aiohttp
 from kazoo.handlers.threading import KazooTimeoutError
 from kazoo.retry import KazooRetry
+from mypy_extensions import TypedDict
 from retry import retry
 
 from . import exceptions
@@ -50,6 +52,14 @@ more examples."""
 MULTIPLE_SLAVES = "There are multiple slaves with that id. Please choose one: "
 
 logger = logging.getLogger(__name__)
+
+
+MesosState = TypedDict(
+    'MesosState',
+    {
+        'slaves': List,
+    },
+)
 
 
 class MesosMaster(object):
@@ -197,10 +207,10 @@ class MesosMaster(object):
             return cfg
 
     @async_ttl_cache(ttl=15)
-    async def state(self):
+    async def state(self) -> MesosState:
         return await (await self.fetch("/master/state.json", cached=True)).json()
 
-    async def state_summary(self):
+    async def state_summary(self) -> MesosState:
         return await (await self.fetch("/master/state-summary")).json()
 
     @async_ttl_cache(ttl=0)

--- a/paasta_tools/mesos/mesos_file.py
+++ b/paasta_tools/mesos/mesos_file.py
@@ -16,7 +16,7 @@
 import os
 
 from . import exceptions
-from . import util
+from paasta_tools.async_utils import async_ttl_cache
 
 
 class File(object):
@@ -31,7 +31,7 @@ class File(object):
         if self.task is None:
             self._host_path = self.path
         else:
-            self._host_path = os.path.join(self.task.directory, self.path)
+            self._host_path = None  # Defer until later (_fetch) so we don't make HTTP requests in __init__.
 
         self._offset = 0
 
@@ -41,10 +41,6 @@ class File(object):
             "offset": -1,
             "length": self.chunk_size,
         }
-
-    def __iter__(self):
-        for line in self._readlines():
-            yield line
 
     def __eq__(self, y):
         return self.key() == y.key()
@@ -65,22 +61,19 @@ class File(object):
     def _where(self):
         return self.task["id"] if self.task is not None else self.host.key()
 
-    def __reversed__(self):
-        for i, line in enumerate(self._readlines_reverse()):
-            # Don't include the terminator when reading in reverse.
-            if i == 0 and line == "":
-                continue
-            yield line
+    async def _fetch(self):
+        # fill in path if it wasn't set in __init__
+        if self._params["path"] is None:
+            self._params["path"] = os.path.join(await self.task.directory(), self.path)
 
-    def _fetch(self):
-        resp = self.host.fetch("/files/read.json", params=self._params)
-        if resp.status_code == 404:
+        resp = await self.host.fetch("/files/read.json", params=self._params)
+        if resp.status == 404:
             raise exceptions.FileDoesNotExist("No such file or directory.")
-        return resp.json()
+        return await resp.json()
 
-    def exists(self):
+    async def exists(self):
         try:
-            self.size
+            await self.size()
             return True
         except exceptions.FileDoesNotExist:
             return False
@@ -91,17 +84,17 @@ class File(object):
     # look at the size to determine where to seek. Instead of requiring
     # multiple requests to the slave, the size is cached for a very short
     # period of time.
-    @util.CachedProperty(ttl=0.5)
-    def size(self):
-        return self._fetch()["offset"]
+    @async_ttl_cache(ttl=0.5)
+    async def size(self):
+        return (await self._fetch())["offset"]
 
-    def seek(self, offset, whence=os.SEEK_SET):
+    async def seek(self, offset, whence=os.SEEK_SET):
         if whence == os.SEEK_SET:
             self._offset = 0 + offset
         elif whence == os.SEEK_CUR:
             self._offset += offset
         elif whence == os.SEEK_END:
-            self._offset = self.size + offset
+            self._offset = await self.size() + offset
 
     def tell(self):
         return self._offset
@@ -111,23 +104,20 @@ class File(object):
             return size - (self.tell() - start)
         return self.chunk_size
 
-    def _get_chunk(self, loc, size=None):
+    async def _get_chunk(self, loc, size=None):
         if size is None:
             size = self.chunk_size
 
-        self.seek(loc, os.SEEK_SET)
+        await self.seek(loc, os.SEEK_SET)
         self._params["offset"] = loc
         self._params["length"] = size
 
-        data = self._fetch()["data"]
-        self.seek(len(data), os.SEEK_CUR)
+        data = (await self._fetch())["data"]
+        await self.seek(len(data), os.SEEK_CUR)
         return data
 
-    def _read(self, size=None):
+    async def _read(self, size=None):
         start = self.tell()
-
-        def fn():
-            return self._get_chunk(self.tell(), size=self._length(start, size))
 
         def pre(x):
             return x == ""
@@ -135,11 +125,13 @@ class File(object):
         def post(x):
             return size and (self.tell() - start) >= size
 
-        for blob in util.iter_until(fn, pre, post):
+        blob = None
+        while blob != "" and not (size and (self.tell() - start) >= size):
+            blob = await self._get_chunk(self.tell(), size=self._length(start, size))
             yield blob
 
-    def _read_reverse(self, size=None):
-        fsize = self.size
+    async def _read_reverse(self, size=None):
+        fsize = await self.size()
         if not size:
             size = fsize
 
@@ -150,20 +142,20 @@ class File(object):
                 yield current
 
         for pos in next_block():
-            yield self._get_chunk(pos)
+            yield await self._get_chunk(pos)
 
-        yield self._get_chunk(fsize - size, size % self.chunk_size)
+        yield await self._get_chunk(fsize - size, size % self.chunk_size)
 
-    def read(self, size=None):
-        return ''.join(self._read(size))
+    # def read(self, size=None):
+    #     return ''.join(self._read(size))
 
-    def readline(self, size=None):
-        for line in self._readlines(size):
-            return line
+    # def readline(self, size=None):
+    #     for line in self._readlines(size):
+    #         return line
 
-    def _readlines(self, size=None):
+    async def _readlines(self, size=None):
         last = ""
-        for blob in self._read(size):
+        async for blob in self._read(size):
 
             # This is not streaming and assumes small chunk sizes
             blob_lines = (last + blob).split("\n")
@@ -172,9 +164,9 @@ class File(object):
 
             last = blob_lines[-1]
 
-    def _readlines_reverse(self, size=None):
+    async def _readlines_reverse(self, size=None):
         buf = ""
-        for blob in self._read_reverse(size):
+        async for blob in self._read_reverse(size):
 
             blob_lines = (blob + buf).split("\n")
             for line in reversed(blob_lines[1:]):
@@ -183,5 +175,5 @@ class File(object):
             buf = blob_lines[0]
         yield buf
 
-    def readlines(self, size=None):
-        return list(self._readlines(size))
+    # def readlines(self, size=None):
+    #     return list(self._readlines(size))

--- a/paasta_tools/mesos/util.py
+++ b/paasta_tools/mesos/util.py
@@ -22,16 +22,6 @@ def merge(obj, *keys):
     return itertools.chain(*[obj[k] for k in keys])
 
 
-def iter_until(func, pre=lambda x: False, post=lambda x: False):
-    while 1:
-        val = func()
-        if pre(val):
-            break
-        yield val
-        if post(val):
-            break
-
-
 class CachedProperty(object):
 
     def __init__(self, ttl=300):

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -94,8 +94,7 @@ class MesosSlaveConnectionError(Exception):
     pass
 
 
-@a_sync.to_blocking
-async def get_mesos_leader() -> str:
+def get_mesos_leader() -> str:
     """Get the current mesos-master leader's hostname.
     Attempts to determine this by using mesos.cli to query ZooKeeper.
 

--- a/paasta_tools/metrics/metastatus_lib.py
+++ b/paasta_tools/metrics/metastatus_lib.py
@@ -31,6 +31,7 @@ from mypy_extensions import TypedDict
 from typing_extensions import Counter as _Counter  # noqa
 
 from paasta_tools import chronos_tools
+from paasta_tools.mesos.master import MesosState
 from paasta_tools.mesos_maintenance import MAINTENANCE_ROLE
 from paasta_tools.mesos_tools import get_all_tasks_from_state
 from paasta_tools.mesos_tools import get_mesos_quorum
@@ -497,7 +498,7 @@ def filter_slaves(slaves, filters):
 
 def get_resource_utilization_by_grouping(
     grouping_func: Callable[..., _KeyFuncRetT],
-    mesos_state: Dict,
+    mesos_state: MesosState,
     filters: List[Callable]=[],
     sort_func=None,
 ) -> Dict[_KeyFuncRetT, ResourceUtilizationDict]:

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -16,7 +16,6 @@ import argparse
 import itertools
 import logging
 import sys
-from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
@@ -34,6 +33,7 @@ from paasta_tools.chronos_tools import load_chronos_config
 from paasta_tools.marathon_tools import get_marathon_clients
 from paasta_tools.marathon_tools import get_marathon_servers
 from paasta_tools.mesos.exceptions import MasterNotAvailableException
+from paasta_tools.mesos.master import MesosState
 from paasta_tools.mesos_tools import get_mesos_master
 from paasta_tools.metrics import metastatus_lib
 from paasta_tools.utils import format_table
@@ -107,7 +107,7 @@ def all_marathon_clients(marathon_clients):
 def utilization_table_by_grouping_from_mesos_state(
     groupings: Sequence[str],
     threshold: float,
-    mesos_state: Dict,
+    mesos_state: MesosState,
 ) -> Tuple[
     List[List[str]],
     bool,

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -1205,7 +1205,10 @@ class TestClusterAutoscaler(unittest.TestCase):
             mock_set_capacity.return_value = True
             mock_master = mock.Mock()
             mock_mesos_state = mock.Mock()
-            mock_master.state_summary.return_value = mock_mesos_state
+            mock_master.state_summary = asynctest.CoroutineMock(
+                return_value=mock_mesos_state,
+                func=asynctest.CoroutineMock(),  # https://github.com/notion/a_sync/pull/40
+            )
             mock_get_mesos_master.return_value = mock_master
             mock_downscale_aws_resource.side_effect = just_sleep
 

--- a/tests/mesos/test_cluster.py
+++ b/tests/mesos/test_cluster.py
@@ -1,40 +1,44 @@
-from mock import MagicMock
+import a_sync
+import asynctest
 from mock import Mock
 from pytest import raises
 
+from paasta_tools.async_utils import aiter_to_list
 from paasta_tools.mesos import cluster
 from paasta_tools.mesos import exceptions
+from paasta_tools.mesos import task
 
 
 def test_get_files_for_tasks_no_files():
     attrs = {'id': 'foo'}
-    mock_task = MagicMock()
+    mock_task = asynctest.MagicMock(spec=task.Task)
     mock_task.__getitem__.side_effect = lambda x: attrs[x]
     mock_file = Mock()
-    mock_file.exists.return_value = False
+    mock_file.exists = asynctest.CoroutineMock(return_value=False)
     mock_task.file.return_value = mock_file
     files = cluster.get_files_for_tasks([mock_task], ['myfile'], 1)
     with raises(exceptions.FileNotFoundForTaskException) as excinfo:
-        files = list(files)
+        files = a_sync.block(aiter_to_list, files)
     assert 'None of the tasks in foo contain the files in list myfile' in str(excinfo.value)
 
 
 def test_get_files_for_tasks_all():
-    mock_task = MagicMock()
+    mock_task = asynctest.MagicMock(spec=task.Task)
     mock_file = Mock()
-    mock_file.exists.return_value = True
+    mock_file.exists = asynctest.CoroutineMock(return_value=True)
     mock_task.file.return_value = mock_file
     files = cluster.get_files_for_tasks([mock_task], ['myfile'], 1)
-    files = list(files)
+    files = a_sync.block(aiter_to_list, files)
     assert files == [mock_file]
 
 
 def test_get_files_for_tasks_some():
-    mock_task = MagicMock()
+    mock_task = asynctest.MagicMock(spec=task.Task)
     mock_file = Mock()
     mock_file_2 = Mock()
-    mock_file.exists.side_effect = [False, True]
+    mock_file.exists = asynctest.CoroutineMock(return_value=False)
+    mock_file_2.exists = asynctest.CoroutineMock(return_value=True)
     mock_task.file.side_effect = [mock_file, mock_file_2]
     files = cluster.get_files_for_tasks([mock_task], ['myfile', 'myotherfile'], 1)
-    files = list(files)
+    files = a_sync.block(aiter_to_list, files)
     assert files == [mock_file_2]


### PR DESCRIPTION
When running the cluster_autoscaler in a stage environment, I found a few problems.

It's an error to call a function that has been decorated with @async.to_blocking from within an async coroutine, unless it (or something further up the call stack) is launched on a different thread, e.g. via a_sync.run / a_sync.to_async. You get something like

```
Traceback (most recent call last):
  File "/nail/home/krall/pg/paasta/paasta_tools/autoscaling/autoscaling_cluster_lib.py", line 1276, in autoscale_cluster_resource
    await scaler.scale_resource(current, target)
  File "/nail/home/krall/pg/paasta/paasta_tools/autoscaling/autoscaling_cluster_lib.py", line 502, in scale_resource
    target_capacity=target_capacity,
  File "/nail/home/krall/pg/paasta/paasta_tools/autoscaling/autoscaling_cluster_lib.py", line 762, in downscale_aws_resource
    await task
  File "/nail/home/krall/pg/paasta/paasta_tools/autoscaling/autoscaling_cluster_lib.py", line 572, in gracefully_terminate_slave
    should_drain=should_drain,
  File "/nail/home/krall/pg/paasta/paasta_tools/autoscaling/autoscaling_cluster_lib.py", line 413, in wait_and_terminate
    if self.can_kill(slave.hostname, should_drain, dry_run, timer):
  File "/nail/home/krall/pg/paasta/paasta_tools/autoscaling/autoscaling_cluster_lib.py", line 372, in can_kill
    if is_safe_to_kill(hostname):
  File "/nail/home/krall/pg/paasta/paasta_tools/paasta_maintenance.py", line 95, in is_safe_to_kill
    return mesos_maintenance.is_host_drained(hostname) or \
  File "/nail/home/krall/pg/paasta/paasta_tools/mesos_maintenance.py", line 733, in is_host_drained
    return is_host_draining(hostname=hostname) and get_count_running_tasks_on_slave(hostname) == 0
  File "/nail/home/krall/pg/paasta/paasta_tools/mesos_tools.py", line 808, in get_count_running_tasks_on_slave
    mesos_state = a_sync.block(get_mesos_master().state_summary)
  File "/nail/home/krall/pg/paasta/.tox/py36/lib/python3.6/site-packages/a_sync/a_sync.py", line 235, in block
    return to_blocking(func)(*args, **kwargs)
  File "/nail/home/krall/pg/paasta/.tox/py36/lib/python3.6/site-packages/a_sync/a_sync.py", line 156, in blocking
    return loop.run_until_complete(async_func(*args, **kwargs))
  File "/usr/lib/python3.6/asyncio/base_events.py", line 454, in run_until_complete
    self.run_forever()
  File "/usr/lib/python3.6/asyncio/base_events.py", line 411, in run_forever
    'Cannot run the event loop while another loop is running')
RuntimeError: Cannot run the event loop while another loop is running
sys:1: RuntimeWarning: coroutine 'MesosMaster.state_summary' was never awaited
```

This kinda makes sense - the inner event loop would just block the outer event loop. But, that's what would happen anyway if we called e.g. `requests` from within the event loop, like we were doing before.

Oh well. Let's just spin up another thread when we need to.