### PR TITLE
Configure default volumes and dockercfg location for Tron

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -266,8 +266,13 @@ def format_volumes(paasta_volume_list):
     ]
 
 
-def format_master_config(master_config, default_volumes):
-    master_config['default_volumes'] = format_volumes(default_volumes)
+def format_master_config(master_config, default_volumes, dockercfg_location):
+    mesos_options = master_config.get('mesos_options', {})
+    mesos_options.update({
+        'default_volumes': format_volumes(default_volumes),
+        'dockercfg_location': dockercfg_location,
+    })
+    master_config['mesos_options'] = mesos_options
     return master_config
 
 
@@ -379,6 +384,7 @@ def create_complete_config(service, soa_dir=DEFAULT_SOA_DIR):
         other_config = format_master_config(
             other_config,
             system_paasta_config.get_volumes(),
+            system_paasta_config.get_dockercfg_location(),
         )
 
     other_config['jobs'] = [

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -29,6 +29,7 @@ from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 
 SPACER = '.'
+MASTER_NAMESPACE = 'MASTER'
 
 
 class TronNotConfigured(Exception):
@@ -255,6 +256,21 @@ class TronJobConfig:
         return False
 
 
+def format_volumes(paasta_volume_list):
+    return [
+        {
+            'container_path': v['containerPath'],
+            'host_path': v['hostPath'],
+            'mode': v['mode'],
+        } for v in paasta_volume_list
+    ]
+
+
+def format_master_config(master_config, default_volumes):
+    master_config['default_volumes'] = format_volumes(default_volumes)
+    return master_config
+
+
 def format_tron_action_dict(action_config, cluster_fqdn_format):
     """Generate a dict of tronfig for an action, from the TronActionConfig.
 
@@ -276,13 +292,7 @@ def format_tron_action_dict(action_config, cluster_fqdn_format):
         result['mem'] = action_config.get_mem()
         result['docker_image'] = action_config.get_docker_url()
         result['env'] = action_config.get_env()
-        result['extra_volumes'] = [
-            {
-                'container_path': v['containerPath'],
-                'host_path': v['hostPath'],
-                'mode': v['mode'],
-            } for v in action_config.get_extra_volumes()
-        ]
+        result['extra_volumes'] = format_volumes(action_config.get_extra_volumes())
         result['docker_parameters'] = [
             {
                 'key': param['key'],
@@ -364,6 +374,13 @@ def create_complete_config(service, soa_dir=DEFAULT_SOA_DIR):
         tron_cluster=tron_config.get_cluster_name(),
         soa_dir=soa_dir,
     )
+
+    if service == MASTER_NAMESPACE:
+        other_config = format_master_config(
+            other_config,
+            system_paasta_config.get_volumes(),
+        )
+
     other_config['jobs'] = [
         format_tron_job_dict(
             job_config=job_config,

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -321,26 +321,34 @@ class TestTronTools:
         master_config = {
             'some_key': 101,
             'another': 'hello',
-            'default_volumes': [{
-                'container_path': '/nail/tmp',
-                'host_path': '/nail/tmp',
-                'mode': 'RW',
-            }],
+            'mesos_options': {
+                'default_volumes': [{
+                    'container_path': '/nail/tmp',
+                    'host_path': '/nail/tmp',
+                    'mode': 'RW',
+                }],
+                'other_mesos': True,
+            },
         }
         paasta_volumes = [{
             'containerPath': '/nail/other',
             'hostPath': '/other/home',
             'mode': 'RW',
         }]
-        result = tron_tools.format_master_config(master_config, paasta_volumes)
+        dockercfg = 'file://somewhere'
+        result = tron_tools.format_master_config(master_config, paasta_volumes, dockercfg)
         assert result == {
             'some_key': 101,
             'another': 'hello',
-            'default_volumes': [{
-                'container_path': '/nail/other',
-                'host_path': '/other/home',
-                'mode': 'RW',
-            }],
+            'mesos_options': {
+                'default_volumes': [{
+                    'container_path': '/nail/other',
+                    'host_path': '/other/home',
+                    'mode': 'RW',
+                }],
+                'dockercfg_location': dockercfg,
+                'other_mesos': True,
+            },
         }
 
     def test_format_tron_action_dict_default_executor(self):
@@ -560,6 +568,7 @@ class TestTronTools:
             mock_format_master_config.assert_called_once_with(
                 other_config,
                 mock_system_config.return_value.get_volumes.return_value,
+                mock_system_config.return_value.get_dockercfg_location.return_value,
             )
         else:
             assert mock_format_master_config.call_count == 0

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -2,6 +2,7 @@ import mock
 import pytest
 
 from paasta_tools import tron_tools
+from paasta_tools.tron_tools import MASTER_NAMESPACE
 from paasta_tools.utils import InvalidInstanceConfig
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
@@ -316,6 +317,32 @@ class TestTronTools:
         with pytest.raises(InvalidInstanceConfig):
             tron_tools.decompose_instance('job_a')
 
+    def test_format_master_config(self):
+        master_config = {
+            'some_key': 101,
+            'another': 'hello',
+            'default_volumes': [{
+                'container_path': '/nail/tmp',
+                'host_path': '/nail/tmp',
+                'mode': 'RW',
+            }],
+        }
+        paasta_volumes = [{
+            'containerPath': '/nail/other',
+            'hostPath': '/other/home',
+            'mode': 'RW',
+        }]
+        result = tron_tools.format_master_config(master_config, paasta_volumes)
+        assert result == {
+            'some_key': 101,
+            'another': 'hello',
+            'default_volumes': [{
+                'container_path': '/nail/other',
+                'host_path': '/other/home',
+                'mode': 'RW',
+            }],
+        }
+
     def test_format_tron_action_dict_default_executor(self):
         action_dict = {
             'name': 'do_something',
@@ -499,24 +526,28 @@ class TestTronTools:
     @mock.patch('paasta_tools.tron_tools.load_tron_config', autospec=True)
     @mock.patch('paasta_tools.tron_tools.load_tron_service_config', autospec=True)
     @mock.patch('paasta_tools.tron_tools.format_tron_job_dict', autospec=True)
+    @mock.patch('paasta_tools.tron_tools.format_master_config', autospec=True)
     @mock.patch('paasta_tools.tron_tools.yaml.dump', autospec=True)
+    @pytest.mark.parametrize('service', [MASTER_NAMESPACE, 'my_app'])
     def test_create_complete_config(
         self,
         mock_yaml_dump,
+        mock_format_master_config,
         mock_format_job,
         mock_tron_service_config,
         mock_tron_system_config,
         mock_system_config,
+        service,
     ):
         job_config = tron_tools.TronJobConfig({})
         other_config = {
             'my_config_value': [1, 2],
         }
+        mock_format_master_config.return_value = other_config
         mock_tron_service_config.return_value = (
             [job_config],
             other_config,
         )
-        service = 'my_app'
         soa_dir = '/testing/services'
 
         assert tron_tools.create_complete_config(service, soa_dir) == mock_yaml_dump.return_value
@@ -525,6 +556,13 @@ class TestTronTools:
             mock_tron_system_config.return_value.get_cluster_name.return_value,
             soa_dir,
         )
+        if service == MASTER_NAMESPACE:
+            mock_format_master_config.assert_called_once_with(
+                other_config,
+                mock_system_config.return_value.get_volumes.return_value,
+            )
+        else:
+            assert mock_format_master_config.call_count == 0
         mock_format_job.assert_called_once_with(
             job_config,
             mock_system_config.return_value.get_cluster_fqdn_format.return_value,


### PR DESCRIPTION
This will overwrite those config keys, while leaving the others.