### PR TITLE
Print a friendlier error to local-run users when secret decryption fails

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -565,9 +565,14 @@ def decrypt_secret_environment_variables(
             cluster_names=[cluster_name],
             secret_provider_kwargs=secret_provider_kwargs,
         )
-        secret_environment = secret_provider.decrypt_environment(
-            secret_env_vars,
-        )
+        try:
+            secret_environment = secret_provider.decrypt_environment(
+                secret_env_vars,
+            )
+        except Exception as e:
+            paasta_print(f"Failed to retrieve secrets with {e.__class__.__name__}: {e}")
+            paasta_print("If you don't need the secrets for local-run, you can add --skip-secrets")
+            sys.exit(1)
     return secret_environment
 
 

--- a/paasta_tools/secret_providers/vault.py
+++ b/paasta_tools/secret_providers/vault.py
@@ -10,10 +10,15 @@ try:
     from vault_tools.gpg import TempGpgKeyring
     from vault_tools.paasta_secret import encrypt_secret
 except ImportError:
-    get_plaintext = None
-    get_vault_client = None
+    def get_plaintext(*args: Any, **kwargs: Any) -> bytes:
+        return b"No plain text available without vault_tools"
+
+    def get_vault_client(*args: Any, **kwargs: Any) -> None:
+        return None
     TempGpgKeyring = None
-    encrypt_secret = None
+
+    def encrypt_secret(*args: Any, **kwargs: Any) -> None:
+        return None
 
 from paasta_tools.secret_providers import BaseSecretProvider
 from paasta_tools.utils import paasta_print

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -1714,7 +1714,7 @@ def test_decrypt_secret_environment_variables():
         assert ret == mock_secret_provider.decrypt_environment.return_value
 
         mock_secret_provider.decrypt_environment.side_effect = KeyError
-        with raises(KeyError):
+        with raises(SystemExit):
             decrypt_secret_environment_variables(
                 secret_provider_name='vault',
                 environment=mock_environment,


### PR DESCRIPTION
Normally I think it is ok for functions to raise, but with local-run, the output goes to real users, and I would prefer they see something friendlier ("permission denied"), also I like the hint.

I considered not catching all exceptions, but there are a lot of possibilities for it to go wrong, including lots of generic NoneType and Callable error junk (which is why I changed the ImportError'd stubs to be more functional)