### PR TITLE
Fix check registered slaves aws

### DIFF
--- a/paasta_tools/contrib/check_registered_slaves_aws.py
+++ b/paasta_tools/contrib/check_registered_slaves_aws.py
@@ -3,9 +3,10 @@ import argparse
 import sys
 
 from a_sync import block
+
 from paasta_tools.autoscaling.autoscaling_cluster_lib import get_scaler
-from paasta_tools.mesos_tools import get_mesos_master
 from paasta_tools.mesos.exceptions import MasterNotAvailableException
+from paasta_tools.mesos_tools import get_mesos_master
 from paasta_tools.utils import load_system_paasta_config
 
 

--- a/paasta_tools/contrib/check_registered_slaves_aws.py
+++ b/paasta_tools/contrib/check_registered_slaves_aws.py
@@ -18,6 +18,9 @@ def check_registration(threshold_percentage):
                 pool_settings=None,
                 config_folder=None,
                 dry_run=True,
+		utilization_error=0.0,
+                max_increase=0.0,
+                max_decrease=0.0,
             )
         except KeyError:
             print("Couldn't find a metric provider for resource of type: {}".format(resource['type']))

--- a/paasta_tools/contrib/check_registered_slaves_aws.py
+++ b/paasta_tools/contrib/check_registered_slaves_aws.py
@@ -24,7 +24,7 @@ def check_registration(threshold_percentage):
                 pool_settings=None,
                 config_folder=None,
                 dry_run=True,
-		utilization_error=0.0,
+                utilization_error=0.0,
                 max_increase=0.0,
                 max_decrease=0.0,
             )

--- a/paasta_tools/contrib/check_registered_slaves_aws.py
+++ b/paasta_tools/contrib/check_registered_slaves_aws.py
@@ -13,7 +13,7 @@ def check_registration(threshold_percentage):
         mesos_state = block(get_mesos_master().state)
     except MasterNotAvailableException as e:
         print("Could not find Mesos Master: %s" % e.message)
-        sys.exit(2)
+        sys.exit(1)
 
     autoscaling_resources = load_system_paasta_config().get_cluster_autoscaling_resources()
     for resource in autoscaling_resources.values():

--- a/paasta_tools/contrib/check_registered_slaves_aws.py
+++ b/paasta_tools/contrib/check_registered_slaves_aws.py
@@ -2,13 +2,19 @@
 import argparse
 import sys
 
+from a_sync import block
 from paasta_tools.autoscaling.autoscaling_cluster_lib import get_scaler
 from paasta_tools.mesos_tools import get_mesos_master
 from paasta_tools.utils import load_system_paasta_config
 
 
 def check_registration(threshold_percentage):
-    mesos_state = get_mesos_master().state
+    try:
+        mesos_state = block(get_mesos_master().state)
+    except MasterNotAvailableException as e:
+        print("Could not find Mesos Master: %s" % e.message)
+        sys.exit(2)
+
     autoscaling_resources = load_system_paasta_config().get_cluster_autoscaling_resources()
     for resource in autoscaling_resources.values():
         print("Checking %s" % resource['id'])

--- a/paasta_tools/contrib/check_registered_slaves_aws.py
+++ b/paasta_tools/contrib/check_registered_slaves_aws.py
@@ -5,6 +5,7 @@ import sys
 from a_sync import block
 from paasta_tools.autoscaling.autoscaling_cluster_lib import get_scaler
 from paasta_tools.mesos_tools import get_mesos_master
+from paasta_tools.mesos.exceptions import MasterNotAvailableException
 from paasta_tools.utils import load_system_paasta_config
 
 


### PR DESCRIPTION
`check_registered_slaves_aws.py` is producing the following error:
```
Traceback (most recent call last):
  File "/opt/venvs/paasta-tools/bin/check_registered_slaves_aws.py", line 58, in <module>
    main()
  File "/opt/venvs/paasta-tools/bin/check_registered_slaves_aws.py", line 52, in main
    if check_registration(threshold):
  File "/opt/venvs/paasta-tools/bin/check_registered_slaves_aws.py", line 22, in check_registration
    dry_run=True,
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/autoscaling/autoscaling_cluster_lib.py", line 959, in __init__
    super(AsgAutoscaler, self).__init__(*args, **kwargs)
TypeError: __init__() missing 3 required positional arguments: 'utilization_error', 'max_increase', and 'max_decrease'
```

This appears to be due to the ClusterAutoscaler class requiring 3 parameters which are not being passed through from check_registered_slaves_aws.py#16
* utilization_error
* max_increase
* max_decrease

I have set these all to `0.0` in the branch to honor the required for a value.

Also, the call to `get_mesos_master().state` on line 11 is to an async function in mesos/master.py#201. Therefore we need to block on this call until it returns.