### PR TITLE
Deploy expected_runtime field for tronfig

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -126,6 +126,9 @@ class TronActionConfig(InstanceConfig):
     def get_requires(self):
         return self.config_dict.get('requires')
 
+    def get_expected_runtime(self):
+        return self.config_dict.get('expected_runtime')
+
     def get_calculated_constraints(self):
         """Combine all configured Mesos constraints."""
         constraints = self.get_constraints()
@@ -192,6 +195,9 @@ class TronJobConfig:
 
     def get_deploy_group(self):
         return self.config_dict.get('deploy_group', '')
+
+    def get_expected_runtime(self):
+        return self.config_dict.get('expected_runtime')
 
     def _get_action_config(self, action_dict, default_paasta_cluster):
         action_service = action_dict.setdefault('service', self.get_service())
@@ -269,6 +275,7 @@ def format_tron_action_dict(action_config, cluster_fqdn_format):
         'requires': action_config.get_requires(),
         'node': action_config.get_node(),
         'retries': action_config.get_retries(),
+        'expected_runtime': action_config.get_expected_runtime(),
     }
     if executor == 'mesos':
         result['mesos_address'] = cluster_fqdn_format.format(cluster=action_config.get_cluster())
@@ -325,6 +332,7 @@ def format_tron_job_dict(job_config, cluster_fqdn_format, default_paasta_cluster
         'allow_overlap': job_config.get_allow_overlap(),
         'max_runtime': job_config.get_max_runtime(),
         'time_zone': job_config.get_time_zone(),
+        'expected_runtime': job_config.get_expected_runtime(),
     }
     cleanup_config = job_config.get_cleanup_action(default_paasta_cluster)
     if cleanup_config:

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -231,6 +231,7 @@ class TestTronJobConfig:
             'deploy_group': 'prod',
             'max_runtime': '2h',
             'actions': [action_dict],
+            'expected_runtime': '1h',
         }
         soa_dir = '/other_dir'
         job_config = tron_tools.TronJobConfig(job_dict, soa_dir=soa_dir)
@@ -248,6 +249,7 @@ class TestTronJobConfig:
             'schedule': 'daily 12:10:00',
             'max_runtime': '2h',
             'actions': [mock_format_action.return_value],
+            'expected_runtime': '1h',
         }
 
     @mock.patch('paasta_tools.tron_tools.TronJobConfig._get_action_config', autospec=True)
@@ -322,6 +324,7 @@ class TestTronTools:
             'command': 'echo something',
             'requires': ['required_action'],
             'retries': 2,
+            'expected_runtime': '30m',
         }
         branch_dict = {
             'docker_image': 'my_service:paasta-123abcde',
@@ -341,6 +344,7 @@ class TestTronTools:
             'command': 'echo something',
             'requires': ['required_action'],
             'retries': 2,
+            'expected_runtime': '30m',
         }
 
     def test_format_tron_action_dict_paasta(self):


### PR DESCRIPTION
Without this, the deploy script doesn't send expected_runtime to Tron.
Tested this with the partnerships namespace, which has already started using expected_runtime!