### PR TITLE
Count all non marathon tasks as batch tasks

### DIFF
--- a/paasta_tools/autoscaling/ec2_fitness.py
+++ b/paasta_tools/autoscaling/ec2_fitness.py
@@ -28,7 +28,7 @@ def sort_by_total_tasks(instances):
 
 
 def sort_by_running_batch_count(instances):
-    return sorted(instances, key=lambda i: i.task_counts.chronos_count, reverse=True)
+    return sorted(instances, key=lambda i: i.task_counts.batch_count, reverse=True)
 
 
 def sort_by_ec2_fitness(instances):

--- a/tests/autoscaling/test_autoscaling_cluster_lib.py
+++ b/tests/autoscaling/test_autoscaling_cluster_lib.py
@@ -1733,7 +1733,7 @@ class TestClusterAutoscaler(unittest.TestCase):
                         'hostname': 'host123',
                     },
                     count=0,
-                    chronos_count=0,
+                    batch_count=0,
                 ),
             }
             mock_slave_2 = {
@@ -1744,7 +1744,7 @@ class TestClusterAutoscaler(unittest.TestCase):
                         'hostname': 'host456',
                     },
                     count=0,
-                    chronos_count=0,
+                    batch_count=0,
                 ),
             }
             mock_slave_3 = {
@@ -1755,7 +1755,7 @@ class TestClusterAutoscaler(unittest.TestCase):
                         'hostname': 'host789',
                     },
                     count=0,
-                    chronos_count=0,
+                    batch_count=0,
                 ),
             }
 
@@ -1914,7 +1914,7 @@ class TestPaastaAwsSlave(unittest.TestCase):
                         'hostname': 'host123',
                     },
                     count=0,
-                    chronos_count=0,
+                    batch_count=0,
                 ),
             }
             mock_instance_type_weights = {'c4.blah': 2, 'm4.whatever': 5}

--- a/tests/autoscaling/test_ec2_fitness.py
+++ b/tests/autoscaling/test_ec2_fitness.py
@@ -8,17 +8,17 @@ from paasta_tools.mesos_tools import SlaveTaskCount
 
 
 def test_sort_by_total_tasks():
-    mock_slave_1 = Mock(task_counts=SlaveTaskCount(count=3, slave=Mock(), chronos_count=0))
-    mock_slave_2 = Mock(task_counts=SlaveTaskCount(count=2, slave=Mock(), chronos_count=1))
-    mock_slave_3 = Mock(task_counts=SlaveTaskCount(count=5, slave=Mock(), chronos_count=0))
+    mock_slave_1 = Mock(task_counts=SlaveTaskCount(count=3, slave=Mock(), batch_count=0))
+    mock_slave_2 = Mock(task_counts=SlaveTaskCount(count=2, slave=Mock(), batch_count=1))
+    mock_slave_3 = Mock(task_counts=SlaveTaskCount(count=5, slave=Mock(), batch_count=0))
     ret = ec2_fitness.sort_by_total_tasks([mock_slave_1, mock_slave_2, mock_slave_3])
     assert ret == [mock_slave_3, mock_slave_1, mock_slave_2]
 
 
 def test_sort_by_running_batch_count():
-    mock_slave_1 = Mock(task_counts=SlaveTaskCount(count=3, slave=Mock(), chronos_count=1))
-    mock_slave_2 = Mock(task_counts=SlaveTaskCount(count=2, slave=Mock(), chronos_count=2))
-    mock_slave_3 = Mock(task_counts=SlaveTaskCount(count=5, slave=Mock(), chronos_count=3))
+    mock_slave_1 = Mock(task_counts=SlaveTaskCount(count=3, slave=Mock(), batch_count=1))
+    mock_slave_2 = Mock(task_counts=SlaveTaskCount(count=2, slave=Mock(), batch_count=2))
+    mock_slave_3 = Mock(task_counts=SlaveTaskCount(count=5, slave=Mock(), batch_count=3))
     ret = ec2_fitness.sort_by_running_batch_count([mock_slave_1, mock_slave_2, mock_slave_3])
     assert ret == [mock_slave_3, mock_slave_2, mock_slave_1]
 
@@ -28,7 +28,7 @@ def test_sort_by_health_system_instance_health_system_status_failed():
     mock_slave_1.task_counts = SlaveTaskCount(
         count=3,
         slave=Mock(),
-        chronos_count=1,
+        batch_count=1,
     )
     mock_slave_1.instance_status = {
         'Events': [
@@ -50,7 +50,7 @@ def test_sort_by_health_system_instance_health_system_status_failed():
     mock_slave_2.task_counts = SlaveTaskCount(
         count=3,
         slave=Mock(),
-        chronos_count=1,
+        batch_count=1,
     ),
     mock_slave_2.instance_status = {
         'Events': [
@@ -77,7 +77,7 @@ def test_sort_by_upcoming_events():
     mock_slave_1.task_counts = SlaveTaskCount(
         count=3,
         slave=Mock(),
-        chronos_count=1,
+        batch_count=1,
     )
     mock_slave_1.instance_status = {
         'Events': [],
@@ -92,7 +92,7 @@ def test_sort_by_upcoming_events():
     mock_slave_2. task_counts = SlaveTaskCount(
         count=3,
         slave=Mock(),
-        chronos_count=1,
+        batch_count=1,
     )
     mock_slave_2.instance_status = {
         'Events': [
@@ -141,7 +141,7 @@ def test_sort_by_fitness():
     mock_slave_1.task_counts = SlaveTaskCount(
         count=3,
         slave=Mock(),
-        chronos_count=1,
+        batch_count=1,
     )
     mock_slave_1.instance_status = {
         'Events': [],
@@ -152,7 +152,7 @@ def test_sort_by_fitness():
     mock_slave_2.task_counts = SlaveTaskCount(
         count=3,
         slave=Mock(),
-        chronos_count=1,
+        batch_count=1,
     )
     mock_slave_2.instance_status = {
         'Events': [
@@ -170,7 +170,7 @@ def test_sort_by_fitness():
     mock_slave_3.task_counts = SlaveTaskCount(
         count=2,
         slave=Mock(),
-        chronos_count=3,
+        batch_count=3,
     )
     mock_slave_3.instance_status = {
         'Events': [],
@@ -181,7 +181,7 @@ def test_sort_by_fitness():
     mock_slave_4.task_counts = SlaveTaskCount(
         count=3,
         slave=Mock(),
-        chronos_count=1,
+        batch_count=1,
     )
     mock_slave_4.instance_status = {
         'Events': [],
@@ -192,7 +192,7 @@ def test_sort_by_fitness():
     mock_slave_5.task_counts = SlaveTaskCount(
         count=1,
         slave=Mock(),
-        chronos_count=1,
+        batch_count=1,
     )
     mock_slave_5.instance_status = {
         'Events': [],

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -633,16 +633,16 @@ async def test_get_mesos_task_count_by_slave():
         ret = await mesos_tools.get_mesos_task_count_by_slave(mock_mesos_state, pool='default')
         assert mock_get_all_running_tasks.called
         expected = [
-            {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=1, slave=mock_slave_1)},
-            {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=0, slave=mock_slave_2)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=2, batch_count=1, slave=mock_slave_1)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=2, batch_count=0, slave=mock_slave_2)},
         ]
         assert len(ret) == len(expected) and utils.sort_dicts(ret) == utils.sort_dicts(expected)
         ret = await mesos_tools.get_mesos_task_count_by_slave(mock_mesos_state, pool=None)
         assert mock_get_all_running_tasks.called
         expected = [
-            {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=1, slave=mock_slave_1)},
-            {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=0, slave=mock_slave_2)},
-            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=2, batch_count=1, slave=mock_slave_1)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=2, batch_count=0, slave=mock_slave_2)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, batch_count=0, slave=mock_slave_3)},
         ]
         assert len(ret) == len(expected) and utils.sort_dicts(ret) == utils.sort_dicts(expected)
 
@@ -653,18 +653,18 @@ async def test_get_mesos_task_count_by_slave():
         mock_tasks = [mock_task1, mock_task2, mock_task3, mock_task4]
         mock_get_all_running_tasks.return_value = mock_tasks
         mock_slaves_list = [
-            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_1)},
-            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_2)},
-            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, batch_count=0, slave=mock_slave_1)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, batch_count=0, slave=mock_slave_2)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, batch_count=0, slave=mock_slave_3)},
         ]
         ret = await mesos_tools.get_mesos_task_count_by_slave(
             mock_mesos_state,
             slaves_list=mock_slaves_list,
         )
         expected = [
-            {'task_counts': mesos_tools.SlaveTaskCount(count=1, chronos_count=1, slave=mock_slave_1)},
-            {'task_counts': mesos_tools.SlaveTaskCount(count=3, chronos_count=0, slave=mock_slave_2)},
-            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=1, batch_count=1, slave=mock_slave_1)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=3, batch_count=0, slave=mock_slave_2)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, batch_count=0, slave=mock_slave_3)},
         ]
         assert len(ret) == len(expected) and utils.sort_dicts(ret) == utils.sort_dicts(expected)
 
@@ -677,9 +677,9 @@ async def test_get_mesos_task_count_by_slave():
         mock_tasks = [mock_task1, mock_task2, mock_task3, mock_task4]
         mock_get_all_running_tasks.return_value = mock_tasks
         mock_slaves_list = [
-            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_1)},
-            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_2)},
-            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, batch_count=0, slave=mock_slave_1)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, batch_count=0, slave=mock_slave_2)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, batch_count=0, slave=mock_slave_3)},
         ]
         ret = await mesos_tools.get_mesos_task_count_by_slave(
             mock_mesos_state,
@@ -687,9 +687,9 @@ async def test_get_mesos_task_count_by_slave():
         )
         # we expect mock_slave_2 to only count 2 tasks, as one of them returned a SlaveDoesNotExist exception
         expected = [
-            {'task_counts': mesos_tools.SlaveTaskCount(count=1, chronos_count=1, slave=mock_slave_1)},
-            {'task_counts': mesos_tools.SlaveTaskCount(count=2, chronos_count=0, slave=mock_slave_2)},
-            {'task_counts': mesos_tools.SlaveTaskCount(count=0, chronos_count=0, slave=mock_slave_3)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=1, batch_count=1, slave=mock_slave_1)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=2, batch_count=0, slave=mock_slave_2)},
+            {'task_counts': mesos_tools.SlaveTaskCount(count=0, batch_count=0, slave=mock_slave_3)},
         ]
         assert len(ret) == len(expected) and utils.sort_dicts(ret) == utils.sort_dicts(expected)
 


### PR DESCRIPTION
I wasn't able to use framework's principle to count chronos, taskproc and spark as batch tasks because taskproc uses the http api where authentication is not enforced. In addition, framework's name is hard to control in spark and taskproc apps. As a workaround, this PR counts all non-marathon tasks as batch tasks. 

AWS claims that "The typical frequency of interruption for Spot Instances in the last 30 days was less than 5% on average." with the new spot pricing model. Hopefully with this change, batch jobs are more stable.