### PR TITLE
Fix `docker_wrapper.py` doesn't see environment variables

### DIFF
--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -33,7 +33,7 @@ MAX_HOSTNAME_LENGTH = 63
 
 
 def parse_env_args(args):
-    result = {}
+    result = {k: v for k, v in os.environ.items()}
     in_env = False
     in_file = False
     for arg in args:


### PR DESCRIPTION
Since PaaSTA passes environment variable values to a Docker container
via `VAR=val docker --env VAR`, fixing `docker_wrapper.py` to read those
values not only from the command line arguments but also from the
environment.