### PR TITLE
Add kubernetes as an instance type

### DIFF
--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -40,6 +40,7 @@ opt/venvs/paasta-tools/bin/paasta_firewall_logging usr/bin/paasta_firewall_loggi
 opt/venvs/paasta-tools/bin/paasta_firewall_update usr/bin/paasta_firewall_update
 opt/venvs/paasta-tools/bin/paasta_list_chronos_jobs usr/bin/list_chronos_jobs
 opt/venvs/paasta-tools/bin/paasta_list_chronos_jobs usr/bin/paasta_list_chronos_jobs
+opt/venvs/paasta-tools/bin/paasta_list_kubernetes_service_instances.py usr/bin/paasta_list_kubernetes_service_instances
 opt/venvs/paasta-tools/bin/paasta_list_tron_namespaces usr/bin/paasta_list_tron_namespaces
 opt/venvs/paasta-tools/bin/paasta_maintenance.py usr/bin/paasta_maintenance
 opt/venvs/paasta-tools/bin/paasta_metastatus.py usr/bin/paasta_metastatus

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -103,6 +103,10 @@ def adhoc_instance_status(instance_status, service, instance, verbose):
     return cstatus
 
 
+def kubernetes_instance_status(instance_status, service, instance, verbose):
+    return {}
+
+
 def marathon_job_status(mstatus, client, job_config, verbose):
     try:
         app_id = job_config.format_marathon_app_dict()['id']
@@ -185,6 +189,8 @@ def instance_status(request):
             instance_status['chronos'] = chronos_instance_status(instance_status, service, instance, verbose)
         elif instance_type == 'adhoc':
             instance_status['adhoc'] = adhoc_instance_status(instance_status, service, instance, verbose)
+        elif instance_type == 'kubernetes':
+            instance_status['kubernetes'] = kubernetes_instance_status(instance_status, service, instance, verbose)
         else:
             error_message = f'Unknown instance_type {instance_type} of {service}.{instance}'
             raise ApiFailure(error_message, 404)

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -34,6 +34,7 @@ from paasta_tools import remote_git
 from paasta_tools.adhoc_tools import load_adhoc_job_config
 from paasta_tools.api import client
 from paasta_tools.chronos_tools import load_chronos_job_config
+from paasta_tools.kubernetes_tools import load_kubernetes_service_config
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.monitoring_tools import _load_sensu_team_data
 from paasta_tools.utils import _run
@@ -970,7 +971,7 @@ def get_instance_configs_for_service(service, soa_dir, type_filter=None):
         soa_dir=soa_dir,
     ):
         if type_filter is None:
-            type_filter = ['marathon', 'chronos', 'adhoc']
+            type_filter = ['marathon', 'chronos', 'adhoc', 'kubernetes']
         if 'marathon' in type_filter:
             for _, instance in get_service_instance_list(
                 service=service,
@@ -1007,6 +1008,20 @@ def get_instance_configs_for_service(service, soa_dir, type_filter=None):
                 soa_dir=soa_dir,
             ):
                 yield load_adhoc_job_config(
+                    service=service,
+                    instance=instance,
+                    cluster=cluster,
+                    soa_dir=soa_dir,
+                    load_deployments=False,
+                )
+        if 'kubernetes' in type_filter:
+            for _, instance in get_service_instance_list(
+                service=service,
+                cluster=cluster,
+                instance_type='kubernetes',
+                soa_dir=soa_dir,
+            ):
+                yield load_kubernetes_service_config(
                     service=service,
                     instance=instance,
                     cluster=cluster,

--- a/paasta_tools/list_kubernetes_service_instances.py
+++ b/paasta_tools/list_kubernetes_service_instances.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Usage: ./list_kubernetes_service_instances.py [options]
+
+Enumerates all kubernetes instances for services in the soa directory that
+are for the current cluster (defined by the kubernetes configuration file).
+
+Outputs (to stdout) a list of service.instance (one per line)
+for each instance found in kubernetes-<CLUSTER>.yaml for every folder
+in the SOA Configuration directory.
+
+Command line options:
+
+- -d <SOA_DIR>, --soa-dir <SOA_DIR>: Specify a SOA config dir to read from
+- -c <CLUSTER>, --cluster <CLUSTER>: Specify which cluster of services to read
+"""
+import argparse
+import sys
+
+from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import get_services_for_cluster
+from paasta_tools.utils import paasta_print
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Lists kubernetes instances for a service.',
+    )
+    parser.add_argument(
+        '-c', '--cluster', dest="cluster", metavar="CLUSTER",
+        default=None,
+        help="define a specific cluster to read from",
+    )
+    parser.add_argument(
+        '-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
+        default=DEFAULT_SOA_DIR,
+        help="define a different soa config directory",
+    )
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+    soa_dir = args.soa_dir
+    cluster = args.cluster
+    instances = get_services_for_cluster(
+        cluster=cluster,
+        instance_type='kubernetes',
+        soa_dir=soa_dir,
+    )
+    service_instances = []
+    for name, instance in instances:
+        service_instances.append(compose_job_id(name, instance))
+    paasta_print('\n'.join(service_instances))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -101,7 +101,7 @@ DEFAULT_CPU_BURST_PCT = 900
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
-INSTANCE_TYPES = ('marathon', 'chronos', 'paasta_native', 'adhoc')
+INSTANCE_TYPES = ('marathon', 'chronos', 'paasta_native', 'adhoc', 'kubernetes')
 
 
 TimeCacheEntry = TypedDict(

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ setup(
             'paasta_cleanup_tron_namespaces=paasta_tools.cleanup_tron_namespaces:main',
             'paasta_check_chronos_jobs=paasta_tools.check_chronos_jobs:main',
             'paasta_list_chronos_jobs=paasta_tools.list_chronos_jobs:main',
+            'paasta_list_kubernetes_service_instances=paasta_tools.list_kubernetes_service_instances:main',
             'paasta_setup_chronos_job=paasta_tools.setup_chronos_job:main',
             'paasta_chronos_rerun=paasta_tools.chronos_rerun:main',
             'paasta_list_tron_namespaces=paasta_tools.list_tron_namespaces:main',

--- a/tests/test_list_kubernetes_service_instances.py
+++ b/tests/test_list_kubernetes_service_instances.py
@@ -1,0 +1,35 @@
+import mock
+from pytest import raises
+
+from paasta_tools.list_kubernetes_service_instances import main
+from paasta_tools.list_kubernetes_service_instances import parse_args
+
+
+def test_parse_args():
+    with mock.patch(
+        'paasta_tools.list_kubernetes_service_instances.argparse.ArgumentParser',
+        autospec=True,
+    ) as mock_parser:
+        assert parse_args() == mock_parser.return_value.parse_args()
+
+
+def test_main():
+    with mock.patch(
+        'paasta_tools.list_kubernetes_service_instances.parse_args', autospec=True,
+    ) as mock_parse_args, mock.patch(
+        'paasta_tools.list_kubernetes_service_instances.get_services_for_cluster', autospec=True,
+        return_value=[('service1', 'instance1'), ('service2', 'instance1')],
+    ) as mock_get_services_for_cluster, mock.patch(
+        'paasta_tools.list_kubernetes_service_instances.paasta_print', autospec=True,
+    ) as mock_print:
+        with raises(SystemExit) as e:
+            main()
+        assert e.value.code == 0
+        mock_get_services_for_cluster.assert_called_with(
+            cluster=mock_parse_args.return_value.cluster,
+            instance_type='kubernetes',
+            soa_dir=mock_parse_args.return_value.soa_dir,
+        )
+        mock_print.assert_called_with(
+            'service1.instance1\nservice2.instance1',
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -688,6 +688,8 @@ def test_get_service_instance_list():
         (fake_name, fake_instance_1),
         (fake_name, fake_instance_1),
         (fake_name, fake_instance_1),
+        (fake_name, fake_instance_1),
+        (fake_name, fake_instance_2),
         (fake_name, fake_instance_2),
         (fake_name, fake_instance_2),
         (fake_name, fake_instance_2),
@@ -701,7 +703,8 @@ def test_get_service_instance_list():
         read_extra_info_patch.assert_any_call(fake_name, 'marathon-16floz', soa_dir=fake_dir)
         read_extra_info_patch.assert_any_call(fake_name, 'chronos-16floz', soa_dir=fake_dir)
         read_extra_info_patch.assert_any_call(fake_name, 'paasta_native-16floz', soa_dir=fake_dir)
-        assert read_extra_info_patch.call_count == 4
+        read_extra_info_patch.assert_any_call(fake_name, 'kubernetes-16floz', soa_dir=fake_dir)
+        assert read_extra_info_patch.call_count == 5
         assert sorted(expected) == sorted(actual)
 
 
@@ -716,6 +719,7 @@ def test_get_service_instance_list_ignores_underscore():
         fake_instance_2: {},
     }
     expected = [
+        (fake_name, fake_instance_1),
         (fake_name, fake_instance_1),
         (fake_name, fake_instance_1),
         (fake_name, fake_instance_1),
@@ -1710,6 +1714,7 @@ def test_validate_service_instance_invalid():
     mock_chronos_services = [('service1', 'worker'), ('service2', 'tailer')]
     mock_paasta_native_services = [('service1', 'main2'), ('service2', 'main2')]
     mock_adhoc_services = [('service1', 'interactive'), ('service2', 'interactive')]
+    mock_k8s_services = [('service1', 'k8s'), ('service2', 'k8s')]
     my_service = 'bad_service'
     my_instance = 'main'
     fake_cluster = 'fake_cluster'
@@ -1720,6 +1725,7 @@ def test_validate_service_instance_invalid():
         side_effect=[
             mock_marathon_services, mock_chronos_services,
             mock_paasta_native_services, mock_adhoc_services,
+            mock_k8s_services,
         ],
     ):
         with raises(utils.NoConfigurationForServiceError):


### PR DESCRIPTION
This is needed to get generate_deployments working for kubernetes- yaml
files. I've deliberately left paasta status not implemented for now.
This also adds the list_kubernetes_service_instances script so we can
start with the list|xargs setup_kubernetes_job like pattern before we
add support for the k8s instances to deployd.

NB: I think this should be safe, I've read some code and checked things still work in the example cluster. I guess the itests should flag if I've broken anything else.