### PR TITLE
Make travis fail if we break example cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,5 @@ deploy:
       repo: Yelp/paasta
 matrix:
   allow_failures:
-    - env: TOXENV=example_cluster
     - env: MAKE_TARGET=itest_bionic
   fast_finish: true


### PR DESCRIPTION
I have three justifications but opinions welcome:
* It seems to be about as stable as the itests give or take
* It occassionally has caught bugs that we don't cover in the itests and
have ended up pushing to prod
* I use it quite a bit for development and it's a pita if it's been
broken by some minor thing that can be hard to work out if it changed
some time in the past.