### PR TITLE
Starting point for validation of Tron configs

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -100,6 +100,10 @@
                     "type": "array",
                     "items": {"type": "string"}
                 },
+                "slack_channels": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                },
                 "ticket": {"type": "boolean"},
                 "project": {"type": "string"},
                 "tags": {

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "tron on paasta yaml (docs todo)",
+  "type": "object",
+  "definitions": {
+    "name": {
+        "type": "string",
+        "pattern": "^[A-Za-z_][\\w\\-]{0,254}$"
+    },
+    "time_delta": {
+        "type": "string",
+        "pattern": "^\\d+\\s*[dhms]$"
+    },
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "name": {"$ref": "#definitions/name"},
+        "command": {"type": "string"},
+        "node": {"$ref": "#definitions/name"},
+        "requires": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "retries": {
+          "type": "integer",
+          "minimum": 0,
+          "exclusiveMinimum": false
+        },
+        "executor": {"enum": ["ssh", "paasta"]},
+        "cpus": {
+          "type": "number",
+          "minumum": 0,
+          "exclusiveMinimum": true
+        },
+        "mem": {
+          "type": "number",
+          "minumum": 32,
+          "exclusiveMinimum": true
+        },
+        "constraints": {
+          "type": "array",
+          "items": {"type": "array"},
+          "uniqueItems": true
+        },
+        "service": {"type": "string"},
+        "deploy_group": {"type": "string"},
+        "pool": {"type": "string"},
+        "env": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "extra_volumes": {
+          "type": "array",
+          "items": {"type": "object"},
+          "uniqueItems": true
+        },
+        "cluster": {"type": "string"},
+        "expected_runtime": {"$ref": "#definitions/time_delta"}
+      }
+    }
+  },
+  "required": ["jobs"],
+  "properties": {
+    "jobs": {
+      "type": ["null", "array"],
+      "items": {
+        "type": "object",
+        "required": ["name", "node", "schedule", "actions"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {"$ref": "#definitions/name"},
+          "node": {"$ref": "#definitions/name"},
+          "schedule": {
+            "type": ["string", "object"]
+          },
+          "actions": {
+            "type": "array",
+            "items": {"$ref": "#definitions/action"}
+          },
+          "monitoring": {
+            "type": "object",
+            "properties": {
+                "team": {"type": "string"},
+                "runbook": {"type": "string"},
+                "page": {"type": "boolean"},
+                "tip": {"type": "string"},
+                "notification_email": {"type": "string"},
+                "realert_every": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "exclusiveMinimum": false
+                },
+                "dependencies": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                },
+                "irc_channels": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                },
+                "ticket": {"type": "boolean"},
+                "project": {"type": "string"},
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                },
+                "component": {
+                    "type": ["string", "array"]
+                },
+                "description": {"type": "string"},
+                "alert_after": {"type": "string"}
+              },
+              "additionalProperties": false
+          },
+          "queueing": {"type": "boolean"},
+          "allow_overlap": {"type": "boolean"},
+          "run_limit": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "all_nodes": {"type": "boolean"},
+          "cleanup_action": {"$ref": "#definitions/action"},
+          "enabled": {"type": "boolean"},
+          "max_runtime": {"$ref": "#definitions/time_delta"},
+          "expected_runtime": {"$ref": "#definitions/time_delta"},
+          "time_zone": {"type": "string"},
+          "service": {"type": "string"},
+          "deploy_group": {"type": "string"}
+        }
+      }
+    }
+  }
+}

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -9,7 +9,7 @@
     },
     "time_delta": {
         "type": "string",
-        "pattern": "^\\d+\\s*[dhms]$"
+        "pattern": "^\\d+\\s*[a-z]+$"
     },
     "action": {
       "type": "object",

--- a/paasta_tools/tron/tron_timeutils.py
+++ b/paasta_tools/tron/tron_timeutils.py
@@ -4,6 +4,11 @@ This is a COPY of https://github.com/Yelp/Tron/blob/master/tron/utils/timeutils.
 import datetime
 import re
 import time
+from typing import Any
+from typing import Tuple
+
+
+TIMEDELTA_PATTERN = re.compile(r'^(\d+)\s*([dhms])$')
 
 
 def current_time():
@@ -26,6 +31,21 @@ def delta_total_seconds(td):
     """
     microseconds, seconds, days = td.microseconds, td.seconds, td.days
     return (microseconds + (seconds + days * 24 * 3600) * 10**6) / 10**6
+
+
+def check_timedelta(value: Any, param_name: str) -> Tuple[bool, str]:
+    if value is None:
+        return True, ''
+
+    message = f'The specified {param_name} value {value} is not a valid timedelta string.'
+    if not isinstance(value, str):
+        return False, message
+
+    match = TIMEDELTA_PATTERN.match(value)
+    if not match:
+        return False, message
+    else:
+        return True, ''
 
 
 def macro_timedelta(start_date, years=0, months=0, days=0, hours=0):

--- a/paasta_tools/tron/tron_timeutils.py
+++ b/paasta_tools/tron/tron_timeutils.py
@@ -4,11 +4,6 @@ This is a COPY of https://github.com/Yelp/Tron/blob/master/tron/utils/timeutils.
 import datetime
 import re
 import time
-from typing import Any
-from typing import Tuple
-
-
-TIMEDELTA_PATTERN = re.compile(r'^(\d+)\s*([dhms])$')
 
 
 def current_time():
@@ -31,21 +26,6 @@ def delta_total_seconds(td):
     """
     microseconds, seconds, days = td.microseconds, td.seconds, td.days
     return (microseconds + (seconds + days * 24 * 3600) * 10**6) / 10**6
-
-
-def check_timedelta(value: Any, param_name: str) -> Tuple[bool, str]:
-    if value is None:
-        return True, ''
-
-    message = f'The specified {param_name} value {value} is not a valid timedelta string.'
-    if not isinstance(value, str):
-        return False, message
-
-    match = TIMEDELTA_PATTERN.match(value)
-    if not match:
-        return False, message
-    else:
-        return True, ''
 
 
 def macro_timedelta(start_date, years=0, months=0, days=0, hours=0):

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -443,7 +443,7 @@ def validate_complete_config(service: str, cluster: str, soa_dir: str=DEFAULT_SO
             default_paasta_cluster=None,
         ) for job_config in job_configs
     ]
-    complete_config = yaml.dump(other_config)
+    complete_config = yaml.dump(other_config, Dumper=Dumper)
 
     proc = subprocess.run(
         ['tronfig', '-', '-V', '-n', service],


### PR DESCRIPTION
Added a JSON schema for Tron configs, and `validate` methods for TronActionConfig and TronJobConfig. `paasta validate` will check the schema and call validate on the configs. Eventually, the goal is to have all of the checks that are done with our pre-commit script and `tronfig` to be included here instead. If `paasta validate` passes, we should be confident that Tron will accept the config.

There's some extra logic in the CLI to support something like `paasta validate -s tron/prod`, so that we can use this in a pre-commit hook for those files, too. Not the cleanest, but I figure it's better than maintaining multiple types of pre-commit checks.

This shows the general approach I'm going for. If this looks reasonable, I'll add tests. And then we can follow up with more check methods.