### PR TITLE
Add --user flag to `paasta docker_exec`

### DIFF
--- a/tests/cli/test_cmds_docker_exec.py
+++ b/tests/cli/test_cmds_docker_exec.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import mock
+import pytest
 from mock import patch
 
 from paasta_tools.cli.cmds import docker_exec
@@ -31,23 +32,46 @@ def test_add_subparser(mock_get_subparser):
 
 
 @patch('paasta_tools.cli.cmds.docker_exec.subprocess', autospec=True)
-@patch('paasta_tools.cli.cmds.docker_exec.get_container_name', autospec=True)
+@patch('paasta_tools.cli.cmds.docker_exec.get_container_name', autospec=True, return_value='7cf1b4f468b9')
 @patch('paasta_tools.cli.cmds.docker_exec.get_task_from_instance', autospec=True)
+@pytest.mark.parametrize(
+    ('mock_args', 'expected_command'),
+    (
+        (
+            mock.Mock(
+                cluster='cluster1',
+                service='mock_service',
+                instance='mock_instance',
+                host='host1',
+                mesos_id=None,
+                exec_command='/bin/bash',
+                user=None,
+            ),
+            ["ssh", "-o", "LogLevel=QUIET", "-tA", 'host1', "sudo docker exec -ti 7cf1b4f468b9 /bin/bash"],
+        ),
+        (
+            mock.Mock(
+                cluster='cluster1',
+                service='mock_service',
+                instance='mock_instance',
+                host='host1',
+                mesos_id=None,
+                exec_command='/bin/bash',
+                user='root',
+            ),
+            ["ssh", "-o", "LogLevel=QUIET", "-tA", 'host1', "sudo docker exec -ti --user root 7cf1b4f468b9 /bin/bash"],
+        ),
+    ),
+)
 def test_paasta_docker_exec(
     mock_get_task_from_instance,
     mock_get_container_name,
     mock_subprocess,
+    mock_args,
+    expected_command,
 ):
     mock_task = mock.Mock(slave={'hostname': 'host1'})
     mock_get_task_from_instance.return_value = mock_task
-    mock_args = mock.Mock(
-        cluster='cluster1',
-        service='mock_service',
-        instance='mock_instance',
-        host='host1',
-        mesos_id=None,
-        exec_command='/bin/bash',
-    )
 
     docker_exec.paasta_docker_exec(mock_args)
 
@@ -60,8 +84,4 @@ def test_paasta_docker_exec(
     )
 
     mock_get_container_name.assert_called_with(mock_task)
-    expected = [
-        "ssh", "-o", "LogLevel=QUIET", "-tA", 'host1',
-        f"sudo docker exec -ti {mock_get_container_name.return_value} ''/bin/bash''",
-    ]
-    mock_subprocess.call.assert_called_with(expected)
+    mock_subprocess.call.assert_called_with(expected_command)


### PR DESCRIPTION
This lets you do `paasta docker_exec ... --user=root`, which is something I often want to do when exec-ing into a container (the `nobody` user isn't always so useful for troubleshooting).

Currently my workflow is `paasta docker_exec`, let it find me a container to exec into, then SSH to the host again and `docker exec --user=root` into it. This argument will let me skip those manual steps.