### PR TITLE
Add a metric for leader elections

### DIFF
--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -176,6 +176,8 @@ class DeployDaemon(PaastaThread):
         self.is_leader = True
         self.log.info("This node is elected as leader {}".format(socket.getfqdn()))
         self.metrics = get_metrics_interface('paasta.deployd')
+        leader_counter = self.metrics.create_counter("leader_elections", paasta_cluster=self.config.get_cluster())
+        leader_counter.count()
         QueueMetrics(self.inbox, self.bounce_q, self.config.get_cluster(), self.metrics).start()
         self.inbox.start()
         self.log.info("Starting all watcher threads")

--- a/tests/metrics/test_metrics_lib.py
+++ b/tests/metrics/test_metrics_lib.py
@@ -20,6 +20,10 @@ class TestNoMetrics(unittest.TestCase):
         gauge = self.metrics.create_gauge('name', dimension='thing')
         gauge.set(1212)
 
+    def test_counter(self):
+        counter = self.metrics.create_counter('name', dimension='thing')
+        counter.count()
+
 
 class TestMeteoriteMetrics(unittest.TestCase):
     def setUp(self):
@@ -42,6 +46,10 @@ class TestMeteoriteMetrics(unittest.TestCase):
     def test_create_gauge(self):
         self.metrics.create_gauge('name', dimension='thing')
         self.mock_meteorite.create_gauge.assert_called_with('paasta.deployd.name', {'dimension': 'thing'})
+
+    def test_create_counter(self):
+        self.metrics.create_counter('name', dimension='thing')
+        self.mock_meteorite.create_counter.assert_called_with('paasta.deployd.name', {'dimension': 'thing'})
 
     def tearDown(self):
         metrics_lib.yelp_meteorite = None


### PR DESCRIPTION
It's useful to know when deployd is "stuck" and just constantly crashing
and electing a new leader. This adds a counter that we can chart/alert
on.