### PR TITLE
Only pass secret environment variables to execlpe

### DIFF
--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -695,8 +695,8 @@ def test_get_docker_run_cmd_with_env_vars():
         memory, chosen_port, container_port, container_name, volumes, env,
         interactive, docker_hash, command, net, docker_params, detach,
     )
-    assert actual[actual.index('foo') - 1] == '--env'
-    assert actual[actual.index('baz') - 1] == '--env'
+    assert actual[actual.index('foo=bar') - 1] == '--env'
+    assert actual[actual.index('baz=qux') - 1] == '--env'
 
 
 def test_get_docker_run_cmd_interactive_false():


### PR DESCRIPTION
Before [the execlpe change](https://github.com/Yelp/paasta/pull/1875), local-run printed:
paasta_docker_wrapper run --env ENV_VAR=VAL1 --env SECRET_VAR=VAL2

After the execlpe change, local-run prints
paasta_docker_wrapper run --env ENV_VAR --env SECRET_VAR

With this change, local-run will print
paasta_docker_wrapper run --env ENV_VAR=VAL1 --env SECRET_VAR

Testing:
$ .tox/py36/bin/paasta local-run -s example_happyhour -i main --pull -C /bin/bash
...
Running docker command:
paasta_docker_wrapper run --env PAASTA_SERVICE=example_happyhour --env PAASTA_INSTANCE=main --env PAASTA_CLUSTER=norcal-devc --env PAASTA_DEPLOY_GROUP=dev.everything ... 
**--env MY_SECRET_VAR** --memory=600m --memory-swap=664m --cpu-period=100000 ...