### PR TITLE
Catch exceptions on format_marathon_app_dict

### DIFF
--- a/paasta_tools/deployd/common.py
+++ b/paasta_tools/deployd/common.py
@@ -17,7 +17,6 @@ from paasta_tools.marathon_tools import get_marathon_servers
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.marathon_tools import load_marathon_service_config_no_cache
 from paasta_tools.marathon_tools import MarathonClients
-from paasta_tools.mesos.exceptions import NoSlavesAvailableError
 from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import NoConfigurationForServiceError
@@ -184,8 +183,10 @@ def get_service_instances_needing_update(
             )
             config_app = config.format_marathon_app_dict()
             app_id = '/{}'.format(config_app['id'])
-        except (NoDockerImageError, InvalidJobNameError, NoDeploymentsAvailable, NoSlavesAvailableError) as e:
-            print("DEBUG: Skipping {}.{} because: '{}'".format(service, instance, str(e)))
+        # Not ideal but we rely on a lot of user input to create the app dict
+        # and we really can't afford to bail if just one app definition is malformed
+        except Exception as e:
+            print("ERROR: Skipping {}.{} because: '{}'".format(service, instance, str(e)))
             continue
         if app_id not in marathon_app_ids:
             service_instances.append((service, instance))

--- a/paasta_tools/list_marathon_service_instances.py
+++ b/paasta_tools/list_marathon_service_instances.py
@@ -35,15 +35,12 @@ from paasta_tools.marathon_tools import get_marathon_clients
 from paasta_tools.marathon_tools import get_marathon_servers
 from paasta_tools.marathon_tools import get_num_at_risk_tasks
 from paasta_tools.marathon_tools import load_marathon_service_config
-from paasta_tools.mesos.exceptions import NoSlavesAvailableError
 from paasta_tools.mesos_maintenance import get_draining_hosts
 from paasta_tools.utils import _log
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import long_job_id_to_short_job_id
-from paasta_tools.utils import NoDeploymentsAvailable
-from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import use_requests_cache
 
@@ -93,7 +90,9 @@ def get_desired_marathon_configs(soa_dir):
             formatted_config = job_config.format_marathon_app_dict()
             formatted_marathon_configs[formatted_config['id'].lstrip('/')] = formatted_config
             job_configs[formatted_config['id'].lstrip('/')] = job_config
-        except NoSlavesAvailableError as errormsg:
+        # Not ideal but we rely on a lot of user input to create the app dict
+        # and we really can't afford to bail if just one app definition is malformed
+        except Exception as errormsg:
             _log(
                 service=service,
                 line=str(errormsg),
@@ -102,8 +101,6 @@ def get_desired_marathon_configs(soa_dir):
                 cluster=cluster,
                 instance=instance,
             )
-        except (NoDeploymentsAvailable, NoDockerImageError):
-            pass
     return formatted_marathon_configs, job_configs
 
 

--- a/tests/deployd/test_common.py
+++ b/tests/deployd/test_common.py
@@ -314,6 +314,19 @@ def test_get_service_instances_needing_update():
         ret = get_service_instances_needing_update(fake_clients, mock_service_instances, 'westeros-prod')
         assert ret == [('universe', 'c138')]
 
+        mock_configs = [
+            mock.Mock(format_marathon_app_dict=mock.Mock(side_effect=Exception)),
+            mock.Mock(format_marathon_app_dict=mock.Mock(return_value={
+                'id': 'universe.c138.c2.g2',
+                'instances': 2,
+            })),
+        ]
+        mock_load_marathon_service_config.side_effect = mock_configs
+        mock_client = mock.Mock(servers=["foo"])
+        fake_clients = MarathonClients(current=[mock_client], previous=[mock_client])
+        ret = get_service_instances_needing_update(fake_clients, mock_service_instances, 'westeros-prod')
+        assert ret == [('universe', 'c138')]
+
 
 def test_get_marathon_clients_from_config():
     with mock.patch(

--- a/tests/test_list_marathon_service_instances.py
+++ b/tests/test_list_marathon_service_instances.py
@@ -25,13 +25,18 @@ def test_get_desired_marathon_configs():
         'paasta_tools.list_marathon_service_instances.load_marathon_service_config', autospec=True,
     ) as mock_load_marathon_service_config, mock.patch(
         'paasta_tools.list_marathon_service_instances.load_system_paasta_config', autospec=True,
+    ), mock.patch(
+        'paasta_tools.list_marathon_service_instances._log', autospec=True,
     ):
         mock_app_dict = {'id': '/service.instance.git.configs'}
         mock_app = mock.MagicMock(
             format_marathon_app_dict=mock.MagicMock(return_value=mock_app_dict),
         )
-        mock_get_services_for_cluster.return_value = [('service', 'instance')]
-        mock_load_marathon_service_config.return_value = mock_app
+        mock_app_2 = mock.MagicMock(
+            format_marathon_app_dict=mock.MagicMock(side_effect=[Exception]),
+        )
+        mock_get_services_for_cluster.return_value = [('service', 'instance'), ('service', 'broken_instance')]
+        mock_load_marathon_service_config.side_effect = [mock_app, mock_app_2]
         assert list_marathon_service_instances.get_desired_marathon_configs(
             '/fake/soa/dir',
         ) == (


### PR DESCRIPTION
We currently only catch the ways we know it can go wrong. There's a lot
of user input and our validation with commit hooks can only be so good.
We need deployd to continue if only one marathon app dict is malformed
so this catches all Exceptions.