### PR TITLE
Add better documentation for local-run

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -323,7 +323,10 @@ def add_subparser(subparsers):
     )
     list_parser.add_argument(
         '-i', '--instance',
-        help=("Simulate a docker run for a particular instance of the service, like 'main' or 'canary'"),
+        help=(
+            "Simulate a docker run for a particular instance of the service, like 'main' or 'canary'"
+            "NOTE: if you don't specify an instance, PaaSTA will run in interactive mode"
+        ),
         required=False,
         default=None,
     ).completer = lazy_choices_completer(list_instances)


### PR DESCRIPTION
Currently, if you don't want local-run to run in interactive mode,
you must specify an instance. This is now specified in local-run's
help page.