### PR TITLE
RFC: smartstack errors meteorite emitter

### DIFF
--- a/paasta_tools/contrib/emit_synapse_services_metrics.py
+++ b/paasta_tools/contrib/emit_synapse_services_metrics.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import yelp_meteorite
+
+from paasta_tools import utils
+from paasta_tools.smartstack_tools import retrieve_haproxy_csv
+
+
+GUAGES = ['ereq', 'rate']
+COUNTERS = ['hrsp_2xx', 'hrsp_3xx', 'hrsp_4xx', 'hrsp_5xx']
+
+
+def parse_haproxy_backend_name(backend):
+    # Currently a hack, the backend doesn't always match service.instance,
+    # but at least the data will be reported.
+    return backend.split('.')[0], backend.split('.')[1]
+
+
+def report_metric_to_meteorite(backend, metric, value, paasta_cluster):
+    try:
+        paasta_service, paasta_instance = parse_haproxy_backend_name(backend)
+    except IndexError:
+        return
+
+    meteorite_dims = {
+        'service_name': paasta_service,
+        'paasta_cluster': paasta_cluster,
+        'instance_name': paasta_instance,
+    }
+    path = f'paasta.service.requests.{metric}'
+    if metric in GUAGES:
+        guage = yelp_meteorite.create_gauge(path, meteorite_dims)
+        guage.set(value)
+    elif metric in COUNTERS:
+        counter = yelp_meteorite.create_counter(path, meteorite_dims)
+        counter.count(value)
+    else:
+        raise ValueError(f"{metric} hasn't been configured as a guage or counter")
+    print(f"Sent {path}: {value} to meteorite")
+
+
+def report_all_metrics_to_meteorite(csv, paasta_cluster):
+    for row in csv:
+        if row['svname'] == 'BACKEND':
+            for metric in GUAGES + COUNTERS:
+                report_metric_to_meteorite(
+                    backend=row['# pxname'],
+                    metric=metric,
+                    value=row[metric],
+                    paasta_cluster=paasta_cluster,
+                )
+
+
+if __name__ == '__main__':
+    system_paasta_config = utils.load_system_paasta_config()
+    csv = retrieve_haproxy_csv(
+        synapse_host=system_paasta_config.get_default_synapse_host(),
+        synapse_port=system_paasta_config.get_synapse_port(),
+        synapse_haproxy_url_format=system_paasta_config.get_synapse_haproxy_url_format(),
+    )
+    report_all_metrics_to_meteorite(
+        csv=csv,
+        paasta_cluster=system_paasta_config.get_local_run_config().get('default_cluster'),
+    )


### PR DESCRIPTION
cc @somic @bplotnick @jnb 

I want to have metrics from our service mesh available "for free" to our service owners. I'm thinking it will be useful to them for the following use-cases:
* free dashboards  (y/paasta-status)
* easy to integrate with the slo framework
* easy to retrieve for auto-rollback / push on green tooling

Additionally, when we move to envoy, we'll be able to update this script and live in "dual" mode, and these other tools won't have to change maybe? Maybe we'll need to translate the metric name.

I'm sure we'll have to update the metric whitelist over time, and maybe munge them to be friendlier.

Also the hack to just assume the backend name is service.instance isn't super great long term.