### PR TITLE
Unified __repr__ across paasta instance objects and send cluster into all TronActionConfigs

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -490,6 +490,9 @@ Each Tron **job** configuration MAY specify the following options:
     also be set on a per-action basis. Tron jobs may be composed of multiple actions
     that use commands from multiple different services.
 
+  * ``cluster``: Configures Tron to execute the job's action in a particular PaaSTA cluster.
+    If unset, it defaults to the global default cluster Tron is configured to use.
+
 Each Tron **action** of a job MAY specify the following:
 
   * Anything in the `Common Settings`_.
@@ -500,7 +503,8 @@ Each Tron **action** of a job MAY specify the following:
     for an action, that setting takes precedence over what is set for the job.
 
   * ``cluster``: Configures Tron to execute the action in a particular PaaSTA cluster.
-    If unset, it defaults to the global default cluster Tron is configured to use.
+    If unset, it defaults to the job's setting for ``cluster``, and it that is unset,
+    it will use the global default.
 
   * ``executor``: Configures Tron to execute the command in a particular way.
     Set to ``paasta`` to configure Tron to launch the job on he PaaSTA cluster.

--- a/paasta_tools/adhoc_tools.py
+++ b/paasta_tools/adhoc_tools.py
@@ -94,16 +94,6 @@ class AdhocJobConfig(LongRunningServiceConfig):
             soa_dir=soa_dir,
         )
 
-    def __repr__(self) -> str:
-        return "AdhocJobConfig({!r}, {!r}, {!r}, {!r}, {!r}, {!r})".format(
-            self.service,
-            self.cluster,
-            self.instance,
-            self.config_dict,
-            self.branch_dict,
-            self.soa_dir,
-        )
-
 
 def get_default_interactive_config(
     service: str,

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -261,16 +261,6 @@ class ChronosJobConfig(InstanceConfig):
             soa_dir=soa_dir,
         )
 
-    def __repr__(self):
-        return "ChronosJobConfig({!r}, {!r}, {!r}, {!r}, {!r}, {!r})".format(
-            self.service,
-            self.cluster,
-            self.instance,
-            self.config_dict,
-            self.branch_dict,
-            self.soa_dir,
-        )
-
     def get_service(self):
         return self.service
 

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -80,6 +80,7 @@
             "type": "array",
             "items": {"$ref": "#definitions/action"}
           },
+          "cluster": {"type": "string"},
           "monitoring": {
             "type": "object",
             "properties": {

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -223,16 +223,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             soa_dir=soa_dir,
         )
 
-    def __repr__(self) -> str:
-        return "KubernetesDeploymentConfig({!r}, {!r}, {!r}, {!r}, {!r}, {!r})".format(
-            self.service,
-            self.cluster,
-            self.instance,
-            self.config_dict,
-            self.branch_dict,
-            self.soa_dir,
-        )
-
     def copy(self) -> "KubernetesDeploymentConfig":
         return self.__class__(
             service=self.service,

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -455,16 +455,6 @@ class MarathonServiceConfig(LongRunningServiceConfig):
             soa_dir=soa_dir,
         )
 
-    def __repr__(self) -> str:
-        return "MarathonServiceConfig({!r}, {!r}, {!r}, {!r}, {!r}, {!r})".format(
-            self.service,
-            self.cluster,
-            self.instance,
-            self.config_dict,
-            self.branch_dict,
-            self.soa_dir,
-        )
-
     def copy(self) -> "MarathonServiceConfig":
         return self.__class__(
             service=self.service,

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -99,9 +99,9 @@ def decompose_instance(instance):
 class TronActionConfig(InstanceConfig):
     config_filename_prefix = 'tron'
 
-    def __init__(self, service, instance, config_dict, branch_dict, soa_dir=DEFAULT_SOA_DIR):
+    def __init__(self, service, instance, cluster, config_dict, branch_dict, soa_dir=DEFAULT_SOA_DIR):
         super(TronActionConfig, self).__init__(
-            cluster=config_dict.get('cluster'),
+            cluster=cluster,
             instance=instance,
             service=service,
             config_dict=config_dict,
@@ -247,12 +247,12 @@ class TronJobConfig:
         else:
             branch_dict = None
 
-        if 'cluster' not in action_dict:
-            action_dict['cluster'] = default_paasta_cluster
+        cluster = action_dict.get('cluster') or default_paasta_cluster
 
         return TronActionConfig(
             service=action_service,
             instance=compose_instance(self.get_name(), action_dict.get('name')),
+            cluster=cluster,
             config_dict=action_dict,
             branch_dict=branch_dict,
             soa_dir=self.soa_dir,
@@ -275,8 +275,9 @@ class TronJobConfig:
         return self._get_action_config(action_dict, default_paasta_cluster)
 
     def check_actions(self) -> Tuple[bool, List[str]]:
-        actions = self.get_actions(None)
-        cleanup_action = self.get_cleanup_action(None)
+        cluster = "fake-cluster-for-validation"
+        actions = self.get_actions(default_paasta_cluster=cluster)
+        cleanup_action = self.get_cleanup_action(default_paasta_cluster=cluster)
         if cleanup_action:
             actions.append(cleanup_action)
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -218,6 +218,9 @@ class TronJobConfig:
     def get_deploy_group(self):
         return self.config_dict.get('deploy_group', '')
 
+    def get_cluster(self):
+        return self.config_dict.get('cluster')
+
     def get_expected_runtime(self):
         return self.config_dict.get('expected_runtime')
 
@@ -247,7 +250,7 @@ class TronJobConfig:
         else:
             branch_dict = None
 
-        cluster = action_dict.get('cluster') or default_paasta_cluster
+        cluster = action_dict.get('cluster') or self.get_cluster() or default_paasta_cluster
 
         return TronActionConfig(
             service=action_service,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -274,11 +274,28 @@ class InstanceConfig(object):
         self.service = service
         self.soa_dir = soa_dir
         self._job_id = compose_job_id(service, instance)
+        self.init_sanity_check()
         config_interpolation_keys = ('deploy_group',)
         interpolation_facts = self.__get_interpolation_facts()
         for key in config_interpolation_keys:
             if key in self.config_dict:
                 self.config_dict[key] = self.config_dict[key].format(**interpolation_facts)  # type: ignore
+
+    def __repr__(self) -> str:
+        return "{!s}({!r}, {!r}, {!r}, {!r}, {!r}, {!r})".format(
+            self.__class__.__name__,
+            self.service,
+            self.instance,
+            self.cluster,
+            self.config_dict,
+            self.branch_dict,
+            self.soa_dir,
+        )
+
+    def init_sanity_check(self) -> None:
+        for attribute in [self.cluster, self.instance, self.service, self.soa_dir]:
+            if attribute is None:
+                raise TypeError(f"A {self.__class__.__name__} cannot be initialized with None: {repr(self)}")
 
     def __get_interpolation_facts(self) -> Dict[str, str]:
         return {
@@ -1002,6 +1019,8 @@ def get_service_docker_registry(
     soa_dir: str=DEFAULT_SOA_DIR,
     system_config: Optional['SystemPaastaConfig']=None,
 ) -> str:
+    if service is None:
+        raise NotImplementedError('"None" is not a valid service')
     service_configuration = service_configuration_lib.read_service_configuration(service, soa_dir)
     try:
         return service_configuration['docker_registry']

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -274,7 +274,6 @@ class InstanceConfig(object):
         self.service = service
         self.soa_dir = soa_dir
         self._job_id = compose_job_id(service, instance)
-        self.init_sanity_check()
         config_interpolation_keys = ('deploy_group',)
         interpolation_facts = self.__get_interpolation_facts()
         for key in config_interpolation_keys:
@@ -291,11 +290,6 @@ class InstanceConfig(object):
             self.branch_dict,
             self.soa_dir,
         )
-
-    def init_sanity_check(self) -> None:
-        for attribute in [self.cluster, self.instance, self.service, self.soa_dir]:
-            if attribute is None:
-                raise TypeError(f"A {self.__class__.__name__} cannot be initialized with None: {repr(self)}")
 
     def __get_interpolation_facts(self) -> Dict[str, str]:
         return {

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1705,15 +1705,6 @@ class TestMarathonTools:
 
 class TestMarathonServiceConfig(object):
 
-    def test_repr(self):
-        actual = repr(marathon_tools.MarathonServiceConfig(
-            'foo', 'bar', '',
-            {'bounce_method': 'baz'}, {'docker_image': 'gum'},
-        ))
-        expect = """MarathonServiceConfig('foo', 'bar', '', {'bounce_method': 'baz'}, """ \
-            """{'docker_image': 'gum'}, '/nail/etc/services')"""
-        assert actual == expect
-
     def test_get_healthcheck_mode_default(self):
         namespace_config = long_running_service_tools.ServiceNamespaceConfig({})
         marathon_config = marathon_tools.MarathonServiceConfig(

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -53,6 +53,7 @@ class TestTronActionConfig:
         action_config = tron_tools.TronActionConfig(
             service='my_service',
             instance=tron_tools.compose_instance('cool_job', 'print'),
+            cluster="fake-cluster",
             config_dict=action_dict,
             branch_dict={},
         )
@@ -66,6 +67,7 @@ class TestTronActionConfig:
         action_config = tron_tools.TronActionConfig(
             service='my_service',
             instance=tron_tools.compose_instance('my_job', 'sleep'),
+            cluster="fake-cluster",
             config_dict=action_dict,
             branch_dict={},
         )
@@ -75,15 +77,15 @@ class TestTronActionConfig:
         action_dict = {
             'name': 'do_something',
             'command': 'echo something',
-            'cluster': 'dev-oregon',
         }
         action_config = tron_tools.TronActionConfig(
             service='my_service',
             instance=tron_tools.compose_instance('my_job', 'do_something'),
+            cluster="fake-cluster",
             config_dict=action_dict,
             branch_dict={},
         )
-        assert action_config.get_cluster() == 'dev-oregon'
+        assert action_config.get_cluster() == 'fake-cluster'
 
     def test_get_executor_default(self):
         action_dict = {
@@ -93,6 +95,7 @@ class TestTronActionConfig:
         action_config = tron_tools.TronActionConfig(
             service='my_service',
             instance=tron_tools.compose_instance('my_job', 'do_something'),
+            cluster="fake-cluster",
             config_dict=action_dict,
             branch_dict={},
         )
@@ -107,6 +110,7 @@ class TestTronActionConfig:
         action_config = tron_tools.TronActionConfig(
             service='my_service',
             instance=tron_tools.compose_instance('my_job', 'do_something'),
+            cluster="fake-cluster",
             config_dict=action_dict,
             branch_dict={},
         )
@@ -158,11 +162,12 @@ class TestTronJobConfig:
             'deploy_group': job_deploy,
             'max_runtime': '2h',
             'actions': [action_dict],
+            'cluster': default_cluster,
         }
         soa_dir = '/other_dir'
         job_config = tron_tools.TronJobConfig(job_dict, soa_dir=soa_dir)
 
-        action_config = job_config._get_action_config(action_dict, default_cluster)
+        action_config = job_config._get_action_config(action_dict=action_dict, default_paasta_cluster=default_cluster)
 
         mock_load_deployments.assert_called_once_with(expected_service, soa_dir)
         mock_deployments_json = mock_load_deployments.return_value
@@ -178,15 +183,10 @@ class TestTronJobConfig:
         assert action_config == tron_tools.TronActionConfig(
             service=expected_service,
             instance=tron_tools.compose_instance('my_job', 'normal'),
-            config_dict={
-                'name': 'normal',
-                'command': 'echo first',
-                'cluster': expected_cluster,
-                'service': expected_service,
-                'deploy_group': expected_deploy,
-            },
+            config_dict=action_dict,
             branch_dict=expected_branch_dict,
             soa_dir=soa_dir,
+            cluster=expected_cluster,
         )
 
     @mock.patch('paasta_tools.tron_tools.load_v2_deployments_json', autospec=True)
@@ -245,11 +245,11 @@ class TestTronJobConfig:
         assert mock_load_deployments.call_count == 0
         assert action_config == tron_tools.TronActionConfig(
             service='my_service',
+            cluster=default_cluster,
             instance=tron_tools.compose_instance('my_job', 'normal'),
             config_dict={
                 'name': 'normal',
                 'command': 'echo first',
-                'cluster': default_cluster,
                 'service': 'my_service',
                 'deploy_group': 'prod',
             },
@@ -339,6 +339,8 @@ class TestTronJobConfig:
             'name': 'my_job',
             'node': 'batch_server',
             'schedule': 'daily 12:10:00',
+            'cluster': 'testcluster',
+            'service': 'testservice',
             'actions': [
                 {
                     'name': 'first',
@@ -442,6 +444,7 @@ class TestTronTools:
             instance=tron_tools.compose_instance('my_job', 'do_something'),
             config_dict=action_dict,
             branch_dict=branch_dict,
+            cluster="test-cluster",
         )
         result = tron_tools.format_tron_action_dict(action_config, '{cluster:s}.com')
         assert result == {
@@ -459,7 +462,6 @@ class TestTronTools:
             'requires': ['required_action'],
             'retries': 2,
             'retries_delay': '5m',
-            'cluster': 'paasta-dev',
             'service': 'my_service',
             'deploy_group': 'prod',
             'executor': 'paasta',
@@ -482,6 +484,7 @@ class TestTronTools:
             instance=tron_tools.compose_instance('my_job', 'do_something'),
             config_dict=action_dict,
             branch_dict=branch_dict,
+            cluster="test-cluster",
         )
 
         with mock.patch.object(
@@ -497,7 +500,7 @@ class TestTronTools:
             'requires': ['required_action'],
             'retries': 2,
             'retries_delay': '5m',
-            'mesos_address': 'paasta-dev.com',
+            'mesos_address': 'test-cluster.com',
             'docker_image': mock.ANY,
             'executor': 'mesos',
             'cpus': 2,
@@ -528,7 +531,6 @@ class TestTronTools:
             'command': 'echo something',
             'requires': ['required_action'],
             'retries': 2,
-            'cluster': 'paasta-dev',
             'service': 'my_service',
             'deploy_group': 'prod',
             'executor': 'paasta',
@@ -545,6 +547,7 @@ class TestTronTools:
             instance=tron_tools.compose_instance('my_job', 'do_something'),
             config_dict=action_dict,
             branch_dict=None,
+            cluster="paasta-dev",
         )
 
         result = tron_tools.format_tron_action_dict(action_config, '{cluster:s}.com')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -911,6 +911,13 @@ def test_sort_dcts(dcts, expected):
 
 class TestInstanceConfig:
 
+    def test_repr(self):
+        actual = repr(utils.InstanceConfig(
+            service='fakeservice', instance='fakeinstance', cluster='fakecluster', config_dict={}, branch_dict={},
+        ))
+        expect = "InstanceConfig('fakeservice', 'fakeinstance', 'fakecluster', {}, {}, '/nail/etc/services')"
+        assert actual == expect
+
     def test_get_monitoring(self):
         fake_info = {'fake_key': 'fake_value'}
         assert utils.InstanceConfig(


### PR DESCRIPTION
I think this is a change that we wanted anyway.

While working on `paasta local-run` for tron, I was chasing down there `None` was coming from when trying to pull docker images. In reaction to that, I added some "defensive" code to protect against `None` in our InstanceConfigs and unified the `__repr__` so Tron could use it.

While doing that though, I needed to get cluster in everywhere. This change allows us to set `cluster` at the Tron Job level instead of each action.

Note: I'm a little concerned that I don't fully understand the intent of the parameterized test on :186 on `test_tron_tools.py`.