### PR TITLE
Added a remote_run option to override dynamodb aws_region config

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -118,6 +118,12 @@ def add_common_args_to_parser(parser):
         default=False,
     )
     parser.add_argument(
+        '--aws-region',
+        choices=['us-east-1', 'us-west-1', 'us-west-2'],
+        help='aws region of the dynamodb state table',
+        default=None,
+    )
+    parser.add_argument(
         '-i', '--instance',
         help=(
             "Simulate a docker run for a particular instance of the "

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -242,6 +242,7 @@ def build_executor_stack(
     run_id,
     system_paasta_config,
     framework_staging_timeout,
+    region,
 ):
 
     cluster_fqdn = system_paasta_config.get_cluster_fqdn_format().format(cluster=cluster)
@@ -283,7 +284,8 @@ def build_executor_stack(
     else:
         raise ValueError("Required aws credentials")
 
-    region = taskproc_config.get('aws_region')
+    if not region:
+        region = taskproc_config.get('aws_region')
 
     endpoint = taskproc_config.get('dynamodb_endpoint')
     session = Session(
@@ -435,6 +437,7 @@ def remote_run_start(args):
             run_id=run_id,
             system_paasta_config=system_paasta_config,
             framework_staging_timeout=args.staging_timeout,
+            region=args.aws_region,
         )
         runner = Sync(executor_stack)
 


### PR DESCRIPTION
When tron runs a remote-run job on pnw-prod, the dynamodb name is taskproc-events-pnw-prod. However, the aws_region is us-west-1, which only has taskproc-events-norcal-prod.

An alternative fix is to infer aws region from paasta cluster name. For example, region will be us-west-2 if the paasta cluster is pnw-prod. Since the problem is only seen with tron (which is not an usual paasta remote-run configuration), I choose to add an option to override the incorrect aws_region config on tron servers. 

Tested on mesosstage (us-west-1) against pnw-devc (us-west-2) cluster.