### PR TITLE
For k8s deployments PUT not PATCH

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -691,7 +691,7 @@ def create_deployment(kube_client: KubeClient, formatted_deployment: V1Deploymen
 
 
 def update_deployment(kube_client: KubeClient, formatted_deployment: V1Deployment) -> None:
-    return kube_client.deployments.patch_namespaced_deployment(
+    return kube_client.deployments.replace_namespaced_deployment(
         name=formatted_deployment.metadata.name,
         namespace='paasta',
         body=formatted_deployment,

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -788,7 +788,7 @@ def test_create_deployment():
 def test_update_deployment():
     mock_client = mock.Mock()
     update_deployment(mock_client, V1Deployment(metadata=V1ObjectMeta(name='kurupt')))
-    mock_client.deployments.patch_namespaced_deployment.assert_called_with(
+    mock_client.deployments.replace_namespaced_deployment.assert_called_with(
         namespace='paasta',
         name='kurupt',
         body=V1Deployment(metadata=V1ObjectMeta(name='kurupt')),


### PR DESCRIPTION
It seems that doing a "replace" is better than an "update" since it
covers cases where your new deployment removes keys from the deployment.

It still seems to trigger a RollingUpdate or whatever strategy you have
defined rather than literally replacing the deployment object.