### PR TITLE
Set k8s deployment spec version

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -479,6 +479,8 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
         code_sha = get_code_sha_from_dockerurl(docker_url)
         complete_config = V1Deployment(
+            api_version='apps/v1',
+            kind='Deployment',
             metadata=V1ObjectMeta(
                 name="{service}-{instance}".format(
                     service=self.get_sanitised_service_name(),

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -493,6 +493,8 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                 force_bounce=mock_get_force_bounce.return_value,
             )
             expected = V1Deployment(
+                api_version='apps/v1',
+                kind='Deployment',
                 metadata=V1ObjectMeta(
                     labels={
                         'config_sha': mock_get_config_hash.return_value,


### PR DESCRIPTION
You can omit but k8s then chooses the latest version which seems to be a
beta spec. So I think we ought to hard code the version of the schema
here.