### PR TITLE
Move list_teams to monitoring_tools

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -30,13 +30,13 @@ from paasta_tools.cli.utils import get_instance_configs_for_service
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import list_services
-from paasta_tools.cli.utils import list_teams
 from paasta_tools.marathon_serviceinit import bouncing_status_human
 from paasta_tools.marathon_serviceinit import desired_state_human
 from paasta_tools.marathon_serviceinit import marathon_app_deploy_status_human
 from paasta_tools.marathon_serviceinit import status_marathon_job_human
 from paasta_tools.marathon_tools import MarathonDeployStatus
 from paasta_tools.monitoring_tools import get_team
+from paasta_tools.monitoring_tools import list_teams
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_soa_cluster_deploy_files
 from paasta_tools.utils import list_all_instances_for_service

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -36,7 +36,6 @@ from paasta_tools.api import client
 from paasta_tools.chronos_tools import load_chronos_job_config
 from paasta_tools.kubernetes_tools import load_kubernetes_service_config
 from paasta_tools.marathon_tools import load_marathon_service_config
-from paasta_tools.monitoring_tools import _load_sensu_team_data
 from paasta_tools.utils import _run
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -384,15 +383,6 @@ def list_instances(**kwargs):
             for instance in list_all_instances_for_service(service):
                 all_instances.add(instance)
     return sorted(all_instances)
-
-
-def list_teams(**kwargs):
-    """Loads team data from the system. Returns a set of team names (or empty
-    set).
-    """
-    team_data = _load_sensu_team_data()
-    teams = set(team_data.get('team_data', {}).keys())
-    return teams
 
 
 def calculate_remote_masters(cluster, system_paasta_config):

--- a/paasta_tools/monitoring_tools.py
+++ b/paasta_tools/monitoring_tools.py
@@ -226,3 +226,12 @@ def read_monitoring_config(service, soa_dir=DEFAULT_SOA_DIR):
     monitoring_file = os.path.join(rootdir, service, "monitoring.yaml")
     monitor_conf = service_configuration_lib.read_monitoring(monitoring_file)
     return monitor_conf
+
+
+def list_teams(**kwargs):
+    """Loads team data from the system. Returns a set of team names (or empty
+    set).
+    """
+    team_data = _load_sensu_team_data()
+    teams = set(team_data.get('team_data', {}).keys())
+    return teams

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -35,7 +35,7 @@ from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import paasta_print
 
-from paasta_tools.cli.utils import list_teams
+from paasta_tools.monitoring_tools import list_teams
 
 MASTER_NAMESPACE = 'MASTER'
 SPACER = '.'

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -513,35 +513,6 @@ def test_list_instances_no_service(
     assert actual == expected
 
 
-def test_list_teams():
-    fake_team_data = {
-        'team_data': {
-            'red_jaguars': {
-                'pagerduty_api_key': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-                'pages_slack_channel': 'red_jaguars_pages',
-                'notifications_slack_channel': 'red_jaguars_notifications',
-                'notification_email': 'red_jaguars+alert@yelp.com',
-                'project': 'REDJAGS',
-            },
-            'blue_barracudas': {
-                'pagerduty_api_key': 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-                'pages_slack_channel': 'blue_barracudas_pages',
-            },
-        },
-    }
-    expected = {
-        'red_jaguars',
-        'blue_barracudas',
-    }
-    with mock.patch(
-        'paasta_tools.cli.utils._load_sensu_team_data',
-        autospec=True,
-        return_value=fake_team_data,
-    ):
-        actual = utils.list_teams()
-    assert actual == expected
-
-
 def test_lazy_choices_completer():
     completer = utils.lazy_choices_completer(lambda: ['1', '2', '3'])
     assert completer(prefix='') == ['1', '2', '3']

--- a/tests/test_monitoring_tools.py
+++ b/tests/test_monitoring_tools.py
@@ -494,3 +494,32 @@ class TestMonitoring_Tools:
             abspath_patch.assert_called_once_with(fake_soa_dir)
             join_patch.assert_called_once_with(fake_path, fake_name, 'monitoring.yaml')
             read_monitoring_patch.assert_called_once_with(fake_fname)
+
+
+def test_list_teams():
+    fake_team_data = {
+        'team_data': {
+            'red_jaguars': {
+                'pagerduty_api_key': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                'pages_slack_channel': 'red_jaguars_pages',
+                'notifications_slack_channel': 'red_jaguars_notifications',
+                'notification_email': 'red_jaguars+alert@yelp.com',
+                'project': 'REDJAGS',
+            },
+            'blue_barracudas': {
+                'pagerduty_api_key': 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+                'pages_slack_channel': 'blue_barracudas_pages',
+            },
+        },
+    }
+    expected = {
+        'red_jaguars',
+        'blue_barracudas',
+    }
+    with mock.patch(
+        'paasta_tools.monitoring_tools._load_sensu_team_data',
+        autospec=True,
+        return_value=fake_team_data,
+    ):
+        actual = monitoring_tools.list_teams()
+    assert actual == expected


### PR DESCRIPTION
This is a small refactor I need in order to allow paasta local-run to work with tron without circular imports.