### PR TITLE
Removed EOF message from paasta status output.

### DIFF
--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -393,7 +393,6 @@ async def format_stdstreams_tail_for_task(task, get_short_task_id, nlines=10):
             # reverse the tail, so that EOF is at the bottom again
             if tail:
                 output.extend(tail[::-1])
-            output.append(PaastaColors.blue("      %s EOF" % fobj.path))
     except (
         mesos_exceptions.MasterNotAvailableException,
         mesos_exceptions.SlaveDoesNotExist,

--- a/tests/test_mesos_tools.py
+++ b/tests/test_mesos_tools.py
@@ -582,7 +582,6 @@ async def test_format_stdstreams_tail_for_task(
             for f in files:
                 output.append(PaastaColors.blue("      {} tail for {}".format(f[0], task_id)))
                 output.extend(f[1][-nlines:])
-                output.append(PaastaColors.blue("      %s EOF" % f[0]))
         else:
             if raise_what == utils.TimeoutError:
                 raise_what = 'timeout'


### PR DESCRIPTION
paasta staus -vv is already pretty verbose, I don't think we need this.