### PR TITLE
Update check_registered_slaves_aws.py ignore recently created asgs and sfrs

### DIFF
--- a/paasta_tools/contrib/check_registered_slaves_aws.py
+++ b/paasta_tools/contrib/check_registered_slaves_aws.py
@@ -4,7 +4,6 @@ import sys
 
 from a_sync import block
 
-from paasta_tools.autoscaling.autoscaling_cluster_lib import CHECK_REGISTERED_SLAVE_THRESHOLD
 from paasta_tools.autoscaling.autoscaling_cluster_lib import get_scaler
 from paasta_tools.mesos.exceptions import MasterNotAvailableException
 from paasta_tools.mesos_tools import get_mesos_master
@@ -18,7 +17,8 @@ def check_registration(threshold_percentage):
         print("Could not find Mesos Master: %s" % e.message)
         sys.exit(1)
 
-    autoscaling_resources = load_system_paasta_config().get_cluster_autoscaling_resources()
+    config = load_system_paasta_config()
+    autoscaling_resources = config.get_cluster_autoscaling_resources()
     for resource in autoscaling_resources.values():
         print("Checking %s" % resource['id'])
         try:
@@ -39,8 +39,9 @@ def check_registration(threshold_percentage):
             continue
         elif scaler.is_new_autoscaling_resource():
             # See OPS-13784
+            threshold = config.get_monitoring_config().get('check_registered_slave_threshold')
             print(
-                f"Autoscaling resource was created within last {CHECK_REGISTERED_SLAVE_THRESHOLD}"
+                f"Autoscaling resource was created within last {threshold}"
                 " seconds and would probably fail this check",
             )
             continue


### PR DESCRIPTION
See OPS-13784 for details.

## Todo
- [x] Build a deb and deploy to stagef/g and verified I did not introduce any regressions with the script https://fluffy.yelpcorp.com/i/QZDhq9XbSL4jZ11z724GhVbwNDC2Rv97.html.  Works as long as I update /etc/paasta/monitoring.json with a check_registered_slave_threshold key.
- [x] Verified that `aws autoscaling describe-auto-scaling-groups --group-name` gives me output unit tests expect https://fluffy.yelpcorp.com/i/Xb526BdnKq03q5TRGlfv40Sd5bCVT6Cm.html
- [x] Verified that  `aws ec2 describe-spot-fleet-requests` gives me the output my unit tests expect  https://fluffy.yelpcorp.com/i/GHnrsHK3n3DjxcNFcPJ4zvKB27Tp4QLn.html. 



I noticed that check_registered_slaves_aws.py looks at /etc/paasta/cluster_autoscaling/{s3_bucket}/{cluster}.json files.  However, I was unable to find any spot fleets in any of those files.  Is that intended?

Unfortunately I can't prove this fixes OPS-13784 unless it stays on stage for a while.  My original plan for testing was going to be build a deb manually, install it on the hosts I care, and disable puppet.  However, cep1070 is going to explicitly ignore hosts with puppet disabled.  I could put my manually built package on the apt repo so that I can install it through puppet but would rather have a jenkins job do that for me rather than me copying the deb.