### PR TITLE
Added dry-run support to paasta_setup_tron_namespace

### DIFF
--- a/general_itests/fake_soa_configs_tron/fake_simple_service/tron-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_tron/fake_simple_service/tron-test-cluster.yaml
@@ -1,0 +1,7 @@
+jobs:
+- name: sample_tron_job
+  actions:
+    - name: action1
+      command: exit 42
+    - name: action2
+      command: /bin/true

--- a/general_itests/fake_soa_configs_tron/tron/test-cluster/MASTER.yaml
+++ b/general_itests/fake_soa_configs_tron/tron/test-cluster/MASTER.yaml
@@ -1,0 +1,17 @@
+---
+ssh_options:
+    agent: false
+    connect_timeout: 60
+
+notification_options:
+    smtp_host: localhost
+
+jobs:
+  -   name: "masterjob"
+      node: "pool"
+      schedule: "7th of month at 11:00"
+      actions:
+          -   name: "master_action1"
+              command:  '/bin/true'
+          -   name: 'master_action2'
+              command: '/bin/true'

--- a/general_itests/local_run.feature
+++ b/general_itests/local_run.feature
@@ -4,23 +4,23 @@ Feature: paasta local-run can be used
     Given Docker is available
       And a simple service to test
      When we run paasta local-run on a Marathon service in non-interactive mode with environment variable "FOO" set to "BAR"
-     Then we should see the expected return code
+     Then it should have a return code of "42"
       And we should see the environment variable "FOO" with the value "BAR" in the output
 
   Scenario: Running paasta local-run in non-interactive mode on a Chronos job
     Given Docker is available
       And a simple service to test
      When we run paasta local-run in non-interactive mode on a chronos job
-     Then we should see the expected return code
+     Then it should have a return code of "42"
 
   Scenario: Running paasta local-run in non-interactive mode on a Chronos job with a complex command
     Given Docker is available
       And a simple service to test
      When we run paasta local-run in non-interactive mode on a chronos job with cmd set to 'echo hello && sleep 5'
-     Then we should see the expected return code
+     Then it should have a return code of "42"
 
   Scenario: Running paasta local-run against an adhoc job
      Given Docker is available
        And a simple service to test
       When we run paasta local-run on an interactive job
-      Then we should see the expected return code
+     Then it should have a return code of "42"

--- a/general_itests/steps/local_run_steps.py
+++ b/general_itests/steps/local_run_steps.py
@@ -19,7 +19,6 @@ from behave import when
 from path import Path
 
 from paasta_tools.utils import _run
-from paasta_tools.utils import paasta_print
 
 
 @given('a simple service to test')
@@ -48,19 +47,12 @@ def non_interactive_local_run(context, var, val):
                         "--instance main "
                         "--build "
                         '''--cmd '/bin/sh -c "echo \\"%s=$%s\\" && sleep 2s && exit 42"' ''' % (var, var))
-        context.local_run_return_code, context.local_run_output = _run(command=localrun_cmd, timeout=90)
-
-
-@then('we should see the expected return code')
-def see_expected_return_code(context):
-    paasta_print(context.local_run_output)
-    paasta_print(context.local_run_return_code)
-    assert context.local_run_return_code == 42
+        context.return_code, context.output = _run(command=localrun_cmd, timeout=90)
 
 
 @then('we should see the environment variable "{var}" with the value "{val}" in the output')
 def env_var_in_output(context, var, val):
-    assert f"{var}={val}" in context.local_run_output
+    assert f"{var}={val}" in context.output
 
 
 @when('we run paasta local-run in non-interactive mode on a chronos job')
@@ -81,7 +73,7 @@ def local_run_on_chronos_job(context):
             "--build "
             "--cmd '/bin/sh -c \"sleep 2s && exit 42\"'"
         )
-        context.local_run_return_code, context.local_run_output = _run(command=local_run_cmd, timeout=90)
+        context.return_code, context.output = _run(command=local_run_cmd, timeout=90)
 
 
 @when('we run paasta local-run on an interactive job')
@@ -95,7 +87,7 @@ def local_run_on_adhoc_job(context):
             "--instance sample_adhoc_job "
             "--build "
         )
-        context.local_run_return_code, context.local_run_output = _run(command=local_run_cmd, timeout=90)
+        context.return_code, context.output = _run(command=local_run_cmd, timeout=90)
 
 
 @when('we run paasta local-run in non-interactive mode on a chronos job with cmd set to \'echo hello && sleep 5\'')
@@ -109,4 +101,4 @@ def local_run_on_chronos_job_with_cmd(context):
             "--instance chronos_job_with_cmd "
             "--build "
         )
-        context.local_run_return_code, context.local_run_output = _run(command=local_run_cmd, timeout=90)
+        context.return_code, context.output = _run(command=local_run_cmd, timeout=90)

--- a/general_itests/steps/shared_steps.py
+++ b/general_itests/steps/shared_steps.py
@@ -1,0 +1,30 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from behave import then
+
+from paasta_tools.utils import paasta_print
+
+
+@then('it should have a return code of "{code:d}"')
+def see_expected_return_code(context, code):
+    paasta_print(context.output)
+    paasta_print(context.return_code)
+    paasta_print()
+    assert context.return_code == code
+
+
+@then('the output should contain "{output_string}"')
+def output_contains(context, output_string):
+    paasta_print(output_string)
+    assert output_string in context.output

--- a/general_itests/steps/tron_steps.py
+++ b/general_itests/steps/tron_steps.py
@@ -1,0 +1,31 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from behave import given
+from behave import when
+
+from paasta_tools.utils import _run
+
+
+@given('some tronfig')
+def step_some_tronfig(context):
+    context.soa_dir = 'fake_soa_configs_tron'
+
+
+@when('we run paasta_setup_tron_namespace in dry-run mode')
+def step_run_paasta_setup_tron_namespace_dry_run(context):
+    cmd = (
+        f"paasta_setup_tron_namespace --dry-run -a --soa-dir {context.soa_dir}"
+        f" --tron-cluster test-cluster --default-paasta-cluster test-cluster"
+    )
+    context.return_code, context.output = _run(command=cmd)

--- a/general_itests/steps/validate_steps.py
+++ b/general_itests/steps/validate_steps.py
@@ -32,28 +32,22 @@ def run_paasta_validate(context):
     validate_cmd = ("paasta validate "
                     "--yelpsoa-config-root %s "
                     "--service %s " % (context.soa_dir, context.service))
-    context.validate_return_code, context.validate_output = _run(command=validate_cmd)
+    context.return_code, context.output = _run(command=validate_cmd)
 
 
 @then('it should have a return code of "{code:d}"')
 def see_expected_return_code(context, code):
-    paasta_print(context.validate_output)
-    paasta_print(context.validate_return_code)
+    paasta_print(context.output)
+    paasta_print(context.return_code)
     paasta_print()
-    assert context.validate_return_code == code
+    assert context.return_code == code
 
 
 @then('everything should pass')
 def validate_status_all_pass(context):
-    assert not context.validate_output or x_mark() not in context.validate_output
+    assert not context.output or x_mark() not in context.output
 
 
 @then('it should report an error in the output')
 def validate_status_something_fail(context):
-    assert x_mark() in context.validate_output
-
-
-@then('the output should contain \'{output_string}\'')
-def output_contains(context, output_string):
-    paasta_print(output_string)
-    assert output_string in context.validate_output
+    assert x_mark() in context.output

--- a/general_itests/tron_integration.feature
+++ b/general_itests/tron_integration.feature
@@ -1,0 +1,7 @@
+Feature: paasta tools can transmogrify tronfigs
+
+  Scenario: paasta_setup_tron_namespace works
+    Given some tronfig
+    When we run paasta_setup_tron_namespace in dry-run mode
+    Then it should have a return code of "0"
+     And the output should contain "['fake_simple_service'], failed: [], skipped: 0"

--- a/general_itests/validate.feature
+++ b/general_itests/validate.feature
@@ -5,11 +5,11 @@ Feature: paasta validate can be used
     When we run paasta validate
     Then it should have a return code of "0"
      And everything should pass
-     And the output should contain 'has a valid instance'
+     And the output should contain "has a valid instance"
 
   Scenario: Running paasta validate against an invalid service
     Given an "invalid" service
     When we run paasta validate
     Then it should have a return code of "1"
      And it should report an error in the output
-     And the output should contain 'The specified epsilon value "foo" does not conform to the ISO8601 format'
+     And the output should contain "The specified epsilon value "foo" does not conform to the ISO8601 format"

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -447,14 +447,13 @@ def load_tron_service_config(service, tron_cluster, load_deployments=True, soa_d
     return job_configs, extra_config
 
 
-def create_complete_config(service, soa_dir=DEFAULT_SOA_DIR):
+def create_complete_config(service, tron_cluster, default_paasta_cluster, soa_dir=DEFAULT_SOA_DIR):
     """Generate a namespace configuration file for Tron, for a service."""
     system_paasta_config = load_system_paasta_config()
-    tron_config = load_tron_config()
 
     job_configs, other_config = load_tron_service_config(
         service=service,
-        tron_cluster=tron_config.get_cluster_name(),
+        tron_cluster=tron_cluster,
         load_deployments=True,
         soa_dir=soa_dir,
     )
@@ -470,7 +469,7 @@ def create_complete_config(service, soa_dir=DEFAULT_SOA_DIR):
         format_tron_job_dict(
             job_config=job_config,
             cluster_fqdn_format=system_paasta_config.get_cluster_fqdn_format(),
-            default_paasta_cluster=tron_config.get_default_paasta_cluster(),
+            default_paasta_cluster=default_paasta_cluster,
         ) for job_config in job_configs
     ]
 

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -778,13 +778,20 @@ class TestTronTools:
             other_config,
         )
         soa_dir = '/testing/services'
+        tron_cluster = 'fake-cluster'
+        default_paasta_cluster = 'test-paasta-cluster'
 
-        assert tron_tools.create_complete_config(service, soa_dir) == mock_yaml_dump.return_value
+        assert tron_tools.create_complete_config(
+            service=service,
+            tron_cluster=tron_cluster,
+            default_paasta_cluster=default_paasta_cluster,
+            soa_dir=soa_dir,
+        ) == mock_yaml_dump.return_value
         mock_tron_service_config.assert_called_once_with(
-            service,
-            mock_tron_system_config.return_value.get_cluster_name.return_value,
-            True,
-            soa_dir,
+            service=service,
+            tron_cluster=tron_cluster,
+            load_deployments=True,
+            soa_dir=soa_dir,
         )
         if service == MASTER_NAMESPACE:
             mock_format_master_config.assert_called_once_with(
@@ -797,7 +804,7 @@ class TestTronTools:
         mock_format_job.assert_called_once_with(
             job_config,
             mock_system_config.return_value.get_cluster_fqdn_format.return_value,
-            mock_tron_system_config.return_value.get_default_paasta_cluster.return_value,
+            default_paasta_cluster,
         )
         complete_config = other_config.copy()
         complete_config.update({


### PR DESCRIPTION
Sorry this is so large. I kinda need both of these changes in place to be able to run `paasta_setup_tron_namespace` in itest mode.

Specifically:
1. I inject more things into `create_complete_config` instead of it loading more stuff. It still loads some things, but in general I think we should inject more and "tell don't ask"
2. I do more `cluster` => `tron_cluster` versus `default_paasta_cluster` stuff. I kinda which I did this change first before I did local-run, because I understand the nuances better.
3. Dry'd out the behave stuff a bit
4. Added the behave test to run this thing on fake soa-configs

I can split this up if you want, just say the word. Also I can postpone on the `tron_cluster` stuff if we think we are going to change that concept.