### PR TITLE
Always deploy tron namespaces in a sorted order

### DIFF
--- a/paasta_tools/setup_tron_namespace.py
+++ b/paasta_tools/setup_tron_namespace.py
@@ -93,7 +93,7 @@ def main():
     failed = []
     skipped = []
 
-    for service in services:
+    for service in sorted(services):
         try:
             new_config = tron_tools.create_complete_config(
                 service=service,


### PR DESCRIPTION
It makes it just a little easier to debug when it is predictable and consistent