### PR TITLE
Add paasta deploy events using yelp_meteorite.

### DIFF
--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -408,7 +408,7 @@ def do_bounce(
                         'cluster': cluster,
                         'instance': instance,
                         'service': service,
-                    }
+                    },
                 )
         return None
 

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -401,13 +401,12 @@ def do_bounce(
             )
 
             if yelp_meteorite:
-                # Emit deploy.paasta event
                 yelp_meteorite.events.emit_event(
                     'deploy.paasta',
                     dimensions={
-                        'cluster': cluster,
-                        'instance': instance,
-                        'service': service,
+                        'paasta_cluster': cluster,
+                        'paasta_instance': instance,
+                        'paasta_service': service,
                     },
                 )
         return None

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -87,6 +87,13 @@ from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import SPACER
 from paasta_tools.utils import SystemPaastaConfig
+try:
+    import yelp_meteorite
+except ImportError:
+    # Sorry to any non-yelpers but you won't
+    # get metrics emitted as our metrics lib
+    # is currently not open source
+    yelp_meteorite = None
 
 # Marathon REST API:
 # https://github.com/mesosphere/marathon/blob/master/REST.md#post-v2apps
@@ -392,6 +399,17 @@ def do_bounce(
                 ),
                 level='event',
             )
+
+            if yelp_meteorite:
+                # Emit deploy.paasta event
+                yelp_meteorite.events.emit_event(
+                    'deploy.paasta',
+                    dimensions={
+                        'cluster': cluster,
+                        'instance': instance,
+                        'service': service,
+                    }
+                )
         return None
 
 

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -642,7 +642,9 @@ class TestSetupMarathonJob:
             'paasta_tools.setup_marathon_job.bounce_lib.create_marathon_app', autospec=True,
         ) as mock_create_marathon_app, mock.patch(
             'paasta_tools.setup_marathon_job.bounce_lib.kill_old_ids', autospec=True,
-        ) as mock_kill_old_ids:
+        ) as mock_kill_old_ids, mock.patch(
+            'paasta_tools.setup_marathon_job.yelp_meteorite', autospec=True,
+        ) as mock_meteorite:
             setup_marathon_job.do_bounce(
                 bounce_func=fake_bounce_func,
                 drain_method=fake_drain_method,
@@ -677,6 +679,7 @@ class TestSetupMarathonJob:
             third_logged_line = mock_log.mock_calls[2][2]["line"]
             assert f'{fake_bounce_method} bounce on {fake_serviceinstance} finish' in third_logged_line
             assert 'Now running %s' % fake_marathon_jobid in third_logged_line
+            assert mock_meteorite.events.emit_event.call_count == 1
 
     def test_do_bounce_when_nothing_to_do(self):
         fake_bounce_func_return: bounce_lib.BounceMethodResult = {


### PR DESCRIPTION
**Summary**
This mimics the internal functionality for event_detector which was
recently decommissioned. Emits an event name-spaced `deploy.paasta`
and along with this sends cluster, instance and service as a dimension.
Open to instrument more dimensions if need be.