### PR TITLE
Add support for StatefulSets

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -182,6 +182,11 @@ class AwsEbsVolume(VolumeWithMode):
     container_path: str
 
 
+class PersistentVolume(VolumeWithMode):
+    size: int
+    container_path: str
+
+
 InstanceConfigDict = TypedDict(
     'InstanceConfigDict',
     {
@@ -201,6 +206,7 @@ InstanceConfigDict = TypedDict(
         'deploy_whitelist': UnsafeDeployWhitelist,
         'monitoring_blacklist': UnsafeDeployBlacklist,
         'pool': str,
+        'persistent_volumes': List[PersistentVolume],
         'role': str,
         'extra_volumes': List[DockerVolume],
         'aws_ebs_volumes': List[AwsEbsVolume],
@@ -715,6 +721,9 @@ class InstanceConfig(object):
         volumes = list(system_volumes) + list(self.get_extra_volumes())
         deduped = {v['containerPath'].rstrip('/') + v['hostPath'].rstrip('/'): v for v in volumes}.values()
         return sort_dicts(deduped)
+
+    def get_persistent_volumes(self) -> List[PersistentVolume]:
+        return self.config_dict.get('persistent_volumes', [])
 
     def get_dependencies_reference(self) -> Optional[str]:
         """Get the reference to an entry in dependencies.yaml


### PR DESCRIPTION
This gives the k8s logic the ability to manage StatefulSets. We manage
them the same way as Deployments. The distinguishing factor is that they
support dynamic EBS volumes that follow the Pods. The new yelpsoa syntax
looks like:
```
persistent_volumes:
  - container_path: /mnt/whatever
    size: 10
    mode: RW
```

Note this is deliberately a bit MVP. The StorageClass has to be created
by hand and we don't enforce constraints on AZ yet so you must be
careful to create everything in 1 AZ.