### PR TITLE
Enable/Disable types of Slack notifications

### DIFF
--- a/paasta_tools/list_marathon_service_instances.py
+++ b/paasta_tools/list_marathon_service_instances.py
@@ -97,7 +97,7 @@ def get_desired_marathon_configs(soa_dir):
                 service=service,
                 line=str(errormsg),
                 component='deploy',
-                level='event',
+                level='debug',
                 cluster=cluster,
                 instance=instance,
             )

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -207,7 +207,7 @@ def test_slack_deploy_notifier(mock_get_authors, mock_client):
     assert sdn.notify_after_good_deploy() is None
     assert sdn.notify_after_auto_rollback() is None
     assert sdn.notify_after_abort() is None
-    assert fake_psc.post.call_count >= 0, fake_psc.post.call_args
+    assert fake_psc.post.call_count > 0, fake_psc.post.call_args
     assert sdn.get_authors_to_be_notified() == "Pinging authors: <@fakeuser1>, <@fakeuser2>"
     assert "Jenkins" or "Run by" in sdn.get_url_message()
 
@@ -256,6 +256,76 @@ def test_slack_deploy_notifier_doesnt_notify_on_same_commit(mock_get_authors, mo
         deploy_group='test_deploy_group',
         commit='samecommit',
         old_commit='samecommit',
+        git_url="foo",
+    )
+    assert sdn.notify_after_mark(ret=1) is None
+    assert sdn.notify_after_mark(ret=0) is None
+    assert sdn.notify_after_good_deploy() is None
+    assert sdn.notify_after_auto_rollback() is None
+    assert sdn.notify_after_abort() is None
+    assert fake_psc.post.call_count == 0, fake_psc.post.call_args
+    assert sdn.get_authors_to_be_notified() == "Pinging authors: <@fakeuser1>, <@fakeuser2>"
+
+
+@patch('paasta_tools.cli.cmds.mark_for_deployment.get_slack_client', autospec=True)
+@patch('paasta_tools.remote_git.get_authors', autospec=True)
+def test_slack_deploy_notifier_notifies_on_deploy_info_flags(mock_get_authors, mock_client):
+    fake_psc = mock.create_autospec(PaastaSlackClient)
+    mock_client.return_value = fake_psc
+    mock_get_authors.return_value = 0, "fakeuser1 fakeuser2"
+    sdn = mark_for_deployment.SlackDeployNotifier(
+        service='testservice',
+        deploy_info={
+            'pipeline':
+            [
+                {
+                    'step': 'test_deploy_group',
+                    'notify_after_mark': True,
+                    'notify_after_good_deploy': True,
+                    'notify_after_auto_rollback': True,
+                    'notify_after_abort': True,
+                },
+            ],
+        },
+        deploy_group='test_deploy_group',
+        commit='newcommit',
+        old_commit='oldcommit',
+        git_url="foo",
+    )
+    assert sdn.notify_after_mark(ret=1) is None
+    assert sdn.notify_after_mark(ret=0) is None
+    assert sdn.notify_after_good_deploy() is None
+    assert sdn.notify_after_auto_rollback() is None
+    assert sdn.notify_after_abort() is None
+    assert fake_psc.post.call_count > 0, fake_psc.post.call_args
+    assert sdn.get_authors_to_be_notified() == "Pinging authors: <@fakeuser1>, <@fakeuser2>"
+    assert "Jenkins" or "Run by" in sdn.get_url_message()
+
+
+@patch('paasta_tools.cli.cmds.mark_for_deployment.get_slack_client', autospec=True)
+@patch('paasta_tools.remote_git.get_authors', autospec=True)
+def test_slack_deploy_notifier_doesnt_notify_on_deploy_info_flags(mock_get_authors, mock_client):
+    fake_psc = mock.create_autospec(PaastaSlackClient)
+    mock_client.return_value = fake_psc
+    mock_get_authors.return_value = 0, "fakeuser1 fakeuser2"
+    sdn = mark_for_deployment.SlackDeployNotifier(
+        service='testservice',
+        deploy_info={
+            'pipeline':
+            [
+                {
+                    'step': 'test_deploy_group',
+                    'slack_notify': True,
+                    'notify_after_mark': False,
+                    'notify_after_good_deploy': False,
+                    'notify_after_auto_rollback': False,
+                    'notify_after_abort': False,
+                },
+            ],
+        },
+        deploy_group='test_deploy_group',
+        commit='newcommit',
+        old_commit='oldcommit',
         git_url="foo",
     )
     assert sdn.notify_after_mark(ret=1) is None

--- a/tests/test_list_marathon_service_instances.py
+++ b/tests/test_list_marathon_service_instances.py
@@ -209,5 +209,3 @@ def test_exceptions_logged_with_debug():
             cluster=mock.ANY,
             instance='broken_instance',
         )
-	    
-


### PR DESCRIPTION
https://jira.yelpcorp.com/browse/PAASTA-14607

Can specify the following types in a deploy.yaml file:
- notify_after_mark
- notify_after_good_deploy
- notify_after_auto_rollback
- notify_after_abort