### PR TITLE
Make Slack notifications more concise

### DIFF
--- a/paasta_tools/slack.py
+++ b/paasta_tools/slack.py
@@ -29,7 +29,8 @@ class PaastaSlackClient(SlackClient):
             self.sc = SlackClient(token)
         self.token = token
 
-    def post(self, channels, message):
+    def post(self, channels, message, *, thread_ts=None):
+        responses = []
         if self.token is not None:
             for channel in channels:
                 log.info(f"Slack notification [{channel}]: {message}")
@@ -37,11 +38,14 @@ class PaastaSlackClient(SlackClient):
                     "chat.postMessage",
                     channel=channel,
                     text=message,
+                    thread_ts=thread_ts,
                 )
                 if response["ok"] is not True:
                     log.error("Posting to slack failed: {}".format(response["error"]))
+                responses.append(response)
         else:
             log.info(f"(not sent to Slack) {channels}: {message}")
+        return responses
 
 
 def get_slack_client():

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -21,13 +21,17 @@ from paasta_tools.slack import PaastaSlackClient
 @mock.patch('slackclient.SlackClient', autospec=True)
 def test_slack_client_doesnt_post_with_no_token(mock_SlackClient):
     psc = PaastaSlackClient(token=None)
-    assert psc.post(channels=["foo"], message="bar") is None
+    assert psc.post(channels=["foo"], message="bar") == []
     assert mock_SlackClient.api_call.call_count == 0
 
 
 def test_slack_client_posts_to_multiple_channels():
     fake_sc = mock.create_autospec(SlackClient)
+    fake_sc.api_call.side_effect = ({'ok': True}, {'ok': False, 'error': 'blah'})
     with mock.patch('paasta_tools.slack.SlackClient', autospec=True, return_value=fake_sc):
         psc = PaastaSlackClient(token='fake_token')
-        assert psc.post(channels=["1", "2"], message="bar") is None
+        assert psc.post(channels=["1", "2"], message="bar") == [
+            {'ok': True},
+            {'ok': False, 'error': 'blah'},
+        ]
         assert fake_sc.api_call.call_count == 2, fake_sc.call_args


### PR DESCRIPTION
The new Slack notifications are great at providing tons of information, but they can be pretty noisy as the typical notification takes up between 5 and 9 lines of chat (plus another 5-8 lines in many cases, when we have a mark-for-deployment followed immediately by a successful deployment notification):

![](https://i.fluffy.cc/6HCbCMVzVxPMl2dV98dfq8JlWnf4h9wx.png)

I was thinking we could use Slack attachments or something to hide most of this information away in a collapsible summary, but I was surprised to not be able to find any way to do this.

Instead, what if we had a one-line summary in the main channel, and posted all the additional details in a thread followup? Here's how those same two messages look with this change:

![](https://i.fluffy.cc/vvXJBHWHRfG6t6VGbB2pNQ2Qvz14nW0B.png)

Clicking to expand the thread has the rest of the information:

![](https://i.fluffy.cc/nb3dJPJCvrzq0wW9nFtxL6jlMpqbrnj6.png)

I haven't updated tests or anything yet, mostly just looking for feedback on the message format. Is this an improvement? Is there a better solution?