### PR TITLE
Make filter_tasks_in_smartstack need a task to be up on more than one box to consider it healthy.

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -196,7 +196,7 @@ instance MAY have:
 
   * ``bounce_method``: Controls the bounce method; see `bounce_lib <generated/paasta_tools.bounce_lib.html>`_
 
-  * ``bounce_method_params``: A dictionary of parameters for the specified bounce_method.
+  * ``bounce_health_params``: A dictionary of parameters for get_happy_tasks.
 
     * ``check_haproxy``: Boolean indicating if PaaSTA should check the local
       haproxy to make sure this task has been registered and discovered
@@ -204,6 +204,10 @@ instance MAY have:
 
     * ``min_task_uptime``: Minimum number of seconds that a task must be
       running before we consider it healthy (Disabled by default)
+
+    * ``haproxy_min_fraction_up``: if ``check_haproxy`` is True, we check haproxy on up to 20 boxes to see whether a task is available.
+      This fraction of boxes must agree that the task is up for the bounce to treat a task as healthy.
+      Defaults to 1.0 -- haproxy on all queried boxes must agree that the task is up.
 
   * ``bounce_margin_factor``: proportionally increase the number of old instances
     to be drained when the crossover bounce method is used.

--- a/mypy.ini
+++ b/mypy.ini
@@ -63,3 +63,6 @@ disallow_untyped_defs = True
 
 [mypy-paasta_tools.drain_lib]
 disallow_untyped_defs = True
+
+[mypy-paasta_tools.smartstack_tools]
+disallow_untyped_defs = True

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -122,6 +122,13 @@
                         },
                         "min_task_uptime": {
                             "type": "number"
+                        },
+                        "haproxy_min_fraction_up": {
+                            "type": "number",
+                            "minimum": 0.0,
+                            "maximum": 1.0,
+                            "exclusiveMinimum": false,
+                            "exclusiveMaximum": false
                         }
                     }
                 },

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -113,7 +113,7 @@
                 "bounce_method": {
                     "type": "string"
                 },
-                "bounce_method_params": {
+                "bounce_health_params": {
                     "type": "object",
                     "properties": {
                         "check_haproxy": {
@@ -127,17 +127,8 @@
                             "type": "number",
                             "minimum": 0.0,
                             "maximum": 1.0,
-                            "exclusiveMinimum": false,
+                            "exclusiveMinimum": true,
                             "exclusiveMaximum": false
-                        }
-                    }
-                },
-                "bounce_health_params": {
-                    "type": "object",
-                    "properties": {
-                        "check_haproxy": {
-                            "type": "boolean",
-                            "default": true
                         }
                     }
                 },

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -236,7 +236,7 @@ def do_bounce(
     drain_method: drain_lib.DrainMethod,
     config: marathon_tools.FormattedMarathonAppDict,
     new_app_running: bool,
-    happy_new_tasks: List[Tuple[MarathonTask, MarathonClient]],
+    happy_new_tasks: List[MarathonTask],
     old_app_live_happy_tasks: Dict[Tuple[str, MarathonClient], Set[MarathonTask]],
     old_app_live_unhappy_tasks: Dict[Tuple[str, MarathonClient], Set[MarathonTask]],
     old_app_draining_tasks: Dict[Tuple[str, MarathonClient], Set[MarathonTask]],


### PR DESCRIPTION
 Add type annotations to smartstack_tools. Clean up unused is_task_in_smartstack.

With #1924, we made a particular race condition much worse: Synapse only restarts haproxy once a minute on each box, with each box restarting at a different point in the minute. Since we consider a task healthy as soon as any of the 20 boxes we query has it up, this means that if a bounce goes very quickly (all tasks come up within a minute), we might drain all old tasks simultaneously, before all boxes have had a chance to restart haproxy to get the new tasks, causing 503s.

This change makes it so that all 20 boxes have to agree that the task is up (by default - configurable by changing haproxy_min_fraction_up to something less than 1 -- something like 0.001 would be roughly equivalent to the current behavior.)