### PR TITLE
Added sudo for docker push to non docker-dev registries

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -641,7 +641,11 @@ def build_and_push_docker_image(args):
     if retcode is not 0:
         return None
 
-    command = 'docker push %s' % docker_url
+    if args.docker_registry != DEFAULT_SPARK_DOCKER_REGISTRY:
+        command = 'sudo -H docker push %s' % docker_url
+    else:
+        command = 'docker push %s' % docker_url
+
     paasta_print(PaastaColors.grey(command))
     retcode, output = _run(command, stream=True)
     if retcode is not 0:


### PR DESCRIPTION
This is to add sudo to "docker push" to non docker-dev registries (e.g. spam). They are going to add sudo::conf puppet changes to allow users without root privilege to run "docker push".