### PR TITLE
Ignore `kind` and `version` when calculating config hash

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -83,7 +83,7 @@ from paasta_tools.utils import VolumeWithMode
 
 log = logging.getLogger(__name__)
 
-CONFIG_HASH_BLACKLIST = {'replicas'}
+CONFIG_HASH_BLACKLIST = {'replicas', 'kind', 'api_version'}
 KUBE_DEPLOY_STATEGY_MAP = {'crossover': 'RollingUpdate', 'downthenup': 'Recreate'}
 KubeDeployment = NamedTuple(
     'KubeDeployment', [

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -716,6 +716,8 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
 
     def test_sanitize_config_hash(self):
         mock_config = V1Deployment(
+            kind='Deployment',
+            api_version='apps/v1',
             metadata=V1ObjectMeta(
                 name='qwe',
                 labels={
@@ -734,6 +736,8 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
         )
         ret = self.deployment.sanitize_for_config_hash(mock_config)
         assert 'replicas' not in ret['spec'].keys()
+        assert 'kind' not in ret.keys()
+        assert 'api_version' not in ret.keys()
 
     def test_get_bounce_margin_factor(self):
         assert isinstance(self.deployment.get_bounce_margin_factor(), float)


### PR DESCRIPTION
We're using `kind` and `api_version` to calculate the config hash, any of these
attributes could be changed during migration to a new version of `k8s` client
library, so we'll restart all instances as a result of such change.

At the same time, these attributes are transport-only and are used only to
inform the `k8s` server endpoint about a class and a version of the class used
to generate JSON.  A change in these attributes without a change in other
attributes is no-op.

Thus, we better ignore changes in these attributes while calculating the config
hash.