### PR TITLE
Remove cluster address from Tron actions

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -91,7 +91,7 @@
                 "notification_email": {"type": "string"},
                 "realert_every": {
                     "type": "integer",
-                    "minimum": 1,
+                    "minimum": -1,
                     "exclusiveMinimum": false
                 },
                 "dependencies": {

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -65,13 +65,6 @@ class TronConfig(dict):
         except KeyError:
             raise TronNotConfigured('Could not find name of Tron cluster in system Tron config')
 
-    def get_default_paasta_cluster(self):
-        """:returns The PaaSTA cluster to run actions on by default"""
-        try:
-            return self['default_paasta_cluster']
-        except KeyError:
-            raise TronNotConfigured('Could not find default PaaSTA cluster in system Tron config')
-
     def get_url(self):
         """:returns The URL for the Tron master's API"""
         try:
@@ -189,13 +182,14 @@ class TronJobConfig:
     """Represents a job in Tron, consisting of action(s) and job-level configuration values."""
 
     def __init__(
-        self, config_dict: Dict[str, Any], service: Optional[str]=None,
+        self, config_dict: Dict[str, Any], cluster: str, service: Optional[str]=None,
         load_deployments: bool=True, soa_dir: str=DEFAULT_SOA_DIR,
     ) -> None:
         self.config_dict = config_dict
+        self.cluster = cluster
+        self.service = service
         self.load_deployments = load_deployments
         self.soa_dir = soa_dir
-        self.service = service
 
     def get_name(self):
         return self.config_dict.get('name')
@@ -237,12 +231,12 @@ class TronJobConfig:
         return self.config_dict.get('deploy_group', None)
 
     def get_cluster(self):
-        return self.config_dict.get('cluster')
+        return self.cluster
 
     def get_expected_runtime(self):
         return self.config_dict.get('expected_runtime')
 
-    def _get_action_config(self, action_dict, default_paasta_cluster):
+    def _get_action_config(self, action_dict):
         action_service = action_dict.setdefault('service', self.get_service())
         action_deploy_group = action_dict.setdefault('deploy_group', self.get_deploy_group())
         if action_service and action_deploy_group and self.load_deployments:
@@ -268,32 +262,30 @@ class TronJobConfig:
         else:
             branch_dict = None
 
-        cluster = action_dict.get('cluster') or self.get_cluster() or default_paasta_cluster
-
         return TronActionConfig(
             service=action_service,
             instance=compose_instance(self.get_name(), action_dict.get('name')),
-            cluster=cluster,
+            cluster=self.get_cluster(),
             config_dict=action_dict,
             branch_dict=branch_dict,
             soa_dir=self.soa_dir,
         )
 
-    def get_actions(self, default_paasta_cluster):
+    def get_actions(self):
         actions = [
-            self._get_action_config(action_dict, default_paasta_cluster)
+            self._get_action_config(action_dict)
             for action_dict in self.config_dict.get('actions')
         ]
         return actions
 
-    def get_cleanup_action(self, default_paasta_cluster):
+    def get_cleanup_action(self):
         action_dict = self.config_dict.get('cleanup_action')
         if not action_dict:
             return None
 
         # TODO: we should keep this trickery outside paasta repo
         action_dict['name'] = 'cleanup'
-        return self._get_action_config(action_dict, default_paasta_cluster)
+        return self._get_action_config(action_dict)
 
     def check_monitoring(self) -> Tuple[bool, str]:
         monitoring = self.get_monitoring()
@@ -308,9 +300,8 @@ class TronJobConfig:
         return True, ''
 
     def check_actions(self) -> Tuple[bool, List[str]]:
-        cluster = "fake-cluster-for-validation"
-        actions = self.get_actions(default_paasta_cluster=cluster)
-        cleanup_action = self.get_cleanup_action(default_paasta_cluster=cluster)
+        actions = self.get_actions()
+        cleanup_action = self.get_cleanup_action()
         if cleanup_action:
             actions.append(cleanup_action)
 
@@ -356,11 +347,10 @@ def format_master_config(master_config, default_volumes, dockercfg_location):
     return master_config
 
 
-def format_tron_action_dict(action_config, cluster_fqdn_format):
+def format_tron_action_dict(action_config):
     """Generate a dict of tronfig for an action, from the TronActionConfig.
 
     :param job_config: TronActionConfig
-    :param cluster_fqdn_format: format string for the Mesos masters, given the cluster
     """
     executor = action_config.get_executor()
     result = {
@@ -374,7 +364,6 @@ def format_tron_action_dict(action_config, cluster_fqdn_format):
         'expected_runtime': action_config.get_expected_runtime(),
     }
     if executor == 'mesos':
-        result['mesos_address'] = cluster_fqdn_format.format(cluster=action_config.get_cluster())
         result['cpus'] = action_config.get_cpus()
         result['mem'] = action_config.get_mem()
         result['env'] = action_config.get_env()
@@ -401,17 +390,14 @@ def format_tron_action_dict(action_config, cluster_fqdn_format):
     return {key: val for key, val in result.items() if val is not None}
 
 
-def format_tron_job_dict(job_config, cluster_fqdn_format, default_paasta_cluster):
+def format_tron_job_dict(job_config):
     """Generate a dict of tronfig for a job, from the TronJobConfig.
 
     :param job_config: TronJobConfig
-    :param cluster_fqdn_format: format string for the Mesos masters, given the cluster
-    :param default_paasta_cluster: str, PaaSTA cluster to use for each action that
-        does not specify a cluster
     """
     action_dicts = [
-        format_tron_action_dict(action_config, cluster_fqdn_format)
-        for action_config in job_config.get_actions(default_paasta_cluster)
+        format_tron_action_dict(action_config)
+        for action_config in job_config.get_actions()
     ]
 
     result = {
@@ -429,9 +415,9 @@ def format_tron_job_dict(job_config, cluster_fqdn_format, default_paasta_cluster
         'time_zone': job_config.get_time_zone(),
         'expected_runtime': job_config.get_expected_runtime(),
     }
-    cleanup_config = job_config.get_cleanup_action(default_paasta_cluster)
+    cleanup_config = job_config.get_cleanup_action()
     if cleanup_config:
-        cleanup_action = format_tron_action_dict(cleanup_config, cluster_fqdn_format)
+        cleanup_action = format_tron_action_dict(cleanup_config)
         del cleanup_action['name']
         result['cleanup_action'] = cleanup_action
 
@@ -455,7 +441,7 @@ def load_tron_instance_config(
     requested_job, requested_action = instance.split('.')
     for job in jobs:
         if job.get_name() == requested_job:
-            for action in job.get_actions(default_paasta_cluster=cluster):
+            for action in job.get_actions():
                 if action.get_action_name() == requested_action:
                     return action
     raise NoConfigurationForServiceError(f"No tron configuration found for {service} {instance}")
@@ -482,6 +468,7 @@ def load_tron_service_config(service, cluster, load_deployments=True, soa_dir=DE
     job_configs = [
         TronJobConfig(
             service=service,
+            cluster=cluster,
             config_dict=job,
             load_deployments=load_deployments,
             soa_dir=soa_dir,
@@ -509,11 +496,8 @@ def create_complete_config(service, cluster, soa_dir=DEFAULT_SOA_DIR):
         )
 
     other_config['jobs'] = [
-        format_tron_job_dict(
-            job_config=job_config,
-            cluster_fqdn_format=system_paasta_config.get_cluster_fqdn_format(),
-            default_paasta_cluster=cluster,
-        ) for job_config in job_configs
+        format_tron_job_dict(job_config)
+        for job_config in job_configs
     ]
 
     return yaml.dump(
@@ -547,8 +531,6 @@ def validate_complete_config(service: str, cluster: str, soa_dir: str=DEFAULT_SO
     other_config['jobs'] = [
         format_tron_job_dict(
             job_config=job_config,
-            cluster_fqdn_format='{cluster}',
-            default_paasta_cluster=cluster,
         ) for job_config in job_configs
     ]
     complete_config = yaml.dump(other_config, Dumper=Dumper)


### PR DESCRIPTION
`mesos_address` is a MASTER-level setting and can't be set in actions anymore, so the tronfig we generate is invalid. (https://github.com/Yelp/Tron/pull/509)

If we take mesos_address out, we don't need the cluster_fqdn_format and default cluster anymore. The cluster name just comes from the filename (i.e. tron-norcal-prod) now.