### PR TITLE
Make paasta-related dimensions consistent

### DIFF
--- a/paasta_tools/contrib/emit_allocated_cpu_metrics.py
+++ b/paasta_tools/contrib/emit_allocated_cpu_metrics.py
@@ -24,9 +24,9 @@ def emit_metrics_for_type(instance_type):
             cluster=cluster,
         )
         dimensions = {
-            'service_name': service_instance_config.service,
+            'paasta_service': service_instance_config.service,
             'paasta_cluster': service_instance_config.cluster,
-            'instance_name': service_instance_config.instance,
+            'paasta_instance': service_instance_config.instance,
         }
 
         log.info(f"Emitting paasta.service.* with dimensions {dimensions}")

--- a/paasta_tools/contrib/emit_synapse_services_metrics.py
+++ b/paasta_tools/contrib/emit_synapse_services_metrics.py
@@ -22,9 +22,9 @@ def report_metric_to_meteorite(backend, metric, value, paasta_cluster):
         return
 
     meteorite_dims = {
-        'service_name': paasta_service,
+        'paasta_service': paasta_service,
         'paasta_cluster': paasta_cluster,
-        'instance_name': paasta_instance,
+        'paasta_instance': paasta_instance,
     }
     path = f'paasta.service.requests.{metric}'
     if metric in GUAGES:

--- a/paasta_tools/contrib/paasta_update_soa_memcpu.py
+++ b/paasta_tools/contrib/paasta_update_soa_memcpu.py
@@ -262,9 +262,9 @@ def main(argv=None):
             m=serv['money'],
             x=serv['old_cpus'],
             y=serv['cpus'],
-            cluster_param=_get_dashboard_qs_param('superregion', serv['cluster'].replace('marathon-', '')),
-            service_param=_get_dashboard_qs_param('service_name', serv['service']),
-            instance_param=_get_dashboard_qs_param('instance_name', serv['instance']),
+            cluster_param=_get_dashboard_qs_param('paasta_cluster', serv['cluster'].replace('marathon-', '')),
+            service_param=_get_dashboard_qs_param('paasta_service', serv['service']),
+            instance_param=_get_dashboard_qs_param('paasta_instance', serv['instance']),
         )
         branch = ''
         if args.no_tick:


### PR DESCRIPTION
This makes the dimensions we emit consistently named. This must be shipped and release with the other changes in order to minimize dashboard breakage.