### PR TITLE
Fix k8s label selector

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -813,7 +813,7 @@ def ensure_paasta_namespace(kube_client: KubeClient) -> None:
 
 def list_deployments(
     kube_client: KubeClient,
-    label_selector: Optional[str] = None,
+    label_selector: str = '',
 ) -> Sequence[KubeDeployment]:
     deployments = kube_client.deployments.list_namespaced_deployment(
         namespace='paasta',


### PR DESCRIPTION
Annoyingly k8s doesn't like the None here and returns 0 deployments
rather than all deployments. However, an empty string does work.

This was breaking the deployment script because it was finding no
deployments and trying to recreate them and getting 409