### PR TITLE
Optimized create_marathon_dashboard

### DIFF
--- a/paasta_tools/marathon_dashboard.py
+++ b/paasta_tools/marathon_dashboard.py
@@ -95,15 +95,11 @@ def create_marathon_dashboard(
         shard_url = marathon_links.split(' ')[0]
         return {cluster: [{'service': si[0], 'instance': si[1], 'shard_url': shard_url} for si in instances]}
 
-    print(cluster, dashboard_links.get(cluster))
-    print(marathon_links)
-    print(shard_url_to_marathon_link_dict)
-
+    # Setup Dict[str, Set[str]] since will instantiate 1 PSCL per service
     service_instances_dict = defaultdict(set)
     for si in instances:
         service, instance = si[0], si[1]
         service_instances_dict[service].add(instance)
-    # Loop through each service and load a PSCL
     for service, instance_set in service_instances_dict.items():
         pscl = PaastaServiceConfigLoader(
             service=service,

--- a/tests/test_marathon_dashboard.py
+++ b/tests/test_marathon_dashboard.py
@@ -40,5 +40,5 @@ def test_create_marathon_dashboard(mock_load_system_paasta_config):
     soa_dir = '/fake/soa/dir'
     cluster = 'fake_cluster'
     expected_output = {'fake_cluster': []}
-    mock_load_system_paasta_config.return_value = SystemPaastaConfig({}, 'fake_directory')
+    mock_load_system_paasta_config.return_value = SystemPaastaConfig({'dashboard_links': {}}, 'fake_directory')
     assert(marathon_dashboard.create_marathon_dashboard(cluster=cluster, soa_dir=soa_dir) == expected_output)


### PR DESCRIPTION
* Used PaastaServiceConfigLoader for each service in the cluster
* Some refactoring of inefficient code: e.g. pull out constant operations out of the loop
* Able to create dashboard for `norcal-prod` very quickly (within 2 sec); tested by rsyncing code to norcal-prod box and running manually