### PR TITLE
Make k8s wait-for-deployment work

### DIFF
--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -246,6 +246,13 @@
             "name": "instance",
             "required": true,
             "type": "string"
+          },
+          {
+            "in": "query",
+            "description": "Include verbose status information",
+            "name": "verbose",
+            "required": false,
+            "type": "boolean"
           }
         ]
       }

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -17,9 +17,11 @@ import logging
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Mapping
 from typing import NamedTuple
 from typing import Optional
 from typing import Sequence
+from typing import Set
 from typing import Tuple
 from typing import Union
 
@@ -46,6 +48,7 @@ from kubernetes.client import V1ObjectFieldSelector
 from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1PersistentVolumeClaim
 from kubernetes.client import V1PersistentVolumeClaimSpec
+from kubernetes.client import V1Pod
 from kubernetes.client import V1PodSpec
 from kubernetes.client import V1PodTemplateSpec
 from kubernetes.client import V1Probe
@@ -56,6 +59,7 @@ from kubernetes.client import V1StatefulSetSpec
 from kubernetes.client import V1TCPSocketAction
 from kubernetes.client import V1Volume
 from kubernetes.client import V1VolumeMount
+from kubernetes.client.rest import ApiException
 
 from paasta_tools.long_running_service_tools import InvalidHealthcheckMode
 from paasta_tools.long_running_service_tools import load_service_namespace_config
@@ -846,11 +850,43 @@ def list_matching_deployments(
     return list_deployments(kube_client, f'instance={instance},service={service}')
 
 
-def get_deployment_by_name(
+def pods_for_service_instance(
+    service: str,
+    instance: str,
+    kube_client: KubeClient,
+) -> Sequence[V1Pod]:
+    return kube_client.core.list_namespaced_pod(
+        namespace='paasta',
+        label_selector=f'service={service},instance={instance}',
+    ).items
+
+
+def get_active_shas_for_service(
+    pod_list: Sequence[V1Pod],
+) -> Mapping[str, Set[str]]:
+    ret: Mapping[str, Set[str]] = {'config_sha': set(), 'git_sha': set()}
+    for pod in pod_list:
+        ret['config_sha'].add(pod.metadata.labels['config_sha'])
+        ret['git_sha'].add(pod.metadata.labels['git_sha'])
+    return ret
+
+
+def get_kubernetes_app_by_name(
     name: str,
     kube_client: KubeClient,
-) -> V1Deployment:
-    return kube_client.deployments.read_namespaced_deployment_status(
+) -> Union[V1Deployment, V1StatefulSet]:
+    try:
+        app = kube_client.deployments.read_namespaced_deployment_status(
+            name=name,
+            namespace='paasta',
+        )
+        return app
+    except ApiException as e:
+        if e.status == 404:
+            pass
+        else:
+            raise
+    return kube_client.deployments.read_namespaced_stateful_set_status(
         name=name,
         namespace='paasta',
     )
@@ -886,11 +922,19 @@ def update_stateful_set(kube_client: KubeClient, formatted_stateful_set: V1State
     )
 
 
-def get_kubernetes_app_deploy_status(kube_client: KubeClient, app: V1Deployment) -> int:
-    if app.status.unavailable_replicas:
+def get_kubernetes_app_deploy_status(
+    kube_client: KubeClient,
+    app: Union[V1Deployment, V1StatefulSet],
+    desired_instances: int,
+) -> int:
+    if app.status.ready_replicas is None or app.status.ready_replicas < desired_instances:
         deploy_status = KubernetesDeployStatus.Waiting
-    elif app.status.updated_replicas < app.status.replicas:
+    # updated_replicas can currently be None for stateful sets so we may not correctly detect status for now
+    # when https://github.com/kubernetes/kubernetes/pull/62943 lands in a release this should work for both:
+    elif app.status.updated_replicas is not None and (app.status.updated_replicas < desired_instances):
         deploy_status = KubernetesDeployStatus.Deploying
+    elif app.status.replicas == 0 and desired_instances == 0:
+        deploy_status = KubernetesDeployStatus.Stopped
     else:
         deploy_status = KubernetesDeployStatus.Running
     return deploy_status
@@ -900,7 +944,7 @@ class KubernetesDeployStatus:
     """ An enum to represent Kubernetes app deploy status.
     Changing name of the keys will affect both the paasta CLI and API.
     """
-    Running, Deploying, Waiting = range(0, 3)
+    Running, Deploying, Waiting, Stopped = range(0, 4)
 
     @classmethod
     def tostring(cls, val: int) -> str:

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -100,6 +100,7 @@ def mock_status_instance_side_effect(service, instance):  # pragma: no cover (ge
         # running the wrong version
         mock_status.git_sha = 'anothersha'
     mock_status.marathon = mock_mstatus
+    mock_status.kubernetes = None
     mock_result = mock_status
     mock_status_instance = Mock()
     mock_status_instance.result.return_value = mock_result
@@ -251,6 +252,8 @@ def test_wait_for_deployment(
     mock_paasta_service_config_loader.return_value.instance_configs.side_effect = [
         [mock_marathon_instance_config('instance1'), mock_marathon_instance_config('instance2')],
         [mock_marathon_instance_config('instance1'), mock_marathon_instance_config('instance2')],
+        [],
+        [],
     ]
     with patch('sys.stdout', autospec=True, flush=Mock()):
         assert mark_for_deployment.wait_for_deployment('service', 'fake_deploy_group', 'somesha', '/nail/soa', 5) == 0
@@ -259,6 +262,8 @@ def test_wait_for_deployment(
     mock_paasta_service_config_loader.return_value.instance_configs.side_effect = [
         [mock_marathon_instance_config('instance1'), mock_marathon_instance_config('instance2')],
         [mock_marathon_instance_config('instance1'), mock_marathon_instance_config('instance3')],
+        [],
+        [],
     ]
     with raises(TimeoutError):
         mark_for_deployment.wait_for_deployment('service', 'fake_deploy_group', 'somesha', '/nail/soa', 0)

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -29,10 +29,14 @@ from kubernetes.client import V1StatefulSetSpec
 from kubernetes.client import V1TCPSocketAction
 from kubernetes.client import V1Volume
 from kubernetes.client import V1VolumeMount
+from kubernetes.client.rest import ApiException
 
 from paasta_tools.kubernetes_tools import create_deployment
 from paasta_tools.kubernetes_tools import create_stateful_set
 from paasta_tools.kubernetes_tools import ensure_paasta_namespace
+from paasta_tools.kubernetes_tools import get_active_shas_for_service
+from paasta_tools.kubernetes_tools import get_kubernetes_app_by_name
+from paasta_tools.kubernetes_tools import get_kubernetes_app_deploy_status
 from paasta_tools.kubernetes_tools import get_kubernetes_services_running_here
 from paasta_tools.kubernetes_tools import get_kubernetes_services_running_here_for_nerve
 from paasta_tools.kubernetes_tools import InvalidKubernetesConfig
@@ -40,10 +44,12 @@ from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import KubeDeployment
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfigDict
+from paasta_tools.kubernetes_tools import KubernetesDeployStatus
 from paasta_tools.kubernetes_tools import KubeService
 from paasta_tools.kubernetes_tools import list_all_deployments
 from paasta_tools.kubernetes_tools import load_kubernetes_service_config
 from paasta_tools.kubernetes_tools import load_kubernetes_service_config_no_cache
+from paasta_tools.kubernetes_tools import pods_for_service_instance
 from paasta_tools.kubernetes_tools import read_all_registrations_for_service_instance
 from paasta_tools.kubernetes_tools import update_deployment
 from paasta_tools.kubernetes_tools import update_stateful_set
@@ -1097,3 +1103,107 @@ def test_update_stateful_set():
         namespace='paasta',
         body=V1StatefulSet(api_version='some'),
     )
+
+
+def test_get_kubernetes_app_deploy_status():
+    mock_status = mock.Mock(
+        replicas=1,
+        ready_replicas=1,
+        updated_replicas=1,
+    )
+    mock_app = mock.Mock(status=mock_status)
+    mock_client = mock.Mock()
+    assert get_kubernetes_app_deploy_status(
+        mock_client,
+        mock_app,
+        desired_instances=1,
+    ) == KubernetesDeployStatus.Running
+
+    assert get_kubernetes_app_deploy_status(
+        mock_client,
+        mock_app,
+        desired_instances=2,
+    ) == KubernetesDeployStatus.Waiting
+
+    mock_status = mock.Mock(
+        replicas=1,
+        ready_replicas=2,
+        updated_replicas=1,
+    )
+    mock_app = mock.Mock(status=mock_status)
+    assert get_kubernetes_app_deploy_status(
+        mock_client,
+        mock_app,
+        desired_instances=2,
+    ) == KubernetesDeployStatus.Deploying
+
+    mock_status = mock.Mock(
+        replicas=0,
+        ready_replicas=0,
+        updated_replicas=0,
+    )
+    mock_app = mock.Mock(status=mock_status)
+    assert get_kubernetes_app_deploy_status(
+        mock_client,
+        mock_app,
+        desired_instances=0,
+    ) == KubernetesDeployStatus.Stopped
+
+    mock_status = mock.Mock(
+        replicas=1,
+        ready_replicas=None,
+        updated_replicas=None,
+    )
+    mock_app = mock.Mock(status=mock_status)
+    assert get_kubernetes_app_deploy_status(
+        mock_client,
+        mock_app,
+        desired_instances=1,
+    ) == KubernetesDeployStatus.Waiting
+
+
+def test_get_kubernetes_app_by_name():
+    mock_client = mock.Mock()
+    mock_deployment = mock.Mock()
+    mock_client.deployments.read_namespaced_deployment_status.return_value = mock_deployment
+    assert get_kubernetes_app_by_name('someservice', mock_client) == mock_deployment
+    assert mock_client.deployments.read_namespaced_deployment_status.called
+    assert not mock_client.deployments.read_namespaced_stateful_set_status.called
+
+    mock_stateful_set = mock.Mock()
+    mock_client.deployments.read_namespaced_deployment_status.reset_mock()
+    mock_client.deployments.read_namespaced_deployment_status.side_effect = ApiException(404)
+    mock_client.deployments.read_namespaced_stateful_set_status.return_value = mock_stateful_set
+    assert get_kubernetes_app_by_name('someservice', mock_client) == mock_stateful_set
+    assert mock_client.deployments.read_namespaced_deployment_status.called
+    assert mock_client.deployments.read_namespaced_stateful_set_status.called
+
+
+def test_pods_for_service_instance():
+    mock_client = mock.Mock()
+    assert pods_for_service_instance(
+        'kurupt',
+        'fm',
+        mock_client,
+    ) == mock_client.core.list_namespaced_pod.return_value.items
+
+
+def test_get_active_shas_for_service():
+    mock_pod_list = [
+        mock.Mock(metadata=mock.Mock(labels={
+            'config_sha': 'a123',
+            'git_sha': 'b456',
+        })),
+        mock.Mock(metadata=mock.Mock(labels={
+            'config_sha': 'a123!!!',
+            'git_sha': 'b456!!!',
+        })),
+        mock.Mock(metadata=mock.Mock(labels={
+            'config_sha': 'a123!!!',
+            'git_sha': 'b456!!!',
+        })),
+    ]
+    assert get_active_shas_for_service(mock_pod_list) == {
+        'git_sha': {'b456', 'b456!!!'},
+        'config_sha': {'a123', 'a123!!!'},
+    }


### PR DESCRIPTION
* generalise checking of marathon status in wait-for-deployment cli to
check "long_running_status" which is either k8s or marathon
* Ensure that app_count in the HTTP status API is an accurate
representation of whether k8s has finished a deployment by counting
pods for a service with unique shas.
* Ensure deployment info for StatefulSet is also accurate. Note that
until https://github.com/kubernetes/kubernetes/pull/62943 is released
the status of a StatefulSet deployment may not be 100% accurate.