### PR TITLE
Change cpu_burst_pct to cpu_burst_add 

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -422,7 +422,7 @@ def mesos_cpu_metrics_provider(
             if system_paasta_config.get_filter_bogus_mesos_cputime_enabled():
                 # It is unlikely that the cputime consumed by a task is greater than the CPU limits
                 # that we enforce. This is a bug in Mesos (tracked in PAASTA-13510)
-                max_cpu_allowed = 1 + marathon_service_config.get_cpu_burst_add()
+                max_cpu_allowed = 1 + marathon_service_config.get_cpu_burst_add() / marathon_service_config.get_cpus()
                 task_cpu_usage = cputime_delta / time_delta
 
                 if task_cpu_usage > (max_cpu_allowed * 1.1):

--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -422,8 +422,9 @@ def mesos_cpu_metrics_provider(
             if system_paasta_config.get_filter_bogus_mesos_cputime_enabled():
                 # It is unlikely that the cputime consumed by a task is greater than the CPU limits
                 # that we enforce. This is a bug in Mesos (tracked in PAASTA-13510)
-                max_cpu_allowed = (100 + marathon_service_config.get_cpu_burst_pct()) / 100
+                max_cpu_allowed = 1 + marathon_service_config.get_cpu_burst_add()
                 task_cpu_usage = cputime_delta / time_delta
+
                 if task_cpu_usage > (max_cpu_allowed * 1.1):
                     log.warning(
                         'Ignoring potentially bogus cpu usage {} for task {}'.format(

--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -86,9 +86,9 @@
                 "maximum": "1000000",
                 "exclusiveMinimum": false
             },
-            "cpu_burst_pct": {
-                "type": "integer",
-                "minimum": 0,
+            "cpu_burst_add": {
+                "type": "float",
+                "minimum": 0.0,
                 "exclusiveMinimum": false
             },
             "extra_docker_args": {

--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -126,9 +126,9 @@
                 "maximum": "1000000",
                 "exclusiveMinimum": false
             },
-            "cpu_burst_pct": {
-                "type": "integer",
-                "minimum": 0,
+            "cpu_burst_add": {
+                "type": "float",
+                "minimum": 0.0,
                 "exclusiveMinimum": false
             },
             "dependencies_reference": {

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -289,9 +289,9 @@
                     "maximum": "1000000",
                     "exclusiveMinimum": false
                 },
-                "cpu_burst_pct": {
-                    "type": "integer",
-                    "minimum": 0,
+                "cpu_burst_add": {
+                    "type": "float",
+                    "minimum": 0.0,
                     "exclusiveMinimum": false
                 },
                 "host_port": {

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -361,7 +361,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
     def get_resource_requirements(self) -> V1ResourceRequirements:
         return V1ResourceRequirements(
             limits={
-                'cpu': self.get_cpus() * self.get_cpu_burst_pct() / 100,
+                'cpu': self.get_cpus() + self.get_cpu_burst_add(),
                 'memory': f'{self.get_mem()}Mi',
             },
             requests={

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -320,10 +320,10 @@ def test_mesos_cpu_metrics_provider_filter_bogus_values_big_cpu_limit():
     |  inst  | prev cputime | elasped_time | cputime | limit |  norm_cputime  |      utilization      |
     +--------+--------------+--------------+---------+-------+----------------+-----------------------+
     | 1      |          126 |          600 |     480 |   2.1 | 480/(2.1-0.1)  | (240-126)/600 => 0.19 |
-    | 2      |            0 |          600 |    2400 |   2.1 | 2400/(2.1-0.1) | 1200/600 => 2.0       |
+    | 2      |            0 |          600 |    6000 |   2.1 | 6000/(2.1-0.1) | 3000/600 => 5.0       |
     | 3(bug) |            0 |          600 |  987654 |   2.1 | 9600/(2.1-0.1) | 493827/600 => 823     |
     | -      |            - |            - |       - |     - | -              | -                     |
-    | avg    |              |              |         |       |                | 1.095                 |
+    | avg    |              |              |         |       |                | 2.595                 |
     +--------+--------------+--------------+---------+-------+----------------+-----------------------+
     """
     fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
@@ -346,7 +346,7 @@ def test_mesos_cpu_metrics_provider_filter_bogus_values_big_cpu_limit():
         stats=asynctest.CoroutineMock(return_value={
             'cpus_limit': 2.1,
             'cpus_system_time_secs': 0,
-            'cpus_user_time_secs': 2400,
+            'cpus_user_time_secs': 6000,
         }),
     )
     fake_mesos_task_3 = mock.MagicMock(
@@ -394,8 +394,7 @@ def test_mesos_cpu_metrics_provider_filter_bogus_values_big_cpu_limit():
     ):
         mock_datetime.now.return_value = current_time
         log_utilization_data = {}
-
-        assert 1.095 == round(
+        assert 2.595 == round(
             autoscaling_service_lib.mesos_cpu_metrics_provider(
                 fake_marathon_service_config,
                 fake_system_paasta_config,
@@ -411,11 +410,11 @@ def test_mesos_cpu_metrics_provider_filter_bogus_values_small_cpu_limit():
     +--------+-------------------+--------------+---------+-------+-----------------+----------------------+
     |  inst  | prev norm_cputime | elasped_time | cputime | limit |  norm_cputime   |     utilization      |
     +--------+-------------------+--------------+---------+-------+-----------------+----------------------+
-    | 1      |              1234 |          600 |   243.4 |   0.2 | 243.4/(0.2-0.1) | (2434-1234)/600 => 2 |
+    | 1      |              1234 |          600 |   423.4 |   0.2 | 423.4/(0.2-0.1) | (4234-1234)/600 => 5 |
     | 2      |                 0 |          600 |      48 |   0.2 | 48/(0.2-0.1)    | 480/600 => 0.8       |
     | 3(bug) |                 0 |          600 |    1234 |   0.2 | 1234/(0.2-0.1)  | 12340/600 => 20.5    |
     | -      |                 - |            - |       - |     - | -               | -                    |
-    | avg    |                   |              |         |       |                 | 1.4                  |
+    | avg    |                   |              |         |       |                 | 2.9                  |
     +--------+-------------------+--------------+---------+-------+-----------------+----------------------+
     """
     fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
@@ -431,7 +430,7 @@ def test_mesos_cpu_metrics_provider_filter_bogus_values_small_cpu_limit():
         stats=asynctest.CoroutineMock(return_value={
             'cpus_limit': 0.2,
             'cpus_system_time_secs': 103.4,
-            'cpus_user_time_secs': 140,
+            'cpus_user_time_secs': 320,
         }),
     )
     fake_mesos_task_2 = mock.MagicMock(
@@ -486,7 +485,7 @@ def test_mesos_cpu_metrics_provider_filter_bogus_values_small_cpu_limit():
     ):
         mock_datetime.now.return_value = current_time
         log_utilization_data = {}
-        assert 1.4 == round(
+        assert 2.9 == round(
             autoscaling_service_lib.mesos_cpu_metrics_provider(
                 fake_marathon_service_config,
                 fake_system_paasta_config,
@@ -502,11 +501,11 @@ def test_mesos_cpu_metrics_provider_filter_no_bogus_values_10_percent_cpu_limit(
     +--------+-------------------+--------------+---------+-------+-----------------+-------------------------+
     |  inst  | prev norm_cputime | elasped_time | cputime | limit |  norm_cputime   |     utilization         |
     +--------+-------------------+--------------+---------+-------+-----------------+-------------------------+
-    | 1      |              1234 |          600 |   223.4 |   0.2 | 223.4/(0.2-0.1) | (2234-1234)/600 => 1.67 |
+    | 1      |              1234 |          600 |   323.4 |   0.2 | 323.4/(0.2-0.1) | (3234-1234)/600 => 3.33 |
     | 2      |                 0 |          600 |      48 |   0.2 | 48/(0.2-0.1)    | 480/600 => 0.8          |
-    | 3      |                 0 |          600 |    630  |   0.2 | 630 /(0.2-0.1)  | 6300 /600 => 2.0        |
+    | 3      |                 0 |          600 |     300 |   0.2 | 300 /(0.2-0.1)  | 3000 /600 => 5          |
     | -      |                 - |            - |       - |     - | -               | -                       |
-    | avg    |                   |              |         |       |                 | 1.4889                  |
+    | avg    |                   |              |         |       |                 | 3.044                   |
     +--------+-------------------+--------------+---------+-------+-----------------+-------------------------+
     """
     fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
@@ -522,7 +521,7 @@ def test_mesos_cpu_metrics_provider_filter_no_bogus_values_10_percent_cpu_limit(
         stats=asynctest.CoroutineMock(return_value={
             'cpus_limit': 0.2,
             'cpus_system_time_secs': 103.4,
-            'cpus_user_time_secs': 120,
+            'cpus_user_time_secs': 220,
         }),
     )
     fake_mesos_task_2 = mock.MagicMock(
@@ -537,7 +536,7 @@ def test_mesos_cpu_metrics_provider_filter_no_bogus_values_10_percent_cpu_limit(
             'cpus_limit': 0.2,
             'cpus_system_time_secs': 0,
             # bogus
-            'cpus_user_time_secs': 120,
+            'cpus_user_time_secs': 300,
         }),
     )
     fake_mesos_task.__getitem__.return_value = 'fake-service.fake-instance'
@@ -577,14 +576,14 @@ def test_mesos_cpu_metrics_provider_filter_no_bogus_values_10_percent_cpu_limit(
     ):
         mock_datetime.now.return_value = current_time
         log_utilization_data = {}
-        assert 1.4889 == round(
+        assert 3.044 == round(
             autoscaling_service_lib.mesos_cpu_metrics_provider(
                 fake_marathon_service_config,
                 fake_system_paasta_config,
                 fake_marathon_tasks,
                 (fake_mesos_task_2, fake_mesos_task_3, fake_mesos_task),
                 log_utilization_data=log_utilization_data,
-            ), 4,
+            ), 3,
         )
 
 

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -1082,8 +1082,8 @@ class TestChronosTools:
         fake_docker_volumes = ['fake_docker_volume']
         fake_cpus = 0.25
         fake_period = 200000
-        fake_burst = 200
-        fake_cpu_quota = fake_cpus * fake_period * (100 + fake_burst) / 100
+        fake_burst = 2
+        fake_cpu_quota = (fake_cpus + fake_burst) * fake_period
 
         chronos_job_config = chronos_tools.ChronosJobConfig(
             service=fake_service,
@@ -1095,7 +1095,7 @@ class TestChronosTools:
                 'epsilon': 'PT60S',
                 'cpus': fake_cpus,
                 'cfs_period_us': fake_period,
-                'cpu_burst_pct': fake_burst,
+                'cpu_burst_add': fake_burst,
             },
             branch_dict=None,
         )
@@ -1427,7 +1427,7 @@ class TestChronosTools:
                     'parameters': [
                         {'key': 'memory-swap', 'value': '1089m'},
                         {"key": "cpu-period", "value": '100000'},
-                        {"key": "cpu-quota", "value": '5500000'},
+                        {"key": "cpu-quota", "value": '650000'},
                         {"key": "label", "value": "paasta_service=test-service"},
                         {"key": "label", "value": "paasta_instance=test"},
                     ],
@@ -1558,7 +1558,7 @@ class TestChronosTools:
                     'parameters': [
                         {'key': 'memory-swap', 'value': '1089m'},
                         {"key": "cpu-period", "value": '100000'},
-                        {"key": "cpu-quota", "value": '5500000'},
+                        {"key": "cpu-quota", "value": '650000'},
                         {"key": "label", "value": "paasta_service=test-service"},
                         {"key": "label", "value": "paasta_instance=test"},
                     ],
@@ -1628,7 +1628,7 @@ class TestChronosTools:
                     'parameters': [
                         {'key': 'memory-swap', 'value': '1089m'},
                         {"key": "cpu-period", "value": '100000'},
-                        {"key": "cpu-quota", "value": '5500000'},
+                        {"key": "cpu-quota", "value": '650000'},
                         {"key": "label", "value": "paasta_service=test-service"},
                         {"key": "label", "value": "paasta_instance=test"},
                     ],
@@ -1714,7 +1714,7 @@ class TestChronosTools:
                     'parameters': [
                         {'key': 'memory-swap', 'value': '1089m'},
                         {"key": "cpu-period", "value": '100000'},
-                        {"key": "cpu-quota", "value": '5500000'},
+                        {"key": "cpu-quota", "value": '650000'},
                         {"key": "label", "value": "paasta_service=test-service"},
                         {"key": "label", "value": "paasta_instance=test"},
                     ],

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -299,15 +299,15 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             'paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_cpus', autospec=True,
             return_value=0.3,
         ), mock.patch(
-            'paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_cpu_burst_pct', autospec=True,
-            return_value=200,
+            'paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_cpu_burst_add', autospec=True,
+            return_value=1,
         ), mock.patch(
             'paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_mem', autospec=True,
             return_value=2048,
         ):
             assert self.deployment.get_resource_requirements() == V1ResourceRequirements(
                 limits={
-                    'cpu': 0.6,
+                    'cpu': 1.3,
                     'memory': '2048Mi',
                 },
                 requests={

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -880,8 +880,8 @@ class TestMarathonTools:
             },
         ]
         fake_period = 200000
-        fake_burst = 200
-        fake_cpu_quota = fake_cpus * fake_period * (100 + fake_burst) / 100
+        fake_burst = 2
+        fake_cpu_quota = (fake_cpus + fake_burst) * fake_period
 
         expected_conf = {
             'id': mock.ANY,
@@ -935,7 +935,7 @@ class TestMarathonTools:
                 'cmd': fake_cmd,
                 'args': fake_args,
                 'cfs_period_us': fake_period,
-                'cpu_burst_pct': fake_burst,
+                'cpu_burst_add': fake_burst,
                 'healthcheck_grace_period_seconds': 3,
                 'healthcheck_interval_seconds': 10,
                 'healthcheck_timeout_seconds': 10,
@@ -2184,7 +2184,7 @@ def test_format_marathon_app_dict_no_smartstack():
                     'parameters': [
                         {'key': 'memory-swap', 'value': '1088m'},
                         {"key": "cpu-period", "value": '100000'},
-                        {"key": "cpu-quota", "value": '250000'},
+                        {"key": "cpu-quota", "value": '125000'},
                         {"key": "label", "value": 'paasta_service=service'},
                         {"key": "label", "value": 'paasta_instance=instance'},
                     ],
@@ -2260,7 +2260,7 @@ def test_format_marathon_app_dict_with_smartstack():
                     'parameters': [
                         {'key': 'memory-swap', 'value': '1088m'},
                         {"key": "cpu-period", "value": '100000'},
-                        {"key": "cpu-quota", "value": '250000'},
+                        {"key": "cpu-quota", "value": '125000'},
                         {"key": "label", "value": 'paasta_service=service'},
                         {"key": "label", "value": 'paasta_instance=instance'},
                     ],
@@ -2408,7 +2408,7 @@ def test_format_marathon_app_dict_utilizes_extra_volumes():
                     'parameters': [
                         {'key': 'memory-swap', 'value': '1088m'},
                         {"key": "cpu-period", "value": '100000'},
-                        {"key": "cpu-quota", "value": '250000'},
+                        {"key": "cpu-quota", "value": '125000'},
                         {"key": "label", "value": 'paasta_service=service'},
                         {"key": "label", "value": 'paasta_instance=instance'},
                     ],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1018,10 +1018,20 @@ class TestInstanceConfig:
             service='fake_name',
             cluster='',
             instance='fake_instance',
-            config_dict={'cpu_burst_pct': 0, 'cpus': 1},
+            config_dict={'cpu_burst_add': 0, 'cpus': 1},
             branch_dict=None,
         )
         assert fake_conf.get_cpu_quota() == 100000
+
+    def test_nonzero_cpu_burst(self):
+        fake_conf = utils.InstanceConfig(
+            service='fake_name',
+            cluster='',
+            instance='fake_instance',
+            config_dict={'cpu_burst_add': 10, 'cpus': 1},
+            branch_dict=None,
+        )
+        assert fake_conf.get_cpu_quota() == 1100000
 
     def test_format_docker_parameters_default(self):
         fake_conf = utils.InstanceConfig(
@@ -1037,7 +1047,7 @@ class TestInstanceConfig:
         assert fake_conf.format_docker_parameters() == [
             {"key": "memory-swap", "value": '1088m'},
             {"key": "cpu-period", "value": "100000"},
-            {"key": "cpu-quota", "value": "1000000"},
+            {"key": "cpu-quota", "value": "200000"},
             {"key": "label", "value": "paasta_service=fake_name"},
             {"key": "label", "value": "paasta_instance=fake_instance"},
         ]
@@ -1048,7 +1058,7 @@ class TestInstanceConfig:
             cluster='',
             instance='fake_instance',
             config_dict={
-                'cpu_burst_pct': 200,
+                'cpu_burst_add': 2,
                 'cfs_period_us': 200000,
                 'cpus': 1,
                 'mem': 1024,
@@ -1077,10 +1087,10 @@ class TestInstanceConfig:
             service='fake_name',
             cluster='',
             instance='fake_instance',
-            config_dict={'cpu_burst_pct': 100, 'cpus': 1},
+            config_dict={'cpu_burst_add': 2, 'cpus': 1},
             branch_dict=None,
         )
-        assert fake_conf.get_cpu_quota() == 200000
+        assert fake_conf.get_cpu_quota() == 300000
 
     def test_get_mem_swap_int(self):
         fake_conf = utils.InstanceConfig(


### PR DESCRIPTION
### Description
- Currently, we enforce a 10x burst on cpu usage via the cpu_burst_pct parameter in PaaSTA configs, but this has led to jobs using too many cpus.
- I changed cpu_burst_pct (i.e. multiplicative) to cpu_burst_add (i.e. additive), which provides a lower and much safer cpu limit.
- Instead of a 10x default, we default to 1 additional cpu.
- I also changed related code in kubernetes and chronos tools, as well as the autoscaling lib (i.e. marathon) to use the new parameter instead.
- Relevant tests were changed as well.

### Testing done
- make test

### Note to reviewers
- We initially considered changing from 10x to 2x, but even 2x is too much for jobs that request more cpus. A +1 is more than enough for smaller jobs, and will not adversely affect larger jobs. If they need more, they can supply their own cpu_burst_add.
- [UPDATE] @EvanKrall asked why I changed some test numbers; the answer is: "There are checks to make sure boxes don't use more cpus than the limit (cpus + burst) allowed. Essentially, the tests we do explicitly use numbers that were good for multiplicative burst, but too high for additive burst. As such, if I left the tests as they were, they would break because the tests would see that more cpus are being used than the limit allows. So, I changed the tests to maintain their intent - testing the limit check."