### PR TITLE
`paasta metastatus` via HTTP API

### DIFF
--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -82,6 +82,7 @@ def make_app(global_config=None):
     config.add_route('service_autoscaler.pause.get', '/v1/service_autoscaler/pause', request_method="GET")
     config.add_route('version', '/v1/version')
     config.add_route('marathon_dashboard', '/v1/marathon_dashboard', request_method="GET")
+    config.add_route('metastatus', '/v1/metastatus')
     config.scan()
     return CORS(config.make_wsgi_app(), headers="*", methods="*", maxage="180", origin="*")
 

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -35,6 +35,36 @@
         "operationId": "showVersion"
       }
     },
+    "/metastatus": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "description": "comma separated list of command arguments",
+            "name": "cmd_args",
+            "required": true,
+            "type": "array",
+            "collectionFormat": "csv",
+            "items": {
+              "type": "string"
+            }
+          }
+	],
+        "responses": {
+          "200": {
+            "description": "Detailed metastatus",
+            "schema": {
+              "$ref": "#/definitions/MetaStatus"
+            }
+          },
+          "500": {
+            "description": "Metastatus failure"
+          }
+        },
+        "summary": "Get metastatus",
+        "operationId": "metastatus"
+      }
+    },
     "/service_autoscaler/pause": {
       "get": {
         "responses": {
@@ -809,6 +839,20 @@
         "shard_url": {
           "type": "string",
           "description": "Marathon Shard URL"
+        }
+      }
+    },
+    "MetaStatus": {
+      "type": "object",
+      "description": "Result of `paasta metastatus` command",
+      "properties": {
+        "output": {
+          "type": "string",
+          "description": "Output from `paasta metastatus` command"
+        },
+        "exit_code": {
+          "type": "integer",
+          "description": "Exit code from `paasta metastatus` command"
         }
       }
     },

--- a/paasta_tools/api/views/metastatus.py
+++ b/paasta_tools/api/views/metastatus.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# Copyright 2018 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+PaaSTA metastatus.
+"""
+from pyramid.view import view_config
+
+from paasta_tools.paasta_metastatus import get_output
+
+
+@view_config(route_name='metastatus', request_method='GET', renderer='json')
+def metastatus(request):
+    cmd_args = request.swagger_data.get('cmd_args', None)
+    output, exit_code = get_output(cmd_args)
+    return {
+        "output": output,
+        "exit_code": exit_code,
+    }

--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -140,8 +140,7 @@ def paasta_metastatus_on_api_endpoint(
         res = client.metastatus.metastatus(cmd_args=[str(arg) for arg in cmd_args]).result()
         output, exit_code = res.output, res.exit_code
     except HTTPError as exc:
-        paasta_print(exc.response.text)
-        return exc.status_code
+        output, exit_code = exc.response.text, exc.status_code
 
     return exit_code, output
 
@@ -158,23 +157,18 @@ def print_cluster_status(
     """With a given cluster and verboseness, returns the status of the cluster
     output is printed directly to provide dashboards even if the cluster is unavailable"""
     if use_api_endpoint:
-        return_code, output = paasta_metastatus_on_api_endpoint(
-            cluster=cluster,
-            system_paasta_config=system_paasta_config,
-            groupings=groupings,
-            verbose=verbose,
-            autoscaling_info=autoscaling_info,
-            use_mesos_cache=use_mesos_cache,
-        )
+        metastatus_func = paasta_metastatus_on_api_endpoint
     else:
-        return_code, output = execute_paasta_metastatus_on_remote_master(
-            cluster=cluster,
-            system_paasta_config=system_paasta_config,
-            groupings=groupings,
-            verbose=verbose,
-            autoscaling_info=autoscaling_info,
-            use_mesos_cache=use_mesos_cache,
-        )
+        metastatus_func = execute_paasta_metastatus_on_remote_master
+
+    return_code, output = metastatus_func(
+        cluster=cluster,
+        system_paasta_config=system_paasta_config,
+        groupings=groupings,
+        verbose=verbose,
+        autoscaling_info=autoscaling_info,
+        use_mesos_cache=use_mesos_cache,
+    )
 
     paasta_print("Cluster: %s" % cluster)
     paasta_print(get_cluster_dashboards(cluster))

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2854,13 +2854,33 @@ def to_bytes(obj: Any) -> bytes:
         return str(obj).encode('UTF-8')
 
 
+TLS = threading.local()
+
+
+@contextlib.contextmanager
+def set_paasta_print_file(file: Any) -> Iterator[None]:
+    TLS.paasta_print_file = file
+    yield
+    TLS.paasta_print_file = None
+
+
 def paasta_print(*args: Any, **kwargs: Any) -> None:
     f = kwargs.pop('file', sys.stdout)
-    f = getattr(f, 'buffer', f)
-    end = to_bytes(kwargs.pop('end', '\n'))
-    sep = to_bytes(kwargs.pop('sep', ' '))
+    f = getattr(TLS, 'paasta_print_file', f)
+    buf = getattr(f, 'buffer', None)
+    # Here we're assuming that the file object works with strings and its
+    # `buffer` works with bytes. So, if the file object doesn't have `buffer`,
+    # we output via the file object itself using strings.
+    obj_to_arg: Callable[[Any], Any]
+    if buf is not None:
+        f = buf
+        obj_to_arg = to_bytes
+    else:
+        def obj_to_arg(o: Any) -> str: return to_bytes(o).decode('UTF-8', errors="ignore")
+    end = obj_to_arg(kwargs.pop('end', '\n'))
+    sep = obj_to_arg(kwargs.pop('sep', ' '))
     assert not kwargs, kwargs
-    to_print = sep.join(to_bytes(x) for x in args) + end
+    to_print = sep.join(obj_to_arg(x) for x in args) + end
     f.write(to_print)
     f.flush()
 


### PR DESCRIPTION
Add HTTP API to executes the code used to generate output of `paasta metastatus` on the HTTP API server side, and returns the output and the exit code for that.
Use that HTTP API to generate result for `paasta metastatus` instead of using `ssh ... /usr/bin/paasta_metastatus` if `USE_API_ENDPOINT` environment variable is `true`.
```
$ paasta metastatus -c norcal-stagef -vv -a >/tmp/paasta-metastatus-ORIG
$ USE_API_ENDPOINT=1 paasta metastatus -c norcal-stagef -vv -a >/tmp/paasta-metastatus-NEW 
$ diff -u /tmp/paasta-metastatus-ORIG /tmp/paasta-metastatus-NEW
--- /tmp/paasta-metastatus-ORIG 2018-09-14 04:15:49.874849796 -0700
+++ /tmp/paasta-metastatus-NEW  2018-09-14 04:15:37.787245547 -0700
@@ -27,8 +27,8 @@
     Resource id                Pool      State   Current  Target  Min capacity  Max capacity  Instances
     spam_paasta_stagef_xenial  spam      active  1        1       1             1             1
     yr_paasta_stagef           yelp_res  active  5        5       3             20            5
-    paasta_stagef              default   active  0        0       0             0             0
     paasta_kew_stagef          kew       active  3        3       3             3             3
+    paasta_stagef              default   active  0        0       0             0             0
 Marathon Status: OK
   marathon apps:       1696
   marathon tasks:      3580
```