### PR TITLE
Update paasta status to use http api when needed

### DIFF
--- a/general_itests/steps/deployments_json_steps.py
+++ b/general_itests/steps/deployments_json_steps.py
@@ -108,7 +108,7 @@ def step_paasta_stop_when(context):
         return_value=context.force_bounce_timestamp,
     ), mock.patch(
         'paasta_tools.cli.cmds.start_stop_restart.apply_args_filters', autospec=True,
-        return_value={fake_args.clusters: {fake_args.service: [fake_args.instances]}},
+        return_value={fake_args.clusters: {fake_args.service: {fake_args.instances: None}}},
     ):
         try:
             paasta_stop(fake_args)

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -156,7 +156,7 @@ def paasta_start_or_stop(args, desired_state):
             paasta_print("Cluster %s:" % cluster)
             for service, instances in services_instances.items():
                 paasta_print("    Service %s:" % service)
-                paasta_print("        Instances %s" % ",".join(instances))
+                paasta_print("        Instances %s" % ",".join(instances.keys()))
 
         if sys.stdin.isatty():
             confirm = choice.Binary('Are you sure you want to continue?', False).ask()
@@ -184,7 +184,7 @@ def paasta_start_or_stop(args, desired_state):
                 paasta_print(msg)
                 return 1
 
-            for instance in instances:
+            for instance in instances.keys():
                 service_config = get_instance_config(
                     service=service,
                     cluster=cluster,

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -151,8 +151,12 @@ def test_paasta_start_or_stop(
     mock_get_latest_deployment_tag.return_value = ('not_a_real_tag', None)
     mock_format_timestamp.return_value = 'not_a_real_timestamp'
     mock_apply_args_filters.return_value = {
-        'cluster1': {'fake_service': ['main1', 'canary']},
-        'cluster2': {'fake_service': ['main1', 'canary']},
+        'cluster1': {
+            'fake_service': {'main1': None, 'canary': None},
+        },
+        'cluster2': {
+            'fake_service': {'main1': None, 'canary': None},
+        },
     }
     ret = args.command(args)
     c1_get_instance_config_call = mock.call(
@@ -236,7 +240,7 @@ def test_paasta_start_or_stop_with_deploy_group(
     mock_get_latest_deployment_tag.return_value = ('not_a_real_tag', None)
     mock_format_timestamp.return_value = 'not_a_real_timestamp'
     mock_apply_args_filters.return_value = {
-        'cluster1': {'fake_service': ['instance1']},
+        'cluster1': {'fake_service': {'instance1': None}},
     }
     ret = args.command(args)
 
@@ -291,8 +295,12 @@ def test_stop_or_start_figures_out_correct_instances(
     mock_get_latest_deployment_tag.return_value = ('not_a_real_tag', None)
     mock_format_timestamp.return_value = 'not_a_real_timestamp'
     mock_apply_args_filters.return_value = {
-        'cluster1': {'fake_service': ['main1']},
-        'cluster2': {'fake_service': ['main1', 'canary']},
+        'cluster1': {
+            'fake_service': {'main1': None},
+        },
+        'cluster2': {
+            'fake_service': {'main1': None, 'canary': None},
+        },
     }
     ret = args.command(args)
     c1_get_instance_config_call = mock.call(
@@ -394,8 +402,8 @@ def test_start_or_stop_bad_refs(
         "refs/tags/paasta-deliberatelyinvalidref-20160304T053919-deploy": "70f7245ccf039d778c7e527af04eac00d261d783",
     }
     mock_apply_args_filters.return_value = {
-        'fake_cluster1': {'fake_service': ['fake_instance']},
-        'fake_cluster2': {'fake_service': ['fake_instance']},
+        'fake_cluster1': {'fake_service': {'fake_instance': None}},
+        'fake_cluster2': {'fake_service': {'fake_instance': None}},
     }
     assert args.command(args) == 1
     assert "No branches found for" in capfd.readouterr()[0]
@@ -438,8 +446,13 @@ def test_stop_or_start_warn_on_multi_instance(
     mock_get_latest_deployment_tag.return_value = ('not_a_real_tag', None)
     mock_format_timestamp.return_value = 'not_a_real_timestamp'
     mock_apply_args_filters.return_value = {
-        'cluster1': {'fake_service': ['main1'], 'other_service': ['main1']},
-        'cluster2': {'fake_service': ['main1', 'canary']},
+        'cluster1': {
+            'fake_service': {'main1': None},
+            'other_service': {'main1': None},
+        },
+        'cluster2': {
+            'fake_service': {'main1': None, 'canary': None},
+        },
     }
     ret = args.command(args)
     out, err = capfd.readouterr()


### PR DESCRIPTION
This makes it so paasta status will force use of the HTTP api for k8s
instances whilst still defaulting to the SSH api for other instance
types. As we add features to the HTTP api e.g. for marathon app status
we can migrate it over to using the HTTP by adding to
HTTP_ONLY_INSTANCE_CONFIG.

I think I've fixed all the tests but lets see what travis says...