### PR TITLE
Add Paasta API objgraph endpoints

### DIFF
--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -83,6 +83,9 @@ def make_app(global_config=None):
     config.add_route('version', '/v1/version')
     config.add_route('marathon_dashboard', '/v1/marathon_dashboard', request_method="GET")
     config.add_route('metastatus', '/v1/metastatus')
+    if os.environ.get("PAASTA_API_OBJGRAPH"):
+        config.add_route('objgraph_show_most_common_types', '/v1/objgraph/show_most_common_types')
+        config.add_route('objgraph_show_backrefs_for_type', '/v1/objgraph/show_backrefs/{type}')
     config.scan()
     return CORS(config.make_wsgi_app(), headers="*", methods="*", maxage="180", origin="*")
 

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -21,6 +21,66 @@
     }
   ],
   "paths": {
+    "/objgraph/show_most_common_types": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "`objgraph.show_most_common_types()` status",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "summary": "`objgraph.show_most_common_types()` output",
+        "operationId": "objgraph_show_most_common_types",
+        "parameters": [
+          {
+            "in": "query",
+            "description": "Maximum number of types",
+            "name": "limit",
+            "required": false,
+            "type": "integer"
+          }
+        ]
+      }
+    },
+    "/objgraph/show_backrefs/{type}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "`objgraph.show_backrefs(objgraph.by_type(type))` status",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "summary": "`objgraph.show_backrefs(objgraph.by_type(type))`",
+        "operationId": "objgraph_show_backrefs_for_type",
+        "parameters": [
+          {
+            "in": "path",
+            "description": "Type name",
+            "name": "type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "description": "Maximum number of objects to show references for",
+            "name": "max_objects",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "in": "query",
+            "description": "Maximum depth of the graph",
+            "name": "max_depth",
+            "required": false,
+            "type": "integer"
+          }
+        ]
+      }
+    },
     "/version": {
       "get": {
         "responses": {

--- a/paasta_tools/api/views/objgraph.py
+++ b/paasta_tools/api/views/objgraph.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# Copyright 2015-2018 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+PaaSTA objgraph
+"""
+import io
+import logging
+import os
+
+import objgraph
+if os.environ.get("PAASTA_API_OBJGRAPH"):
+    from pyramid.view import view_config
+else:
+    def view_config(*args, **kwargs):
+        def noop_wrapper(func):
+            return func
+        return noop_wrapper
+
+log = logging.getLogger(__name__)
+
+
+@view_config(route_name='objgraph_show_most_common_types', request_method='GET', renderer='json')
+def objgraph_show_most_common_types(request):
+    limit = request.swagger_data.get('limit')
+    if limit is None or limit <= 0:
+        limit = 20
+    output = io.StringIO()
+    print(f'PID={os.getpid()}', file=output)
+    print(f'>>> objgraph.show_most_common_types(limit={limit})', file=output)
+    objgraph.show_most_common_types(limit=limit, file=output)
+    log.error(output.getvalue())
+    return "See the paasta-api log for the output"
+
+
+@view_config(route_name='objgraph_show_backrefs_for_type', request_method='GET', renderer='json')
+def objgraph_show_backrefs_for_type(request):
+    type_name = request.swagger_data.get('type')
+    max_objects = request.swagger_data.get('max_objects')
+    if max_objects is None or max_objects <= 0:
+        max_objects = 20
+    max_depth = request.swagger_data.get('max_depth')
+    if max_depth is None or max_depth <= 0:
+        max_depth = 3
+    output = io.StringIO()
+    print(f'PID={os.getpid()}', file=output)
+    print(
+        f'>>> objgraph.show_backrefs(objgraph.by_type("{type_name}")'
+        f'[:{max_objects}], max_depth={max_depth})', file=output,
+    )
+    objs = objgraph.by_type(type_name)
+    objgraph.show_backrefs(objs[:max_objects], max_depth=max_depth)
+    log.error(output.getvalue())
+    return "See the paasta-api log for the output"

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -14,6 +14,7 @@ docker-py >= 1.2.3
 dulwich >= 0.17.3
 ephemeral-port-reserve >= 1.0.1
 gevent >= 1.1.1
+graphviz
 gunicorn
 humanize >= 0.5.1
 inotify >= 0.2.8
@@ -23,6 +24,7 @@ kazoo >= 2.0.0
 kubernetes
 marathon >= 0.9.3
 mypy-extensions >= 0.3.0
+objgraph
 progressbar2 >= 3.10.0
 pymesos >= 0.2.0
 pyramid >= 1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ ephemeral-port-reserve==1.1.0
 future==0.16.0
 gevent==1.1.1
 google-auth==1.2.0
+graphviz==0.8.2
 greenlet==0.4.12
 gunicorn==19.8.1
 http-parser==0.8.3
@@ -52,6 +53,7 @@ msgpack-python==0.4.8
 multidict==4.1.0
 mypy-extensions==0.3.0
 oauthlib==2.0.7
+objgraph==3.4.0
 PasteDeploy==1.5.2
 ply==3.4
 poyo==0.4.0


### PR DESCRIPTION
Add the following `objgraph`-based endpoints to help debugging memory
leaks:
 * `/v1/objgraph_show_most_common_types?limit=20` to output most common
types sorted by instance count.
 * `/v1/objgraph_show_backrefs_for_type/SomeTypeName?max_objects=20&max_depth=3`
to output back references for objects of given type.

All endpoints write their output into the `paasta-api` log.

You should run `paasta-api` with the `PAASTA_API_OBJGRAPH` environment
variable defined to enable these endpoints.

Please see https://mg.pov.lt/objgraph/ for an information about using
`objgraph` for memory leak investigation.