### PR TITLE
Add docs for cpu_burst_add

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -17,10 +17,10 @@ specify the following options:
     available free CPU, but is guaranteed to get the CPU shares specified.  For
     a more detailed read on how this works in practice, see the docs on `isolation <isolation.html>`_.
 
-    * ``cpu_burst_add``: Number of additional CPUs an instance may use while
-      bursting; if unspecified, PaaSTA defaults to 1. For example, if a service
-      specifies that it needs 2 CPUs normally and 1 for burst, the service may
-      go up to 3 CPUs, if needed.
+  * ``cpu_burst_add``: Maximum number of additional CPUs an instance may use
+    while bursting; if unspecified, PaaSTA defaults to 1. For example, if a
+    service specifies that it needs 2 CPUs normally and 1 for burst, the service
+    may go up to 3 CPUs, if needed.
 
   * ``mem``: Memory (in MB) an instance needs. Defaults to 1024 (1GB). In Mesos
     memory is constrained to the specified limit, and tasks will reach

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -18,7 +18,9 @@ specify the following options:
     a more detailed read on how this works in practice, see the docs on `isolation <isolation.html>`_.
 
     * ``cpu_burst_add``: Number of additional CPUs an instance may use while
-      bursting; if unspecified, PaaSTA defaults to 1.
+      bursting; if unspecified, PaaSTA defaults to 1. For example, if a service
+      specifies that it needs 2 CPUs normally and 1 for burst, the service may
+      go up to 3 CPUs, if needed.
 
   * ``mem``: Memory (in MB) an instance needs. Defaults to 1024 (1GB). In Mesos
     memory is constrained to the specified limit, and tasks will reach

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -17,6 +17,9 @@ specify the following options:
     available free CPU, but is guaranteed to get the CPU shares specified.  For
     a more detailed read on how this works in practice, see the docs on `isolation <isolation.html>`_.
 
+    * ``cpu_burst_add``: Number of additional CPUs an instance may use while
+      bursting; if unspecified, PaaSTA defaults to 1.
+
   * ``mem``: Memory (in MB) an instance needs. Defaults to 1024 (1GB). In Mesos
     memory is constrained to the specified limit, and tasks will reach
     out-of-memory (OOM) conditions if they attempt to exceed these limits, and


### PR DESCRIPTION
By @solarkennedy's request, I have added some documentation for the `cpu_burst_add` parameter under the cpus bullet point, just so people know it exists and specifies a number of cpus (no longer percentage based).