### PR TITLE
Add {}-type formatting for Tron commands

### DIFF
--- a/paasta_tools/chronos_rerun.py
+++ b/paasta_tools/chronos_rerun.py
@@ -79,8 +79,8 @@ def modify_command_for_date(chronos_job, date, verbose, use_percent):
     current_command = chronos_job['command']
     if current_command is not None:
         chronos_job['command'] = chronos_tools.parse_time_variables(
-            current_command,
-            date,
+            command=current_command,
+            parse_time=date,
             use_percent=use_percent,
         )
     else:

--- a/paasta_tools/chronos_rerun.py
+++ b/paasta_tools/chronos_rerun.py
@@ -77,7 +77,7 @@ def modify_command_for_date(chronos_job, date, verbose):
     """
     current_command = chronos_job['command']
     if current_command is not None:
-        chronos_job['command'] = chronos_tools.parse_time_variables(current_command, date)
+        chronos_job['command'] = chronos_tools.parse_time_variables(current_command, date, use_percent=True)
     else:
         if verbose:
             job_name = ".".join(chronos_tools.decompose_job_id(chronos_job['name']))

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -32,7 +32,7 @@ from paasta_tools import monitoring_tools
 from paasta_tools.mesos_tools import get_mesos_network_for_net
 from paasta_tools.mesos_tools import mesos_services_running_here
 from paasta_tools.secret_tools import get_secret_hashes
-from paasta_tools.tron import tron_command_context
+from paasta_tools.tron_tools import parse_time_variables
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_config_hash
@@ -396,7 +396,7 @@ class ChronosJobConfig(InstanceConfig):
         command = self.get_cmd()
         if command:
             try:
-                parse_time_variables(command)
+                parse_time_variables(command, use_percent=True)
                 return True, ""
             except (ValueError, KeyError, TypeError):
                 return False, ("Unparseable command '%s'. Hint: do you need to escape %% chars?") % command
@@ -530,7 +530,7 @@ class ChronosJobConfig(InstanceConfig):
             'cpus': self.get_cpus(),
             'disk': self.get_disk(),
             'constraints': constraints,
-            'command': parse_time_variables(self.get_cmd()) if self.get_cmd() else self.get_cmd(),
+            'command': parse_time_variables(self.get_cmd(), use_percent=True) if self.get_cmd() else self.get_cmd(),
             'arguments': self.get_args(),
             'epsilon': self.get_epsilon(),
             'retries': self.get_retries(),
@@ -924,34 +924,12 @@ def parse_execution_date(execution_date_string):
     return parsed
 
 
-def parse_time_variables(input_string, parse_time=None):
-    """Parses an input string and uses the Tron-style dateparsing
-    to replace time variables. Currently supports only the date/time
-    variables listed in the tron documentation:
-    http://tron.readthedocs.io/en/latest/command_context.html#built-in-cc
-
-    :param input_string: input string to be parsed
-    :param parse_time: Reference Datetime object to parse the date and time strings, defaults to now.
-    :returns: A string with the date and time variables replaced
-    """
-    if parse_time is None:
-        parse_time = datetime.datetime.now()
-    # We build up a tron context object that has the right
-    # methods to parse tron-style time syntax
-    job_context = tron_command_context.JobRunContext(tron_command_context.CommandContext())
-    # The tron context object needs the run_time attribute set so it knows
-    # how to interpret the date strings
-    job_context.job_run.run_time = parse_time
-    # The job_context object works like a normal dictionary for string replacement
-    return input_string % job_context
-
-
 def uses_time_variables(chronos_job):
     """
     Given a chronos job config, returns True the if the command uses time variables
     """
     current_command = chronos_job.get_cmd()
-    interpolated_command = parse_time_variables(current_command, datetime.datetime.utcnow())
+    interpolated_command = parse_time_variables(current_command, datetime.datetime.utcnow(), use_percent=True)
     return current_command != interpolated_command
 
 

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -399,7 +399,7 @@ class ChronosJobConfig(InstanceConfig):
         command = self.get_cmd()
         if command:
             try:
-                parse_time_variables(command, use_percent=self.is_cmd_percent_format())
+                parse_time_variables(command=command, use_percent=self.is_cmd_percent_format())
                 return True, ""
             except (ValueError, KeyError, TypeError):
                 return False, ("Unparseable command '%s'. Hint: do you need to escape %% chars?") % command
@@ -519,7 +519,7 @@ class ChronosJobConfig(InstanceConfig):
         net = get_mesos_network_for_net(self.get_net())
         if self.get_cmd():
             command = parse_time_variables(
-                self.get_cmd(),
+                command=self.get_cmd(),
                 use_percent=self.is_cmd_percent_format(),
             )
         else:
@@ -940,8 +940,8 @@ def uses_time_variables(chronos_job):
     """
     current_command = chronos_job.get_cmd()
     interpolated_command = parse_time_variables(
-        current_command,
-        datetime.datetime.utcnow(),
+        command=current_command,
+        parse_time=datetime.datetime.utcnow(),
         use_percent=chronos_job.is_cmd_percent_format(),
     )
     return current_command != interpolated_command

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -775,7 +775,7 @@ def run_docker_container(
     return returncode
 
 
-def command_function_for_framework(framework, date):
+def command_function_for_framework(framework, date, use_percent=False):
     """
     Given a framework, return a function that appropriately formats
     the command to be run.
@@ -784,7 +784,7 @@ def command_function_for_framework(framework, date):
         return cmd
 
     def format_chronos_command(cmd):
-        interpolated_command = parse_time_variables(cmd, date, use_percent=True)
+        interpolated_command = parse_time_variables(cmd, date, use_percent)
         return interpolated_command
 
     def format_tron_command(cmd: str) -> str:
@@ -925,8 +925,10 @@ def configure_and_run_docker_container(
         command = args.cmd
     else:
         command_from_config = instance_config.get_cmd()
+        # TODO: remove after all Chronos configs have been updated
+        use_percent = instance_config.is_cmd_percent_format() if instance_type == 'chronos' else False
         if command_from_config:
-            command_modifier = command_function_for_framework(instance_type, args.date)
+            command_modifier = command_function_for_framework(instance_type, args.date, use_percent)
             command = command_modifier(command_from_config)
         else:
             command = instance_config.get_args()

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -784,11 +784,11 @@ def command_function_for_framework(framework, date):
         return cmd
 
     def format_chronos_command(cmd):
-        interpolated_command = parse_time_variables(cmd, date)
+        interpolated_command = parse_time_variables(cmd, date, use_percent=True)
         return interpolated_command
 
     def format_tron_command(cmd: str) -> str:
-        interpolated_command = parse_time_variables(cmd, date)
+        interpolated_command = parse_time_variables(cmd, date, use_percent=False)
         return interpolated_command
 
     def format_adhoc_command(cmd):

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -784,11 +784,19 @@ def command_function_for_framework(framework, date, use_percent=False):
         return cmd
 
     def format_chronos_command(cmd):
-        interpolated_command = parse_time_variables(cmd, date, use_percent)
+        interpolated_command = parse_time_variables(
+            command=cmd,
+            parse_time=date,
+            use_percent=use_percent,
+        )
         return interpolated_command
 
     def format_tron_command(cmd: str) -> str:
-        interpolated_command = parse_time_variables(cmd, date, use_percent=False)
+        interpolated_command = parse_time_variables(
+            command=cmd,
+            parse_time=date,
+            use_percent=False,
+        )
         return interpolated_command
 
     def format_adhoc_command(cmd):

--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -14,6 +14,9 @@
             "cmd": {
                 "type": "string"
             },
+            "use_percent_format": {
+                "type": "boolean"
+            },
             "args": {
                 "type": "array",
                 "items": {

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -1489,7 +1489,18 @@ def test_command_function_for_framework_for_chronos(mock_datetime, mock_parse_ti
     mock_parse_time_variables.return_value = "foo"
     fn = command_function_for_framework('chronos', fake_date)
     fn("foo")
-    mock_parse_time_variables.assert_called_once_with('foo', fake_date)
+    mock_parse_time_variables.assert_called_once_with('foo', fake_date, use_percent=True)
+
+
+@mock.patch('paasta_tools.cli.cmds.local_run.parse_time_variables', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.local_run.datetime', autospec=True)
+def test_command_function_for_framework_for_tron(mock_datetime, mock_parse_time_variables):
+    fake_date = mock.Mock()
+    mock_datetime.datetime.now.return_value = fake_date
+    mock_parse_time_variables.return_value = "foo"
+    fn = command_function_for_framework('tron', fake_date)
+    fn("foo")
+    mock_parse_time_variables.assert_called_once_with('foo', fake_date, use_percent=False)
 
 
 def test_command_function_for_framework_throws_error():

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -1487,7 +1487,7 @@ def test_command_function_for_framework_for_chronos(mock_datetime, mock_parse_ti
     fake_date = mock.Mock()
     mock_datetime.datetime.now.return_value = fake_date
     mock_parse_time_variables.return_value = "foo"
-    fn = command_function_for_framework('chronos', fake_date)
+    fn = command_function_for_framework('chronos', fake_date, True)
     fn("foo")
     mock_parse_time_variables.assert_called_once_with('foo', fake_date, use_percent=True)
 

--- a/tests/test_chronos_rerun.py
+++ b/tests/test_chronos_rerun.py
@@ -30,9 +30,10 @@ def test_modify_command_for_date(mock_parse_time_variables):
         'command': 'foo',
     }
     actual = chronos_rerun.modify_command_for_date(
-        fake_chronos_job_config,
-        datetime.datetime.now(),
-        False,
+        chronos_job=fake_chronos_job_config,
+        date=datetime.datetime.now(),
+        verbose=False,
+        use_percent=True,
     )
 
     assert actual == {
@@ -46,9 +47,10 @@ def test_modify_command_for_date_no_command():
         'name': "service instance",
     }
     actual = chronos_rerun.modify_command_for_date(
-        fake_chronos_job_config,
-        datetime.datetime.now(),
-        True,
+        chronos_job=fake_chronos_job_config,
+        date=datetime.datetime.now(),
+        verbose=True,
+        use_percent=True,
     )
     assert actual == fake_chronos_job_config
 
@@ -92,7 +94,7 @@ def test_clone_job(
     }
     mock_get_job_type.return_value = chronos_tools.JobType.Dependent
     timestamp = datetime.datetime.utcnow().isoformat()
-    chronos_rerun.clone_job(fake_chronos_job_config, '2016-03-2016T04:40:31', timestamp=timestamp)
+    chronos_rerun.clone_job(fake_chronos_job_config, timestamp=timestamp)
     assert mock_get_job_type.call_count == 1
     assert mock_set_tmp_naming_scheme.call_count == 1
 
@@ -115,7 +117,6 @@ def test_clone_job_dependent_jobs(
 
     cloned_job = chronos_rerun.clone_job(
         fake_chronos_job_config,
-        '2016-03-2016T04:40:31',
         timestamp=timestamp,
     )
 

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-import datetime
 
 import mock
 from mock import Mock
@@ -373,7 +372,7 @@ class TestChronosTools:
                 system_paasta_config.get_dockercfg_location(),
                 fake_constraints,
             )
-            mock_parse_time_variables.assert_called_with(fake_cmd)
+            mock_parse_time_variables.assert_called_with(fake_cmd, use_percent=True)
 
     def test_get_owner(self):
         fake_owner = 'fake_team'
@@ -1739,20 +1738,6 @@ class TestChronosTools:
         with mock.patch('paasta_tools.chronos_tools.sleep', autospec=True) as mock_sleep:
             assert chronos_tools.wait_for_job(client, 'foo')
             assert mock_sleep.call_count == 2
-
-    def test_parse_time_variables_parses_shortdate(self):
-        input_time = datetime.datetime(2012, 3, 14)
-        test_input = 'ls %(shortdate-1)s foo'
-        expected = 'ls 2012-03-13 foo'
-        actual = chronos_tools.parse_time_variables(input_string=test_input, parse_time=input_time)
-        assert actual == expected
-
-    def test_parse_time_variables_parses_percent(self):
-        input_time = datetime.datetime(2012, 3, 14)
-        test_input = './mycommand --date %(shortdate-1)s --format foo/logs/%%L/%%Y/%%m/%%d/'
-        expected = './mycommand --date 2012-03-13 --format foo/logs/%L/%Y/%m/%d/'
-        actual = chronos_tools.parse_time_variables(input_string=test_input, parse_time=input_time)
-        assert actual == expected
 
     def test_check_cmd_escaped_percent(self):
         test_input = './mycommand --date %(shortdate-1)s --format foo/logs/%%L/%%Y/%%m/%%d/'

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1,3 +1,5 @@
+import datetime
+
 import mock
 import pytest
 
@@ -34,6 +36,30 @@ class TestTronConfig:
         config = tron_tools.TronConfig(config_dict)
         with pytest.raises(tron_tools.TronNotConfigured):
             config.get_url()
+
+
+class TestParseTimeVariables:
+
+    def test_parse_time_variables_parses_shortdate_with_percent(self):
+        input_time = datetime.datetime(2012, 3, 14)
+        test_input = 'ls %(shortdate-1)s foo'
+        expected = 'ls 2012-03-13 foo'
+        actual = tron_tools.parse_time_variables(command=test_input, parse_time=input_time, use_percent=True)
+        assert actual == expected
+
+    def test_parse_time_variables_parses_percent(self):
+        input_time = datetime.datetime(2012, 3, 14)
+        test_input = './mycommand --date %(shortdate-1)s --format foo/logs/%%L/%%Y/%%m/%%d/'
+        expected = './mycommand --date 2012-03-13 --format foo/logs/%L/%Y/%m/%d/'
+        actual = tron_tools.parse_time_variables(command=test_input, parse_time=input_time, use_percent=True)
+        assert actual == expected
+
+    def test_parse_time_variables_parses_shortdate_with_braces(self):
+        input_time = datetime.datetime(2012, 3, 14)
+        test_input = 'ls {shortdate-1} foo'
+        expected = 'ls 2012-03-13 foo'
+        actual = tron_tools.parse_time_variables(command=test_input, parse_time=input_time, use_percent=False)
+        assert actual == expected
 
 
 class TestTronActionConfig:


### PR DESCRIPTION
Now that Tron commands use {} instead of %, parse_time_variables needs to handle those differently for local-run.

Chronos commands still use % now... The 2nd commit provides a migration path forward:
1. Release this version of paasta tools
2. change all commands to {} in soaconfigs, with use_percent_format: False
3. Change parse time variables to always use {} instead of percent
4. Remove use_percent_format from soaconfigs
5. Remove use_percent_format from paasta tools

Alternatively, we could not bother with migrating and leave use_percent hardcoded to True for Chronos. Then we wouldn't need the 2nd commit at all.