### PR TITLE
Refactor check_marathon_services_replication

### DIFF
--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -32,7 +32,6 @@ instance then it will be used instead.
 """
 import argparse
 import logging
-import os
 from datetime import datetime
 from datetime import timedelta
 
@@ -41,57 +40,19 @@ import pysensu_yelp
 
 from paasta_tools import marathon_tools
 from paasta_tools import monitoring_tools
+from paasta_tools.long_running_service_tools import get_proxy_port_for_instance
 from paasta_tools.marathon_tools import format_job_id
 from paasta_tools.mesos_tools import get_slaves
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.smartstack_tools import SmartstackReplicationChecker
-from paasta_tools.utils import _log
 from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import is_under_replicated
+from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 
 
 log = logging.getLogger(__name__)
-
-
-def send_event(instance_config, status, output):
-    """Send an event to sensu via pysensu_yelp with the given information.
-
-    :param instance_config: an instance of MarathonServiceConfig
-    :param status: The status to emit for this event
-    :param output: The output to emit for this event"""
-    # This function assumes the input is a string like "mumble.main"
-    monitoring_overrides = instance_config.get_monitoring()
-    if 'alert_after' not in monitoring_overrides:
-        monitoring_overrides['alert_after'] = '2m'
-    monitoring_overrides['check_every'] = '1m'
-    monitoring_overrides['runbook'] = monitoring_tools.get_runbook(
-        monitoring_overrides,
-        instance_config.service, soa_dir=instance_config.soa_dir,
-    )
-
-    check_name = (
-        'check_marathon_services_replication.%s' %
-        instance_config.job_id
-    )
-    monitoring_tools.send_event(
-        service=instance_config.service,
-        check_name=check_name,
-        overrides=monitoring_overrides,
-        status=status,
-        output=output,
-        soa_dir=instance_config.soa_dir,
-        cluster=instance_config.cluster,
-    )
-    _log(
-        service=instance_config.service,
-        line='Replication: %s' % output,
-        component='monitoring',
-        level='debug',
-        cluster=instance_config.cluster,
-        instance=instance_config.instance,
-    )
 
 
 def parse_args():
@@ -110,104 +71,6 @@ def parse_args():
     options = parser.parse_args()
 
     return options
-
-
-def check_smartstack_replication_for_instance(
-    instance_config,
-    expected_count,
-    smartstack_replication_checker,
-):
-    """Check a set of namespaces to see if their number of available backends is too low,
-    emitting events to Sensu based on the fraction available and the thresholds defined in
-    the corresponding yelpsoa config.
-
-    :param instance_config: an instance of MarathonServiceConfig
-    :param smartstack_replication_checker: an instance of SmartstackReplicationChecker
-    """
-
-    crit_threshold = instance_config.get_replication_crit_percentage()
-
-    log.info('Checking instance %s in smartstack', instance_config.job_id)
-    smartstack_replication_info = \
-        smartstack_replication_checker.get_replication_for_instance(instance_config)
-
-    log.debug('Got smartstack replication info for %s: %s' %
-              (instance_config.job_id, smartstack_replication_info))
-
-    if len(smartstack_replication_info) == 0:
-        status = pysensu_yelp.Status.CRITICAL
-        output = (
-            'Service %s has no Smartstack replication info. Make sure the discover key in your smartstack.yaml '
-            'is valid!\n'
-        ) % instance_config.job_id
-        log.error(output)
-    else:
-        expected_count_per_location = int(expected_count / len(smartstack_replication_info))
-        output = ''
-        output_critical = ''
-        output_ok = ''
-        under_replication_per_location = []
-
-        for location, available_backends in sorted(smartstack_replication_info.items()):
-            num_available_in_location = available_backends.get(instance_config.job_id, 0)
-            under_replicated, ratio = is_under_replicated(
-                num_available_in_location, expected_count_per_location, crit_threshold,
-            )
-            if under_replicated:
-                output_critical += '- Service %s has %d out of %d expected instances in %s (CRITICAL: %d%%)\n' % (
-                    instance_config.job_id, num_available_in_location, expected_count_per_location, location, ratio,
-                )
-            else:
-                output_ok += '- Service %s has %d out of %d expected instances in %s (OK: %d%%)\n' % (
-                    instance_config.job_id, num_available_in_location, expected_count_per_location, location, ratio,
-                )
-            under_replication_per_location.append(under_replicated)
-
-        output += output_critical
-        if output_critical and output_ok:
-            output += '\n\n'
-            output += 'The following locations are OK:\n'
-        output += output_ok
-
-        if any(under_replication_per_location):
-            status = pysensu_yelp.Status.CRITICAL
-            output += (
-                "\n\n"
-                "What this alert means:\n"
-                "\n"
-                "  This replication alert means that a SmartStack powered loadbalancer (haproxy)\n"
-                "  doesn't have enough healthy backends. Not having enough healthy backends\n"
-                "  means that clients of that service will get 503s (http) or connection refused\n"
-                "  (tcp) when trying to connect to it.\n"
-                "\n"
-                "Reasons this might be happening:\n"
-                "\n"
-                "  The service may simply not have enough copies or it could simply be\n"
-                "  unhealthy in that location. There also may not be enough resources\n"
-                "  in the cluster to support the requested instance count.\n"
-                "\n"
-                "Things you can do:\n"
-                "\n"
-                "  * You can view the logs for the job with:\n"
-                "      paasta logs -s %(service)s -i %(instance)s -c %(cluster)s\n"
-                "\n"
-                "  * Fix the cause of the unhealthy service. Try running:\n"
-                "\n"
-                "      paasta status -s %(service)s -i %(instance)s -c %(cluster)s -vv\n"
-                "\n"
-                "  * Widen SmartStack discovery settings\n"
-                "  * Increase the instance count\n"
-                "\n"
-            ) % {
-                'service': instance_config.service,
-                'instance': instance_config.instance,
-                'cluster': instance_config.cluster,
-            }
-            log.error(output)
-        else:
-            status = pysensu_yelp.Status.OK
-            log.info(output)
-    send_event(instance_config=instance_config, status=status, output=output)
 
 
 def filter_healthy_marathon_instances_for_short_app_id(all_tasks, app_id):
@@ -234,14 +97,14 @@ def check_healthy_marathon_tasks_for_service_instance(
         app_id=app_id,
     )
     log.info("Checking %s in marathon as it is not in smartstack" % app_id)
-    send_event_if_under_replication(
+    send_replication_event_if_under_replication(
         instance_config=instance_config,
         expected_count=expected_count,
         num_available=num_healthy_tasks,
     )
 
 
-def send_event_if_under_replication(
+def send_replication_event_if_under_replication(
     instance_config,
     expected_count,
     num_available,
@@ -281,7 +144,7 @@ def send_event_if_under_replication(
     else:
         log.info(output)
         status = pysensu_yelp.Status.OK
-    send_event(
+    monitoring_tools.send_replication_event(
         instance_config=instance_config,
         status=status,
         output=output,
@@ -301,18 +164,13 @@ def check_service_replication(
     """
     expected_count = instance_config.get_instances()
     log.info("Expecting %d total tasks for %s" % (expected_count, instance_config.job_id))
-    proxy_port = marathon_tools.get_proxy_port_for_instance(
-        name=instance_config.service,
-        instance=instance_config.instance,
-        cluster=instance_config.cluster,
-        soa_dir=instance_config.soa_dir,
-    )
+    proxy_port = get_proxy_port_for_instance(instance_config)
 
     registrations = instance_config.get_registrations()
     # if the primary registration does not match the service_instance name then
     # the best we can do is check marathon for replication (for now).
     if proxy_port is not None and registrations[0] == instance_config.job_id:
-        check_smartstack_replication_for_instance(
+        monitoring_tools.check_smartstack_replication_for_instance(
             instance_config=instance_config,
             expected_count=expected_count,
             smartstack_replication_checker=smartstack_replication_checker,
@@ -323,11 +181,6 @@ def check_service_replication(
             expected_count=expected_count,
             all_tasks=all_tasks,
         )
-
-
-def list_services(soa_dir):
-    rootdir = os.path.abspath(soa_dir)
-    return os.listdir(rootdir)
 
 
 def main():

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -44,7 +44,7 @@ from paasta_tools.long_running_service_tools import get_proxy_port_for_instance
 from paasta_tools.marathon_tools import format_job_id
 from paasta_tools.mesos_tools import get_slaves
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
-from paasta_tools.smartstack_tools import SmartstackReplicationChecker
+from paasta_tools.smartstack_tools import MesosSmartstackReplicationChecker
 from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import is_under_replicated
@@ -160,7 +160,7 @@ def check_service_replication(
     should be monitored. (smartstack or mesos)
 
     :param instance_config: an instance of MarathonServiceConfig
-    :param smartstack_replication_checker: an instance of SmartstackReplicationChecker
+    :param smartstack_replication_checker: an instance of MesosSmartstackReplicationChecker
     """
     expected_count = instance_config.get_instances()
     log.info("Expecting %d total tasks for %s" % (expected_count, instance_config.job_id))
@@ -200,7 +200,7 @@ def main():
     for client in all_clients:
         all_tasks.extend(client.list_tasks())
     mesos_slaves = a_sync.block(get_slaves)
-    smartstack_replication_checker = SmartstackReplicationChecker(mesos_slaves, system_paasta_config)
+    smartstack_replication_checker = MesosSmartstackReplicationChecker(mesos_slaves, system_paasta_config)
 
     for service in list_services(soa_dir=args.soa_dir):
         service_config = PaastaServiceConfigLoader(service=service, soa_dir=args.soa_dir)

--- a/paasta_tools/cli/cmds/autoscale.py
+++ b/paasta_tools/cli/cmds/autoscale.py
@@ -18,8 +18,8 @@ from paasta_tools.api import client
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
-from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import list_services
 from paasta_tools.utils import paasta_print
 
 

--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -25,7 +25,6 @@ from paasta_tools.cli.utils import get_file_contents
 from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.cli.utils import is_file_in_dir
 from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import NoSuchService
 from paasta_tools.cli.utils import PaastaCheckMessages
 from paasta_tools.cli.utils import success
@@ -40,6 +39,7 @@ from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import INSTANCE_TYPES
 from paasta_tools.utils import is_deploy_step
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import list_services
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
 

--- a/paasta_tools/cli/cmds/emergency_restart.py
+++ b/paasta_tools/cli/cmds/emergency_restart.py
@@ -16,10 +16,10 @@ from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
-from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 

--- a/paasta_tools/cli/cmds/emergency_start.py
+++ b/paasta_tools/cli/cmds/emergency_start.py
@@ -16,10 +16,10 @@ from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
-from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors

--- a/paasta_tools/cli/cmds/emergency_stop.py
+++ b/paasta_tools/cli/cmds/emergency_stop.py
@@ -16,10 +16,10 @@ from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
-from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 

--- a/paasta_tools/cli/cmds/generate_pipeline.py
+++ b/paasta_tools/cli/cmds/generate_pipeline.py
@@ -18,7 +18,6 @@ import re
 
 from paasta_tools.cli.utils import guess_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import NoSuchService
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.monitoring_tools import get_team
@@ -26,6 +25,7 @@ from paasta_tools.monitoring_tools import get_team_email_address
 from paasta_tools.utils import _run
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_git_url
+from paasta_tools.utils import list_services
 from paasta_tools.utils import paasta_print
 
 

--- a/paasta_tools/cli/cmds/get_latest_deployment.py
+++ b/paasta_tools/cli/cmds/get_latest_deployment.py
@@ -16,11 +16,11 @@ import sys
 
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
-from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import PaastaColors
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.deployment_utils import get_currently_deployed_sha
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import list_services
 from paasta_tools.utils import paasta_print
 
 

--- a/paasta_tools/cli/cmds/info.py
+++ b/paasta_tools/cli/cmds/info.py
@@ -20,13 +20,13 @@ from service_configuration_lib import read_service_configuration
 from paasta_tools.cli.cmds.status import get_actual_deployments
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.cli.utils import list_services
 from paasta_tools.marathon_tools import get_all_namespaces_for_service
 from paasta_tools.marathon_tools import load_service_namespace_config
 from paasta_tools.monitoring_tools import get_runbook
 from paasta_tools.monitoring_tools import get_team
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_git_url
+from paasta_tools.utils import list_services
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors

--- a/paasta_tools/cli/cmds/itest.py
+++ b/paasta_tools/cli/cmds/itest.py
@@ -16,13 +16,13 @@ import os
 
 from paasta_tools.cli.utils import get_jenkins_build_output_url
 from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.utils import _log
 from paasta_tools.utils import _run
 from paasta_tools.utils import build_docker_tag
 from paasta_tools.utils import check_docker_image
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import list_services
 
 
 def add_subparser(subparsers):

--- a/paasta_tools/cli/cmds/list.py
+++ b/paasta_tools/cli/cmds/list.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from paasta_tools.cli.utils import list_paasta_services
 from paasta_tools.cli.utils import list_service_instances
-from paasta_tools.cli.utils import list_services
+from paasta_tools.utils import list_services
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import SPACER
 

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -34,7 +34,6 @@ from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
-from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import pick_random_port
 from paasta_tools.long_running_service_tools import get_healthcheck_for_instance
 from paasta_tools.paasta_execute_docker_command import execute_in_container
@@ -45,6 +44,7 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_docker_client
 from paasta_tools.utils import get_username
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -49,7 +49,7 @@ from paasta_tools.marathon_tools import format_job_id
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import guess_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.cli.utils import list_services
+from paasta_tools.utils import list_services
 from paasta_tools.utils import ANY_CLUSTER
 from paasta_tools.utils import datetime_convert_timezone
 from paasta_tools.utils import datetime_from_utc_to_local

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -37,7 +37,6 @@ from paasta_tools.api import client
 from paasta_tools.cli.cmds.push_to_registry import is_docker_image_already_in_registry
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
-from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import validate_git_sha
 from paasta_tools.cli.utils import validate_given_deploy_groups
 from paasta_tools.cli.utils import validate_service_name
@@ -52,6 +51,7 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import format_tag
 from paasta_tools.utils import get_git_url
 from paasta_tools.utils import get_paasta_tag_from_deploy_group
+from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors

--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -23,9 +23,9 @@ from paasta_tools.api.client import get_paasta_api_client
 from paasta_tools.cli.utils import execute_paasta_metastatus_on_remote_master
 from paasta_tools.cli.utils import get_paasta_metastatus_cmd_args
 from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -19,9 +19,9 @@ from shlex import quote
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_clusters
 from paasta_tools.cli.utils import list_instances
-from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import run_on_master
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors

--- a/paasta_tools/cli/cmds/rerun.py
+++ b/paasta_tools/cli/cmds/rerun.py
@@ -24,9 +24,9 @@ from paasta_tools.cli.utils import execute_chronos_rerun_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
-from paasta_tools.cli.utils import list_services
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import paasta_print

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -19,7 +19,6 @@ from paasta_tools.cli.utils import extract_tags
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
-from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import validate_full_git_sha
 from paasta_tools.cli.utils import validate_given_deploy_groups
 from paasta_tools.remote_git import list_remote_refs
@@ -27,6 +26,7 @@ from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import format_table
 from paasta_tools.utils import get_git_url
+from paasta_tools.utils import list_services
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import parse_timestamp

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -16,9 +16,9 @@ import os
 import sys
 
 from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.cli.utils import list_services
 from paasta_tools.secret_tools import get_secret_provider
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -14,7 +14,6 @@ from paasta_tools.cli.cmds.cook_image import paasta_cook_image
 from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
-from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import pick_random_port
 from paasta_tools.clusterman import get_clusterman_metrics
 from paasta_tools.mesos_tools import find_mesos_leader
@@ -22,6 +21,7 @@ from paasta_tools.mesos_tools import MESOS_MASTER_PORT
 from paasta_tools.utils import _run
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_username
+from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -39,7 +39,6 @@ from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_instance_configs_for_service
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
-from paasta_tools.cli.utils import list_services
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.kubernetes_tools import KubernetesDeployStatus
 from paasta_tools.marathon_serviceinit import bouncing_status_human
@@ -55,6 +54,7 @@ from paasta_tools.utils import get_soa_cluster_deploy_files
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import list_all_instances_for_service
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import list_services
 from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -30,7 +30,6 @@ from paasta_tools.chronos_tools import TMP_JOB_IDENTIFIER
 from paasta_tools.cli.utils import failure
 from paasta_tools.cli.utils import get_file_contents
 from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import PaastaColors
 from paasta_tools.cli.utils import success
 from paasta_tools.tron_tools import list_tron_clusters
@@ -38,6 +37,7 @@ from paasta_tools.tron_tools import validate_complete_config
 from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import list_all_instances_for_service
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import list_services
 from paasta_tools.utils import paasta_print
 
 

--- a/paasta_tools/cli/cmds/wait_for_deployment.py
+++ b/paasta_tools/cli/cmds/wait_for_deployment.py
@@ -22,7 +22,6 @@ from paasta_tools.cli.cmds.mark_for_deployment import report_waiting_aborted
 from paasta_tools.cli.cmds.mark_for_deployment import wait_for_deployment
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
-from paasta_tools.cli.utils import list_services
 from paasta_tools.cli.utils import NoSuchService
 from paasta_tools.cli.utils import validate_git_sha
 from paasta_tools.cli.utils import validate_given_deploy_groups
@@ -33,6 +32,7 @@ from paasta_tools.remote_git import LSRemoteException
 from paasta_tools.utils import _log
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_git_url
+from paasta_tools.utils import list_services
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import TimeoutError

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -52,6 +52,7 @@ from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import list_all_instances_for_service
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import list_services
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import SystemPaastaConfig
@@ -351,12 +352,6 @@ def validate_service_name(service, soa_dir=DEFAULT_SOA_DIR):
     if not service or not os.path.isdir(os.path.join(soa_dir, service)):
         raise NoSuchService(service)
     return True
-
-
-def list_services(**kwargs):
-    """Returns a sorted list of all services"""
-    soa_dir = kwargs.get('soa_dir', DEFAULT_SOA_DIR)
-    return sorted(os.listdir(os.path.abspath(soa_dir)))
 
 
 def list_paasta_services():

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -389,3 +389,23 @@ def set_instances_for_marathon_service(
     with ZookeeperPool() as zookeeper_client:
         zookeeper_client.ensure_path(zookeeper_path)
         zookeeper_client.set(zookeeper_path, str(instance_count).encode('utf8'))
+
+
+def get_proxy_port_for_instance(
+    service_config: LongRunningServiceConfig,
+) -> Optional[int]:
+    """Get the proxy_port defined in the first namespace configuration for a
+    service instance.
+
+    This means that the namespace first has to be loaded from the service instance's
+    configuration, and then the proxy_port has to loaded from the smartstack configuration
+    for that namespace.
+
+    :param service_config: The instance of the services LongRunningServiceConfig
+    :returns: The proxy_port for the service instance, or None if not defined"""
+    registration = service_config.get_registrations()[0]
+    service, namespace, _, __ = decompose_job_id(registration)
+    nerve_dict = load_service_namespace_config(
+        service=service, namespace=namespace, soa_dir=service_config.soa_dir,
+    )
+    return nerve_dict.get('proxy_port')

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -969,79 +969,6 @@ def deformat_job_id(job_id: str) -> Tuple[str, str, str, str]:
     return decompose_job_id(job_id)
 
 
-def read_all_registrations_for_service_instance(
-    service: str,
-    instance: str,
-    cluster: Optional[str]=None,
-    soa_dir: str=DEFAULT_SOA_DIR,
-) -> List[str]:
-    """Retrieve all registrations as fully specified name.instance pairs
-    for a particular service instance.
-
-    For example, the 'main' paasta instance of the 'test' service may register
-    in the 'test.main' namespace as well as the 'other_svc.main' namespace.
-
-    If one is not defined in the config file, returns a list containing
-    name.instance instead.
-    """
-    if not cluster:
-        cluster = load_system_paasta_config().get_cluster()
-
-    marathon_service_config = load_marathon_service_config(
-        service, instance, cluster, load_deployments=False, soa_dir=soa_dir,
-    )
-    return marathon_service_config.get_registrations()
-
-
-def read_registration_for_service_instance(
-    service: str,
-    instance: str,
-    cluster: Optional[str]=None,
-    soa_dir: str=DEFAULT_SOA_DIR,
-) -> str:
-    """Retrieve a service instance's primary registration for a particular
-    service instance.
-
-    This is the service and namespace that clients ought talk to, as well as
-    paasta ought monitor. In this context "primary" just means the first one
-    in the list of registrations.
-
-    If registrations are not defined in the marathon config file, returns
-    name.instance instead.
-
-    :returns a fully qualified service.instance registration
-    """
-    return read_all_registrations_for_service_instance(
-        service, instance, cluster, soa_dir,
-    )[0]
-
-
-def get_proxy_port_for_instance(
-    name: str,
-    instance: str,
-    cluster: Optional[str]=None,
-    soa_dir: str=DEFAULT_SOA_DIR,
-) -> Optional[int]:
-    """Get the proxy_port defined in the first namespace configuration for a
-    service instance.
-
-    This means that the namespace first has to be loaded from the service instance's
-    configuration, and then the proxy_port has to loaded from the smartstack configuration
-    for that namespace.
-
-    :param name: The service name
-    :param instance: The instance of the service
-    :param cluster: The cluster to read the configuration for
-    :param soa_dir: The SOA config directory to read from
-    :returns: The proxy_port for the service instance, or None if not defined"""
-    registration = read_registration_for_service_instance(name, instance, cluster, soa_dir)
-    service, namespace, _, __ = decompose_job_id(registration)
-    nerve_dict = load_service_namespace_config(
-        service=service, namespace=namespace, soa_dir=soa_dir,
-    )
-    return nerve_dict.get('proxy_port')
-
-
 def get_all_namespaces_for_service(
     service: str,
     soa_dir: str=DEFAULT_SOA_DIR,
@@ -1124,10 +1051,14 @@ def get_marathon_services_running_here_for_nerve(
     nerve_list = []
     for name, instance, port in marathon_services:
         try:
-            registrations = read_all_registrations_for_service_instance(
-                name, instance, cluster, soa_dir,
+            marathon_service_config = load_marathon_service_config(
+                service=name,
+                instance=instance,
+                cluster=cluster,
+                load_deployments=False,
+                soa_dir=soa_dir,
             )
-            for registration in registrations:
+            for registration in marathon_service_config.get_registrations():
                 reg_service, reg_namespace, _, __ = decompose_job_id(registration)
                 nerve_dict = load_service_namespace_config(
                     service=reg_service, namespace=reg_namespace, soa_dir=soa_dir,

--- a/paasta_tools/native_mesos_scheduler.py
+++ b/paasta_tools/native_mesos_scheduler.py
@@ -109,10 +109,14 @@ def get_paasta_native_services_running_here_for_nerve(cluster, soa_dir, hostname
     nerve_list = []
     for name, instance, port in paasta_native_services:
         try:
-            registrations = read_all_registrations_for_service_instance(
-                name, instance, cluster, soa_dir,
+            job_config = load_paasta_native_job_config(
+                service=name,
+                instance=instance,
+                cluster=cluster,
+                load_deployments=False,
+                soa_dir=soa_dir,
             )
-            for registration in registrations:
+            for registration in job_config.get_registrations():
                 reg_service, reg_namespace, _, __ = decompose_job_id(registration)
                 nerve_dict = load_service_namespace_config(
                     service=reg_service, namespace=reg_namespace, soa_dir=soa_dir,
@@ -124,29 +128,6 @@ def get_paasta_native_services_running_here_for_nerve(cluster, soa_dir, hostname
         except KeyError:
             continue  # SOA configs got deleted for this app, it'll get cleaned up
     return nerve_list
-
-
-def read_all_registrations_for_service_instance(service, instance, cluster=None, soa_dir=DEFAULT_SOA_DIR):
-    """Retrieve all registrations as fully specified name.instance pairs
-    for a particular service instance.
-
-    For example, the 'main' paasta instance of the 'test' service may register
-    in the 'test.main' namespace as well as the 'other_svc.main' namespace.
-
-    If one is not defined in the config file, returns a list containing
-    name.instance instead.
-    """
-    if not cluster:
-        cluster = load_system_paasta_config().get_cluster()
-
-    job_config = load_paasta_native_job_config(
-        service=service,
-        instance=instance,
-        cluster=cluster,
-        load_deployments=False,
-        soa_dir=soa_dir,
-    )
-    return job_config.get_registrations()
 
 
 if __name__ == '__main__':

--- a/paasta_tools/paasta_maintenance.py
+++ b/paasta_tools/paasta_maintenance.py
@@ -23,8 +23,8 @@ from socket import gethostname
 from paasta_tools import mesos_maintenance
 from paasta_tools import utils
 from paasta_tools.marathon_tools import get_expected_instance_count_for_namespace
+from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.marathon_tools import marathon_services_running_here
-from paasta_tools.marathon_tools import read_registration_for_service_instance
 from paasta_tools.smartstack_tools import backend_is_up
 from paasta_tools.smartstack_tools import get_backends
 from paasta_tools.smartstack_tools import get_replication_for_services
@@ -130,11 +130,14 @@ def is_healthy_in_haproxy(local_port, backends):
 
 def synapse_replication_is_low(service, instance, system_paasta_config, local_backends):
     crit_threshold = 80
-    reg_svc, reg_namespace, _, __ = utils.decompose_job_id(
-        read_registration_for_service_instance(
-            service=service, instance=instance,
-        ),
+    cluster = system_paasta_config.get_cluster()
+    marathon_service_config = load_marathon_service_config(
+        service=service,
+        instance=instance,
+        cluster=cluster,
+        load_deployments=False,
     )
+    reg_svc, reg_namespace, _, __ = utils.decompose_job_id(marathon_service_config.get_registrations())
     # We only actually care about the replication of where we're registering
     service, namespace = reg_svc, reg_namespace
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2963,3 +2963,8 @@ def suggest_possibilities(word: str, possibilities: Iterable[str], max_suggestio
         return f"\nDid you mean one of: {', '.join(suggestions)}?"
     else:
         return ""
+
+
+def list_services(soa_dir: str=DEFAULT_SOA_DIR) -> Sequence[str]:
+    """Returns a sorted list of all services"""
+    return sorted(os.listdir(os.path.abspath(soa_dir)))

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -15,7 +15,6 @@ from datetime import datetime
 from datetime import timedelta
 
 import mock
-import pysensu_yelp
 import pytest
 
 from paasta_tools import check_marathon_services_replication
@@ -41,387 +40,15 @@ def instance_config():
     return mock_instance_config
 
 
-def test_send_event_users_monitoring_tools_send_event_properly(instance_config):
-    fake_status = '999999'
-    fake_output = 'YOU DID IT'
-    instance_config.get_monitoring.return_value = {'fake_key': 'fake_value'}
-
-    expected_check_name = 'check_marathon_services_replication.%s' % instance_config.job_id
-    with mock.patch(
-        'paasta_tools.monitoring_tools.send_event', autospec=True,
-    ) as send_event_patch, mock.patch(
-        'paasta_tools.check_marathon_services_replication._log', autospec=True,
-    ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.monitoring_tools.get_runbook',
-        autospec=True,
-        return_value='y/runbook',
-    ):
-        check_marathon_services_replication.send_event(
-            instance_config=instance_config,
-            status=fake_status,
-            output=fake_output,
-        )
-        send_event_patch.assert_called_once_with(
-            service=instance_config.service,
-            check_name=expected_check_name,
-            overrides={
-                'fake_key': 'fake_value', 'runbook': 'y/runbook',
-                'alert_after': '2m', 'check_every': '1m',
-            },
-            status=fake_status,
-            output=fake_output,
-            soa_dir=instance_config.soa_dir,
-            cluster=instance_config.cluster,
-        )
-
-
-def test_send_event_users_monitoring_tools_send_event_respects_alert_after(instance_config):
-    fake_status = '999999'
-    fake_output = 'YOU DID IT'
-    instance_config.get_monitoring.return_value = {'alert_after': '666m'}
-    expected_check_name = (
-        'check_marathon_services_replication.%s' %
-        instance_config.job_id
-    )
-    with mock.patch(
-        "paasta_tools.monitoring_tools.send_event", autospec=True,
-    ) as send_event_patch, mock.patch(
-        "paasta_tools.check_marathon_services_replication._log", autospec=True,
-    ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.monitoring_tools.get_runbook',
-        autospec=True,
-        return_value='y/runbook',
-    ):
-        check_marathon_services_replication.send_event(
-            instance_config=instance_config,
-            status=fake_status,
-            output=fake_output,
-        )
-        send_event_patch.call_count == 1
-        send_event_patch.assert_called_once_with(
-            service=instance_config.service,
-            check_name=expected_check_name,
-            overrides={
-                'runbook': 'y/runbook',
-                'alert_after': '666m', 'check_every': '1m',
-            },
-            status=fake_status,
-            output=fake_output,
-            soa_dir=instance_config.soa_dir,
-            cluster=instance_config.cluster,
-        )
-
-
-def test_check_smartstack_replication_for_instance_ok_when_expecting_zero(instance_config):
-    expected_replication_count = 0
-    mock_smartstack_replication_checker = mock.Mock()
-    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
-        {'fake_region': {'test.main': 1, 'test.three': 4, 'test.four': 8}}
-
-    with mock.patch(
-        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
-    ) as mock_send_event:
-        check_marathon_services_replication.check_smartstack_replication_for_instance(
-            instance_config=instance_config,
-            expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
-        )
-        mock_send_event.assert_called_once_with(
-            instance_config=instance_config,
-            status=pysensu_yelp.Status.OK,
-            output=mock.ANY,
-        )
-
-
-def test_check_smartstack_replication_for_instance_crit_when_absent(instance_config):
-    expected_replication_count = 8
-    mock_smartstack_replication_checker = mock.Mock()
-    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
-        {'fake_region': {'test.two': 1, 'test.three': 4, 'test.four': 8}}
-    with mock.patch(
-        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
-    ) as mock_send_event:
-        check_marathon_services_replication.check_smartstack_replication_for_instance(
-            instance_config=instance_config,
-            expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
-        )
-        mock_send_event.assert_called_once_with(
-            instance_config=instance_config,
-            status=pysensu_yelp.Status.CRITICAL,
-            output=mock.ANY,
-        )
-
-
-def test_check_smartstack_replication_for_instance_crit_when_zero_replication(instance_config):
-    expected_replication_count = 8
-    mock_smartstack_replication_checker = mock.Mock()
-    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
-        {
-            'fake_region': {
-                'fake_service.fake_instance': 0,
-                'test.main': 8,
-                'test.fully_replicated': 8,
-            },
-        }
-    with mock.patch(
-        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
-    ) as mock_send_event:
-        check_marathon_services_replication.check_smartstack_replication_for_instance(
-            instance_config=instance_config,
-            expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
-        )
-        mock_send_event.assert_called_once_with(
-            instance_config=instance_config,
-            status=pysensu_yelp.Status.CRITICAL,
-            output=mock.ANY,
-        )
-        _, send_event_kwargs = mock_send_event.call_args
-        alert_output = send_event_kwargs["output"]
-        assert ('Service {} has 0 out of 8 expected instances in fake_region'
-                .format(instance_config.job_id)) in alert_output
-        assert ('paasta status -s {} -i {} -c {} -vv'
-                .format(
-                    instance_config.service,
-                    instance_config.instance,
-                    instance_config.cluster,
-                )) in alert_output
-
-
-def test_check_smartstack_replication_for_instance_crit_when_low_replication(instance_config):
-    expected_replication_count = 8
-    mock_smartstack_replication_checker = mock.Mock()
-    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
-        {
-            'fake_region': {
-                'test.canary': 1,
-                'fake_service.fake_instance': 4,
-                'test.fully_replicated': 8,
-            },
-        }
-    with mock.patch(
-        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
-    ) as mock_send_event:
-        check_marathon_services_replication.check_smartstack_replication_for_instance(
-            instance_config=instance_config,
-            expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
-        )
-        mock_send_event.assert_called_once_with(
-            instance_config=instance_config,
-            status=pysensu_yelp.Status.CRITICAL,
-            output=mock.ANY,
-        )
-        _, send_event_kwargs = mock_send_event.call_args
-        alert_output = send_event_kwargs["output"]
-        assert ('Service {} has 4 out of 8 expected instances in fake_region'
-                .format(instance_config.job_id)) in alert_output
-        assert ('paasta status -s {} -i {} -c {} -vv'
-                .format(
-                    instance_config.service,
-                    instance_config.instance,
-                    instance_config.cluster,
-                )) in alert_output
-
-
-def test_check_smartstack_replication_for_instance_ok_with_enough_replication(instance_config):
-    expected_replication_count = 8
-    mock_smartstack_replication_checker = mock.Mock()
-    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
-        {
-            'fake_region': {
-                'test.canary': 1,
-                'test.low_replication': 4,
-                'fake_service.fake_instance': 8,
-            },
-        }
-    with mock.patch(
-        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
-    ) as mock_send_event:
-        check_marathon_services_replication.check_smartstack_replication_for_instance(
-            instance_config=instance_config,
-            expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
-        )
-        mock_send_event.assert_called_once_with(
-            instance_config=instance_config,
-            status=pysensu_yelp.Status.OK,
-            output=mock.ANY,
-        )
-        _, send_event_kwargs = mock_send_event.call_args
-        alert_output = send_event_kwargs["output"]
-        assert ('{} has 8 out of 8 expected instances in fake_region (OK: 100%)'
-                .format(instance_config.job_id)) in alert_output
-
-
-def test_check_smartstack_replication_for_instance_ok_with_enough_replication_multilocation(
-    instance_config,
-):
-    expected_replication_count = 2
-    mock_smartstack_replication_checker = mock.Mock()
-    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
-        {
-            'fake_region': {'fake_service.fake_instance': 1},
-            'fake_other_region': {'fake_service.fake_instance': 1},
-        }
-    with mock.patch(
-        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
-    ) as mock_send_event:
-        check_marathon_services_replication.check_smartstack_replication_for_instance(
-            instance_config=instance_config,
-            expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
-        )
-        mock_send_event.assert_called_once_with(
-            instance_config=instance_config,
-            status=pysensu_yelp.Status.OK,
-            output=mock.ANY,
-        )
-        _, send_event_kwargs = mock_send_event.call_args
-        alert_output = send_event_kwargs["output"]
-        assert ("{} has 1 out of 1 expected instances in fake_region"
-                .format(instance_config.job_id)) in alert_output
-        assert ("{} has 1 out of 1 expected instances in fake_other_region"
-                .format(instance_config.job_id)) in alert_output
-
-
-def test_check_smartstack_replication_for_instance_crit_when_low_replication_multilocation(
-    instance_config,
-):
-    expected_replication_count = 2
-    mock_smartstack_replication_checker = mock.Mock()
-    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
-        {
-            'fake_region': {'fake_service.fake_instance': 1},
-            'fake_other_region': {'fake_service.fake_instance': 0},
-        }
-    with mock.patch(
-        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
-    ) as mock_send_event:
-        check_marathon_services_replication.check_smartstack_replication_for_instance(
-            instance_config=instance_config,
-            expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
-        )
-        mock_send_event.assert_called_once_with(
-            instance_config=instance_config,
-            status=pysensu_yelp.Status.CRITICAL,
-            output=mock.ANY,
-        )
-        _, send_event_kwargs = mock_send_event.call_args
-        alert_output = send_event_kwargs["output"]
-        assert ("{} has 1 out of 1 expected instances in fake_region"
-                .format(instance_config.job_id)) in alert_output
-        assert ("{} has 0 out of 1 expected instances in fake_other_region"
-                .format(instance_config.job_id)) in alert_output
-        assert ("paasta status -s {} -i {} -c {} -vv"
-                .format(
-                    instance_config.service,
-                    instance_config.instance,
-                    instance_config.cluster,
-                )) in alert_output
-
-
-def test_check_smartstack_replication_for_instance_crit_when_zero_replication_multilocation(
-    instance_config,
-):
-    expected_replication_count = 2
-    mock_smartstack_replication_checker = mock.Mock()
-    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
-        {
-            'fake_region': {'fake_service.fake_instance': 0},
-            'fake_other_region': {'fake_service.fake_instance': 0},
-        }
-    with mock.patch(
-        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
-    ) as mock_send_event:
-        check_marathon_services_replication.check_smartstack_replication_for_instance(
-            instance_config=instance_config,
-            expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
-        )
-        mock_send_event.assert_called_once_with(
-            instance_config=instance_config,
-            status=pysensu_yelp.Status.CRITICAL,
-            output=mock.ANY,
-        )
-        _, send_event_kwargs = mock_send_event.call_args
-        alert_output = send_event_kwargs["output"]
-        assert ("{} has 0 out of 1 expected instances in fake_region"
-                .format(instance_config.job_id)) in alert_output
-        assert ("{} has 0 out of 1 expected instances in fake_other_region"
-                .format(instance_config.job_id)) in alert_output
-        assert ("paasta status -s {} -i {} -c {} -vv"
-                .format(
-                    instance_config.service,
-                    instance_config.instance,
-                    instance_config.cluster,
-                )) in alert_output
-
-
-def test_check_smartstack_replication_for_instance_crit_when_missing_replication_multilocation(
-    instance_config,
-):
-    expected_replication_count = 2
-    mock_smartstack_replication_checker = mock.Mock()
-    mock_smartstack_replication_checker.get_replication_for_instance.return_value = \
-        {'fake_region': {'test.main': 0}, 'fake_other_region': {'test.main': 0}}
-    with mock.patch(
-        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
-    ) as mock_send_event:
-        check_marathon_services_replication.check_smartstack_replication_for_instance(
-            instance_config=instance_config,
-            expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
-        )
-        mock_send_event.assert_called_once_with(
-            instance_config=instance_config,
-            status=pysensu_yelp.Status.CRITICAL,
-            output=mock.ANY,
-        )
-        _, send_event_kwargs = mock_send_event.call_args
-        alert_output = send_event_kwargs["output"]
-        assert ("{} has 0 out of 1 expected instances in fake_region"
-                .format(instance_config.job_id)) in alert_output
-        assert ("{} has 0 out of 1 expected instances in fake_other_region"
-                .format(instance_config.job_id)) in alert_output
-
-
-def test_check_smartstack_replication_for_instance_crit_when_no_smartstack_info(
-    instance_config,
-):
-    expected_replication_count = 2
-    mock_smartstack_replication_checker = mock.Mock()
-    mock_smartstack_replication_checker.get_replication_for_instance.return_value = {}
-    with mock.patch(
-        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
-    ) as mock_send_event:
-        check_marathon_services_replication.check_smartstack_replication_for_instance(
-            instance_config=instance_config,
-            expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
-        )
-        mock_send_event.assert_called_once_with(
-            instance_config=instance_config,
-            status=pysensu_yelp.Status.CRITICAL,
-            output=mock.ANY,
-        )
-        _, send_event_kwargs = mock_send_event.call_args
-        alert_output = send_event_kwargs["output"]
-        assert ("{} has no Smartstack replication info."
-                .format(instance_config.job_id)) in alert_output
-
-
 def test_check_service_replication_for_normal_smartstack(instance_config):
     instance_config.get_instances.return_value = 100
     all_tasks = []
     with mock.patch(
-        'paasta_tools.marathon_tools.get_proxy_port_for_instance',
+        'paasta_tools.check_marathon_services_replication.get_proxy_port_for_instance',
         autospec=True,
         return_value=666,
     ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.check_smartstack_replication_for_instance',
+        'paasta_tools.monitoring_tools.check_smartstack_replication_for_instance',
         autospec=True,
     ) as mock_check_smartstack_replication_for_service:
         check_marathon_services_replication.check_service_replication(
@@ -440,11 +67,11 @@ def test_check_service_replication_for_smartstack_with_different_namespace(insta
     instance_config.get_instances.return_value = 100
     all_tasks = []
     with mock.patch(
-        'paasta_tools.marathon_tools.get_proxy_port_for_instance',
+        'paasta_tools.check_marathon_services_replication.get_proxy_port_for_instance',
         autospec=True,
         return_value=666,
     ), mock.patch(
-        'paasta_tools.check_marathon_services_replication.check_smartstack_replication_for_instance',
+        'paasta_tools.monitoring_tools.check_smartstack_replication_for_instance',
         autospec=True,
     ) as mock_check_smartstack_replication_for_service, mock.patch(
         'paasta_tools.check_marathon_services_replication.check_healthy_marathon_tasks_for_service_instance',
@@ -468,7 +95,7 @@ def test_check_service_replication_for_non_smartstack(instance_config):
     instance_config.get_instances.return_value = 100
 
     with mock.patch(
-        'paasta_tools.marathon_tools.get_proxy_port_for_instance',
+        'paasta_tools.check_marathon_services_replication.get_proxy_port_for_instance',
         autospec=True,
         return_value=None,
     ), mock.patch(
@@ -539,11 +166,14 @@ def test_get_healthy_marathon_instances_for_short_app_id_considers_none_start_ti
     assert actual == 0
 
 
-@mock.patch('paasta_tools.check_marathon_services_replication.send_event_if_under_replication', autospec=True)
+@mock.patch(
+    'paasta_tools.check_marathon_services_replication.send_replication_event_if_under_replication',
+    autospec=True,
+)
 @mock.patch('paasta_tools.check_marathon_services_replication.filter_healthy_marathon_instances_for_short_app_id', autospec=True)  # noqa
 def test_check_healthy_marathon_tasks_for_service_instance(
     mock_healthy_instances,
-    mock_send_event_if_under_replication,
+    mock_send_replication_event_if_under_replication,
     instance_config,
 ):
     mock_healthy_instances.return_value = 2
@@ -552,18 +182,18 @@ def test_check_healthy_marathon_tasks_for_service_instance(
         expected_count=10,
         all_tasks=mock.Mock(),
     )
-    mock_send_event_if_under_replication.assert_called_once_with(
+    mock_send_replication_event_if_under_replication.assert_called_once_with(
         instance_config=instance_config,
         expected_count=10,
         num_available=2,
     )
 
 
-def test_send_event_if_under_replication_handles_0_expected(instance_config):
+def test_send_replication_event_if_under_replication_handles_0_expected(instance_config):
     with mock.patch(
-        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
+        'paasta_tools.monitoring_tools.send_replication_event', autospec=True,
     ) as mock_send_event:
-        check_marathon_services_replication.send_event_if_under_replication(
+        check_marathon_services_replication.send_replication_event_if_under_replication(
             instance_config=instance_config,
             expected_count=0,
             num_available=0,
@@ -579,11 +209,11 @@ def test_send_event_if_under_replication_handles_0_expected(instance_config):
                 .format(instance_config.job_id)) in alert_output
 
 
-def test_send_event_if_under_replication_good(instance_config):
+def test_send_replication_event_if_under_replication_good(instance_config):
     with mock.patch(
-        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
+        'paasta_tools.monitoring_tools.send_replication_event', autospec=True,
     ) as mock_send_event:
-        check_marathon_services_replication.send_event_if_under_replication(
+        check_marathon_services_replication.send_replication_event_if_under_replication(
             instance_config=instance_config,
             expected_count=100,
             num_available=100,
@@ -599,11 +229,11 @@ def test_send_event_if_under_replication_good(instance_config):
                 .format(instance_config.job_id)) in alert_output
 
 
-def test_send_event_if_under_replication_critical(instance_config):
+def test_send_replication_event_if_under_replication_critical(instance_config):
     with mock.patch(
-        'paasta_tools.check_marathon_services_replication.send_event', autospec=True,
+        'paasta_tools.monitoring_tools.send_replication_event', autospec=True,
     ) as mock_send_event:
-        check_marathon_services_replication.send_event_if_under_replication(
+        check_marathon_services_replication.send_replication_event_if_under_replication(
             instance_config=instance_config,
             expected_count=100,
             num_available=89,

--- a/tests/test_long_running_service_tools.py
+++ b/tests/test_long_running_service_tools.py
@@ -246,3 +246,24 @@ class TestServiceNamespaceConfig:
 
     def test_get_discover_default(self):
         assert long_running_service_tools.ServiceNamespaceConfig().get_discover() == 'region'
+
+
+def test_get_proxy_port_for_instance():
+    mock_config = mock.Mock(
+        get_registrations=mock.Mock(
+            return_value=['thing.main.sha.sha'],
+        ),
+        soa_dir='/nail/blah',
+    )
+    with mock.patch(
+        'paasta_tools.long_running_service_tools.load_service_namespace_config', autospec=True,
+    ) as mock_load_service_namespace_config:
+        mock_load_service_namespace_config.return_value = {
+            'proxy_port': 1234,
+        }
+        assert long_running_service_tools.get_proxy_port_for_instance(mock_config) == 1234
+        mock_load_service_namespace_config.assert_called_once_with(
+            service='thing',
+            namespace='main',
+            soa_dir='/nail/blah',
+        )

--- a/tests/test_native_mesos_scheduler.py
+++ b/tests/test_native_mesos_scheduler.py
@@ -103,20 +103,34 @@ def test_get_paasta_native_services_running_here_for_nerve():
         autospec=True,
         return_value=fake_marathon_services,
     ) as pnsrh_patch, mock.patch(
-        'paasta_tools.native_mesos_scheduler.read_all_registrations_for_service_instance',
+        'paasta_tools.native_mesos_scheduler.load_paasta_native_job_config',
         autospec=True,
-        side_effect=lambda *args, **kwargs: registrations.pop(),
-    ) as get_namespace_patch, mock.patch(
+    ) as mock_load_paasta_native_job_config, mock.patch(
         'paasta_tools.native_mesos_scheduler.load_service_namespace_config',
         autospec=True,
         side_effect=lambda *args, **kwargs: nerve_dicts.pop(),
     ) as read_ns_config_patch:
+        def mock_registrations_side_effect(*args, **kwargs):
+            return registrations.pop()
+        mock_load_paasta_native_job_config.return_value.get_registrations.side_effect = mock_registrations_side_effect
         actual = native_mesos_scheduler.get_paasta_native_services_running_here_for_nerve(cluster, soa_dir)
         assert expected == actual
         pnsrh_patch.assert_called_once_with(hostname=None)
-        get_namespace_patch.assert_any_call('no_test', 'left_behind', cluster, soa_dir)
-        get_namespace_patch.assert_any_call('no_docstrings', 'forever_abandoned', cluster, soa_dir)
-        assert get_namespace_patch.call_count == 2
+        mock_load_paasta_native_job_config.assert_any_call(
+            service='no_test',
+            instance='left_behind',
+            cluster=cluster,
+            load_deployments=False,
+            soa_dir=soa_dir,
+        )
+        mock_load_paasta_native_job_config.assert_any_call(
+            service='no_docstrings',
+            instance='forever_abandoned',
+            cluster=cluster,
+            load_deployments=False,
+            soa_dir=soa_dir,
+        )
+        assert mock_load_paasta_native_job_config.call_count == 2
         read_ns_config_patch.assert_any_call('no_test', 'uno', soa_dir)
         read_ns_config_patch.assert_any_call('no_docstrings', 'dos', soa_dir)
         assert read_ns_config_patch.call_count == 2
@@ -150,20 +164,34 @@ def test_get_paasta_native_services_running_here_for_nerve_multiple_namespaces()
         autospec=True,
         return_value=fake_marathon_services,
     ) as pnsrh_patch, mock.patch(
-        'paasta_tools.native_mesos_scheduler.read_all_registrations_for_service_instance',
+        'paasta_tools.native_mesos_scheduler.load_paasta_native_job_config',
         autospec=True,
-        side_effect=lambda *args, **kwargs: namespaces.pop(),
-    ) as get_namespace_patch, mock.patch(
+    ) as mock_load_paasta_native_job_config, mock.patch(
         'paasta_tools.native_mesos_scheduler.load_service_namespace_config',
         autospec=True,
         side_effect=lambda service, namespace, soa_dir: nerve_dicts.pop((service, namespace)),
     ) as read_ns_config_patch:
+        def mock_registrations_side_effect(*args, **kwargs):
+            return namespaces.pop()
+        mock_load_paasta_native_job_config.return_value.get_registrations.side_effect = mock_registrations_side_effect
         actual = native_mesos_scheduler.get_paasta_native_services_running_here_for_nerve(cluster, soa_dir)
         assert expected == actual
         pnsrh_patch.assert_called_once_with(hostname=None)
-        get_namespace_patch.assert_any_call('no_test', 'left_behind', cluster, soa_dir)
-        get_namespace_patch.assert_any_call('no_docstrings', 'forever_abandoned', cluster, soa_dir)
-        assert get_namespace_patch.call_count == 2
+        mock_load_paasta_native_job_config.assert_any_call(
+            service='no_test',
+            instance='left_behind',
+            cluster=cluster,
+            load_deployments=False,
+            soa_dir=soa_dir,
+        )
+        mock_load_paasta_native_job_config.assert_any_call(
+            service='no_docstrings',
+            instance='forever_abandoned',
+            cluster=cluster,
+            load_deployments=False,
+            soa_dir=soa_dir,
+        )
+        assert mock_load_paasta_native_job_config.call_count == 2
         read_ns_config_patch.assert_any_call('no_test', 'uno', soa_dir)
         read_ns_config_patch.assert_any_call('no_test', 'dos', soa_dir)
         read_ns_config_patch.assert_any_call('no_test', 'tres', soa_dir)
@@ -192,20 +220,34 @@ def test_get_paasta_native_services_running_here_for_nerve_when_not_in_smartstac
         autospec=True,
         return_value=fake_marathon_services,
     ) as pnsrh_patch, mock.patch(
-        'paasta_tools.native_mesos_scheduler.read_all_registrations_for_service_instance',
+        'paasta_tools.native_mesos_scheduler.load_paasta_native_job_config',
         autospec=True,
-        side_effect=lambda *args, **kwargs: registrations.pop(),
-    ) as get_namespace_patch, mock.patch(
+    ) as mock_load_paasta_native_job_config, mock.patch(
         'paasta_tools.native_mesos_scheduler.load_service_namespace_config',
         autospec=True,
         side_effect=lambda *args, **kwargs: nerve_dicts.pop(),
     ) as read_ns_config_patch:
+        def mock_registrations_side_effect(*args, **kwargs):
+            return registrations.pop()
+        mock_load_paasta_native_job_config.return_value.get_registrations.side_effect = mock_registrations_side_effect
         actual = native_mesos_scheduler.get_paasta_native_services_running_here_for_nerve(cluster, soa_dir)
         assert expected == actual
         pnsrh_patch.assert_called_once_with(hostname=None)
-        get_namespace_patch.assert_any_call('no_test', 'left_behind', cluster, soa_dir)
-        get_namespace_patch.assert_any_call('no_docstrings', 'forever_abandoned', cluster, soa_dir)
-        assert get_namespace_patch.call_count == 2
+        mock_load_paasta_native_job_config.assert_any_call(
+            service='no_test',
+            instance='left_behind',
+            cluster=cluster,
+            load_deployments=False,
+            soa_dir=soa_dir,
+        )
+        mock_load_paasta_native_job_config.assert_any_call(
+            service='no_docstrings',
+            instance='forever_abandoned',
+            cluster=cluster,
+            load_deployments=False,
+            soa_dir=soa_dir,
+        )
+        assert mock_load_paasta_native_job_config.call_count == 2
         read_ns_config_patch.assert_any_call('no_test', 'uno', soa_dir)
         read_ns_config_patch.assert_any_call('no_docstrings', 'dos', soa_dir)
         assert read_ns_config_patch.call_count == 2

--- a/tests/test_paasta_maintenance.py
+++ b/tests/test_paasta_maintenance.py
@@ -119,7 +119,7 @@ def test_are_local_tasks_in_danger_is_true_with_an_healthy_service_in_danger(
     assert mock_synapse_replication_is_low.call_count == 1
 
 
-@mock.patch('paasta_tools.paasta_maintenance.read_registration_for_service_instance', autospec=True)
+@mock.patch('paasta_tools.paasta_maintenance.load_marathon_service_config', autospec=True)
 @mock.patch('paasta_tools.paasta_maintenance.load_smartstack_info_for_service', autospec=True)
 @mock.patch('paasta_tools.paasta_maintenance.get_expected_instance_count_for_namespace', autospec=True)
 @mock.patch('paasta_tools.paasta_maintenance.get_replication_for_services', autospec=True)
@@ -127,9 +127,9 @@ def test_synapse_replication_is_low_understands_underreplicated_services(
     mock_get_replication_for_services,
     mock_get_expected_instance_count_for_namespace,
     mock_load_smartstack_info_for_service,
-    mock_read_registration_for_service_instance,
+    mock_load_marathon_service_config,
 ):
-    mock_read_registration_for_service_instance.return_value = "service.main"
+    mock_load_marathon_service_config.return_value.get_registrations.return_value = "service.main"
     mock_get_expected_instance_count_for_namespace.return_value = 3
     mock_load_smartstack_info_for_service.return_value = {
         "local_region": {"service.main": "up"},


### PR DESCRIPTION
This should be a noop in terms of functionality

Mostly moving things from check_marathon_services_replication to
monitoring_tools so that I will be able to re-use some of these
methods to create check_kubernetes_services_replication.

I also changed get_proxy_port_for_instance to take an InstanceConfig so
that I can reuse for k8s too. And removed the
read_all_registrations_for_service_instance and
read_registration_for_service_instance which I feel are not really
necessary to be separate functions.