### PR TITLE
Remote Python interpreter for `paasta-api`

### DIFF
--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -20,6 +20,7 @@ import logging
 import os
 import sys
 
+import manhole
 import requests_cache
 import service_configuration_lib
 from pyramid.config import Configurator
@@ -98,6 +99,9 @@ def application(env, start_response):
     global _app
     if not _app:
         _app = make_app()
+        manhole_path = os.environ.get("PAASTA_MANHOLE_PATH")
+        if manhole_path:
+            manhole.install(socket_path=f'{manhole_path}-{os.getpid()}', locals={'_app': _app})
     return _app(env, start_response)
 
 

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -22,6 +22,7 @@ isodate >= 0.5.0
 jsonschema[format]
 kazoo >= 2.0.0
 kubernetes
+manhole
 marathon >= 0.9.3
 mypy-extensions >= 0.3.0
 objgraph

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,7 @@ jsonref==0.1
 jsonschema==2.5.1
 kazoo==2.4.0
 kubernetes==6.0.0
+manhole==1.5.0
 marathon==0.9.3
 MarkupSafe==1.0
 msgpack-python==0.4.8


### PR DESCRIPTION
Add Python interpreter CLI available via a Unix domain socket.