### PR TITLE
Remove percent formatting

### DIFF
--- a/paasta_itests/chronos_rerun.feature
+++ b/paasta_itests/chronos_rerun.feature
@@ -26,7 +26,7 @@ Feature: chronos_rerun can rerun old jobs
     Given a working paasta cluster
       And we have yelpsoa-configs for the service "testservice" with enabled scheduled chronos instance "testinstance"
       And we have a deployments.json for the service "testservice" with enabled chronos instance "testinstance"
-     When we set the "cmd" field of the chronos config for service "testservice" and instance "testinstance" to "echo '%(shortdate)s'"
+     When we set the "cmd" field of the chronos config for service "testservice" and instance "testinstance" to "echo '{shortdate}'"
      When we run chronos_rerun for service_instance "testservice testinstance"
      Then we should get exit code 0
      When we store the name of the job for the service testservice and instance testinstance as myjob

--- a/paasta_tools/chronos_rerun.py
+++ b/paasta_tools/chronos_rerun.py
@@ -63,7 +63,7 @@ def parse_args():
     return args
 
 
-def modify_command_for_date(chronos_job, date, verbose, use_percent):
+def modify_command_for_date(chronos_job, date, verbose):
     """
     Given a chronos job config, return a cloned job config where the command
     has been modified to reflect what it would have run as on
@@ -72,7 +72,6 @@ def modify_command_for_date(chronos_job, date, verbose, use_percent):
     :param chronos_job: a chronos job dictionary, as created by
         ``chronos_tools.create_complete_config``
     :param date: a ``datetime.datetime`` object.
-    :param use_percent: if time variables use percent formatting
     :returns chronos_job: a chronos_job dict with the command modified to
         interpolate in the context of the date provided.
     """
@@ -81,7 +80,6 @@ def modify_command_for_date(chronos_job, date, verbose, use_percent):
         chronos_job['command'] = chronos_tools.parse_time_variables(
             command=current_command,
             parse_time=date,
-            use_percent=use_percent,
         )
     else:
         if verbose:
@@ -274,7 +272,6 @@ def main():
             chronos_job=clone,
             date=datetime.datetime.strptime(args.execution_date, "%Y-%m-%dT%H:%M:%S"),
             verbose=args.verbose,
-            use_percent=chronos_job_config.is_cmd_percent_format(),
         )
 
         if not args.run_all_related_jobs and chronos_tools.get_job_type(clone) == chronos_tools.JobType.Dependent:

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -367,9 +367,6 @@ class ChronosJobConfig(InstanceConfig):
         args = self.get_args()
         return args == [] or args is None
 
-    def is_cmd_percent_format(self):
-        return self.config_dict.get('use_percent_format', True)
-
     def check_epsilon(self):
         epsilon = self.get_epsilon()
         try:
@@ -399,7 +396,7 @@ class ChronosJobConfig(InstanceConfig):
         command = self.get_cmd()
         if command:
             try:
-                parse_time_variables(command=command, use_percent=self.is_cmd_percent_format())
+                parse_time_variables(command=command)
                 return True, ""
             except (ValueError, KeyError, TypeError):
                 return False, ("Unparseable command '%s'. Hint: do you need to escape %% chars?") % command
@@ -517,13 +514,7 @@ class ChronosJobConfig(InstanceConfig):
             raise InvalidChronosConfigError("\n".join(error_msgs))
 
         net = get_mesos_network_for_net(self.get_net())
-        if self.get_cmd():
-            command = parse_time_variables(
-                command=self.get_cmd(),
-                use_percent=self.is_cmd_percent_format(),
-            )
-        else:
-            command = self.get_cmd()
+        command = parse_time_variables(self.get_cmd()) if self.get_cmd() else self.get_cmd()
 
         complete_config = {
             'name': self.get_job_name(),
@@ -942,7 +933,6 @@ def uses_time_variables(chronos_job):
     interpolated_command = parse_time_variables(
         command=current_command,
         parse_time=datetime.datetime.utcnow(),
-        use_percent=chronos_job.is_cmd_percent_format(),
     )
     return current_command != interpolated_command
 

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -399,7 +399,7 @@ class ChronosJobConfig(InstanceConfig):
                 parse_time_variables(command=command)
                 return True, ""
             except (ValueError, KeyError, TypeError):
-                return False, ("Unparseable command '%s'. Hint: do you need to escape %% chars?") % command
+                return False, ("Unparseable command '%s'. Hint: do you need to escape {} chars?") % command
         else:
             return True, ""
 

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -775,7 +775,7 @@ def run_docker_container(
     return returncode
 
 
-def command_function_for_framework(framework, date, use_percent=False):
+def command_function_for_framework(framework, date):
     """
     Given a framework, return a function that appropriately formats
     the command to be run.
@@ -784,19 +784,11 @@ def command_function_for_framework(framework, date, use_percent=False):
         return cmd
 
     def format_chronos_command(cmd):
-        interpolated_command = parse_time_variables(
-            command=cmd,
-            parse_time=date,
-            use_percent=use_percent,
-        )
+        interpolated_command = parse_time_variables(cmd, date)
         return interpolated_command
 
     def format_tron_command(cmd: str) -> str:
-        interpolated_command = parse_time_variables(
-            command=cmd,
-            parse_time=date,
-            use_percent=False,
-        )
+        interpolated_command = parse_time_variables(cmd, date)
         return interpolated_command
 
     def format_adhoc_command(cmd):
@@ -933,10 +925,8 @@ def configure_and_run_docker_container(
         command = args.cmd
     else:
         command_from_config = instance_config.get_cmd()
-        # TODO: remove after all Chronos configs have been updated
-        use_percent = instance_config.is_cmd_percent_format() if instance_type == 'chronos' else False
         if command_from_config:
-            command_modifier = command_function_for_framework(instance_type, args.date, use_percent)
+            command_modifier = command_function_for_framework(instance_type, args.date)
             command = command_modifier(command_from_config)
         else:
             command = instance_config.get_args()

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -118,6 +118,7 @@ class StringFormatter(Formatter):
 def parse_time_variables(
     command: str,
     parse_time: datetime.datetime=None,
+    use_percent: bool=False,
 ) -> str:
     """Parses an input string and uses the Tron-style dateparsing
     to replace time variables. Currently supports only the date/time
@@ -126,6 +127,7 @@ def parse_time_variables(
 
     :param input_string: input string to be parsed
     :param parse_time: Reference Datetime object to parse the date and time strings, defaults to now.
+    :param use_percent: use percent formatting for the command (deprecated)
     :returns: A string with the date and time variables replaced
     """
     if parse_time is None:
@@ -136,7 +138,11 @@ def parse_time_variables(
     # The tron context object needs the run_time attribute set so it knows
     # how to interpret the date strings
     job_context.job_run.run_time = parse_time
-    return StringFormatter(job_context).format(command)
+    if use_percent:
+        # Deprecated, here for migration purposes
+        return command % job_context
+    else:
+        return StringFormatter(job_context).format(command)
 
 
 class TronActionConfig(InstanceConfig):

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -118,7 +118,6 @@ class StringFormatter(Formatter):
 def parse_time_variables(
     command: str,
     parse_time: datetime.datetime=None,
-    use_percent: bool=False,
 ) -> str:
     """Parses an input string and uses the Tron-style dateparsing
     to replace time variables. Currently supports only the date/time
@@ -137,11 +136,7 @@ def parse_time_variables(
     # The tron context object needs the run_time attribute set so it knows
     # how to interpret the date strings
     job_context.job_run.run_time = parse_time
-    # The job_context object works like a normal dictionary for string replacement
-    if use_percent:
-        return command % job_context
-    else:
-        return StringFormatter(job_context).format(command)
+    return StringFormatter(job_context).format(command)
 
 
 class TronActionConfig(InstanceConfig):

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -1487,9 +1487,9 @@ def test_command_function_for_framework_for_chronos(mock_datetime, mock_parse_ti
     fake_date = mock.Mock()
     mock_datetime.datetime.now.return_value = fake_date
     mock_parse_time_variables.return_value = "foo"
-    fn = command_function_for_framework('chronos', fake_date, True)
+    fn = command_function_for_framework('chronos', fake_date)
     fn("foo")
-    mock_parse_time_variables.assert_called_once_with('foo', fake_date, use_percent=True)
+    mock_parse_time_variables.assert_called_once_with('foo', fake_date)
 
 
 @mock.patch('paasta_tools.cli.cmds.local_run.parse_time_variables', autospec=True)
@@ -1500,7 +1500,7 @@ def test_command_function_for_framework_for_tron(mock_datetime, mock_parse_time_
     mock_parse_time_variables.return_value = "foo"
     fn = command_function_for_framework('tron', fake_date)
     fn("foo")
-    mock_parse_time_variables.assert_called_once_with('foo', fake_date, use_percent=False)
+    mock_parse_time_variables.assert_called_once_with('foo', fake_date)
 
 
 def test_command_function_for_framework_throws_error():

--- a/tests/test_chronos_rerun.py
+++ b/tests/test_chronos_rerun.py
@@ -33,7 +33,6 @@ def test_modify_command_for_date(mock_parse_time_variables):
         chronos_job=fake_chronos_job_config,
         date=datetime.datetime.now(),
         verbose=False,
-        use_percent=True,
     )
 
     assert actual == {
@@ -50,7 +49,6 @@ def test_modify_command_for_date_no_command():
         chronos_job=fake_chronos_job_config,
         date=datetime.datetime.now(),
         verbose=True,
-        use_percent=True,
     )
     assert actual == fake_chronos_job_config
 
@@ -140,6 +138,7 @@ def test_clone_job_dependent_jobs(
     ),
 )
 @mock.patch('paasta_tools.chronos_rerun.clone_job', autospec=True)
+@mock.patch('paasta_tools.chronos_rerun.modify_command_for_date', autospec=True)
 @mock.patch('paasta_tools.chronos_rerun.chronos_tools.get_job_type', autospec=True)
 @mock.patch('paasta_tools.chronos_rerun.remove_parents', autospec=True)
 @mock.patch('paasta_tools.chronos_tools.create_complete_config', autospec=True)
@@ -159,6 +158,7 @@ def test_chronos_rerun_main_with_independent_job(
     mock_create_complete_config,
     mock_remove_parents,
     mock_get_job_type,
+    mock_modify_command_for_date,
     mock_clone_job,
     cluster, service, instance, run_all_related_jobs, is_dependent_job,
 ):

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -372,7 +372,7 @@ class TestChronosTools:
                 system_paasta_config.get_dockercfg_location(),
                 fake_constraints,
             )
-            mock_parse_time_variables.assert_called_with(fake_cmd, use_percent=True)
+            mock_parse_time_variables.assert_called_with(fake_cmd)
 
     def test_get_owner(self):
         fake_owner = 'fake_team'
@@ -1739,8 +1739,8 @@ class TestChronosTools:
             assert chronos_tools.wait_for_job(client, 'foo')
             assert mock_sleep.call_count == 2
 
-    def test_check_cmd_escaped_percent(self):
-        test_input = './mycommand --date %(shortdate-1)s --format foo/logs/%%L/%%Y/%%m/%%d/'
+    def test_check_cmd_escaped_brace(self):
+        test_input = './mycommand --date {shortdate-1} --config {{"key": "value"}}'
         fake_conf = chronos_tools.ChronosJobConfig(
             service='fake_name',
             cluster='fake_cluster',
@@ -1752,8 +1752,8 @@ class TestChronosTools:
         assert okay is True
         assert msg == ''
 
-    def test_check_cmd_unescaped_percent(self):
-        test_input = './mycommand --date %(shortdate-1)s --format foo/logs/%L/%Y/%m/%d/'
+    def test_check_cmd_unescaped_brace(self):
+        test_input = './mycommand --date {shortdate-1} --config {"key": "value"}'
         fake_conf = chronos_tools.ChronosJobConfig(
             service='fake_name',
             cluster='fake_cluster',
@@ -1763,7 +1763,7 @@ class TestChronosTools:
         )
         okay, msg = fake_conf.check_cmd()
         assert okay is False
-        assert './mycommand --date %(shortdate-1)s --format foo/logs/%L/%Y/%m/%d/' in msg
+        assert './mycommand --date {shortdate-1} --config {"key": "value"}' in msg
 
     def test_cmp_datetimes(self):
         before = '2015-09-22T16:46:25.111Z'
@@ -1938,7 +1938,7 @@ class TestChronosTools:
 
     def test_uses_time_variables_true(self):
         fake_chronos_job_config = copy.deepcopy(self.fake_chronos_job_config)
-        fake_chronos_job_config.config_dict['cmd'] = '/usr/bin/printf %(shortdate)s'
+        fake_chronos_job_config.config_dict['cmd'] = '/usr/bin/printf {shortdate}'
         assert chronos_tools.uses_time_variables(fake_chronos_job_config)
 
     @mock.patch('paasta_tools.mesos_tools.get_local_slave_state', autospec=True)

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -38,28 +38,12 @@ class TestTronConfig:
             config.get_url()
 
 
-class TestParseTimeVariables:
-
-    def test_parse_time_variables_parses_shortdate_with_percent(self):
-        input_time = datetime.datetime(2012, 3, 14)
-        test_input = 'ls %(shortdate-1)s foo'
-        expected = 'ls 2012-03-13 foo'
-        actual = tron_tools.parse_time_variables(command=test_input, parse_time=input_time, use_percent=True)
-        assert actual == expected
-
-    def test_parse_time_variables_parses_percent(self):
-        input_time = datetime.datetime(2012, 3, 14)
-        test_input = './mycommand --date %(shortdate-1)s --format foo/logs/%%L/%%Y/%%m/%%d/'
-        expected = './mycommand --date 2012-03-13 --format foo/logs/%L/%Y/%m/%d/'
-        actual = tron_tools.parse_time_variables(command=test_input, parse_time=input_time, use_percent=True)
-        assert actual == expected
-
-    def test_parse_time_variables_parses_shortdate_with_braces(self):
-        input_time = datetime.datetime(2012, 3, 14)
-        test_input = 'ls {shortdate-1} foo'
-        expected = 'ls 2012-03-13 foo'
-        actual = tron_tools.parse_time_variables(command=test_input, parse_time=input_time, use_percent=False)
-        assert actual == expected
+def test_parse_time_variables_parses_shortdate():
+    input_time = datetime.datetime(2012, 3, 14)
+    test_input = 'mycommand --date {shortdate-1} --format foo/logs/%L/%Y/%m/%d/'
+    expected = 'mycommand --date 2012-03-13 --format foo/logs/%L/%Y/%m/%d/'
+    actual = tron_tools.parse_time_variables(command=test_input, parse_time=input_time)
+    assert actual == expected
 
 
 class TestTronActionConfig:


### PR DESCRIPTION
Step 3 of https://github.com/Yelp/paasta/pull/1996
use_percent_format is allowed in the Chronos schema, but it won't be used anywhere. We can remove it after step 4.