### PR TITLE
Fix paasta api memory leak

### DIFF
--- a/paasta_tools/api/views/marathon_dashboard.py
+++ b/paasta_tools/api/views/marathon_dashboard.py
@@ -15,15 +15,19 @@
 """
 Marathon Dashboard
 """
+import logging
+
 from pyramid.view import view_config
 
 from paasta_tools.api import settings
 from paasta_tools.marathon_dashboard import create_marathon_dashboard
 
+log = logging.getLogger(__name__)
+
 
 @view_config(route_name='marathon_dashboard', request_method='GET', renderer='json')
 def marathon_dashboard(request):
-    print("marathon_dashboard view")
+    log.debug("marathon_dashboard view")
     return create_marathon_dashboard(
         cluster=settings.cluster,
         soa_dir=settings.soa_dir,

--- a/paasta_tools/async_utils.py
+++ b/paasta_tools/async_utils.py
@@ -1,9 +1,13 @@
 import asyncio
 import functools
 import time
+import weakref
+from collections import defaultdict
+from typing import Any
 from typing import AsyncIterable
 from typing import Awaitable
 from typing import Callable
+from typing import DefaultDict
 from typing import Dict  # noqa: imported for typing
 from typing import List
 from typing import TypeVar
@@ -14,28 +18,56 @@ T = TypeVar('T')
 
 def async_ttl_cache(
     ttl: float=300,
+    cleanup_self: bool = False,
 ) -> Callable[
     [Callable[..., Awaitable[T]]],  # wrapped
     Callable[..., Awaitable[T]],  # inner
 ]:
-    _cache: Dict = {}  # Should be Dict[Any, T] but that doesn't work.
+    async def call_or_get_from_cache(cache, coro, args, kwargs):
+        key = functools._make_key(args, kwargs, typed=False)
+        try:
+            future, last_update = cache[key]
+            if ttl > 0 and time.time() - last_update > ttl:
+                raise KeyError
+        except KeyError:
+            future = asyncio.ensure_future(coro)
+            # set the timestamp to +infinity so that we always wait on the in-flight request.
+            cache[key] = (future, float('Inf'))
+        value = await future
+        cache[key] = (future, time.time())
+        return value
 
-    def outer(wrapped):
-        @functools.wraps(wrapped)
-        async def inner(*args, **kwargs):
-            key = functools._make_key(args, kwargs, typed=False)
-            try:
-                future, last_update = _cache[key]
-                if ttl > 0 and time.time() - last_update > ttl:
-                    raise KeyError
-            except KeyError:
-                future = asyncio.ensure_future(wrapped(*args, **kwargs))
-                # set the timestamp to +infinity so that we always wait on the in-flight request.
-                _cache[key] = (future, float('Inf'))
-            value = await future
-            _cache[key] = (future, time.time())
-            return value
-        return inner
+    if cleanup_self:
+        cache: DefaultDict[Any, Dict] = defaultdict(dict)
+
+        def on_delete(w):
+            del cache[w]
+
+        def outer(wrapped):
+            @functools.wraps(wrapped)
+            async def inner(self, *args, **kwargs):
+                w = weakref.ref(self, on_delete)
+                self_cache = cache[w]
+                return await call_or_get_from_cache(
+                    self_cache,
+                    wrapped(self, *args, **kwargs),
+                    args,
+                    kwargs,
+                )
+            return inner
+    else:
+        cache2: Dict = {}  # Should be Dict[Any, T] but that doesn't work.
+
+        def outer(wrapped):
+            @functools.wraps(wrapped)
+            async def inner(*args, **kwargs):
+                return await call_or_get_from_cache(
+                    cache2,
+                    wrapped(*args, **kwargs),
+                    args,
+                    kwargs,
+                )
+            return inner
     return outer
 
 

--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -206,14 +206,14 @@ class MesosMaster:
         else:
             return cfg
 
-    @async_ttl_cache(ttl=15)
+    @async_ttl_cache(ttl=15, cleanup_self=True)
     async def state(self) -> MesosState:
         return await (await self.fetch("/master/state.json", cached=True)).json()
 
     async def state_summary(self) -> MesosState:
         return await (await self.fetch("/master/state-summary")).json()
 
-    @async_ttl_cache(ttl=0)
+    @async_ttl_cache(ttl=0, cleanup_self=True)
     async def slave(self, fltr):
         lst = await self.slaves(fltr)
 
@@ -289,7 +289,7 @@ class MesosMaster:
             keys.append("completed_frameworks")
         return util.merge(await self._frameworks(), *keys)
 
-    @async_ttl_cache(ttl=15)
+    @async_ttl_cache(ttl=15, cleanup_self=True)
     async def _frameworks(self):
         return await (await self.fetch("/master/frameworks", cached=True)).json()
 

--- a/paasta_tools/mesos/mesos_file.py
+++ b/paasta_tools/mesos/mesos_file.py
@@ -84,7 +84,7 @@ class File:
     # look at the size to determine where to seek. Instead of requiring
     # multiple requests to the slave, the size is cached for a very short
     # period of time.
-    @async_ttl_cache(ttl=0.5)
+    @async_ttl_cache(ttl=0.5, cleanup_self=True)
     async def size(self):
         return (await self._fetch())["offset"]
 

--- a/paasta_tools/mesos/slave.py
+++ b/paasta_tools/mesos/slave.py
@@ -66,7 +66,7 @@ class MesosSlave:
                     f"Unable to connect to the slave at {self.host}",
                 )
 
-    @async_ttl_cache(ttl=5)
+    @async_ttl_cache(ttl=5, cleanup_self=True)
     async def state(self):
         return await (await self.fetch("/slave(1)/state.json")).json()
 
@@ -98,7 +98,7 @@ class MesosSlave:
     def file(self, task, path):
         return mesos_file.File(self, task, path)
 
-    @async_ttl_cache(ttl=1)
+    @async_ttl_cache(ttl=1, cleanup_self=True)
     async def stats(self):
         return await (await self.fetch("/monitor/statistics.json")).json()
 

--- a/paasta_tools/mesos/task.py
+++ b/paasta_tools/mesos/task.py
@@ -45,14 +45,14 @@ class Task:
     async def framework(self):
         return framework.Framework(await self.master.framework(self["framework_id"]))
 
-    @async_ttl_cache()
+    @async_ttl_cache(cleanup_self=True)
     async def directory(self):
         try:
             return (await self.executor())["directory"]
         except exceptions.MissingExecutor:
             return ""
 
-    @async_ttl_cache()
+    @async_ttl_cache(cleanup_self=True)
     async def slave(self):
         return await self.master.slave(self["slave_id"])
 


### PR DESCRIPTION
Add `cleanup_self` to `@async_ttl_cache` and use it for all methods

`@async_ttl_cache` decorator caches a function call result using a key
composed from function's args values.  If it's used for a method, it
will use `self` as a part of the key, creating a strong reference to the
class instances in the internal cache as a result.  After some time,
references to the class instances are removed, so the class instance
reference in the cache becomes the only existing reference to that class
instance, and since the method is never called with that class instance
as a `self` arg, the corresponding record in the internal cache is never
expired, creating the memory leak as a result.

Introducing `cleanup_self` arg to `@async_ttl_cache` decorator, so while
it's `True` the decorator creates a weak reference to `self`, and
autocleans corresponding cache record on the object finalisation.  Using
it for all methods, so there will be no more corresponding memory leaks
in `paasta-api`.

While here, also replaced annoying `print()` with logging.