### PR TITLE
Run all tron actions in paasta with the docker '--init' option

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -423,7 +423,7 @@ def get_docker_run_cmd(
         cmd.append(f'{k}')
     cmd.append('--memory=%dm' % memory)
     for i in docker_params:
-        cmd.append('--{}={}'.format(i['key'], i['value']))
+        cmd.append(f"--{i['key']}={i['value']}")
     if net == 'bridge' and container_port is not None:
         cmd.append('--publish=%d:%d' % (chosen_port, container_port))
     elif net == 'host':

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -174,6 +174,12 @@ class TronActionConfig(InstanceConfig):
         executor = self.config_dict.get('executor', None)
         return 'mesos' if executor == 'paasta' else executor
 
+    def format_docker_parameters(self):
+        init = {'key': 'init', 'value': 'true'}
+        params = super().format_docker_parameters()
+        params.append(init)
+        return params
+
     def get_healthcheck_mode(self, _) -> None:
         return None
 

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -134,6 +134,7 @@ class TestTronActionConfig:
             branch_dict={},
         )
         assert action_config.get_executor() == 'mesos'
+        assert {'key': 'init', 'value': 'true'} in action_config.format_docker_parameters()
 
 
 class TestTronJobConfig:


### PR DESCRIPTION
I know I just made a screencast explaining how to properly use dumb-init with complex shell commands, but we can solve this for every user simultaneously with this option, and eliminate an entire class of user-error by not making them have another set of quotes and stuff with `/bin/sh -c 'something'`

Tron on paasta is greenfield, so I'm not afraid of pushing this change for tron things only.

@chriskuehl 