### PR TITLE
APOLLO-565: Add a flag on updating haproxy on the map updates

### DIFF
--- a/paasta_tools/contrib/get_containers_and_ips.py
+++ b/paasta_tools/contrib/get_containers_and_ips.py
@@ -96,6 +96,12 @@ def main():
         ),
     )
     parser.add_argument(
+        '--update-haproxy',
+        '-U',
+        action='store_true',
+        help='Whether to update haproxy for map updates',
+    )
+    parser.add_argument(
         'map_file',
         nargs='?',
         default='/var/run/synapse/maps/ip_to_service.map',
@@ -111,19 +117,21 @@ def main():
 
     for ip_addr, task_id in service_ips_and_ids:
         ip_addrs.append(ip_addr)
-        update_haproxy_mapping(
-            ip_addr,
-            task_id,
-            prev_ip_to_task_id,
-            args.map_file,
-        )
+        if args.update_haproxy:
+            update_haproxy_mapping(
+                ip_addr,
+                task_id,
+                prev_ip_to_task_id,
+                args.map_file,
+            )
         new_lines.append(f'{ip_addr} {task_id}')
 
-    remove_stopped_container_entries(
-        prev_ip_to_task_id.keys(),
-        ip_addrs,
-        args.map_file,
-    )
+    if args.update_haproxy:
+        remove_stopped_container_entries(
+            prev_ip_to_task_id.keys(),
+            ip_addrs,
+            args.map_file,
+        )
 
     # Replace the file contents with the new map
     with atomic_file_write(args.map_file) as fp:


### PR DESCRIPTION
APOLLO-565: Add a flag on updating haproxy on the map updates.

This commit adds a flag (--update-haproxy) which when provide updates
the haproxy with updated map information. The map file contains
the internal bridge IP address of a service and mesos task information
of the service.

This changes the present default behavior which updates haproxy on every
map update. This is not scalable (often fails with `Errno 11`)
and not needed since with synapse haproxy is restarted quite often.
The map_file is part of haproxy.cfg which means we don't need to
actively update haproxy, instead rely on these restarts for haproxy
to pick up updated info.

Note that we are only changing the default, hence, to revert to old behavior,
the flag (--update-haproxy) needs to be provided wherever it is invoked
(puppet).

Tested on a stage box.
