### PR TITLE
Expose calculated (pre-limited) number of instance by autoscaler

### DIFF
--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -534,6 +534,9 @@
               "properties": {
                 "desired_instances": {
                   "type": "integer"
+                },
+                "calculated_instances": {
+                  "type": "integer"
                 }
               }
             }

--- a/paasta_tools/api/views/autoscaler.py
+++ b/paasta_tools/api/views/autoscaler.py
@@ -42,7 +42,10 @@ def get_autoscaler_count(request):
         error_message = f'Unable to load service config for {service}.{instance}'
         raise ApiFailure(error_message, 404)
 
-    response_body = {'desired_instances': service_config.get_instances()}
+    response_body = {
+        'desired_instances': service_config.get_instances(),
+        'calculated_instances': service_config.get_instances(with_limit=False),
+    }
     return Response(json_body=response_body, status_code=200)
 
 

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -185,7 +185,7 @@ class LongRunningServiceConfig(InstanceConfig):
         """
         return self.config_dict.get('bounce_priority', 0) * -1
 
-    def get_instances(self) -> int:
+    def get_instances(self, with_limit: bool=True) -> int:
         """Gets the number of instances for a service, ignoring whether the user has requested
         the service to be started or stopped"""
         if self.get_max_instances() is not None:
@@ -199,7 +199,7 @@ class LongRunningServiceConfig(InstanceConfig):
                 log.debug("No zookeeper data, returning max_instances (%d)" % self.get_max_instances())
                 return self.get_max_instances()
             else:
-                limited_instances = self.limit_instance_count(zk_instances)
+                limited_instances = self.limit_instance_count(zk_instances) if with_limit else zk_instances
                 return limited_instances
         else:
             instances = self.config_dict.get('instances', 1)

--- a/tests/api/test_autoscaler.py
+++ b/tests/api/test_autoscaler.py
@@ -31,6 +31,7 @@ def test_get_autoscaler_count():
         mock_load_marathon_service_config.return_value = mock.MagicMock(get_instances=mock.MagicMock(return_value=123))
         response = autoscaler.get_autoscaler_count(request)
         assert response.json_body['desired_instances'] == 123
+        assert response.json_body['calculated_instances'] == 123
 
 
 @mock.patch('paasta_tools.api.views.autoscaler.load_marathon_service_config', autospec=True)


### PR DESCRIPTION
This change
  * adds the function get_instances_without_limiting() which gets number of instance required as calculated by autoscaler without limiting.
 * adds response parameter calculated_instance which exposes this in the API endpoint v1/services/{service}/{instance}/autoscaling.

This change is to find out the acutal desired instances, since min & max
instance values could be adjusted by the operators/users in emergency
scenarious to pre-scale the services.

Example response now
```
{
  "desired_instances": 3,
  "calculated_instances": 2
}
```