### PR TITLE
Don't log expected exception for `paasta-api`

### DIFF
--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -126,6 +126,9 @@ def setup_paasta_api():
 
     try:
         settings.kubernetes_client = kubernetes_tools.KubeClient()
+    except FileNotFoundError:
+        log.info('Kubernetes not found')
+        settings.kubernetes_client = None
     except Exception:
         log.exception('Error while initializing KubeClient')
         settings.kubernetes_client = None


### PR DESCRIPTION
Don't output the following scary exception into the log, as that is expected
when `paasta-api` runs on a master without Kubernetes:
```
ERROR:paasta_tools.api.api:Error while initializing KubeClient
Traceback (most recent call last):
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/api/api.py", line 128, in setup_paasta_api
    settings.kubernetes_client = kubernetes_tools.KubeClient()
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/kubernetes_tools.py", line 785, in __init__
    kube_config.load_kube_config(config_file='/etc/kubernetes/admin.conf')
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/config/kube_config.py", line 470, in load_kube_config
    config_persister=config_persister)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/config/kube_config.py", line 427, in _get_kube_config_loader_for_yaml_file
    with open(filename) as f:
'/etc/kubernetes/admin.conf'
```