### PR TITLE
convert cmd to a list for kubernetes deployments

### DIFF
--- a/paasta_tools/frameworks/native_service_config.py
+++ b/paasta_tools/frameworks/native_service_config.py
@@ -243,7 +243,7 @@ class NativeServiceConfig(LongRunningServiceConfig):
                 ],
             },
             'command': {
-                'value': self.get_cmd(),
+                'value': str(self.get_cmd()),
                 'uris': [
                     {
                         'value': system_paasta_config.get_dockercfg_location(),

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -263,7 +263,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         cmd = super(LongRunningServiceConfig, self).get_cmd()
         if cmd:
             if isinstance(cmd, str):
-                return cmd.split(' ')
+                return ['sh', '-c', cmd]
             elif isinstance(cmd, list):
                 return cmd
             else:

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -259,6 +259,18 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             soa_dir=self.soa_dir,
         )
 
+    def get_cmd(self) -> Optional[List[str]]:
+        cmd = super(LongRunningServiceConfig, self).get_cmd()
+        if cmd:
+            if isinstance(cmd, str):
+                return cmd.split(' ')
+            elif isinstance(cmd, list):
+                return cmd
+            else:
+                raise ValueError("cmd should be str or list")
+        else:
+            return None
+
     def get_bounce_method(self) -> str:
         """Get the bounce method specified in the service's kubernetes configuration."""
         # map existing bounce methods to k8s equivalents.

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -455,6 +455,17 @@ class MarathonServiceConfig(LongRunningServiceConfig):
             soa_dir=soa_dir,
         )
 
+    def format_cmd(self) -> str:
+        cmd = self.get_cmd()
+        if cmd is None:
+            return None
+        if isinstance(cmd, str):
+            return cmd
+        elif isinstance(cmd, list):
+            return " ".join(cmd)
+        else:
+            raise ValueError("only list or str accepted for cmd")
+
     def copy(self) -> "MarathonServiceConfig":
         return self.__class__(
             service=self.service,
@@ -675,7 +686,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
                 service_namespace_config=service_namespace_config,
             ),
             'instances': self.get_desired_instances(),
-            'cmd': self.get_cmd(),
+            'cmd': self.format_cmd(),
             'args': self.get_args(),
         }
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -464,7 +464,7 @@ class InstanceConfig:
         gpus = self.config_dict.get('gpus', default)
         return gpus
 
-    def get_cmd(self) -> Optional[str]:
+    def get_cmd(self) -> Optional[Union[str, list]]:
         """Get the docker cmd specified in the service's configuration.
 
         Defaults to None if not specified in the config.

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -464,7 +464,7 @@ class InstanceConfig:
         gpus = self.config_dict.get('gpus', default)
         return gpus
 
-    def get_cmd(self) -> Optional[Union[str, list]]:
+    def get_cmd(self) -> Optional[Union[str, List[str]]]:
         """Get the docker cmd specified in the service's configuration.
 
         Defaults to None if not specified in the config.

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -189,7 +189,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             branch_dict=None,
             soa_dir='/nail/blah',
         )
-        assert deployment.get_cmd() == ['/bin/echo', 'hi']
+        assert deployment.get_cmd() == ['sh', '-c', '/bin/echo hi']
 
     def test_get_cmd_list(self):
         deployment = KubernetesDeploymentConfig(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -169,6 +169,39 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
         assert self.deployment.copy() == self.deployment
         assert self.deployment.copy() is not self.deployment
 
+    def test_get_cmd_returns_None(self):
+        deployment = KubernetesDeploymentConfig(
+            service='kurupt',
+            instance='fm',
+            cluster='brentford',
+            config_dict={'cmd': None},
+            branch_dict=None,
+            soa_dir='/nail/blah',
+        )
+        assert deployment.get_cmd() is None
+
+    def test_get_cmd_converts_str_to_list(self):
+        deployment = KubernetesDeploymentConfig(
+            service='kurupt',
+            instance='fm',
+            cluster='brentford',
+            config_dict={'cmd': "/bin/echo hi"},
+            branch_dict=None,
+            soa_dir='/nail/blah',
+        )
+        assert deployment.get_cmd() == ['/bin/echo', 'hi']
+
+    def test_get_cmd_list(self):
+        deployment = KubernetesDeploymentConfig(
+            service='kurupt',
+            instance='fm',
+            cluster='brentford',
+            config_dict={'cmd': ['/bin/echo', 'hi']},
+            branch_dict=None,
+            soa_dir='/nail/blah',
+        )
+        assert deployment.get_cmd() == ['/bin/echo', 'hi']
+
     def test_get_bounce_method(self):
         with mock.patch(
             'paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_aws_ebs_volumes', autospec=True,


### PR DESCRIPTION
kubernetes requires cmd to be a list of strings, rather than a string.
support splitting a string into a list, or even supplying a list as the
cmd