### PR TITLE
use healthcheck_mode before mode

### DIFF
--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -57,6 +57,17 @@ BounceMethodConfigDict = TypedDict('BounceMethodConfigDict', {"instances": int})
 
 class ServiceNamespaceConfig(dict):
 
+    def get_healthcheck_mode(self) -> str:
+        """Get the healthcheck mode for the service. In most cases, this will match the mode
+        of the service, but we do provide the opportunity for users to specify both. Default to the mode
+        if no healthcheck_mode is specified.
+        """
+        healthcheck_mode = self.get('healthcheck_mode', None)
+        if not healthcheck_mode:
+            return self.get_mode()
+        else:
+            return healthcheck_mode
+
     def get_mode(self) -> str:
         """Get the mode that the service runs in and check that we support it.
         If the mode is not specified, we check whether the service uses smartstack
@@ -178,7 +189,7 @@ class LongRunningServiceConfig(InstanceConfig):
     def get_healthcheck_mode(self, service_namespace_config: ServiceNamespaceConfig) -> str:
         mode = self.config_dict.get('healthcheck_mode', None)
         if mode is None:
-            mode = service_namespace_config.get_mode()
+            mode = service_namespace_config.get_healthcheck_mode()
         elif mode not in ['http', 'https', 'tcp', 'cmd', None]:
             raise InvalidHealthcheckMode("Unknown mode: %s" % mode)
         return mode

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -400,7 +400,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                 ), 'mock_sidecar',
             ]
             service_namespace_config = mock.Mock()
-            service_namespace_config.get_mode.return_value = 'http'
+            service_namespace_config.get_healthcheck_mode.return_value = 'http'
             service_namespace_config.get_healthcheck_uri.return_value = '/status'
             assert self.deployment.get_kubernetes_containers(
                 docker_volumes=mock_docker_volumes,
@@ -423,14 +423,14 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
         )
 
         service_namespace_config = mock.Mock()
-        service_namespace_config.get_mode.return_value = 'http'
+        service_namespace_config.get_healthcheck_mode.return_value = 'http'
         service_namespace_config.get_healthcheck_uri.return_value = '/status'
 
         assert self.deployment.get_liveness_probe(service_namespace_config) == liveness_probe
 
     def test_get_liveness_probe_non_smartstack(self):
         service_namespace_config = mock.Mock()
-        service_namespace_config.get_mode.return_value = None
+        service_namespace_config.get_healthcheck_mode.return_value = None
         assert self.deployment.get_liveness_probe(service_namespace_config) is None
 
     def test_get_liveness_probe_numbers(self):
@@ -447,7 +447,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
         )
 
         service_namespace_config = mock.Mock()
-        service_namespace_config.get_mode.return_value = 'http'
+        service_namespace_config.get_healthcheck_mode.return_value = 'http'
         service_namespace_config.get_healthcheck_uri.return_value = '/status'
 
         self.deployment.config_dict['healthcheck_max_consecutive_failures'] = 1
@@ -467,9 +467,9 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             period_seconds=10,
             timeout_seconds=10,
         )
-        service_namespace_config = mock.Mock()
-        service_namespace_config.get_mode.return_value = 'tcp'
-        assert self.deployment.get_liveness_probe(service_namespace_config) == liveness_probe
+        mock_service_namespace_config = mock.Mock()
+        mock_service_namespace_config.get_healthcheck_mode.return_value = 'tcp'
+        assert self.deployment.get_liveness_probe(mock_service_namespace_config) == liveness_probe
 
     def test_get_liveness_probe_cmd(self):
         liveness_probe = V1Probe(
@@ -482,7 +482,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             timeout_seconds=10,
         )
         service_namespace_config = mock.Mock()
-        service_namespace_config.get_mode.return_value = 'cmd'
+        service_namespace_config.get_healthcheck_mode.return_value = 'cmd'
         self.deployment.config_dict['healthcheck_cmd'] = '/bin/true'
         assert self.deployment.get_liveness_probe(service_namespace_config) == liveness_probe
 


### PR DESCRIPTION
right now we default to looking at 'mode' in smartstack.yaml for
what mode should be used for healthchecks. there is nothing in place
that one must include mode for a service, and healthcheck mode 'should'
be enough. ensure that we look at 'healthcheck_mode' before 'mode' when
figuring out the healthcheck for a service.

also fixes a bug that meant that healthcheck_cmd was ignored if it was
specified in smartstack.yaml rather than the instance config


Edit: I guess this raises the question of what having 2 keys is even for? outside of healthchecks, what do we care about the mode for?