### PR TITLE
Bump task-processing to 0.1.3 over 0.0.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -94,7 +94,7 @@ slackclient==1.2.1
 strict-rfc3339==0.7
 swagger-spec-validator==2.1.0
 syslogmp==0.2.2
-task-processing==0.0.16
+task-processing==0.1.3
 thriftpy==0.1.15
 translationstring==1.3
 typing==3.6.2


### PR DESCRIPTION
### Description
Small change to bump task-processing in paasta to 0.1.3.

### Testing
make test

### Notes
 I'd like to make release and push it to dev and stage, before going to prod. Too safe?