### PR TITLE
Added the option to our configs to selectively disable the docker --init behavior

### DIFF
--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -308,6 +308,10 @@
                     "type": "object",
                     "additionalProperties": { "type": "string" }
                 },
+                "docker_init": {
+                  "type": "boolean",
+                  "default": true
+                },
                 "security": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
@chriskuehl is right, it is super likely we are going to need an "escape hatch" from the --init behavior in favor of other things, like Lyft does.

This is the first pass at enabling this, so I can have a toggle so I can enable/disable this behavior "en-mass".

I don't plan on having a toggle like this for non-marathon jobs, as they don't really bounce.