### PR TITLE
Fix `is_pod_ready()` always returns `True`

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -932,7 +932,7 @@ def filter_pods_by_service_instance(
 def is_pod_ready(
     pod: V1Pod,
 ) -> bool:
-    ready_conditions = [cond.status for cond in pod.status.conditions if cond.type == 'Ready']
+    ready_conditions = [cond.status == 'True' for cond in pod.status.conditions if cond.type == 'Ready']
     return all(ready_conditions) if ready_conditions else False
 
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1290,11 +1290,11 @@ def test_is_pod_ready():
             conditions=[
                 mock.MagicMock(
                     type='Ready',
-                    status=True,
+                    status='True',
                 ),
                 mock.MagicMock(
                     type='Another',
-                    status=False,
+                    status='False',
                 ),
             ],
         ),
@@ -1306,11 +1306,11 @@ def test_is_pod_ready():
             conditions=[
                 mock.MagicMock(
                     type='Ready',
-                    status=False,
+                    status='False',
                 ),
                 mock.MagicMock(
                     type='Another',
-                    status=False,
+                    status='False',
                 ),
             ],
         ),
@@ -1322,7 +1322,7 @@ def test_is_pod_ready():
             conditions=[
                 mock.MagicMock(
                     type='Another',
-                    status=False,
+                    status='False',
                 ),
             ],
         ),


### PR DESCRIPTION
`V1PodCondition.status` is a string, see
https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1PodCondition.md