### PR TITLE
Set kubernetes pods DNS policy to `Default`

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -715,6 +715,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     docker_volumes=docker_volumes,
                     aws_ebs_volumes=self.get_aws_ebs_volumes(),
                 ),
+                dns_policy="Default",
             ),
         )
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -749,6 +749,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     containers=mock_get_kubernetes_containers.return_value,
                     restart_policy='Always',
                     volumes=[],
+                    dns_policy='Default',
                 ),
             )
 


### PR DESCRIPTION
Since we don't use cluster DNS for kubernetes, set kubernetes pods DNS
policy to `Default` to prevent the following warnings:
```
  Type     Reason             Age                 From                                      Message
  ----     ------             ----                ----                                      -------
  Warning  MissingClusterDNS  1m (x937 over 19h)  kubelet, ip-10-40-11-76.dev.yelpcorp.com  pod: "opengrok-main--k8s-74c99f7487-7tz6p_paasta(d29ca9d6-d2ea-11e8-b7c5-06b74992d402)". kubelet does not have ClusterDNS IP configured and cannot create Pod using "ClusterFirst" policy. Falling back to "Default" policy.
```