### PR TITLE
Update pre-commit hooks to fix internal build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,10 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.4.0
+    rev: v2.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
         exclude: CHANGELOG.md
-    -   id: autopep8-wrapper
     -   id: check-docstring-first
     -   id: check-json
     -   id: check-yaml
@@ -19,17 +18,17 @@ repos:
     -   id: fix-encoding-pragma
         args: [--remove]
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.1.0
+    rev: v1.3.2
     hooks:
     -   id: reorder-python-imports
         args: [--py3-plus]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.6.0
+    rev: v1.8.0
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
-    rev: v0.7.0
+    rev: v0.7.1
     hooks:
     -   id: add-trailing-comma
         args: [--py36-plus]
@@ -39,6 +38,10 @@ repos:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
         exclude: .*tests/.*|.*yelp/testing/.*|\.pre-commit-config\.yaml
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.3.1
+    hooks:
+    -   id: autopep8
 -   repo: local
     hooks:
     -   id: patch-enforce-autospec

--- a/paasta_tools/cli/fsm/autosuggest.py
+++ b/paasta_tools/cli/fsm/autosuggest.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import os.path
 import random
 
 import yaml

--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import inspect
 import logging
-import logging.handlers
 import socket
 import sys
 import time


### PR DESCRIPTION
See the "Seeing autopep8 failures on Jenkins? Run pre-commit autoupdate" email.