### PR TITLE
Re-factor paasta cluster boost

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_cluster_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_cluster_lib.py
@@ -42,8 +42,8 @@ from botocore.exceptions import ClientError
 from mypy_extensions import TypedDict
 from requests.exceptions import HTTPError
 
-from paasta_tools.autoscaling import cluster_boost
 from paasta_tools.autoscaling import ec2_fitness
+from paasta_tools.autoscaling import load_boost
 from paasta_tools.mesos.master import MesosState
 from paasta_tools.mesos_maintenance import drain
 from paasta_tools.mesos_maintenance import undrain
@@ -1465,7 +1465,10 @@ def get_mesos_utilization_error(
 
         # We apply the boost only on the cpu resource.
         if resource == 'cpus' and system_config.get_cluster_boost_enabled():
-            boosted_load = cluster_boost.get_boosted_load(region=region, pool=pool, current_load=current_load)
+            boosted_load = load_boost.get_boosted_load(
+                zk_boost_path=load_boost.get_zk_cluster_boost_path(region=region, pool=pool),
+                current_load=current_load,
+            )
         else:
             boosted_load = current_load
 

--- a/paasta_tools/cli/cmds/boost.py
+++ b/paasta_tools/cli/cmds/boost.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from paasta_tools.autoscaling import cluster_boost
+from paasta_tools.autoscaling import load_boost
 from paasta_tools.cli.utils import execute_paasta_cluster_boost_on_remote_master
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -67,13 +67,13 @@ def add_subparser(subparsers):
     boost_parser.add_argument(
         '-b', '--boost',
         type=float,
-        default=cluster_boost.DEFAULT_BOOST_FACTOR,
+        default=load_boost.DEFAULT_BOOST_FACTOR,
         help="Boost factor to apply. Default is 1.5. A big failover should be 2, 3 is the max.",
     )
     boost_parser.add_argument(
         '-d', '--duration',
         type=int,
-        default=cluster_boost.DEFAULT_BOOST_DURATION,
+        default=load_boost.DEFAULT_BOOST_DURATION,
         help="Duration of the capacity boost in minutes. Default is 40",
     )
     boost_parser.add_argument(

--- a/tests/test_paasta_cluster_boost.py
+++ b/tests/test_paasta_cluster_boost.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import mock
+from pytest import raises
 
 from paasta_tools import paasta_cluster_boost
 
@@ -65,3 +66,103 @@ def test_get_regions_wrong_pool():
             return_value=FAKE_SLAVE_DATA,
         )
         assert paasta_cluster_boost.get_regions('piscine') == []
+
+
+def test_main():
+    with mock.patch(
+        'paasta_tools.paasta_cluster_boost.parse_args', autospec=True,
+        return_value=mock.Mock(verbose=1),
+    ), mock.patch(
+        'paasta_tools.paasta_cluster_boost.paasta_cluster_boost', autospec=True,
+    ) as mock_paasta_cluster_boost:
+        mock_paasta_cluster_boost.return_value = True
+        with raises(SystemExit) as e:
+            paasta_cluster_boost.main()
+        assert e.value.code == 0
+
+        mock_paasta_cluster_boost.return_value = False
+        with raises(SystemExit) as e:
+            paasta_cluster_boost.main()
+        assert e.value.code == 1
+
+
+def test_paasta_cluster_boost():
+    with mock.patch(
+        'paasta_tools.paasta_cluster_boost.load_system_paasta_config', autospec=True,
+    ) as mock_load_system_paasta_config, mock.patch(
+        'paasta_tools.paasta_cluster_boost.get_regions', autospec=True,
+    ) as mock_get_regions, mock.patch(
+        'paasta_tools.paasta_cluster_boost.load_boost.get_zk_cluster_boost_path', autospec=True,
+    ) as mock_get_zk_cluster_boost_path, mock.patch(
+        'paasta_tools.paasta_cluster_boost.load_boost.set_boost_factor', autospec=True,
+    ) as mock_set_boost_factor, mock.patch(
+        'paasta_tools.paasta_cluster_boost.load_boost.clear_boost', autospec=True,
+    ) as mock_clear_boost, mock.patch(
+        'paasta_tools.paasta_cluster_boost.load_boost.get_boost_factor', autospec=True,
+    ):
+        mock_load_system_paasta_config.return_value = mock.Mock(
+            get_cluster_boost_enabled=mock.Mock(return_value=False),
+        )
+        mock_get_regions.return_value = ['useast1-dev']
+        assert not paasta_cluster_boost.paasta_cluster_boost(
+            action='status',
+            pool='default',
+            boost=1.0,
+            duration=20,
+            override=False,
+        )
+
+        mock_load_system_paasta_config.return_value = mock.Mock(
+            get_cluster_boost_enabled=mock.Mock(return_value=True),
+        )
+        mock_get_regions.return_value = []
+        assert not paasta_cluster_boost.paasta_cluster_boost(
+            action='status',
+            pool='default',
+            boost=1.0,
+            duration=20,
+            override=False,
+        )
+
+        mock_load_system_paasta_config.return_value = mock.Mock(
+            get_cluster_boost_enabled=mock.Mock(return_value=True),
+        )
+        mock_get_regions.return_value = ['useast1-dev']
+        assert paasta_cluster_boost.paasta_cluster_boost(
+            action='status',
+            pool='default',
+            boost=1.0,
+            duration=20,
+            override=False,
+        )
+        assert not mock_set_boost_factor.called
+        assert not mock_clear_boost.called
+
+        assert paasta_cluster_boost.paasta_cluster_boost(
+            action='set',
+            pool='default',
+            boost=1.0,
+            duration=20,
+            override=False,
+        )
+        mock_set_boost_factor.assert_called_with(
+            zk_boost_path=mock_get_zk_cluster_boost_path.return_value,
+            region='useast1-dev',
+            pool='default',
+            send_clusterman_metrics=True,
+            factor=1.0,
+            duration_minutes=20,
+            override=False,
+        )
+        assert not mock_clear_boost.called
+
+        assert paasta_cluster_boost.paasta_cluster_boost(
+            action='clear',
+            pool='default',
+            boost=1.0,
+            duration=20,
+            override=False,
+        )
+        mock_clear_boost.assert_called_with(
+            zk_boost_path=mock_get_zk_cluster_boost_path.return_value,
+        )


### PR DESCRIPTION
I'd like to re-use the cluster boost logic to boost the service
autoscalers on a per-service level. Soon we will only need the
clusterman metrics bit for clusters anyway so I intend to separate that
block completely soon. This is just the refactor and I will add the
changes to the service autoscaler and boost cli in a second commit.

This:
* renames the module to load_boost.
* makes all the functions take a zk_boost_path which is {region}/{pool}
for cluster boost but can be like {cluster}/{service}/{instance} for the
service autoscaler
* adds some tests and tidy up