### PR TITLE
set pipefail on our bash scripts

### DIFF
--- a/paasta_tools/deploy_marathon_services
+++ b/paasta_tools/deploy_marathon_services
@@ -1,2 +1,3 @@
 #!/bin/bash
+set -eo pipefail
 list_marathon_service_instances | shuf | xargs -n 1 -r -P 5 setup_marathon_job

--- a/paasta_tools/generate_all_deployments
+++ b/paasta_tools/generate_all_deployments
@@ -3,5 +3,7 @@
 # Generates all the per-service deployments.json files
 #
 
+set -eo pipefail
+
 # xargs will return 0 if everything went ok, but 12X if something else went wrong
 paasta list | shuf | xargs -n 1 -r -P 4 generate_deployments_for_service -s

--- a/paasta_tools/paasta_deploy_chronos_jobs
+++ b/paasta_tools/paasta_deploy_chronos_jobs
@@ -1,2 +1,3 @@
 #!/bin/bash
+set -eo pipefail
 list_chronos_jobs | shuf | xargs -n 1 -r -P 5 setup_chronos_job

--- a/paasta_tools/paasta_deploy_tron_jobs
+++ b/paasta_tools/paasta_deploy_tron_jobs
@@ -1,2 +1,3 @@
 #!/bin/bash
+set -eo pipefail
 paasta_list_tron_namespaces | xargs -n 1 -r -P 1 paasta_setup_tron_namespace


### PR DESCRIPTION
I added this to all the bash scripts that I think need it?  I guess this could break things somewhere if something's been silently failing and now noisily fails?