### PR TITLE
Null Tron jobs not allowed

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -139,7 +139,7 @@
   "required": ["jobs"],
   "properties": {
     "jobs": {
-      "type": ["null", "array", "object"],
+      "type": ["array", "object"],
       "items": {"$ref": "#definitions/job"},
       "patternProperties": {
         ".+": {"$ref": "#definitions/job"}


### PR DESCRIPTION
This breaks get_tron_instance_list_from_yaml. I think I left it here for backwards-compatibility, but now there's no reason to allow them for jobs in service directories.

`paasta validate` gets called in the pre-receive for all tron files in service directories.