### PR TITLE
fix paasta info bug

### DIFF
--- a/paasta_tools/cli/cmds/info.py
+++ b/paasta_tools/cli/cmds/info.py
@@ -67,7 +67,7 @@ def add_subparser(subparsers):
 def deployments_to_clusters(deployments: Collection[str]) -> Collection[str]:
     clusters = []
     for deployment in deployments:
-        cluster, _ = deployment.split('.')
+        cluster = deployment.split('.')[0]
         clusters.append(cluster)
     return set(clusters)
 

--- a/tests/cli/test_cmds_info.py
+++ b/tests/cli/test_cmds_info.py
@@ -76,7 +76,7 @@ def test_get_service_info():
 
 
 def test_deployments_to_clusters():
-    deployments = ['A.main', 'A.canary', 'B.main', 'C.othermain']
+    deployments = ['A.main', 'A.canary', 'B.main', 'C.othermain.dev']
     expected = {'A', 'B', 'C'}
     actual = info.deployments_to_clusters(deployments)
     assert actual == expected


### PR DESCRIPTION
Tron uses "[namespace].[job_name].[action_name]", and this breaks paasta info command.