### PR TITLE
Service autoscaler performance stuff

### DIFF
--- a/paasta_tools/autoscale_all_services.py
+++ b/paasta_tools/autoscale_all_services.py
@@ -30,6 +30,10 @@ def parse_args():
         '-v', '--verbose', action='store_true',
         help="Increase logging verboseness",
     )
+    parser.add_argument(
+        'services', type=str, nargs='*',
+        help='name of services to scale (optional defaults to all autoscaling enabled services)',
+    )
     args = parser.parse_args()
     return args
 
@@ -40,7 +44,7 @@ def main():
         logging.basicConfig(level=logging.DEBUG)
     else:
         logging.basicConfig(level=logging.WARNING)
-    autoscale_services(soa_dir=args.soa_dir)
+    autoscale_services(soa_dir=args.soa_dir, services=args.services)
 
 
 if __name__ == '__main__':

--- a/paasta_tools/mesos/slave.py
+++ b/paasta_tools/mesos/slave.py
@@ -98,7 +98,7 @@ class MesosSlave:
     def file(self, task, path):
         return mesos_file.File(self, task, path)
 
-    @async_ttl_cache(ttl=1, cleanup_self=True)
+    @async_ttl_cache(ttl=30, cleanup_self=True)
     async def stats(self):
         return await (await self.fetch("/monitor/statistics.json")).json()
 

--- a/tests/test_autoscale_all_services.py
+++ b/tests/test_autoscale_all_services.py
@@ -21,6 +21,6 @@ from paasta_tools.autoscale_all_services import main
 @mock.patch('paasta_tools.autoscale_all_services.autoscale_services', autospec=True)
 @mock.patch('paasta_tools.autoscale_all_services.parse_args', autospec=True)
 def test_main(mock_parse_args, mock_autoscale_services, logging):
-    mock_parse_args.return_value = mock.Mock(soa_dir='/nail/blah')
+    mock_parse_args.return_value = mock.Mock(soa_dir='/nail/blah', services=None)
     main()
-    mock_autoscale_services.assert_called_with(soa_dir='/nail/blah')
+    mock_autoscale_services.assert_called_with(soa_dir='/nail/blah', services=None)


### PR DESCRIPTION
Probably best to review the commits independently
* The first is a change to caching which I think is safe? Hopefully nothing long-running is going to break?
* The second makes it possible to run multiple autoscalers (e.g. using xargs). By default it will stick with the current behaviour of iterating through all the services sequentially