### PR TITLE
Use HTTP API for `paasta metastatus` by default

### DIFF
--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -221,7 +221,7 @@ def paasta_metastatus(
     if 'USE_API_ENDPOINT' in os.environ:
         use_api_endpoint = strtobool(os.environ['USE_API_ENDPOINT'])
     else:
-        use_api_endpoint = False
+        use_api_endpoint = True
 
     all_clusters = list_clusters(soa_dir=soa_dir)
     clusters_to_inspect = figure_out_clusters_to_inspect(args, all_clusters)


### PR DESCRIPTION
Switch `paasta metastatus` to use the HTTP API endpoint by default.

It can be forced to use the old ssh-based method by specifying a false
value for `USE_API_ENDPOINT` environment variable, e.g.:
```
$ USE_API_ENDPOINT=0 paasta metastatus -c somecluster -vv -a
```