### PR TITLE
Fix `paasta metastatus -vvv` output for Kubernetes

### DIFF
--- a/paasta_tools/metrics/metastatus_lib.py
+++ b/paasta_tools/metrics/metastatus_lib.py
@@ -39,6 +39,7 @@ from paasta_tools.kubernetes_tools import get_pod_status
 from paasta_tools.kubernetes_tools import is_node_ready
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import list_all_deployments
+from paasta_tools.kubernetes_tools import maybe_add_yelp_prefix
 from paasta_tools.kubernetes_tools import PodStatus
 from paasta_tools.marathon_tools import MarathonClient
 from paasta_tools.mesos.master import MesosMetrics
@@ -618,7 +619,7 @@ def key_func_for_attribute_multi_kube(
     :returns: a closure, which takes a node and returns the value of those attributes
     """
     def get_attribute(node, attribute):
-        return node.metadata.labels.get(f'yelp.com/{attribute}', 'unknown')
+        return node.metadata.labels.get(maybe_add_yelp_prefix(attribute), 'unknown')
 
     def key_func(node):
         return tuple((a, get_attribute(node, a)) for a in attributes)

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -478,7 +478,7 @@ def print_output(argv: Optional[Sequence[str]]=None) -> None:
             # The last column from utilization_table_by_grouping_from_kube is "Agent count", which will always be
             # 1 for per-node resources, so delete it.
             for row in all_rows:
-                row.pop(-2)
+                row.pop()
 
             for line in format_table(all_rows):
                 print_with_indent(line, 4)


### PR DESCRIPTION
Remove `Agent count` column instead of `GPU (used/total)` one.

While here also replaced hardcoded `yelp.com/` prefix for Kubernetes
labels with the `maybe_add_yelp_prefix()` function call.

Before:
```
  Per Node Utilization
    Region        Hostname                                    CPU (used/total)  RAM (used/total)      Disk (used/total)    Agent count
    uswest1-devc  10-40-10-205-uswest1adevc.dev.yelpcorp.com  0.00/16 (0.00%)   100.0M/29.4G (0.33%)  5.8G/58.1G (10.00%)  1
    uswest1-devc  10-40-10-244-uswest1adevc.dev.yelpcorp.com  0.00/16 (0.00%)   100.0M/29.4G (0.33%)  5.8G/58.1G (10.00%)  1
    uswest1-devc  10-40-11-189-uswest1adevc.dev.yelpcorp.com  0.00/16 (0.00%)   100.0M/29.4G (0.33%)  5.8G/58.1G (10.00%)  1
    uswest1-devc  kubestage1-uswest1adevc.dev.yelpcorp.com    0.00/2 (0.00%)    100.0M/7.5G (1.30%)   9.7G/96.9G (10.00%)  1
    uswest1-devc  kubestage1-uswest1cdevc.dev.yelpcorp.com    0.00/2 (0.00%)    100.0M/7.5G (1.30%)   9.7G/96.9G (10.00%)  1
    uswest1-devc  kubestage2-uswest1cdevc.dev.yelpcorp.com    0.00/2 (0.00%)    100.0M/7.5G (1.30%)   9.7G/96.9G (10.00%)  1
```

After:
```
  Per Node Utilization
    Region        Hostname                                    CPU (used/total)  RAM (used/total)      Disk (used/total)    GPU (used/total)
    uswest1-devc  10-40-10-205-uswest1adevc.dev.yelpcorp.com  0.00/16 (0.00%)   100.0M/29.4G (0.33%)  5.8G/58.1G (10.00%)  0.00/0 (100.00%)
    uswest1-devc  10-40-10-244-uswest1adevc.dev.yelpcorp.com  0.00/16 (0.00%)   100.0M/29.4G (0.33%)  5.8G/58.1G (10.00%)  0.00/0 (100.00%)
    uswest1-devc  10-40-11-189-uswest1adevc.dev.yelpcorp.com  0.00/16 (0.00%)   100.0M/29.4G (0.33%)  5.8G/58.1G (10.00%)  0.00/0 (100.00%)
    uswest1-devc  kubestage1-uswest1adevc.dev.yelpcorp.com    0.00/2 (0.00%)    100.0M/7.5G (1.30%)   9.7G/96.9G (10.00%)  0.00/0 (100.00%)
    uswest1-devc  kubestage1-uswest1cdevc.dev.yelpcorp.com    0.00/2 (0.00%)    100.0M/7.5G (1.30%)   9.7G/96.9G (10.00%)  0.00/0 (100.00%)
    uswest1-devc  kubestage2-uswest1cdevc.dev.yelpcorp.com    0.00/2 (0.00%)    100.0M/7.5G (1.30%)   9.7G/96.9G (10.00%)  0.00/0 (100.00%)
```