### PR TITLE
Add the Mesos containerizer to Marathon

### DIFF
--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -29,8 +29,7 @@
             "gpus": {
                 "type": "integer",
                 "minimum": 0,
-                "exclusiveMinimum": true,
-                "default": 0
+                "exclusiveMinimum": false
             },
             "cmd": {
                 "type": "string"

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -80,6 +80,11 @@
                     "exclusiveMinimum": true,
                     "default": 1024
                 },
+                "gpus": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": false
+                },
                 "instances": {
                     "type": "integer",
                     "minimum": 0,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1186,7 +1186,7 @@ class TestInstanceConfig:
             config_dict={},
             branch_dict=None,
         )
-        assert fake_conf.get_gpus() == 0
+        assert fake_conf.get_gpus() is None
 
     def test_get_ulimit_in_config(self):
         fake_conf = utils.InstanceConfig(


### PR DESCRIPTION
I ran setup_marathon_job.py dsc-test-service.gpu manually with below patch on a mesos master. The task can grab 1 gpu and run in a mesos containerizer.

V2: 
*Removed containerizer type from config. Instead, it is inferred depending on if gpu is used.
*Changed gpus type from float to int.