### PR TITLE
confirm affected cluster and instances before really start or stop

### DIFF
--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -140,6 +140,19 @@ def print_chronos_message(desired_state):
         )
 
 
+def confirm_to_continue(cluster_service_instances, desired_state):
+    paasta_print(f'You are about to {desired_state} the following instances:')
+    i_count = 0
+    for cluster, services_instances in cluster_service_instances:
+        for service, instances in services_instances.items():
+            for instance in instances.keys():
+                paasta_print(f'cluster = {cluster}, instance = {service}')
+                i_count += 1
+    if sys.stdin.isatty():
+        return choice.Binary(f'Are you sure you want to {desired_state} these {i_count} instances?', False).ask()
+    return False
+
+
 def paasta_start_or_stop(args, desired_state):
     """Requests a change of state to start or stop given branches of a service."""
     soa_dir = args.soa_dir
@@ -169,6 +182,12 @@ def paasta_start_or_stop(args, desired_state):
 
     invalid_deploy_groups = []
     marathon_message_printed, chronos_message_printed = False, False
+
+    if confirm_to_continue(pargs.items(), desired_state) is False:
+        paasta_print()
+        paasta_print("exiting")
+        return 1
+
     for cluster, services_instances in pargs.items():
         for service, instances in services_instances.items():
             try:

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -119,6 +119,7 @@ def test_log_event():
         )
 
 
+@mock.patch('paasta_tools.cli.cmds.start_stop_restart.confirm_to_continue', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.apply_args_filters', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.issue_state_change_for_service', autospec=True)
 @mock.patch('paasta_tools.utils.format_timestamp', autospec=True)
@@ -138,6 +139,7 @@ def test_paasta_start_or_stop(
     mock_format_timestamp,
     mock_issue_state_change_for_service,
     mock_apply_args_filters,
+    mock_confirm_to_continue,
 ):
     args, _ = parse_args([
         'start', '-s', 'fake_service', '-i', 'main1,canary',
@@ -158,6 +160,8 @@ def test_paasta_start_or_stop(
             'fake_service': {'main1': None, 'canary': None},
         },
     }
+    mock_confirm_to_continue.return_value = True
+
     ret = args.command(args)
     c1_get_instance_config_call = mock.call(
         service='fake_service',
@@ -208,6 +212,7 @@ def test_paasta_start_or_stop(
     assert(ret == 0)
 
 
+@mock.patch('paasta_tools.cli.cmds.start_stop_restart.confirm_to_continue', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.apply_args_filters', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.issue_state_change_for_service', autospec=True)
 @mock.patch('paasta_tools.utils.format_timestamp', autospec=True)
@@ -227,6 +232,7 @@ def test_paasta_start_or_stop_with_deploy_group(
     mock_format_timestamp,
     mock_issue_state_change_for_service,
     mock_apply_args_filters,
+    mock_confirm_to_continue,
 ):
     args, _ = parse_args([
         'start', '-s', 'fake_service', '-c', 'cluster1',
@@ -242,6 +248,8 @@ def test_paasta_start_or_stop_with_deploy_group(
     mock_apply_args_filters.return_value = {
         'cluster1': {'fake_service': {'instance1': None}},
     }
+    mock_confirm_to_continue.return_value = True
+
     ret = args.command(args)
 
     mock_get_instance_config.assert_called_once_with(
@@ -263,6 +271,7 @@ def test_paasta_start_or_stop_with_deploy_group(
     assert ret == 0
 
 
+@mock.patch('paasta_tools.cli.cmds.start_stop_restart.confirm_to_continue', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.apply_args_filters', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.issue_state_change_for_service', autospec=True)
 @mock.patch('paasta_tools.utils.format_timestamp', autospec=True)
@@ -282,6 +291,7 @@ def test_stop_or_start_figures_out_correct_instances(
     mock_format_timestamp,
     mock_issue_state_change_for_service,
     mock_apply_args_filters,
+    mock_confirm_to_continue,
 ):
     args, _ = parse_args([
         'start', '-s', 'fake_service', '-i', 'main1,canary',
@@ -302,6 +312,8 @@ def test_stop_or_start_figures_out_correct_instances(
             'fake_service': {'main1': None, 'canary': None},
         },
     }
+    mock_confirm_to_continue.return_value = True
+
     ret = args.command(args)
     c1_get_instance_config_call = mock.call(
         service='fake_service',
@@ -344,6 +356,7 @@ def test_stop_or_start_figures_out_correct_instances(
     assert(ret == 0)
 
 
+@mock.patch('paasta_tools.cli.cmds.start_stop_restart.confirm_to_continue', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.apply_args_filters', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.remote_git.list_remote_refs', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.get_instance_config', autospec=True)
@@ -355,6 +368,7 @@ def test_stop_or_start_handle_ls_remote_failures(
     mock_get_instance_config,
     mock_list_remote_refs,
     mock_apply_args_filters,
+    mock_confirm_to_continue,
     capfd,
 ):
     args, _ = parse_args([
@@ -369,11 +383,13 @@ def test_stop_or_start_handle_ls_remote_failures(
     mock_apply_args_filters.return_value = {
         'cluster1': {'fake_service': ['instance1']},
     }
+    mock_confirm_to_continue.return_value = True
 
     assert args.command(args) == 1
     assert "may be down" in capfd.readouterr()[0]
 
 
+@mock.patch('paasta_tools.cli.cmds.start_stop_restart.confirm_to_continue', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.apply_args_filters', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.get_instance_config', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.start_stop_restart.remote_git.list_remote_refs', autospec=True)
@@ -383,6 +399,7 @@ def test_start_or_stop_bad_refs(
     mock_list_remote_refs,
     mock_get_instance_config,
     mock_apply_args_filters,
+    mock_confirm_to_continue,
     capfd,
 ):
     args, _ = parse_args([
@@ -405,6 +422,7 @@ def test_start_or_stop_bad_refs(
         'fake_cluster1': {'fake_service': {'fake_instance': None}},
         'fake_cluster2': {'fake_service': {'fake_instance': None}},
     }
+    mock_confirm_to_continue.return_value = True
     assert args.command(args) == 1
     assert "No branches found for" in capfd.readouterr()[0]
 


### PR DESCRIPTION
Before the instances are actually started/stopped, the command line would ask for the confirmation. An example is [here](https://fluffy.yelpcorp.com/i/dcmP9ThnSmN4CdXM6kDKwW6dsdNvxj4L.html).