### PR TITLE
RFC: Added tron support in the paasta api

### DIFF
--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -563,15 +563,19 @@
         },
         "marathon": {
           "$ref": "#/definitions/InstanceStatusMarathon",
-          "description": "Marathon specific instance status"
+          "description": "Marathon instance status"
         },
         "kubernetes": {
           "$ref": "#/definitions/InstanceStatusKubernetes",
-          "description": "Kubernetes specific instance status"
+          "description": "Kubernetes instance status"
         },
         "chronos": {
           "$ref": "#/definitions/InstanceStatusChronos",
-          "description": "Chronos specifid instance status"
+          "description": "Chronos instance status"
+        },
+        "tron": {
+          "$ref": "#/definitions/InstanceStatusTron",
+          "description": "Tron instance status"
         }
       }
     },
@@ -803,7 +807,43 @@
         "last_status"
       ]
     },
-    "InstanceTasks": {
+    "InstanceStatusTron": {
+      "type": "object",
+      "properties": {
+        "state": {
+          "type": "string",
+          "description": "State of a Tron action or job"
+        },
+        "command": {
+          "type": "string",
+          "description": "The command for the action"
+        },
+        "raw_command": {
+          "type": "string",
+          "description": "The raw command for the action"
+        },
+        "stdout": {
+          "type": "string",
+          "description": "The stdout for the action"
+        },
+        "stderr": {
+          "type": "string",
+          "description": "The stderr command for the action"
+        },
+        "last_status": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            },
+            "time": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+   "InstanceTasks": {
       "type": "array",
       "description": "List of tasks associated with instance",
       "items": {

--- a/paasta_tools/tron/client.py
+++ b/paasta_tools/tron/client.py
@@ -109,3 +109,15 @@ class TronClient:
         """Gets the namespaces that are currently configured."""
         response = self._get('/api')
         return response.get('namespaces', [])
+
+    def get_latest_job_run_id(self, job):
+        job_content = self._get(f"/api/jobs/{job}/")
+        job_runs = sorted(
+            job_content.get('runs', []),
+            key=lambda k: (k['end_time'] is None, k['end_time'], k['run_time']),
+            reverse=True,
+        )
+        return job_runs[0]["run_num"]
+
+    def get_action_run(self, job, action, run_id):
+        return self._get(f"/api/jobs/{job}/{run_id}/{action}?include_stderr=1&include_stdout=1&num_lines=10")


### PR DESCRIPTION
This is an experimental branch to see what it would take to get tron stuff in `paasta status`.

I think I want `paasta status` to be able see tron stuff for a couple reasons:
* Gets users to "feel" like they are interacting with paasta?
* Understands the `--cluster` argument instead of requiring users to "be" in the right place

But there are some serious downsides:
* The concept of looking at a whole "job" doesn't match up with the status api (which looks at individual actions
* The concept of a run_id doesn't fit anywhere in the paasta api?
* Idk, I just feel like it would take a lot of work to get feature parity with tronview.

Is this the direction you think we should go? (getting paasta status with feature parity with tronview?)