### PR TITLE
RFC: Address the identity=0 race condition by managing IP addresses ourselves

### DIFF
--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -174,7 +174,7 @@ def get_ip_for_container():
     return new_ip
 
 
-def add_ip_address(argv, service, instance):
+def add_ip_address(argv)
     ip_addr = get_ip_for_container()
     # Only add the --ip argument if we actually got an IP
     if ip_addr:

--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -164,7 +164,7 @@ def get_ip_for_container():
     ), shell=True).split()
     # Then try to get one in the subnet of the docker
     # Ideally get this from config etc
-    subnet = ip_network(u'169.254.1.1/20', False)
+    subnet = ip_network(u'169.254.16.0/24', False)
     hosts = list(subnet.hosts())
     new_ip = random.choice(hosts)
     while new_ip in current_ip_addresses:
@@ -179,6 +179,7 @@ def add_ip_address(argv, service, instance):
     # Only add the --ip argument if we actually got an IP
     if ip_addr:
         argv = add_argument(argv, f'--ip={ip_addr}')
+        argv = add_argument(argv, f'--net=dswg')
     }
     return argv
 
@@ -381,7 +382,7 @@ def main(argv=None):
 
     # Would probably also be based on some configuration so that
     # the feature can be toggled for rollout / rollback
-    if can_add_ip_address(argv):
+    if can_add_ip_address(argv) and 'run' in argv:
         with ip_flock:
             try:
                 argv = add_ip_address(argv)

--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -154,9 +154,15 @@ def can_add_ip_address(args):
 def get_ip_for_container():
     # This would look at the currently outstanding IP addresses
     # Something like but not necessarily =>
-    # for i in $(sudo docker network ls | cut -d ' ' -f 1 | tail -n +2); do sudo docker network inspect $i; done | jq -r '.[].Containers | to_entries | .[].value.IPv4Address'
-    current_ip_addresses = []
-    # Then try to get one in the subnet of the docker 
+    current_ip_addresses = subprocess.check_output((
+        "for i in $(sudo docker network ls | cut -d ' ' -f 1 | tail -n +2); "
+        "do "
+            "sudo docker network inspect $i; "
+        "done "
+            "| jq -r '.[].Containers | to_entries | .[].value.IPv4Address' "
+            "| sed 's/\/.*$//g'"
+    ), shell=True).split()
+    # Then try to get one in the subnet of the docker
     # Ideally get this from config etc
     subnet = ip_network(u'169.254.1.1/20', False)
     hosts = list(subnet.hosts())

--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -180,7 +180,6 @@ def add_ip_address(argv, service, instance):
     if ip_addr:
         argv = add_argument(argv, f'--ip={ip_addr}')
         argv = add_argument(argv, f'--net=dswg')
-    }
     return argv
 
 

--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -382,7 +382,7 @@ def main(argv=None):
     # Would probably also be based on some configuration so that
     # the feature can be toggled for rollout / rollback
     if can_add_ip_address(argv) and 'run' in argv:
-        with ip_flock:
+        with ip_flock():
             try:
                 argv = add_ip_address(argv)
             except Exception as e:

--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -19,6 +19,7 @@ import os
 import random
 import re
 import socket
+import subprocess
 import sys
 
 from ipaddress import ip_network

--- a/paasta_tools/ip.py
+++ b/paasta_tools/ip.py
@@ -1,0 +1,16 @@
+import io
+
+from contextlib import contextmanager
+
+from paasta_tools.utils import timed_flock
+
+DEFAULT_IP_FLOCK_PATH = '/var/lib/paasta/ip.flock'
+DEFAULT_IP_FLOCK_TIMEOUT_SECS = 2
+
+@contextmanager
+def ip_flock(flock_path=DEFAULT_IP_FLOCK_PATH):
+    """ Grab an exclusive flock to avoid concurrent ip allocations
+    """
+    with io.FileIO(flock_path, 'w') as f:
+        with timed_flock(f, seconds=DEFAULT_IP_FLOCK_TIMEOUT_SECS):
+            yield


### PR DESCRIPTION
Sending this out as a request for comments on how good/bad/okay of an idea this is.

The idea is that we do our own IP address management and tell docker to use the IP address we choose, so that we can have a chance to update the mapfile before actually launching the container. If we wanted to go this way, we'd probably want to stop generating the mapfile out of band. But, we'd also need something to manage "garbage collection" of old entries in the mapfile over time, which could be done but introduces more locking/synchronization semantics between more things.

There are definitely a few things to think through here (for e.g. will we need changes to our docker networking infra to enable this?), but this seems like it could do the trick. Thoughts?