### PR TITLE
Check get_gpus() return value for meta-status and remote-run

### DIFF
--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -65,7 +65,7 @@ logging.basicConfig()
 logging.getLogger("kazoo").setLevel(logging.CRITICAL)
 logging.getLogger("paasta_tools.autoscaling.autoscaling_cluster_lib").setLevel(logging.ERROR)
 
-ServiceInstanceStats = TypedDict('ServiceInstanceStats', {'mem': float, 'cpus': float, 'disk': float, 'gpus': float})
+ServiceInstanceStats = TypedDict('ServiceInstanceStats', {'mem': float, 'cpus': float, 'disk': float, 'gpus': int})
 
 
 class FatalError(Exception):
@@ -300,11 +300,15 @@ def get_service_instance_stats(
     try:
         instance_config = get_instance_config(service, instance, cluster)
         # Get all fields that are showed in the 'paasta metastatus -vvv' command
+        if instance_config.get_gpus():
+            gpus = int(instance_config.get_gpus())
+        else:
+            gpus = 0
         service_instance_stats = ServiceInstanceStats(
             mem=instance_config.get_mem(),
             cpus=instance_config.get_cpus(),
             disk=instance_config.get_disk(),
-            gpus=instance_config.get_gpus(),
+            gpus=gpus,
         )
         return service_instance_stats
     except Exception as e:

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -210,7 +210,7 @@ def paasta_to_task_config_kwargs(
     }
     if cmd:
         kwargs['cmd'] = cmd
-    if gpus > 0:
+    if gpus:
         kwargs['gpus'] = int(gpus)
         kwargs['containerizer'] = 'MESOS'
 

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -130,6 +130,7 @@ def test_get_service_instance_stats():
     # The patch stuff is confusing.
     # Basically we patch the validate_service_instance in the paasta_metastatus module and not the utils module
     instance_config_mock = Mock()
+    instance_config_mock.get_gpus.return_value = None
     with patch(
         'paasta_tools.paasta_metastatus.get_instance_config', autospec=True, return_value=instance_config_mock,
     ):


### PR DESCRIPTION
The change was tested with 
$ .tox/py36/bin/paasta_metastatus.py -s dsc-test-service -i gpu -vvv
$ .tox/py36/bin/paasta_remote_run.py start -s taskproc_canary -i remote -c norcal-devc