### PR TITLE
Read Marathon and Chronos logs as strings not bytes

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -788,7 +788,7 @@ class ScribeLogReader(LogReader):
                 for line in scribe_reader:
                     # temporary until all log lines are strings not byte strings
                     if isinstance(line, bytes):
-                        line = line.decode()
+                        line = line.decode('utf-8')
                     if parser_fn:
                         line = parser_fn(line, clusters, service)
                     if filter_fn:

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -786,6 +786,9 @@ class ScribeLogReader(LogReader):
         with scribe_reader_ctx as scribe_reader:
             try:
                 for line in scribe_reader:
+                    # temporary until all log lines are strings not byte strings
+                    if isinstance(line, bytes):
+                        line = line.decode()
                     if parser_fn:
                         line = parser_fn(line, clusters, service)
                     if filter_fn:


### PR DESCRIPTION
### Description
- Sometimes logs are read in as byte strings, but we attempt to decode them as strs, which can result in errors.
- This change checks if log lines are bytes; if they are, we convert them to strs first.

### Testing done
- manual testing

### Reviewers
- According @solarkennedy, @EvanKrall may have strong opinions about this. However, given that some people need this, I suggest making this change, at least temporarily, until we can come to an agreement about how to do this better going forward.