### PR TITLE
Allow underscores in instance configs for marathon/chronos/adhoc

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -1,9 +1,35 @@
 Preparation: paasta_tools and yelpsoa-configs
 =========================================================
 
-
 paasta_tools reads configuration about services from several YAML
 files in `soa-configs <soa_configs.html>`_:
+
+Each object inside of these YAML files is called an "instance" of a PaaSTA
+service. It describes a unique way to run the service, with a unique command,
+cpu and ram requirements, etc.
+
+Duplication can be reduced by using YAML `anchors and merges<https://gist.github.com/bowsersenior/979804>`_.
+PaaSTA will **not** attempt to run any definition prefixed with ``_``,
+so you are free to use them for YAML templates.
+
+Example::
+
+    _template: &template
+        env:
+            foo: bar
+
+    main:
+        <<: *template
+        cpus: 1.0
+        mem: 1000
+        command: busybox httpd
+
+    worker:
+        <<: *template
+        cpus: 0.1
+        mem: 100
+        command: python -m worker
+
 
 ``Common Settings``
 -------------------
@@ -458,7 +484,7 @@ Each job configuration MAY specify the following options:
 
   * ``monitoring``: See the `marathon-[clustername].yaml`_ section for details
 
-  * ``deploy_group``: Same as ``deploy_group`` for marathon-*.yaml.
+  * ``deploy_group``: Same as ``deploy_group`` for marathon-\*.yaml.
 
   * ``schedule_time_zone``: The time zone name to use when scheduling the job.
     Unlike schedule, this is specified in the tz database format, not the ISO 8601 format.
@@ -474,7 +500,7 @@ Each job configuration MAY specify the following options:
           schedule_time_zone: America/Los_Angeles
 
 ``tron-[tron-clustername].yaml``
-------------------------------
+--------------------------------
 
 This file stores configuration for periodically scheduled jobs for execution on
 `Tron <https://github.com/yelp/tron>`_.

--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -3,102 +3,109 @@
     "description": "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html#adhoc-clustername-yaml",
     "type": "object",
     "minProperties": 1,
-    "additionalProperties": {
-        "type": "object",
-        "additionalProperties": false,
-        "minProperties": 1,
-        "properties": {
-            "cpus": {
-                "type": "number",
-                "minimum": 0,
-                "exclusiveMinimum": true,
-                "default": 1
-            },
-            "mem": {
-                "type": "number",
-                "minimum": 32,
-                "exclusiveMinimum": true,
-                "default": 1024
-            },
-            "disk": {
-                "type": "number",
-                "minimum": 0,
-                "exclusiveMinimum": true,
-                "default": 1024
-            },
-            "gpus": {
-                "type": "integer",
-                "minimum": 0,
-                "exclusiveMinimum": false
-            },
-            "cmd": {
-                "type": "string"
-            },
-            "args": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
-            },
-            "env": {
-                "type": "object",
-                "additionalProperties": { "type": "string" }
-            },
-            "extra_volumes": {
-                "type": "array",
-                "items": {
-                    "type": "object"
+    "additionalProperties": false,
+    "patternProperties": {
+        "^_.*$": {
+            "type": "object",
+            "additionalProperties": true
+        },
+        "^([a-z0-9]|[a-z0-9][a-z0-9_-]*[a-z0-9])*$": {
+            "type": "object",
+            "additionalProperties": false,
+            "minProperties": 1,
+            "properties": {
+                "cpus": {
+                    "type": "number",
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
+                    "default": 1
                 },
-                "uniqueItems": true
-            },
-            "deploy_group": {
-                "type": "string"
-            },
-            "net": {
-                "type": "string"
-            },
-            "ulimit": {
-                "type": "object",
-                "additionalProperties": {
+                "mem": {
+                    "type": "number",
+                    "minimum": 32,
+                    "exclusiveMinimum": true,
+                    "default": 1024
+                },
+                "disk": {
+                    "type": "number",
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
+                    "default": 1024
+                },
+                "gpus": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": false
+                },
+                "cmd": {
+                    "type": "string"
+                },
+                "args": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "env": {
                     "type": "object",
-                    "properties": {
-                        "soft": {
-                            "type": "number"
-                        },
-                        "hard": {
-                            "type": "number"
-                        }
+                    "additionalProperties": { "type": "string" }
+                },
+                "extra_volumes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
                     },
-                    "required": ["soft"],
-                    "additionalProperties": false
-                }
-            },
-            "cap_add": {
-                "type": "array",
-                "items": {
+                    "uniqueItems": true
+                },
+                "deploy_group": {
+                    "type": "string"
+                },
+                "net": {
+                    "type": "string"
+                },
+                "ulimit": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                            "soft": {
+                                "type": "number"
+                            },
+                            "hard": {
+                                "type": "number"
+                            }
+                        },
+                        "required": ["soft"],
+                        "additionalProperties": false
+                    }
+                },
+                "cap_add": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "cfs_period_us": {
+                    "type": "integer",
+                    "minimum": "1000",
+                    "maximum": "1000000",
+                    "exclusiveMinimum": false
+                },
+                "cpu_burst_add": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "exclusiveMinimum": false
+                },
+                "extra_docker_args": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                },
+                "pool": {
+                    "type": "string"
+                },
+                "role": {
                     "type": "string"
                 }
-            },
-            "cfs_period_us": {
-                "type": "integer",
-                "minimum": "1000",
-                "maximum": "1000000",
-                "exclusiveMinimum": false
-            },
-            "cpu_burst_add": {
-                "type": "number",
-                "minimum": 0.0,
-                "exclusiveMinimum": false
-            },
-            "extra_docker_args": {
-                "type": "object",
-                "additionalProperties": { "type": "string" }
-            },
-            "pool": {
-                "type": "string"
-            },
-            "role": {
-                "type": "string"
             }
         }
     }

--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -3,159 +3,166 @@
     "description": "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html#chronos-clustername-yaml",
     "type": "object",
     "minProperties": 1,
-    "additionalProperties": {
-        "type": "object",
-        "additionalProperties": false,
-        "minProperties": 1,
-        "properties": {
-            "schedule": {
-                "type": "string"
-            },
-            "cmd": {
-                "type": "string"
-            },
-            "args": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
-            },
-            "epsilon": {
-                "type": "string"
-            },
-            "retries": {
-                "type": "integer",
-                "default": 2
-            },
-            "deploy_group": {
-                "type": "string"
-            },
-            "schedule_time_zone": {
-                "type": "string"
-            },
-            "disabled": {
-                "type": "boolean",
-                "default": false
-            },
-            "cpus": {
-                "type": "number",
-                "minimum": 0,
-                "exclusiveMinimum": true,
-                "default": 0.25
-            },
-            "mem": {
-                "type": "number",
-                "minimum": 32,
-                "exclusiveMinimum": true,
-                "default": 1024
-            },
-            "disk": {
-                "type": "number",
-                "minimum": 0,
-                "exclusiveMinimum": true,
-                "default": 1024
-            },
-            "bounce_method": {
-                "enum": [ "graceful" ],
-                "default": "graceful"
-            },
-            "monitoring": {
-                "type": "object",
-                "properties": {
-                    "team": {
-                        "type": "string"
-                    },
-                    "page": {
-                        "type": "boolean"
-                    }
-                },
-                "additionalProperties": true
-            },
-            "env": {
-                "type": "object",
-                "additionalProperties": { "type": "string" }
-            },
-            "deploy_whitelist": {
-                "type": "array"
-            },
-            "deploy_blacklist": {
-                "type": "array"
-            },
-            "extra_volumes": {
-                "type": "array",
-                "items": {
-                    "type": "object"
-                },
-                "uniqueItems": true
-            },
-            "constraints": {
-                "type": "array",
-                "items": {
-                    "type": "array"
-                },
-                "uniqueItems": true
-            },
-            "extra_constraints": {
-                "type": "array",
-                "items": {
-                    "type": "array"
-                },
-                "uniqueItems": true
-            },
-            "net": {
-                "type": "string"
-            },
-            "pool": {
-                "type": "string"
-            },
-            "parents": {
-                "oneOf": [
-                    { "$ref": "#/definitions/jobName" },
-                    {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/definitions/jobName"
-                        },
-                        "uniqueItems": true
-                    }
-                ]
-            },
-            "cfs_period_us": {
-                "type": "integer",
-                "minimum": "1000",
-                "maximum": "1000000",
-                "exclusiveMinimum": false
-            },
-            "cpu_burst_add": {
-                "type": "number",
-                "minimum": 0.0,
-                "exclusiveMinimum": false
-            },
-            "dependencies_reference": {
-                "type": "string"
-            },
-            "extra_docker_args": {
-                "type": "object",
-                "additionalProperties": { "type": "string" }
-            },
-            "security": {
-                "type": "object",
-                "properties": {
-                    "outbound_firewall": {
-                        "enum": ["block", "monitor"]
-                    }
-                }
-            }
+    "additionalProperties": false,
+    "patternProperties": {
+        "^_.*$": {
+            "type": "object",
+            "additionalProperties": true
         },
-        "oneOf": [
-            {"required": ["schedule"]},
-            {"required": ["parents"]}
-        ]
-    },
-    "definitions": {
-        "jobName": {
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9_-]+\\.[a-zA-Z0-9_-]+$"
+        "^([a-z0-9]|[a-z0-9][a-z0-9_-]*[a-z0-9])*$": {
+            "type": "object",
+            "additionalProperties": false,
+            "minProperties": 1,
+            "properties": {
+                "schedule": {
+                    "type": "string"
+                },
+                "cmd": {
+                    "type": "string"
+                },
+                "args": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "epsilon": {
+                    "type": "string"
+                },
+                "retries": {
+                    "type": "integer",
+                    "default": 2
+                },
+                "deploy_group": {
+                    "type": "string"
+                },
+                "schedule_time_zone": {
+                    "type": "string"
+                },
+                "disabled": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "cpus": {
+                    "type": "number",
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
+                    "default": 0.25
+                },
+                "mem": {
+                    "type": "number",
+                    "minimum": 32,
+                    "exclusiveMinimum": true,
+                    "default": 1024
+                },
+                "disk": {
+                    "type": "number",
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
+                    "default": 1024
+                },
+                "bounce_method": {
+                    "enum": [ "graceful" ],
+                    "default": "graceful"
+                },
+                "monitoring": {
+                    "type": "object",
+                    "properties": {
+                        "team": {
+                            "type": "string"
+                        },
+                        "page": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": true
+                },
+                "env": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                },
+                "deploy_whitelist": {
+                    "type": "array"
+                },
+                "deploy_blacklist": {
+                    "type": "array"
+                },
+                "extra_volumes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    },
+                    "uniqueItems": true
+                },
+                "constraints": {
+                    "type": "array",
+                    "items": {
+                        "type": "array"
+                    },
+                    "uniqueItems": true
+                },
+                "extra_constraints": {
+                    "type": "array",
+                    "items": {
+                        "type": "array"
+                    },
+                    "uniqueItems": true
+                },
+                "net": {
+                    "type": "string"
+                },
+                "pool": {
+                    "type": "string"
+                },
+                "parents": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/jobName" },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/jobName"
+                            },
+                            "uniqueItems": true
+                        }
+                    ]
+                },
+                "cfs_period_us": {
+                    "type": "integer",
+                    "minimum": "1000",
+                    "maximum": "1000000",
+                    "exclusiveMinimum": false
+                },
+                "cpu_burst_add": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "exclusiveMinimum": false
+                },
+                "dependencies_reference": {
+                    "type": "string"
+                },
+                "extra_docker_args": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                },
+                "security": {
+                    "type": "object",
+                    "properties": {
+                        "outbound_firewall": {
+                            "enum": ["block", "monitor"]
+                        }
+                    }
+                }
+            },
+            "oneOf": [
+                {"required": ["schedule"]},
+                {"required": ["parents"]}
+            ]
+        },
+        "definitions": {
+            "jobName": {
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9_-]+\\.[a-zA-Z0-9_-]+$"
+            }
         }
     }
 }

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -5,7 +5,11 @@
     "additionalProperties": false,
     "minProperties": 1,
     "patternProperties": {
-        "^([a-z0-9_]|[a-z0-9_][a-z0-9_-]*[a-z0-9])*$": {
+        "^_.*$": {
+            "type": "object",
+            "additionalProperties": true
+        },
+        "^([a-z0-9]|[a-z0-9][a-z0-9_-]*[a-z0-9])*$": {
             "type": "object",
             "additionalProperties": false,
             "minProperties": 1,

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -174,6 +174,27 @@ _main_http:
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
+def test_marathon_validate_understands_underscores(
+    mock_get_file_contents, capfd,
+):
+    marathon_content = """
+---
+_template: &template
+  foo: bar
+
+main:
+  cpus: 0.1
+  instances: 2
+  env:
+    <<: *template
+"""
+    mock_get_file_contents.return_value = marathon_content
+    assert validate_schema('unused_service_path.yaml', 'marathon')
+    output, _ = capfd.readouterr()
+    assert SCHEMA_VALID in output
+
+
+@patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_schema_healthcheck_non_cmd(
     mock_get_file_contents, capfd,
 ):


### PR DESCRIPTION
This has been undocumented and not allowed via the json schema for a while.