### PR TITLE
[WIP] add some api endpoints that return k8s objects

### DIFF
--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -71,6 +71,21 @@ def make_app(global_config=None):
     config.include('pyramid_swagger')
     config.add_route('resources.utilization', '/v1/resources/utilization')
     config.add_route('service.instance.status', '/v1/services/{service}/{instance}/status')
+    config.add_route(
+        'service.instance.kube_config',
+        '/v1/services/{service}/{instance}/kube_config',
+        request_method="POST",
+    )
+    config.add_route(
+        'service.instance.kube_volumes',
+        '/v1/services/{service}/{instance}/kube_volumes',
+        request_method="POST",
+    )
+    config.add_route(
+        'service.instance.kube_pod_template_spec',
+        '/v1/services/{service}/{instance}/kube_pod_template_spec',
+        request_method="POST",
+    )
     config.add_route('service.instance.delay', '/v1/services/{service}/{instance}/delay')
     config.add_route('service.instance.tasks', '/v1/services/{service}/{instance}/tasks')
     config.add_route('service.instance.tasks.task', '/v1/services/{service}/{instance}/tasks/{task_id}')

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -287,6 +287,141 @@
         ]
       }
     },
+    "/services/{service}/{instance}/kube_pod_template_spec": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Returns kube pods for instance",
+            "schema": {
+              "$ref": "#/definitions/KubePodTemplateSpec"
+            }
+          },
+          "500": {
+            "description": "Failure"
+          }
+        },
+        "summary": "Get kube pods from posted config",
+        "operationId": "get_kubernetes_pod_template_spec",
+        "tags": [
+          "service"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "description": "Service name",
+            "name": "service",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "description": "Instance name",
+            "name": "instance",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "json_body",
+            "required": true,
+            "schema": {
+              "type": "object",
+	      "additionalProperties": true
+            }
+          }
+        ]
+      }
+    },
+    "/services/{service}/{instance}/kube_volumes": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Returns kube volumes for instance",
+            "schema": {
+              "$ref": "#/definitions/KubeVolumes"
+            }
+          },
+          "500": {
+            "description": "Failure"
+          }
+        },
+        "summary": "Get kube volumes from posted config",
+        "operationId": "get_kubernetes_volumes",
+        "tags": [
+          "service"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "description": "Service name",
+            "name": "service",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "description": "Instance name",
+            "name": "instance",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "json_body",
+            "required": true,
+            "schema": {
+              "type": "object",
+	      "additionalProperties": true
+            }
+          }
+        ]
+      }
+    },
+    "/services/{service}/{instance}/kube_config": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Returns kube config for instance",
+            "schema": {
+              "$ref": "#/definitions/KubeConfig"
+            }
+          },
+          "500": {
+            "description": "Failure"
+          }
+        },
+        "summary": "Get kube config from posted config",
+        "operationId": "get_kubernetes_deployment",
+        "tags": [
+          "service"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "description": "Service name",
+            "name": "service",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "description": "Instance name",
+            "name": "instance",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "json_body",
+            "required": true,
+            "schema": {
+              "type": "object",
+	      "additionalProperties": true
+            }
+          }
+        ]
+      }
+    },
     "/services/{service}/{instance}/delay": {
       "get": {
         "responses": {
@@ -576,6 +711,18 @@
       }
     },
     "InstanceDelay": {
+      "type": "object"
+    },
+    "KubeConfig": {
+      "type": "object"
+    },
+    "KubeVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "KubePodTemplateSpec": {
       "type": "object"
     },
     "InstanceStatusMarathon": {


### PR DESCRIPTION
This is a bit speculative but mostly to demonstrate how this would work if we think it's helpful. The idea is that our k8s operator could just post a paastay looking instance config and get ready to use k8s json back.

I've added a few endpoints as an example that allow you to get a `Deployment` a `PodTemplateSpec` or a list of `V1Volume`s

Here's what it looks like in practice:
```
$ cat thing.json 
{
  "cpus": 1,
  "deploy_group": "testcluster.everything",
  "disk": 40,
  "instances": 2,
  "mem": 101,
  "container_image": "something...",
  "registrations": ["hello-world.main"]
}
$ curl -s -XPOST -d@thing.json localhost:5054/v1/services/hello-world/thing/kube_config | jq .
{
  "api_version": "apps/v1",
  "kind": "Deployment",
  "metadata": {
    "annotations": null,
...
```