### PR TITLE
Fix `get_cluster()` throws `PaastaNotConfiguredError` on non-PaaSTA hosts

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1061,13 +1061,13 @@ def get_marathon_services_running_here_for_nerve(
     if not cluster:
         try:
             system_paasta_config = load_system_paasta_config()
+            cluster = system_paasta_config.get_cluster()
         # In the cases where there is *no* cluster or in the case
         # where there isn't a Paasta configuration file at *all*, then
         # there must be no marathon services running here, so we catch
         # these custom exceptions and return [].
         except (PaastaNotConfiguredError):
             return []
-        cluster = system_paasta_config.get_cluster()
         if not system_paasta_config.get_register_marathon_services():
             return []
     # When a cluster is defined in mesos, let's iterate through marathon services


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/bin/configure_nerve", line 11, in <module>
    sys.exit(main())
  File "/opt/venvs/nerve-tools/lib/python3.6/site-packages/nerve_tools/configure_nerve.py", line 313, in main
    ) + get_kubernetes_services_running_here_for_nerve(
  File "/opt/venvs/nerve-tools/lib/python3.6/site-packages/paasta_tools/marathon_tools.py", line 1070, in get_marathon_services_running_here_for_nerve
    cluster = system_paasta_config.get_cluster()
  File "/opt/venvs/nerve-tools/lib/python3.6/site-packages/paasta_tools/utils.py", line 1563, in get_cluster
    raise PaastaNotConfiguredError('Could not find cluster in configuration directory: %s' % self.directory)
paasta_tools.utils.PaastaNotConfiguredError: Could not find cluster in configuration directory: /etc/paasta/\u001b[0m
\u001b[1;31mError: /Stage[main]/Nerve_simple::Service/Service[nerve]: Could not restart Service[nerve]: Execution of '/usr/bin/configure_nerve --heartbeat-path /var/run/nerve/heartbeat --heartbeat-threshold 0' returned 1: Traceback (most recent call last):
  File "/opt/venvs/nerve-tools/lib/python3.6/site-packages/paasta_tools/utils.py", line 1561, in get_cluster
    return self.config_dict['cluster']
KeyError: 'cluster'
```