### PR TITLE
Fix `healthcheck_cmd` not working for kube

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -445,7 +445,11 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             )
         elif mode == 'cmd':
             probe._exec = V1ExecAction(
-                command=self.get_healthcheck_cmd(),
+                command=[
+                    "/bin/sh",
+                    "-c",
+                    self.get_healthcheck_cmd(),
+                ],
             )
         else:
             raise InvalidHealthcheckMode(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -509,7 +509,11 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
         liveness_probe = V1Probe(
             failure_threshold=30,
             _exec=V1ExecAction(
-                command='/bin/true',
+                command=[
+                    '/bin/sh',
+                    '-c',
+                    '/bin/true',
+                ],
             ),
             initial_delay_seconds=60,
             period_seconds=10,


### PR DESCRIPTION
The actual command for `healthcheck_cmd` is a string in SOA config, but
Kubernetes expects a list of `argv`s for it's `V1ExecAction.command`, so
just call `/bin/sh -c` with given command string here.