### PR TITLE
Bump vault-tools to get newlines at end of secrets files

### DIFF
--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -2,7 +2,7 @@
 clusterman_metrics==2.0.0
 crypto_lib==4.0.0
 scribereader==0.2.6
-vault-tools==0.6.12
+vault-tools==0.7.22
 yelp-cgeom==1.3.1
 yelp-logging==1.0.37
 yelp_meteorite


### PR DESCRIPTION
pre-commit end-of-file newline fixer keeps wanting to modify paasta secrets. @Qmando made vault-tools add a newline to the end of the secrets files back in June, but we're running a version from March. This bumps to the latest version.