### PR TITLE
Add setup custom resource script

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -955,20 +955,9 @@ def list_custom_resources(
                 ),
             )
         except KeyError:
+            log.debug(f"Ignoring custom resource that is missing paasta labels: {cr}")
             continue
     return kube_custom_resources
-
-
-def list_all_custom_resources(
-    kind: KubeKind,
-    version: str,
-    kube_client: KubeClient,
-) -> Sequence[KubeCustomResource]:
-    return list_custom_resources(
-        version=version,
-        kind=kind,
-        kube_client=kube_client,
-    )
 
 
 def max_unavailable(instance_count: int, bounce_margin_factor: float) -> int:

--- a/paasta_tools/setup_crd.py
+++ b/paasta_tools/setup_crd.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python
+# Copyright 2015-2018 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Usage: ./setup_kubernetes_job.py <service.instance> [options]
+
+Command line options:
+
+- -d <SOA_DIR>, --soa-dir <SOA_DIR>: Specify a SOA config dir to read from
+- -v, --verbose: Verbose output
+"""
+import argparse
+import logging
+import sys
+from typing import Any
+from typing import Mapping
+from typing import NamedTuple
+from typing import Sequence
+
+import service_configuration_lib
+
+from paasta_tools.kubernetes_tools import create_custom_resource
+from paasta_tools.kubernetes_tools import ensure_paasta_namespace
+from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.kubernetes_tools import KubeCustomResource
+from paasta_tools.kubernetes_tools import list_all_custom_resources
+from paasta_tools.kubernetes_tools import update_custom_resource
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import get_config_hash
+from paasta_tools.utils import get_services_for_cluster
+from paasta_tools.utils import load_system_paasta_config
+
+log = logging.getLogger(__name__)
+
+
+class KubeKind(NamedTuple):
+    singular: str
+    plural: str
+
+
+class CustomResource(NamedTuple):
+    file_prefix: str
+    version: str
+    kube_kind: KubeKind
+
+
+CUSTOM_RESOURCES = [
+    CustomResource(
+        file_prefix='flinkcluster',
+        version='v1alpha1',
+        kube_kind=KubeKind(singular='FlinkCluster', plural='flinkclusters'),
+    ),
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Creates custom_resources.')
+    parser.add_argument(
+        '-d', '--soa-dir', dest="soa_dir", metavar="SOA_DIR",
+        default=DEFAULT_SOA_DIR,
+        help="define a different soa config directory",
+    )
+    parser.add_argument(
+        '-v', '--verbose', action='store_true',
+        dest="verbose", default=False,
+    )
+    args = parser.parse_args()
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    soa_dir = args.soa_dir
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
+    kube_client = KubeClient()
+
+    ensure_paasta_namespace(kube_client)
+
+    setup_kube_succeeded = setup_all_custom_resources(
+        kube_client=kube_client,
+        soa_dir=soa_dir,
+        cluster=load_system_paasta_config().get_cluster(),
+    )
+    sys.exit(0 if setup_kube_succeeded else 1)
+
+
+def setup_all_custom_resources(
+    kube_client: KubeClient,
+    soa_dir: str,
+    cluster: str,
+) -> bool:
+    results = []
+    for custom_resource in CUSTOM_RESOURCES:
+        config_dicts = load_all_configs(
+            cluster=cluster,
+            file_prefix=custom_resource.file_prefix,
+            soa_dir=soa_dir,
+        )
+        results.append(
+            setup_custom_resources(
+                kube_client=kube_client,
+                kind=custom_resource.kube_kind,
+                config_dicts=config_dicts,
+                version=custom_resource.version,
+            ),
+        )
+    return all(results) if results else True
+
+
+def load_all_configs(cluster: str, file_prefix: str, soa_dir: str) -> Mapping[str, Mapping[str, Any]]:
+    config_dicts = {}
+    for service, _ in get_services_for_cluster(
+        cluster=cluster,
+        instance_type=file_prefix,
+        soa_dir=soa_dir,
+    ):
+        config_dicts[service] = service_configuration_lib.read_extra_service_information(
+            service,
+            f"{file_prefix}-{cluster}",
+            soa_dir=soa_dir,
+        )
+    return config_dicts
+
+
+def setup_custom_resources(
+    kube_client: KubeClient,
+    kind: KubeKind,
+    version: str,
+    config_dicts: Mapping[str, Mapping[str, Any]],
+) -> bool:
+    succeded = True
+    if config_dicts:
+        crs = list_all_custom_resources(
+            kube_client=kube_client,
+            plural_kind=kind.plural,
+            version=version,
+        )
+    for service, config in config_dicts.items():
+        if not reconcile_kubernetes_resource(
+            kube_client=kube_client,
+            service=service,
+            instance_configs=config,
+            kind=kind,
+            custom_resources=crs,
+            version=version,
+        ):
+            succeded = False
+    return succeded
+
+
+def format_custom_resource(
+    instance_config: Mapping[str, Any],
+    service: str,
+    instance: str,
+    kind: str,
+    version: str,
+) -> Mapping[str, Any]:
+    sanitised_service = service.replace('_', '--')
+    sanitised_instance = instance.replace('_', '--')
+    resource = {
+        'apiVersion': f'yelp.com/{version}',
+        'kind': kind,
+        'metadata': {
+            'name': f'{sanitised_service}-{sanitised_instance}',
+            'labels': {
+                'paasta_service': service,
+                'paasta_instance': instance,
+            },
+        },
+        'spec': instance_config,
+    }
+    config_hash = get_config_hash(
+        instance_config,
+        force_bounce=False,
+    )
+    resource['metadata']['labels']['paasta_config_sha'] = config_hash
+    return resource
+
+
+def reconcile_kubernetes_resource(
+    kube_client: KubeClient,
+    service: str,
+    instance_configs: Mapping[str, Any],
+    custom_resources: Sequence[KubeCustomResource],
+    kind: KubeKind,
+    version: str,
+) -> bool:
+
+    results = []
+    for instance, config in instance_configs.items():
+        formatted_resource = format_custom_resource(
+            instance_config=config,
+            service=service,
+            instance=instance,
+            kind=kind.singular,
+            version=version,
+        )
+        desired_resource = KubeCustomResource(
+            service=service,
+            instance=instance,
+            config_sha=formatted_resource['metadata']['labels']['paasta_config_sha'],
+            kind=kind.singular,
+        )
+
+        try:
+            if not (service, instance, kind.singular) in [(c.service, c.instance, c.kind) for c in custom_resources]:
+                log.debug(f"{desired_resource} does not exist so creating")
+                create_custom_resource(
+                    kube_client=kube_client,
+                    version=version,
+                    plural_kind=kind.plural,
+                    formatted_resource=formatted_resource,
+                )
+            elif desired_resource not in custom_resources:
+                sanitised_service = service.replace('_', '--')
+                sanitised_instance = instance.replace('_', '--')
+                log.debug(f"{desired_resource} exists but config_sha doesn't match")
+                update_custom_resource(
+                    kube_client=kube_client,
+                    name=f'{sanitised_service}-{sanitised_instance}',
+                    version=version,
+                    plural_kind=kind.plural,
+                    formatted_resource=formatted_resource,
+                )
+            else:
+                log.debug(f"{desired_resource} is up to date, no action taken")
+        except Exception as e:
+            log.error(e)
+            results.append(False)
+        results.append(True)
+    return all(results) if results else True
+
+
+if __name__ == "__main__":
+    main()

--- a/paasta_tools/setup_crd.py
+++ b/paasta_tools/setup_crd.py
@@ -35,7 +35,7 @@ from paasta_tools.kubernetes_tools import ensure_namespace
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import KubeCustomResource
 from paasta_tools.kubernetes_tools import KubeKind
-from paasta_tools.kubernetes_tools import list_all_custom_resources
+from paasta_tools.kubernetes_tools import list_custom_resources
 from paasta_tools.kubernetes_tools import update_custom_resource
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_config_hash
@@ -143,7 +143,7 @@ def setup_custom_resources(
 ) -> bool:
     succeded = True
     if config_dicts:
-        crs = list_all_custom_resources(
+        crs = list_custom_resources(
             kube_client=kube_client,
             kind=kind,
             version=version,
@@ -170,7 +170,7 @@ def format_custom_resource(
 ) -> Mapping[str, Any]:
     sanitised_service = service.replace('_', '--')
     sanitised_instance = instance.replace('_', '--')
-    resource = {
+    resource: Mapping[str, Any] = {
         'apiVersion': f'yelp.com/{version}',
         'kind': kind,
         'metadata': {
@@ -184,7 +184,6 @@ def format_custom_resource(
     }
     config_hash = get_config_hash(
         instance_config,
-        force_bounce=False,
     )
     resource['metadata']['labels']['paasta_config_sha'] = config_hash
     return resource
@@ -238,7 +237,7 @@ def reconcile_kubernetes_resource(
             else:
                 log.info(f"{desired_resource} is up to date, no action taken")
         except Exception as e:
-            log.error(e)
+            log.error(str(e))
             results.append(False)
         results.append(True)
     return all(results) if results else True

--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -37,7 +37,7 @@ from kubernetes.client.rest import ApiException
 from paasta_tools.kubernetes_tools import create_deployment
 from paasta_tools.kubernetes_tools import create_pod_disruption_budget
 from paasta_tools.kubernetes_tools import create_stateful_set
-from paasta_tools.kubernetes_tools import ensure_paasta_namespace
+from paasta_tools.kubernetes_tools import ensure_namespace
 from paasta_tools.kubernetes_tools import InvalidKubernetesConfig
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import KubeDeployment
@@ -89,7 +89,7 @@ def main() -> None:
     # system_paasta_config = load_system_paasta_config()
     kube_client = KubeClient()
 
-    ensure_paasta_namespace(kube_client)
+    ensure_namespace(kube_client, namespace='paasta')
     setup_kube_succeeded = setup_kube_deployments(
         kube_client=kube_client,
         service_instances=args.service_instance_list,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2321,7 +2321,7 @@ def get_service_instance_list_no_cache(
     instance_list: List[Tuple[str, str]] = []
     for srv_instance_type in instance_types:
         conf_file = f"{srv_instance_type}-{cluster}"
-        log.info(f"Enumerating all instances for config file: {soa_dir}/*/{conf_file}.yaml")
+        log.debug(f"Enumerating all instances for config file: {soa_dir}/*/{conf_file}.yaml")
         if srv_instance_type == 'tron':
             instance_list.extend(
                 get_tron_instance_list_from_yaml(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -38,7 +38,7 @@ from kubernetes.client.rest import ApiException
 from paasta_tools.kubernetes_tools import create_deployment
 from paasta_tools.kubernetes_tools import create_pod_disruption_budget
 from paasta_tools.kubernetes_tools import create_stateful_set
-from paasta_tools.kubernetes_tools import ensure_paasta_namespace
+from paasta_tools.kubernetes_tools import ensure_namespace
 from paasta_tools.kubernetes_tools import filter_nodes_by_blacklist
 from paasta_tools.kubernetes_tools import filter_pods_by_service_instance
 from paasta_tools.kubernetes_tools import get_active_shas_for_service
@@ -1042,25 +1042,25 @@ def test_KubeClient():
         assert client.core == mock_kube_client.CoreV1Api()
 
 
-def test_ensure_paasta_namespace():
+def test_ensure_namespace():
     mock_metadata = mock.Mock()
     type(mock_metadata).name = 'paasta'
     mock_namespaces = mock.Mock(items=[mock.Mock(metadata=mock_metadata)])
     mock_client = mock.Mock(core=mock.Mock(list_namespace=mock.Mock(return_value=mock_namespaces)))
-    ensure_paasta_namespace(mock_client)
+    ensure_namespace(mock_client, namespace='paasta')
     assert not mock_client.core.create_namespace.called
 
     mock_metadata = mock.Mock()
     type(mock_metadata).name = 'kube-system'
     mock_namespaces = mock.Mock(items=[mock.Mock(metadata=mock_metadata)])
     mock_client = mock.Mock(core=mock.Mock(list_namespace=mock.Mock(return_value=mock_namespaces)))
-    ensure_paasta_namespace(mock_client)
+    ensure_namespace(mock_client, namespace='paasta')
     assert mock_client.core.create_namespace.called
 
     mock_client.core.create_namespace.reset_mock()
     mock_namespaces = mock.Mock(items=[])
     mock_client = mock.Mock(core=mock.Mock(list_namespace=mock.Mock(return_value=mock_namespaces)))
-    ensure_paasta_namespace(mock_client)
+    ensure_namespace(mock_client, namespace='paasta')
     assert mock_client.core.create_namespace.called
 
 

--- a/tests/test_setup_crd.py
+++ b/tests/test_setup_crd.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python
+# Copyright 2015-2018 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+import pytest
+
+from paasta_tools import setup_crd
+from paasta_tools.kubernetes_tools import KubeCustomResource
+
+
+def test_main():
+    with mock.patch(
+        'paasta_tools.setup_crd.KubeClient', autospec=True,
+    ), mock.patch(
+        'paasta_tools.setup_crd.setup_all_custom_resources', autospec=True,
+    ) as mock_setup:
+        mock_setup.return_value = True
+        with pytest.raises(SystemExit) as e:
+            setup_crd.main()
+            assert e.value.code == 0
+
+        mock_setup.return_value = False
+        with pytest.raises(SystemExit) as e:
+            setup_crd.main()
+            assert e.value.code == 1
+
+
+def test_setup_all_custom_resources():
+    with mock.patch(
+        'paasta_tools.setup_crd.ensure_namespace', autospec=True,
+    ), mock.patch(
+        'paasta_tools.setup_crd.load_all_configs', autospec=True,
+    ), mock.patch(
+        'paasta_tools.setup_crd.setup_custom_resources', autospec=True,
+    ) as mock_setup:
+        setup_crd.CUSTOM_RESOURCES = [mock.Mock(plural='flinkclusters'), mock.Mock(plural='cassandraclusters')]
+        mock_setup.side_effect = [True, False]
+        mock_client = mock.Mock()
+        assert not setup_crd.setup_all_custom_resources(mock_client, '/nail/soa', 'westeros-prod')
+
+        setup_crd.CUSTOM_RESOURCES = [mock.Mock(plural='flinkclusters'), mock.Mock(plural='cassandraclusters')]
+        mock_setup.side_effect = [True, True]
+        mock_client = mock.Mock()
+        assert setup_crd.setup_all_custom_resources(mock_client, '/nail/soa', 'westeros-prod')
+
+        setup_crd.CUSTOM_RESOURCES = []
+        mock_client = mock.Mock()
+        assert setup_crd.setup_all_custom_resources(mock_client, '/nail/soa', 'westeros-prod')
+
+
+def test_load_all_configs():
+    with mock.patch(
+        'paasta_tools.setup_crd.get_services_for_cluster', autospec=True,
+    ) as mock_get_services_for_cluster, mock.patch(
+        'paasta_tools.setup_crd.service_configuration_lib.read_extra_service_information', autospec=True,
+    ) as mock_read_info:
+        mock_get_services_for_cluster.return_value = [('kurupt', 'fm'), ('mc', 'grindah')]
+        ret = setup_crd.load_all_configs(
+            cluster='westeros-prod',
+            file_prefix='thing',
+            soa_dir='/nail/soa',
+        )
+        mock_read_info.assert_has_calls(
+            [
+                mock.call('mc', 'thing-westeros-prod', soa_dir='/nail/soa'),
+                mock.call('kurupt', 'thing-westeros-prod', soa_dir='/nail/soa'),
+            ], any_order=True,
+        )
+        assert 'kurupt' in ret.keys()
+        assert 'mc' in ret.keys()
+
+
+def test_setup_custom_resources():
+    with mock.patch(
+        'paasta_tools.setup_crd.list_custom_resources', autospec=True,
+    ) as mock_list_cr, mock.patch(
+        'paasta_tools.setup_crd.reconcile_kubernetes_resource', autospec=True,
+    ) as mock_reconcile_kubernetes_resource:
+        mock_client = mock.Mock()
+        mock_kind = mock.Mock()
+        assert setup_crd.setup_custom_resources(
+            kube_client=mock_client,
+            kind=mock_kind,
+            version='v1',
+            config_dicts={},
+        )
+
+        mock_reconcile_kubernetes_resource.side_effect = [True, False]
+        assert not setup_crd.setup_custom_resources(
+            kube_client=mock_client,
+            kind=mock_kind,
+            version='v1',
+            config_dicts={'kurupt': 'something', 'mc': 'another'},
+        )
+
+        mock_reconcile_kubernetes_resource.side_effect = [True, True]
+        assert setup_crd.setup_custom_resources(
+            kube_client=mock_client,
+            kind=mock_kind,
+            version='v1',
+            config_dicts={'kurupt': 'something', 'mc': 'another'},
+        )
+        mock_reconcile_kubernetes_resource.assert_has_calls([
+            mock.call(
+                kube_client=mock_client,
+                service='kurupt',
+                instance_configs='something',
+                kind=mock_kind,
+                custom_resources=mock_list_cr.return_value,
+                version='v1',
+            ),
+            mock.call(
+                kube_client=mock_client,
+                service='mc',
+                instance_configs='another',
+                kind=mock_kind,
+                custom_resources=mock_list_cr.return_value,
+                version='v1',
+            ),
+        ])
+
+
+def test_format_custom_resource():
+    with mock.patch(
+        'paasta_tools.setup_crd.get_config_hash', autospec=True,
+    ) as mock_get_config_hash:
+        expected = {
+            'apiVersion': 'yelp.com/v1',
+            'kind': 'flinkcluster',
+            'metadata': {
+                'name': 'kurupt--fm-radio--station',
+                'labels': {
+                    'paasta_service': 'kurupt_fm',
+                    'paasta_instance': 'radio_station',
+                    'paasta_config_sha': mock_get_config_hash.return_value,
+                },
+            },
+            'spec': {'dummy': 'conf'},
+        }
+        assert setup_crd.format_custom_resource(
+            instance_config={'dummy': 'conf'},
+            service='kurupt_fm',
+            instance='radio_station',
+            kind='flinkcluster',
+            version='v1',
+        ) == expected
+
+
+def test_reconcile_kubernetes_resource():
+    with mock.patch(
+        'paasta_tools.setup_crd.format_custom_resource', autospec=True,
+    ) as mock_format_custom_resource, mock.patch(
+        'paasta_tools.setup_crd.create_custom_resource', autospec=True,
+    ) as mock_create_custom_resource, mock.patch(
+        'paasta_tools.setup_crd.update_custom_resource', autospec=True,
+    ) as mock_update_custom_resource:
+        mock_kind = mock.Mock(singular='flinkcluster')
+        mock_custom_resources = [
+            KubeCustomResource(
+                service='kurupt',
+                instance='fm',
+                config_sha='conf123',
+                kind='flinkcluster',
+            ),
+        ]
+        mock_client = mock.Mock()
+        # no instances, do nothing
+        assert setup_crd.reconcile_kubernetes_resource(
+            kube_client=mock_client,
+            service='mc',
+            instance_configs={},
+            custom_resources=mock_custom_resources,
+            kind=mock_kind,
+            version='v1',
+        )
+        assert not mock_create_custom_resource.called
+        assert not mock_update_custom_resource.called
+
+        # instance up to date, do nothing
+        mock_format_custom_resource.return_value = {
+            'metadata': {
+                'labels': {
+                    'paasta_config_sha': 'conf123',
+                },
+            },
+        }
+        assert setup_crd.reconcile_kubernetes_resource(
+            kube_client=mock_client,
+            service='kurupt',
+            instance_configs={'fm': {'some': 'config'}},
+            custom_resources=mock_custom_resources,
+            kind=mock_kind,
+            version='v1',
+        )
+        assert not mock_create_custom_resource.called
+        assert not mock_update_custom_resource.called
+
+        # instance diff config, update
+        mock_format_custom_resource.return_value = {
+            'metadata': {
+                'labels': {
+                    'paasta_config_sha': 'conf456',
+                },
+            },
+        }
+        assert setup_crd.reconcile_kubernetes_resource(
+            kube_client=mock_client,
+            service='kurupt',
+            instance_configs={'fm': {'some': 'config'}},
+            custom_resources=mock_custom_resources,
+            kind=mock_kind,
+            version='v1',
+        )
+        assert not mock_create_custom_resource.called
+        mock_update_custom_resource.assert_called_with(
+            kube_client=mock_client,
+            name='kurupt-fm',
+            version='v1',
+            kind=mock_kind,
+            formatted_resource=mock_format_custom_resource.return_value,
+        )
+
+        # instance not exist, create
+        assert setup_crd.reconcile_kubernetes_resource(
+            kube_client=mock_client,
+            service='mc',
+            instance_configs={'grindah': {'some': 'conf'}},
+            custom_resources=mock_custom_resources,
+            kind=mock_kind,
+            version='v1',
+        )
+        mock_create_custom_resource.assert_called_with(
+            kube_client=mock_client,
+            version='v1',
+            kind=mock_kind,
+            formatted_resource=mock_format_custom_resource.return_value,
+        )
+
+        # instance not exist, create but error with k8s
+        mock_create_custom_resource.side_effect = Exception
+        assert not setup_crd.reconcile_kubernetes_resource(
+            kube_client=mock_client,
+            service='mc',
+            instance_configs={'grindah': {'some': 'conf'}},
+            custom_resources=mock_custom_resources,
+            kind=mock_kind,
+            version='v1',
+        )
+        mock_create_custom_resource.assert_called_with(
+            kube_client=mock_client,
+            version='v1',
+            kind=mock_kind,
+            formatted_resource=mock_format_custom_resource.return_value,
+        )

--- a/tests/test_setup_kubernetes_job.py
+++ b/tests/test_setup_kubernetes_job.py
@@ -37,15 +37,15 @@ def test_main():
     ) as mock_parse_args, mock.patch(
         'paasta_tools.setup_kubernetes_job.KubeClient', autospec=True,
     ) as mock_kube_client, mock.patch(
-        'paasta_tools.setup_kubernetes_job.ensure_paasta_namespace', autospec=True,
-    ) as mock_ensure_paasta_namespace, mock.patch(
+        'paasta_tools.setup_kubernetes_job.ensure_namespace', autospec=True,
+    ) as mock_ensure_namespace, mock.patch(
         'paasta_tools.setup_kubernetes_job.setup_kube_deployments', autospec=True,
     ) as mock_setup_kube_deployments:
         mock_setup_kube_deployments.return_value = True
         with raises(SystemExit) as e:
             main()
         assert e.value.code == 0
-        assert mock_ensure_paasta_namespace.called
+        assert mock_ensure_namespace.called
         mock_setup_kube_deployments.assert_called_with(
             kube_client=mock_kube_client.return_value,
             service_instances=mock_parse_args.return_value.service_instance_list,


### PR DESCRIPTION
Pushing for early feedback. This is a script that allows us to specify a
file prefix like flinkcluster- or cassandra- etc. and map it to a
kubernetes custom object like FlinkCluster. For now it just adds the
neccessary metadata and submits the instances YAML config as the spec for
the k8s object. Like other paasta things we sha and check the sha to see
if we need to update.

Unit tests to follow if we think this is the way to go.