### PR TITLE
Add marker that paasta_tools provides typing annotations

### DIFF
--- a/paasta_tools/py.typed
+++ b/paasta_tools/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The paasta package uses inline types.


### PR DESCRIPTION
Add `py.typed` file, which is a marker required by PEP-561 to indicate
that a package provides typing annotations.
See https://www.python.org/dev/peps/pep-0561/#packaging-type-information
for details.

Tested on [synapse-tools](https://github.com/Yelp/synapse-tools) by running `mypy` with `ignore_missing_imports = False` before and after 
```
$ touch ./.tox/mypy/lib/python3.6/site-packages/paasta_tools/py.typed
```