### PR TITLE
Constrain the maximum cpu a Spark executor can use

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -499,6 +499,9 @@ def get_spark_config(
         )
         sys.exit(1)
 
+    # Limit a container's cpu usage
+    non_user_args['spark.mesos.executor.docker.parameters'] += ',cpus={}'.format(user_args['spark.executor.cores'])
+
     return dict(non_user_args, **user_args)
 
 


### PR DESCRIPTION
Tested with a spark run with --spark-args "spark.cores.max=10 spark.executor.cores=5" and make sure the docker run command on the mesos agent has "--cpus=5".