### PR TITLE
Reorganize remote-run args/options

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -29,51 +29,51 @@ from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
 
 
-def add_start_args_to_parser(parser):
+REMOTE_RUN_ACTIONS = ['start', 'stop', 'list']
+
+
+def add_output_args(parser):
+    """ Adds CLI options for the following output modifiers:
+    - verbose: Verbosity of log output
+    - debug: Whether or not to show debug output
+
+    Note: These arguments are common to all remote-run actions
+    """
     parser.add_argument(
-        '-C', '--cmd',
-        help=(
-            'Run Docker container with particular command, for example: '
-            '"bash". By default will use the command or args specified by the '
-            'soa-configs or what was specified in the Dockerfile'
-        ),
-        required=False,
-        default=None,
-    )
-    parser.add_argument(
-        '-D', '--detach',
-        help='Launch in background',
+        '-v', '--verbose',
+        help='Show more output',
         action='store_true',
-        required=False,
         default=False,
     )
     parser.add_argument(
-        '-t', '--staging-timeout',
-        help='A timeout for the task to be launching before killed',
-        required=False,
-        default=240,
-        type=float,
-    )
-    parser.add_argument(
-        '-j', '--instances',
-        help='Number of copies of the task to launch',
-        required=False,
-        default=None,
-        type=int,
-    )
-    parser.add_argument(
-        '--docker-image',
-        help='Docker image to use. Defaults to using the deployed docker image',
-        required=False,
-        default=None,
+        '--debug',
+        help='Show debug output',
+        action='store_true',
+        default=False,
     )
 
 
-def add_common_args_to_parser(parser):
+def add_selector_args(parser):
+    """ Adds CLI options for the following selectors:
+    - service: Name of the service to inspect
+    - instance: Instance of the service simulate
+    - cluster: Name of cluster to run in
+
+    Note: These arguments should only be used for start and list actions only,
+    and not for the stop action.
+    """
     parser.add_argument(
         '-s', '--service',
         help='The name of the service you wish to inspect',
     ).completer = lazy_choices_completer(list_services)
+    parser.add_argument(
+        '-i', '--instance',
+        help=(
+            "Simulate a docker run for a particular instance of the "
+            "service, like 'main' or 'canary'"
+        ),
+        default=None,
+    ).completer = lazy_choices_completer(list_instances)
     parser.add_argument(
         '-c', '--cluster',
         help=(
@@ -83,33 +83,11 @@ def add_common_args_to_parser(parser):
         ),
         default=None,
     ).completer = lazy_choices_completer(list_clusters)
-    parser.add_argument(
-        '-y', '--yelpsoa-config-root',
-        dest='yelpsoa_config_root',
-        help='A directory from which yelpsoa-configs should be read from',
-        default=DEFAULT_SOA_DIR,
-    )
-    parser.add_argument(
-        '-v', '--verbose',
-        help='Show more output',
-        action='store_true',
-        required=False,
-        default=False,
-    )
-    parser.add_argument(
-        '--debug',
-        help='Show debug output',
-        action='store_true',
-        required=False,
-        default=False,
-    )
-    parser.add_argument(
-        '-R', '--run-id',
-        help='Identifier to assign/refer to individual task runs',
-        action='store',
-        required=False,
-        default=None,
-    )
+
+
+def add_start_args(parser):
+    """ Adds CLI options specific to the start action """
+    ### Run related arguments
     parser.add_argument(
         '-d', '--dry-run',
         help='Don\'t launch the task',
@@ -118,24 +96,113 @@ def add_common_args_to_parser(parser):
         default=False,
     )
     parser.add_argument(
-        '--aws-region',
-        choices=['us-east-1', 'us-west-1', 'us-west-2'],
-        help='aws region of the dynamodb state table',
+        '-D', '--detach',
+        help='Launch in background',
+        action='store_true',
+        default=False,
+    )
+
+    ### Task config related arguments
+    parser.add_argument(
+        '-R', '--run-id',
+        help='Identifier to assign to individual task runs',
+        action='store',
         default=None,
     )
     parser.add_argument(
-        '-i', '--instance',
+        '-C', '--cmd',
         help=(
-            "Simulate a docker run for a particular instance of the "
-            "service, like 'main' or 'canary'"
+            'Run Docker container with particular command, for example: '
+            '"bash". By default will use the command or args specified by the '
+            'soa-configs or what was specified in the Dockerfile'
         ),
-        required=False,
         default=None,
-    ).completer = lazy_choices_completer(list_instances)
+    )
+    parser.add_argument(
+        '-j', '--instances',
+        help='Number of copies of the task to launch',
+        default=None,
+        type=int,
+    )
+    parser.add_argument(
+        '-t', '--staging-timeout',
+        help='A timeout for the task to be launching before killed',
+        default=240,
+        type=float,
+    )
+    parser.add_argument(
+        '--docker-image',
+        help='Docker image to use. Defaults to using the deployed docker image',
+        default=None,
+    )
+    parser.add_argument(
+        '-X', '--constraint',
+        help='Constraint option, format: <attr>,OP[,<value>], OP can be one '
+        'of the following: EQUALS matches attribute value exactly, LIKE and '
+        'UNLIKE match on regular expression, MAX_PER constrains number of '
+        'tasks per attribute value, UNIQUE is the same as MAX_PER,1',
+        action='append',
+        default=[],
+    )
 
 
-def add_subparser(subparsers):
-    main_parser = subparsers.add_parser(
+def add_stop_args(parser):
+    """ Adds CLI options specific to the stop action """
+    parser.add_argument(
+        '-R', '--run-id',
+        help='Identifier for the task run to stop',
+        action='store',
+        default=None,
+    )
+    parser.add_argument(
+        '-F', '--framework-id',
+        help='ID of framework to stop. Must belong to remote-run of selected'
+        'service instance.',
+        default=None,
+    )
+
+
+def add_list_args(parser):
+    """ Adds CLI options specific to the list action """
+    pass  # there are no list-specific args, but incl func for organization
+
+
+def add_action_parsers(parser):
+    """ Adds start, stop, and list action parsers, including all their
+    options.
+    """
+    action_parser = parser.add_subparsers(
+        dest='action',
+        help='Subcommands of remote-run',
+    )
+    action_descriptions = {
+        'start': "Start a task",
+        'stop': "Stop a task",
+        'list': "List active tasks",
+    }
+    action_args_adders = {
+        'start': [add_output_args, add_selector_args, add_start_args],
+        # stop is the only action for which we do not add "selector" args (to
+        # specify service, instance, and cluster), since users should know
+        # exactly which task they want to stop
+        'stop': [add_output_args, add_stop_args],
+        'list': [add_output_args, add_selector_args, add_list_args],
+    }
+    for action in REMOTE_RUN_ACTIONS:
+        # create the subparser
+        action_subparser = action_parser.add_parser(
+            action,
+            description=action_descriptions[action],
+            help=action_descriptions[action],
+        )
+        # add all options for the action
+        for adder in action_args_adders[action]:
+            adder(action_subparser)
+
+
+def add_subparser(parser):
+    """ Adds the remote-run subcommand to paasta """
+    remote_run_parser = parser.add_parser(
         'remote-run',
         help="Schedule Mesos to run adhoc command in context of a service",
         description=(
@@ -149,49 +216,8 @@ def add_subparser(subparsers):
             "authentication."
         ),
     )
-
-    main_subs = main_parser.add_subparsers(
-        dest='action',
-        help='Subcommands of remote-run',
-    )
-
-    start_parser = main_subs.add_parser(
-        'start',
-        help="Start task subcommand",
-    )
-    add_start_args_to_parser(start_parser)
-    add_common_args_to_parser(start_parser)
-    start_parser.add_argument(
-        '-X', '--constraint',
-        help='Constraint option, format: <attr>,OP[,<value>], OP can be one '
-        'of the following: EQUALS matches attribute value exactly, LIKE and '
-        'UNLIKE match on regular expression, MAX_PER constrains number of '
-        'tasks per attribute value, UNIQUE is the same as MAX_PER,1',
-        required=False,
-        action='append',
-        default=[],
-    )
-
-    stop_parser = main_subs.add_parser(
-        'stop',
-        help="Stop task subcommand",
-    )
-    add_common_args_to_parser(stop_parser)
-    stop_parser.add_argument(
-        '-F', '--framework-id',
-        help='ID of framework to stop. Must belong to remote-run of selected'
-        'service instance.',
-        required=False,
-        default=None,
-    )
-
-    list_parser = main_subs.add_parser(
-        'list',
-        help="List tasks subcommand",
-    )
-    add_common_args_to_parser(list_parser)
-
-    main_parser.set_defaults(command=paasta_remote_run)
+    add_action_parsers(remote_run_parser)
+    remote_run_parser.set_defaults(command=paasta_remote_run)
 
 
 def paasta_remote_run(args):

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -60,11 +60,7 @@ def emit_counter_metric(counter_name, service, instance):
 
 def parse_args(argv):
     parser = argparse.ArgumentParser(description='')
-    subs = parser.add_subparsers(
-        dest='action',
-        help='Subcommands of paasta_remote_run',
-    )
-    parser.add_action_parsers(parser)
+    add_action_parsers(parser)
     return parser.parse_args(argv)
 
 
@@ -290,7 +286,7 @@ def remote_run_start(args):
         soa_dir, instance, instance_type = extract_args(args)
     overrides_dict = {}
 
-    constraints_json = args.constraints_json
+    constraints_json = args.constraints
     if constraints_json:
         try:
             constraints = json.loads(constraints_json)

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -34,8 +34,7 @@ from task_processing.runners.sync import Sync
 from task_processing.task_processor import TaskProcessor
 
 from paasta_tools import mesos_tools
-from paasta_tools.cli.cmds.remote_run import add_common_args_to_parser
-from paasta_tools.cli.cmds.remote_run import add_start_args_to_parser
+from paasta_tools.cli.cmds.remote_run import add_action_parsers
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.frameworks.native_service_config import load_paasta_native_job_config
 from paasta_tools.mesos_tools import get_all_frameworks
@@ -65,29 +64,7 @@ def parse_args(argv):
         dest='action',
         help='Subcommands of paasta_remote_run',
     )
-
-    start_parser = subs.add_parser('start', help='Start task')
-    add_start_args_to_parser(start_parser)
-    add_common_args_to_parser(start_parser)
-    start_parser.add_argument(
-        '-X', '--constraints-json',
-        help=('Mesos constraints JSON'),
-        required=False,
-        default=None,
-    )
-
-    stop_parser = subs.add_parser('stop', help='Stop task')
-    add_common_args_to_parser(stop_parser)
-    stop_parser.add_argument(
-        '-F', '--framework-id',
-        help=('ID of framework to stop'),
-        required=False,
-        default=None,
-    )
-
-    list_parser = subs.add_parser('list', help='List tasks')
-    add_common_args_to_parser(list_parser)
-
+    parser.add_action_parsers(parser)
     return parser.parse_args(argv)
 
 


### PR DESCRIPTION
### Description
- Currently, each remote-run action's options are somewhat disorganized.
- I have reorganized options to ensure each action only has arguments that are relevant to it

### Testing done
- manual testing

### Notes to reviewers
- When looking at the code diff, I advise looking only at the final code.