### PR TITLE
Ignore starting underscores in instance names in chronos dependencies

### DIFF
--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -1091,6 +1091,8 @@ def _get_related_jobs_and_configs(cluster, soa_dir=DEFAULT_SOA_DIR):
     chronos_configs = {}
     for service in service_configuration_lib.read_services_configuration(soa_dir=soa_dir):
         for instance in read_chronos_jobs_for_service(service=service, cluster=cluster, soa_dir=soa_dir):
+            if instance.startswith('_'):  # some dependencies are templates
+                instance = instance.lstrip('_')
             try:
                 chronos_configs[(service, instance)] = load_chronos_job_config(
                     service=service,

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -1091,8 +1091,8 @@ def _get_related_jobs_and_configs(cluster, soa_dir=DEFAULT_SOA_DIR):
     chronos_configs = {}
     for service in service_configuration_lib.read_services_configuration(soa_dir=soa_dir):
         for instance in read_chronos_jobs_for_service(service=service, cluster=cluster, soa_dir=soa_dir):
-            if instance.startswith('_'):  # some dependencies are templates
-                instance = instance.lstrip('_')
+            if instance.startswith('_'):  # some dependencies are templates, ignore
+                continue
             try:
                 chronos_configs[(service, instance)] = load_chronos_job_config(
                     service=service,


### PR DESCRIPTION
Some chronos service instances depend on template "instances", which start with underscores. They are not valid instance names but are valid template names, but we don't differentiate between the two when loading dependencies. This change creates an exception during that loading process.