### PR TITLE
Stream docker logs while healthchecking local-run

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -205,7 +205,6 @@ def simulate_healthcheck_on_service(
                 except StopIteration:  # natural end of logs
                     break
 
-        paasta_print('Starting docker logs stream throughout health check:')
         docker_logs_generator = docker_client.logs(container_id, stderr=True, stream=True)
         threading.Thread(
             target=_stream_docker_logs,

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -17,6 +17,7 @@ import json
 import os
 import socket
 import sys
+import threading
 import time
 import uuid
 from os import execlpe
@@ -188,6 +189,30 @@ def simulate_healthcheck_on_service(
         # silently start performing health checks until grace period ends or first check succeeds
         graceperiod_end_time = time.time() + grace_period
         after_grace_period_attempts = 0
+        healthchecking = True
+
+        def _stream_docker_logs(container_id, generator):
+            while healthchecking:
+                try:
+                    # the generator will block until another log line is available
+                    log_line = next(generator).decode("utf-8").rstrip('\n')
+                    if healthchecking:
+                        paasta_print(f'container [{container_id[:12]}]: {log_line}')
+                    else:
+                        # stop streaming at first opportunity, since generator.close()
+                        # cant be used until the container is dead
+                        break
+                except StopIteration:  # natural end of logs
+                    break
+
+        paasta_print('Starting docker logs stream throughout health check:')
+        docker_logs_generator = docker_client.logs(container_id, stderr=True, stream=True)
+        threading.Thread(
+            target=_stream_docker_logs,
+            daemon=True,
+            args=(container_id, docker_logs_generator),
+        ).start()
+
         while True:
             # First inspect the container for early exits
             container_state = docker_client.inspect_container(container_id)
@@ -236,6 +261,7 @@ def simulate_healthcheck_on_service(
                 break
 
             time.sleep(interval)
+        healthchecking = False   # end docker logs stream
     else:
         paasta_print('\nPaaSTA would have healthchecked your service via\n%s' % healthcheck_link)
         healthcheck_passed = True
@@ -777,17 +803,13 @@ def run_docker_container(
                 healthcheck_enabled=healthcheck,
             )
 
-        def _output_stdout_and_exit_code():
+        def _output_exit_code():
             returncode = docker_client.inspect_container(container_id)['State']['ExitCode']
-            paasta_print('Container exited: %d)' % returncode)
-            paasta_print('Here is the stdout and stderr:\n\n')
-            paasta_print(
-                docker_client.attach(container_id, stderr=True, stream=False, logs=True),
-            )
+            paasta_print(f'Container exited: {returncode})')
 
         if healthcheck_only:
             if container_started:
-                _output_stdout_and_exit_code()
+                _output_exit_code()
                 _cleanup_container(docker_client, container_id)
             if healthcheck_mode is None:
                 paasta_print('--healthcheck-only, but no healthcheck is defined for this instance!')
@@ -803,7 +825,7 @@ def run_docker_container(
             for line in docker_client.attach(container_id, stderr=True, stream=True, logs=True):
                 paasta_print(line)
         else:
-            _output_stdout_and_exit_code()
+            _output_exit_code()
             returncode = 3
 
     except KeyboardInterrupt:

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -1222,7 +1222,7 @@ def test_run_docker_container_terminates_with_healthcheck_only_fail(
     assert mock_docker_client.stop.call_count == 1
     assert mock_docker_client.remove_container.call_count == 1
     assert excinfo.value.code == 1
-    assert ATTACH_OUTPUT in capfd.readouterr()[0]
+    assert ATTACH_OUTPUT not in capfd.readouterr()[0]  # streamed by docker lgos thread instead
 
 
 @mock.patch('paasta_tools.cli.cmds.local_run.pick_random_port', autospec=True)


### PR DESCRIPTION
### Description
- This change causes local-run to stream docker logs while health checking
- I have also removed the complete docker log output after health checking, given that we are streaming. Now, only the container exit code is printed.

### Testing done
- Manual testing with the `example_happyhour` service
    - log output example: https://gist.github.com/kawaiwanyelp/6945e383e6a82b6ead09b21fcfee40b5

### Notes to reviewers
- Getting the next log line is done via `next(generator)`. This call blocks until the generator finishes, or there is a new log line available. As a result, this call cannot be on the main thread; it must be in its own thread. If the generator is already 'executing', there isn't a way to close it, even with `generator.close()`, which raises an exception telling the caller that the generator is still executing. Hence, after consulting with @solarkennedy, the hack around that is to use the `healthchecking` boolean; if it says that we are not healthchecking, we break out of the generator streaming loop and terminate the thread.