### PR TITLE
Catch error parsing mesos task IDs

### DIFF
--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -879,7 +879,11 @@ def mesos_services_running_here(framework_filter, parse_service_instance_from_ex
                  if 'TASK_RUNNING' in [t['state'] for t in ex.get('tasks', [])]]
     srv_list = []
     for executor in executors:
-        srv_name, srv_instance = parse_service_instance_from_executor_id(executor['id'])
+        try:
+            srv_name, srv_instance = parse_service_instance_from_executor_id(executor['id'])
+        except ValueError:
+            log.error("Failed to decode paasta service instance from {}".format(executor['id']))
+            continue
         if 'ports' in executor['resources']:
             srv_port = int(re.findall('[0-9]+', executor['resources']['ports'])[0])
         else:


### PR DESCRIPTION
Sometimes they don't have dots and I think we can ignore these because
they won't be paasta services.

I think this is safe? This was breaking graceful_mesos_shutdown but the code is used by configure nerve so we should be pretty careful that this makes sense...