### PR TITLE
Add spacing between sentences

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -928,8 +928,8 @@ def configure_and_run_docker_container(
     except NoDeploymentsAvailable:
         paasta_print(
             PaastaColors.red(
-                "Error: No deployments.json found in %(soa_dir)s/%(service)s."
-                "You can generate this by running:"
+                "Error: No deployments.json found in %(soa_dir)s/%(service)s. "
+                "You can generate this by running: "
                 "generate_deployments_for_service -d %(soa_dir)s -s %(service)s" % {
                     'soa_dir': soa_dir,
                     'service': service,


### PR DESCRIPTION
Before this change:

`Error: No deployments.json found in ../yelpsoa-configs/my_service.You can generate this by running:generate_deployments_for_service -d ../yelpsoa-configs -s my_service`