### PR TITLE
Bump vault_tools

### DIFF
--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -2,7 +2,7 @@
 clusterman_metrics==2.0.0
 crypto_lib==4.0.0
 scribereader==0.2.6
-vault-tools==0.7.22
+vault-tools==0.7.24
 yelp-cgeom==1.3.1
 yelp-logging==1.0.37
 yelp_meteorite


### PR DESCRIPTION
Fixes token error on `paasta secret add` caused by incompatible return
type from the previous version of vault_tools...