### PR TITLE
Reorganize remote-run args and make paasta_remote_run respect `--dry-run`

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -15,7 +15,6 @@
 import json
 import re
 from functools import lru_cache
-from shlex import quote
 
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_clusters

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -256,12 +256,12 @@ def create_remote_run_command(args):
         if isinstance(v, bool) and v:
             cmd_parts.append(f'--{k}')
         else:
-            cmd_parts.extend([f'--{k}', quote(str(v))])
+            cmd_parts.extend([f'--{k}', str(v)])
 
     # constraint, convert to json
     if len(arg_vars['constraint']) > 0:
         constraints = split_constraints(arg_vars['constraint'])
-        cmd_parts.extend(['--constraints-json', quote(json.dumps(constraints))])
+        cmd_parts.extend(['--constraints-json', json.dumps(constraints)])
 
     return cmd_parts
 
@@ -272,11 +272,12 @@ def paasta_remote_run(args):
         paasta_print(PaastaColors.red("Error: no cluster specified and no default cluster available"))
         return 1
 
+    cmd_parts = create_remote_run_command(args)
     graceful_exit = (args.action == 'start' and not args.detach)
     return_code, status = run_on_master(
         cluster=args.cluster,
         system_paasta_config=get_system_paasta_config(),
-        cmd_parts=create_remote_run_command(args),
+        cmd_parts=cmd_parts,
         graceful_exit=graceful_exit,
     )
 

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import json
 import re
+from functools import lru_cache
 from shlex import quote
 
 from paasta_tools.cli.utils import lazy_choices_completer
@@ -29,7 +30,90 @@ from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
 
 
-def add_start_args_to_parser(parser):
+@lru_cache(maxsize=1)
+def _get_system_paasta_config():
+    try:
+        return load_system_paasta_config()
+    except PaastaNotConfiguredError:
+        paasta_print(
+            PaastaColors.yellow(
+                "Warning: Couldn't load config files from '/etc/paasta'. This "
+                "indicates PaaSTA is not configured locally on this host, and "
+                "remote-run may not behave the same way it would behave on a "
+                "server configured for PaaSTA.",
+            ),
+            sep='\n',
+        )
+        return SystemPaastaConfig(
+            {"volumes": []},
+            '/etc/paasta',
+        )
+
+
+@lru_cache(maxsize=1)
+def _get_default_cluster():
+    remote_run_config = _get_system_paasta_config().get_remote_run_config()
+    return remote_run_config.get('default_cluster')
+
+
+ARG_DEFAULTS = dict(
+    common=dict(
+        service=None,
+        instance=None,
+        cluster=_get_default_cluster(),
+        verbose=False,
+    ),
+    start=dict(
+        cmd=None,
+        detach=False,
+        staging_timeout=240.0,
+        instances=1,
+        docker_image=None,
+        dry_run=False,
+        constraint=[],
+    ),
+    stop=dict(run_id=None, framework_id=None),
+)
+
+
+def add_common_args_to_parser(parser):
+    parser.add_argument(
+        '-s', '--service',
+        help='The name of the service you wish to inspect. Required.',
+        required=True,
+    ).completer = lazy_choices_completer(list_services)
+    parser.add_argument(
+        '-i', '--instance',
+        help=(
+            "Simulate a docker run for a particular instance of the "
+            "service, like 'main' or 'canary'. Required."
+        ),
+        required=True,
+    ).completer = lazy_choices_completer(list_instances)
+    default_cluster = ARG_DEFAULTS['common']['cluster']
+    parser.add_argument(
+        '-c', '--cluster',
+        help=(
+            'The name of the cluster you wish to run your task on. '
+            'If omitted, uses the default cluster defined in the paasta '
+            f'remote-run configs: {default_cluster}'
+        ),
+        default=default_cluster,
+    ).completer = lazy_choices_completer(list_clusters)
+    parser.add_argument(
+        '-v', '--verbose',
+        help='Show more output',
+        action='store_true',
+        default=ARG_DEFAULTS['common']['verbose'],
+    )
+
+
+def add_start_parser(main_subparser):
+    parser = main_subparser.add_parser(
+        'start',
+        help="Start task subcommand",
+    )
+    add_common_args_to_parser(parser)
     parser.add_argument(
         '-C', '--cmd',
         help=(
@@ -37,101 +121,85 @@ def add_start_args_to_parser(parser):
             '"bash". By default will use the command or args specified by the '
             'soa-configs or what was specified in the Dockerfile'
         ),
-        required=False,
-        default=None,
-    )
+        default=ARG_DEFAULTS['start']['cmd'],
+    ),
     parser.add_argument(
         '-D', '--detach',
         help='Launch in background',
         action='store_true',
-        required=False,
-        default=False,
+        default=ARG_DEFAULTS['start']['detach'],
     )
     parser.add_argument(
         '-t', '--staging-timeout',
         help='A timeout for the task to be launching before killed',
-        required=False,
-        default=240,
+        default=ARG_DEFAULTS['start']['staging_timeout'],
         type=float,
     )
     parser.add_argument(
         '-j', '--instances',
         help='Number of copies of the task to launch',
-        required=False,
-        default=None,
+        default=ARG_DEFAULTS['start']['instances'],
         type=int,
     )
     parser.add_argument(
         '--docker-image',
-        help='Docker image to use. Defaults to using the deployed docker image',
-        required=False,
-        default=None,
-    )
-
-
-def add_common_args_to_parser(parser):
-    parser.add_argument(
-        '-s', '--service',
-        help='The name of the service you wish to inspect',
-    ).completer = lazy_choices_completer(list_services)
-    parser.add_argument(
-        '-c', '--cluster',
         help=(
-            'The name of the cluster you wish to run your task on. '
-            'If omitted, uses the default cluster defined in the paasta'
-            'remote-run configs'
+            'URL of docker image to use. '
+            'Defaults to using the deployed docker image.'
         ),
-        default=None,
-    ).completer = lazy_choices_completer(list_clusters)
-    parser.add_argument(
-        '-y', '--yelpsoa-config-root',
-        dest='yelpsoa_config_root',
-        help='A directory from which yelpsoa-configs should be read from',
-        default=DEFAULT_SOA_DIR,
-    )
-    parser.add_argument(
-        '-v', '--verbose',
-        help='Show more output',
-        action='store_true',
-        required=False,
-        default=False,
-    )
-    parser.add_argument(
-        '--debug',
-        help='Show debug output',
-        action='store_true',
-        required=False,
-        default=False,
-    )
-    parser.add_argument(
-        '-R', '--run-id',
-        help='Identifier to assign/refer to individual task runs',
-        action='store',
-        required=False,
-        default=None,
+        default=ARG_DEFAULTS['start']['docker_image'],
     )
     parser.add_argument(
         '-d', '--dry-run',
-        help='Don\'t launch the task',
-        action='store_true',
-        required=False,
-        default=False,
-    )
-    parser.add_argument(
-        '--aws-region',
-        choices=['us-east-1', 'us-west-1', 'us-west-2'],
-        help='aws region of the dynamodb state table',
-        default=None,
-    )
-    parser.add_argument(
-        '-i', '--instance',
         help=(
-            "Simulate a docker run for a particular instance of the "
-            "service, like 'main' or 'canary'"
+            'Don\'t launch the task. '
+            'Instead output task that would have been launched'
         ),
-        required=False,
-        default=None,
-    ).completer = lazy_choices_completer(list_instances)
+        action='store_true',
+        default=ARG_DEFAULTS['start']['dry_run'],
+    )
+    parser.add_argument(
+        '-X', '--constraint',
+        help='Constraint option, format: <attr>,OP[,<value>], OP can be one '
+        'of the following: EQUALS matches attribute value exactly, LIKE and '
+        'UNLIKE match on regular expression, MAX_PER constrains number of '
+        'tasks per attribute value, UNIQUE is the same as MAX_PER,1',
+        action='append',
+        default=ARG_DEFAULTS['start']['constraint'],
+    )
+    return parser
+
+
+def add_stop_parser(main_subparser):
+    parser = main_subparser.add_parser(
+        'stop',
+        help="Stop task subcommand",
+    )
+    add_common_args_to_parser(parser)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        '-R', '--run-id',
+        help='ID of task to stop',
+        default=ARG_DEFAULTS['stop']['run_id'],
+    )
+    group.add_argument(
+        '-F', '--framework-id',
+        help=(
+            'ID of framework to stop. Must belong to remote-run of selected '
+            'service instance.'
+        ),
+        default=ARG_DEFAULTS['stop']['framework_id'],
+    )
+    return parser
+
+
+def add_list_parser(main_subparser):
+    parser = main_subparser.add_parser(
+        'list',
+        help="List tasks subcommand",
+    )
+    add_common_args_to_parser(parser)
+    return parser
 
 
 def add_subparser(subparsers):
@@ -149,127 +217,57 @@ def add_subparser(subparsers):
             "authentication."
         ),
     )
-
     main_subs = main_parser.add_subparsers(
         dest='action',
         help='Subcommands of remote-run',
     )
-
-    start_parser = main_subs.add_parser(
-        'start',
-        help="Start task subcommand",
-    )
-    add_start_args_to_parser(start_parser)
-    add_common_args_to_parser(start_parser)
-    start_parser.add_argument(
-        '-X', '--constraint',
-        help='Constraint option, format: <attr>,OP[,<value>], OP can be one '
-        'of the following: EQUALS matches attribute value exactly, LIKE and '
-        'UNLIKE match on regular expression, MAX_PER constrains number of '
-        'tasks per attribute value, UNIQUE is the same as MAX_PER,1',
-        required=False,
-        action='append',
-        default=[],
-    )
-
-    stop_parser = main_subs.add_parser(
-        'stop',
-        help="Stop task subcommand",
-    )
-    add_common_args_to_parser(stop_parser)
-    stop_parser.add_argument(
-        '-F', '--framework-id',
-        help='ID of framework to stop. Must belong to remote-run of selected'
-        'service instance.',
-        required=False,
-        default=None,
-    )
-
-    list_parser = main_subs.add_parser(
-        'list',
-        help="List tasks subcommand",
-    )
-    add_common_args_to_parser(list_parser)
-
+    add_start_parser(main_subs)
+    add_stop_parser(main_subs)
+    add_list_parser(main_subs)
     main_parser.set_defaults(command=paasta_remote_run)
 
 
-def paasta_remote_run(args):
-    try:
-        system_paasta_config = load_system_paasta_config()
-    except PaastaNotConfiguredError:
-        paasta_print(
-            PaastaColors.yellow(
-                "Warning: Couldn't load config files from '/etc/paasta'. This "
-                "indicates PaaSTA is not configured locally on this host, and "
-                "remote-run may not behave the same way it would behave on a "
-                "server configured for PaaSTA.",
-            ),
-            sep='\n',
-        )
-        system_paasta_config = SystemPaastaConfig(
-            {"volumes": []},
-            '/etc/paasta',
-        )
-
+def _create_remote_run_command(args):
     cmd_parts = ['/usr/bin/paasta_remote_run', args.action]
-    args_vars = vars(args)
-    args_keys = {
-        'service': None,
-        'yelpsoa_config_root': DEFAULT_SOA_DIR,
-        'cmd': None,
-        'verbose': False,
-        'debug': False,
-        'dry_run': False,
-        'staging_timeout': None,
-        'detach': False,
-        'run_id': None,
-        'framework_id': None,
-        'instances': None,
-        'instance': None,
-        'docker_image': None,
-    }
+    arg_vars = vars(args)
+    arg_defaults = dict(ARG_DEFAULTS[args.action])  # copy dict
+    arg_defaults.update(ARG_DEFAULTS['common'])
 
-    # copy relevant arguments into cmd_parts
-    for key in args_vars:
-        # skip args we don't know about
-        if key not in args_keys:
+    arg_defaults['cluster'] = None  # special case, we always want to append cluster below
+    del arg_defaults['constraint']  # special case, needs conversion to json
+
+    for k in arg_vars.keys():
+        if k not in arg_defaults:  # skip keys we don't know about
             continue
-
-        value = args_vars[key]
-
-        # skip args that have default value
-        if value == args_keys[key]:
+        v = arg_vars[k]
+        if v == arg_defaults[k]:  # skip values that have default value
             continue
+        k = re.sub(r'_', '-', k)
+        if isinstance(v, bool) and v:
+            cmd_parts.append(f'--{k}')
+        else:
+            cmd_parts.extend([f'--{k}', quote(str(v))])
 
-        arg_key = re.sub(r'_', '-', key)
-
-        if isinstance(value, bool) and value:
-            cmd_parts.append('--%s' % arg_key)
-        elif not isinstance(value, bool):
-            cmd_parts.extend(['--%s' % arg_key, quote(str(value))])
-
-    constraints = [x.split(',', 2) for x in args_vars.get('constraint', [])]
+    # constraint, convert to json
+    constraints = [c.split(',', 2) for c in arg_vars.get('constraint', [])]
     if len(constraints) > 0:
-        cmd_parts.extend(
-            ['--constraints-json', quote(json.dumps(constraints))],
-        )
+        cmd_parts.extend(['--constraints-json', quote(json.dumps(constraints))])
 
-    if not args.cluster:
-        default_cluster = system_paasta_config.get_remote_run_config().get('default_cluster')
-        if not default_cluster and not args.cluster:
-            paasta_print(PaastaColors.red("Error: no cluster specified and no default cluster available"))
-            return 1
-        cluster = default_cluster
-    else:
-        cluster = args.cluster
+    return cmd_parts
 
-    cmd_parts.extend(
-        ['--cluster', quote(cluster)],
-    )
+
+def paasta_remote_run(args):
+    system_paasta_config = _get_system_paasta_config()
+
+    # ensure we have a cluster
+    if not args.cluster and not ARG_DEFAULTS['common']['cluster']:
+        paasta_print(PaastaColors.red("Error: no cluster specified and no default cluster available"))
+        return 1
+
+    cmd_parts = _create_remote_run_command(args)
     graceful_exit = (args.action == 'start' and not args.detach)
     return_code, status = run_on_master(
-        cluster=cluster,
+        cluster=args.cluster,
         system_paasta_config=system_paasta_config,
         cmd_parts=cmd_parts,
         graceful_exit=graceful_exit,
@@ -278,6 +276,6 @@ def paasta_remote_run(args):
     # Status results are streamed. This print is for possible error messages.
     if status is not None:
         for line in status.rstrip().split('\n'):
-            paasta_print('    %s' % line)
+            paasta_print(f'    {line}')
 
     return return_code

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -15,8 +15,8 @@
 import argparse
 import json
 import logging
-import pprint
 import os
+import pprint
 import random
 import re
 import signal
@@ -39,7 +39,6 @@ from paasta_tools.cli.cmds.remote_run import add_list_parser
 from paasta_tools.cli.cmds.remote_run import add_start_parser
 from paasta_tools.cli.cmds.remote_run import add_stop_parser
 from paasta_tools.cli.cmds.remote_run import get_system_paasta_config
-from paasta_tools.cli.cmds.remote_run import get_default_cluster
 from paasta_tools.cli.cmds.remote_run import split_constraints
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.frameworks.native_service_config import load_paasta_native_job_config
@@ -49,12 +48,9 @@ from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_code_sha_from_dockerurl
 from paasta_tools.utils import get_config_hash
-from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
-from paasta_tools.utils import PaastaNotConfiguredError
-from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import validate_service_instance
 
 MESOS_TASK_SPACER = '.'
@@ -440,7 +436,7 @@ def remote_run_start(args):
 
     default_role = system_paasta_config.get_remote_run_config().get('default_role')
     assert default_role
-    build_kwargs=dict(
+    build_kwargs = dict(
         service=service,
         instance=instance,
         role=native_job_config.get_role() or default_role,
@@ -448,8 +444,6 @@ def remote_run_start(args):
         cluster=cluster,
         framework_staging_timeout=args.staging_timeout,
     )
-    role = native_job_config.get_role() or default_role
-    pool = native_job_config.get_pool()
 
     if args.dry_run:
         task_config_dict = task_config_to_dict(task_config)

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -19,6 +19,7 @@ import os
 import random
 import re
 import signal
+import simplejson as json
 import string
 import sys
 import traceback
@@ -34,13 +35,18 @@ from task_processing.runners.sync import Sync
 from task_processing.task_processor import TaskProcessor
 
 from paasta_tools import mesos_tools
-from paasta_tools.cli.cmds.remote_run import add_common_args_to_parser
-from paasta_tools.cli.cmds.remote_run import add_start_args_to_parser
+from paasta_tools.cli.cmds.remote_run import add_list_parser
+from paasta_tools.cli.cmds.remote_run import add_start_parser
+from paasta_tools.cli.cmds.remote_run import add_stop_parser
+from paasta_tools.cli.cmds.remote_run import get_system_paasta_config
+from paasta_tools.cli.cmds.remote_run import get_default_cluster
+from paasta_tools.cli.cmds.remote_run import split_constraints
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.frameworks.native_service_config import load_paasta_native_job_config
 from paasta_tools.mesos_tools import get_all_frameworks
 from paasta_tools.mesos_tools import get_mesos_master
 from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_code_sha_from_dockerurl
 from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import load_system_paasta_config
@@ -54,31 +60,30 @@ from paasta_tools.utils import validate_service_instance
 MESOS_TASK_SPACER = '.'
 
 
-# def add_common_args_to_parser(parser):
-#     parser.add_argument(
-#         '-y', '--yelpsoa-config-root',
-#         dest='yelpsoa_config_root',
-#         help='A directory from which yelpsoa-configs should be read from',
-#         default=DEFAULT_SOA_DIR,
-#     )
-#     parser.add_argument(
-#         '--debug',
-#         help='Show debug output',
-#         action='store_true',
-#         required=False,
-#         default=False,
-#     )
-#     parser.add_argument(
-#         '--aws-region',
-#         choices=['us-east-1', 'us-west-1', 'us-west-2'],
-#         help='aws region of the dynamodb state table',
-#         default=None,
-#     )
-
-
 def emit_counter_metric(counter_name, service, instance):
     create_counter(counter_name, {'service': service, 'instance': instance})
     get_metric(counter_name).count(1)
+
+
+def add_debug_args_to_parser(parser):
+    parser.add_argument(
+        '-y', '--yelpsoa-config-root',
+        dest='yelpsoa_config_root',
+        help='A directory from which yelpsoa-configs should be read from',
+        default=DEFAULT_SOA_DIR,
+    )
+    parser.add_argument(
+        '--debug',
+        help='Show debug output',
+        action='store_true',
+        default=False,
+    )
+    parser.add_argument(
+        '--aws-region',
+        choices=['us-east-1', 'us-west-1', 'us-west-2'],
+        help='aws region of the dynamodb state table',
+        default=None,
+    )
 
 
 def parse_args(argv):
@@ -87,49 +92,39 @@ def parse_args(argv):
         dest='action',
         help='Subcommands of paasta_remote_run',
     )
+    action_parsers = dict(
+        start=add_start_parser(subs),
+        stop=add_stop_parser(subs),
+        list=add_list_parser(subs),
+    )
+    for ap in action_parsers.values():
+        add_debug_args_to_parser(ap)
 
-    start_parser = subs.add_parser('start', help='Start task')
-    add_start_args_to_parser(start_parser)
-    add_common_args_to_parser(start_parser)
-    start_parser.add_argument(
-        '-X', '--constraints-json',
-        help=('Mesos constraints JSON'),
-        required=False,
+    action_parsers['start'].add_argument(
+        '--constraints-json',
+        help='Mesos constraints JSON',
         default=None,
     )
 
-    stop_parser = subs.add_parser('stop', help='Stop task')
-    add_common_args_to_parser(stop_parser)
-    stop_parser.add_argument(
-        '-F', '--framework-id',
-        help=('ID of framework to stop'),
-        required=False,
-        default=None,
-    )
+    args = parser.parse_args(argv)
 
-    list_parser = subs.add_parser('list', help='List tasks')
-    add_common_args_to_parser(list_parser)
+    # convert constraints into json
+    if len(args.constraint) > 0:
+        constraints = split_constraints(args.constraint)
+        if args.constraints_json is None:
+            args.constraints_json = json.dumps(constraints)
+        else:
+            constraints_json = json.loads(args.constraints_json)
+            args.constraints_json = json.dumps(constraints_json + constraints)
 
-    return parser.parse_args(argv)
+    return args
 
 
 def extract_args(args):
-    try:
-        system_paasta_config = load_system_paasta_config()
-    except PaastaNotConfiguredError:
-        paasta_print(
-            PaastaColors.yellow(
-                "Warning: Couldn't load config files from '/etc/paasta'. This indicates"
-                "PaaSTA is not configured locally on this host, and remote-run may not behave"
-                "the same way it would behave on a server configured for PaaSTA.",
-            ),
-            sep='\n',
-        )
-        system_paasta_config = SystemPaastaConfig({"volumes": []}, '/etc/paasta')
+    soa_dir = args.yelpsoa_config_root
+    service = figure_out_service_name(args, soa_dir=soa_dir)
 
-    service = figure_out_service_name(args, soa_dir=args.yelpsoa_config_root)
-    cluster = args.cluster or system_paasta_config.get_local_run_config().get('default_cluster', None)
-
+    cluster = args.cluster  # by default, already default cluster in paasta config
     if not cluster:
         paasta_print(
             PaastaColors.red(
@@ -142,7 +137,6 @@ def extract_args(args):
         emit_counter_metric('paasta.remote_run.' + args.action + '.failed', service, 'UNKNOWN')
         sys.exit(1)
 
-    soa_dir = args.yelpsoa_config_root
     instance = args.instance
     if instance is None:
         instance_type = 'adhoc'
@@ -169,14 +163,7 @@ def extract_args(args):
             emit_counter_metric('paasta.remote_run.' + args.action + '.failed', service, instance)
             sys.exit(1)
 
-    return (
-        system_paasta_config,
-        service,
-        cluster,
-        soa_dir,
-        instance,
-        instance_type,
-    )
+    return service, cluster, soa_dir, instance, instance_type
 
 
 def paasta_to_task_config_kwargs(
@@ -330,9 +317,8 @@ def build_executor_stack(
 
 
 def remote_run_start(args):
-
-    system_paasta_config, service, cluster, \
-        soa_dir, instance, instance_type = extract_args(args)
+    system_paasta_config = get_system_paasta_config()
+    service, cluster, soa_dir, instance, instance_type = extract_args(args)
     overrides_dict = {}
 
     constraints_json = args.constraints_json
@@ -438,10 +424,7 @@ def remote_run_start(args):
         )
         if runner is not None:
             runner.stop()
-        if _signum == signal.SIGTERM:
-            sys.exit(143)
-        else:
-            sys.exit(1)
+        sys.exit(143 if _signum == signal.SIGTERM else 1)
     signal.signal(signal.SIGINT, handle_interrupt)
     signal.signal(signal.SIGTERM, handle_interrupt)
 
@@ -486,7 +469,7 @@ def remote_run_start(args):
 
 # TODO: reimplement using build_executor_stack and task uuid instead of run_id
 def remote_run_stop(args):
-    _, service, cluster, _, instance, _ = extract_args(args)
+    service, cluster, _, instance, _ = extract_args(args)
     if args.framework_id is None and args.run_id is None:
         paasta_print(PaastaColors.red("Must provide either run id or framework id to stop."))
         emit_counter_metric('paasta.remote_run.stop.failed', service, instance)
@@ -567,7 +550,7 @@ def remote_run_list_report(service, instance, cluster, frameworks=None):
 
 
 def remote_run_list(args, frameworks=None):
-    _, service, cluster, _, instance, _ = extract_args(args)
+    service, cluster, _, instance, _ = extract_args(args)
     return remote_run_list_report(
         service=service,
         instance=instance,
@@ -583,8 +566,6 @@ def main(argv):
         logging.basicConfig(level=logging.DEBUG)
     elif args.verbose:
         logging.basicConfig(level=logging.INFO)
-    # elif args.quiet:
-    #     logging.basicConfig(level=logging.ERROR)
     else:
         logging.basicConfig(level=logging.WARNING)
 

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -54,6 +54,28 @@ from paasta_tools.utils import validate_service_instance
 MESOS_TASK_SPACER = '.'
 
 
+# def add_common_args_to_parser(parser):
+#     parser.add_argument(
+#         '-y', '--yelpsoa-config-root',
+#         dest='yelpsoa_config_root',
+#         help='A directory from which yelpsoa-configs should be read from',
+#         default=DEFAULT_SOA_DIR,
+#     )
+#     parser.add_argument(
+#         '--debug',
+#         help='Show debug output',
+#         action='store_true',
+#         required=False,
+#         default=False,
+#     )
+#     parser.add_argument(
+#         '--aws-region',
+#         choices=['us-east-1', 'us-west-1', 'us-west-2'],
+#         help='aws region of the dynamodb state table',
+#         default=None,
+#     )
+
+
 def emit_counter_metric(counter_name, service, instance):
     create_counter(counter_name, {'service': service, 'instance': instance})
     get_metric(counter_name).count(1)

--- a/tox.ini
+++ b/tox.ini
@@ -171,6 +171,7 @@ commands =
 
 [flake8]
 max-line-length = 120
+ignore = W504,E252,W605
 
 [pep8]
 ignore = E265,E309,E501


### PR DESCRIPTION
### Description
- Currently, `remote-run` args are sort of wonky:
    - Some args do not and cannot work (e.g. `-y`, which cannot work since `paasta remote-run` SSHs to a master to run a task, and so cannot take local soa-configs with it)
    - Some args do not work but should (e.g. `--dry-run`)
    - Some args are internal, but are exposed via `paasta remote-run` (e.g. `--aws-region`, which determines which dynamodb table we persist to; this isn't a user concern, however)
- In this PR, I have:
    - Reorganized arguments so that actions only have the options specific to them instead of sharing some irrelevant ones
    - Moved 'internal' options to `paasta_remote_run`, which is 'called' from `paasta remote-run`, but isn't meant to be publicly used (like `-y`, `--debug`, etc.)
   - Make `--dry-run` work

### Tests
- manual testing (since no unit and integration tests currently exist - that's a separate issue)