### PR TITLE
Filter out 'None' deploy groups now that we have tron

### DIFF
--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -235,7 +235,7 @@ def get_deploy_groups_used_by_framework(instance_type, service, soa_dir):
                 deploy_groups.append(config.get_deploy_group())
             except NotImplementedError:
                 pass
-    return deploy_groups
+    return set(filter(None, deploy_groups))
 
 
 def deployments_check(service, soa_dir):

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -757,9 +757,9 @@ def run_on_master(
         cmd_parts.append(
             # send process to background and capture it's pid
             '& p=$!; ' +
-            # wait for stdin with timeout in a loop, exit when original process finished
+            # noqa: W504 wait for stdin with timeout in a loop, exit when original process finished
             'while ! read -t1; do ! kill -0 $p 2>/dev/null && kill $$; done; ' +
-            # kill original process if loop finished (something on stdin)
+            # noqa: W504 kill original process if loop finished (something on stdin)
             'kill $p; wait',
         )
         stdin = subprocess.PIPE
@@ -873,10 +873,13 @@ def list_deploy_groups(
     parsed_args=None,
     **kwargs,
 ) -> Set:
-    return {config.get_deploy_group() for config in get_instance_configs_for_service(
-        service=service if service is not None else parsed_args.service or guess_service_name(),
-        soa_dir=soa_dir,
-    )}
+    return set(filter(
+        None,
+        {config.get_deploy_group() for config in get_instance_configs_for_service(
+            service=service if service is not None else parsed_args.service or guess_service_name(),
+            soa_dir=soa_dir,
+        )},
+    ))
 
 
 def validate_given_deploy_groups(

--- a/tests/cli/test_cmds_check.py
+++ b/tests/cli/test_cmds_check.py
@@ -478,7 +478,7 @@ def test_get_deploy_groups_used_by_framework(
             config_dict={},
             branch_dict=None,
         )
-    expected = ['cluster1.instance1', 'cluster1.instance2']
+    expected = {'cluster1.instance1', 'cluster1.instance2'}
     actual = get_deploy_groups_used_by_framework('marathon', service='unused', soa_dir='/fake/path')
     assert actual == expected
 


### PR DESCRIPTION
I like that `get_deploy_group` returns `None` on tron stuff. 

But I think the tools that print the listed deploy groups should filter it out.