### PR TITLE
don't emit sensu events from security-check

### DIFF
--- a/paasta_tools/cli/cmds/security_check.py
+++ b/paasta_tools/cli/cmds/security_check.py
@@ -12,10 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pysensu_yelp
-
-from paasta_tools.chronos_tools import DEFAULT_SOA_DIR
-from paasta_tools.monitoring_tools import send_event
 from paasta_tools.utils import _run
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
@@ -61,11 +57,5 @@ def perform_security_check(args):
             "The security-check failed. Please visit y/security-check-runbook to learn how to fix it ("
             "including whitelisting safe versions of packages and docker images).",
         )
-
-    sensu_status = pysensu_yelp.Status.CRITICAL if ret_code != 0 else pysensu_yelp.Status.OK
-    send_event(
-        service=args.service, check_name='%s.security_check' % args.service,
-        overrides={'page': False, 'ticket': True}, status=sensu_status, output=output, soa_dir=DEFAULT_SOA_DIR,
-    )
 
     return ret_code


### PR DESCRIPTION
We sort of forgot this existed because it hasn't been working. Now that it's working again, we're finding it disruptive. We'd like to remove the sensu alerting for now while we re-think how to do this (it'll probably end up being implemented inside the security-check command itself).

(This is APPSEC-998 internally.)