### PR TITLE
increase timeout when talking to git

### DIFF
--- a/paasta_tools/remote_git.py
+++ b/paasta_tools/remote_git.py
@@ -79,7 +79,7 @@ class LSRemoteException(Exception):
 
 
 @timeout(
-    seconds=20,
+    seconds=60,
     error_message="Timed out connecting to git server, is it reachable from where you are?",
     use_signals=False,
 )


### PR DESCRIPTION
It is taking longer than 20s in yelp-main, since the repo is so big. Increasing timeout should be helpful.
More details are [here](https://jira.yelpcorp.com/browse/PAASTA-15089).