### PR TITLE
Add remote-run retries and notification emails

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -12,8 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import json
+import os
 import re
 from shlex import quote
 

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -44,7 +44,7 @@ ARG_DEFAULTS = dict(
         docker_image=None,
         dry_run=False,
         constraint=[],
-        notification_email=None,  # always append to remote-run command, so no default
+        notification_email=None,
         retries=0,
     ),
     stop=dict(run_id=None, framework_id=None),
@@ -176,10 +176,9 @@ def add_start_parser(subparser):
         help=(
             'Email address to send remote-run notifications to. '
             'A notification will be sent when a task either succeeds or fails. '
-            'Required if environment variable $EMAIL not set. '
-        ) + (f'Default: {default_email}' if default_email else ''),
+            'Defaults to env variable $EMAIL if set'
+        ) + (f': {default_email}' if default_email else '.'),
         default=default_email,
-        required=default_email is None,
     )
     default_retries = ARG_DEFAULTS['start']['retries']
     parser.add_argument(

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -176,15 +176,15 @@ def add_start_parser(subparser):
         help=(
             'Email address to send remote-run notifications to. '
             'A notification will be sent when a task either succeeds or fails. '
-            'Defaults to env variable $EMAIL if set'
-        ) + (f': {default_email}' if default_email else '.'),
+            'Defaults to env variable $EMAIL: '
+        ) + (default_email if default_email else '(currently not set)'),
         default=default_email,
     )
     default_retries = ARG_DEFAULTS['start']['retries']
     parser.add_argument(
         '-r', '--retries',
         help=(
-            'Number of times to retry if task fails to launch. '
+            'Number of times to retry if task fails at launch or at runtime. '
             f'Default: {default_retries}'
         ),
         type=int,
@@ -211,7 +211,7 @@ def add_stop_parser(subparser):
             'ID of framework to stop. Must belong to remote-run of selected '
             'service instance.'
         ),
-        type=int,
+        type=str,
         default=ARG_DEFAULTS['stop']['framework_id'],
     )
     return parser

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -45,7 +45,7 @@ ARG_DEFAULTS = dict(
         dry_run=False,
         constraint=[],
         notification_email=None,  # always append to remote-run command, so no default
-        retries=3,
+        retries=0,
     ),
     stop=dict(run_id=None, framework_id=None),
     list=dict(),

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import json
 import re
 from shlex import quote
@@ -43,6 +44,8 @@ ARG_DEFAULTS = dict(
         docker_image=None,
         dry_run=False,
         constraint=[],
+        notification_email=None,  # always append to remote-run command, so no default
+        retries=3,
     ),
     stop=dict(run_id=None, framework_id=None),
     list=dict(),
@@ -120,9 +123,13 @@ def add_start_parser(subparser):
         action='store_true',
         default=ARG_DEFAULTS['start']['detach'],
     )
+    default_staging_timeout = ARG_DEFAULTS['start']['staging_timeout']
     parser.add_argument(
         '-t', '--staging-timeout',
-        help='A timeout for the task to be launching before killed',
+        help=(
+            'A timeout in seconds for the task to be launching before killed. '
+            f'Default: {default_staging_timeout}s'
+        ),
         default=ARG_DEFAULTS['start']['staging_timeout'],
         type=float,
     )
@@ -163,6 +170,27 @@ def add_start_parser(subparser):
         action='append',
         default=ARG_DEFAULTS['start']['constraint'],
     )
+    default_email = os.environ.get('EMAIL', None)
+    parser.add_argument(
+        '-E', '--notification-email',
+        help=(
+            'Email address to send remote-run notifications to. '
+            'A notification will be sent when a task either succeeds or fails. '
+            'Required if environment variable $EMAIL not set. '
+        ) + (f'Default: {default_email}' if default_email else ''),
+        default=default_email,
+        required=default_email is None,
+    )
+    default_retries = ARG_DEFAULTS['start']['retries']
+    parser.add_argument(
+        '-r', '--retries',
+        help=(
+            'Number of times to retry if task fails to launch. '
+            f'Default: {default_retries}'
+        ),
+        type=int,
+        default=default_retries,
+    )
     return parser
 
 
@@ -184,6 +212,7 @@ def add_stop_parser(subparser):
             'ID of framework to stop. Must belong to remote-run of selected '
             'service instance.'
         ),
+        type=int,
         default=ARG_DEFAULTS['stop']['framework_id'],
     )
     return parser


### PR DESCRIPTION
### Description
- Currently, remote-run does not support retries.
    - I've added an option to specify the number of retries remote-run should do; by default it is 0.
- Currently, if remote-run finishes (by success or failure), it does nothing more. If the user does a detached run or otherwise is not watching remote-run go, then the user would never know the results of the task until they check things manually.
    - I've added email notifications to alert the user of the results of the final attempt of the task run.
    - The user's email address defaults to the $EMAIL env variable, but can be set manually. If the env variable is not set or the user doesn't specify an email address, there will be no notification. This will happen if remote-run is used by, say, a non-human user.

### Tests
- manual testing on norcal-devc

### Notes to reviewers
- This review includes a refactor remote-run's start to make things more clear (I hope)
- Example of a task success notification: https://gist.github.com/kawaiwanyelp/588240cc8ac7d76bd21e748701a4121a
- Example of a task failure notification: https://gist.github.com/kawaiwanyelp/d613a551facf53a6e4eebd893acb931a