### PR TITLE
Make vault key settable

### DIFF
--- a/paasta_tools/secret_providers/__init__.py
+++ b/paasta_tools/secret_providers/__init__.py
@@ -3,6 +3,8 @@ from typing import Any
 from typing import Dict
 from typing import List
 
+from service_configuration_lib import read_service_configuration
+
 
 class BaseSecretProvider:
 
@@ -17,6 +19,8 @@ class BaseSecretProvider:
         self.service_name = service_name
         self.secret_dir = os.path.join(self.soa_dir, self.service_name, "secrets")
         self.cluster_names = cluster_names
+        service_config = read_service_configuration(self.service_name, self.soa_dir)
+        self.encryption_key = service_config.get('encryption_key', 'paasta')
 
     def decrypt_environment(self, environment: Dict[str, str], **kwargs: Any) -> Dict[str, str]:
         raise NotImplementedError

--- a/paasta_tools/secret_providers/vault.py
+++ b/paasta_tools/secret_providers/vault.py
@@ -83,7 +83,12 @@ class SecretProvider(BaseSecretProvider):
             )
             raise
 
-    def write_secret(self, action: str, secret_name: str, plaintext: bytes) -> None:
+    def write_secret(
+        self,
+        action: str,
+        secret_name: str,
+        plaintext: bytes,
+    ) -> None:
         with TempGpgKeyring(overwrite=True):
             ecosystems = self.get_vault_ecosystems_for_clusters()
             if 'VAULT_TOKEN_OVERRIDE' not in os.environ:
@@ -106,6 +111,7 @@ class SecretProvider(BaseSecretProvider):
                     soa_dir=self.soa_dir,
                     plaintext=plaintext,
                     service_name=self.service_name,
+                    transit_key=self.encryption_key,
                 )
 
     def decrypt_secret(self, secret_name: str) -> str:

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -2,7 +2,7 @@
 clusterman_metrics==2.0.0
 crypto_lib==4.0.0
 scribereader==0.2.6
-vault-tools==0.7.24
+vault-tools==0.7.25
 yelp-cgeom==1.3.1
 yelp-logging==1.0.37
 yelp_meteorite


### PR DESCRIPTION
This makes it possible to override the vault transit key used for
encyption/decryption in service.yaml. This will allow services to
specify their own key and then customise the policies to determine who
has access to decrypt/encrypt.