### PR TITLE
bump requests to 2.21.0 to fix failing itest_trusty

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ pytimeparse==1.1.5
 pytz==2016.10
 PyYAML==3.12
 repoze.lru==0.6
-requests==2.19.0
+requests==2.21.0
 requests-cache==0.4.10
 requests-oauthlib==0.8.0
 requests-toolbelt==0.4.0


### PR DESCRIPTION
`itest_trusty` for the yelp package is failing a good portion of the time (unsure why not always?) with
```
21:24:40 [trusty] Error: version conflict: requests 2.19.0 (.tox/manpages/lib/python3.6/site-packages) <-> requests>=2.21.0 (from hvac>=0.2.17->vault-tools==0.7.24->-r /work/requirements.txt (line 120))
```