### PR TITLE
Remove duplicate authors list on "Finished deployment"

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -312,7 +312,6 @@ class SlackDeployNotifier:
                     f"{self.authors}"
                 ),
                 (
-                    f"{self.authors}\n"
                     f"{self.url_message}\n"
                     "If you need to roll back, run:\n"
                     f"`paasta rollback --service {self.service} --deploy-group {self.deploy_group} "


### PR DESCRIPTION
Whoops. In #2090 I missed this, we're including authors in both the thread and the initial message now for this one specific message.