### PR TITLE
Set yaml width to 120 for rightsizing script

### DIFF
--- a/paasta_tools/contrib/paasta_update_soa_memcpu.py
+++ b/paasta_tools/contrib/paasta_update_soa_memcpu.py
@@ -188,7 +188,7 @@ def edit_soa_configs(filename, instance, cpu):
 
     instdict = data[instance]
     instdict['cpus'] = cpu
-    out = yaml.round_trip_dump(data, width=10000)
+    out = yaml.round_trip_dump(data, width=120)
 
     with open(filename, 'w') as fi:
         fi.write(out)


### PR DESCRIPTION
The pre-commit hook for yelpsoa-configs uses width=120.