### PR TITLE
Don't try to pin python setup stuff in the trusty dockerfile

### DIFF
--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update > /dev/null && \
         libyaml-dev \
         python3.6-dev \
         python-pip \
+        python-tox \
         wget \
         zsh > /dev/null \
     && rm -rf /var/lib/apt/lists/*
@@ -43,8 +44,6 @@ RUN apt-get update && cd /tmp && \
     wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
     gdebi -n dh-virtualenv*.deb && \
     rm dh-virtualenv_*.deb
-
-RUN pip install virtualenv==15.1.0 tox-pip-extensions==1.2.1 tox==3.1.3
 
 ADD mesos-slave-secret /etc/mesos-slave-secret
 


### PR DESCRIPTION
We don't do this in the xenial build, so I don't know why we would need to do it in the trusty one.

I think this is causing weird trusty pip breakage in our jenkins that I can't repro.