### PR TITLE
make boost work for non-default pools

### DIFF
--- a/paasta_tools/autoscaling/load_boost.py
+++ b/paasta_tools/autoscaling/load_boost.py
@@ -135,12 +135,12 @@ def get_boost_values(
 
 def set_boost_factor(
     zk_boost_path: str,
-    region: str='',
-    pool: str='',
-    send_clusterman_metrics: bool=False,
-    factor: float=DEFAULT_BOOST_FACTOR,
-    duration_minutes: int=DEFAULT_BOOST_DURATION,
-    override: bool=False,
+    region: str = '',
+    pool: str = '',
+    send_clusterman_metrics: bool = False,
+    factor: float = DEFAULT_BOOST_FACTOR,
+    duration_minutes: int = DEFAULT_BOOST_DURATION,
+    override: bool = False,
 ) -> bool:
     """
     Set a boost factor for a path in zk
@@ -174,7 +174,7 @@ def set_boost_factor(
 
     if clusterman_metrics and send_clusterman_metrics:
         cluster = load_system_paasta_config().get_cluster()
-        metrics_client = clusterman_metrics.ClustermanMetricsBotoClient(region_name=region, app_identifier='default')
+        metrics_client = clusterman_metrics.ClustermanMetricsBotoClient(region_name=region, app_identifier=pool)
         with metrics_client.get_writer(clusterman_metrics.APP_METRICS) as writer:
             metrics_key = clusterman_metrics.generate_key_with_dimensions(
                 'boost_factor',


### PR DESCRIPTION
* make flake8 shut up about white space
* pass in the pool as the app_identifier for clusterman.  This works right now because we assume that the pool name and the app identifier are the same thing, this will break at some point in the future if/when that assumption no longer holds.  But honestly, I'm kinda hoping we're not using boost at that point anyways so *shrug*

Confirmed this works on the jade_m5 pool.