### PR TITLE
Bump versions of pip, tox and virtualenv in Makefile, make tests pass on macos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_cache:
 python:
   - "3.6"
 env:
-  - TOXENV=py36,docs,mypy
+  - TOXENV=py36-linux,docs,mypy
   - TOXENV=general_itests
   - TOXENV=paasta_itests
   - TOXENV=example_cluster

--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,7 @@ test: .paasta/bin/activate
 
 .paasta/bin/activate: requirements.txt requirements-dev.txt
 	test -d .paasta/bin/activate || virtualenv -p python3.6 .paasta
-	.paasta/bin/pip install -U pip==9.0.1
-	.paasta/bin/pip install -U virtualenv==15.1.0
-	.paasta/bin/pip install -U tox==2.6.0
-	.paasta/bin/pip install -U tox-pip-extensions==1.2.1
+	.paasta/bin/pip install -U pip virtualenv tox tox-pip-extensions
 	touch .paasta/bin/activate
 
 itest: test .paasta/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,11 @@ test: .paasta/bin/activate
 
 .paasta/bin/activate: requirements.txt requirements-dev.txt
 	test -d .paasta/bin/activate || virtualenv -p python3.6 .paasta
-	.paasta/bin/pip install -U pip virtualenv tox tox-pip-extensions
+	.paasta/bin/pip install -U \
+		pip==18.1 \
+		virtualenv==16.2.0 \
+		tox==3.7.0 \
+		tox-pip-extensions==1.4.2
 	touch .paasta/bin/activate
 
 itest: test .paasta/bin/activate

--- a/paasta_tools/autoscaling/pause_service_autoscaler.py
+++ b/paasta_tools/autoscaling/pause_service_autoscaler.py
@@ -3,7 +3,7 @@ import time
 from datetime import datetime
 
 import pytz
-from tzlocal import get_localzone as wrong_localzone
+from tzlocal import get_localzone as tzlocal_get_localzone
 
 from paasta_tools.api import client
 from paasta_tools.utils import paasta_print
@@ -13,7 +13,7 @@ def get_localzone():
     if 'TZ' in os.environ:
         return pytz.timezone(os.environ['TZ'])
     else:
-        return wrong_localzone()
+        return tzlocal_get_localzone()
 
 
 def get_service_autoscale_pause_time(cluster):

--- a/paasta_tools/autoscaling/pause_service_autoscaler.py
+++ b/paasta_tools/autoscaling/pause_service_autoscaler.py
@@ -1,10 +1,19 @@
+import os
 import time
 from datetime import datetime
 
-from tzlocal import get_localzone
+import pytz
+from tzlocal import get_localzone as wrong_localzone
 
 from paasta_tools.api import client
 from paasta_tools.utils import paasta_print
+
+
+def get_localzone():
+    if 'TZ' in os.environ:
+        return pytz.timezone(os.environ['TZ'])
+    else:
+        return wrong_localzone()
 
 
 def get_service_autoscale_pause_time(cluster):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,5 +30,5 @@ requirements-tools==1.1.2
 snowballstemmer==1.2.0
 Sphinx==1.4.1
 toml==0.9.4
-virtualenv==15.1.0
+virtualenv==16.2.0
 wrapt==1.10.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,18 @@
 [tox]
 skipsdist=True
-envlist = py36
-# The Makefile and .travis.yml override the indexserver to the public one when
-# running outside of Yelp.
-indexserver =
-    default = https://pypi.yelpcorp.com/simple
+envlist=py36-{macos,linux}
 tox_pip_extensions_ext_pip_custom_platform = true
 tox_pip_extensions_ext_venv_update = true
 docker_compose_version = 1.18.0
 
 [testenv]
+platform= macos: darwin
+          linux: linux
+# The Makefile and .travis.yml override the indexserver to the public one when
+# running outside of Yelp.
+indexserver =
+    default = macos: https://pypi.python.org/simple
+              linux: https://pypi.yelpcorp.com/simple
 basepython = python3.6
 setenv =
     TZ = UTC
@@ -17,9 +20,11 @@ deps =
     --requirement={toxinidir}/requirements.txt
     --requirement={toxinidir}/requirements-dev.txt
     --editable={toxinidir}
+pre=check-requirements
 commands =
     check-requirements
-    py.test {posargs:tests}
+    macos: py.test --ignore tests/test_iptables.py --ignore tests/test_firewall_update.py --ignore tests/test_docker_wrapper.py --ignore tests/test_firewall.py --ignore tests/test_firewall_logging.py {posargs:tests}
+    linux: py.test {posargs:tests}
 
 [testenv:docs]
 commands =


### PR DESCRIPTION
Any particular reason we need that pin?

The reason i made this PR is `make test` was failing worse than it usually does on macos.