### PR TITLE
Allow templates prefixed with underscores in tronfigs

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -157,5 +157,11 @@
         ".+": {"$ref": "#definitions/job"}
       }
     }
+  },
+  "patternProperties": {
+    "^_.*$": {
+      "type": "object",
+      "additionalProperties": true
+    }
   }
 }

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -530,6 +530,7 @@ def load_tron_yaml(service: str, cluster: str, soa_dir: str) -> Dict[str, Any]:
 def load_tron_service_config(service, cluster, load_deployments=True, soa_dir=DEFAULT_SOA_DIR):
     """Load all configured jobs for a service, and any additional config values."""
     config = load_tron_yaml(service=service, cluster=cluster, soa_dir=soa_dir)
+    config = {key: value for key, value in config.items() if not key.startswith('_')}  # filter templates
     extra_config = {key: value for key, value in config.items() if key != 'jobs'}
     jobs = config.get('jobs') or []
     if isinstance(jobs, list):

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -660,6 +660,30 @@ jobs:
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
+def test_tron_validate_schema_understands_underscores(
+    mock_get_file_contents, capfd,
+):
+    tron_content = """
+_my_template: &a_template
+    actions:
+        - name: first
+          command: echo hello world
+
+jobs:
+    - name: test_job
+      node: batch_box
+      schedule:
+        type: cron
+        value: "0 7 * * 5"
+      <<: *a_template
+"""
+    mock_get_file_contents.return_value = tron_content
+    assert validate_schema('unused_service_path.yaml', 'tron')
+    output, _ = capfd.readouterr()
+    assert SCHEMA_VALID in output
+
+
+@patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_tron_validate_schema_job_extra_properties_bad(
     mock_get_file_contents, capfd,
 ):

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -686,6 +686,7 @@ class TestTronTools:
     @mock.patch('paasta_tools.tron_tools.load_tron_yaml', autospec=True)
     def test_load_tron_service_config(self, mock_load_tron_yaml):
         mock_load_tron_yaml.return_value = {
+            '_template': {'actions': {'action1': {}}},
             'extra': 'data',
             'jobs': {
                 'job1': {
@@ -706,7 +707,7 @@ class TestTronTools:
                 soa_dir='fake',
             ),
         ]
-        assert extra_config == {'extra': 'data'}
+        assert extra_config == {'extra': 'data'}  # template filtered out
         mock_load_tron_yaml.assert_called_once_with(
             service='service',
             cluster='test-cluster',


### PR DESCRIPTION
### Description
Roses are red,
Violet are blue,
If marathon and chronos configs allow underscore-prefixed templates,
then tronfigs can too!

### Testing
make test
manual testing on soa-configs files

### Notes to reviewers
- I ran into an edge case where if we put templates into a MASTER file, `tronfig` (as part of validation) will fail on any file that depends on it. But since we are moving tronfigs to service directories and jobs will no longer live in MASTER files, this will not be a factor much longer so I am removing it.