### PR TITLE
Creates an audit log across services

### DIFF
--- a/paasta_tools/cli/cmds/autoscale.py
+++ b/paasta_tools/cli/cmds/autoscale.py
@@ -18,6 +18,7 @@ from paasta_tools.api import client
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
+from paasta_tools.utils import _log_audit
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
 from paasta_tools.utils import paasta_print
@@ -71,6 +72,14 @@ def paasta_autoscale(args):
         res, http = api.autoscaler.update_autoscaler_count(
             service=service, instance=args.instance, json_body=body,
         ).result()
+
+        _log_audit(
+            action='manual-scale',
+            action_details=body,
+            service=service,
+            instance=args.instance,
+            cluster=args.cluster,
+        )
 
     log.debug(f"Res: {res} Http: {http}")
     print(res["desired_instances"])

--- a/paasta_tools/cli/cmds/cook_image.py
+++ b/paasta_tools/cli/cmds/cook_image.py
@@ -19,6 +19,7 @@ import sys
 from paasta_tools.cli.cmds.check import makefile_responds_to
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.utils import _log
+from paasta_tools.utils import _log_audit
 from paasta_tools.utils import _run
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_username
@@ -93,6 +94,15 @@ def paasta_cook_image(args, service=None, soa_dir=None):
                 line='ERROR: make cook-image failed for %s.' % service,
                 component='build',
                 level='event',
+            )
+        else:
+            action_details = {
+                'tag': tag,
+            }
+            _log_audit(
+                action='cook-image',
+                action_details=action_details,
+                service=service,
             )
         return returncode
 

--- a/paasta_tools/cli/cmds/emergency_restart.py
+++ b/paasta_tools/cli/cmds/emergency_restart.py
@@ -16,6 +16,7 @@ from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
+from paasta_tools.utils import _log_audit
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
@@ -78,6 +79,13 @@ def paasta_emergency_restart(args):
         instances=args.instance,
         system_paasta_config=system_paasta_config,
     )
+    _log_audit(
+        action='emergency-restart',
+        service=args.service,
+        cluster=args.cluster,
+        instance=args.instance,
+    )
+
     paasta_print("Output: %s" % output)
     paasta_print("%s" % "\n".join(paasta_emergency_restart.__doc__.splitlines()[-7:]))
     paasta_print("Run this to see the status:")

--- a/paasta_tools/cli/cmds/emergency_start.py
+++ b/paasta_tools/cli/cmds/emergency_start.py
@@ -16,6 +16,7 @@ from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
+from paasta_tools.utils import _log_audit
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
@@ -73,6 +74,13 @@ def paasta_emergency_start(args):
         instances=args.instance,
         system_paasta_config=system_paasta_config,
     )
+    _log_audit(
+        action='emergency-start',
+        service=service,
+        cluster=args.cluster,
+        instance=args.instance,
+    )
+
     paasta_print("%s" % "\n".join(paasta_emergency_start.__doc__.splitlines()[-8:]))
     paasta_print("Output: %s" % PaastaColors.grey(output))
     paasta_print("Run this command to see the status:")

--- a/paasta_tools/cli/cmds/emergency_stop.py
+++ b/paasta_tools/cli/cmds/emergency_stop.py
@@ -16,6 +16,7 @@ from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
+from paasta_tools.utils import _log_audit
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
@@ -70,6 +71,13 @@ def paasta_emergency_stop(args):
         instances=args.instance,
         system_paasta_config=system_paasta_config,
     )
+    _log_audit(
+        action='emergency-stop',
+        service=service,
+        cluster=args.cluster,
+        instance=args.instance,
+    )
+
     paasta_print("Output: %s" % output)
     paasta_print("%s" % "\n".join(paasta_emergency_stop.__doc__.splitlines()[-7:]))
     paasta_print("To start this service again asap, run:")

--- a/paasta_tools/cli/cmds/generate_pipeline.py
+++ b/paasta_tools/cli/cmds/generate_pipeline.py
@@ -22,6 +22,7 @@ from paasta_tools.cli.utils import NoSuchService
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.monitoring_tools import get_team
 from paasta_tools.monitoring_tools import get_team_email_address
+from paasta_tools.utils import _log_audit
 from paasta_tools.utils import _run
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_git_url
@@ -59,6 +60,7 @@ def paasta_generate_pipeline(args):
         return 1
 
     generate_pipeline(service=service, soa_dir=soa_dir)
+    _log_audit(action='generate-pipeline', service=service)
 
 
 def get_git_repo_for_fab_repo(service, soa_dir):

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -47,6 +47,7 @@ from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.slack import get_slack_client
 from paasta_tools.utils import _log
+from paasta_tools.utils import _log_audit
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import format_tag
 from paasta_tools.utils import get_git_url
@@ -190,6 +191,17 @@ def mark_for_deployment(git_url, deploy_group, service, commit):
                 component='deploy',
                 level='event',
             )
+
+            audit_action_details = {
+                'deploy_group': deploy_group,
+                'commit': commit,
+            }
+            _log_audit(
+                action='mark-for-deployment',
+                action_details=audit_action_details,
+                service=service,
+            )
+
             return 0
     return 1
 

--- a/paasta_tools/cli/cmds/pause_service_autoscaler.py
+++ b/paasta_tools/cli/cmds/pause_service_autoscaler.py
@@ -15,6 +15,7 @@
 from paasta_tools.autoscaling.pause_service_autoscaler import delete_service_autoscale_pause_time
 from paasta_tools.autoscaling.pause_service_autoscaler import get_service_autoscale_pause_time
 from paasta_tools.autoscaling.pause_service_autoscaler import update_service_autoscale_pause_time
+from paasta_tools.utils import _log_audit
 from paasta_tools.utils import paasta_print
 
 MAX_PAUSE_DURATION = 320
@@ -82,8 +83,17 @@ def paasta_pause_service_autoscaler(args):
         return_code = get_service_autoscale_pause_time(args.cluster)
     elif args.resume:
         return_code = delete_service_autoscale_pause_time(args.cluster)
+        _log_audit(
+            action='resume-service-autoscaler',
+            cluster=args.cluster,
+        )
     else:
         minutes = args.duration
         return_code = update_service_autoscale_pause_time(args.cluster, minutes)
+        _log_audit(
+            action='pause-service-autoscaler',
+            action_details={'duration': minutes},
+            cluster=args.cluster,
+        )
 
     return return_code

--- a/paasta_tools/cli/cmds/push_to_registry.py
+++ b/paasta_tools/cli/cmds/push_to_registry.py
@@ -29,6 +29,7 @@ from paasta_tools.cli.utils import validate_full_git_sha
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.generate_deployments_for_service import build_docker_image_name
 from paasta_tools.utils import _log
+from paasta_tools.utils import _log_audit
 from paasta_tools.utils import _run
 from paasta_tools.utils import build_docker_tag
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -132,6 +133,11 @@ def paasta_push_to_registry(args):
             loglines.append('See output: %s' % output)
     else:
         loglines.append('Successfully pushed image for %s to registry' % args.commit)
+        _log_audit(
+            action='push-to-registry',
+            action_details={'commit': args.commit},
+            service=service,
+        )
     for logline in loglines:
         _log(
             service=service,

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -18,6 +18,7 @@ import sys
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.secret_tools import get_secret_provider
 from paasta_tools.secret_tools import SHARED_SECRET_SERVICE
+from paasta_tools.utils import _log_audit
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
@@ -184,6 +185,15 @@ def paasta_secret(args):
             plaintext=plaintext,
         )
         secret_path = os.path.join(secret_provider.secret_dir, f"{args.secret_name}.json")
+        _log_audit(
+            action=f'{args.action}-secret',
+            action_details={
+                'secret_name': args.secret_name,
+                'clusters': args.clusters,
+            },
+            service=service,
+        )
+
         print_paasta_helper(secret_path, args.secret_name, args.shared)
     elif args.action == "decrypt":
         print(decrypt_secret(

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -98,6 +98,13 @@ def log_event(service_config, desired_state):
         line=line,
     )
 
+    utils._log_audit(
+        action=desired_state,
+        service=service_config.get_service(),
+        cluster=service_config.get_cluster(),
+        instance=service_config.get_instance(),
+    )
+
 
 def issue_state_change_for_service(service_config, force_bounce, desired_state):
     ref_mutator = make_mutate_refs_func(

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -45,6 +45,7 @@ from paasta_tools.chronos_tools import load_chronos_job_config
 from paasta_tools.kubernetes_tools import load_kubernetes_service_config
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.tron_tools import load_tron_instance_config
+from paasta_tools.utils import _log_audit
 from paasta_tools.utils import _run
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -685,6 +686,19 @@ def execute_paasta_cluster_boost_on_remote_master(
             override=override,
             boost=boost,
             verbose=verbose,
+        )
+
+        audit_details = {
+            'boost_action': action,
+            'pool': pool,
+            'duration': duration,
+            'override': override,
+            'boost': boost,
+        }
+        _log_audit(
+            action='cluster-boost',
+            action_details=audit_details,
+            cluster=cluster,
         )
 
     aggregated_code = 0

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -29,6 +29,7 @@ import queue
 import re
 import shlex
 import signal
+import socket
 import sys
 import tempfile
 import threading
@@ -93,6 +94,11 @@ ANY_CLUSTER = 'N/A'
 ANY_INSTANCE = 'N/A'
 DEFAULT_LOGLEVEL = 'event'
 no_escape = re.compile(r'\x1B\[[0-9;]*[mK]')
+
+# instead of the convention of using underscores in this scribe channel name,
+# the audit log uses dashes to prevent collisions with a service that might be
+# named 'audit_log'
+AUDIT_LOG_STREAM = 'stream_paasta-audit-log'
 
 DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT = "http://{host:s}:{port:d}/;csv;norefresh"
 
@@ -1084,6 +1090,18 @@ class LogWriter:
     ) -> None:
         raise NotImplementedError()
 
+    def log_audit(
+        self,
+        user: str,
+        host: str,
+        action: str,
+        action_details: dict = None,
+        service: str = None,
+        cluster: str = ANY_CLUSTER,
+        instance: str = ANY_INSTANCE,
+    ) -> None:
+        raise NotImplementedError()
+
 
 _LogWriterTypeT = TypeVar('_LogWriterTypeT', bound=Type[LogWriter])
 
@@ -1133,6 +1151,30 @@ def _log(
     )
 
 
+def _log_audit(
+    action: str,
+    action_details: dict = None,
+    service: str = None,
+    cluster: str = ANY_CLUSTER,
+    instance: str = ANY_INSTANCE,
+) -> None:
+    if _log_writer is None:
+        configure_log()
+
+    user = get_username()
+    host = get_hostname()
+
+    return _log_writer.log_audit(
+        user=user,
+        host=host,
+        action=action,
+        action_details=action_details,
+        service=service,
+        cluster=cluster,
+        instance=instance,
+    )
+
+
 def _now() -> str:
     return datetime.datetime.utcnow().isoformat()
 
@@ -1169,6 +1211,47 @@ def format_log_line(
             'instance': instance,
             'component': component,
             'message': line,
+        }, sort_keys=True,
+    )
+    return message
+
+
+def format_audit_log_line(
+    cluster: str,
+    instance: str,
+    user: str,
+    host: str,
+    action: str,
+    action_details: dict = None,
+    service: str = None,
+    timestamp: str = None,
+) -> str:
+    """Accepts:
+
+        * a string 'user' describing the user that initiated the action
+        * a string 'host' describing the server where the user initiated the action
+        * a string 'action' describing an action performed by paasta_tools
+        * a dict 'action_details' optional information about the action
+
+    Returns an appropriately-formatted dictionary which can be serialized to
+    JSON for logging and which contains details about an action performed on
+    a service/instance.
+    """
+    if not timestamp:
+        timestamp = _now()
+    if not action_details:
+        action_details = {}
+
+    message = json.dumps(
+        {
+            'timestamp': timestamp,
+            'cluster': cluster,
+            'service': service,
+            'instance': instance,
+            'user': user,
+            'host': host,
+            'action': action,
+            'action_details': action_details,
         }, sort_keys=True,
     )
     return message
@@ -1214,6 +1297,28 @@ class ScribeLogWriter(LogWriter):
         formatted_line = format_log_line(level, cluster, service, instance, component, line)
         self.clog.log_line(log_name, formatted_line)
 
+    def log_audit(
+        self,
+        user: str,
+        host: str,
+        action: str,
+        action_details: dict = None,
+        service: str = None,
+        cluster: str = ANY_CLUSTER,
+        instance: str = ANY_INSTANCE,
+    ) -> None:
+        log_name = AUDIT_LOG_STREAM
+        formatted_line = format_audit_log_line(
+            user=user,
+            host=host,
+            action=action,
+            action_details=action_details,
+            service=service,
+            cluster=cluster,
+            instance=instance,
+        )
+        self.clog.log_line(log_name, formatted_line)
+
 
 @register_log_writer('null')
 class NullLogWriter(LogWriter):
@@ -1234,6 +1339,18 @@ class NullLogWriter(LogWriter):
     ) -> None:
         pass
 
+    def log_audit(
+        self,
+        user: str,
+        host: str,
+        action: str,
+        action_details: dict = None,
+        service: str = None,
+        cluster: str = ANY_CLUSTER,
+        instance: str = ANY_INSTANCE,
+    ) -> None:
+        pass
+
 
 @contextlib.contextmanager
 def _empty_context() -> Iterator[None]:
@@ -1249,13 +1366,13 @@ class FileLogWriter(LogWriter):
         self,
         path_format: str,
         mode: str = 'a+',
-        line_delimeter: str = '\n',
+        line_delimiter: str = '\n',
         flock: bool = False,
     ) -> None:
         self.path_format = path_format
         self.mode = mode
         self.flock = flock
-        self.line_delimeter = line_delimeter
+        self.line_delimiter = line_delimiter
 
     def maybe_flock(self, fd: _AnyIO) -> ContextManager:
         if self.flock:
@@ -1273,6 +1390,24 @@ class FileLogWriter(LogWriter):
             instance=instance,
         )
 
+    def _log_message(self, path: str, message: str) -> None:
+        # We use io.FileIO here because it guarantees that write() is implemented with a single write syscall,
+        # and on Linux, writes to O_APPEND files with a single write syscall are atomic.
+        #
+        # https://docs.python.org/2/library/io.html#io.FileIO
+        # http://article.gmane.org/gmane.linux.kernel/43445
+
+        try:
+            with io.FileIO(path, mode=self.mode, closefd=True) as f:
+                with self.maybe_flock(f):
+                    # remove type ignore comment below once https://github.com/python/typeshed/pull/1541 is merged.
+                    f.write(message.encode('UTF-8'))  # type: ignore
+        except IOError as e:
+            paasta_print(
+                "Could not log to {}: {}: {} -- would have logged: {}".format(path, type(e).__name__, str(e), message),
+                file=sys.stderr,
+            )
+
     def log(
         self,
         service: str,
@@ -1283,28 +1418,37 @@ class FileLogWriter(LogWriter):
         instance: str = ANY_INSTANCE,
     ) -> None:
         path = self.format_path(service, component, level, cluster, instance)
-
-        # We use io.FileIO here because it guarantees that write() is implemented with a single write syscall,
-        # and on Linux, writes to O_APPEND files with a single write syscall are atomic.
-        #
-        # https://docs.python.org/2/library/io.html#io.FileIO
-        # http://article.gmane.org/gmane.linux.kernel/43445
-
         to_write = "{}{}".format(
             format_log_line(level, cluster, service, instance, component, line),
-            self.line_delimeter,
+            self.line_delimiter,
         )
 
-        try:
-            with io.FileIO(path, mode=self.mode, closefd=True) as f:
-                with self.maybe_flock(f):
-                    # remove type ignore comment below once https://github.com/python/typeshed/pull/1541 is merged.
-                    f.write(to_write.encode('UTF-8'))  # type: ignore
-        except IOError as e:
-            paasta_print(
-                "Could not log to {}: {}: {} -- would have logged: {}".format(path, type(e).__name__, str(e), to_write),
-                file=sys.stderr,
-            )
+        self._log_message(path, to_write)
+
+    def log_audit(
+        self,
+        user: str,
+        host: str,
+        action: str,
+        action_details: dict = None,
+        service: str = None,
+        cluster: str = ANY_CLUSTER,
+        instance: str = ANY_INSTANCE,
+    ) -> None:
+        path = self.format_path(AUDIT_LOG_STREAM, '', '', cluster, instance)
+        formatted_line = format_audit_log_line(
+            user=user,
+            host=host,
+            action=action,
+            action_details=action_details,
+            service=service,
+            cluster=cluster,
+            instance=instance,
+        )
+
+        to_write = f"{formatted_line}{self.line_delimiter}"
+
+        self._log_message(path, to_write)
 
 
 @contextlib.contextmanager
@@ -2174,6 +2318,13 @@ def get_username() -> str:
     http://stackoverflow.com/a/2899055
     """
     return os.environ.get('SUDO_USER', pwd.getpwuid(os.getuid())[0])
+
+
+def get_hostname() -> str:
+    """Returns the fully-qualified domain name of the server this code is
+    running on.
+    """
+    return socket.getfqdn()
 
 
 def get_soa_cluster_deploy_files(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1400,8 +1400,7 @@ class FileLogWriter(LogWriter):
         try:
             with io.FileIO(path, mode=self.mode, closefd=True) as f:
                 with self.maybe_flock(f):
-                    # remove type ignore comment below once https://github.com/python/typeshed/pull/1541 is merged.
-                    f.write(message.encode('UTF-8'))  # type: ignore
+                    f.write(message.encode('UTF-8'))
         except IOError as e:
             paasta_print(
                 "Could not log to {}: {}: {} -- would have logged: {}".format(path, type(e).__name__, str(e), message),

--- a/tests/cli/test_cmds_cook_image.py
+++ b/tests/cli/test_cmds_cook_image.py
@@ -14,12 +14,15 @@
 import mock
 
 from paasta_tools.cli.cmds.cook_image import paasta_cook_image
+from paasta_tools.utils import get_username
 
 
 @mock.patch('paasta_tools.cli.cmds.cook_image.validate_service_name', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.cook_image.makefile_responds_to', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.cook_image._run', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.cook_image._log_audit', autospec=True)
 def test_run_success(
+    mock_log_audit,
     mock_run,
     mock_makefile_responds_to,
     mock_validate_service_name,
@@ -32,11 +35,19 @@ def test_run_success(
     args.service = 'fake_service'
     assert paasta_cook_image(args) is 0
 
+    mock_log_audit.assert_called_once_with(
+        action='cook-image',
+        action_details={'tag': 'paasta-cook-image-fake_service-{}'.format(get_username())},
+        service='fake_service',
+    )
+
 
 @mock.patch('paasta_tools.cli.cmds.cook_image.validate_service_name', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.cook_image.makefile_responds_to', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.cook_image._run', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.cook_image._log_audit', autospec=True)
 def test_run_makefile_fail(
+    mock_log_audit,
     mock_run,
     mock_makefile_responds_to,
     mock_validate_service_name,
@@ -49,6 +60,7 @@ def test_run_makefile_fail(
     args.service = 'fake_service'
 
     assert paasta_cook_image(args) == 1
+    assert not mock_log_audit.called
 
 
 class FakeKeyboardInterrupt(KeyboardInterrupt):
@@ -58,7 +70,9 @@ class FakeKeyboardInterrupt(KeyboardInterrupt):
 @mock.patch('paasta_tools.cli.cmds.cook_image.validate_service_name', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.cook_image.makefile_responds_to', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.cook_image._run', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.cook_image._log_audit', autospec=True)
 def test_run_keyboard_interrupt(
+    mock_log_audit,
     mock_run,
     mock_makefile_responds_to,
     mock_validate_service_name,
@@ -72,3 +86,4 @@ def test_run_keyboard_interrupt(
     args.service = 'fake_service'
 
     assert paasta_cook_image(args) == 2
+    assert not mock_log_audit.called

--- a/tests/cli/test_cmds_generate_pipeline.py
+++ b/tests/cli/test_cmds_generate_pipeline.py
@@ -126,7 +126,9 @@ def test_generate_pipeline_uses_team_name_as_fallback_for_owner(
 @patch('paasta_tools.cli.cmds.generate_pipeline.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.generate_pipeline.guess_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.generate_pipeline.generate_pipeline', autospec=True)
+@patch('paasta_tools.cli.cmds.generate_pipeline._log_audit', autospec=True)
 def test_paasta_generate_pipeline_success_guesses_service_name(
+        mock_log_audit,
         mock_generate_pipeline,
         mock_guess_service_name,
         mock_validate_service_name,
@@ -138,11 +140,14 @@ def test_paasta_generate_pipeline_success_guesses_service_name(
     args.service = None
     assert paasta_generate_pipeline(args) is None
     mock_generate_pipeline.assert_called_once_with(service='fake_service', soa_dir=ANY)
+    mock_log_audit.assert_called_once_with(action='generate-pipeline', service='fake_service')
 
 
 @patch('paasta_tools.cli.cmds.generate_pipeline.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.generate_pipeline.generate_pipeline', autospec=True)
+@patch('paasta_tools.cli.cmds.generate_pipeline._log_audit', autospec=True)
 def test_generate_pipeline_success_with_no_opts(
+        mock_log_audit,
         mock_generate_pipeline,
         mock_validate_service_name,
 ):
@@ -152,6 +157,7 @@ def test_generate_pipeline_success_with_no_opts(
     args.service = 'fake_service'
     assert paasta_generate_pipeline(args) is None
     mock_generate_pipeline.assert_called_once_with(service='fake_service', soa_dir=ANY)
+    mock_log_audit.assert_called_once_with(action='generate-pipeline', service='fake_service')
 
 
 @patch('paasta_tools.cli.cmds.generate_pipeline.get_git_url', autospec=True)

--- a/tests/cli/test_cmds_pause_service_autoscaler.py
+++ b/tests/cli/test_cmds_pause_service_autoscaler.py
@@ -17,7 +17,8 @@ from paasta_tools.cli.cmds.pause_service_autoscaler import MAX_PAUSE_DURATION
 from paasta_tools.cli.cmds.pause_service_autoscaler import paasta_pause_service_autoscaler
 
 
-def test_pause_autoscaler_defaults():
+@mock.patch('paasta_tools.cli.cmds.pause_service_autoscaler._log_audit', autospec=True)
+def test_pause_autoscaler_defaults(mock_log_audit):
     args = mock.Mock(
         cluster='cluster1',
         duration=30,
@@ -33,9 +34,15 @@ def test_pause_autoscaler_defaults():
         return_code = paasta_pause_service_autoscaler(args)
         mock_exc.assert_called_once_with('cluster1', 30)
         assert return_code == 0
+        mock_log_audit.assert_called_once_with(
+            action='pause-service-autoscaler',
+            action_details={'duration': 30},
+            cluster='cluster1',
+        )
 
 
-def test_pause_autoscaler_long():
+@mock.patch('paasta_tools.cli.cmds.pause_service_autoscaler._log_audit', autospec=True)
+def test_pause_autoscaler_long(mock_log_audit):
     args = mock.Mock(
         cluster='cluster1',
         duration=MAX_PAUSE_DURATION + 10,
@@ -50,9 +57,11 @@ def test_pause_autoscaler_long():
     ):
         return_code = paasta_pause_service_autoscaler(args)
         assert return_code == 3
+        assert not mock_log_audit.called
 
 
-def test_pause_autoscaler_resume():
+@mock.patch('paasta_tools.cli.cmds.pause_service_autoscaler._log_audit', autospec=True)
+def test_pause_autoscaler_resume(mock_log_audit):
     args = mock.Mock(
         cluster='cluster1',
         duration=120,
@@ -69,9 +78,14 @@ def test_pause_autoscaler_resume():
         return_code = paasta_pause_service_autoscaler(args)
         mock_exc.assert_called_once_with('cluster1')
         assert return_code == 0
+        mock_log_audit.assert_called_once_with(
+            action='resume-service-autoscaler',
+            cluster='cluster1',
+        )
 
 
-def test_pause_autoscaler_force():
+@mock.patch('paasta_tools.cli.cmds.pause_service_autoscaler._log_audit', autospec=True)
+def test_pause_autoscaler_force(mock_log_audit):
     args = mock.Mock(
         cluster='cluster1',
         duration=MAX_PAUSE_DURATION + 10,
@@ -88,9 +102,15 @@ def test_pause_autoscaler_force():
         return_code = paasta_pause_service_autoscaler(args)
         assert return_code == 0
         mock_exc.assert_called_once_with('cluster1', 330)
+        mock_log_audit.assert_called_once_with(
+            action='pause-service-autoscaler',
+            action_details={'duration': 330},
+            cluster='cluster1',
+        )
 
 
-def test_pause_autoscaler_info():
+@mock.patch('paasta_tools.cli.cmds.pause_service_autoscaler._log_audit', autospec=True)
+def test_pause_autoscaler_info(mock_log_audit):
     args = mock.Mock(
         cluster='cluster1',
         duration=30,
@@ -107,3 +127,4 @@ def test_pause_autoscaler_info():
         return_code = paasta_pause_service_autoscaler(args)
         mock_exc.assert_called_once_with('cluster1')
         assert return_code == 0
+        assert not mock_log_audit.called

--- a/tests/cli/test_cmds_rerun.py
+++ b/tests/cli/test_cmds_rerun.py
@@ -150,6 +150,8 @@ def test_rerun_validations(test_case, capfd, system_paasta_config):
     ) as mock_get_default_execution_date, patch(
         'paasta_tools.cli.cmds.rerun.load_system_paasta_config', autospec=True,
     ) as mock_load_system_paasta_config, patch(
+        'paasta_tools.cli.cmds.rerun._log_audit', autospec=True,
+    ) as mock_log_audit, patch(
         'paasta_tools.chronos_tools.read_chronos_jobs_for_service', autospec=True,
     ) as mock_read_chronos_jobs_for_service, patch(
         'service_configuration_lib.read_services_configuration', autospec=True,
@@ -218,6 +220,17 @@ def test_rerun_validations(test_case, capfd, system_paasta_config):
                 run_all_related_jobs=bool(args.rerun_type and args.rerun_type == 'graph'),
                 force_disabled=args.force_disabled,
                 system_paasta_config=mock_load_system_paasta_config.return_value,
+            )
+
+            mock_log_audit.assert_called_once_with(
+                action='chronos-rerun',
+                action_details={
+                    'rerun_type': args.rerun_type,
+                    'execution_date': execution_date.strftime(EXECUTION_DATE_FORMAT),
+                },
+                service=args.service,
+                cluster=mock.ANY,
+                instance=args.instance,
             )
 
         # The job does use time vars interpolation. Make sure the User supplied date was used.

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -118,7 +118,9 @@ def test_paasta_secret():
         'paasta_tools.cli.cmds.secret.decrypt_secret', autospec=True,
     ) as mock_decrypt_secret, mock.patch(
         'paasta_tools.cli.cmds.secret.get_plaintext_input', autospec=True,
-    ) as mock_get_plaintext_input:
+    ) as mock_get_plaintext_input, mock.patch(
+        'paasta_tools.cli.cmds.secret._log_audit', autospec=True,
+    ) as mock_log_audit:
         mock_secret_provider = mock.Mock(secret_dir='/nail/blah')
         mock_get_secret_provider_for_service.return_value = mock_secret_provider
         mock_args = mock.Mock(
@@ -135,6 +137,14 @@ def test_paasta_secret():
             secret_name='theonering',
             plaintext=mock_get_plaintext_input.return_value,
         )
+        mock_log_audit.assert_called_with(
+            action='add-secret',
+            action_details={
+                'secret_name': 'theonering',
+                'clusters': 'mesosstage',
+            },
+            service='middleearth',
+        )
 
         mock_args = mock.Mock(
             action='update',
@@ -149,6 +159,14 @@ def test_paasta_secret():
             action='update',
             secret_name='theonering',
             plaintext=mock_get_plaintext_input.return_value,
+        )
+        mock_log_audit.assert_called_with(
+            action='update-secret',
+            action_details={
+                'secret_name': 'theonering',
+                'clusters': 'mesosstage',
+            },
+            service='middleearth',
         )
 
         mock_args = mock.Mock(
@@ -180,6 +198,14 @@ def test_paasta_secret():
         mock_decrypt_secret.assert_called_with(
             secret_provider=mock_secret_provider,
             secret_name='theonering',
+        )
+        mock_log_audit.assert_called_with(
+            action='add-secret',
+            action_details={
+                'secret_name': 'theonering',
+                'clusters': 'mesosstage',
+            },
+            service='_shared',
         )
 
         mock_args = mock.Mock(

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -94,10 +94,14 @@ def test_log_event():
     with mock.patch(
         'paasta_tools.utils.get_username', autospec=True, return_value='fake_user',
     ), mock.patch(
+        'paasta_tools.utils.get_hostname', autospec=True, return_value='fake_fqdn',
+    ), mock.patch(
         'socket.getfqdn', autospec=True, return_value='fake_fqdn',
     ), mock.patch(
         'paasta_tools.utils._log', autospec=True,
-    ) as mock_log:
+    ) as mock_log, mock.patch(
+        'paasta_tools.utils._log_audit', autospec=True,
+    ) as mock_log_audit:
         service_config = MarathonServiceConfig(
             cluster='fake_cluster',
             instance='fake_instance',
@@ -105,7 +109,7 @@ def test_log_event():
             config_dict={'deploy_group': 'fake_deploy_group'},
             branch_dict=None,
         )
-        start_stop_restart.log_event(service_config, 'stopped')
+        start_stop_restart.log_event(service_config, 'stop')
         mock_log.assert_called_once_with(
             instance='fake_instance',
             service='fake_service',
@@ -114,8 +118,14 @@ def test_log_event():
             cluster='fake_cluster',
             line=(
                 "Issued request to change state of fake_instance (an instance of "
-                "fake_service) to 'stopped' by fake_user@fake_fqdn"
+                "fake_service) to 'stop' by fake_user@fake_fqdn"
             ),
+        )
+        mock_log_audit.assert_called_once_with(
+            action='stop',
+            instance='fake_instance',
+            service='fake_service',
+            cluster='fake_cluster',
         )
 
 


### PR DESCRIPTION
This commit creates an "audit log" of administrative actions taken on services
and clusters. The goal of this log is to provide a central view of actions
being taken to services across the platform. Currently this information is both
incompletely and inconsistently logged, and the information that is logged is
distributed across every service's individual logs, which is challenging and
slow to collate.

This change also renames the setting for the 'file' log writer that was
previously named 'delimeter' to 'delimiter', because spelling.

### Test Plan

I've tested this change by:

* running the unit tests (spoiler: they passed)
* running the itests (spoiler: they passed)
* poking around with the [example cluster](https://paasta.readthedocs.io/en/latest/installation/example_cluster.html)

The example cluster produced positive results for the `cook-image`, `emergency-stop/start/restart`, `mark-for-deployment`, `pause-service-autoscaler`, `push-to-registry`, `rerun`, `start`, `stop`, `restart`, `rollback`, and `boost` commands (even though the cluster boost command is disabled in the example cluster). This change contains support for audit logging in the `autoscale`, `generate-pipeline`, and `secret add/update` commands, but I was unable to validate those commands on the example cluster. I've made a note to test those specifically on mesosstage. I've also not yet run this code configured to log to scribe (any hints on how to do that prior to releasing to mesosstage?).

Here's what the audit log looks like for the actions I was able to validate:

```
{"action": "push-to-registry", "action_details": {"commit": "9cdf957d3fbbb61fa17388adb2d8e282446271fc"}, "cluster": "N/A", "host": "e93514543345", "instance": "N/A", "service": "hello-world", "timestamp": "2019-01-18T19:22:57.826991", "user": "root"}
```

```
{"action": "mark-for-deployment", "action_details": {"commit": "9cdf957d3fbbb61fa17388adb2d8e282446271fc", "deploy_group": "testcluster.everything"}, "cluster": "N/A", "host": "e93514543345", "instance": "N/A", "service": "hello-world", "timestamp": "2019-01-18T19:23:06.415982", "user": "root”}
```

```
{"action": "cook-image", "action_details": {"tag": "paasta-cook-image-hello-world-root"}, "cluster": "N/A", "host": "e93514543345", "instance": "N/A", "service": "hello-world", "timestamp": "2019-01-18T19:27:55.220279", "user": "root"}
```

```
{"action": "emergency-stop", "action_details": {}, "cluster": "testcluster", "host": "c906b1737af0", "instance": "test_chronos", "service": "hello-world", "timestamp": "2019-01-18T19:58:16.022126", "user": "root"}
{"action": "emergency-start", "action_details": {}, "cluster": "testcluster", "host": "c906b1737af0", "instance": "test_chronos", "service": "hello-world", "timestamp": "2019-01-18T19:58:44.572353", "user": "root"}
{"action": "emergency-restart", "action_details": {}, "cluster": "testcluster", "host": "c906b1737af0", "instance": "test_chronos", "service": "hello-world", "timestamp": "2019-01-18T19:59:14.576234", "user": "root"}
```

```
{"action": "pause-service-autoscaler", "action_details": {"duration": 30}, "cluster": "testcluster", "host": "e93514543345", "instance": "N/A", "service": null, "timestamp": "2019-01-18T19:33:05.925792", "user": "root"}
{"action": "resume-service-autoscaler", "action_details": {}, "cluster": "testcluster", "host": "e93514543345", "instance": "N/A", "service": null, "timestamp": "2019-01-18T19:33:14.844322", "user": "root”}
```

```
{"action": "chronos-rerun", "action_details": {"execution_date": "2019-01-18T19:35:06", "rerun_type": null}, "cluster": "testcluster", "host": "e93514543345", "instance": "test_chronos", "service": "hello-world", "timestamp": "2019-01-18T19:35:07.311133", "user": "root”}
```

```
{"action": "start", "action_details": {}, "cluster": "testcluster", "host": "e93514543345", "instance": "main", "service": "hello-world", "timestamp": "2019-01-18T19:37:52.351385", "user": "root"}
{"action": "start", "action_details": {}, "cluster": "testcluster", "host": "e93514543345", "instance": "test_chronos", "service": "hello-world", "timestamp": "2019-01-18T19:37:52.468566", "user": "root"}
{"action": "start", "action_details": {}, "cluster": "testcluster", "host": "e93514543345", "instance": "remote", "service": "hello-world", "timestamp": "2019-01-18T19:37:52.592409", "user": "root”}    
```

```
{"action": "stop", "action_details": {}, "cluster": "testcluster", "host": "e93514543345", "instance": "main", "service": "hello-world", "timestamp": "2019-01-18T19:38:31.321584", "user": "root"}
{"action": "stop", "action_details": {}, "cluster": "testcluster", "host": "e93514543345", "instance": "test_chronos", "service": "hello-world", "timestamp": "2019-01-18T19:38:31.440025", "user": "root"}
{"action": "stop", "action_details": {}, "cluster": "testcluster", "host": "e93514543345", "instance": "remote", "service": "hello-world", "timestamp": "2019-01-18T19:38:31.556309", "user": "root”}
```

```
{"action": "start", "action_details": {}, "cluster": "testcluster", "host": "e93514543345", "instance": "main", "service": "hello-world", "timestamp": "2019-01-18T19:39:00.673805", "user": "root"}
{"action": "start", "action_details": {}, "cluster": "testcluster", "host": "e93514543345", "instance": "test_chronos", "service": "hello-world", "timestamp": "2019-01-18T19:39:00.788387", "user": "root"}
{"action": "start", "action_details": {}, "cluster": "testcluster", "host": "e93514543345", "instance": "remote", "service": "hello-world", "timestamp": "2019-01-18T19:39:00.904008", "user": "root”}
```

```
{"action": "mark-for-deployment", "action_details": {"commit": "9cdf957d3fbbb61fa17388adb2d8e282446271fc", "deploy_group": "testcluster.everything"}, "cluster": "N/A", "host": "e93514543345", "instance": "N/A", "service": "hello-world", "timestamp": "2019-01-18T19:39:58.197461", "user": "root”}
```

```
{"action": "cluster-boost", "action_details": {"boost": 1.5, "boost_action": "set", "duration": 10, "override": false, "pool": "default"}, "cluster": "testcluster", "host": "e93514543345", "instance": "N/A", "service": null, "timestamp": "2019-01-18T19:41:02.163337", "user": "root"}
```

