### PR TITLE
Bump pysensu-yelp, add more monitoring options

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -888,6 +888,23 @@ Here is a list of options that PaaSTA will pass through:
  * ``project``: String naming the project where JIRA tickets will be created.
    Overrides the global default for the team.
 
+ * ``priority``: A JIRA ticket priority to use. This value should be a string
+   value like ``'0'``, ``'1'``, ``'3.14'``, etc. If not set, the default will
+   be the ``default_priority`` setting for the sensu team or the default
+   priority used for the JIRA project.
+
+ * ``tags``: An list of tags that are used as labels when creating a JIRA
+   ticket. Note that this list of tags does not overwrite the default values
+   added for sensu checks (tags like ``SENSU`` for example), it just adds to
+   that existing list.
+
+ * ``component``: Array of components affected by this check. These are used as
+   components when creating a JIRA ticket.
+
+ * ``description``: A description giving more context on the check or event.
+   This should be a longer expansion of information than what is included in
+   the ``tip`` option.
+
  * ``alert_after``: Time string that represents how long a a check should be
    failing before an actual alert should be fired. Currently defaults to ``2m``
    for the replication alert.

--- a/paasta_tools/monitoring_tools.py
+++ b/paasta_tools/monitoring_tools.py
@@ -46,6 +46,7 @@ def monitoring_defaults(key):
         'ticket': False,
         'project': None,
         'realert_every': -1,
+        'tags': [],
     }
     return defaults.get(key, None)
 
@@ -109,6 +110,22 @@ def get_ticket(overrides, service, soa_dir=DEFAULT_SOA_DIR):
 
 def get_project(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value('project', overrides, service, soa_dir)
+
+
+def get_priority(overrides, service, soa_dir=DEFAULT_SOA_DIR):
+    return __get_monitoring_config_value('priority', overrides, service, soa_dir)
+
+
+def get_tags(overrides, service, soa_dir=DEFAULT_SOA_DIR):
+    return __get_monitoring_config_value('tags', overrides, service, soa_dir)
+
+
+def get_component(overrides, service, soa_dir=DEFAULT_SOA_DIR):
+    return __get_monitoring_config_value('component', overrides, service, soa_dir)
+
+
+def get_description(overrides, service, soa_dir=DEFAULT_SOA_DIR):
+    return __get_monitoring_config_value('description', overrides, service, soa_dir)
 
 
 def __get_monitoring_config_value(
@@ -186,36 +203,41 @@ def send_event(service, check_name, overrides, status, output, soa_dir, ttl=None
     if not team:
         return
 
-    runbook = overrides.get('runbook', 'http://y/paasta-troubleshooting')
     system_paasta_config = load_system_paasta_config()
     if cluster is None:
         try:
             cluster = system_paasta_config.get_cluster()
         except PaastaNotConfiguredError:
             cluster = 'localhost'
+
     result_dict = {
+        'name': check_name,
+        'runbook': overrides.get('runbook', 'http://y/paasta-troubleshooting'),
+        'status': status,
+        'output': output,
+        'team': team,
+        'page': get_page(overrides, service, soa_dir),
         'tip': get_tip(overrides, service, soa_dir),
         'notification_email': get_notification_email(overrides, service, soa_dir),
+        'check_every': overrides.get('check_every', '1m'),
+        'realert_every': overrides.get('realert_every', monitoring_defaults('realert_every')),
+        'alert_after': overrides.get('alert_after', '5m'),
         'irc_channels': get_irc_channels(overrides, service, soa_dir),
         'slack_channels': get_slack_channels(overrides, service, soa_dir),
         'ticket': get_ticket(overrides, service, soa_dir),
         'project': get_project(overrides, service, soa_dir),
-        'page': get_page(overrides, service, soa_dir),
-        'alert_after': overrides.get('alert_after', '5m'),
-        'check_every': overrides.get('check_every', '1m'),
-        'realert_every': overrides.get('realert_every', monitoring_defaults('realert_every')),
+        'priority': get_priority(overrides, service, soa_dir),
         'source': 'paasta-%s' % cluster,
+        'tags': get_tags(overrides, service, soa_dir),
         'ttl': ttl,
+        'sensu_host': system_paasta_config.get_sensu_host(),
+        'sensu_port': system_paasta_config.get_sensu_port(),
+        'component': get_component(overrides, service, soa_dir),
+        'description': get_description(overrides, service, soa_dir),
     }
 
-    sensu_host = system_paasta_config.get_sensu_host()
-    sensu_port = system_paasta_config.get_sensu_port()
-
-    if sensu_host is not None:
-        pysensu_yelp.send_event(
-            check_name, runbook, status, output, team, sensu_host=sensu_host, sensu_port=sensu_port,
-            **result_dict,
-        )
+    if result_dict.get('sensu_host'):
+        pysensu_yelp.send_event(**result_dict)
 
 
 def read_monitoring_config(service, soa_dir=DEFAULT_SOA_DIR):

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ pymesos==0.3.9
 pyramid==1.8.4
 pyramid-swagger==2.4.1
 pyrsistent==0.13.0
-pysensu-yelp==0.4.0
+pysensu-yelp==0.4.1
 PyStaticConfiguration==0.10.3
 python-crontab==2.1.1
 python-dateutil==2.5.3

--- a/tests/test_monitoring_tools.py
+++ b/tests/test_monitoring_tools.py
@@ -331,18 +331,29 @@ class TestMonitoring_Tools:
         expected_runbook = 'http://y/paasta-troubleshooting'
         expected_check_name = fake_check_name
         expected_kwargs = {
+            'name': expected_check_name,
+            'runbook': expected_runbook,
+            'status': fake_status,
+            'output': fake_output,
+            'team': fake_team,
+            'page': True,
             'tip': fake_tip,
             'notification_email': fake_notification_email,
-            'irc_channels': fake_irc,
-            'slack_channels': fake_slack,
-            'project': None,
-            'ticket': False,
-            'page': True,
-            'alert_after': '5m',
             'check_every': '1m',
             'realert_every': -1,
+            'alert_after': '5m',
+            'irc_channels': fake_irc,
+            'slack_channels': fake_slack,
+            'ticket': False,
+            'project': None,
+            'priority': None,
             'source': 'paasta-fake_cluster',
+            'tags': [],
             'ttl': None,
+            'sensu_host': fake_sensu_host,
+            'sensu_port': fake_sensu_port,
+            'component': None,
+            'description': None,
         }
         with mock.patch(
             "paasta_tools.monitoring_tools.get_team",
@@ -377,6 +388,22 @@ class TestMonitoring_Tools:
             return_value=True,
             autospec=True,
         ) as get_page_patch, mock.patch(
+            "paasta_tools.monitoring_tools.get_priority",
+            return_value=None,
+            autospec=True,
+        ), mock.patch(
+            "paasta_tools.monitoring_tools.get_tags",
+            return_value=[],
+            autospec=True,
+        ), mock.patch(
+            "paasta_tools.monitoring_tools.get_component",
+            return_value=None,
+            autospec=True,
+        ), mock.patch(
+            "paasta_tools.monitoring_tools.get_description",
+            return_value=None,
+            autospec=True,
+        ), mock.patch(
             "pysensu_yelp.send_event", autospec=True,
         ) as pysensu_yelp_send_event_patch, mock.patch(
             'paasta_tools.monitoring_tools.load_system_paasta_config', autospec=True,
@@ -425,13 +452,6 @@ class TestMonitoring_Tools:
                 fake_soa_dir,
             )
             pysensu_yelp_send_event_patch.assert_called_once_with(
-                expected_check_name,
-                expected_runbook,
-                fake_status,
-                fake_output,
-                fake_team,
-                sensu_host=fake_sensu_host,
-                sensu_port=fake_sensu_port,
                 **expected_kwargs,
             )
             load_system_paasta_config_patch.return_value.get_cluster.assert_called_once_with()


### PR DESCRIPTION
This is mostly for the `priority` option, but having `tags`, `component`, and `description` can be useful too.

I'm also planning on refactoring this soon to just pass through any supported options to `pysensu-yelp` (except a few that can't be configured, like `check_every` for example). I'm hoping this should make the monitoring overrides a bit simpler anyway since a new function and dictionary key doesn't have to be added for every new option in `pysensu-yelp`. Thoughts?