### PR TITLE
ignore folders in marathon

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1437,7 +1437,7 @@ def kill_given_tasks(
     try:
         return client.kill_given_tasks(task_ids=task_ids, scale=scale, force=True)
     except MarathonHttpError as e:
-        # hon's interface is always async, so it is possible for you to see
+        # Marathon's interface is always async, so it is possible for you to see
         # a task in the interface and kill it, yet by the time it tries to kill
         # it, it is already gone. This is not really a failure condition, so we
         # swallow this error.

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1400,7 +1400,8 @@ def get_marathon_apps_with_clients(
     marathon_apps_with_clients: List[Tuple[MarathonApp, MarathonClient]] = []
     for client in clients:
         for app in get_all_marathon_apps(client, service_name, embed_tasks=embed_tasks):
-            marathon_apps_with_clients.append((app, client))
+            if len(app.id.split('/')) <= 2: # Ignore all folders
+                marathon_apps_with_clients.append((app, client))
     return marathon_apps_with_clients
 
 
@@ -1436,7 +1437,7 @@ def kill_given_tasks(
     try:
         return client.kill_given_tasks(task_ids=task_ids, scale=scale, force=True)
     except MarathonHttpError as e:
-        # Marathon's interface is always async, so it is possible for you to see
+        # hon's interface is always async, so it is possible for you to see
         # a task in the interface and kill it, yet by the time it tries to kill
         # it, it is already gone. This is not really a failure condition, so we
         # swallow this error.

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1389,7 +1389,11 @@ def get_all_marathon_apps(
     if service_name:
         return client.list_apps(embed_tasks=embed_tasks, app_id='/' + format_job_id(service=service_name, instance=''))
     else:
-        return client.list_apps(embed_tasks=embed_tasks)
+        # Ignore apps inside a folder
+        return [
+            app for app in client.list_apps(embed_tasks=embed_tasks)
+            if len(app.id.split('/')) <= 2
+        ]
 
 
 def get_marathon_apps_with_clients(
@@ -1400,8 +1404,7 @@ def get_marathon_apps_with_clients(
     marathon_apps_with_clients: List[Tuple[MarathonApp, MarathonClient]] = []
     for client in clients:
         for app in get_all_marathon_apps(client, service_name, embed_tasks=embed_tasks):
-            if len(app.id.split('/')) <= 2:  # Ignore all folders
-                marathon_apps_with_clients.append((app, client))
+            marathon_apps_with_clients.append((app, client))
     return marathon_apps_with_clients
 
 

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1400,7 +1400,7 @@ def get_marathon_apps_with_clients(
     marathon_apps_with_clients: List[Tuple[MarathonApp, MarathonClient]] = []
     for client in clients:
         for app in get_all_marathon_apps(client, service_name, embed_tasks=embed_tasks):
-            if len(app.id.split('/')) <= 2: # Ignore all folders
+            if len(app.id.split('/')) <= 2:  # Ignore all folders
                 marathon_apps_with_clients.append((app, client))
     return marathon_apps_with_clients
 

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -2423,7 +2423,7 @@ def test_format_marathon_app_dict_utilizes_extra_volumes():
 
 def test_get_marathon_apps_with_clients_ignore_folders():
     fake_normal_apps = [
-        mock.Mock(id='/test_app{}'.format(idx)) for idx in range(10)
+        mock.Mock(id=f'/test_app{idx}') for idx in range(10)
     ]
     fake_apps_in_folder = [
         mock.Mock(id='/folder/app'),

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1636,7 +1636,11 @@ class TestMarathonTools:
             mock.Mock(id='/fake--service.fake--instance.bouncingold'),
             mock.Mock(id='/fake--service.fake--instance.bouncingnew'),
         ]
-        list_apps_mock = mock.Mock(return_value=apps)
+        apps_inside_folder = [
+            mock.Mock(id='/folder/fake-app.fake--instance.ignoreme'),
+            mock.Mock(id='/deep/folder/fake-app.fake--instance.ignoreme'),
+        ]
+        list_apps_mock = mock.Mock(return_value=apps + apps_inside_folder)
         fake_client = mock.Mock(list_apps=list_apps_mock)
         actual = marathon_tools.get_all_marathon_apps(fake_client)
         assert actual == apps
@@ -2419,25 +2423,6 @@ def test_format_marathon_app_dict_utilizes_extra_volumes():
 
         # Assert that the complete config can be inserted into the MarathonApp model
         assert MarathonApp(**actual)
-
-
-def test_get_marathon_apps_with_clients_ignore_folders():
-    fake_normal_apps = [
-        mock.Mock(id=f'/test_app{idx}') for idx in range(10)
-    ]
-    fake_apps_in_folder = [
-        mock.Mock(id='/folder/app'),
-        mock.Mock(id='/deeper/folder/app'),
-    ]
-    with mock.patch(
-        'paasta_tools.marathon_tools.get_all_marathon_apps', autospec=True,
-        return_value=fake_normal_apps + fake_apps_in_folder,
-    ):
-        apps_returned = [
-            app for app, _
-            in marathon_tools.get_marathon_apps_with_clients([mock.Mock()])
-        ]
-        assert apps_returned == fake_normal_apps
 
 
 def test_kill_tasks_passes_through():

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -2421,6 +2421,25 @@ def test_format_marathon_app_dict_utilizes_extra_volumes():
         assert MarathonApp(**actual)
 
 
+def test_get_marathon_apps_with_clients_ignore_folders():
+    fake_normal_apps = [
+        mock.Mock(id='/test_app{}'.format(idx)) for idx in range(10)
+    ]
+    fake_apps_in_folder = [
+        mock.Mock(id='/folder/app'),
+        mock.Mock(id='/deeper/folder/app'),
+    ]
+    with mock.patch(
+        'paasta_tools.marathon_tools.get_all_marathon_apps', autospec=True,
+        return_value=fake_normal_apps + fake_apps_in_folder,
+    ):
+        apps_returned = [
+            app for app, _
+            in marathon_tools.get_marathon_apps_with_clients([mock.Mock()])
+        ]
+        assert apps_returned == fake_normal_apps
+
+
 def test_kill_tasks_passes_through():
     fake_client = mock.Mock()
     marathon_tools.kill_task(client=fake_client, app_id='app_id', task_id='task_id', scale=True)


### PR DESCRIPTION
There are some other apps also want to use marathon which make deployd unhappy. The change ignore all marathon apps if they are not the top folder, so that we can have a better work separation. 