### PR TITLE
K8S nerve updates

### DIFF
--- a/paasta_tools/cleanup_kubernetes_crds.py
+++ b/paasta_tools/cleanup_kubernetes_crds.py
@@ -93,12 +93,12 @@ def cleanup_kube_crd(
         dry_run: bool = False,
 ) -> bool:
     existing_crds = kube_client.apiextensions.list_custom_resource_definition(
-        label_selector="paasta_service",
+        label_selector="yelp.com/paasta_service",
     )
 
     success = True
     for crd in existing_crds.items:
-        service = crd.metadata.labels['paasta_service']
+        service = crd.metadata.labels['yelp.com/paasta_service']
         if not service:
             log.error(
                 f"CRD {crd.metadata.name} has empty paasta_service label",

--- a/paasta_tools/setup_kubernetes_crd.py
+++ b/paasta_tools/setup_kubernetes_crd.py
@@ -94,7 +94,7 @@ def setup_kube_crd(
         soa_dir: str = DEFAULT_SOA_DIR,
 ) -> bool:
     existing_crds = kube_client.apiextensions.list_custom_resource_definition(
-        label_selector="paasta_service",
+        label_selector="yelp.com/paasta_service",
     )
 
     success = True
@@ -109,7 +109,7 @@ def setup_kube_crd(
         metadata = crd_config.get('metadata', {})
         if 'labels' not in metadata:
             metadata['labels'] = {}
-        metadata['labels']['paasta_service'] = service
+        metadata['labels']['yelp.com/paasta_service'] = service
         desired_crd = V1beta1CustomResourceDefinition(
             api_version=crd_config.get('apiVersion'),
             kind=crd_config.get('kind'),

--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -157,8 +157,8 @@ def reconcile_kubernetes_deployment(
     desired_deployment = KubeDeployment(
         service=service,
         instance=instance,
-        git_sha=formatted_application.metadata.labels["git_sha"],
-        config_sha=formatted_application.metadata.labels["config_sha"],
+        git_sha=formatted_application.metadata.labels["yelp.com/paasta_git_sha"],
+        config_sha=formatted_application.metadata.labels["yelp.com/paasta_config_sha"],
         replicas=formatted_application.spec.replicas,
     )
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -685,8 +685,8 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     replicas=mock_get_instances.return_value,
                     selector=V1LabelSelector(
                         match_labels={
-                            'instance': mock_get_instance.return_value,
-                            'service': mock_get_service.return_value,
+                            'yelp.com/paasta_instance': mock_get_instance.return_value,
+                            'yelp.com/paasta_service': mock_get_service.return_value,
                         },
                     ),
                     strategy=mock_get_deployment_strategy_config.return_value,
@@ -694,9 +694,11 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                 ),
             )
             assert ret == expected
-            ret.metadata.labels.__setitem__.assert_called_with('config_sha', mock_get_config_hash.return_value)
+            ret.metadata.labels.__setitem__.assert_called_with(
+                'yelp.com/paasta_config_sha', mock_get_config_hash.return_value,
+            )
             ret.spec.template.metadata.labels.__setitem__.assert_called_with(
-                'config_sha',
+                'yelp.com/paasta_config_sha',
                 mock_get_config_hash.return_value,
             )
 
@@ -715,8 +717,8 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     replicas=mock_get_instances.return_value,
                     selector=V1LabelSelector(
                         match_labels={
-                            'instance': mock_get_instance.return_value,
-                            'service': mock_get_service.return_value,
+                            'yelp.com/paasta_instance': mock_get_instance.return_value,
+                            'yelp.com/paasta_service': mock_get_service.return_value,
                         },
                     ),
                     template=mock_get_pod_template_spec.return_value,
@@ -724,9 +726,11 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                 ),
             )
             assert ret == expected
-            ret.metadata.labels.__setitem__.assert_called_with('config_sha', mock_get_config_hash.return_value)
+            ret.metadata.labels.__setitem__.assert_called_with(
+                'yelp.com/paasta_config_sha', mock_get_config_hash.return_value,
+            )
             ret.spec.template.metadata.labels.__setitem__.assert_called_with(
-                'config_sha',
+                'yelp.com/paasta_config_sha',
                 mock_get_config_hash.return_value,
             )
 
@@ -749,9 +753,9 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             assert ret == V1PodTemplateSpec(
                 metadata=V1ObjectMeta(
                     labels={
-                        'git_sha': 'aaaa123',
-                        'instance': mock_get_instance.return_value,
-                        'service': mock_get_service.return_value,
+                        'yelp.com/paasta_git_sha': 'aaaa123',
+                        'yelp.com/paasta_instance': mock_get_instance.return_value,
+                        'yelp.com/paasta_service': mock_get_service.return_value,
                     },
                 ),
                 spec=V1PodSpec(
@@ -774,9 +778,9 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             ret = self.deployment.get_kubernetes_metadata('aaa123')
             assert ret == V1ObjectMeta(
                 labels={
-                    'git_sha': 'aaa123',
-                    'instance': mock_get_instance.return_value,
-                    'service': mock_get_service.return_value,
+                    'yelp.com/paasta_git_sha': 'aaa123',
+                    'yelp.com/paasta_instance': mock_get_instance.return_value,
+                    'yelp.com/paasta_service': mock_get_service.return_value,
                 },
                 name='kurupt-fm',
             )
@@ -890,8 +894,8 @@ def test_get_kubernetes_services_running_here():
                 'metadata': {
                     'namespace': 'paasta',
                     'labels': {
-                        'service': 'kurupt',
-                        'instance': 'fm',
+                        'yelp.com/paasta_service': 'kurupt',
+                        'yelp.com/paasta_instance': 'fm',
                     },
                 },
                 'spec': spec,
@@ -903,8 +907,8 @@ def test_get_kubernetes_services_running_here():
                 'metadata': {
                     'namespace': 'paasta',
                     'labels': {
-                        'service': 'kurupt',
-                        'instance': 'garage',
+                        'yelp.com/paasta_service': 'kurupt',
+                        'yelp.com/paasta_instance': 'garage',
                     },
                 },
                 'spec': spec,
@@ -915,8 +919,8 @@ def test_get_kubernetes_services_running_here():
                 'metadata': {
                     'namespace': 'paasta',
                     'labels': {
-                        'service': 'kurupt',
-                        'instance': 'grindah',
+                        'yelp.com/paasta_service': 'kurupt',
+                        'yelp.com/paasta_instance': 'grindah',
                     },
                 },
                 'spec': spec,
@@ -928,8 +932,8 @@ def test_get_kubernetes_services_running_here():
                 'metadata': {
                     'namespace': 'kube-system',
                     'labels': {
-                        'service': 'kurupt',
-                        'instance': 'beats',
+                        'yelp.com/paasta_service': 'kurupt',
+                        'yelp.com/paasta_instance': 'beats',
                     },
                 },
                 'spec': spec,
@@ -1083,20 +1087,20 @@ def test_list_all_deployments():
         mock.Mock(
             metadata=mock.Mock(
                 labels={
-                    'service': 'kurupt',
-                    'instance': 'fm',
-                    'git_sha': 'a12345',
-                    'config_sha': 'b12345',
+                    'yelp.com/paasta_service': 'kurupt',
+                    'yelp.com/paasta_instance': 'fm',
+                    'yelp.com/paasta_git_sha': 'a12345',
+                    'yelp.com/paasta_config_sha': 'b12345',
                 },
             ),
         ),
         mock.Mock(
             metadata=mock.Mock(
                 labels={
-                    'service': 'kurupt',
-                    'instance': 'am',
-                    'git_sha': 'a12345',
-                    'config_sha': 'b12345',
+                    'yelp.com/paasta_service': 'kurupt',
+                    'yelp.com/paasta_instance': 'am',
+                    'yelp.com/paasta_git_sha': 'a12345',
+                    'yelp.com/paasta_config_sha': 'b12345',
                 },
             ),
         ),
@@ -1149,8 +1153,8 @@ def test_pod_disruption_budget_for_service_instance():
     assert x.metadata.namespace == "paasta"
     assert x.spec.min_available == 10
     assert x.spec.selector.match_labels == {
-        'service': 'foo',
-        'instance': 'bar',
+        'yelp.com/paasta_service': 'foo',
+        'yelp.com/paasta_instance': 'bar',
     }
 
 
@@ -1232,9 +1236,9 @@ def test_list_custom_resources():
                 'kind': 'somecluster',
                 'metadata': {
                     'labels': {
-                        'paasta_service': 'kurupt',
-                        'paasta_instance': 'fm',
-                        'paasta_config_sha': 'con123',
+                        'yelp.com/paasta_service': 'kurupt',
+                        'yelp.com/paasta_instance': 'fm',
+                        'yelp.com/paasta_config_sha': 'con123',
                     },
                 },
             },
@@ -1367,16 +1371,16 @@ def test_pods_for_service_instance():
 def test_get_active_shas_for_service():
     mock_pod_list = [
         mock.Mock(metadata=mock.Mock(labels={
-            'config_sha': 'a123',
-            'git_sha': 'b456',
+            'yelp.com/paasta_config_sha': 'a123',
+            'yelp.com/paasta_git_sha': 'b456',
         })),
         mock.Mock(metadata=mock.Mock(labels={
-            'config_sha': 'a123!!!',
-            'git_sha': 'b456!!!',
+            'yelp.com/paasta_config_sha': 'a123!!!',
+            'yelp.com/paasta_git_sha': 'b456!!!',
         })),
         mock.Mock(metadata=mock.Mock(labels={
-            'config_sha': 'a123!!!',
-            'git_sha': 'b456!!!',
+            'yelp.com/paasta_config_sha': 'a123!!!',
+            'yelp.com/paasta_git_sha': 'b456!!!',
         })),
     ]
     assert get_active_shas_for_service(mock_pod_list) == {
@@ -1398,12 +1402,12 @@ def test_get_all_nodes():
 def test_filter_pods_for_service_instance():
     mock_pod_1 = mock.MagicMock(
         metadata=mock.MagicMock(
-            labels={'service': 'kurupt', 'instance': 'fm'},
+            labels={'yelp.com/paasta_service': 'kurupt', 'yelp.com/paasta_instance': 'fm'},
         ),
     )
     mock_pod_2 = mock.MagicMock(
         metadata=mock.MagicMock(
-            labels={'service': 'kurupt', 'instance': 'garage'},
+            labels={'yelp.com/paasta_service': 'kurupt', 'yelp.com/paasta_instance': 'garage'},
         ),
     )
     mock_pods = [mock_pod_1, mock_pod_2]

--- a/tests/test_setup_kubernetes_job.py
+++ b/tests/test_setup_kubernetes_job.py
@@ -229,8 +229,8 @@ def test_reconcile_kubernetes_deployment():
                 return_value=V1Deployment(
                     metadata=V1ObjectMeta(
                         labels={
-                            'git_sha': 'a12345',
-                            'config_sha': 'b12345',
+                            'yelp.com/paasta_git_sha': 'a12345',
+                            'yelp.com/paasta_config_sha': 'b12345',
                         },
                     ),
                     spec=V1DeploymentSpec(
@@ -268,8 +268,8 @@ def test_reconcile_kubernetes_deployment():
                 return_value=V1Deployment(
                     metadata=V1ObjectMeta(
                         labels={
-                            'git_sha': 'new_image',
-                            'config_sha': 'b12345',
+                            'yelp.com/paasta_git_sha': 'new_image',
+                            'yelp.com/paasta_config_sha': 'b12345',
                         },
                     ),
                     spec=V1DeploymentSpec(
@@ -312,8 +312,8 @@ def test_reconcile_kubernetes_deployment():
                 return_value=V1Deployment(
                     metadata=V1ObjectMeta(
                         labels={
-                            'git_sha': 'a12345',
-                            'config_sha': 'newconfig',
+                            'yelp.com/paasta_git_sha': 'a12345',
+                            'yelp.com/paasta_config_sha': 'newconfig',
                         },
                     ),
                     spec=V1DeploymentSpec(
@@ -356,8 +356,8 @@ def test_reconcile_kubernetes_deployment():
                 return_value=V1Deployment(
                     metadata=V1ObjectMeta(
                         labels={
-                            'git_sha': 'a12345',
-                            'config_sha': 'b12345',
+                            'yelp.com/paasta_git_sha': 'a12345',
+                            'yelp.com/paasta_config_sha': 'b12345',
                         },
                     ),
                     spec=V1DeploymentSpec(


### PR DESCRIPTION
Probably easiest to review commits separately:
* Prefix paasta k8s labels with paasta_ 
* Enable registration of non-paasta k8s services

I haven't been careful to make this backwards compatible. Right now it takes destroying the exisiting resources and causes de-registration of running things in nerve. I think I'm okay with that at the moment because we don't have too much running. I have tested this on kubestage and it will require a bump of nerve-tools too.