### PR TITLE
Add config for kubernetes custom resources

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -899,9 +899,10 @@ def create_custom_resource(
     formatted_resource: Mapping[str, Any],
     version: str,
     kind: KubeKind,
+    group: str,
 ) -> None:
     return kube_client.custom.create_namespaced_custom_object(
-        group='yelp.com',
+        group=group,
         version=version,
         namespace=f'paasta-{kind.plural}',
         plural=kind.plural,
@@ -915,10 +916,11 @@ def update_custom_resource(
     version: str,
     name: str,
     kind: KubeKind,
+    group: str,
 ) -> None:
     co = kube_client.custom.get_namespaced_custom_object(
         name=name,
-        group='yelp.com',
+        group=group,
         version=version,
         namespace=f'paasta-{kind.plural}',
         plural=kind.plural,
@@ -926,7 +928,7 @@ def update_custom_resource(
     formatted_resource['metadata']['resourceVersion'] = co['metadata']['resourceVersion']
     return kube_client.custom.replace_namespaced_custom_object(
         name=name,
-        group='yelp.com',
+        group=group,
         version=version,
         namespace=f'paasta-{kind.plural}',
         plural=kind.plural,
@@ -938,10 +940,11 @@ def list_custom_resources(
     kind: KubeKind,
     version: str,
     kube_client: KubeClient,
+    group: str,
     label_selector: str = '',
 ) -> Sequence[KubeCustomResource]:
     crs = kube_client.custom.list_namespaced_custom_object(
-        group='yelp.com',
+        group=group,
         version=version,
         label_selector=label_selector,
         plural=kind.plural,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1564,6 +1564,17 @@ class PaastaNativeConfig(TypedDict, total=False):
 ExpectedSlaveAttributes = List[Dict[str, Any]]
 
 
+class KubeKindDict(TypedDict, total=False):
+    singular: str
+    plural: str
+
+
+class KubeCustomResourceDict(TypedDict, total=False):
+    version: str
+    file_prefix: str
+    kube_kind: KubeKindDict
+
+
 class SystemPaastaConfigDict(TypedDict, total=False):
     auto_hostname_unique_size: int
     zookeeper: str
@@ -1619,6 +1630,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     secret_provider: str
     slack: Dict[str, str]
     maintenance_resource_reservation_enabled: bool
+    kubernetes_custom_resources: List[KubeCustomResourceDict]
     hacheck_sidecar_image_url: str
     enable_nerve_readiness_check: bool
     register_k8s_pods: bool
@@ -2026,6 +2038,10 @@ class SystemPaastaConfig:
     def get_register_k8s_pods(self) -> bool:
         """Enable registration of k8s services in nerve"""
         return self.config_dict.get('register_k8s_pods', False)
+
+    def get_kubernetes_custom_resources(self) -> Sequence[KubeCustomResourceDict]:
+        """List of custom resources that should be synced by setup_kubernetes_cr """
+        return self.config_dict.get('kubernetes_custom_resources', [])
 
     def get_register_marathon_services(self) -> bool:
         """Enable registration of marathon services in nerve"""

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1573,6 +1573,7 @@ class KubeCustomResourceDict(TypedDict, total=False):
     version: str
     file_prefix: str
     kube_kind: KubeKindDict
+    group: str
 
 
 class SystemPaastaConfigDict(TypedDict, total=False):

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1193,7 +1193,13 @@ def test_update_deployment():
 def test_create_custom_resource():
     mock_client = mock.Mock()
     formatted_resource = mock.Mock()
-    create_custom_resource(mock_client, formatted_resource, version='v1', kind=mock.Mock(plural='someclusters'))
+    create_custom_resource(
+        kube_client=mock_client,
+        formatted_resource=formatted_resource,
+        version='v1',
+        kind=mock.Mock(plural='someclusters'),
+        group='yelp.com',
+    )
     mock_client.custom.create_namespaced_custom_object.assert_called_with(
         namespace='paasta-someclusters',
         body=formatted_resource,
@@ -1213,6 +1219,7 @@ def test_update_custom_resource():
         version='v1',
         kind=mock.Mock(plural='someclusters'),
         name='grindah',
+        group='yelp.com',
     )
     mock_client.custom.replace_namespaced_custom_object.assert_called_with(
         namespace='paasta-someclusters',
@@ -1252,6 +1259,7 @@ def test_list_custom_resources():
         kind=mock.Mock(plural='someclusters'),
         version='v1',
         kube_client=mock_client,
+        group='yelp.com',
     ) == expected
 
 

--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -24,12 +24,14 @@ def test_load_custom_resources():
         'version': 'v1',
         'kube_kind': {'plural': 'FlinkClusters', 'singular': 'flinkcluster'},
         'file_prefix': 'flinkcluster',
+        'group': 'yelp.com',
     }]
     mock_config = mock.Mock(get_kubernetes_custom_resources=mock.Mock(return_value=mock_resources))
     assert setup_kubernetes_cr.load_custom_resources(mock_config) == [setup_kubernetes_cr.CustomResource(
         version='v1',
         kube_kind=setup_kubernetes_cr.KubeKind(plural='FlinkClusters', singular='flinkcluster'),
         file_prefix='flinkcluster',
+        group='yelp.com',
     )]
 
 
@@ -117,6 +119,7 @@ def test_setup_custom_resources():
             kind=mock_kind,
             version='v1',
             config_dicts={},
+            group='yelp.com',
         )
 
         mock_reconcile_kubernetes_resource.side_effect = [True, False]
@@ -125,6 +128,7 @@ def test_setup_custom_resources():
             kind=mock_kind,
             version='v1',
             config_dicts={'kurupt': 'something', 'mc': 'another'},
+            group='yelp.com',
         )
 
         mock_reconcile_kubernetes_resource.side_effect = [True, True]
@@ -133,6 +137,7 @@ def test_setup_custom_resources():
             kind=mock_kind,
             version='v1',
             config_dicts={'kurupt': 'something', 'mc': 'another'},
+            group='yelp.com',
         )
         mock_reconcile_kubernetes_resource.assert_has_calls([
             mock.call(
@@ -142,6 +147,7 @@ def test_setup_custom_resources():
                 kind=mock_kind,
                 custom_resources=mock_list_cr.return_value,
                 version='v1',
+                group='yelp.com',
             ),
             mock.call(
                 kube_client=mock_client,
@@ -150,6 +156,7 @@ def test_setup_custom_resources():
                 kind=mock_kind,
                 custom_resources=mock_list_cr.return_value,
                 version='v1',
+                group='yelp.com',
             ),
         ])
 
@@ -177,6 +184,7 @@ def test_format_custom_resource():
             instance='radio_station',
             kind='flinkcluster',
             version='v1',
+            group='yelp.com',
         ) == expected
 
 
@@ -206,6 +214,7 @@ def test_reconcile_kubernetes_resource():
             custom_resources=mock_custom_resources,
             kind=mock_kind,
             version='v1',
+            group='yelp.com',
         )
         assert not mock_create_custom_resource.called
         assert not mock_update_custom_resource.called
@@ -225,6 +234,7 @@ def test_reconcile_kubernetes_resource():
             custom_resources=mock_custom_resources,
             kind=mock_kind,
             version='v1',
+            group='yelp.com',
         )
         assert not mock_create_custom_resource.called
         assert not mock_update_custom_resource.called
@@ -244,6 +254,7 @@ def test_reconcile_kubernetes_resource():
             custom_resources=mock_custom_resources,
             kind=mock_kind,
             version='v1',
+            group='yelp.com',
         )
         assert not mock_create_custom_resource.called
         mock_update_custom_resource.assert_called_with(
@@ -252,6 +263,7 @@ def test_reconcile_kubernetes_resource():
             version='v1',
             kind=mock_kind,
             formatted_resource=mock_format_custom_resource.return_value,
+            group='yelp.com',
         )
 
         # instance not exist, create
@@ -262,12 +274,14 @@ def test_reconcile_kubernetes_resource():
             custom_resources=mock_custom_resources,
             kind=mock_kind,
             version='v1',
+            group='yelp.com',
         )
         mock_create_custom_resource.assert_called_with(
             kube_client=mock_client,
             version='v1',
             kind=mock_kind,
             formatted_resource=mock_format_custom_resource.return_value,
+            group='yelp.com',
         )
 
         # instance not exist, create but error with k8s
@@ -279,10 +293,12 @@ def test_reconcile_kubernetes_resource():
             custom_resources=mock_custom_resources,
             kind=mock_kind,
             version='v1',
+            group='yelp.com',
         )
         mock_create_custom_resource.assert_called_with(
             kube_client=mock_client,
             version='v1',
             kind=mock_kind,
             formatted_resource=mock_format_custom_resource.return_value,
+            group='yelp.com',
         )


### PR DESCRIPTION
This makes it possible to set the CustomResources that we will sync in
kubernetes as a paasta config dictionary. Means we can add more custom
resources without releasing paasta_tools.