### PR TITLE
Add disk to tron validation

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -32,12 +32,17 @@
         "executor": {"enum": ["ssh", "paasta"]},
         "cpus": {
           "type": "number",
-          "minumum": 0,
+          "minimum": 0,
           "exclusiveMinimum": true
         },
         "mem": {
           "type": "number",
-          "minumum": 32,
+          "minimum": 32,
+          "exclusiveMinimum": true
+        },
+        "disk": {
+          "type": "number",
+          "minimum": 0,
           "exclusiveMinimum": true
         },
         "constraints": {

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -651,6 +651,7 @@ jobs:
           cluster: paasta-cluster-1
           cpus: 0.5
           mem: 100
+          disk: 500
           pool: custom
 """
     mock_get_file_contents.return_value = tron_content


### PR DESCRIPTION
### Description
- In order to complete adding disk support to Tron, we need to make sure tronfigs can be validated by paasta, which includes the new disk field

### Testing
make test