### PR TITLE
List all services for setup_kubernetes_cr

### DIFF
--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -22,6 +22,7 @@ Command line options:
 """
 import argparse
 import logging
+import os
 import sys
 from typing import Any
 from typing import Mapping
@@ -39,7 +40,6 @@ from paasta_tools.kubernetes_tools import list_custom_resources
 from paasta_tools.kubernetes_tools import update_custom_resource
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_config_hash
-from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import SystemPaastaConfig
 
@@ -126,11 +126,7 @@ def setup_all_custom_resources(
 
 def load_all_configs(cluster: str, file_prefix: str, soa_dir: str) -> Mapping[str, Mapping[str, Any]]:
     config_dicts = {}
-    for service, _ in get_services_for_cluster(
-        cluster=cluster,
-        instance_type=file_prefix,
-        soa_dir=soa_dir,
-    ):
+    for service in os.listdir(soa_dir):
         config_dicts[service] = service_configuration_lib.read_extra_service_information(
             service,
             f"{file_prefix}-{cluster}",

--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -86,11 +86,11 @@ def test_setup_all_custom_resources():
 
 def test_load_all_configs():
     with mock.patch(
-        'paasta_tools.setup_kubernetes_cr.get_services_for_cluster', autospec=True,
-    ) as mock_get_services_for_cluster, mock.patch(
         'paasta_tools.setup_kubernetes_cr.service_configuration_lib.read_extra_service_information', autospec=True,
-    ) as mock_read_info:
-        mock_get_services_for_cluster.return_value = [('kurupt', 'fm'), ('mc', 'grindah')]
+    ) as mock_read_info, mock.patch(
+        'os.listdir', autospec=True,
+    ) as mock_oslist:
+        mock_oslist.return_value = ['kurupt', 'mc']
         ret = setup_kubernetes_cr.load_all_configs(
             cluster='westeros-prod',
             file_prefix='thing',


### PR DESCRIPTION
We need to list all services not just ones with known instance types. By
definition custom CRs can have many file prefixes.