### PR TITLE
Make using hacheck sidecars optional

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -837,7 +837,8 @@ def get_kubernetes_services_running_here_for_nerve(
                     continue
                 nerve_dict['port'] = kubernetes_service.port
                 nerve_dict['service_ip'] = kubernetes_service.pod_ip
-                nerve_dict['hacheck_ip'] = kubernetes_service.pod_ip
+                if system_paasta_config.get_kubernetes_use_hacheck_sidecar():
+                    nerve_dict['hacheck_ip'] = kubernetes_service.pod_ip
                 nerve_list.append((registration, nerve_dict))
         except (KeyError):
             continue  # SOA configs got deleted for this app, it'll get cleaned up

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1632,6 +1632,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     slack: Dict[str, str]
     maintenance_resource_reservation_enabled: bool
     kubernetes_custom_resources: List[KubeCustomResourceDict]
+    kubernetes_use_hacheck_sidecar: bool
     hacheck_sidecar_image_url: str
     enable_nerve_readiness_check: bool
     register_k8s_pods: bool
@@ -2043,6 +2044,9 @@ class SystemPaastaConfig:
     def get_kubernetes_custom_resources(self) -> Sequence[KubeCustomResourceDict]:
         """List of custom resources that should be synced by setup_kubernetes_cr """
         return self.config_dict.get('kubernetes_custom_resources', [])
+
+    def get_kubernetes_use_hacheck_sidecar(self) -> bool:
+        return self.config_dict.get('kubernetes_use_hacheck_sidecar', True)
 
     def get_register_marathon_services(self) -> bool:
         """Enable registration of marathon services in nerve"""

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1023,6 +1023,20 @@ def test_get_kubernetes_services_running_here_for_nerve():
             },
         )]
 
+        mock_load_system_config.return_value = mock.Mock(
+            get_cluster=mock.Mock(return_value='brentford'),
+            get_register_k8s_pods=mock.Mock(return_value=True),
+            get_kubernetes_use_hacheck_sidecar=mock.Mock(return_value=False),
+        )
+        ret = get_kubernetes_services_running_here_for_nerve('brentford', '/nail/blah')
+        assert ret == [(
+            'kurupt.fm', {
+                'name': 'fm',
+                'service_ip': '10.1.1.1',
+                'port': 8888,
+            },
+        )]
+
         def mock_load_namespace_side(service, namespace, soa_dir):
             if namespace != 'kurupt':
                 raise Exception


### PR DESCRIPTION
This is so I can test a new version of hacheck with a patch to read the
service IP from X-Haproxy-Server-State as we already do for marathon
ports. If this works then we wont need hacheck in a sidecar for
kubernetes services.