### PR TITLE
raise `paasta security-check` timeout

### DIFF
--- a/paasta_tools/cli/cmds/security_check.py
+++ b/paasta_tools/cli/cmds/security_check.py
@@ -51,7 +51,7 @@ def perform_security_check(args):
 
     command = f"{security_check_command} {args.service} {args.commit}"
 
-    ret_code, output = _run(command, timeout=300, stream=True)
+    ret_code, output = _run(command, timeout=3600, stream=True)
     if ret_code != 0:
         paasta_print(
             "The security-check failed. Please visit y/security-check-runbook to learn how to fix it ("


### PR DESCRIPTION
Raise `paasta security-check` timeout to 3600 seconds to match `paasta itest`.

The security-check command now builds a service image for itself if it can't find the one created by `paasta itest`, that means we sometimes hit the 300s timeout. 3600s (the same as `paasta itest` has) should be sufficient (since security-check should take no longer than itest).