### PR TITLE
added mesos leader to metastatus command output

### DIFF
--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -23,14 +23,15 @@ from paasta_tools.api.client import get_paasta_api_client
 from paasta_tools.cli.utils import execute_paasta_metastatus_on_remote_master
 from paasta_tools.cli.utils import get_paasta_metastatus_cmd_args
 from paasta_tools.cli.utils import lazy_choices_completer
+from paasta_tools.mesos_tools import get_mesos_leader
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
+from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
-from paasta_tools.mesos_tools import get_mesos_leader
 
 
 def add_subparser(
@@ -172,7 +173,10 @@ def print_cluster_status(
     )
 
     paasta_print("Cluster: %s" % cluster)
-    paasta_print("Mesos leader: %s" % get_mesos_leader())
+    try:
+        paasta_print("Mesos leader: %s" % get_mesos_leader())
+    except PaastaNotConfiguredError:
+        pass
     paasta_print(get_cluster_dashboards(cluster))
     paasta_print(output)
     paasta_print()

--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -23,14 +23,12 @@ from paasta_tools.api.client import get_paasta_api_client
 from paasta_tools.cli.utils import execute_paasta_metastatus_on_remote_master
 from paasta_tools.cli.utils import get_paasta_metastatus_cmd_args
 from paasta_tools.cli.utils import lazy_choices_completer
-from paasta_tools.mesos_tools import get_mesos_leader
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
-from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
 
 
@@ -173,10 +171,6 @@ def print_cluster_status(
     )
 
     paasta_print("Cluster: %s" % cluster)
-    try:
-        paasta_print("Mesos leader: %s" % get_mesos_leader())
-    except PaastaNotConfiguredError:
-        pass
     paasta_print(get_cluster_dashboards(cluster))
     paasta_print(output)
     paasta_print()

--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -30,6 +30,7 @@ from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import SystemPaastaConfig
+from paasta_tools.mesos_tools import get_mesos_leader
 
 
 def add_subparser(
@@ -171,6 +172,7 @@ def print_cluster_status(
     )
 
     paasta_print("Cluster: %s" % cluster)
+    paasta_print("Mesos leader: %s" % get_mesos_leader())
     paasta_print(get_cluster_dashboards(cluster))
     paasta_print(output)
     paasta_print()

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -43,6 +43,7 @@ from paasta_tools.marathon_tools import MarathonClients
 from paasta_tools.mesos.exceptions import MasterNotAvailableException
 from paasta_tools.mesos.master import MesosMaster
 from paasta_tools.mesos.master import MesosState
+from paasta_tools.mesos_tools import get_mesos_leader
 from paasta_tools.mesos_tools import get_mesos_master
 from paasta_tools.mesos_tools import is_mesos_available
 from paasta_tools.metrics import metastatus_lib
@@ -408,6 +409,7 @@ def print_output(argv: Optional[Sequence[str]] = None) -> None:
     healthy_exit = True if all([mesos_ok, marathon_ok, chronos_ok]) else False
 
     paasta_print(f"Master paasta_tools version: {__version__}")
+    paasta_print("Mesos leader: %s" % get_mesos_leader())
     metastatus_lib.print_results_for_healthchecks(mesos_summary, mesos_ok, all_mesos_results, args.verbose)
     if args.verbose > 1 and mesos_available:
         print_with_indent('Resources Grouped by %s' % ", ".join(args.groupings), 2)

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -44,6 +44,9 @@ def test_main_no_marathon_servers():
         'paasta_tools.metrics.metastatus_lib.get_marathon_status',
         autospec=True,
         return_value=([HealthCheckResult(message='fake_output', healthy=True)]),
+    ), patch(
+        'paasta_tools.paasta_metastatus.get_mesos_leader', autospec=True,
+        return_value='localhost',
     ):
         fake_master = Mock(autospace=True)
         fake_master.state.return_value = {}
@@ -76,6 +79,9 @@ def test_main_no_chronos_config():
         'paasta_tools.metrics.metastatus_lib.get_marathon_status',
         autospec=True,
         return_value=([HealthCheckResult(message='fake_output', healthy=True)]),
+    ), patch(
+        'paasta_tools.paasta_metastatus.get_mesos_leader', autospec=True,
+        return_value='localhost',
     ):
         fake_master = Mock(autospace=True)
         fake_master.state.return_value = {}


### PR DESCRIPTION
Test
```
(py36) mingqiz@dev9-uswest1cdevc:~/paasta/paasta_tools/api/views (PAASTA-9049) $ paasta metastatus  -s example_happyhour -c mesosstage -i main -vv
here
paasta-mesosstage.yelp:5054

Master paasta_tools version: 0.83.5
Master leader: 10-40-11-110-uswest1adevc.dev.yelpcorp.com
Mesos Status: OK
  Quorum: masters: 3 configured quorum: 2
  Frameworks:
    Framework: marathon count: 3
    Framework: chronos count: 1
  CPUs: 4.34 / 297 in use (1.46%)
  Memory: 15.76 / 1294.35GB in use (1.22%)
  Disk: 24.00 / 7972.80GB in use (0.30%)
  No GPUs found!
  Tasks: running: 9 staging: 0 starting: 0
  Nodes: active: 15 inactive: 0
  Resources Grouped by region
    Region        CPU (used/total)  RAM (used/total)    Disk (used/total)   GPU (used/total)  Agent count
    uswest1-devc  4.34/297 (1.46%)  15.8G/1.3T (1.22%)  24.0G/7.8T (0.30%)  0.00/0 (100.00%)  15
Marathon Status: OK
  marathon apps:        208
  marathon tasks:        16
  marathon deployments:   8
Kubernetes Status: OK
  Kubernetes is not configured to run here
Chronos Status: OK
  Enabled chronos jobs: 7
  Jobs Queued: 0 (0.0%)


Cluster: mesosstage
Dashboards:
  Marathon RO:
    http://marathon.paasta-mesosstage.yelp/
    http://marathon1.paasta-mesosstage.yelp/
    http://marathon2.paasta-mesosstage.yelp/
  Chronos RO:  http://chronos.paasta-mesosstage.yelp/
  Mesos:       http://mesos.paasta-mesosstage.yelp
  Smartstack:  http://paasta-mesosstage.yelp:3212
```