### PR TITLE
marathon list_apps should use the function from marathon_tools

### DIFF
--- a/paasta_tools/list_marathon_service_instances.py
+++ b/paasta_tools/list_marathon_service_instances.py
@@ -31,6 +31,7 @@ import argparse
 import sys
 
 from paasta_tools.marathon_tools import DEFAULT_SOA_DIR
+from paasta_tools.marathon_tools import get_marathon_apps_with_clients
 from paasta_tools.marathon_tools import get_marathon_clients
 from paasta_tools.marathon_tools import get_marathon_servers
 from paasta_tools.marathon_tools import get_num_at_risk_tasks
@@ -111,9 +112,10 @@ def get_service_instances_that_need_bouncing(marathon_clients, soa_dir):
     for app_id, job_config in desired_job_configs.items():
         desired_ids_and_clients.add((app_id, marathon_clients.get_current_client_for_service(job_config)))
 
-    current_apps_with_clients = {}
-    for client in marathon_clients.get_all_clients():
-        current_apps_with_clients.update({(app.id.lstrip('/'), client): app for app in client.list_apps()})
+    current_apps_with_clients = {
+        (app.id.lstrip('/'), client): app
+        for app, client in get_marathon_apps_with_clients(marathon_clients.get_all_clients())
+    }
     actual_ids_and_clients = set(current_apps_with_clients.keys())
 
     undesired_apps_and_clients = actual_ids_and_clients.symmetric_difference(desired_ids_and_clients)

--- a/paasta_tools/metrics/metastatus_lib.py
+++ b/paasta_tools/metrics/metastatus_lib.py
@@ -41,6 +41,7 @@ from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import list_all_deployments
 from paasta_tools.kubernetes_tools import maybe_add_yelp_prefix
 from paasta_tools.kubernetes_tools import PodStatus
+from paasta_tools.marathon_tools import get_all_marathon_apps
 from paasta_tools.marathon_tools import MarathonClient
 from paasta_tools.mesos.master import MesosMetrics
 from paasta_tools.mesos.master import MesosState
@@ -969,7 +970,7 @@ def run_healthchecks_with_param(
 def assert_marathon_apps(
     clients: Sequence[MarathonClient],
 ) -> HealthCheckResult:
-    num_apps = [len(c.list_apps()) for c in clients]
+    num_apps = [len(get_all_marathon_apps(c)) for c in clients]
     if sum(num_apps) < 1:
         return HealthCheckResult(
             message="CRITICAL: No marathon apps running",

--- a/tests/monitoring/test_check_marathon_has_apps.py
+++ b/tests/monitoring/test_check_marathon_has_apps.py
@@ -47,12 +47,15 @@ def test_marathon_jobs_no_jobs(capfd):
 
 def test_marathon_jobs_some_jobs(capfd):
     mock_client = mock.MagicMock()
-    mock_client.list_apps.return_value = ['foo', 'bar']
     with mock.patch(
         # We expect this is tested properly elsewhere
         'paasta_tools.marathon_tools.get_list_of_marathon_clients',
         autospec=True,
         return_value=[mock_client],
+    ), mock.patch(
+        'paasta_tools.metrics.metastatus_lib.get_all_marathon_apps',
+        autospec=True,
+        return_value=['foo', 'bar'],
     ):
         with pytest.raises(SystemExit) as error:
             check_marathon_apps()


### PR DESCRIPTION
Fix issue of deployd: https://fluffy.yelpcorp.com/i/1Lwj7NqfBwpc8NHrqtPDxPjjN2J53PCR.html

git grep list_apps and trying to make them all use marathon_tools instead. 