### PR TITLE
Pass X-Nerve-Check-IP to configure_nerve

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -942,6 +942,8 @@ def get_kubernetes_services_running_here_for_nerve(
                 nerve_dict['service_ip'] = kubernetes_service.pod_ip
                 if system_paasta_config.get_kubernetes_use_hacheck_sidecar():
                     nerve_dict['hacheck_ip'] = kubernetes_service.pod_ip
+                else:
+                    nerve_dict['extra_healthcheck_headers'] = {'X-Nerve-Check-IP': kubernetes_service.pod_ip}
                 nerve_list.append((registration, nerve_dict))
         except (KeyError):
             continue  # SOA configs got deleted for this app, it'll get cleaned up

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1093,6 +1093,7 @@ def test_get_kubernetes_services_running_here_for_nerve():
                 'name': 'fm',
                 'service_ip': '10.1.1.1',
                 'port': 8888,
+                'extra_healthcheck_headers': {'X-Nerve-Check-IP': '10.1.1.1'},
             },
         )]
 


### PR DESCRIPTION
This is so that we send the IP of Kubernetes Pods to Nerve in this
header. That way a system level hacheck knows what IP to check against.
Note that I am also making us send the header in the case of marathon
tasks. This is so we can use the same hacheck for both marathon and
kubernetes tasks.