### PR TITLE
Use HTTP API for `paasta status` by default

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -640,7 +640,7 @@ def paasta_status(
     if 'USE_API_ENDPOINT' in os.environ:
         use_api_endpoint = strtobool(os.environ['USE_API_ENDPOINT'])
     else:
-        use_api_endpoint = False
+        use_api_endpoint = True
 
     return_codes = [0]
     tasks = []

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -584,7 +584,7 @@ def test_status_calls_sergeants(
         instance_whitelist={'fi': mock_instance_config.__class__},
         system_paasta_config=system_paasta_config,
         verbose=False,
-        use_api_endpoint=False,
+        use_api_endpoint=True,
     )
 
 


### PR DESCRIPTION
Switch `paasta status` to use the HTTP API endpoint by default.

It can be forced to use the old ssh-based method by specifying a false
value for `USE_API_ENDPOINT` environment variable, e.g.:
```
$ USE_API_ENDPOINT=0 paasta status -c somecluster -s someservice -i someinstance -vv
```