### PR TITLE
validate deploy groups for Tron in paasta validate

### DIFF
--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -17,8 +17,6 @@ passes all the markers required to be considered paasta ready."""
 import os
 import re
 
-from service_configuration_lib import read_service_configuration
-
 from paasta_tools.cli.cmds.validate import paasta_validate_soa_configs
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_file_contents
@@ -35,6 +33,7 @@ from paasta_tools.monitoring_tools import get_team
 from paasta_tools.utils import _run
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_git_url
+from paasta_tools.utils import get_pipeline_config
 from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import INSTANCE_TYPES
 from paasta_tools.utils import is_deploy_step
@@ -42,11 +41,6 @@ from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
-
-
-def get_pipeline_config(service, soa_dir):
-    service_configuration = read_service_configuration(service, soa_dir)
-    return service_configuration.get('deploy', {}).get('pipeline', [])
 
 
 def add_subparser(subparsers):

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -40,6 +40,8 @@ from paasta_tools.utils import paasta_print
 
 from paasta_tools import monitoring_tools
 from paasta_tools.monitoring_tools import list_teams
+from paasta_tools.utils import get_pipeline_config
+from paasta_tools.utils import is_deploy_step
 from typing import Optional
 from typing import Dict
 from typing import Any
@@ -387,11 +389,22 @@ class TronJobConfig:
                 msgs.extend(action_msgs)
         return checks_passed, msgs
 
+    def check_deploy_group(self) -> Tuple[bool, str]:
+        deploy_group = self.get_deploy_group()
+        if deploy_group is not None:
+            pipeline_steps = [step['step'] for step in get_pipeline_config(self.service, self.soa_dir)]
+            pipeline_deploy_groups = [step for step in pipeline_steps if is_deploy_step(step)]
+            if deploy_group not in pipeline_deploy_groups:
+                return False, f'deploy_group {deploy_group} is not in deploy.yaml'
+        return True, ''
+
     def validate(self) -> List[str]:
         _, error_msgs = self.check_actions()
-        check_passed, check_msg = self.check_monitoring()
-        if not check_passed:
-            error_msgs.append(check_msg)
+        checks = ['check_monitoring', 'check_deploy_group']
+        for check in checks:
+            check_passed, check_msg = getattr(self, check)()
+            if not check_passed:
+                error_msgs.append(check_msg)
         return error_msgs
 
     def __eq__(self, other):

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -224,15 +224,28 @@ class TronActionConfig(InstanceConfig):
     def get_nerve_namespace(self) -> None:
         return None
 
+    def check_deploy_group(self) -> Tuple[bool, str]:
+        deploy_group = self.get_deploy_group()
+        if deploy_group is not None:
+            pipeline_steps = [step['step'] for step in get_pipeline_config(self.service, self.soa_dir)]
+            pipeline_deploy_groups = [step for step in pipeline_steps if is_deploy_step(step)]
+            if deploy_group not in pipeline_deploy_groups:
+                return False, f'deploy_group {deploy_group} is not in service {self.service} deploy.yaml'
+        return True, ''
+
     def validate(self) -> List[str]:
         # Use InstanceConfig to validate shared config keys like cpus and mem
         error_msgs = super().validate()
-
+        name = self.get_instance()
+        msgs: List[str] = []
         if error_msgs:
-            name = self.get_instance()
-            return [f'{name}: {msg}' for msg in error_msgs]
-        else:
-            return []
+            msgs += [f'{name}: {msg}' for msg in error_msgs]
+
+        check_pass, check_msg = self.check_deploy_group()
+        if check_pass is False:
+            msgs.append(f'{name}: {check_msg}')
+
+        return msgs
 
 
 class TronJobConfig:
@@ -389,21 +402,9 @@ class TronJobConfig:
                 msgs.extend(action_msgs)
         return checks_passed, msgs
 
-    def check_deploy_group(self) -> Tuple[bool, str]:
-        deploy_groups = [action.get_deploy_group() for action in self.get_actions()]
-        deploy_groups.append(self.get_deploy_group())
-        check_deploy_groups = [deploy_group for deploy_group in deploy_groups if deploy_group is not None]
-        if len(check_deploy_groups) > 0:
-            pipeline_steps = [step['step'] for step in get_pipeline_config(self.service, self.soa_dir)]
-            pipeline_deploy_groups = [step for step in pipeline_steps if is_deploy_step(step)]
-            error_groups = [d for d in check_deploy_groups if d not in pipeline_deploy_groups]
-            if len(error_groups) > 0:
-                return False, f'deploy_group {error_groups} is not in deploy.yaml'
-        return True, ''
-
     def validate(self) -> List[str]:
         _, error_msgs = self.check_actions()
-        checks = ['check_monitoring', 'check_deploy_group']
+        checks = ['check_monitoring']
         for check in checks:
             check_passed, check_msg = getattr(self, check)()
             if not check_passed:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -71,6 +71,7 @@ from docker import Client
 from docker.utils import kwargs_from_env
 from kazoo.client import KazooClient
 from mypy_extensions import TypedDict
+from service_configuration_lib import read_service_configuration
 
 import paasta_tools.cli.fsm
 
@@ -2464,6 +2465,11 @@ def get_instance_list_from_yaml(service: str, conf_file: str, soa_dir: str) -> C
         else:
             instance_list.append((service, instance))
     return instance_list
+
+
+def get_pipeline_config(service: str, soa_dir: str = DEFAULT_SOA_DIR) -> List[Dict]:
+    service_configuration = read_service_configuration(service, soa_dir)
+    return service_configuration.get('deploy', {}).get('pipeline', [])
 
 
 def get_service_instance_list_no_cache(

--- a/tests/cli/test_cmds_check.py
+++ b/tests/cli/test_cmds_check.py
@@ -316,7 +316,7 @@ def test_check_smartstack_check_missing_port(
 
 
 @patch(
-    'paasta_tools.cli.cmds.check.'
+    'paasta_tools.utils.'
     'read_service_configuration', autospec=True,
 )
 @patch('paasta_tools.cli.cmds.check.is_file_in_dir', autospec=True)

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -396,6 +396,48 @@ class TestTronJobConfig:
         errors = job_config.validate()
         assert len(errors) == 3
 
+    @mock.patch('paasta_tools.tron_tools.get_pipeline_config', autospec=True)
+    def test_validate_invalid_deploy_group(self, mock_pipeline_config):
+        job_dict = {
+            'node': 'batch_server',
+            'schedule': 'daily 12:10:00',
+            'deploy_group': 'invalid_deploy_group',
+            'monitoring': {
+                'team': 'noop',
+                'page': True,
+            },
+            'actions': {
+                'first': {
+                    'command': 'echo first',
+                },
+            },
+        }
+        mock_pipeline_config.return_value = [{'step': 'deploy_group_1'}, {'step': 'deploy_group_2'}]
+        job_config = tron_tools.TronJobConfig('my_job', job_dict, 'fake-cluster')
+        errors = job_config.validate()
+        assert len(errors) == 1
+
+    @mock.patch('paasta_tools.tron_tools.get_pipeline_config', autospec=True)
+    def test_validate_valid_deploy_group(self, mock_pipeline_config):
+        job_dict = {
+            'node': 'batch_server',
+            'schedule': 'daily 12:10:00',
+            'deploy_group': 'deploy_group_1',
+            'monitoring': {
+                'team': 'noop',
+                'page': True,
+            },
+            'actions': {
+                'first': {
+                    'command': 'echo first',
+                },
+            },
+        }
+        mock_pipeline_config.return_value = [{'step': 'deploy_group_1'}, {'step': 'deploy_group_2'}]
+        job_config = tron_tools.TronJobConfig('my_job', job_dict, 'fake-cluster')
+        errors = job_config.validate()
+        assert len(errors) == 0
+
     def test_validate_monitoring(self):
         job_dict = {
             'node': 'batch_server',

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -438,6 +438,49 @@ class TestTronJobConfig:
         errors = job_config.validate()
         assert len(errors) == 0
 
+    @mock.patch('paasta_tools.tron_tools.get_pipeline_config', autospec=True)
+    def test_validate_invalid_action_deploy_group(self, mock_pipeline_config):
+        job_dict = {
+            'node': 'batch_server',
+            'schedule': 'daily 12:10:00',
+            'monitoring': {
+                'team': 'noop',
+                'page': True,
+            },
+            'actions': {
+                'first': {
+                    'command': 'echo first',
+                    'deploy_group': 'invalid_deploy_group',
+                },
+            },
+        }
+        mock_pipeline_config.return_value = [{'step': 'deploy_group_1'}, {'step': 'deploy_group_2'}]
+        job_config = tron_tools.TronJobConfig('my_job', job_dict, 'fake-cluster')
+        errors = job_config.validate()
+        assert len(errors) == 1
+
+    @mock.patch('paasta_tools.tron_tools.get_pipeline_config', autospec=True)
+    def test_validate_action_valid_deploy_group(self, mock_pipeline_config):
+        job_dict = {
+            'node': 'batch_server',
+            'schedule': 'daily 12:10:00',
+            'deploy_group': 'deploy_group_1',
+            'monitoring': {
+                'team': 'noop',
+                'page': True,
+            },
+            'actions': {
+                'first': {
+                    'command': 'echo first',
+                    'deploy_group': 'deploy_group_2',
+                },
+            },
+        }
+        mock_pipeline_config.return_value = [{'step': 'deploy_group_1'}, {'step': 'deploy_group_2'}]
+        job_config = tron_tools.TronJobConfig('my_job', job_dict, 'fake-cluster')
+        errors = job_config.validate()
+        assert len(errors) == 0
+
     def test_validate_monitoring(self):
         job_dict = {
             'node': 'batch_server',


### PR DESCRIPTION
If the deploy_group doesn't exist in deploy.yaml, the error message looks like:

✗ tron-mesosstage.yaml is invalid:
  deploy_group everything1 is not in deploy.yaml
  More info: http://tron.readthedocs.io/en/latest/jobs.html