### PR TITLE
`paasta status` for Flink on Kubernetes

### DIFF
--- a/paasta_itests/README.md
+++ b/paasta_itests/README.md
@@ -18,7 +18,13 @@ Once in the `paastatools` container, run the tests. The first run will take a wh
 (as it has to install the tox env), but if you don't exit the contaienr between
 runs it will be faster in the future.
 
-4. `tox -e paasta_itests_inside_container -- -i paasta-api`
+4. `tox -e paasta_itests_inside_container -- -i paasta_api`
 
-Run only, for example, the `paasta-api` itests. Just be sure to run the full tests
+Run only, for example, the `paasta_api` itests. Just be sure to run the full tests
 once before pushing, or travis might be sad.
+
+5. `tox -e paasta_itests_inside_container -- -n 'instance GET shows the marathon status of service.instance'`
+
+Run only, for example, the `instance GET shows the marathon status of service.instance`
+scenario. Just be sure to run the full tests once before pushing, or travis
+might be sad.

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -572,6 +572,10 @@
         "chronos": {
           "$ref": "#/definitions/InstanceStatusChronos",
           "description": "Chronos specifid instance status"
+        },
+        "flinkcluster": {
+          "$ref": "#/definitions/InstanceStatusFlinkCluster",
+          "description": "Flink instance status"
         }
       }
     },
@@ -802,6 +806,9 @@
         "command",
         "last_status"
       ]
+    },
+    "InstanceStatusFlinkCluster": {
+      "type": "object"
     },
     "InstanceTasks": {
       "type": "array",

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -30,6 +30,7 @@ from pyramid.response import Response
 from pyramid.view import view_config
 
 from paasta_tools import chronos_tools
+from paasta_tools import flinkcluster_tools
 from paasta_tools import kubernetes_tools
 from paasta_tools import marathon_tools
 from paasta_tools.api import settings
@@ -120,6 +121,23 @@ def adhoc_instance_status(
 ) -> Mapping[str, Any]:
     cstatus: Dict[str, Any] = {}
     return cstatus
+
+
+def flinkcluster_instance_status(
+    instance_status: Mapping[str, Any],
+    service: str,
+    instance: str,
+    verbose: bool,
+) -> Mapping[str, Any]:
+    status: Mapping[str, Any] = {}
+    client = settings.kubernetes_client
+    if client is not None:
+        status = flinkcluster_tools.get_flinkcluster_config(
+            kube_client=client,
+            service=service,
+            instance=instance,
+        )
+    return status
 
 
 def kubernetes_instance_status(
@@ -240,21 +258,29 @@ def instance_status(request):
     instance_status['instance'] = instance
 
     try:
-        actual_deployments = get_actual_deployments(service, settings.soa_dir)
+        instance_type = validate_service_instance(service, instance, settings.cluster, settings.soa_dir)
     except Exception:
         error_message = traceback.format_exc()
         raise ApiFailure(error_message, 500)
 
-    version = get_deployment_version(actual_deployments, settings.cluster, instance)
-    # exit if the deployment key is not found
-    if not version:
-        error_message = 'deployment key %s not found' % '.'.join([settings.cluster, instance])
-        raise ApiFailure(error_message, 404)
+    if instance_type != 'flinkcluster':
+        try:
+            actual_deployments = get_actual_deployments(service, settings.soa_dir)
+        except Exception:
+            error_message = traceback.format_exc()
+            raise ApiFailure(error_message, 500)
 
-    instance_status['git_sha'] = version
+        version = get_deployment_version(actual_deployments, settings.cluster, instance)
+        # exit if the deployment key is not found
+        if not version:
+            error_message = 'deployment key %s not found' % '.'.join([settings.cluster, instance])
+            raise ApiFailure(error_message, 404)
+
+        instance_status['git_sha'] = version
+    else:
+        instance_status['git_sha'] = ''
 
     try:
-        instance_type = validate_service_instance(service, instance, settings.cluster, settings.soa_dir)
         if instance_type == 'marathon':
             instance_status['marathon'] = marathon_instance_status(instance_status, service, instance, verbose)
         elif instance_type == 'chronos':
@@ -263,6 +289,8 @@ def instance_status(request):
             instance_status['adhoc'] = adhoc_instance_status(instance_status, service, instance, verbose)
         elif instance_type == 'kubernetes':
             instance_status['kubernetes'] = kubernetes_instance_status(instance_status, service, instance, verbose)
+        elif instance_type == 'flinkcluster':
+            instance_status['flinkcluster'] = flinkcluster_instance_status(instance_status, service, instance, verbose)
         else:
             error_message = f'Unknown instance_type {instance_type} of {service}.{instance}'
             raise ApiFailure(error_message, 404)

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -43,6 +43,7 @@ from paasta_tools.mesos_tools import get_tasks_from_app_id
 from paasta_tools.mesos_tools import select_tasks_by_id
 from paasta_tools.mesos_tools import TaskNotFound
 from paasta_tools.paasta_serviceinit import get_deployment_version
+from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import validate_service_instance
 log = logging.getLogger(__name__)
@@ -259,6 +260,9 @@ def instance_status(request):
 
     try:
         instance_type = validate_service_instance(service, instance, settings.cluster, settings.soa_dir)
+    except NoConfigurationForServiceError:
+        error_message = 'deployment key %s not found' % '.'.join([settings.cluster, instance])
+        raise ApiFailure(error_message, 404)
     except Exception:
         error_message = traceback.format_exc()
         raise ApiFailure(error_message, 500)

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -17,6 +17,7 @@ import difflib
 import os
 import sys
 from collections import defaultdict
+from datetime import datetime
 from distutils.util import strtobool
 from typing import Callable
 from typing import DefaultDict
@@ -29,6 +30,7 @@ from typing import Set
 from typing import Tuple
 from typing import Type
 
+import humanize
 from bravado.exception import HTTPError
 from service_configuration_lib import read_deploy
 
@@ -41,6 +43,7 @@ from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_instance_configs_for_service
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
+from paasta_tools.flinkcluster_tools import FlinkClusterConfig
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.kubernetes_tools import KubernetesDeployStatus
 from paasta_tools.marathon_serviceinit import bouncing_status_human
@@ -51,6 +54,7 @@ from paasta_tools.marathon_tools import MarathonDeployStatus
 from paasta_tools.monitoring_tools import get_team
 from paasta_tools.monitoring_tools import list_teams
 from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_soa_cluster_deploy_files
 from paasta_tools.utils import InstanceConfig
@@ -62,7 +66,10 @@ from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import SystemPaastaConfig
-HTTP_ONLY_INSTANCE_CONFIG = [KubernetesDeploymentConfig]
+HTTP_ONLY_INSTANCE_CONFIG: Sequence[Type[InstanceConfig]] = [
+    FlinkClusterConfig,
+    KubernetesDeploymentConfig,
+]
 SSH_ONLY_INSTANCE_CONFIG = [
     ChronosJobConfig,
     AdhocJobConfig,
@@ -225,12 +232,15 @@ def paasta_status_on_api_endpoint(
         return exc.status_code
 
     output.append('    instance: %s' % PaastaColors.blue(instance))
-    output.append('    Git sha:    %s (desired)' % status.git_sha)
+    if status.git_sha != '':
+        output.append('    Git sha:    %s (desired)' % status.git_sha)
 
     if status.marathon is not None:
         return print_marathon_status(service, instance, output, status.marathon)
     elif status.kubernetes is not None:
         return print_kubernetes_status(service, instance, output, status.kubernetes)
+    elif status.flinkcluster is not None:
+        return print_flinkcluster_status(service, instance, output, status.flinkcluster, verbose)
     else:
         paasta_print("Not implemented: Looks like %s is not a Marathon or Kubernetes instance" % instance)
         return 0
@@ -327,6 +337,48 @@ def status_kubernetes_job_human(
         )
 
 
+def print_flinkcluster_status(
+    service: str,
+    instance: str,
+    output: List[str],
+    status,
+    verbose: int,
+) -> int:
+    if verbose:
+        output.append(f"    Flink version: {status.config['flink-version']} {status.config['flink-revision']}")
+    else:
+        output.append(f"    Flink version: {status.config['flink-version']}")
+
+    output.append(f"    Jobs:")
+    if verbose:
+        output.append(f"      Job Name                         State       Job ID                           Started")
+    else:
+        output.append(f"      Job Name                         State       Started")
+    for job in status.jobs:
+        job_id = job['jid']
+        if verbose:
+            fmt = "      {job_name: <32.32} {state: <11} {job_id} {start_time}"
+        else:
+            fmt = "      {job_name: <32.32} {state: <11} {start_time}"
+        start_time = datetime_from_utc_to_local(datetime.utcfromtimestamp(int(job['start-time']) // 1000))
+        output.append(fmt.format(
+            job_id=job_id,
+            job_name=job['name'].split('.', 2)[2],
+            state=job['state'],
+            start_time=f'{str(start_time)} ({humanize.naturaltime(start_time)})',
+        ))
+        if job_id in status.exceptions:
+            exceptions = status.exceptions[job_id]
+            root_exception = exceptions['root-exception']
+            if root_exception is not None:
+                output.append(f"        Exception: {root_exception}")
+                ts = exceptions['timestamp']
+                if ts is not None:
+                    exc_ts = datetime_from_utc_to_local(datetime.utcfromtimestamp(int(ts) // 1000))
+                    output.append(f"            {str(exc_ts)} ({humanize.naturaltime(exc_ts)})")
+    return 0
+
+
 def print_kubernetes_status(
     service: str,
     instance: str,
@@ -402,6 +454,10 @@ def report_status_for_cluster(
 
         # Case: service deployed to cluster.instance
         if namespace in actual_deployments:
+            deployed_instances.append(instance)
+
+        # Case: flinkcluster instances don't use `deployments.json`
+        elif instance_whitelist.get(instance) == FlinkClusterConfig:
             deployed_instances.append(instance)
 
         # Case: service NOT deployed to cluster.instance

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -348,6 +348,18 @@ def print_flinkcluster_status(
         output.append(f"    Flink version: {status.config['flink-version']} {status.config['flink-revision']}")
     else:
         output.append(f"    Flink version: {status.config['flink-version']}")
+    output.append(
+        "    Jobs:"
+        f" {status.overview['jobs-running']} running,"
+        f" {status.overview['jobs-finished']} finished,"
+        f" {status.overview['jobs-failed']} failed,"
+        f" {status.overview['jobs-cancelled']} cancelled",
+    )
+    output.append(
+        "   "
+        f" {status.overview['taskmanagers']} taskmanagers,"
+        f" {status.overview['slots-available']}/{status.overview['slots-total']} slots available",
+    )
 
     output.append(f"    Jobs:")
     if verbose:

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -42,6 +42,7 @@ from paasta_tools import remote_git
 from paasta_tools.adhoc_tools import load_adhoc_job_config
 from paasta_tools.api import client
 from paasta_tools.chronos_tools import load_chronos_job_config
+from paasta_tools.flinkcluster_tools import load_flinkcluster_instance_config
 from paasta_tools.kubernetes_tools import load_kubernetes_service_config
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.tron_tools import load_tron_instance_config
@@ -860,6 +861,8 @@ def get_instance_config(
         instance_config_load_function = load_kubernetes_service_config
     elif instance_type == 'tron':
         instance_config_load_function = load_tron_instance_config
+    elif instance_type == 'flinkcluster':
+        instance_config_load_function = load_flinkcluster_instance_config
     else:
         raise NotImplementedError(
             "instance is %s of type %s which is not supported by paasta"
@@ -1037,7 +1040,7 @@ def get_instance_configs_for_service(
         soa_dir=soa_dir,
     ):
         if type_filter is None:
-            type_filter = ['marathon', 'chronos', 'adhoc', 'kubernetes', 'tron']
+            type_filter = ['marathon', 'chronos', 'adhoc', 'kubernetes', 'tron', 'flinkcluster']
         if 'marathon' in type_filter:
             for _, instance in get_service_instance_list(
                 service=service,
@@ -1102,6 +1105,20 @@ def get_instance_configs_for_service(
                 soa_dir=soa_dir,
             ):
                 yield load_tron_instance_config(
+                    service=service,
+                    instance=instance,
+                    cluster=cluster,
+                    soa_dir=soa_dir,
+                    load_deployments=False,
+                )
+        if 'flinkcluster' in type_filter:
+            for _, instance in get_service_instance_list(
+                service=service,
+                cluster=cluster,
+                instance_type='flinkcluster',
+                soa_dir=soa_dir,
+            ):
+                yield load_flinkcluster_instance_config(
                     service=service,
                     instance=instance,
                     cluster=cluster,

--- a/paasta_tools/flinkcluster_tools.py
+++ b/paasta_tools/flinkcluster_tools.py
@@ -1,0 +1,81 @@
+# Copyright 2015-2019 Yelp Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any
+from typing import List
+from typing import Mapping
+
+from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import InstanceConfig
+
+
+class FlinkClusterConfig(InstanceConfig):
+    config_filename_prefix = 'flinkcluster'
+
+    def __init__(self, service, instance, cluster, soa_dir=DEFAULT_SOA_DIR):
+        super().__init__(
+            cluster=cluster,
+            instance=instance,
+            service=service,
+            soa_dir=soa_dir,
+            config_dict={},
+            branch_dict={},
+        )
+
+    def validate(self) -> List[str]:
+        # Use InstanceConfig to validate shared config keys like cpus and mem
+        error_msgs = super().validate()
+
+        if error_msgs:
+            name = self.get_instance()
+            return [f'{name}: {msg}' for msg in error_msgs]
+        else:
+            return []
+
+
+def load_flinkcluster_instance_config(
+    service: str,
+    instance: str,
+    cluster: str,
+    load_deployments: bool = True,
+    soa_dir: str = DEFAULT_SOA_DIR,
+) -> FlinkClusterConfig:
+    return FlinkClusterConfig(
+        service=service,
+        instance=instance,
+        cluster=cluster,
+    )
+
+
+def get_flinkcluster_config(
+    kube_client: KubeClient,
+    service: str,
+    instance: str,
+) -> Mapping[str, Any]:
+    sanitised_service = service.replace('_', '--')
+    sanitised_instance = instance.replace('_', '--')
+
+    group = 'yelp.com'
+    version = 'v1alpha1'
+    namespace = 'paasta-flinkclusters'
+    plural = 'flinkclusters'
+    name = f'{sanitised_service}-{sanitised_instance}'
+    co = kube_client.custom.get_namespaced_custom_object(
+        name=name,
+        group=group,
+        version=version,
+        namespace=namespace,
+        plural=plural,
+    )
+    status = co.get('status')
+    return status

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -108,7 +108,15 @@ DEFAULT_CPU_BURST_ADD = 1
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
-INSTANCE_TYPES = ('marathon', 'chronos', 'paasta_native', 'adhoc', 'kubernetes', 'tron')
+INSTANCE_TYPES = (
+    'marathon',
+    'chronos',
+    'paasta_native',
+    'adhoc',
+    'kubernetes',
+    'tron',
+    'flinkcluster',
+)
 
 
 class TimeCacheEntry(TypedDict):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -803,6 +803,8 @@ def test_get_service_instance_list():
         (fake_name, fake_instance_1),
         (fake_name, fake_instance_1),
         (fake_name, fake_instance_1),
+        (fake_name, fake_instance_1),
+        (fake_name, fake_instance_2),
         (fake_name, fake_instance_2),
         (fake_name, fake_instance_2),
         (fake_name, fake_instance_2),
@@ -819,7 +821,8 @@ def test_get_service_instance_list():
         read_extra_info_patch.assert_any_call(fake_name, 'paasta_native-16floz', soa_dir=fake_dir)
         read_extra_info_patch.assert_any_call(fake_name, 'kubernetes-16floz', soa_dir=fake_dir)
         read_extra_info_patch.assert_any_call(fake_name, 'tron-16floz', soa_dir=fake_dir)
-        assert read_extra_info_patch.call_count == 6
+        read_extra_info_patch.assert_any_call(fake_name, 'flinkcluster-16floz', soa_dir=fake_dir)
+        assert read_extra_info_patch.call_count == 7
         assert sorted(expected) == sorted(actual)
 
 
@@ -834,6 +837,7 @@ def test_get_service_instance_list_ignores_underscore():
         fake_instance_2: {},
     }
     expected = [
+        (fake_name, fake_instance_1),
         (fake_name, fake_instance_1),
         (fake_name, fake_instance_1),
         (fake_name, fake_instance_1),
@@ -1950,6 +1954,7 @@ def test_validate_service_instance_invalid():
     mock_adhoc_instances = [('service1', 'interactive')]
     mock_k8s_instances = [('service1', 'k8s')]
     mock_tron_instances = [('service1', 'job.action')]
+    mock_flinkcluster_instances = [('service1', 'flink')]
     my_service = 'service1'
     my_instance = 'main'
     fake_cluster = 'fake_cluster'
@@ -1958,9 +1963,13 @@ def test_validate_service_instance_invalid():
         'paasta_tools.utils.get_service_instance_list',
         autospec=True,
         side_effect=[
-            mock_marathon_instances, mock_chronos_instances,
-            mock_paasta_native_instances, mock_adhoc_instances,
-            mock_k8s_instances, mock_tron_instances,
+            mock_marathon_instances,
+            mock_chronos_instances,
+            mock_paasta_native_instances,
+            mock_adhoc_instances,
+            mock_k8s_instances,
+            mock_tron_instances,
+            mock_flinkcluster_instances,
         ],
     ):
         with raises(utils.NoConfigurationForServiceError, match='Did you mean one of: main3, main2, main1?'):


### PR DESCRIPTION
```shell
$ paasta status -c kubestage -s compute-infra-test-service -i flink-stream-sql-demo

service: compute-infra-test-service
cluster: kubestage
    instance: flink-stream-sql-demo
    Flink version: 1.6.3
    Jobs: 1 running, 0 finished, 0 failed, 0 cancelled
    10 taskmanagers, 17/20 slots available
    Jobs:
      Job Name                         State       Started
      scribeheartbeat_auditing         RUNNING     2019-02-25 06:44:35 (7 hours ago)

$ paasta status -c kubestage -s compute-infra-test-service -i flink-stream-sql-demo -v

service: compute-infra-test-service
cluster: kubestage
    instance: flink-stream-sql-demo
    Flink version: 1.6.3 54e6cde @ 18.12.2018 @ 02:34:17 UTC
    Jobs: 1 running, 0 finished, 0 failed, 0 cancelled
    10 taskmanagers, 17/20 slots available
    Jobs:
      Job Name                         State       Job ID                           Started
      scribeheartbeat_auditing         RUNNING     eceed55d88a1610fc323efe02ebc9a2e 2019-02-25 06:44:35 (7 hours ago)
```