### PR TITLE
use mesos 1.7.1 in itests

### DIFF
--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update > /dev/null && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF && \
     apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        libsasl2-modules mesos=1.7.0-2.0.3 > /dev/null && \
+        libsasl2-modules mesos=1.7.1-2.0.1 > /dev/null && \
     apt-get clean
 
 RUN apt-get update > /dev/null && \

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update > /dev/null && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF && \
     apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        libsasl2-modules mesos=1.7.0-2.0.3 > /dev/null && \
+        libsasl2-modules mesos=1.7.1-2.0.1 > /dev/null && \
     apt-get clean
 
 RUN apt-get update > /dev/null && \

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -38,7 +38,7 @@ RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources
         docker-ce=17.03.2~ce-0~ubuntu-trusty \
         libsasl2-modules \
         libstdc++6 \
-        mesos=1.7.0-2.0.3 > /dev/null && \
+        mesos=1.7.1-2.0.1 > /dev/null && \
     rm -rf /var/lib/apt/lists/*
 
 COPY mesos-secrets mesos-slave-secret /etc/


### PR DESCRIPTION
There isn't a 1.7.2 package just yet in the mesossphere apt repos.  I'll make myself a reminder to check for that next week.