### PR TITLE
Strip leading and trailing whitespace in paasta logs

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1210,7 +1210,7 @@ def format_log_line(
     validate_log_component(component)
     if not timestamp:
         timestamp = _now()
-    line = remove_ansi_escape_sequences(line)
+    line = remove_ansi_escape_sequences(line.strip())
     message = json.dumps(
         {
             'timestamp': timestamp,


### PR DESCRIPTION
Sometimes logs are going to have extra newlines at the end, which makes paasta logs look funny.