### PR TITLE
set the desired state of the custom resource

### DIFF
--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -204,6 +204,9 @@ def format_custom_resource(
                 'yelp.com/paasta_instance': instance,
                 'yelp.com/paasta_cluster': cluster,
             },
+            'annotations': {
+                'yelp.com/desired_state': 'running',
+            },
         },
         'spec': instance_config,
     }

--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -190,6 +190,9 @@ def test_format_custom_resource():
                     'yelp.com/paasta_cluster': 'mycluster',
                     'yelp.com/paasta_config_sha': mock_get_config_hash.return_value,
                 },
+                'annotations': {
+                    'yelp.com/desired_state': 'running',
+                },
             },
             'spec': {'dummy': 'conf'},
         }


### PR DESCRIPTION
we want the initial state to be running: this'll have the same semantics
as paasta start/stop, where any changes to the desired state are
forgotten with each deployment