### PR TITLE
Show flink cluster state in `paasta status`

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -352,6 +352,7 @@ def print_flinkcluster_status(
         output.append(f"    Flink version: {status.config['flink-version']} {status.config['flink-revision']}")
     else:
         output.append(f"    Flink version: {status.config['flink-version']}")
+    output.append(f"    State: {status.state}")
     output.append(
         "    Jobs:"
         f" {status.overview['jobs-running']} running,"


### PR DESCRIPTION
```
$ paasta status -c kubestage -s stream_sql

service: stream_sql
cluster: kubestage
    instance: main_k8s
    Flink version: 1.6.4
    State: running
    Jobs: 2 running, 0 finished, 1 failed, 0 cancelled
```