### PR TITLE
Added tron support in the paasta api

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -580,9 +580,9 @@ def report_status_for_cluster(
                     output.append('    %s' % line)
 
     jobs: dict = {}
-    for name, instance in instance_whitelist.items():
-        if str(instance) == "<class 'paasta_tools.tron_tools.TronActionConfig'>":
-            seen_instances.append(instance)
+    for name, tron_instance in instance_whitelist.items():
+        if str(tron_instance) == "<class 'paasta_tools.tron_tools.TronActionConfig'>":
+            seen_instances.append(tron_instance)
             job_content, action_run = tron_instance_status(service, cluster, name)
             jobs[job_content['name']] = jobs.get(job_content['name'], (job_content, []))
             jobs[job_content['name']][1].append(action_run)

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -78,7 +78,7 @@ SSH_ONLY_INSTANCE_CONFIG = [
     ChronosJobConfig,
     AdhocJobConfig,
 ]
-TRON_CLIENTS = {}
+TRON_CLIENTS: dict = {}
 
 
 def add_subparser(
@@ -471,7 +471,7 @@ def tron_instance_status(
     return job_content, action_run
 
 
-def write_job_status(job_content: dict, output: Sequence[str], verbose: bool) -> None:
+def write_job_status(job_content: dict, output: List[str], verbose: int) -> None:
     # job
     output.append("    Tron job: {}".format(job_content['name']))
     if verbose:
@@ -480,7 +480,7 @@ def write_job_status(job_content: dict, output: Sequence[str], verbose: bool) ->
     output.append("      DashBoard: {}".format(PaastaColors.blue(job_content['url'])))
 
 
-def write_action_run_status(action_run: dict, output: Sequence[str], verbose: bool) -> None:
+def write_action_run_status(action_run: dict, output: List[str], verbose: int) -> None:
     # action
     output.append("    Action: {}".format(action_run['name']))
     output.append("      Status: {}".format(action_run['state']))
@@ -579,7 +579,7 @@ def report_status_for_cluster(
                 for line in status.rstrip().split('\n'):
                     output.append('    %s' % line)
 
-    jobs = {}
+    jobs: dict = {}
     for name, instance in instance_whitelist.items():
         if str(instance) == "<class 'paasta_tools.tron_tools.TronActionConfig'>":
             seen_instances.append(instance)

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -771,9 +771,9 @@ def run_on_master(
         # signals don't travel over ssh, kill process when anything lands on stdin instead
         cmd_parts.append(
             # send process to background and capture it's pid
-            '& p=$!; ' +
+            '& p=$!; '
             # wait for stdin with timeout in a loop, exit when original process finished
-            'while ! read -t1; do ! kill -0 $p 2>/dev/null && kill $$; done; ' +
+            'while ! read -t1; do ! kill -0 $p 2>/dev/null && kill $$; done; '
             # kill original process if loop finished (something on stdin)
             'kill $p; wait',
         )

--- a/paasta_tools/tron/client.py
+++ b/paasta_tools/tron/client.py
@@ -109,3 +109,17 @@ class TronClient:
         """Gets the namespaces that are currently configured."""
         response = self._get('/api')
         return response.get('namespaces', [])
+
+    def get_job_content(self, job):
+        return self._get(f"/api/jobs/{job}/")
+
+    def get_latest_job_run_id(self, job_content):
+        job_runs = sorted(
+            job_content.get('runs', []),
+            key=lambda k: (k['end_time'] is None, k['end_time'], k['run_time']),
+            reverse=True,
+        )
+        return job_runs[0]["run_num"]
+
+    def get_action_run(self, job, action, run_id):
+        return self._get(f"/api/jobs/{job}/{run_id}/{action}?include_stderr=1&include_stdout=1&num_lines=10")

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -127,7 +127,7 @@ class StringFormatter(Formatter):
 
 def get_tron_api_endpoints(cluster: str):
     endpoints = load_system_paasta_config().config_dict.get('tron_api_endpoints', {})
-    if cluster not in endpoints.keys():
+    if cluster not in endpoints:
         raise Exception(f"tron api endpoint is not defined for cluster {cluster}")
     return endpoints[cluster]
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -125,6 +125,17 @@ class StringFormatter(Formatter):
                 return Formatter.get_value(key, args, kwds)
 
 
+def get_tron_api_endpoints(cluster: str):
+    endpoints = load_system_paasta_config().config_dict.get('tron_api_endpoints', {})
+    if cluster not in endpoints.keys():
+        raise Exception(f"tron api endpoint is not defined for cluster {cluster}")
+    return endpoints[cluster]
+
+
+def get_tron_client_for_cluster(cluster: str):
+    return TronClient(get_tron_api_endpoints(cluster))
+
+
 def parse_time_variables(
     command: str,
     parse_time: datetime.datetime = None,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2097,7 +2097,7 @@ class SystemPaastaConfig:
         return self.config_dict.get('slack', {}).get('token', None)
 
     def get_tron_config(self) -> dict:
-        return self.config_dict.get('tron', {})
+        return self.config_dict.get('tron_api_endpoints', {})
 
 
 def _run(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1649,7 +1649,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     register_marathon_services: bool
     register_native_services: bool
     nerve_readiness_check_script: str
-    tron: Dict
+    tron_api_endpoints: Dict
 
 
 def load_system_paasta_config(path: str = PATH_TO_SYSTEM_PAASTA_CONFIG_DIR) -> 'SystemPaastaConfig':


### PR DESCRIPTION
I picked up kwa's work. #2045
But instead of adding it to frontend, I added get requests directly to paasta client. This requires me to add tron api endpoints in /etc/paasta to work. I have updated puppet and will post a review for that later.

Test output (updated):
https://fluffy.yelpcorp.com/i/mXRZNMNg5GjMxKzNt1kFkPQN31F7k1Nd.html