### PR TITLE
Show flinkcluster dashboard URLs without -v flag

### DIFF
--- a/paasta_tools/flinkcluster_tools.py
+++ b/paasta_tools/flinkcluster_tools.py
@@ -110,3 +110,12 @@ def set_flinkcluster_desired_state(
     kube_client.custom.replace_namespaced_custom_object(**co_id, body=co)
     status = co.get('status')
     return status
+
+
+def get_dashboard_url(
+    cluster: str,
+    service: str,
+    instance: str,
+) -> str:
+    sname = sanitised_name(service, instance)
+    return f'http://flink.k8s.paasta-{cluster}.yelp:{FLINK_INGRESS_PORT}/{sname}'


### PR DESCRIPTION
```
$ paasta status -c kubestage -s stream_sql -i main_k8s

service: stream_sql
cluster: kubestage
    instance: main_k8s
    Flink version: 1.6.4
    URL: http://flink.k8s.paasta-kubestage.yelp:31080/stream--sql-main--k8s
    State: running
    Jobs: 2 running, 0 finished, 0 failed, 0 cancelled
    10 taskmanagers, 74/80 slots available
    Jobs:
      Job Name                         State       Started
      copy_of_scribeheartbeat_auditing RUNNING     2019-03-13 10:22:08 (a day ago)
      scribeheartbeat_auditing         RUNNING     2019-03-13 10:22:43 (a day ago)


$ paasta status -c kubestage -s stream_sql -i main_k8s -v

service: stream_sql
cluster: kubestage
    instance: main_k8s
    Flink version: 1.6.4 6f41481 @ 14.02.2019 @ 20:51:48 CST
    URL: http://flink.k8s.paasta-kubestage.yelp:31080/stream--sql-main--k8s
    State: running
    Jobs: 2 running, 0 finished, 0 failed, 0 cancelled
    10 taskmanagers, 74/80 slots available
    Jobs:
      Job Name                         State       Job ID
Started
      copy_of_scribeheartbeat_auditing RUNNING     ccc8db580210d819534dc9e16ac909b2
2019-03-13 10:22:08 (a day ago)
        http://flink.k8s.paasta-kubestage.yelp:31080/stream--sql-main--k8s/#/jobs/ccc8db580210d819534dc9e16ac909b2
      scribeheartbeat_auditing         RUNNING     8808041382c8af47ef778ae8f6b52066
2019-03-13 10:22:43 (a day ago)
        http://flink.k8s.paasta-kubestage.yelp:31080/stream--sql-main--k8s/#/jobs/8808041382c8af47ef778ae8f6b52066
```