### PR TITLE
make sure we send clusterman metrics when clearing the boost

### DIFF
--- a/paasta_tools/autoscaling/load_boost.py
+++ b/paasta_tools/autoscaling/load_boost.py
@@ -137,7 +137,7 @@ def set_boost_factor(
     zk_boost_path: str,
     region: str = '',
     pool: str = '',
-    send_clusterman_metrics: bool = False,
+    send_clusterman_metrics: bool = True,
     factor: float = DEFAULT_BOOST_FACTOR,
     duration_minutes: int = DEFAULT_BOOST_DURATION,
     override: bool = False,


### PR DESCRIPTION
`set_boost_factor` is only called in two places:
* [clear_cluster_boost](https://github.com/Yelp/paasta/blob/master/paasta_tools/autoscaling/load_boost.py#L224) which isn't setting `send_clusterman_metrics`
* [paasta_cluster_boost](https://github.com/Yelp/paasta/blob/master/paasta_tools/paasta_cluster_boost.py#L117) which is already setting it.

Let's just make it the default.