### PR TITLE
Rename the deployd inbox_q to 'instances_that_need_to_be_bounced_in_the_future'

### DIFF
--- a/paasta_tools/deployd/metrics.py
+++ b/paasta_tools/deployd/metrics.py
@@ -7,17 +7,21 @@ class QueueMetrics(PaastaThread):
     def __init__(self, inbox, bounce_q, cluster, metrics_provider):
         super().__init__()
         self.daemon = True
-        self.inbox_q = inbox.inbox_q
+        self.instances_that_need_to_be_bounced_in_the_future = inbox.instances_that_need_to_be_bounced_in_the_future
         self.inbox = inbox.to_bounce
         self.bounce_q = bounce_q
         self.metrics = metrics_provider
-        self.inbox_q_gauge = self.metrics.create_gauge("inbox_queue", paasta_cluster=cluster)
+        self.instances_that_need_to_be_bounced_in_the_future_gauge = self.metrics.create_gauge(
+            "instances_that_need_to_be_bounced_in_the_future", paasta_cluster=cluster,
+        )
         self.inbox_gauge = self.metrics.create_gauge("inbox", paasta_cluster=cluster)
         self.bounce_q_gauge = self.metrics.create_gauge("bounce_queue", paasta_cluster=cluster)
 
     def run(self):
         while True:
-            self.inbox_q_gauge.set(self.inbox_q.qsize())
+            self.instances_that_need_to_be_bounced_in_the_future_gauge.set(
+                self.instances_that_need_to_be_bounced_in_the_future.qsize(),
+            )
             self.inbox_gauge.set(len(self.inbox.keys()))
             self.bounce_q_gauge.set(self.bounce_q.qsize())
             time.sleep(20)

--- a/paasta_tools/deployd/workers.py
+++ b/paasta_tools/deployd/workers.py
@@ -13,11 +13,13 @@ BounceResults = namedtuple('BounceResults', ['bounce_again_in_seconds', 'return_
 
 
 class PaastaDeployWorker(PaastaThread):
-    def __init__(self, worker_number, inbox_q, bounce_q, config, metrics_provider):
+    def __init__(
+        self, worker_number, instances_that_need_to_be_bounced_in_the_future, bounce_q, config, metrics_provider,
+    ):
         super().__init__()
         self.daemon = True
         self.name = f"Worker{worker_number}"
-        self.inbox_q = inbox_q
+        self.instances_that_need_to_be_bounced_in_the_future = instances_that_need_to_be_bounced_in_the_future
         self.bounce_q = bounce_q
         self.metrics = metrics_provider
         self.config = config
@@ -91,7 +93,7 @@ class PaastaDeployWorker(PaastaThread):
                     priority=service_instance.priority,
                     failures=failures,
                 )
-                self.inbox_q.put(service_instance)
+                self.instances_that_need_to_be_bounced_in_the_future.put(service_instance)
             time.sleep(0.1)
 
     def process_service_instance(self, service_instance):

--- a/tests/deployd/test_deployd_master.py
+++ b/tests/deployd/test_deployd_master.py
@@ -90,8 +90,8 @@ class TestDedupedPriorityQueue(unittest.TestCase):
 class TestInbox(unittest.TestCase):
     def setUp(self):
         self.mock_bounce_q = mock.Mock()
-        self.mock_inbox_q = mock.Mock()
-        self.inbox = Inbox(self.mock_inbox_q, self.mock_bounce_q)
+        self.mock_instances_that_need_to_be_bounced_in_the_future = mock.Mock()
+        self.inbox = Inbox(self.mock_instances_that_need_to_be_bounced_in_the_future, self.mock_bounce_q)
 
     def test_run(self):
         with mock.patch(
@@ -103,8 +103,8 @@ class TestInbox(unittest.TestCase):
             assert mock_process.called
 
     def test_process_inbox(self):
-        self.mock_inbox_q.get.side_effect = Empty
-        self.mock_inbox_q.empty.return_value = True
+        self.mock_instances_that_need_to_be_bounced_in_the_future.get.side_effect = Empty
+        self.mock_instances_that_need_to_be_bounced_in_the_future.empty.return_value = True
         self.inbox.to_bounce = {}
         with mock.patch(
             'paasta_tools.deployd.master.Inbox.process_service_instance', autospec=True,
@@ -114,20 +114,20 @@ class TestInbox(unittest.TestCase):
             'time.sleep', autospec=True,
         ):
             self.inbox.process_inbox()
-            self.mock_inbox_q.get.assert_called_with(block=False)
+            self.mock_instances_that_need_to_be_bounced_in_the_future.get.assert_called_with(block=False)
             assert not mock_process_service_instance.called
             assert not mock_process_to_bounce.called
 
             mock_si = mock.Mock()
-            self.mock_inbox_q.get.side_effect = None
-            self.mock_inbox_q.get.return_value = mock_si
-            self.mock_inbox_q.empty.return_value = False
+            self.mock_instances_that_need_to_be_bounced_in_the_future.get.side_effect = None
+            self.mock_instances_that_need_to_be_bounced_in_the_future.get.return_value = mock_si
+            self.mock_instances_that_need_to_be_bounced_in_the_future.empty.return_value = False
             self.inbox.process_inbox()
             mock_process_service_instance.assert_called_with(self.inbox, mock_si)
             assert not mock_process_to_bounce.called
 
             self.inbox.to_bounce = {'service.instance': mock_si}
-            self.mock_inbox_q.empty.return_value = True
+            self.mock_instances_that_need_to_be_bounced_in_the_future.empty.return_value = True
             self.inbox.process_inbox()
             mock_process_service_instance.assert_called_with(self.inbox, mock_si)
             assert mock_process_to_bounce.called
@@ -213,7 +213,7 @@ class TestDeployDaemon(unittest.TestCase):
     def test_bounce(self):
         mock_si = mock.Mock()
         self.deployd.bounce(mock_si)
-        self.deployd.inbox_q.put.assert_called_with(mock_si)
+        self.deployd.instances_that_need_to_be_bounced_in_the_future.put.assert_called_with(mock_si)
 
     def test_startup(self):
         assert not hasattr(self.deployd, 'is_leader')
@@ -405,7 +405,7 @@ class TestDeployDaemon(unittest.TestCase):
                     failures=0,
                 )),
             ]
-            self.deployd.inbox_q.put.assert_has_calls(calls, any_order=True)
+            self.deployd.instances_that_need_to_be_bounced_in_the_future.put.assert_has_calls(calls, any_order=True)
 
     def test_start_watchers(self):
         class FakeWatchers:  # pragma: no cover

--- a/tests/deployd/test_metrics.py
+++ b/tests/deployd/test_metrics.py
@@ -10,7 +10,7 @@ class TestQueueMetrics(unittest.TestCase):
     def setUp(self):
         mock_metrics_provider = mock.Mock()
         self.mock_gauge = mock.Mock()
-        self.mock_inbox = mock.Mock(inbox_q=mock.Mock(), to_bounce={})
+        self.mock_inbox = mock.Mock(instances_that_need_to_be_bounced_in_the_future=mock.Mock(), to_bounce={})
         self.mock_bounce_q = mock.Mock()
         mock_create_gauge = mock.Mock(return_value=self.mock_gauge)
         mock_metrics_provider.create_gauge = mock_create_gauge

--- a/tests/deployd/test_workers.py
+++ b/tests/deployd/test_workers.py
@@ -12,7 +12,7 @@ from paasta_tools.marathon_tools import DEFAULT_SOA_DIR
 
 class TestPaastaDeployWorker(unittest.TestCase):
     def setUp(self):
-        self.mock_inbox_q = mock.Mock()
+        self.mock_instances_that_need_to_be_bounced_in_the_future = mock.Mock()
         self.mock_bounce_q = mock.Mock()
         self.mock_metrics = mock.Mock()
         mock_config = mock.Mock(
@@ -24,7 +24,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
         ):
             self.worker = PaastaDeployWorker(
                 1,
-                self.mock_inbox_q,
+                self.mock_instances_that_need_to_be_bounced_in_the_future,
                 self.mock_bounce_q,
                 mock_config,
                 self.mock_metrics,
@@ -101,7 +101,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
             with raises(LoopBreak):
                 self.worker.run()
             mock_process_service_instance.assert_called_with(self.worker, mock_si)
-            assert not self.mock_inbox_q.put.called
+            assert not self.mock_instances_that_need_to_be_bounced_in_the_future.put.called
 
             mock_bounce_results = BounceResults(
                 bounce_again_in_seconds=60,
@@ -121,7 +121,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
             with raises(LoopBreak):
                 self.worker.run()
             mock_process_service_instance.assert_called_with(self.worker, mock_si)
-            self.mock_inbox_q.put.assert_called_with(mock_queued_si)
+            self.mock_instances_that_need_to_be_bounced_in_the_future.put.assert_called_with(mock_queued_si)
 
             mock_si = mock.Mock(
                 service='universe',
@@ -143,7 +143,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
             with raises(LoopBreak):
                 self.worker.run()
             mock_process_service_instance.assert_called_with(self.worker, mock_si)
-            self.mock_inbox_q.put.assert_called_with(mock_queued_si)
+            self.mock_instances_that_need_to_be_bounced_in_the_future.put.assert_called_with(mock_queued_si)
 
     def test_process_service_instance(self):
         mock_client = mock.Mock()


### PR DESCRIPTION
I think this is an easier to understand name, in the code and on the graphs.

I'll make one PR per rename for my own sanity and so we can bikeshed things one at a time.