### PR TITLE
Remove characters that are not allowed in env vars

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import re
 import sys
 
 from paasta_tools.cli.utils import lazy_choices_completer
@@ -48,9 +49,7 @@ def add_subparser(subparsers):
         help="The name of the secret to create/update, "
              "this is the name you will reference in your "
              "services marathon/chronos yaml files and should "
-             "be unique per service. Please prefix with "
-             "PAASTA_SECRET_ if you are going to use the "
-             "yelp_servlib client library.",
+             "be unique per service.",
     )
 
     # Must choose valid service or act on a shared secret
@@ -93,6 +92,12 @@ def add_subparser(subparsers):
     secret_parser.set_defaults(command=paasta_secret)
 
 
+def secret_name_for_env(secret_name):
+    secret_name = secret_name.upper()
+    valid_parts = re.findall(r'[a-zA-Z0-9_]+', secret_name)
+    return '_'.join(valid_parts)
+
+
 def print_paasta_helper(secret_path, secret_name, is_shared):
     print(
         "\nYou have successfully encrypted your new secret and it\n"
@@ -111,7 +116,7 @@ def print_paasta_helper(secret_path, secret_name, is_shared):
         "specified. The PAASTA_SECRET_ prefix is optional but necessary\n"
         "for the yelp_servlib client library".format(
             secret_path,
-            secret_name.upper(),
+            secret_name_for_env(secret_name),
             'SHARED_' if is_shared else '',
             secret_name,
         ),

--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -48,7 +48,10 @@
                 },
                 "env": {
                     "type": "object",
-                    "additionalProperties": { "type": "string" }
+                    "patternProperties": {
+                        "^[a-zA-Z_]+[a-zA-Z0-9_]*$": { "type": "string" }
+                    },
+                    "additionalProperties": false
                 },
                 "extra_volumes": {
                     "type": "array",

--- a/paasta_tools/cli/schemas/chronos_schema.json
+++ b/paasta_tools/cli/schemas/chronos_schema.json
@@ -79,7 +79,10 @@
                 },
                 "env": {
                     "type": "object",
-                    "additionalProperties": { "type": "string" }
+                    "patternProperties": {
+                        "^[a-zA-Z_]+[a-zA-Z0-9_]*$": { "type": "string" }
+                    },
+                    "additionalProperties": false
                 },
                 "deploy_whitelist": {
                     "type": "array"

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -196,7 +196,10 @@
                 },
                 "env": {
                     "type": "object",
-                    "additionalProperties": { "type": "string" }
+                    "patternProperties": {
+                        "^[a-zA-Z_]+[a-zA-Z0-9_]*$": { "type": "string" }
+                    },
+                    "additionalProperties": false
                 },
                 "extra_volumes": {
                     "type": "array",

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -55,7 +55,10 @@
         "pool": {"type": "string"},
         "env": {
           "type": "object",
-          "additionalProperties": {"type": "string"}
+          "patternProperties": {
+              "^[a-zA-Z_]+[a-zA-Z0-9_]*$": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "extra_volumes": {
           "type": "array",

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -26,6 +26,11 @@ def test_add_subparser():
     )
 
 
+def test_secret_name_for_env():
+    assert secret.secret_name_for_env('test-secret2') == 'TEST_SECRET2'
+    assert secret.secret_name_for_env('test.secret.foo') == 'TEST_SECRET_FOO'
+
+
 def test_print_paasta_helper():
     secret.print_paasta_helper('/blah/what', 'keepithidden', False)
     secret.print_paasta_helper('/blah/what', 'keepithidden', True)


### PR DESCRIPTION
Secret names with dashes are commonly used, like `my-secret`. But dashes aren't allowed in bash variables.