### PR TITLE
fix cluster boost clearing script

### DIFF
--- a/paasta_tools/autoscaling/load_boost.py
+++ b/paasta_tools/autoscaling/load_boost.py
@@ -221,9 +221,17 @@ def set_boost_factor(
         )
 
 
-def clear_boost(zk_boost_path) -> bool:
+def clear_boost(
+    zk_boost_path: str,
+    region: str = '',
+    pool: str = '',
+    send_clusterman_metrics: bool = True,
+) -> bool:
     return set_boost_factor(
         zk_boost_path,
+        region=region,
+        pool=pool,
+        send_clusterman_metrics=send_clusterman_metrics,
         factor=1,
         duration_minutes=0,
         override=True,

--- a/paasta_tools/paasta_cluster_boost.py
+++ b/paasta_tools/paasta_cluster_boost.py
@@ -118,7 +118,6 @@ def paasta_cluster_boost(
                 zk_boost_path=zk_boost_path,
                 region=region,
                 pool=pool,
-                send_clusterman_metrics=True,
                 factor=boost,
                 duration_minutes=duration,
                 override=override,
@@ -130,7 +129,11 @@ def paasta_cluster_boost(
             pass
 
         elif action == 'clear':
-            if not load_boost.clear_boost(zk_boost_path):
+            if not load_boost.clear_boost(
+                zk_boost_path,
+                region=region,
+                pool=pool,
+            ):
                 paasta_print('ERROR: Failed to clear the boost for pool {}, region {}.')
                 return False
 

--- a/tests/test_paasta_cluster_boost.py
+++ b/tests/test_paasta_cluster_boost.py
@@ -149,7 +149,6 @@ def test_paasta_cluster_boost():
             zk_boost_path=mock_get_zk_cluster_boost_path.return_value,
             region='useast1-dev',
             pool='default',
-            send_clusterman_metrics=True,
             factor=1.0,
             duration_minutes=20,
             override=False,
@@ -165,4 +164,6 @@ def test_paasta_cluster_boost():
         )
         mock_clear_boost.assert_called_with(
             zk_boost_path=mock_get_zk_cluster_boost_path.return_value,
+            region='useast1-dev',
+            pool='default',
         )


### PR DESCRIPTION
In #2179 I tried to made sure we were sending clusterman metrics when we cleared the boost (I think that since we switched to using Clusterman we haven't been clearing the boost), but I didn't realize that I needed to fix some of the wiring.  This PR fixes that and adds a test of the clusterman_metrics functionality in the `load_boost` module.