### PR TITLE
Make kill_bad_containers handle the edge case where a second container is missing

### DIFF
--- a/paasta_tools/contrib/kill_bad_containers.py
+++ b/paasta_tools/contrib/kill_bad_containers.py
@@ -51,6 +51,12 @@ def kill_containers_with_duplicate_iptables_rules(docker_client):
             print(targets_seen[target])
             dport2 = target_rule_to_dport(targets_seen[target])
             container2 = get_container_from_dport(dport2, docker_client)
+            if container1 is None or container2 is None:
+                print("Error: there is only one container here and we couldn't determine the other:")
+                print(f"container1: {container1}")
+                print(f"container2: {container2}")
+                print("This script currently doesn't understand this situation and manual intervention is required")
+                return 1
             if container1["Id"] == container2["Id"]:
                 print("The same container is getting traffic for both ports!")
                 print(container1)


### PR DESCRIPTION
It looks like this happens every once in a while in the past 30 days. 
I don't know why, so I've made the script print out what it does know and exit non-zero so we'll get a ticket. (instead of stack tracing)