### PR TITLE
Only use a tty for local-run if stdin is a tty.

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -474,7 +474,7 @@ def get_docker_run_cmd(
         cmd.append('--volume=%s' % volume)
     if interactive:
         cmd.append('--interactive=true')
-        if sys.stdout.isatty():
+        if sys.stdin.isatty():
             cmd.append('--tty=true')
     else:
         if detach:


### PR DESCRIPTION
This is pretty easy to repro with a bash script that redirects stdin:
```
paasta local-run --skip-secrets --pull --no-healthcheck --cluster foo --service bar --instance batach  --cmd '/bin/true' </dev/null
...
the input device is not a TTY
```

But we only want `--tty` when the *input* is a tty, output doesn't really matter.