### PR TITLE
Don't print newline when decrypting

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -201,10 +201,12 @@ def paasta_secret(args):
 
         print_paasta_helper(secret_path, args.secret_name, args.shared)
     elif args.action == "decrypt":
-        print(decrypt_secret(
-            secret_provider=secret_provider,
-            secret_name=args.secret_name,
-        ))
+        print(
+            decrypt_secret(
+                secret_provider=secret_provider,
+                secret_name=args.secret_name,
+            ), end='',
+        )
     else:
         print("Unknown action")
         sys.exit(1)


### PR DESCRIPTION
This is just used by humans at the moment so we haven't cared about the
whitespace that much. I've updated a runbook where I tell people they
can "recreate" a secret using this as the stdin. We need to not print
the newline in that case.