### PR TITLE
Renamed 'inbox' gauge to 'instances_that_need_to_be_checked_up_on'

### DIFF
--- a/paasta_tools/deployd/metrics.py
+++ b/paasta_tools/deployd/metrics.py
@@ -4,26 +4,34 @@ from paasta_tools.deployd.common import PaastaThread
 
 
 class QueueMetrics(PaastaThread):
-    def __init__(self, inbox, instances_that_need_to_be_bounced_asap, cluster, metrics_provider):
+    def __init__(self, inbox, cluster, metrics_provider):
         super().__init__()
         self.daemon = True
-        self.instances_that_need_to_be_bounced_in_the_future = inbox.instances_that_need_to_be_bounced_in_the_future
-        self.inbox = inbox.to_bounce
-        self.instances_that_need_to_be_bounced_asap = instances_that_need_to_be_bounced_asap
         self.metrics = metrics_provider
-        self.instances_that_need_to_be_bounced_in_the_future_gauge = self.metrics.create_gauge(
-            "instances_that_need_to_be_bounced_in_the_future", paasta_cluster=cluster,
+
+        self.inbox = inbox.to_bounce
+        self.instances_to_bounce_later = inbox.instances_to_bounce_later
+        self.instances_to_bounce_now = inbox.instances_to_bounce_now
+
+        self.instances_to_bounce_later_gauge = self.metrics.create_gauge(
+            "instances_to_bounce_later", paasta_cluster=cluster,
         )
-        self.inbox_gauge = self.metrics.create_gauge("inbox", paasta_cluster=cluster)
-        self.instances_that_need_to_be_bounced_asap_gauge = self.metrics.create_gauge(
-            "instances_that_need_to_be_bounced_asap", paasta_cluster=cluster,
+        self.instances_that_need_to_be_checked_up_on_gauge = self.metrics.create_gauge(
+            "instances_that_need_to_be_checked_up_on", paasta_cluster=cluster,
+        )
+        self.instances_to_bounce_now_gauge = self.metrics.create_gauge(
+            "instances_to_bounce_now", paasta_cluster=cluster,
         )
 
     def run(self):
         while True:
-            self.instances_that_need_to_be_bounced_in_the_future_gauge.set(
-                self.instances_that_need_to_be_bounced_in_the_future.qsize(),
+            self.instances_to_bounce_later_gauge.set(
+                self.instances_to_bounce_later.qsize(),
             )
-            self.inbox_gauge.set(len(self.inbox.keys()))
-            self.instances_that_need_to_be_bounced_asap_gauge.set(self.instances_that_need_to_be_bounced_asap.qsize())
+            self.instances_that_need_to_be_checked_up_on_gauge.set(
+                len(self.inbox.keys()),
+            )
+            self.instances_to_bounce_now_gauge.set(
+                self.instances_to_bounce_now.qsize(),
+            )
             time.sleep(20)

--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -31,10 +31,10 @@ from paasta_tools.utils import PATH_TO_SYSTEM_PAASTA_CONFIG_DIR
 
 class PaastaWatcher(PaastaThread):
 
-    def __init__(self, instances_that_need_to_be_bounced_in_the_future, cluster, config):
+    def __init__(self, instances_to_bounce_later, cluster, config):
         super().__init__()
         self.daemon = True
-        self.instances_that_need_to_be_bounced_in_the_future = instances_that_need_to_be_bounced_in_the_future
+        self.instances_to_bounce_later = instances_to_bounce_later
         self.cluster = cluster
         self.config = config
         self.is_ready = False
@@ -42,8 +42,8 @@ class PaastaWatcher(PaastaThread):
 
 class AutoscalerWatcher(PaastaWatcher):
 
-    def __init__(self, instances_that_need_to_be_bounced_in_the_future, cluster, config, **kwargs):
-        super().__init__(instances_that_need_to_be_bounced_in_the_future, cluster, config)
+    def __init__(self, instances_to_bounce_later, cluster, config, **kwargs):
+        super().__init__(instances_to_bounce_later, cluster, config)
         self.zk = kwargs.pop('zookeeper_client')
         self.watchers: Dict[str, PaastaWatcher] = {}
 
@@ -75,7 +75,7 @@ class AutoscalerWatcher(PaastaWatcher):
             watcher=type(self).__name__,
             failures=0,
         )
-        self.instances_that_need_to_be_bounced_in_the_future.put(service_instance)
+        self.instances_to_bounce_later.put(service_instance)
 
     def watch_node(self, path, enqueue=False):
         self.log.info(f"Adding zk node watch on {path}")
@@ -107,8 +107,8 @@ class AutoscalerWatcher(PaastaWatcher):
 
 class SoaFileWatcher(PaastaWatcher):
 
-    def __init__(self, instances_that_need_to_be_bounced_in_the_future, cluster, config, **kwargs):
-        super().__init__(instances_that_need_to_be_bounced_in_the_future, cluster, config)
+    def __init__(self, instances_to_bounce_later, cluster, config, **kwargs):
+        super().__init__(instances_to_bounce_later, cluster, config)
         self.wm = pyinotify.WatchManager()
         self.wm.add_watch(DEFAULT_SOA_DIR, self.mask, rec=True)
         self.notifier = pyinotify.Notifier(
@@ -133,8 +133,8 @@ class SoaFileWatcher(PaastaWatcher):
 
 class PublicConfigFileWatcher(PaastaWatcher):
 
-    def __init__(self, instances_that_need_to_be_bounced_in_the_future, cluster, config, **kwargs):
-        super().__init__(instances_that_need_to_be_bounced_in_the_future, cluster, config)
+    def __init__(self, instances_to_bounce_later, cluster, config, **kwargs):
+        super().__init__(instances_to_bounce_later, cluster, config)
         self.wm = pyinotify.WatchManager()
         self.wm.add_watch(PATH_TO_SYSTEM_PAASTA_CONFIG_DIR, self.mask, rec=True)
         self.notifier = pyinotify.Notifier(
@@ -158,8 +158,8 @@ class PublicConfigFileWatcher(PaastaWatcher):
 
 
 class MaintenanceWatcher(PaastaWatcher):
-    def __init__(self, instances_that_need_to_be_bounced_in_the_future, cluster, config, **kwargs):
-        super().__init__(instances_that_need_to_be_bounced_in_the_future, cluster, config)
+    def __init__(self, instances_to_bounce_later, cluster, config, **kwargs):
+        super().__init__(instances_to_bounce_later, cluster, config)
         self.draining: Set[str] = set()
         self.marathon_clients = get_marathon_clients_from_config()
 
@@ -186,7 +186,7 @@ class MaintenanceWatcher(PaastaWatcher):
                 self.log.info(f"Found new draining hosts: {new_draining_hosts}")
                 service_instances = self.get_at_risk_service_instances(new_draining_hosts)
             for service_instance in service_instances:
-                self.instances_that_need_to_be_bounced_in_the_future.put(service_instance)
+                self.instances_to_bounce_later.put(service_instance)
             time.sleep(self.config.get_deployd_maintenance_polling_frequency())
 
     def get_at_risk_service_instances(self, draining_hosts) -> List[ServiceInstance]:
@@ -276,7 +276,7 @@ class PublicConfigEventHandler(pyinotify.ProcessEvent):
                     watcher_name=type(self).__name__,
                     priority=99,
                 ):
-                    self.filewatcher.instances_that_need_to_be_bounced_in_the_future.put(service_instance)
+                    self.filewatcher.instances_to_bounce_later.put(service_instance)
 
 
 class YelpSoaEventHandler(pyinotify.ProcessEvent):
@@ -354,4 +354,4 @@ class YelpSoaEventHandler(pyinotify.ProcessEvent):
             for service, instance in service_instances
         ]
         for service_instance in service_instances_to_queue:
-            self.filewatcher.instances_that_need_to_be_bounced_in_the_future.put(service_instance)
+            self.filewatcher.instances_to_bounce_later.put(service_instance)

--- a/tests/deployd/test_metrics.py
+++ b/tests/deployd/test_metrics.py
@@ -10,13 +10,12 @@ class TestQueueMetrics(unittest.TestCase):
     def setUp(self):
         mock_metrics_provider = mock.Mock()
         self.mock_gauge = mock.Mock()
-        self.mock_inbox = mock.Mock(instances_that_need_to_be_bounced_in_the_future=mock.Mock(), to_bounce={})
-        self.mock_instances_that_need_to_be_bounced_asap = mock.Mock()
+        self.mock_inbox = mock.Mock(instances_to_bounce_later=mock.Mock(), to_bounce={})
+        self.mock_instances_to_bounce_now = mock.Mock()
         mock_create_gauge = mock.Mock(return_value=self.mock_gauge)
         mock_metrics_provider.create_gauge = mock_create_gauge
         self.metrics = metrics.QueueMetrics(
-            self.mock_inbox, self.mock_instances_that_need_to_be_bounced_asap,
-            "mock-cluster", mock_metrics_provider,
+            self.mock_inbox, "mock-cluster", mock_metrics_provider,
         )
 
     def test_run(self):

--- a/tests/deployd/test_watchers.py
+++ b/tests/deployd/test_watchers.py
@@ -43,16 +43,16 @@ from paasta_tools.deployd.watchers import MaintenanceWatcher  # noqa
 
 class TestPaastaWatcher(unittest.TestCase):
     def test_init(self):
-        mock_instances_that_need_to_be_bounced_in_the_future = mock.Mock()
-        PaastaWatcher(mock_instances_that_need_to_be_bounced_in_the_future, 'westeros-prod', config=mock.Mock())
+        mock_instances_to_bounce_later = mock.Mock()
+        PaastaWatcher(mock_instances_to_bounce_later, 'westeros-prod', config=mock.Mock())
 
 
 class TestAutoscalerWatcher(unittest.TestCase):
     def setUp(self):
         self.mock_zk = mock.Mock()
-        self.mock_instances_that_need_to_be_bounced_in_the_future = mock.Mock()
+        self.mock_instances_to_bounce_later = mock.Mock()
         self.watcher = AutoscalerWatcher(
-            self.mock_instances_that_need_to_be_bounced_in_the_future,
+            self.mock_instances_to_bounce_later,
             "westeros-prod",
             zookeeper_client=self.mock_zk,
             config=mock.Mock(),
@@ -149,7 +149,7 @@ class TestAutoscalerWatcher(unittest.TestCase):
                 type=mock_event_other,
                 path='/autoscaling/service/instance/instances',
             )
-            assert not self.mock_instances_that_need_to_be_bounced_in_the_future.put.called
+            assert not self.mock_instances_to_bounce_later.put.called
 
             mock_event_created = mock_event_type.CREATED
             mock_event = mock.Mock(
@@ -157,7 +157,7 @@ class TestAutoscalerWatcher(unittest.TestCase):
                 path='/autoscaling/service/instance/instances',
             )
             self.watcher.process_node_event(mock.Mock(), mock.Mock(), mock_event)
-            self.mock_instances_that_need_to_be_bounced_in_the_future.put.assert_called_with(BaseServiceInstance(
+            self.mock_instances_to_bounce_later.put.assert_called_with(BaseServiceInstance(
                 service='service',
                 instance='instance',
                 bounce_by=1,
@@ -173,7 +173,7 @@ class TestAutoscalerWatcher(unittest.TestCase):
                 path='/autoscaling/service/instance/instances',
             )
             self.watcher.process_node_event(mock.Mock(), mock.Mock(), mock_event)
-            self.mock_instances_that_need_to_be_bounced_in_the_future.put.assert_called_with(BaseServiceInstance(
+            self.mock_instances_to_bounce_later.put.assert_called_with(BaseServiceInstance(
                 service='service',
                 instance='instance',
                 bounce_by=1,
@@ -228,7 +228,7 @@ class LoopBreak(Exception):
 
 class TestSoaFileWatcher(unittest.TestCase):
     def setUp(self):
-        mock_instances_that_need_to_be_bounced_in_the_future = mock.Mock()
+        mock_instances_to_bounce_later = mock.Mock()
         with mock.patch(
             'paasta_tools.deployd.watchers.pyinotify.WatchManager', autospec=True,
         ), mock.patch(
@@ -241,7 +241,7 @@ class TestSoaFileWatcher(unittest.TestCase):
             self.mock_notifier = mock.Mock()
             mock_notifier_class.return_value = self.mock_notifier
             self.watcher = SoaFileWatcher(
-                mock_instances_that_need_to_be_bounced_in_the_future, 'westeros-prod', config=mock.Mock(),
+                mock_instances_to_bounce_later, 'westeros-prod', config=mock.Mock(),
             )
             assert mock_notifier_class.called
 
@@ -264,7 +264,7 @@ class TestSoaFileWatcher(unittest.TestCase):
 
 class TestPublicConfigWatcher(unittest.TestCase):
     def setUp(self):
-        mock_instances_that_need_to_be_bounced_in_the_future = mock.Mock()
+        mock_instances_to_bounce_later = mock.Mock()
         with mock.patch(
             'paasta_tools.deployd.watchers.pyinotify.WatchManager', autospec=True,
         ), mock.patch(
@@ -277,7 +277,7 @@ class TestPublicConfigWatcher(unittest.TestCase):
             self.mock_notifier = mock.Mock()
             mock_notifier_class.return_value = self.mock_notifier
             self.watcher = PublicConfigFileWatcher(
-                mock_instances_that_need_to_be_bounced_in_the_future, 'westeros-prod', config=mock.Mock(),
+                mock_instances_to_bounce_later, 'westeros-prod', config=mock.Mock(),
             )
             assert mock_notifier_class.called
 
@@ -300,14 +300,14 @@ class TestPublicConfigWatcher(unittest.TestCase):
 
 class TestMaintenanceWatcher(unittest.TestCase):
     def setUp(self):
-        self.mock_instances_that_need_to_be_bounced_in_the_future = mock.Mock()
+        self.mock_instances_to_bounce_later = mock.Mock()
         self.mock_marathon_client = mock.Mock()
         mock_config = mock.Mock(get_deployd_maintenance_polling_frequency=mock.Mock(return_value=20))
         with mock.patch(
             'paasta_tools.deployd.watchers.get_marathon_clients_from_config', autospec=True,
         ):
             self.watcher = MaintenanceWatcher(
-                self.mock_instances_that_need_to_be_bounced_in_the_future, "westeros-prod", config=mock_config,
+                self.mock_instances_to_bounce_later, "westeros-prod", config=mock_config,
             )
 
     def test_get_new_draining_hosts(self):
@@ -360,7 +360,7 @@ class TestMaintenanceWatcher(unittest.TestCase):
                 mock.call('si1'),
                 mock.call('si2'),
             ]
-            self.mock_instances_that_need_to_be_bounced_in_the_future.put.assert_has_calls(calls)
+            self.mock_instances_to_bounce_later.put.assert_has_calls(calls)
 
     def test_get_at_risk_service_instances(self):
         with mock.patch(
@@ -478,7 +478,7 @@ class TestPublicConfigEventHandler(unittest.TestCase):
             assert not mock_get_services_for_cluster.called
             assert not mock_get_service_instances_needing_update.called
             assert not mock_rate_limit_instances.called
-            assert not self.mock_filewatcher.instances_that_need_to_be_bounced_in_the_future.put.called
+            assert not self.mock_filewatcher.instances_to_bounce_later.put.called
 
             mock_load_system_config.return_value = mock.Mock(get_cluster=mock.Mock())
             mock_get_service_instances_needing_update.return_value = []
@@ -487,7 +487,7 @@ class TestPublicConfigEventHandler(unittest.TestCase):
             assert mock_get_services_for_cluster.called
             assert mock_get_service_instances_needing_update.called
             assert not mock_rate_limit_instances.called
-            assert not self.mock_filewatcher.instances_that_need_to_be_bounced_in_the_future.put.called
+            assert not self.mock_filewatcher.instances_to_bounce_later.put.called
 
             mock_load_system_config.return_value = mock.Mock(get_deployd_big_bounce_rate=mock.Mock())
             mock_si = mock.Mock()
@@ -498,7 +498,7 @@ class TestPublicConfigEventHandler(unittest.TestCase):
             assert mock_get_services_for_cluster.called
             assert mock_get_service_instances_needing_update.called
             assert mock_rate_limit_instances.called
-            self.mock_filewatcher.instances_that_need_to_be_bounced_in_the_future.put.assert_called_with(mock_si)
+            self.mock_filewatcher.instances_to_bounce_later.put.assert_called_with(mock_si)
 
 
 class TestYelpSoaEventHandler(unittest.TestCase):
@@ -627,5 +627,5 @@ class TestYelpSoaEventHandler(unittest.TestCase):
                 priority=0,
                 failures=0,
             )
-            self.mock_filewatcher.instances_that_need_to_be_bounced_in_the_future.put.assert_called_with(expected_si)
-            assert self.mock_filewatcher.instances_that_need_to_be_bounced_in_the_future.put.call_count == 1
+            self.mock_filewatcher.instances_to_bounce_later.put.assert_called_with(expected_si)
+            assert self.mock_filewatcher.instances_to_bounce_later.put.call_count == 1


### PR DESCRIPTION
`instances_that_need_to_be_checked_up_on` is the best string I can think of that represents what the `inbox.to_bounce` list "is".