### PR TITLE
Fixups to check_spark_jobs

### DIFF
--- a/paasta_tools/check_spark_jobs.py
+++ b/paasta_tools/check_spark_jobs.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import datetime
 import logging
@@ -160,10 +161,11 @@ def report_spark_jobs(min_hours, no_notify):
             print(f'{message}\n')
         else:
             messages_for_unknown_services.append(message)
-    print('\nINVALID SERVICES')
-    print('----------------')
-    print('The following frameworks are associated with services that are not configured in PaaSTA.\n')
-    print('\n\n'.join(messages_for_unknown_services))
+    if messages_for_unknown_services:
+        print('\nINVALID SERVICES')
+        print('----------------')
+        print('The following frameworks are associated with services that are not configured in PaaSTA.\n')
+        print('\n\n'.join(messages_for_unknown_services))
 
     if not no_notify:
         for service in valid_services:

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'paasta_tools/check_kubernetes_api.py',
         'paasta_tools/check_kubernetes_services_replication.py',
         'paasta_tools/check_oom_events.py',
+        'paasta_tools/check_spark_jobs.py',
         'paasta_tools/cleanup_marathon_jobs.py',
         'paasta_tools/cleanup_kubernetes_crds.py',
         'paasta_tools/paasta_deploy_chronos_jobs',


### PR DESCRIPTION
Add the script to bin/, and make sure there is no output if there are no long-running frameworks we want to report.