### PR TITLE
Add --nvidia command line option to spark-run

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -165,6 +165,13 @@ def add_subparser(subparsers):
     )
 
     list_parser.add_argument(
+        '--nvidia',
+        help='Use nvidia docker runtime for Spark driver process (requires GPU)',
+        action='store_true',
+        default=False,
+    )
+
+    list_parser.add_argument(
         '--mrjob',
         help='Pass Spark arguments to invoked command in the format expected by mrjobs',
         action='store_true',
@@ -277,6 +284,7 @@ def get_docker_run_cmd(
     env,
     docker_img,
     docker_cmd,
+    nvidia,
 ):
     cmd = ['paasta_docker_wrapper', 'run']
     cmd.append('--rm')
@@ -299,6 +307,10 @@ def get_docker_run_cmd(
             cmd.append(k)
         else:
             cmd.append(f'{k}={v}')
+    if nvidia:
+        cmd.append('--env')
+        cmd.append('NVIDIA_VISIBLE_DEVICES=all')
+        cmd.append('--runtime=nvidia')
     for volume in volumes:
         cmd.append('--volume=%s' % volume)
     cmd.append('%s' % docker_img)
@@ -587,6 +599,7 @@ def run_docker_container(
     docker_img,
     docker_cmd,
     dry_run,
+    nvidia,
 ):
     docker_run_args = dict(
         container_name=container_name,
@@ -594,6 +607,7 @@ def run_docker_container(
         env=environment,
         docker_img=docker_img,
         docker_cmd=docker_cmd,
+        nvidia=nvidia,
     )
     docker_run_cmd = get_docker_run_cmd(**docker_run_args)
 
@@ -681,6 +695,7 @@ def configure_and_run_docker_container(
         docker_img=docker_img,
         docker_cmd=docker_cmd,
         dry_run=args.dry_run,
+        nvidia=args.nvidia,
     )
 
 

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -191,6 +191,36 @@ class TestConfigureAndRunDockerContainer:
             nvidia=False,
         )
 
+    def test_configure_and_run_docker_container_nvidia(
+        self,
+        mock_time,
+        mock_run_docker_container,
+        mock_get_spark_config,
+        mock_get_username,
+        mock_pick_random_port,
+        mock_os_path_exists,
+        mock_get_aws_credentials,
+    ):
+        mock_get_aws_credentials.return_value = ('id', 'secret')
+        with mock.patch(
+            'paasta_tools.cli.cmds.spark_run.emit_resource_requirements', autospec=True,
+        ) as mock_emit_resource_requirements, mock.patch(
+            'paasta_tools.cli.cmds.spark_run.clusterman_metrics', autospec=True,
+        ):
+            mock_get_spark_config.return_value = {'spark.cores.max': 5, 'spark.master': 'mesos://spark.master'}
+            args = mock.MagicMock(cmd='pyspark', nvidia=True)
+
+            configure_and_run_docker_container(
+                args=args,
+                docker_img='fake-registry/fake-service',
+                instance_config=self.instance_config,
+                system_paasta_config=self.system_paasta_config,
+            )
+
+            args, kwargs = mock_run_docker_container.call_args
+            assert kwargs['nvidia']
+            assert mock_emit_resource_requirements.called
+
     def test_configure_and_run_docker_container_mrjob(
         self,
         mock_time,

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -43,6 +43,7 @@ def test_get_docker_run_cmd(
     env = {'k1': 'v1', 'k2': 'v2'}
     docker_img = 'fake-registry/fake-service'
     docker_cmd = 'pyspark'
+    nvidia = False
 
     actual = get_docker_run_cmd(
         container_name,
@@ -50,6 +51,7 @@ def test_get_docker_run_cmd(
         env,
         docker_img,
         docker_cmd,
+        nvidia,
     )
 
     assert actual[5:] == [
@@ -152,6 +154,7 @@ class TestConfigureAndRunDockerContainer:
         args.work_dir = '/fake_dir:/spark_driver'
         args.dry_run = True
         args.mrjob = False
+        args.nvidia = False
 
         retcode = configure_and_run_docker_container(
             args=args,
@@ -185,6 +188,7 @@ class TestConfigureAndRunDockerContainer:
             docker_img='fake-registry/fake-service',
             docker_cmd='pyspark --conf spark.app.name=fake_app',
             dry_run=True,
+            nvidia=False,
         )
 
     def test_configure_and_run_docker_container_mrjob(


### PR DESCRIPTION
This will have the effect of running Spark driver docker container with extra parameters `--runtime=nvidia --env NVIDIA_VISIBLE_DEVICES=all`, which will allow deep learning libraries such as tensorflow-gpu running inside Spark driver process to work. Such libraries can then be used inside the driver process to build the model which even though does not need GPU compute, it does require CUDA for the library initialisation to complete.