### PR TITLE
Dry out git_pipeline_deploy_groups

### DIFF
--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -34,9 +34,9 @@ from paasta_tools.utils import _run
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_git_url
 from paasta_tools.utils import get_pipeline_config
+from paasta_tools.utils import get_pipeline_deploy_groups
 from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import INSTANCE_TYPES
-from paasta_tools.utils import is_deploy_step
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
 from paasta_tools.utils import paasta_print
@@ -79,7 +79,7 @@ def deploy_check(service_path):
 
 
 def deploy_has_security_check(service, soa_dir):
-    pipeline = get_pipeline_config(service, soa_dir)
+    pipeline = get_pipeline_config(service=service, soa_dir=soa_dir)
     steps = [step['step'] for step in pipeline]
     if 'security-check' in steps:
         paasta_print(PaastaCheckMessages.DEPLOY_SECURITY_FOUND)
@@ -90,7 +90,7 @@ def deploy_has_security_check(service, soa_dir):
 
 
 def deploy_has_performance_check(service, soa_dir):
-    pipeline = get_pipeline_config(service, soa_dir)
+    pipeline = get_pipeline_config(service=service, soa_dir=soa_dir)
     steps = [step['step'] for step in pipeline]
     if 'performance-check' in steps:
         paasta_print(PaastaCheckMessages.DEPLOY_PERFORMANCE_FOUND)
@@ -235,8 +235,7 @@ def get_deploy_groups_used_by_framework(instance_type, service, soa_dir):
 def deployments_check(service, soa_dir):
     """Checks for consistency between deploy.yaml and the marathon/chronos yamls"""
     the_return = True
-    pipeline_steps = [step['step'] for step in get_pipeline_config(service, soa_dir)]
-    pipeline_deploy_groups = [step for step in pipeline_steps if is_deploy_step(step)]
+    pipeline_deploy_groups = get_pipeline_deploy_groups(service=service, soa_dir=soa_dir)
 
     framework_deploy_groups = {}
     in_deploy_not_frameworks = set(pipeline_deploy_groups)

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -42,8 +42,7 @@ from paasta_tools.utils import paasta_print
 
 from paasta_tools import monitoring_tools
 from paasta_tools.monitoring_tools import list_teams
-from paasta_tools.utils import get_pipeline_config
-from paasta_tools.utils import is_deploy_step
+from paasta_tools.utils import get_pipeline_deploy_groups
 from typing import Optional
 from typing import Dict
 from typing import Any
@@ -234,8 +233,7 @@ class TronActionConfig(InstanceConfig):
     def check_deploy_group(self) -> Tuple[bool, str]:
         deploy_group = self.get_deploy_group()
         if deploy_group is not None:
-            pipeline_steps = [step['step'] for step in get_pipeline_config(self.service, self.soa_dir)]
-            pipeline_deploy_groups = [step for step in pipeline_steps if is_deploy_step(step)]
+            pipeline_deploy_groups = get_pipeline_deploy_groups(service=self.service, soa_dir=self.soa_dir)
             if deploy_group not in pipeline_deploy_groups:
                 return False, f'deploy_group {deploy_group} is not in service {self.service} deploy.yaml'
         return True, ''

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2476,6 +2476,11 @@ def get_pipeline_config(service: str, soa_dir: str = DEFAULT_SOA_DIR) -> List[Di
     return service_configuration.get('deploy', {}).get('pipeline', [])
 
 
+def get_pipeline_deploy_groups(service: str, soa_dir: str = DEFAULT_SOA_DIR) -> List[str]:
+    pipeline_steps = [step['step'] for step in get_pipeline_config(service, soa_dir)]
+    return [step for step in pipeline_steps if is_deploy_step(step)]
+
+
 def get_service_instance_list_no_cache(
     service: str,
     cluster: Optional[str] = None,

--- a/tests/cli/test_cmds_check.py
+++ b/tests/cli/test_cmds_check.py
@@ -483,71 +483,42 @@ def test_get_deploy_groups_used_by_framework(
     assert actual == expected
 
 
-@patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
+@patch('paasta_tools.cli.cmds.check.get_pipeline_deploy_groups', autospec=True)
 @patch('paasta_tools.cli.cmds.check.get_deploy_groups_used_by_framework', autospec=True)
 def test_marathon_deployments_check_good(
     mock_get_deploy_groups_used_by_framework,
-    mock_get_pipeline_config,
+    mock_get_pipeline_deploy_groups,
     capfd,
 ):
-    mock_get_pipeline_config.return_value = [
-        {'step': 'itest', },
-        {'step': 'performance-check', },
-        {'step': 'push-to-registry', },
-        {'step': 'hab.canary', 'trigger_next_step_manually': True, },
-        {'step': 'hab.main', },
-    ]
-    mock_get_deploy_groups_used_by_framework.return_value = [
-        'hab.canary',
-        'hab.main',
-    ]
+    mock_get_pipeline_deploy_groups.return_value = ['hab.canary', 'hab.main']
+    mock_get_deploy_groups_used_by_framework.return_value = ['hab.canary', 'hab.main']
     actual = deployments_check(service='fake_service', soa_dir='/fake/path')
     assert actual is True
 
 
-@patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
+@patch('paasta_tools.cli.cmds.check.get_pipeline_deploy_groups', autospec=True)
 @patch('paasta_tools.cli.cmds.check.get_deploy_groups_used_by_framework', autospec=True)
 def test_marathon_deployments_deploy_but_not_marathon(
     mock_get_deploy_groups_used_by_framework,
-    mock_get_pipeline_config,
+    mock_get_pipeline_deploy_groups,
     capfd,
 ):
-    mock_get_pipeline_config.return_value = [
-        {'step': 'itest', },
-        {'step': 'performance-check', },
-        {'step': 'push-to-registry', },
-        {'step': 'hab.canary', 'trigger_next_step_manually': True, },
-        {'step': 'hab.main', },
-        {'step': 'hab.EXTRA', },
-    ]
-    mock_get_deploy_groups_used_by_framework.return_value = [
-        'hab.canary',
-        'hab.main',
-    ]
+    mock_get_pipeline_deploy_groups.return_value = ['hab.canary', 'hab.main', 'hab.EXTRA']
+    mock_get_deploy_groups_used_by_framework.return_value = ['hab.canary', 'hab.main']
     actual = deployments_check(service='fake_service', soa_dir='/fake/service')
     assert actual is False
     assert 'EXTRA' in capfd.readouterr()[0]
 
 
-@patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
+@patch('paasta_tools.cli.cmds.check.get_pipeline_deploy_groups', autospec=True)
 @patch('paasta_tools.cli.cmds.check.get_deploy_groups_used_by_framework', autospec=True)
 def test_marathon_deployments_marathon_but_not_deploy(
     mock_get_deploy_groups_used_by_framework,
-    mock_get_pipeline_config,
+    mock_get_pipeline_deploy_groups,
     capfd,
 ):
-    mock_get_pipeline_config.return_value = [
-        {'step': 'itest', },
-        {'step': 'performance-check', },
-        {'step': 'push-to-registry', },
-        {'step': 'hab.canary', 'trigger_next_step_manually': True, },
-        {'step': 'hab.main', },
-    ]
-    mock_get_deploy_groups_used_by_framework.return_value = [
-        'hab.canary',
-        'hab.main',
-        'hab.BOGUS',
-    ]
+    mock_get_pipeline_deploy_groups.return_value = ['hab.canary', 'hab.main']
+    mock_get_deploy_groups_used_by_framework.return_value = ['hab.canary', 'hab.main', 'hab.BOGUS']
     actual = deployments_check(service='fake_service', soa_dir='/fake/path')
     assert actual is False
     assert 'BOGUS' in capfd.readouterr()[0]

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -396,8 +396,8 @@ class TestTronJobConfig:
         errors = job_config.validate()
         assert len(errors) == 3
 
-    @mock.patch('paasta_tools.tron_tools.get_pipeline_config', autospec=True)
-    def test_validate_invalid_deploy_group(self, mock_pipeline_config):
+    @mock.patch('paasta_tools.tron_tools.get_pipeline_deploy_groups', autospec=True)
+    def test_validate_invalid_deploy_group(self, mock_get_pipeline_deploy_groups):
         job_dict = {
             'node': 'batch_server',
             'schedule': 'daily 12:10:00',
@@ -412,13 +412,13 @@ class TestTronJobConfig:
                 },
             },
         }
-        mock_pipeline_config.return_value = [{'step': 'deploy_group_1'}, {'step': 'deploy_group_2'}]
+        mock_get_pipeline_deploy_groups.return_value = ['deploy_group_1', 'deploy_group_2']
         job_config = tron_tools.TronJobConfig('my_job', job_dict, 'fake-cluster')
         errors = job_config.validate()
         assert len(errors) == 1
 
-    @mock.patch('paasta_tools.tron_tools.get_pipeline_config', autospec=True)
-    def test_validate_valid_deploy_group(self, mock_pipeline_config):
+    @mock.patch('paasta_tools.tron_tools.get_pipeline_deploy_groups', autospec=True)
+    def test_validate_valid_deploy_group(self, mock_get_pipeline_deploy_groups):
         job_dict = {
             'node': 'batch_server',
             'schedule': 'daily 12:10:00',
@@ -433,13 +433,13 @@ class TestTronJobConfig:
                 },
             },
         }
-        mock_pipeline_config.return_value = [{'step': 'deploy_group_1'}, {'step': 'deploy_group_2'}]
+        mock_get_pipeline_deploy_groups.return_value = ['deploy_group_1', 'deploy_group_2']
         job_config = tron_tools.TronJobConfig('my_job', job_dict, 'fake-cluster')
         errors = job_config.validate()
         assert len(errors) == 0
 
-    @mock.patch('paasta_tools.tron_tools.get_pipeline_config', autospec=True)
-    def test_validate_invalid_action_deploy_group(self, mock_pipeline_config):
+    @mock.patch('paasta_tools.tron_tools.get_pipeline_deploy_groups', autospec=True)
+    def test_validate_invalid_action_deploy_group(self, mock_get_pipeline_deploy_groups):
         job_dict = {
             'node': 'batch_server',
             'schedule': 'daily 12:10:00',
@@ -454,13 +454,13 @@ class TestTronJobConfig:
                 },
             },
         }
-        mock_pipeline_config.return_value = [{'step': 'deploy_group_1'}, {'step': 'deploy_group_2'}]
+        mock_get_pipeline_deploy_groups.return_value = ['deploy_group_1', 'deploy_group_2']
         job_config = tron_tools.TronJobConfig('my_job', job_dict, 'fake-cluster')
         errors = job_config.validate()
         assert len(errors) == 1
 
-    @mock.patch('paasta_tools.tron_tools.get_pipeline_config', autospec=True)
-    def test_validate_action_valid_deploy_group(self, mock_pipeline_config):
+    @mock.patch('paasta_tools.tron_tools.get_pipeline_deploy_groups', autospec=True)
+    def test_validate_action_valid_deploy_group(self, mock_get_pipeline_deploy_groups):
         job_dict = {
             'node': 'batch_server',
             'schedule': 'daily 12:10:00',
@@ -476,7 +476,7 @@ class TestTronJobConfig:
                 },
             },
         }
-        mock_pipeline_config.return_value = [{'step': 'deploy_group_1'}, {'step': 'deploy_group_2'}]
+        mock_get_pipeline_deploy_groups.return_value = ['deploy_group_1', 'deploy_group_2']
         job_config = tron_tools.TronJobConfig('my_job', job_dict, 'fake-cluster')
         errors = job_config.validate()
         assert len(errors) == 0


### PR DESCRIPTION
This is a small refactor to make it easier to use the same deploy_group validation code we have in tron for all things.