### PR TITLE
Bump the drain timeout to 10min

### DIFF
--- a/paasta_tools/drain_lib.py
+++ b/paasta_tools/drain_lib.py
@@ -165,7 +165,7 @@ class HacheckDrainMethod(DrainMethod):
         service: str,
         instance: str,
         registrations: List[str],
-        delay: float = 240,
+        delay: float = 600,
         hacheck_port: int = 6666,
         expiration: float = 0,
         **kwargs: Dict,


### PR DESCRIPTION
I think it isn't so bad to have a long drain timeout.

When things go bad, it is nice that a large bounce can still make progress, even under heavy load.

Otherwise, we can get into a situation where we can *never* make progress!