### PR TITLE
Print message about cost when emitting resource request for Spark

### DIFF
--- a/paasta_tools/clusterman.py
+++ b/paasta_tools/clusterman.py
@@ -7,6 +7,7 @@ CLUSTERMAN_METRICS_YAML_FILE_PATH = '/nail/srv/configs/clusterman_metrics.yaml'
 def get_clusterman_metrics():
     try:
         import clusterman_metrics
+        import clusterman_metrics.util.costs
         clusterman_yaml = CLUSTERMAN_YAML_FILE_PATH
         staticconf.YamlConfiguration(CLUSTERMAN_METRICS_YAML_FILE_PATH, namespace='clusterman_metrics')
     except (ImportError, FileNotFoundError):

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -1,5 +1,5 @@
 --extra-index-url=https://pypi.yelpcorp.com/simple
-clusterman_metrics==2.0.0
+clusterman_metrics==2.2.0
 crypto_lib==4.0.0
 scribereader==0.2.6
 vault-tools==0.7.25


### PR DESCRIPTION
Core ML suggested we always print the message in spark_tools, so doing the same here. If it's over the warning threshold, the message turns red and gets an extra "WARNING". 

Example:
```
$ python paasta_tools/cli/cli.py spark-run --cmd pyspark
Please wait while the image (docker-paasta.yelpcorp.com:443/services-spark:paasta-aaef4e8357a941b35085da120b6572e9a876e721) is pulled (times out after 5m)...
paasta-aaef4e8357a941b35085da120b6572e9a876e721: Pulling from services-spark
Digest: sha256:57821f1f7f23249e105ac154a8ce4543297d4a9d135e93f44ad1c5aaa9f34180
Status: Image is up to date for docker-paasta.yelpcorp.com:443/services-spark:paasta-aaef4e8357a941b35085da120b6572e9a876e721

Spark monitoring URL http://dev54-uswest1adevc.dev.yelpcorp.com:45653

Sending resource request metrics to Clusterman
WARNING: Resource request (4 cpus and 9010.0 MB memory total) is estimated to cost $0.064 per hour
Python 3.6.0 (default, Jan 13 2017, 20:56:47) 
...
```