### PR TITLE
Place the bash completion script in the completion dir

### DIFF
--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -53,7 +53,7 @@ opt/venvs/paasta-tools/bin/paasta_serviceinit.py usr/bin/paasta_serviceinit
 opt/venvs/paasta-tools/bin/paasta_setup_chronos_job usr/bin/paasta_setup_chronos_job
 opt/venvs/paasta-tools/bin/paasta_setup_chronos_job usr/bin/setup_chronos_job
 opt/venvs/paasta-tools/bin/paasta_setup_tron_namespace usr/bin/paasta_setup_tron_namespace
-opt/venvs/paasta-tools/bin/paasta_tabcomplete.sh etc/bash_completion.d/paasta.bash
+opt/venvs/paasta-tools/bin/paasta_tabcomplete.sh usr/share/bash-completion/completions/paasta
 opt/venvs/paasta-tools/bin/paasta usr/bin/paasta
 opt/venvs/paasta-tools/bin/setup_marathon_job.py usr/bin/setup_marathon_job
 opt/venvs/paasta-tools/bin/setup_kubernetes_job.py usr/bin/setup_kubernetes_job


### PR DESCRIPTION
Stop using the compatibility dir and use the standard completion dir, introduced in bash-completion 2.x. Completion scripts in there are lazily loaded, which defers the ~40ms cost of invoking the completion registration.