### PR TITLE
rename flink to flinkcluster in more places

### DIFF
--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -862,7 +862,7 @@ def get_instance_config(
         instance_config_load_function = load_kubernetes_service_config
     elif instance_type == 'tron':
         instance_config_load_function = load_tron_instance_config
-    elif instance_type == 'flink':
+    elif instance_type == 'flinkcluster':
         instance_config_load_function = load_flink_instance_config
     else:
         raise NotImplementedError(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -117,7 +117,7 @@ INSTANCE_TYPES = (
     'adhoc',
     'kubernetes',
     'tron',
-    'flink',
+    'flinkcluster',
 )
 
 


### PR DESCRIPTION
@analogue just a couple of places that were missed in the flink/flinkcluster rename that have left (atleast) paasta stop broken.