### PR TITLE
Paasta dump locally running services script

### DIFF
--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -38,6 +38,7 @@ opt/venvs/paasta-tools/bin/paasta_deploy_chronos_jobs usr/bin/paasta_deploy_chro
 opt/venvs/paasta-tools/bin/paasta_deploy_tron_jobs usr/bin/paasta_deploy_tron_jobs
 opt/venvs/paasta-tools/bin/paasta-deployd usr/bin/paasta-deployd
 opt/venvs/paasta-tools/bin/paasta_docker_wrapper usr/bin/paasta_docker_wrapper
+opt/venvs/paasta-tools/bin/paasta_dump_locally_running_services usr/bin/paasta_dump_locally_running_services
 opt/venvs/paasta-tools/bin/paasta_execute_docker_command.py usr/bin/paasta_execute_docker_command
 opt/venvs/paasta-tools/bin/paasta_firewall_logging usr/bin/paasta_firewall_logging
 opt/venvs/paasta-tools/bin/paasta_firewall_update usr/bin/paasta_firewall_update

--- a/paasta_tools/dump_locally_running_services.py
+++ b/paasta_tools/dump_locally_running_services.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# Copyright 2015-2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Usage: ./paasta_dump_locally_running_services.py
+
+Outputs a JSON-encoded list of services that are running on this host along
+with the host port that each service is listening on.
+"""
+import json
+import sys
+
+from paasta_tools.marathon_tools import get_marathon_services_running_here_for_nerve
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import paasta_print
+
+
+def main():
+    local_services = get_marathon_services_running_here_for_nerve(
+        cluster=None,
+        soa_dir=DEFAULT_SOA_DIR,
+    )
+    paasta_print(json.dumps(local_services))
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
             'paasta_firewall_logging=paasta_tools.firewall_logging:main',
             'paasta_oom_logger=paasta_tools.oom_logger:main',
             'paasta_broadcast_log=paasta_tools.marathon_tools:broadcast_log_all_services_running_here_from_stdin',
+            'paasta_dump_locally_running_services=paasta_tools.dump_locally_running_services:main',
         ],
         'paste.app_factory': [
             'paasta-api-config=paasta_tools.api.api:make_app',


### PR DESCRIPTION
Adds a script to dump the output of `get_marathon_services_running_here_for_nerve` in JSON format on the command line.

This will be used to determine which services are running on the current host in order to set up proper proxy routing.

Since this script just calls `get_marathon_services_running_here_for_nerve` directly, the existing tests in `tests/test_marathon_tools.py` and `paasta_itests/marathon.feature' are sufficient.