### PR TITLE
Script for getting resource allocation for each task

### DIFF
--- a/paasta_tools/contrib/get_container_allocation.py
+++ b/paasta_tools/contrib/get_container_allocation.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+import a_sync
+
+from paasta_tools import mesos_tools
+from paasta_tools.utils import load_system_paasta_config
+
+
+def get_mesos_container_id_from_task(task):
+    for status in task['statuses']:
+        container_id = status.get('container_status', {}).get('container_id', {}).get('value')
+        if container_id:
+            return container_id
+
+
+def get_paasta_service_instance_from_task(task):
+    docker_params = task['container'].get('docker', {}).get('parameters', [])
+    service, instance = None, None
+    for param in docker_params:
+        if param['key'] == 'label':
+            label = param['value']
+            if label.startswith('paasta_service='):
+                service = label.split('=')[1]
+            if label.startswith('paasta_instance='):
+                instance = label.split('=')[1]
+    return service, instance
+
+
+@a_sync.to_blocking
+async def get_task_allocation_info():
+    tasks = await mesos_tools.get_cached_list_of_running_tasks_from_frameworks()
+    info_list = []
+    for task in tasks:
+        info = {'resources': task['resources']}
+        info['mesos_container_id'] = get_mesos_container_id_from_task(task)
+        service, instance = get_paasta_service_instance_from_task(task)
+        info['service'] = service
+        info['instance'] = instance
+        info_list.append(info)
+
+
+def main():
+    cluster = load_system_paasta_config().get_cluster()
+    info_list = get_task_allocation_info()
+    for info in info_list:
+        info['cluster'] = cluster
+        print(info)
+
+
+if __name__ == '__main__':
+    main()

--- a/paasta_tools/contrib/get_running_task_allocation.py
+++ b/paasta_tools/contrib/get_running_task_allocation.py
@@ -1,15 +1,22 @@
 #!/usr/bin/env python
+import time
+
 import a_sync
+import simplejson as json
 
 from paasta_tools import mesos_tools
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import paasta_print
 
 
-def get_mesos_container_id_from_task(task):
+def get_container_info_from_task(task):
     for status in task['statuses']:
+        if status['state'] != 'TASK_RUNNING':
+            continue
         container_id = status.get('container_status', {}).get('container_id', {}).get('value')
-        if container_id:
-            return container_id
+        time_start = status.get('timestamp')
+        return container_id, time_start
+    return None, None
 
 
 def get_paasta_service_instance_from_task(task):
@@ -25,25 +32,32 @@ def get_paasta_service_instance_from_task(task):
     return service, instance
 
 
+async def get_pool_from_task(task):
+    attributes = (await task.slave())['attributes']
+    return attributes.get('pool', 'default')
+
+
 @a_sync.to_blocking
 async def get_task_allocation_info():
     tasks = await mesos_tools.get_cached_list_of_running_tasks_from_frameworks()
     info_list = []
     for task in tasks:
         info = {'resources': task['resources']}
-        info['mesos_container_id'] = get_mesos_container_id_from_task(task)
-        service, instance = get_paasta_service_instance_from_task(task)
-        info['service'] = service
-        info['instance'] = instance
+        info['mesos_container_id'], info['start_time'] = get_container_info_from_task(task)
+        info['paasta_service'], info['paasta_instance'] = get_paasta_service_instance_from_task(task)
+        info['paasta_pool'] = await get_pool_from_task(task)
         info_list.append(info)
+    return info_list
 
 
 def main():
     cluster = load_system_paasta_config().get_cluster()
     info_list = get_task_allocation_info()
+    timestamp = time.time()
     for info in info_list:
         info['cluster'] = cluster
-        print(info)
+        info['timestamp'] = timestamp
+        paasta_print(json.dumps(info))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I was thinking we could run this in a cron job, pipe the output of this into a scribe log, and ingest that into splunk.

The contents of this log should be enough to track how long each task runs and how many resources it uses. We can also join this with the DockerStats logs, for utilization data, through the mesos_container_id - the DockerStats include container_name, which is just `mesos-{mesos_container_id}`. 

Does this look reasonable?