### PR TITLE
Support SSL for paasta-api client

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1607,6 +1607,9 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     cluster: str
     dashboard_links: Dict[str, Dict[str, str]]
     api_endpoints: Dict[str, str]
+    api_ca_certificates: Dict[str, str]
+    default_api_ca_certificate: str
+    enable_client_cert_auth: bool
     fsm_template: str
     log_reader: LogReaderConfig
     log_writer: LogWriterConfig
@@ -1785,6 +1788,22 @@ class SystemPaastaConfig:
 
     def get_api_endpoints(self) -> Mapping[str, str]:
         return self.config_dict['api_endpoints']
+
+    def get_api_ca_certificates(self) -> Mapping[str, str]:
+        """ A mapping of cluster name to CA certificate for validating API server identity """
+        return self.config_dict.get('api_ca_certificates', {})
+
+    def get_default_api_ca_certificate(self) -> str:
+        """ A default CA certificate to fall back to if there is not a cluster mapped in
+        get_api_ca_certificates
+        """
+        return self.config_dict.get('default_api_ca_certificate', '/etc/paasta/pki/ca.crt')
+
+    def get_enable_client_cert_auth(self) -> bool:
+        """
+        If enabled present a client certificate from ~/.paasta/pki/<cluster>.crt and ~/.paasta/pki/<cluster>.key
+        """
+        return self.config_dict.get('enable_client_cert_auth', True)
 
     def get_fsm_template(self) -> str:
         fsm_path = os.path.dirname(paasta_tools.cli.fsm.__file__)

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -3,7 +3,7 @@ aiohttp >= 3.2.1
 argcomplete >= 0.8.1
 boto3
 botocore
-bravado >= 8.4.0
+bravado >= 10.2.0
 choice >= 0.1
 chronos-python >= 1.2.0
 cookiecutter >= 1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ binaryornot==0.4.4
 boto==2.48.0
 boto3==1.4.7
 botocore==1.7.21
-bravado==9.2.2
-bravado-core==4.13.1
+bravado==10.4.1
+bravado-core==5.12.1
 cachetools==2.0.1
 certifi==2017.11.5
 chardet==3.0.4
@@ -50,7 +50,8 @@ kubernetes==6.0.0
 manhole==1.5.0
 marathon==0.9.3
 MarkupSafe==1.0
-msgpack-python==0.4.8
+monotonic==1.4
+msgpack-python==0.5.6
 multidict==4.1.0
 mypy-extensions==0.3.0
 oauthlib==2.0.7

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -14,6 +14,7 @@
 import mock
 
 from paasta_tools.api.client import get_paasta_api_client
+from paasta_tools.api.client import PaastaRequestsClient
 
 
 def test_get_paasta_api_client(system_paasta_config):
@@ -24,4 +25,17 @@ def test_get_paasta_api_client(system_paasta_config):
         mock_load_system_paasta_config.return_value = system_paasta_config
 
         client = get_paasta_api_client()
+        assert client
+
+
+def test_PaastaRequestsClient():
+    with mock.patch(
+        'paasta_tools.api.client.RequestsClient',
+        autospec=True,
+    ):
+        client = PaastaRequestsClient(
+            scheme='http',
+            cluster='westeros-prod',
+            system_paasta_config=mock.Mock(),
+        )
         assert client


### PR DESCRIPTION
This is so we can support SSL from the swagger client. This is only
enabled once we configure https endpoints for our API. It also supports
presenting client certificates. I tested this all with the
example-cluster and an nginx proxy and it seems to work fine.