### PR TITLE
move source of truth of valid clusters to config

### DIFF
--- a/example_cluster/paasta/clusters.json
+++ b/example_cluster/paasta/clusters.json
@@ -1,0 +1,1 @@
+{"clusters": ["testcluster"]}

--- a/general_itests/deployments_json.feature
+++ b/general_itests/deployments_json.feature
@@ -2,6 +2,7 @@ Feature: Per-Service Deployments.json can be written and read back
 
     Scenario: Per-Service Deployments.json can be written and read back
        Given a test git repo is setup with commits
+	   And a valid system paasta config
 	When paasta mark-for-deployments is run against the repo
 	 And paasta stop is run against the repo
 	 And we generate deployments.json for that service

--- a/general_itests/fake_etc_paasta/clusters.json
+++ b/general_itests/fake_etc_paasta/clusters.json
@@ -1,0 +1,1 @@
+{"clusters": ["test-cluster"]}

--- a/general_itests/fake_soa_configs/fake_deployments_json_service/marathon-test-cluster.yaml
+++ b/general_itests/fake_soa_configs/fake_deployments_json_service/marathon-test-cluster.yaml
@@ -8,4 +8,4 @@ test_instance_2:
    cpus: 0.1
    ram: 250
    disk: 256.7
-   deploy_group: test_cluster.test_instance
+   deploy_group: test-cluster.test_instance

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -40,11 +40,14 @@ class FakeArgs:
 @patch('paasta_tools.cli.cmds.mark_for_deployment.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment.mark_for_deployment', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment.get_currently_deployed_sha', autospec=True)
+@patch('paasta_tools.cli.cmds.mark_for_deployment.list_deploy_groups', autospec=True)
 def test_paasta_mark_for_deployment_acts_like_main(
+    mock_list_deploy_groups,
     mock_get_currently_deployed_sha,
     mock_mark_for_deployment,
     mock_validate_service_name,
 ):
+    mock_list_deploy_groups.return_value = ['test_deploy_group']
     mock_mark_for_deployment.return_value = 42
     assert mark_for_deployment.paasta_mark_for_deployment(FakeArgs) == 42
     mock_mark_for_deployment.assert_called_once_with(
@@ -99,7 +102,9 @@ def test_mark_for_deployment_sad(mock_create_remote_refs, mock__log_audit, mock_
 @patch('paasta_tools.cli.cmds.mark_for_deployment.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment.is_docker_image_already_in_registry', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment.get_currently_deployed_sha', autospec=True)
+@patch('paasta_tools.cli.cmds.mark_for_deployment.list_deploy_groups', autospec=True)
 def test_paasta_mark_for_deployment_when_verify_image_fails(
+    mock_list_deploy_groups,
     mock_get_currently_deployed_sha,
     mock_is_docker_image_already_in_registry,
     mock_validate_service_name,
@@ -107,6 +112,7 @@ def test_paasta_mark_for_deployment_when_verify_image_fails(
     class FakeArgsRollback(FakeArgs):
         verify_image = True
 
+    mock_list_deploy_groups.return_value = ['test_deploy_groups']
     mock_is_docker_image_already_in_registry.return_value = False
     with raises(ValueError):
         mark_for_deployment.paasta_mark_for_deployment(FakeArgsRollback)
@@ -115,7 +121,9 @@ def test_paasta_mark_for_deployment_when_verify_image_fails(
 @patch('paasta_tools.cli.cmds.mark_for_deployment.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment.is_docker_image_already_in_registry', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment.get_currently_deployed_sha', autospec=True)
+@patch('paasta_tools.cli.cmds.mark_for_deployment.list_deploy_groups', autospec=True)
 def test_paasta_mark_for_deployment_when_verify_image_succeeds(
+    mock_list_deploy_groups,
     mock_get_currently_deployed_sha,
     mock_is_docker_image_already_in_registry,
     mock_validate_service_name,
@@ -123,6 +131,7 @@ def test_paasta_mark_for_deployment_when_verify_image_succeeds(
     class FakeArgsRollback(FakeArgs):
         verify_image = True
 
+    mock_list_deploy_groups.return_value = ['test_deploy_groups']
     mock_is_docker_image_already_in_registry.return_value = False
     with raises(ValueError):
         mark_for_deployment.paasta_mark_for_deployment(FakeArgsRollback)
@@ -139,7 +148,9 @@ def test_paasta_mark_for_deployment_when_verify_image_succeeds(
 @patch('paasta_tools.cli.cmds.mark_for_deployment.mark_for_deployment', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment.MarkForDeploymentProcess.do_wait_for_deployment', autospec=True)
 @patch('paasta_tools.cli.cmds.mark_for_deployment.get_currently_deployed_sha', autospec=True)
+@patch('paasta_tools.cli.cmds.mark_for_deployment.list_deploy_groups', autospec=True)
 def test_paasta_mark_for_deployment_with_good_rollback(
+    mock_list_deploy_groups,
     mock_get_currently_deployed_sha,
     mock_do_wait_for_deployment,
     mock_mark_for_deployment,
@@ -151,6 +162,7 @@ def test_paasta_mark_for_deployment_with_good_rollback(
         block = True
         timeout = 600
 
+    mock_list_deploy_groups.return_value = ['test_deploy_groups']
     mock_mark_for_deployment.return_value = 0
 
     def do_wait_for_deployment_side_effect(self, target_commit):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -707,12 +707,20 @@ def test_missing_cluster_configs_are_ignored():
         '/nail/etc/services/service1/marathon-cluster1.yaml',
         '/nail/etc/services/service2/chronos-cluster2.yaml',
     ]
+    fake_system_paasta_config = utils.SystemPaastaConfig(
+        {
+            'clusters': ['cluster1', 'cluster2'],
+        }, fake_soa_dir,
+    )
     expected = []
     with mock.patch(
         'os.path.join', autospec=True, return_value='%s/*' % fake_soa_dir,
     ) as mock_join_path, mock.patch(
         'glob.glob', autospec=True, return_value=fake_cluster_configs,
-    ) as mock_glob:
+    ) as mock_glob, mock.patch(
+        'paasta_tools.utils.load_system_paasta_config',
+        return_value=fake_system_paasta_config, autospec=True,
+    ):
         actual = utils.list_clusters(soa_dir=fake_soa_dir)
         assert actual == expected
         mock_join_path.assert_called_once_with(fake_soa_dir, '*')
@@ -757,6 +765,11 @@ def test_list_clusters_ignores_bogus_clusters():
         '/nail/etc/services/service1/chronos-cluster2.yaml',
         '/nail/etc/services/service1/chronos-SHARED.yaml',
     ]
+    fake_system_paasta_config = utils.SystemPaastaConfig(
+        {
+            'clusters': ['cluster1', 'cluster2'],
+        }, fake_soa_dir,
+    )
     expected = ['cluster1', 'cluster2']
     with mock.patch(
         'os.path.join', autospec=True, return_value=f'{fake_soa_dir}/{fake_service}',
@@ -764,8 +777,12 @@ def test_list_clusters_ignores_bogus_clusters():
         'glob.glob', autospec=True, return_value=fake_cluster_configs,
     ), mock.patch(
         'builtins.open', autospec=None, path=mock.mock_open(read_data="fakedata"),
+    ), mock.patch(
+        'paasta_tools.utils.load_system_paasta_config',
+        return_value=fake_system_paasta_config, autospec=True,
     ):
         actual = utils.list_clusters(service=fake_service)
+
         assert actual == expected
 
 


### PR DESCRIPTION
rather than dynamically generating the list out of a regex, use the list
of clusters that is defined in system paasta config. This will stop files
distributed with yelpsoa-configs but not managed by paasta-tools from
causing issues when they have unexpected naming conventions


internal ticket PAASTA-15450 - accompanying puppet review /r/404806 which needs to be shipped first