### PR TITLE
Mesos task does not always have container info

### DIFF
--- a/paasta_tools/contrib/get_running_task_allocation.py
+++ b/paasta_tools/contrib/get_running_task_allocation.py
@@ -20,7 +20,10 @@ def get_container_info_from_task(task):
 
 
 def get_paasta_service_instance_from_task(task):
-    docker_params = task['container'].get('docker', {}).get('parameters', [])
+    try:
+        docker_params = task['container'].get('docker', {}).get('parameters', [])
+    except KeyError:
+        return None, None
     service, instance = None, None
     for param in docker_params:
         if param['key'] == 'label':


### PR DESCRIPTION
Small fix - the script returns a KeyError on Jenkins frameworks, which don't have container info in the task. The other keys the script expects are `statuses` and `resources`, which I think will always exist.