### PR TITLE
Add instance type as env variable

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -331,6 +331,7 @@ def get_spark_env(
     spark_env['AWS_ACCESS_KEY_ID'] = access_key
     spark_env['AWS_SECRET_ACCESS_KEY'] = secret_key
     spark_env['PAASTA_LAUNCHED_BY'] = get_possible_launched_by_user_variable_from_env()
+    spark_env['PAASTA_INSTANCE_TYPE'] = 'spark'
 
     # Run spark (and mesos framework) as root.
     spark_env['SPARK_USER'] = 'root'
@@ -437,6 +438,7 @@ def get_spark_config(
         'spark.executorEnv.PAASTA_SERVICE': args.service,
         'spark.executorEnv.PAASTA_INSTANCE': '{}_{}'.format(args.instance, get_username()),
         'spark.executorEnv.PAASTA_CLUSTER': args.cluster,
+        'spark.executorEnv.PAASTA_INSTANCE_TYPE': 'spark',
         'spark.mesos.executor.docker.parameters': 'label=paasta_service={},label=paasta_instance={}_{}'.format(
             args.service, args.instance, get_username(),
         ),

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -506,6 +506,9 @@ class InstanceConfig:
         :returns: A string specified in the config, None if not specified"""
         return self.config_dict.get('cmd', None)
 
+    def get_instance_type(self) -> Optional[str]:
+        return getattr(self, 'config_filename_prefix', None)
+
     def get_env_dictionary(self) -> Dict[str, str]:
         """A dictionary of key/value pairs that represent environment variables
         to be injected to the container environment"""
@@ -519,6 +522,9 @@ class InstanceConfig:
         team = self.get_team()
         if team:
             env["PAASTA_MONITORING_TEAM"] = team
+        instance_type = self.get_instance_type()
+        if instance_type:
+            env["PAASTA_INSTANCE_TYPE"] = instance_type
         user_env = self.config_dict.get('env', {})
         env.update(user_env)
         return {str(k): str(v) for (k, v) in env.items()}

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -177,6 +177,7 @@ class TestConfigureAndRunDockerContainer:
                 'PAASTA_SERVICE': 'fake_service',
                 'PAASTA_INSTANCE': 'fake_instance',
                 'PAASTA_CLUSTER': 'fake_cluster',
+                'PAASTA_INSTANCE_TYPE': 'spark',
                 'PAASTA_DEPLOY_GROUP': 'fake_cluster.fake_instance',
                 'PAASTA_DOCKER_IMAGE': 'fake_service:fake_sha',
                 'PAASTA_LAUNCHED_BY': mock.ANY,

--- a/tests/test_chronos_tools.py
+++ b/tests/test_chronos_tools.py
@@ -429,6 +429,7 @@ class TestChronosTools:
             {"name": "PAASTA_SERVICE", "value": "fake_name"},
             {"name": "PAASTA_INSTANCE", "value": "fake_instance"},
             {"name": "PAASTA_DEPLOY_GROUP", "value": "fake_cluster.fake_instance"},
+            {"name": "PAASTA_INSTANCE_TYPE", "value": "chronos"},
             {"name": "PAASTA_DOCKER_IMAGE", "value": ""},
             {"name": "foo", "value": "bar"},
             {"name": "biz", "value": "baz"},

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -781,6 +781,7 @@ class TestMarathonTools:
             'PAASTA_SERVICE': 'can_you_dig_it',
             'PAASTA_DEPLOY_GROUP': 'fake_cluster.yes_i_can',
             'PAASTA_DOCKER_IMAGE': 'dockervania_from_konami',
+            'PAASTA_INSTANCE_TYPE': 'marathon',
         }
         fake_cpus = .42
         fake_disk = 1234.5


### PR DESCRIPTION
For spark-run we need to manually override the value, because it loads other instance configs (e.g. adhoc, marathon, etc).