### PR TITLE
set paasta_config_sha as annotation on crs

### DIFF
--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -285,7 +285,7 @@ def format_custom_resource(
     config_hash = get_config_hash(
         instance_config,
     )
-    resource['metadata']['labels']['yelp.com/paasta_config_sha'] = config_hash
+    resource['metadata']['annotations']['yelp.com/paasta_config_sha'] = config_hash
     return resource
 
 
@@ -317,7 +317,7 @@ def reconcile_kubernetes_resource(
         desired_resource = KubeCustomResource(
             service=service,
             instance=inst,
-            config_sha=formatted_resource['metadata']['labels']['yelp.com/paasta_config_sha'],
+            config_sha=formatted_resource['metadata']['annotations']['yelp.com/paasta_config_sha'],
             kind=kind.singular,
         )
 

--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -195,10 +195,10 @@ def test_format_custom_resource():
                     'yelp.com/paasta_service': 'kurupt_fm',
                     'yelp.com/paasta_instance': 'radio_station',
                     'yelp.com/paasta_cluster': 'mycluster',
-                    'yelp.com/paasta_config_sha': mock_get_config_hash.return_value,
                 },
                 'annotations': {
                     'yelp.com/desired_state': 'running',
+                    'yelp.com/paasta_config_sha': mock_get_config_hash.return_value,
                 },
             },
             'spec': {'dummy': 'conf'},
@@ -249,7 +249,7 @@ def test_reconcile_kubernetes_resource():
         # instance up to date, do nothing
         mock_format_custom_resource.return_value = {
             'metadata': {
-                'labels': {
+                'annotations': {
                     'yelp.com/paasta_config_sha': 'conf123',
                 },
             },
@@ -270,7 +270,7 @@ def test_reconcile_kubernetes_resource():
         # instance diff config, update
         mock_format_custom_resource.return_value = {
             'metadata': {
-                'labels': {
+                'annotations': {
                     'yelp.com/paasta_config_sha': 'conf456',
                 },
             },


### PR DESCRIPTION
we currently set them as a label, rather than an annotation. however,
labelselectors used by deployments and other k8s objects  tend to be
immutable, and as such can't easily be modified to track changes to
paasta_config_sha. change to an annotation so we still have the metadata