### PR TITLE
Updated deployd logging a bit

### DIFF
--- a/paasta_tools/deployd/master.py
+++ b/paasta_tools/deployd/master.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import datetime
 import inspect
 import logging
 import socket
@@ -6,6 +7,7 @@ import sys
 import time
 from queue import Empty
 
+import humanize
 import service_configuration_lib
 
 from paasta_tools.deployd import watchers
@@ -71,16 +73,14 @@ class Inbox(PaastaThread):
             self.process_inbox()
 
     def process_inbox(self):
+        """Takes things from the bounce_later queue, adds them to the to_bounce queue, then
+        takes things from the to_bounce queue and puts them on the bounce_now queue when they are due"""
         try:
             service_instance = self.instances_to_bounce_later.get(block=False)
         except Empty:
             service_instance = None
         if service_instance:
-            self.log.debug("Processing {}.{} to see if we need to add it "
-                           "to bounce queue".format(
-                               service_instance.service,
-                               service_instance.instance,
-                           ))
+            self.log.debug(f"Processing {service_instance.service}.{service_instance.instance} from the bounce_later queue to see if we need to bounce it now")  # noqa: E501
             self.process_service_instance(service_instance)
         if self.instances_to_bounce_later.empty() and self.to_bounce:
             self.process_to_bounce()
@@ -89,23 +89,26 @@ class Inbox(PaastaThread):
     def process_service_instance(self, service_instance):
         service_instance_key = f"{service_instance.service}.{service_instance.instance}"
         if self.should_add_to_bounce(service_instance, service_instance_key):
-            self.log.info(f"Enqueuing {service_instance} to be bounced ASAP")
             self.to_bounce[service_instance_key] = service_instance
 
     def should_add_to_bounce(self, service_instance, service_instance_key):
         if service_instance_key in self.to_bounce:
             if service_instance.bounce_by > self.to_bounce[service_instance_key].bounce_by:
-                self.log.debug(f"{service_instance} already in bounce queue with higher priority")
+                self.log.debug(f"{service_instance} already in to_bounce queue with higher priority")
                 return False
         return True
 
     def process_to_bounce(self):
         bounced = []
-        self.log.debug("Processing %d bounce queue entries..." % len(self.to_bounce.keys()))
+        self.log.debug(f"Processing {len(self.to_bounce.keys())} to_bounce queue entries...")
         for service_instance_key in self.to_bounce.keys():
             if self.to_bounce[service_instance_key].bounce_by < int(time.time()):
                 service_instance = self.to_bounce[service_instance_key]
+                human_bounce_by = humanize.naturaldelta(
+                    datetime.timedelta(seconds=(time.time() - service_instance.bounce_by)),
+                )
                 bounced.append(service_instance_key)
+                self.log.info(f"Enqueuing {service_instance.service}.{service_instance.instance} to the bounce_now queue (bounce_by {human_bounce_by} ago)")  # noqa E501
                 self.instances_to_bounce_now.put(service_instance.priority, service_instance)
         for service_instance_key in bounced:
             self.to_bounce.pop(service_instance_key)

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -438,10 +438,10 @@ def get_tasks_by_state_for_app(
     async def categorize_task(task: MarathonTask) -> None:
         try:
             is_draining = await drain_method.is_draining(task)
-        except Exception:
+        except Exception as e:
             log_deploy_error(
-                f"Ignoring exception during is_draining of task {task.id}: "
-                f"{traceback.format_exc()}. Treating task as 'unhappy'.",
+                f"Ignoring {type(e).__name__} exception during is_draining of task "
+                f"{task.id} ({e.args[0]}). Treating task as 'unhappy'.",
             )
             state = 'unhappy'
         else:

--- a/tests/deployd/test_workers.py
+++ b/tests/deployd/test_workers.py
@@ -170,6 +170,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 instance='c137',
                 failures=0,
                 processed_count=0,
+                bounce_by=0,
             )
             ret = self.worker.process_service_instance(mock_si)
             expected = BounceResults(None, 0, mock_setup_timers.return_value)
@@ -192,6 +193,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 instance='c137',
                 failures=0,
                 processed_count=1,
+                bounce_by=0,
             )
             mock_setup_timers.return_value.bounce_length.stop.reset_mock()
             ret = self.worker.process_service_instance(mock_si)
@@ -202,6 +204,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 instance='c137',
                 failures=0,
                 processed_count=1,
+                bounce_by=0,
             )
             mock_deploy_marathon_service.return_value = (0, 60)
             mock_setup_timers.return_value.bounce_length.stop.reset_mock()

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -2007,11 +2007,8 @@ class TestGetOldHappyUnhappyDrainingTasks:
             )
 
         fake_log_deploy_error.assert_any_call(
-            RegexMatcher(
-                r'Ignoring exception during is_draining of task fake_down_unhappy: Traceback \(most recent call last\):'
-                '.*Exception: ohai',
-                flags=re.DOTALL,
-            ),
+            "Ignoring Exception exception during is_draining of task "
+            "fake_down_unhappy (ohai). Treating task as 'unhappy'.",
         )
 
 


### PR DESCRIPTION
I'm trying my best to really understand how deployd works.

My queue renaming helps, but there is still the `to_bounce` queue, which isn't really the bounce_now or bounce_later queues.

I have a hunch that we might have a bottleneck on the single inbox worker. I also think we could get rid of the bounce_now queue entirely and just have a bounce_now and bounce_later queue.

For now this is just more logging and stuff.