### PR TITLE
Pass POD_NAME to kubernetes pods

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -473,6 +473,16 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     ),
                 ),
             ),
+            V1EnvVar(
+                # this is used by some functions of operator-sdk
+                # it uses this environment variable to get the pods
+                name='POD_NAME',
+                value_from=V1EnvVarSource(
+                    field_ref=V1ObjectFieldSelector(
+                        field_path='metadata.name',
+                    ),
+                ),
+            ),
         ]
         return kubernetes_env
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -379,6 +379,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
     def test_get_kubernetes_environment(self):
         ret = self.deployment.get_kubernetes_environment()
         assert 'PAASTA_POD_IP' in [env.name for env in ret]
+        assert 'POD_NAME' in [env.name for env in ret]
 
     def test_get_resource_requirements(self):
         with mock.patch(


### PR DESCRIPTION
- As it's needed by operator-sdk for some functionalities like leader election, see https://github.com/operator-framework/operator-sdk/blob/a9ee17ecae3d1de4e1231ed46fb4d6bc69769054/pkg/k8sutil/k8sutil.go#L94