### PR TITLE
Fix deployd bounce_length timer

### DIFF
--- a/paasta_tools/deployd/common.py
+++ b/paasta_tools/deployd/common.py
@@ -33,6 +33,7 @@ BaseServiceInstance = namedtuple(
         'bounce_timers',
         'failures',
         'priority',
+        'processed_count',
     ],
 )
 
@@ -50,6 +51,7 @@ class ServiceInstance(BaseServiceInstance):
         failures: int = 0,
         bounce_timers: Optional[BounceTimers] = None,
         priority: Optional[int] = None,
+        processed_count: int = 0,
     ) -> 'ServiceInstance':
         if priority is None:
             priority = get_priority(service, instance, cluster)
@@ -62,6 +64,7 @@ class ServiceInstance(BaseServiceInstance):
             failures=failures,
             bounce_timers=bounce_timers,
             priority=priority,
+            processed_count=processed_count,
         )
 
 

--- a/paasta_tools/deployd/workers.py
+++ b/paasta_tools/deployd/workers.py
@@ -97,6 +97,7 @@ class PaastaDeployWorker(PaastaThread):
                     bounce_timers=bounce_timers,
                     priority=service_instance.priority,
                     failures=failures,
+                    processed_count=service_instance.processed_count + 1,
                 )
                 self.instances_to_bounce_later.put(service_instance)
             time.sleep(0.1)
@@ -129,9 +130,10 @@ class PaastaDeployWorker(PaastaThread):
                               bounce_again_in_seconds,
                           ))
         else:
-            bounce_timers.bounce_length.stop()
             self.log.info("{}.{} in steady state".format(
                 service_instance.service,
                 service_instance.instance,
             ))
+            if service_instance.processed_count > 0:
+                bounce_timers.bounce_length.stop()
         return BounceResults(bounce_again_in_seconds, return_code, bounce_timers)

--- a/tests/deployd/test_common.py
+++ b/tests/deployd/test_common.py
@@ -95,6 +95,7 @@ class TestServiceInstance(unittest.TestCase):
                 failures=0,
                 bounce_timers=None,
                 priority=1,
+                processed_count=0,
             )
             assert self.service_instance == expected
 
@@ -106,6 +107,7 @@ class TestServiceInstance(unittest.TestCase):
                 failures=0,
                 bounce_timers=None,
                 priority=2,
+                processed_count=0,
             )
             # https://github.com/python/mypy/issues/2852
             assert ServiceInstance(  # type: ignore
@@ -159,6 +161,7 @@ def test_rate_limit_instances():
                 bounce_by=1,
                 bounce_timers=None,
                 failures=0,
+                processed_count=0,
             ),
             BaseServiceInstance(
                 service='universe',
@@ -168,6 +171,7 @@ def test_rate_limit_instances():
                 bounce_by=31,
                 bounce_timers=None,
                 failures=0,
+                processed_count=0,
             ),
         ]
         assert ret == expected
@@ -182,6 +186,7 @@ def test_rate_limit_instances():
                 bounce_by=1,
                 bounce_timers=None,
                 failures=0,
+                processed_count=0,
             ),
             BaseServiceInstance(
                 service='universe',
@@ -191,6 +196,7 @@ def test_rate_limit_instances():
                 bounce_by=31,
                 bounce_timers=None,
                 failures=0,
+                processed_count=0,
             ),
         ]
         assert ret == expected

--- a/tests/deployd/test_deployd_master.py
+++ b/tests/deployd/test_deployd_master.py
@@ -49,6 +49,7 @@ class TestDedupedPriorityQueue(unittest.TestCase):
             bounce_by=1,
             bounce_timers=None,
             failures=0,
+            processed_count=0,
         )
 
     def test_put(self):
@@ -78,6 +79,7 @@ class TestDedupedPriorityQueue(unittest.TestCase):
                 bounce_by=1,
                 bounce_timers=None,
                 failures=0,
+                processed_count=0,
             )
             self.queue.bouncing.add('universe.c137')
             mock_paasta_queue_get.return_value = self.mock_service_instance
@@ -398,6 +400,7 @@ class TestDeployDaemon(unittest.TestCase):
                     bounce_by=1,
                     bounce_timers=None,
                     failures=0,
+                    processed_count=0,
                 )),
                 mock.call(BaseServiceInstance(
                     service='universe',
@@ -407,6 +410,7 @@ class TestDeployDaemon(unittest.TestCase):
                     bounce_by=1,
                     bounce_timers=None,
                     failures=0,
+                    processed_count=0,
                 )),
             ]
             self.deployd.instances_to_bounce_later.put.assert_has_calls(calls, any_order=True)

--- a/tests/deployd/test_watchers.py
+++ b/tests/deployd/test_watchers.py
@@ -165,6 +165,7 @@ class TestAutoscalerWatcher(unittest.TestCase):
                 watcher=self.watcher.__class__.__name__,
                 priority=0,
                 failures=0,
+                processed_count=0,
             ))
 
             mock_event_changed = mock_event_type.CHANGED
@@ -181,6 +182,7 @@ class TestAutoscalerWatcher(unittest.TestCase):
                 watcher=self.watcher.__class__.__name__,
                 priority=0,
                 failures=0,
+                processed_count=0,
             ))
 
     def test_process_folder_event(self):
@@ -402,6 +404,7 @@ class TestMaintenanceWatcher(unittest.TestCase):
                     priority=0,
                     bounce_timers=None,
                     failures=0,
+                    processed_count=0,
                 ),
                 BaseServiceInstance(
                     service='universe',
@@ -411,6 +414,7 @@ class TestMaintenanceWatcher(unittest.TestCase):
                     priority=0,
                     bounce_timers=None,
                     failures=0,
+                    processed_count=0,
                 ),
             ]
             assert ret == expected
@@ -626,6 +630,7 @@ class TestYelpSoaEventHandler(unittest.TestCase):
                 bounce_timers=None,
                 priority=0,
                 failures=0,
+                processed_count=0,
             )
             self.mock_filewatcher.instances_to_bounce_later.put.assert_called_with(expected_si)
             assert self.mock_filewatcher.instances_to_bounce_later.put.call_count == 1

--- a/tests/deployd/test_workers.py
+++ b/tests/deployd/test_workers.py
@@ -96,6 +96,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 instance='c137',
                 failures=0,
                 priority=0,
+                processed_count=0,
             )
             self.mock_instances_to_bounce_now.get.return_value = mock_si
             with raises(LoopBreak):
@@ -117,6 +118,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 bounce_timers=mock_timers,
                 failures=1,
                 priority=0,
+                processed_count=1,
             )
             with raises(LoopBreak):
                 self.worker.run()
@@ -128,6 +130,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 instance='c137',
                 failures=0,
                 priority=0,
+                processed_count=0,
             )
             self.mock_instances_to_bounce_now.get.return_value = mock_si
             mock_process_service_instance.side_effect = Exception
@@ -139,6 +142,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 bounce_timers=mock_si.bounce_timers,
                 failures=1,
                 priority=0,
+                processed_count=1,
             )
             with raises(LoopBreak):
                 self.worker.run()
@@ -165,6 +169,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 service='universe',
                 instance='c137',
                 failures=0,
+                processed_count=0,
             )
             ret = self.worker.process_service_instance(mock_si)
             expected = BounceResults(None, 0, mock_setup_timers.return_value)
@@ -180,8 +185,24 @@ class TestPaastaDeployWorker(unittest.TestCase):
             )
             assert mock_setup_timers.return_value.setup_marathon.stop.called
             assert not mock_setup_timers.return_value.processed_by_worker.start.called
+            assert not mock_setup_timers.return_value.bounce_length.stop.called
+
+            mock_si = mock.Mock(
+                service='universe',
+                instance='c137',
+                failures=0,
+                processed_count=1,
+            )
+            mock_setup_timers.return_value.bounce_length.stop.reset_mock()
+            ret = self.worker.process_service_instance(mock_si)
             assert mock_setup_timers.return_value.bounce_length.stop.called
 
+            mock_si = mock.Mock(
+                service='universe',
+                instance='c137',
+                failures=0,
+                processed_count=1,
+            )
             mock_deploy_marathon_service.return_value = (0, 60)
             mock_setup_timers.return_value.bounce_length.stop.reset_mock()
             ret = self.worker.process_service_instance(mock_si)


### PR DESCRIPTION
We currently include bounces where we just run setup_marathon_job and
find that the state is already good. In our dashboards we mostly exclude
this by just excluding stuff less than 60s which is the default sleep
between reprocessing. That's not always the case though if the queues
are busy or we ever change that sleep. This should ditch the metric for
things that aren't processed more than once i.e. they aren't really
bounced.