### PR TITLE
Fix spark-run history-server class path

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -355,6 +355,7 @@ def get_spark_env(
             args.spark_args,
             spark_ui_port,
         )
+        spark_env['SPARK_DAEMON_CLASSPATH'] = '/opt/spark/extra_jars/*'
         spark_env['SPARK_NO_DAEMONIZE'] = 'true'
 
     return spark_env


### PR DESCRIPTION
make test
.tox/py36-linux/bin/paasta spark-run --spark-args 'spark.history.fs.logDirectory=s3a://TEST_PATH ' --cmd history-server