### PR TITLE
Actually validate the instance configs when we run paasta validate

### DIFF
--- a/general_itests/fake_soa_configs_validate/fake_valid_service/chronos-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_valid_service/chronos-test-cluster.yaml
@@ -4,4 +4,4 @@ chronos_job:
   mem: 100
   disk: 250.2
   schedule: 'R/2015-08-14T10:00:00+00:00/PT10M'
-  deploy_group: test_deploy_group
+  deploy_group: fake_deploy_group

--- a/general_itests/fake_soa_configs_validate/fake_valid_service/deploy.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_valid_service/deploy.yaml
@@ -1,3 +1,3 @@
 ---
 pipeline:
-- step: test_deploy_group
+- step: fake_deploy_group

--- a/general_itests/validate.feature
+++ b/general_itests/validate.feature
@@ -5,7 +5,6 @@ Feature: paasta validate can be used
     When we run paasta validate
     Then it should have a return code of "0"
      And everything should pass
-     And the output should contain "has a valid instance"
 
   Scenario: Running paasta validate against an invalid service
     Given an "invalid" service

--- a/paasta_tools/chronos_tools.py
+++ b/paasta_tools/chronos_tools.py
@@ -551,17 +551,15 @@ class ChronosJobConfig(InstanceConfig):
         error_msgs = []
         # Use InstanceConfig to validate shared config keys like cpus and mem
         error_msgs.extend(super().validate())
-
         for param in [
-            'epsilon', 'retries', 'cpus', 'mem', 'disk',
+            'epsilon', 'retries', 'disk',
             'schedule', 'scheduleTimeZone', 'parents', 'cmd',
             'security', 'dependencies_reference',
         ]:
             check_passed, check_msg = self.check(param)
             if not check_passed:
                 error_msgs.append(check_msg)
-
-        return len(error_msgs) == 0, error_msgs
+        return error_msgs
 
     def get_healthcheck_mode(self, _):
         # Healthchecks are not supported yet in chronos

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -235,6 +235,15 @@ class TronActionConfig(InstanceConfig):
     def get_nerve_namespace(self) -> None:
         return None
 
+    def validate(self):
+        error_msgs = []
+        error_msgs.extend(super().validate())
+        # Tron is a little special, because it can *not* have a deploy group
+        # But only if an action is running via ssh and not via paasta
+        if self.get_deploy_group() is None and self.get_executor() == "mesos":
+            error_msgs.append(f"{self.get_job_name()}.{self.get_action_name()} must have a deploy_group set")
+        return error_msgs
+
 
 class TronJobConfig:
     """Represents a job in Tron, consisting of action(s) and job-level configuration values."""

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -569,10 +569,10 @@ class InstanceConfig:
         as a list of constraints.
         """
         return (
-            deploy_blacklist_to_constraints(blacklist) +
-            deploy_whitelist_to_constraints(whitelist) +
-            deploy_blacklist_to_constraints(system_deploy_blacklist) +
-            deploy_whitelist_to_constraints(system_deploy_whitelist)
+            deploy_blacklist_to_constraints(blacklist)
+            + deploy_whitelist_to_constraints(whitelist)
+            + deploy_blacklist_to_constraints(system_deploy_blacklist)
+            + deploy_whitelist_to_constraints(system_deploy_whitelist)
         )
 
     def get_deploy_blacklist(self) -> DeployBlacklist:
@@ -591,9 +591,9 @@ class InstanceConfig:
         """The monitoring_blacklist is a list of tuples of (location type, location value), where the tuples indicate
         which locations the user doesn't care to be monitored"""
         return (
-            safe_deploy_blacklist(self.config_dict.get('monitoring_blacklist', [])) +
-            self.get_deploy_blacklist() +
-            system_deploy_blacklist
+            safe_deploy_blacklist(self.config_dict.get('monitoring_blacklist', []))
+            + self.get_deploy_blacklist()
+            + system_deploy_blacklist
         )
 
     def get_docker_image(self) -> str:
@@ -715,7 +715,7 @@ class InstanceConfig:
         if deploy_group is not None:
             pipeline_deploy_groups = get_pipeline_deploy_groups(service=self.service, soa_dir=self.soa_dir)
             if deploy_group not in pipeline_deploy_groups:
-                return False, f'deploy_group {deploy_group} is not in service {self.service} deploy.yaml'
+                return False, f'{self.service}.{self.instance} uses deploy_group {deploy_group}, but it is not deploy.yaml'  # noqa: E501
         return True, ''
 
     def get_extra_volumes(self) -> List[DockerVolume]:
@@ -2841,8 +2841,8 @@ def get_config_hash(config: Any, force_bounce: str = None) -> str:
     """
     hasher = hashlib.md5()
     hasher.update(
-        json.dumps(config, sort_keys=True).encode('UTF-8') +
-        (force_bounce or '').encode('UTF-8'),
+        json.dumps(config, sort_keys=True).encode('UTF-8')
+        + (force_bounce or '').encode('UTF-8'),
     )
     return "config%s" % hasher.hexdigest()[:8]
 

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -21,13 +21,11 @@ import paasta_tools.chronos_tools
 from paasta_tools.cli.cmds.validate import check_service_path
 from paasta_tools.cli.cmds.validate import get_schema
 from paasta_tools.cli.cmds.validate import get_service_path
-from paasta_tools.cli.cmds.validate import invalid_chronos_instance
 from paasta_tools.cli.cmds.validate import paasta_validate
 from paasta_tools.cli.cmds.validate import paasta_validate_soa_configs
 from paasta_tools.cli.cmds.validate import SCHEMA_INVALID
 from paasta_tools.cli.cmds.validate import SCHEMA_VALID
 from paasta_tools.cli.cmds.validate import UNKNOWN_SERVICE
-from paasta_tools.cli.cmds.validate import valid_chronos_instance
 from paasta_tools.cli.cmds.validate import validate_chronos
 from paasta_tools.cli.cmds.validate import validate_schema
 from paasta_tools.cli.cmds.validate import validate_tron
@@ -35,6 +33,7 @@ from paasta_tools.cli.cmds.validate import validate_unique_instance_names
 
 
 @patch('paasta_tools.cli.cmds.validate.validate_unique_instance_names', autospec=True)
+@patch('paasta_tools.cli.cmds.validate.validate_paasta_objects', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.validate_all_schemas', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.validate_chronos', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.validate_tron', autospec=True)
@@ -46,6 +45,7 @@ def test_paasta_validate_calls_everything(
     mock_validate_tron,
     mock_validate_chronos,
     mock_validate_all_schemas,
+    mock_validate_paasta_objects,
     mock_validate_unique_instance_names,
 ):
     # Ensure each check in 'paasta_validate' is called
@@ -55,6 +55,7 @@ def test_paasta_validate_calls_everything(
     mock_validate_all_schemas.return_value = True
     mock_validate_chronos.return_value = True
     mock_validate_tron.return_value = True
+    mock_validate_paasta_objects.return_value = True
     mock_validate_unique_instance_names.return_value = True
 
     args = mock.MagicMock()
@@ -67,6 +68,7 @@ def test_paasta_validate_calls_everything(
     assert mock_validate_chronos.called
     assert mock_validate_tron.called
     assert mock_validate_unique_instance_names.called
+    assert mock_validate_paasta_objects.called
 
 
 def test_get_service_path_unknown(capfd):
@@ -486,40 +488,6 @@ some_batch:
 @patch('paasta_tools.cli.cmds.validate.list_all_instances_for_service', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.load_chronos_job_config', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service', autospec=True)
-def test_failing_chronos_job_validate(
-    mock_path_to_soa_dir_service,
-    mock_load_chronos_job_config,
-    mock_list_all_instances_for_service,
-    mock_list_clusters,
-    mock_get_services_for_cluster,
-    capfd,
-):
-    fake_service = 'fake-service'
-    fake_instance = 'fake-instance'
-    fake_cluster = 'penguin'
-
-    mock_chronos_job = mock.Mock(autospec=True)
-    mock_chronos_job.get_parents.return_value = None
-    mock_chronos_job.validate.return_value = (False, ['something is wrong with the config'])
-
-    mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', fake_service)
-    mock_list_clusters.return_value = [fake_cluster]
-    mock_list_all_instances_for_service.return_value = [fake_instance]
-    mock_get_services_for_cluster.return_value = [(fake_service, fake_instance)]
-    mock_load_chronos_job_config.return_value = mock_chronos_job
-
-    assert not validate_chronos('fake_service_path')
-
-    output, _ = capfd.readouterr()
-    expected_output = 'something is wrong with the config'
-    assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
-
-
-@patch('paasta_tools.cli.cmds.validate.get_services_for_cluster', autospec=True)
-@patch('paasta_tools.cli.cmds.validate.list_clusters', autospec=True)
-@patch('paasta_tools.cli.cmds.validate.list_all_instances_for_service', autospec=True)
-@patch('paasta_tools.cli.cmds.validate.load_chronos_job_config', autospec=True)
-@patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service', autospec=True)
 def test_failing_chronos_job_self_dependent(
     mock_path_to_soa_dir_service,
     mock_load_chronos_job_config,
@@ -535,7 +503,7 @@ def test_failing_chronos_job_self_dependent(
 
     mock_chronos_job = mock.Mock(autospec=True)
     mock_chronos_job.get_parents.return_value = [f"{fake_service}{chronos_spacer}{fake_instance}"]
-    mock_chronos_job.validate.return_value = (True, [])
+    mock_chronos_job.validate.return_value = []
 
     mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', fake_service)
     mock_list_clusters.return_value = [fake_cluster]
@@ -547,7 +515,7 @@ def test_failing_chronos_job_self_dependent(
 
     output, _ = capfd.readouterr()
     expected_output = 'Job fake-service.fake-instance cannot depend on itself'
-    assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
+    assert expected_output in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_services_for_cluster', autospec=True)
@@ -570,7 +538,7 @@ def test_failing_chronos_job_missing_parent(
 
     mock_chronos_job = mock.Mock(autospec=True)
     mock_chronos_job.get_parents.return_value = ["{}{}{}".format(fake_service, chronos_spacer, 'parent-1')]
-    mock_chronos_job.validate.return_value = (True, [])
+    mock_chronos_job.validate.return_value = []
 
     mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', fake_service)
     mock_list_clusters.return_value = [fake_cluster]
@@ -582,7 +550,7 @@ def test_failing_chronos_job_missing_parent(
 
     output, _ = capfd.readouterr()
     expected_output = 'Parent job fake-service.parent-1 could not be found'
-    assert invalid_chronos_instance(fake_cluster, fake_instance, expected_output) in output
+    assert expected_output in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_services_for_cluster', autospec=True)
@@ -604,7 +572,7 @@ def test_validate_chronos_valid_instance(
 
     mock_chronos_job = mock.Mock(autospec=True)
     mock_chronos_job.get_parents.return_value = None
-    mock_chronos_job.validate.return_value = (True, [])
+    mock_chronos_job.validate.return_value = []
 
     mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', fake_service)
     mock_list_clusters.return_value = [fake_cluster]
@@ -615,7 +583,7 @@ def test_validate_chronos_valid_instance(
     assert validate_chronos('fake_service_path')
 
     output, _ = capfd.readouterr()
-    assert valid_chronos_instance(fake_cluster, fake_instance) in output
+    assert "chronos instances are valid" in output
 
 
 @patch("paasta_tools.chronos_tools.TMP_JOB_IDENTIFIER", 'tmp', autospec=None)

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -26,7 +26,8 @@ from paasta_tools.cli.cmds.validate import paasta_validate_soa_configs
 from paasta_tools.cli.cmds.validate import SCHEMA_INVALID
 from paasta_tools.cli.cmds.validate import SCHEMA_VALID
 from paasta_tools.cli.cmds.validate import UNKNOWN_SERVICE
-from paasta_tools.cli.cmds.validate import validate_chronos
+from paasta_tools.cli.cmds.validate import validate_chronos_dependencies
+from paasta_tools.cli.cmds.validate import validate_paasta_objects
 from paasta_tools.cli.cmds.validate import validate_schema
 from paasta_tools.cli.cmds.validate import validate_tron
 from paasta_tools.cli.cmds.validate import validate_unique_instance_names
@@ -35,7 +36,7 @@ from paasta_tools.cli.cmds.validate import validate_unique_instance_names
 @patch('paasta_tools.cli.cmds.validate.validate_unique_instance_names', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.validate_paasta_objects', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.validate_all_schemas', autospec=True)
-@patch('paasta_tools.cli.cmds.validate.validate_chronos', autospec=True)
+@patch('paasta_tools.cli.cmds.validate.validate_chronos_dependencies', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.validate_tron', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.get_service_path', autospec=True)
 @patch('paasta_tools.cli.cmds.validate.check_service_path', autospec=True)
@@ -43,7 +44,7 @@ def test_paasta_validate_calls_everything(
     mock_check_service_path,
     mock_get_service_path,
     mock_validate_tron,
-    mock_validate_chronos,
+    mock_validate_chronos_dependencies,
     mock_validate_all_schemas,
     mock_validate_paasta_objects,
     mock_validate_unique_instance_names,
@@ -53,7 +54,7 @@ def test_paasta_validate_calls_everything(
     mock_check_service_path.return_value = True
     mock_get_service_path.return_value = 'unused_path'
     mock_validate_all_schemas.return_value = True
-    mock_validate_chronos.return_value = True
+    mock_validate_chronos_dependencies.return_value = True
     mock_validate_tron.return_value = True
     mock_validate_paasta_objects.return_value = True
     mock_validate_unique_instance_names.return_value = True
@@ -65,19 +66,51 @@ def test_paasta_validate_calls_everything(
     paasta_validate(args)
 
     assert mock_validate_all_schemas.called
-    assert mock_validate_chronos.called
+    assert mock_validate_chronos_dependencies.called
     assert mock_validate_tron.called
     assert mock_validate_unique_instance_names.called
     assert mock_validate_paasta_objects.called
 
 
-def test_get_service_path_unknown(capfd):
+@patch('paasta_tools.cli.cmds.validate.get_instance_config', autospec=True)
+@patch('paasta_tools.cli.cmds.validate.get_services_for_cluster', autospec=True)
+@patch('paasta_tools.cli.cmds.validate.list_clusters', autospec=True)
+@patch('paasta_tools.cli.cmds.validate.list_all_instances_for_service', autospec=True)
+@patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service', autospec=True)
+def test_validate_paasta_objects(
+    mock_path_to_soa_dir_service,
+    mock_list_all_instances_for_service,
+    mock_list_clusters,
+    mock_get_services_for_cluster,
+    mock_get_instance_config,
+    capsys,
+):
+
+    fake_service = 'fake-service'
+    fake_instance = 'fake-instance'
+    fake_cluster = 'penguin'
+
+    mock_chronos_job = mock.Mock(autospec=True)
+    mock_chronos_job.validate.return_value = ["Something is wrong!"]
+
+    mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', fake_service)
+    mock_list_clusters.return_value = [fake_cluster]
+    mock_list_all_instances_for_service.return_value = [fake_instance]
+    mock_get_services_for_cluster.return_value = [(fake_service, fake_instance)]
+    mock_get_instance_config.return_value = mock_chronos_job
+
+    assert validate_paasta_objects('fake-service-path') is False, capsys
+    captured = capsys.readouterr()
+    assert 'Something is wrong!' in captured.out
+
+
+def test_get_service_path_unknown(capsys):
     service = None
     soa_dir = 'unused'
 
     assert get_service_path(service, soa_dir) is None
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert UNKNOWN_SERVICE in output
 
 
@@ -155,7 +188,7 @@ def test_get_schema_missing():
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_schema_list_hashes_good(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     marathon_content = """
 ---
@@ -176,13 +209,13 @@ _main_http:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_understands_underscores(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     marathon_content = """
 ---
@@ -197,13 +230,13 @@ main:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_schema_healthcheck_non_cmd(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     marathon_content = """
 ---
@@ -217,7 +250,7 @@ main_worker:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
     marathon_content = """
 ---
@@ -230,13 +263,13 @@ main_worker:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_id(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     marathon_content = """
 ---
@@ -249,7 +282,7 @@ valid:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
     marathon_content = """
@@ -263,7 +296,7 @@ this_is_okay_too_1:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
     marathon_content = """
@@ -277,7 +310,7 @@ dashes-are-okay-too:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
     marathon_content = """
@@ -291,7 +324,7 @@ main_worker_CAPITALS_INVALID:
 """
     mock_get_file_contents.return_value = marathon_content
     assert not validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
     marathon_content = """
@@ -305,13 +338,13 @@ $^&*()(&*^%&definitely_not_okay:
 """
     mock_get_file_contents.return_value = marathon_content
     assert not validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_schema_healthcheck_cmd_has_cmd(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     marathon_content = """
 ---
@@ -325,7 +358,7 @@ main_worker:
 """
     mock_get_file_contents.return_value = marathon_content
     assert not validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
     marathon_content = """
 ---
@@ -340,13 +373,13 @@ main_worker:
 """
     mock_get_file_contents.return_value = marathon_content
     assert validate_schema('unused_service_path.yaml', 'marathon')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_schema_keys_outside_instance_blocks_bad(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     mock_get_file_contents.return_value = """
 {
@@ -358,13 +391,13 @@ def test_marathon_validate_schema_keys_outside_instance_blocks_bad(
 """
     assert not validate_schema('unused_service_path.json', 'marathon')
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_schema_security_good(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     mock_get_file_contents.return_value = """
 main:
@@ -374,13 +407,13 @@ main:
 """
     assert validate_schema('unused_service_path.yaml', 'marathon')
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_schema_security_bad(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     mock_get_file_contents.return_value = """
 main:
@@ -390,13 +423,13 @@ main:
 """
     assert not validate_schema('unused_service_path.yaml', 'marathon')
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_marathon_validate_invalid_key_bad(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     mock_get_file_contents.return_value = """
 {
@@ -407,13 +440,13 @@ def test_marathon_validate_invalid_key_bad(
 """
     assert not validate_schema('unused_service_path.json', 'marathon')
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_chronos_validate_schema_list_hashes_good(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     mock_get_file_contents.return_value = """
 {
@@ -427,13 +460,13 @@ def test_chronos_validate_schema_list_hashes_good(
 """
     assert validate_schema('unused_service_path.json', 'chronos')
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_chronos_validate_schema_keys_outside_instance_blocks_bad(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     mock_get_file_contents.return_value = """
 {
@@ -445,13 +478,13 @@ def test_chronos_validate_schema_keys_outside_instance_blocks_bad(
 """
     assert not validate_schema('unused_service_path.json', 'chronos')
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_chronos_validate_schema_security_good(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     mock_get_file_contents.return_value = """
 some_batch:
@@ -462,13 +495,13 @@ some_batch:
 """
     assert validate_schema('unused_service_path.yaml', 'chronos')
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_chronos_validate_schema_security_bad(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     mock_get_file_contents.return_value = """
 some_batch:
@@ -479,7 +512,7 @@ some_batch:
 """
     assert not validate_schema('unused_service_path.yaml', 'chronos')
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
 
@@ -494,7 +527,7 @@ def test_failing_chronos_job_self_dependent(
     mock_list_all_instances_for_service,
     mock_list_clusters,
     mock_get_services_for_cluster,
-    capfd,
+    capsys,
 ):
     fake_service = 'fake-service'
     fake_instance = 'fake-instance'
@@ -511,9 +544,9 @@ def test_failing_chronos_job_self_dependent(
     mock_get_services_for_cluster.return_value = [(fake_service, fake_instance)]
     mock_load_chronos_job_config.return_value = mock_chronos_job
 
-    assert not validate_chronos('fake_service_path')
+    assert not validate_chronos_dependencies('fake_service_path')
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     expected_output = 'Job fake-service.fake-instance cannot depend on itself'
     assert expected_output in output
 
@@ -529,7 +562,7 @@ def test_failing_chronos_job_missing_parent(
     mock_list_all_instances_for_service,
     mock_list_clusters,
     mock_get_services_for_cluster,
-    capfd,
+    capsys,
 ):
     fake_service = 'fake-service'
     fake_instance = 'fake-instance'
@@ -546,9 +579,9 @@ def test_failing_chronos_job_missing_parent(
     mock_get_services_for_cluster.return_value = [(fake_service, fake_instance)]
     mock_load_chronos_job_config.return_value = mock_chronos_job
 
-    assert not validate_chronos('fake_service_path')
+    assert not validate_chronos_dependencies('fake_service_path')
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     expected_output = 'Parent job fake-service.parent-1 could not be found'
     assert expected_output in output
 
@@ -564,7 +597,7 @@ def test_validate_chronos_valid_instance(
     mock_list_all_instances_for_service,
     mock_list_clusters,
     mock_get_services_for_cluster,
-    capfd,
+    capsys,
 ):
     fake_service = 'fake-service'
     fake_instance = 'fake-instance'
@@ -580,27 +613,27 @@ def test_validate_chronos_valid_instance(
     mock_get_services_for_cluster.return_value = [(fake_service, fake_instance)]
     mock_load_chronos_job_config.return_value = mock_chronos_job
 
-    assert validate_chronos('fake_service_path')
+    assert validate_chronos_dependencies('fake_service_path')
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert "chronos instances are valid" in output
 
 
 @patch("paasta_tools.chronos_tools.TMP_JOB_IDENTIFIER", 'tmp', autospec=None)
 @patch('paasta_tools.cli.cmds.validate.path_to_soa_dir_service', autospec=True)
-def test_validate_chronos_tmp_job(mock_path_to_soa_dir_service, capfd):
+def test_validate_dependencies_chronos_tmp_job(mock_path_to_soa_dir_service, capsys):
     mock_path_to_soa_dir_service.return_value = ('fake_soa_dir', 'tmp')
-    assert validate_chronos('fake_path/tmp') is False
+    assert validate_chronos_dependencies('fake_path/tmp') is False
     assert (
         "Services using scheduled tasks cannot be named tmp, as it clashes"
         " with the identifier used for temporary jobs"
     ) in \
-        capfd.readouterr()[0]
+        capsys.readouterr()[0]
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_tron_validate_schema_good(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     tron_content = """
 test_job:
@@ -628,13 +661,13 @@ test_job:
 """
     mock_get_file_contents.return_value = tron_content
     assert validate_schema('unused_service_path.yaml', 'tron')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_tron_validate_schema_understands_underscores(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     tron_content = """
 _my_template: &a_template
@@ -651,13 +684,13 @@ test_job:
 """
     mock_get_file_contents.return_value = tron_content
     assert validate_schema('unused_service_path.yaml', 'tron')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_VALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_tron_validate_schema_job_extra_properties_bad(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     tron_content = """
 test_job:
@@ -670,13 +703,13 @@ test_job:
 """
     mock_get_file_contents.return_value = tron_content
     assert not validate_schema('unused_service_path.yaml', 'tron')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_tron_validate_schema_actions_extra_properties_bad(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     tron_content = """
 test_job:
@@ -689,13 +722,13 @@ test_job:
 """
     mock_get_file_contents.return_value = tron_content
     assert not validate_schema('unused_service_path.yaml', 'tron')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
 
 @patch('paasta_tools.cli.cmds.validate.get_file_contents', autospec=True)
 def test_tron_validate_schema_cleanup_action_extra_properties_bad(
-    mock_get_file_contents, capfd,
+    mock_get_file_contents, capsys,
 ):
     tron_content = """
 test_job:
@@ -710,7 +743,7 @@ test_job:
 """
     mock_get_file_contents.return_value = tron_content
     assert not validate_schema('unused_service_path.yaml', 'tron')
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
 
 
@@ -728,7 +761,7 @@ def test_validate_tron_with_tron_dir(
     mock_ls,
     mock_validate_tron_config,
     mock_validate_schema,
-    capfd,
+    capsys,
     schema_valid,
     config_msgs,
     expected_return,
@@ -744,7 +777,7 @@ def test_validate_tron_with_tron_dir(
         'foo', 'dev', 'soa',
     )
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     for error in config_msgs:
         assert error in output
 
@@ -754,7 +787,7 @@ def test_validate_tron_with_tron_dir(
 def test_validate_tron_with_service_invalid(
     mock_validate_tron_config,
     mock_list_clusters,
-    capfd,
+    capsys,
 ):
     mock_list_clusters.return_value = ['dev', 'stage', 'prod']
     mock_validate_tron_config.side_effect = [[], ['some error'], []]
@@ -767,7 +800,7 @@ def test_validate_tron_with_service_invalid(
     ]
     assert mock_validate_tron_config.call_args_list == expected_calls
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert 'some error' in output
 
 
@@ -776,7 +809,7 @@ def test_validate_tron_with_service_invalid(
 def test_validate_tron_with_service_valid(
     mock_validate_tron_config,
     mock_list_clusters,
-    capfd,
+    capsys,
 ):
     mock_list_clusters.return_value = ['dev', 'prod']
     mock_validate_tron_config.side_effect = [[], []]
@@ -789,25 +822,25 @@ def test_validate_tron_with_service_valid(
     ]
     assert mock_validate_tron_config.call_args_list == expected_calls
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert 'tron-dev.yaml is valid' in output
 
 
-def test_check_service_path_none(capfd):
+def test_check_service_path_none(capsys):
     service_path = None
     assert not check_service_path(service_path)
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert "%s is not a directory" % service_path in output
 
 
 @patch('paasta_tools.cli.cmds.validate.os.path.isdir', autospec=True)
-def test_check_service_path_empty(mock_isdir, capfd):
+def test_check_service_path_empty(mock_isdir, capsys):
     mock_isdir.return_value = True
     service_path = 'fake/path'
     assert not check_service_path(service_path)
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert "%s does not contain any .yaml files" % service_path in output
 
 
@@ -844,7 +877,7 @@ def test_validate_unique_service_name_success(
 def test_validate_unique_service_name_failure(
     mock_list_clusters,
     mock_get_service_instance_list,
-    capfd,
+    capsys,
 ):
     service_name = 'service_1'
     mock_list_clusters.return_value = ['cluster_1']
@@ -855,5 +888,5 @@ def test_validate_unique_service_name_failure(
     ]
     assert not validate_unique_instance_names(f'soa/{service_name}')
 
-    output, _ = capfd.readouterr()
+    output, _ = capsys.readouterr()
     assert 'instance_1' in output


### PR DESCRIPTION
This is the new #1 mistake we make at yelp, now `paasta validate` will actually run the `validate` functions and validate things.