### PR TITLE
Begin logging service autoscaler state in a json format

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -22,7 +22,6 @@ from contextlib import contextmanager
 from datetime import datetime
 from math import ceil
 from math import floor
-from typing import Dict
 from typing import Iterator
 from typing import Mapping
 from typing import Optional
@@ -608,6 +607,7 @@ def autoscale_marathon_instance(
                 num_healthy_instances=num_healthy_instances,
                 new_instance_count=new_instance_count,
                 safe_downscaling_threshold=safe_downscaling_threshold,
+                task_data_insufficient=task_data_insufficient,
             )
             if new_instance_count != current_instances:
                 if new_instance_count < current_instances and task_data_insufficient:
@@ -644,12 +644,13 @@ def _record_autoscaling_decision(
     marathon_service_config: MarathonServiceConfig,
     autoscaling_params: AutoscalingParamsDict,
     utilization: float,
-    log_utilization_data: Dict[str, str],
+    log_utilization_data: Mapping[any, any],
     error: float,
     current_instances: int,
     num_healthy_instances: int,
     new_instance_count: int,
     safe_downscaling_threshold: int,
+    task_data_insufficient: bool,
 ) -> None:
     """
     Based on the calculations made, perform observability side effects.
@@ -670,6 +671,7 @@ def _record_autoscaling_decision(
                 num_healthy_instances=num_healthy_instances,
                 new_instance_count=new_instance_count,
                 safe_downscaling_threshold=safe_downscaling_threshold,
+                task_data_insufficient=task_data_insufficient,
             ),
         ),
         level='debug',

--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2015-2016 Yelp Inc.
+# Copyright 2015-2019 Yelp Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import json
 import logging
 import struct
 import time
@@ -21,6 +22,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from math import ceil
 from math import floor
+from typing import Dict
 from typing import Iterator
 from typing import Mapping
 from typing import Optional
@@ -46,6 +48,7 @@ from paasta_tools.bounce_lib import ZK_LOCK_CONNECT_TIMEOUT_S
 from paasta_tools.long_running_service_tools import compose_autoscaling_zookeeper_root
 from paasta_tools.long_running_service_tools import set_instances_for_marathon_service
 from paasta_tools.long_running_service_tools import ZK_PAUSE_AUTOSCALE_PATH
+from paasta_tools.marathon_tools import AutoscalingParamsDict
 from paasta_tools.marathon_tools import format_job_id
 from paasta_tools.marathon_tools import get_marathon_apps_with_clients
 from paasta_tools.marathon_tools import get_marathon_clients
@@ -585,68 +588,121 @@ def autoscale_marathon_instance(
                 setpoint=autoscaling_params['setpoint'],
                 current_instances=current_instances,
             )
+            num_healthy_instances = len(marathon_tasks)
             new_instance_count = get_new_instance_count(
                 utilization=utilization,
                 error=error,
                 autoscaling_params=autoscaling_params,
                 current_instances=current_instances,
                 marathon_service_config=marathon_service_config,
-                num_healthy_instances=len(marathon_tasks),
+                num_healthy_instances=num_healthy_instances,
             )
-
             safe_downscaling_threshold = int(current_instances * 0.7)
-            if new_instance_count != current_instances:
-                if new_instance_count < current_instances and task_data_insufficient:
-                    write_to_log(
-                        config=marathon_service_config,
-                        line='Delaying scaling *down* as we found too few healthy tasks running in marathon. '
-                             'This can happen because tasks are delayed/waiting/unhealthy or because we are '
-                             'waiting for tasks to be killed. Will wait for sufficient healthy tasks before '
-                             'we make a decision to scale down.',
-                    )
-                    return
-                if new_instance_count == safe_downscaling_threshold:
-                    write_to_log(
-                        config=marathon_service_config,
-                        line='Autoscaler clamped: %s' % str(log_utilization_data),
-                        level='debug',
-                    )
-
-                write_to_log(
-                    config=marathon_service_config,
-                    line='Scaling from %d to %d instances (%s)' % (
-                        current_instances, new_instance_count, humanize_error(error),
-                    ),
-                )
+            if new_instance_count > current_instances or \
+               new_instance_count < current_instances and not task_data_insufficient:
                 set_instances_for_marathon_service(
                     service=marathon_service_config.service,
                     instance=marathon_service_config.instance,
                     instance_count=new_instance_count,
                 )
-            else:
-                write_to_log(
-                    config=marathon_service_config,
-                    line='Staying at %d instances (%s)' % (current_instances, humanize_error(error)),
-                    level='debug',
-                )
-            meteorite_dims = {
-                'service_name': marathon_service_config.service,
-                'decision_policy': autoscaling_params[DECISION_POLICY_KEY],  # type: ignore
-                'paasta_cluster': marathon_service_config.cluster,
-                'instance_name': marathon_service_config.instance,
-            }
-            if yelp_meteorite:
-                gauge = yelp_meteorite.create_gauge('paasta.service.instances', meteorite_dims)
-                gauge.set(new_instance_count)
-                gauge = yelp_meteorite.create_gauge('paasta.service.max_instances', meteorite_dims)
-                gauge.set(marathon_service_config.get_max_instances())
-                gauge = yelp_meteorite.create_gauge('paasta.service.min_instances', meteorite_dims)
-                gauge.set(marathon_service_config.get_min_instances())
+            _record_autoscaling_decision(
+                marathon_service_config,
+                autoscaling_params,
+                utilization,
+                log_utilization_data,
+                error,
+                current_instances,
+                num_healthy_instances,
+                new_instance_count,
+                task_data_insufficient,
+                safe_downscaling_threshold,
+            )
     except LockHeldException:
         log.warning("Skipping autoscaling run for {service}.{instance} because the lock is held".format(
             service=marathon_service_config.service,
             instance=marathon_service_config.instance,
         ))
+
+
+def _record_autoscaling_decision(
+    marathon_service_config: MarathonServiceConfig,
+    autoscaling_params: AutoscalingParamsDict,
+    utilization: float,
+    log_utilization_data: Dict[str, str],
+    error: float,
+    current_instances: int,
+    num_healthy_instances: int,
+    new_instance_count: int,
+    task_data_insufficient: bool,
+    safe_downscaling_threshold: int,
+) -> None:
+    """
+    Based on the calculations made, perform observability side effects.
+    Log messages, generate time series, send any alerts, etc.
+    """
+    write_to_log(
+        config=marathon_service_config,
+        line=json.dumps(
+            dict(
+                timestamp=time.time(),
+                paasta_cluster=marathon_service_config.get_cluster(),
+                paasta_service=marathon_service_config.get_service(),
+                paasta_instance=marathon_service_config.get_instance(),
+                autoscaling_params=autoscaling_params,
+                utilization=utilization,
+                error=error,
+                current_instances=current_instances,
+                num_healthy_instances=num_healthy_instances,
+                new_instance_count=new_instance_count,
+                task_data_insufficient=task_data_insufficient,
+                safe_downscaling_threshold=safe_downscaling_threshold,
+            ),
+        ),
+        level='debug',
+    )
+    if new_instance_count != current_instances:
+        if new_instance_count < current_instances and task_data_insufficient:
+            write_to_log(
+                config=marathon_service_config,
+                line='Delaying scaling *down* as we found too few healthy tasks running in marathon. '
+                        'This can happen because tasks are delayed/waiting/unhealthy or because we are '
+                        'waiting for tasks to be killed. Will wait for sufficient healthy tasks before '
+                        'we make a decision to scale down.',
+                level='debug',
+            )
+            return
+        if new_instance_count == safe_downscaling_threshold:
+            write_to_log(
+                config=marathon_service_config,
+                line='Autoscaler clamped: %s' % str(log_utilization_data),
+                level='debug',
+            )
+        write_to_log(
+            config=marathon_service_config,
+            line='Scaling from %d to %d instances (%s)' % (
+                current_instances, new_instance_count, humanize_error(error),
+            ),
+            level='event',
+        )
+    else:
+        write_to_log(
+            config=marathon_service_config,
+            line='Staying at %d instances (%s)' % (current_instances, humanize_error(error)),
+            level='debug',
+        )
+    meteorite_dims = {
+        'service_name': marathon_service_config.service,
+        'decision_policy': autoscaling_params[DECISION_POLICY_KEY],  # type: ignore
+        'paasta_cluster': marathon_service_config.cluster,
+        'instance_name': marathon_service_config.instance,
+    }
+    if yelp_meteorite:
+        gauge = yelp_meteorite.create_gauge('paasta.service.instances', meteorite_dims)
+        gauge.set(new_instance_count)
+        gauge = yelp_meteorite.create_gauge('paasta.service.max_instances', meteorite_dims)
+        gauge.set(marathon_service_config.get_max_instances())
+        gauge = yelp_meteorite.create_gauge('paasta.service.min_instances', meteorite_dims)
+        gauge.set(marathon_service_config.get_min_instances())
 
 
 def humanize_error(error):
@@ -737,7 +793,11 @@ def autoscale_service_configs(
                     mesos_tasks,
                 )
             except Exception as e:
-                write_to_log(config=config, line='Caught Exception %s' % e)
+                write_to_log(
+                    config=config,
+                    line='Caught Exception %s' % e,
+                    level='debug',
+                )
 
 
 def filter_autoscaling_tasks(

--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -644,7 +644,7 @@ def _record_autoscaling_decision(
     marathon_service_config: MarathonServiceConfig,
     autoscaling_params: AutoscalingParamsDict,
     utilization: float,
-    log_utilization_data: Mapping[any, any],
+    log_utilization_data: Mapping[str, str],
     error: float,
     current_instances: int,
     num_healthy_instances: int,

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -462,6 +462,8 @@ def test_autoscale_marathon_instance():
         'paasta_tools.autoscaling.autoscaling_service_lib.set_instances_for_marathon_service',
         autospec=True,
     ) as mock_set_instances_for_marathon_service, mock.patch(
+        'paasta_tools.autoscaling.autoscaling_service_lib.json', autospec=True,
+    ) as mock_json, mock.patch(
         'paasta_tools.autoscaling.autoscaling_service_lib.get_service_metrics_provider', autospec=True,
         **{'return_value.return_value': 0},
     ), mock.patch(
@@ -486,6 +488,7 @@ def test_autoscale_marathon_instance():
             service='fake-service', instance='fake-instance', instance_count=2,
         )
         mock_meteorite.create_gauge.call_count == 3
+        mock_json.dumps.call_count == 1
 
 
 def test_autoscale_marathon_instance_up_to_min_instances():
@@ -976,6 +979,7 @@ def test_autoscale_services_not_healthy():
         mock_write_to_log.assert_called_with(
             config=fake_marathon_service_config,
             line="Caught Exception Couldn't find any healthy marathon tasks",
+            level='debug',
         )
 
         mock_autoscale_marathon_instance.reset_mock()


### PR DESCRIPTION
This will provide us with detailed information about steady state operation of the autoscaler, most common failure modes and provide the data we'll use to set thresholds for automatic alerting about dangerous utilization before moving ahead with that.

I considered writing to clog directly here but it's inside a loop for all the master's autoscaling decisions, so stdout getting piped over seems preferable almost? Downside is that a service's (not the central) log will be harder to read without grepping for `event`. Open to ideas here.

Make test green. Make itest green.

This is tracked by PAASTA-15443.