### PR TITLE
Use ClusterFirst DNS policy for kube pods

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -814,7 +814,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     docker_volumes=docker_volumes,
                     aws_ebs_volumes=self.get_aws_ebs_volumes(),
                 ),
-                dns_policy="Default",
             ),
         )
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -792,7 +792,6 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     containers=mock_get_kubernetes_containers.return_value,
                     restart_policy='Always',
                     volumes=[],
-                    dns_policy='Default',
                 ),
             )
 


### PR DESCRIPTION
Since now we're using CoreDNS to resolve service IPs, let's switch back
to using `ClusterFirst` DNS policy for kube pods.