### PR TITLE
Spark set intelligent defaults shuffle partitions

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -483,16 +483,16 @@ def get_spark_config(
             user_args[fields[0]] = fields[1]
 
     if 'spark.sql.shuffle.partitions' not in user_args:
-        user_args['spark.sql.shuffle.partitions'] = str(
+        num_partitions = str(
             2 * int(user_args['spark.cores.max']),
         )
+        user_args['spark.sql.shuffle.partitions'] = num_partitions
         paasta_print(
             PaastaColors.yellow(
-                'Warning: spark.sql.shuffle.partitions has been set to {num_partitions} '
-                'to be equal to twice the number of requested cores, but you should '
-                'consider setting a higher value if necessary.'.format(
-                    num_partitions=user_args['spark.sql.shuffle.partitions'],
-                ),
+                f'Warning: spark.sql.shuffle.partitions has been set to'
+                f' {num_partitions} to be equal to twice the number of '
+                f'requested cores, but you should consider setting a '
+                f'higher value if necessary.'
             ),
         )
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -492,7 +492,7 @@ def get_spark_config(
                 f'Warning: spark.sql.shuffle.partitions has been set to'
                 f' {num_partitions} to be equal to twice the number of '
                 f'requested cores, but you should consider setting a '
-                f'higher value if necessary.'
+                f'higher value if necessary.',
             ),
         )
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -482,6 +482,20 @@ def get_spark_config(
             # Update default configuration
             user_args[fields[0]] = fields[1]
 
+    if 'spark.sql.shuffle.partitions' not in user_args:
+        user_args['spark.sql.shuffle.partitions'] = str(
+            2 * int(user_args['spark.cores.max']),
+        )
+        paasta_print(
+            PaastaColors.yellow(
+                'Warning: spark.sql.shuffle.partitions has been set to {num_partitions} '
+                'to be equal to twice the number of requested cores, but you should '
+                'consider setting a higher value if necessary.'.format(
+                    num_partitions=user_args['spark.sql.shuffle.partitions'],
+                ),
+            ),
+        )
+
     if int(user_args['spark.cores.max']) < int(user_args['spark.executor.cores']):
         paasta_print(
             PaastaColors.red(


### PR DESCRIPTION
set intelligent defaults for spark.sql.shuffle.partitions.

Spark sets a default value of 200. 
We set it to default to 2*spark.cores.max, and print a warning message that ideally the user
should be setting this themselves.

Also, added tests that verify that we default to twice the number of max cores only when the 
user does not provide a value for spark.sql.shuffle.partitions.

make test green.
