### PR TITLE
mv cleanup_kubernetes_crds cleanup_kubernetes_crd

### DIFF
--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -13,7 +13,7 @@ opt/venvs/paasta-tools/bin/check_mesos_quorum.py usr/bin/check_mesos_quorum
 opt/venvs/paasta-tools/bin/check_oom_events.py usr/bin/check_oom_events
 opt/venvs/paasta-tools/bin/check_synapse_replication.py usr/bin/check_synapse_replication
 opt/venvs/paasta-tools/bin/cleanup_marathon_jobs.py usr/bin/cleanup_marathon_jobs
-opt/venvs/paasta-tools/bin/cleanup_kubernetes_crds.py usr/bin/cleanup_kubernetes_crds
+opt/venvs/paasta-tools/bin/cleanup_kubernetes_crd.py usr/bin/cleanup_kubernetes_crd
 opt/venvs/paasta-tools/bin/deploy_marathon_services usr/bin/deploy_marathon_services
 opt/venvs/paasta-tools/bin/generate_all_deployments usr/bin/generate_all_deployments
 opt/venvs/paasta-tools/bin/generate_deployments_for_service.py usr/bin/generate_deployments_for_service

--- a/docs/source/generated/paasta_tools.cleanup_kubernetes_crd.rst
+++ b/docs/source/generated/paasta_tools.cleanup_kubernetes_crd.rst
@@ -1,7 +1,7 @@
-paasta_tools.cleanup_kubernetes_crds module
+paasta_tools.cleanup_kubernetes_crd module
 ===========================================
 
-.. automodule:: paasta_tools.cleanup_kubernetes_crds
+.. automodule:: paasta_tools.cleanup_kubernetes_crd
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/generated/paasta_tools.rst
+++ b/docs/source/generated/paasta_tools.rst
@@ -40,7 +40,7 @@ Submodules
    paasta_tools.chronos_serviceinit
    paasta_tools.chronos_tools
    paasta_tools.cleanup_chronos_jobs
-   paasta_tools.cleanup_kubernetes_crds
+   paasta_tools.cleanup_kubernetes_crd
    paasta_tools.cleanup_maintenance
    paasta_tools.cleanup_marathon_jobs
    paasta_tools.cleanup_tron_namespaces

--- a/paasta_tools/cleanup_kubernetes_crd.py
+++ b/paasta_tools/cleanup_kubernetes_crd.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Usage: ./cleanup_kubernetes_crds.py [options]
+Usage: ./cleanup_kubernetes_crd.py [options]
 
 Command line options:
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'paasta_tools/check_oom_events.py',
         'paasta_tools/check_spark_jobs.py',
         'paasta_tools/cleanup_marathon_jobs.py',
-        'paasta_tools/cleanup_kubernetes_crds.py',
+        'paasta_tools/cleanup_kubernetes_crd.py',
         'paasta_tools/paasta_deploy_chronos_jobs',
         'paasta_tools/deploy_marathon_services',
         'paasta_tools/paasta_deploy_tron_jobs',


### PR DESCRIPTION
Since we're using `*_kubernetes_crd` names everywhere else, and also use `cleanup_kubernetes_crd` in the existing crontab, let rename `cleanup_kubernetes_crds` into `cleanup_kubernetes_crd`.