### PR TITLE
Coreml 838 set aws region spark run

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -924,9 +924,6 @@ def paasta_spark_run(args):
             )
             return 1
 
-    paasta_print(PaastaColors.red('lolololol'))
-    paasta_print(PaastaColors.red(os.environ['AWS_DEFAULT_REGION']))
-
     return configure_and_run_docker_container(
         args,
         docker_img=docker_url,

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -241,7 +241,7 @@ def add_subparser(subparsers):
     aws_group.add_argument(
         '--aws-credentials-yaml',
         help='Load aws keys from the provided yaml file. The yaml file must '
-        'have keys for aws_access_key_id, aws_secret_access_key',
+        'have keys for aws_access_key_id and aws_secret_access_key.',
     )
 
     aws_group.add_argument(

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -20,7 +20,7 @@ from paasta_tools.cli.cmds.spark_run import configure_and_run_docker_container
 from paasta_tools.cli.cmds.spark_run import create_spark_config_str
 from paasta_tools.cli.cmds.spark_run import DEFAULT_SERVICE
 from paasta_tools.cli.cmds.spark_run import emit_resource_requirements
-from paasta_tools.cli.cmds.spark_run import get_aws_credentials
+from paasta_tools.cli.cmds.spark_run import get_aws_credentials_and_region
 from paasta_tools.cli.cmds.spark_run import get_docker_cmd
 from paasta_tools.cli.cmds.spark_run import get_docker_run_cmd
 from paasta_tools.cli.cmds.spark_run import get_spark_config
@@ -107,7 +107,7 @@ def test_get_spark_config(
     assert int(spark_conf['spark.sql.shuffle.partitions']) == 14
 
 
-@mock.patch('paasta_tools.cli.cmds.spark_run.get_aws_credentials', autospec=True)
+@mock.patch('paasta_tools.cli.cmds.spark_run.get_aws_credentials_and_region', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.spark_run.os.path.exists', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.spark_run.pick_random_port', autospec=True)
 @mock.patch('paasta_tools.cli.cmds.spark_run.get_username', autospec=True)
@@ -157,13 +157,13 @@ class TestConfigureAndRunDockerContainer:
         mock_get_username,
         mock_pick_random_port,
         mock_os_path_exists,
-        mock_get_aws_credentials,
+        mock_get_aws_credentials_and_region,
     ):
         mock_pick_random_port.return_value = 123
         mock_get_username.return_value = 'fake_user'
         mock_get_spark_config.return_value = {'spark.app.name': 'fake_app'}
         mock_run_docker_container.return_value = 0
-        mock_get_aws_credentials.return_value = ('id', 'secret')
+        mock_get_aws_credentials_and_region.return_value = ('id', 'secret', 'region')
 
         args = mock.MagicMock()
         args.cluster = 'fake_cluster'
@@ -200,6 +200,7 @@ class TestConfigureAndRunDockerContainer:
                 'PAASTA_LAUNCHED_BY': mock.ANY,
                 'AWS_ACCESS_KEY_ID': 'id',
                 'AWS_SECRET_ACCESS_KEY': 'secret',
+                'AWS_DEFAULT_REGION': 'region',
                 'SPARK_USER': 'root',
                 'SPARK_OPTS': '--conf spark.app.name=fake_app',
             },
@@ -217,9 +218,9 @@ class TestConfigureAndRunDockerContainer:
         mock_get_username,
         mock_pick_random_port,
         mock_os_path_exists,
-        mock_get_aws_credentials,
+        mock_get_aws_credentials_and_region,
     ):
-        mock_get_aws_credentials.return_value = ('id', 'secret')
+        mock_get_aws_credentials_and_region.return_value = ('id', 'secret', 'region')
         with mock.patch(
             'paasta_tools.cli.cmds.spark_run.emit_resource_requirements', autospec=True,
         ) as mock_emit_resource_requirements, mock.patch(
@@ -247,9 +248,9 @@ class TestConfigureAndRunDockerContainer:
         mock_get_username,
         mock_pick_random_port,
         mock_os_path_exists,
-        mock_get_aws_credentials,
+        mock_get_aws_credentials_and_region,
     ):
-        mock_get_aws_credentials.return_value = ('id', 'secret')
+        mock_get_aws_credentials_and_region.return_value = ('id', 'secret', 'region')
         with mock.patch(
             'paasta_tools.cli.cmds.spark_run.emit_resource_requirements', autospec=True,
         ) as mock_emit_resource_requirements, mock.patch(
@@ -280,10 +281,10 @@ class TestConfigureAndRunDockerContainer:
         mock_get_username,
         mock_pick_random_port,
         mock_os_path_exists,
-        mock_get_aws_credentials,
+        mock_get_aws_credentials_and_region,
         mock_create_spark_config_str,
     ):
-        mock_get_aws_credentials.return_value = ('id', 'secret')
+        mock_get_aws_credentials_and_region.return_value = ('id', 'secret', 'region')
 
         with mock.patch(
             'paasta_tools.cli.cmds.spark_run.emit_resource_requirements', autospec=True,
@@ -322,10 +323,10 @@ class TestConfigureAndRunDockerContainer:
         mock_get_username,
         mock_pick_random_port,
         mock_os_path_exists,
-        mock_get_aws_credentials,
+        mock_get_aws_credentials_and_region,
         mock_create_spark_config_str,
     ):
-        mock_get_aws_credentials.return_value = ('id', 'secret')
+        mock_get_aws_credentials_and_region.return_value = ('id', 'secret', 'region')
         with mock.patch(
             'paasta_tools.cli.cmds.spark_run.emit_resource_requirements', autospec=True,
         ) as mock_emit_resource_requirements, mock.patch(
@@ -433,15 +434,18 @@ def test_get_docker_cmd_mrjob():
 def test_load_aws_credentials_from_yaml(tmpdir):
     fake_access_key_id = 'fake_access_key_id'
     fake_secret_access_key = 'fake_secret_access_key'
+    fake_region = 'fake_region'
     yaml_file = tmpdir.join('test.yaml')
     yaml_file.write(
         f'aws_access_key_id: "{fake_access_key_id}"\n'
-        f'aws_secret_access_key: "{fake_secret_access_key}"',
+        f'aws_secret_access_key: "{fake_secret_access_key}"\n'
+        f'region: "{fake_region}"',
     )
 
-    aws_access_key_id, aws_secret_access_key = load_aws_credentials_from_yaml(yaml_file)
+    aws_access_key_id, aws_secret_access_key, aws_region = load_aws_credentials_from_yaml(yaml_file)
     assert aws_access_key_id == fake_access_key_id
     assert aws_secret_access_key == fake_secret_access_key
+    assert aws_region == fake_region
 
 
 class TestGetAwsCredentials:
@@ -451,43 +455,74 @@ class TestGetAwsCredentials:
         with mock.patch(
             'paasta_tools.cli.cmds.spark_run.load_aws_credentials_from_yaml',
             autospec=True,
+            return_value=('file_access_key', 'file_secret_key', 'file_region'),
         ) as self.mock_load_aws_credentials_from_yaml:
             yield
 
-    def test_yaml_provided(self):
-        args = mock.Mock(aws_credentials_yaml='credentials.yaml')
-        credentials = get_aws_credentials(args)
+    @pytest.mark.parametrize(
+        'args_region, expected_region',
+        [
+            ('args_region', 'args_region'),
+            (None, 'file_region'),
+        ],
+    )
+    def test_yaml_provided(self, args_region, expected_region):
+        args = mock.Mock(aws_credentials_yaml='credentials.yaml', aws_region=args_region)
+        credentials_and_region = get_aws_credentials_and_region(args)
 
         self.mock_load_aws_credentials_from_yaml.assert_called_once_with('credentials.yaml')
-        assert credentials == self.mock_load_aws_credentials_from_yaml.return_value
+        assert credentials_and_region == ('file_access_key', 'file_secret_key', expected_region)
 
     @mock.patch('paasta_tools.cli.cmds.spark_run.os', autospec=True)
     @mock.patch('paasta_tools.cli.cmds.spark_run.get_service_aws_credentials_path', autospec=True)
-    def test_service_provided_no_yaml(self, mock_get_credentials_path, mock_os):
-        args = mock.Mock(aws_credentials_yaml=None, service='service_name')
+    @pytest.mark.parametrize(
+        'args_region, expected_region',
+        [
+            ('args_region', 'args_region'),
+            (None, 'file_region'),
+        ],
+    )
+    def test_service_provided_no_yaml(self, mock_get_credentials_path, mock_os, args_region, expected_region):
+        args = mock.Mock(aws_credentials_yaml=None, service='service_name', aws_region=args_region)
         mock_os.path.exists.return_value = True
-        credentials = get_aws_credentials(args)
+        credentials_and_region = get_aws_credentials_and_region(args)
 
         mock_get_credentials_path.assert_called_once_with(args.service)
         self.mock_load_aws_credentials_from_yaml.assert_called_once_with(
             mock_get_credentials_path.return_value,
         )
-        assert credentials == self.mock_load_aws_credentials_from_yaml.return_value
+        assert credentials_and_region == ('file_access_key', 'file_secret_key', expected_region)
 
-    @mock.patch('paasta_tools.cli.cmds.spark_run.Session.get_credentials', autospec=True)
-    def test_use_default_creds(self, mock_get_credentials):
-        args = mock.Mock(aws_credentials_yaml=None, service=DEFAULT_SERVICE)
-        mock_get_credentials.return_value = mock.MagicMock(access_key='id', secret_key='secret')
-        credentials = get_aws_credentials(args)
+    @mock.patch('paasta_tools.cli.cmds.spark_run.Session', autospec=True)
+    @pytest.mark.parametrize(
+        'args_region, expected_region',
+        [
+            ('args_region', 'args_region'),
+            (None, 'file_region'),
+        ],
+    )
+    def test_use_default_creds_no_region(self, mock_session, args_region, expected_region):
+        args = mock.Mock(aws_credentials_yaml=None, service=DEFAULT_SERVICE, aws_region=args_region)
+        mock_session.return_value.get_credentials.return_value = mock.MagicMock(access_key='id', secret_key='secret')
+        mock_session.return_value.region_name = 'file_region'
+        credentials = get_aws_credentials_and_region(args)
 
-        assert credentials == ('id', 'secret')
+        assert credentials == ('id', 'secret', expected_region)
 
     @mock.patch('paasta_tools.cli.cmds.spark_run.os', autospec=True)
-    @mock.patch('paasta_tools.cli.cmds.spark_run.Session.get_credentials', autospec=True)
-    def test_service_provided_fallback_to_default(self, mock_get_credentials, mock_os):
-        args = mock.Mock(aws_credentials_yaml=None, service='service_name')
+    @mock.patch('paasta_tools.cli.cmds.spark_run.Session', autospec=True)
+    @pytest.mark.parametrize(
+        'args_region, expected_region',
+        [
+            ('args_region', 'args_region'),
+            (None, 'session_region'),
+        ],
+    )
+    def test_service_provided_fallback_to_default(self, mock_session, mock_os, args_region, expected_region):
+        args = mock.Mock(aws_credentials_yaml=None, service='service_name', aws_region=args_region)
         mock_os.path.exists.return_value = False
-        mock_get_credentials.return_value = mock.MagicMock(access_key='id', secret_key='secret')
-        credentials = get_aws_credentials(args)
+        mock_session.return_value.get_credentials.return_value = mock.MagicMock(access_key='id', secret_key='secret')
+        mock_session.return_value.region_name = 'session_region'
+        credentials = get_aws_credentials_and_region(args)
 
-        assert credentials == ('id', 'secret')
+        assert credentials == ('id', 'secret', expected_region)


### PR DESCRIPTION
make test green
make itest green

This review changes paasta spark-run to set the aws_region in the environment, in 
addition the the aws creds which are already set in the environment.
We want aws_region to be set in the environment because we are removing aws creds management from spark_etl, and many flows in spark_etl require an aws region to be specified.