### PR TITLE
Add certificate issue/renewal logic

### DIFF
--- a/paasta_tools/api/auth_decorator.py
+++ b/paasta_tools/api/auth_decorator.py
@@ -1,0 +1,143 @@
+import functools
+
+from bravado.docstring_property import docstring_property
+from bravado.exception import HTTPBadRequest
+
+import paasta_tools.api
+from paasta_tools.utils import load_system_paasta_config
+
+
+class AuthFutureDecorator:
+
+    def __init__(self, future, cluster_name):
+        self.future = future
+        self.attempts = 0
+        self.cluster_name = cluster_name
+
+    def result(self, timeout=None):
+        """ Wraps a Future's result method with a timer. """
+        try:
+            result = self.future.result(timeout)
+        except HTTPBadRequest as e:
+            # Yes nginx responds with a 400 if the certificate
+            # is expired. So the best we can do is watch for that
+            # return code and check the body of the response
+            if 'SSL' in e.response.text:
+                if self.attempts >= 3:
+                    raise
+                self.attempts += 1
+                system_paasta_config = load_system_paasta_config()
+                paasta_tools.api.client.renew_issue_cert(
+                    system_paasta_config=system_paasta_config,
+                    cluster=self.cluster_name,
+                )
+                result = self.result(timeout)
+            else:
+                raise
+        return result
+
+
+class AuthResourceDecorator:
+
+    def __init__(self, resource, cluster_name):
+        self.resource = resource
+        self.cluster_name = cluster_name
+
+    def __getattr__(self, name):
+        return decorate_client(self.resource, self._with_auth_check, name)
+
+    def _with_auth_check(self, call_name, *args, **kwargs):
+        return AuthFutureDecorator(
+            getattr(self.resource, call_name)(*args, **kwargs),
+            self.cluster_name,
+        )
+
+
+class AuthClientDecorator:
+    """
+    """
+
+    def __init__(self, client, cluster_name):
+        """ Create a auth client decorator.
+        :param client: The client that will have all resource operation calls
+            tracked.
+        :type client: swaggerpy.SwaggerClient
+        :return: A wrapped swagger client that should be used in place of a
+            plain swagger client.
+        """
+        self.client = client
+        self.cluster_name = cluster_name
+
+    def __getattr__(self, name):
+        return AuthResourceDecorator(
+            getattr(self.client, name),
+            self.cluster_name,
+        )
+
+    def __dir__(self):
+        return dir(self.client)
+
+
+# below helpers borrowed from bravado_decorators/decorate_client.py
+# maybe move into one of the open bravado packages?
+
+def decorate_client(api_client, func, name):
+    """A helper for decorating :class:`bravado.client.SwaggerClient`.
+    :class:`bravado.client.SwaggerClient` can be extended by creating a class
+    which wraps all calls to it. This helper is used in a :func:`__getattr__`
+    to check if the attr exists on the api_client. If the attr does not exist
+    raise :class:`AttributeError`, if it exists and is not callable return it,
+    and if it is callable return a partial function calling `func` with `name`.
+    Example usage:
+    .. code-block:: python
+        class SomeClientDecorator(object):
+            def __init__(self, api_client, ...):
+                self.api_client = api_client
+            # First arg should be suffiently unique to not conflict with any of
+            # the kwargs
+            def wrap_call(self, client_call_name, *args, **kwargs):
+                ...
+            def __getattr__(self, name):
+                return decorate_client(self.api_client, self.wrap_call, name)
+    :param api_client: the client which is being decorated
+    :type  api_client: :class:`bravado.client.SwaggerClient`
+    :param func: a callable which accepts `name`, `*args`, `**kwargs`
+    :type  func: callable
+    :param name: the attribute being accessed
+    :type  name: string
+    :returns: the attribute from the `api_client` or a partial of `func`
+    :raises: :class:`AttributeError`
+    """
+    client_attr = getattr(api_client, name)
+    if not callable(client_attr):
+        return client_attr
+
+    return OperationDecorator(client_attr, functools.partial(func, name))
+
+
+class OperationDecorator:
+    """A helper to preserve attributes of :class:`swaggerpy.client.Operation`
+    and :class:`bravado.client.CallableOperation` while decorating their
+    __call__() methods
+    :param operation: callable operation, e.g., attributes of
+        :class:`swaggerpy.client.Resource` or
+        :class:`bravado_core.resource.Resource`
+    :type  operation: :class:`swaggerpy.client.Operation` or
+        :class:`bravado.client.CallableOperation`
+    :param func: a callable which accepts `*args`, `**kwargs`
+    :type  func: callable
+    """
+
+    @docstring_property(__doc__)
+    def __doc__(self):
+        return self.operation.__doc__
+
+    def __init__(self, operation, func):
+        self.operation = operation
+        self.func = func
+
+    def __getattr__(self, name):
+        return getattr(self.operation, name)
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)

--- a/paasta_tools/secret_providers/__init__.py
+++ b/paasta_tools/secret_providers/__init__.py
@@ -12,17 +12,18 @@ class BaseSecretProvider:
 
     def __init__(
         self,
-        soa_dir: str,
-        service_name: str,
+        soa_dir: Optional[str],
+        service_name: Optional[str],
         cluster_names: List[str],
         **kwargs: Any,
     ) -> None:
         self.soa_dir = soa_dir
-        self.service_name = service_name
-        self.secret_dir = os.path.join(self.soa_dir, self.service_name, "secrets")
         self.cluster_names = cluster_names
-        service_config = read_service_configuration(self.service_name, self.soa_dir)
-        self.encryption_key = service_config.get('encryption_key', 'paasta')
+        self.service_name = service_name
+        if service_name:
+            self.secret_dir = os.path.join(self.soa_dir, self.service_name, "secrets")
+            service_config = read_service_configuration(self.service_name, self.soa_dir)
+            self.encryption_key = service_config.get('encryption_key', 'paasta')
 
     def decrypt_environment(self, environment: Dict[str, str], **kwargs: Any) -> Dict[str, str]:
         raise NotImplementedError
@@ -37,6 +38,9 @@ class BaseSecretProvider:
         raise NotImplementedError
 
     def get_secret_signature_from_data(self, data: Mapping[str, Any]) -> Optional[str]:
+        raise NotImplementedError
+
+    def renew_issue_cert(self, pki_backend: str, ttl: str) -> None:
         raise NotImplementedError
 
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1608,8 +1608,8 @@ class KubeCustomResourceDict(TypedDict, total=False):
 
 
 class SystemPaastaConfigDict(TypedDict, total=False):
-    api_ca_certificates: Dict[str, str]
     api_endpoints: Dict[str, str]
+    auth_certificate_ttl: str
     auto_hostname_unique_size: int
     chronos_config: ChronosConfig
     cluster: str
@@ -1621,7 +1621,6 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     cluster_fqdn_format: str
     clusters: Sequence[str]
     dashboard_links: Dict[str, Dict[str, str]]
-    default_api_ca_certificate: str
     deploy_blacklist: UnsafeDeployBlacklist
     deploy_whitelist: UnsafeDeployWhitelist
     deployd_big_bounce_rate: float
@@ -1653,6 +1652,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     monitoring_config: Dict
     nerve_readiness_check_script: str
     paasta_native: PaastaNativeConfig
+    pki_backend: str
     previous_marathon_servers: List[MarathonConfigDict]
     register_k8s_pods: bool
     register_marathon_services: bool
@@ -1798,21 +1798,24 @@ class SystemPaastaConfig:
     def get_api_endpoints(self) -> Mapping[str, str]:
         return self.config_dict['api_endpoints']
 
-    def get_api_ca_certificates(self) -> Mapping[str, str]:
-        """ A mapping of cluster name to CA certificate for validating API server identity """
-        return self.config_dict.get('api_ca_certificates', {})
-
-    def get_default_api_ca_certificate(self) -> str:
-        """ A default CA certificate to fall back to if there is not a cluster mapped in
-        get_api_ca_certificates
-        """
-        return self.config_dict.get('default_api_ca_certificate', '/etc/paasta/pki/ca.crt')
-
     def get_enable_client_cert_auth(self) -> bool:
         """
         If enabled present a client certificate from ~/.paasta/pki/<cluster>.crt and ~/.paasta/pki/<cluster>.key
         """
         return self.config_dict.get('enable_client_cert_auth', True)
+
+    def get_auth_certificate_ttl(self) -> str:
+        """
+        How long to request for ttl on auth certificates. Note that this maybe limited
+        by policy in Vault
+        """
+        return self.config_dict.get('auth_certificate_ttl', '11h')
+
+    def get_pki_backend(self) -> str:
+        """
+        The Vault pki backend to use for issueing certificates
+        """
+        return self.config_dict.get('pki_backend', 'paastaca')
 
     def get_fsm_template(self) -> str:
         fsm_path = os.path.dirname(paasta_tools.cli.fsm.__file__)

--- a/tests/api/test_auth_decorator.py
+++ b/tests/api/test_auth_decorator.py
@@ -1,0 +1,29 @@
+import mock
+import pytest
+from bravado.exception import HTTPBadRequest
+
+from paasta_tools.api.auth_decorator import AuthFutureDecorator
+
+
+def test_auth_future_decorator():
+    with mock.patch(
+        'paasta_tools.api.client.renew_issue_cert',
+        autospec=True,
+    ) as mock_renew, mock.patch(
+        'paasta_tools.api.auth_decorator.load_system_paasta_config',
+        autospec=True,
+    ):
+        mock_future = mock.Mock()
+        afd = AuthFutureDecorator(mock_future, "westeros-prod")
+        assert afd.result() == mock_future.result.return_value
+        assert not mock_renew.called
+
+        mock_result = mock.Mock()
+        mock_future.result.side_effect = [HTTPBadRequest(mock.Mock(status_code=400, text='Some problem')), mock_result]
+        with pytest.raises(HTTPBadRequest):
+            afd.result()
+        assert not mock_renew.called
+
+        mock_future.result.side_effect = [HTTPBadRequest(mock.Mock(status_code=400, text='SSL problem')), mock_result]
+        assert afd.result() is mock_result
+        assert mock_renew.called

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -15,6 +15,7 @@ import mock
 
 from paasta_tools.api.client import get_paasta_api_client
 from paasta_tools.api.client import PaastaRequestsClient
+from paasta_tools.api.client import renew_issue_cert
 
 
 def test_get_paasta_api_client(system_paasta_config):
@@ -39,3 +40,16 @@ def test_PaastaRequestsClient():
             system_paasta_config=mock.Mock(),
         )
         assert client
+
+
+def test_renew_issue_cert():
+    with mock.patch(
+        'paasta_tools.api.client.get_secret_provider',
+        autospec=True,
+    ) as mock_get_secret_provider:
+        mock_config = mock.Mock()
+        renew_issue_cert(mock_config, 'westeros-prod')
+        mock_get_secret_provider.return_value.renew_issue_cert.assert_called_with(
+            pki_backend=mock_config.get_pki_backend(),
+            ttl=mock_config.get_auth_certificate_ttl(),
+        )

--- a/tests/secret_providers/test_vault.py
+++ b/tests/secret_providers/test_vault.py
@@ -149,3 +149,11 @@ def test_get_secret_signature_from_data(mock_secret_provider):
         assert mock_secret_provider.get_secret_signature_from_data(
             {'environments': {'devc': {'signature': 'abc'}}},
         ) == 'abc'
+
+
+def test_renew_issue_cert(mock_secret_provider):
+    with mock.patch(
+        'paasta_tools.secret_providers.vault.do_renew', autospec=True,
+    ) as mock_do_renew:
+        mock_secret_provider.renew_issue_cert('paasta', '30m')
+        assert mock_do_renew.called

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -11,7 +11,7 @@ scribereader==0.2.6
 signalform-tools==0.0.16
 slo-transcoder==2.4.0
 smmap2==2.0.3
-vault-tools==0.7.25
+vault-tools==0.7.34
 yelp-cgeom==1.3.1
 yelp-logging==1.0.37
 yelp_meteorite


### PR DESCRIPTION
Issues a certificate via vault if https is enabled for the API endpoint.
If the certificate is expired then we renew it and retry the request.