### PR TITLE
Small updates to deployment processes

### DIFF
--- a/paasta_tools/automatic_rollbacks/slack.py
+++ b/paasta_tools/automatic_rollbacks/slack.py
@@ -99,6 +99,7 @@ class SlackDeploymentProcess(DeploymentProcess, abc.ABC):
         self.human_readable_status = "Initializing..."
         self.slack_client = self.get_slack_client()
         self.last_action = None
+        self.send_initial_slack_message()
 
         slack_thread = Thread(target=self.listen_for_slack_events, args=(), daemon=True)
         slack_thread.start()

--- a/paasta_tools/automatic_rollbacks/state_machine.py
+++ b/paasta_tools/automatic_rollbacks/state_machine.py
@@ -90,6 +90,9 @@ class DeploymentProcess(abc.ABC):
     def is_terminal_state(self, state: str) -> bool:
         return (state in self.status_code_by_state())
 
+    def is_finished(self) -> bool:
+        return self.finished_event.is_set()
+
     def finish(self):
         self.finished_event.set()
 

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -612,9 +612,9 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
         self.auto_rollback_delay = auto_rollback_delay
         self.slo_watchers = []
 
-        super().__init__()
         self.start_slo_watcher_threads(self.service)
-        self.send_initial_slack_message()
+        # Initialize Slack threads and send the first message
+        super().__init__()
         self.ping_authors()
 
     def get_progress(self) -> str:

--- a/tests/automatic_rollbacks/test_slack.py
+++ b/tests/automatic_rollbacks/test_slack.py
@@ -9,6 +9,7 @@ REAL_ROLLBACK_PRESS = {'type': 'block_actions', 'team': {'id': 'T0289TLJY', 'dom
 
 class DummySlackDeploymentProcess(slack.SlackDeploymentProcess):
     """A minimum-viable SlackDeploymentProcess subclass."""
+    slack_channel = 'test'
 
     def status_code_by_state(self):
         return {}
@@ -26,7 +27,15 @@ class DummySlackDeploymentProcess(slack.SlackDeploymentProcess):
         return '_begin'
 
     def get_slack_client(self):
-        return mock.Mock(spec=SlackClient)
+        mock_client = mock.Mock(spec=SlackClient)
+        mock_client.api_call.return_value = {
+            'ok': True,
+            'message': {
+                'ts': 10,
+            },
+            'channel': 'test',
+        }
+        return mock_client
 
     def get_slack_channel(self):
         raise NotImplementedError()


### PR DESCRIPTION
1. call `send_initial_slack_message` in `SlackDeploymentProcess.__init__` to avoid the race condition where the `periodically_update_slack` thread fails because `self.slack_channel_id` hasn't been initialized yet
2. Add a method to check if a deploy process is done, for the srv-configs integration