### PR TITLE
No jobs keyword again

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -520,30 +520,29 @@ The documentation here is for the PaaSTA-specific options. For all other
 settings, please see the
 `canonical docs <https://tron.readthedocs.io/en/latest/jobs.html>`_.
 
-.. warning:: The PaaSTA-Tron Integration is currently in an ALPHA state. Do not use it unless directed to.
 
 Example Job
 ^^^^^^^^^^^
 
 ::
 
-  jobs:
-      - name: convert_logs
-        node: node1
-        schedule:
-          start_time: 04:00:00
-        actions:
-          - name: verify_logs_present
-            command: "ls /var/log/app/log_%(shortdate-1)s.txt"
-            executor: ssh
-          - name: convert_logs
-            requires: [verify_logs_present]
-            command: "convert_logs /var/log/app/log_%(shortdate-1)s.txt /var/log/app_converted/log_%(shortdate-1)s.txt"
-            executor: paasta
-            service: test_service
-            deploy_group: prod
-            cpus: .5
-            mem: 100
+    ---
+    convert_logs:
+      node: paasta
+      schedule:
+        start_time: 04:00:00
+      actions:
+        verify_logs_present:
+          command: "ls /var/log/app/log_%(shortdate-1)s.txt"
+          executor: ssh
+        convert_logs:
+          requires: [verify_logs_present]
+          command: "convert_logs /var/log/app/log_%(shortdate-1)s.txt /var/log/app_converted/log_%(shortdate-1)s.txt"
+          executor: paasta
+          service: test_service
+          deploy_group: prod
+          cpus: .5
+          mem: 100
 
 PaaSTA-Specific Options
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/general_itests/fake_soa_configs_local_run/fake_simple_service/tron-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_local_run/fake_simple_service/tron-test-cluster.yaml
@@ -1,7 +1,6 @@
-jobs:
-  "sample_tron_job":
-    actions:
-      - name: action1
-        command: exit 42
-      - name: action2
-        command: /bin/true
+sample_tron_job:
+  actions:
+    action1:
+      command: exit 42
+    action2:
+      command: /bin/true

--- a/general_itests/fake_soa_configs_tron/fake_simple_service/tron-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_tron/fake_simple_service/tron-test-cluster.yaml
@@ -1,7 +1,6 @@
-jobs:
- "sample_tron_job":
-    actions:
-      - name: action1
-        command: exit 42
-      - name: action2
+sample_tron_job:
+  actions:
+    "action1":
+       command: exit 42
+    "action2":
         command: /bin/true

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -39,6 +39,7 @@ from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import paasta_print
+from paasta_tools.utils import load_tron_yaml
 
 from paasta_tools import monitoring_tools
 from paasta_tools.monitoring_tools import list_teams
@@ -524,17 +525,6 @@ def load_tron_instance_config(
                 if action.get_action_name() == requested_action:
                     return action
     raise NoConfigurationForServiceError(f"No tron configuration found for {service} {instance}")
-
-
-def load_tron_yaml(service: str, cluster: str, soa_dir: str) -> Dict[str, Any]:
-    config = service_configuration_lib.read_extra_service_information(
-        service_name=service,
-        extra_info=f'tron-{cluster}',
-        soa_dir=soa_dir,
-    )
-    if not config:
-        raise NoConfigurationForServiceError('No Tron configuration found for service %s' % service)
-    return config
 
 
 def extract_jobs_from_tron_yaml(config):

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -40,6 +40,7 @@ from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import load_tron_yaml
+from paasta_tools.utils import extract_jobs_from_tron_yaml
 
 from paasta_tools import monitoring_tools
 from paasta_tools.monitoring_tools import list_teams
@@ -525,15 +526,6 @@ def load_tron_instance_config(
                 if action.get_action_name() == requested_action:
                     return action
     raise NoConfigurationForServiceError(f"No tron configuration found for {service} {instance}")
-
-
-def extract_jobs_from_tron_yaml(config):
-    config = {key: value for key, value in config.items() if not key.startswith('_')}  # filter templates
-    if 'jobs' in config and config.get('jobs') is None:
-        return {}
-    if config.get('jobs') == {}:
-        return {}
-    return config.get('jobs') or config or {}
 
 
 def load_tron_service_config(service, cluster, load_deployments=True, soa_dir=DEFAULT_SOA_DIR):

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2487,7 +2487,7 @@ def get_tron_instance_list_from_yaml(service: str, cluster: str, soa_dir: str) -
     return instance_list
 
 
-def get_action_names_from_job(job):
+def get_action_names_from_job(job: dict) -> Collection[str]:
     # Warning: This duplicates some logic from TronActionConfig, but can't be imported here
     # dute to circular imports
     actions = job.get('actions')
@@ -2510,7 +2510,7 @@ def load_tron_yaml(service: str, cluster: str, soa_dir: str) -> Dict[str, Any]:
     return config
 
 
-def extract_jobs_from_tron_yaml(config):
+def extract_jobs_from_tron_yaml(config: Dict) -> Dict[str, Any]:
     config = {key: value for key, value in config.items() if not key.startswith('_')}  # filter templates
     if 'jobs' in config and config.get('jobs') is None:
         return {}

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2512,6 +2512,15 @@ def load_tron_yaml(service: str, cluster: str, soa_dir: str) -> Dict[str, Any]:
     return config
 
 
+def extract_jobs_from_tron_yaml(config):
+    config = {key: value for key, value in config.items() if not key.startswith('_')}  # filter templates
+    if 'jobs' in config and config.get('jobs') is None:
+        return {}
+    if config.get('jobs') == {}:
+        return {}
+    return config.get('jobs') or config or {}
+
+
 def get_instance_list_from_yaml(service: str, conf_file: str, soa_dir: str) -> Collection[Tuple[str, str]]:
     instance_list = []
     instances = service_configuration_lib.read_extra_service_information(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2501,6 +2501,17 @@ def get_tron_instance_list_from_yaml(service: str, conf_file: str, soa_dir: str)
     return instance_list
 
 
+def load_tron_yaml(service: str, cluster: str, soa_dir: str) -> Dict[str, Any]:
+    config = service_configuration_lib.read_extra_service_information(
+        service_name=service,
+        extra_info=f'tron-{cluster}',
+        soa_dir=soa_dir,
+    )
+    if not config:
+        raise NoConfigurationForServiceError('No Tron configuration found for service %s' % service)
+    return config
+
+
 def get_instance_list_from_yaml(service: str, conf_file: str, soa_dir: str) -> Collection[Tuple[str, str]]:
     instance_list = []
     instances = service_configuration_lib.read_extra_service_information(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2477,7 +2477,10 @@ def list_all_instances_for_service(
 
 def get_tron_instance_list_from_yaml(service: str, cluster: str, soa_dir: str) -> Collection[Tuple[str, str]]:
     instance_list = []
-    tron_config_content = load_tron_yaml(service=service, cluster=cluster, soa_dir=soa_dir)
+    try:
+        tron_config_content = load_tron_yaml(service=service, cluster=cluster, soa_dir=soa_dir)
+    except NoConfigurationForServiceError:
+        return []
     jobs = extract_jobs_from_tron_yaml(config=tron_config_content)
     for job_name, job in jobs.items():
         action_names = get_action_names_from_job(job=job)

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -721,11 +721,13 @@ def test_apply_args_filters_clusters_return_none_when_cluster_not_in_deploy_grou
 @patch('paasta_tools.cli.cmds.status.list_services', autospec=True)
 @patch('paasta_tools.cli.cmds.status.figure_out_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.status.list_clusters', autospec=True)
+@patch('paasta_tools.cli.cmds.status.list_all_instances_for_service', autospec=True)
 def test_apply_args_filters_clusters_return_none_when_instance_not_in_deploy_group(
     mock_list_clusters,
     mock_figure_out_service_name,
     mock_list_services,
     mock_get_instance_configs_for_service,
+    mock_list_all_instances_for_service,
 ):
     args = StatusArgs(
         service='fake_service',
@@ -740,6 +742,7 @@ def test_apply_args_filters_clusters_return_none_when_instance_not_in_deploy_gro
     mock_list_clusters.return_value = ['cluster1', 'cluster2']
     mock_figure_out_service_name.return_value = 'fake_service'
     mock_list_services.return_value = ['fake_service']
+    mock_list_all_instances_for_service.return_value = []
     mock_get_instance_configs_for_service.return_value = [
         make_fake_instance_conf('cluster1', 'fake_service', 'instance1', 'other_fake_deploy_group'),
         make_fake_instance_conf('cluster1', 'fake_service', 'instance2', 'other_fake_deploy_group'),

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1005,38 +1005,3 @@ class TestTronTools:
         ]
         result = tron_tools.list_tron_clusters('foo')
         assert sorted(result) == ['dev-cluster2', 'prod']
-
-
-def test_extract_jobs_from_tron_yaml_with_empty_dict():
-    assert tron_tools.extract_jobs_from_tron_yaml({}) == {}
-
-
-def test_extract_jobs_from_tron_yaml_with_None():
-    assert tron_tools.extract_jobs_from_tron_yaml({"jobs": None}) == {}
-
-
-def test_extract_jobs_from_tron_yaml_with_no_jobs():
-    assert tron_tools.extract_jobs_from_tron_yaml({"jobs": {}}) == {}
-
-
-def test_extract_jobs_from_tron_yaml_with_just_jobs():
-    assert tron_tools.extract_jobs_from_tron_yaml({"job0": "foo"}) == {"job0": "foo"}
-
-
-def test_extract_jobs_from_tron_yaml_with_mix():
-    config = {
-        "_template": "foo",
-        "job0": "bar",
-    }
-    assert tron_tools.extract_jobs_from_tron_yaml(config) == {"job0": "bar"}
-
-
-def test_extract_jobs_from_tron_yaml_defaults_to_jobs_if_available():
-    config = {
-        "_template": "foo",
-        "job0": "bar",
-        "jobs": {
-            "job1": "baz",
-        },
-    }
-    assert tron_tools.extract_jobs_from_tron_yaml(config) == {"job1": "baz"}

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -6,7 +6,6 @@ import pytest
 from paasta_tools import tron_tools
 from paasta_tools.tron_tools import MASTER_NAMESPACE
 from paasta_tools.utils import InvalidInstanceConfig
-from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 
 
@@ -763,19 +762,6 @@ class TestTronTools:
         }
         assert result['env']['SHELL'] == '/bin/bash'
         assert isinstance(result['docker_parameters'], list)
-
-    @mock.patch('paasta_tools.tron_tools.service_configuration_lib.read_extra_service_information', autospec=True)
-    @mock.patch('paasta_tools.tron_tools.service_configuration_lib._read_yaml_file', autospec=True)
-    def test_load_tron_yaml_empty(self, mock_read_file, mock_read_service_info):
-        mock_read_file.return_value = {}
-        mock_read_service_info.return_value = {}
-        soa_dir = '/other/services'
-
-        with pytest.raises(NoConfigurationForServiceError):
-            tron_tools.load_tron_yaml('foo', 'dev', soa_dir=soa_dir)
-
-        assert mock_read_service_info.call_count == 1
-        mock_read_service_info.assert_has_calls([mock.call('foo', 'tron-dev', soa_dir)])
 
     @mock.patch('service_configuration_lib.read_extra_service_information', autospec=True)
     def test_load_tron_yaml_picks_service_dir(self, mock_read_extra_service_configuration):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -883,40 +883,6 @@ def test_load_tron_yaml_empty(mock_read_file, mock_read_service_info):
     mock_read_service_info.assert_has_calls([mock.call('foo', 'tron-dev', soa_dir)])
 
 
-def test_get_tron_instance_list_from_yaml_finds_actions_properly():
-    fake_tron_job_config = {
-        "ssh_option": "foo",
-        "jobs": [
-            {
-                "name": "job1",
-                "actions": [
-                    {"name": "actionA"},
-                    {"name": "actionB"},
-                ],
-            },
-            {
-                "name": "job2",
-                "actions": [
-                    {"name": "actionC"},
-                    {"name": "actionD"},
-                ],
-            },
-        ],
-    }
-    expected = [
-        ("fake_service", "job1.actionA"),
-        ("fake_service", "job1.actionB"),
-        ("fake_service", "job2.actionC"),
-        ("fake_service", "job2.actionD"),
-    ]
-    with mock.patch(
-        'paasta_tools.utils.service_configuration_lib.read_extra_service_information', autospec=True,
-        return_value=fake_tron_job_config,
-    ):
-        actual = utils.get_tron_instance_list_from_yaml(service='fake_service', conf_file='fake', soa_dir='fake_dir')
-        assert sorted(expected) == sorted(actual)
-
-
 def test_get_tron_instance_list_from_yaml_with_dicts():
     fake_tron_job_config = {
         "ssh_option": "foo",
@@ -942,10 +908,40 @@ def test_get_tron_instance_list_from_yaml_with_dicts():
         ("fake_service", "job2.actionD"),
     ]
     with mock.patch(
-        'paasta_tools.utils.service_configuration_lib.read_extra_service_information', autospec=True,
+        'paasta_tools.utils.load_tron_yaml', autospec=True,
         return_value=fake_tron_job_config,
     ):
-        actual = utils.get_tron_instance_list_from_yaml(service='fake_service', conf_file='fake', soa_dir='fake_dir')
+        actual = utils.get_tron_instance_list_from_yaml(service='fake_service', cluster='fake', soa_dir='fake_dir')
+        assert sorted(expected) == sorted(actual)
+
+
+def test_get_tron_instance_list_from_yaml_with_no_jobs_and_templates():
+    fake_tron_job_config = {
+        "_template": "foo",
+        "job1": {
+            "actions": {
+                "actionA": {},
+                "actionB": {},
+            },
+        },
+        "job2": {
+            "actions": {
+                "actionC": {},
+                "actionD": {},
+            },
+        },
+    }
+    expected = [
+        ("fake_service", "job1.actionA"),
+        ("fake_service", "job1.actionB"),
+        ("fake_service", "job2.actionC"),
+        ("fake_service", "job2.actionD"),
+    ]
+    with mock.patch(
+        'paasta_tools.utils.load_tron_yaml', autospec=True,
+        return_value=fake_tron_job_config,
+    ):
+        actual = utils.get_tron_instance_list_from_yaml(service='fake_service', cluster='fake', soa_dir='fake_dir')
         assert sorted(expected) == sorted(actual)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -869,6 +869,20 @@ def test_get_service_instance_list_ignores_underscore():
         assert sorted(expected) == sorted(actual)
 
 
+@mock.patch('paasta_tools.utils.service_configuration_lib.read_extra_service_information', autospec=True)
+@mock.patch('paasta_tools.utils.service_configuration_lib._read_yaml_file', autospec=True)
+def test_load_tron_yaml_empty(mock_read_file, mock_read_service_info):
+    mock_read_file.return_value = {}
+    mock_read_service_info.return_value = {}
+    soa_dir = '/other/services'
+
+    with pytest.raises(utils.NoConfigurationForServiceError):
+        utils.load_tron_yaml('foo', 'dev', soa_dir=soa_dir)
+
+    assert mock_read_service_info.call_count == 1
+    mock_read_service_info.assert_has_calls([mock.call('foo', 'tron-dev', soa_dir)])
+
+
 def test_get_tron_instance_list_from_yaml_finds_actions_properly():
     fake_tron_job_config = {
         "ssh_option": "foo",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -945,6 +945,36 @@ def test_get_tron_instance_list_from_yaml_with_no_jobs_and_templates():
         assert sorted(expected) == sorted(actual)
 
 
+def test_get_tron_instance_list_from_yaml_with_no_jobs_and_action_lists():
+    fake_tron_job_config = {
+        "_template": "foo",
+        "job1": {
+            "actions": [
+                {"name": "actionA"},
+                {"name": "actionB"},
+            ],
+        },
+        "job2": {
+            "actions": [
+                {"name": "actionC"},
+                {"name": "actionD"},
+            ],
+        },
+    }
+    expected = [
+        ("fake_service", "job1.actionA"),
+        ("fake_service", "job1.actionB"),
+        ("fake_service", "job2.actionC"),
+        ("fake_service", "job2.actionD"),
+    ]
+    with mock.patch(
+        'paasta_tools.utils.load_tron_yaml', autospec=True,
+        return_value=fake_tron_job_config,
+    ):
+        actual = utils.get_tron_instance_list_from_yaml(service='fake_service', cluster='fake', soa_dir='fake_dir')
+        assert sorted(expected) == sorted(actual)
+
+
 def test_get_services_for_cluster():
     cluster = 'honey_bunches_of_oats'
     soa_dir = 'completely_wholesome'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2422,3 +2422,38 @@ def test_suggest_possibilities_one():
     expected = "FOOBAR?"
     actual = utils.suggest_possibilities(word='FOO', possibilities=["FOOBAR", "BAZ"])
     assert expected in actual
+
+
+def test_extract_jobs_from_tron_yaml_with_empty_dict():
+    assert utils.extract_jobs_from_tron_yaml({}) == {}
+
+
+def test_extract_jobs_from_tron_yaml_with_None():
+    assert utils.extract_jobs_from_tron_yaml({"jobs": None}) == {}
+
+
+def test_extract_jobs_from_tron_yaml_with_no_jobs():
+    assert utils.extract_jobs_from_tron_yaml({"jobs": {}}) == {}
+
+
+def test_extract_jobs_from_tron_yaml_with_just_jobs():
+    assert utils.extract_jobs_from_tron_yaml({"job0": "foo"}) == {"job0": "foo"}
+
+
+def test_extract_jobs_from_tron_yaml_with_mix():
+    config = {
+        "_template": "foo",
+        "job0": "bar",
+    }
+    assert utils.extract_jobs_from_tron_yaml(config) == {"job0": "bar"}
+
+
+def test_extract_jobs_from_tron_yaml_defaults_to_jobs_if_available():
+    config = {
+        "_template": "foo",
+        "job0": "bar",
+        "jobs": {
+            "job1": "baz",
+        },
+    }
+    assert utils.extract_jobs_from_tron_yaml(config) == {"job1": "baz"}


### PR DESCRIPTION
I was able to unify the `job` loading code, but not quite the action loading code.

For action names, we really just need the name, and not the other code for parsing other things about the action, so I thought it was an ok compromise.