### PR TITLE
Expand max_duration on SLOWatcher to 3600 seconds.

### DIFF
--- a/paasta_tools/automatic_rollbacks/slo.py
+++ b/paasta_tools/automatic_rollbacks/slo.py
@@ -53,7 +53,7 @@ class SLODemultiplexer:
         sink: Any,
         individual_slo_callback: Callable[['SLOWatcher'], None],
         start_timestamp: Optional[float] = None,
-        max_duration: float = 300,
+        max_duration: float = 3600,
     ) -> None:
         self.sink = sink
         self.individual_slo_callback = individual_slo_callback
@@ -82,7 +82,7 @@ class SLOWatcher:
         callback: Callable[['SLOWatcher'], Any],
         start_timestamp: float,
         label: str,
-        max_duration: float = 300,
+        max_duration: float,
     ) -> None:
         self.slo = slo
         self.window: List[Tuple[float, float]] = []


### PR DESCRIPTION
Having this set to 300 seconds was misguided. Several services have SLOs that are tuned to have a sensitive threshold but a long duration/low percent_of_duration. These SLOs are made flaky by messing with the max_duration, resulting in automatically-rolled-back pushes that were actually fine.