### PR TITLE
Increase log level of autoscaler http utilization timeouts

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -263,7 +263,7 @@ def get_http_utilization_for_a_task(task, service, endpoint, json_mapper):
         # If we time out querying an endpoint, assume the task is fully loaded
         # This won't trigger in the event of DNS error or when a request is refused
         # a requests.exception.ConnectionError is raised in those cases
-        log.debug("Received a timeout when querying %s on %s:%s. Assuming the service "
+        log.error("Received a timeout when querying %s on %s:%s. Assuming the service "
                   "is at full utilization." % (service, task.host, task.ports[0]))
         return 1.0
     except Exception as e:


### PR DESCRIPTION
We are seeing some outlier utilization that doesn't agree with meteorite utilization. It makes sense that this code is why, so let's log these as errors so they will flow through the rest of the log pipeline and we can count them and understand when and why it happens.