### PR TITLE
Email Spark framework users if possible

### DIFF
--- a/paasta_tools/check_spark_jobs.py
+++ b/paasta_tools/check_spark_jobs.py
@@ -128,15 +128,15 @@ def format_message_for_service(service, frameworks):
     return output
 
 
-def get_messages_by_service(results):
-    results_by_service = defaultdict(list)
-    for result in results:
-        service = result['service']
-        results_by_service[service].append(result)
+def get_messages_by_service(frameworks):
+    frameworks_by_service = defaultdict(list)
+    for framework in frameworks:
+        service = framework['service']
+        frameworks_by_service[service].append(framework)
 
     return {
-        service: format_message_for_service(service, results)
-        for service, results in results_by_service.items()
+        service: format_message_for_service(service, frameworks)
+        for service, frameworks in frameworks_by_service.items()
     }
 
 
@@ -168,7 +168,9 @@ def email_user(framework_info, email_domain):
         except IndexError:
             pass
 
-    if not guessed_user:
+    if guessed_user:
+        print(f'Guessed {framework_info["name"]} belongs to {guessed_user}, sending email')
+    else:
         print(f'Could not guess user from {framework_info}, skipping user email')
         return
 
@@ -184,10 +186,10 @@ def email_user(framework_info, email_domain):
 
 
 def report_spark_jobs(min_hours, no_notify, email_domain=None):
-    results = get_matching_framework_info(
+    frameworks = get_matching_framework_info(
         min_hours=min_hours,
     )
-    messages_by_service = get_messages_by_service(results)
+    messages_by_service = get_messages_by_service(frameworks)
     valid_services = set(list_services())
 
     messages_for_unknown_services = []
@@ -209,10 +211,10 @@ def report_spark_jobs(min_hours, no_notify, email_domain=None):
             else:
                 update_check_status(service, 'No long running spark jobs', pysensu_yelp.Status.OK)
         if email_domain:
-            for result in results:
-                email_user(result, email_domain)
+            for framework in frameworks:
+                email_user(framework, email_domain)
 
-    return 0 if len(results) == 0 else 1
+    return 0 if len(frameworks) == 0 else 1
 
 
 def main():

--- a/tests/test_check_spark_jobs.py
+++ b/tests/test_check_spark_jobs.py
@@ -8,6 +8,12 @@ from paasta_tools.mesos.framework import Framework
 
 
 @pytest.fixture
+def mock_smtp():
+    with mock.patch('paasta_tools.check_spark_jobs.smtplib', autospec=True) as mock_smtp:
+        yield mock_smtp
+
+
+@pytest.fixture
 def mock_current_time():
     return datetime.datetime(2019, 4, 3, 0, 0, 0)
 
@@ -104,11 +110,39 @@ def test_get_matching_framework_info(mock_guess_service, mock_get_spark_properti
     assert result_names == ['spark_2_hours', 'spark_25_hours']
 
 
+@pytest.mark.parametrize(
+    'framework_user,framework_name,expected', [
+        ('me', 'paasta_spark_run_something', 'me'),
+        ('root', 'Custom Spark App', None),
+        ('root', 'jupyterhub_bill-search-learning_bill_39904', 'bill'),
+    ],
+)
+def test_email_user(mock_smtp, framework_user, framework_name, expected):
+    info = {
+        'id': 'id1',
+        'name': framework_name,
+        'webui_url': 'url1',
+        'service': 'something',
+        'user': framework_user,
+        'time_running': '1 day, 03:32:00',
+    }
+    check_spark_jobs.email_user(info, 'test.com')
+
+    mock_send_message = mock_smtp.SMTP.return_value.__enter__.return_value.send_message
+    if expected:
+        assert mock_send_message.call_count == 1
+        msg = mock_send_message.call_args[0][0]
+        assert msg['To'] == f'{expected}@test.com'
+    else:
+        assert mock_send_message.call_count == 0
+
+
+@mock.patch('paasta_tools.check_spark_jobs.email_user', autospec=True)
 @mock.patch('paasta_tools.check_spark_jobs.list_services', autospec=True)
 @mock.patch('paasta_tools.check_spark_jobs.get_matching_framework_info', autospec=True)
 @mock.patch('paasta_tools.check_spark_jobs.update_check_status', autospec=True)
-@pytest.mark.parametrize('no_notify', [(True,), (False,)])
-def test_report_spark_jobs(mock_check, mock_get_info, mock_list_services, no_notify):
+@pytest.mark.parametrize('no_notify', [True, False])
+def test_report_spark_jobs(mock_check, mock_get_info, mock_list_services, mock_email_user, no_notify):
     mock_list_services.return_value = ['service1', 'service2', 'other_service']
     mock_get_info.return_value = [
         {
@@ -144,13 +178,16 @@ def test_report_spark_jobs(mock_check, mock_get_info, mock_list_services, no_not
             'time_running': '7:00:00',
         },
     ]
-    check_spark_jobs.report_spark_jobs(1, no_notify)
+    assert check_spark_jobs.report_spark_jobs(1, no_notify, 'test.com') == 1
     assert mock_get_info.call_args_list == [mock.call(min_hours=1)]
     if no_notify:
         assert mock_check.call_count == 0
     else:
-        assert mock_check.call_args_list == [
+        assert sorted(mock_check.call_args_list) == sorted([
             mock.call('service1', mock.ANY, 1),
             mock.call('service2', mock.ANY, 1),
             mock.call('other_service', mock.ANY, 0),
+        ])
+        assert mock_email_user.call_args_list == [
+            mock.call(info, 'test.com') for info in mock_get_info.return_value
         ]


### PR DESCRIPTION
Guess from the framework user and name. It won't work for Spark apps defined in code, which are often run by root and have a custom framework name, but those should be covered by the service notification.

Also return with the appropriate return code so we can control the frequency that our team gets the full check output.