### PR TITLE
Fail gracefully when a tron service hasn't been deployed yet

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -14,6 +14,7 @@ import datetime
 import difflib
 import glob
 import json
+import logging
 import os
 import pkgutil
 import re
@@ -47,6 +48,9 @@ from paasta_tools.monitoring_tools import list_teams
 from typing import Optional
 from typing import Dict
 from typing import Any
+
+log = logging.getLogger(__name__)
+logging.getLogger('tron').setLevel(logging.WARNING)
 
 MASTER_NAMESPACE = 'MASTER'
 SPACER = '.'
@@ -317,15 +321,11 @@ class TronJobConfig:
                     'force_bounce': None,
                 }
             except NoDeploymentsAvailable:
-                raise InvalidTronConfig(
-                    'No deployment found for action {action} in job {job}, looking for {deploy_group} '
-                    'in service {service}'.format(
-                        action=action_dict.get('name'),
-                        job=self.get_name(),
-                        deploy_group=action_deploy_group,
-                        service=action_service,
-                    ),
+                log.warning(
+                    f'Docker image unavailable for {action_service}.{self.get_name()}.{action_dict.get("name")}'
+                    ' is it deployed yet?',
                 )
+                branch_dict = None
         else:
             branch_dict = None
         action_dict['monitoring'] = self.get_monitoring()

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -213,28 +213,6 @@ class TestTronJobConfig:
         )
 
     @mock.patch('paasta_tools.tron_tools.load_v2_deployments_json', autospec=True)
-    def test_get_action_config_no_deployment(
-        self,
-        mock_load_deployments,
-    ):
-        action_dict = {
-            'command': 'echo first',
-        }
-        job_dict = {
-            'node': 'batch_server',
-            'schedule': 'daily 12:10:00',
-            'service': 'my_service',
-            'deploy_group': 'prod',
-            'max_runtime': '2h',
-            'actions': {'normal': action_dict},
-        }
-        job_config = tron_tools.TronJobConfig('my_job', job_dict, 'fake-cluster')
-        mock_load_deployments.side_effect = NoDeploymentsAvailable
-
-        with pytest.raises(tron_tools.InvalidTronConfig):
-            job_config._get_action_config('normal', action_dict)
-
-    @mock.patch('paasta_tools.tron_tools.load_v2_deployments_json', autospec=True)
     def test_get_action_config_load_deployments_false(
         self,
         mock_load_deployments,


### PR DESCRIPTION
It is pretty "normal" for a user to add a new service with tronfig that isn't deployed yet.
I think we should warn, but not block a tronfig update for this. A developer will get notified because their job is failing, which should encourage them to deploy it.

This is different than doing validation on a typo'd deploy_group, this should be tackled in a different way.