### PR TITLE
Removed the option to disabled docker init

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -55,13 +55,6 @@ specify the following options:
     met, other than a ``TASK_FAILED`` message. For more a more detailed read on
     how this works, see the docs on `isolation <isolation.html>`_
 
-  * ``docker_init``: Bool. If set ``false``, will disable the ``--init`` functionality
-    of Docker. Without ``--init``, it is up to the user to properly respond to
-    signals when behaving as PID #1 in a container. (See
-    `dumb-init <https://github.com/Yelp/dumb-init#why-you-need-an-init-system>`_
-    as an example of how to run a program in a container properly without
-    ``--init``) Defaults to ``true``.
-
   * ``env``: A dictionary of environment variables that will be made available
     to the container. PaaSTA additionally will inject the following variables:
 

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -320,10 +320,6 @@
                     "type": "object",
                     "additionalProperties": { "type": "string" }
                 },
-                "docker_init": {
-                  "type": "boolean",
-                  "default": true
-                },
                 "security": {
                     "type": "object",
                     "properties": {

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -214,7 +214,6 @@ class InstanceConfigDict(TypedDict, total=False):
     ulimit: Dict[str, Dict[str, Any]]
     cap_add: List
     env: Dict[str, str]
-    docker_init: bool
     monitoring: Dict[str, str]
     deploy_blacklist: UnsafeDeployBlacklist
     deploy_whitelist: UnsafeDeployWhitelist
@@ -465,10 +464,7 @@ class InstanceConfig:
         return parameters
 
     def get_docker_init(self) -> Iterable[DockerParameter]:
-        if self.config_dict.get('docker_init', True) is True:
-            return [{'key': 'init', 'value': 'true'}]
-        else:
-            return []
+        return [{'key': 'init', 'value': 'true'}]
 
     def get_disk(self, default: float = 1024) -> float:
         """Gets the  amount of disk space required from the service's configuration.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1290,7 +1290,6 @@ class TestInstanceConfig:
                     'nice': {'soft': 20},
                 },
                 'cap_add': ['IPC_LOCK', 'SYS_PTRACE'],
-                'docker_init': False,
             },
             branch_dict=None,
         )
@@ -1304,6 +1303,7 @@ class TestInstanceConfig:
             {"key": "ulimit", "value": "nofile=1024:2048"},
             {"key": "cap-add", "value": "IPC_LOCK"},
             {"key": "cap-add", "value": "SYS_PTRACE"},
+            {'key': 'init', 'value': 'true'},
             {'key': 'cap-drop', 'value': 'SETPCAP'},
             {'key': 'cap-drop', 'value': 'MKNOD'},
             {'key': 'cap-drop', 'value': 'AUDIT_WRITE'},


### PR DESCRIPTION
We don't use this.
We've lived with --init for a while, I don't think we'll ever use it.