### PR TITLE
Error on all methods in draining itest

### DIFF
--- a/paasta_itests/bounces.feature
+++ b/paasta_itests/bounces.feature
@@ -124,33 +124,9 @@ Feature: Bounces work as expected
       And setup_service is initiated
      Then the old app should be configured to have 1 instances
 
-  Scenario: Bounces make progress even if drain method fails to drain
+  Scenario: Bounces make progress even if drain method fails to respond
     Given a working paasta cluster
       And a new healthy app to be deployed, with bounce strategy "crossover" and drain method "crashy_drain"
-      And an old app to be destroyed
-
-     When there are 2 old healthy tasks
-      And setup_service is initiated
-     Then the new app should be running
-      And the old app should be running
-
-
-     When there are 1 new healthy tasks
-      And setup_service is initiated
-     Then the new app should be running
-      And the old app should be running
-      # Note: this is different from the "wait for drain method" scenario because the drain method raises an exception.
-      And the old app should be configured to have 1 instances
-
-     When there are 2 new healthy tasks
-      And setup_service is initiated
-     Then the new app should be running
-     When we wait a bit for the old app to disappear
-     Then the old app should be gone
-
-  Scenario: Bounces make progress even if drain method fails is_safe_to_kill
-    Given a working paasta cluster
-      And a new healthy app to be deployed, with bounce strategy "crossover" and drain method "crashy_is_safe_to_kill"
       And an old app to be destroyed
 
      When there are 2 old healthy tasks

--- a/paasta_tools/drain_lib.py
+++ b/paasta_tools/drain_lib.py
@@ -149,10 +149,13 @@ class CrashyDrainDrainMethod(NoopDrainMethod):
     async def drain(self, task: DrainTask) -> None:
         raise Exception("Intentionally crashing for testing purposes")
 
-
-@register_drain_method('crashy_is_safe_to_kill')
-class CrashySafeToKillDrainMethod(NoopDrainMethod):
     async def is_safe_to_kill(self, task: DrainTask) -> bool:
+        raise Exception("Intentionally crashing for testing purposes")
+
+    async def stop_draining(self, task: DrainTask) -> None:
+        raise Exception("Intentionally crashing for testing purposes")
+
+    async def is_draining(self, task: DrainTask) -> bool:
         raise Exception("Intentionally crashing for testing purposes")
 
 


### PR DESCRIPTION
An attempt to improve itests in response to DAR-634. We have tests to make sure the bounce makes progress when some draining methods are failing, might as well check all of them.

This would have caught the error in DAR-634 (fails at L135, "the old app should be running") if we took out the "Intentionally crashing for testing purposes" so that the Exception has no args and would have triggered the e.args[0] IndexError. But now we have a unit test for both the 0 arg and 1 arg cases, so keeping it seems reasonable?