### PR TITLE
fix volume naming in kubernetes tools to support files

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -346,7 +346,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
     def get_sanitised_volume_name(self, volume_name: str) -> str:
         """I know but we really aren't allowed many characters..."""
         volume_name = volume_name.rstrip('/')
-        sanitised = volume_name.replace('/', 'slash-')
+        sanitised = volume_name.replace('/', 'slash-').replace('.', 'dot-')
         return sanitised.replace('_', '--')
 
     def get_docker_volume_name(self, docker_volume: DockerVolume) -> str:

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -255,8 +255,9 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             )
 
     def test_get_sanitised_volume_name(self):
-        self.deployment.get_sanitised_volume_name('/var/tmp') == 'slash-varslash-tmp'
-        self.deployment.get_sanitised_volume_name('/var/tmp/') == 'slash-varslash-tmp'
+        assert self.deployment.get_sanitised_volume_name('/var/tmp') == 'slash-varslash-tmp'
+        assert self.deployment.get_sanitised_volume_name('/var/tmp/') == 'slash-varslash-tmp'
+        assert self.deployment.get_sanitised_volume_name('/var/tmp_file.json') == 'slash-varslash-tmp--filedot-json'
 
     def test_get_sidecar_containers(self):
         with mock.patch(


### PR DESCRIPTION
The error message is as follows:

> HTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json', 'Date': 'Fri, 12 Jul 2019 20:22:37 GMT', 'Content-Length': '1214'})
> HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Deployment.apps \"yelp-main-main--uswest1\" is invalid: [spec.template.spec.volumes[1].name: Invalid value: \"host--slash-etcslash-yelp--clog.json\": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), spec.template.spec.containers[0].volumeMounts[1].name: Not found: \"host--slash-etcslash-yelp--clog.json\"]","reason":"Invalid","details":{"name":"yelp-main-main--uswest1","group":"apps","kind":"Deployment","causes":[{"reason":"FieldValueInvalid","message":"Invalid value: \"host--slash-etcslash-yelp--clog.json\": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')","field":"spec.template.spec.volumes[1].name"},{"reason":"FieldValueNotFound","message":"Not found: \"host--slash-etcslash-yelp--clog.json\"","field":"spec.template.spec.containers[0].volumeMounts[1].name"}]},"code":422}