### PR TITLE
[paasta secret add]  clarify how to terminate stdin and echo secret to stdout for confirmation

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -129,7 +129,7 @@ def get_plaintext_input(args):
     elif args.plain_text:
         plaintext = args.plain_text.encode('utf-8')
     else:
-        print("Please enter the plaintext for the secret, press Ctrl-D when done.")
+        print("Please enter the plaintext for the secret, then enter a newline and Ctrl-D when done.")
         lines = []
         while True:
             try:
@@ -138,6 +138,8 @@ def get_plaintext_input(args):
                 break
             lines.append(line)
         plaintext = '\n'.join(lines).encode('utf-8')
+        print("The secret as a Python string is:", repr(plaintext))
+        print("Please make sure this is correct.")
     return plaintext
 
 


### PR DESCRIPTION
We've seen people get confused by the instructions and either 1) get an extra newline in their secret, or 2) attempt to terminate stdin using just ctrl+d's (no newline), which in Python due to a weird bug causes your last character to get cut off.

This clarifies the instructions to say you should type in your secret then type exactly one newline and one ctrl+d. Then for good measure it echos back the secret so you can confirm that it didn't cut anything off or insert any stray newlines. There's no risk of leaking secrets this way because typing in the secret makes it show up on stdout anyway.