### PR TITLE
Remove performance-check from paasta check

### DIFF
--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -89,17 +89,6 @@ def deploy_has_security_check(service, soa_dir):
         return False
 
 
-def deploy_has_performance_check(service, soa_dir):
-    pipeline = get_pipeline_config(service=service, soa_dir=soa_dir)
-    steps = [step['step'] for step in pipeline]
-    if 'performance-check' in steps:
-        paasta_print(PaastaCheckMessages.DEPLOY_PERFORMANCE_FOUND)
-        return True
-    else:
-        paasta_print(PaastaCheckMessages.DEPLOY_PERFORMANCE_MISSING)
-        return False
-
-
 def docker_check():
     """Check whether Dockerfile exists in service directory, and is valid.
     Prints suitable message depending on outcome"""
@@ -308,7 +297,6 @@ def paasta_check(args):
     service_dir_check(service, soa_dir)
     deploy_check(service_path)
     deploy_has_security_check(service, soa_dir)
-    deploy_has_performance_check(service, soa_dir)
     git_repo_check(service, soa_dir)
     docker_check()
     makefile_check()

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -165,14 +165,6 @@ class PaastaCheckMessages:
         "More info:", "http://paasta.readthedocs.io/en/latest/generated/paasta_tools.cli.cmds.security_check.html",
     )
 
-    DEPLOY_PERFORMANCE_FOUND = success("Found a performance-check entry in your deploy pipeline")
-    DEPLOY_PERFORMANCE_MISSING = failure(
-        "No 'performance-check' entry was found in your deploy.yaml.\n"
-        "Please add a performance-check entry *AFTER* the security-check entry in deploy.yaml\n"
-        "so your docker image can be checked for performance regressions.\n"
-        "More info:", "http://paasta.readthedocs.io/en/latest/generated/paasta_tools.cli.cmds.performance_check.html",
-    )
-
     DOCKERFILE_FOUND = success("Found Dockerfile")
 
     DOCKERFILE_MISSING = failure(

--- a/tests/cli/test_cmds_check.py
+++ b/tests/cli/test_cmds_check.py
@@ -18,7 +18,6 @@ from mock import MagicMock
 from mock import patch
 
 from paasta_tools.cli.cmds.check import deploy_check
-from paasta_tools.cli.cmds.check import deploy_has_performance_check
 from paasta_tools.cli.cmds.check import deploy_has_security_check
 from paasta_tools.cli.cmds.check import deployments_check
 from paasta_tools.cli.cmds.check import docker_check
@@ -40,7 +39,6 @@ from paasta_tools.marathon_tools import MarathonServiceConfig
 @patch('paasta_tools.cli.cmds.check.service_dir_check', autospec=True)
 @patch('paasta_tools.cli.cmds.check.validate_service_name', autospec=True)
 @patch('paasta_tools.cli.cmds.check.figure_out_service_name', autospec=True)
-@patch('paasta_tools.cli.cmds.check.deploy_has_performance_check', autospec=True)
 @patch('paasta_tools.cli.cmds.check.deploy_has_security_check', autospec=True)
 @patch('paasta_tools.cli.cmds.check.deploy_check', autospec=True)
 @patch('paasta_tools.cli.cmds.check.docker_check', autospec=True)
@@ -58,7 +56,6 @@ def test_check_paasta_check_calls_everything(
         mock_docker_check,
         mock_deploy_check,
         mock_deploy_security_check,
-        mock_deploy_performance_check,
         mock_figure_out_service_name,
         mock_validate_service_name,
         mock_service_dir_check,
@@ -76,7 +73,6 @@ def test_check_paasta_check_calls_everything(
     assert mock_service_dir_check.called
     assert mock_deploy_check.called
     assert mock_deploy_security_check.called
-    assert mock_deploy_performance_check.called
     assert mock_docker_check.called
     assert mock_makefile_check.called
     assert mock_sensu_check.called
@@ -397,31 +393,6 @@ def test_deploy_has_security_check_true(mock_pipeline_config, capfd):
         {'step': 'hab.main', },
     ]
     actual = deploy_has_security_check(service='fake_service', soa_dir='/fake/path')
-    assert actual is True
-
-
-@patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
-def test_deploy_has_performance_check_false(mock_pipeline_config, capfd):
-    mock_pipeline_config.return_value = [
-        {'step': 'itest', },
-        {'step': 'push-to-registry', },
-        {'step': 'hab.canary', 'trigger_next_step_manually': True, },
-        {'step': 'hab.main', },
-    ]
-    actual = deploy_has_performance_check(service='fake_service', soa_dir='/fake/path')
-    assert actual is False
-
-
-@patch('paasta_tools.cli.cmds.check.get_pipeline_config', autospec=True)
-def test_deploy_has_performance_check_true(mock_pipeline_config, capfd):
-    mock_pipeline_config.return_value = [
-        {'step': 'itest', },
-        {'step': 'performance-check', },
-        {'step': 'push-to-registry', },
-        {'step': 'hab.canary', 'trigger_next_step_manually': True, },
-        {'step': 'hab.main', },
-    ]
-    actual = deploy_has_performance_check(service='fake_service', soa_dir='/fake/path')
     assert actual is True
 
 


### PR DESCRIPTION
We no longer have performance-check in our deploy.yaml template, so we
can go ahead and stop making people that run "paasta check" on a new
service think that they've done something wrong.