### PR TITLE
slos attribute disappeared from sink object between slo-transcoder 2.…

### DIFF
--- a/paasta_tools/automatic_rollbacks/slo.py
+++ b/paasta_tools/automatic_rollbacks/slo.py
@@ -75,7 +75,7 @@ class SLODemultiplexer:
             self.start_timestamp = start_timestamp
 
         self.slo_watchers_by_label: Dict[str, 'SLOWatcher'] = {}
-        for slo in sink.slos:
+        for slo in sink.source.slos:
             label = sink._get_detector_label(slo)
             watcher = SLOWatcher(slo, individual_slo_callback, self.start_timestamp, label, max_duration=max_duration)
             self.slo_watchers_by_label[label] = watcher

--- a/tests/automatic_rollbacks/test_slo.py
+++ b/tests/automatic_rollbacks/test_slo.py
@@ -78,11 +78,11 @@ def test_SLODemultiplexer():
     bad = 2.0
 
     sink = mock.Mock(
-        slos=[
+        source=mock.Mock(slos=[
             mock.Mock(label='slo_1', config=slo_config),
             mock.Mock(label='slo_2', config=slo_config),
             mock.Mock(label='slo_3', config=slo_config),
-        ],
+        ]),
         _get_detector_label=lambda slo: slo.label,
     )
     individual_slo_callback = mock.Mock()
@@ -123,11 +123,11 @@ def test_watch_slos_for_service_alerting():
     bad = 2.0
 
     sink = mock.Mock(
-        slos=[
+        source=mock.Mock(slos=[
             mock.Mock(label='slo_1', config=slo_config),
             mock.Mock(label='slo_2', config=slo_config),
             mock.Mock(label='slo_3', config=slo_config),
-        ],
+        ]),
         _get_detector_label=lambda slo: slo.label,
     )
     individual_slo_callback = mock.Mock()


### PR DESCRIPTION
…4.0 and 2.5.6 - access it a different way