### PR TITLE
cap_add support in k8s

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -40,6 +40,7 @@ from kubernetes.client import models
 from kubernetes.client import V1AWSElasticBlockStoreVolumeSource
 from kubernetes.client import V1beta1PodDisruptionBudget
 from kubernetes.client import V1beta1PodDisruptionBudgetSpec
+from kubernetes.client import V1Capabilities
 from kubernetes.client import V1ConfigMap
 from kubernetes.client import V1Container
 from kubernetes.client import V1ContainerPort
@@ -69,6 +70,7 @@ from kubernetes.client import V1ResourceRequirements
 from kubernetes.client import V1RollingUpdateDeployment
 from kubernetes.client import V1Secret
 from kubernetes.client import V1SecretKeySelector
+from kubernetes.client import V1SecurityContext
 from kubernetes.client import V1StatefulSet
 from kubernetes.client import V1StatefulSetSpec
 from kubernetes.client import V1TCPSocketAction
@@ -553,6 +555,16 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
         return probe
 
+    def get_security_context(self) -> V1SecurityContext:
+        cap_add = self.config_dict.get('cap_add', None)
+        if cap_add is None:
+            return None
+        return V1SecurityContext(
+            capabilities=V1Capabilities(
+                add=cap_add,
+            ),
+        )
+
     def get_kubernetes_containers(
         self,
         docker_volumes: Sequence[DockerVolume],
@@ -584,6 +596,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     container_port=self.get_container_port(),
                 ),
             ],
+            security_context=self.get_security_context(),
             volume_mounts=self.get_volume_mounts(
                 docker_volumes=docker_volumes,
                 aws_ebs_volumes=aws_ebs_volumes,

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -8,6 +8,7 @@ from hypothesis.strategies import floats
 from hypothesis.strategies import integers
 from kubernetes.client import V1AWSElasticBlockStoreVolumeSource
 from kubernetes.client import V1beta1PodDisruptionBudget
+from kubernetes.client import V1Capabilities
 from kubernetes.client import V1Container
 from kubernetes.client import V1ContainerPort
 from kubernetes.client import V1Deployment
@@ -30,6 +31,7 @@ from kubernetes.client import V1Probe
 from kubernetes.client import V1ResourceRequirements
 from kubernetes.client import V1RollingUpdateDeployment
 from kubernetes.client import V1SecretKeySelector
+from kubernetes.client import V1SecurityContext
 from kubernetes.client import V1StatefulSet
 from kubernetes.client import V1StatefulSetSpec
 from kubernetes.client import V1TCPSocketAction
@@ -555,6 +557,16 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
         service_namespace_config.get_healthcheck_mode.return_value = 'cmd'
         self.deployment.config_dict['healthcheck_cmd'] = '/bin/true'
         assert self.deployment.get_liveness_probe(service_namespace_config) == liveness_probe
+
+    def test_get_security_context_without_cap_add(self):
+        assert self.deployment.get_security_context() is None
+
+    def test_get_security_context_with_cap_add(self):
+        self.deployment.config_dict['cap_add'] = ["SETGID"]
+        expected_security_context = V1SecurityContext(
+            capabilities=V1Capabilities(add=["SETGID"]),
+        )
+        assert self.deployment.get_security_context() == expected_security_context
 
     def test_get_pod_volumes(self):
         mock_docker_volumes = [


### PR DESCRIPTION
Add capabilities for containers. For example, yelp-main main_uswest1 instances needs these capabilities: "DAC_OVERRIDE", "CHOWN", "SETGID", "SETUID"]