### PR TITLE
Fix secret name sanitisation

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1380,12 +1380,12 @@ def create_secret(
     secret_provider: BaseSecretProvider,
 ) -> None:
     service = sanitise_kubernetes_name(service)
-    secret = sanitise_kubernetes_name(secret)
+    sanitised_secret = sanitise_kubernetes_name(secret)
     kube_client.core.create_namespaced_secret(
         namespace="paasta",
         body=V1Secret(
             metadata=V1ObjectMeta(
-                name=f"paasta-secret-{service}-{secret}",
+                name=f"paasta-secret-{service}-{sanitised_secret}",
                 labels={"yelp.com/paasta_service": service},
             ),
             data={secret: base64.b64encode(secret_provider.decrypt_secret_raw(secret)).decode('utf-8')},
@@ -1400,13 +1400,13 @@ def update_secret(
     secret_provider: BaseSecretProvider,
 ) -> None:
     service = sanitise_kubernetes_name(service)
-    secret = sanitise_kubernetes_name(secret)
+    sanitised_secret = sanitise_kubernetes_name(secret)
     kube_client.core.replace_namespaced_secret(
-        name=f"paasta-secret-{service}-{secret}",
+        name=f"paasta-secret-{service}-{sanitised_secret}",
         namespace="paasta",
         body=V1Secret(
             metadata=V1ObjectMeta(
-                name=f"paasta-secret-{service}-{secret}",
+                name=f"paasta-secret-{service}-{sanitised_secret}",
                 labels={"yelp.com/paasta_service": service},
             ),
             data={secret: base64.b64encode(secret_provider.decrypt_secret_raw(secret)).decode('utf-8')},

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1721,11 +1721,20 @@ def test_create_secret():
     assert mock_client.core.create_namespaced_secret.called
     mock_secret_provider.decrypt_secret_raw.assert_called_with('mortys-fate')
 
+    create_secret(
+        kube_client=mock_client,
+        service='universe',
+        secret='mortys_fate',
+        secret_provider=mock_secret_provider,
+    )
+    mock_secret_provider.decrypt_secret_raw.assert_called_with('mortys_fate')
+
 
 def test_update_secret():
     mock_client = mock.Mock()
     mock_secret_provider = mock.Mock()
     mock_secret_provider.decrypt_secret_raw.return_value = bytes("plaintext", 'utf-8')
+
     update_secret(
         kube_client=mock_client,
         service='universe',
@@ -1734,6 +1743,14 @@ def test_update_secret():
     )
     assert mock_client.core.replace_namespaced_secret.called
     mock_secret_provider.decrypt_secret_raw.assert_called_with('mortys-fate')
+
+    update_secret(
+        kube_client=mock_client,
+        service='universe',
+        secret='mortys_fate',
+        secret_provider=mock_secret_provider,
+    )
+    mock_secret_provider.decrypt_secret_raw.assert_called_with('mortys_fate')
 
 
 def test_get_kubernetes_secret_hashes():


### PR DESCRIPTION
We need to send the "real" name to vault_tools when decrypting. So in
other words my fix in https://github.com/Yelp/paasta/pull/2321 was not
quite right.