### PR TITLE
Drop mem validation for cassandra

### DIFF
--- a/paasta_tools/cassandracluster_tools.py
+++ b/paasta_tools/cassandracluster_tools.py
@@ -56,9 +56,14 @@ class CassandraClusterDeploymentConfig(LongRunningServiceConfig):
     def get_instances(self, with_limit: bool = True) -> int:
         return self.config_dict.get('replicas', 1)
 
-    def validate(self) -> List[str]:
+    def validate(
+        self,
+        params: List[str] = ['cpus', 'security', 'dependencies_reference', 'deploy_group'],
+    ) -> List[str]:
         # Use InstanceConfig to validate shared config keys like cpus and mem
-        error_msgs = super().validate()
+        # TODO: add mem back to this list once we fix PAASTA-15582 and
+        # move to using the same units as flink/marathon etc.
+        error_msgs = super().validate(params=params)
 
         if error_msgs:
             name = self.get_instance()

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -66,9 +66,12 @@ class FlinkDeploymentConfig(LongRunningServiceConfig):
             branch_dict=branch_dict,
         )
 
-    def validate(self) -> List[str]:
+    def validate(
+        self,
+        params: List[str] = ['cpus', 'mem', 'security', 'dependencies_reference', 'deploy_group'],
+    ) -> List[str]:
         # Use InstanceConfig to validate shared config keys like cpus and mem
-        error_msgs = super().validate()
+        error_msgs = super().validate(params=params)
 
         if error_msgs:
             name = self.get_instance()

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -702,9 +702,12 @@ class InstanceConfig:
         else:
             return False, 'Your service config specifies "%s", an unsupported parameter.' % param
 
-    def validate(self) -> List[str]:
+    def validate(
+        self,
+        params: List[str] = ['cpus', 'mem', 'security', 'dependencies_reference', 'deploy_group'],
+    ) -> List[str]:
         error_msgs = []
-        for param in ['cpus', 'mem', 'security', 'dependencies_reference', 'deploy_group']:
+        for param in params:
             check_passed, check_msg = self.check(param)
             if not check_passed:
                 error_msgs.append(check_msg)


### PR DESCRIPTION
Just temporary whilst we fix a bug and move to using the same units as
everything else.