### PR TITLE
fix type for security context in k8s

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -556,7 +556,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
         return probe
 
-    def get_security_context(self) -> V1SecurityContext:
+    def get_security_context(self) -> Optional[V1SecurityContext]:
         cap_add = self.config_dict.get('cap_add', None)
         if cap_add is None:
             return None


### PR DESCRIPTION
get_security_context would return None if nothing is specified for cap_add.