### PR TITLE
Fix a typo in the help message

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -357,7 +357,7 @@ def add_subparser(subparsers):
     list_parser.add_argument(
         '-i', '--instance',
         help=(
-            "Simulate a docker run for a particular instance of the service, like 'main' or 'canary'"
+            "Simulate a docker run for a particular instance of the service, like 'main' or 'canary'. "
             "NOTE: if you don't specify an instance, PaaSTA will run in interactive mode"
         ),
         required=False,


### PR DESCRIPTION
It was missing a space in the string concatenation.