### PR TITLE
Use PaaSTA API server for `paasta start/stop` Flink commands

### DIFF
--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -76,6 +76,7 @@ def make_app(global_config=None):
     config.include('pyramid_swagger')
     config.add_route('resources.utilization', '/v1/resources/utilization')
     config.add_route('service.instance.status', '/v1/services/{service}/{instance}/status')
+    config.add_route('service.instance.set_state', '/v1/services/{service}/{instance}/state/{desired_state}')
     config.add_route('service.instance.delay', '/v1/services/{service}/{instance}/delay')
     config.add_route('service.instance.tasks', '/v1/services/{service}/{instance}/tasks')
     config.add_route('service.instance.tasks.task', '/v1/services/{service}/{instance}/tasks/{task_id}')

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -241,6 +241,49 @@
                 ]
             }
         },
+        "/services/{service}/{instance}/state/{desired_state}": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Result of instance state change"
+                    },
+                    "404": {
+                        "description": "Deployment key not found"
+                    },
+                    "500": {
+                        "description": "Instance failure"
+                    }
+                },
+                "summary": "Change state of service_name.instance_name",
+                "operationId": "instance_set_state",
+                "tags": [
+                    "service"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "Service name",
+                        "name": "service",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "description": "Instance name",
+                        "name": "instance",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "description": "Desired state",
+                        "name": "desired_state",
+                        "required": true,
+                        "type": "string"
+                    }
+                ]
+            }
+        },
         "/services/{service}/{instance}/status": {
             "get": {
                 "responses": {


### PR DESCRIPTION
No error:
```
$ PAASTA_SYSTEM_CONFIG_DIR=~/etc-paasta paasta stop -s beam_happyhour -c norcal-devc
You are about to stop the following instances:
Either --instances or --clusters not specified. Asking for confirmation.
cluster = norcal-devc, instance = main
Are you sure you want to stop these 1 instances?
(y/N)? y

```

with error
```
$ PAASTA_SYSTEM_CONFIG_DIR=~/etc-paasta paasta stop -s beam_happyhour -c norcal-devc
You are about to stop the following instances:
Either --instances or --clusters not specified. Asking for confirmation.
cluster = norcal-devc, instance = main
Are you sure you want to stop these 1 instances?
(y/N)? y
ERROR: Error while setting state stop of beam_happyhour.main: (403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'Date': 'Mon, 29 Jul
 2019 15:07:07 GMT', 'Content-Length': '373'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"flinks.yelp.com \"beam--happyhour
-main\" is forbidden: User \"yelp.com/paasta-api-server\" cannot get resource \"flinks\" in API group \"yelp.com\" in the namespace
\"paasta-flinks\"","reason":"Forbidden","details":{"name":"beam--happyhour-main","group":"yelp.com","kind":"flinks"},"code":403}
```