### PR TITLE
apply min/max_instance clamps later

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -706,6 +706,12 @@ def autoscale_marathon_instance(
                         ),
                         level="event",
                     )
+            else:
+                write_to_log(
+                    config=marathon_service_config,
+                    line="Staying at %d instances (%s)" % (current_instances, humanize_error(error)),
+                    level="debug",
+                )
     except LockHeldException:
         log.warning(
             "Skipping autoscaling run for {service}.{instance} because the lock is held".format(

--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -142,8 +142,6 @@ def threshold_decision_policy(current_instances, error, **kwargs):
 def proportional_decision_policy(
     zookeeper_path,
     current_instances,
-    min_instances,
-    max_instances,
     setpoint,
     utilization,
     num_healthy_instances,
@@ -197,11 +195,6 @@ def proportional_decision_policy(
         )
         if low <= predicted_load_per_instance_with_current_instances <= high:
             desired_number_instances = current_instances
-
-    if desired_number_instances < min_instances:
-        desired_number_instances = min_instances
-    if desired_number_instances > max_instances:
-        desired_number_instances = max_instances
 
     return (
         desired_number_instances - current_instances
@@ -580,8 +573,6 @@ def get_new_instance_count(
     autoscaling_amount = autoscaling_decision_policy(
         utilization=utilization,
         error=error,
-        min_instances=marathon_service_config.get_min_instances(),
-        max_instances=marathon_service_config.get_max_instances(),
         current_instances=current_instances,
         zookeeper_path=zookeeper_path,
         num_healthy_instances=num_healthy_instances,

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -247,7 +247,7 @@ class LongRunningServiceConfig(InstanceConfig):
     def get_min_instances(self) -> int:
         return self.config_dict.get("min_instances", 1)
 
-    def get_max_instances(self) -> int:
+    def get_max_instances(self) -> Optional[int]:
         return self.config_dict.get("max_instances", None)
 
     def get_desired_instances(self) -> int:

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -1717,20 +1717,6 @@ def test_proportional_decision_policy_good_enough(
         good_enough_window=(0.45, 0.55),
     )
 
-    # current_instances < min_instances, so scale up.
-    assert 25 == autoscaling_service_lib.proportional_decision_policy(
-        zookeeper_path="/test",
-        current_instances=25,
-        num_healthy_instances=25,
-        min_instances=50,
-        max_instances=150,
-        forecast_policy="current",
-        offset=0.0,
-        setpoint=0.50,
-        utilization=0.46,
-        good_enough_window=(0.45, 0.55),
-    )
-
 
 def test_filter_autoscaling_tasks_considers_old_versions():
     marathon_apps = [


### PR DESCRIPTION
This change

a) always calls `set_instances_for_marathon_service`
b) applies the min/max instance clamps at s-m-j time