### PR TITLE
Refactor deployd to use a single queue for simplicity.

### DIFF
--- a/paasta_tools/deployd/metrics.py
+++ b/paasta_tools/deployd/metrics.py
@@ -4,14 +4,11 @@ from paasta_tools.deployd.common import PaastaThread
 
 
 class QueueMetrics(PaastaThread):
-    def __init__(self, inbox, cluster, metrics_provider):
+    def __init__(self, queue, cluster, metrics_provider):
         super().__init__()
         self.daemon = True
         self.metrics = metrics_provider
-
-        self.inbox = inbox.to_bounce
-        self.instances_to_bounce_later = inbox.instances_to_bounce_later
-        self.instances_to_bounce_now = inbox.instances_to_bounce_now
+        self.queue = queue
 
         self.instances_to_bounce_later_gauge = self.metrics.create_gauge(
             "instances_to_bounce_later", paasta_cluster=cluster
@@ -26,10 +23,9 @@ class QueueMetrics(PaastaThread):
     def run(self):
         while True:
             self.instances_to_bounce_later_gauge.set(
-                self.instances_to_bounce_later.qsize()
+                self.queue.unavailable_service_instances.qsize()
             )
-            self.instances_that_need_to_be_checked_up_on_gauge.set(
-                len(self.inbox.keys())
+            self.instances_to_bounce_now_gauge.set(
+                self.queue.available_service_instances.qsize()
             )
-            self.instances_to_bounce_now_gauge.set(self.instances_to_bounce_now.qsize())
             time.sleep(20)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1737,12 +1737,12 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     dashboard_links: Dict[str, Dict[str, str]]
     deploy_blacklist: UnsafeDeployBlacklist
     deploy_whitelist: UnsafeDeployWhitelist
-    deployd_big_bounce_rate: float
+    deployd_big_bounce_deadline: float
     deployd_log_level: str
     deployd_maintenance_polling_frequency: int
     deployd_metrics_provider: str
     deployd_number_workers: int
-    deployd_startup_bounce_rate: float
+    deployd_startup_bounce_deadline: float
     deployd_startup_oracle_enabled: bool
     deployd_worker_failure_backoff_factor: int
     disabled_watchers: List
@@ -2191,22 +2191,26 @@ class SystemPaastaConfig:
         """
         return self.config_dict.get("deployd_number_workers", 4)
 
-    def get_deployd_big_bounce_rate(self) -> float:
-        """Get the number of deploys to do per minute when deployd starts
-        or determines it needs to bounce all services
+    def get_deployd_big_bounce_deadline(self) -> float:
+        """Get the amount of time in the future to set the deadline when enqueuing instances for SystemPaastaConfig
+        changes.
 
         :return: float
         """
 
-        return float(self.config_dict.get("deployd_big_bounce_rate", 0.1))
+        return float(
+            self.config_dict.get("deployd_big_bounce_deadline", 7 * 24 * 60 * 60)
+        )
 
-    def get_deployd_startup_bounce_rate(self) -> float:
-        """Get the number of deploys to do per minute when deployd starts
+    def get_deployd_startup_bounce_deadline(self) -> float:
+        """Get the amount of time in the future to set the deadline when enqueuing instances on deployd startup.
 
         :return: float
         """
 
-        return float(self.config_dict.get("deployd_startup_bounce_rate", 0.1))
+        return float(
+            self.config_dict.get("deployd_startup_bounce_deadline", 7 * 24 * 60 * 60)
+        )
 
     def get_deployd_log_level(self) -> str:
         """Get the log level for paasta-deployd

--- a/tests/deployd/test_common.py
+++ b/tests/deployd/test_common.py
@@ -1,16 +1,15 @@
 import unittest
+from queue import Empty
 
 import mock
 
 from paasta_tools.deployd.common import BaseServiceInstance
+from paasta_tools.deployd.common import DelayDeadlineQueue
 from paasta_tools.deployd.common import exponential_back_off
 from paasta_tools.deployd.common import get_marathon_clients_from_config
-from paasta_tools.deployd.common import get_priority
 from paasta_tools.deployd.common import get_service_instances_needing_update
-from paasta_tools.deployd.common import PaastaPriorityQueue
 from paasta_tools.deployd.common import PaastaQueue
 from paasta_tools.deployd.common import PaastaThread
-from paasta_tools.deployd.common import rate_limit_instances
 from paasta_tools.deployd.common import ServiceInstance
 from paasta_tools.marathon_tools import MarathonClients
 from paasta_tools.mesos.exceptions import NoSlavesAvailableError
@@ -43,166 +42,95 @@ class TestPaastaQueue(unittest.TestCase):
             mock_q_put.assert_called_with(self.queue, "human")
 
 
-class TestPaastaPriorityQueue(unittest.TestCase):
+class TestDelayDeadlineQueue(unittest.TestCase):
     def setUp(self):
-        self.queue = PaastaPriorityQueue("AtThePostOffice")
+        self.queue = DelayDeadlineQueue()
 
     def test_log(self):
         self.queue.log.info("HAAAALP ME")
 
     def test_put(self):
-        with mock.patch(
-            "paasta_tools.deployd.common.PriorityQueue.put", autospec=True
-        ) as mock_q_put:
-            self.queue.put_with_priority(3, "human")
-            mock_q_put.assert_called_with(self.queue, (3, 1, "human"))
+        with mock.patch.object(
+            self.queue.unavailable_service_instances,
+            "put",
+            wraps=self.queue.unavailable_service_instances.put,
+        ) as mock_unavailable_service_instances_put, mock.patch.object(
+            self.queue.available_service_instances,
+            "put",
+            wraps=self.queue.available_service_instances.put,
+        ) as mock_available_service_instances_put:
+            si1 = mock.Mock(wait_until=6, bounce_by=4)
+            self.queue.put(si1, now=5)
+            mock_unavailable_service_instances_put.assert_called_with((6, 4, si1))
+            assert mock_available_service_instances_put.call_count == 0
 
-            self.queue.put_with_priority(3, "human")
-            mock_q_put.assert_called_with(self.queue, (3, 2, "human"))
+            mock_unavailable_service_instances_put.reset_mock()
+            si2 = mock.Mock(wait_until=3, bounce_by=4)
+            self.queue.put(si2, now=5)
+            print(mock_unavailable_service_instances_put.mock_calls)
+            mock_unavailable_service_instances_put.assert_any_call((3, 4, si2))
+            # this is left over from the previous insertion, and gets re-inserted by
+            # process_unavailable_service_instances because 6 > now
+            mock_unavailable_service_instances_put.assert_any_call((6, 4, si1))
+            mock_available_service_instances_put.assert_called_with((4, si2))
 
     def test_get(self):
-        with mock.patch(
-            "paasta_tools.deployd.common.PriorityQueue.get", autospec=True
-        ) as mock_q_get:
-            mock_q_get.return_value = (3, 2, "human")
+        with mock.patch.object(
+            self.queue.unavailable_service_instances, "get", autospec=True
+        ) as mock_unavailable_service_instances_get:
+            mock_unavailable_service_instances_get.side_effect = [
+                (3, 2, "human"),
+                Empty,
+            ]
             assert self.queue.get() == "human"
 
 
 class TestServiceInstance(unittest.TestCase):
     def setUp(self):
-        with mock.patch(
-            "paasta_tools.deployd.common.get_priority", autospec=True
-        ) as mock_get_priority:
-            mock_get_priority.return_value = 1
-            # https://github.com/python/mypy/issues/2852
-            self.service_instance = ServiceInstance(  # type: ignore
-                service="universe",
-                instance="c137",
-                watcher="mywatcher",
-                cluster="westeros-prod",
-                bounce_by=0,
-            )
+        self.service_instance = ServiceInstance(  # type: ignore
+            service="universe",
+            instance="c137",
+            watcher="mywatcher",
+            cluster="westeros-prod",
+            bounce_by=0,
+            wait_until=0,
+        )
 
     def test___new__(self):
-        with mock.patch("paasta_tools.deployd.common.get_priority", autospec=True):
-            expected = BaseServiceInstance(
-                service="universe",
-                instance="c137",
-                watcher="mywatcher",
-                bounce_by=0,
-                failures=0,
-                bounce_timers=None,
-                priority=1,
-                processed_count=0,
-            )
-            assert self.service_instance == expected
-
-            expected = BaseServiceInstance(
-                service="universe",
-                instance="c137",
-                watcher="mywatcher",
-                bounce_by=0,
-                failures=0,
-                bounce_timers=None,
-                priority=2,
-                processed_count=0,
-            )
-            # https://github.com/python/mypy/issues/2852
-            assert (
-                ServiceInstance(  # type: ignore
-                    service="universe",
-                    instance="c137",
-                    watcher="mywatcher",
-                    cluster="westeros-prod",
-                    bounce_by=0,
-                    priority=2,
-                )
-                == expected
-            )
-
-    def test_get_priority(self):
-        with mock.patch(
-            "paasta_tools.deployd.common.load_marathon_service_config", autospec=True
-        ) as mock_load_marathon_service_config:
-            mock_load_marathon_service_config.return_value = mock.Mock(
-                get_bounce_priority=mock.Mock(return_value=1)
-            )
-            assert get_priority("universe", "c137", "westeros-prod") == 1
-            mock_load_marathon_service_config.assert_called_with(
-                service="universe",
-                instance="c137",
-                cluster="westeros-prod",
-                soa_dir="/nail/etc/services",
-            )
-
-            mock_load_marathon_service_config.side_effect = NoDockerImageError()
-            assert get_priority("universe", "c137", "westeros-prod") == 0
-
-            mock_load_marathon_service_config.side_effect = InvalidJobNameError()
-            assert get_priority("universe", "c137", "westeros-prod") == 0
-
-            mock_load_marathon_service_config.side_effect = NoDeploymentsAvailable()
-            assert get_priority("universe", "c137", "westeros-prod") == 0
-
-
-def test_rate_limit_instances():
-    with mock.patch(
-        "paasta_tools.deployd.common.get_priority", autospec=True, return_value=0
-    ), mock.patch("time.time", autospec=True) as mock_time:
-        mock_time.return_value = 1
-        mock_si_1 = ("universe", "c137")
-        mock_si_2 = ("universe", "c138")
-        ret = rate_limit_instances([mock_si_1, mock_si_2], "westeros-prod", 2, "Custos")
-        expected = [
-            BaseServiceInstance(
-                service="universe",
-                instance="c137",
-                watcher="Custos",
-                priority=0,
-                bounce_by=1,
-                bounce_timers=None,
-                failures=0,
-                processed_count=0,
-            ),
-            BaseServiceInstance(
-                service="universe",
-                instance="c138",
-                watcher="Custos",
-                priority=0,
-                bounce_by=31,
-                bounce_timers=None,
-                failures=0,
-                processed_count=0,
-            ),
-        ]
-        assert ret == expected
-
-        ret = rate_limit_instances(
-            [mock_si_1, mock_si_2], "westeros-prod", 2, "Custos", priority=99
+        expected = BaseServiceInstance(
+            service="universe",
+            instance="c137",
+            watcher="mywatcher",
+            bounce_by=0,
+            wait_until=0,
+            failures=0,
+            bounce_timers=None,
+            processed_count=0,
         )
-        expected = [
-            BaseServiceInstance(
+        assert self.service_instance == expected
+
+        expected = BaseServiceInstance(
+            service="universe",
+            instance="c137",
+            watcher="mywatcher",
+            bounce_by=0,
+            wait_until=0,
+            failures=0,
+            bounce_timers=None,
+            processed_count=0,
+        )
+        # https://github.com/python/mypy/issues/2852
+        assert (
+            ServiceInstance(  # type: ignore
                 service="universe",
                 instance="c137",
-                watcher="Custos",
-                priority=99,
-                bounce_by=1,
-                bounce_timers=None,
-                failures=0,
-                processed_count=0,
-            ),
-            BaseServiceInstance(
-                service="universe",
-                instance="c138",
-                watcher="Custos",
-                priority=99,
-                bounce_by=31,
-                bounce_timers=None,
-                failures=0,
-                processed_count=0,
-            ),
-        ]
-        assert ret == expected
+                watcher="mywatcher",
+                cluster="westeros-prod",
+                bounce_by=0,
+                wait_until=0,
+            )
+            == expected
+        )
 
 
 def test_exponential_back_off():

--- a/tests/deployd/test_metrics.py
+++ b/tests/deployd/test_metrics.py
@@ -22,7 +22,7 @@ class TestQueueMetrics(unittest.TestCase):
         with mock.patch("time.sleep", autospec=True, side_effect=LoopBreak):
             with raises(LoopBreak):
                 self.metrics.run()
-            assert self.mock_gauge.set.call_count == 3
+            assert self.mock_gauge.set.call_count == 2
 
 
 class LoopBreak(Exception):

--- a/tests/deployd/test_workers.py
+++ b/tests/deployd/test_workers.py
@@ -12,8 +12,7 @@ from paasta_tools.marathon_tools import DEFAULT_SOA_DIR
 
 class TestPaastaDeployWorker(unittest.TestCase):
     def setUp(self):
-        self.mock_instances_to_bounce_later = mock.Mock()
-        self.mock_instances_to_bounce_now = mock.Mock()
+        self.mock_instances_to_bounce = mock.Mock()
         self.mock_metrics = mock.Mock()
         mock_config = mock.Mock(
             get_cluster=mock.Mock(return_value="westeros-prod"),
@@ -23,11 +22,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
             "paasta_tools.deployd.workers.PaastaDeployWorker.setup", autospec=True
         ):
             self.worker = PaastaDeployWorker(
-                1,
-                self.mock_instances_to_bounce_later,
-                self.mock_instances_to_bounce_now,
-                mock_config,
-                self.mock_metrics,
+                1, self.mock_instances_to_bounce, mock_config, self.mock_metrics
             )
 
     def test_setup(self):
@@ -87,17 +82,13 @@ class TestPaastaDeployWorker(unittest.TestCase):
             mock_process_service_instance.return_value = mock_bounce_results
             mock_sleep.side_effect = LoopBreak
             mock_si = mock.Mock(
-                service="universe",
-                instance="c137",
-                failures=0,
-                priority=0,
-                processed_count=0,
+                service="universe", instance="c137", failures=0, processed_count=0
             )
-            self.mock_instances_to_bounce_now.get.return_value = mock_si
+            self.mock_instances_to_bounce.get.return_value = mock_si
             with raises(LoopBreak):
                 self.worker.run()
             mock_process_service_instance.assert_called_with(self.worker, mock_si)
-            assert not self.mock_instances_to_bounce_later.put.called
+            assert not self.mock_instances_to_bounce.put.called
 
             mock_bounce_results = BounceResults(
                 bounce_again_in_seconds=60, return_code=1, bounce_timers=mock_timers
@@ -107,40 +98,36 @@ class TestPaastaDeployWorker(unittest.TestCase):
                 service="universe",
                 instance="c137",
                 bounce_by=61,
+                wait_until=61,
                 watcher="Worker1",
                 bounce_timers=mock_timers,
                 failures=1,
-                priority=0,
                 processed_count=1,
             )
             with raises(LoopBreak):
                 self.worker.run()
             mock_process_service_instance.assert_called_with(self.worker, mock_si)
-            self.mock_instances_to_bounce_later.put.assert_called_with(mock_queued_si)
+            self.mock_instances_to_bounce.put.assert_called_with(mock_queued_si)
 
             mock_si = mock.Mock(
-                service="universe",
-                instance="c137",
-                failures=0,
-                priority=0,
-                processed_count=0,
+                service="universe", instance="c137", failures=0, processed_count=0
             )
-            self.mock_instances_to_bounce_now.get.return_value = mock_si
+            self.mock_instances_to_bounce.get.return_value = mock_si
             mock_process_service_instance.side_effect = Exception
             mock_queued_si = BaseServiceInstance(
                 service="universe",
                 instance="c137",
                 bounce_by=61,
+                wait_until=61,
                 watcher="Worker1",
                 bounce_timers=mock_si.bounce_timers,
                 failures=1,
-                priority=0,
                 processed_count=1,
             )
             with raises(LoopBreak):
                 self.worker.run()
             mock_process_service_instance.assert_called_with(self.worker, mock_si)
-            self.mock_instances_to_bounce_later.put.assert_called_with(mock_queued_si)
+            self.mock_instances_to_bounce.put.assert_called_with(mock_queued_si)
 
     def test_process_service_instance(self):
         mock_client = mock.Mock()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -551,12 +551,12 @@ def test_SystemPaastaConfig_get_deployd_number_workers():
     assert actual == expected
 
 
-def test_SystemPaastaConfig_get_deployd_big_bounce_rate():
+def test_SystemPaastaConfig_get_deployd_big_bounce_deadline():
     fake_config = utils.SystemPaastaConfig(
-        {"deployd_big_bounce_rate": 3}, "/some/fake/dir"
+        {"deployd_big_bounce_deadline": 305}, "/some/fake/dir"
     )
-    actual = fake_config.get_deployd_big_bounce_rate()
-    expected = 3
+    actual = fake_config.get_deployd_big_bounce_deadline()
+    expected = 305
     assert actual == expected
 
 


### PR DESCRIPTION
Since I have already spent time on fixing it, I feel it's better to publish it anyway.
This is result of
```shell
git co master
git br -D zzzzzz || true
git br -D 3q21q-fixed || true
git co -b zzzzzz fdbbc27aabc37
git cherry-pick e03546701
git cherry-pick 564ceeeddda
black --target-version py36 .
git ci -am black
git cherry-pick 1d07626bc93
git diff 1d07626bc93 >111.patch
git co -b 3q21q-fixed master
patch -p1 <111.patch
git ci -a
```
The last cherry-pick results in easy resolvable merge conflict because some code changed by `1d07626bc93` was removed by `e03546701`.
@EvanKrall, please feel free to do whatever you want with it.