### PR TITLE
Do not require AWS credentials for paasta spark-run

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -259,8 +259,8 @@ def add_subparser(subparsers):
 
     aws_group.add_argument(
         "--no-aws-credentials",
-        help="Do not load any AWS credentials; allow the service to use its "
-        "its own logic to load credentials",
+        help="Do not load any AWS credentials; allow the Spark job to use its "
+        "own logic to load credentials",
         action='store_true',
         default=False,
     )

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -261,7 +261,7 @@ def add_subparser(subparsers):
         "--no-aws-credentials",
         help="Do not load any AWS credentials; allow the Spark job to use its "
         "own logic to load credentials",
-        action='store_true',
+        action="store_true",
         default=False,
     )
 

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -174,7 +174,6 @@ class TestGetSparkConfig:
             == expected_dir
         )
 
-
     @pytest.mark.parametrize(
         "default_event_log_dir,spark_args,expected_spark_config",
         [
@@ -580,7 +579,8 @@ class TestGetAwsCredentials:
 
     def test_yaml_provided(self):
         args = mock.Mock(
-            no_aws_credentials=False, aws_credentials_yaml="credentials.yaml")
+            no_aws_credentials=False, aws_credentials_yaml="credentials.yaml"
+        )
         credentials = get_aws_credentials(args)
 
         self.mock_load_aws_credentials_from_yaml.assert_called_once_with(
@@ -595,8 +595,8 @@ class TestGetAwsCredentials:
     )
     def test_service_provided_no_yaml(self, mock_get_credentials_path, mock_os):
         args = mock.Mock(
-            no_aws_credentials=False, aws_credentials_yaml=None,
-            service="service_name")
+            no_aws_credentials=False, aws_credentials_yaml=None, service="service_name"
+        )
         mock_os.path.exists.return_value = True
         credentials = get_aws_credentials(args)
 
@@ -611,8 +611,8 @@ class TestGetAwsCredentials:
     )
     def test_use_default_creds(self, mock_get_credentials):
         args = mock.Mock(
-            no_aws_credentials=False, aws_credentials_yaml=None,
-            service=DEFAULT_SERVICE)
+            no_aws_credentials=False, aws_credentials_yaml=None, service=DEFAULT_SERVICE
+        )
         mock_get_credentials.return_value = mock.MagicMock(
             access_key="id", secret_key="secret"
         )
@@ -626,8 +626,8 @@ class TestGetAwsCredentials:
     )
     def test_service_provided_fallback_to_default(self, mock_get_credentials, mock_os):
         args = mock.Mock(
-            no_aws_credentials=False, aws_credentials_yaml=None,
-            service="service_name")
+            no_aws_credentials=False, aws_credentials_yaml=None, service="service_name"
+        )
         mock_os.path.exists.return_value = False
         mock_get_credentials.return_value = mock.MagicMock(
             access_key="id", secret_key="secret"


### PR DESCRIPTION
For the `yelp_spam` service, we do not configure the AWS credential arguments of `paasta spark-run`. Our AWS credentials are not present on the batch machine, so it wouldn't be possible for Paasta to load them until the service is started. Instead, our service configures AWS credentials (and the resulting Spark configuration changes) itself.

When we use `paasta spark-run` (invoked by tron), Paasta fails to find AWS credentials and crashes, with the traceback below:

```
Traceback (most recent call last):
  File "/usr/bin/paasta", line 10, in <module>
    sys.exit(main())
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cli.py", line 124, in main
    return_code = args.command(args)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cmds/spark_run.py", line 959, in paasta_spark_run
    system_paasta_config=system_paasta_config,
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cmds/spark_run.py", line 716, in configure_and_run_docker_container
    access_key, secret_key = get_aws_credentials(args)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/cmds/spark_run.py", line 404, in get_aws_credentials
    creds = Session(profile=args.aws_profile).get_credentials()
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/botocore/session.py", line 474, in get_credentials
    'credential_provider').load_credentials()
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/botocore/session.py", line 922, in get_component
    self._components[name] = factory()
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/botocore/session.py", line 179, in <lambda>
    lambda:  botocore.credentials.create_credential_resolver(self))
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/botocore/credentials.py", line 55, in create_credential_resolver
    metadata_timeout = session.get_config_variable('metadata_service_timeout')
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/botocore/session.py", line 279, in get_config_variable
    elif self._found_in_config_file(methods, var_config):
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/botocore/session.py", line 306, in _found_in_config_file
    return var_config[0] in self.get_scoped_config()
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/botocore/session.py", line 383, in get_scoped_config
    raise ProfileNotFound(profile=profile_name)
botocore.exceptions.ProfileNotFound: The config profile (default) could not be found
```

This branch adds a `--no-aws-credentials` argument to `paasta spark-run`, and adjusts the internal workings of the command to support missing credentials. I've updated some relevant unit tests to reflect this, but would love feedback on how to end-to-end test this.