### PR TITLE
Fix broken yelp-clog dependencies

### DIFF
--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -6,6 +6,7 @@ gitdb2==2.0.3
 gitpython==2.1.9
 inflection==0.3.1
 markdown==2.4
+monk==0.7.0
 python-jsonschema-objects==0.3.1
 scribereader==0.2.6
 signalform-tools==0.0.16


### PR DESCRIPTION
Install `monk` 0.7.0 to fix broken `yelp-clog` 3.3.1 dependencies.

For testing, built `deb` package, installed it locally, and checked that the issue was fixed.
Also run `make test` and `make itest`.