### PR TITLE
refactor setup_kubernetes_job to use controller_wrappers

### DIFF
--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -157,7 +157,6 @@ class Application(ABC):
             return create_pod_disruption_budget(
                 kube_client=kube_client, pod_disruption_budget=pdr
             )
-            raise Exception("Unknown kubernetes object to update")
 
 
 class DeploymentWrapper(Application):

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -104,7 +104,6 @@ from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError
-from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import PersistentVolume
 from paasta_tools.utils import SystemPaastaConfig
@@ -1474,35 +1473,3 @@ def load_custom_resource_definitions(
             CustomResourceDefinition(kube_kind=kube_kind, **custom_resource_dict)
         )
     return custom_resources
-
-
-def get_deployment_config(
-    kube_deployment: KubeDeployment, soa_dir: str, cluster: str
-) -> Optional["KubernetesDeploymentConfig"]:
-    try:
-        return load_kubernetes_service_config_no_cache(
-            service=kube_deployment.service,
-            instance=kube_deployment.instance,
-            cluster=cluster,
-            soa_dir=soa_dir,
-        )
-    except NoDeploymentsAvailable:
-        log.debug(
-            "No deployments found for %s.%s in cluster %s. Skipping."
-            % (
-                kube_deployment.service,
-                kube_deployment.instance,
-                load_system_paasta_config().get_cluster(),
-            )
-        )
-    except NoConfigurationForServiceError:
-        error_msg = (
-            "Could not read kubernetes configuration file for %s.%s in cluster %s"
-            % (
-                kube_deployment.service,
-                kube_deployment.instance,
-                load_system_paasta_config().get_cluster(),
-            )
-        )
-        log.error(error_msg)
-    return None

--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -23,30 +23,20 @@ Command line options:
 import argparse
 import logging
 import sys
-from typing import Optional
 from typing import Sequence
-from typing import Tuple
 from typing import Union
 
-from kubernetes.client import V1beta1PodDisruptionBudget
-from kubernetes.client import V1DeleteOptions
 from kubernetes.client import V1Deployment
 from kubernetes.client import V1StatefulSet
-from kubernetes.client.rest import ApiException
 
-from paasta_tools.kubernetes_tools import create_deployment
-from paasta_tools.kubernetes_tools import create_pod_disruption_budget
-from paasta_tools.kubernetes_tools import create_stateful_set
+from paasta_tools.kubernetes.application.controller_wrappers import Application
+from paasta_tools.kubernetes.application.controller_wrappers import DeploymentWrapper
+from paasta_tools.kubernetes.application.controller_wrappers import StatefulSetWrapper
 from paasta_tools.kubernetes_tools import ensure_namespace
 from paasta_tools.kubernetes_tools import InvalidKubernetesConfig
 from paasta_tools.kubernetes_tools import KubeClient
-from paasta_tools.kubernetes_tools import KubeDeployment
 from paasta_tools.kubernetes_tools import list_all_deployments
 from paasta_tools.kubernetes_tools import load_kubernetes_service_config_no_cache
-from paasta_tools.kubernetes_tools import max_unavailable
-from paasta_tools.kubernetes_tools import pod_disruption_budget_for_service_instance
-from paasta_tools.kubernetes_tools import update_deployment
-from paasta_tools.kubernetes_tools import update_stateful_set
 from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import InvalidJobNameError
@@ -56,6 +46,7 @@ from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import SPACER
 
 log = logging.getLogger(__name__)
+setup_kube_succeeded = True
 
 
 def parse_args() -> argparse.Namespace:
@@ -82,6 +73,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    global setup_kube_succeeded
     args = parse_args()
     soa_dir = args.soa_dir
     if args.verbose:
@@ -93,7 +85,7 @@ def main() -> None:
     kube_client = KubeClient()
 
     ensure_namespace(kube_client, namespace="paasta")
-    setup_kube_succeeded = setup_kube_deployments(
+    setup_kube_deployments(
         kube_client=kube_client,
         service_instances=args.service_instance_list,
         soa_dir=soa_dir,
@@ -101,42 +93,59 @@ def main() -> None:
     sys.exit(0 if setup_kube_succeeded else 1)
 
 
+def validate_job_name(service_instance):
+    try:
+        service, instance, _, __ = decompose_job_id(service_instance)
+    except InvalidJobNameError:
+        log.error(
+            "Invalid service instance specified. Format is service%sinstance." % SPACER
+        )
+        return False
+    return True
+
+
 def setup_kube_deployments(
     kube_client: KubeClient,
     service_instances: Sequence[str],
     soa_dir: str = DEFAULT_SOA_DIR,
-) -> bool:
-    succeeded = True
+) -> None:
     if service_instances:
-        deployments = list_all_deployments(kube_client)
-    for service_instance in service_instances:
-        try:
-            service, instance, _, __ = decompose_job_id(service_instance)
-        except InvalidJobNameError:
-            log.error(
-                "Invalid service instance specified. Format is service%sinstance."
-                % SPACER
-            )
-            succeeded = False
+        existing_kube_deployments = set(list_all_deployments(kube_client))
+        existing_apps = {
+            (deployment.service, deployment.instance)
+            for deployment in existing_kube_deployments
+        }
+    service_instances_with_valid_names = [
+        decompose_job_id(service_instance)
+        for service_instance in service_instances
+        if validate_job_name(service_instance)
+    ]
+    applications = [
+        create_application_object(
+            kube_client=kube_client,
+            service=service_instance[0],
+            instance=service_instance[1],
+            soa_dir=soa_dir,
+        )
+        for service_instance in service_instances_with_valid_names
+    ]
+    for app in applications:
+        if (
+            app
+            and (app.kube_deployment.service, app.kube_deployment.instance)
+            not in existing_apps
+        ):
+            app.create(kube_client)
+        elif app and app.kube_deployment not in existing_kube_deployments:
+            app.update(kube_client)
         else:
-            if reconcile_kubernetes_deployment(
-                kube_client=kube_client,
-                service=service,
-                instance=instance,
-                kube_deployments=deployments,
-                soa_dir=soa_dir,
-            )[0]:
-                succeeded = False
-    return succeeded
+            log.debug(f"{app} is up to date, no action taken")
 
 
-def reconcile_kubernetes_deployment(
-    kube_client: KubeClient,
-    service: str,
-    instance: str,
-    kube_deployments: Sequence[KubeDeployment],
-    soa_dir: str,
-) -> Tuple[int, Optional[int]]:
+def create_application_object(
+    kube_client: KubeClient, service: str, instance: str, soa_dir: str
+) -> Union[Application, None]:
+    global setup_kube_succeeded
     try:
         service_instance_config = load_kubernetes_service_config_no_cache(
             service,
@@ -149,121 +158,32 @@ def reconcile_kubernetes_deployment(
             "No deployments found for %s.%s in cluster %s. Skipping."
             % (service, instance, load_system_paasta_config().get_cluster())
         )
-        return 0, None
+        return None
     except NoConfigurationForServiceError:
         error_msg = (
             "Could not read kubernetes configuration file for %s.%s in cluster %s"
             % (service, instance, load_system_paasta_config().get_cluster())
         )
         log.error(error_msg)
-        return 1, None
-
+        setup_kube_succeeded = False
+        return None
     try:
         formatted_application = service_instance_config.format_kubernetes_app()
     except InvalidKubernetesConfig as e:
         log.error(str(e))
-        return (1, None)
+        setup_kube_succeeded = False
+        return None
 
-    desired_deployment = KubeDeployment(
-        service=service,
-        instance=instance,
-        git_sha=formatted_application.metadata.labels["yelp.com/paasta_git_sha"],
-        config_sha=formatted_application.metadata.labels["yelp.com/paasta_config_sha"],
-        replicas=formatted_application.spec.replicas,
-    )
-
-    if not (service, instance) in [
-        (kd.service, kd.instance) for kd in kube_deployments
-    ]:
-        log.debug(f"{desired_deployment} does not exist so creating")
-        create_kubernetes_application(
-            kube_client=kube_client, application=formatted_application
-        )
-    elif desired_deployment not in kube_deployments:
-        log.debug(
-            f"{desired_deployment} exists but config_sha or git_sha doesn't match or number of instances changed"
-        )
-        update_kubernetes_application(
-            kube_client=kube_client, application=formatted_application
-        )
-    else:
-        log.debug(f"{desired_deployment} is up to date, no action taken")
-
-    ensure_pod_disruption_budget(
-        kube_client=kube_client,
-        service=service,
-        instance=instance,
-        min_instances=service_instance_config.get_desired_instances()
-        - max_unavailable(
-            instance_count=service_instance_config.get_desired_instances(),
-            bounce_margin_factor=service_instance_config.get_bounce_margin_factor(),
-        ),
-    )
-    return 0, None
-
-
-def ensure_pod_disruption_budget(
-    kube_client: KubeClient, service: str, instance: str, min_instances: int
-) -> V1beta1PodDisruptionBudget:
-    pdr = pod_disruption_budget_for_service_instance(
-        service=service, instance=instance, min_instances=min_instances
-    )
-    try:
-        existing_pdr = kube_client.policy.read_namespaced_pod_disruption_budget(
-            name=pdr.metadata.name, namespace=pdr.metadata.namespace
-        )
-    except ApiException as e:
-        if e.status == 404:
-            existing_pdr = None
-        else:
-            raise
-
-    if existing_pdr:
-        if existing_pdr.spec.min_available != pdr.spec.min_available:
-            # poddisruptionbudget objects are not mutable like most things in the kubernetes api,
-            # so we have to do a delete/replace.
-            # unfortunately we can't really do this transactionally, but I guess we'll just hope for the best?
-            logging.debug(
-                f"existing poddisruptionbudget {pdr.metadata.name} is out of date; deleting"
-            )
-            kube_client.policy.delete_namespaced_pod_disruption_budget(
-                name=pdr.metadata.name,
-                namespace=pdr.metadata.namespace,
-                body=V1DeleteOptions(),
-            )
-            logging.debug(f"creating poddisruptionbudget {pdr.metadata.name}")
-            return create_pod_disruption_budget(
-                kube_client=kube_client, pod_disruption_budget=pdr
-            )
-        else:
-            logging.debug(f"poddisruptionbudget {pdr.metadata.name} up to date")
-    else:
-        logging.debug(f"creating poddisruptionbudget {pdr.metadata.name}")
-        return create_pod_disruption_budget(
-            kube_client=kube_client, pod_disruption_budget=pdr
-        )
-
-
-def create_kubernetes_application(
-    kube_client: KubeClient, application: Union[V1Deployment, V1StatefulSet]
-) -> None:
-    if isinstance(application, V1Deployment):
-        create_deployment(kube_client=kube_client, formatted_deployment=application)
-    elif isinstance(application, V1StatefulSet):
-        create_stateful_set(kube_client=kube_client, formatted_stateful_set=application)
-    else:
-        raise Exception("Unknown kubernetes object to create")
-
-
-def update_kubernetes_application(
-    kube_client: KubeClient, application: Union[V1Deployment, V1StatefulSet]
-) -> None:
-    if isinstance(application, V1Deployment):
-        update_deployment(kube_client=kube_client, formatted_deployment=application)
-    elif isinstance(application, V1StatefulSet):
-        update_stateful_set(kube_client=kube_client, formatted_stateful_set=application)
+    app = None
+    if isinstance(formatted_application, V1Deployment):
+        app = DeploymentWrapper(formatted_application)
+    elif isinstance(formatted_application, V1StatefulSet):
+        app = StatefulSetWrapper(formatted_application)
     else:
         raise Exception("Unknown kubernetes object to update")
+
+    app.load_local_config(soa_dir, load_system_paasta_config())
+    return app
 
 
 if __name__ == "__main__":

--- a/tests/kubernetes/application/test_controller_wrapper.py
+++ b/tests/kubernetes/application/test_controller_wrapper.py
@@ -1,0 +1,79 @@
+import mock
+from kubernetes.client import V1DeleteOptions
+from kubernetes.client.rest import ApiException
+
+from paasta_tools.kubernetes.application.controller_wrappers import Application
+
+
+def test_ensure_pod_disruption_budget_create():
+    with mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.pod_disruption_budget_for_service_instance",
+        autospec=True,
+    ) as mock_pdr_for_service_instance, mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.create_pod_disruption_budget",
+        autospec=True,
+    ) as mock_create_pdr, mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.max_unavailable",
+        autospec=True,
+        return_value=0,
+    ):
+        mock_req_pdr = mock.Mock()
+        mock_req_pdr.spec.min_available = 10
+        mock_pdr_for_service_instance.return_value = mock_req_pdr
+
+        mock_client = mock.Mock()
+
+        mock_pdr = mock.Mock()
+        mock_pdr.spec.min_available = 10
+
+        mock_client.read_namespaced_pod_disruption_budget.side_effect = ApiException(
+            status=404
+        )
+
+        app = mock.MagicMock()
+        app.soa_config.get_desired_instances.return_value = 10
+        app.item.service.return_value = "fake_service"
+        app.item.instance.return_value = "fake_instance"
+        Application.ensure_pod_disruption_budget(self=app, kube_client=mock_client)
+        mock_create_pdr.assert_called_once_with(
+            kube_client=mock_client, pod_disruption_budget=mock_req_pdr
+        )
+
+
+def test_ensure_pod_disruption_budget_replaces_outdated():
+    with mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.pod_disruption_budget_for_service_instance",
+        autospec=True,
+    ) as mock_pdr_for_service_instance, mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.create_pod_disruption_budget",
+        autospec=True,
+    ) as mock_create_pdr, mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.max_unavailable",
+        autospec=True,
+        return_value=0,
+    ):
+        mock_req_pdr = mock.Mock()
+        mock_req_pdr.spec.min_available = 10
+        mock_pdr_for_service_instance.return_value = mock_req_pdr
+
+        mock_client = mock.Mock()
+
+        mock_pdr = mock.Mock()
+        mock_pdr.spec.min_available = 10
+
+        mock_client.read_namespaced_pod_disruption_budget.return_value = mock_pdr
+
+        app = mock.MagicMock()
+        app.soa_config.get_desired_instances.return_value = 10
+        app.item.service.return_value = "fake_service"
+        app.item.instance.return_value = "fake_instance"
+        Application.ensure_pod_disruption_budget(self=app, kube_client=mock_client)
+
+        mock_client.policy.delete_namespaced_pod_disruption_budget.assert_called_once_with(
+            name=mock_req_pdr.metadata.name,
+            namespace=mock_req_pdr.metadata.namespace,
+            body=V1DeleteOptions(),
+        )
+        mock_create_pdr.assert_called_once_with(
+            kube_client=mock_client, pod_disruption_budget=mock_req_pdr
+        )

--- a/tests/test_setup_kubernetes_job.py
+++ b/tests/test_setup_kubernetes_job.py
@@ -3,23 +3,18 @@ from typing import Sequence
 import mock
 from kubernetes.client import V1DeleteOptions
 from kubernetes.client import V1Deployment
-from kubernetes.client import V1DeploymentSpec
-from kubernetes.client import V1LabelSelector
-from kubernetes.client import V1ObjectMeta
-from kubernetes.client import V1PodTemplateSpec
 from kubernetes.client import V1StatefulSet
 from kubernetes.client.rest import ApiException
 from pytest import raises
 
+from paasta_tools import setup_kubernetes_job
+from paasta_tools.kubernetes.application.controller_wrappers import Application
 from paasta_tools.kubernetes_tools import InvalidKubernetesConfig
 from paasta_tools.kubernetes_tools import KubeDeployment
-from paasta_tools.setup_kubernetes_job import create_kubernetes_application
-from paasta_tools.setup_kubernetes_job import ensure_pod_disruption_budget
+from paasta_tools.setup_kubernetes_job import create_application_object
 from paasta_tools.setup_kubernetes_job import main
 from paasta_tools.setup_kubernetes_job import parse_args
-from paasta_tools.setup_kubernetes_job import reconcile_kubernetes_deployment
 from paasta_tools.setup_kubernetes_job import setup_kube_deployments
-from paasta_tools.setup_kubernetes_job import update_kubernetes_application
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 
@@ -41,7 +36,7 @@ def test_main():
     ) as mock_ensure_namespace, mock.patch(
         "paasta_tools.setup_kubernetes_job.setup_kube_deployments", autospec=True
     ) as mock_setup_kube_deployments:
-        mock_setup_kube_deployments.return_value = True
+        setup_kubernetes_job.setup_kube_succeeded = True
         with raises(SystemExit) as e:
             main()
         assert e.value.code == 0
@@ -51,78 +46,45 @@ def test_main():
             service_instances=mock_parse_args.return_value.service_instance_list,
             soa_dir=mock_parse_args.return_value.soa_dir,
         )
-
-        mock_setup_kube_deployments.return_value = False
+        setup_kubernetes_job.setup_kube_succeeded = False
         with raises(SystemExit) as e:
             main()
         assert e.value.code == 1
 
 
-def test_setup_kube_deployment():
+def test_setup_kube_deployment_invalid_job_name():
     with mock.patch(
-        "paasta_tools.setup_kubernetes_job.reconcile_kubernetes_deployment",
-        autospec=True,
-    ) as mock_reconcile_kubernetes_deployment, mock.patch(
+        "paasta_tools.setup_kubernetes_job.create_application_object", autospec=True
+    ) as mock_create_application_object, mock.patch(
         "paasta_tools.setup_kubernetes_job.list_all_deployments", autospec=True
     ) as mock_list_all_deployments:
         mock_client = mock.Mock()
-        mock_service_instances: Sequence[str] = []
-        assert (
-            setup_kube_deployments(
-                kube_client=mock_client,
-                service_instances=mock_service_instances,
-                soa_dir="/nail/blah",
+        mock_list_all_deployments.return_value = [
+            KubeDeployment(
+                service="kurupt", instance="f_m", git_sha="", config_sha="", replicas=0
             )
-            is True
+        ]
+        mock_service_instances = ["kuruptf_m"]
+        setup_kube_deployments(
+            kube_client=mock_client,
+            service_instances=mock_service_instances,
+            soa_dir="/nail/blah",
         )
-
-        mock_reconcile_kubernetes_deployment.return_value = (0, 0)
-        mock_service_instances = ["kurupt.fm", "kurupt.garage"]
-        assert (
-            setup_kube_deployments(
-                kube_client=mock_client,
-                service_instances=mock_service_instances,
-                soa_dir="/nail/blah",
-            )
-            is True
-        )
-        mock_reconcile_kubernetes_deployment.assert_has_calls(
-            [
-                mock.call(
-                    kube_client=mock_client,
-                    service="kurupt",
-                    instance="fm",
-                    kube_deployments=mock_list_all_deployments.return_value,
-                    soa_dir="/nail/blah",
-                ),
-                mock.call(
-                    kube_client=mock_client,
-                    service="kurupt",
-                    instance="garage",
-                    kube_deployments=mock_list_all_deployments.return_value,
-                    soa_dir="/nail/blah",
-                ),
-            ]
-        )
-
-        mock_reconcile_kubernetes_deployment.return_value = (1, 0)
-        assert (
-            setup_kube_deployments(
-                kube_client=mock_client,
-                service_instances=mock_service_instances,
-                soa_dir="/nail/blah",
-            )
-            is False
-        )
+        assert mock_create_application_object.call_count == 0
 
 
 def test_ensure_pod_disruption_budget_create():
     with mock.patch(
-        "paasta_tools.setup_kubernetes_job.pod_disruption_budget_for_service_instance",
+        "paasta_tools.kubernetes.application.controller_wrappers.pod_disruption_budget_for_service_instance",
         autospec=True,
     ) as mock_pdr_for_service_instance, mock.patch(
-        "paasta_tools.setup_kubernetes_job.create_pod_disruption_budget", autospec=True
-    ) as mock_create_pdr:
+        "paasta_tools.kubernetes.application.controller_wrappers.create_pod_disruption_budget",
+        autospec=True,
+    ) as mock_create_pdr, mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.max_unavailable",
+        autospec=True,
+        return_value=0,
+    ):
         mock_req_pdr = mock.Mock()
         mock_req_pdr.spec.min_available = 10
         mock_pdr_for_service_instance.return_value = mock_req_pdr
@@ -136,9 +98,11 @@ def test_ensure_pod_disruption_budget_create():
             status=404
         )
 
-        ensure_pod_disruption_budget(
-            mock_client, "fake_service", "fake_instances", min_instances=10
-        )
+        app = mock.MagicMock()
+        app.soa_config.get_desired_instances.return_value = 10
+        app.item.service.return_value = "fake_service"
+        app.item.instance.return_value = "fake_instance"
+        Application.ensure_pod_disruption_budget(self=app, kube_client=mock_client)
         mock_create_pdr.assert_called_once_with(
             kube_client=mock_client, pod_disruption_budget=mock_req_pdr
         )
@@ -146,11 +110,16 @@ def test_ensure_pod_disruption_budget_create():
 
 def test_ensure_pod_disruption_budget_replaces_outdated():
     with mock.patch(
-        "paasta_tools.setup_kubernetes_job.pod_disruption_budget_for_service_instance",
+        "paasta_tools.kubernetes.application.controller_wrappers.pod_disruption_budget_for_service_instance",
         autospec=True,
     ) as mock_pdr_for_service_instance, mock.patch(
-        "paasta_tools.setup_kubernetes_job.create_pod_disruption_budget", autospec=True
-    ) as mock_create_pdr:
+        "paasta_tools.kubernetes.application.controller_wrappers.create_pod_disruption_budget",
+        autospec=True,
+    ) as mock_create_pdr, mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.max_unavailable",
+        autospec=True,
+        return_value=0,
+    ):
         mock_req_pdr = mock.Mock()
         mock_req_pdr.spec.min_available = 10
         mock_pdr_for_service_instance.return_value = mock_req_pdr
@@ -162,9 +131,12 @@ def test_ensure_pod_disruption_budget_replaces_outdated():
 
         mock_client.read_namespaced_pod_disruption_budget.return_value = mock_pdr
 
-        ensure_pod_disruption_budget(
-            mock_client, "fake_service", "fake_instances", min_instances=10
-        )
+        app = mock.MagicMock()
+        app.soa_config.get_desired_instances.return_value = 10
+        app.item.service.return_value = "fake_service"
+        app.item.instance.return_value = "fake_instance"
+        Application.ensure_pod_disruption_budget(self=app, kube_client=mock_client)
+
         mock_client.policy.delete_namespaced_pod_disruption_budget.assert_called_once_with(
             name=mock_req_pdr.metadata.name,
             namespace=mock_req_pdr.metadata.namespace,
@@ -175,272 +147,86 @@ def test_ensure_pod_disruption_budget_replaces_outdated():
         )
 
 
-def test_reconcile_kubernetes_deployment():
+def test_create_application_object():
     with mock.patch(
         "paasta_tools.setup_kubernetes_job.load_kubernetes_service_config_no_cache",
         autospec=True,
     ) as mock_load_kubernetes_service_config_no_cache, mock.patch(
         "paasta_tools.setup_kubernetes_job.load_system_paasta_config", autospec=True
     ), mock.patch(
-        "paasta_tools.setup_kubernetes_job.create_kubernetes_application", autospec=True
-    ) as mock_create_kubernetes_application, mock.patch(
-        "paasta_tools.setup_kubernetes_job.update_kubernetes_application", autospec=True
-    ) as mock_update_kubernetes_application:
+        "paasta_tools.kubernetes.application.controller_wrappers.Application.load_local_config",
+        autospec=True,
+    ), mock.patch(
+        "paasta_tools.setup_kubernetes_job.DeploymentWrapper", autospec=True
+    ) as mock_deployment_wrapper, mock.patch(
+        "paasta_tools.setup_kubernetes_job.StatefulSetWrapper", autospec=True
+    ) as mock_stateful_set_wrapper:
         mock_kube_client = mock.Mock()
-        mock_deployments: Sequence[KubeDeployment] = []
-
+        mock_deploy = mock.MagicMock(spec=V1Deployment)
         service_config = mock.MagicMock()
-        service_config.get_desired_instances.return_value = 5
         mock_load_kubernetes_service_config_no_cache.return_value = service_config
+        service_config.format_kubernetes_app.return_value = mock_deploy
 
-        # no deployments so should create
-        ret = reconcile_kubernetes_deployment(
+        # Create DeploymentWrapper
+        create_application_object(
             kube_client=mock_kube_client,
             service="kurupt",
             instance="fm",
-            kube_deployments=mock_deployments,
             soa_dir="/nail/blah",
         )
-        assert ret == (0, None)
-        mock_deploy = (
-            mock_load_kubernetes_service_config_no_cache.return_value.format_kubernetes_app()
-        )
-        mock_create_kubernetes_application.assert_called_with(
-            kube_client=mock_kube_client, application=mock_deploy
-        )
 
-        # different instance so should create
-        mock_deployments = [
-            KubeDeployment(
-                service="kurupt",
-                instance="garage",
-                git_sha="a12345",
-                config_sha="b12345",
-                replicas=3,
+        mock_deployment_wrapper.assert_called_with(mock_deploy)
+
+        mock_deploy = mock.MagicMock(spec=V1StatefulSet)
+        service_config.format_kubernetes_app.return_value = mock_deploy
+        # Create StatefulSetWrapper
+        create_application_object(
+            kube_client=mock_kube_client,
+            service="kurupt",
+            instance="fm",
+            soa_dir="/nail/blah",
+        )
+        mock_stateful_set_wrapper.assert_called_with(mock_deploy)
+
+        # Create object that is not statefulset/deployment
+        with raises(Exception):
+            service_config.format_kubernetes_app.return_value = mock.MagicMock()
+            create_application_object(
+                kube_client=mock_kube_client, service="kurupt", instance="fm"
             )
-        ]
-        ret = reconcile_kubernetes_deployment(
-            kube_client=mock_kube_client,
-            service="kurupt",
-            instance="fm",
-            kube_deployments=mock_deployments,
-            soa_dir="/nail/blah",
-        )
-        assert ret == (0, None)
-        mock_create_kubernetes_application.assert_called_with(
-            kube_client=mock_kube_client, application=mock_deploy
-        )
 
-        # instance correc so do nothing
-        mock_create_kubernetes_application.reset_mock()
-        mock_load_kubernetes_service_config_no_cache.return_value = mock.Mock(
-            get_desired_instances=mock.Mock(return_value=3),
-            get_bounce_margin_factor=mock.Mock(return_value=1),
-            format_kubernetes_app=mock.Mock(
-                return_value=V1Deployment(
-                    metadata=V1ObjectMeta(
-                        labels={
-                            "yelp.com/paasta_git_sha": "a12345",
-                            "yelp.com/paasta_config_sha": "b12345",
-                        }
-                    ),
-                    spec=V1DeploymentSpec(
-                        selector=V1LabelSelector(),
-                        template=V1PodTemplateSpec(),
-                        replicas=3,
-                    ),
-                )
-            ),
-        )
-        mock_deployments = [
-            KubeDeployment(
-                service="kurupt",
-                instance="fm",
-                git_sha="a12345",
-                config_sha="b12345",
-                replicas=3,
-            )
-        ]
-        ret = reconcile_kubernetes_deployment(
-            kube_client=mock_kube_client,
-            service="kurupt",
-            instance="fm",
-            kube_deployments=mock_deployments,
-            soa_dir="/nail/blah",
-        )
-        assert ret == (0, None)
-        assert not mock_create_kubernetes_application.called
-        assert not mock_update_kubernetes_application.called
-
-        # changed gitsha so update
-        mock_create_kubernetes_application.reset_mock()
-        mock_load_kubernetes_service_config_no_cache.return_value = mock.Mock(
-            get_desired_instances=mock.Mock(return_value=3),
-            get_bounce_margin_factor=mock.Mock(return_value=1),
-            format_kubernetes_app=mock.Mock(
-                return_value=V1Deployment(
-                    metadata=V1ObjectMeta(
-                        labels={
-                            "yelp.com/paasta_git_sha": "new_image",
-                            "yelp.com/paasta_config_sha": "b12345",
-                        }
-                    ),
-                    spec=V1DeploymentSpec(
-                        selector=V1LabelSelector(),
-                        template=V1PodTemplateSpec(),
-                        replicas=3,
-                    ),
-                )
-            ),
-        )
-        mock_deployments = [
-            KubeDeployment(
-                service="kurupt",
-                instance="fm",
-                git_sha="a12345",
-                config_sha="b12345",
-                replicas=3,
-            )
-        ]
-        ret = reconcile_kubernetes_deployment(
-            kube_client=mock_kube_client,
-            service="kurupt",
-            instance="fm",
-            kube_deployments=mock_deployments,
-            soa_dir="/nail/blah",
-        )
-        assert ret == (0, None)
-        assert not mock_create_kubernetes_application.called
-        mock_deploy = (
-            mock_load_kubernetes_service_config_no_cache.return_value.format_kubernetes_app()
-        )
-        mock_update_kubernetes_application.assert_called_with(
-            kube_client=mock_kube_client, application=mock_deploy
-        )
-
-        # changed configsha so update
-        mock_create_kubernetes_application.reset_mock()
-        mock_update_kubernetes_application.reset_mock()
-        mock_load_kubernetes_service_config_no_cache.return_value = mock.Mock(
-            get_desired_instances=mock.Mock(return_value=3),
-            get_bounce_margin_factor=mock.Mock(return_value=1),
-            format_kubernetes_app=mock.Mock(
-                return_value=V1Deployment(
-                    metadata=V1ObjectMeta(
-                        labels={
-                            "yelp.com/paasta_git_sha": "a12345",
-                            "yelp.com/paasta_config_sha": "newconfig",
-                        }
-                    ),
-                    spec=V1DeploymentSpec(
-                        selector=V1LabelSelector(),
-                        template=V1PodTemplateSpec(),
-                        replicas=3,
-                    ),
-                )
-            ),
-        )
-        mock_deployments = [
-            KubeDeployment(
-                service="kurupt",
-                instance="fm",
-                git_sha="a12345",
-                config_sha="b12345",
-                replicas=3,
-            )
-        ]
-        ret = reconcile_kubernetes_deployment(
-            kube_client=mock_kube_client,
-            service="kurupt",
-            instance="fm",
-            kube_deployments=mock_deployments,
-            soa_dir="/nail/blah",
-        )
-        assert ret == (0, None)
-        assert not mock_create_kubernetes_application.called
-        mock_deploy = (
-            mock_load_kubernetes_service_config_no_cache.return_value.format_kubernetes_app()
-        )
-        mock_update_kubernetes_application.assert_called_with(
-            kube_client=mock_kube_client, application=mock_deploy
-        )
-
-        # changed number of replicas so update
-        mock_create_kubernetes_application.reset_mock()
-        mock_update_kubernetes_application.reset_mock()
-        mock_load_kubernetes_service_config_no_cache.return_value = mock.Mock(
-            get_desired_instances=mock.Mock(return_value=3),
-            get_bounce_margin_factor=mock.Mock(return_value=1),
-            format_kubernetes_app=mock.Mock(
-                return_value=V1Deployment(
-                    metadata=V1ObjectMeta(
-                        labels={
-                            "yelp.com/paasta_git_sha": "a12345",
-                            "yelp.com/paasta_config_sha": "b12345",
-                        }
-                    ),
-                    spec=V1DeploymentSpec(
-                        selector=V1LabelSelector(),
-                        template=V1PodTemplateSpec(),
-                        replicas=2,
-                    ),
-                )
-            ),
-        )
-        mock_deployments = [
-            KubeDeployment(
-                service="kurupt",
-                instance="fm",
-                git_sha="a12345",
-                config_sha="b12345",
-                replicas=3,
-            )
-        ]
-        ret = reconcile_kubernetes_deployment(
-            kube_client=mock_kube_client,
-            service="kurupt",
-            instance="fm",
-            kube_deployments=mock_deployments,
-            soa_dir="/nail/blah",
-        )
-        assert ret == (0, None)
-        assert not mock_create_kubernetes_application.called
-        mock_deploy = (
-            mock_load_kubernetes_service_config_no_cache.return_value.format_kubernetes_app()
-        )
-        mock_update_kubernetes_application.assert_called_with(
-            kube_client=mock_kube_client, application=mock_deploy
-        )
-
-        # error cases...
-        mock_create_kubernetes_application.reset_mock()
-        mock_update_kubernetes_application.reset_mock()
+        mock_deployment_wrapper.reset_mock()
+        mock_stateful_set_wrapper.reset_mock()
         mock_load_kubernetes_service_config_no_cache.side_effect = (
             NoDeploymentsAvailable
         )
-        ret = reconcile_kubernetes_deployment(
+        setup_kubernetes_job.setup_kube_succeeded = True
+        ret = create_application_object(
             kube_client=mock_kube_client,
             service="kurupt",
             instance="fm",
-            kube_deployments=mock_deployments,
             soa_dir="/nail/blah",
         )
-        assert ret == (0, None)
-        assert not mock_create_kubernetes_application.called
-        assert not mock_update_kubernetes_application.called
+        assert ret is None
+        assert setup_kubernetes_job.setup_kube_succeeded
+        assert not mock_deployment_wrapper.called
+        assert not mock_stateful_set_wrapper.called
+
         mock_load_kubernetes_service_config_no_cache.side_effect = (
             NoConfigurationForServiceError
         )
-        ret = reconcile_kubernetes_deployment(
+        setup_kubernetes_job.setup_kube_succeeded = True
+        ret = create_application_object(
             kube_client=mock_kube_client,
             service="kurupt",
             instance="fm",
-            kube_deployments=mock_deployments,
             soa_dir="/nail/blah",
         )
-        assert ret == (1, None)
-        assert not mock_create_kubernetes_application.called
-        assert not mock_update_kubernetes_application.called
+
+        assert ret is None
+        assert not setup_kubernetes_job.setup_kube_succeeded
+        assert not mock_deployment_wrapper.called
+        assert not mock_stateful_set_wrapper.called
 
         mock_load_kubernetes_service_config_no_cache.side_effect = None
         mock_load_kubernetes_service_config_no_cache.return_value = mock.Mock(
@@ -448,67 +234,150 @@ def test_reconcile_kubernetes_deployment():
                 side_effect=InvalidKubernetesConfig(Exception("Oh no!"), "kurupt", "fm")
             )
         )
-        ret = reconcile_kubernetes_deployment(
+        setup_kubernetes_job.setup_kube_succeeded = True
+        ret = create_application_object(
             kube_client=mock_kube_client,
             service="kurupt",
             instance="fm",
-            kube_deployments=mock_deployments,
             soa_dir="/nail/blah",
         )
-        assert ret == (1, None)
-        assert not mock_create_kubernetes_application.called
-        assert not mock_update_kubernetes_application.called
+
+        assert ret is None
+        assert not setup_kubernetes_job.setup_kube_succeeded
+        assert not mock_deployment_wrapper.called
+        assert not mock_stateful_set_wrapper.called
 
 
-def test_create_kubernetes_application():
+def test_setup_kube_deployment_create_update():
+    fake_create = mock.MagicMock()
+    fake_update = mock.MagicMock()
+
+    def simple_create_application_object(kube_client, service, instance, soa_dir):
+        fake_app = mock.MagicMock(spec=Application)
+        fake_app.kube_deployment = KubeDeployment(
+            service=service, instance=instance, git_sha="1", config_sha="1", replicas=1
+        )
+        fake_app.create = fake_create
+        fake_app.update = fake_update
+        return fake_app
+
     with mock.patch(
-        "paasta_tools.setup_kubernetes_job.create_deployment", autospec=True
-    ) as mock_create_deployment, mock.patch(
-        "paasta_tools.setup_kubernetes_job.create_stateful_set", autospec=True
-    ) as mock_create_stateful_set:
-        mock_stateful_set = V1StatefulSet()
+        "paasta_tools.setup_kubernetes_job.create_application_object",
+        autospec=True,
+        side_effect=simple_create_application_object,
+    ) as mock_create_application_object, mock.patch(
+        "paasta_tools.setup_kubernetes_job.list_all_deployments", autospec=True
+    ) as mock_list_all_deployments:
         mock_client = mock.Mock()
-        create_kubernetes_application(mock_client, mock_stateful_set)
-        assert not mock_create_deployment.called
-        mock_create_stateful_set.assert_called_with(
-            kube_client=mock_client, formatted_stateful_set=mock_stateful_set
+        # No instances created
+        mock_service_instances: Sequence[str] = []
+        setup_kube_deployments(
+            kube_client=mock_client,
+            service_instances=mock_service_instances,
+            soa_dir="/nail/blah",
+        )
+        assert mock_create_application_object.call_count == 0
+
+        # Create a new instance
+        mock_service_instances = ["kurupt.fm"]
+        setup_kube_deployments(
+            kube_client=mock_client,
+            service_instances=mock_service_instances,
+            soa_dir="/nail/blah",
+        )
+        assert fake_create.call_count == 1
+        assert fake_update.call_count == 0
+
+        # Update when gitsha changed
+        fake_create.reset_mock()
+        fake_update.reset_mock()
+        mock_service_instances = ["kurupt.fm"]
+        mock_list_all_deployments.return_value = [
+            KubeDeployment(
+                service="kurupt", instance="fm", git_sha="2", config_sha="1", replicas=1
+            )
+        ]
+        setup_kube_deployments(
+            kube_client=mock_client,
+            service_instances=mock_service_instances,
+            soa_dir="/nail/blah",
         )
 
-        mock_create_stateful_set.reset_mock()
-        mock_deployment = V1Deployment()
-        mock_client = mock.Mock()
-        create_kubernetes_application(mock_client, mock_deployment)
-        assert not mock_create_stateful_set.called
-        mock_create_deployment.assert_called_with(
-            kube_client=mock_client, formatted_deployment=mock_deployment
+        assert fake_update.call_count == 1
+        assert fake_create.call_count == 0
+
+        # Update when configsha changed
+        fake_create.reset_mock()
+        fake_update.reset_mock()
+        mock_service_instances = ["kurupt.fm"]
+        mock_list_all_deployments.return_value = [
+            KubeDeployment(
+                service="kurupt", instance="fm", git_sha="1", config_sha="2", replicas=1
+            )
+        ]
+        setup_kube_deployments(
+            kube_client=mock_client,
+            service_instances=mock_service_instances,
+            soa_dir="/nail/blah",
         )
+        assert fake_update.call_count == 1
+        assert fake_create.call_count == 0
 
-        with raises(Exception):
-            create_kubernetes_application(mock_client, mock.Mock())
-
-
-def test_update_kubernetes_application():
-    with mock.patch(
-        "paasta_tools.setup_kubernetes_job.update_deployment", autospec=True
-    ) as mock_update_deployment, mock.patch(
-        "paasta_tools.setup_kubernetes_job.update_stateful_set", autospec=True
-    ) as mock_update_stateful_set:
-        mock_stateful_set = V1StatefulSet()
-        mock_client = mock.Mock()
-        update_kubernetes_application(mock_client, mock_stateful_set)
-        assert not mock_update_deployment.called
-        mock_update_stateful_set.assert_called_with(
-            kube_client=mock_client, formatted_stateful_set=mock_stateful_set
+        # Update when replica changed
+        fake_create.reset_mock()
+        fake_update.reset_mock()
+        mock_service_instances = ["kurupt.fm"]
+        mock_list_all_deployments.return_value = [
+            KubeDeployment(
+                service="kurupt", instance="fm", git_sha="1", config_sha="1", replicas=2
+            )
+        ]
+        setup_kube_deployments(
+            kube_client=mock_client,
+            service_instances=mock_service_instances,
+            soa_dir="/nail/blah",
         )
+        assert fake_update.call_count == 1
+        assert fake_create.call_count == 0
 
-        mock_update_stateful_set.reset_mock()
-        mock_deployment = V1Deployment()
-        mock_client = mock.Mock()
-        update_kubernetes_application(mock_client, mock_deployment)
-        assert not mock_update_stateful_set.called
-        mock_update_deployment.assert_called_with(
-            kube_client=mock_client, formatted_deployment=mock_deployment
+        # Update one and Create One
+        fake_create.reset_mock()
+        fake_update.reset_mock()
+        mock_service_instances = ["kurupt.fm", "kurupt.garage"]
+        mock_list_all_deployments.return_value = [
+            KubeDeployment(
+                service="kurupt",
+                instance="garage",
+                git_sha="2",
+                config_sha="2",
+                replicas=1,
+            )
+        ]
+        setup_kube_deployments(
+            kube_client=mock_client,
+            service_instances=mock_service_instances,
+            soa_dir="/nail/blah",
         )
+        assert fake_update.call_count == 1
+        assert fake_create.call_count == 1
 
-        with raises(Exception):
-            update_kubernetes_application(mock_client, mock.Mock())
+        # not create existing instances
+        fake_create.reset_mock()
+        fake_update.reset_mock()
+        mock_service_instances = ["kurupt.garage"]
+        mock_list_all_deployments.return_value = [
+            KubeDeployment(
+                service="kurupt",
+                instance="garage",
+                git_sha="1",
+                config_sha="1",
+                replicas=1,
+            )
+        ]
+        setup_kube_deployments(
+            kube_client=mock_client,
+            service_instances=mock_service_instances,
+            soa_dir="/nail/blah",
+        )
+        assert fake_update.call_count == 0
+        assert fake_create.call_count == 0

--- a/tests/test_setup_kubernetes_job.py
+++ b/tests/test_setup_kubernetes_job.py
@@ -252,7 +252,7 @@ def test_setup_kube_deployment_create_update():
         )
         fake_app.create = fake_create
         fake_app.update = fake_update
-        return fake_app
+        return True, fake_app
 
     with mock.patch(
         "paasta_tools.setup_kubernetes_job.create_application_object",

--- a/tests/test_setup_kubernetes_job.py
+++ b/tests/test_setup_kubernetes_job.py
@@ -1,10 +1,8 @@
 from typing import Sequence
 
 import mock
-from kubernetes.client import V1DeleteOptions
 from kubernetes.client import V1Deployment
 from kubernetes.client import V1StatefulSet
-from kubernetes.client.rest import ApiException
 from pytest import raises
 
 from paasta_tools.kubernetes.application.controller_wrappers import Application
@@ -70,80 +68,6 @@ def test_setup_kube_deployment_invalid_job_name():
             soa_dir="/nail/blah",
         )
         assert mock_create_application_object.call_count == 0
-
-
-def test_ensure_pod_disruption_budget_create():
-    with mock.patch(
-        "paasta_tools.kubernetes.application.controller_wrappers.pod_disruption_budget_for_service_instance",
-        autospec=True,
-    ) as mock_pdr_for_service_instance, mock.patch(
-        "paasta_tools.kubernetes.application.controller_wrappers.create_pod_disruption_budget",
-        autospec=True,
-    ) as mock_create_pdr, mock.patch(
-        "paasta_tools.kubernetes.application.controller_wrappers.max_unavailable",
-        autospec=True,
-        return_value=0,
-    ):
-        mock_req_pdr = mock.Mock()
-        mock_req_pdr.spec.min_available = 10
-        mock_pdr_for_service_instance.return_value = mock_req_pdr
-
-        mock_client = mock.Mock()
-
-        mock_pdr = mock.Mock()
-        mock_pdr.spec.min_available = 10
-
-        mock_client.read_namespaced_pod_disruption_budget.side_effect = ApiException(
-            status=404
-        )
-
-        app = mock.MagicMock()
-        app.soa_config.get_desired_instances.return_value = 10
-        app.item.service.return_value = "fake_service"
-        app.item.instance.return_value = "fake_instance"
-        Application.ensure_pod_disruption_budget(self=app, kube_client=mock_client)
-        mock_create_pdr.assert_called_once_with(
-            kube_client=mock_client, pod_disruption_budget=mock_req_pdr
-        )
-
-
-def test_ensure_pod_disruption_budget_replaces_outdated():
-    with mock.patch(
-        "paasta_tools.kubernetes.application.controller_wrappers.pod_disruption_budget_for_service_instance",
-        autospec=True,
-    ) as mock_pdr_for_service_instance, mock.patch(
-        "paasta_tools.kubernetes.application.controller_wrappers.create_pod_disruption_budget",
-        autospec=True,
-    ) as mock_create_pdr, mock.patch(
-        "paasta_tools.kubernetes.application.controller_wrappers.max_unavailable",
-        autospec=True,
-        return_value=0,
-    ):
-        mock_req_pdr = mock.Mock()
-        mock_req_pdr.spec.min_available = 10
-        mock_pdr_for_service_instance.return_value = mock_req_pdr
-
-        mock_client = mock.Mock()
-
-        mock_pdr = mock.Mock()
-        mock_pdr.spec.min_available = 10
-
-        mock_client.read_namespaced_pod_disruption_budget.return_value = mock_pdr
-
-        app = mock.MagicMock()
-        app.soa_config.get_desired_instances.return_value = 10
-        app.item.service.return_value = "fake_service"
-        app.item.instance.return_value = "fake_instance"
-        Application.ensure_pod_disruption_budget(self=app, kube_client=mock_client)
-
-        mock_client.policy.delete_namespaced_pod_disruption_budget.assert_called_once_with(
-            name=mock_req_pdr.metadata.name,
-            namespace=mock_req_pdr.metadata.namespace,
-            body=V1DeleteOptions(),
-        )
-        mock_create_pdr.assert_called_once_with(
-            kube_client=mock_client, pod_disruption_budget=mock_req_pdr
-        )
 
 
 def test_create_application_object():


### PR DESCRIPTION
I tested on kubestage. I installed this package, disabled it for all other than the three apps I used for the test, and ran `bash -c "paasta_list_kubernetes_service_instances | shuf |xargs setup_kubernetes_job -v"`
Change: https://reviewboard.yelpcorp.com/r/428545/
Result: https://fluffy.yelpcorp.com/i/TrKP15nGsZmRLP1WlTnR0TBHHwg9w74D.html