### PR TITLE
Add HPA for paasta services(k8s deployments)

### DIFF
--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -213,7 +213,7 @@ class DeploymentWrapper(Application):
         """
         hpa_exists = self.exists_hpa(kube_client)
         # NO autoscaling
-        if self.get_soa_config().get("instances", {}):
+        if self.get_soa_config().get("instances"):
             # Remove HPA if autoscaling is disabled
             if hpa_exists:
                 self.delete_horizontal_pod_autoscaler(kube_client)
@@ -288,7 +288,7 @@ class DeploymentWrapper(Application):
                 ),
             ),
         )
-        if hpa_exists:
+        if not hpa_exists:
             kube_client.autoscaling.create_namespaced_horizontal_pod_autoscaler(
                 namespace=self.item.metadata.namespace, body=body, pretty=True
             )

--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -230,7 +230,7 @@ class DeploymentWrapper(Application):
         min_instnace, max_instance, and instance
         """
         self.logging.info(
-            "Syncing HPA setting for {self.item.metadata.name}/name in {self.item.metadata.namespace}"
+            f"Syncing HPA setting for {self.item.metadata.name}/name in {self.item.metadata.namespace}"
         )
         hpa_exists = self.exists_hpa(kube_client)
         # NO autoscaling
@@ -244,7 +244,7 @@ class DeploymentWrapper(Application):
         max_replicas = self.get_soa_config().get("max_instances")
         if not min_replicas or not max_replicas:
             self.logging.error(
-                "min/max_instances are not specified. Autoscaling is not enabled."
+                "Please specify min_instances and max_instances for autoscaling to work"
             )
             return
         metrics_provider = (

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -695,9 +695,11 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
         if self.get_desired_state() == "start":
             instances = self.config_dict.get("instances") or self.get_min_instances()
-        else:
+        elif self.get_desired_state() == "stop":
             instances = 0
             log.debug("Instance is set to stop. Returning '0' instances")
+        else:
+            raise Exception(f"The state of {self.service}.{self.instance} is unknown.")
 
         if self.get_aws_ebs_volumes() and instances not in [1, 0]:
             raise Exception(
@@ -828,7 +830,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "metrics_provider", ""
         )
         if metrics_provider in {"http", "uwsgi"}:
-            annotations["autoscaling"] = metrics_provider  # type: ignore
+            annotations["autoscaling"] = metrics_provider
 
         return V1PodTemplateSpec(
             metadata=V1ObjectMeta(

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -672,7 +672,13 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         """ For now if we have an EBS instance it means we can only have 1 instance
         since we can't attach to multiple instances. In the future we might support
         statefulsets which are clever enough to manage EBS for you"""
-        instances = super().get_desired_instances()
+
+        if self.get_desired_state() == "start":
+            instances = self.config_dict.get("instances") or self.get_min_instances()
+        else:
+            instances = 0
+            log.debug("Instance is set to stop. Returning '0' instances")
+
         if self.get_aws_ebs_volumes() and instances not in [1, 0]:
             raise Exception(
                 "Number of instances must be 1 or 0 if an EBS volume is defined."

--- a/tests/kubernetes/application/test_controller_wrapper.py
+++ b/tests/kubernetes/application/test_controller_wrapper.py
@@ -24,15 +24,12 @@ def test_ensure_pod_disruption_budget_create():
 
         mock_client = mock.MagicMock()
 
-        mock_pdr = mock.Mock()
-        mock_pdr.spec.max_unavailable = 10
-
         mock_client.policy.read_namespaced_pod_disruption_budget.side_effect = ApiException(
             status=404
         )
 
         app = mock.MagicMock()
-        app.soa_config.get_bounce_margin_factor.return_value = 10
+        app.soa_config.get_bounce_margin_factor.return_value = 0.1
         app.kube_deployment.service.return_value = "fake_service"
         app.kube_deployment.instance.return_value = "fake_instance"
         Application.ensure_pod_disruption_budget(self=app, kube_client=mock_client)
@@ -58,7 +55,7 @@ def test_ensure_pod_disruption_budget_replaces_outdated():
         mock_client.policy.read_namespaced_pod_disruption_budget.return_value = mock_pdr
 
         app = mock.MagicMock()
-        app.soa_config.get_bounce_margin_factor.return_value = 10
+        app.soa_config.get_bounce_margin_factor.return_value = 0.1
         app.kube_deployment.service.return_value = "fake_service"
         app.kube_deployment.instance.return_value = "fake_instance"
         Application.ensure_pod_disruption_budget(self=app, kube_client=mock_client)
@@ -71,7 +68,7 @@ def test_ensure_pod_disruption_budget_replaces_outdated():
 
 
 def test_sync_horizontal_pod_autoscaler():
-    mock_client = mock.MagicMock(autospec=True)
+    mock_client = mock.MagicMock()
     app = mock.MagicMock(autospec=True)
     app.item.metadata.name = "fake_name"
     app.item.metadata.namespace = "faasta"

--- a/tests/kubernetes/application/test_controller_wrapper.py
+++ b/tests/kubernetes/application/test_controller_wrapper.py
@@ -3,6 +3,7 @@ from kubernetes.client import V1DeleteOptions
 from kubernetes.client.rest import ApiException
 
 from paasta_tools.kubernetes.application.controller_wrappers import Application
+from paasta_tools.kubernetes.application.controller_wrappers import DeploymentWrapper
 
 
 def test_ensure_pod_disruption_budget_create():
@@ -77,3 +78,43 @@ def test_ensure_pod_disruption_budget_replaces_outdated():
         mock_create_pdr.assert_called_once_with(
             kube_client=mock_client, pod_disruption_budget=mock_req_pdr
         )
+
+
+def test_sync_horizontal_pod_autoscaler():
+    with mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.DeploymentWrapper.exists_hpa",
+        autospec=True,
+    ) as mock_exists_hpa, mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.DeploymentWrapper.delete_horizontal_pod_autoscaler",
+        autospec=True,
+    ) as mock_delete_hpa, mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.Application.get_soa_config",
+        autospec=True,
+    ) as mock_soa_config, mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.Application.get_soa_config",
+        autospec=True,
+    ):
+        mock_client = mock.MagicMock()
+        app = mock.MagicMock()
+        app.kube_deployment.service.return_value = "fake_service"
+        app.kube_deployment.instance.return_value = "fake_instance"
+
+        # Do nothing
+        config_dict = {"instances": 1}
+        mock_soa_config.return_value = config_dict
+        mock_exists_hpa.return_value = False
+        DeploymentWrapper.ensure_pod_disruption_budget(
+            self=app, kube_client=mock_client
+        )
+        assert mock_delete_hpa.call_count == 1
+
+        # old HPA got removed so delete
+        config_dict = {"instances": 1}
+        mock_soa_config.return_value = config_dict
+        mock_exists_hpa.return_value = True
+        DeploymentWrapper.ensure_pod_disruption_budget(
+            self=app, kube_client=mock_client
+        )
+        assert mock_delete_hpa.call_count == 1
+
+        # Called with mesos HPA

--- a/tests/kubernetes/application/test_controller_wrapper.py
+++ b/tests/kubernetes/application/test_controller_wrapper.py
@@ -5,6 +5,7 @@ from kubernetes.client import V2beta1CrossVersionObjectReference
 from kubernetes.client import V2beta1HorizontalPodAutoscaler
 from kubernetes.client import V2beta1HorizontalPodAutoscalerSpec
 from kubernetes.client import V2beta1MetricSpec
+from kubernetes.client import V2beta1PodsMetricSource
 from kubernetes.client import V2beta1ResourceMetricSource
 from kubernetes.client.rest import ApiException
 
@@ -237,8 +238,8 @@ def test_sync_horizontal_pod_autoscaler():
                 metrics=[
                     V2beta1MetricSpec(
                         type="Pods",
-                        resource=V2beta1ResourceMetricSource(
-                            name="http", target_average_value=50.0
+                        pods=V2beta1PodsMetricSource(
+                            metric_name="http", target_average_value=50.0
                         ),
                     )
                 ],
@@ -279,8 +280,8 @@ def test_sync_horizontal_pod_autoscaler():
                 metrics=[
                     V2beta1MetricSpec(
                         type="Pods",
-                        resource=V2beta1ResourceMetricSource(
-                            name="uwsgi", target_average_value=50.0
+                        pods=V2beta1PodsMetricSource(
+                            metric_name="uwsgi", target_average_value=50.0
                         ),
                     )
                 ],

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1262,12 +1262,12 @@ def test_max_unavailable(instances, bmf):
 
 def test_pod_disruption_budget_for_service_instance():
     x = pod_disruption_budget_for_service_instance(
-        service="foo", instance="bar", min_instances=10
+        service="foo", instance="bar", max_unavailable="10%"
     )
 
     assert x.metadata.name == "foo-bar"
     assert x.metadata.namespace == "paasta"
-    assert x.spec.min_available == 10
+    assert x.spec.max_unavailable == "10%"
     assert x.spec.selector.match_labels == {
         "yelp.com/paasta_service": "foo",
         "yelp.com/paasta_instance": "bar",


### PR DESCRIPTION
Summary
* HPA is only created for deployments.
* Whenever setup_kubernetes_job runs, HPA is synced to the lastest autoscaling setting. It is created, updated, or deleted based on yelpsoa_config setting.
* existing number of replicas in deployment objects do not change when the service is updated if autoscaling is enabled. 
* I assume when instance keyword exists in yelpsoa_config, autoscaling is disabled.

Tested on kubestage.
https://fluffy.yelpcorp.com/i/rcMS6M9r6jVP8ncJ557z6lQb5RRFsDzq.html
