### PR TITLE
Speedup paasta status for services with many instances

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -40,11 +40,11 @@ from paasta_tools.adhoc_tools import AdhocJobConfig
 from paasta_tools.api.client import get_paasta_api_client
 from paasta_tools.cli.utils import execute_paasta_serviceinit_on_remote_master
 from paasta_tools.cli.utils import figure_out_service_name
-from paasta_tools.cli.utils import validate_service_name
-from paasta_tools.cli.utils import NoSuchService
 from paasta_tools.cli.utils import get_instance_configs_for_service
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
+from paasta_tools.cli.utils import NoSuchService
+from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.flink_tools import FlinkDeploymentConfig
 from paasta_tools.flink_tools import get_dashboard_url
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
@@ -818,7 +818,9 @@ def apply_args_filters(
         try:
             validate_service_name(args.service, soa_dir=args.soa_dir)
         except NoSuchService:
-            paasta_print(PaastaColors.red(f'The service "{args.service}" does not exist.'))
+            paasta_print(
+                PaastaColors.red(f'The service "{args.service}" does not exist.')
+            )
             all_services = list_services(soa_dir=args.soa_dir)
             suggestions = difflib.get_close_matches(
                 args.service, all_services, n=5, cutoff=0.5

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -22,6 +22,7 @@ import random
 import re
 import subprocess
 import sys
+from collections import defaultdict
 from shlex import quote
 from socket import gaierror
 from socket import gethostbyname_ex
@@ -33,8 +34,6 @@ from typing import Optional
 from typing import Sequence
 from typing import Set
 from typing import Tuple
-
-from collections import defaultdict
 
 import ephemeral_port_reserve
 from bravado.exception import HTTPError
@@ -849,6 +848,7 @@ def get_jenkins_build_output_url():
         build_output = build_output + "console"
     return build_output
 
+
 InstanceListerSig = Callable[
     [
         NamedArg(str, "service"),
@@ -870,8 +870,10 @@ InstanceLoaderSig = Callable[
     InstanceConfig,
 ]
 
-INSTANCE_TYPE_HANDLERS: Mapping[str, Tuple[InstanceListerSig, InstanceLoaderSig]] = defaultdict(
-    lambda: (None, None,),
+INSTANCE_TYPE_HANDLERS: Mapping[
+    str, Tuple[InstanceListerSig, InstanceLoaderSig]
+] = defaultdict(
+    lambda: (None, None),
     marathon=(get_service_instance_list, load_marathon_service_config),
     chronos=(get_service_instance_list, load_chronos_job_config),
     adhoc=(get_service_instance_list, load_adhoc_job_config),
@@ -880,6 +882,7 @@ INSTANCE_TYPE_HANDLERS: Mapping[str, Tuple[InstanceListerSig, InstanceLoaderSig]
     flink=(get_service_instance_list, load_flink_instance_config),
     cassandracluster=(get_service_instance_list, load_cassandracluster_instance_config),
 )
+
 
 def get_instance_config(
     service: str,

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -478,10 +478,11 @@ class WrappedMarkForDeploymentProcess(mark_for_deployment.MarkForDeploymentProce
     autospec=True,
 )
 @patch("paasta_tools.cli.cmds.mark_for_deployment.wait_for_deployment", autospec=True)
+@patch("paasta_tools.cli.cmds.mark_for_deployment._log", autospec=True)
 def test_MarkForDeployProcess_happy_path(
-    mock_wait_for_deployment, mock_mark_for_deployment, mock_periodically_update_slack
+    mock_log, mock_wait_for_deployment, mock_mark_for_deployment, mock_periodically_update_slack
 ):
-
+    mock_log.return_value = None
     mfdp = WrappedMarkForDeploymentProcess(
         service="service",
         deploy_info=MagicMock(),
@@ -515,10 +516,13 @@ def test_MarkForDeployProcess_happy_path(
     autospec=True,
 )
 @patch("paasta_tools.cli.cmds.mark_for_deployment.wait_for_deployment", autospec=True)
+@patch("paasta_tools.cli.cmds.mark_for_deployment._log", autospec=True)
+@patch("paasta_tools.cli.cmds.wait_for_deployment._log", autospec=True)
 def test_MarkForDeployProcess_happy_path_skips_complete_if_no_auto_rollback(
-    mock_wait_for_deployment, mock_mark_for_deployment, mock_periodically_update_slack
+    mock__log1, mock__log2, mock_wait_for_deployment, mock_mark_for_deployment, mock_periodically_update_slack
 ):
-
+    mock__log1.return_value = None
+    mock__log2.return_value = None
     mfdp = WrappedMarkForDeploymentProcess(
         service="service",
         deploy_info=MagicMock(),

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -480,7 +480,10 @@ class WrappedMarkForDeploymentProcess(mark_for_deployment.MarkForDeploymentProce
 @patch("paasta_tools.cli.cmds.mark_for_deployment.wait_for_deployment", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log", autospec=True)
 def test_MarkForDeployProcess_happy_path(
-    mock_log, mock_wait_for_deployment, mock_mark_for_deployment, mock_periodically_update_slack
+    mock_log,
+    mock_wait_for_deployment,
+    mock_mark_for_deployment,
+    mock_periodically_update_slack,
 ):
     mock_log.return_value = None
     mfdp = WrappedMarkForDeploymentProcess(
@@ -519,7 +522,11 @@ def test_MarkForDeployProcess_happy_path(
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log", autospec=True)
 @patch("paasta_tools.cli.cmds.wait_for_deployment._log", autospec=True)
 def test_MarkForDeployProcess_happy_path_skips_complete_if_no_auto_rollback(
-    mock__log1, mock__log2, mock_wait_for_deployment, mock_mark_for_deployment, mock_periodically_update_slack
+    mock__log1,
+    mock__log2,
+    mock_wait_for_deployment,
+    mock_mark_for_deployment,
+    mock_periodically_update_slack,
 ):
     mock__log1.return_value = None
     mock__log2.return_value = None

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -79,7 +79,9 @@ def test_figure_out_service_name_not_found(mock_validate_service_name, capfd):
 @patch("paasta_tools.cli.cmds.status.load_system_paasta_config", autospec=True)
 @patch("paasta_tools.cli.utils.validate_service_name", autospec=True)
 @patch("paasta_tools.cli.utils.guess_service_name", autospec=True)
+@patch("paasta_tools.cli.cmds.status.list_services", autospec=True)
 def test_status_arg_service_not_found(
+    mock_list_services,
     mock_guess_service_name,
     mock_validate_service_name,
     mock_load_system_paasta_config,
@@ -88,6 +90,7 @@ def test_status_arg_service_not_found(
     system_paasta_config,
 ):
     # paasta_status with no args and non-service directory results in error
+    mock_list_services.return_value = []
     mock_guess_service_name.return_value = "not_a_service"
     error = NoSuchService("fake_service")
     mock_validate_service_name.side_effect = error
@@ -467,7 +470,11 @@ def test_report_status_calls_report_invalid_whitelist_values(
 @patch("paasta_tools.cli.cmds.status.figure_out_service_name", autospec=True)
 @patch("paasta_tools.cli.cmds.status.get_deploy_info", autospec=True)
 @patch("paasta_tools.cli.cmds.status.get_actual_deployments", autospec=True)
+@patch("paasta_tools.cli.cmds.status.validate_service_name", autospec=True)
+@patch("paasta_tools.cli.cmds.status.list_clusters", autospec=True)
 def test_status_pending_pipeline_build_message(
+    mock_list_clusters,
+    mock_validate_service_name,
     mock_get_actual_deployments,
     mock_get_deploy_info,
     mock_figure_out_service_name,
@@ -479,6 +486,8 @@ def test_status_pending_pipeline_build_message(
 ):
     # If deployments.json is missing SERVICE, output the appropriate message
     service = "fake_service"
+    mock_list_clusters.return_value = ["cluster"]
+    mock_validate_service_name.return_value = None
     mock_figure_out_service_name.return_value = service
     mock_list_services.return_value = [service]
     pipeline = [{"instancename": "cluster.instance"}]
@@ -551,7 +560,11 @@ def test_get_deploy_info_does_not_exist(mock_read_deploy, capfd):
 @patch("paasta_tools.cli.cmds.status.get_actual_deployments", autospec=True)
 @patch("paasta_tools.cli.cmds.status.get_planned_deployments", autospec=True)
 @patch("paasta_tools.cli.cmds.status.report_status_for_cluster", autospec=True)
+@patch("paasta_tools.cli.cmds.status.validate_service_name", autospec=True)
+@patch("paasta_tools.cli.cmds.status.list_clusters", autospec=True)
 def test_status_calls_sergeants(
+    mock_list_clusters,
+    mock_validate_service_name,
     mock_report_status,
     mock_get_planned_deployments,
     mock_get_actual_deployments,
@@ -563,6 +576,8 @@ def test_status_calls_sergeants(
 ):
     service = "fake_service"
     cluster = "fake_cluster"
+    mock_list_clusters.return_value = ["cluster1", "cluster2", "fake_cluster"]
+    mock_validate_service_name.return_value = None
     mock_figure_out_service_name.return_value = service
     mock_list_services.return_value = [service]
 
@@ -645,7 +660,11 @@ StatusArgs = namedtuple(
 @patch("paasta_tools.cli.cmds.status.get_instance_configs_for_service", autospec=True)
 @patch("paasta_tools.cli.cmds.status.list_services", autospec=True)
 @patch("paasta_tools.cli.cmds.status.figure_out_service_name", autospec=True)
+@patch("paasta_tools.cli.cmds.status.validate_service_name", autospec=True)
+@patch("paasta_tools.cli.cmds.status.list_clusters", autospec=True)
 def test_apply_args_filters_clusters_and_instances_clusters_instances_deploy_group(
+    mock_list_clusters,
+    mock_validate_service_name,
     mock_figure_out_service_name,
     mock_list_services,
     mock_get_instance_configs_for_service,
@@ -660,6 +679,8 @@ def test_apply_args_filters_clusters_and_instances_clusters_instances_deploy_gro
         registration=None,
         verbose=False,
     )
+    mock_list_clusters.return_value = ["cluster1", "cluster2"]
+    mock_validate_service_name.return_value = None
     mock_figure_out_service_name.return_value = "fake_service"
     mock_list_services.return_value = ["fake_service"]
     mock_inst1 = make_fake_instance_conf(
@@ -685,7 +706,11 @@ def test_apply_args_filters_clusters_and_instances_clusters_instances_deploy_gro
 @patch("paasta_tools.cli.cmds.status.get_instance_configs_for_service", autospec=True)
 @patch("paasta_tools.cli.cmds.status.list_services", autospec=True)
 @patch("paasta_tools.cli.cmds.status.figure_out_service_name", autospec=True)
+@patch("paasta_tools.cli.cmds.status.validate_service_name", autospec=True)
+@patch("paasta_tools.cli.cmds.status.list_clusters", autospec=True)
 def test_apply_args_filters_clusters_uses_deploy_group_when_no_clusters_and_instances(
+    mock_list_clusters,
+    mock_validate_service_name,
     mock_figure_out_service_name,
     mock_list_services,
     mock_get_instance_configs_for_service,
@@ -700,7 +725,8 @@ def test_apply_args_filters_clusters_uses_deploy_group_when_no_clusters_and_inst
         registration=None,
         verbose=False,
     )
-
+    mock_list_clusters.return_value = ["cluster1", "cluster2"]
+    mock_validate_service_name.return_value = None
     mock_figure_out_service_name.return_value = "fake_service"
     mock_list_services.return_value = ["fake_service"]
     mock_inst1 = make_fake_instance_conf(
@@ -806,7 +832,9 @@ def test_apply_args_filters_clusters_return_none_when_instance_not_in_deploy_gro
 @patch("paasta_tools.cli.cmds.status.get_instance_configs_for_service", autospec=True)
 @patch("paasta_tools.cli.cmds.status.list_services", autospec=True)
 @patch("paasta_tools.cli.cmds.status.figure_out_service_name", autospec=True)
+@patch("paasta_tools.cli.cmds.status.validate_service_name", autospec=True)
 def test_apply_args_filters_clusters_and_instances(
+    mock_validate_service_name,
     mock_figure_out_service_name,
     mock_list_services,
     mock_get_instance_configs_for_service,
@@ -821,6 +849,7 @@ def test_apply_args_filters_clusters_and_instances(
         registration=None,
         verbose=False,
     )
+    mock_validate_service_name.return_value = None
     mock_figure_out_service_name.return_value = "fake_service"
     mock_list_services.return_value = ["fake_service"]
     mock_inst1 = make_fake_instance_conf(
@@ -871,7 +900,9 @@ def test_apply_args_filters_bad_service_name(mock_list_services, capfd):
 @patch("paasta_tools.cli.cmds.status.get_instance_configs_for_service", autospec=True)
 @patch("paasta_tools.cli.cmds.status.list_services", autospec=True)
 @patch("paasta_tools.cli.cmds.status.figure_out_service_name", autospec=True)
+@patch("paasta_tools.cli.cmds.status.validate_service_name", autospec=True)
 def test_apply_args_filters_no_instances_found(
+    mock_validate_service_name,
     mock_figure_out_service_name,
     mock_list_services,
     mock_get_instance_configs_for_service,
@@ -888,6 +919,7 @@ def test_apply_args_filters_no_instances_found(
         registration=None,
         verbose=False,
     )
+    mock_validate_service_name.return_value = None
     mock_figure_out_service_name.return_value = "fake_service"
     mock_list_services.return_value = ["fake_service"]
     mock_get_instance_configs_for_service.return_value = [
@@ -1027,7 +1059,9 @@ def test_status_with_owner(
 @patch("paasta_tools.cli.cmds.status.load_system_paasta_config", autospec=True)
 @patch("paasta_tools.cli.cmds.status.report_status_for_cluster", autospec=True)
 @patch("paasta_tools.cli.cmds.status.get_planned_deployments", autospec=True)
+@patch("paasta_tools.cli.cmds.status.validate_service_name", autospec=True)
 def test_status_with_registration(
+    mock_validate_service_name,
     mock_get_planned_deployments,
     mock_report_status,
     mock_load_system_paasta_config,
@@ -1038,6 +1072,7 @@ def test_status_with_registration(
     mock_list_clusters,
     system_paasta_config,
 ):
+    mock_validate_service_name.return_value = None
     mock_load_system_paasta_config.return_value = system_paasta_config
     mock_list_services.return_value = ["fakeservice", "otherservice"]
     cluster = "fake_cluster"

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1019,6 +1019,7 @@ def test_status_with_owner(
     assert mock_report_status.call_count == 2
 
 
+@patch("paasta_tools.cli.cmds.status.list_clusters", autospec=True)
 @patch("paasta_tools.cli.cmds.status.get_instance_configs_for_service", autospec=True)
 @patch("paasta_tools.cli.cmds.status.list_services", autospec=True)
 @patch("paasta_tools.cli.cmds.status.figure_out_service_name", autospec=True)
@@ -1034,11 +1035,13 @@ def test_status_with_registration(
     mock_figure_out_service_name,
     mock_list_services,
     mock_get_instance_configs_for_service,
+    mock_list_clusters,
     system_paasta_config,
 ):
     mock_load_system_paasta_config.return_value = system_paasta_config
     mock_list_services.return_value = ["fakeservice", "otherservice"]
     cluster = "fake_cluster"
+    mock_list_clusters.return_value = [cluster]
     mock_get_planned_deployments.return_value = [
         "fakeservice.main",
         "fakeservice.not_main",

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -370,7 +370,11 @@ def test_paasta_wait_for_deployment_return_1_when_deploy_group_not_found(
     autospec=True,
 )
 @patch("paasta_tools.cli.cmds.wait_for_deployment.list_deploy_groups", autospec=True)
+@patch("paasta_tools.cli.cmds.mark_for_deployment._log", autospec=True)
+@patch("paasta_tools.cli.cmds.wait_for_deployment._log", autospec=True)
 def test_paasta_wait_for_deployment_return_0_when_no_instances_in_deploy_group(
+    mock__log1,
+    mock__log2,
     mock_list_deploy_groups,
     mock_validate_git_sha_is_latest,
     mock_validate_git_sha,
@@ -379,6 +383,8 @@ def test_paasta_wait_for_deployment_return_0_when_no_instances_in_deploy_group(
     mock_load_system_paasta_config,
     system_paasta_config,
 ):
+    mock__log1.return_value = None
+    mock__log2.return_value = None
     mock_load_system_paasta_config.return_value = system_paasta_config
     mock_paasta_service_config_loader.return_value.instance_configs.return_value = [
         mock_marathon_instance_config("some_instance")

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -502,12 +502,11 @@ def test_modules_in_pkg():
     assert "cook_image" in ret
     assert "list_clusters" in ret
 
+
 @mock.patch("paasta_tools.cli.utils.INSTANCE_TYPE_HANDLERS", dict(), autospec=None)
 @mock.patch("paasta_tools.cli.utils.validate_service_instance", autospec=True)
-def test_get_instance_config_by_instance_type(
-    mock_validate_service_instance,
-):
-    instance_type = 'fake_type'
+def test_get_instance_config_by_instance_type(mock_validate_service_instance,):
+    instance_type = "fake_type"
     mock_validate_service_instance.return_value = instance_type
     mock_load_config = mock.MagicMock()
     mock_load_config.return_value = "fake_service_config"

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -502,14 +502,16 @@ def test_modules_in_pkg():
     assert "cook_image" in ret
     assert "list_clusters" in ret
 
-
+@mock.patch("paasta_tools.cli.utils.INSTANCE_TYPE_HANDLERS", dict())
 @mock.patch("paasta_tools.cli.utils.validate_service_instance", autospec=True)
-@mock.patch("paasta_tools.cli.utils.load_marathon_service_config", autospec=True)
-def test_get_instance_config_marathon(
-    mock_load_marathon_service_config, mock_validate_service_instance
+def test_get_instance_config_by_instance_type(
+    mock_validate_service_instance,
 ):
-    mock_validate_service_instance.return_value = "marathon"
-    mock_load_marathon_service_config.return_value = "fake_service_config"
+    instance_type = 'fake_type'
+    mock_validate_service_instance.return_value = instance_type
+    mock_load_config = mock.MagicMock()
+    mock_load_config.return_value = "fake_service_config"
+    utils.INSTANCE_TYPE_HANDLERS[instance_type] = (None, mock_load_config)
     actual = utils.get_instance_config(
         service="fake_service",
         instance="fake_instance",
@@ -517,43 +519,7 @@ def test_get_instance_config_marathon(
         soa_dir="fake_soa_dir",
     )
     assert mock_validate_service_instance.call_count == 1
-    assert mock_load_marathon_service_config.call_count == 1
-    assert actual == "fake_service_config"
-
-
-@mock.patch("paasta_tools.cli.utils.validate_service_instance", autospec=True)
-@mock.patch("paasta_tools.cli.utils.load_chronos_job_config", autospec=True)
-def test_get_instance_Config_chronos(
-    mock_load_chronos_job_config, mock_validate_service_instance
-):
-    mock_validate_service_instance.return_value = "chronos"
-    mock_load_chronos_job_config.return_value = "fake_service_config"
-    actual = utils.get_instance_config(
-        service="fake_service",
-        instance="fake_instance",
-        cluster="fake_cluster",
-        soa_dir="fake_soa_dir",
-    )
-    assert mock_validate_service_instance.call_count == 1
-    assert mock_load_chronos_job_config.call_count == 1
-    assert actual == "fake_service_config"
-
-
-@mock.patch("paasta_tools.cli.utils.validate_service_instance", autospec=True)
-@mock.patch("paasta_tools.cli.utils.load_kubernetes_service_config", autospec=True)
-def test_get_instance_config_kubernetes(
-    mock_load_kubernetes_service_config, mock_validate_service_instance
-):
-    mock_validate_service_instance.return_value = "kubernetes"
-    mock_load_kubernetes_service_config.return_value = "fake_service_config"
-    actual = utils.get_instance_config(
-        service="fake_service",
-        instance="fake_instance",
-        cluster="fake_cluster",
-        soa_dir="fake_soa_dir",
-    )
-    assert mock_validate_service_instance.call_count == 1
-    assert mock_load_kubernetes_service_config.call_count == 1
+    assert mock_load_config.call_count == 1
     assert actual == "fake_service_config"
 
 

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -502,7 +502,7 @@ def test_modules_in_pkg():
     assert "cook_image" in ret
     assert "list_clusters" in ret
 
-@mock.patch("paasta_tools.cli.utils.INSTANCE_TYPE_HANDLERS", dict())
+@mock.patch("paasta_tools.cli.utils.INSTANCE_TYPE_HANDLERS", dict(), autospec=None)
 @mock.patch("paasta_tools.cli.utils.validate_service_instance", autospec=True)
 def test_get_instance_config_by_instance_type(
     mock_validate_service_instance,


### PR DESCRIPTION
Filter out clusters and instances more aggressively when fetching service status. This brings y-m status walltime from ~20s down to ~5s.

Also refactored `get_instance_configs_for_service` a bit.