### PR TITLE
Upgrade pre-commit

### DIFF
--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -7,7 +7,7 @@ hypothesis
 mock
 path.py
 pep8
-pre-commit==1.10.1
+pre-commit
 pylint
 pytest
 pytest-asyncio

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,13 +3,14 @@ aspy.yaml==0.3.0
 astroid==1.5.3
 asynctest==0.12.0
 Babel==2.3.4
-cached-property==1.3.1
-cfgv==1.0.0
+cfgv==2.0.1
 flake8==3.5.0
 freezegun==0.3.7
 hypothesis==3.71.10
 identify==1.0.6
 imagesize==0.7.1
+importlib-metadata==0.19
+importlib-resources==1.0.2
 isort==4.2.5
 lazy-object-proxy==1.2.1
 mccabe==0.6.1
@@ -19,7 +20,7 @@ path.py==8.1
 pbr==3.1.1
 pep8==1.5.7
 pluggy==0.6.0
-pre-commit==1.10.1
+pre-commit==1.18.0
 pycodestyle==2.3.1
 pyflakes==1.6.0
 Pygments==2.2.0
@@ -32,3 +33,4 @@ Sphinx==1.4.1
 toml==0.9.4
 virtualenv==16.2.0
 wrapt==1.10.8
+zipp==0.5.2


### PR DESCRIPTION
Newer versions of pre-commit are able to run hooks in parallel, leading to faster hook runs, both at commit time and test time.

Before this, `pre-commit run --all-files` takes 100.79 seconds on my devbox; afterwards, it takes 27.53 seconds.