### PR TITLE
Upgrade python-iptables to work on bionic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ pysensu-yelp==0.4.1
 PyStaticConfiguration==0.10.3
 python-crontab==2.1.1
 python-dateutil==2.5.3
-python-iptables==0.11.0
+python-iptables==0.12.0
 python-utils==2.0.1
 pytimeparse==1.1.5
 pytz==2016.10


### PR DESCRIPTION
python-iptables==0.11.0 doesn't work on bionic as the libraries have:

1. changed location
2. changed version

see: https://github.com/ldx/python-iptables/issues/203