### PR TITLE
Add new metrics about deployd queues.

### DIFF
--- a/paasta_tools/deployd/metrics.py
+++ b/paasta_tools/deployd/metrics.py
@@ -1,31 +1,130 @@
 import time
+from typing import List
 
+from paasta_tools.deployd.common import DelayDeadlineQueue
 from paasta_tools.deployd.common import PaastaThread
+from paasta_tools.deployd.workers import PaastaDeployWorker
+from paasta_tools.metrics.metrics_lib import BaseMetrics
 
 
-class QueueMetrics(PaastaThread):
-    def __init__(self, queue, cluster, metrics_provider):
+class MetricsThread(PaastaThread):
+    def __init__(self, metrics_provider):
         super().__init__()
-        self.daemon = True
         self.metrics = metrics_provider
+
+    def run_once(self):
+        raise NotImplementedError()
+
+    def run(self):
+        while True:
+            last_run_time = time.time()
+            self.run_once()
+            time.sleep(last_run_time + 20 - time.time())
+
+
+class QueueAndWorkerMetrics(MetricsThread):
+    def __init__(
+        self,
+        queue: DelayDeadlineQueue,
+        workers: List[PaastaDeployWorker],
+        cluster: str,
+        metrics_provider: BaseMetrics,
+    ) -> None:
+        super().__init__(metrics_provider)
+        self.daemon = True
         self.queue = queue
 
         self.instances_to_bounce_later_gauge = self.metrics.create_gauge(
             "instances_to_bounce_later", paasta_cluster=cluster
         )
-        self.instances_that_need_to_be_checked_up_on_gauge = self.metrics.create_gauge(
-            "instances_that_need_to_be_checked_up_on", paasta_cluster=cluster
-        )
         self.instances_to_bounce_now_gauge = self.metrics.create_gauge(
             "instances_to_bounce_now", paasta_cluster=cluster
         )
+        self.instances_with_past_deadline_gauge = self.metrics.create_gauge(
+            "instances_with_past_deadline", paasta_cluster=cluster
+        )
+        self.instances_with_deadline_in_next_n_seconds_gauges = {
+            (available, n): self.metrics.create_gauge(
+                f"{available}_instances_with_deadline_in_next_{n}s",
+                paasta_cluster=cluster,
+            )
+            for n in [60, 300, 3600]
+            for available in ["available", "unavailable"]
+        }
+        self.max_time_past_deadline_gauge = self.metrics.create_gauge(
+            "max_time_past_deadline", paasta_cluster=cluster
+        )
+        self.sum_time_past_deadline_gauge = self.metrics.create_gauge(
+            "sum_time_past_deadline", paasta_cluster=cluster
+        )
 
-    def run(self):
-        while True:
-            self.instances_to_bounce_later_gauge.set(
-                self.queue.unavailable_service_instances.qsize()
+        self.workers = workers
+
+        self.workers_busy_gauge = self.metrics.create_gauge(
+            "workers_busy", paasta_cluster=cluster
+        )
+        self.workers_idle_gauge = self.metrics.create_gauge(
+            "workers_idle", paasta_cluster=cluster
+        )
+        self.workers_dead_gauge = self.metrics.create_gauge(
+            "workers_dead", paasta_cluster=cluster
+        )
+
+    def run_once(self) -> None:
+        self.instances_to_bounce_later_gauge.set(
+            self.queue.unavailable_service_instances.qsize()
+        )
+        self.instances_to_bounce_now_gauge.set(
+            self.queue.available_service_instances.qsize()
+        )
+
+        currently_available_instances = tuple(
+            self.queue.available_service_instances.queue
+        )
+        currently_unavailable_instances = tuple(
+            self.queue.unavailable_service_instances.queue
+        )
+
+        available_deadlines = [
+            deadline for deadline, _ in currently_available_instances
+        ]
+        unavailable_deadlines = [
+            deadline for _, deadline, _ in currently_unavailable_instances
+        ]
+
+        now = time.time()
+        self.instances_with_past_deadline_gauge.set(
+            len([1 for deadline in available_deadlines if deadline < now])
+        )
+
+        for (
+            (available, n),
+            gauge,
+        ) in self.instances_with_deadline_in_next_n_seconds_gauges.items():
+            if available == "available":
+                deadlines = available_deadlines
+            else:
+                deadlines = unavailable_deadlines
+
+            gauge.set(len([1 for deadline in deadlines if now < deadline < now + n]))
+
+        self.max_time_past_deadline_gauge.set(
+            max(
+                [now - deadline for deadline in available_deadlines if deadline < now],
+                default=0,
             )
-            self.instances_to_bounce_now_gauge.set(
-                self.queue.available_service_instances.qsize()
-            )
-            time.sleep(20)
+        )
+
+        self.sum_time_past_deadline_gauge.set(
+            sum([max(0, now - deadline) for deadline in available_deadlines])
+        )
+
+        self.workers_busy_gauge.set(
+            len([worker for worker in self.workers if worker.busy])
+        )
+        self.workers_idle_gauge.set(
+            len([worker for worker in self.workers if not worker.busy])
+        )
+        self.workers_dead_gauge.set(
+            len([worker for worker in self.workers if not worker.is_alive()])
+        )

--- a/paasta_tools/deployd/workers.py
+++ b/paasta_tools/deployd/workers.py
@@ -26,6 +26,7 @@ class PaastaDeployWorker(PaastaThread):
         self.metrics = metrics_provider
         self.config = config
         self.cluster = self.config.get_cluster()
+        self.busy = False
         self.setup()
 
     def setup(self):
@@ -74,6 +75,7 @@ class PaastaDeployWorker(PaastaThread):
         self.log.info(f"{self.name} starting up")
         while True:
             service_instance = self.instances_to_bounce.get()
+            self.busy = True
             try:
                 bounce_again_in_seconds, return_code, bounce_timers = self.process_service_instance(
                     service_instance
@@ -108,6 +110,7 @@ class PaastaDeployWorker(PaastaThread):
                     processed_count=service_instance.processed_count + 1,
                 )
                 self.instances_to_bounce.put(service_instance)
+            self.busy = False
             time.sleep(0.1)
 
     def process_service_instance(self, service_instance):

--- a/tests/deployd/test_metrics.py
+++ b/tests/deployd/test_metrics.py
@@ -1,29 +1,74 @@
 import unittest
 
 import mock
-from py.test import raises
 
 from paasta_tools.deployd import metrics
 
 
-class TestQueueMetrics(unittest.TestCase):
+class TestQueueAndWorkerMetrics(unittest.TestCase):
     def setUp(self):
         mock_metrics_provider = mock.Mock()
-        self.mock_gauge = mock.Mock()
-        self.mock_inbox = mock.Mock(instances_to_bounce_later=mock.Mock(), to_bounce={})
-        self.mock_instances_to_bounce_now = mock.Mock()
-        mock_create_gauge = mock.Mock(return_value=self.mock_gauge)
+        self.mock_queue = mock.Mock()
+        self.mock_workers = []
+        mock_create_gauge = mock.Mock(side_effect=lambda *args, **kwargs: mock.Mock())
         mock_metrics_provider.create_gauge = mock_create_gauge
-        self.metrics = metrics.QueueMetrics(
-            self.mock_inbox, "mock-cluster", mock_metrics_provider
+        self.metrics = metrics.QueueAndWorkerMetrics(
+            self.mock_queue, self.mock_workers, "mock-cluster", mock_metrics_provider
         )
 
-    def test_run(self):
-        with mock.patch("time.sleep", autospec=True, side_effect=LoopBreak):
-            with raises(LoopBreak):
-                self.metrics.run()
-            assert self.mock_gauge.set.call_count == 2
+    def test_all_metrics(self):
+        with mock.patch("time.time", autospec=True, return_value=10):
+            self.mock_queue.available_service_instances.queue = [
+                (0, mock.Mock()),
+                (1, mock.Mock()),
+                (2, mock.Mock()),
+                (3, mock.Mock()),
+                (4, mock.Mock()),
+                # 0-60
+                (11, mock.Mock()),
+                (12, mock.Mock()),
+                # 60-300
+                (71, mock.Mock()),
+                (72, mock.Mock()),
+                (73, mock.Mock()),
+                # 300-3600
+                (311, mock.Mock()),
+                # 3600+
+                (3611, mock.Mock()),
+            ]
+            self.mock_queue.unavailable_service_instances.queue = [
+                (15, 75, mock.Mock())
+            ]
+            self.metrics.run_once()
 
+            # Don't bother testing instances_to_bounce_later_gauge and instances_to_bounce_now_gauge -- they just call
+            # qsize on things we've mocked out.
 
-class LoopBreak(Exception):
-    pass
+            self.metrics.instances_with_past_deadline_gauge.set.assert_called_once_with(
+                5
+            )
+
+            self.metrics.instances_with_deadline_in_next_n_seconds_gauges[
+                "available", 60
+            ].set.assert_called_once_with(2)
+            self.metrics.instances_with_deadline_in_next_n_seconds_gauges[
+                "available", 300
+            ].set.assert_called_once_with(5)
+            self.metrics.instances_with_deadline_in_next_n_seconds_gauges[
+                "available", 3600
+            ].set.assert_called_once_with(6)
+
+            self.metrics.instances_with_deadline_in_next_n_seconds_gauges[
+                "unavailable", 60
+            ].set.assert_called_once_with(0)
+            self.metrics.instances_with_deadline_in_next_n_seconds_gauges[
+                "unavailable", 300
+            ].set.assert_called_once_with(1)
+            self.metrics.instances_with_deadline_in_next_n_seconds_gauges[
+                "unavailable", 3600
+            ].set.assert_called_once_with(1)
+
+            self.metrics.max_time_past_deadline_gauge.set.assert_called_once_with(10)
+            self.metrics.sum_time_past_deadline_gauge.set.assert_called_once_with(
+                10 + 9 + 8 + 7 + 6
+            )


### PR DESCRIPTION
[Here](https://app.signalfx.com/#/dashboard/EB0FKzIAgAA?groupId=EB0FKkdAcAA&configId=EB0FL7GAgAA&startTimeUTC=1565659876000&endTimeUTC=1565662563000) is an example of where I'm going with this -- you can see the yelp-main cert bump from 18:41 to 18:48, then at 18:59 I restarted deployd, so from 18:59 to 19:11 you can see the startup behavior.

During the yelp-main bump, because so many instances are added to the queue at once, you can see `instances_with_past_deadline` jump, as well as `max_time_past_deadline` and `average time past deadline` (which is `max_time_past_deadline` / `instances_with_past_deadline`) on the second chart. You can also see how we stop processing the backlog when all these to-be-bounced-immediately instances show up.

The backlog = `instances_to_bounce_now` - `available_instances_with_deadline_in_next_60s` = all instances in `available_instances` with deadline more than 60s in the future.