### PR TITLE
Revert "Merge pull request #2369 from Yelp/bump-iptables-latest"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ pysensu-yelp==0.4.1
 PyStaticConfiguration==0.10.3
 python-crontab==2.1.1
 python-dateutil==2.5.3
-python-iptables==0.14.0
+python-iptables==0.12.0
 python-utils==2.0.1
 pytimeparse==1.1.5
 pytz==2016.10


### PR DESCRIPTION
This reverts commit 0800b0800f2848b3820d3262014ab97758df7f31, reversing
changes made to 0ee9bd3ff170b9723f57075d478289048e4991d6.

This is being reverted since it breaks `paasta_docker_wrapper` with:
```
          Traceback (most recent call last):
            File "/opt/venvs/paasta-tools/bin/paasta_docker_wrapper", line 6, in <module>
              from paasta_tools.docker_wrapper import main
            File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/docker_wrapper.py", line 23, in <module>
              from paasta_tools.firewall import DEFAULT_SYNAPSE_SERVICE_DIR
            File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/firewall.py", line 12, in <module>
              from paasta_tools import iptables
            File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/iptables.py", line 11, in <module>
              import iptc
            File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/iptc/__init__.py", line 10, in <module>
              from iptc.ip4tc import (is_table_available, Table, Chain, Rule, Match, Target, Policy, IPTCError)
            File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/iptc/ip4tc.py", line 13, in <module>
              from .xtables import (XT_INV_PROTO, NFPROTO_IPV4, XTablesError, xtables,
            File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/iptc/xtables.py", line 812, in <module>
              stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
            File "/usr/lib/python3.6/subprocess.py", line 707, in __init__
              restore_signals, start_new_session)
            File "/usr/lib/python3.6/subprocess.py", line 1326, in _execute_child
              raise child_exception_type(errno_num, err_msg)
          FileNotFoundError: [Errno 2] No such file or directory: 'ldconfig'
```