### PR TITLE
RFC: Prevent scaling down services if the utilization > setpoint

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -194,9 +194,9 @@ def proportional_decision_policy(
     if desired_number_instances < current_instances:
         if good_enough_window:
             _, high = good_enough_window
-            if utilization - offset >= high:
+            if utilization >= high:
                 desired_number_instances = current_instances
-        elif utilization - offset >= setpoint:
+        elif utilization >= setpoint:
             desired_number_instances = current_instances
 
     if good_enough_window:

--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -188,6 +188,17 @@ def proportional_decision_policy(
 
     desired_number_instances = int(round(predicted_load / (setpoint - offset)))
 
+    # Don't scale down if the current utilization >= the setpoint (or the high point of the good enough window)
+    # This prevents the case where the moving_average forcast_policy thinks the service needs to scale
+    #  down several times in a row due to under-utilization in the near past
+    if desired_number_instances < current_instances:
+        if good_enough_window:
+            _, high = good_enough_window
+            if utilization - offset >= high:
+                desired_number_instances = current_instances
+        elif utilization - offset >= setpoint:
+            desired_number_instances = current_instances
+
     if good_enough_window:
         low, high = good_enough_window
         predicted_load_per_instance_with_current_instances = (


### PR DESCRIPTION
The affects the moving_average forcast policy.  If the usage was low for
several minutes, this could affect the average enough to prompt scaling
down in more than one service autoscaler run.
This prevents that case by refusing to scale down if the current usage
is greater than the setpoint (or the high point of the good_enough_window).

Internal ticket PAASTA-15711

I could also add some logging of what this would do in different situations; eg, what it would have done before this change, or what it would do with an exponentially weighted average.