### PR TITLE
Pass commit to debItestUpload so we upload the same version we test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ ircMsgResult(CHANNELS) {
 
     // Runs `make itest_${version}` and attempts to upload to apt server if not an automatically timed run
     // This will automatically break all the steps into stages for you
-    debItestUpload(PACKAGE_NAME, DIST)
+    debItestUpload(PACKAGE_NAME, DIST, committish: commit)
 
     ystage('Upload to PyPi') {
         node {


### PR DESCRIPTION
Without this, debItestUpload clones master when it begins, which may have changed since the build started.