### PR TITLE
Don't record current load to ZK when task data is insufficient, becau…

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -145,6 +145,7 @@ def proportional_decision_policy(
     setpoint,
     utilization,
     num_healthy_instances,
+    persist_data: bool,
     noop=False,
     offset=0.0,
     forecast_policy="current",
@@ -182,7 +183,8 @@ def proportional_decision_policy(
 
     historical_load = fetch_historical_load(zk_path_prefix=zookeeper_path)
     historical_load.append((time.time(), current_load))
-    save_historical_load(historical_load, zk_path_prefix=zookeeper_path)
+    if persist_data:
+        save_historical_load(historical_load, zk_path_prefix=zookeeper_path)
 
     predicted_load = forecast_policy_func(historical_load, **kwargs)
 
@@ -539,6 +541,7 @@ def get_autoscaling_info(apps_with_clients, service_config):
                 current_instances=service_config.get_instances(),
                 marathon_service_config=service_config,
                 num_healthy_instances=len(marathon_tasks),
+                persist_data=False,
             )
         except MetricsProviderNoDataError:
             utilization = None
@@ -560,6 +563,7 @@ def get_new_instance_count(
     current_instances,
     marathon_service_config,
     num_healthy_instances,
+    persist_data: bool,
 ):
     autoscaling_decision_policy = get_decision_policy(
         autoscaling_params[DECISION_POLICY_KEY]
@@ -575,6 +579,7 @@ def get_new_instance_count(
         current_instances=current_instances,
         zookeeper_path=zookeeper_path,
         num_healthy_instances=num_healthy_instances,
+        persist_data=persist_data,
         **autoscaling_params,
     )
 
@@ -664,6 +669,7 @@ def autoscale_marathon_instance(
                 current_instances=current_instances,
                 marathon_service_config=marathon_service_config,
                 num_healthy_instances=num_healthy_instances,
+                persist_data=(not task_data_insufficient),
             )
             safe_downscaling_threshold = int(current_instances * 0.7)
             _record_autoscaling_decision(

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -1390,6 +1390,7 @@ def test_get_new_instance_count():
             current_instances=4,
             marathon_service_config=mock_marathon_service_config,
             num_healthy_instances=4,
+            persist_data=False,
         )
         assert mock_decision_policy.called_with(
             error=0.1,
@@ -1416,6 +1417,7 @@ def test_get_new_instance_count():
             current_instances=10,
             marathon_service_config=mock_marathon_service_config,
             num_healthy_instances=10,
+            persist_data=False,
         )
         mock_marathon_service_config.limit_instance_count.assert_called_with(7)
 
@@ -1490,6 +1492,7 @@ def test_get_autoscaling_info():
             current_instances=4,
             marathon_service_config=mock_service_config,
             num_healthy_instances=1,
+            persist_data=False,
         )
         expected = autoscaling_service_lib.ServiceAutoscalingInfo(
             current_instances=4,
@@ -1560,17 +1563,11 @@ def test_serialize_historical_load_trims_oldest_data():
 
 
 @mock.patch(
-    "paasta_tools.autoscaling.autoscaling_service_lib.save_historical_load",
-    autospec=True,
-)
-@mock.patch(
     "paasta_tools.autoscaling.autoscaling_service_lib.fetch_historical_load",
     autospec=True,
     return_value=[],
 )
-def test_proportional_decision_policy(
-    mock_save_historical_load, mock_fetch_historical_load
-):
+def test_proportional_decision_policy(mock_fetch_historical_load):
 
     common_kwargs = {
         "zookeeper_path": "/test",
@@ -1579,6 +1576,7 @@ def test_proportional_decision_policy(
         "max_instances": 15,
         "num_healthy_instances": 10,
         "forecast_policy": "current",
+        "persist_data": False,
     }
 
     # if utilization == setpoint, delta should be 0.
@@ -1618,17 +1616,11 @@ def test_proportional_decision_policy(
 
 
 @mock.patch(
-    "paasta_tools.autoscaling.autoscaling_service_lib.save_historical_load",
-    autospec=True,
-)
-@mock.patch(
     "paasta_tools.autoscaling.autoscaling_service_lib.fetch_historical_load",
     autospec=True,
     return_value=[],
 )
-def test_proportional_decision_policy_nonzero_offset(
-    mock_save_historical_load, mock_fetch_historical_load
-):
+def test_proportional_decision_policy_nonzero_offset(mock_fetch_historical_load):
     common_kwargs = {
         "zookeeper_path": "/test",
         "current_instances": 10,
@@ -1637,6 +1629,7 @@ def test_proportional_decision_policy_nonzero_offset(
         "max_instances": 15,
         "forecast_policy": "current",
         "offset": 0.2,
+        "persist_data": False,
     }
 
     # if utilization == setpoint, delta should be 0.
@@ -1680,17 +1673,11 @@ def test_proportional_decision_policy_nonzero_offset(
 
 
 @mock.patch(
-    "paasta_tools.autoscaling.autoscaling_service_lib.save_historical_load",
-    autospec=True,
-)
-@mock.patch(
     "paasta_tools.autoscaling.autoscaling_service_lib.fetch_historical_load",
     autospec=True,
     return_value=[],
 )
-def test_proportional_decision_policy_good_enough(
-    mock_save_historical_load, mock_fetch_historical_load
-):
+def test_proportional_decision_policy_good_enough(mock_fetch_historical_load):
     assert 0 == autoscaling_service_lib.proportional_decision_policy(
         zookeeper_path="/test",
         current_instances=100,
@@ -1702,6 +1689,7 @@ def test_proportional_decision_policy_good_enough(
         setpoint=0.50,
         utilization=0.54,
         good_enough_window=(0.45, 0.55),
+        persist_data=False,
     )
 
     assert 0 == autoscaling_service_lib.proportional_decision_policy(
@@ -1715,6 +1703,7 @@ def test_proportional_decision_policy_good_enough(
         setpoint=0.50,
         utilization=0.46,
         good_enough_window=(0.45, 0.55),
+        persist_data=False,
     )
 
 


### PR DESCRIPTION
…se we're probably underestimating it.