### PR TITLE
Don't consider task data insufficient if there are too many tasks.

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -632,13 +632,7 @@ def get_utilization(
 def is_task_data_insufficient(
     marathon_service_config, marathon_tasks, current_instances
 ):
-    too_many_instances_running = len(marathon_tasks) > int(
-        (1 + MAX_TASK_DELTA) * current_instances
-    )
-    too_few_instances_running = len(marathon_tasks) < int(
-        (1 - MAX_TASK_DELTA) * current_instances
-    )
-    return too_many_instances_running or too_few_instances_running
+    return len(marathon_tasks) < int((1 - MAX_TASK_DELTA) * current_instances)
 
 
 def autoscale_marathon_instance(

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -821,14 +821,6 @@ def test_is_task_data_insufficient():
     )
     assert ret
 
-    # Test more instances above threshold
-    ret = autoscaling_service_lib.is_task_data_insufficient(
-        fake_marathon_service_config,
-        [mock.Mock()] * (int(10 * (1 + MAX_TASK_DELTA)) + 1),
-        10,
-    )
-    assert ret
-
     # Test more instances below threshold
     ret = autoscaling_service_lib.is_task_data_insufficient(
         fake_marathon_service_config,
@@ -844,14 +836,6 @@ def test_is_task_data_insufficient():
         10,
     )
     assert ret
-
-    # Test fewer above threshold
-    ret = autoscaling_service_lib.is_task_data_insufficient(
-        fake_marathon_service_config,
-        [mock.Mock()] * (int(10 * (1 - MAX_TASK_DELTA)) + 1),
-        10,
-    )
-    assert not ret
 
 
 def test_autoscale_marathon_instance_aborts_when_wrong_number_tasks():


### PR DESCRIPTION
The autoscaler can complain about task_data_insufficient in situations where we have _too many_ tasks.

I'm not exactly sure how apps are getting into this situation, but I think it can happen if the autoscaler runs but SMJ doesn't actually adjust a marathon app downwards. It may also happen during bounces?

In any case, I think it's unnecessary to protect against this. It's also causing false alarms on our `Paasta autoscaler daytime not scaling` alert.