### PR TITLE
Add Flink metadata to paasta_tools API

### DIFF
--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -646,9 +646,12 @@
                     "properties": {
                         "status": {
                             "$ref": "#/definitions/InstanceStatusFlink"
+                        },
+                        "metadata": {
+                            "$ref": "#/definitions/InstanceMetadataFlink"
                         }
                     },
-                    "description": "Nullable Flink instance status"
+                    "description": "Nullable Flink instance status and metadata"
                 }
             }
         },
@@ -1190,6 +1193,10 @@
         "InstanceStatusFlink": {
             "type": "object",
             "description": "Flink instance status"
+        },
+        "InstanceMetadataFlink": {
+            "type": "object",
+            "description": "Flink instance metadata"
         },
         "InstanceTasks": {
             "type": "array",

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -161,7 +161,7 @@ def flink_instance_status(
     status: Optional[Mapping[str, Any]] = None
     client = settings.kubernetes_client
     if client is not None:
-        status = flink_tools.get_flink_config(
+        status = flink_tools.get_flink_status(
             kube_client=client, service=service, instance=instance
         )
     return status

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -183,6 +183,22 @@ def get_flink_status(
             raise
 
 
+def get_flink_metadata(
+    kube_client: KubeClient, service: str, instance: str
+) -> Optional[Mapping[str, Any]]:
+    try:
+        co = kube_client.custom.get_namespaced_custom_object(
+            **flink_custom_object_id(service, instance)
+        )
+        metadata = co.get("metadata")
+        return metadata
+    except ApiException as e:
+        if e.status == 404:
+            return None
+        else:
+            raise
+
+
 def set_flink_desired_state(
     kube_client: KubeClient, service: str, instance: str, desired_state: str
 ) -> str:

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -167,7 +167,7 @@ def flink_custom_object_id(service: str, instance: str) -> Mapping[str, str]:
     )
 
 
-def get_flink_config(
+def get_flink_status(
     kube_client: KubeClient, service: str, instance: str
 ) -> Optional[Mapping[str, Any]]:
     try:


### PR DESCRIPTION
This will expose metadata in API endpoint, hence allowing us to extend `paasta status` to show more useful information for Flink instances.

A separate pull request to use this metadata in `paasta status` yet to come.