### PR TITLE
Bumped to the latest version of the k8s client

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -19,6 +19,7 @@ graphviz
 gunicorn
 humanize >= 0.5.1
 inotify >= 0.2.8
+ipaddress >= 1.0.22
 isodate >= 0.5.0
 jsonschema[format]
 kazoo >= 2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ jmespath==0.9.3
 jsonref==0.1
 jsonschema==2.5.1
 kazoo==2.4.0
-kubernetes==6.0.0
+kubernetes==10.0.1
 manhole==1.5.0
 marathon==0.9.3
 MarkupSafe==1.0

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -53,6 +53,10 @@ def test_main_no_marathon_servers():
         "paasta_tools.paasta_metastatus.get_mesos_leader",
         autospec=True,
         return_value="localhost",
+    ), patch(
+        "paasta_tools.paasta_metastatus.is_kubernetes_available",
+        autospec=True,
+        return_value=False,
     ):
         fake_master = Mock(autospace=True)
         fake_master.state.return_value = {}
@@ -92,6 +96,10 @@ def test_main_no_chronos_config():
         "paasta_tools.paasta_metastatus.get_mesos_leader",
         autospec=True,
         return_value="localhost",
+    ), patch(
+        "paasta_tools.paasta_metastatus.is_kubernetes_available",
+        autospec=True,
+        return_value=False,
     ):
         fake_master = Mock(autospace=True)
         fake_master.state.return_value = {}


### PR DESCRIPTION
Not sure how to fully test this.
metastatus tests were trying to connect kubestage, so I mocked them out.
Upgrading for good measure, but also to remove a YAML loading warning.