### PR TITLE
Change mesos api read timeout from 1s to 2s

### DIFF
--- a/paasta_tools/mesos_maintenance.py
+++ b/paasta_tools/mesos_maintenance.py
@@ -64,7 +64,7 @@ def base_api():
     """
     leader = get_mesos_leader()
 
-    def execute_request(method, endpoint, timeout=(3, 1), **kwargs):
+    def execute_request(method, endpoint, timeout=(3, 2), **kwargs):
         url = "http://%s:%d%s" % (leader, MESOS_MASTER_PORT, endpoint)
         s = Session()
         s.auth = (get_principal(), get_secret())


### PR DESCRIPTION
### Description
We are hammering the Mesos API and sometimes it times out, preventing things like maintenance clean ups from happening. To alleviate this problem, I have bumped the default read timeout for the Mesos API from 1s to 2s.

### Testing done
`make test`