### PR TITLE
Stop async_ttl_cache from caching failures

### DIFF
--- a/paasta_tools/async_utils.py
+++ b/paasta_tools/async_utils.py
@@ -17,8 +17,13 @@ from typing import TypeVar
 T = TypeVar("T")
 
 
+# NOTE: this method is not thread-safe due to lack of locking while checking
+# and updating the cache
 def async_ttl_cache(
-    ttl: Optional[float] = 300, cleanup_self: bool = False
+    ttl: Optional[float] = 300,
+    cleanup_self: bool = False,
+    *,
+    cache: Optional[Dict] = None,
 ) -> Callable[
     [Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]  # wrapped  # inner
 ]:
@@ -32,21 +37,31 @@ def async_ttl_cache(
             future = asyncio.ensure_future(async_func(*args, **kwargs))
             # set the timestamp to +infinity so that we always wait on the in-flight request.
             cache[key] = (future, float("Inf"))
-        value = await future
-        cache[key] = (future, time.time())
-        return value
+
+        try:
+            value = await future
+        except Exception:
+            # only update the cache if it's the same future we awaited and
+            # it hasn't already been updated by another coroutine
+            if cache[key] == (future, float("Inf")):
+                del cache[key]
+            raise
+        else:
+            if cache[key] == (future, float("Inf")):
+                cache[key] = (future, time.time())
+            return value
 
     if cleanup_self:
-        cache: DefaultDict[Any, Dict] = defaultdict(dict)
+        instance_caches: DefaultDict[Any, Dict] = defaultdict(dict)
 
         def on_delete(w):
-            del cache[w]
+            del instance_caches[w]
 
         def outer(wrapped):
             @functools.wraps(wrapped)
             async def inner(self, *args, **kwargs):
                 w = weakref.ref(self, on_delete)
-                self_cache = cache[w]
+                self_cache = instance_caches[w]
                 return await call_or_get_from_cache(
                     self_cache, wrapped, (self,) + args, kwargs
                 )
@@ -54,7 +69,7 @@ def async_ttl_cache(
             return inner
 
     else:
-        cache2: Dict = {}  # Should be Dict[Any, T] but that doesn't work.
+        cache2: Dict = cache or {}  # Should be Dict[Any, T] but that doesn't work.
 
         def outer(wrapped):
             @functools.wraps(wrapped)

--- a/paasta_tools/async_utils.py
+++ b/paasta_tools/async_utils.py
@@ -10,6 +10,7 @@ from typing import Callable
 from typing import DefaultDict
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import TypeVar
 
 
@@ -17,7 +18,7 @@ T = TypeVar("T")
 
 
 def async_ttl_cache(
-    ttl: float = 300, cleanup_self: bool = False
+    ttl: Optional[float] = 300, cleanup_self: bool = False
 ) -> Callable[
     [Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]  # wrapped  # inner
 ]:
@@ -25,7 +26,7 @@ def async_ttl_cache(
         key = functools._make_key(args, kwargs, typed=False)
         try:
             future, last_update = cache[key]
-            if ttl > 0 and time.time() - last_update > ttl:
+            if ttl is not None and time.time() - last_update > ttl:
                 raise KeyError
         except KeyError:
             future = asyncio.ensure_future(async_func(*args, **kwargs))

--- a/paasta_tools/mesos/master.py
+++ b/paasta_tools/mesos/master.py
@@ -218,7 +218,7 @@ class MesosMaster:
     async def state_summary(self) -> MesosState:
         return await (await self.fetch("/master/state-summary")).json()
 
-    @async_ttl_cache(ttl=0, cleanup_self=True)
+    @async_ttl_cache(ttl=None, cleanup_self=True)
     async def slave(self, fltr):
         lst = await self.slaves(fltr)
 

--- a/tests/test_async_utils.py
+++ b/tests/test_async_utils.py
@@ -1,0 +1,128 @@
+import asyncio
+import functools
+
+import mock
+import pytest
+
+from paasta_tools.async_utils import async_ttl_cache
+
+
+@pytest.mark.asyncio
+async def test_async_ttl_cache_hit():
+    return_values = iter(range(10))
+
+    @async_ttl_cache(ttl=None)
+    async def range_coroutine():
+        return next(return_values)
+
+    assert await range_coroutine() == await range_coroutine()
+
+
+@pytest.mark.asyncio
+async def test_async_ttl_cache_miss():
+    return_values = iter(range(10))
+
+    @async_ttl_cache(ttl=0)
+    async def range_coroutine():
+        return next(return_values)
+
+    assert await range_coroutine() != await range_coroutine()
+
+
+@pytest.mark.asyncio
+async def test_async_ttl_cache_doesnt_cache_failures():
+    flaky_error_raiser = mock.Mock(side_effect=[Exception, None])
+
+    @async_ttl_cache(ttl=None)
+    async def flaky_coroutine():
+        return flaky_error_raiser()
+
+    with pytest.raises(Exception):
+        await flaky_coroutine()
+
+    # if we were caching failures, this would fail
+    assert await flaky_coroutine() is None
+
+
+@pytest.mark.asyncio
+async def test_async_ttl_cache_returns_in_flight_future():
+    return_values = iter(range(10))
+    condition = asyncio.Condition()
+    event = asyncio.Event()
+
+    class WaitingCoroutines:
+        count = 0
+
+    # Wait until we have enough coroutines waiting to return a result.  This
+    # ensures that dependent coroutines have a chance to get a future out of
+    # the cache
+    @async_ttl_cache(ttl=0)
+    async def range_coroutine():
+        await event.wait()
+        return next(return_values)
+
+    # Wait until we have enough coroutines waiting on range_coroutine, then
+    # wake range_coroutine
+    async def event_setter():
+        async with condition:
+            while WaitingCoroutines.count != 2:
+                await condition.wait()
+            event.set()
+
+    # Keep track of how many waiting range_coroutines we have to ensure both
+    # have had a chance to get the in-flight future out of the cache.  This has
+    # to be separate from range_coroutine since we only end up with one
+    # invocation of that method due to caching.  It also has to be separate
+    # from event_setter to ensure that the event is not set until both
+    # coroutines are waiting.
+    async def cache_waiter():
+        async with condition:
+            WaitingCoroutines.count += 1
+            condition.notify_all()
+        return await range_coroutine()
+
+    event_setter_future = asyncio.ensure_future(event_setter())
+    future1 = asyncio.ensure_future(cache_waiter())
+    future2 = asyncio.ensure_future(cache_waiter())
+    await asyncio.wait([event_setter_future, future1, future2])
+
+    assert future1.result() == future2.result() == 0
+
+
+@pytest.mark.asyncio
+async def test_async_ttl_cache_dont_overwrite_new_cache_entry():
+    """Make sure that we don't overwrite a new cache entry that was placed
+    while we were waiting to handle the result of a previously cached future
+    """
+    range_continue_event = asyncio.Event()
+    update_cache_event = asyncio.Event()
+    return_values = iter(range(10))
+
+    # Wait until awaiter has had a chance to get the in-flight future out of
+    # the cache, then signal to the cache_updater to replace the cached future
+    # before returning.  Because cache_updater is signalled first, it will
+    # replace the previously cached future before async_ttl_cache decides
+    # whether save the result of that future in the cache
+    async def range_coroutine():
+        await range_continue_event.wait()
+        update_cache_event.set()
+        return next(return_values)
+
+    range_coroutine_future = asyncio.ensure_future(range_coroutine())
+    cache_key = functools._make_key((), {}, typed=False)
+    cache = {cache_key: (range_coroutine_future, float("Inf"))}
+
+    cached_range_coroutine = async_ttl_cache(cache=cache, ttl=0)(range_coroutine)
+
+    new_range_coroutine_future = asyncio.ensure_future(range_coroutine())
+
+    async def awaiter():
+        range_continue_event.set()
+        await cached_range_coroutine()
+
+    async def cache_updater():
+        await update_cache_event.wait()
+        cache[cache_key] = (new_range_coroutine_future, float("Inf"))
+
+    await asyncio.gather(awaiter(), cache_updater())
+    assert cache[cache_key] == (new_range_coroutine_future, float("Inf"))


### PR DESCRIPTION
Currently if the future raises an exception, we store that in the cache, and we never end up executing the logic that changes its `last_update` timestamp back to something other than `float("Inf")`.  This makes sure that we remove the cache entry on exception.

This also handles a subtle race condition where two coroutines get the same in-flight future out of the cache, and one of them returns long before the other.  The first to return will either set the `last_update` timestamp on the entry so that it eventually expires, or, if the future raised an exception, it will delete the cache entry.  It's possible that, before the second coroutine gets to run again, a third coroutine will run the cached method and insert a new in-flight coroutine into the cache.  If the second coroutine gets control again, it shouldn't alter the cache since its context is long out of date.  I am pretty sure my code fixes this, but I can't for the life of me figure out how to test that case very easily.  The test to make sure we share in-flight requests involves pretty complex asyncio synchronization primitives as it is :-/