### PR TITLE
Show config SHA from Flink metadata

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -246,8 +246,10 @@ def paasta_status_on_api_endpoint(
             cluster, service, instance, output, status.adhoc, verbose
         )
     elif status.flink is not None:
+        flink_status = status.flink.get("status")
+        flink_metadata = status.flink.get("metadata")
         return print_flink_status(
-            cluster, service, instance, output, status.flink.get("status"), verbose
+            cluster, service, instance, output, flink_status, flink_metadata, verbose
         )
     elif status.chronos is not None:
         return print_chronos_status(output, status.chronos.output)
@@ -713,12 +715,36 @@ def status_kubernetes_job_human(
         )
 
 
+def _strip_config_prefix(config_sha: str) -> str:
+    prefix = "config"
+    prefix_len = len(prefix)
+    if len(config_sha) > prefix_len and config_sha[:prefix_len] == prefix:
+        return config_sha[prefix_len:]
+    return config_sha
+
+
 def print_flink_status(
-    cluster: str, service: str, instance: str, output: List[str], status, verbose: int
+    cluster: str,
+    service: str,
+    instance: str,
+    output: List[str],
+    status,
+    metadata,
+    verbose: int,
 ) -> int:
     if status is None:
         output.append(PaastaColors.red("    Flink cluster is not available yet"))
         return 1
+
+    config_sha = None
+    if metadata is not None and metadata.labels is not None:
+        config_sha = metadata.labels.get("yelp.com/paasta_config_sha")
+        if config_sha is not None:
+            config_sha = _strip_config_prefix(config_sha)
+
+    # Since metadata should be available no matter the state, we show it before state
+    if config_sha is not None:
+        output.append(f"    Config SHA: {config_sha}")
 
     if status.state != "running":
         output.append(

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -727,15 +727,15 @@ def print_flink_status(
         output.append(PaastaColors.red("    Flink cluster is not available yet"))
         return 1
 
+    # Since metadata should be available no matter the state, we show it first. If this errors out
+    # then we cannot really do much to recover, because cluster is not in usable state anyway
     metadata = flink.get("metadata")
-    config_sha = None
-    if metadata and metadata.labels:
-        config_sha = metadata.labels.get("yelp.com/paasta_config_sha")
-        if config_sha and config_sha.startswith("config"):
-            config_sha = config_sha[6:]
+    config_sha = metadata.labels.get("yelp.com/paasta_config_sha")
+    if config_sha is None:
+        raise ValueError(f"expected config sha on Flink, but received {metadata}")
+    if config_sha.startswith("config"):
+        config_sha = config_sha[6:]
 
-    # Since metadata should be available no matter the state, we show it before state
-    config_sha = config_sha or "(unknown)"
     output.append(f"    Config SHA: {config_sha}")
 
     if status.state != "running":


### PR DESCRIPTION
Show config SHA from metadata, for Flink clusters only

It is conceivable that in the future we could extend this to show more data, or handle metadata for other types of clusters (if API is extended as well). At this moment we only have demand for config SHA in Flink,  though.