### PR TITLE
Make tests produce more output

### DIFF
--- a/yelp_package/dockerfiles/bionic/Dockerfile
+++ b/yelp_package/dockerfiles/bionic/Dockerfile
@@ -19,11 +19,11 @@ RUN apt-get update && apt-get install -yq gnupg2
 #     apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
 
 # Need Python 3.6
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa
 
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         debhelper \
@@ -38,7 +38,7 @@ RUN apt-get update > /dev/null && \
         python-pip \
         python-tox \
         wget \
-        zsh > /dev/null \
+        zsh \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp && \

--- a/yelp_package/dockerfiles/gitremote/Dockerfile
+++ b/yelp_package/dockerfiles/gitremote/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:xenial
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         git \
-        openssh-server > /dev/null && \
+        openssh-server && \
     apt-get clean
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 RUN mkdir /var/run/sshd

--- a/yelp_package/dockerfiles/itest/api/Dockerfile
+++ b/yelp_package/dockerfiles/itest/api/Dockerfile
@@ -15,11 +15,11 @@
 FROM ubuntu:xenial
 
 # Need Python 3.6
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa
 
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         git \
@@ -27,8 +27,8 @@ RUN apt-get update > /dev/null && \
         libffi-dev \
         libssl-dev \
         libyaml-dev \
-        virtualenv > /dev/null \
-    && apt-get clean > /dev/null
+        virtualenv \
+    && apt-get clean
 
 WORKDIR /work
 

--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -14,20 +14,20 @@
 
 FROM ubuntu:xenial
 
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
-        software-properties-common > /dev/null && \
+        software-properties-common && \
     echo "deb https://dl.bintray.com/yelp/paasta xenial main" > /etc/apt/sources.list.d/paasta.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv 8756C4F765C9AC3CB6B85D62379CE192D401AB61 && \
     echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF && \
-    apt-get update > /dev/null && \
+    apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        libsasl2-modules mesos=1.7.2-2.0.1 > /dev/null && \
+        libsasl2-modules mesos=1.7.2-2.0.1 && \
     apt-get clean
 
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install \
         -y --no-install-recommends --allow-unauthenticated \
         lsb-release \

--- a/yelp_package/dockerfiles/itest/hacheck/Dockerfile
+++ b/yelp_package/dockerfiles/itest/hacheck/Dockerfile
@@ -14,12 +14,12 @@
 
 FROM ubuntu:xenial
 
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
         git \
         python2.7-dev \
         libyaml-dev \
-        virtualenv > /dev/null && \
+        virtualenv && \
     apt-get clean
 
 RUN git clone git://github.com/Yelp/hacheck

--- a/yelp_package/dockerfiles/itest/httpdrain/Dockerfile
+++ b/yelp_package/dockerfiles/itest/httpdrain/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic
 
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         python3 \
         python3-pip

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -14,20 +14,20 @@
 
 FROM ubuntu:xenial
 
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
-        software-properties-common > /dev/null && \
+        software-properties-common && \
     echo "deb https://dl.bintray.com/yelp/paasta xenial main" > /etc/apt/sources.list.d/paasta.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv 8756C4F765C9AC3CB6B85D62379CE192D401AB61 && \
     echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF && \
-    apt-get update > /dev/null && \
+    apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        libsasl2-modules mesos=1.7.2-2.0.1 > /dev/null && \
+        libsasl2-modules mesos=1.7.2-2.0.1 && \
     apt-get clean
 
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         lsb-release \
         marathon=1.4.11-1.0.676.ubuntu1604 \

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -16,7 +16,7 @@ FROM ubuntu:xenial
 
 # Install packages to allow apt to use a repository over HTTPS
 # https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#xenial-1604
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         apt-transport-https \
         ca-certificates \
@@ -33,13 +33,13 @@ RUN echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv 9DC858229FC7DD38854AE2D88D81803C0EBFCD88 && \
-    apt-get update > /dev/null && \
+    apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         docker-ce=17.03.2~ce-0~ubuntu-xenial \
         libsasl2-modules \
         build-essential \
         sudo \
-        mesos=1.7.2-2.0.1 > /dev/null && \
+        mesos=1.7.2-2.0.1 && \
     rm -rf /var/lib/apt/lists/*
 
 # mesos detects systemd and tries to use it, so let remove it

--- a/yelp_package/dockerfiles/itest/zookeeper/Dockerfile
+++ b/yelp_package/dockerfiles/itest/zookeeper/Dockerfile
@@ -14,9 +14,9 @@
 
 FROM ubuntu:xenial
 
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-         zookeeper > /dev/null && \
+         zookeeper && \
     apt-get clean
 
 EXPOSE 2181

--- a/yelp_package/dockerfiles/mesos-paasta/Dockerfile
+++ b/yelp_package/dockerfiles/mesos-paasta/Dockerfile
@@ -1,13 +1,13 @@
 FROM examplecluster_mesosbase
 
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libffi-dev \
         libssl-dev \
         libyaml-dev \
         python-pip \
         python3.6-dev \
-        openssh-server > /dev/null && \
+        openssh-server && \
     apt-get clean
 
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd

--- a/yelp_package/dockerfiles/playground/Dockerfile
+++ b/yelp_package/dockerfiles/playground/Dockerfile
@@ -1,12 +1,12 @@
 FROM examplecluster_itest_xenial
 
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         curl \
         docker.io \
         jq \
         openssh-server \
-        vim > /dev/null && \
+        vim && \
     apt-get clean
 
 RUN mkdir -p /var/log/paasta_logs /var/run/sshd /nail/etc

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -18,11 +18,11 @@ RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources
     apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
 
 # Need Python 3.6
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa
 
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         debhelper \
@@ -35,7 +35,7 @@ RUN apt-get update > /dev/null && \
         python3.6-dev \
         python-pip \
         wget \
-        zsh > /dev/null \
+        zsh \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && cd /tmp && \

--- a/yelp_package/dockerfiles/xenial/Dockerfile
+++ b/yelp_package/dockerfiles/xenial/Dockerfile
@@ -18,11 +18,11 @@ RUN echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources
     apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
 
 # Need Python 3.6
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa
 
-RUN apt-get update > /dev/null && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         debhelper \
@@ -36,7 +36,7 @@ RUN apt-get update > /dev/null && \
         python-pip \
         python-tox \
         wget \
-        zsh > /dev/null \
+        zsh \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp && \


### PR DESCRIPTION
Travis fails a build/test run if there is no output for more than 10
minutes from it.  In the case of slow network and many packages to
process, `apt-get update/install` could easily take more than 10
minutes.  Since we redirect the output from `apt-get` in our test runs
into `/dev/null`, Travis could terminate out runs in such case.

On the other hand, having the output from `apt-get` run may be useful.

So, let stop redirecting the output from `apt-get` into `/dev/null`