### PR TITLE
Pass commit to debItestUpload so we upload the same version that we've tested.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,11 @@ ircMsgResult(CHANNELS) {
 
     // Runs `make itest_${version}` and attempts to upload to apt server if not an automatically timed run
     // This will automatically break all the steps into stages for you
-    debItestUpload(PACKAGE_NAME, DIST)
+    debItestUpload(
+        repo: PACKAGE_NAME,
+        versions: DIST,
+        committish: commit,
+    )
 
     ystage('Upload to PyPi') {
         node {


### PR DESCRIPTION


This is take 2; take 1 was 7ff3d0432, which was reverted in 9b9233713
because debItestUpload didn't support keyword arguments. Releng has
since fixed this.