### PR TITLE
treat tasks that are old with missing healthchecks as happy

### DIFF
--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -301,9 +301,10 @@ def get_happy_tasks(
             continue
 
         # if there are health check results, check if at least one healthcheck is passing
+        # BUT if the task is "old" and Marathon forgot about its healthcheck, treat it as happy
         if not marathon_tools.is_task_healthy(
             task, require_all=False, default_healthy=True
-        ):
+        ) and not marathon_tools.is_old_task_missing_healthchecks(task, app):
             continue
 
         happy.append(task)

--- a/tests/test_bounce_lib.py
+++ b/tests/test_bounce_lib.py
@@ -268,6 +268,21 @@ class TestBounceLib:
         expected = tasks[-1:]
         assert actual == expected
 
+    def test_get_happy_tasks_when_some_old_and_unknown(self):
+        """Only tasks with a passing healthcheck should be happy"""
+        fake_successful_healthcheck_results = [mock.Mock(alive=True)]
+        tasks = [
+            mock.Mock(health_check_results=None, started_at=0),
+            mock.Mock(health_check_results=fake_successful_healthcheck_results),
+            mock.Mock(health_check_results=fake_successful_healthcheck_results),
+        ]
+        fake_app = mock.Mock(tasks=tasks, health_checks=[])
+        actual = bounce_lib.get_happy_tasks(
+            fake_app, "service", "namespace", self.fake_system_paasta_config()
+        )
+        expected = tasks
+        assert actual == expected
+
     def test_get_happy_tasks_with_multiple_healthchecks_success(self):
         """All tasks with at least one passing healthcheck should be happy"""
         fake_successful_healthcheck_results = [


### PR DESCRIPTION
We *think* this should be relatively non-disruptive and will cause us to not treat really-long-running services which Marathon has lost healthcheck state for as "unhappy".