### PR TITLE
Use common docker images to greatly speed up itest/builds

### DIFF
--- a/general_itests/fake_simple_service/Dockerfile
+++ b/general_itests/fake_simple_service/Dockerfile
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
+FROM yelp/paastatools_xenial_container

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -32,21 +32,11 @@ else
 	ADD_VERSION_SUFFIX=dch -b -v $(ACTUAL_PACKAGE_VERSION) --force-distribution --distribution $* --changelog ../debian/changelog 'Build for $*'
 endif
 
-build_%_docker:
-	[ -d ../dist ] || mkdir ../dist
-	docker pull "yelp/paastatools_$*_container" || true
-	cd dockerfiles/$*/ && docker build -t "yelp/paastatools_$*_container" .
-	if [ "$$TRAVIS_BRANCH" = "master" -a \
-	     "$$TRAVIS_PULL_REQUEST" = "false" -a \
-	     "$$DOCKER_USERNAME" != "" ]; then \
-	  docker push "yelp/paastatools_$*_container"; \
-	fi
-
 .SECONDEXPANSION:
 itest_%: package_$$* bintray_$$*
 	$(DOCKER_RUN) /work/yelp_package/itest/ubuntu.sh paasta-tools_$(ACTUAL_PACKAGE_VERSION)_amd64.deb
 
-package_%: build_$$*_docker
+package_%:
 	# Copy these files to .old before maybe clobbering them
 	cp ../requirements.txt ../requirements.txt.old
 	cp ../debian/changelog ../debian/changelog.old

--- a/yelp_package/dockerfiles/gitremote/Dockerfile
+++ b/yelp_package/dockerfiles/gitremote/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM yelp/paastatools_xenial_container
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         git \

--- a/yelp_package/dockerfiles/itest/api/Dockerfile
+++ b/yelp_package/dockerfiles/itest/api/Dockerfile
@@ -12,23 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
-
-# Need Python 3.6
-RUN apt-get update > /dev/null && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
-
-RUN apt-get update > /dev/null && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        gcc \
-        git \
-        python3.6-dev \
-        libffi-dev \
-        libssl-dev \
-        libyaml-dev \
-        virtualenv > /dev/null \
-    && apt-get clean > /dev/null
+FROM yelp/paastatools_xenial_container
 
 WORKDIR /work
 

--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -12,29 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
-
-RUN apt-get update > /dev/null && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        apt-transport-https \
-        software-properties-common > /dev/null && \
-    echo "deb https://dl.bintray.com/yelp/paasta xenial main" > /etc/apt/sources.list.d/paasta.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv 8756C4F765C9AC3CB6B85D62379CE192D401AB61 && \
-    echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF && \
-    apt-get update > /dev/null && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        libsasl2-modules mesos=1.7.2-2.0.1 > /dev/null && \
-    apt-get clean
-
-RUN apt-get update > /dev/null && \
-    DEBIAN_FRONTEND=noninteractive apt-get install \
-        -y --no-install-recommends --allow-unauthenticated \
-        lsb-release \
-        chronos=2.5.0-yelp32-1.ubuntu1604 \
-        rsyslog \
-        && \
-    apt-get clean
+FROM yelp/paastatools_xenial_container
 
 # Chronos will look in here for zk config, so we blow away the bogus defaults
 RUN rm -rf /etc/mesos/

--- a/yelp_package/dockerfiles/itest/hacheck/Dockerfile
+++ b/yelp_package/dockerfiles/itest/hacheck/Dockerfile
@@ -12,15 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
-
-RUN apt-get update > /dev/null && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        git \
-        python2.7-dev \
-        libyaml-dev \
-        virtualenv > /dev/null && \
-    apt-get clean
+FROM yelp/paastatools_xenial_container
 
 RUN git clone git://github.com/Yelp/hacheck
 WORKDIR /hacheck

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -12,27 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
-
-RUN apt-get update > /dev/null && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        apt-transport-https \
-        software-properties-common > /dev/null && \
-    echo "deb https://dl.bintray.com/yelp/paasta xenial main" > /etc/apt/sources.list.d/paasta.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv 8756C4F765C9AC3CB6B85D62379CE192D401AB61 && \
-    echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF && \
-    apt-get update > /dev/null && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        libsasl2-modules mesos=1.7.2-2.0.1 > /dev/null && \
-    apt-get clean
-
-RUN apt-get update > /dev/null && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        lsb-release \
-        marathon=1.4.11-1.0.676.ubuntu1604 \
-        && \
-    apt-get clean
+FROM yelp/paastatools_xenial_container
 
 RUN echo -n "secret2" > /etc/marathon_framework_secret
 

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -12,35 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
-
-# Install packages to allow apt to use a repository over HTTPS
-# https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#xenial-1604
-RUN apt-get update > /dev/null && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        apt-transport-https \
-        ca-certificates \
-        curl \
-        software-properties-common && \
-    rm -rf /var/lib/apt/lists/*
-
-
-# Need Python 3.6
-RUN add-apt-repository ppa:deadsnakes/ppa
-
-RUN echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
-    add-apt-repository ppa:ubuntu-toolchain-r/test && \
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv 9DC858229FC7DD38854AE2D88D81803C0EBFCD88 && \
-    apt-get update > /dev/null && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        docker-ce=17.03.2~ce-0~ubuntu-xenial \
-        libsasl2-modules \
-        build-essential \
-        sudo \
-        mesos=1.7.2-2.0.1 > /dev/null && \
-    rm -rf /var/lib/apt/lists/*
+FROM yelp/paastatools_xenial_container
 
 # mesos detects systemd and tries to use it, so let remove it
 RUN apt-get remove -y --allow-remove-essential systemd

--- a/yelp_package/dockerfiles/itest/zookeeper/Dockerfile
+++ b/yelp_package/dockerfiles/itest/zookeeper/Dockerfile
@@ -12,12 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
-
-RUN apt-get update > /dev/null && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-         zookeeper > /dev/null && \
-    apt-get clean
+FROM yelp/paastatools_xenial_container
 
 EXPOSE 2181
 CMD ["/usr/share/zookeeper/bin/zkServer.sh", "start-foreground"]

--- a/yelp_package/dockerfiles/paastatools_xenial_container/Dockerfile
+++ b/yelp_package/dockerfiles/paastatools_xenial_container/Dockerfile
@@ -1,0 +1,73 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:xenial
+
+# Install packages to allow apt to use a repository over HTTPS
+# https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#xenial-1604
+RUN apt-get update > /dev/null && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        software-properties-common && \
+    echo "deb https://dl.bintray.com/yelp/paasta xenial main" > /etc/apt/sources.list.d/paasta.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv 8756C4F765C9AC3CB6B85D62379CE192D401AB61 && \
+    echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF  && \
+    rm -rf /var/lib/apt/lists/*
+
+# Need Python 3.6
+RUN add-apt-repository ppa:deadsnakes/ppa
+
+# Build Deps
+RUN apt-get update > /dev/null && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        debhelper \
+        gdebi-core \
+        git \
+        libffi-dev \
+        libgpgme11 \
+        libssl-dev \
+        libyaml-dev \
+        python3.6-dev \
+        python-pip \
+        python-tox \
+        wget \
+        zsh > /dev/null \
+    && rm -rf /var/lib/apt/lists/*
+RUN cd /tmp && \
+    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
+    gdebi -n dh-virtualenv*.deb && \
+    rm dh-virtualenv_*.deb
+
+# Itest Deps
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv 9DC858229FC7DD38854AE2D88D81803C0EBFCD88 && \
+    apt-get update > /dev/null && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        libsasl2-modules \
+        build-essential \
+        sudo \
+        lsb-release \
+        docker-ce=17.03.2~ce-0~ubuntu-xenial \
+        mesos=1.7.2-2.0.1 \
+        chronos=2.5.0-yelp32-1.ubuntu1604 \
+        marathon=1.4.11-1.0.676.ubuntu1604 \
+        rsyslog \
+        python2.7-dev \
+        virtualenv \
+        zookeeper

--- a/yelp_package/dockerfiles/xenial/Dockerfile
+++ b/yelp_package/dockerfiles/xenial/Dockerfile
@@ -12,42 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
-
-RUN echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-
-# Need Python 3.6
-RUN apt-get update > /dev/null && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
-
-RUN apt-get update > /dev/null && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        build-essential \
-        debhelper \
-        gdebi-core \
-        git \
-        libffi-dev \
-        libgpgme11 \
-        libssl-dev \
-        libyaml-dev \
-        python3.6-dev \
-        python-pip \
-        python-tox \
-        wget \
-        zsh > /dev/null \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN cd /tmp && \
-    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
-    gdebi -n dh-virtualenv*.deb && \
-    rm dh-virtualenv_*.deb
+FROM yelp/paastatools_xenial_container
 
 ADD mesos-slave-secret /etc/mesos-slave-secret
 
 COPY requirements.txt requirements.txt
 RUN virtualenv --python=python3.6 venv && venv/bin/pip install -r requirements.txt
-
 
 WORKDIR /work


### PR DESCRIPTION
I'm not sure if this is actually a good idea or not. Here is the big change:

* Uses docker hub automated builds instead of having travis push
* Makes our biggest images use the common images

This will mean we need to do a kind of "two phase" push if we change the base image. I think that is ok due to how rare that is.

It also means things are a bit indirected, because you have to look in the base image to see what is inside. Eh?

It also means that the docker pulls are longer at first, but hopefully shorter in the long term than having to build all these images over and over via apt-get.


The end goal is to never (or have very few) apt-gets in our builds at all.