### PR TITLE
Use gce ubuntu mirrors for better apt-get performance

### DIFF
--- a/yelp_package/dockerfiles/bionic/Dockerfile
+++ b/yelp_package/dockerfiles/bionic/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM ubuntu:bionic
+RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
 RUN rm /etc/dpkg/dpkg.cfg.d/excludes
 RUN apt-get update && apt-get install -yq gnupg2
 # RUN echo "deb http://repos.mesosphere.com/ubuntu bionic main" > /etc/apt/sources.list.d/mesosphere.list && \

--- a/yelp_package/dockerfiles/gitremote/Dockerfile
+++ b/yelp_package/dockerfiles/gitremote/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:xenial
+RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         git \

--- a/yelp_package/dockerfiles/itest/api/Dockerfile
+++ b/yelp_package/dockerfiles/itest/api/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM ubuntu:xenial
+RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
 
 # Need Python 3.6
 RUN apt-get update > /dev/null && \

--- a/yelp_package/dockerfiles/itest/chronos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/chronos/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM ubuntu:xenial
+RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/yelp_package/dockerfiles/itest/hacheck/Dockerfile
+++ b/yelp_package/dockerfiles/itest/hacheck/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM ubuntu:xenial
+RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \

--- a/yelp_package/dockerfiles/itest/httpdrain/Dockerfile
+++ b/yelp_package/dockerfiles/itest/httpdrain/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:bionic
+RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM ubuntu:xenial
+RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM ubuntu:xenial
+RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
 
 # Install packages to allow apt to use a repository over HTTPS
 # https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#xenial-1604

--- a/yelp_package/dockerfiles/itest/zookeeper/Dockerfile
+++ b/yelp_package/dockerfiles/itest/zookeeper/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM ubuntu:xenial
+RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM ubuntu:trusty
+RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
 
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF

--- a/yelp_package/dockerfiles/xenial/Dockerfile
+++ b/yelp_package/dockerfiles/xenial/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM ubuntu:xenial
+RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
 
 RUN echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF


### PR DESCRIPTION
Different approach to improving build speed and avoiding timeouts.

Travis uses [us-east-1](https://github.com/travis-ci/terraform-config/blob/master/gce-production-2/main.tf) in gce, so just use their local mirror.