### PR TITLE
Show git sha for flink

### DIFF
--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -686,7 +686,7 @@ def instance_status(request):
         error_message = traceback.format_exc()
         raise ApiFailure(error_message, 500)
 
-    if instance_type != "flink" and instance_type != "tron":
+    if instance_type != "tron":
         try:
             actual_deployments = get_actual_deployments(service, settings.soa_dir)
         except Exception:


### PR DESCRIPTION
Removes obsolete condition which was preventing deployment `git sha` from being displayed by `paasta status` command. That condition was needed before we started properly building deplyments.json for flink containers and it no longer applies.