### PR TITLE
apply min/max instance clamps only when reading from zookeeper, not when writing

### DIFF
--- a/paasta_itests/paasta_deployd.feature
+++ b/paasta_itests/paasta_deployd.feature
@@ -74,7 +74,9 @@ Feature: paasta-deployd deploys apps
       And we set the instance count in zookeeper for service "test-service" instance "main" to 3
      Then we should see "test-service.main" listed in marathon after 45 seconds
      Then we should see the number of instances become 3
-     When we set the instance count in zookeeper for service "test-service" instance "main" to 4
+     # we are testing that even if the values written to ZK are outside the min/max bounds, the instances still get
+     # clamped to the right values.
+     When we set the instance count in zookeeper for service "test-service" instance "main" to 5
      Then we should see the number of instances become 4
 
   Scenario: deployd will scale down an app if the instance count changes in zk

--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -142,8 +142,6 @@ def threshold_decision_policy(current_instances, error, **kwargs):
 def proportional_decision_policy(
     zookeeper_path,
     current_instances,
-    min_instances,
-    max_instances,
     setpoint,
     utilization,
     num_healthy_instances,
@@ -210,11 +208,6 @@ def proportional_decision_policy(
         )
         if low <= predicted_load_per_instance_with_current_instances <= high:
             desired_number_instances = current_instances
-
-    if desired_number_instances < min_instances:
-        desired_number_instances = min_instances
-    if desired_number_instances > max_instances:
-        desired_number_instances = max_instances
 
     return (
         desired_number_instances - current_instances
@@ -594,8 +587,6 @@ def get_new_instance_count(
     autoscaling_amount = autoscaling_decision_policy(
         utilization=utilization,
         error=error,
-        min_instances=marathon_service_config.get_min_instances(),
-        max_instances=marathon_service_config.get_max_instances(),
         current_instances=current_instances,
         zookeeper_path=zookeeper_path,
         num_healthy_instances=num_healthy_instances,
@@ -725,6 +716,13 @@ def autoscale_marathon_instance(
                         ),
                         level="event",
                     )
+            else:
+                write_to_log(
+                    config=marathon_service_config,
+                    line="Staying at %d instances (%s)"
+                    % (current_instances, humanize_error(error)),
+                    level="debug",
+                )
     except LockHeldException:
         log.warning(
             "Skipping autoscaling run for {service}.{instance} because the lock is held".format(

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -241,7 +241,7 @@ class LongRunningServiceConfig(InstanceConfig):
     def get_min_instances(self) -> int:
         return self.config_dict.get("min_instances", 1)
 
-    def get_max_instances(self) -> int:
+    def get_max_instances(self) -> Optional[int]:
         return self.config_dict.get("max_instances", None)
 
     def get_desired_instances(self) -> int:

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -1736,21 +1736,6 @@ def test_proportional_decision_policy_moving_average(
         setpoint=0.7, utilization=0.8, **common_kwargs
     )
 
-    # current_instances < min_instances, so scale up.
-    assert 25 == autoscaling_service_lib.proportional_decision_policy(
-        zookeeper_path="/test",
-        current_instances=25,
-        num_healthy_instances=25,
-        min_instances=50,
-        max_instances=150,
-        forecast_policy="current",
-        offset=0.0,
-        setpoint=0.50,
-        utilization=0.46,
-        good_enough_window=(0.45, 0.55),
-        persist_data=False,
-    )
-
 
 def test_filter_autoscaling_tasks_considers_old_versions():
     marathon_apps = [


### PR DESCRIPTION
The last time I pushed this we tried to clamp in s-m-j, but @EvanKrall pointed out that we already clamp when we read values from ZK, so there's no need to try to do this logic again in s-m-j.  So this time we're _only_ removing the code that clamps when writing to ZK, which should solve the problems where we sometimes bottom out to min_instances even if there's load on the cluster.