### PR TITLE
Make service autoscaler consider tasks healthy if they are in smartstack, even if Marathon thinks they are unhealthy.

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -22,7 +22,9 @@ from contextlib import contextmanager
 from datetime import datetime
 from math import ceil
 from math import floor
+from typing import Dict
 from typing import Iterator
+from typing import List
 from typing import Mapping
 from typing import Optional
 from typing import Sequence
@@ -41,10 +43,12 @@ from marathon.models.app import MarathonTask
 from paasta_tools.autoscaling.forecasting import get_forecast_policy
 from paasta_tools.autoscaling.utils import get_autoscaling_component
 from paasta_tools.autoscaling.utils import register_autoscaling_component
+from paasta_tools.bounce_lib import filter_tasks_in_smartstack
 from paasta_tools.bounce_lib import LockHeldException
 from paasta_tools.bounce_lib import LockTimeout
 from paasta_tools.bounce_lib import ZK_LOCK_CONNECT_TIMEOUT_S
 from paasta_tools.long_running_service_tools import compose_autoscaling_zookeeper_root
+from paasta_tools.long_running_service_tools import load_service_namespace_config
 from paasta_tools.long_running_service_tools import set_instances_for_marathon_service
 from paasta_tools.long_running_service_tools import ZK_PAUSE_AUTOSCALE_PATH
 from paasta_tools.marathon_tools import AutoscalingParamsDict
@@ -538,6 +542,7 @@ def get_autoscaling_info(apps_with_clients, service_config):
                 [app for (app, client) in apps_with_clients],
                 all_mesos_tasks,
                 service_config,
+                system_paasta_config,
             )
             utilization = get_utilization(
                 marathon_service_config=service_config,
@@ -872,6 +877,7 @@ def autoscale_service_configs(
                     [app for (app, client) in apps_with_clients],
                     all_mesos_tasks,
                     config,
+                    system_paasta_config,
                 )
                 autoscale_marathon_instance(
                     config,
@@ -889,32 +895,65 @@ def filter_autoscaling_tasks(
     marathon_apps: Sequence[MarathonApp],
     all_mesos_tasks: Sequence[Task],
     config: MarathonServiceConfig,
+    system_paasta_config: SystemPaastaConfig,
 ) -> Tuple[Mapping[str, MarathonTask], Sequence[Task]]:
+    """Find the tasks that are serving traffic. We care about this because many tasks have a period of high CPU when
+    they first start up, during which they warm up code, load and process data, etc., and we don't want this high load
+    to drag our overall load estimate upwards. Allowing these tasks to count towards overall load could cause a cycle of
+    scaling up, seeing high load due to new warming-up containers, scaling up, until we hit max_instances.
+
+    However, accidentally omitting a task that actually is serving traffic will cause us to underestimate load; this is
+    generally much worse than overestimating, since it can cause us to incorrectly scale down or refuse to scale up when
+    necessary. For this reason, we look at several sources of health information, and if they disagree, assume the task
+    is serving traffic.
+    """
     job_id_prefix = "{}{}".format(
         format_job_id(service=config.service, instance=config.instance),
         MESOS_TASK_SPACER,
     )
 
-    # Get a dict of healthy tasks, we assume tasks with no healthcheck defined
-    # are healthy. We assume tasks with no healthcheck results but a defined
-    # healthcheck to be unhealthy (unless they are "old" in which case we
-    # assume that marathon has screwed up and stopped healthchecking but that
-    # they are healthy
+    # Get a dict of healthy tasks, we assume tasks with no healthcheck defined are healthy.
+    # We assume tasks with no healthcheck results but a defined healthcheck to be unhealthy, unless they are "old" in
+    # which case we assume that Marathon has screwed up and stopped healthchecking but that they are healthy.
+
     log.info("Inspecting %s for autoscaling" % job_id_prefix)
-    marathon_tasks = {}
-    for app in marathon_apps:
-        for task in app.tasks:
-            if task.id.startswith(job_id_prefix) and (
+
+    relevant_tasks_by_app: Dict[MarathonApp, List[MarathonTask]] = {
+        app: app.tasks for app in marathon_apps if app.id.startswith(job_id_prefix)
+    }
+
+    healthy_marathon_tasks: Dict[str, MarathonTask] = {}
+
+    for app, tasks in relevant_tasks_by_app.items():
+        for task in tasks:
+            if (
                 is_task_healthy(task)
                 or not app.health_checks
                 or is_old_task_missing_healthchecks(task, app)
             ):
-                marathon_tasks[task.id] = task
+                healthy_marathon_tasks[task.id] = task
 
-    if not marathon_tasks:
+    service_namespace_config = load_service_namespace_config(
+        service=config.service, namespace=config.get_nerve_namespace()
+    )
+    if service_namespace_config.is_in_smartstack():
+
+        for task in filter_tasks_in_smartstack(
+            [task for tasks in relevant_tasks_by_app.values() for task in tasks],
+            service=config.service,
+            nerve_ns=config.get_nerve_namespace(),
+            system_paasta_config=system_paasta_config,
+            max_hosts_to_query=20,
+            haproxy_min_fraction_up=0.01,  # Be very liberal. See docstring above for rationale.
+        ):
+            healthy_marathon_tasks[task.id] = task
+
+    if not healthy_marathon_tasks:
         raise MetricsProviderNoDataError("Couldn't find any healthy marathon tasks")
-    mesos_tasks = [task for task in all_mesos_tasks if task["id"] in marathon_tasks]
-    return (marathon_tasks, mesos_tasks)
+    mesos_tasks = [
+        task for task in all_mesos_tasks if task["id"] in healthy_marathon_tasks
+    ]
+    return (healthy_marathon_tasks, mesos_tasks)
 
 
 def write_to_log(config, line, level="event"):

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -1227,6 +1227,7 @@ def test_autoscaling_is_paused():
 
 
 def test_filter_autoscaling_tasks():
+    fake_system_paasta_config = mock.MagicMock()
     fake_marathon_service_config = marathon_tools.MarathonServiceConfig(
         service="fake-service",
         instance="fake-instance",
@@ -1257,7 +1258,10 @@ def test_filter_autoscaling_tasks():
             tasks=[mock.Mock(id="fake-service.fake-instance.sha123.sha456.uuid")],
         )
         ret = autoscaling_service_lib.filter_autoscaling_tasks(
-            [mock_marathon_app], mock_mesos_tasks, fake_marathon_service_config
+            [mock_marathon_app],
+            mock_mesos_tasks,
+            fake_marathon_service_config,
+            fake_system_paasta_config,
         )
         assert ret == (
             {
@@ -1279,7 +1283,10 @@ def test_filter_autoscaling_tasks():
         )
         with raises(autoscaling_service_lib.MetricsProviderNoDataError):
             autoscaling_service_lib.filter_autoscaling_tasks(
-                [mock_marathon_app], mock_mesos_tasks, fake_marathon_service_config
+                [mock_marathon_app],
+                mock_mesos_tasks,
+                fake_marathon_service_config,
+                fake_system_paasta_config,
             )
 
         # Test no healthcheck defined
@@ -1289,7 +1296,10 @@ def test_filter_autoscaling_tasks():
         mock_health_check = mock.Mock()
         mock_marathon_app = mock.Mock(health_checks=[], tasks=mock_marathon_tasks)
         ret = autoscaling_service_lib.filter_autoscaling_tasks(
-            [mock_marathon_app], mock_mesos_tasks, fake_marathon_service_config
+            [mock_marathon_app],
+            mock_mesos_tasks,
+            fake_marathon_service_config,
+            fake_system_paasta_config,
         )
         assert ret == (
             {"fake-service.fake-instance.sha123.sha456.uuid": mock_marathon_tasks[0]},
@@ -1308,7 +1318,10 @@ def test_filter_autoscaling_tasks():
             health_checks=[mock_health_check], tasks=mock_marathon_tasks
         )
         ret = autoscaling_service_lib.filter_autoscaling_tasks(
-            [mock_marathon_app], mock_mesos_tasks, fake_marathon_service_config
+            [mock_marathon_app],
+            mock_mesos_tasks,
+            fake_marathon_service_config,
+            fake_system_paasta_config,
         )
         assert ret == (
             {"fake-service.fake-instance.sha123.sha456.uuid": mock_marathon_tasks[0]},
@@ -1455,6 +1468,7 @@ def test_get_autoscaling_info():
             [mock_apps_with_clients[0][0]],
             mock_get_all_running_tasks.return_value,
             mock_service_config,
+            autoscaling_service_lib.load_system_paasta_config(),
         )
         mock_get_utilization.assert_called_with(
             marathon_service_config=mock_service_config,
@@ -1753,6 +1767,7 @@ def test_proportional_decision_policy_moving_average(
 
 
 def test_filter_autoscaling_tasks_considers_old_versions():
+    fake_system_paasta_config = mock.MagicMock()
     marathon_apps = [
         mock.Mock(
             tasks=[
@@ -1807,7 +1822,10 @@ def test_filter_autoscaling_tasks_considers_old_versions():
         autospec=True,
     ):
         actual = filter_autoscaling_tasks(
-            marathon_apps, all_mesos_tasks, service_config
+            marathon_apps,
+            all_mesos_tasks,
+            service_config,
+            system_paasta_config=fake_system_paasta_config,
         )
 
     assert actual == expected
@@ -1830,7 +1848,11 @@ def test_autoscale_service_configs():
         )
     ]
 
-    mock_app = mock.Mock(tasks=mock_marathon_tasks, health_checks=[mock.Mock()])
+    mock_app = mock.Mock(
+        id="fake-service.fake-instance.sha123.sha456",
+        tasks=mock_marathon_tasks,
+        health_checks=[mock.Mock()],
+    )
     mock_system_paasta_config = (mock.Mock(get_cluster=mock.Mock()),)
     with mock.patch(
         "paasta_tools.autoscaling.autoscaling_service_lib.autoscale_marathon_instance",


### PR DESCRIPTION
Based on https://github.com/Yelp/paasta/pull/2398 which I plan to merge shortly, so ignore the changes to marathon_tools.py

I think the docstring I added to filter_autoscaling_tasks justifies this change pretty well.