### PR TITLE
ignore incomplete jobs

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -776,11 +776,16 @@ def print_flink_status(
         )
     else:
         output.append(f"      Job Name                         State       Started")
+
     # Use only the most recent jobs
     unique_jobs = (
         sorted(jobs, key=lambda j: -j["start-time"])[0]
         for _, jobs in groupby(
-            sorted(status.jobs, key=lambda j: j["name"]), lambda j: j["name"]
+            sorted(
+                (j for j in status.jobs if j.get("name") and j.get("start-time")),
+                key=lambda j: j["name"],
+            ),
+            lambda j: j["name"],
         )
     )
     for job in unique_jobs:

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -802,7 +802,7 @@ def print_flink_status(
             fmt.format(
                 job_id=job_id,
                 job_name=job["name"].split(".", 2)[2],
-                state=job["state"],
+                state=(job.get("state") or "unknown"),
                 start_time=f"{str(start_time)} ({humanize.naturaltime(start_time)})",
                 dashboard_url=PaastaColors.grey(f"{dashboard_url}/#/jobs/{job_id}"),
             )


### PR DESCRIPTION
A cluster in startup phase may report incomplete job data. Trying to show these only creates problems, so let's just skip over.