### PR TITLE
fix traceback for paasta status on kubernetes cluster

### DIFF
--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -244,7 +244,7 @@ def kubernetes_job_status(
         app.status.ready_replicas if app.status.ready_replicas else 0
     )
     kstatus["create_timestamp"] = app.metadata.creation_timestamp.timestamp()
-    kstatus["namespace"] = app.metadata.namesapce
+    kstatus["namespace"] = app.metadata.namespace
 
 
 def marathon_instance_status(

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -776,7 +776,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         """
         if self.get_max_instances() is not None:
             try:
-                return kube_client.deployments.read_namespaced_deployment(
+                return KubeClient().deployments.read_namespaced_deployment(
                     name=self.get_sanitised_deployment_name(), namespace="paasta"
                 ).spec.replicas
             except ApiException as e:


### PR DESCRIPTION
The error traceback looks like:

ERROR: Traceback (most recent call last):
  File "/nail/home/chl/paasta/paasta_tools/api/views/instance.py", line 735, in instance_status
    instance_status, service, instance, verbose
  File "/nail/home/chl/paasta/paasta_tools/api/views/instance.py", line 209, in kubernetes_instance_status
    pod_list=pod_list,
  File "/nail/home/chl/paasta/paasta_tools/api/views/instance.py", line 226, in kubernetes_job_status
    kstatus["expected_instance_count"] = job_config.get_instances()
  File "/nail/home/chl/paasta/paasta_tools/kubernetes_tools.py", line 781, in get_instances
    return kube_client.deployments.read_namespaced_deployment(
AttributeError: module 'kubernetes.client' has no attribute 'deployments'