### PR TITLE
Store flink dashboard url in metadata:annotations

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -49,7 +49,6 @@ from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import NoSuchService
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.flink_tools import FlinkDeploymentConfig
-from paasta_tools.flink_tools import get_dashboard_url
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.kubernetes_tools import KubernetesDeployStatus
 from paasta_tools.marathon_serviceinit import bouncing_status_human
@@ -785,9 +784,8 @@ def print_flink_status(
         output.append(f"    No other information available in non-running state")
         return 0
 
-    dashboard_url = get_dashboard_url(
-        cluster=cluster, service=service, instance=instance
-    )
+    dashboard_url = metadata.annotations.get("yelp.com/flink_dashboard_url")
+    dashboard_url += metadata.name
     if verbose:
         output.append(
             f"    Flink version: {status.config['flink-version']} {status.config['flink-revision']}"

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -784,7 +784,7 @@ def print_flink_status(
         output.append(f"    No other information available in non-running state")
         return 0
 
-    dashboard_url = metadata.annotations.get("yelp.com/flink_dashboard_url")
+    dashboard_url = metadata.annotations.get("yelp.com/dashboard_url")
     dashboard_url += metadata.name
     if verbose:
         output.append(

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -217,6 +217,5 @@ def set_flink_desired_state(
     return status
 
 
-def get_dashboard_url(cluster: str, service: str, instance: str) -> str:
-    sname = sanitised_name(service, instance)
-    return f"http://flink.k8s.paasta-{cluster}.yelp:{FLINK_INGRESS_PORT}/{sname}"
+def get_flink_ingress_port() -> int:
+    return FLINK_INGRESS_PORT

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -255,14 +255,15 @@ def format_custom_resource(
                 "yelp.com/paasta_instance": instance,
                 "yelp.com/paasta_cluster": cluster,
             },
-            "annotations": {"yelp.com/desired_state": "running"},
+            "annotations": {},
         },
         "spec": instance_config,
     }
     url = get_dashboard_url(kind, cluster)
     if url:
         resource["metadata"]["annotations"]["yelp.com/dashboard_url"] = url
-    config_hash = get_config_hash(instance_config)
+    config_hash = get_config_hash(resource)
+    resource["metadata"]["annotations"]["yelp.com/desired_state"] = "running"
     resource["metadata"]["labels"]["yelp.com/paasta_config_sha"] = config_hash
     return resource
 

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -25,10 +25,13 @@ import logging
 import sys
 from typing import Any
 from typing import Mapping
+from typing import Optional
 from typing import Sequence
+from typing import Tuple
 
 import yaml
 
+from paasta_tools.flink_tools import get_flink_ingress_port
 from paasta_tools.kubernetes_tools import create_custom_resource
 from paasta_tools.kubernetes_tools import CustomResourceDefinition
 from paasta_tools.kubernetes_tools import ensure_namespace
@@ -216,6 +219,20 @@ def setup_custom_resources(
     return succeded
 
 
+def get_dashboard_url(
+    kind: str, service: str, instance: str, cluster: str
+) -> Tuple[Optional[str], Optional[str]]:
+    system_paasta_config = load_system_paasta_config()
+    dashboard_links = system_paasta_config.get_dashboard_links()
+    if kind.lower() == "flink":
+        flink_link = dashboard_links.get(cluster, {}).get("Flink")
+        if flink_link is None:
+            ingress_port = get_flink_ingress_port()
+            flink_link = f"http://flink.k8s.paasta-{cluster}.yelp:{ingress_port}/"
+        return flink_link, "yelp.com/flink_dashboard_url"
+    return None, None
+
+
 def format_custom_resource(
     instance_config: Mapping[str, Any],
     service: str,
@@ -243,6 +260,9 @@ def format_custom_resource(
         },
         "spec": instance_config,
     }
+    url, selector = get_dashboard_url(kind, service, instance, cluster)
+    if url and selector:
+        resource["metadata"]["annotations"][selector] = url
     config_hash = get_config_hash(instance_config)
     resource["metadata"]["labels"]["yelp.com/paasta_config_sha"] = config_hash
     return resource

--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -204,7 +204,10 @@ def test_format_custom_resource():
                     "yelp.com/paasta_cluster": "mycluster",
                     "yelp.com/paasta_config_sha": mock_get_config_hash.return_value,
                 },
-                "annotations": {"yelp.com/desired_state": "running"},
+                "annotations": {
+                    "yelp.com/desired_state": "running",
+                    "yelp.com/flink_dashboard_url": "http://flink.k8s.paasta-mycluster.yelp:31080/",
+                },
             },
             "spec": {"dummy": "conf"},
         }


### PR DESCRIPTION
This change implies that we will perhaps want to apply similar design to other K8s resources, because of the addition of a k8s metadata label.

The idea is to store a `yelp.com/dashboard_url` in `metadata:labels` ; this is created inside `setup_kubernetes_cr.py` ; the actual URL string-building function is `get_dashboard_url` and is likely to change. At this moment the assumption is that we want to maintain sanitized name at its current location and also that we will not bother defining Flink dashboard url in configuration for **every** cluster, so this function is capable of building a "default" one, same as the old function 'flink_tools.get_dashboard_url' did.

Yet to update integration tests for this one.