### PR TITLE
Make it easier to understand http draining exceptions

### DIFF
--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -193,6 +193,14 @@ def drain_tasks_and_find_tasks_to_kill(
                 return
             try:
                 await drain_method.drain(task)
+            except drain_lib.StatusCodeNotAcceptableError as e:
+                log_bounce_action(
+                    line=f"{bounce_method} bounce killing task {task.id} "
+                    f"due to exception when draining: {e}"
+                )
+                tasks_to_kill.add((task, client))
+            # Any other type of exception is really unexpected, so we need to log
+            # The whole traceback for later debugging
             except Exception:
                 log_bounce_action(
                     line=f"{bounce_method} bounce killing task {task.id} "

--- a/tests/test_drain_lib.py
+++ b/tests/test_drain_lib.py
@@ -16,7 +16,6 @@ import contextlib
 import asynctest
 import mock
 import pytest
-from pytest import raises
 
 from paasta_tools import drain_lib
 
@@ -172,11 +171,10 @@ class TestHTTPDrainMethod:
         )
 
         # Happy case
-        drain_method.check_response_code(200, "200-299")
+        assert drain_method.check_response_code(200, "200-299") is True
 
         # Sad case
-        with raises(drain_lib.StatusCodeNotAcceptableError):
-            drain_method.check_response_code(500, "200-299")
+        assert drain_method.check_response_code(500, "200-299") is False
 
     @pytest.mark.asyncio
     async def test_issue_request(self):

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -2290,7 +2290,7 @@ class RegexMatcher:
 
 
 class TestDrainTasksAndFindTasksToKill:
-    def test_catches_exception_during_drain(self):
+    def test_catches_unknown_exception_during_drain(self):
         tasks_to_drain: Set[Tuple[MarathonTask, MarathonClient]] = {
             (mock.Mock(id="to_drain", state="TASK_FOO"), mock.Mock())
         }
@@ -2323,7 +2323,6 @@ class TestDrainTasksAndFindTasksToKill:
                 flags=re.MULTILINE | re.DOTALL,
             )
         )
-
         fake_log_bounce_action.assert_any_call(
             line="fake bounce killing not_running or drained task to_drain TASK_FOO"
         )


### PR DESCRIPTION
I have two goals:
* want to make it easy to see what url we were trying to hit and make it really obvious what the code was
* I want paasta logs lines to always just be one line, I don't think we need the whole traceback in there (if you think we need the traceback, I think I would prefer to just `log` it.