### PR TITLE
Make sure we only print strings when running start/stop/restart.

### DIFF
--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -328,11 +328,8 @@ def paasta_start_or_stop(args, desired_state):
                 return_val = 0
 
     if invalid_deploy_groups:
-        paasta_print(
-            "No branches found for %s in %s."
-            % (", ".join(invalid_deploy_groups), remote_refs)
-        )
-        paasta_print("Has %s been deployed there yet?" % service)
+        paasta_print(f"No deploy tags found for {', '.join(invalid_deploy_groups)}.")
+        paasta_print(f"Has {service} been deployed there yet?")
         return_val = 1
 
     return return_val

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -502,7 +502,7 @@ def test_start_or_stop_bad_refs(
     }
     mock_confirm_to_continue.return_value = True
     assert args.command(args) == 1
-    assert "No branches found for" in capfd.readouterr()[0]
+    assert "deployed there yet?" in capfd.readouterr()[0]
 
 
 def test_cluster_list_defaults_to_all():


### PR DESCRIPTION
This is "None" sometimes, but I don't think we need to print remote_refs anyway