### PR TITLE
fix error when secret contains underscore

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -560,12 +560,13 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         for k, v in secret_env_vars.items():
             service = self.get_sanitised_service_name()
             secret = get_secret_name_from_ref(v)
+            sanitised_secret = sanitise_kubernetes_name(secret)
             ret.append(
                 V1EnvVar(
                     name=k,
                     value_from=V1EnvVarSource(
                         secret_key_ref=V1SecretKeySelector(
-                            name=f"paasta-secret-{service}-{secret}",
+                            name=f"paasta-secret-{service}-{sanitised_secret}",
                             key=secret,
                             optional=False,
                         )
@@ -575,12 +576,13 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         for k, v in shared_secret_env_vars.items():
             service = sanitise_kubernetes_name(SHARED_SECRET_SERVICE)
             secret = get_secret_name_from_ref(v)
+            sanitised_secret = sanitise_kubernetes_name(secret)
             ret.append(
                 V1EnvVar(
                     name=k,
                     value_from=V1EnvVarSource(
                         secret_key_ref=V1SecretKeySelector(
-                            name=f"paasta-secret-{service}-{secret}",
+                            name=f"paasta-secret-{service}-{sanitised_secret}",
                             key=secret,
                             optional=False,
                         )

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1008,14 +1008,14 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
 
     def test_get_kubernetes_secret_env_vars(self):
         assert self.deployment.get_kubernetes_secret_env_vars(
-            secret_env_vars={"SOME": "SECRET(ref)"},
-            shared_secret_env_vars={"A": "SHAREDSECRET(ref1)"},
+            secret_env_vars={"SOME": "SECRET(_ref)"},
+            shared_secret_env_vars={"A": "SHAREDSECRET(_ref1)"},
         ) == [
             V1EnvVar(
                 name="SOME",
                 value_from=V1EnvVarSource(
                     secret_key_ref=V1SecretKeySelector(
-                        name="paasta-secret-kurupt-ref", key="ref", optional=False
+                        name="paasta-secret-kurupt---ref", key="_ref", optional=False
                     )
                 ),
             ),
@@ -1023,7 +1023,9 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                 name="A",
                 value_from=V1EnvVarSource(
                     secret_key_ref=V1SecretKeySelector(
-                        name="paasta-secret---shared-ref1", key="ref1", optional=False
+                        name="paasta-secret---shared---ref1",
+                        key="_ref1",
+                        optional=False,
                     )
                 ),
             ),


### PR DESCRIPTION
The error happens when the secret contains '_', such as https://sourcegraph.yelpcorp.com/sysgit/yelpsoa-configs@0a71a848abe35298acd96630a727abd586ee80b1/-/blob/waitlist_pages/marathon-pnw-prod.yaml#L10:5

The error messages for reference:
Traceback (most recent call last):
  File "/usr/bin/setup_kubernetes_job", line 191, in <module>
    main()
  File "/usr/bin/setup_kubernetes_job", line 90, in main
    soa_dir=soa_dir,
  File "/usr/bin/setup_kubernetes_job", line 138, in setup_kube_deployments
    app.create(kube_client)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/kubernetes/application/controller_wrappers.py", line 193, in create
    create_deployment(kube_client=kube_client, formatted_deployment=self.item)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/kubernetes_tools.py", line 1431, in create_deployment
    namespace="paasta", body=formatted_deployment
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/apis/apps_v1_api.py", line 290, in create_namespaced_deployment
    (data) = self.create_namespaced_deployment_with_http_info(namespace, body, **kwargs)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/apis/apps_v1_api.py", line 381, in create_namespaced_deployment_with_http_info
    collection_formats=collection_formats)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/api_client.py", line 334, in call_api
    _return_http_data_only, collection_formats, _preload_content, _request_timeout)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/api_client.py", line 168, in __call_api
    _request_timeout=_request_timeout)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/api_client.py", line 377, in request
    body=body)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/rest.py", line 266, in POST
    body=body)
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/rest.py", line 222, in request
    raise ApiException(http_resp=r)
kubernetes.client.rest.ApiException: (422)
Reason: Unprocessable Entity
HTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json', 'Date': 'Wed, 25 Sep 2019 20:31:26 GMT', 'Content-Length': '1122'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Deployment.apps \"yelp-main-k8s--main--uswest1\" is invalid: spec.template.spec.containers[0].env[12].valueFrom.secretKeyRef.name: Invalid value: \"paasta-secret---shared-waitlist_pages_obfuscation_key\": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')","reason":"Invalid","details":{"name":"yelp-main-k8s--main--uswest1","group":"apps","kind":"Deployment","causes":[{"reason":"FieldValueInvalid","message":"Invalid value: \"paasta-secret---shared-waitlist_pages_obfuscation_key\": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')","field":"spec.template.spec.containers[0].env[12].valueFrom.secretKeyRef.name"}]},"code":422}