### PR TITLE
RFC: Change how CLI commands are constructed to use the git methodology

### DIFF
--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -14,117 +14,13 @@
 # limitations under the License.
 # PYTHON_ARGCOMPLETE_OK
 """A command line tool for viewing information from the PaaSTA stack."""
-import argparse
-import logging
+import os
 import sys
 
-import argcomplete
-import pkg_resources
 
-from paasta_tools.cli import cmds
-from paasta_tools.cli.utils import load_method
-from paasta_tools.cli.utils import modules_in_pkg as paasta_commands_dir
-from paasta_tools.utils import paasta_print
-
-
-class PrintsHelpOnErrorArgumentParser(argparse.ArgumentParser):
-    """Overriding the error method allows us to print the whole help page,
-    otherwise the python arg parser prints a not-so-useful usage message that
-    is way too terse"""
-
-    def error(self, message):
-        paasta_print("Argument parse error: %s" % message)
-        self.print_help()
-        sys.exit(1)
-
-
-def add_subparser(command, subparsers):
-    """Given a command name, paasta_cmd, execute the add_subparser method
-    implemented in paasta_cmd.py.
-
-    Each paasta client command must implement a method called add_subparser.
-    This allows the client to dynamically add subparsers to its subparser, which
-    provides the benefits of argcomplete/argparse but gets it done in a modular
-    fashion.
-
-    :param command: a simple string - e.g. 'list'
-    :param subparsers: an ArgumentParser object"""
-    module_name = "paasta_tools.cli.cmds.%s" % command
-    add_subparser_fn = load_method(module_name, "add_subparser")
-    add_subparser_fn(subparsers)
-
-
-def get_argparser():
-    parser = PrintsHelpOnErrorArgumentParser(
-        description=(
-            "The PaaSTA command line tool. The 'paasta' command is the entry point "
-            "to multiple subcommands, see below.\n\n"
-            "You can see more help for individual commands by appending them with '--help', "
-            "for example, 'paasta status --help' or see the man page with 'man paasta status'."
-        ),
-        epilog=(
-            "The 'paasta' command line tool is designed to be used by humans, and therefore has "
-            "command line completion for almost all options and uses pretty formatting when "
-            "possible."
-        ),
-        # Suppressing usage prevents it from being printed twice upon print_help
-        usage=argparse.SUPPRESS,
-    )
-
-    # http://stackoverflow.com/a/8521644/812183
-    parser.add_argument(
-        "-V",
-        "--version",
-        action="version",
-        version="paasta-tools {}".format(
-            pkg_resources.get_distribution("paasta-tools").version
-        ),
-    )
-
-    subparsers = parser.add_subparsers(
-        help="[-h, --help] for subcommand help", dest="command"
-    )
-    subparsers.required = True
-
-    # Adding a separate help subparser allows us to respond to "help" without --help
-    help_parser = subparsers.add_parser("help", add_help=False)
-    help_parser.set_defaults(command=None)
-
-    for command in sorted(paasta_commands_dir(cmds)):
-        add_subparser(command, subparsers)
-
-    return parser
-
-
-def parse_args(argv):
-    """Initialize autocompletion and configure the argument parser.
-
-    :return: an argparse.Namespace object mapping parameter names to the inputs
-             from sys.argv
-    """
-    parser = get_argparser()
-    argcomplete.autocomplete(parser)
-
-    return parser.parse_args(argv), parser
-
-
-def main(argv=None):
-    """Perform a paasta call. Read args from sys.argv and pass parsed args onto
-    appropriate command in paasta_cli/cmds directory.
-
-    Ensure we kill any child pids before we quit
-    """
-    logging.basicConfig()
-    try:
-        args, parser = parse_args(argv)
-        if args.command is None:
-            parser.print_help()
-            return_code = 0
-        else:
-            return_code = args.command(args)
-    except KeyboardInterrupt:
-        return_code = 1
-    sys.exit(return_code)
+def main(argv=sys.argv):
+    subcommand = argv[1]
+    os.execlp(f"paasta-{subcommand}", *argv[1:])
 
 
 if __name__ == "__main__":

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import concurrent.futures
 import difflib
 import os
@@ -1341,3 +1342,27 @@ def paasta_status(args,) -> int:
             return_codes.append(return_code)
 
     return max(return_codes)
+
+
+def main():
+    status_parser = argparse.ArgumentParser()
+    status_parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        dest="verbose",
+        default=0,
+        help="Print out more output regarding the state of the service. "
+        "A second -v will also print the stdout/stderr tail.",
+    )
+    status_parser.add_argument(
+        "-d",
+        "--soa-dir",
+        dest="soa_dir",
+        metavar="SOA_DIR",
+        default=DEFAULT_SOA_DIR,
+        help="define a different soa config directory",
+    )
+    add_instance_filter_arguments(status_parser)
+    args = status_parser.parse_args()
+    sys.exit(paasta_status(args))

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
             "paasta_oom_logger=paasta_tools.oom_logger:main",
             "paasta_broadcast_log=paasta_tools.marathon_tools:broadcast_log_all_services_running_here_from_stdin",
             "paasta_dump_locally_running_services=paasta_tools.dump_locally_running_services:main",
+            "paasta-status=paasta_tools.cli.cmds.status:main",
         ],
         "paste.app_factory": ["paasta-api-config=paasta_tools.api.api:make_app"],
     },


### PR DESCRIPTION
This fundamentally changes how we do CLI commands in paasta, for a couple of reasons:

1. Paasta cli commands are slow. A long time ago we had a review to make it work more like the `bzr` command, where cli parsing and import/execution were distinct. This greatly sped up the paasta-cli, but we rejected it because of the complexity it had. This makes it at least possible to do this without the big complexity, because each cli tool will be completely self-contained. The `paasta-status` command is self-contained with this change, and we can actually separate out cli parsing from execution, and then maybe we can make tab completion great again.

2. the `paasta` command doesn't need to import all the things. This will allow it to scale as we add new capabilities. In practice this doesn't actually speed anything up yet though :(

3. It makes room for other cli plugins, like git. Similar to how `git yelp-list-repos` works, new cli args can be added via `paasta-$subcommand` and they will automatically become available. We can add private commands if we wanted to. We an add new commands in other languages, etc. Maybe that means we need to give up and have `paasta flink-status`, but at least the `paasta-status` command can detect this and defer to the `flink-status` command, regardless of the language it is written in.