### PR TITLE
Verify number of taskmanagers reported by Flink dashboard when monitoring

### DIFF
--- a/paasta_tools/check_flink_services_health.py
+++ b/paasta_tools/check_flink_services_health.py
@@ -17,6 +17,7 @@ Usage: ./check_flink_services_health.py [options]
 """
 import datetime
 import logging
+from typing import Optional
 from typing import Sequence
 
 import pysensu_yelp
@@ -79,8 +80,8 @@ Things you can do:
 def send_event_if_not_enough_taskmanagers(
     instance_config: FlinkDeploymentConfig,
     expected_count: int,
-    num_reported: int,
-    strerror: str,
+    num_reported: Optional[int],
+    strerror: Optional[str],
 ) -> None:
     under_replicated = False
     if strerror is None:

--- a/paasta_tools/check_flink_services_health.py
+++ b/paasta_tools/check_flink_services_health.py
@@ -19,6 +19,8 @@ import datetime
 import logging
 from typing import Sequence
 
+import pysensu_yelp
+
 from paasta_tools import flink_tools
 from paasta_tools import monitoring_tools
 from paasta_tools.check_services_replication_tools import main
@@ -26,7 +28,9 @@ from paasta_tools.flink_tools import FlinkDeploymentConfig
 from paasta_tools.kubernetes_tools import filter_pods_by_service_instance
 from paasta_tools.kubernetes_tools import is_pod_ready
 from paasta_tools.kubernetes_tools import V1Pod
+from paasta_tools.monitoring_tools import send_replication_event
 from paasta_tools.smartstack_tools import KubeSmartstackReplicationChecker
+from paasta_tools.utils import is_under_replicated
 
 
 log = logging.getLogger(__name__)
@@ -53,6 +57,66 @@ def healthy_flink_containers_cnt(si_pods: Sequence[V1Pod], container_type: str) 
     )
 
 
+def send_event_if_not_enough_taskmanagers(
+    instance_config: FlinkDeploymentConfig,
+    expected_count: int,
+    num_reported: int,
+    strerror: str,
+) -> None:
+    under_replicated = False
+    if strerror is None:
+        crit_threshold = instance_config.get_replication_crit_percentage()
+        output = (
+            "Service %s has %d out of %d expected instances of %s reported by dashboard!\n"
+            + "(threshold: %d%%)"
+        ) % (
+            instance_config.job_id,
+            num_reported,
+            expected_count,
+            "taskmanager",
+            crit_threshold,
+        )
+        under_replicated, _ = is_under_replicated(
+            num_reported, expected_count, crit_threshold
+        )
+    else:
+        output = ("Dashboard of service %s is not available!\n" + "(%s)") % (
+            instance_config.job_id,
+            strerror,
+        )
+    if under_replicated or strerror:
+        output += (
+            "\n\n"
+            "What this alert means:\n"
+            "\n"
+            "  This alert means that the Flink service is not reporting the\n"
+            "  requested number of taskmanagers.\n"
+            "\n"
+            "Reasons this might be happening:\n"
+            "\n"
+            "  The service may simply be unhealthy. There also may not be enough resources\n"
+            "  in the cluster to support the requested instance count.\n"
+            "\n"
+            "Things you can do:\n"
+            "\n"
+            "  * Fix the cause of the unhealthy service. Try running:\n"
+            "\n"
+            "      paasta status -s %(service)s -i %(instance)s -c %(cluster)s -vv\n"
+        ) % {
+            "service": instance_config.service,
+            "instance": instance_config.instance,
+            "cluster": instance_config.cluster,
+        }
+        log.error(output)
+        status = pysensu_yelp.Status.CRITICAL
+    else:
+        log.info(output)
+        status = pysensu_yelp.Status.OK
+    send_replication_event(
+        instance_config=instance_config, status=status, output=output
+    )
+
+
 def check_flink_service_health(
     instance_config: FlinkDeploymentConfig,
     all_pods: Sequence[V1Pod],
@@ -70,7 +134,22 @@ def check_flink_service_health(
     num_healthy_jobmanagers = healthy_flink_containers_cnt(si_pods, "jobmanager")
     num_healthy_taskmanagers = healthy_flink_containers_cnt(si_pods, "taskmanager")
 
-    # TBD: check cnt according to Flink
+    strerror = None
+    reported_taskmanagers = None
+    try:
+        overview = flink_tools.get_flink_jobmanager_overview(
+            instance_config.service, instance_config.instance, instance_config.cluster
+        )
+        reported_taskmanagers = overview.get("taskmanagers", 0)
+    except ValueError as e:
+        strerror = str(e)
+
+    send_event_if_not_enough_taskmanagers(
+        instance_config=instance_config,
+        expected_count=taskmanagers_expected_cnt,
+        num_reported=reported_taskmanagers,
+        strerror=strerror,
+    )
 
     monitoring_tools.send_replication_event_if_under_replication(
         instance_config=instance_config,

--- a/paasta_tools/check_flink_services_health.py
+++ b/paasta_tools/check_flink_services_health.py
@@ -57,6 +57,25 @@ def healthy_flink_containers_cnt(si_pods: Sequence[V1Pod], container_type: str) 
     )
 
 
+def _event_explanation() -> str:
+    return """
+What this alert means:
+
+  This alert means that the Flink dashboard is not reporting the expected
+  number of taskmanagers.
+
+Reasons this might be happening:
+
+  The service may simply be unhealthy. There also may not be enough resources
+  in the cluster to support the requested instance count.
+
+Things you can do:
+
+  * Fix the cause of the unhealthy service. Try running:
+
+"""
+
+
 def send_event_if_not_enough_taskmanagers(
     instance_config: FlinkDeploymentConfig,
     expected_count: int,
@@ -85,22 +104,8 @@ def send_event_if_not_enough_taskmanagers(
             strerror,
         )
     if under_replicated or strerror:
+        output += _event_explanation()
         output += (
-            "\n\n"
-            "What this alert means:\n"
-            "\n"
-            "  This alert means that the Flink service is not reporting the\n"
-            "  requested number of taskmanagers.\n"
-            "\n"
-            "Reasons this might be happening:\n"
-            "\n"
-            "  The service may simply be unhealthy. There also may not be enough resources\n"
-            "  in the cluster to support the requested instance count.\n"
-            "\n"
-            "Things you can do:\n"
-            "\n"
-            "  * Fix the cause of the unhealthy service. Try running:\n"
-            "\n"
             "      paasta status -s %(service)s -i %(instance)s -c %(cluster)s -vv\n"
         ) % {
             "service": instance_config.service,

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -798,7 +798,6 @@ def print_flink_status(
         return 0
 
     dashboard_url = metadata.annotations.get("yelp.com/dashboard_url")
-    dashboard_url += metadata.name
     if verbose:
         output.append(
             f"    Flink version: {status.config['flink-version']} {status.config['flink-revision']}"

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -217,5 +217,5 @@ def set_flink_desired_state(
     return status
 
 
-def get_flink_ingress_port() -> int:
-    return FLINK_INGRESS_PORT
+def get_flink_ingress_url_root(cluster: str) -> str:
+    return f"http://flink.k8s.paasta-{cluster}.yelp:{FLINK_INGRESS_PORT}/"

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -244,5 +244,4 @@ def get_flink_jobmanager_overview(
         err = e.strerror
         raise ValueError(f"failed HTTP request to Jobmanager dashboard {url}: {err}")
     except json.JSONDecodeError as e:
-        err = str(e)
-        raise ValueError(f"JSON decoding error from Jobmanager dashboard: {err}")
+        raise ValueError(f"JSON decoding error from Jobmanager dashboard: {e}")

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -10,11 +10,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from typing import Any
 from typing import List
 from typing import Mapping
 from typing import Optional
 
+import requests
 import service_configuration_lib
 from kubernetes.client.rest import ApiException
 from mypy_extensions import TypedDict
@@ -32,6 +34,7 @@ from paasta_tools.utils import load_v2_deployments_json
 
 
 FLINK_INGRESS_PORT = 31080
+FLINK_DASHBOARD_TIMEOUT_SECONDS = 5
 
 
 class TaskManagerConfig(TypedDict, total=False):
@@ -219,3 +222,27 @@ def set_flink_desired_state(
 
 def get_flink_ingress_url_root(cluster: str) -> str:
     return f"http://flink.k8s.paasta-{cluster}.yelp:{FLINK_INGRESS_PORT}/"
+
+
+def _dashboard_get(service: str, instance: str, cluster: str, path: str) -> str:
+    root = get_flink_ingress_url_root(cluster)
+    name = sanitised_name(service, instance)
+    url = f"{root}{name}/{path}"
+    response = requests.get(url, timeout=FLINK_DASHBOARD_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    return response.text
+
+
+def get_flink_jobmanager_overview(
+    service: str, instance: str, cluster: str
+) -> Mapping[str, Any]:
+    try:
+        response = _dashboard_get(service, instance, cluster, "overview")
+        return json.loads(response)
+    except requests.RequestException as e:
+        url = e.request.url
+        err = e.strerror
+        raise ValueError(f"failed HTTP request to Jobmanager dashboard {url}: {err}")
+    except json.JSONDecodeError as e:
+        err = str(e)
+        raise ValueError(f"JSON decoding error from Jobmanager dashboard: {err}")

--- a/tests/test_check_flink_services_health.py
+++ b/tests/test_check_flink_services_health.py
@@ -89,3 +89,115 @@ def test_check_flink_service_health(instance_config):
             status=pysensu_yelp.Status.OK,
             output="Service fake_service.fake_instance has 3 out of 3 expected instances of taskmanager reported by dashboard!\n(threshold: 90%)",
         )
+
+
+def test_check_flink_service_health_too_few_taskmanagers(instance_config):
+    all_pods = []
+    with mock.patch(
+        "paasta_tools.check_flink_services_health.healthy_flink_containers_cnt",
+        autospec=True,
+        return_value=1,
+    ), mock.patch(
+        "paasta_tools.check_flink_services_health._event_explanation",
+        autospec=True,
+        return_value="",
+    ), mock.patch(
+        "paasta_tools.flink_tools.get_flink_jobmanager_overview",
+        autospec=True,
+        return_value={"taskmanagers": 2},
+    ), mock.patch(
+        "paasta_tools.monitoring_tools.send_replication_event_if_under_replication",
+        autospec=True,
+    ) as mock_send_replication_event_if_under_replication, mock.patch(
+        "paasta_tools.check_flink_services_health.send_replication_event", autospec=True
+    ) as mock_send_replication_event:
+        instance_config.config_dict["taskmanager"] = {"instances": 3}
+        check_flink_services_health.check_flink_service_health(
+            instance_config=instance_config,
+            all_pods=all_pods,
+            smartstack_replication_checker=None,
+        )
+        expected = [
+            mock.call(
+                instance_config=instance_config,
+                expected_count=1,
+                num_available=1,
+                sub_component="supervisor",
+            ),
+            mock.call(
+                instance_config=instance_config,
+                expected_count=1,
+                num_available=1,
+                sub_component="jobmanager",
+            ),
+            mock.call(
+                instance_config=instance_config,
+                expected_count=3,
+                num_available=1,
+                sub_component="taskmanager",
+            ),
+        ]
+        mock_send_replication_event_if_under_replication.assert_has_calls(expected)
+        mock_send_replication_event.assert_called_once_with(
+            instance_config=instance_config,
+            status=pysensu_yelp.Status.CRITICAL,
+            output="Service fake_service.fake_instance has 2 out of 3 expected instances of taskmanager reported by dashboard!\n(threshold: 90%)      paasta status -s fake_service -i fake_instance -c fake_cluster -vv\n",
+        )
+
+
+def _raise_dummy_exception(*args):
+    raise ValueError("dummy exception")
+
+
+def test_check_flink_service_health_dashboard_error(instance_config):
+    all_pods = []
+    with mock.patch(
+        "paasta_tools.check_flink_services_health.healthy_flink_containers_cnt",
+        autospec=True,
+        return_value=1,
+    ), mock.patch(
+        "paasta_tools.check_flink_services_health._event_explanation",
+        autospec=True,
+        return_value="",
+    ), mock.patch(
+        "paasta_tools.flink_tools.get_flink_jobmanager_overview",
+        side_effect=_raise_dummy_exception,
+        autospec=True,
+    ), mock.patch(
+        "paasta_tools.monitoring_tools.send_replication_event_if_under_replication",
+        autospec=True,
+    ) as mock_send_replication_event_if_under_replication, mock.patch(
+        "paasta_tools.check_flink_services_health.send_replication_event", autospec=True
+    ) as mock_send_replication_event:
+        instance_config.config_dict["taskmanager"] = {"instances": 3}
+        check_flink_services_health.check_flink_service_health(
+            instance_config=instance_config,
+            all_pods=all_pods,
+            smartstack_replication_checker=None,
+        )
+        expected = [
+            mock.call(
+                instance_config=instance_config,
+                expected_count=1,
+                num_available=1,
+                sub_component="supervisor",
+            ),
+            mock.call(
+                instance_config=instance_config,
+                expected_count=1,
+                num_available=1,
+                sub_component="jobmanager",
+            ),
+            mock.call(
+                instance_config=instance_config,
+                expected_count=3,
+                num_available=1,
+                sub_component="taskmanager",
+            ),
+        ]
+        mock_send_replication_event_if_under_replication.assert_has_calls(expected)
+        mock_send_replication_event.assert_called_once_with(
+            instance_config=instance_config,
+            status=pysensu_yelp.Status.CRITICAL,
+            output="Dashboard of service fake_service.fake_instance is not available!\n(dummy exception)      paasta status -s fake_service -i fake_instance -c fake_cluster -vv\n",
+        )

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -1,0 +1,44 @@
+# Copyright 2015-2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+
+import paasta_tools.flink_tools as flink_tools
+
+
+def test_get_flink_ingress_url_root():
+    assert (
+        flink_tools.get_flink_ingress_url_root("mycluster")
+        == "http://flink.k8s.paasta-mycluster.yelp:31080/"
+    )
+
+
+def test_get_flink_jobmanager_overview():
+    with mock.patch(
+        "paasta_tools.flink_tools._dashboard_get",
+        autospec=True,
+        return_value='{"taskmanagers":10,"slots-total":10,"flink-version":"1.6.4","flink-commit":"6241481"}',
+    ) as mock_dashboard_get:
+        cluster = "mycluster"
+        service = "kurupt_fm"
+        instance = "radio_station"
+        overview = flink_tools.get_flink_jobmanager_overview(service, instance, cluster)
+        mock_dashboard_get.assert_called_once_with(
+            service=service, instance=instance, cluster=cluster, path="overview"
+        )
+        assert overview == {
+            "taskmanagers": 10,
+            "slots-total": 10,
+            "flink-version": "1.6.4",
+            "flink-commit": "6241481",
+        }

--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -212,7 +212,7 @@ def test_format_custom_resource():
                 },
                 "annotations": {
                     "yelp.com/desired_state": "running",
-                    "yelp.com/dashboard_url": "http://flink.k8s.paasta-mycluster.yelp:31080/",
+                    "yelp.com/dashboard_url": "http://flink.k8s.paasta-mycluster.yelp:31080/kurupt--fm-radio--station",
                 },
             },
             "spec": {"dummy": "conf"},
@@ -244,9 +244,14 @@ def test_paasta_config_flink_dashboard_url():
             },
             "",
         )
-        expected = "http://flink.paasta-mycluster.yelp/"
+        expected = "http://flink.paasta-mycluster.yelp/kurupt--fm-radio--station"
         assert (
-            setup_kubernetes_cr.get_dashboard_url(kind="flink", cluster="mycluster")
+            setup_kubernetes_cr.get_dashboard_url(
+                kind="flink",
+                service="kurupt_fm",
+                instance="radio_station",
+                cluster="mycluster",
+            )
             == expected
         )
 


### PR DESCRIPTION
This will add HTTP call to Flink dashboard inside the monitoring job, and in turn compare the number of taskmanagers (as reported by Flink) against the expected number. Since this call makes use of a significant part of the stack, it is a good end-to-end test.

Extended the unit test for the "happy path", yet need to extend unit tests to cover error cases (e.g. dashboard not reachable etc.)

Note, as a result of refactoring there is also an internal change in how dashboard URL is reported by `paasta status` because now annotation will contain the full URL rather than only "root" part.