### PR TITLE
Fix duplicate leader bug

### DIFF
--- a/paasta_tools/deployd/leader.py
+++ b/paasta_tools/deployd/leader.py
@@ -64,4 +64,3 @@ class PaastaLeaderElection(Election):
         ]
         self.log.info(f"Thread info: {thread_info}")
         self.control.put("ABORT")
-        self.client.stop()

--- a/tests/deployd/test_leader.py
+++ b/tests/deployd/test_leader.py
@@ -44,7 +44,6 @@ class TestPaastaLeaderElection(unittest.TestCase):
             assert self.election.waiting_for_reconnect
             self.election.connection_listener(KazooState.LOST)
             self.mock_control.put.assert_called_with("ABORT")
-            assert self.mock_client.stop.called
 
     def test_reconnection_listener(self):
         self.mock_client.state = KazooState.CONNECTED


### PR DESCRIPTION
It turns out that we have an extra `client.stop()` call to the ZK client
which can happen too early in a ZK connection flap. We already cleanup
later here:
https://github.com/Yelp/paasta/blob/1048a41a45cae134750281843b61480f84cf9015/paasta_tools/utils.py#L3176
so it should be safe to drop this.

The sequence of the bug is like so:
* Connection to ZK drops and we start retry loop to reconnect
* After 10s the ZK session times out and a new leader picks up somewhere
* This triggers a LOST transition which triggers `_terminate` and calls
`stop()` on the client
* Meanwhile the main thread exits and so the `__exit__` is called on the
lock we hold in ZK
https://github.com/python-zk/kazoo/blob/ab0cd00c12624b07dcc3b2d62aa96f8f1e658f65/kazoo/recipe/election.py#L53
* This blocks forever because we've already stopped the ZK client and so
we're unable to give up the lock.
* Now we have a situation where the main thread is done but the
PaastaLeaderElection code is hanging on and so the Workers and Watchers
will keep doing stuff even though a new leader has taken over.