### PR TITLE
silence deprecation warnings

### DIFF
--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -17,6 +17,7 @@
 import argparse
 import logging
 import sys
+import warnings
 
 import argcomplete
 import pkg_resources
@@ -115,6 +116,7 @@ def main(argv=None):
     Ensure we kill any child pids before we quit
     """
     logging.basicConfig()
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
     try:
         args, parser = parse_args(argv)
         if args.command is None:


### PR DESCRIPTION
I can't work out why these started showing up in the first place, but this at least should make them stop (at least for the CLI, I didn't really want to silence them everywhere?)