### PR TITLE
add script for cleaning up notready nodes

### DIFF
--- a/paasta_tools/kubernetes/bin/cleanup_nodes.py
+++ b/paasta_tools/kubernetes/bin/cleanup_nodes.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+# Copyright 2015-2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Usage: ./cleanup_nodes.py [options]
+
+Command line options:
+
+- -v, --verbose: Verbose output
+- -n, --dry-run: Only report what would have been deleted
+"""
+import argparse
+import logging
+import sys
+from typing import List, Tuple, Union
+from kubernetes.client import V1Node, V1DeleteOptions
+from kubernetes.client.rest import ApiException
+from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.kubernetes_tools import get_all_nodes
+from paasta_tools.utils import load_system_paasta_config
+
+log = logging.getLogger(__name__)
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Removes stale kubernetes CRDs.")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", dest="verbose", default=False
+    )
+    parser.add_argument(
+        "-n", "--dry-run", action="store_true", dest="dry_run", default=False
+    )
+    args = parser.parse_args()
+    return args
+
+
+def nodes_for_cleanup(nodes: List[V1Node]) -> List[V1Node]:
+    not_ready = [
+        node for node in nodes if not is_node_ready(node)
+    ]
+    return not_ready
+
+def terminate_nodes(client: KubeClient, nodes: List[V1Node]) -> Tuple[List[str], List[Tuple[str, Exception]]]:
+    success = []
+    errors = []
+    for node in nodes:
+        try:
+            body = V1DeleteOptions()
+            client.core.delete_node(node, body=body, propagation_policy='foreground')
+        except ApiException as e:
+            errors.append((node, e))
+            continue
+        success.append(node)
+    return (success, errors)
+
+def is_node_ready(node: V1Node) -> bool:
+    for condition in node.status.conditions:
+        if condition.type == 'Ready':
+            if condition.status == 'Unknown':
+                return False
+            return condition.status
+    log.error(f"no KubeletReady condition found for node {node.metadata.name}. Conditions {node.status.conditions}")
+    return True
+
+def main() -> None:
+    args = parse_args()
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
+    dry_run = args.dry_run
+
+    kube_client = KubeClient()
+    all_nodes = get_all_nodes(kube_client)
+    log.debug(f"found nodes in cluster {[node.metadata.name for node in all_nodes]}")
+    filtered_nodes = nodes_for_cleanup(all_nodes)
+    log.debug(f"nodes to be deleted: {[node.metadata.name for node in filtered_nodes]}")
+
+    if not dry_run:
+        success, errors = terminate_nodes(kube_client, [node.metadata.name for node in filtered_nodes])
+    else:
+        success, errors = [], []
+        log.info("dry run mode detected: not deleting nodes")
+    
+    for node_name in success:
+        log.info(f"successfully deleted node {node_name}")
+
+    for node_name, exception in errors:
+        log.error(f"error deleting node: {node_name}: {exception}")
+
+    if errors:
+        sys.exit(1)
+        
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kubernetes/bin/test_cleanup_nodes.py
+++ b/tests/kubernetes/bin/test_cleanup_nodes.py
@@ -1,0 +1,108 @@
+import mock
+import pytest
+from kubernetes.client.rest import ApiException
+from kubernetes.client import V1DeleteOptions
+
+from paasta_tools.kubernetes.bin.cleanup_nodes import main
+from paasta_tools.kubernetes.bin.cleanup_nodes import nodes_for_cleanup
+from paasta_tools.kubernetes.bin.cleanup_nodes import terminate_nodes
+
+def test_nodes_for_cleanup():
+    with mock.patch('paasta_tools.kubernetes.bin.cleanup_nodes.is_node_ready', side_effect=[True, False, False]):
+        m1, m2, m3 = mock.Mock(), mock.Mock(), mock.Mock()
+        for_cleanup = nodes_for_cleanup([m1,m2,m3])
+        assert for_cleanup == [m2,m3]
+
+def test_terminate_nodes():
+
+    mock_client = mock.MagicMock()
+    mock_client.core.delete_node.side_effect = [None, ApiException(404), None]
+
+    m1, m2, m3 = mock.Mock(), mock.Mock(), mock.Mock()
+    success, errors = terminate_nodes(
+        client=mock_client, 
+        nodes=[m1, m2, m3], 
+    )
+    expected_calls = [
+        mock.call.core.delete_node(node, body=V1DeleteOptions(), propagation_policy='foreground') 
+        for node in [m1, m2, m3]
+    ]
+
+    assert mock_client.mock_calls == expected_calls
+    assert success == [m1, m3]
+    assert errors[0][0] == m2
+    assert isinstance(errors[0][1], ApiException)
+
+
+    mock_client.reset_mock()
+
+    mock_client.core.delete_node.side_effect = [None, ApiException(404), None]
+    success, errors = terminate_nodes(
+        client=mock_client, 
+        nodes=[m1, m2, m3], 
+    )
+    expected_calls = [
+        mock.call.core.delete_node(node, body=V1DeleteOptions(), propagation_policy='foreground') 
+        for node in [m1,m2,m3]
+    ]
+    assert mock_client.mock_calls == expected_calls
+    assert success == [m1, m3]
+    assert errors[0][0] == m2
+    assert isinstance(errors[0][1], ApiException)
+
+
+def test_main():
+    with mock.patch(
+        "paasta_tools.kubernetes.bin.cleanup_nodes.get_all_nodes", autospec=True
+    ) as mock_get_all_nodes, mock.patch(
+        "paasta_tools.kubernetes.bin.cleanup_nodes.KubeClient", autospec=True
+    ) as mock_kube_client, mock.patch(
+        'paasta_tools.kubernetes.bin.cleanup_nodes.is_node_ready', autospec=True
+    ) as mock_is_node_ready, mock.patch(
+        'paasta_tools.kubernetes.bin.cleanup_nodes.nodes_for_cleanup', autospec=True
+    ) as mock_nodes_for_cleanup, mock.patch(
+        'paasta_tools.kubernetes.bin.cleanup_nodes.terminate_nodes', autospec=True
+    ) as mock_terminate_nodes, mock.patch(
+        'paasta_tools.kubernetes.bin.cleanup_nodes.parse_args', autospec=True
+    ) as mock_parse_args:
+        mock_args = mock.MagicMock()
+        mock_args.dry_run = False
+
+        mock_parse_args.return_value = mock_args
+
+        m1, m2, m3 = mock.MagicMock(), mock.MagicMock(), mock.MagicMock()
+        mock_get_all_nodes.return_value = [m1, m2, m3]
+
+        mock_is_node_ready.side_effect = [True, False, False]
+
+        mock_terminate_nodes.return_value = ([], [('foo', mock.MagicMock())])
+        with pytest.raises(SystemExit) as e:
+            main()
+            mock_terminate_nodes.assert_called_once_with([m2, m3])
+            assert e.value.code == 1
+
+
+def test_main_dry_run():
+    with mock.patch(
+        "paasta_tools.kubernetes.bin.cleanup_nodes.get_all_nodes", autospec=True
+    ) as mock_get_all_nodes, mock.patch(
+        "paasta_tools.kubernetes.bin.cleanup_nodes.KubeClient", autospec=True
+    ) as mock_kube_client, mock.patch(
+        'paasta_tools.kubernetes.bin.cleanup_nodes.is_node_ready', autospec=True
+    ) as mock_is_node_ready, mock.patch(
+        'paasta_tools.kubernetes.bin.cleanup_nodes.nodes_for_cleanup', autospec=True
+    ) as mock_nodes_for_cleanup, mock.patch(
+        'paasta_tools.kubernetes.bin.cleanup_nodes.terminate_nodes', 
+    ) as mock_terminate_nodes, mock.patch(
+        'paasta_tools.kubernetes.bin.cleanup_nodes.parse_args', autospec=True
+    ) as mock_parse_args:
+        mock_args = mock.MagicMock()
+        mock_args.dry_run = True
+
+        mock_parse_args.return_value = mock_args
+        m1, m2, m3 = mock.MagicMock(), mock.MagicMock(), mock.MagicMock()
+        mock_get_all_nodes.return_value = [m1, m2, m3]
+        mock_is_node_ready.side_effect = [True, False, False]
+
+        main()
+        mock_terminate_nodes.assert_not_called()


### PR DESCRIPTION
we commonly see this with nodes being shutdown. the 'Ready' condition
goes to unknown. This could also happen if we experience a network
partition or the kubelet loses contact. if that happens, then the
kubelet will re-register when it returns.

open question for reviewers: should we also verify that the node doesn't exist with boto before we delete it?