### PR TITLE
use instance name as container name to avoid 63 character restriction

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -680,7 +680,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     _exec=V1ExecAction(command=["/bin/sh", "-c", "sleep 30"])
                 )
             ),
-            name=self.get_sanitised_deployment_name(),
+            name=self.get_sanitised_instance_name(),
             liveness_probe=self.get_liveness_probe(service_namespace_config),
             ports=[V1ContainerPort(container_port=self.get_container_port())],
             security_context=self.get_security_context(),

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -495,7 +495,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                         period_seconds=10,
                         timeout_seconds=10,
                     ),
-                    name="kurupt-fm",
+                    name="fm",
                     ports=[V1ContainerPort(container_port=8888)],
                     volume_mounts=mock_get_volume_mounts.return_value,
                 ),


### PR DESCRIPTION
WIth this change together with replacing '_' with '-' in yelpsoa_configs, we can avoid majority  of errors like https://fluffy.yelpcorp.com/i/tvb8Mwj1txVq4QDGSxm8LkFDRx5VWKTH.html 

I'm not sure where else container name is used. Definitely let me know if you know. Just ignore this PR if you don't know.