### PR TITLE
fix another hpa bug (target_average_utilization has to be int)

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -392,7 +392,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 V2beta1MetricSpec(
                     type="Resource",
                     resource=V2beta1ResourceMetricSource(
-                        name="cpu", target_average_utilization=target
+                        name="cpu", target_average_utilization=int(target)
                     ),
                 )
             )


### PR DESCRIPTION
I found this bug when I was migrating. Should have tested all configs manually beforehand. 