### PR TITLE
Fix k8s pod filter

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1319,8 +1319,8 @@ def filter_pods_by_service_instance(
         pod
         for pod in pod_list
         if pod.metadata.labels is not None
-        and pod.metadata.labels["yelp.com/paasta_service"] == service
-        and pod.metadata.labels["yelp.com/paasta_instance"] == instance
+        and pod.metadata.labels.get("yelp.com/paasta_service", "") == service
+        and pod.metadata.labels.get("yelp.com/paasta_instance", "") == instance
     ]
 
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1667,7 +1667,8 @@ def test_filter_pods_for_service_instance():
         )
     )
     mock_pod_3 = mock.MagicMock(metadata=mock.MagicMock(labels=None))
-    mock_pods = [mock_pod_1, mock_pod_2, mock_pod_3]
+    mock_pod_4 = mock.MagicMock(metadata=mock.MagicMock(labels={"some": "thing"}))
+    mock_pods = [mock_pod_1, mock_pod_2, mock_pod_3, mock_pod_4]
     assert filter_pods_by_service_instance(mock_pods, "kurupt", "fm") == [mock_pod_1]
     assert filter_pods_by_service_instance(mock_pods, "kurupt", "garage") == [
         mock_pod_2


### PR DESCRIPTION
This can fail if the labels aren't there. If they aren't labelled they
shouldn't be in the filter so just skipping them.