### PR TITLE
Improve error reporting

### DIFF
--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -189,7 +189,9 @@ def get_flink_jobmanager_overview(
         return json.loads(response)
     except requests.RequestException as e:
         url = e.request.url
-        err = e.strerror
+        err = e.response or str(e)
         raise ValueError(f"failed HTTP request to Jobmanager dashboard {url}: {err}")
     except json.JSONDecodeError as e:
         raise ValueError(f"JSON decoding error from Jobmanager dashboard: {e}")
+    except ConnectionError as e:
+        raise ValueError(f"failed HTTP request to Jobmanager dashboard: {e}")


### PR DESCRIPTION
As per https://requests.kennethreitz.org/en/master/_modules/requests/exceptions/ , some of the `requests` exceptions inherit from `ConnectionError` and these need to be handled, too. Also we want to show `e.response` when available