### PR TITLE
Set disk quota for k8s

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -615,8 +615,13 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             limits={
                 "cpu": self.get_cpus() + self.get_cpu_burst_add(),
                 "memory": f"{self.get_mem()}Mi",
+                "ephemeral-storage": f"{self.get_disk()}Mi",
             },
-            requests={"cpu": self.get_cpus(), "memory": f"{self.get_mem()}Mi"},
+            requests={
+                "cpu": self.get_cpus(),
+                "memory": f"{self.get_mem()}Mi",
+                "ephemeral-storage": f"{self.get_disk()}Mi",
+            },
         )
 
     def get_liveness_probe(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -433,10 +433,18 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_mem",
             autospec=True,
             return_value=2048,
+        ), mock.patch(
+            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_disk",
+            autospec=True,
+            return_value=4096,
         ):
             assert self.deployment.get_resource_requirements() == V1ResourceRequirements(
-                limits={"cpu": 1.3, "memory": "2048Mi"},
-                requests={"cpu": 0.3, "memory": "2048Mi"},
+                limits={"cpu": 1.3, "memory": "2048Mi", "ephemeral-storage": "4096Mi"},
+                requests={
+                    "cpu": 0.3,
+                    "memory": "2048Mi",
+                    "ephemeral-storage": "4096Mi",
+                },
             )
 
     def test_get_kubernetes_containers(self):


### PR DESCRIPTION
Set `ephemeral-storage` resource and limit for pods according to the
configuration, setting the disk quota as a result.

Please note that that is a soft disk quota which doesn't prevent a pod
from using more disk space than requested.  Instead of that, Kubernetes
evicts the violating pod, which then either rescheduled to another node
or becomes `Evicted`.  Please see the corresponding KEP for more
information:
https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20180906-quotas-for-ephemeral-storage.md