### PR TITLE
validate instance/service names no more than 63 characters

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -14,7 +14,7 @@ so you are free to use them for YAML templates.
 
 **Note** that service names (the name of the folder where your config file is located) should be no more than 63 characters.
 For kubernetes services(config files with kubernetes as prefix), the instance names should be nore more than 63 characters as well.
-_ is counted as two characters.
+_ is counted as two character. We convert _  to -- because underscore is not allowed in kubernetes pod names.
 
 Example::
 

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -12,6 +12,10 @@ Duplication can be reduced by using YAML `anchors and merges <https://gist.githu
 PaaSTA will **not** attempt to run any definition prefixed with ``_``,
 so you are free to use them for YAML templates.
 
+**Note** that service names (the name of the folder where your config file is located) should be no more than 63 characters.
+For kubernetes services(config files with kubernetes as prefix), the instance names should be nore more than 63 characters as well.
+_ is counted as two characters.
+
 Example::
 
     _template: &template

--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -326,7 +326,7 @@ def paasta_check(args):
     deployments_check(service, soa_dir)
     sensu_check(service, service_path, soa_dir)
     smartstack_check(service, service_path, soa_dir)
-    paasta_validate_soa_configs(service_path)
+    paasta_validate_soa_configs(service, service_path)
 
 
 def read_dockerfile_lines(path):

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -110,21 +110,23 @@ def get_schema(file_type):
 
 
 def validate_instance_names(config_file_object, file_path):
-    return_code = True
+    errors = []
     for instance_name in config_file_object:
         if (
             not instance_name.startswith("_")
             and len(sanitise_kubernetes_name(instance_name)) > 63
         ):
-            return_code = False
-            paasta_print(
-                failure(
-                    f"Length of instance name {instance_name} should be no more than 63."
-                    + " Note _ is replaced with - due to Kubernetes restriction",
-                    "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html",
-                )
+            errors.append(instance_name)
+    if errors:
+        error_string = "\n".join(errors)
+        paasta_print(
+            failure(
+                f"Length of instance name \n{error_string}\n should be no more than 63."
+                + " Note _ is replaced with -- due to Kubernetes restriction",
+                "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html",
             )
-    return return_code
+        )
+    return len(errors) == 0
 
 
 def validate_service_name(service):

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -30,6 +30,7 @@ from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import PaastaColors
 from paasta_tools.cli.utils import success
+from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
 from paasta_tools.tron_tools import list_tron_clusters
 from paasta_tools.tron_tools import validate_complete_config
 from paasta_tools.utils import get_service_instance_list
@@ -108,6 +109,37 @@ def get_schema(file_type):
     return json.loads(schema)
 
 
+def validate_instance_names(config_file_object, file_path):
+    return_code = True
+    for instance_name in config_file_object:
+        if (
+            not instance_name.startswith("_")
+            and len(sanitise_kubernetes_name(instance_name)) > 63
+        ):
+            return_code = False
+            paasta_print(
+                failure(
+                    f"Length of instance name {instance_name} should be no more than 63."
+                    + " Note _ is replaced with - due to Kubernetes restriction",
+                    "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html",
+                )
+            )
+    return return_code
+
+
+def validate_service_name(service):
+    if len(sanitise_kubernetes_name(service)) > 63:
+        paasta_print(
+            failure(
+                f"Length of service name {service} should be no more than 63."
+                + " Note _ is replaced with - due to Kubernetes restriction",
+                "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html",
+            )
+        )
+        return False
+    return True
+
+
 def validate_schema(file_path, file_type):
     """Check if the specified config file has a valid schema
 
@@ -139,6 +171,10 @@ def validate_schema(file_path, file_type):
         raise
     try:
         validator.validate(config_file_object)
+        if file_type == "kubernetes" and not validate_instance_names(
+            config_file_object, file_path
+        ):
+            return
     except ValidationError:
         paasta_print(f"{SCHEMA_INVALID}: {file_path}")
 
@@ -352,12 +388,15 @@ def validate_unique_instance_names(service_path):
     return check_passed
 
 
-def paasta_validate_soa_configs(service_path):
+def paasta_validate_soa_configs(service, service_path):
     """Analyze the service in service_path to determine if the conf files are valid
 
     :param service_path: Path to directory containing soa conf yaml files for service
     """
     if not check_service_path(service_path):
+        return False
+
+    if not validate_service_name(service):
         return False
 
     returncode = True
@@ -385,5 +424,5 @@ def paasta_validate(args):
     service = args.service
     soa_dir = args.yelpsoa_config_root
     service_path = get_service_path(service, soa_dir)
-    if not paasta_validate_soa_configs(service_path):
+    if not paasta_validate_soa_configs(service, service_path):
         return 1

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -25,6 +25,7 @@ from paasta_tools.cli.cmds.validate import paasta_validate_soa_configs
 from paasta_tools.cli.cmds.validate import SCHEMA_INVALID
 from paasta_tools.cli.cmds.validate import SCHEMA_VALID
 from paasta_tools.cli.cmds.validate import UNKNOWN_SERVICE
+from paasta_tools.cli.cmds.validate import validate_instance_names
 from paasta_tools.cli.cmds.validate import validate_paasta_objects
 from paasta_tools.cli.cmds.validate import validate_schema
 from paasta_tools.cli.cmds.validate import validate_tron
@@ -55,7 +56,7 @@ def test_paasta_validate_calls_everything(
     mock_validate_unique_instance_names.return_value = True
 
     args = mock.MagicMock()
-    args.service = None
+    args.service = "test"
     args.soa_dir = None
 
     paasta_validate(args)
@@ -112,10 +113,18 @@ def test_validate_unknown_service():
     paasta_validate(args) == 1
 
 
+def test_validate_service_name():
+    args = mock.MagicMock()
+    args.service = "aa________________________________a"
+    args.yelpsoa_config_root = "unused"
+    paasta_validate(args) == 1
+
+
 def test_validate_unknown_service_service_path():
     service_path = "unused/path"
+    service = "unused"
 
-    assert not paasta_validate_soa_configs(service_path)
+    assert not paasta_validate_soa_configs(service, service_path)
 
 
 @patch("paasta_tools.cli.cmds.validate.os.path.isdir", autospec=True)
@@ -190,6 +199,17 @@ _main_http:
         assert validate_schema("unused_service_path.yaml", schema_type)
         output, _ = capsys.readouterr()
         assert SCHEMA_VALID in output
+
+
+@patch("paasta_tools.cli.cmds.validate.get_file_contents", autospec=True)
+def test_validate_instance_names(mock_get_file_contents, capsys):
+    fake_instances = {
+        "a_________________________________________a": {},
+        "b_________________________________________b": {},
+    }
+    assert not validate_instance_names(fake_instances, "fake_path")
+    output, _ = capsys.readouterr()
+    assert "Length of instance name" in output
 
 
 @patch("paasta_tools.cli.cmds.validate.get_file_contents", autospec=True)


### PR DESCRIPTION
Check if service name is longer than 63 for all serivces.
Check if instance name is longer than 63 for k8s instances.