### PR TITLE
deprecate upthedown bounce methoed for k8s

### DIFF
--- a/docs/source/bouncing.rst
+++ b/docs/source/bouncing.rst
@@ -104,6 +104,8 @@ combined with a limited cluster size.
 .. image:: bounce_upthendown.png
    :scale: 100%
 
+**Note**: This is deprecated on kubernetes.
+
 downthenup
 """"""""""
 

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -13,7 +13,7 @@ PaaSTA will **not** attempt to run any definition prefixed with ``_``,
 so you are free to use them for YAML templates.
 
 **Note** that service names (the name of the folder where your config file is located) should be no more than 63 characters.
-For kubernetes services(config files with kubernetes as prefix), the instance names should be nore more than 63 characters as well.
+For kubernetes services(config files with kubernetes as prefix), the instance names should be no more than 63 characters as well.
 _ is counted as two character. We convert _  to -- because underscore is not allowed in kubernetes pod names.
 
 Example::

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -150,7 +150,11 @@
                     "uniqueItems": true
                 },
                 "bounce_method": {
-                    "type": "string"
+                    "enum": [
+                        "crossover",
+                        "brutal",
+                        "downtheup"
+                    ]
                 },
                 "bounce_health_params": {
                     "type": "object",

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -153,7 +153,7 @@
                     "enum": [
                         "crossover",
                         "brutal",
-                        "downtheup"
+                        "downthenup"
                     ]
                 },
                 "bounce_health_params": {


### PR DESCRIPTION
This should be enough to deprecate upthendown. We just need to change upthendown to crossover when migrating to k8s then. 