### PR TITLE
add missing boto3-type-annotations req

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -3,6 +3,7 @@ aiohttp >= 3.5.4
 argcomplete >= 0.8.1
 boto
 boto3
+boto3-type-annotations
 botocore
 bravado >= 10.2.0
 choice >= 0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ attrs==17.4.0
 binaryornot==0.4.4
 boto==2.48.0
 boto3==1.4.7
+boto3-type-annotations==0.3.1
 botocore==1.7.21
 bravado==10.4.1
 bravado-core==5.12.1


### PR DESCRIPTION
even though it is only used for type checking, we still need included so
the import works