### PR TITLE
Fix crash in get_bounce_method when bounce_method = brutal…

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -124,7 +124,11 @@ log = logging.getLogger(__name__)
 KUBE_CONFIG_PATH = "/etc/kubernetes/admin.conf"
 YELP_ATTRIBUTE_PREFIX = "yelp.com/"
 CONFIG_HASH_BLACKLIST = {"replicas"}
-KUBE_DEPLOY_STATEGY_MAP = {"crossover": "RollingUpdate", "downthenup": "Recreate"}
+KUBE_DEPLOY_STATEGY_MAP = {
+    "crossover": "RollingUpdate",
+    "brutal": "RollingUpdate",  # Added for backwards compatibility with marathon app configs
+    "downthenup": "Recreate",
+}
 KUBE_DEPLOY_STATEGY_REVMAP = {v: k for k, v in KUBE_DEPLOY_STATEGY_MAP.items()}
 HACHECK_POD_NAME = "hacheck"
 


### PR DESCRIPTION
…by defining an entry for brutal in KUBE_DEPLOY_STRATEGY_MAP.

This fixes this traceback, seen in paasta status -v:

```
ERROR: Traceback (most recent call last):
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/api/views/instance.py", line 866, in instance_status
    include_smartstack=include_smartstack,
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/api/views/instance.py", line 193, in kubernetes_instance_status
    job_config.get_bounce_method()
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/kubernetes_tools.py", line 361, in get_bounce_method
    return KUBE_DEPLOY_STATEGY_MAP[bounce_method]
KeyError: 'brutal'
```