### PR TITLE
set the paasta_instance docker label for spark-run

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -489,18 +489,15 @@ def get_spark_config(
         cluster=args.cluster
     )
     mesos_address = "{}:{}".format(find_mesos_leader(cluster_fqdn), MESOS_MASTER_PORT)
+    paasta_instance = get_smart_paasta_instance_name(args.instance)
     non_user_args = {
         "spark.master": "mesos://%s" % mesos_address,
         "spark.ui.port": spark_ui_port,
         "spark.executorEnv.PAASTA_SERVICE": args.service,
-        "spark.executorEnv.PAASTA_INSTANCE": get_smart_paasta_instance_name(
-            args.instance
-        ),
+        "spark.executorEnv.PAASTA_INSTANCE": paasta_instance,
         "spark.executorEnv.PAASTA_CLUSTER": args.cluster,
         "spark.executorEnv.PAASTA_INSTANCE_TYPE": "spark",
-        "spark.mesos.executor.docker.parameters": "label=paasta_service={},label=paasta_instance={}_{}".format(
-            args.service, args.instance, get_username()
-        ),
+        "spark.mesos.executor.docker.parameters": f"label=paasta_service={args.service},label=paasta_instance={paasta_instance}",
         "spark.mesos.executor.docker.volumes": ",".join(volumes),
         "spark.mesos.executor.docker.image": docker_img,
         "spark.mesos.principal": "spark",


### PR DESCRIPTION
@qui said:

> no, because that info isn’t readily available from the Mesos master, but the labels are
> i mean, the environment variables are used by the DockerStats collector
> both are necessary
> the paasta_instance_resource_utilization_summary report joins the tmp_paasta_allocation report (which uses labels) and the fullerite data (which uses env)

So this change makes the Docker labels match the environment variables, which should make this stuff show up in Splunk.