### PR TITLE
Always share the process namespace in k8s pods

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -997,6 +997,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     system_paasta_config=system_paasta_config,
                     service_namespace_config=service_namespace_config,
                 ),
+                share_process_namespace=True,
                 node_selector=self.get_node_selector(),
                 restart_policy="Always",
                 volumes=self.get_pod_volumes(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -949,6 +949,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                 spec=V1PodSpec(
                     service_account_name=None,
                     containers=mock_get_kubernetes_containers.return_value,
+                    share_process_namespace=True,
                     node_selector={"yelp.com/pool": "default"},
                     restart_policy="Always",
                     volumes=[],


### PR DESCRIPTION
With k8s, in some sense we are moving forward with the pause container, to keep all the random namespaces together. 

But in a different sense, we are moving backwards, because the pid namespaces are not shared (they used to be by default, but then that was reverted). 

Because of this, now "every" container needs to solve the dumb-init problem again, which I don't want.

Instead, I would like to turn this option on for all paasta pods, so that we don't need to add dumb-init to every container we run.

Ref: "Some Context on PID Namespace Sharing"