### PR TITLE
Basic support for paasta local-run for k8s

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -897,30 +897,16 @@ def run_docker_container(
     return returncode
 
 
-def command_function_for_framework(framework, date):
+def format_command_for_type(command, instance_type, date):
     """
-    Given a framework, return a function that appropriately formats
+    Given an instance_type, return a function that appropriately formats
     the command to be run.
     """
-
-    def format_marathon_command(cmd):
-        return cmd
-
-    def format_tron_command(cmd: str) -> str:
-        interpolated_command = parse_time_variables(cmd, date)
+    if instance_type == "tron":
+        interpolated_command = parse_time_variables(command, date)
         return interpolated_command
-
-    def format_adhoc_command(cmd):
-        return cmd
-
-    if framework == "marathon":
-        return format_marathon_command
-    elif framework == "adhoc":
-        return format_adhoc_command
-    elif framework == "tron":
-        return format_tron_command
     else:
-        raise ValueError("Invalid Framework")
+        return command
 
 
 def configure_and_run_docker_container(
@@ -1055,8 +1041,9 @@ def configure_and_run_docker_container(
     else:
         command_from_config = instance_config.get_cmd()
         if command_from_config:
-            command_modifier = command_function_for_framework(instance_type, args.date)
-            command = command_modifier(command_from_config)
+            command = format_command_for_type(
+                command=command_from_config, instance_type=instance_type, date=args.date
+            )
         else:
             command = instance_config.get_args()
 

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -19,11 +19,11 @@ from pytest import raises
 
 from paasta_tools.adhoc_tools import AdhocJobConfig
 from paasta_tools.cli.cli import main
-from paasta_tools.cli.cmds.local_run import command_function_for_framework
 from paasta_tools.cli.cmds.local_run import configure_and_run_docker_container
 from paasta_tools.cli.cmds.local_run import decrypt_secret_environment_for_service
 from paasta_tools.cli.cmds.local_run import decrypt_secret_environment_variables
 from paasta_tools.cli.cmds.local_run import docker_pull_image
+from paasta_tools.cli.cmds.local_run import format_command_for_type
 from paasta_tools.cli.cmds.local_run import get_container_id
 from paasta_tools.cli.cmds.local_run import get_container_name
 from paasta_tools.cli.cmds.local_run import get_docker_run_cmd
@@ -1786,27 +1786,20 @@ def test_pull_docker_image_exists_with_failure(mock_run, mock_flock):
     )
 
 
-def test_command_function_for_framework_for_marathon():
-    fn = command_function_for_framework("marathon", "fake-date")
-    assert fn("foo") == "foo"
+def test_format_command_for_type_for_marathon():
+    actual = format_command_for_type("foo", "marathon", "fake-date")
+    assert actual == "foo"
 
 
 @mock.patch("paasta_tools.cli.cmds.local_run.parse_time_variables", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.local_run.datetime", autospec=True)
-def test_command_function_for_framework_for_tron(
-    mock_datetime, mock_parse_time_variables
-):
+def test_format_command_for_tron(mock_datetime, mock_parse_time_variables):
     fake_date = mock.Mock()
     mock_datetime.datetime.now.return_value = fake_date
     mock_parse_time_variables.return_value = "foo"
-    fn = command_function_for_framework("tron", fake_date)
-    fn("foo")
-    mock_parse_time_variables.assert_called_once_with("foo", fake_date)
-
-
-def test_command_function_for_framework_throws_error():
-    with raises(ValueError):
-        assert command_function_for_framework("bogus_string", "fake_date")
+    actual = format_command_for_type("{foo}", "tron", fake_date)
+    mock_parse_time_variables.assert_called_once_with("{foo}", fake_date)
+    assert actual == "foo"
 
 
 @mock.patch(


### PR DESCRIPTION
This doesn't do anything fancy about sidecars or whatever yet, but will prevent local-run from crashing when running it for something in stagef.

This code looks a little overkill? But maybe we need room for more stuff and other frameworks?