### PR TITLE
check_oom_events shouldn't crash on a parsing error

### DIFF
--- a/paasta_tools/check_oom_events.py
+++ b/paasta_tools/check_oom_events.py
@@ -163,13 +163,19 @@ def send_sensu_event(instance, oom_events, args):
         oom_events=oom_events,
         is_check_enabled=monitoring_overrides.get("check_oom_events", True),
     )
+    memory_limit = instance.get_mem()
+    try:
+        memory_limit_str = f"{int(memory_limit)}MB"
+    except ValueError:
+        memory_limit_str = memory_limit
+
     monitoring_overrides.update(
         {
             "page": False,
             "alert_after": "0m",
             "realert_every": args.realert_every,
             "runbook": "y/check-oom-events",
-            "tip": "Try bumping the memory limit past %dMB" % instance.get_mem(),
+            "tip": "Try bumping the memory limit past %s" % memory_limit_str,
         }
     )
     return monitoring_tools.send_event(


### PR DESCRIPTION
This has been broken since Oct 24 (though the relevant block has been in yelpsoa for four months).

```
Traceback (most recent call last):
  File "/usr/bin/check_oom_events", line 207, in <module>
    main(sys.argv)
  File "/usr/bin/check_oom_events", line 201, in main
    send_sensu_event(instance_config, oom_events, args)
  File "/usr/bin/check_oom_events", line 174, in send_sensu_event
    "tip": "Try bumping the memory limit past %dMB" % instance.get_mem(),
TypeError: %d format: a number is required, not str
```