### PR TITLE
fix paasta status error on stagef

### DIFF
--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -750,7 +750,11 @@ def get_mesos_slaves_grouped_by_attribute(slaves, attribute):
               (response can contain multiple 'attribute_value)
     """
     sorted_slaves = sorted(
-        slaves, key=lambda slave: slave["attributes"].get(attribute, "")
+        slaves,
+        key=lambda slave: (
+            slave["attributes"].get(attribute) is None,
+            slave["attributes"].get(attribute),
+        ),
     )
     return {
         key: list(group)

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -749,7 +749,9 @@ def get_mesos_slaves_grouped_by_attribute(slaves, attribute):
     :returns: a dictionary of the form {'<attribute_value>': [<list of hosts with attribute=attribute_value>]}
               (response can contain multiple 'attribute_value)
     """
-    sorted_slaves = sorted(slaves, key=lambda slave: slave["attributes"].get(attribute))
+    sorted_slaves = sorted(
+        slaves, key=lambda slave: slave["attributes"].get(attribute, "")
+    )
     return {
         key: list(group)
         for key, group in itertools.groupby(


### PR DESCRIPTION
>   File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/mesos_tools.py", line 752, in get_mesos_slaves_grouped_by_attribute
>     sorted_slaves = sorted(slaves, key=lambda slave: slave["attributes"].get(attribute))
> TypeError: '<' not supported between instances of 'str' and 'NoneType'

I don't know why attribute would be none. But setting it to '' should fix the issue. 