### PR TITLE
RELENG-41130: Track PaaSTA rollback events

### DIFF
--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -21,7 +21,9 @@ from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import validate_full_git_sha
 from paasta_tools.cli.utils import validate_given_deploy_groups
+from paasta_tools.deployment_utils import get_currently_deployed_sha
 from paasta_tools.remote_git import list_remote_refs
+from paasta_tools.utils import _log_audit
 from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import format_table
@@ -30,6 +32,7 @@ from paasta_tools.utils import list_services
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import parse_timestamp
+from paasta_tools.utils import RollbackTypes
 
 
 def add_subparser(subparsers):
@@ -206,14 +209,22 @@ def paasta_rollback(args):
     returncode = 0
 
     for deploy_group in deploy_groups:
-        returncode = max(
-            mark_for_deployment(
-                git_url=git_url,
-                service=service,
-                deploy_group=deploy_group,
-                commit=commit,
-            ),
-            returncode,
+        rolled_back_from = get_currently_deployed_sha(service, deploy_group)
+        returncode |= mark_for_deployment(
+            git_url=git_url, service=service, deploy_group=deploy_group, commit=commit
         )
+
+        # we could also gate this by the return code from m-f-d, but we probably care more about someone wanting to
+        # rollback than we care about if the underlying machinery was successfully able to complete the request
+        if rolled_back_from != commit:
+            audit_action_details = {
+                "rolled_back_from": rolled_back_from,
+                "rolled_back_to": commit,
+                "rollback_type": RollbackTypes.USER_INITIATED_ROLLBACK.value,
+                "deploy_group": deploy_group,
+            }
+            _log_audit(
+                action="rollback", action_details=audit_action_details, service=service
+            )
 
     return returncode

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -37,6 +37,7 @@ import threading
 import time
 import warnings
 from collections import OrderedDict
+from enum import Enum
 from fnmatch import fnmatch
 from functools import lru_cache
 from functools import wraps
@@ -128,6 +129,11 @@ INSTANCE_TYPES = (
 )
 INSTANCE_TYPES_K8S = {"flink", "cassandracluster", "kafkacluster"}
 INSTANCE_TYPES_WITH_SET_STATE = {"flink"}
+
+
+class RollbackTypes(Enum):
+    AUTOMATIC_SLO_ROLLBACK = "automatic_slo_rollback"
+    USER_INITIATED_ROLLBACK = "user_initiated_rollback"
 
 
 class TimeCacheEntry(TypedDict):


### PR DESCRIPTION
We want to track rollback rates for services in EE Metrics, so we've instrumented both the `paasta rollback` command and the Slack/SLO rollback events to log to the same audit stream that we use for m-f-d.

I wanted to log this as part of the existing _log_audit calls in m-f-d, but it doesn't seem like there's any way of knowing at that point if we're rolling back and why.

**testing done**: 

- `make test itest`
- manual (i.e., clicking buttons and checking the audit stream)


**questions**:
- writing tests for the state machine stuff doesn't look particularly simple from what I saw - any ideas here?
- I added an enum for type safety, but not sure if it'd be preferable to just use simple named constants and type things as `str` - in the same vein, would we prefer TypedDicts for all new dicts (e.g., the one returned by `__build_rollback_audit_details`) or am I overthinking things?
- maybe it would make more sense to just build mock.call objects and compare those in the rollback tests?