### PR TITLE
supports min_task_uptime and check_haproxy in k8s

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2194,11 +2194,6 @@ class SystemPaastaConfig:
             "docker-paasta.yelpcorp.com:443/hacheck-k8s-sidecar",
         )
 
-    def get_enable_nerve_readiness_check(self) -> bool:
-        """Enables a k8s readiness check on the Pod to ensure that all registrations
-        are UP on the local synapse haproxy"""
-        return self.config_dict.get("enable_nerve_readiness_check", True)
-
     def get_register_k8s_pods(self) -> bool:
         """Enable registration of k8s services in nerve"""
         return self.config_dict.get("register_k8s_pods", False)

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1,5 +1,4 @@
 import unittest
-from pprint import pprint
 from typing import Sequence
 
 import mock
@@ -385,7 +384,6 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     ports=[V1ContainerPort(container_port=6666)],
                 )
             ]
-            pprint(ret)
             assert ret == expected
             mock_get_enable_nerve_readiness_check.return_value = True
             mock_system_config = mock.Mock(


### PR DESCRIPTION
I changed the behavior of get_enable_nerve_readiness_check so that the condition when it's triggered is the same as check_haproxy. enable_nerve_readiness_check param is never used in yelpsoa_configs so it's fine. I think we probably want to paasta configs later. It does not make sense to put check_haproxy under bounce_health_params anymore, as it is irrelevant to bouncing essentially.