### PR TITLE
Fix bounce_method on k8s instances

### DIFF
--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -195,9 +195,7 @@ def kubernetes_instance_status(
             len(active_shas["config_sha"]), len(active_shas["git_sha"])
         )
         kstatus["desired_state"] = job_config.get_desired_state()
-        kstatus["bounce_method"] = kubernetes_tools.KUBE_DEPLOY_STATEGY_REVMAP[
-            job_config.get_bounce_method()
-        ]
+        kstatus["bounce_method"] = job_config.get_bounce_method()
         kubernetes_job_status(
             kstatus=kstatus,
             client=client,

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -132,7 +132,6 @@ KUBE_DEPLOY_STATEGY_MAP = {
     "downthenup": "Recreate",
     "brutal": "RollingUpdate",
 }
-KUBE_DEPLOY_STATEGY_REVMAP = {v: k for k, v in KUBE_DEPLOY_STATEGY_MAP.items()}
 HACHECK_POD_NAME = "hacheck"
 
 

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -956,3 +956,31 @@ def test_tron_instance_status(
     assert response["tron"]["action_start_time"] == "fake_start_time"
     assert response["tron"]["action_stdout"] == "fake_stdout"
     assert response["tron"]["action_stderr"] == "fake_stderr"
+
+
+@mock.patch("paasta_tools.api.views.instance.kubernetes_job_status", autospec=True)
+@mock.patch("paasta_tools.kubernetes_tools.get_active_shas_for_service", autospec=True)
+@mock.patch(
+    "paasta_tools.kubernetes_tools.replicasets_for_service_instance", autospec=True
+)
+@mock.patch("paasta_tools.kubernetes_tools.pods_for_service_instance", autospec=True)
+@mock.patch(
+    "paasta_tools.kubernetes_tools.load_kubernetes_service_config", autospec=True
+)
+def test_kubernetes_instance_status_bounce_method(
+    mock_load_kubernetes_service_config,
+    mock_pods_for_service_instance,
+    mock_replicasets_for_service_instance,
+    mock_get_active_shas_for_service,
+    mock_kubernetes_job_status,
+):
+    settings.kubernetes_client = True
+    st = {}
+    svc = "fake-svc"
+    inst = "fake-inst"
+
+    mock_job_config = mock.Mock()
+    mock_load_kubernetes_service_config.return_value = mock_job_config
+
+    actual = instance.kubernetes_instance_status(st, svc, inst, 0, False)
+    assert actual["bounce_method"] == mock_job_config.get_bounce_method()


### PR DESCRIPTION
also drop REVMAP as it's no longer used anywhere