### PR TITLE
Always make sure we are using the safe c loader for yaml

### DIFF
--- a/paasta_itests/steps/paasta_native_steps.py
+++ b/paasta_itests/steps/paasta_native_steps.py
@@ -7,7 +7,6 @@ from typing import Tuple
 
 import a_sync
 import mock
-import yaml
 from behave import given
 from behave import then
 from behave import when
@@ -16,6 +15,7 @@ from requests import HTTPError
 
 from paasta_tools import drain_lib
 from paasta_tools import mesos_tools
+from paasta_tools import yaml
 from paasta_tools.adhoc_tools import AdhocJobConfig
 from paasta_tools.frameworks.adhoc_scheduler import AdhocScheduler
 from paasta_tools.frameworks.native_scheduler import create_driver
@@ -162,7 +162,7 @@ def write_paasta_native_cluster_yaml_files(context, service, instance):
         "w",
     ) as f:
         f.write(
-            yaml.safe_dump(
+            yaml.dump(
                 {
                     instance: {
                         "cmd": 'echo "Taking a nap..." && sleep 1m && echo "Nap time over, back to work"',

--- a/paasta_itests/steps/setup_steps.py
+++ b/paasta_itests/steps/setup_steps.py
@@ -15,7 +15,6 @@ import json
 import os
 from tempfile import NamedTemporaryFile
 
-import yaml
 from behave import given
 from behave import when
 from bravado.client import SwaggerClient
@@ -23,6 +22,7 @@ from itest_utils import get_service_connection_string
 
 from paasta_tools import marathon_tools
 from paasta_tools import utils
+from paasta_tools import yaml
 from paasta_tools.frameworks import native_scheduler
 from paasta_tools.utils import decompose_job_id
 from paasta_tools.utils import paasta_print
@@ -279,7 +279,7 @@ def write_soa_dir_marathon_job(context, job_id, shard=None, previous_shard=None)
     with open(
         os.path.join(soa_dir, service, "marathon-%s.yaml" % context.cluster), "w"
     ) as f:
-        f.write(yaml.safe_dump(soa))
+        f.write(yaml.dump(soa))
 
     context.soa_dir = soa_dir
 
@@ -297,7 +297,7 @@ def write_soa_dir_native_service(context, job_id):
         os.path.join(soa_dir, service, "paasta_native-%s.yaml" % context.cluster), "w"
     ) as f:
         f.write(
-            yaml.safe_dump(
+            yaml.dump(
                 {"%s" % instance: {"cpus": 0.1, "mem": 100, "cmd": "/bin/sleep 300"}}
             )
         )
@@ -383,10 +383,10 @@ def modify_configs(context, field, framework, service, instance, value):
     with open(
         os.path.join(soa_dir, service, f"{framework}-{context.cluster}.yaml"), "r+"
     ) as f:
-        data = yaml.safe_load(f.read())
+        data = yaml.load(f.read())
         data[instance][field] = value
         f.seek(0)
-        f.write(yaml.safe_dump(data))
+        f.write(yaml.dump(data))
         f.truncate()
 
 

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -18,12 +18,12 @@ import pkgutil
 from collections import Counter
 from glob import glob
 
-import yaml
 from jsonschema import Draft4Validator
 from jsonschema import exceptions
 from jsonschema import FormatChecker
 from jsonschema import ValidationError
 
+from paasta_tools import yaml
 from paasta_tools.cli.utils import failure
 from paasta_tools.cli.utils import get_file_contents
 from paasta_tools.cli.utils import get_instance_config
@@ -163,7 +163,7 @@ def validate_schema(file_path, file_type):
     try:
         config_file = get_file_contents(file_path)
         if extension == ".yaml":
-            config_file_object = yaml.safe_load(config_file)
+            config_file_object = yaml.load(config_file)
         elif extension == ".json":
             config_file_object = json.loads(config_file)
         else:

--- a/paasta_tools/cli/fsm/autosuggest.py
+++ b/paasta_tools/cli/fsm/autosuggest.py
@@ -14,7 +14,7 @@
 import os
 import random
 
-import yaml
+from paasta_tools import yaml
 
 
 def _get_smartstack_proxy_ports_from_file(root, file):
@@ -24,7 +24,7 @@ def _get_smartstack_proxy_ports_from_file(root, file):
     """
     ports = set()
     with open(os.path.join(root, file)) as f:
-        data = yaml.safe_load(f)
+        data = yaml.load(f)
 
     if file.endswith("service.yaml") and "smartstack" in data:
         # Specifying this in service.yaml is old and deprecated and doesn't

--- a/paasta_tools/contrib/check_orphans.py
+++ b/paasta_tools/contrib/check_orphans.py
@@ -16,9 +16,10 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 
-import yaml
 from kazoo.client import KazooClient
 from kazoo.exceptions import NoNodeError
+
+from paasta_tools import yaml
 
 logger = logging.getLogger("check_orphans")
 

--- a/paasta_tools/contrib/graceful_container_drain.py
+++ b/paasta_tools/contrib/graceful_container_drain.py
@@ -10,8 +10,7 @@ from subprocess import PIPE
 from subprocess import Popen
 from subprocess import STDOUT
 
-import yaml
-
+from paasta_tools import yaml
 from paasta_tools.utils import paasta_print
 
 
@@ -89,7 +88,7 @@ def get_proxy_port(service_name, instance_name):
     proxy_port = None
     if os.path.exists(smartstack_yaml):
         with open(smartstack_yaml, "r") as stream:
-            data = yaml.safe_load(stream)
+            data = yaml.load(stream)
             if instance_name in data:
                 proxy_port = data[instance_name].get("proxy_port", None)
     return proxy_port

--- a/paasta_tools/generate_services_file.py
+++ b/paasta_tools/generate_services_file.py
@@ -23,8 +23,8 @@ import socket
 from datetime import datetime
 
 import service_configuration_lib
-import yaml
 
+from paasta_tools import yaml
 from paasta_tools.marathon_tools import get_all_namespaces
 from paasta_tools.marathon_tools import get_all_namespaces_for_service
 from paasta_tools.utils import atomic_file_write
@@ -72,7 +72,7 @@ def get_service_lines_for_service(service):
 
 
 def write_yaml_file(filename):
-    previous_config = maybe_load_previous_config(filename, yaml.safe_load)
+    previous_config = maybe_load_previous_config(filename, yaml.load)
     configuration = generate_configuration()
 
     if previous_config and previous_config == configuration:
@@ -85,7 +85,7 @@ def write_yaml_file(filename):
                 host=socket.getfqdn(), now=datetime.now().isoformat()
             )
         )
-        yaml.safe_dump(
+        yaml.dump(
             configuration,
             fp,
             indent=2,

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -28,8 +28,7 @@ from typing import Mapping
 from typing import Optional
 from typing import Sequence
 
-import yaml
-
+from paasta_tools import yaml
 from paasta_tools.flink_tools import get_flink_ingress_url_root
 from paasta_tools.kubernetes_tools import create_custom_resource
 from paasta_tools.kubernetes_tools import CustomResourceDefinition
@@ -72,7 +71,7 @@ class StdoutKubeClient:
                 if "metadata" not in body:
                     body["metadata"] = {}
                 body["metadata"]["namespace"] = ns
-            yaml.safe_dump(body, sys.stdout, indent=4, explicit_start=True)
+            yaml.dump(body, sys.stdout, indent=4, explicit_start=True)
 
     def __init__(self, kube_client) -> None:
         self.deployments = StdoutKubeClient.StdoutWrapper(kube_client.deployments)

--- a/paasta_tools/tron/client.py
+++ b/paasta_tools/tron/client.py
@@ -14,8 +14,8 @@ import logging
 from urllib.parse import urljoin
 
 import requests
-import yaml
 
+from paasta_tools import yaml
 from paasta_tools.utils import get_user_agent
 
 
@@ -82,7 +82,7 @@ class TronClient:
         current_config = self._get("/api/config", {"name": namespace, "no_header": 1})
 
         if skip_if_unchanged:
-            if yaml.safe_load(new_config) == yaml.safe_load(current_config["config"]):
+            if yaml.load(new_config) == yaml.load(current_config["config"]):
                 log.debug("No change in config, skipping update.")
                 return
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -20,35 +20,29 @@ import pkgutil
 import re
 import subprocess
 from string import Formatter
+from typing import Any
+from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 import service_configuration_lib
-import yaml
 
-try:
-    from yaml.cyaml import CSafeDumper as Dumper
-except ImportError:  # pragma: no cover (no libyaml-dev / pypy)
-    Dumper = yaml.SafeDumper  # type: ignore
-
-from paasta_tools.tron.client import TronClient
+from paasta_tools import monitoring_tools
+from paasta_tools import yaml
+from paasta_tools.monitoring_tools import list_teams
 from paasta_tools.tron import tron_command_context
+from paasta_tools.tron.client import TronClient
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import extract_jobs_from_tron_yaml
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import InvalidInstanceConfig
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import load_tron_yaml
 from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import paasta_print
-from paasta_tools.utils import load_tron_yaml
-from paasta_tools.utils import extract_jobs_from_tron_yaml
-
-from paasta_tools import monitoring_tools
-from paasta_tools.monitoring_tools import list_teams
-from typing import Optional
-from typing import Dict
-from typing import Any
 
 log = logging.getLogger(__name__)
 logging.getLogger("tron").setLevel(logging.WARNING)
@@ -590,7 +584,7 @@ def create_complete_master_config(cluster, soa_dir=DEFAULT_SOA_DIR):
         system_paasta_config.get_volumes(),
         system_paasta_config.get_dockercfg_location(),
     )
-    return yaml.dump(master_config, Dumper=Dumper, default_flow_style=False)
+    return yaml.dump(master_config, default_flow_style=False)
 
 
 def create_complete_config(service, cluster, soa_dir=DEFAULT_SOA_DIR):
@@ -603,7 +597,7 @@ def create_complete_config(service, cluster, soa_dir=DEFAULT_SOA_DIR):
         job_config.get_name(): format_tron_job_dict(job_config)
         for job_config in job_configs
     }
-    return yaml.dump(preproccessed_config, Dumper=Dumper, default_flow_style=False)
+    return yaml.dump(preproccessed_config, default_flow_style=False)
 
 
 def validate_complete_config(
@@ -630,7 +624,7 @@ def validate_complete_config(
         for job_config in job_configs
     }
 
-    complete_config = yaml.dump(preproccessed_config, Dumper=Dumper)
+    complete_config = yaml.dump(preproccessed_config)
 
     proc = subprocess.run(
         ["tronfig", "-", "-V", "-n", service, "-m", master_config_path],

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -69,7 +69,6 @@ import choice
 import dateutil.tz
 import requests_cache
 import service_configuration_lib
-import yaml
 from docker import Client
 from docker.utils import kwargs_from_env
 from kazoo.client import KazooClient
@@ -77,6 +76,7 @@ from mypy_extensions import TypedDict
 from service_configuration_lib import read_service_configuration
 
 import paasta_tools.cli.fsm
+from paasta_tools import yaml
 
 
 # DO NOT CHANGE SPACER, UNLESS YOU'RE PREPARED TO CHANGE ALL INSTANCES
@@ -2794,7 +2794,7 @@ def get_services_for_cluster(
 
 
 def parse_yaml_file(yaml_file: str) -> Any:
-    return yaml.safe_load(open(yaml_file))
+    return yaml.load(open(yaml_file))
 
 
 def get_docker_host() -> str:

--- a/paasta_tools/yaml.py
+++ b/paasta_tools/yaml.py
@@ -1,0 +1,21 @@
+import yaml
+
+try:
+    from yaml.cyaml import CSafeLoader as Loader  # type: ignore
+except ImportError:  # pragma: no cover
+    Loader = yaml.SafeLoader  # type: ignore
+
+try:
+    from yaml.cyaml import CSafeDumper as Dumper  # type: ignore
+except ImportError:  # pragma: no cover
+    Dumper = yaml.SafeDumper  # type: ignore
+
+
+def dump(*args, **kwargs):
+    kwargs["Dumper"] = Dumper
+    return yaml.dump(*args, **kwargs)
+
+
+def load(*args, **kwargs):
+    kwargs["Loader"] = Loader
+    return yaml.load(*args, **kwargs)

--- a/tests/cli/fsm/test_autosuggest.py
+++ b/tests/cli/fsm/test_autosuggest.py
@@ -26,7 +26,7 @@ class TestGetSmartstackProxyPortFromFile:
             with mock.patch(
                 "paasta_tools.cli.fsm.autosuggest.yaml", autospec=True
             ) as mock_yaml:
-                mock_yaml.safe_load.return_value = {
+                mock_yaml.load.return_value = {
                     "main": {"proxy_port": 1},
                     "foo": {"proxy_port": 2},
                 }

--- a/tests/test_firewall_update.py
+++ b/tests/test_firewall_update.py
@@ -15,10 +15,10 @@ import subprocess
 
 import mock
 import pytest
-import yaml
 
 from paasta_tools import firewall
 from paasta_tools import firewall_update
+from paasta_tools import yaml
 from paasta_tools.utils import TimeoutError
 
 
@@ -88,7 +88,7 @@ def test_smartstack_dependencies_of_running_firewalled_services(_, __, tmpdir):
         },
         "nosecurity": {"dependencies_reference": "my_ref"},
     }
-    myservice_dir.join("marathon-mycluster.yaml").write(yaml.safe_dump(marathon_config))
+    myservice_dir.join("marathon-mycluster.yaml").write(yaml.dump(marathon_config))
 
     dependencies_config = {
         "my_ref": [
@@ -97,7 +97,7 @@ def test_smartstack_dependencies_of_running_firewalled_services(_, __, tmpdir):
             {"smartstack": "another.one"},
         ]
     }
-    myservice_dir.join("dependencies.yaml").write(yaml.safe_dump(dependencies_config))
+    myservice_dir.join("dependencies.yaml").write(yaml.dump(dependencies_config))
 
     result = firewall_update.smartstack_dependencies_of_running_firewalled_services(
         soa_dir=str(soa_dir)

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -763,7 +763,7 @@ class TestTronTools:
         mock_format_job.assert_called_once_with(job_config)
         complete_config = {"jobs": {"my_job": mock_format_job.return_value}}
         mock_yaml_dump.assert_called_once_with(
-            complete_config, Dumper=mock.ANY, default_flow_style=mock.ANY
+            complete_config, default_flow_style=mock.ANY
         )
 
     @mock.patch("paasta_tools.tron_tools.load_tron_service_config", autospec=True)


### PR DESCRIPTION
I was doing a thing and wondering why the yaml loading was slow.

I would like to add wrappers so nobody can ever forget to use yaml in the right way (although they can forget to use the wrapper).

Modern version of yaml are now safe by default, but we need to still use the c loader where we can.