### PR TITLE
Replace reads of old kubernetes labels

### DIFF
--- a/paasta_tools/cleanup_kubernetes_cr.py
+++ b/paasta_tools/cleanup_kubernetes_cr.py
@@ -88,7 +88,7 @@ def cleanup_all_custom_resources(
     cluster_crds = {
         crd.spec.names.kind
         for crd in kube_client.apiextensions.list_custom_resource_definition(
-            label_selector="yelp.com/paasta_service"
+            label_selector="paasta.yelp.com/service"
         ).items
     }
     log.debug(f"CRDs found: {cluster_crds}")

--- a/paasta_tools/cleanup_kubernetes_crd.py
+++ b/paasta_tools/cleanup_kubernetes_crd.py
@@ -94,14 +94,16 @@ def cleanup_kube_crd(
     dry_run: bool = False,
 ) -> bool:
     existing_crds = kube_client.apiextensions.list_custom_resource_definition(
-        label_selector="yelp.com/paasta_service"
+        label_selector="paasta.yelp.com/service"
     )
 
     success = True
     for crd in existing_crds.items:
-        service = crd.metadata.labels["yelp.com/paasta_service"]
+        service = crd.metadata.labels["paasta.yelp.com/service"]
         if not service:
-            log.error(f"CRD {crd.metadata.name} has empty paasta_service label")
+            log.error(
+                f"CRD {crd.metadata.name} has empty paasta.yelp.com/service label"
+            )
             continue
 
         crd_config = service_configuration_lib.read_extra_service_information(

--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -42,10 +42,10 @@ class Application(ABC):
         if not item.metadata.namespace:
             item.metadata.namespace = "paasta"
         self.kube_deployment = KubeDeployment(
-            service=item.metadata.labels["yelp.com/paasta_service"],
-            instance=item.metadata.labels["yelp.com/paasta_instance"],
-            git_sha=item.metadata.labels["yelp.com/paasta_git_sha"],
-            config_sha=item.metadata.labels["yelp.com/paasta_config_sha"],
+            service=item.metadata.labels["paasta.yelp.com/service"],
+            instance=item.metadata.labels["paasta.yelp.com/instance"],
+            git_sha=item.metadata.labels["paasta.yelp.com/git_sha"],
+            config_sha=item.metadata.labels["paasta.yelp.com/config_sha"],
             replicas=item.spec.replicas,
         )
         self.item = item

--- a/paasta_tools/kubernetes/application/tools.py
+++ b/paasta_tools/kubernetes/application/tools.py
@@ -16,15 +16,16 @@ log = logging.getLogger(__name__)
 
 def is_valid_application(deployment: V1Deployment):
     is_valid = (
-        "yelp.com/paasta_service" in deployment.metadata.labels
-        and "yelp.com/paasta_instance" in deployment.metadata.labels
-        and "yelp.com/paasta_git_sha" in deployment.metadata.labels
-        and "yelp.com/paasta_config_sha" in deployment.metadata.labels
+        "paasta.yelp.com/service" in deployment.metadata.labels
+        and "paasta.yelp.com/instance" in deployment.metadata.labels
+        and "paasta.yelp.com/git_sha" in deployment.metadata.labels
+        and "paasta.yelp.com/config_sha" in deployment.metadata.labels
     )
     if not is_valid:
         log.warning(
-            f"deployment/{deployment.metadata.name} in namespace/{deployment.metadata.namespace}\
-         does not have complete set of labels"
+            f"deployment/{deployment.metadata.name} in "
+            f"namespace/{deployment.metadata.namespace} "
+            "does not have complete set of labels"
         )
         log.warning(deployment)
     return is_valid

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -937,8 +937,8 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                         revision_history_limit=0,
                         selector=V1LabelSelector(
                             match_labels={
-                                "yelp.com/paasta_service": self.get_service(),
-                                "yelp.com/paasta_instance": self.get_instance(),
+                                "paasta.yelp.com/service": self.get_service(),
+                                "paasta.yelp.com/instance": self.get_instance(),
                             }
                         ),
                         template=self.get_pod_template_spec(
@@ -956,8 +956,8 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                         min_ready_seconds=self.get_min_task_uptime(),
                         selector=V1LabelSelector(
                             match_labels={
-                                "yelp.com/paasta_service": self.get_service(),
-                                "yelp.com/paasta_instance": self.get_instance(),
+                                "paasta.yelp.com/service": self.get_service(),
+                                "paasta.yelp.com/instance": self.get_instance(),
                             }
                         ),
                         revision_history_limit=0,
@@ -1098,8 +1098,8 @@ def get_kubernetes_services_running_here() -> Sequence[KubeService]:
                     break
             services.append(
                 KubeService(
-                    name=pod["metadata"]["labels"]["yelp.com/paasta_service"],
-                    instance=pod["metadata"]["labels"]["yelp.com/paasta_instance"],
+                    name=pod["metadata"]["labels"]["paasta.yelp.com/service"],
+                    instance=pod["metadata"]["labels"]["paasta.yelp.com/instance"],
                     port=port,
                     pod_ip=pod["status"]["podIP"],
                     registrations=json.loads(
@@ -1222,10 +1222,10 @@ def list_deployments(
     )
     return [
         KubeDeployment(
-            service=item.metadata.labels["yelp.com/paasta_service"],
-            instance=item.metadata.labels["yelp.com/paasta_instance"],
-            git_sha=item.metadata.labels["yelp.com/paasta_git_sha"],
-            config_sha=item.metadata.labels["yelp.com/paasta_config_sha"],
+            service=item.metadata.labels["paasta.yelp.com/service"],
+            instance=item.metadata.labels["paasta.yelp.com/instance"],
+            git_sha=item.metadata.labels["paasta.yelp.com/git_sha"],
+            config_sha=item.metadata.labels["paasta.yelp.com/config_sha"],
             replicas=item.spec.replicas,
         )
         for item in deployments.items + stateful_sets.items
@@ -1313,9 +1313,9 @@ def list_custom_resources(
         try:
             kube_custom_resources.append(
                 KubeCustomResource(
-                    service=cr["metadata"]["labels"]["yelp.com/paasta_service"],
-                    instance=cr["metadata"]["labels"]["yelp.com/paasta_instance"],
-                    config_sha=cr["metadata"]["labels"]["yelp.com/paasta_config_sha"],
+                    service=cr["metadata"]["labels"]["paasta.yelp.com/service"],
+                    instance=cr["metadata"]["labels"]["paasta.yelp.com/instance"],
+                    config_sha=cr["metadata"]["labels"]["paasta.yelp.com/config_sha"],
                     kind=cr["kind"],
                     namespace=cr["metadata"]["namespace"],
                     name=cr["metadata"]["name"],
@@ -1365,8 +1365,8 @@ def pod_disruption_budget_for_service_instance(
             max_unavailable=max_unavailable,
             selector=V1LabelSelector(
                 match_labels={
-                    "yelp.com/paasta_service": service,
-                    "yelp.com/paasta_instance": instance,
+                    "paasta.yelp.com/service": service,
+                    "paasta.yelp.com/instance": instance,
                 }
             ),
         ),
@@ -1390,7 +1390,7 @@ def list_matching_deployments(
 ) -> Sequence[KubeDeployment]:
     return list_deployments(
         kube_client,
-        f"yelp.com/paasta_instance={instance},yelp.com/paasta_service={service}",
+        f"paasta.yelp.com/service={service},paasta.yelp.com/instance={instance}",
     )
 
 
@@ -1398,7 +1398,7 @@ def replicasets_for_service_instance(
     service: str, instance: str, kube_client: KubeClient, namespace: str = "paasta"
 ) -> Sequence[V1ReplicaSet]:
     return kube_client.deployments.list_namespaced_replica_set(
-        label_selector=f"yelp.com/paasta_service={service},yelp.com/paasta_instance={instance}",
+        label_selector=f"paasta.yelp.com/service={service},paasta.yelp.com/instance={instance}",
         namespace=namespace,
     ).items
 
@@ -1407,7 +1407,7 @@ def pods_for_service_instance(
     service: str, instance: str, kube_client: KubeClient, namespace: str = "paasta"
 ) -> Sequence[V1Pod]:
     return kube_client.core.list_namespaced_pod(
-        label_selector=f"yelp.com/paasta_service={service},yelp.com/paasta_instance={instance}",
+        label_selector=f"paasta.yelp.com/service={service},paasta.yelp.com/instance={instance}",
         namespace=namespace,
     ).items
 
@@ -1423,8 +1423,8 @@ def filter_pods_by_service_instance(
         pod
         for pod in pod_list
         if pod.metadata.labels is not None
-        and pod.metadata.labels.get("yelp.com/paasta_service", "") == service
-        and pod.metadata.labels.get("yelp.com/paasta_instance", "") == instance
+        and pod.metadata.labels.get("paasta.yelp.com/service", "") == service
+        and pod.metadata.labels.get("paasta.yelp.com/instance", "") == instance
     ]
 
 
@@ -1462,8 +1462,8 @@ def get_pod_status(pod: V1Pod,) -> PodStatus:
 def get_active_shas_for_service(pod_list: Sequence[V1Pod],) -> Mapping[str, Set[str]]:
     ret: Mapping[str, Set[str]] = {"config_sha": set(), "git_sha": set()}
     for pod in pod_list:
-        ret["config_sha"].add(pod.metadata.labels["yelp.com/paasta_config_sha"])
-        ret["git_sha"].add(pod.metadata.labels["yelp.com/paasta_git_sha"])
+        ret["config_sha"].add(pod.metadata.labels["paasta.yelp.com/config_sha"])
+        ret["git_sha"].add(pod.metadata.labels["paasta.yelp.com/git_sha"])
     return ret
 
 

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -152,7 +152,7 @@ def setup_all_custom_resources(
     cluster_crds = {
         crd.spec.names.kind
         for crd in kube_client.apiextensions.list_custom_resource_definition(
-            label_selector="yelp.com/paasta_service"
+            label_selector="paasta.yelp.com/service"
         ).items
     }
     log.debug(f"CRDs found: {cluster_crds}")
@@ -307,7 +307,7 @@ def reconcile_kubernetes_resource(
             service=service,
             instance=inst,
             config_sha=formatted_resource["metadata"]["labels"][
-                "yelp.com/paasta_config_sha"
+                "paasta.yelp.com/config_sha"
             ],
             kind=kind.singular,
             name=formatted_resource["metadata"]["name"],

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -824,8 +824,8 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     replicas=mock_get_instances.return_value,
                     selector=V1LabelSelector(
                         match_labels={
-                            "yelp.com/paasta_instance": mock_get_instance.return_value,
-                            "yelp.com/paasta_service": mock_get_service.return_value,
+                            "paasta.yelp.com/instance": mock_get_instance.return_value,
+                            "paasta.yelp.com/service": mock_get_service.return_value,
                         }
                     ),
                     revision_history_limit=0,
@@ -876,8 +876,8 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     replicas=mock_get_instances.return_value,
                     selector=V1LabelSelector(
                         match_labels={
-                            "yelp.com/paasta_instance": mock_get_instance.return_value,
-                            "yelp.com/paasta_service": mock_get_service.return_value,
+                            "paasta.yelp.com/instance": mock_get_instance.return_value,
+                            "paasta.yelp.com/service": mock_get_service.return_value,
                         }
                     ),
                     revision_history_limit=0,
@@ -1529,8 +1529,8 @@ def test_pod_disruption_budget_for_service_instance():
     assert x.metadata.namespace == "paasta"
     assert x.spec.max_unavailable == "10%"
     assert x.spec.selector.match_labels == {
-        "yelp.com/paasta_service": "foo",
-        "yelp.com/paasta_instance": "bar",
+        "paasta.yelp.com/service": "foo",
+        "paasta.yelp.com/instance": "bar",
     }
 
 

--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -323,7 +323,7 @@ def test_reconcile_kubernetes_resource():
         # instance diff config, update
         mock_format_custom_resource.return_value = {
             "metadata": {
-                "labels": {"yelp.com/paasta_config_sha": "conf456"},
+                "labels": {"paasta.yelp.com/config_sha": "conf456"},
                 "name": "foo",
                 "namespace": "paasta-flinks",
             }


### PR DESCRIPTION
this is a subset of my reverted pull request. Don't remove old labels, just don't read them anywhere.