### PR TITLE
Avoid cutting name of flink jobs running in cluster

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -852,7 +852,6 @@ def print_flink_status(
 
     output.append(f"    Jobs:")
     if verbose:
-        fmt = "      {job_name_var: <{max_column_length}} State       Job ID                           Started"
         output.append(
             f'      {"Job Name": <{allowed_max_job_name_length}} State       Job ID                           Started'
         )

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -844,11 +844,14 @@ def print_flink_status(
     )
 
     # Avoid cutting job name. As opposed to default hardcoded value of 32, we will use max length of job name
-    max_job_name_length = max([len(get_flink_job_name(job)) for job in status.jobs])
+    if status.jobs:
+        max_job_name_length = max([len(get_flink_job_name(job)) for job in status.jobs])
+    else:
+        max_job_name_length = 10
     # Apart from this column total length of one row is around 52 columns, using remaining terminal columns for job name
     # Note: for terminals smaller than 90 columns the row will overflow in verbose printing
     allowed_max_job_name_length = min(
-        max(8, shutil.get_terminal_size().columns - 52), max_job_name_length
+        max(10, shutil.get_terminal_size().columns - 52), max_job_name_length
     )
 
     output.append(f"    Jobs:")

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -845,9 +845,10 @@ def print_flink_status(
 
     # Avoid cutting job name. As opposed to default hardcoded value of 32, we will use max length of job name
     max_job_name_length = max([len(get_flink_job_name(job)) for job in status.jobs])
-    # Limiting longest allowed job name to be 120 chars. This is to ensure while printing on cli the formatting is maintained on normal screens
+    # Apart from this column total length of one row is around 52 columns, using remaining terminal columns for job name
+    # Note: for terminals smaller than 90 columns the row will overflow in verbose printing
     allowed_max_job_name_length = min(
-        shutil.get_terminal_size((120, 50)).columns, max_job_name_length
+        shutil.get_terminal_size().columns - 52, max_job_name_length
     )
 
     output.append(f"    Jobs:")

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -848,7 +848,7 @@ def print_flink_status(
     # Apart from this column total length of one row is around 52 columns, using remaining terminal columns for job name
     # Note: for terminals smaller than 90 columns the row will overflow in verbose printing
     allowed_max_job_name_length = min(
-        shutil.get_terminal_size().columns - 52, max_job_name_length
+        max(8, shutil.get_terminal_size().columns - 52), max_job_name_length
     )
 
     output.append(f"    Jobs:")

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -15,6 +15,7 @@
 import concurrent.futures
 import difflib
 import os
+import shutil
 import sys
 import traceback
 from collections import defaultdict
@@ -845,22 +846,19 @@ def print_flink_status(
     # Avoid cutting job name. As opposed to default hardcoded value of 32, we will use max length of job name
     max_job_name_length = max([len(get_flink_job_name(job)) for job in status.jobs])
     # Limiting longest allowed job name to be 120 chars. This is to ensure while printing on cli the formatting is maintained on normal screens
-    allowed_max_job_name_length = min(120, max_job_name_length)
+    allowed_max_job_name_length = min(
+        shutil.get_terminal_size((120, 50)).columns, max_job_name_length
+    )
 
     output.append(f"    Jobs:")
     if verbose:
         fmt = "      {job_name_var: <{max_column_length}} State       Job ID                           Started"
         output.append(
-            fmt.format(
-                job_name_var="Job Name", max_column_length=allowed_max_job_name_length,
-            )
+            f'      {"Job Name": <{allowed_max_job_name_length}} State       Job ID                           Started'
         )
     else:
-        fmt = "      {job_name_var: <{max_column_length}} State       Started"
         output.append(
-            fmt.format(
-                job_name_var="Job Name", max_column_length=allowed_max_job_name_length,
-            )
+            f'      {"Job Name": <{allowed_max_job_name_length}} State       Started'
         )
 
     # Use only the most recent jobs

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -785,6 +785,10 @@ def status_kubernetes_job_human(
         )
 
 
+def get_flink_job_name(flink_job):
+    return flink_job["name"].split(".", 2)[2]
+
+
 def print_flink_status(
     cluster: str,
     service: str,
@@ -839,9 +843,7 @@ def print_flink_status(
     )
 
     # Avoid cutting job name. As opposed to default hardcoded value of 32, we will use max length of job name
-    max_job_name_length = max(
-        [len(job["name"].split(".", 2)[2]) for job in status.jobs]
-    )
+    max_job_name_length = max([len(get_flink_job_name(job)) for job in status.jobs])
     # Limiting longest allowed job name to be 120 chars. This is to ensure while printing on cli the formatting is maintained on normal screens
     allowed_max_job_name_length = min(120, max_job_name_length)
 
@@ -885,7 +887,7 @@ def print_flink_status(
         output.append(
             fmt.format(
                 job_id=job_id,
-                job_name=job["name"].split(".", 2)[2],
+                job_name=get_flink_job_name(job),
                 allowed_max_job_name_length=allowed_max_job_name_length,
                 state=(job.get("state") or "unknown"),
                 start_time=f"{str(start_time)} ({humanize.naturaltime(start_time)})",


### PR DESCRIPTION
Currently, it is assumed that job name length will be 32 characters. While checking paasta status we see that name of jobs is getting trimmed. If we avoid cutting the names, it will  be useful while using the flink-supervisor cli. Refer to FLINK-1830 for further details.