### PR TITLE
add hpa_metrics_collector

### DIFF
--- a/paasta_tools/hpa_metrics_collector/hpa_metrics_collector.py
+++ b/paasta_tools/hpa_metrics_collector/hpa_metrics_collector.py
@@ -1,0 +1,140 @@
+import argparse
+import logging
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+import signalfx
+
+from paasta_tools.hpa_metrics_collector.parsers import http_parser
+from paasta_tools.hpa_metrics_collector.parsers import uwsgi_parser
+from paasta_tools.hpa_metrics_collector.ticker import Ticker
+from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
+
+READ_ONLY_PORT = 10255
+PARSER = {"uwsgi": uwsgi_parser, "http": http_parser}
+METRICS_ENDPOINT = {"uwsgi": "status/uwsgi", "http": "status"}
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+log = logging.getLogger(__name__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--token", dest="token", type=str, required=True)
+    parser.add_argument("--cluster", dest="cluster", type=str, required=True)
+    args = parser.parse_args()
+    return args
+
+
+def sanitize_sfx_dimensions_keys(k):
+    return k.replace(".", "_").replace("/", "_")
+
+
+def update_metrics(name, namespace, metrics_name, value, labels, token, cluster):
+    """
+    Sanitize all labels and send the metrics to sfx with labels as dimnesions.
+    """
+    labels.update(
+        {
+            "kubernetes_namespace": namespace,
+            "kubernetes_pod_name": name,
+            "kubernetes_cluster": cluster,
+        }
+    )
+    labels = {sanitize_sfx_dimensions_keys(k): v for k, v in labels.items()}
+    with signalfx.SignalFx(ingest_endpoint="https://ingest.signalfx.com").ingest(
+        token
+    ) as sfx:
+        t = int(time.time() * 1000)
+        sfx.send(
+            gauges=[
+                {
+                    "metric": metrics_name,
+                    "value": value,
+                    "timestamp": t,
+                    "dimensions": labels,
+                }
+            ]
+        )
+    log.info(f"updated metrics {metrics_name} with dimensions {labels} to {value}")
+
+
+def get_container(pod, container_name):
+    """
+    Find and return container spec of a particular container with container_name
+    """
+    for container in pod["spec"]["containers"]:
+        if container["name"].startswith(container_name):
+            return container
+
+
+def is_container_ready(conditions):
+    for cond in conditions:
+        if cond["type"] == "Ready" and cond["status"] == "True":
+            return True
+    return False
+
+
+def collect(token, cluster):
+    log.info("Collecting metrics")
+    # Get all pod metadata on this node
+    node_info = requests.get(f"http://169.254.255.254:{READ_ONLY_PORT}/pods/").json()
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        for pod in node_info["items"]:
+            # Fiter out instances that are not running
+            if pod["status"]["phase"] != "Running":
+                continue
+            # Fiter out instances that do not use http/uwsgi metrics for autoscaling
+            metrics_name = pod["metadata"].get("annotations", {}).get("autoscaling")
+            if not metrics_name:
+                continue
+            # Find port, and metric_provider in order to get metrics from container
+            pod_name = pod["metadata"]["name"]
+            namespace = pod["metadata"]["namespace"]
+            labels = dict(pod["metadata"]["labels"])
+            pod_IP = pod["status"]["podIP"]
+            # Use the first 45 character of instance name to determine container because some
+            # hash might be added to the end of container name
+            instance_name = sanitise_kubernetes_name(
+                labels["paasta.yelp.com/instance"]
+            )[:45]
+            container = get_container(pod, instance_name)
+            container_port = container["ports"][0]["containerPort"]
+            # Fetch metrics from the containers
+            try:
+                output = requests.get(
+                    f"http://{pod_IP}:{container_port}/{METRICS_ENDPOINT[metrics_name]}"
+                ).json()
+                value = str(PARSER[metrics_name](output))
+            except Exception as e:
+                log.error(
+                    f"hpa-metrics-collector have trouble querying metrics from pod/{pod_name} namespace/{namespace}"
+                )
+                if output:
+                    log.error(output)
+                log.error(e)
+            else:
+                # Update metrics on SFX
+                executor.submit(
+                    update_metrics,
+                    pod_name,
+                    namespace,
+                    metrics_name,
+                    value,
+                    labels,
+                    token,
+                    cluster,
+                )
+        log.info("Finished updating metrics")
+
+
+def main():
+    args = parse_args()
+    # Executes every 5 seconds.
+    Ticker(5, collect, args.token, args.cluster)
+
+
+if __name__ == "__main__":
+    main()

--- a/paasta_tools/hpa_metrics_collector/parsers.py
+++ b/paasta_tools/hpa_metrics_collector/parsers.py
@@ -1,0 +1,11 @@
+from statistics import mean
+
+
+def uwsgi_parser(json):
+    workers = json["workers"]
+    utilization = [1.0 if worker["status"] != "idle" else 0.0 for worker in workers]
+    return mean(utilization) * 100
+
+
+def http_parser(json):
+    return float(json["utilization"]) * 100

--- a/paasta_tools/hpa_metrics_collector/ticker.py
+++ b/paasta_tools/hpa_metrics_collector/ticker.py
@@ -1,0 +1,29 @@
+import time
+from threading import Event
+from threading import Thread
+
+
+class Ticker:
+    """Repeat `function` every `interval` seconds."""
+
+    def __init__(self, interval, function, *args, **kwargs):
+        self.interval = interval
+        self.function = function
+        self.args = args
+        self.kwargs = kwargs
+        self.start = time.time()
+        self.event = Event()
+        self.thread = Thread(target=self._target)
+        self.thread.start()
+
+    def _target(self):
+        while not self.event.wait(self._time):
+            self.function(*self.args, **self.kwargs)
+
+    @property
+    def _time(self):
+        return self.interval - ((time.time() - self.start) % self.interval)
+
+    def stop(self):
+        self.event.set()
+        self.thread.join()

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ s3transfer==0.1.13
 sensu-plugin==0.3.1
 service-configuration-lib==0.12.0
 setuptools==39.0.1
-signalfx==1.0.17
+signalfx==1.1.1
 simplejson==3.10.0
 six==1.11.0
 slackclient==1.2.1

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "paasta_tools/cleanup_kubernetes_cr.py",
         "paasta_tools/cleanup_kubernetes_crd.py",
         "paasta_tools/cleanup_kubernetes_jobs.py",
+        "paasta_tools/hpa_metrics_collector/hpa_metrics_collector.py",
         "paasta_tools/deploy_marathon_services",
         "paasta_tools/paasta_deploy_tron_jobs",
         "paasta_tools/generate_all_deployments",

--- a/tests/hpa_metrics_collector/test_hpa_metrics_collector.py
+++ b/tests/hpa_metrics_collector/test_hpa_metrics_collector.py
@@ -1,0 +1,105 @@
+from copy import deepcopy
+
+import mock
+
+from paasta_tools.hpa_metrics_collector.hpa_metrics_collector import collect
+
+fake_data = {
+    "items": [
+        {
+            "metadata": {
+                "name": "transactions-prepaid--revert--commission--billing--update-99lcs",
+                "namespace": "paasta",
+                "annotations": {"autoscaling": "http"},
+                "labels": {
+                    "paasta.yelp.com/config_sha": "config93f369e8",
+                    "paasta.yelp.com/git_sha": "git0d598687",
+                    "paasta.yelp.com/instance": "prepaid_revert_commission_billing_update",
+                    "paasta.yelp.com/service": "transactions",
+                },
+            },
+            "status": {"phase": "Running", "podIP": "10.145.27.71"},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "prepaid--revert--commission--billing--update",
+                        "ports": [{"containerPort": 8888, "protocol": "TCP"}],
+                    }
+                ]
+            },
+        }
+    ]
+}
+
+
+def mock_responses(responses, default_response=None):
+    return lambda input: responses[input] if input in responses else default_response
+
+
+def test_collect():
+    with mock.patch(
+        "paasta_tools.hpa_metrics_collector.hpa_metrics_collector.update_metrics",
+        autospec=True,
+    ) as mock_update_metrics, mock.patch(
+        "paasta_tools.hpa_metrics_collector.hpa_metrics_collector.requests",
+        autospec=True,
+    ) as mock_requests:
+        mock_json = mock.MagicMock()
+        mock_json.json.return_value = {"utilization": "0.17"}
+        mock_node_info = mock.MagicMock()
+        mock_node_info.json.return_value = fake_data
+        mock_requests.get.side_effect = mock_responses(
+            {"http://169.254.255.254:10255/pods/": mock_node_info},
+            default_response=mock_json,
+        )
+        collect("fake_token", "fake_cluster")
+        mock_update_metrics.assert_called_with(
+            "transactions-prepaid--revert--commission--billing--update-99lcs",
+            "paasta",
+            "http",
+            "17.0",
+            fake_data["items"][0]["metadata"]["labels"],
+            "fake_token",
+            "fake_cluster",
+        )
+
+
+def test_collect_no_autoscaling():
+    with mock.patch(
+        "paasta_tools.hpa_metrics_collector.hpa_metrics_collector.update_metrics",
+        autospec=True,
+    ) as mock_update_metrics, mock.patch(
+        "paasta_tools.hpa_metrics_collector.hpa_metrics_collector.requests",
+        autospec=True,
+    ) as mock_requests:
+        mock_json = mock.MagicMock()
+        mock_json.json.return_value = {"utilization": "0.17"}
+        mock_node_info = mock.MagicMock()
+        node_info = deepcopy(fake_data)
+        node_info["items"][0]["metadata"]["annotations"] = {}
+        mock_node_info.json.return_value = node_info
+        mock_requests.get.side_effect = mock_responses(
+            {"http://169.254.255.254:10255/pods/": mock_node_info},
+            default_response=mock_json,
+        )
+        collect("fake_token", "fake_cluster")
+        assert mock_update_metrics.call_count == 0
+
+
+def test_collect_no_status_no_exception(capfd):
+    with mock.patch(
+        "paasta_tools.hpa_metrics_collector.hpa_metrics_collector.update_metrics",
+        autospec=True,
+    ) as mock_update_metrics, mock.patch(
+        "paasta_tools.hpa_metrics_collector.hpa_metrics_collector.requests",
+        autospec=True,
+    ) as mock_requests:
+        mock_json = mock.MagicMock()
+        mock_json.json.return_value = {"something is wrong"}
+        mock_node_info = mock.MagicMock()
+        mock_node_info.json.return_value = fake_data
+        mock_requests.get.side_effect = mock_responses(
+            {"http://169.254.255.254:10255/pods/": mock_node_info},
+            default_response=mock_json,
+        )
+        assert mock_update_metrics.call_count == 0


### PR DESCRIPTION
I haven't tested this yet after modification and will test this manually after shipped a new change to HPA to add a label that enables sfx adapter.
 I plan to run this as a daemon that launches together with kubernetes pod (or paasta?). Cluster name and sfx token will be passed in as arguments specified in puppet.