### PR TITLE
limit the length of the volume name

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 import base64
 import copy
+import hashlib
 import itertools
 import json
 import logging
@@ -474,20 +475,27 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
         return V1DeploymentStrategy(type=strategy_type, rolling_update=rolling_update)
 
-    def get_sanitised_volume_name(self, volume_name: str) -> str:
+    def get_sanitised_volume_name(self, volume_name: str, length_limit: int = 0) -> str:
         """I know but we really aren't allowed many characters..."""
         volume_name = volume_name.rstrip("/")
         sanitised = volume_name.replace("/", "slash-").replace(".", "dot-")
-        return sanitise_kubernetes_name(sanitised)
+        sanitised_name = sanitise_kubernetes_name(sanitised)
+        if length_limit and len(sanitised_name) > length_limit:
+            sanitised_name = (
+                sanitised_name[0 : length_limit - 6]
+                + "--"
+                + hashlib.md5(sanitised_name.encode("ascii")).hexdigest()[:4]
+            )
+        return sanitised_name
 
     def get_docker_volume_name(self, docker_volume: DockerVolume) -> str:
         return self.get_sanitised_volume_name(
-            "host--{name}".format(name=docker_volume["hostPath"])
+            "host--{name}".format(name=docker_volume["hostPath"]), length_limit=63
         )
 
     def get_persistent_volume_name(self, docker_volume: PersistentVolume) -> str:
         return self.get_sanitised_volume_name(
-            "pv--{name}".format(name=docker_volume["container_path"])
+            "pv--{name}".format(name=docker_volume["container_path"]), length_limit=253
         )
 
     def get_aws_ebs_volume_name(self, aws_ebs_volume: AwsEbsVolume) -> str:

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -320,6 +320,10 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             self.deployment.get_sanitised_volume_name("/var/tmp_file.json")
             == "slash-varslash-tmp--filedot-json"
         )
+        assert (
+            self.deployment.get_sanitised_volume_name("/var/tmp_file.json", 20)
+            == "slash-varslash--1953"
+        )
 
     def test_get_sidecar_containers(self):
         with mock.patch(


### PR DESCRIPTION
The length of the docker volume can't be more than 63 characters. Also, persistent name can't be more than 253 characters.