### PR TITLE
Silence DeprecationWarnings on python 3.6.8 (bionic)

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1376,6 +1376,10 @@ def get_log_name_for_service(service: str, prefix: str = None) -> str:
 try:
     import clog
 
+    # Somehow clog turns on DeprecationWarnings, so we need to disable them
+    # again after importing it.
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+
     @register_log_writer("scribe")
     class ScribeLogWriter(LogWriter):
         def __init__(


### PR DESCRIPTION
Importing yelp_clog somehow turns on DeprecationWarning on bionic (python 3.6.8).

The `warnings.filterwarnings` in `paasta_tools/cli/cli.py` doesn't catch all of them because the ones from kubernetes happen at import time.

```python
(paasta-tools)
drolando@dev128-uswest1adevc pg
~>  python
Python 3.6.8 (default, Oct  7 2019, 12:59:55)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from kubernetes import client as kube_client
>>> from kubernetes import config as kube_config
>>>
```

```python
(paasta-tools)
drolando@dev128-uswest1adevc pg
~>  python
Python 3.6.8 (default, Oct  7 2019, 12:59:55)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import clog
>>> from kubernetes import client as kube_client
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/admissionregistration_v1beta1_webhook_client_config.py:82: DeprecationWarning: invalid escape sequence \/
  if ca_bundle is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', ca_bundle):
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/admissionregistration_v1beta1_webhook_client_config.py:83: DeprecationWarning: invalid escape sequence \/
  raise ValueError("Invalid value for `ca_bundle`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/apiextensions_v1beta1_webhook_client_config.py:82: DeprecationWarning: invalid escape sequence \/
  if ca_bundle is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', ca_bundle):
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/apiextensions_v1beta1_webhook_client_config.py:83: DeprecationWarning: invalid escape sequence \/
  raise ValueError("Invalid value for `ca_bundle`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/runtime_raw_extension.py:73: DeprecationWarning: invalid escape sequence \/
  if raw is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', raw):
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/runtime_raw_extension.py:74: DeprecationWarning: invalid escape sequence \/
  raise ValueError("Invalid value for `raw`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/v1_api_service_spec.py:99: DeprecationWarning: invalid escape sequence \/
  if ca_bundle is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', ca_bundle):
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/v1_api_service_spec.py:100: DeprecationWarning: invalid escape sequence \/
  raise ValueError("Invalid value for `ca_bundle`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/v1alpha1_webhook_client_config.py:82: DeprecationWarning: invalid escape sequence \/
  if ca_bundle is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', ca_bundle):
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/v1alpha1_webhook_client_config.py:83: DeprecationWarning: invalid escape sequence \/
  raise ValueError("Invalid value for `ca_bundle`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/v1beta1_api_service_spec.py:99: DeprecationWarning: invalid escape sequence \/
  if ca_bundle is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', ca_bundle):
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/v1beta1_api_service_spec.py:100: DeprecationWarning: invalid escape sequence \/
  raise ValueError("Invalid value for `ca_bundle`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/v1beta1_certificate_signing_request_spec.py:144: DeprecationWarning: invalid escape sequence \/
  if request is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', request):
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/v1beta1_certificate_signing_request_spec.py:145: DeprecationWarning: invalid escape sequence \/
  raise ValueError("Invalid value for `request`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/v1beta1_certificate_signing_request_status.py:77: DeprecationWarning: invalid escape sequence \/
  if certificate is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', certificate):
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/models/v1beta1_certificate_signing_request_status.py:78: DeprecationWarning: invalid escape sequence \/
  raise ValueError("Invalid value for `certificate`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/api_client.py:265: DeprecationWarning: invalid escape sequence \[
  sub_kls = re.match('list\[(.*)\]', klass).group(1)
/opt/venvs/paasta-tools/lib/python3.6/site-packages/kubernetes/client/api_client.py:270: DeprecationWarning: invalid escape sequence \(
  sub_kls = re.match('dict\(([^,]*), (.*)\)', klass).group(2)
/opt/venvs/paasta-tools/lib/python3.6/site-packages/requests_oauthlib/oauth1_session.py:266: DeprecationWarning: invalid escape sequence \*
  """
>>>
```

```
(paasta-tools)
drolando@dev128-uswest1adevc pg
~>  python
Python 3.6.8 (default, Oct  7 2019, 12:59:55)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import clog
>>> import warnings
>>> warnings.filterwarnings("ignore", category=DeprecationWarning)
>>> from kubernetes import client as kube_client
>>>
```