### PR TITLE
Add install-hooks make and tox targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,3 +75,7 @@ yelpy: ## Installs the yelp-internal packages into the default tox environment
 .PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: install-hooks
+install-hooks:
+	tox -e install-hooks

--- a/tox.ini
+++ b/tox.ini
@@ -171,6 +171,11 @@ mypy_paths =
 commands =
     mypy {posargs:{[testenv:mypy]mypy_paths}}
 
+[testenv:install-hooks]
+basepython = python3.6
+deps = pre-commit
+commands = pre-commit install -f --install-hooks
+
 [flake8]
 max-line-length = 120
 extend-ignore = E501,E203,W503


### PR DESCRIPTION
Adds a make target that lets you easily install the pre-commit hooks for this repo without having to run the entire test suite.

There doesn't seem to be a generic virtualenv (.paasta only contains tox, no other dependencies afaict), so I had to create a new one (.tox/install-hooks). But since the only dependency is pre-commit I don't think it's a big deal