### PR TITLE
Fix hpa to work with sfx metrics adapter

### DIFF
--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -279,7 +279,9 @@ class DeploymentWrapper(Application):
             return
 
         body = self.soa_config.get_autoscaling_metric_spec(
-            name=self.item.metadata.name, namespace=self.item.metadata.namespace
+            name=self.item.metadata.name,
+            cluster=self.soa_config.cluster,
+            namespace=self.item.metadata.namespace,
         )
         if not body:
             raise Exception(

--- a/tests/kubernetes/application/test_controller_wrapper.py
+++ b/tests/kubernetes/application/test_controller_wrapper.py
@@ -189,7 +189,9 @@ def test_sync_horizontal_pod_autoscaler_create_hpa():
     assert app.delete_horizontal_pod_autoscaler.call_count == 0
     mock_client.autoscaling.create_namespaced_horizontal_pod_autoscaler.assert_called_once_with(
         namespace="faasta",
-        body=app.soa_config.get_autoscaling_metric_spec("fake_name", "faasta"),
+        body=app.soa_config.get_autoscaling_metric_spec(
+            "fake_name", "cluster", "faasta"
+        ),
         pretty=True,
     )
 
@@ -208,7 +210,9 @@ def test_sync_horizontal_pod_autoscaler_update_hpa():
     mock_client.autoscaling.patch_namespaced_horizontal_pod_autoscaler.assert_called_once_with(
         namespace="faasta",
         name="fake_name",
-        body=app.soa_config.get_autoscaling_metric_spec("fake_name", "faasta"),
+        body=app.soa_config.get_autoscaling_metric_spec(
+            "fake_name", "cluster", "faasta"
+        ),
         pretty=True,
     )
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -995,11 +995,14 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             branch_dict=None,
         )
         return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
-            mock_config, "fake_name"
+            mock_config, "fake_name", "cluster"
         )
+        annotations = {}
         expected_res = V2beta1HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
-            metadata=V1ObjectMeta(name="fake_name", namespace="paasta"),
+            metadata=V1ObjectMeta(
+                name="fake_name", namespace="paasta", annotations=annotations
+            ),
             spec=V2beta1HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
@@ -1012,9 +1015,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     )
                 ],
                 scale_target_ref=V2beta1CrossVersionObjectReference(
-                    api_version="extensions/v1beta1",
-                    kind="Deployment",
-                    name="fake_name",
+                    api_version="apps/v1", kind="Deployment", name="fake_name",
                 ),
             ),
         )
@@ -1035,11 +1036,14 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             branch_dict=None,
         )
         return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
-            mock_config, "fake_name"
+            mock_config, "fake_name", "cluster"
         )
+        annotations = {"signalfx.com.custom.metrics": ""}
         expected_res = V2beta1HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
-            metadata=V1ObjectMeta(name="fake_name", namespace="paasta"),
+            metadata=V1ObjectMeta(
+                name="fake_name", namespace="paasta", annotations=annotations
+            ),
             spec=V2beta1HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
@@ -1047,14 +1051,16 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     V2beta1MetricSpec(
                         type="Pods",
                         pods=V2beta1PodsMetricSource(
-                            metric_name="http", target_average_value=50.0
+                            metric_name="http",
+                            target_average_value=50.0,
+                            selector=V1LabelSelector(
+                                match_labels={"kubernetes_cluster": "cluster"}
+                            ),
                         ),
                     )
                 ],
                 scale_target_ref=V2beta1CrossVersionObjectReference(
-                    api_version="extensions/v1beta1",
-                    kind="Deployment",
-                    name="fake_name",
+                    api_version="apps/v1", kind="Deployment", name="fake_name",
                 ),
             ),
         )
@@ -1074,11 +1080,15 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             branch_dict=None,
         )
         return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
-            mock_config, "fake_name"
+            mock_config, "fake_name", "cluster"
         )
+
+        annotations = {"signalfx.com.custom.metrics": ""}
         expected_res = V2beta1HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
-            metadata=V1ObjectMeta(name="fake_name", namespace="paasta"),
+            metadata=V1ObjectMeta(
+                name="fake_name", namespace="paasta", annotations=annotations
+            ),
             spec=V2beta1HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
@@ -1086,14 +1096,16 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     V2beta1MetricSpec(
                         type="Pods",
                         pods=V2beta1PodsMetricSource(
-                            metric_name="uwsgi", target_average_value=50.0
+                            metric_name="uwsgi",
+                            target_average_value=50.0,
+                            selector=V1LabelSelector(
+                                match_labels={"kubernetes_cluster": "cluster"}
+                            ),
                         ),
                     )
                 ],
                 scale_target_ref=V2beta1CrossVersionObjectReference(
-                    api_version="extensions/v1beta1",
-                    kind="Deployment",
-                    name="fake_name",
+                    api_version="apps/v1", kind="Deployment", name="fake_name",
                 ),
             ),
         )
@@ -1113,7 +1125,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             branch_dict=None,
         )
         return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
-            mock_config, "fake_name"
+            mock_config, "fake_name", "cluster"
         )
         expected_res = None
         assert expected_res == return_value


### PR DESCRIPTION
* Added a metrics selector that allows sfx adapter to filter out cluster specific metrics
* Fix api version.
Tested on kubestage.