### PR TITLE
Make bionic tests required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,5 @@ deploy:
       repo: Yelp/paasta
 matrix:
   allow_failures:
-    - env: MAKE_TARGET=itest_bionic
     - env: TOXENV=example_cluster_k8s
   fast_finish: true


### PR DESCRIPTION
We now have bionic devboxes and other hosts. We should make sure the
itest_bionic tests pass then.