### PR TITLE
ready_replicas should always be an int

### DIFF
--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -285,7 +285,7 @@ async def kubernetes_job_status(
             try:
                 ready_replicas = replicaset.status.ready_replicas
             except AttributeError:
-                ready_replicas = None
+                ready_replicas = 0
 
             kstatus["replicasets"].append(
                 {


### PR DESCRIPTION
previously, we occasionally emitted `None`, which would cause a 500 as this is not allowed by the schema. 0 is the correct value to emit in this case anyway.