### PR TITLE
Fix times in paasta status for k8s; fix timestamps in CLI for marathon

### DIFF
--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -34,6 +34,7 @@ import argparse
 import logging
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 
 import a_sync
 
@@ -44,7 +45,6 @@ from paasta_tools.marathon_tools import format_job_id
 from paasta_tools.mesos_tools import get_slaves
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.smartstack_tools import MesosSmartstackReplicationChecker
-from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
@@ -77,14 +77,14 @@ def filter_healthy_marathon_instances_for_short_app_id(all_tasks, app_id):
     tasks_for_app = [
         task for task in all_tasks if task.app_id.startswith("/%s" % app_id)
     ]
-    one_minute_ago = datetime.now() - timedelta(minutes=1)
+    one_minute_ago = datetime.now(timezone.utc) - timedelta(minutes=1)
 
     healthy_tasks = []
     for task in tasks_for_app:
         if (
             marathon_tools.is_task_healthy(task, default_healthy=True)
             and task.started_at is not None
-            and datetime_from_utc_to_local(task.started_at) < one_minute_ago
+            and task.started_at < one_minute_ago
         ):
             healthy_tasks.append(task)
     return len(healthy_tasks)

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -63,7 +63,6 @@ from paasta_tools.monitoring_tools import get_team
 from paasta_tools.monitoring_tools import list_teams
 from paasta_tools.tron_tools import TronActionConfig
 from paasta_tools.utils import compose_job_id
-from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import format_table
 from paasta_tools.utils import get_soa_cluster_deploy_files
@@ -583,9 +582,7 @@ def format_marathon_task_table(tasks):
         ("Mesos Task ID", "Host deployed to", "Deployed at what localtime", "Health")
     ]
     for task in tasks:
-        local_deployed_datetime = datetime_from_utc_to_local(
-            datetime.fromtimestamp(task.deployed_timestamp)
-        )
+        local_deployed_datetime = datetime.fromtimestamp(task.deployed_timestamp)
         if task.host is not None:
             hostname = f"{task.host}:{task.port}"
         else:
@@ -647,9 +644,7 @@ def format_kubernetes_pod_table(pods):
 def format_kubernetes_replicaset_table(replicasets):
     rows = [("ReplicaSet Name", "Ready / Desired", "Created at what localtime")]
     for replicaset in replicasets:
-        local_created_datetime = datetime_from_utc_to_local(
-            datetime.fromtimestamp(replicaset.create_timestamp)
-        )
+        local_created_datetime = datetime.fromtimestamp(replicaset.create_timestamp)
 
         replica_status = f"{replicaset.ready_replicas}/{replicaset.replicas}"
         if replicaset.ready_replicas >= replicaset.replicas:
@@ -886,9 +881,7 @@ def print_flink_status(
         {dashboard_url}"""
         else:
             fmt = "      {job_name: <{allowed_max_job_name_length}.{allowed_max_job_name_length}} {state: <11} {start_time}"
-        start_time = datetime_from_utc_to_local(
-            datetime.utcfromtimestamp(int(job["start-time"]) // 1000)
-        )
+        start_time = datetime.fromtimestamp(int(job["start-time"]) // 1000)
         output.append(
             fmt.format(
                 job_id=job_id,
@@ -906,9 +899,7 @@ def print_flink_status(
                 output.append(f"        Exception: {root_exception}")
                 ts = exceptions["timestamp"]
                 if ts is not None:
-                    exc_ts = datetime_from_utc_to_local(
-                        datetime.utcfromtimestamp(int(ts) // 1000)
-                    )
+                    exc_ts = datetime.fromtimestamp(int(ts) // 1000)
                     output.append(
                         f"            {str(exc_ts)} ({humanize.naturaltime(exc_ts)})"
                     )

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -616,9 +616,7 @@ def format_marathon_task_table(tasks):
 def format_kubernetes_pod_table(pods):
     rows = [("Pod ID", "Host deployed to", "Deployed at what localtime", "Health")]
     for pod in pods:
-        local_deployed_datetime = datetime_from_utc_to_local(
-            datetime.fromtimestamp(pod.deployed_timestamp)
-        )
+        local_deployed_datetime = datetime.fromtimestamp(pod.deployed_timestamp)
         hostname = f"{pod.host}" if pod.host is not None else "Unknown"
         if pod.phase is None or pod.phase == "Pending":
             health_check_status = PaastaColors.grey("N/A")

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1543,17 +1543,11 @@ def is_old_task_missing_healthchecks(task: MarathonTask, app: MarathonApp) -> bo
     """
     health_checks = app.health_checks
     if not task.health_check_results and health_checks and task.started_at:
-        if task.started_at.tzinfo:
-            started_at_utc = task.started_at.astimezone(pytz.utc)
-        else:
-            started_at_utc = task.started_at.replace(tzinfo=pytz.utc)
-
+        now_utc = datetime.datetime.now(pytz.utc)
         healthcheck_startup_time = datetime.timedelta(
             seconds=health_checks[0].grace_period_seconds
         ) + datetime.timedelta(seconds=health_checks[0].interval_seconds * 5)
-        is_task_old = started_at_utc + healthcheck_startup_time < datetime.datetime.now(
-            pytz.utc
-        )
+        is_task_old = task.started_at + healthcheck_startup_time < now_utc
         return is_task_old
     return False
 

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -24,7 +24,7 @@ jsonschema[format]
 kazoo >= 2.0.0
 kubernetes
 manhole
-marathon >= 0.9.3
+marathon >= 0.12.0
 mypy-extensions >= 0.3.0
 objgraph
 ply

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ jsonschema==2.5.1
 kazoo==2.4.0
 kubernetes==10.0.1
 manhole==1.5.0
-marathon==0.9.3
+marathon==0.12.0
 MarkupSafe==1.0
 monotonic==1.4
 msgpack-python==0.5.6

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 
 import mock
 import pytest
@@ -113,7 +114,7 @@ def test_check_service_replication_for_non_smartstack(instance_config):
 
 
 def _make_fake_task(app_id, **kwargs):
-    kwargs.setdefault("started_at", datetime(1991, 7, 5, 6, 13, 0))
+    kwargs.setdefault("started_at", datetime(1991, 7, 5, 6, 13, 0, tzinfo=timezone.utc))
     return mock.Mock(app_id=app_id, **kwargs)
 
 
@@ -138,7 +139,7 @@ def test_filter_healthy_marathon_instances_for_short_app_id_considers_new_tasks_
             f"/service.instance.foo{i}.bar{i}",
             # when i == 0, produces a task that has just started (not healthy yet)
             # otherwise produces a task that was started over a minute ago (healthy)
-            started_at=datetime.now() - one_minute * i,
+            started_at=datetime.now(timezone.utc) - one_minute * i,
         )
 
         mock_result = mock.Mock(alive=True)

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -2900,21 +2900,27 @@ def test_is_old_task_missing_healthchecks():
     mock_health_check = mock.Mock(grace_period_seconds=10, interval_seconds=10)
     mock_marathon_app = mock.Mock(health_checks=[mock_health_check])
     mock_task = mock.Mock(
-        health_check_results=[], started_at=datetime.datetime(year=1990, month=1, day=1)
+        health_check_results=[],
+        started_at=datetime.datetime(
+            year=1990, month=1, day=1, tzinfo=datetime.timezone.utc
+        ),
     )
 
     # test old task missing hcrs
     assert marathon_tools.is_old_task_missing_healthchecks(mock_task, mock_marathon_app)
 
     # test new task missing hcrs
-    mock_task = mock.Mock(health_check_results=[], started_at=datetime.datetime.now())
+    mock_task = mock.Mock(
+        health_check_results=[], started_at=datetime.datetime.now(datetime.timezone.utc)
+    )
     assert not marathon_tools.is_old_task_missing_healthchecks(
         mock_task, mock_marathon_app
     )
 
     # test new task with hcrs
     mock_task = mock.Mock(
-        health_check_results=["SOMERESULTS"], started_at=datetime.datetime.now()
+        health_check_results=["SOMERESULTS"],
+        started_at=datetime.datetime.now(datetime.timezone.utc),
     )
     assert not marathon_tools.is_old_task_missing_healthchecks(
         mock_task, mock_marathon_app


### PR DESCRIPTION
Basically, the paasta API was outputting timestamps for Marathon tasks/apps that were off by 7 or 8 hours; we had code in the CLI to correct this. The Paasta API was producing correct timestamps for k8s, but we copy-pasted the same correction code from the Marathon status CLI, which resulted in incorrect timestamps.

The first commit fixes the k8s bug; the second commit fixes the paasta API for marathon tasks and removes the correction; it does so by bumping marathon-python to a version that [produces TZ-aware datetime objects](https://github.com/thefactory/marathon-python/pull/267)