### PR TITLE
Switch another use of naive datetimes to TZ-aware, to fix crash …

### DIFF
--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -285,7 +285,7 @@ def get_happy_tasks(
     """
     tasks = app.tasks
     happy = []
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     for task in tasks:
         if task.started_at is None:

--- a/tests/test_bounce_lib.py
+++ b/tests/test_bounce_lib.py
@@ -342,7 +342,7 @@ class TestBounceLib:
 
     def test_get_happy_tasks_min_task_uptime(self):
         """If we specify a minimum task age, tasks newer than that should not be considered happy."""
-        now = datetime.datetime(2000, 1, 1, 0, 0, 0)
+        now = datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
         tasks = [
             mock.Mock(
                 health_check_results=[],
@@ -356,7 +356,7 @@ class TestBounceLib:
         # datetime.datetime instead, and give it a utcnow attribute.
         with mock.patch(
             "paasta_tools.bounce_lib.datetime.datetime",
-            utcnow=lambda: now,
+            now=lambda tz: now,
             autospec=True,
         ):
             actual = bounce_lib.get_happy_tasks(
@@ -371,7 +371,7 @@ class TestBounceLib:
 
     def test_get_happy_tasks_min_task_uptime_when_unhealthy(self):
         """If we specify a minimum task age, tasks newer than that should not be considered happy."""
-        now = datetime.datetime(2000, 1, 1, 0, 0, 0)
+        now = datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
         tasks = [
             mock.Mock(
                 health_check_results=[mock.Mock(alive=False)],
@@ -383,7 +383,7 @@ class TestBounceLib:
 
         with mock.patch(
             "paasta_tools.bounce_lib.datetime.datetime",
-            utcnow=lambda: now,
+            now=lambda tz: now,
             autospec=True,
         ):
             actual = bounce_lib.get_happy_tasks(


### PR DESCRIPTION
…when comparing to datetimes from marathon-python, which are TZ-aware as of 8de79b94426a5d64ed01fe746bfa8e1f1b66c532

I've also grepped the codebase for remaining uses of `utcnow` -- they all seem related to logging and start/stop/restart (force_bounce); so I'm fairly confident we aren't going to see another instance of this exact bug.
