### PR TITLE
paasta validate has to take service argument

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -423,6 +423,9 @@ def paasta_validate(args):
 
     :param args: argparse.Namespace obj created from sys.args by cli
     """
+    if args.service is None:
+        print("Warning: Please specify service to validate.")
+        return 1
     service = args.service
     soa_dir = args.yelpsoa_config_root
     service_path = get_service_path(service, soa_dir)

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -27,6 +27,7 @@ from jsonschema import ValidationError
 from paasta_tools.cli.utils import failure
 from paasta_tools.cli.utils import get_file_contents
 from paasta_tools.cli.utils import get_instance_config
+from paasta_tools.cli.utils import guess_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import PaastaColors
 from paasta_tools.cli.utils import success
@@ -423,11 +424,7 @@ def paasta_validate(args):
 
     :param args: argparse.Namespace obj created from sys.args by cli
     """
-    if args.service is None:
-        print("Warning: Please specify service to validate.")
-        return 1
-    service = args.service
-    soa_dir = args.yelpsoa_config_root
-    service_path = get_service_path(service, soa_dir)
+    service_path = get_service_path(args.service, args.yelpsoa_config_root)
+    service = args.service or guess_service_name()
     if not paasta_validate_soa_configs(service, service_path):
         return 1


### PR DESCRIPTION
Otherwise, it throws exception:

Traceback (most recent call last):
  File "/nail/home/chl/paasta/.tox/py36/bin/paasta", line 11, in <module>
    load_entry_point('paasta-tools', 'console_scripts', 'paasta')()
  File "/nail/home/chl/paasta/paasta_tools/cli/cli.py", line 166, in main
    return_code = args.command(args)
  File "/nail/home/chl/paasta/paasta_tools/cli/cmds/validate.py", line 430, in paasta_validate
    if not paasta_validate_soa_configs(service, service_path):
  File "/nail/home/chl/paasta/paasta_tools/cli/cmds/validate.py", line 401, in paasta_validate_soa_configs
    if not validate_service_name(service):
  File "/nail/home/chl/paasta/paasta_tools/cli/cmds/validate.py", line 133, in validate_service_name
    if len(sanitise_kubernetes_name(service)) > 63:
  File "/nail/home/chl/paasta/paasta_tools/kubernetes_tools.py", line 1757, in sanitise_kubernetes_name
    name = service.replace("_", "--")