### PR TITLE
Fix example cluster build

### DIFF
--- a/yelp_package/dockerfiles/xenial/Dockerfile
+++ b/yelp_package/dockerfiles/xenial/Dockerfile
@@ -48,6 +48,7 @@ RUN cd /tmp && \
 ADD mesos-slave-secret /etc/mesos-slave-secret
 
 COPY requirements.txt requirements.txt
+RUN pip install virtualenv==16.7.7
 RUN virtualenv --python=python3.6 venv && venv/bin/pip install -r requirements.txt
 
 

--- a/yelp_package/dockerfiles/xenial/requirements.txt
+++ b/yelp_package/dockerfiles/xenial/requirements.txt
@@ -1,4 +1,4 @@
-setuptools==31.0.1
+setuptools==39.0.1
 tox==2.9.1
 tox-pip-extensions==1.2.1
 tox-virtualenv-no-download==1.0.0


### PR DESCRIPTION
Think a new release of virtualenv is causing some failure in pip install
for example cluster. Trying this pin which I think will fix it..