### PR TITLE
better parsing of spark command when env variables are set

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -58,6 +58,8 @@ deprecated_opts = {
     "driver-memory": "spark.driver.memory",
 }
 
+SPARK_COMMANDS = {"pyspark", "spark-submit"}
+
 log = logging.getLogger(__name__)
 
 
@@ -338,7 +340,15 @@ def get_smart_paasta_instance_name(args):
         tron_action = os.environ.get("TRON_ACTION")
         return f"{tron_job}.{tron_action}"
     else:
-        how_submitted = "mrjob" if args.mrjob else args.cmd.split(" ")[0]
+        how_submitted = None
+        if args.mrjob:
+            how_submitted = "mrjob"
+        else:
+            for spark_cmd in SPARK_COMMANDS:
+                if spark_cmd in args.cmd:
+                    how_submitted = spark_cmd
+                    break
+        how_submitted = how_submitted or "other"
         return f"{args.instance}_{get_username()}_{how_submitted}"
 
 

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -70,7 +70,7 @@ def test_get_docker_run_cmd(mock_getegid, mock_geteuid):
 @pytest.mark.parametrize("mrjob", [True, False])
 def test_get_smart_paasta_instance_name(mrjob):
     args = argparse.Namespace(
-        instance="foo", cmd="spark-submit blah blah blah", mrjob=mrjob,
+        instance="foo", cmd="USER blah spark-submit blah blah blah", mrjob=mrjob,
     )
     with mock.patch(
         "paasta_tools.cli.cmds.spark_run.get_username",


### PR DESCRIPTION
If the first word of the command wasn't actual spark command, we'd end up with things like `adhoc_username_USER` which is useless.