### PR TITLE
Add additional authors as a CLI argument

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -199,6 +199,13 @@ def add_subparser(subparsers):
         default=30,
         help="After noticing an SLO failure, wait this many seconds before automatically rolling back.",
     )
+    list_parser.add_argument(
+        "--author",
+        dest="additional_authors",
+        default=None,
+        action='append',
+        help="Additional author(s) of the deploy, who will be pinged in Slack"
+    )
 
     list_parser.set_defaults(command=paasta_mark_for_deployment)
 
@@ -253,21 +260,27 @@ def report_waiting_aborted(service, deploy_group):
     paasta_print()
 
 
-def get_authors_to_be_notified(git_url, from_sha, to_sha):
+def get_authors_to_be_notified(git_url, from_sha, to_sha, additional_authors):
     if from_sha is None:
         return ""
-    ret, authors = remote_git.get_authors(
+    ret, git_authors = remote_git.get_authors(
         git_url=git_url, from_sha=from_sha, to_sha=to_sha
     )
-    if ret == 0:
-        if authors == "":
-            return ""
-        else:
-            slacky_authors = ", ".join({f"<@{a}>" for a in authors.split()})
-            log.debug(f"Authors: {slacky_authors}")
-            return f"^ {slacky_authors}"
+    if ret == 1: 
+        if not additional_authors:
+            return f"(Could not get authors: {git_authors})"
+        git_authors = []
     else:
-        return f"(Could not get authors: {authors})"
+        git_authors = git_authors.split()
+    
+    authors = git_authors + (additional_authors or [])
+    if authors == []:
+        log.debug(f"No authors found or provided")
+        return ""
+
+    slacky_authors = ", ".join({f"<@{a}>" for a in authors})
+    log.debug(f"Authors: {slacky_authors}")
+    return f"^ {slacky_authors}"
 
 
 def deploy_group_is_set_to_notify(deploy_info, deploy_group, notify_type):
@@ -370,6 +383,7 @@ def paasta_mark_for_deployment(args):
         auto_certify_delay=args.auto_certify_delay,
         auto_abandon_delay=args.auto_abandon_delay,
         auto_rollback_delay=args.auto_rollback_delay,
+        additional_authors=args.additional_authors,
     )
     ret = deploy_process.run()
     return ret
@@ -422,6 +436,7 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
         auto_certify_delay,
         auto_abandon_delay,
         auto_rollback_delay,
+        additional_authors=None,
     ):
         self.service = service
         self.deploy_info = deploy_info
@@ -440,6 +455,7 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
         self.auto_certify_delay = auto_certify_delay
         self.auto_abandon_delay = auto_abandon_delay
         self.auto_rollback_delay = auto_rollback_delay
+        self.additional_authors = additional_authors
 
         # Separate green_light per commit, so that we can tell wait_for_deployment for one commit to shut down
         # and quickly launch wait_for_deployment for another commit without causing a race condition.
@@ -489,7 +505,10 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
         if from_sha is None:
             from_sha = self.old_git_sha
         return get_authors_to_be_notified(
-            git_url=self.git_url, from_sha=from_sha, to_sha=self.commit
+            git_url=self.git_url,
+            from_sha=from_sha, 
+            to_sha=self.commit,
+            additional_authors=self.additional_authors
         )
 
     def ping_authors(self, message: str = None) -> None:

--- a/paasta_tools/remote_git.py
+++ b/paasta_tools/remote_git.py
@@ -117,7 +117,7 @@ def get_authors(git_url, from_sha, to_sha):
             f"could not understand the git repo in {git_url} for authors detection",
         )
 
-    if "yelpcorp.com" in git_server:
+    if "git.yelpcorp.com" in git_server:
         ssh_command = (
             f"ssh {git_server} authors-of-changeset {git_repo} {from_sha} {to_sha}"
         )

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -37,6 +37,7 @@ class FakeArgs:
     auto_certify_delay = 1.0
     auto_abandon_delay = 1.0
     auto_rollback_delay = 1.0
+    additional_authors = None
 
 
 @fixture
@@ -341,9 +342,10 @@ def test_MarkForDeployProcess_get_authors_diffs_against_prod_deploy_group(
         auto_certify_delay=1,
         auto_abandon_delay=1,
         auto_rollback_delay=1,
+        additional_authors=['fakeuser1']
     )
     mock_get_authors_to_be_notified.assert_called_once_with(
-        git_url=None, from_sha="aaaaaaaa", to_sha="abc123512"
+        git_url=None, from_sha="aaaaaaaa", to_sha="abc123512", additional_authors=['fakeuser1']
     )
 
 
@@ -375,9 +377,10 @@ def test_MarkForDeployProcess_get_authors_falls_back_to_current_deploy_group(
         auto_certify_delay=1,
         auto_abandon_delay=1,
         auto_rollback_delay=1,
+        additional_authors='fakeuser1'
     )
     mock_get_authors_to_be_notified.assert_called_once_with(
-        git_url=None, from_sha="asgdser23", to_sha="abc123512"
+        git_url=None, from_sha="asgdser23", to_sha="abc123512", additional_authors='fakeuser1'
     )
 
 
@@ -574,6 +577,7 @@ def test_MarkForDeployProcess_happy_path(
         auto_certify_delay=None,
         auto_abandon_delay=600,
         auto_rollback_delay=30,
+        additional_authors=None,
     )
 
     mfdp.run_timeout = 1
@@ -618,6 +622,7 @@ def test_MarkForDeployProcess_happy_path_skips_complete_if_no_auto_rollback(
         auto_certify_delay=None,
         auto_abandon_delay=600,
         auto_rollback_delay=30,
+        additional_authors=None,
     )
 
     mfdp.run_timeout = 1


### PR DESCRIPTION
Not all git hosts are gitolite, and relying on the authors-of-changeset
gitolite script is not an option for repositories hosted there.  
Since most calls to this command are automated, Release
Engineering will be modifying those calls to pass in the git authors
directly. This change enables that.

For those manual calls by developers, we intend to pull out the username
of the developer from OS calls, which will be done in a future CR. 

This argument is an `append ` action, so authors will be passed in via `--author user1 --author user2` and so on.
