### PR TITLE
More consistent paasta prefixed attributes

### DIFF
--- a/paasta_tools/cleanup_kubernetes_cr.py
+++ b/paasta_tools/cleanup_kubernetes_cr.py
@@ -30,6 +30,7 @@ from paasta_tools.kubernetes_tools import delete_custom_resource
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import list_custom_resources
 from paasta_tools.kubernetes_tools import load_custom_resource_definitions
+from paasta_tools.kubernetes_tools import paasta_prefixed
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import load_all_configs
 from paasta_tools.utils import load_system_paasta_config
@@ -88,7 +89,7 @@ def cleanup_all_custom_resources(
     cluster_crds = {
         crd.spec.names.kind
         for crd in kube_client.apiextensions.list_custom_resource_definition(
-            label_selector="paasta.yelp.com/service"
+            label_selector=paasta_prefixed("service")
         ).items
     }
     log.debug(f"CRDs found: {cluster_crds}")

--- a/paasta_tools/cleanup_kubernetes_crd.py
+++ b/paasta_tools/cleanup_kubernetes_crd.py
@@ -103,9 +103,7 @@ def cleanup_kube_crd(
     for crd in existing_crds.items:
         service = crd.metadata.labels[service_attr]
         if not service:
-            log.error(
-                f"CRD {crd.metadata.name} has empty {service_attr} label"
-            )
+            log.error(f"CRD {crd.metadata.name} has empty {service_attr} label")
             continue
 
         crd_config = service_configuration_lib.read_extra_service_information(

--- a/paasta_tools/cleanup_kubernetes_crd.py
+++ b/paasta_tools/cleanup_kubernetes_crd.py
@@ -31,6 +31,7 @@ from kubernetes.client import V1DeleteOptions
 from kubernetes.client.rest import ApiException
 
 from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.kubernetes_tools import paasta_prefixed
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import load_system_paasta_config
 
@@ -93,16 +94,17 @@ def cleanup_kube_crd(
     soa_dir: str = DEFAULT_SOA_DIR,
     dry_run: bool = False,
 ) -> bool:
+    service_attr = paasta_prefixed("service")
     existing_crds = kube_client.apiextensions.list_custom_resource_definition(
-        label_selector="paasta.yelp.com/service"
+        label_selector=service_attr
     )
 
     success = True
     for crd in existing_crds.items:
-        service = crd.metadata.labels["paasta.yelp.com/service"]
+        service = crd.metadata.labels[service_attr]
         if not service:
             log.error(
-                f"CRD {crd.metadata.name} has empty paasta.yelp.com/service label"
+                f"CRD {crd.metadata.name} has empty {service_attr} label"
             )
             continue
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -55,6 +55,7 @@ from paasta_tools.flink_tools import FlinkDeploymentConfig
 from paasta_tools.kafkacluster_tools import KafkaClusterDeploymentConfig
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.kubernetes_tools import KubernetesDeployStatus
+from paasta_tools.kubernetes_tools import paasta_prefixed
 from paasta_tools.marathon_tools import MarathonDeployStatus
 from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.mesos_tools import format_tail_lines_for_mesos_task
@@ -811,7 +812,7 @@ def print_flink_status(
     # Since metadata should be available no matter the state, we show it first. If this errors out
     # then we cannot really do much to recover, because cluster is not in usable state anyway
     metadata = flink.get("metadata")
-    config_sha = metadata.labels.get("paasta.yelp.com/config_sha")
+    config_sha = metadata.labels.get(paasta_prefixed("config_sha"))
     if config_sha is None:
         raise ValueError(f"expected config sha on Flink, but received {metadata}")
     if config_sha.startswith("config"):
@@ -825,7 +826,7 @@ def print_flink_status(
         )
     else:
         output.append(f"    Flink version: {status.config['flink-version']}")
-    dashboard_url = metadata.annotations.get("paasta.yelp.com/dashboard_url")
+    dashboard_url = metadata.annotations.get(paasta_prefixed("dashboard_url"))
     output.append(f"    URL: {dashboard_url}/")
 
     if status.state != "running":

--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -41,10 +41,10 @@ class Application(ABC):
         """
         if not item.metadata.namespace:
             item.metadata.namespace = "paasta"
-        attrs = dict(**{
+        attrs = {
             attr: item.metadata.labels[paasta_prefixed(attr)]
             for attr in ["service", "instance", "git_sha", "config_sha"]
-        })
+        }
         self.kube_deployment = KubeDeployment(replicas=item.spec.replicas, **attrs)
         self.item = item
         self.soa_config = None  # type: KubernetesDeploymentConfig

--- a/paasta_tools/kubernetes/application/tools.py
+++ b/paasta_tools/kubernetes/application/tools.py
@@ -9,23 +9,22 @@ from paasta_tools.kubernetes.application.controller_wrappers import Application
 from paasta_tools.kubernetes.application.controller_wrappers import DeploymentWrapper
 from paasta_tools.kubernetes.application.controller_wrappers import StatefulSetWrapper
 from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.kubernetes_tools import paasta_prefixed
 from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
 
 log = logging.getLogger(__name__)
 
 
 def is_valid_application(deployment: V1Deployment):
-    is_valid = (
-        "paasta.yelp.com/service" in deployment.metadata.labels
-        and "paasta.yelp.com/instance" in deployment.metadata.labels
-        and "paasta.yelp.com/git_sha" in deployment.metadata.labels
-        and "paasta.yelp.com/config_sha" in deployment.metadata.labels
+    required = map(
+        paasta_prefixed, ["service", "instance", "git_sha", "config_sha"]
     )
+    is_valid = all(label in deployment.metadata.labels for label in required)
     if not is_valid:
         log.warning(
             f"deployment/{deployment.metadata.name} in "
             f"namespace/{deployment.metadata.namespace} "
-            "does not have complete set of labels"
+            f"does not have complete set of labels: {required}"
         )
         log.warning(deployment)
     return is_valid

--- a/paasta_tools/kubernetes/application/tools.py
+++ b/paasta_tools/kubernetes/application/tools.py
@@ -16,17 +16,19 @@ log = logging.getLogger(__name__)
 
 
 def is_valid_application(deployment: V1Deployment):
-    required = map(
-        paasta_prefixed, ["service", "instance", "git_sha", "config_sha"]
-    )
-    is_valid = all(label in deployment.metadata.labels for label in required)
-    if not is_valid:
+    is_valid = True
+    missing = []
+    for attr in ["service", "instance", "git_sha", "config_sha"]:
+        prefixed_attr = paasta_prefixed(attr)
+        if prefixed_attr not in deployment.metadata.labels:
+            is_valid = False
+            missing.append(prefixed_attr)
+    if missing:
         log.warning(
             f"deployment/{deployment.metadata.name} in "
             f"namespace/{deployment.metadata.namespace} "
-            f"does not have complete set of labels: {required}"
+            f"is missing following labels: {missing}"
         )
-        log.warning(deployment)
     return is_valid
 
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -136,6 +136,7 @@ KUBE_DEPLOY_STATEGY_MAP = {
 }
 HACHECK_POD_NAME = "hacheck"
 KUBERNETES_NAMESPACE = "paasta"
+DISCOVERY_ATTRIBUTES = {"region", "superregion", "ecosystem", "habitat"}
 
 
 # For detail, https://github.com/kubernetes-client/python/issues/553
@@ -1522,8 +1523,7 @@ def filter_nodes_by_blacklist(
 
 def paasta_prefixed(attribute: str,) -> str:
     # discovery attributes are exempt for now
-    discovery_attributes = ["region", "superregion", "ecosystem", "habitat"]
-    if attribute in discovery_attributes:
+    if attribute in DISCOVERY_ATTRIBUTES:
         return YELP_ATTRIBUTE_PREFIX + attribute
     elif "/" in attribute:
         return attribute

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -126,7 +126,7 @@ from paasta_tools.utils import VolumeWithMode
 log = logging.getLogger(__name__)
 
 KUBE_CONFIG_PATH = "/etc/kubernetes/admin.conf"
-YELP_ATTRIBUTE_PREFIX = "yelp.com/"
+PAASTA_ATTRIBUTE_PREFIX = "paasta.yelp.com/"
 CONFIG_HASH_BLACKLIST = {"replicas"}
 KUBE_DEPLOY_STATEGY_MAP = {
     "crossover": "RollingUpdate",
@@ -1509,8 +1509,8 @@ def filter_nodes_by_blacklist(
     :returns: The list of nodes after the filter
     """
     if whitelist:
-        whitelist = (maybe_add_yelp_prefix(whitelist[0]), whitelist[1])
-    blacklist = [(maybe_add_yelp_prefix(entry[0]), entry[1]) for entry in blacklist]
+        whitelist = (paasta_prefixed(whitelist[0]), whitelist[1])
+    blacklist = [(paasta_prefixed(entry[0]), entry[1]) for entry in blacklist]
     return [
         node
         for node in nodes
@@ -1519,14 +1519,14 @@ def filter_nodes_by_blacklist(
     ]
 
 
-def maybe_add_yelp_prefix(attribute: str,) -> str:
-    return YELP_ATTRIBUTE_PREFIX + attribute if "/" not in attribute else attribute
+def paasta_prefixed(attribute: str,) -> str:
+    return attribute if "/" in attribute else PAASTA_ATTRIBUTE_PREFIX + attribute
 
 
 def get_nodes_grouped_by_attribute(
     nodes: Sequence[V1Node], attribute: str
 ) -> Mapping[str, Sequence[V1Node]]:
-    attribute = maybe_add_yelp_prefix(attribute)
+    attribute = paasta_prefixed(attribute)
     sorted_nodes = sorted(
         nodes, key=lambda node: node.metadata.labels.get(attribute, "")
     )

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -126,6 +126,7 @@ from paasta_tools.utils import VolumeWithMode
 log = logging.getLogger(__name__)
 
 KUBE_CONFIG_PATH = "/etc/kubernetes/admin.conf"
+YELP_ATTRIBUTE_PREFIX = "yelp.com/"
 PAASTA_ATTRIBUTE_PREFIX = "paasta.yelp.com/"
 CONFIG_HASH_BLACKLIST = {"replicas"}
 KUBE_DEPLOY_STATEGY_MAP = {
@@ -1520,7 +1521,14 @@ def filter_nodes_by_blacklist(
 
 
 def paasta_prefixed(attribute: str,) -> str:
-    return attribute if "/" in attribute else PAASTA_ATTRIBUTE_PREFIX + attribute
+    # discovery attributes are exempt for now
+    discovery_attributes = ["region", "superregion", "ecosystem", "habitat"]
+    if attribute in discovery_attributes:
+        return YELP_ATTRIBUTE_PREFIX + attribute
+    elif "/" in attribute:
+        return attribute
+    else:
+        return PAASTA_ATTRIBUTE_PREFIX + attribute
 
 
 def get_nodes_grouped_by_attribute(

--- a/paasta_tools/metrics/metastatus_lib.py
+++ b/paasta_tools/metrics/metastatus_lib.py
@@ -38,7 +38,7 @@ from paasta_tools.kubernetes_tools import get_pod_status
 from paasta_tools.kubernetes_tools import is_node_ready
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import list_all_deployments
-from paasta_tools.kubernetes_tools import maybe_add_yelp_prefix
+from paasta_tools.kubernetes_tools import paasta_prefixed
 from paasta_tools.kubernetes_tools import PodStatus
 from paasta_tools.marathon_tools import get_all_marathon_apps
 from paasta_tools.marathon_tools import MarathonClient
@@ -570,7 +570,7 @@ def key_func_for_attribute_multi_kube(
     """
 
     def get_attribute(node, attribute):
-        return node.metadata.labels.get(maybe_add_yelp_prefix(attribute), "unknown")
+        return node.metadata.labels.get(paasta_prefixed(attribute), "unknown")
 
     def key_func(node):
         return tuple((a, get_attribute(node, a)) for a in attributes)

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -39,6 +39,7 @@ from paasta_tools.kubernetes_tools import KubeCustomResource
 from paasta_tools.kubernetes_tools import KubeKind
 from paasta_tools.kubernetes_tools import list_custom_resources
 from paasta_tools.kubernetes_tools import load_custom_resource_definitions
+from paasta_tools.kubernetes_tools import paasta_prefixed
 from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
 from paasta_tools.kubernetes_tools import sanitised_cr_name
 from paasta_tools.kubernetes_tools import update_custom_resource
@@ -152,7 +153,7 @@ def setup_all_custom_resources(
     cluster_crds = {
         crd.spec.names.kind
         for crd in kube_client.apiextensions.list_custom_resource_definition(
-            label_selector="paasta.yelp.com/service"
+            label_selector=paasta_prefixed("service")
         ).items
     }
     log.debug(f"CRDs found: {cluster_crds}")
@@ -257,9 +258,9 @@ def format_custom_resource(
                 "yelp.com/paasta_service": service,
                 "yelp.com/paasta_instance": instance,
                 "yelp.com/paasta_cluster": cluster,
-                "paasta.yelp.com/service": service,
-                "paasta.yelp.com/instance": instance,
-                "paasta.yelp.com/cluster": cluster,
+                paasta_prefixed("service"): service,
+                paasta_prefixed("instance"): instance,
+                paasta_prefixed("cluster"): cluster,
             },
             "annotations": {},
         },
@@ -268,12 +269,12 @@ def format_custom_resource(
     url = get_dashboard_url(kind, service, instance, cluster)
     if url:
         resource["metadata"]["annotations"]["yelp.com/dashboard_url"] = url
-        resource["metadata"]["annotations"]["paasta.yelp.com/dashboard_url"] = url
+        resource["metadata"]["annotations"][paasta_prefixed("dashboard_url")] = url
     config_hash = get_config_hash(resource)
     resource["metadata"]["annotations"]["yelp.com/desired_state"] = "running"
-    resource["metadata"]["annotations"]["paasta.yelp.com/desired_state"] = "running"
+    resource["metadata"]["annotations"][paasta_prefixed("desired_state")] = "running"
     resource["metadata"]["labels"]["yelp.com/paasta_config_sha"] = config_hash
-    resource["metadata"]["labels"]["paasta.yelp.com/config_sha"] = config_hash
+    resource["metadata"]["labels"][paasta_prefixed("config_sha")] = config_hash
     return resource
 
 
@@ -307,7 +308,7 @@ def reconcile_kubernetes_resource(
             service=service,
             instance=inst,
             config_sha=formatted_resource["metadata"]["labels"][
-                "paasta.yelp.com/config_sha"
+                paasta_prefixed("config_sha")
             ],
             kind=kind.singular,
             name=formatted_resource["metadata"]["name"],

--- a/paasta_tools/setup_kubernetes_crd.py
+++ b/paasta_tools/setup_kubernetes_crd.py
@@ -31,6 +31,7 @@ from kubernetes.client import V1beta1CustomResourceDefinition
 from kubernetes.client.rest import ApiException
 
 from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.kubernetes_tools import paasta_prefixed
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import load_system_paasta_config
 
@@ -100,7 +101,7 @@ def setup_kube_crd(
     soa_dir: str = DEFAULT_SOA_DIR,
 ) -> bool:
     existing_crds = kube_client.apiextensions.list_custom_resource_definition(
-        label_selector="paasta.yelp.com/service"
+        label_selector=paasta_prefixed("service")
     )
 
     success = True
@@ -116,7 +117,7 @@ def setup_kube_crd(
         if "labels" not in metadata:
             metadata["labels"] = {}
         metadata["labels"]["yelp.com/paasta_service"] = service
-        metadata["labels"]["paasta.yelp.com/service"] = service
+        metadata["labels"][paasta_prefixed("service")] = service
         desired_crd = V1beta1CustomResourceDefinition(
             api_version=crd_config.get("apiVersion"),
             kind=crd_config.get("kind"),

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -82,7 +82,7 @@ from paasta_tools.kubernetes_tools import list_custom_resources
 from paasta_tools.kubernetes_tools import load_kubernetes_service_config
 from paasta_tools.kubernetes_tools import load_kubernetes_service_config_no_cache
 from paasta_tools.kubernetes_tools import max_unavailable
-from paasta_tools.kubernetes_tools import maybe_add_yelp_prefix
+from paasta_tools.kubernetes_tools import paasta_prefixed
 from paasta_tools.kubernetes_tools import pod_disruption_budget_for_service_instance
 from paasta_tools.kubernetes_tools import pods_for_service_instance
 from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
@@ -1917,7 +1917,7 @@ def test_filter_nodes_by_blacklist():
     ) as mock_host_passes_whitelist, mock.patch(
         "paasta_tools.kubernetes_tools.host_passes_blacklist", autospec=True
     ) as mock_host_passes_blacklist, mock.patch(
-        "paasta_tools.kubernetes_tools.maybe_add_yelp_prefix",
+        "paasta_tools.kubernetes_tools.paasta_prefixed",
         autospec=True,
         side_effect=lambda x: x,
     ):
@@ -1969,7 +1969,7 @@ def test_filter_nodes_by_blacklist():
 
 def test_get_nodes_grouped_by_attribute():
     with mock.patch(
-        "paasta_tools.kubernetes_tools.maybe_add_yelp_prefix",
+        "paasta_tools.kubernetes_tools.paasta_prefixed",
         autospec=True,
         side_effect=lambda x: x,
     ):
@@ -1989,9 +1989,9 @@ def test_get_nodes_grouped_by_attribute():
         )
 
 
-def test_maybe_add_yelp_prefix():
-    assert maybe_add_yelp_prefix("kubernetes.io/thing") == "kubernetes.io/thing"
-    assert maybe_add_yelp_prefix("region") == "yelp.com/region"
+def test_paasta_prefixed():
+    assert paasta_prefixed("kubernetes.io/thing") == "kubernetes.io/thing"
+    assert paasta_prefixed("region") == "yelp.com/region"
 
 
 def test_sanitise_kubernetes_name():


### PR DESCRIPTION
* rename `maybe_add_yelp_prefix` with `paasta_prefixed`
* fix `paasta_prefixed` for discovery attributes, that aren't under `paasta.yelp.com` namespace
* replace hardcoded namespacing with `paasta_prefixed` everywhere