### PR TITLE
validate new autoscaling configurations

### DIFF
--- a/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster.yaml
@@ -8,6 +8,8 @@ main2:
     FOO: BAR
   deploy_group: fake_deploy_group
   horizontal_autoscaling:
+      max_replicas: 3
+      max_replicas: 1
       cpu:
           target_average_value: 70
           signalflow_metrics_query: "data(\"fake-external\").publish"

--- a/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster.yaml
@@ -1,0 +1,16 @@
+---
+main2:
+  cpus: .1
+  mem: 100
+  disk: 200.0
+  instances: 1
+  env:
+    FOO: BAR
+  deploy_group: fake_deploy_group
+  horizontal_autoscaling:
+      cpu:
+          target_average_value: 0.7
+          signalflow_metrics_query: "data(\"fake-external\").publish"
+      fake-external:
+          target_average_value: 0.55
+          signalflow_metrics_query: "data(\"fake-external\").publish"

--- a/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster.yaml
@@ -9,8 +9,8 @@ main2:
   deploy_group: fake_deploy_group
   horizontal_autoscaling:
       cpu:
-          target_average_value: 0.7
+          target_average_value: 70
           signalflow_metrics_query: "data(\"fake-external\").publish"
       fake-external:
-          target_average_value: 0.55
+          target_average_value: 55
           signalflow_metrics_query: "data(\"fake-external\").publish"

--- a/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster2.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster2.yaml
@@ -9,4 +9,4 @@ main4:
   deploy_group: fake_deploy_group
   horizontal_autoscaling:
       custom:
-          target_average_value: 0.55
+          target_average_value: 55

--- a/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster2.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster2.yaml
@@ -1,0 +1,12 @@
+---
+main4:
+  cpus: .1
+  mem: 100
+  disk: 200.0
+  instances: 1
+  env:
+    FOO: BAR
+  deploy_group: fake_deploy_group
+  horizontal_autoscaling:
+      custom:
+          target_average_value: 0.55

--- a/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster2.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster2.yaml
@@ -8,5 +8,7 @@ main4:
     FOO: BAR
   deploy_group: fake_deploy_group
   horizontal_autoscaling:
+      max_replicas: 3
+      max_replicas: 1
       custom:
           target_average_value: 55

--- a/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster3.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster3.yaml
@@ -8,6 +8,8 @@ main2:
     FOO: BAR
   deploy_group: fake_deploy_group
   horizontal_autoscaling:
+      max_replicas: 3
+      max_replicas: 1
       http:
           target_average_value: 55
           dimension:

--- a/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster3.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster3.yaml
@@ -1,0 +1,15 @@
+---
+main2:
+  cpus: .1
+  mem: 100
+  disk: 200.0
+  instances: 1
+  env:
+    FOO: BAR
+  deploy_group: fake_deploy_group
+  horizontal_autoscaling:
+      http:
+          target_average_value: 0.55
+          dimension:
+              sf_x: "should fail"
+              gcp_x: "should fail"

--- a/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster3.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_invalid_service/kubernetes-test-cluster3.yaml
@@ -9,7 +9,7 @@ main2:
   deploy_group: fake_deploy_group
   horizontal_autoscaling:
       http:
-          target_average_value: 0.55
+          target_average_value: 55
           dimension:
               sf_x: "should fail"
               gcp_x: "should fail"

--- a/general_itests/fake_soa_configs_validate/fake_invalid_service/marathon-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_invalid_service/marathon-test-cluster.yaml
@@ -4,5 +4,6 @@ main:
     mem: 100
     disk: 200
     instances: 1
+    oops: oops
     env:
       FOO: BAR

--- a/general_itests/fake_soa_configs_validate/fake_valid_service/kubernetes-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_valid_service/kubernetes-test-cluster.yaml
@@ -1,0 +1,24 @@
+---
+main2:
+  cpus: .1
+  mem: 100
+  disk: 200.0
+  instances: 1
+  env:
+    FOO: BAR
+  deploy_group: fake_deploy_group
+  horizontal_autoscaling:
+      cpu:
+          target_average_value: 0.7
+      memory:
+          target_average_value: 0.7
+      uwsgi:
+          target_average_value: 0.4
+      http:
+          target_average_value: 0.6
+          dimensions:
+              d1: "1"
+              d2: "2"
+      fake-external:
+          target_average_value: 0.55
+          signalflow_metrics_query: "data(\"fake-external\").publish"

--- a/general_itests/fake_soa_configs_validate/fake_valid_service/kubernetes-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_valid_service/kubernetes-test-cluster.yaml
@@ -9,16 +9,16 @@ main2:
   deploy_group: fake_deploy_group
   horizontal_autoscaling:
       cpu:
-          target_average_value: 0.7
+          target_average_value: 7
       memory:
-          target_average_value: 0.7
+          target_average_value: 7
       uwsgi:
-          target_average_value: 0.4
+          target_average_value: 4
       http:
-          target_average_value: 0.6
+          target_average_value: 6
           dimensions:
               d1: "1"
               d2: "2"
       fake-external:
-          target_average_value: 0.55
+          target_average_value: 55
           signalflow_metrics_query: "data(\"fake-external\").publish"

--- a/general_itests/fake_soa_configs_validate/fake_valid_service/kubernetes-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_valid_service/kubernetes-test-cluster.yaml
@@ -22,5 +22,5 @@ main2:
               d1: "1"
               d2: "2"
       fake-external:
-          target_average_value: 55
+          target_value: 55
           signalflow_metrics_query: "data(\"fake-external\").publish"

--- a/general_itests/fake_soa_configs_validate/fake_valid_service/kubernetes-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_valid_service/kubernetes-test-cluster.yaml
@@ -8,6 +8,8 @@ main2:
     FOO: BAR
   deploy_group: fake_deploy_group
   horizontal_autoscaling:
+      max_replicas: 100
+      min_replicas: 1
       cpu:
           target_average_value: 7
       memory:

--- a/general_itests/steps/validate_steps.py
+++ b/general_itests/steps/validate_steps.py
@@ -52,4 +52,5 @@ def validate_status_all_pass(context):
 
 @then("it should report an error in the output")
 def validate_status_something_fail(context):
-    assert x_mark() in context.output
+    paasta_print(context.output)
+    assert "Successfully validated schema" not in context.output

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -413,17 +413,14 @@ def validate_autoscaling_configs(service_path):
             cluster = basename[basename.rfind("kuernetes-") + 1 :]
             instances[cluster] = get_config_file_dict(file_name)
     # Validate autoscaling configurations for all instances
-    for cluster_name, cluster in instances:
+    for cluster_name, cluster in instances.items():
         for instance_name, instance in cluster.items():
             for metric, params in instance.get("new_autoscaling", {}).items():
                 if len(metric) > 63:
                     returncode = False
                     paasta_print(f"length of metric name {metric} exceeds 63")
                     continue
-                if (
-                    metric in {"http_custom_metrics", "uwsgi_custom_metrics"}
-                    and "dimensions" in params
-                ):
+                if metric in {"http", "uwsgi"} and "dimensions" in params:
                     for k, v in params["dimensions"].items():
                         if len(k) > 128:
                             returncode = False

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -194,9 +194,11 @@
                 },
                 "horizontal_autoscaling": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "cpu": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "target_average_value": {
                                     "type": "number",
@@ -206,10 +208,14 @@
                                     "exclusiveMinimum": true,
                                     "exclusiveMaximum": false
                                 }
-                            }
+                            },
+                            "required": [
+                                "target_average_value"
+                            ]
                         },
                         "memory": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "target_average_value": {
                                     "type": "number",
@@ -219,10 +225,14 @@
                                     "exclusiveMinimum": true,
                                     "exclusiveMaximum": false
                                 }
-                            }
+                            },
+                            "required": [
+                                "target_average_value"
+                            ]
                         },
-                        "uwsgi_custom_metrics": {
+                        "uwsgi": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "target_average_value": {
                                     "type": "number",
@@ -241,10 +251,14 @@
                                         }
                                     }
                                 }
-                            }
+                            },
+                            "required": [
+                                "target_average_value"
+                            ]
                         },
-                        "http_custom_metrics": {
+                        "http": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "target_average_value": {
                                     "type": "number",
@@ -263,13 +277,16 @@
                                         }
                                     }
                                 }
-                            }
+                            },
+                            "required": [
+                                "target_average_value"
+                            ]
                         }
                     },
                     "patternProperties": {
-                        "^[a-z]([-a-z0-9]*[a-z0-9])?$": {
+                        "(?!(^cpu|memory|http|uwsgi)$)(^[a-z]([-a-z0-9]*[a-z0-9])?$)": {
                             "type": "object",
-                            "minProperties": 2,
+                            "additionalProperties": false,
                             "properties": {
                                 "target_average_value": {
                                     "type": "number",
@@ -282,7 +299,10 @@
                                 "signalflow_metrics_query": {
                                     "type": "string"
                                 }
-                            }
+                            },
+                            "required": [
+                                "signalflow_metrics_query"
+                            ]
                         }
                     }
                 },

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -196,15 +196,22 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "min_replicas": {
+                            "type": "integer",
+                            "default": 1
+                        },
+                        "max_replicas": {
+                            "type": "integer"
+                        },
                         "cpu": {
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {
                                 "target_average_value": {
-                                    "type": "number",
-                                    "default": 0.7,
+                                    "type": "integer",
+                                    "default": 70,
                                     "minimum": 0,
-                                    "maximum": 1,
+                                    "maximum": 100,
                                     "exclusiveMinimum": true,
                                     "exclusiveMaximum": false
                                 }
@@ -218,10 +225,10 @@
                             "additionalProperties": false,
                             "properties": {
                                 "target_average_value": {
-                                    "type": "number",
-                                    "default": 0.7,
+                                    "type": "integer",
+                                    "default": 70,
                                     "minimum": 0,
-                                    "maximum": 1,
+                                    "maximum": 100,
                                     "exclusiveMinimum": true,
                                     "exclusiveMaximum": false
                                 }
@@ -235,10 +242,10 @@
                             "additionalProperties": false,
                             "properties": {
                                 "target_average_value": {
-                                    "type": "number",
-                                    "default": 0.7,
+                                    "type": "integer",
+                                    "default": 70,
                                     "minimum": 0,
-                                    "maximum": 1,
+                                    "maximum": 100,
                                     "exclusiveMinimum": true,
                                     "exclusiveMaximum": false
                                 },
@@ -262,9 +269,9 @@
                             "properties": {
                                 "target_average_value": {
                                     "type": "number",
-                                    "default": 0.7,
+                                    "default": 70,
                                     "minimum": 0,
-                                    "maximum": 1,
+                                    "maximum": 100,
                                     "exclusiveMinimum": true,
                                     "exclusiveMaximum": false
                                 },
@@ -288,23 +295,24 @@
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {
-                                "target_average_value": {
+                                "target_value": {
                                     "type": "number",
-                                    "default": 0.7,
                                     "minimum": 0,
-                                    "maximum": 1,
-                                    "exclusiveMinimum": true,
-                                    "exclusiveMaximum": false
+                                    "exclusiveMinimum": true
                                 },
                                 "signalflow_metrics_query": {
                                     "type": "string"
                                 }
                             },
                             "required": [
-                                "signalflow_metrics_query"
+                                "signalflow_metrics_query",
+                                "target_value"
                             ]
                         }
-                    }
+                    },
+                    "required": [
+                        "max_replicas"
+                    ]
                 },
                 "sfn_autoscaling": {
                     "type": "object"

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -192,7 +192,7 @@
                 "autoscaling": {
                     "type": "object"
                 },
-                "new_autoscaling": {
+                "horizontal_autoscaling": {
                     "type": "object",
                     "properties": {
                         "cpu": {
@@ -232,7 +232,7 @@
                                     "exclusiveMinimum": true,
                                     "exclusiveMaximum": false
                                 },
-                                "service_scope_dimensions": {
+                                "dimensions": {
                                     "type": "object",
                                     "minProperties": 1,
                                     "patternProperties": {
@@ -254,7 +254,7 @@
                                     "exclusiveMinimum": true,
                                     "exclusiveMaximum": false
                                 },
-                                "service_scope_dimensions": {
+                                "dimensions": {
                                     "type": "object",
                                     "minProperties": 1,
                                     "patternProperties": {

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -192,6 +192,100 @@
                 "autoscaling": {
                     "type": "object"
                 },
+                "new_autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "type": "object",
+                            "properties": {
+                                "target_average_value": {
+                                    "type": "number",
+                                    "default": 0.7,
+                                    "minimum": 0,
+                                    "maximum": 1,
+                                    "exclusiveMinimum": true,
+                                    "exclusiveMaximum": false
+                                }
+                            }
+                        },
+                        "memory": {
+                            "type": "object",
+                            "properties": {
+                                "target_average_value": {
+                                    "type": "number",
+                                    "default": 0.7,
+                                    "minimum": 0,
+                                    "maximum": 1,
+                                    "exclusiveMinimum": true,
+                                    "exclusiveMaximum": false
+                                }
+                            }
+                        },
+                        "uwsgi_custom_metrics": {
+                            "type": "object",
+                            "properties": {
+                                "target_average_value": {
+                                    "type": "number",
+                                    "default": 0.7,
+                                    "minimum": 0,
+                                    "maximum": 1,
+                                    "exclusiveMinimum": true,
+                                    "exclusiveMaximum": false
+                                },
+                                "service_scope_dimensions": {
+                                    "type": "object",
+                                    "minProperties": 1,
+                                    "patternProperties": {
+                                        "^(?!(sf_|gcp_|azure_|aws_))[a-zA-Z]([-_a-zA-Z0-9])*$": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "http_custom_metrics": {
+                            "type": "object",
+                            "properties": {
+                                "target_average_value": {
+                                    "type": "number",
+                                    "default": 0.7,
+                                    "minimum": 0,
+                                    "maximum": 1,
+                                    "exclusiveMinimum": true,
+                                    "exclusiveMaximum": false
+                                },
+                                "service_scope_dimensions": {
+                                    "type": "object",
+                                    "minProperties": 1,
+                                    "patternProperties": {
+                                        "^(?!(sf_|gcp_|azure_|aws_))[a-zA-Z]([-_a-zA-Z0-9])*$": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "patternProperties": {
+                        "^[a-z]([-a-z0-9]*[a-z0-9])?$": {
+                            "type": "object",
+                            "minProperties": 2,
+                            "properties": {
+                                "target_average_value": {
+                                    "type": "number",
+                                    "default": 0.7,
+                                    "minimum": 0,
+                                    "maximum": 1,
+                                    "exclusiveMinimum": true,
+                                    "exclusiveMaximum": false
+                                },
+                                "signalflow_metrics_query": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
                 "sfn_autoscaling": {
                     "type": "object"
                 },

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -208,6 +208,7 @@ class KubernetesDeploymentConfigDict(LongRunningServiceConfigDict, total=False):
     bounce_health_params: Dict[str, Any]
     service_account_name: str
     autoscaling: AutoscalingParamsDict
+    horizontal_autoscaling: Dict[str, Any]
 
 
 def load_kubernetes_service_config_no_cache(
@@ -1103,7 +1104,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         docker_volumes = self.get_volumes(
             system_volumes=system_paasta_config.get_volumes()
         )
-        annotations = {"smartstack_registrations": json.dumps(self.get_registrations())}
+        annotations: Dict[str, Any] = {
+            "smartstack_registrations": json.dumps(self.get_registrations())
+        }
 
         # For legacy autoscaling
         metrics_provider = self.get_autoscaling_params()["metrics_provider"]

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1111,11 +1111,11 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         docker_volumes = self.get_volumes(
             system_volumes=system_paasta_config.get_volumes()
         )
-        metrics_provider = self.get_autoscaling_params()["metrics_provider"]
-        annotations = {
+        annotations: Dict[str, Any] = {
             "smartstack_registrations": json.dumps(self.get_registrations()),
             "iam.amazonaws.com/role": self.get_iam_role(),
         }
+        metrics_provider = self.get_autoscaling_params()["metrics_provider"]
         if metrics_provider in {"http", "uwsgi"}:
             annotations["autoscaling"] = metrics_provider
         # If legacy autoscaling is not configured

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -79,6 +79,7 @@ from kubernetes.client import V1TCPSocketAction
 from kubernetes.client import V1Volume
 from kubernetes.client import V1VolumeMount
 from kubernetes.client import V2beta1CrossVersionObjectReference
+from kubernetes.client import V2beta1ExternalMetricSource
 from kubernetes.client import V2beta1HorizontalPodAutoscaler
 from kubernetes.client import V2beta1HorizontalPodAutoscalerCondition
 from kubernetes.client import V2beta1HorizontalPodAutoscalerSpec
@@ -383,9 +384,90 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             defaults=default_params,
         )
 
+    def get_hpa_metric_spec(
+        self, name: str, cluster: str, namespace: str = "paasta"
+    ) -> Optional[V2beta1HorizontalPodAutoscaler]:
+        hpa_config = self.config_dict["horizontal_autoscaling"]
+        min_replicas = hpa_config["min_replicas"]
+        max_replicas = hpa_config["max_replicas"]
+        selector = V1LabelSelector(match_labels={"kubernetes_cluster": cluster})
+        annotations = {"signalfx.com.custom.metrics": ""}
+        metrics = []
+        for metric_name, value in hpa_config.items():
+            if metric_name in {"min_replicas", "max_replicas"}:
+                continue
+            if metric_name in {"cpu", "memory"}:
+                metrics.append(
+                    V2beta1MetricSpec(
+                        type="Resource",
+                        resource=V2beta1ResourceMetricSource(
+                            name=metric_name,
+                            target_average_utilization=value["target_average_value"],
+                        ),
+                    )
+                )
+            elif metric_name in {"http", "uwsgi"}:
+                if "dimensions" not in value:
+                    metrics.append(
+                        V2beta1MetricSpec(
+                            type="Pods",
+                            pods=V2beta1PodsMetricSource(
+                                metric_name=metric_name,
+                                target_average_value=value["target_average_value"],
+                                selector=selector,
+                            ),
+                        )
+                    )
+                else:
+                    metrics.append(
+                        V2beta1MetricSpec(
+                            type="External",
+                            external=V2beta1ExternalMetricSource(
+                                metric_name=metric_name,
+                                target_value=value["target_average_value"],
+                            ),
+                        )
+                    )
+                    filters = " and ".join(
+                        f'filter("{k}", "{v}")' for k, v in value["dimensions"].items()
+                    )
+                    annotations[
+                        f"signalfx.com.external.metric/{metric_name}"
+                    ] = f'data("{metric_name}", filter={filters}).mean().publish()'
+            else:
+                metrics.append(
+                    V2beta1MetricSpec(
+                        type="External",
+                        external=V2beta1ExternalMetricSource(
+                            metric_name=metric_name, target_value=value["target_value"]
+                        ),
+                    )
+                )
+                annotations[f"signalfx.com.external.metric/{metric_name}"] = value[
+                    "signalflow_metrics_query"
+                ]
+
+        return V2beta1HorizontalPodAutoscaler(
+            kind="HorizontalPodAutoscaler",
+            metadata=V1ObjectMeta(
+                name=name, namespace=namespace, annotations=annotations
+            ),
+            spec=V2beta1HorizontalPodAutoscalerSpec(
+                max_replicas=max_replicas,
+                min_replicas=min_replicas,
+                metrics=metrics,
+                scale_target_ref=V2beta1CrossVersionObjectReference(
+                    api_version="apps/v1", kind="Deployment", name=name
+                ),
+            ),
+        )
+
     def get_autoscaling_metric_spec(
         self, name: str, cluster: str, namespace: str = "paasta"
     ) -> Optional[V2beta1HorizontalPodAutoscaler]:
+        # use new autoscaling configuration if it exists.
+        if "horizontal_autoscaling" in self.config_dict:
+            return self.get_hpa_metric_spec(name, cluster, namespace)
         min_replicas = self.get_min_instances()
         max_replicas = self.get_max_instances()
         if not min_replicas or not max_replicas:
@@ -1022,9 +1104,23 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             system_volumes=system_paasta_config.get_volumes()
         )
         annotations = {"smartstack_registrations": json.dumps(self.get_registrations())}
+
+        # For legacy autoscaling
         metrics_provider = self.get_autoscaling_params()["metrics_provider"]
         if metrics_provider in {"http", "uwsgi"}:
             annotations["autoscaling"] = metrics_provider
+        # If legacy autoscaling is not configured
+        if "autoscaling" not in self.config_dict:
+            for metric_name in ["http", "uwsgi"]:
+                hpa_config = self.config_dict.get("horizontal_autoscaling", {})
+                if metric_name in hpa_config:
+                    if "hpa" not in annotations:
+                        annotations["hpa"] = {}
+                    annotations["hpa"][metric_name] = hpa_config[metric_name].get(
+                        "dimensions", {}
+                    )
+            if "hpa" in annotations:
+                annotations["hpa"] = json.dumps(annotations["hpa"])
 
         return V1PodTemplateSpec(
             metadata=V1ObjectMeta(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -39,6 +39,7 @@ from kubernetes.client import V1TCPSocketAction
 from kubernetes.client import V1Volume
 from kubernetes.client import V1VolumeMount
 from kubernetes.client import V2beta1CrossVersionObjectReference
+from kubernetes.client import V2beta1ExternalMetricSource
 from kubernetes.client import V2beta1HorizontalPodAutoscaler
 from kubernetes.client import V2beta1HorizontalPodAutoscalerSpec
 from kubernetes.client import V2beta1MetricSpec
@@ -226,8 +227,17 @@ def test_load_kubernetes_service_config():
 
 class TestKubernetesDeploymentConfig(unittest.TestCase):
     def setUp(self):
+        hpa_config = {
+            "min_replicas": 1,
+            "max_replicas": 3,
+            "cpu": {"target_average_value": 70},
+            "memory": {"target_average_value": 70},
+            "uwsgi": {"target_average_value": 70},
+            "http": {"target_average_value": 70, "dimensions": {"any": "random"}},
+            "external": {"target_value": 70, "signalflow_metrics_query": "fake_query"},
+        }
         mock_config_dict = KubernetesDeploymentConfigDict(
-            bounce_method="crossover", instances=3
+            bounce_method="crossover", instances=3, horizontal_autoscaling=hpa_config,
         )
         self.deployment = KubernetesDeploymentConfig(
             service="kurupt",
@@ -938,6 +948,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             )
             assert mock_get_pod_volumes.called
             assert mock_get_volumes.called
+            print(ret.metadata.annotations)
             assert ret == V1PodTemplateSpec(
                 metadata=V1ObjectMeta(
                     labels={
@@ -948,7 +959,10 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                         "paasta.yelp.com/instance": mock_get_instance.return_value,
                         "paasta.yelp.com/service": mock_get_service.return_value,
                     },
-                    annotations={"smartstack_registrations": '["kurupt.fm"]'},
+                    annotations={
+                        "smartstack_registrations": '["kurupt.fm"]',
+                        "hpa": '{"http": {"any": "random"}, "uwsgi": {}}',
+                    },
                 ),
                 spec=V1PodSpec(
                     service_account_name=None,
@@ -983,6 +997,87 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                 },
                 name="kurupt-fm",
             )
+
+    def test_get_hpa_metric_spec(self):
+        config_dict = {
+            "horizontal_autoscaling": {
+                "min_replicas": 1,
+                "max_replicas": 3,
+                "cpu": {"target_average_value": 70},
+                "memory": {"target_average_value": 70},
+                "uwsgi": {"target_average_value": 70},
+                "http": {"target_average_value": 70, "dimensions": {"any": "random"}},
+                "external": {
+                    "target_value": 70,
+                    "signalflow_metrics_query": "fake_query",
+                },
+            }
+        }
+        mock_config = KubernetesDeploymentConfig(
+            service="service",
+            cluster="cluster",
+            instance="instance",
+            config_dict=config_dict,
+            branch_dict=None,
+        )
+        return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
+            mock_config, "fake_name", "cluster"
+        )
+        annotations = {
+            "signalfx.com.custom.metrics": "",
+            "signalfx.com.external.metric/external": "fake_query",
+            "signalfx.com.external.metric/http": 'data("http", filter=filter("any", "random")).mean().publish()',
+        }
+        expected_res = V2beta1HorizontalPodAutoscaler(
+            kind="HorizontalPodAutoscaler",
+            metadata=V1ObjectMeta(
+                name="fake_name", namespace="paasta", annotations=annotations
+            ),
+            spec=V2beta1HorizontalPodAutoscalerSpec(
+                max_replicas=3,
+                min_replicas=1,
+                metrics=[
+                    V2beta1MetricSpec(
+                        type="Resource",
+                        resource=V2beta1ResourceMetricSource(
+                            name="cpu", target_average_utilization=70
+                        ),
+                    ),
+                    V2beta1MetricSpec(
+                        type="Resource",
+                        resource=V2beta1ResourceMetricSource(
+                            name="memory", target_average_utilization=70
+                        ),
+                    ),
+                    V2beta1MetricSpec(
+                        type="Pods",
+                        pods=V2beta1PodsMetricSource(
+                            metric_name="uwsgi",
+                            target_average_value=70,
+                            selector=V1LabelSelector(
+                                match_labels={"kubernetes_cluster": "cluster"}
+                            ),
+                        ),
+                    ),
+                    V2beta1MetricSpec(
+                        type="External",
+                        external=V2beta1ExternalMetricSource(
+                            metric_name="http", target_value=70,
+                        ),
+                    ),
+                    V2beta1MetricSpec(
+                        type="External",
+                        external=V2beta1ExternalMetricSource(
+                            metric_name="external", target_value=70,
+                        ),
+                    ),
+                ],
+                scale_target_ref=V2beta1CrossVersionObjectReference(
+                    api_version="apps/v1", kind="Deployment", name="fake_name",
+                ),
+            ),
+        )
+        assert expected_res == return_value
 
     def test_get_autoscaling_metric_spec_mesos_cpu(self):
         # with cpu


### PR DESCRIPTION
Design a new autoscaling configuration before implementing it. Only validation part is added and fully tested now.
 **Purpose**
* Add support for external metrics based on any signalfx metrics, multiple metrics, and memory. 
* Simplify existing autoscaling configuration by removing unused parameters. 
* Make the new configuration as simple as possible and as powerful as possible, while restrict potential intended user mistakes. 

**Complex User cases**
*  Scale instance A based on instance B
*  Use the same signalfx metrics for multiple instances across different clusters. 
*  Set canary to a certain percent of non-canary by using the number of instances of non-canary as metrics. 

I believe all of above use cases could be supported by allowing users to customize the dimension of their metrics. They can either user http metrics collector and override its metrics, or sent their own metrics to signalfx. Adding dimension parameter to http/uwsgi is mostly for users who have already implemented http metrics to use advanced autoscaling without modifying existing code. For new users, it's probably better to define and implement their own collector instead. Writing their own collector is not harder than exposing http metrics anyway.

**Potential issues** 
*  Users might corrupt other metrics.
* SignalFX queries for custom metrics is not validated since I can't find appropriate library for this.
* It could be complex for users to configure complex autoscaling behavior. For use cases like canary percentage, perhaps it is worth adding another configuration. But that would increase the complexity of implementation and configuration.  