### PR TITLE
replace jupyter with jupyter-lab in spark-run

### DIFF
--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -335,6 +335,7 @@ class TestConfigureAndRunDockerContainer:
                 "/fake_dir:/spark_driver:rw",
                 "/etc/passwd:/etc/passwd:ro",
                 "/etc/group:/etc/group:ro",
+                "/nail/home:/nail/home:rw",
             ],
             environment={
                 "PAASTA_SERVICE": "fake_service",


### PR DESCRIPTION
This PR enables users to have the jupyterhub experience on their local boxes for whatever reason. It opens additional opportunities since /nail/home is mounted (required for aws creds). Users are expected to use images with the yelp_jupyterhub package, for example, the docker-dev.yelpcorp.com/core-ml-centralized-jupyterhub-gpu image.