### PR TITLE
Check services replication metrics

### DIFF
--- a/paasta_tools/check_flink_services_health.py
+++ b/paasta_tools/check_flink_services_health.py
@@ -107,11 +107,11 @@ Things you can do:
 
 def check_flink_service_health(
     instance_config: FlinkDeploymentConfig,
-    all_pods: Sequence[V1Pod],
+    all_tasks_or_pods: Sequence[V1Pod],
     smartstack_replication_checker: KubeSmartstackReplicationChecker,
 ) -> None:
     si_pods = filter_pods_by_service_instance(
-        pod_list=all_pods,
+        pod_list=all_tasks_or_pods,
         service=instance_config.service,
         instance=instance_config.instance,
     )

--- a/paasta_tools/check_kubernetes_services_replication.py
+++ b/paasta_tools/check_kubernetes_services_replication.py
@@ -70,7 +70,7 @@ def check_healthy_kubernetes_tasks_for_service_instance(
 
 def check_kubernetes_pod_replication(
     instance_config: KubernetesDeploymentConfig,
-    all_pods: Sequence[V1Pod],
+    all_tasks_or_pods: Sequence[V1Pod],
     smartstack_replication_checker: KubeSmartstackReplicationChecker,
 ) -> None:
     """Checks a service's replication levels based on how the service's replication
@@ -98,7 +98,7 @@ def check_kubernetes_pod_replication(
         check_healthy_kubernetes_tasks_for_service_instance(
             instance_config=instance_config,
             expected_count=expected_count,
-            all_pods=all_pods,
+            all_pods=all_tasks_or_pods,
         )
 
 

--- a/paasta_tools/check_kubernetes_services_replication.py
+++ b/paasta_tools/check_kubernetes_services_replication.py
@@ -31,6 +31,7 @@ CRITICAL. If replication_threshold is defined in the yelpsoa config for a servic
 instance then it will be used instead.
 """
 import logging
+from typing import Optional
 from typing import Sequence
 
 from paasta_tools import kubernetes_tools
@@ -72,7 +73,7 @@ def check_kubernetes_pod_replication(
     instance_config: KubernetesDeploymentConfig,
     all_tasks_or_pods: Sequence[V1Pod],
     smartstack_replication_checker: KubeSmartstackReplicationChecker,
-) -> None:
+) -> Optional[bool]:
     """Checks a service's replication levels based on how the service's replication
     should be monitored. (smartstack or k8s)
 
@@ -89,17 +90,19 @@ def check_kubernetes_pod_replication(
     # if the primary registration does not match the service_instance name then
     # the best we can do is check k8s for replication (for now).
     if proxy_port is not None and registrations[0] == instance_config.job_id:
-        monitoring_tools.check_smartstack_replication_for_instance(
+        is_well_replicated = monitoring_tools.check_smartstack_replication_for_instance(
             instance_config=instance_config,
             expected_count=expected_count,
             smartstack_replication_checker=smartstack_replication_checker,
         )
+        return is_well_replicated
     else:
         check_healthy_kubernetes_tasks_for_service_instance(
             instance_config=instance_config,
             expected_count=expected_count,
             all_pods=all_tasks_or_pods,
         )
+        return None
 
 
 if __name__ == "__main__":

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -96,17 +96,19 @@ def check_service_replication(
     # if the primary registration does not match the service_instance name then
     # the best we can do is check marathon for replication (for now).
     if proxy_port is not None and registrations[0] == instance_config.job_id:
-        monitoring_tools.check_smartstack_replication_for_instance(
+        is_well_replicated = monitoring_tools.check_smartstack_replication_for_instance(
             instance_config=instance_config,
             expected_count=expected_count,
             smartstack_replication_checker=smartstack_replication_checker,
         )
+        return is_well_replicated
     else:
         check_healthy_marathon_tasks_for_service_instance(
             instance_config=instance_config,
             expected_count=expected_count,
             all_tasks=all_tasks_or_pods,
         )
+        return None
 
 
 if __name__ == "__main__":

--- a/paasta_tools/check_services_replication_tools.py
+++ b/paasta_tools/check_services_replication_tools.py
@@ -13,23 +13,37 @@
 # limitations under the License.
 import argparse
 import logging
+from typing import Any
 from typing import Callable
+from typing import List
 from typing import Sequence
+from typing import Tuple
 from typing import Type
+from typing import Union
 
+import a_sync
+from marathon import MarathonClient
+from marathon.models.task import MarathonTask
 from mypy_extensions import Arg
 
 from paasta_tools.kubernetes_tools import get_all_nodes
 from paasta_tools.kubernetes_tools import get_all_pods
 from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.kubernetes_tools import V1Node
 from paasta_tools.kubernetes_tools import V1Pod
+from paasta_tools.marathon_tools import get_marathon_clients
+from paasta_tools.marathon_tools import get_marathon_servers
+from paasta_tools.mesos_tools import get_slaves
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.smartstack_tools import KubeSmartstackReplicationChecker
+from paasta_tools.smartstack_tools import MesosSmartstackReplicationChecker
+from paasta_tools.smartstack_tools import SmartstackReplicationChecker
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import InstanceConfig_T
 from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import SPACER
+from paasta_tools.utils import SystemPaastaConfig
 
 
 log = logging.getLogger(__name__)
@@ -37,8 +51,8 @@ log = logging.getLogger(__name__)
 CheckServiceReplication = Callable[
     [
         Arg(InstanceConfig_T, "instance_config"),
-        Arg(Sequence[V1Pod], "all_pods"),
-        Arg(KubeSmartstackReplicationChecker, "smartstack_replication_checker"),
+        Arg(Sequence[Union[MarathonTask, V1Pod]], "all_tasks_or_pods"),
+        Arg(Any, "smartstack_replication_checker"),
     ],
     None,
 ]
@@ -68,22 +82,17 @@ def parse_args() -> argparse.Namespace:
     return options
 
 
-def check_all_kubernetes_based_services_replication(
+def check_services_replication(
     soa_dir: str,
+    system_paasta_config: SystemPaastaConfig,
     service_instances: Sequence[str],
     instance_type_class: Type[InstanceConfig_T],
     check_service_replication: CheckServiceReplication,
-    namespace: str,
+    replication_checker: SmartstackReplicationChecker,
+    all_tasks_or_pods: Sequence[Union[MarathonTask, V1Pod]],
 ) -> None:
-    kube_client = KubeClient()
-    all_pods = get_all_pods(kube_client=kube_client, namespace=namespace)
-    all_nodes = get_all_nodes(kube_client)
-    system_paasta_config = load_system_paasta_config()
-    cluster = system_paasta_config.get_cluster()
-    smartstack_replication_checker = KubeSmartstackReplicationChecker(
-        nodes=all_nodes, system_paasta_config=system_paasta_config
-    )
     service_instances_set = set(service_instances)
+    cluster = system_paasta_config.get_cluster()
 
     for service in list_services(soa_dir=soa_dir):
         service_config = PaastaServiceConfigLoader(service=service, soa_dir=soa_dir)
@@ -99,9 +108,10 @@ def check_all_kubernetes_based_services_replication(
             if instance_config.get_docker_image():
                 check_service_replication(
                     instance_config=instance_config,
-                    all_pods=all_pods,
-                    smartstack_replication_checker=smartstack_replication_checker,
+                    all_tasks_or_pods=all_tasks_or_pods,
+                    smartstack_replication_checker=replication_checker,
                 )
+
             else:
                 log.debug(
                     "%s is not deployed. Skipping replication monitoring."
@@ -113,16 +123,57 @@ def main(
     instance_type_class: Type[InstanceConfig_T],
     check_service_replication: CheckServiceReplication,
     namespace: str,
+    mesos: bool = False,
 ) -> None:
     args = parse_args()
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
     else:
         logging.basicConfig(level=logging.WARNING)
-    check_all_kubernetes_based_services_replication(
+
+    system_paasta_config = load_system_paasta_config()
+    replication_checker: SmartstackReplicationChecker
+
+    if mesos:
+        tasks_or_pods, slaves = get_mesos_tasks_and_slaves(system_paasta_config)
+        replication_checker = MesosSmartstackReplicationChecker(
+            mesos_slaves=slaves, system_paasta_config=system_paasta_config,
+        )
+    else:
+        tasks_or_pods, nodes = get_kubernetes_pods_and_nodes(namespace)
+        replication_checker = KubeSmartstackReplicationChecker(
+            nodes=nodes, system_paasta_config=system_paasta_config,
+        )
+
+    check_services_replication(
         soa_dir=args.soa_dir,
+        system_paasta_config=system_paasta_config,
         service_instances=args.service_instance_list,
         instance_type_class=instance_type_class,
         check_service_replication=check_service_replication,
-        namespace=namespace,
+        replication_checker=replication_checker,
+        all_tasks_or_pods=tasks_or_pods,
     )
+
+
+def get_mesos_tasks_and_slaves(
+    system_paasta_config: SystemPaastaConfig,
+) -> Tuple[Sequence[MarathonTask], List[Any]]:
+    clients = get_marathon_clients(get_marathon_servers(system_paasta_config))
+    all_clients: Sequence[MarathonClient] = clients.get_all_clients()
+    all_tasks: List[MarathonTask] = []
+    for client in all_clients:
+        all_tasks.extend(client.list_tasks())
+    mesos_slaves = a_sync.block(get_slaves)
+
+    return all_tasks, mesos_slaves
+
+
+def get_kubernetes_pods_and_nodes(
+    namespace: str,
+) -> Tuple[Sequence[V1Pod], Sequence[V1Node]]:
+    kube_client = KubeClient()
+    all_pods = get_all_pods(kube_client=kube_client, namespace=namespace)
+    all_nodes = get_all_nodes(kube_client)
+
+    return all_pods, all_nodes

--- a/tests/test_check_flink_services_health.py
+++ b/tests/test_check_flink_services_health.py
@@ -119,7 +119,7 @@ def test_check_flink_service_health_healthy(instance_config):
         instance_config.config_dict["taskmanager"] = {"instances": 3}
         check_flink_services_health.check_flink_service_health(
             instance_config=instance_config,
-            all_pods=all_pods,
+            all_tasks_or_pods=all_pods,
             smartstack_replication_checker=None,
         )
         expected = [
@@ -181,7 +181,7 @@ def test_check_flink_service_health_too_few_taskmanagers(instance_config):
         instance_config.config_dict["taskmanager"] = {"instances": 3}
         check_flink_services_health.check_flink_service_health(
             instance_config=instance_config,
-            all_pods=all_pods,
+            all_tasks_or_pods=all_pods,
             smartstack_replication_checker=None,
         )
         expected = [
@@ -235,7 +235,7 @@ def test_check_flink_service_health_under_registered_taskamanagers(instance_conf
         instance_config.config_dict["taskmanager"] = {"instances": 3}
         check_flink_services_health.check_flink_service_health(
             instance_config=instance_config,
-            all_pods=all_pods,
+            all_tasks_or_pods=all_pods,
             smartstack_replication_checker=None,
         )
         expected = [

--- a/tests/test_check_service_replication_tools.py
+++ b/tests/test_check_service_replication_tools.py
@@ -1,0 +1,88 @@
+import mock
+
+from paasta_tools import check_services_replication_tools
+from paasta_tools.utils import SystemPaastaConfig
+
+
+def test_main_kubernetes():
+    with mock.patch(
+        "paasta_tools.check_services_replication_tools.check_services_replication",
+        autospec=True,
+    ) as mock_check_services_replication, mock.patch(
+        "paasta_tools.check_services_replication_tools.parse_args", autospec=True
+    ), mock.patch(
+        "paasta_tools.check_services_replication_tools.get_kubernetes_pods_and_nodes",
+        autospec=True,
+        return_value=([mock.Mock()], [mock.Mock()]),
+    ):
+        check_services_replication_tools.main(
+            instance_type_class=None, check_service_replication=None, namespace="baz",
+        )
+        assert mock_check_services_replication.called
+
+
+def test_main_mesos():
+    with mock.patch(
+        "paasta_tools.check_services_replication_tools.check_services_replication",
+        autospec=True,
+    ) as mock_check_services_replication, mock.patch(
+        "paasta_tools.check_services_replication_tools.parse_args", autospec=True
+    ), mock.patch(
+        "paasta_tools.check_services_replication_tools.get_mesos_tasks_and_slaves",
+        autospec=True,
+        return_value=([mock.Mock()], [mock.Mock()]),
+    ):
+        check_services_replication_tools.main(
+            instance_type_class=None,
+            check_service_replication=None,
+            namespace=None,
+            mesos=True,
+        )
+        assert mock_check_services_replication.called
+
+
+def test_check_services_replication():
+    soa_dir = "anw"
+    instance_config = mock.Mock()
+    instance_config.get_docker_image.return_value = True
+    with mock.patch(
+        "paasta_tools.check_services_replication_tools.list_services",
+        autospec=True,
+        return_value=["a"],
+    ), mock.patch(
+        "paasta_tools.check_kubernetes_services_replication.check_kubernetes_pod_replication",
+        autospec=True,
+    ) as mock_check_service_replication, mock.patch(
+        "paasta_tools.check_services_replication_tools.PaastaServiceConfigLoader",
+        autospec=True,
+    ) as mock_paasta_service_config_loader, mock.patch(
+        "paasta_tools.check_services_replication_tools.KubeClient", autospec=True
+    ) as mock_kube_client:
+        mock_kube_client.return_value = mock.Mock()
+        mock_paasta_service_config_loader.return_value.instance_configs.return_value = [
+            instance_config
+        ]
+        mock_client = mock.Mock()
+        mock_client.list_tasks.return_value = []
+        mock_system_paasta_config = mock.Mock(spec=SystemPaastaConfig)
+        mock_replication_checker = mock.Mock()
+        mock_pods = [mock.Mock(), mock.Mock()]
+
+        check_services_replication_tools.check_services_replication(
+            soa_dir=soa_dir,
+            system_paasta_config=mock_system_paasta_config,
+            service_instances=[],
+            instance_type_class=None,
+            check_service_replication=mock_check_service_replication,
+            replication_checker=mock_replication_checker,
+            all_tasks_or_pods=mock_pods,
+        )
+        mock_paasta_service_config_loader.assert_called_once_with(
+            service="a", soa_dir=soa_dir
+        )
+        instance_config.get_docker_image.assert_called_once_with()
+        mock_check_service_replication.assert_called_once_with(
+            instance_config=instance_config,
+            all_tasks_or_pods=mock_pods,
+            smartstack_replication_checker=mock_replication_checker,
+        )

--- a/tests/test_check_service_replication_tools.py
+++ b/tests/test_check_service_replication_tools.py
@@ -1,7 +1,6 @@
 import mock
 
 from paasta_tools import check_services_replication_tools
-from paasta_tools.utils import SystemPaastaConfig
 
 
 def test_main_kubernetes():
@@ -10,15 +9,40 @@ def test_main_kubernetes():
         autospec=True,
     ) as mock_check_services_replication, mock.patch(
         "paasta_tools.check_services_replication_tools.parse_args", autospec=True
-    ), mock.patch(
+    ) as mock_parse_args, mock.patch(
         "paasta_tools.check_services_replication_tools.get_kubernetes_pods_and_nodes",
         autospec=True,
         return_value=([mock.Mock()], [mock.Mock()]),
-    ):
+    ), mock.patch(
+        "paasta_tools.check_services_replication_tools.load_system_paasta_config",
+        autospec=True,
+    ) as mock_load_system_paasta_config, mock.patch(
+        "paasta_tools.check_services_replication_tools.yelp_meteorite", autospec=True,
+    ) as mock_yelp_meteorite, mock.patch(
+        "paasta_tools.check_services_replication_tools.sys.exit", autospec=True,
+    ) as mock_sys_exit:
+        mock_parse_args.return_value.under_replicated_crit_pct = 10
+        mock_parse_args.return_value.under_replicated_warn_pct = 5
+        mock_check_services_replication.return_value = 6
+
         check_services_replication_tools.main(
             instance_type_class=None, check_service_replication=None, namespace="baz",
         )
         assert mock_check_services_replication.called
+
+        mock_yelp_meteorite.create_gauge.assert_called_once_with(
+            "paasta.pct_services_under_replicated",
+            {
+                "paasta_cluster": mock_load_system_paasta_config.return_value.get_cluster.return_value,
+                "scheduler": "kubernetes",
+            },
+        )
+        mock_gauge = mock_yelp_meteorite.create_gauge.return_value
+        mock_gauge.set.assert_called_once_with(
+            mock_check_services_replication.return_value
+        )
+
+        mock_sys_exit.assert_called_once_with(1)
 
 
 def test_main_mesos():
@@ -27,11 +51,22 @@ def test_main_mesos():
         autospec=True,
     ) as mock_check_services_replication, mock.patch(
         "paasta_tools.check_services_replication_tools.parse_args", autospec=True
-    ), mock.patch(
+    ) as mock_parse_args, mock.patch(
         "paasta_tools.check_services_replication_tools.get_mesos_tasks_and_slaves",
         autospec=True,
         return_value=([mock.Mock()], [mock.Mock()]),
-    ):
+    ), mock.patch(
+        "paasta_tools.check_services_replication_tools.load_system_paasta_config",
+        autospec=True,
+    ) as mock_load_system_paasta_config, mock.patch(
+        "paasta_tools.check_services_replication_tools.yelp_meteorite", autospec=True,
+    ) as mock_yelp_meteorite, mock.patch(
+        "paasta_tools.check_services_replication_tools.sys.exit", autospec=True,
+    ) as mock_sys_exit:
+        mock_parse_args.return_value.under_replicated_crit_pct = 10
+        mock_parse_args.return_value.under_replicated_warn_pct = 5
+        mock_check_services_replication.return_value = 6
+
         check_services_replication_tools.main(
             instance_type_class=None,
             check_service_replication=None,
@@ -39,6 +74,20 @@ def test_main_mesos():
             mesos=True,
         )
         assert mock_check_services_replication.called
+
+        mock_yelp_meteorite.create_gauge.assert_called_once_with(
+            "paasta.pct_services_under_replicated",
+            {
+                "paasta_cluster": mock_load_system_paasta_config.return_value.get_cluster.return_value,
+                "scheduler": "mesos",
+            },
+        )
+        mock_gauge = mock_yelp_meteorite.create_gauge.return_value
+        mock_gauge.set.assert_called_once_with(
+            mock_check_services_replication.return_value
+        )
+
+        mock_sys_exit.assert_called_once_with(1)
 
 
 def test_check_services_replication():
@@ -64,13 +113,13 @@ def test_check_services_replication():
         ]
         mock_client = mock.Mock()
         mock_client.list_tasks.return_value = []
-        mock_system_paasta_config = mock.Mock(spec=SystemPaastaConfig)
         mock_replication_checker = mock.Mock()
         mock_pods = [mock.Mock(), mock.Mock()]
+        mock_check_service_replication.return_value = True
 
-        check_services_replication_tools.check_services_replication(
+        pct_under_replicated = check_services_replication_tools.check_services_replication(
             soa_dir=soa_dir,
-            system_paasta_config=mock_system_paasta_config,
+            cluster="westeros-prod",
             service_instances=[],
             instance_type_class=None,
             check_service_replication=mock_check_service_replication,
@@ -86,3 +135,4 @@ def test_check_services_replication():
             all_tasks_or_pods=mock_pods,
             smartstack_replication_checker=mock_replication_checker,
         )
+        assert pct_under_replicated == 0


### PR DESCRIPTION
first commit unifies the two scripts for monitoring replication in mesos/marathon and kubernetes

second commit adds logic to emit metrics about the replication of each service and also track replication in aggregate in a cluster so that we can alert when there are widespread problems with the service mesh (instead of waiting for folks to complain to us)

I have already run all of these scripts on the norcal-devc masters and they work and emit metrics.