### PR TITLE
Endpoint timeout override doc update

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -796,6 +796,13 @@ Routing and Reliability
    in milliseconds, defaults to 1000.
  * ``timeout_client_ms``: HAProxy `client inactivity timeout <http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-timeout%20client>`_
    in milliseconds, defaults to 1000.
+ * ``endpoint_timeouts``: Allows you to specify non-default server timeouts for
+   specific endpoints. This is useful for when there is a long running endpoint
+   that requires a large timeout value but would like to keep the default timeout
+   at a resonable value. Example::
+
+     endpoint_timeouts:
+         "/specials/bulk/v1": 15000
 
 Fault Injection
 ```````````````

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -798,12 +798,15 @@ Routing and Reliability
    in milliseconds, defaults to 1000.
  * ``endpoint_timeouts``: Allows you to specify non-default server timeouts for
    specific endpoints. This is useful for when there is a long running endpoint
-   that requires a large timeout value but would like to keep the default timeout
-   at a resonable value. Example::
+   that requires a large timeout value but you would like to keep the default
+   timeout at a resonable value. Endpoints are prefix-matched to what is
+   specified here so for example ``/specials/bulk/v1`` will match the
+   endpoints ``/specials/bulk/v1/foo`` and ``/specials/bulk/v1/bar``. 
+   Example::
 
      endpoint_timeouts:
          "/specials/bulk/v1": 15000
-
+   
 Fault Injection
 ```````````````
 


### PR DESCRIPTION
Now that endpoint timeout overrides are in GA, we should add their usage to the docs. 