### PR TITLE
Print right error output when no authors found for mark-for-deployment

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -273,7 +273,7 @@ def get_authors_to_be_notified(git_url, from_sha, to_sha, authors):
         if ret == 0:
             authors_to_notify = git_authors.split()
         else:
-            return f"(Could not get authors: {authors})"
+            return f"(Could not get authors: {git_authors})"
 
     slacky_authors = ", ".join({f"<@{a}>" for a in authors_to_notify})
     log.debug(f"Authors: {slacky_authors}")


### PR DESCRIPTION
`git_authors` is the return error text from the get_authors method, not `authors`.  This corrects to the right variable name so that errors will show up in slack pings. 