### PR TITLE
Instance support modules

### DIFF
--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -31,9 +31,6 @@ from typing import Tuple
 
 import a_sync
 import isodate
-from kubernetes.client import V1Pod
-from kubernetes.client import V1ReplicaSet
-from kubernetes.client.rest import ApiException
 from marathon import MarathonClient
 from marathon.models.app import MarathonApp
 from marathon.models.app import MarathonTask
@@ -42,10 +39,6 @@ from pyramid.view import view_config
 from requests.exceptions import ReadTimeout
 
 import paasta_tools.mesos.exceptions as mesos_exceptions
-from paasta_tools import cassandracluster_tools
-from paasta_tools import flink_tools
-from paasta_tools import kafkacluster_tools
-from paasta_tools import kubernetes_tools
 from paasta_tools import marathon_tools
 from paasta_tools import paasta_remote_run
 from paasta_tools import smartstack_tools
@@ -54,11 +47,7 @@ from paasta_tools.api import settings
 from paasta_tools.api.views.exception import ApiFailure
 from paasta_tools.autoscaling.autoscaling_service_lib import get_autoscaling_info
 from paasta_tools.cli.cmds.status import get_actual_deployments
-from paasta_tools.cli.utils import LONG_RUNNING_INSTANCE_TYPE_HANDLERS
-from paasta_tools.kubernetes_tools import get_tail_lines_for_kubernetes_pod
-from paasta_tools.kubernetes_tools import KubeClient
-from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
-from paasta_tools.long_running_service_tools import LongRunningServiceConfig
+from paasta_tools.instance import kubernetes as pik
 from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
 from paasta_tools.marathon_tools import get_short_task_id
 from paasta_tools.mesos.task import Task
@@ -152,163 +141,6 @@ def adhoc_instance_status(
             {"launch_time": launch_time, "run_id": run_id, "framework_id": f.id}
         )
     return status
-
-
-def kubernetes_cr_status(cr_id: dict, verbose: int) -> Optional[Mapping[str, Any]]:
-    client = settings.kubernetes_client
-    if client is not None:
-        return kubernetes_tools.get_cr_status(kube_client=client, cr_id=cr_id)
-    return None
-
-
-def kubernetes_cr_metadata(cr_id: dict, verbose: int) -> Optional[Mapping[str, Any]]:
-    client = settings.kubernetes_client
-    if client is not None:
-        return kubernetes_tools.get_cr_metadata(kube_client=client, cr_id=cr_id)
-    return None
-
-
-def kubernetes_instance_status(
-    instance_status: Mapping[str, Any],
-    service: str,
-    instance: str,
-    verbose: int,
-    include_smartstack: bool,
-    instance_type: str,
-) -> Mapping[str, Any]:
-    kstatus: Dict[str, Any] = {}
-    config_loader = LONG_RUNNING_INSTANCE_TYPE_HANDLERS[instance_type].loader
-    job_config = config_loader(
-        service=service,
-        instance=instance,
-        cluster=settings.cluster,
-        soa_dir=settings.soa_dir,
-        load_deployments=True,
-    )
-    client = settings.kubernetes_client
-    if client is not None:
-        # bouncing status can be inferred from app_count, ref get_bouncing_status
-        pod_list = kubernetes_tools.pods_for_service_instance(
-            service=job_config.service,
-            instance=job_config.instance,
-            kube_client=client,
-            namespace=job_config.get_kubernetes_namespace(),
-        )
-        replicaset_list = kubernetes_tools.replicasets_for_service_instance(
-            service=job_config.service,
-            instance=job_config.instance,
-            kube_client=client,
-            namespace=job_config.get_kubernetes_namespace(),
-        )
-        active_shas = kubernetes_tools.get_active_shas_for_service(pod_list)
-        kstatus["app_count"] = max(
-            len(active_shas["config_sha"]), len(active_shas["git_sha"])
-        )
-        kstatus["desired_state"] = job_config.get_desired_state()
-        kstatus["bounce_method"] = job_config.get_bounce_method()
-        kubernetes_job_status(
-            kstatus=kstatus,
-            client=client,
-            namespace=job_config.get_kubernetes_namespace(),
-            job_config=job_config,
-            verbose=verbose,
-            pod_list=pod_list,
-            replicaset_list=replicaset_list,
-        )
-
-        evicted_count = 0
-        for pod in pod_list:
-            if pod.status.reason == "Evicted":
-                evicted_count += 1
-        kstatus["evicted_count"] = evicted_count
-
-        if include_smartstack:
-            service_namespace_config = kubernetes_tools.load_service_namespace_config(
-                service=job_config.get_service_name_smartstack(),
-                namespace=job_config.get_nerve_namespace(),
-                soa_dir=settings.soa_dir,
-            )
-            if "proxy_port" in service_namespace_config:
-                kstatus["smartstack"] = kubernetes_smartstack_status(
-                    service=job_config.get_service_name_smartstack(),
-                    instance=job_config.get_nerve_namespace(),
-                    job_config=job_config,
-                    service_namespace_config=service_namespace_config,
-                    pods=pod_list,
-                    should_return_individual_backends=verbose > 0,
-                )
-    return kstatus
-
-
-@a_sync.to_blocking
-async def kubernetes_job_status(
-    kstatus: MutableMapping[str, Any],
-    client: kubernetes_tools.KubeClient,
-    job_config: LongRunningServiceConfig,
-    pod_list: Sequence[V1Pod],
-    replicaset_list: Sequence[V1ReplicaSet],
-    verbose: int,
-    namespace: str,
-) -> None:
-    app_id = job_config.get_sanitised_deployment_name()
-    kstatus["app_id"] = app_id
-    kstatus["pods"] = []
-    kstatus["replicasets"] = []
-    if verbose > 0:
-        num_tail_lines = calculate_tail_lines(verbose)
-
-        for pod in pod_list:
-            if num_tail_lines > 0:
-                tail_lines = await get_tail_lines_for_kubernetes_pod(
-                    client, pod, num_tail_lines
-                )
-            else:
-                tail_lines = {}
-
-            kstatus["pods"].append(
-                {
-                    "name": pod.metadata.name,
-                    "host": pod.spec.node_name,
-                    "deployed_timestamp": pod.metadata.creation_timestamp.timestamp(),
-                    "phase": pod.status.phase,
-                    "tail_lines": tail_lines,
-                    "reason": pod.status.reason,
-                    "message": pod.status.message,
-                }
-            )
-        for replicaset in replicaset_list:
-            try:
-                ready_replicas = replicaset.status.ready_replicas
-                if ready_replicas is None:
-                    ready_replicas = 0
-            except AttributeError:
-                ready_replicas = 0
-
-            kstatus["replicasets"].append(
-                {
-                    "name": replicaset.metadata.name,
-                    "replicas": replicaset.spec.replicas,
-                    "ready_replicas": ready_replicas,
-                    "create_timestamp": replicaset.metadata.creation_timestamp.timestamp(),
-                }
-            )
-
-    kstatus["expected_instance_count"] = job_config.get_instances()
-
-    app = kubernetes_tools.get_kubernetes_app_by_name(
-        name=app_id, kube_client=client, namespace=namespace
-    )
-    deploy_status = kubernetes_tools.get_kubernetes_app_deploy_status(
-        app=app, desired_instances=job_config.get_instances()
-    )
-    kstatus["deploy_status"] = kubernetes_tools.KubernetesDeployStatus.tostring(
-        deploy_status
-    )
-    kstatus["running_instance_count"] = (
-        app.status.ready_replicas if app.status.ready_replicas else 0
-    )
-    kstatus["create_timestamp"] = app.metadata.creation_timestamp.timestamp()
-    kstatus["namespace"] = app.metadata.namespace
 
 
 def marathon_instance_status(
@@ -539,65 +371,6 @@ def marathon_smartstack_status(
     return smartstack_status
 
 
-def kubernetes_smartstack_status(
-    service: str,
-    instance: str,
-    job_config: LongRunningServiceConfig,
-    service_namespace_config: ServiceNamespaceConfig,
-    pods: Sequence[V1Pod],
-    should_return_individual_backends: bool = False,
-) -> Mapping[str, Any]:
-
-    registration = job_config.get_registrations()[0]
-    instance_pool = job_config.get_pool()
-
-    smartstack_replication_checker = KubeSmartstackReplicationChecker(
-        nodes=kubernetes_tools.get_all_nodes(settings.kubernetes_client),
-        system_paasta_config=settings.system_paasta_config,
-    )
-    node_hostname_by_location = smartstack_replication_checker.get_allowed_locations_and_hosts(
-        job_config
-    )
-
-    expected_smartstack_count = marathon_tools.get_expected_instance_count_for_namespace(
-        service=service,
-        namespace=instance,
-        cluster=settings.cluster,
-        instance_type_class=KubernetesDeploymentConfig,
-    )
-    expected_count_per_location = int(
-        expected_smartstack_count / len(node_hostname_by_location)
-    )
-    smartstack_status: MutableMapping[str, Any] = {
-        "registration": registration,
-        "expected_backends_per_location": expected_count_per_location,
-        "locations": [],
-    }
-
-    for location, hosts in node_hostname_by_location.items():
-        synapse_host = smartstack_replication_checker.get_first_host_in_pool(
-            hosts, instance_pool
-        )
-        sorted_backends = sorted(
-            get_backends(
-                registration,
-                synapse_host=synapse_host,
-                synapse_port=settings.system_paasta_config.get_synapse_port(),
-                synapse_haproxy_url_format=settings.system_paasta_config.get_synapse_haproxy_url_format(),
-            ),
-            key=lambda backend: backend["status"],
-            reverse=True,  # put 'UP' backends above 'MAINT' backends
-        )
-
-        matched_backends_and_pods = match_backends_and_pods(sorted_backends, pods)
-        location_dict = build_smartstack_location_dict(
-            location, matched_backends_and_pods, should_return_individual_backends
-        )
-        smartstack_status["locations"].append(location_dict)
-
-    return smartstack_status
-
-
 @a_sync.to_blocking
 async def marathon_mesos_status(
     service: str, instance: str, verbose: int
@@ -740,20 +513,6 @@ async def get_mesos_non_running_task_dict(
     return task_dict
 
 
-INSTANCE_TYPE_CR_ID = dict(
-    flink=flink_tools.cr_id,
-    cassandracluster=cassandracluster_tools.cr_id,
-    kafkacluster=kafkacluster_tools.cr_id,
-)
-
-
-def cr_id_fn_for_instance_type(instance_type: str):
-    if instance_type not in INSTANCE_TYPE_CR_ID:
-        raise ApiFailure(f"Error looking up cr_id function for {instance_type}", 500)
-
-    return INSTANCE_TYPE_CR_ID[instance_type]
-
-
 @view_config(
     route_name="service.instance.status", request_method="GET", renderer="json"
 )
@@ -819,43 +578,26 @@ def instance_status(request):
             instance_status["adhoc"] = adhoc_instance_status(
                 instance_status, service, instance, verbose
             )
-        elif instance_type == "kubernetes":
-            instance_status["kubernetes"] = kubernetes_instance_status(
-                instance_status,
-                service,
-                instance,
-                verbose,
-                include_smartstack=include_smartstack,
-                instance_type=instance_type,
+        elif instance_type in INSTANCE_TYPES_K8S:
+            instance_status.update(
+                pik.instance_status(
+                    service=service,
+                    instance=instance,
+                    verbose=verbose,
+                    include_smartstack=include_smartstack,
+                    instance_type=instance_type,
+                    settings=settings,
+                )
             )
         elif instance_type == "tron":
             instance_status["tron"] = tron_instance_status(
                 instance_status, service, instance, verbose
             )
-        elif instance_type in INSTANCE_TYPES_K8S:
-            cr_id_fn = cr_id_fn_for_instance_type(instance_type)
-            cr_id = cr_id_fn(service, instance)
-            status = kubernetes_cr_status(cr_id, verbose)
-            metadata = kubernetes_cr_metadata(cr_id, verbose)
-            instance_status[instance_type] = {}
-            if status is not None:
-                instance_status[instance_type]["status"] = status
-            if metadata is not None:
-                instance_status[instance_type]["metadata"] = metadata
         else:
             error_message = (
                 f"Unknown instance_type {instance_type} of {service}.{instance}"
             )
             raise ApiFailure(error_message, 404)
-        if instance_type == "cassandracluster":
-            instance_status["kubernetes"] = kubernetes_instance_status(
-                instance_status,
-                service,
-                instance,
-                verbose,
-                include_smartstack=include_smartstack,
-                instance_type=instance_type,
-            )
     except Exception:
         error_message = traceback.format_exc()
         raise ApiFailure(error_message, 500)
@@ -886,19 +628,15 @@ def instance_set_state(request,) -> None:
 
     if instance_type in INSTANCE_TYPES_WITH_SET_STATE:
         try:
-            cr_id_fn = cr_id_fn_for_instance_type(instance_type)
-            kube_client = KubeClient()
-            kubernetes_tools.set_cr_desired_state(
-                kube_client=kube_client,
-                cr_id=cr_id_fn(service=service, instance=instance),
+            pik.set_cr_desired_state(
+                kube_client=settings.kubernetes_client,
+                service=service,
+                instance=instance,
+                instance_type=instance_type,
                 desired_state=desired_state,
             )
-        except ApiException as e:
-            error_message = (
-                f"Error while setting state {desired_state} of "
-                f"{service}.{instance}: {e}"
-            )
-            raise ApiFailure(error_message, 500)
+        except RuntimeError as e:
+            raise ApiFailure(e, 500)
     else:
         error_message = (
             f"instance_type {instance_type} of {service}.{instance} doesn't "

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -69,8 +69,6 @@ from paasta_tools.mesos_tools import TaskNotFound
 from paasta_tools.smartstack_tools import get_backends
 from paasta_tools.smartstack_tools import match_backends_and_tasks
 from paasta_tools.utils import calculate_tail_lines
-from paasta_tools.utils import INSTANCE_TYPES_K8S
-from paasta_tools.utils import INSTANCE_TYPES_WITH_SET_STATE
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import TimeoutError
@@ -578,7 +576,7 @@ def instance_status(request):
             instance_status["adhoc"] = adhoc_instance_status(
                 instance_status, service, instance, verbose
             )
-        elif instance_type in INSTANCE_TYPES_K8S:
+        elif instance_type in pik.INSTANCE_TYPES_K8S:
             instance_status.update(
                 pik.instance_status(
                     service=service,
@@ -626,7 +624,7 @@ def instance_set_state(request,) -> None:
         error_message = traceback.format_exc()
         raise ApiFailure(error_message, 500)
 
-    if instance_type in INSTANCE_TYPES_WITH_SET_STATE:
+    if instance_type in pik.INSTANCE_TYPES_WITH_SET_STATE:
         try:
             pik.set_cr_desired_state(
                 kube_client=settings.kubernetes_client,
@@ -641,7 +639,7 @@ def instance_set_state(request,) -> None:
         error_message = (
             f"instance_type {instance_type} of {service}.{instance} doesn't "
             f"support set_state, must be in INSTANCE_TYPES_WITH_SET_STATE, "
-            f"currently: {INSTANCE_TYPES_WITH_SET_STATE}"
+            f"currently: {pik.INSTANCE_TYPES_WITH_SET_STATE}"
         )
         raise ApiFailure(error_message, 404)
 

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -34,11 +34,16 @@ INSTANCE_TYPE_CR_ID = dict(
 
 
 def set_cr_desired_state(
-    kube_client, service: str, instance: str, instance_type: str, desired_state: str,
+    kube_client: kubernetes_tools.KubeClient,
+    service: str,
+    instance: str,
+    instance_type: str,
+    desired_state: str,
 ):
     try:
         cr_id_fn = INSTANCE_TYPE_CR_ID[instance_type]
         kubernetes_tools.set_cr_desired_state(
+            kube_client=kube_client,
             cr_id=cr_id_fn(service=service, instance=instance),
             desired_state=desired_state,
         )
@@ -184,7 +189,7 @@ def smartstack_status(
 def cr_status(
     service: str, instance: str, verbose: int, instance_type: str, kube_client: Any,
 ) -> Mapping[str, Any]:
-    status: Mapping[str, Any] = {}
+    status: MutableMapping[str, Any] = {}
     cr_id_fn = INSTANCE_TYPE_CR_ID[instance_type]
     cr_id = cr_id_fn(service, instance)
     crstatus = kubernetes_tools.get_cr_status(kube_client=kube_client, cr_id=cr_id)
@@ -264,6 +269,7 @@ def kubernetes_status(
                     service_namespace_config=service_namespace_config,
                     pods=pod_list,
                     should_return_individual_backends=verbose > 0,
+                    settings=settings,
                 )
     return kstatus
 

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -1,0 +1,300 @@
+from typing import Any
+from typing import Dict
+from typing import Mapping
+from typing import MutableMapping
+from typing import Sequence
+
+import a_sync
+from kubernetes.client import V1Pod
+from kubernetes.client import V1ReplicaSet
+from kubernetes.client.rest import ApiException
+
+from paasta_tools import cassandracluster_tools
+from paasta_tools import flink_tools
+from paasta_tools import kafkacluster_tools
+from paasta_tools import kubernetes_tools
+from paasta_tools import marathon_tools
+from paasta_tools import smartstack_tools
+from paasta_tools.cli.utils import LONG_RUNNING_INSTANCE_TYPE_HANDLERS
+from paasta_tools.kubernetes_tools import get_tail_lines_for_kubernetes_pod
+from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
+from paasta_tools.long_running_service_tools import LongRunningServiceConfig
+from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
+from paasta_tools.smartstack_tools import KubeSmartstackReplicationChecker
+from paasta_tools.smartstack_tools import match_backends_and_pods
+from paasta_tools.utils import calculate_tail_lines
+from paasta_tools.utils import INSTANCE_TYPES_K8S
+from paasta_tools.utils import INSTANCE_TYPES_K8S_STATUS
+
+INSTANCE_TYPE_CR_ID = dict(
+    flink=flink_tools.cr_id,
+    cassandracluster=cassandracluster_tools.cr_id,
+    kafkacluster=kafkacluster_tools.cr_id,
+)
+
+
+def set_cr_desired_state(
+    kube_client, service: str, instance: str, instance_type: str, desired_state: str,
+):
+    try:
+        cr_id_fn = INSTANCE_TYPE_CR_ID[instance_type]
+        kubernetes_tools.set_cr_desired_state(
+            cr_id=cr_id_fn(service=service, instance=instance),
+            desired_state=desired_state,
+        )
+    except ApiException as e:
+        error_message = (
+            f"Error while setting state {desired_state} of "
+            f"{service}.{instance}: {e}"
+        )
+        raise RuntimeError(error_message)
+
+
+@a_sync.to_blocking
+async def job_status(
+    kstatus: MutableMapping[str, Any],
+    client: kubernetes_tools.KubeClient,
+    job_config: LongRunningServiceConfig,
+    pod_list: Sequence[V1Pod],
+    replicaset_list: Sequence[V1ReplicaSet],
+    verbose: int,
+    namespace: str,
+) -> None:
+    app_id = job_config.get_sanitised_deployment_name()
+    kstatus["app_id"] = app_id
+    kstatus["pods"] = []
+    kstatus["replicasets"] = []
+    if verbose > 0:
+        num_tail_lines = calculate_tail_lines(verbose)
+
+        for pod in pod_list:
+            if num_tail_lines > 0:
+                tail_lines = await get_tail_lines_for_kubernetes_pod(
+                    client, pod, num_tail_lines
+                )
+            else:
+                tail_lines = {}
+
+            kstatus["pods"].append(
+                {
+                    "name": pod.metadata.name,
+                    "host": pod.spec.node_name,
+                    "deployed_timestamp": pod.metadata.creation_timestamp.timestamp(),
+                    "phase": pod.status.phase,
+                    "tail_lines": tail_lines,
+                    "reason": pod.status.reason,
+                    "message": pod.status.message,
+                }
+            )
+        for replicaset in replicaset_list:
+            try:
+                ready_replicas = replicaset.status.ready_replicas
+                if ready_replicas is None:
+                    ready_replicas = 0
+            except AttributeError:
+                ready_replicas = 0
+
+            kstatus["replicasets"].append(
+                {
+                    "name": replicaset.metadata.name,
+                    "replicas": replicaset.spec.replicas,
+                    "ready_replicas": ready_replicas,
+                    "create_timestamp": replicaset.metadata.creation_timestamp.timestamp(),
+                }
+            )
+
+    kstatus["expected_instance_count"] = job_config.get_instances()
+
+    app = kubernetes_tools.get_kubernetes_app_by_name(
+        name=app_id, kube_client=client, namespace=namespace
+    )
+    deploy_status = kubernetes_tools.get_kubernetes_app_deploy_status(
+        app=app, desired_instances=job_config.get_instances()
+    )
+    kstatus["deploy_status"] = kubernetes_tools.KubernetesDeployStatus.tostring(
+        deploy_status
+    )
+    kstatus["running_instance_count"] = (
+        app.status.ready_replicas if app.status.ready_replicas else 0
+    )
+    kstatus["create_timestamp"] = app.metadata.creation_timestamp.timestamp()
+    kstatus["namespace"] = app.metadata.namespace
+
+
+def smartstack_status(
+    service: str,
+    instance: str,
+    job_config: LongRunningServiceConfig,
+    service_namespace_config: ServiceNamespaceConfig,
+    pods: Sequence[V1Pod],
+    settings: Any,
+    should_return_individual_backends: bool = False,
+) -> Mapping[str, Any]:
+
+    registration = job_config.get_registrations()[0]
+    instance_pool = job_config.get_pool()
+
+    smartstack_replication_checker = KubeSmartstackReplicationChecker(
+        nodes=kubernetes_tools.get_all_nodes(settings.kubernetes_client),
+        system_paasta_config=settings.system_paasta_config,
+    )
+    node_hostname_by_location = smartstack_replication_checker.get_allowed_locations_and_hosts(
+        job_config
+    )
+
+    expected_smartstack_count = marathon_tools.get_expected_instance_count_for_namespace(
+        service=service,
+        namespace=instance,
+        cluster=settings.cluster,
+        instance_type_class=KubernetesDeploymentConfig,
+    )
+    expected_count_per_location = int(
+        expected_smartstack_count / len(node_hostname_by_location)
+    )
+    smartstack_status: MutableMapping[str, Any] = {
+        "registration": registration,
+        "expected_backends_per_location": expected_count_per_location,
+        "locations": [],
+    }
+
+    for location, hosts in node_hostname_by_location.items():
+        synapse_host = smartstack_replication_checker.get_first_host_in_pool(
+            hosts, instance_pool
+        )
+        sorted_backends = sorted(
+            smartstack_tools.get_backends(
+                registration,
+                synapse_host=synapse_host,
+                synapse_port=settings.system_paasta_config.get_synapse_port(),
+                synapse_haproxy_url_format=settings.system_paasta_config.get_synapse_haproxy_url_format(),
+            ),
+            key=lambda backend: backend["status"],
+            reverse=True,  # put 'UP' backends above 'MAINT' backends
+        )
+
+        matched_backends_and_pods = match_backends_and_pods(sorted_backends, pods)
+        location_dict = smartstack_tools.build_smartstack_location_dict(
+            location, matched_backends_and_pods, should_return_individual_backends
+        )
+        smartstack_status["locations"].append(location_dict)
+
+    return smartstack_status
+
+
+def cr_status(
+    service: str, instance: str, verbose: int, instance_type: str, kube_client: Any,
+) -> Mapping[str, Any]:
+    status: Mapping[str, Any] = {}
+    cr_id_fn = INSTANCE_TYPE_CR_ID[instance_type]
+    cr_id = cr_id_fn(service, instance)
+    crstatus = kubernetes_tools.get_cr_status(kube_client=kube_client, cr_id=cr_id)
+    metadata = kubernetes_tools.get_cr_metadata(kube_client=kube_client, cr_id=cr_id)
+    if crstatus is not None:
+        status["status"] = crstatus
+    if metadata is not None:
+        status["metadata"] = metadata
+    return status
+
+
+def kubernetes_status(
+    service: str,
+    instance: str,
+    verbose: int,
+    include_smartstack: bool,
+    instance_type: str,
+    settings: Any,
+) -> Mapping[str, Any]:
+    kstatus: Dict[str, Any] = {}
+    config_loader = LONG_RUNNING_INSTANCE_TYPE_HANDLERS[instance_type].loader
+    job_config = config_loader(
+        service=service,
+        instance=instance,
+        cluster=settings.cluster,
+        soa_dir=settings.soa_dir,
+        load_deployments=True,
+    )
+    kube_client = settings.kubernetes_client
+    if kube_client is not None:
+        # bouncing status can be inferred from app_count, ref get_bouncing_status
+        pod_list = kubernetes_tools.pods_for_service_instance(
+            service=job_config.service,
+            instance=job_config.instance,
+            kube_client=kube_client,
+            namespace=job_config.get_kubernetes_namespace(),
+        )
+        replicaset_list = kubernetes_tools.replicasets_for_service_instance(
+            service=job_config.service,
+            instance=job_config.instance,
+            kube_client=kube_client,
+            namespace=job_config.get_kubernetes_namespace(),
+        )
+        active_shas = kubernetes_tools.get_active_shas_for_service(pod_list)
+        kstatus["app_count"] = max(
+            len(active_shas["config_sha"]), len(active_shas["git_sha"])
+        )
+        kstatus["desired_state"] = job_config.get_desired_state()
+        kstatus["bounce_method"] = job_config.get_bounce_method()
+        job_status(
+            kstatus=kstatus,
+            kube_client=kube_client,
+            namespace=job_config.get_kubernetes_namespace(),
+            job_config=job_config,
+            verbose=verbose,
+            pod_list=pod_list,
+            replicaset_list=replicaset_list,
+        )
+
+        evicted_count = 0
+        for pod in pod_list:
+            if pod.status.reason == "Evicted":
+                evicted_count += 1
+        kstatus["evicted_count"] = evicted_count
+
+        if include_smartstack:
+            service_namespace_config = kubernetes_tools.load_service_namespace_config(
+                service=job_config.get_service_name_smartstack(),
+                namespace=job_config.get_nerve_namespace(),
+                soa_dir=settings.soa_dir,
+            )
+            if "proxy_port" in service_namespace_config:
+                kstatus["smartstack"] = smartstack_status(
+                    service=job_config.get_service_name_smartstack(),
+                    instance=job_config.get_nerve_namespace(),
+                    job_config=job_config,
+                    service_namespace_config=service_namespace_config,
+                    pods=pod_list,
+                    should_return_individual_backends=verbose > 0,
+                )
+    return kstatus
+
+
+def instance_status(
+    service: str,
+    instance: str,
+    verbose: int,
+    include_smartstack: bool,
+    instance_type: str,
+    settings: Any,
+) -> Mapping[str, Any]:
+    status = {}
+
+    if instance_type in INSTANCE_TYPES_K8S:
+        status[instance_type] = cr_status(
+            service=service,
+            instance=instance,
+            instance_type=instance_type,
+            verbose=verbose,
+            kube_client=settings.kubernetes_client,
+        )
+
+    if instance_type in INSTANCE_TYPES_K8S_STATUS:
+        status["kubernetes"] = kubernetes_status(
+            service=service,
+            instance=instance,
+            instance_type=instance_type,
+            verbose=verbose,
+            include_smartstack=include_smartstack,
+            settings=settings,
+        )
+
+    return status

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -23,9 +23,11 @@ from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
 from paasta_tools.smartstack_tools import KubeSmartstackReplicationChecker
 from paasta_tools.smartstack_tools import match_backends_and_pods
 from paasta_tools.utils import calculate_tail_lines
-from paasta_tools.utils import INSTANCE_TYPES_K8S
-from paasta_tools.utils import INSTANCE_TYPES_K8S_STATUS
 
+
+INSTANCE_TYPES_K8S = {"kubernetes", "flink", "cassandracluster", "kafkacluster"}
+INSTANCE_TYPES_K8S_STATUS = {"kubernetes", "cassandracluster"}
+INSTANCE_TYPES_WITH_SET_STATE = {"flink"}
 INSTANCE_TYPE_CR_ID = dict(
     flink=flink_tools.cr_id,
     cassandracluster=cassandracluster_tools.cr_id,

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1893,7 +1893,9 @@ def sanitised_cr_name(service: str, instance: str) -> str:
     return f"{sanitised_service}-{sanitised_instance}"
 
 
-def get_cr(kube_client: KubeClient, cr_id: dict) -> Optional[Mapping[str, Any]]:
+def get_cr(
+    kube_client: KubeClient, cr_id: Mapping[str, str]
+) -> Optional[Mapping[str, Any]]:
     try:
         return kube_client.custom.get_namespaced_custom_object(**cr_id)
     except ApiException as e:
@@ -1903,18 +1905,20 @@ def get_cr(kube_client: KubeClient, cr_id: dict) -> Optional[Mapping[str, Any]]:
             raise
 
 
-def get_cr_status(kube_client: KubeClient, cr_id: dict) -> Optional[Mapping[str, Any]]:
+def get_cr_status(
+    kube_client: KubeClient, cr_id: Mapping[str, str]
+) -> Optional[Mapping[str, Any]]:
     return (get_cr(kube_client, cr_id) or {}).get("status")
 
 
 def get_cr_metadata(
-    kube_client: KubeClient, cr_id: dict
+    kube_client: KubeClient, cr_id: Mapping[str, str]
 ) -> Optional[Mapping[str, Any]]:
     return (get_cr(kube_client, cr_id) or {}).get("metadata")
 
 
 def set_cr_desired_state(
-    kube_client: KubeClient, cr_id: dict, desired_state: str
+    kube_client: KubeClient, cr_id: Mapping[str, str], desired_state: str
 ) -> str:
     cr = kube_client.custom.get_namespaced_custom_object(**cr_id)
     if cr.get("status", {}).get("state") == desired_state:

--- a/paasta_tools/smartstack_tools.py
+++ b/paasta_tools/smartstack_tools.py
@@ -22,6 +22,7 @@ from typing import DefaultDict
 from typing import Dict
 from typing import Iterable
 from typing import List
+from typing import Mapping
 from typing import MutableMapping
 from typing import NamedTuple
 from typing import Optional
@@ -642,14 +643,14 @@ class KubeSmartstackReplicationChecker(SmartstackReplicationChecker):
 
 def build_smartstack_location_dict(
     location: str,
-    matched_backends_and_tasks=List[
+    matched_backends_and_tasks: List[
         Tuple[
             Optional[HaproxyBackend],
             Optional[Union[marathon_tools.MarathonTask, V1Pod]],
         ]
     ],
     should_return_individual_backends: bool = False,
-):
+) -> Mapping[str, Any]:
     running_backends_count = 0
     backends = []
     for backend, task in matched_backends_and_tasks:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -127,9 +127,6 @@ INSTANCE_TYPES = (
     "cassandracluster",
     "kafkacluster",
 )
-INSTANCE_TYPES_K8S = {"kubernetes", "flink", "cassandracluster", "kafkacluster"}
-INSTANCE_TYPES_K8S_STATUS = {"kubernetes", "cassandracluster"}
-INSTANCE_TYPES_WITH_SET_STATE = {"flink"}
 
 
 class RollbackTypes(Enum):

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -127,7 +127,8 @@ INSTANCE_TYPES = (
     "cassandracluster",
     "kafkacluster",
 )
-INSTANCE_TYPES_K8S = {"flink", "cassandracluster", "kafkacluster"}
+INSTANCE_TYPES_K8S = {"kubernetes", "flink", "cassandracluster", "kafkacluster"}
+INSTANCE_TYPES_K8S_STATUS = {"kubernetes", "cassandracluster"}
 INSTANCE_TYPES_WITH_SET_STATE = {"flink"}
 
 

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -427,13 +427,18 @@ def test_marathon_smartstack_status(
     }
 
 
-@mock.patch("paasta_tools.api.views.instance.match_backends_and_pods", autospec=True)
-@mock.patch("paasta_tools.api.views.instance.get_backends", autospec=True)
 @mock.patch(
-    "paasta_tools.api.views.instance.KubeSmartstackReplicationChecker", autospec=True
+    "paasta_tools.api.views.instance.pik.match_backends_and_pods", autospec=True
 )
 @mock.patch(
-    "paasta_tools.api.views.instance.kubernetes_tools.get_all_nodes", autospec=True
+    "paasta_tools.api.views.instance.pik.smartstack_tools.get_backends", autospec=True
+)
+@mock.patch(
+    "paasta_tools.api.views.instance.pik.KubeSmartstackReplicationChecker",
+    autospec=True,
+)
+@mock.patch(
+    "paasta_tools.api.views.instance.pik.kubernetes_tools.get_all_nodes", autospec=True
 )
 @mock.patch(
     "paasta_tools.api.views.instance.marathon_tools.get_expected_instance_count_for_namespace",
@@ -474,14 +479,16 @@ def test_kubernetes_smartstack_status(
         branch_dict=None,
     )
     mock_service_namespace_config = ServiceNamespaceConfig()
+    mock_settings = mock.Mock()
 
-    smartstack_status = instance.kubernetes_smartstack_status(
-        "fake_service",
-        "fake_instance",
-        mock_job_config,
-        mock_service_namespace_config,
+    smartstack_status = instance.pik.smartstack_status(
+        service="fake_service",
+        instance="fake_instance",
+        job_config=mock_job_config,
+        service_namespace_config=mock_service_namespace_config,
         pods=[mock_pod],
         should_return_individual_backends=True,
+        settings=mock_settings,
     )
     assert smartstack_status == {
         "registration": "fake_service.fake_instance",
@@ -958,14 +965,15 @@ def test_tron_instance_status(
     assert response["tron"]["action_stderr"] == "fake_stderr"
 
 
-@mock.patch("paasta_tools.api.views.instance.kubernetes_job_status", autospec=True)
+@mock.patch("paasta_tools.instance.kubernetes.job_status", autospec=True)
 @mock.patch("paasta_tools.kubernetes_tools.get_active_shas_for_service", autospec=True)
 @mock.patch(
     "paasta_tools.kubernetes_tools.replicasets_for_service_instance", autospec=True
 )
 @mock.patch("paasta_tools.kubernetes_tools.pods_for_service_instance", autospec=True)
 @mock.patch(
-    "paasta_tools.api.views.instance.LONG_RUNNING_INSTANCE_TYPE_HANDLERS", autospec=True
+    "paasta_tools.instance.kubernetes.LONG_RUNNING_INSTANCE_TYPE_HANDLERS",
+    autospec=True,
 )
 def test_kubernetes_instance_status_bounce_method(
     mock_long_running_instance_type_handlers,
@@ -975,7 +983,6 @@ def test_kubernetes_instance_status_bounce_method(
     mock_kubernetes_job_status,
 ):
     settings.kubernetes_client = True
-    st = {}
     svc = "fake-svc"
     inst = "fake-inst"
 
@@ -984,18 +991,26 @@ def test_kubernetes_instance_status_bounce_method(
         return_value=mock.Mock(loader=mock.Mock(return_value=mock_job_config))
     )
 
-    actual = instance.kubernetes_instance_status(st, svc, inst, 0, False, "kubernetes")
+    actual = instance.pik.kubernetes_status(
+        service=svc,
+        instance=inst,
+        instance_type="kubernetes",
+        verbose=0,
+        include_smartstack=False,
+        settings=settings,
+    )
     assert actual["bounce_method"] == mock_job_config.get_bounce_method()
 
 
-@mock.patch("paasta_tools.api.views.instance.kubernetes_job_status", autospec=True)
+@mock.patch("paasta_tools.instance.kubernetes.job_status", autospec=True)
 @mock.patch("paasta_tools.kubernetes_tools.get_active_shas_for_service", autospec=True)
 @mock.patch(
     "paasta_tools.kubernetes_tools.replicasets_for_service_instance", autospec=True
 )
 @mock.patch("paasta_tools.kubernetes_tools.pods_for_service_instance", autospec=True)
 @mock.patch(
-    "paasta_tools.api.views.instance.LONG_RUNNING_INSTANCE_TYPE_HANDLERS", autospec=True
+    "paasta_tools.instance.kubernetes.LONG_RUNNING_INSTANCE_TYPE_HANDLERS",
+    autospec=True,
 )
 def test_kubernetes_instance_status_evicted_nodes(
     mock_long_running_instance_type_handlers,
@@ -1008,8 +1023,15 @@ def test_kubernetes_instance_status_evicted_nodes(
     mock_pod_2 = mock.Mock()
     mock_pods_for_service_instance.return_value = [mock_pod_1, mock_pod_2]
 
-    instance_status = instance.kubernetes_instance_status(
-        {}, "fake-svc", "fake-inst", 0, False, "kubernetes"
+    mock_settings = mock.Mock(cluster="kubernetes")
+
+    instance_status = instance.pik.kubernetes_status(
+        service="fake-svc",
+        instance="fake-inst",
+        instance_type="kubernetes",
+        verbose=0,
+        include_smartstack=False,
+        settings=mock_settings,
     )
     assert instance_status["evicted_count"] == 1
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,12 +26,13 @@ import pytest
 from pytest import raises
 
 from paasta_tools import utils
+from paasta_tools.instance import kubernetes as pik
 
 
 def test_instance_types_integrity():
-    for it in utils.INSTANCE_TYPES_K8S:
+    for it in pik.INSTANCE_TYPES_K8S:
         assert it in utils.INSTANCE_TYPES
-    for it in utils.INSTANCE_TYPES_WITH_SET_STATE:
+    for it in pik.INSTANCE_TYPES_WITH_SET_STATE:
         assert it in utils.INSTANCE_TYPES
 
 


### PR DESCRIPTION
Paasta codebase is littered with long `if ... elif` chains switching on `instance_type` values. I'm trying to make instance type more of a first-class citizen by moving everything related to how certain instance types are handled into their own modules. Currently we can largely categorize paasta codebase in following big categories:

a) api handles request/response and how things are represented on the wire
b) cli handles commands, args parsing and rendering to terminal
c) various `_tools` and other modules dealing with concrete tech (mesos, kubernetes, tron)

In this PR I'm adding `paasta_tools.instance` layer that should sit in between [ab] and [c].

Eventually it's useful to have a more pluggable system where modules or other binaries can be registered in paasta configuration system to "handle" certain instance_types, but we need to figure out the interface between these components first.