### PR TITLE
Support spark args with spaces in them

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import logging
 import os
+import shlex
 import socket
 import sys
 import time
@@ -519,7 +520,7 @@ def get_spark_config(
         non_user_args["spark.mesos.uris"] = "file:///root/.dockercfg"
 
     if args.spark_args:
-        spark_args = args.spark_args.split()
+        spark_args = shlex.split(args.spark_args)
         for spark_arg in spark_args:
             fields = spark_arg.split("=", 1)
             if len(fields) != 2:
@@ -608,7 +609,8 @@ def create_spark_config_str(spark_config_dict, is_mrjob):
         spark_config_entries.append(f"--spark-master={spark_master}")
 
     for opt, val in spark_config_dict.items():
-        spark_config_entries.append(f"{conf_option} {opt}={val}")
+        quoted_opt = shlex.quote(f"{opt}={val}")
+        spark_config_entries.append(f"{conf_option} {quoted_opt}")
     return " ".join(spark_config_entries)
 
 


### PR DESCRIPTION
This addresses PAASTA-16138. Spark arguments which contain spaces will get split improperly, and even if they were split correctly, they will be joined again improperly when set in `SPARK_OPTS`. This patch uses shlex to split and quote arguments correctly. It only works on Python 3.3 and above, due to the use of `shlex.quote()`. Not sure if that will be a problem here.

Tested this in dev by invoking a spark job with spark args in spaces. I checked in the spark UI and saw that the value was successfully passed in.