### PR TITLE
Kubernetes active sha fix

### DIFF
--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -222,6 +222,11 @@ def kubernetes_status(
     )
     kube_client = settings.kubernetes_client
     if kube_client is not None:
+        app = kubernetes_tools.get_kubernetes_app_by_name(
+            name=job_config.get_sanitised_deployment_name(),
+            kube_client=kube_client,
+            namespace=job_config.get_kubernetes_namespace(),
+        )
         # bouncing status can be inferred from app_count, ref get_bouncing_status
         pod_list = kubernetes_tools.pods_for_service_instance(
             service=job_config.service,
@@ -235,7 +240,9 @@ def kubernetes_status(
             kube_client=kube_client,
             namespace=job_config.get_kubernetes_namespace(),
         )
-        active_shas = kubernetes_tools.get_active_shas_for_service(pod_list)
+        active_shas = kubernetes_tools.get_active_shas_for_service(
+            [app, *pod_list, *replicaset_list]
+        )
         kstatus["app_count"] = max(
             len(active_shas["config_sha"]), len(active_shas["git_sha"])
         )

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1591,11 +1591,17 @@ def get_pod_status(pod: V1Pod,) -> PodStatus:
     return _POD_STATUS_NAME_TO_STATUS[pod.status.phase.upper()]
 
 
-def get_active_shas_for_service(pod_list: Sequence[V1Pod],) -> Mapping[str, Set[str]]:
-    ret: Mapping[str, Set[str]] = {"config_sha": set(), "git_sha": set()}
-    for pod in pod_list:
-        ret["config_sha"].add(pod.metadata.labels["paasta.yelp.com/config_sha"])
-        ret["git_sha"].add(pod.metadata.labels["paasta.yelp.com/git_sha"])
+def get_active_shas_for_service(
+    obj_list: Sequence[Union[V1Pod, V1ReplicaSet, V1Deployment, V1StatefulSet]],
+) -> Mapping[str, Set[str]]:
+    ret = {"config_sha": set(), "git_sha": set()}
+    for obj in obj_list:
+        config_sha = obj.metadata.labels.get("paasta.yelp.com/config_sha")
+        if config_sha is not None:
+            ret["config_sha"].add(config_sha)
+        git_sha = obj.metadata.labels.get("paasta.yelp.com/git_sha")
+        if git_sha is not None:
+            ret["git_sha"].add(git_sha)
     return ret
 
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1594,7 +1594,7 @@ def get_pod_status(pod: V1Pod,) -> PodStatus:
 def get_active_shas_for_service(
     obj_list: Sequence[Union[V1Pod, V1ReplicaSet, V1Deployment, V1StatefulSet]],
 ) -> Mapping[str, Set[str]]:
-    ret = {"config_sha": set(), "git_sha": set()}
+    ret: MutableMapping[str, Set[str]] = {"config_sha": set(), "git_sha": set()}
     for obj in obj_list:
         config_sha = obj.metadata.labels.get("paasta.yelp.com/config_sha")
         if config_sha is not None:

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -965,6 +965,7 @@ def test_tron_instance_status(
     assert response["tron"]["action_stderr"] == "fake_stderr"
 
 
+@mock.patch("paasta_tools.kubernetes_tools.get_kubernetes_app_by_name", autospec=True)
 @mock.patch("paasta_tools.instance.kubernetes.job_status", autospec=True)
 @mock.patch("paasta_tools.kubernetes_tools.get_active_shas_for_service", autospec=True)
 @mock.patch(
@@ -981,6 +982,7 @@ def test_kubernetes_instance_status_bounce_method(
     mock_replicasets_for_service_instance,
     mock_get_active_shas_for_service,
     mock_kubernetes_job_status,
+    mock_get_kubernetes_app_by_name,
 ):
     settings.kubernetes_client = True
     svc = "fake-svc"
@@ -990,6 +992,7 @@ def test_kubernetes_instance_status_bounce_method(
     mock_long_running_instance_type_handlers.__getitem__ = mock.Mock(
         return_value=mock.Mock(loader=mock.Mock(return_value=mock_job_config))
     )
+    mock_get_kubernetes_app_by_name.return_value = mock.Mock()
 
     actual = instance.pik.kubernetes_status(
         service=svc,


### PR DESCRIPTION
- don't error out when `_sha` labels aren't present, we may be looking at operator-created pods and those don't necessarily carry over all the labels
- look into deployments, replica sets and stateful sets for `_sha` labels