### PR TITLE
Use the service configuration library to set up Spark on Tron

### DIFF
--- a/.activate.sh
+++ b/.activate.sh
@@ -1,0 +1,1 @@
+.tox/py36-linux/bin/activate

--- a/.deactivate.sh
+++ b/.deactivate.sh
@@ -1,0 +1,1 @@
+deactivate

--- a/.dockerignore
+++ b/.dockerignore
@@ -26,3 +26,6 @@ fake_service_uno/
 paasta_itests/mesos-cli.json
 paasta_itests/fake_etc_paasta/marathon.json
 yelp_package/bintray.json
+
+.activate.sh
+.deactivate.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,13 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=1.13.1-0~ubuntu-xenial devscripts --force-yes
   - 'if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" -a "$DOCKER_USERNAME" != "" ]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi'
-install: pip install coveralls tox==3.2 tox-pip-extensions==1.3.0
+install:
+  - pip install coveralls tox==3.2 tox-pip-extensions==1.3.0
+  # There's some weird breakage between travis, python, virtualenvs, and eggs that I don't really
+  # understand, but it was causing the build to fail because of ContextualVersionConflicts.
+  # It seems as though we're hitting https://github.com/pypa/pip/issues/6275
+  # I also don't understand why but running setup.py egg_info is a workaround that appears to fix things
+  - python setup.py egg_info
 script: if [[ -n "$MAKE_TARGET" ]]; then make "$MAKE_TARGET"; else tox -i https://pypi.python.org/simple; fi
 after_success:
   - coveralls

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,14 @@ endif
 
 .PHONY: all docs test itest
 
+dev: .paasta/bin/activate
+	.paasta/bin/tox -i $(PIP_INDEX_URL)
+
 docs: .paasta/bin/activate
 	.paasta/bin/tox -i $(PIP_INDEX_URL) -e docs
 
 test: .paasta/bin/activate
-	.paasta/bin/tox -i $(PIP_INDEX_URL)
+	.paasta/bin/tox -i $(PIP_INDEX_URL) -e test
 
 .tox/py36-linux: .paasta/bin/activate
 	.paasta/bin/tox -i $(PIP_INDEX_URL)
@@ -60,13 +63,13 @@ release:
 	make -C yelp_package release
 
 clean:
-	rm -rf ./dist
-	make -C yelp_package clean
-	rm -rf docs/build
-	find . -name '*.pyc' -delete
-	find . -name '__pycache__' -delete
-	rm -rf .tox
-	rm -rf .paasta
+	-rm -rf ./dist
+	-make -C yelp_package clean
+	-rm -rf docs/build
+	-find . -name '*.pyc' -delete
+	-find . -name '__pycache__' -delete
+	-rm -rf .tox
+	-rm -rf .paasta
 
 yelpy: ## Installs the yelp-internal packages into the default tox environment
 	.tox/py36-linux/bin/pip-custom-platform install -i https://pypi.yelpcorp.com/simple -r yelp_package/extra_requirements_yelp.txt -r ./extra-linux-requirements.txt

--- a/docs/source/generated/paasta_tools.rst
+++ b/docs/source/generated/paasta_tools.rst
@@ -11,6 +11,7 @@ Subpackages
     paasta_tools.cli
     paasta_tools.deployd
     paasta_tools.frameworks
+    paasta_tools.instance
     paasta_tools.kubernetes
     paasta_tools.mesos
     paasta_tools.metrics
@@ -91,6 +92,7 @@ Submodules
    paasta_tools.setup_tron_namespace
    paasta_tools.slack
    paasta_tools.smartstack_tools
+   paasta_tools.spark_tools
    paasta_tools.synapse_srv_namespaces_fact
    paasta_tools.tron_tools
    paasta_tools.utils

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -6,9 +6,7 @@ import socket
 import sys
 import time
 
-import boto3
 from boto3.exceptions import Boto3Error
-from botocore.session import Session
 from ruamel.yaml import YAML
 
 from paasta_tools.cli.cmds.check import makefile_responds_to
@@ -19,7 +17,10 @@ from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import pick_random_port
 from paasta_tools.clusterman import get_clusterman_metrics
 from paasta_tools.mesos_tools import find_mesos_leader
-from paasta_tools.mesos_tools import MESOS_MASTER_PORT
+from paasta_tools.mesos_tools import load_mesos_secret
+from paasta_tools.spark_tools import DEFAULT_SPARK_SERVICE
+from paasta_tools.spark_tools import get_aws_credentials
+from paasta_tools.spark_tools import get_default_event_log_dir
 from paasta_tools.utils import _run
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_possible_launched_by_user_variable_from_env
@@ -35,14 +36,10 @@ from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
 
 
-AWS_CREDENTIALS_DIR = "/etc/boto_cfg/"
-DEFAULT_SPARK_RUN_CONFIG = "/nail/srv/configs/spark.yaml"
 DEFAULT_AWS_REGION = "us-west-2"
-DEFAULT_SERVICE = "spark"
 DEFAULT_SPARK_WORK_DIR = "/spark_driver"
 DEFAULT_SPARK_DOCKER_IMAGE_PREFIX = "paasta-spark-run"
 DEFAULT_SPARK_DOCKER_REGISTRY = "docker-dev.yelpcorp.com"
-DEFAULT_SPARK_MESOS_SECRET_FILE = "/nail/etc/paasta_spark_secret"
 SENSITIVE_ENV = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
 clusterman_metrics, CLUSTERMAN_YAML_FILE_PATH = get_clusterman_metrics()
 
@@ -112,7 +109,7 @@ def add_subparser(subparsers):
         "-s",
         "--service",
         help="The name of the service from which the Spark image is built.",
-        default=DEFAULT_SERVICE,
+        default=DEFAULT_SPARK_SERVICE,
     ).completer = lazy_choices_completer(list_services)
 
     list_parser.add_argument(
@@ -352,36 +349,6 @@ def get_smart_paasta_instance_name(args):
         return f"{args.instance}_{get_username()}_{how_submitted}"
 
 
-def get_default_event_log_dir(access_key, secret_key):
-    if access_key is None:
-        log.warning(
-            "Since no AWS credentials were provided, spark event logging "
-            "will be disabled"
-        )
-        return None
-
-    with open(DEFAULT_SPARK_RUN_CONFIG) as fp:
-        spark_run_conf = YAML().load(fp.read())
-    try:
-        account_id = (
-            boto3.client(
-                "sts", aws_access_key_id=access_key, aws_secret_access_key=secret_key
-            )
-            .get_caller_identity()
-            .get("Account")
-        )
-    except Exception as e:
-        log.warning("Failed to identify account ID, error: {}".format(str(e)))
-        return None
-
-    for conf in spark_run_conf["environments"].values():
-        if account_id == conf["account_id"]:
-            default_event_log_dir = conf["default_event_log_dir"]
-            paasta_print(f"default event logging at: {default_event_log_dir}")
-            return default_event_log_dir
-    return None
-
-
 def get_spark_env(args, spark_conf, spark_ui_port, access_key, secret_key):
     spark_env = {}
 
@@ -422,52 +389,6 @@ def get_spark_env(args, spark_conf, spark_ui_port, access_key, secret_key):
     return spark_env
 
 
-def get_aws_credentials(args):
-    if args.no_aws_credentials:
-        return None, None
-    elif args.aws_credentials_yaml:
-        return load_aws_credentials_from_yaml(args.aws_credentials_yaml)
-    elif args.service != DEFAULT_SERVICE:
-        service_credentials_path = get_service_aws_credentials_path(args.service)
-        if os.path.exists(service_credentials_path):
-            return load_aws_credentials_from_yaml(service_credentials_path)
-        else:
-            paasta_print(
-                PaastaColors.yellow(
-                    "Did not find service AWS credentials at %s.  Falling back to "
-                    "user credentials." % (service_credentials_path)
-                )
-            )
-
-    creds = Session(profile=args.aws_profile).get_credentials()
-    return creds.access_key, creds.secret_key
-
-
-def get_service_aws_credentials_path(service_name):
-    service_yaml = "%s.yaml" % service_name
-    return os.path.join(AWS_CREDENTIALS_DIR, service_yaml)
-
-
-def load_aws_credentials_from_yaml(yaml_file_path):
-    with open(yaml_file_path, "r") as yaml_file:
-        try:
-            credentials_yaml = YAML().load(yaml_file.read())
-        except Exception as e:
-            paasta_print(
-                PaastaColors.red(
-                    "Encountered %s when trying to parse AWS credentials yaml %s. "
-                    "Suppressing further output to avoid leaking credentials."
-                    % (type(e), yaml_file_path)
-                )
-            )
-            sys.exit(1)
-
-        return (
-            credentials_yaml["aws_access_key_id"],
-            credentials_yaml["aws_secret_access_key"],
-        )
-
-
 def get_spark_config(
     args,
     spark_app_name,
@@ -490,16 +411,15 @@ def get_spark_config(
         "spark.mesos.executor.docker.forcePullImage": "true",
     }
 
-    default_event_log_dir = get_default_event_log_dir(access_key, secret_key)
+    default_event_log_dir = get_default_event_log_dir(
+        access_key=access_key, secret_key=secret_key
+    )
     if default_event_log_dir is not None:
         user_args["spark.eventLog.enabled"] = "true"
         user_args["spark.eventLog.dir"] = default_event_log_dir
 
     # Spark options managed by PaaSTA
-    cluster_fqdn = system_paasta_config.get_cluster_fqdn_format().format(
-        cluster=args.cluster
-    )
-    mesos_address = "{}:{}".format(find_mesos_leader(cluster_fqdn), MESOS_MASTER_PORT)
+    mesos_address = find_mesos_leader(args.cluster)
     paasta_instance = get_smart_paasta_instance_name(args)
     non_user_args = {
         "spark.master": "mesos://%s" % mesos_address,
@@ -512,7 +432,7 @@ def get_spark_config(
         "spark.mesos.executor.docker.volumes": ",".join(volumes),
         "spark.mesos.executor.docker.image": docker_img,
         "spark.mesos.principal": "spark",
-        "spark.mesos.secret": _load_mesos_secret(),
+        "spark.mesos.secret": load_mesos_secret(),
     }
 
     if not args.build and not args.image:
@@ -585,18 +505,6 @@ def get_spark_config(
     )
 
     return dict(non_user_args, **user_args)
-
-
-def _load_mesos_secret():
-    try:
-        with open(DEFAULT_SPARK_MESOS_SECRET_FILE, "r") as f:
-            return f.read()
-    except IOError:
-        paasta_print(
-            "Cannot load mesos secret from %s" % DEFAULT_SPARK_MESOS_SECRET_FILE,
-            file=sys.stderr,
-        )
-        sys.exit(1)
 
 
 def create_spark_config_str(spark_config_dict, is_mrjob):

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -17,10 +17,10 @@ from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import pick_random_port
 from paasta_tools.clusterman import get_clusterman_metrics
 from paasta_tools.mesos_tools import find_mesos_leader
-from paasta_tools.mesos_tools import load_mesos_secret
 from paasta_tools.spark_tools import DEFAULT_SPARK_SERVICE
 from paasta_tools.spark_tools import get_aws_credentials
 from paasta_tools.spark_tools import get_default_event_log_dir
+from paasta_tools.spark_tools import load_mesos_secret_for_spark
 from paasta_tools.utils import _run
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_possible_launched_by_user_variable_from_env
@@ -432,7 +432,7 @@ def get_spark_config(
         "spark.mesos.executor.docker.volumes": ",".join(volumes),
         "spark.mesos.executor.docker.image": docker_img,
         "spark.mesos.principal": "spark",
-        "spark.mesos.secret": load_mesos_secret(),
+        "spark.mesos.secret": load_mesos_secret_for_spark(),
     }
 
     if not args.build and not args.image:

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -18,7 +18,6 @@ import json
 import logging
 import re
 import socket
-import sys
 from collections import namedtuple
 from pathlib import Path
 from typing import Any
@@ -59,12 +58,10 @@ from paasta_tools.utils import DeployWhitelist
 from paasta_tools.utils import format_table
 from paasta_tools.utils import get_user_agent
 from paasta_tools.utils import load_system_paasta_config
-from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import TimeoutError
 
 MARATHON_FRAMEWORK_NAME_PREFIX = "marathon"
-DEFAULT_SPARK_MESOS_SECRET_FILE = "/nail/etc/paasta_spark_secret"
 
 ZookeeperHostPath = namedtuple("ZookeeperHostPath", ["host", "path"])
 SlaveTaskCount = namedtuple("SlaveTaskCount", ["count", "batch_count", "slave"])
@@ -161,18 +158,6 @@ def find_mesos_leader(cluster):
     response = requests.get(url)
     hostname = urlparse(response.url).hostname
     return f"{hostname}:{MESOS_MASTER_PORT}"
-
-
-def load_mesos_secret():
-    try:
-        with open(DEFAULT_SPARK_MESOS_SECRET_FILE, "r") as f:
-            return f.read()
-    except IOError as e:
-        paasta_print(
-            "Cannot load mesos secret from %s" % DEFAULT_SPARK_MESOS_SECRET_FILE,
-            file=sys.stderr,
-        )
-        raise e
 
 
 async def get_current_tasks(job_id: str) -> List[Task]:

--- a/paasta_tools/paasta_remote_run.py
+++ b/paasta_tools/paasta_remote_run.py
@@ -216,12 +216,7 @@ def create_mesos_executor(
     """ Create a Mesos executor specific to our cluster """
     MesosExecutor = processor.executor_cls("mesos_task")
 
-    cluster_fqdn = system_paasta_config.get_cluster_fqdn_format().format(
-        cluster=cluster
-    )
-    mesos_address = "{}:{}".format(
-        mesos_tools.find_mesos_leader(cluster_fqdn), mesos_tools.MESOS_MASTER_PORT
-    )
+    mesos_address = mesos_tools.find_mesos_leader(cluster)
 
     return MesosExecutor(
         role=role,

--- a/paasta_tools/setup_tron_namespace.py
+++ b/paasta_tools/setup_tron_namespace.py
@@ -127,7 +127,7 @@ def main():
                     skipped.append(service)
                     log.debug(f"Skipped {service}")
         except Exception as e:
-            log.exception(f"Update for {service} failed: {str(e)}")
+            log.error(f"Update for {service} failed: {str(e)}")
             log.debug(f"Exception while updating {service}", exc_info=1)
             failed.append(service)
 

--- a/paasta_tools/setup_tron_namespace.py
+++ b/paasta_tools/setup_tron_namespace.py
@@ -127,7 +127,7 @@ def main():
                     skipped.append(service)
                     log.debug(f"Skipped {service}")
         except Exception as e:
-            log.error(f"Update for {service} failed: {str(e)}")
+            log.exception(f"Update for {service} failed: {str(e)}")
             log.debug(f"Exception while updating {service}", exc_info=1)
             failed.append(service)
 

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -1,0 +1,111 @@
+import logging
+import os
+import sys
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+import boto3
+from botocore.session import Session
+from ruamel.yaml import YAML
+
+from paasta_tools.utils import paasta_print
+from paasta_tools.utils import PaastaColors
+
+AWS_CREDENTIALS_DIR = "/etc/boto_cfg/"
+DEFAULT_SPARK_RUN_CONFIG = "/nail/srv/configs/spark.yaml"
+DEFAULT_SPARK_SERVICE = "spark"
+EXTRA_SPARK_VOLUMES = ("/etc/passwd", "/etc/group")
+log = logging.getLogger(__name__)
+
+
+def _load_aws_credentials_from_yaml(yaml_file_path) -> Tuple[str, str]:
+    with open(yaml_file_path, "r") as yaml_file:
+        try:
+            credentials_yaml = YAML().load(yaml_file.read())
+        except Exception as e:
+            paasta_print(
+                PaastaColors.red(
+                    "Encountered %s when trying to parse AWS credentials yaml %s. "
+                    "Suppressing further output to avoid leaking credentials."
+                    % (type(e), yaml_file_path)
+                )
+            )
+            sys.exit(1)
+
+        return (
+            credentials_yaml["aws_access_key_id"],
+            credentials_yaml["aws_secret_access_key"],
+        )
+
+
+def get_aws_credentials(
+    service: str = DEFAULT_SPARK_SERVICE,
+    no_aws_credentials: bool = False,
+    aws_credentials_yaml: Optional[str] = None,
+    profile_name: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    if no_aws_credentials:
+        return None, None
+    elif aws_credentials_yaml:
+        return _load_aws_credentials_from_yaml(aws_credentials_yaml)
+    elif service != DEFAULT_SPARK_SERVICE:
+        service_credentials_path = os.path.join(AWS_CREDENTIALS_DIR, f"{service}.yaml")
+        if os.path.exists(service_credentials_path):
+            return _load_aws_credentials_from_yaml(service_credentials_path)
+        else:
+            paasta_print(
+                PaastaColors.yellow(
+                    "Did not find service AWS credentials at %s.  Falling back to "
+                    "user credentials." % (service_credentials_path)
+                )
+            )
+
+    creds = Session(profile=profile_name).get_credentials()
+    return creds.access_key, creds.secret_key
+
+
+def get_default_event_log_dir(**kwargs) -> str:
+    if "access_key" not in kwargs or "secret_key" not in kwargs:
+        access_key, secret_key = get_aws_credentials(**kwargs)
+    else:
+        access_key, secret_key = kwargs["access_key"], kwargs["secret_key"]
+    if access_key is None:
+        log.warning(
+            "Since no AWS credentials were provided, spark event logging "
+            "will be disabled"
+        )
+        return None
+
+    with open(DEFAULT_SPARK_RUN_CONFIG) as fp:
+        spark_run_conf = YAML().load(fp.read())
+    try:
+        account_id = (
+            boto3.client(
+                "sts", aws_access_key_id=access_key, aws_secret_access_key=secret_key
+            )
+            .get_caller_identity()
+            .get("Account")
+        )
+    except Exception as e:
+        log.warning("Failed to identify account ID, error: {}".format(str(e)))
+        return None
+
+    for conf in spark_run_conf["environments"].values():
+        if account_id == conf["account_id"]:
+            default_event_log_dir = conf["default_event_log_dir"]
+            paasta_print(f"default event logging at: {default_event_log_dir}")
+            return default_event_log_dir
+    return None
+
+
+def get_formatted_spark_volumes(instance_config, system_volumes) -> List[str]:
+    volume_dicts = instance_config.get_volumes(system_volumes)
+    volumes = [
+        f"{v['hostPath']}:{v['containerPath']}:{v['mode'].lower()}"
+        for v in volume_dicts
+        if os.path.exists(v["hostPath"]) and v["hostPath"] not in EXTRA_SPARK_VOLUMES
+    ]
+    for v in EXTRA_SPARK_VOLUMES:
+        volumes.append(f"{v}:{v}:ro")
+    return volumes

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -19,18 +19,25 @@ import os
 import pkgutil
 import re
 import subprocess
+from getpass import getuser
 from string import Formatter
 from typing import List
 from typing import Tuple
 
-import service_configuration_lib
 import yaml
+from service_configuration_lib import pick_random_port
+from service_configuration_lib import read_yaml_file
+from service_configuration_lib.spark_config import get_mesos_spark_env
+from service_configuration_lib.spark_config import stringify_spark_env
 
 try:
     from yaml.cyaml import CSafeDumper as Dumper
 except ImportError:  # pragma: no cover (no libyaml-dev / pypy)
     Dumper = yaml.SafeDumper  # type: ignore
 
+from paasta_tools.spark_tools import get_default_event_log_dir
+from paasta_tools.mesos_tools import load_mesos_secret
+from paasta_tools.mesos_tools import find_mesos_leader
 from paasta_tools.tron.client import TronClient
 from paasta_tools.tron import tron_command_context
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -43,6 +50,7 @@ from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import load_tron_yaml
 from paasta_tools.utils import extract_jobs_from_tron_yaml
+from paasta_tools.spark_tools import get_formatted_spark_volumes
 
 from paasta_tools import monitoring_tools
 from paasta_tools.monitoring_tools import list_teams
@@ -60,6 +68,7 @@ VALID_MONITORING_KEYS = set(
         pkgutil.get_data("paasta_tools.cli", "schemas/tron_schema.json").decode()
     )["definitions"]["job"]["properties"]["monitoring"]["properties"].keys()
 )
+MESOS_EXECUTOR_NAMES = ("mesos", "paasta", "spark")
 
 
 class TronNotConfigured(Exception):
@@ -189,7 +198,39 @@ class TronActionConfig(InstanceConfig):
         return self.config_dict.get("deploy_group", None)
 
     def get_cmd(self):
-        return self.config_dict.get("command")
+        command = self.config_dict.get("command")
+        if self.get_executor() == "spark":
+            command = "unset MESOS_DIRECTORY MESOS_SANDBOX; " + command
+        return command
+
+    def get_env(self):
+        env = super().get_env()
+        spark_env = {}
+        if self.get_executor() == "spark":
+            spark_env = get_mesos_spark_env(
+                spark_app_name="tron_spark_{self.get_service()}_{self.get_instance()}",
+                spark_ui_port=pick_random_port(
+                    f"{self.get_service()},{getuser()}".encode("utf8")
+                ),
+                mesos_leader=find_mesos_leader(self.get_cluster()),
+                mesos_secret=load_mesos_secret(),
+                paasta_cluster=self.get_cluster(),
+                paasta_pool=self.get_pool(),
+                paasta_service=self.get_service(),
+                paasta_instance=self.get_instance(),
+                docker_img=self.get_docker_url(),
+                volumes=get_formatted_spark_volumes(
+                    self, load_system_paasta_config().get_volumes()
+                ),
+                user_spark_opts=self.config_dict.get("spark"),
+                event_log_dir=get_default_event_log_dir(
+                    service=self.get_service(),
+                    aws_credentials_yaml=self.config_dict.get("aws_credentials"),
+                ),
+            )
+            env["SPARK_OPTS"] = stringify_spark_env(spark_env)
+
+        return env
 
     def get_cpu_burst_add(self) -> float:
         """ For Tron jobs, we don't let them burst by default, because they
@@ -198,8 +239,7 @@ class TronActionConfig(InstanceConfig):
         return self.config_dict.get("cpu_burst_add", 0)
 
     def get_executor(self):
-        executor = self.config_dict.get("executor", None)
-        return "mesos" if executor == "paasta" else executor
+        return self.config_dict.get("executor", None)
 
     def get_healthcheck_mode(self, _) -> None:
         return None
@@ -482,7 +522,8 @@ def format_tron_action_dict(action_config):
         "on_upstream_rerun": action_config.get_on_upstream_rerun(),
         "trigger_timeout": action_config.get_trigger_timeout(),
     }
-    if executor == "mesos":
+    if executor in MESOS_EXECUTOR_NAMES:
+        result["executor"] = "mesos"
         result["cpus"] = action_config.get_cpus()
         result["mem"] = action_config.get_mem()
         result["disk"] = action_config.get_disk()
@@ -588,9 +629,7 @@ def load_tron_service_config(
 def create_complete_master_config(cluster, soa_dir=DEFAULT_SOA_DIR):
     system_paasta_config = load_system_paasta_config()
     tronfig_folder = get_tronfig_folder(soa_dir=soa_dir, cluster=cluster)
-    config = service_configuration_lib._read_yaml_file(
-        os.path.join(tronfig_folder, f"MASTER.yaml")
-    )
+    config = read_yaml_file(os.path.join(tronfig_folder, f"MASTER.yaml"))
     master_config = format_master_config(
         config,
         system_paasta_config.get_volumes(),

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -44,7 +44,7 @@ requests-cache >= 0.4.10,<= 0.5.0
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 0.12.0
+service-configuration-lib >= 2.1.0
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,7 +87,7 @@ rsa==3.4.2
 ruamel.yaml==0.15.96
 s3transfer==0.1.13
 sensu-plugin==0.3.1
-service-configuration-lib==1.1.0
+service-configuration-lib==2.1.0
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -141,9 +141,9 @@ class TestGetSparkConfig:
         yield spark_run_file
 
     @pytest.fixture(autouse=True)
-    def mock_load_mesos_secret(self):
+    def mock_load_mesos_secret_for_spark(self):
         with mock.patch(
-            "paasta_tools.cli.cmds.spark_run.load_mesos_secret", autospec=True
+            "paasta_tools.cli.cmds.spark_run.load_mesos_secret_for_spark", autospec=True
         ) as m:
             yield m
 

--- a/tests/test_spark_tools.py
+++ b/tests/test_spark_tools.py
@@ -1,0 +1,142 @@
+import mock
+import pytest
+from ruamel.yaml import YAML
+
+from paasta_tools.spark_tools import _load_aws_credentials_from_yaml
+from paasta_tools.spark_tools import DEFAULT_SPARK_SERVICE
+from paasta_tools.spark_tools import get_aws_credentials
+from paasta_tools.spark_tools import get_default_event_log_dir
+
+
+def test_load_aws_credentials_from_yaml(tmpdir):
+    fake_access_key_id = "fake_access_key_id"
+    fake_secret_access_key = "fake_secret_access_key"
+    yaml_file = tmpdir.join("test.yaml")
+    yaml_file.write(
+        f'aws_access_key_id: "{fake_access_key_id}"\n'
+        f'aws_secret_access_key: "{fake_secret_access_key}"'
+    )
+
+    aws_access_key_id, aws_secret_access_key = _load_aws_credentials_from_yaml(
+        yaml_file
+    )
+    assert aws_access_key_id == fake_access_key_id
+    assert aws_secret_access_key == fake_secret_access_key
+
+
+def test_creds_disabled():
+    credentials = get_aws_credentials(no_aws_credentials=True)
+    assert credentials == (None, None)
+
+
+@mock.patch("paasta_tools.spark_tools._load_aws_credentials_from_yaml", autospec=True)
+def test_yaml_provided(mock_load_aws_credentials_from_yaml):
+    credentials = get_aws_credentials(aws_credentials_yaml="credentials.yaml")
+
+    mock_load_aws_credentials_from_yaml.assert_called_once_with("credentials.yaml")
+    assert credentials == mock_load_aws_credentials_from_yaml.return_value
+
+
+@mock.patch("paasta_tools.spark_tools.os.path.exists", autospec=True)
+@mock.patch("paasta_tools.spark_tools._load_aws_credentials_from_yaml", autospec=True)
+def test_service_provided_no_yaml(
+    mock_load_aws_credentials_from_yaml, mock_os,
+):
+    mock_os.return_value = True
+    credentials = get_aws_credentials(service="service_name")
+
+    mock_load_aws_credentials_from_yaml.assert_called_once_with(
+        "/etc/boto_cfg/service_name.yaml"
+    )
+    assert credentials == mock_load_aws_credentials_from_yaml.return_value
+
+
+@mock.patch("paasta_tools.spark_tools.Session.get_credentials", autospec=True)
+@mock.patch("paasta_tools.spark_tools._load_aws_credentials_from_yaml", autospec=True)
+def test_use_default_creds(mock_load_aws_credentials_from_yaml, mock_get_credentials):
+    args = mock.Mock(
+        no_aws_credentials=False,
+        aws_credentials_yaml=None,
+        service=DEFAULT_SPARK_SERVICE,
+    )
+    mock_get_credentials.return_value = mock.MagicMock(
+        access_key="id", secret_key="secret"
+    )
+    credentials = get_aws_credentials(args)
+
+    assert credentials == ("id", "secret")
+
+
+@mock.patch("paasta_tools.spark_tools.os", autospec=True)
+@mock.patch("paasta_tools.spark_tools.Session.get_credentials", autospec=True)
+def test_service_provided_fallback_to_default(mock_get_credentials, mock_os):
+    args = mock.Mock(
+        no_aws_credentials=False, aws_credentials_yaml=None, service="service_name"
+    )
+    mock_os.path.exists.return_value = False
+    mock_get_credentials.return_value = mock.MagicMock(
+        access_key="id", secret_key="secret"
+    )
+    credentials = get_aws_credentials(args)
+
+    assert credentials == ("id", "secret")
+
+
+class TestStuff:
+    dev_account_id = "12345"
+    dev_log_dir = "s3a://dev/log/path"
+
+    other_account_id = "23456"
+    other_log_dir = "s3a://other/log/path"
+
+    unrecognized_account_id = "34567"
+
+    @pytest.fixture(autouse=True)
+    def mock_account_id(self):
+        with mock.patch("paasta_tools.spark_tools.boto3.client", autospec=True) as m:
+            mock_account_id = m.return_value.get_caller_identity.return_value.get
+            mock_account_id.return_value = self.dev_account_id
+            yield mock_account_id
+
+    @pytest.fixture(autouse=True)
+    def mock_spark_run_config(self, tmpdir):
+        spark_run_file = str(tmpdir.join("spark_config.yaml"))
+        spark_run_conf = {
+            "environments": {
+                "dev": {
+                    "account_id": self.dev_account_id,
+                    "default_event_log_dir": self.dev_log_dir,
+                },
+                "test_dev": {
+                    "account_id": self.other_account_id,
+                    "default_event_log_dir": self.other_log_dir,
+                },
+            }
+        }
+        with open(spark_run_file, "w") as fp:
+            YAML().dump(spark_run_conf, fp)
+
+        with mock.patch(
+            "paasta_tools.spark_tools.DEFAULT_SPARK_RUN_CONFIG",
+            spark_run_file,
+            autospec=None,
+        ):
+            yield spark_run_file
+
+    @pytest.mark.parametrize(
+        "account_id,expected_dir",
+        [
+            (dev_account_id, dev_log_dir),
+            (other_account_id, other_log_dir),
+            ("34567", None),
+            (None, None),
+        ],
+    )
+    def test_get_default_event_log_dir(self, mock_account_id, account_id, expected_dir):
+        mock_account_id.return_value = account_id
+        assert (
+            get_default_event_log_dir(
+                access_key="test_access_key", secret_key="test_secret_key"
+            )
+            == expected_dir
+        )

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -102,7 +102,7 @@ class TestTronActionConfig:
             config_dict=action_dict,
             branch_dict={},
         )
-        assert action_config.get_executor() == "mesos"
+        assert action_config.get_executor() == "paasta"
 
 
 class TestTronJobConfig:

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -5,6 +5,7 @@ import pytest
 
 from paasta_tools import tron_tools
 from paasta_tools.tron_tools import MASTER_NAMESPACE
+from paasta_tools.tron_tools import MESOS_EXECUTOR_NAMES
 from paasta_tools.utils import InvalidInstanceConfig
 from paasta_tools.utils import NoDeploymentsAvailable
 
@@ -45,64 +46,51 @@ def test_parse_time_variables_parses_shortdate():
 
 
 class TestTronActionConfig:
-    def test_get_job_name(self):
+    @pytest.fixture
+    def action_config(self):
         action_dict = {"name": "print", "command": "echo something"}
-        action_config = tron_tools.TronActionConfig(
+        return tron_tools.TronActionConfig(
             service="my_service",
             instance=tron_tools.compose_instance("cool_job", "print"),
             cluster="fake-cluster",
             config_dict=action_dict,
-            branch_dict={},
+            branch_dict={"docker_image": "foo:latest"},
         )
+
+    def test_action_config(self, action_config):
         assert action_config.get_job_name() == "cool_job"
-
-    def test_get_action_name(self):
-        action_dict = {"name": "sleep", "command": "sleep 10"}
-        action_config = tron_tools.TronActionConfig(
-            service="my_service",
-            instance=tron_tools.compose_instance("my_job", "sleep"),
-            cluster="fake-cluster",
-            config_dict=action_dict,
-            branch_dict={},
-        )
-        assert action_config.get_action_name() == "sleep"
-
-    def test_get_cluster(self):
-        action_dict = {"name": "do_something", "command": "echo something"}
-        action_config = tron_tools.TronActionConfig(
-            service="my_service",
-            instance=tron_tools.compose_instance("my_job", "do_something"),
-            cluster="fake-cluster",
-            config_dict=action_dict,
-            branch_dict={},
-        )
+        assert action_config.get_action_name() == "print"
         assert action_config.get_cluster() == "fake-cluster"
 
-    def test_get_executor_default(self):
-        action_dict = {"name": "do_something", "command": "echo something"}
-        action_config = tron_tools.TronActionConfig(
-            service="my_service",
-            instance=tron_tools.compose_instance("my_job", "do_something"),
-            cluster="fake-cluster",
-            config_dict=action_dict,
-            branch_dict={},
-        )
+    @pytest.mark.parametrize("executor", MESOS_EXECUTOR_NAMES)
+    def test_get_env(self, action_config, executor):
+        action_config.config_dict["executor"] = executor
+        with mock.patch(
+            "paasta_tools.tron_tools.get_mesos_spark_env", autospec=True
+        ), mock.patch(
+            "paasta_tools.tron_tools.pick_random_port", autospec=True,
+        ), mock.patch(
+            "paasta_tools.tron_tools.find_mesos_leader", autospec=True,
+        ), mock.patch(
+            "paasta_tools.tron_tools.load_mesos_secret_for_spark", autospec=True,
+        ), mock.patch(
+            "paasta_tools.tron_tools.get_default_event_log_dir", autospec=True,
+        ), mock.patch(
+            "paasta_tools.tron_tools.stringify_spark_env", autospec=True,
+        ):
+            env = action_config.get_env()
+        if executor == "spark":
+            assert env["SPARK_OPTS"] is not None
+        else:
+            assert env.get("SPARK_OPTS") is None
+
+    def test_get_executor_default(self, action_config):
         assert action_config.get_executor() is None
 
-    def test_get_executor_paasta(self):
-        action_dict = {
-            "name": "do_something",
-            "command": "echo something",
-            "executor": "paasta",
-        }
-        action_config = tron_tools.TronActionConfig(
-            service="my_service",
-            instance=tron_tools.compose_instance("my_job", "do_something"),
-            cluster="fake-cluster",
-            config_dict=action_dict,
-            branch_dict={},
-        )
-        assert action_config.get_executor() == "paasta"
+    @pytest.mark.parametrize("executor", MESOS_EXECUTOR_NAMES)
+    def test_get_executor_paasta(self, executor, action_config):
+        action_config.config_dict["executor"] = executor
+        assert action_config.get_executor() == executor
 
 
 class TestTronJobConfig:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -953,7 +953,7 @@ def test_get_service_instance_list_ignores_underscore():
     autospec=True,
 )
 @mock.patch(
-    "paasta_tools.utils.service_configuration_lib._read_yaml_file", autospec=True
+    "paasta_tools.utils.service_configuration_lib.read_yaml_file", autospec=True
 )
 def test_load_tron_yaml_empty(mock_read_file, mock_read_service_info):
     mock_read_file.return_value = {}

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,16 @@
 [tox]
 skipsdist=True
-envlist=py36-{macos,linux}
+envlist=py36-linux
 tox_pip_extensions_ext_pip_custom_platform = true
 tox_pip_extensions_ext_venv_update = true
 docker_compose_version = 1.18.0
 
 [testenv]
-platform= macos: darwin
-          linux: linux
 # The Makefile and .travis.yml override the indexserver to the public one when
 # running outside of Yelp.
-indexserver =
-    default = macos: https://pypi.python.org/simple
-              linux: https://pypi.yelpcorp.com/simple
+indexserver = https://pypi.yelpcorp.com/simple
 basepython = python3.6
+passenv = SSH_AUTH_SOCK
 setenv =
     TZ = UTC
 deps =
@@ -22,9 +19,11 @@ deps =
     --editable={toxinidir}
 pre=check-requirements
 commands =
-    check-requirements
-    macos: py.test --ignore tests/test_iptables.py --ignore tests/test_firewall_update.py --ignore tests/test_docker_wrapper.py --ignore tests/test_firewall.py --ignore tests/test_firewall_logging.py {posargs:tests}
-    linux: py.test {posargs:tests}
+
+[testenv:test]
+envdir = .tox/py36-linux/
+commands =
+    py.test {posargs:tests}
 
 [testenv:docs]
 commands =


### PR DESCRIPTION
This uses the changes in https://github.com/Yelp/service_configuration_lib/pull/39 to set up a spark environment for Tron.  Tested manually, but there's still going to be more work to do.

I also made changes so that we actually get a "real" development virtualenv for paasta, cuz I'm sick of typing `.tox/py36-linux/bin/pytbnon` all the time.