### PR TITLE
Notify service config git master of deployments directly for yelp services

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -214,7 +214,7 @@ def trigger_deploys(service):
     """Connects to the deploymentsd watcher on sysgit, which is an extremely simple
     service that listens for a service string and then generates a service deployment"""
     logline = f"Notifying sysgit to generate a deployment for {service}"
-    _log(service=service, line=logline, compoment="deploy", level="event")
+    _log(service=service, line=logline, component="deploy", level="event")
     client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     client.connect(("sysgit.yelpcorp.com", 5049))
     client.send(f"{service}\n".encode("utf-8"))

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -210,6 +210,17 @@ def add_subparser(subparsers):
     list_parser.set_defaults(command=paasta_mark_for_deployment)
 
 
+def trigger_deploys(service):
+    """Connects to the deploymentsd watcher on sysgit, which is an extremely simple
+    service that listens for a service string and then generates a service deployment"""
+    logline = f"Notifying sysgit to generate a deployment for {service}"
+    _log(service=service, line=logline, compoment="deploy", level="event")
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client.connect(("sysgit.yelpcorp.com", 5049))
+    client.send(f"{service}\n".encode("utf-8"))
+    client.close()
+
+
 def mark_for_deployment(git_url, deploy_group, service, commit):
     """Mark a docker image for deployment"""
     tag = get_paasta_tag_from_deploy_group(
@@ -226,6 +237,8 @@ def mark_for_deployment(git_url, deploy_group, service, commit):
             remote_git.create_remote_refs(
                 git_url=git_url, ref_mutator=ref_mutator, force=True
             )
+            if "yelpcorp.com" in git_url:
+                trigger_deploys(service)
         except Exception:
             logline = "Failed to mark {} for deployment in deploy group {}! (attempt {}/{})".format(
                 commit, deploy_group, attempt, max_attempts

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -224,6 +224,32 @@ def test_paasta_mark_for_deployment_with_good_rollback(
     assert mock__log_audit.call_count == len(mock_list_deploy_groups.return_value)
 
 
+@patch("paasta_tools.remote_git.create_remote_refs", autospec=True)
+@patch("paasta_tools.cli.cmds.mark_for_deployment.trigger_deploys", autospec=True)
+def test_mark_for_deployment_yelpy_repo(mock_trigger_deploys, mock_create_remote_refs):
+    mark_for_deployment.mark_for_deployment(
+        git_url="git://false.repo.yelpcorp.com/services/test_services",
+        deploy_group="fake_deploy_group",
+        service="fake_service",
+        commit="fake_commit",
+    )
+    mock_trigger_deploys.assert_called_once_with(service="fake_service")
+
+
+@patch("paasta_tools.remote_git.create_remote_refs", autospec=True)
+@patch("paasta_tools.cli.cmds.mark_for_deployment.trigger_deploys", autospec=True)
+def test_mark_for_deployment_nonyelpy_repo(
+    mock_trigger_deploys, mock_create_remote_refs
+):
+    mark_for_deployment.mark_for_deployment(
+        git_url="git://false.repo/services/test_services",
+        deploy_group="fake_deploy_group",
+        service="fake_service",
+        commit="fake_commit",
+    )
+    assert not mock_trigger_deploys.called
+
+
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log_audit", autospec=True)
 @patch("paasta_tools.remote_git.get_authors", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.get_slack_client", autospec=True)


### PR DESCRIPTION
Notify service config git master of deployments directly for yelp services

Context for change:

Currently, to mark a service for deployment, tags are pushed to the
service's git repository, and a gitolite hook reads those tags, then
notifies sysgit, which has the master copy of our service configs, to
generate a deployment for that service. That hook lives here:
https://sourcegraph.yelpcorp.com/packages/py-gitolite@e4e52bf91f3351b840e012b8373e642c2db0032f/-/blob/gitolite/hooks/repo_specific/paasta_deploymentsd.py#L21-41
And the service on sysgit that just calls `generate_deployment_for_service` lives here:
https://sourcegraph.yelpcorp.com/sysgit/puppet@02d24429c51c6f27e9aa9b1adc0401a1b0558842/-/blob/modules/paasta_tools/files/paasta-deploymentsd

Release Engineering is moving paasta services off of gitolite, and
decommisioning the gitolite master, so this hook needs its functionality
moved. Having the generate_deployment call triggered at the point in code when
the tags are pushed makes the most sense at. We'll be taking a deeper look
at moving other parts of service functionality that rely on existing git
infrastructure in 2020. For now though, this unblocks the moving of
PaaSTA services to our new git infrastructure.


I had a small discussion with @EvanKrall over Slack in #paasta beginning here: https://yelp.slack.com/archives/CA05GTDB9/p1576705814188100 a