### PR TITLE
remove paasta validate for tron directory

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -292,28 +292,9 @@ def validate_tron(service_path):
     soa_dir, service = path_to_soa_dir_service(service_path)
     returncode = True
 
-    if soa_dir.endswith("/tron"):
-        # Makes it possible to validate files in tron/ rather than service directories
-        # TODO: Clean up after migration to services is complete
-        cluster = service
-        soa_dir = soa_dir[:-5]
-        filenames = [
-            filename
-            for filename in os.listdir(service_path)
-            if filename.endswith(".yaml")
-        ]
-        for filename in filenames:
-            namespace = os.path.splitext(filename)[0]
-            file_path = os.path.join(service_path, filename)
-            if not validate_schema(file_path, "tron"):
-                returncode = False
-            if not validate_tron_namespace(namespace, cluster, soa_dir, tron_dir=True):
-                returncode = False
-    else:
-        # Normal service directory
-        for cluster in list_tron_clusters(service, soa_dir):
-            if not validate_tron_namespace(service, cluster, soa_dir):
-                returncode = False
+    for cluster in list_tron_clusters(service, soa_dir):
+        if not validate_tron_namespace(service, cluster, soa_dir):
+            returncode = False
 
     return returncode
 

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -14,7 +14,6 @@
 import os
 
 import mock
-import pytest
 from mock import patch
 
 from paasta_tools.cli.cmds.validate import check_service_path
@@ -520,36 +519,6 @@ test_job:
     assert not validate_schema("unused_service_path.yaml", "tron")
     output, _ = capsys.readouterr()
     assert SCHEMA_INVALID in output
-
-
-@patch("paasta_tools.cli.cmds.validate.validate_schema", autospec=True)
-@patch("paasta_tools.cli.cmds.validate.validate_complete_config", autospec=True)
-@patch("os.listdir", autospec=True)
-@pytest.mark.parametrize(
-    "schema_valid,config_msgs,expected_return",
-    [(False, [], False), (True, ["something wrong"], False), (True, [], True)],
-)
-def test_validate_tron_with_tron_dir(
-    mock_ls,
-    mock_validate_tron_config,
-    mock_validate_schema,
-    capsys,
-    schema_valid,
-    config_msgs,
-    expected_return,
-):
-    mock_ls.return_value = ["foo.yaml"]
-    mock_validate_schema.return_value = schema_valid
-    mock_validate_tron_config.return_value = config_msgs
-
-    assert validate_tron("soa/tron/dev") == expected_return
-    mock_ls.assert_called_once_with("soa/tron/dev")
-    mock_validate_schema.assert_called_once_with("soa/tron/dev/foo.yaml", "tron")
-    mock_validate_tron_config.assert_called_once_with("foo", "dev", "soa")
-
-    output, _ = capsys.readouterr()
-    for error in config_msgs:
-        assert error in output
 
 
 @patch("paasta_tools.cli.cmds.validate.list_tron_clusters", autospec=True)


### PR DESCRIPTION
Tronfig has been moved to service directory, so let's remove the related validation codes.