### PR TITLE
Fix paasta autoscale error messaging

### DIFF
--- a/paasta_tools/cli/cmds/autoscale.py
+++ b/paasta_tools/cli/cmds/autoscale.py
@@ -66,34 +66,39 @@ def paasta_autoscale(args):
             "Could not connect to paasta api. Maybe you misspelled the cluster?"
         )
         return 1
-
-    if args.set is None:
-        log.debug("Getting the current autoscaler count...")
-        res, http = api.autoscaler.get_autoscaler_count(
-            service=service, instance=args.instance
-        ).result()
-    else:
-        log.debug(f"Setting desired instances to {args.set}.")
-        body = {"desired_instances": int(args.set)}
-        try:
+    try:
+        if args.set is None:
+            log.debug("Getting the current autoscaler count...")
+            res, http = api.autoscaler.get_autoscaler_count(
+                service=service, instance=args.instance
+            ).result()
+        else:
+            log.debug(f"Setting desired instances to {args.set}.")
+            body = {"desired_instances": int(args.set)}
             res, http = api.autoscaler.update_autoscaler_count(
                 service=service, instance=args.instance, json_body=body
             ).result()
-        except HTTPNotFound:
-            paasta_print(
-                PaastaColors.red(
-                    f"ERROR: No such service or service is not configured to autoscale."
-                )
-            )
-            return 0
 
-        _log_audit(
-            action="manual-scale",
-            action_details=body,
-            service=service,
-            instance=args.instance,
-            cluster=args.cluster,
+            _log_audit(
+                action="manual-scale",
+                action_details=body,
+                service=service,
+                instance=args.instance,
+                cluster=args.cluster,
+            )
+    except HTTPNotFound:
+        paasta_print(
+            PaastaColors.red(
+                f"ERROR: '{args.instance}' is not configured to autoscale, "
+                f"so paasta autoscale could not scale it up on demand. "
+                f"If you want to be able to boost this service, please configure autoscaling for the service "
+                f"in its config file by setting min and max instances. Example:"
+                f"\n{args.instance}:"
+                f"\n      min_instances: 5"
+                f"\n      max_instances: 50"
+            )
         )
+        return 0
 
     log.debug(f"Res: {res} Http: {http}")
     print(res["desired_instances"])

--- a/paasta_tools/cli/cmds/autoscale.py
+++ b/paasta_tools/cli/cmds/autoscale.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 import logging
 
+from bravado.exception import HTTPNotFound
+
 from paasta_tools.api import client
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import lazy_choices_completer
@@ -22,6 +24,7 @@ from paasta_tools.utils import _log_audit
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
 from paasta_tools.utils import paasta_print
+from paasta_tools.utils import PaastaColors
 
 
 log = logging.getLogger(__name__)
@@ -72,9 +75,17 @@ def paasta_autoscale(args):
     else:
         log.debug(f"Setting desired instances to {args.set}.")
         body = {"desired_instances": int(args.set)}
-        res, http = api.autoscaler.update_autoscaler_count(
-            service=service, instance=args.instance, json_body=body
-        ).result()
+        try:
+            res, http = api.autoscaler.update_autoscaler_count(
+                service=service, instance=args.instance, json_body=body
+            ).result()
+        except HTTPNotFound:
+            paasta_print(
+                PaastaColors.red(
+                    f"ERROR: No such service or service is not configured to autoscale."
+                )
+            )
+            return 0
 
         _log_audit(
             action="manual-scale",

--- a/paasta_tools/cli/cmds/autoscale.py
+++ b/paasta_tools/cli/cmds/autoscale.py
@@ -92,10 +92,10 @@ def paasta_autoscale(args):
                 f"ERROR: '{args.instance}' is not configured to autoscale, "
                 f"so paasta autoscale could not scale it up on demand. "
                 f"If you want to be able to boost this service, please configure autoscaling for the service "
-                f"in its config file by setting min and max instances. Example:"
-                f"\n{args.instance}:"
-                f"\n      min_instances: 5"
-                f"\n      max_instances: 50"
+                f"in its config file by setting min and max instances. Example: \n"
+                f"{args.instance}:\n"
+                f"     min_instances: 5\n"
+                f"     max_instances: 50"
             )
         )
         return 0


### PR DESCRIPTION
Description:
The following code is used to catch bravado exception 404s when a user specifies an unknown service name or a service that does not have autoscaling configured. Instead of returning the stack trace, we relay an error message.

Testing Done:
* `make test`
* Example of service without autoscaling configured: `paasta autoscale -c norcal-prod -s billing -i sfn_flat_rate_subscription_bookkeeping_worker --set=30`