### PR TITLE
let ingress envoy know kubernets services

### DIFF
--- a/paasta_tools/dump_locally_running_services.py
+++ b/paasta_tools/dump_locally_running_services.py
@@ -26,6 +26,7 @@ import argparse
 import json
 import sys
 
+from paasta_tools.kubernetes_tools import get_kubernetes_services_running_here_for_nerve
 from paasta_tools.marathon_tools import get_marathon_services_running_here_for_nerve
 from paasta_tools.marathon_tools import get_puppet_services_running_here_for_nerve
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -51,9 +52,11 @@ def main(argv=None):
     args = parse_args(argv)
     soa_dir = args.soa_dir
 
-    service_dump = get_marathon_services_running_here_for_nerve(
-        cluster=None, soa_dir=soa_dir
-    ) + get_puppet_services_running_here_for_nerve(soa_dir=soa_dir)
+    service_dump = (
+        get_marathon_services_running_here_for_nerve(cluster=None, soa_dir=soa_dir)
+        + get_puppet_services_running_here_for_nerve(soa_dir=soa_dir)
+        + get_kubernetes_services_running_here_for_nerve(cluster=None, soa_dir=soa_dir)
+    )
 
     paasta_print(json.dumps(service_dump))
     sys.exit(0)


### PR DESCRIPTION
I've tested this script at stagef, and it works fine. However, I've noticed the nerve_dict is different between marathon services and kubernetes services. The [marathon service's](https://sourcegraph.yelpcorp.com/mirrors/Yelp/paasta@f317d96d83a2ff8da5c1e6985fe804b0c2d8038c/-/blob/paasta_tools/marathon_tools.py#L1147) nerve dict has the keys including "port", "paasta_instance", "deploy_group" and "extra_healthcheck_headers", while [kubernetes service's](https://sourcegraph.yelpcorp.com/mirrors/Yelp/paasta@f317d96d83a2ff8da5c1e6985fe804b0c2d8038c/-/blob/paasta_tools/kubernetes_tools.py#L1282) nerve dict only has "port" and "service_ip".