### PR TITLE
send clusterman metrics info as environment variables to Tron

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -536,13 +536,8 @@ def emit_resource_requirements(spark_config_dict, paasta_cluster, webui_url):
         region_name=aws_region, app_identifier=pool
     )
 
-    cpus, mem = None, None
-    for key, value in desired_resources.items():
-        if "requested_cpus" in key:
-            cpus = value
-        elif "requested_mem" in key:
-            mem = value
-
+    cpus = desired_resources["cpus"][1]
+    mem = desired_resources["mem"][1]
     est_cost = clusterman_metrics.util.costs.estimate_cost_per_hour(
         cluster=paasta_cluster, pool=pool, cpus=cpus, mem=mem,
     )
@@ -556,7 +551,7 @@ def emit_resource_requirements(spark_config_dict, paasta_cluster, webui_url):
     with metrics_client.get_writer(
         clusterman_metrics.APP_METRICS, aggregate_meteorite_dims=True
     ) as writer:
-        for metric_key, desired_quantity in desired_resources.items():
+        for _, (metric_key, desired_quantity) in desired_resources.items():
             writer.send((metric_key, int(time.time()), desired_quantity))
 
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -5,6 +5,7 @@ import os
 import socket
 import sys
 import time
+from typing import Mapping
 
 from boto3.exceptions import Boto3Error
 from ruamel.yaml import YAML
@@ -20,6 +21,8 @@ from paasta_tools.mesos_tools import find_mesos_leader
 from paasta_tools.spark_tools import DEFAULT_SPARK_SERVICE
 from paasta_tools.spark_tools import get_aws_credentials
 from paasta_tools.spark_tools import get_default_event_log_dir
+from paasta_tools.spark_tools import get_spark_resource_requirements
+from paasta_tools.spark_tools import get_webui_url
 from paasta_tools.spark_tools import load_mesos_secret_for_spark
 from paasta_tools.utils import _run
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -522,44 +525,29 @@ def create_spark_config_str(spark_config_dict, is_mrjob):
 
 
 def emit_resource_requirements(spark_config_dict, paasta_cluster, webui_url):
-    num_executors = int(spark_config_dict["spark.cores.max"]) / int(
-        spark_config_dict["spark.executor.cores"]
-    )
-    memory_per_executor = calculate_memory_per_executor(
-        spark_config_dict["spark.executor.memory"],
-        spark_config_dict.get("spark.mesos.executor.memoryOverhead"),
-    )
+    paasta_print("Sending resource request metrics to Clusterman")
 
-    desired_resources = {
-        "cpus": int(spark_config_dict["spark.cores.max"]),
-        "mem": memory_per_executor * num_executors,
-        "disk": memory_per_executor
-        * num_executors,  # rough guess since spark does not collect this information
-    }
-    dimensions = {
-        "framework_name": spark_config_dict["spark.app.name"],
-        "webui_url": webui_url,
-    }
-
+    desired_resources = get_spark_resource_requirements(spark_config_dict, webui_url)
     constraints = parse_constraints_string(spark_config_dict["spark.mesos.constraints"])
     pool = constraints["pool"]
 
-    paasta_print("Sending resource request metrics to Clusterman")
     aws_region = get_aws_region_for_paasta_cluster(paasta_cluster)
     metrics_client = clusterman_metrics.ClustermanMetricsBotoClient(
         region_name=aws_region, app_identifier=pool
     )
 
-    estimated_cost = clusterman_metrics.util.costs.estimate_cost_per_hour(
-        cluster=paasta_cluster,
-        pool=pool,
-        cpus=desired_resources["cpus"],
-        mem=desired_resources["mem"],
+    cpus, mem = None, None
+    for key, value in desired_resources.items():
+        if "requested_cpus" in key:
+            cpus = value
+        elif "requested_mem" in key:
+            mem = value
+
+    est_cost = clusterman_metrics.util.costs.estimate_cost_per_hour(
+        cluster=paasta_cluster, pool=pool, cpus=cpus, mem=mem,
     )
-    message = "Resource request ({} cpus and {} MB memory total) is estimated to cost ${} per hour".format(
-        desired_resources["cpus"], desired_resources["mem"], estimated_cost
-    )
-    if clusterman_metrics.util.costs.should_warn(estimated_cost):
+    message = f"Resource request ({cpus} cpus and {mem} MB memory total) is estimated to cost ${est_cost} per hour"
+    if clusterman_metrics.util.costs.should_warn(est_cost):
         message = "WARNING: " + message
         paasta_print(PaastaColors.red(message))
     else:
@@ -568,34 +556,17 @@ def emit_resource_requirements(spark_config_dict, paasta_cluster, webui_url):
     with metrics_client.get_writer(
         clusterman_metrics.APP_METRICS, aggregate_meteorite_dims=True
     ) as writer:
-        for resource, desired_quantity in desired_resources.items():
-            metric_key = clusterman_metrics.generate_key_with_dimensions(
-                f"requested_{resource}", dimensions
-            )
+        for metric_key, desired_quantity in desired_resources.items():
             writer.send((metric_key, int(time.time()), desired_quantity))
 
 
-def get_aws_region_for_paasta_cluster(paasta_cluster):
+def get_aws_region_for_paasta_cluster(paasta_cluster: str) -> str:
     with open(CLUSTERMAN_YAML_FILE_PATH, "r") as clusterman_yaml_file:
         clusterman_yaml = YAML().load(clusterman_yaml_file.read())
         return clusterman_yaml["clusters"][paasta_cluster]["aws_region"]
 
 
-def calculate_memory_per_executor(spark_memory_string, memory_overhead):
-    # expected to be in format "dg" where d is an integer
-    base_memory_per_executor = 1024 * int(spark_memory_string[:-1])
-
-    # by default, spark adds an overhead of 10% of the executor memory, with
-    # a minimum of 384mb
-    if memory_overhead is None:
-        memory_overhead = max(384, int(0.1 * base_memory_per_executor))
-    else:
-        memory_overhead = int(memory_overhead)
-
-    return base_memory_per_executor + memory_overhead
-
-
-def parse_constraints_string(constraints_string):
+def parse_constraints_string(constraints_string: str) -> Mapping[str, str]:
     constraints = {}
     for constraint in constraints_string.split(";"):
         if constraint[-1] == "\\":
@@ -686,7 +657,7 @@ def configure_and_run_docker_container(
         get_spark_env(args, spark_conf_str, spark_ui_port, access_key, secret_key)
     )
 
-    webui_url = f"http://{socket.getfqdn()}:{spark_ui_port}"
+    webui_url = get_webui_url(spark_ui_port)
 
     docker_cmd = get_docker_cmd(args, instance_config, spark_conf_str)
     if "history-server" in docker_cmd:

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -137,7 +137,7 @@ def _calculate_memory_per_executor(spark_memory_string, memory_overhead):
 
 def get_spark_resource_requirements(
     spark_config_dict: Mapping[str, str], webui_url: str,
-) -> Mapping[str, int]:
+) -> Mapping[str, Tuple[str, int]]:
     if not clusterman_metrics:
         return {}
     num_executors = int(spark_config_dict["spark.cores.max"]) / int(
@@ -151,8 +151,8 @@ def get_spark_resource_requirements(
     desired_resources = {
         "cpus": int(spark_config_dict["spark.cores.max"]),
         "mem": memory_per_executor * num_executors,
-        "disk": memory_per_executor
-        * num_executors,  # rough guess since spark does not collect this information
+        # rough guess since spark does not collect this information
+        "disk": memory_per_executor * num_executors,
     }
     dimensions = {
         "framework_name": spark_config_dict["spark.app.name"],
@@ -160,11 +160,12 @@ def get_spark_resource_requirements(
     }
     qualified_resources = {}
     for resource, quantity in desired_resources.items():
-        qualified_resources[
+        qualified_resources[resource] = (
             clusterman_metrics.generate_key_with_dimensions(
                 f"requested_{resource}", dimensions
-            )
-        ] = desired_resources[resource]
+            ),
+            desired_resources[resource],
+        )
 
     return qualified_resources
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -244,8 +244,11 @@ class TronActionConfig(InstanceConfig):
             env["EXECUTOR_POOL"] = self.get_spark_pool()
             env["SPARK_OPTS"] = stringify_spark_env(spark_env)
             env["CLUSTERMAN_RESOURCES"] = json.dumps(
-                get_spark_resource_requirements(
-                    spark_config_dict=spark_env, webui_url=get_webui_url(spark_ui_port)
+                dict(
+                    get_spark_resource_requirements(
+                        spark_config_dict=spark_env,
+                        webui_url=get_webui_url(spark_ui_port),
+                    ).values()
                 )
             )
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -49,6 +49,8 @@ from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import load_tron_yaml
 from paasta_tools.utils import extract_jobs_from_tron_yaml
+from paasta_tools.spark_tools import get_spark_resource_requirements
+from paasta_tools.spark_tools import get_webui_url
 
 from paasta_tools import monitoring_tools
 from paasta_tools.monitoring_tools import list_teams
@@ -205,32 +207,47 @@ class TronActionConfig(InstanceConfig):
             command = "unset MESOS_DIRECTORY MESOS_SANDBOX; " + command
         return command
 
+    def get_spark_cluster(self):
+        return self.config_dict.get("spark_cluster", self.get_cluster())
+
+    def get_spark_pool(self):
+        return self.config_dict.get("spark_pool", "default")
+
     def get_env(self):
         env = super().get_env()
         spark_env = {}
         if self.get_executor() == "spark":
+            spark_ui_port = pick_random_port(
+                f"{self.get_service()}{self.get_instance()}".encode()
+            )
             spark_env = get_mesos_spark_env(
-                spark_app_name="tron_spark_{self.get_service()}_{self.get_instance()}",
-                spark_ui_port=pick_random_port(
-                    f"{self.get_service()}{self.get_instance()}".encode()
-                ),
-                mesos_leader=find_mesos_leader(self.get_cluster()),
+                spark_app_name=f"tron_spark_{self.get_service()}_{self.get_instance()}",
+                spark_ui_port=spark_ui_port,
+                mesos_leader=find_mesos_leader(self.get_spark_cluster()),
                 mesos_secret=load_mesos_secret_for_spark(),
-                paasta_cluster=self.get_cluster(),
-                paasta_pool=self.get_pool(),
+                paasta_cluster=self.get_spark_cluster(),
+                paasta_pool=self.get_spark_pool(),
                 paasta_service=self.get_service(),
                 paasta_instance=self.get_instance(),
                 docker_img=self.get_docker_url(),
-                volumes=format_volumes(
-                    self.get_volumes(load_system_paasta_config().get_volumes())
-                ),
+                volumes=[
+                    f"{v['hostPath']}:{v['containerPath']}:{v['mode']}"
+                    for v in self.get_volumes(load_system_paasta_config().get_volumes())
+                ],
                 user_spark_opts=self.config_dict.get("spark_args"),
                 event_log_dir=get_default_event_log_dir(
                     service=self.get_service(),
                     aws_credentials_yaml=self.config_dict.get("aws_credentials"),
                 ),
             )
+            env["EXECUTOR_CLUSTER"] = self.get_spark_cluster()
+            env["EXECUTOR_POOL"] = self.get_spark_pool()
             env["SPARK_OPTS"] = stringify_spark_env(spark_env)
+            env["CLUSTERMAN_RESOURCES"] = json.dumps(
+                get_spark_resource_requirements(
+                    spark_config_dict=spark_env, webui_url=get_webui_url(spark_ui_port)
+                )
+            )
 
         return env
 

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -510,9 +510,15 @@ def test_emit_resource_requirements(tmpdir):
         metric_key_template = "requested_{resource}|framework_name=paasta_spark_run_johndoe_2_3,webui_url=http://spark.yelp"
         expected_memory_request = (4 * 1024 + 555) * 2
         mock_spark_requirements.return_value = {
-            metric_key_template.format(resource="cpus"): 4,
-            metric_key_template.format(resource="mem"): expected_memory_request,
-            metric_key_template.format(resource="disk"): expected_memory_request,
+            "cpus": (metric_key_template.format(resource="cpus"), 4),
+            "mem": (
+                metric_key_template.format(resource="mem"),
+                expected_memory_request,
+            ),
+            "disk": (
+                metric_key_template.format(resource="disk"),
+                expected_memory_request,
+            ),
         }
         emit_resource_requirements(
             spark_config_dict, "anywhere-prod", "http://spark.yelp"

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -502,11 +502,18 @@ def test_emit_resource_requirements(tmpdir):
         autospec=None,  # we're replacing this name, so we can't autospec
     ), mock.patch(
         "time.time", return_value=1234, autospec=True
-    ):
-        mock_clusterman_metrics.generate_key_with_dimensions.side_effect = lambda name, dims: (
-            f'{name}|framework_name={dims["framework_name"]},webui_url={dims["webui_url"]}'
-        )
+    ), mock.patch(
+        "paasta_tools.cli.cmds.spark_run.get_spark_resource_requirements",
+        autospec=True,
+    ) as mock_spark_requirements:
 
+        metric_key_template = "requested_{resource}|framework_name=paasta_spark_run_johndoe_2_3,webui_url=http://spark.yelp"
+        expected_memory_request = (4 * 1024 + 555) * 2
+        mock_spark_requirements.return_value = {
+            metric_key_template.format(resource="cpus"): 4,
+            metric_key_template.format(resource="mem"): expected_memory_request,
+            metric_key_template.format(resource="disk"): expected_memory_request,
+        }
         emit_resource_requirements(
             spark_config_dict, "anywhere-prod", "http://spark.yelp"
         )
@@ -517,10 +524,6 @@ def test_emit_resource_requirements(tmpdir):
         metrics_writer = (
             mock_clusterman_metrics.ClustermanMetricsBotoClient.return_value.get_writer.return_value.__enter__.return_value
         )
-
-        metric_key_template = "requested_{resource}|framework_name=paasta_spark_run_johndoe_2_3,webui_url=http://spark.yelp"
-
-        expected_memory_request = (4 * 1024 + 555) * 2
 
         metrics_writer.send.assert_has_calls(
             [

--- a/tests/test_spark_tools.py
+++ b/tests/test_spark_tools.py
@@ -173,7 +173,7 @@ def test_get_spark_resource_requirements(tmpdir):
         )
 
     assert resources == {
-        metric_key_template.format(resource="cpus"): 4,
-        metric_key_template.format(resource="mem"): expected_memory_request,
-        metric_key_template.format(resource="disk"): expected_memory_request,
+        "cpus": (metric_key_template.format(resource="cpus"), 4),
+        "mem": (metric_key_template.format(resource="mem"), expected_memory_request),
+        "disk": (metric_key_template.format(resource="disk"), expected_memory_request),
     }

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -80,7 +80,10 @@ class TestTronActionConfig:
         ), mock.patch(
             "paasta_tools.tron_tools.get_spark_resource_requirements",
             autospec=True,
-            return_value={"cpus": 1900, "mem": "42"},
+            return_value={
+                "cpus": ("cpus|dimension=2", 1900),
+                "mem": ("mem|dimension=1", "42"),
+            },
         ):
             env = action_config.get_env()
         if executor == "spark":

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -77,12 +77,16 @@ class TestTronActionConfig:
             "paasta_tools.tron_tools.get_default_event_log_dir", autospec=True,
         ), mock.patch(
             "paasta_tools.tron_tools.stringify_spark_env", autospec=True,
+        ), mock.patch(
+            "paasta_tools.tron_tools.get_spark_resource_requirements",
+            autospec=True,
+            return_value={"cpus": 1900, "mem": "42"},
         ):
             env = action_config.get_env()
         if executor == "spark":
-            assert env["SPARK_OPTS"] is not None
+            assert all([env["SPARK_OPTS"], env["CLUSTERMAN_RESOURCES"]])
         else:
-            assert env.get("SPARK_OPTS") is None
+            assert not any([env.get("SPARK_OPTS"), env.get("CLUSTERMAN_RESOURCES")])
 
     def test_get_executor_default(self, action_config):
         assert action_config.get_executor() is None


### PR DESCRIPTION
manual testing in a local dev environment, confirmed that metrics show up in DynamoDB after running setup_tron_namespace and watching the job run.