### PR TITLE
Use statefulset when aws_ebs_volume is configured

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1036,7 +1036,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             docker_url = self.get_docker_url()
             code_sha = get_code_sha_from_dockerurl(docker_url)
             complete_config: Union[V1StatefulSet, V1Deployment]
-            if self.get_persistent_volumes():
+            if self.get_persistent_volumes() or self.get_aws_ebs_volumes():
                 complete_config = V1StatefulSet(
                     api_version="apps/v1",
                     kind="StatefulSet",

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -840,6 +840,9 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_persistent_volumes",
             autospec=True,
         ) as mock_get_persistent_volumes, mock.patch(
+            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_aws_ebs_volumes",
+            autospec=True,
+        ) as mock_get_aws_ebs_volumes, mock.patch(
             "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_volume_claim_templates",
             autospec=True,
         ) as mock_get_volumes_claim_templates, mock.patch(
@@ -850,6 +853,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             autospec=True,
         ) as mock_get_kubernetes_metadata:
             mock_get_persistent_volumes.return_value = []
+            mock_get_aws_ebs_volumes.return_value = []
             ret = self.deployment.format_kubernetes_app()
             assert mock_load_system_config.called
             assert mock_get_docker_url.called


### PR DESCRIPTION
Right now, we use statefulset when persistent volume is configured. We should do the same with ebs volume as well. The only services using this configuration are test services run by us.
```
mingqiz@dev54-uswest1adevc:~/yelpsoa-configs (master) $ git grep aws_ebs_volumes
compute-infra-test-service/kubernetes-kubestage.yaml:  aws_ebs_volumes:
compute-infra-test-service/kubernetes-norcal-stagef.yaml:  aws_ebs_volumes:
kubernetes-service/kubernetes-kubestage.yaml:  aws_ebs_volumes:
```