### PR TITLE
Use requirements-bootstrap.txt to pin version of pip

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,4 +18,4 @@ override_dh_auto_test:
 	true
 
 override_dh_virtualenv:
-	dh_virtualenv -i $(PIP_INDEX_URL) --python=/usr/bin/python3.6 --preinstall no-manylinux1 --preinstall pip-custom-platform --pip-tool pip-custom-platform
+	dh_virtualenv -i $(PIP_INDEX_URL) --python=/usr/bin/python3.6 --preinstall no-manylinux1 --preinstall -rrequirements-bootstrap.txt --pip-tool pip-custom-platform

--- a/requirements-bootstrap.txt
+++ b/requirements-bootstrap.txt
@@ -1,0 +1,6 @@
+pip==9.0.3
+pip-custom-platform==0.4.1
+pymonkey==0.2.2
+setuptools==39.0.1
+venv-update==3.0.0
+wheel==0.33.6


### PR DESCRIPTION
The build is failing because of pip-custom-platform's incompatibility with pip>=20. See https://github.com/asottile/pip-custom-platform/issues/32

This pins the version of pip used in the itests via a requirements-bootstrap.txt file.