### PR TITLE
Showing pod status irrespective of state of flink cluster

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -866,6 +866,17 @@ def should_job_info_be_shown(cluster_state):
     )
 
 
+def append_pod_status(pod_status, output: List[str]):
+    output.append(f"    Pods:")
+    rows: List[Union[str, Tuple[str, str, str]]] = [("Pod Name", "Host", "Phase")]
+    for pod in pod_status:
+        rows.append((pod["name"], pod["host"], pod["phase"]))
+        if pod["reason"] != "":
+            rows.append(PaastaColors.grey(f"  {pod['reason']}: {pod['message']}"))
+    pods_table = format_table(rows)
+    output.extend([f"      {line}" for line in pods_table])
+
+
 def print_flink_status(
     cluster: str,
     service: str,
@@ -907,6 +918,11 @@ def print_flink_status(
         output.append(f"    State: {status.state}")
 
     if not should_job_info_be_shown(status.state):
+        # In case where the jobmanager of cluster is in crashloopbackoff
+        # The pods for the cluster will be available and we need to show the pods.
+        # So that paasta status -v and kubectl get pods show the same consistent result.
+        if verbose and len(status.pod_status) > 0:
+            append_pod_status(status.pod_status, output)
         output.append(f"    No other information available in non-running state")
         return 0
 
@@ -1005,14 +1021,7 @@ def print_flink_status(
                         f"            {str(exc_ts)} ({humanize.naturaltime(exc_ts)})"
                     )
     if verbose and len(status.pod_status) > 0:
-        output.append(f"    Pods:")
-        rows: List[Union[str, Tuple[str, str, str]]] = [("Pod Name", "Host", "Phase")]
-        for pod in status.pod_status:
-            rows.append((pod["name"], pod["host"], pod["phase"]))
-            if pod["reason"] != "":
-                rows.append(PaastaColors.grey(f"  {pod['reason']}: {pod['message']}"))
-        pods_table = format_table(rows)
-        output.extend([f"      {line}" for line in pods_table])
+        append_pod_status(status.pod_status, output)
     return 0
 
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -917,16 +917,9 @@ def print_flink_status(
     else:
         output.append(f"    State: {status.state}")
 
-    if not should_job_info_be_shown(status.state):
-        # In case where the jobmanager of cluster is in crashloopbackoff
-        # The pods for the cluster will be available and we need to show the pods.
-        # So that paasta status -v and kubectl get pods show the same consistent result.
-        if verbose and len(status.pod_status) > 0:
-            append_pod_status(status.pod_status, output)
-        output.append(f"    No other information available in non-running state")
-        return 0
-
     pod_running_count = pod_evicted_count = pod_other_count = 0
+    # default for evicted in case where pod status is not available
+    evicted = f"{pod_evicted_count}"
     for pod in status.pod_status:
         if pod["phase"] == "Running":
             pod_running_count += 1
@@ -945,6 +938,15 @@ def print_flink_status(
         f" {evicted} evicted,"
         f" {pod_other_count} other"
     )
+
+    if not should_job_info_be_shown(status.state):
+        # In case where the jobmanager of cluster is in crashloopbackoff
+        # The pods for the cluster will be available and we need to show the pods.
+        # So that paasta status -v and kubectl get pods show the same consistent result.
+        if verbose and len(status.pod_status) > 0:
+            append_pod_status(status.pod_status, output)
+        output.append(f"    No other information available in non-running state")
+        return 0
 
     output.append(
         "    Jobs:"


### PR DESCRIPTION
Currently, if a flink cluster is in unrecoverable state, paasta status doesn't show pod status while pods might be running and some of them might be in crashloopbackoff if we check them using kubectl. The change will enable paasta status -v to show pod status if it is available irrespective of the state of the cluster.