### PR TITLE
Update requirements-bootstrap.txt to the state in v0.93.2

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,4 +18,4 @@ override_dh_auto_test:
 	true
 
 override_dh_virtualenv:
-	dh_virtualenv -i $(PIP_INDEX_URL) --python=/usr/bin/python3.6 --preinstall no-manylinux1 --preinstall -rrequirements-bootstrap.txt --pip-tool pip-custom-platform
+	dh_virtualenv -i $(PIP_INDEX_URL) --python=/usr/bin/python3.6 --preinstall no-manylinux1 --preinstall pip==18.1 --preinstall pip-custom-platform --pip-tool pip-custom-platform

--- a/requirements-bootstrap.txt
+++ b/requirements-bootstrap.txt
@@ -1,6 +1,0 @@
-pip==9.0.3
-pip-custom-platform==0.4.1
-pymonkey==0.2.2
-setuptools==39.0.1
-venv-update==3.0.0
-wheel==0.33.6


### PR DESCRIPTION
Set requirements to the state they were in `0.93.2` version of
`paasta-tools` and pin `pip` to `18.1`.