### PR TITLE
Add second docker wrapper

### DIFF
--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -34,7 +34,8 @@ opt/venvs/paasta-tools/bin/paasta_cleanup_tron_namespaces usr/bin/paasta_cleanup
 opt/venvs/paasta-tools/bin/paasta_cluster_boost.py usr/bin/paasta_cluster_boost
 opt/venvs/paasta-tools/bin/paasta_deploy_tron_jobs usr/bin/paasta_deploy_tron_jobs
 opt/venvs/paasta-tools/bin/paasta-deployd usr/bin/paasta-deployd
-opt/venvs/paasta-tools/bin/paasta_docker_wrapper usr/bin/paasta_docker_wrapper
+opt/venvs/paasta-tools/bin/paasta_docker_wrapper usr/bin/paasta_docker_wrapper_python
+opt/venvs/paasta-tools/bin/paasta_docker_wrapper.sh usr/bin/paasta_docker_wrapper
 opt/venvs/paasta-tools/bin/paasta_dump_locally_running_services usr/bin/paasta_dump_locally_running_services
 opt/venvs/paasta-tools/bin/paasta_execute_docker_command.py usr/bin/paasta_execute_docker_command
 opt/venvs/paasta-tools/bin/paasta_firewall_logging usr/bin/paasta_firewall_logging

--- a/paasta_tools/paasta_docker_wrapper.sh
+++ b/paasta_tools/paasta_docker_wrapper.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# This is just a performance optimisation. Python is slow
+# especially when importing large projects like paasta_tools
+# our wrapper isn't needed for docker inspect so lets fall
+# back to regular docker fast if we are inspecting
+USE_SYSTEM_DOCKER=0
+for arg in "$@"; do
+    if [ "$arg" = "inspect" ]; then
+        USE_SYSTEM_DOCKER=1
+    fi
+done
+
+if [ $USE_SYSTEM_DOCKER -eq 1 ]; then
+    exec docker "$@"
+else
+    exec /usr/bin/paasta_docker_wrapper_python "$@"
+fi

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
         "paasta_tools/setup_kubernetes_cr.py",
         "paasta_tools/setup_marathon_job.py",
         "paasta_tools/synapse_srv_namespaces_fact.py",
+        "paasta_tools/paasta_docker_wrapper.sh",
     ]
     + glob.glob("paasta_tools/contrib/*"),
     entry_points={


### PR DESCRIPTION
This is kinda ugly but it does mean that docker inspects will be fast
again. With this 100 docker inspects ~ 15s without ~ 105s

There might be a better fix but just putting this up so we can consider
it.

The motivation is that mesos times out on slow docker inspects and the
python wrapper can be very slow at importing all the python code.

It might be simpler to "fix" this in the python script. @Bronek has this branch: https://github.com/Yelp/paasta/compare/u/bronek/delay_firewall_import but it does break a few tests. It's a bit ugly to move the imports but maybe it's less ugly than a second wrapper?