### PR TITLE
Adding container state and reason in case container is not running

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -803,6 +803,12 @@ def append_pod_status(pod_status, output: List[str]):
         rows.append((pod["name"], pod["host"], pod["phase"]))
         if pod["reason"] != "":
             rows.append(PaastaColors.grey(f"  {pod['reason']}: {pod['message']}"))
+        if "container_state" in pod and pod["container_state"] != "Running":
+            rows.append(
+                PaastaColors.grey(
+                    f"  {pod['container_state']}: {pod['container_state_reason']}"
+                )
+            )
     pods_table = format_table(rows)
     output.extend([f"      {line}" for line in pods_table])
 


### PR DESCRIPTION
We updated the Flink resource for k8s to have information on the state of each container. This change was done as a workaround for https://github.com/kubernetes/kubernetes/issues/76619 

In case where container state is not running, it would be a better idea to show the state of the container and reason for container to be in that state. Pod phase will still be running in cases of containers in waiting state.