### PR TITLE
Delay paasta_tools imports inside docker_wrapper.add_firewall

### DIFF
--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -30,7 +30,6 @@ if "PATH" not in os.environ:
     os.environ["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 
-
 LOCK_DIRECTORY = "/var/lib/paasta/mac-address"
 ENV_MATCH_RE = re.compile(r"^(-\w*e\w*|--env(?P<file>-file)?)(=(?P<arg>\S.*))?$")
 MAX_HOSTNAME_LENGTH = 60
@@ -297,13 +296,12 @@ def append_cpuset_args(argv, env_args):
 
 
 def add_firewall(argv, service, instance):
-    # Delay importing these until we really need to, because they are
-    # expensive to import and we need to be fast, most of the time
-    from paasta_tools.firewall import DEFAULT_SYNAPSE_SERVICE_DIR
-    from paasta_tools.firewall import firewall_flock
-    from paasta_tools.firewall import prepare_new_container
-    from paasta_tools.mac_address import reserve_unique_mac_address
-    from paasta_tools.utils import DEFAULT_SOA_DIR
+    # Delayed import to improve performance when add_firewall is not used
+    from paasta_tools.docker_wrapper_imports import DEFAULT_SYNAPSE_SERVICE_DIR
+    from paasta_tools.docker_wrapper_imports import firewall_flock
+    from paasta_tools.docker_wrapper_imports import prepare_new_container
+    from paasta_tools.docker_wrapper_imports import reserve_unique_mac_address
+    from paasta_tools.docker_wrapper_imports import DEFAULT_SOA_DIR
 
     output = ""
     try:

--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -30,12 +30,6 @@ if "PATH" not in os.environ:
     os.environ["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 
-from paasta_tools.firewall import DEFAULT_SYNAPSE_SERVICE_DIR
-from paasta_tools.firewall import firewall_flock
-from paasta_tools.firewall import prepare_new_container
-from paasta_tools.mac_address import reserve_unique_mac_address
-from paasta_tools.utils import DEFAULT_SOA_DIR
-
 
 LOCK_DIRECTORY = "/var/lib/paasta/mac-address"
 ENV_MATCH_RE = re.compile(r"^(-\w*e\w*|--env(?P<file>-file)?)(=(?P<arg>\S.*))?$")
@@ -303,6 +297,14 @@ def append_cpuset_args(argv, env_args):
 
 
 def add_firewall(argv, service, instance):
+    # Delay importing these until we really need to, because they are
+    # expensive to import and we need to be fast, most of the time
+    from paasta_tools.firewall import DEFAULT_SYNAPSE_SERVICE_DIR
+    from paasta_tools.firewall import firewall_flock
+    from paasta_tools.firewall import prepare_new_container
+    from paasta_tools.mac_address import reserve_unique_mac_address
+    from paasta_tools.utils import DEFAULT_SOA_DIR
+
     output = ""
     try:
         mac_address, lockfile = reserve_unique_mac_address(LOCK_DIRECTORY)

--- a/paasta_tools/docker_wrapper_imports.py
+++ b/paasta_tools/docker_wrapper_imports.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# flake8: noqa: E402
+""" Delayed imports for paasta_tools.docker_wrapper, meant to improve the performance
+of docker_wrapper for execution paths when we do not use add_firewall. It turns out
+that the imports needed add a fair amount of overhead to "docker inspect" command
+which does not use add_firewall, and Mesos executes this command quite a lot. We can
+make it faster by moving all the paasta_tools imports to separate file, i.e. here
+"""
+from paasta_tools.firewall import DEFAULT_SYNAPSE_SERVICE_DIR
+from paasta_tools.firewall import firewall_flock
+from paasta_tools.firewall import prepare_new_container
+from paasta_tools.mac_address import reserve_unique_mac_address
+from paasta_tools.utils import DEFAULT_SOA_DIR

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -5,6 +5,7 @@ import mock
 import pytest
 
 from paasta_tools import docker_wrapper
+from paasta_tools import docker_wrapper_imports
 
 
 @contextmanager
@@ -712,7 +713,7 @@ class TestMain:
     @pytest.yield_fixture
     def mock_mac_address(self):
         with mock.patch.object(
-            docker_wrapper,
+            docker_wrapper_imports,
             "reserve_unique_mac_address",
             return_value=("00:00:00:00:00:00", None),
         ) as mock_mac_address:
@@ -726,8 +727,8 @@ class TestMain:
             "--env=PAASTA_INSTANCE=myinstance",
         ]
 
-    @mock.patch.object(docker_wrapper, "firewall_flock", autospec=True)
-    @mock.patch.object(docker_wrapper, "prepare_new_container", autospec=True)
+    @mock.patch.object(docker_wrapper_imports, "firewall_flock", autospec=True)
+    @mock.patch.object(docker_wrapper_imports, "prepare_new_container", autospec=True)
     def test_mac_address(
         self,
         mock_prepare_new_container,
@@ -753,8 +754,8 @@ class TestMain:
 
         assert mock_prepare_new_container.mock_calls == [
             mock.call(
-                docker_wrapper.DEFAULT_SOA_DIR,
-                docker_wrapper.DEFAULT_SYNAPSE_SERVICE_DIR,
+                docker_wrapper_imports.DEFAULT_SOA_DIR,
+                docker_wrapper_imports.DEFAULT_SYNAPSE_SERVICE_DIR,
                 "myservice",
                 "myinstance",
                 "00:00:00:00:00:00",
@@ -810,12 +811,12 @@ class TestMain:
             )
 
     @mock.patch.object(
-        docker_wrapper,
+        docker_wrapper_imports,
         "firewall_flock",
         autospec=True,
         side_effect=Exception("Oh noes"),
     )
-    @mock.patch.object(docker_wrapper, "prepare_new_container", autospec=True)
+    @mock.patch.object(docker_wrapper_imports, "prepare_new_container", autospec=True)
     def test_prepare_new_container_error(
         self,
         mock_prepare_new_container,


### PR DESCRIPTION
Python imports are sometimes slow and we pay the price for that on every `docker inspect`, which does not need them, and which is executed by Mesos very often.

Let's move them to a separate file and import in the body of the function, so we have our cake (i.e. do not pay the price of imports when `add_firewall` is not used) and eat it too (i.e. `add_firewall` working as usual when needed). Moving all the imports to a separate file was necessary to maintain mocks inside unit tests for the `docker_wrapper`.