### PR TITLE
Make the default tron executor and node be paasta

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -261,13 +261,13 @@ class TronActionConfig(InstanceConfig):
         return self.config_dict.get("cpu_burst_add", 0)
 
     def get_executor(self):
-        return self.config_dict.get("executor", None)
+        return self.config_dict.get("executor", "paasta")
 
     def get_healthcheck_mode(self, _) -> None:
         return None
 
     def get_node(self):
-        return self.config_dict.get("node")
+        return self.config_dict.get("node", "paasta")
 
     def get_retries(self):
         return self.config_dict.get("retries")
@@ -353,7 +353,7 @@ class TronJobConfig:
         return self.name
 
     def get_node(self):
-        return self.config_dict.get("node")
+        return self.config_dict.get("node", "paasta")
 
     def get_schedule(self):
         return self.config_dict.get("schedule")


### PR DESCRIPTION
We made it!
There are no jobs at yelp that do not have an explicit executor/node.

I think implicit is better than explicit (sane defaults) when it comes to lots and lots of configs that humans have to interact with all the time, so I would like to make the default executor/node be paasta.

After shipping, I would like to simplify all our tron job configs by removing the things that are already set with this default.