### PR TITLE
Swap default service location from gitolite to GitHub

### DIFF
--- a/paasta_tools/contrib/mass-deploy-tag.sh
+++ b/paasta_tools/contrib/mass-deploy-tag.sh
@@ -26,7 +26,7 @@ for service in ${services} ; do
 	fi
 	# git_repo=$(paasta info -s ${service} | grep -oP 'Git Repo: \K.*$')
 	git_repo=$(script -qc "paasta info -s ${service}" | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" | grep 'Git Repo: ' | cut -d' ' -f3)
-	default_git_repo=git@git.yelpcorp.com:services/${service}.git
+	default_git_repo=git@github.yelpcorp.com:services/${service}.git
 	echo git clone ${git_repo-${default_git_repo}} ${service}
 	git clone ${git_repo} ${service}
 	unset git_repo

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -25,7 +25,7 @@ For example, if the service paasta_test has an instance called main with no
 deploy group in its configuration in the hab cluster, then this script
 will create a key/value pair of 'paasta_test:paasta-hab.main': 'services-paasta_test:paasta-SHA',
 where SHA is the current SHA at the tip of the branch named hab in
-git@git.yelpcorp.com:services/paasta_test.git. If main had a deploy_group key with
+git@github.yelpcorp.com:services/paasta_test.git. If main had a deploy_group key with
 a value of 'master', the key would be paasta_test:master instead, and the SHA
 would be the SHA at the tip of master.
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1138,14 +1138,14 @@ def get_git_url(service: str, soa_dir: str = DEFAULT_SOA_DIR) -> str:
     """Get the git url for a service. Assumes that the service's
     repo matches its name, and that it lives in services- i.e.
     if this is called with the string 'test', the returned
-    url will be git@git.yelpcorp.com:services/test.
+    url will be git@github.yelpcorp.com:services/test.
 
     :param service: The service name to get a URL for
     :returns: A git url to the service's repository"""
     general_config = service_configuration_lib.read_service_configuration(
         service, soa_dir=soa_dir
     )
-    default_location = "git@git.yelpcorp.com:services/%s" % service
+    default_location = "git@github.yelpcorp.com:services/%s" % service
     return general_config.get("git_url", default_location)
 
 
@@ -2476,7 +2476,7 @@ def build_docker_image_name(service: str) -> str:
     will look for your images.
 
     :returns: a sanitized-for-Jenkins (s,/,-,g) version of the
-    service's path in git. E.g. For git.yelpcorp.com:services/foo the
+    service's path in git. E.g. For github.yelpcorp.com:services/foo the
     docker image name is docker_registry/services-foo.
     """
     docker_registry_url = get_service_docker_registry(service)

--- a/tests/cli/test_cmds_info.py
+++ b/tests/cli/test_cmds_info.py
@@ -57,7 +57,7 @@ def test_get_service_info():
         assert "fake_runbook" in actual
         assert "Description: a fake service" in actual
         assert "http://bla" in actual
-        assert "Git Repo: git@git.yelpcorp.com:services/fake_service" in actual
+        assert "Git Repo: git@github.yelpcorp.com:services/fake_service" in actual
         assert "Deployed to the following" in actual
         assert (
             "clusterA (%s)"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,7 +46,7 @@ def test_get_git_url_provided_by_serviceyaml():
 
 def test_get_git_url_default():
     service = "giiiiiiiiiiit"
-    expected = "git@git.yelpcorp.com:services/%s" % service
+    expected = "git@github.yelpcorp.com:services/%s" % service
     with (
         mock.patch(
             "service_configuration_lib.read_service_configuration", autospec=True


### PR DESCRIPTION
All `services/` repositories are on github.yelpcorp.com now, and any
stragglers outside of that namespace have their git_url manually
specified in their config. New repositories are always created on
GitHub, so changing the default host to GitHub lets new services work
without requiring extra config changes