### PR TITLE
is_in_smartstack bug caused erroneous behaviour from CNI wrapper

### DIFF
--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -92,7 +92,7 @@ class ServiceNamespaceConfig(dict):
         return self.get("discover", "region")
 
     def is_in_smartstack(self) -> bool:
-        if self.get("proxy_port") is not None:
+        if self.get("proxy_port") is not None or self.get("registrations") is not None:
             return True
         else:
             return False


### PR DESCRIPTION
First draft.