### PR TITLE
Don't try to retrieve authors from GitHub repos with gitolite commands

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -279,9 +279,11 @@ def get_authors_to_be_notified(git_url, from_sha, to_sha, authors):
     if from_sha is None:
         return ""
 
+    authors_to_notify = []
+
     if authors:
         authors_to_notify = authors
-    else:
+    elif 'git.yelpcorp.com' in git_url:
         ret, git_authors = remote_git.get_authors(
             git_url=git_url, from_sha=from_sha, to_sha=to_sha
         )
@@ -289,6 +291,9 @@ def get_authors_to_be_notified(git_url, from_sha, to_sha, authors):
             authors_to_notify = git_authors.split()
         else:
             return f"(Could not get authors: {git_authors})"
+    else:
+        # We have no way of getting authors on the fly if the repository is not on gitolite
+        pass
 
     slacky_authors = ", ".join({f"<@{a}>" for a in authors_to_notify})
     log.debug(f"Authors: {slacky_authors}")

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -279,8 +279,6 @@ def get_authors_to_be_notified(git_url, from_sha, to_sha, authors):
     if from_sha is None:
         return ""
 
-    authors_to_notify = []
-
     if authors:
         authors_to_notify = authors
     elif 'git.yelpcorp.com' in git_url:
@@ -293,7 +291,7 @@ def get_authors_to_be_notified(git_url, from_sha, to_sha, authors):
             return f"(Could not get authors: {git_authors})"
     else:
         # We have no way of getting authors on the fly if the repository is not on gitolite
-        pass
+        return ""
 
     slacky_authors = ", ".join({f"<@{a}>" for a in authors_to_notify})
     log.debug(f"Authors: {slacky_authors}")

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -281,7 +281,7 @@ def get_authors_to_be_notified(git_url, from_sha, to_sha, authors):
 
     if authors:
         authors_to_notify = authors
-    elif 'git.yelpcorp.com' in git_url:
+    elif "git.yelpcorp.com" in git_url:
         ret, git_authors = remote_git.get_authors(
             git_url=git_url, from_sha=from_sha, to_sha=to_sha
         )

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -278,7 +278,7 @@ def test_MarkForDeployProcess_handles_wait_for_deployment_failure(
         deploy_group="test_deploy_group",
         commit="abc123432u49",
         old_git_sha="abc123455",
-        git_url=None,
+        git_url="git@git.yelpcorp.com:services/repo",
         soa_dir=None,
         timeout=None,
         auto_certify_delay=1,
@@ -322,7 +322,7 @@ def test_MarkForDeployProcess_handles_first_time_deploys(
         deploy_group=None,
         commit="abc123432u49",
         old_git_sha=None,
-        git_url=None,
+        git_url="git@git.yelpcorp.com:services/repo",
         soa_dir=None,
         timeout=None,
         auto_certify_delay=1,
@@ -362,7 +362,7 @@ def test_MarkForDeployProcess_get_authors_diffs_against_prod_deploy_group(
         deploy_group=None,
         commit="abc123512",
         old_git_sha="asgdser23",
-        git_url=None,
+        git_url="git@git.yelpcorp.com:services/repo",
         soa_dir=None,
         timeout=None,
         auto_certify_delay=1,
@@ -371,7 +371,7 @@ def test_MarkForDeployProcess_get_authors_diffs_against_prod_deploy_group(
         authors=["fakeuser1"],
     )
     mock_get_authors_to_be_notified.assert_called_once_with(
-        git_url=None, from_sha="aaaaaaaa", to_sha="abc123512", authors=["fakeuser1"]
+        git_url="git@git.yelpcorp.com:services/repo", from_sha="aaaaaaaa", to_sha="abc123512", authors=["fakeuser1"]
     )
 
 
@@ -397,7 +397,7 @@ def test_MarkForDeployProcess_get_authors_falls_back_to_current_deploy_group(
         deploy_group=None,
         commit="abc123512",
         old_git_sha="asgdser23",
-        git_url=None,
+        git_url="git@git.yelpcorp.com:services/repo1",
         soa_dir=None,
         timeout=None,
         auto_certify_delay=1,
@@ -406,7 +406,7 @@ def test_MarkForDeployProcess_get_authors_falls_back_to_current_deploy_group(
         authors="fakeuser1",
     )
     mock_get_authors_to_be_notified.assert_called_once_with(
-        git_url=None, from_sha="asgdser23", to_sha="abc123512", authors="fakeuser1"
+        git_url="git@git.yelpcorp.com:services/repo1", from_sha="asgdser23", to_sha="abc123512", authors="fakeuser1"
     )
 
 
@@ -436,7 +436,7 @@ def test_MarkForDeployProcess_handles_wait_for_deployment_cancelled(
         deploy_group=None,
         commit="abc123512",
         old_git_sha="asgdser23",
-        git_url=None,
+        git_url="git@git.yelpcorp.com:services/repo1",
         soa_dir=None,
         timeout=None,
         auto_certify_delay=1,
@@ -481,7 +481,7 @@ def test_MarkForDeployProcess_skips_wait_for_deployment_when_block_is_False(
         deploy_group=None,
         commit="abc123456789",
         old_git_sha="oldsha1234",
-        git_url=None,
+        git_url="git@git.yelpcorp.com:services/repo1",
         soa_dir=None,
         timeout=None,
         auto_certify_delay=1,
@@ -524,7 +524,7 @@ def test_MarkForDeployProcess_goes_to_mfd_failed_when_mark_for_deployment_fails(
         deploy_group=None,
         commit="asbjkslerj",
         old_git_sha="abscerwerr",
-        git_url=None,
+        git_url="git@git.yelpcorp.com:services/repo1",
         soa_dir=None,
         timeout=None,
         auto_certify_delay=1,

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -371,7 +371,10 @@ def test_MarkForDeployProcess_get_authors_diffs_against_prod_deploy_group(
         authors=["fakeuser1"],
     )
     mock_get_authors_to_be_notified.assert_called_once_with(
-        git_url="git@git.yelpcorp.com:services/repo", from_sha="aaaaaaaa", to_sha="abc123512", authors=["fakeuser1"]
+        git_url="git@git.yelpcorp.com:services/repo",
+        from_sha="aaaaaaaa",
+        to_sha="abc123512",
+        authors=["fakeuser1"],
     )
 
 
@@ -406,7 +409,10 @@ def test_MarkForDeployProcess_get_authors_falls_back_to_current_deploy_group(
         authors="fakeuser1",
     )
     mock_get_authors_to_be_notified.assert_called_once_with(
-        git_url="git@git.yelpcorp.com:services/repo1", from_sha="asgdser23", to_sha="abc123512", authors="fakeuser1"
+        git_url="git@git.yelpcorp.com:services/repo1",
+        from_sha="asgdser23",
+        to_sha="abc123512",
+        authors="fakeuser1",
     )
 
 


### PR DESCRIPTION
The old way of finding authors was to call a gitolite command that
finds the authors between two commits. For services on GitHub, we pass
in the authors when making a mark-for-deployment call, so there is no
benefit to trying to call this gitolite command on a GitHub repository.

This change was prompted by the noisiness of timed deploys for shas
already on master not having authors passed in, and paasta's slackbot
complaining about not being able to find any authors from GitHub as a 
fallback when there are no authors for gitolite either.

I updated all `git_url=None` in tests to have a reasonable value, since get_authors_to_be_notified  requires an actual string and adding a check for the case where `git_url` is None doesn't make a lot of sense, since it will always actually exist for real mark for deployment calls