### PR TITLE
Add check_flink_pods_running script

### DIFF
--- a/paasta_tools/check_flink_pods_running.py
+++ b/paasta_tools/check_flink_pods_running.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# Copyright 2015-2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Usage: ./check_flink_pods_running.py [options]
+"""
+import logging
+from typing import Sequence
+
+import pysensu_yelp
+
+from paasta_tools import flink_tools
+from paasta_tools import kubernetes_tools
+from paasta_tools.check_services_replication_tools import main
+from paasta_tools.flink_tools import FlinkDeploymentConfig
+from paasta_tools.kubernetes_tools import filter_pods_by_service_instance
+from paasta_tools.kubernetes_tools import PodStatus
+from paasta_tools.kubernetes_tools import V1Pod
+from paasta_tools.monitoring_tools import check_under_replication
+from paasta_tools.monitoring_tools import send_replication_event
+from paasta_tools.smartstack_tools import KubeSmartstackReplicationChecker
+
+log = logging.getLogger(__name__)
+TEAM = "stream-processing-flink"
+
+
+def running_flink_pods_cnt(si_pods: Sequence[V1Pod]) -> int:
+    """Return count of running pods
+    """
+    return len(
+        [
+            pod
+            for pod in si_pods
+            if kubernetes_tools.get_pod_status(pod) == PodStatus.RUNNING
+        ]
+    )
+
+
+def check_flink_pods_running(
+    instance_config: FlinkDeploymentConfig,
+    all_tasks_or_pods: Sequence[V1Pod],
+    smartstack_replication_checker: KubeSmartstackReplicationChecker,
+) -> None:
+    si_pods = filter_pods_by_service_instance(
+        pod_list=all_tasks_or_pods,
+        service=instance_config.service,
+        instance=instance_config.instance,
+    )
+    taskmanager_expected_running_cnt = instance_config.config_dict.get(
+        "taskmanager", {"instances": 10}
+    ).get("instances", 10)
+    # Total expected running count:
+    # +1 for supervisor
+    # +1 for jobmanager
+    # + number of configured taskmanagers, defaults to 10
+    total_expected_running_cnt = 1 + 1 + taskmanager_expected_running_cnt
+    result = check_under_replication(
+        instance_config=instance_config,
+        expected_count=total_expected_running_cnt,
+        num_available=running_flink_pods_cnt(si_pods),
+    )
+    pod_not_running, output = result
+    if pod_not_running:
+        log.error(output)
+        status = pysensu_yelp.Status.CRITICAL
+    else:
+        log.info(output)
+        status = pysensu_yelp.Status.OK
+    send_replication_event(
+        instance_config=instance_config,
+        status=status,
+        output=output,
+        team_override=TEAM,
+    )
+
+
+if __name__ == "__main__":
+    main(
+        flink_tools.FlinkDeploymentConfig,
+        check_flink_pods_running,
+        namespace="paasta-flinks",
+    )

--- a/paasta_tools/monitoring_tools.py
+++ b/paasta_tools/monitoring_tools.py
@@ -265,7 +265,7 @@ def list_teams(**kwargs):
     return teams
 
 
-def send_replication_event(instance_config, status, output):
+def send_replication_event(instance_config, status, output, team_override=None):
     """Send an event to sensu via pysensu_yelp with the given information.
 
     :param instance_config: an instance of LongRunningServiceConfig
@@ -279,7 +279,8 @@ def send_replication_event(instance_config, status, output):
     monitoring_overrides["runbook"] = get_runbook(
         monitoring_overrides, instance_config.service, soa_dir=instance_config.soa_dir
     )
-
+    if team_override:
+        monitoring_overrides["team"] = team_override
     check_name = "check_paasta_services_replication.%s" % instance_config.job_id
     send_event(
         service=instance_config.service,

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     scripts=[
         "paasta_tools/am_i_mesos_leader.py",
         "paasta_tools/autoscale_all_services.py",
+        "paasta_tools/check_flink_pods_running.py",
         "paasta_tools/check_flink_services_health.py",
         "paasta_tools/check_cassandracluster_services_replication.py",
         "paasta_tools/check_marathon_services_replication.py",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 import time
 
+import mock
 import pytest
 
+from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import SystemPaastaConfig
 
 
@@ -32,3 +34,21 @@ def system_paasta_config():
         },
         "/fake_dir/",
     )
+
+
+@pytest.fixture
+def flink_instance_config():
+    service = "fake_service"
+    instance = "fake_instance"
+    job_id = compose_job_id(service, instance)
+    mock_instance_config = mock.Mock(
+        service=service,
+        instance=instance,
+        cluster="fake_cluster",
+        soa_dir="fake_soa_dir",
+        job_id=job_id,
+        config_dict={},
+    )
+    mock_instance_config.get_replication_crit_percentage.return_value = 100
+    mock_instance_config.get_registrations.return_value = [job_id]
+    return mock_instance_config

--- a/tests/test_check_flink_pods_running.py
+++ b/tests/test_check_flink_pods_running.py
@@ -1,0 +1,78 @@
+import mock
+import pysensu_yelp
+import pytest
+
+from paasta_tools import check_flink_pods_running
+from paasta_tools import check_services_replication_tools
+from paasta_tools.check_flink_pods_running import running_flink_pods_cnt
+from paasta_tools.check_flink_pods_running import TEAM
+from paasta_tools.kubernetes_tools import PodStatus
+from paasta_tools.kubernetes_tools import V1Pod
+
+check_flink_pods_running.log = mock.Mock()
+check_services_replication_tools.log = mock.Mock()
+
+
+class TestRunningFlinkPodCnt:
+    @pytest.mark.parametrize(
+        "pod_status, expected_cnt",
+        [pytest.param(PodStatus.RUNNING, 1), pytest.param(PodStatus.PENDING, 0)],
+    )
+    def test_running_flink_pod(self, pod_status, expected_cnt):
+        all_pods = [V1Pod()]
+        with mock.patch(
+            "paasta_tools.kubernetes_tools.get_pod_status",
+            autospec=True,
+            return_value=pod_status,
+        ):
+            assert running_flink_pods_cnt(all_pods) == expected_cnt
+
+
+class TestCheckFlinkPodRunning:
+    @pytest.mark.parametrize(
+        "running_cnt, under_replication_return_value, status",
+        [
+            pytest.param(
+                5, (False, "OK"), pysensu_yelp.Status.OK, id="when_all_running"
+            ),
+            pytest.param(
+                4,
+                (True, "NOT OK"),
+                pysensu_yelp.Status.CRITICAL,
+                id="when_not_all_running",
+            ),
+        ],
+    )
+    def test_check_flink_pod_running(
+        self, flink_instance_config, running_cnt, under_replication_return_value, status
+    ):
+        all_pods = []
+        flink_instance_config.config_dict["taskmanager"] = {"instances": 3}
+        with mock.patch(
+            "paasta_tools.check_flink_pods_running.running_flink_pods_cnt",
+            autospec=True,
+            return_value=running_cnt,
+        ), mock.patch(
+            "paasta_tools.check_flink_pods_running.check_under_replication",
+            autospec=True,
+            return_value=under_replication_return_value,
+        ) as mock_check_under_replication, mock.patch(
+            "paasta_tools.check_flink_pods_running.send_replication_event",
+            autospec=True,
+        ) as mock_send_replication_event:
+            check_flink_pods_running.check_flink_pods_running(
+                instance_config=flink_instance_config,
+                all_tasks_or_pods=all_pods,
+                smartstack_replication_checker=None,
+            )
+            mock_check_under_replication.assert_called_once_with(
+                instance_config=flink_instance_config,
+                expected_count=5,
+                num_available=running_cnt,
+            )
+            mock_send_replication_event.assert_called_once_with(
+                instance_config=flink_instance_config,
+                status=status,
+                output=under_replication_return_value[1],
+                team_override=TEAM,
+            )


### PR DESCRIPTION
Testing done:
1) make test
2) manual test: https://fluffy.yelpcorp.com/i/40HFkZSmWF1zVqkF3S4lHbfXBzWSv6cB.html

I'm treating pods of different subcomponent in the same way and sending one sensu event as long as there's any pod in the service.instance that's not in running state. Don't see much benefit for splitting them up considering the actions to take when getting this alert is pretty much the same (describe the pod and see why it's in pending state). But I'm happy to split them if you'd prefer