### PR TITLE
Stop reading datacenter (aws region) attribute from expected_slave_at…

### DIFF
--- a/paasta_tools/paasta_cluster_boost.py
+++ b/paasta_tools/paasta_cluster_boost.py
@@ -70,23 +70,6 @@ def parse_args():
     return parser.parse_args()
 
 
-def get_regions(pool: str) -> list:
-    """ Return the regions where we have slaves running for a given pool
-    """
-    system_paasta_config = load_system_paasta_config()
-    expected_slave_attributes = system_paasta_config.get_expected_slave_attributes()
-    if expected_slave_attributes is None:
-        return []
-
-    regions = []  # type: list
-    for slave in expected_slave_attributes:
-        slave_region = slave["datacenter"]
-        if slave["pool"] == pool:
-            if slave_region not in regions:
-                regions.append(slave_region)
-    return regions
-
-
 def paasta_cluster_boost(
     action: str, pool: str, boost: float, duration: int, override: bool
 ) -> bool:
@@ -99,10 +82,9 @@ def paasta_cluster_boost(
         paasta_print("ERROR: cluster_boost feature is not enabled.")
         return False
 
-    regions = get_regions(pool)
-
+    regions = system_config.get_boost_regions()
     if len(regions) == 0:
-        paasta_print(f"ERROR: no slaves found in pool {pool}")
+        paasta_print(f"ERROR: no boost_regions configured in {system_config.directory}")
         return False
 
     for region in regions:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1717,6 +1717,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     api_endpoints: Dict[str, str]
     auth_certificate_ttl: str
     auto_hostname_unique_size: int
+    boost_regions: List[str]
     cluster: str
     cluster_autoscaler_max_decrease: float
     cluster_autoscaler_max_increase: float
@@ -2304,6 +2305,9 @@ class SystemPaastaConfig:
 
     def get_pdb_max_unavailable(self) -> Union[str, int]:
         return self.config_dict.get("pdb_max_unavailable", 0)
+
+    def get_boost_regions(self) -> List[str]:
+        return self.config_dict.get("boost_regions", [])
 
 
 def _run(


### PR DESCRIPTION
…tributes, since yelp-autoconfigure-mesos doesn't set it. Use a setting in /etc/paasta instead. PAASTA-16304

Corresponding puppet review: https://reviewboard.yelpcorp.com/r/481051/