### PR TITLE
Add aws_credentials_yaml and aws_region options

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -623,6 +623,11 @@ If a Tron **action** of a job is of executor type ``spark``, it MAY specify the 
     https://github.com/Yelp/service_configuration_lib/blob/master/service_configuration_lib/spark_config.py#L9
     for a complete list of such configurations.
 
+  * ``aws_credentials_yaml``: Path to the yaml file containing credentials to be set in the task's
+    AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables. Default to
+    ``/etc/boto_cfg/<your-service-name>.yaml``. If the file path does not exist, or the file does
+    not contain keys for aws_access_key_id and aws_secret_access_key, those variables will be unset.
+
 ``adhoc-[clustername].yaml``
 -------------------------------
 

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -149,6 +149,9 @@
                 },
                 "spark_args": {
                     "type": "object"
+                },
+                "aws_credentials_yaml": {
+                    "type": "string"
                 }
             }
         },


### PR DESCRIPTION
Some spark jobs require aws credentials be read from a yaml file on disk, and be provided to spark driver container as env variables ("AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY").

We need to support aws_credentials_yaml option, which is the path to aws credential yaml file on disk, and read them in code, as well as aws_region option, which is used to populate AWS_DEFAULT_REGION env variable.