### PR TITLE
Restore Report Envoy backend status #2595

### DIFF
--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -351,6 +351,13 @@
                     },
                     {
                         "in": "query",
+                        "description": "Include Envoy information",
+                        "name": "include_envoy",
+                        "required": false,
+                        "type": "boolean"
+                    },
+                    {
+                        "in": "query",
                         "description": "Include Mesos information",
                         "name": "include_mesos",
                         "required": false,
@@ -745,6 +752,10 @@
                     "$ref": "#/definitions/SmartstackStatus",
                     "description": "Status of the service in smartstack"
                 },
+                "envoy": {
+                    "$ref": "#/definitions/EnvoyStatus",
+                    "description": "Status of the service in Envoy"
+                },
                 "error_message": {
                     "type": "string",
                     "description": "Error message when a marathon job ID cannot be found"
@@ -1062,6 +1073,83 @@
                     "type": "integer",
                     "format": "int32",
                     "description": "Seconds since last change in backend status"
+                },
+                "has_associated_task": {
+                    "type": "boolean",
+                    "description": "Whether this backend has an associated task running"
+                }
+            }
+        },
+        "EnvoyStatus": {
+            "type": "object",
+            "properties": {
+                "registration": {
+                    "type": "string",
+                    "description": "Registration name of the service in Smartstack"
+                },
+                "expected_backends_per_location": {
+                    "type": "integer",
+                    "format": "int32",
+                    "description": "Number of backends expected to be present in each location"
+                },
+                "locations": {
+                    "type": "array",
+                    "description": "Locations the service is deployed",
+                    "items": {
+                        "$ref": "#/definitions/EnvoyLocation"
+                    }
+                }
+            }
+        },
+        "EnvoyLocation": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the location"
+                },
+                "running_backends_count": {
+                    "type": "integer",
+                    "format": "int32",
+                    "description": "Number of running backends for the service in this location"
+                },
+                "backends": {
+                    "type": "array",
+                    "description": "Envoy backends running in this location",
+                    "items": {
+                        "$ref": "#/definitions/EnvoyBackend"
+                    }
+                },
+                "is_proxied_through_casper": {
+                    "type": "boolean",
+                    "description": "Whether this backend is proxied through Casper"
+                }
+            }
+        },
+        "EnvoyBackend": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string",
+                    "description": "Address of the host on which the backend is running"
+                },
+                "port_value": {
+                    "type": "integer",
+                    "format": "int32",
+                    "description": "Port number on which the backend responds"
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Name of the host on which the backend is running"
+                },
+                "eds_health_status": {
+                    "type": "string",
+                    "description": "Status of the backend in Envoy as reported by the EDS"
+                },
+                "weight": {
+                    "type": "integer",
+                    "format": "int32",
+                    "description": "The weight of this backend in the cluster"
                 },
                 "has_associated_task": {
                     "type": "boolean",

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1173,6 +1173,7 @@ def _run_instance_worker(cluster_data, instances_out, green_light):
                 service=cluster_data.service,
                 instance=instance,
                 include_smartstack=False,
+                include_envoy=False,
                 include_mesos=False,
             ).result()
         except HTTPError as e:

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -21,9 +21,11 @@ from collections import defaultdict
 from collections import OrderedDict
 from datetime import datetime
 from datetime import timedelta
+from enum import Enum
 from itertools import groupby
 from typing import Any
 from typing import Callable
+from typing import Collection
 from typing import DefaultDict
 from typing import Dict
 from typing import Iterable
@@ -353,6 +355,14 @@ def print_marathon_status(
         )
         output.extend([f"    {line}" for line in smartstack_status_human])
 
+    if marathon_status.envoy is not None:
+        envoy_status_human = get_envoy_status_human(
+            marathon_status.envoy.registration,
+            marathon_status.envoy.expected_backends_per_location,
+            marathon_status.envoy.locations,
+        )
+        output.extend([f"    {line}" for line in envoy_status_human])
+
     return 0
 
 
@@ -667,7 +677,7 @@ def format_kubernetes_replicaset_table(replicasets):
 
 
 def get_smartstack_status_human(
-    registration, expected_backends_per_location, locations
+    registration: str, expected_backends_per_location: int, locations: Collection[Any],
 ) -> List[str]:
     if len(locations) == 0:
         return [f"Smartstack: ERROR - {registration} is NOT in smartstack at all!"]
@@ -688,8 +698,8 @@ def get_smartstack_status_human(
     return output
 
 
-def build_smartstack_backends_table(backends):
-    rows = [("Name", "LastCheck", "LastChange", "Status")]
+def build_smartstack_backends_table(backends: Iterable[Any]) -> List[str]:
+    rows: List[Tuple[str, ...]] = [("Name", "LastCheck", "LastChange", "Status")]
     for backend in backends:
         if backend.status == "UP":
             status = PaastaColors.default(backend.status)
@@ -705,10 +715,70 @@ def build_smartstack_backends_table(backends):
         else:
             check_duration = str(backend.check_duration)
 
-        row = (
+        row: Tuple[str, ...] = (
             f"{backend.hostname}:{backend.port}",
             f"{backend.check_status}/{backend.check_code} in {check_duration}ms",
             humanize.naturaltime(timedelta(seconds=backend.last_change)),
+            status,
+        )
+
+        if not backend.has_associated_task:
+            row = tuple(
+                PaastaColors.grey(remove_ansi_escape_sequences(col)) for col in row
+            )
+
+        rows.append(row)
+
+    return format_table(rows)
+
+
+def get_envoy_status_human(
+    registration: str, expected_backends_per_location: int, locations: Collection[Any],
+) -> List[str]:
+    if len(locations) == 0:
+        return [f"Envoy: ERROR - {registration} is NOT in Envoy at all!"]
+
+    output = ["Envoy:"]
+    output.append(f"  Service Name: {registration}")
+    output.append(f"  Backends:")
+    for location in locations:
+        backend_status = envoy_backend_report(
+            expected_backends_per_location, location.running_backends_count
+        )
+        output.append(f"    {location.name} - {backend_status}")
+
+        if location.backends:
+            color = (
+                PaastaColors.green
+                if location.is_proxied_through_casper
+                else PaastaColors.grey
+            )
+            is_proxied_through_casper_output = color(
+                f"{location.is_proxied_through_casper}"
+            )
+            output.append(
+                f"      Proxied through Casper: {is_proxied_through_casper_output}"
+            )
+
+            backends_table = build_envoy_backends_table(location.backends)
+            output.extend([f"      {line}" for line in backends_table])
+
+    return output
+
+
+def build_envoy_backends_table(backends: Iterable[Any]) -> List[str]:
+    rows: List[Tuple[str, ...]] = [("Hostname:Port", "Weight", "Status")]
+    for backend in backends:
+        if backend.eds_health_status == "HEALTHY":
+            status = PaastaColors.default(backend.eds_health_status)
+        elif backend.eds_health_status == "UNHEALTHY":
+            status = PaastaColors.red(backend.eds_health_status)
+        else:
+            status = PaastaColors.yellow(backend.eds_health_status)
+
+        row: Tuple[str, ...] = (
+            f"{backend.hostname}:{backend.port_value}",
+            f"{backend.weight}",
             status,
         )
 
@@ -1411,7 +1481,22 @@ def desired_state_human(desired_state, instances):
         return PaastaColors.red("Unknown (desired_state: %s)" % desired_state)
 
 
-def haproxy_backend_report(normal_instance_count, up_backends):
+class BackendType(Enum):
+    ENVOY = "Envoy"
+    HAPROXY = "haproxy"
+
+
+def envoy_backend_report(normal_instance_count: int, up_backends: int) -> str:
+    return _backend_report(normal_instance_count, up_backends, BackendType.ENVOY)
+
+
+def haproxy_backend_report(normal_instance_count: int, up_backends: int) -> str:
+    return _backend_report(normal_instance_count, up_backends, BackendType.HAPROXY)
+
+
+def _backend_report(
+    normal_instance_count: int, up_backends: int, system_name: BackendType
+) -> str:
     """Given that a service is in smartstack, this returns a human readable
     report of the up backends"""
     # TODO: Take into account a configurable threshold, PAASTA-1102
@@ -1430,7 +1515,7 @@ def haproxy_backend_report(normal_instance_count, up_backends):
         status = PaastaColors.green("Healthy")
         count = PaastaColors.green("(%d/%d)" % (up_backends, normal_instance_count))
     up_string = PaastaColors.bold("UP")
-    return f"{status} - in haproxy with {count} total backends {up_string} in this namespace."
+    return f"{status} - in {system_name} with {count} total backends {up_string} in this namespace."
 
 
 def marathon_app_deploy_status_human(status, backoff_seconds=None):

--- a/paasta_tools/envoy_tools.py
+++ b/paasta_tools/envoy_tools.py
@@ -1,0 +1,234 @@
+# Copyright 2015-2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import collections
+import socket
+from typing import AbstractSet
+from typing import Any
+from typing import Collection
+from typing import DefaultDict
+from typing import Dict
+from typing import FrozenSet
+from typing import Iterable
+from typing import List
+from typing import MutableMapping
+from typing import Optional
+from typing import Set
+from typing import Tuple
+
+import requests
+from mypy_extensions import TypedDict
+
+from paasta_tools import marathon_tools
+from paasta_tools.api import settings
+from paasta_tools.utils import get_user_agent
+from paasta_tools.utils import SystemPaastaConfig
+
+
+EnvoyBackend = TypedDict(
+    "EnvoyBackend",
+    {
+        "address": str,
+        "port_value": int,
+        "hostname": str,
+        "eds_health_status": str,
+        "weight": int,
+        "has_associated_task": bool,
+    },
+    total=False,
+)
+
+
+def retrieve_envoy_clusters(
+    envoy_host: str, envoy_admin_port: int, system_paasta_config: SystemPaastaConfig
+) -> Dict[str, Any]:
+    envoy_uri = system_paasta_config.get_envoy_admin_endpoint_format().format(
+        host=envoy_host, port=envoy_admin_port, endpoint="clusters?format=json"
+    )
+
+    # timeout after 1 second and retry 3 times
+    envoy_admin_request = requests.Session()
+    envoy_admin_request.headers.update({"User-Agent": get_user_agent()})
+    envoy_admin_request.mount("http://", requests.adapters.HTTPAdapter(max_retries=3))
+    envoy_admin_request.mount("https://", requests.adapters.HTTPAdapter(max_retries=3))
+    envoy_admin_response = envoy_admin_request.get(envoy_uri, timeout=1)
+    return envoy_admin_response.json()
+
+
+def get_casper_endpoints(clusters_info: Dict[str, Any]) -> FrozenSet[Tuple[str, int]]:
+    """Filters out and returns casper endpoints from Envoy clusters."""
+    casper_endpoints: Set[Tuple[str, int]] = set()
+    for cluster_status in clusters_info["cluster_statuses"]:
+        if "host_statuses" in cluster_status:
+            if cluster_status["name"].startswith("spectre.") and cluster_status[
+                "name"
+            ].endswith(".egress_cluster"):
+                for host_status in cluster_status["host_statuses"]:
+                    casper_endpoints.add(
+                        (
+                            host_status["address"]["socket_address"]["address"],
+                            host_status["address"]["socket_address"]["port_value"],
+                        )
+                    )
+    return frozenset(casper_endpoints)
+
+
+def get_backends(
+    service: str, envoy_host: str, envoy_admin_port: int,
+) -> List[Tuple[EnvoyBackend, bool]]:
+    """Fetches JSON from Envoy admin's /clusters endpoint and returns a list of backends.
+
+    :param service: If None, return backends for all services, otherwise only return backends for this particular
+                    service.
+    :param envoy_host: The host that this check should contact for replication information.
+    :param envoy_admin_port: The port that Envoy's admin interface is listening on
+    :returns backends: A list of dicts representing the backends of all
+                       services or the requested service
+    """
+    if service:
+        services = [service]
+    else:
+        services = None
+    return get_multiple_backends(
+        services, envoy_host=envoy_host, envoy_admin_port=envoy_admin_port,
+    )
+
+
+def get_multiple_backends(
+    services: Optional[Collection[str]], envoy_host: str, envoy_admin_port: int,
+):
+    """Fetches JSON from Envoy admin's /clusters endpoint and returns a list of backends.
+
+    :param services: If None, return backends for all services, otherwise only return backends for these particular
+                     services.
+    :param envoy_host: The host that this check should contact for replication information.
+    :param envoy_admin_port: The port that Envoy's admin interface is listening on
+    :returns backends: A list of dicts representing the backends of all
+                       services or the requested service
+    """
+    clusters_info = retrieve_envoy_clusters(
+        envoy_host=envoy_host,
+        envoy_admin_port=envoy_admin_port,
+        system_paasta_config=settings.system_paasta_config,
+    )
+
+    casper_endpoints = get_casper_endpoints(clusters_info)
+
+    backends: List[Tuple[EnvoyBackend, bool]] = []
+    for cluster_status in clusters_info["cluster_statuses"]:
+        if "host_statuses" in cluster_status:
+            if cluster_status["name"].endswith(".egress_cluster"):
+                service_name = cluster_status["name"][: -len(".egress_cluster")]
+
+                if services is None or service_name in services:
+                    cluster_backends = []
+                    casper_endpoint_found = False
+                    for host_status in cluster_status["host_statuses"]:
+                        address = host_status["address"]["socket_address"]["address"]
+                        port_value = host_status["address"]["socket_address"][
+                            "port_value"
+                        ]
+
+                        # Check if this endpoint is actually a casper backend
+                        # If so, omit from the service's list of backends
+                        if not service_name.startswith("spectre."):
+                            if (address, port_value) in casper_endpoints:
+                                casper_endpoint_found = True
+                                continue
+
+                        cluster_backends.append(
+                            (
+                                EnvoyBackend(
+                                    address=address,
+                                    port_value=port_value,
+                                    hostname=socket.gethostbyaddr(
+                                        host_status["address"]["socket_address"][
+                                            "address"
+                                        ]
+                                    )[0].split(".")[0],
+                                    eds_health_status=host_status["health_status"][
+                                        "eds_health_status"
+                                    ],
+                                    weight=host_status["weight"],
+                                ),
+                                casper_endpoint_found,
+                            )
+                        )
+                    backends += cluster_backends
+    return backends
+
+
+def match_backends_and_tasks(
+    backends: Iterable[EnvoyBackend], tasks: Iterable[marathon_tools.MarathonTask]
+) -> List[Tuple[Optional[EnvoyBackend], Optional[marathon_tools.MarathonTask]]]:
+    """Returns tuples of matching (backend, task) pairs, as matched by IP and port. Each backend will be listed exactly
+    once, and each task will be listed once per port. If a backend does not match with a task, (backend, None) will
+    be included. If a task's port does not match with any backends, (None, task) will be included.
+
+    :param backends: An iterable of Envoy backend dictionaries, e.g. the list returned by
+                     envoy_tools.get_multiple_backends.
+    :param tasks: An iterable of MarathonTask objects.
+    """
+
+    # { (ip, port) : [backend1, backend2], ... }
+    backends_by_ip_port: DefaultDict[
+        Tuple[str, int], List[EnvoyBackend]
+    ] = collections.defaultdict(list)
+    backend_task_pairs = []
+
+    for backend in backends:
+        ip = backend["address"]
+        port = backend["port_value"]
+        backends_by_ip_port[ip, port].append(backend)
+
+    for task in tasks:
+        ip = socket.gethostbyname(task.host)
+        for port in task.ports:
+            for backend in backends_by_ip_port.pop((ip, port), [None]):
+                backend_task_pairs.append((backend, task))
+
+    # we've been popping in the above loop, so anything left didn't match a marathon task.
+    for backends in backends_by_ip_port.values():
+        for backend in backends:
+            backend_task_pairs.append((backend, None))
+
+    return backend_task_pairs
+
+
+def build_envoy_location_dict(
+    location: str,
+    matched_envoy_backends_and_tasks: List[
+        Tuple[Optional[EnvoyBackend], Optional[marathon_tools.MarathonTask]]
+    ],
+    should_return_individual_backends: bool,
+    casper_proxied_backends: AbstractSet[Tuple[str, int]],
+) -> MutableMapping[str, Any]:
+    running_backends_count = 0
+    envoy_backends = []
+    is_proxied_through_casper = False
+    for backend, task in matched_envoy_backends_and_tasks:
+        if backend is None:
+            continue
+        if backend["eds_health_status"] == "HEALTHY":
+            running_backends_count += 1
+        if should_return_individual_backends:
+            backend["has_associated_task"] = task is not None
+            envoy_backends.append(backend)
+        if (backend["address"], backend["port_value"]) in casper_proxied_backends:
+            is_proxied_through_casper = True
+    return {
+        "name": location,
+        "running_backends_count": running_backends_count,
+        "backends": envoy_backends,
+        "is_proxied_through_casper": is_proxied_through_casper,
+    }

--- a/paasta_tools/smartstack_tools.py
+++ b/paasta_tools/smartstack_tools.py
@@ -22,7 +22,6 @@ from typing import DefaultDict
 from typing import Dict
 from typing import Iterable
 from typing import List
-from typing import Mapping
 from typing import MutableMapping
 from typing import NamedTuple
 from typing import Optional
@@ -650,7 +649,7 @@ def build_smartstack_location_dict(
         ]
     ],
     should_return_individual_backends: bool = False,
-) -> Mapping[str, Any]:
+) -> MutableMapping[str, Any]:
     running_backends_count = 0
     backends = []
     for backend, task in matched_backends_and_tasks:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1743,6 +1743,8 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     enable_client_cert_auth: bool
     enable_nerve_readiness_check: bool
     enforce_disk_quota: bool
+    envoy_admin_domain_name: str
+    envoy_admin_endpoint_format: str
     expected_slave_attributes: ExpectedSlaveAttributes
     filter_bogus_mesos_cputime_enabled: bool
     fsm_template: str
@@ -2285,6 +2287,19 @@ class SystemPaastaConfig:
 
     def get_clusters(self) -> Sequence[str]:
         return self.config_dict.get("clusters", [])
+
+    def get_envoy_admin_endpoint_format(self) -> str:
+        """ Get the format string for Envoy's admin interface. """
+        return self.config_dict.get(
+            "envoy_admin_endpoint_format", "http://{host:s}:{port:d}/{endpoint:s}"
+        )
+
+    def get_envoy_admin_port(self) -> int:
+        """ Get the port that Envoy's admin interface is listening on
+        from /etc/services. """
+        return socket.getservbyname(
+            self.config_dict.get("envoy_admin_domain_name", "envoy-admin")
+        )
 
 
 def _run(

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -27,6 +27,7 @@ from paasta_tools import marathon_tools
 from paasta_tools.api import settings
 from paasta_tools.api.views import instance
 from paasta_tools.autoscaling.autoscaling_service_lib import ServiceAutoscalingInfo
+from paasta_tools.envoy_tools import EnvoyBackend
 from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
 from paasta_tools.marathon_tools import get_short_task_id
 from paasta_tools.mesos.exceptions import SlaveDoesNotExist
@@ -40,9 +41,12 @@ from paasta_tools.utils import TimeoutError
 
 
 @pytest.mark.parametrize("include_mesos", [False, True])
+@pytest.mark.parametrize("include_envoy", [False, True])
 @pytest.mark.parametrize("include_smartstack", [False, True])
 @mock.patch("paasta_tools.api.views.instance.marathon_mesos_status", autospec=True)
-@mock.patch("paasta_tools.api.views.instance.marathon_smartstack_status", autospec=True)
+@mock.patch(
+    "paasta_tools.api.views.instance.marathon_service_mesh_status", autospec=True
+)
 @mock.patch(
     "paasta_tools.api.views.instance.marathon_tools.load_service_namespace_config",
     autospec=True,
@@ -70,9 +74,10 @@ def test_instance_status_marathon(
     mock_get_matching_apps_with_clients,
     mock_marathon_job_status,
     mock_load_service_namespace_config,
-    mock_marathon_smartstack_status,
+    mock_marathon_service_mesh_status,
     mock_marathon_mesos_status,
     include_smartstack,
+    include_envoy,
     include_mesos,
 ):
     settings.cluster = "fake_cluster"
@@ -110,6 +115,7 @@ def test_instance_status_marathon(
         "instance": "fake_instance",
         "verbose": 2,
         "include_smartstack": include_smartstack,
+        "include_envoy": include_envoy,
         "include_mesos": include_mesos,
     }
     response = instance.instance_status(request)
@@ -119,7 +125,9 @@ def test_instance_status_marathon(
         "marathon_job_status_field2": "field2_value",
     }
     if include_smartstack:
-        expected_response["smartstack"] = mock_marathon_smartstack_status.return_value
+        expected_response["smartstack"] = mock_marathon_service_mesh_status.return_value
+    if include_envoy:
+        expected_response["envoy"] = mock_marathon_service_mesh_status.return_value
     if include_mesos:
         expected_response["mesos"] = mock_marathon_mesos_status.return_value
     assert response["marathon"] == expected_response
@@ -135,15 +143,37 @@ def test_instance_status_marathon(
         mock_marathon_mesos_status.assert_called_once_with(
             "fake_service", "fake_instance", 2
         )
+    expected_marathon_service_mesh_status_calls = []
     if include_smartstack:
-        mock_marathon_smartstack_status.assert_called_once_with(
-            "fake_service",
-            "fake_instance",
-            mock_service_config,
-            mock_load_service_namespace_config.return_value,
-            mock_app.tasks,
-            should_return_individual_backends=True,
+        expected_marathon_service_mesh_status_calls.append(
+            mock.call(
+                "fake_service",
+                instance.ServiceMesh.SMARTSTACK,
+                "fake_instance",
+                mock_service_config,
+                mock_load_service_namespace_config.return_value,
+                mock_app.tasks,
+                should_return_individual_backends=True,
+            ),
         )
+    if include_envoy:
+        expected_marathon_service_mesh_status_calls.append(
+            mock.call(
+                "fake_service",
+                instance.ServiceMesh.ENVOY,
+                "fake_instance",
+                mock_service_config,
+                mock_load_service_namespace_config.return_value,
+                mock_app.tasks,
+                should_return_individual_backends=True,
+            )
+        )
+    mock_marathon_service_mesh_status.assert_has_calls(
+        expected_marathon_service_mesh_status_calls,
+    )
+    assert mock_marathon_service_mesh_status.call_count == len(
+        expected_marathon_service_mesh_status_calls
+    )
 
 
 @pytest.fixture
@@ -355,25 +385,37 @@ class TestMarathonAppStatus:
         ]
 
 
-@mock.patch("paasta_tools.api.views.instance.match_backends_and_tasks", autospec=True)
-@mock.patch("paasta_tools.api.views.instance.get_backends", autospec=True)
 @mock.patch(
     "paasta_tools.api.views.instance.marathon_tools.get_expected_instance_count_for_namespace",
     autospec=True,
 )
+@mock.patch(
+    "paasta_tools.api.views.instance.smartstack_tools.match_backends_and_tasks",
+    autospec=True,
+)
+@mock.patch(
+    "paasta_tools.api.views.instance.smartstack_tools.get_backends", autospec=True
+)
+@mock.patch(
+    "paasta_tools.api.views.instance.envoy_tools.match_backends_and_tasks",
+    autospec=True,
+)
+@mock.patch("paasta_tools.api.views.instance.envoy_tools.get_backends", autospec=True)
 @mock.patch("paasta_tools.api.views.instance.get_slaves", autospec=True)
-def test_marathon_smartstack_status(
+def test_marathon_service_mesh_status(
     mock_get_slaves,
+    mock_envoy_tools_get_backends,
+    mock_envoy_tools_match_backends_and_tasks,
+    mock_smartstack_tools_get_backends,
+    mock_smartstack_tools_match_backends_and_tasks,
     mock_get_expected_instance_count_for_namespace,
-    mock_get_backends,
-    mock_match_backends_and_tasks,
 ):
     mock_get_slaves.return_value = [
         {"hostname": "host1.paasta.party", "attributes": {"region": "us-north-3"}}
     ]
     mock_get_expected_instance_count_for_namespace.return_value = 2
 
-    mock_backend = HaproxyBackend(
+    mock_haproxy_backend = HaproxyBackend(
         status="UP",
         svname="host1_1.2.3.4:123",
         check_status="L7OK",
@@ -382,7 +424,9 @@ def test_marathon_smartstack_status(
         lastchg="9876",
     )
     mock_task = mock.create_autospec(MarathonTask)
-    mock_match_backends_and_tasks.return_value = [(mock_backend, mock_task)]
+    mock_smartstack_tools_match_backends_and_tasks.return_value = [
+        (mock_haproxy_backend, mock_task)
+    ]
 
     settings.system_paasta_config = mock.create_autospec(SystemPaastaConfig)
     settings.system_paasta_config.get_deploy_blacklist.return_value = []
@@ -395,8 +439,9 @@ def test_marathon_smartstack_status(
     )
     mock_service_namespace_config = ServiceNamespaceConfig()
 
-    smartstack_status = instance.marathon_smartstack_status(
+    smartstack_status = instance.marathon_service_mesh_status(
         "fake_service",
+        instance.ServiceMesh.SMARTSTACK,
         "fake_instance",
         mock_service_config,
         mock_service_namespace_config,
@@ -422,6 +467,48 @@ def test_marathon_smartstack_status(
                         "check_duration": 1,
                     }
                 ],
+            }
+        ],
+    }
+
+    mock_envoy_backend = EnvoyBackend(
+        address="1.2.3.4",
+        port_value=123,
+        hostname="host1_1.2.3.4",
+        eds_health_status="HEALTHY",
+        weight=1,
+        has_associated_task=False,
+    )
+    mock_envoy_tools_match_backends_and_tasks.return_value = [
+        (mock_envoy_backend, mock_task)
+    ]
+    envoy_status = instance.marathon_service_mesh_status(
+        "fake_service",
+        instance.ServiceMesh.ENVOY,
+        "fake_instance",
+        mock_service_config,
+        mock_service_namespace_config,
+        tasks=[mock_task],
+        should_return_individual_backends=True,
+    )
+    assert envoy_status == {
+        "registration": "fake_service.fake_instance",
+        "expected_backends_per_location": 2,
+        "locations": [
+            {
+                "name": "us-north-3",
+                "running_backends_count": 1,
+                "backends": [
+                    {
+                        "address": "1.2.3.4",
+                        "port_value": 123,
+                        "hostname": "host1_1.2.3.4",
+                        "eds_health_status": "HEALTHY",
+                        "weight": 1,
+                        "has_associated_task": True,
+                    }
+                ],
+                "is_proxied_through_casper": False,
             }
         ],
     }

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -937,6 +937,11 @@ def mock_marathon_status():
             expected_backends_per_location=1,
             locations=[],
         ),
+        envoy=Struct(
+            registration="fake_service.fake_instance",
+            expected_backends_per_location=1,
+            locations=[],
+        ),
     )
 
 
@@ -1038,10 +1043,12 @@ class TestPrintMarathonStatus:
         )
         assert return_value == 0
 
+    @pytest.mark.parametrize("include_envoy", [True, False])
     @pytest.mark.parametrize("include_smartstack", [True, False])
     @pytest.mark.parametrize("include_autoscaling_info", [True, False])
     @patch("paasta_tools.cli.cmds.status.create_autoscaling_info_table", autospec=True)
     @patch("paasta_tools.cli.cmds.status.get_smartstack_status_human", autospec=True)
+    @patch("paasta_tools.cli.cmds.status.get_envoy_status_human", autospec=True)
     @patch("paasta_tools.cli.cmds.status.marathon_mesos_status_human", autospec=True)
     @patch("paasta_tools.cli.cmds.status.marathon_app_status_human", autospec=True)
     @patch("paasta_tools.cli.cmds.status.status_marathon_job_human", autospec=True)
@@ -1054,11 +1061,13 @@ class TestPrintMarathonStatus:
         mock_status_marathon_job_human,
         mock_marathon_app_status_human,
         mock_marathon_mesos_status_human,
+        mock_get_envoy_status_human,
         mock_get_smartstack_status_human,
         mock_create_autoscaling_info_table,
         mock_marathon_status,
         include_autoscaling_info,
         include_smartstack,
+        include_envoy,
     ):
         mock_marathon_app_status_human.side_effect = lambda desired_app_id, app_status: [
             f"{app_status.id} status 1",
@@ -1067,6 +1076,10 @@ class TestPrintMarathonStatus:
         mock_marathon_mesos_status_human.return_value = [
             "mesos status 1",
             "mesos status 2",
+        ]
+        mock_get_envoy_status_human.return_value = [
+            "envoy status 1",
+            "envoy status 2",
         ]
         mock_get_smartstack_status_human.return_value = [
             "smartstack status 1",
@@ -1082,6 +1095,8 @@ class TestPrintMarathonStatus:
             mock_marathon_status.autoscaling_info = Struct()
         if not include_smartstack:
             mock_marathon_status.smartstack = None
+        if not include_envoy:
+            mock_marathon_status.envoy = None
 
         output = []
         print_marathon_status(
@@ -1107,6 +1122,8 @@ class TestPrintMarathonStatus:
         ]
         if include_smartstack:
             expected_output += [f"    smartstack status 1", f"    smartstack status 2"]
+        if include_envoy:
+            expected_output += [f"    envoy status 1", f"    envoy status 2"]
 
         assert expected_output == output
 

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -41,7 +41,7 @@ class fake_args:
 
 
 def mock_status_instance_side_effect(
-    service, instance, include_smartstack, include_mesos
+    service, instance, include_smartstack, include_envoy, include_mesos
 ):
     if instance in ["instance1", "instance6", "notaninstance", "api_error"]:
         # valid completed instance

--- a/tests/envoy_admin_clusters_snapshot.txt
+++ b/tests/envoy_admin_clusters_snapshot.txt
@@ -1,0 +1,234 @@
+{
+ "cluster_statuses": [
+  {
+   "name": "service1.main.egress_cluster",
+   "added_via_api": true,
+   "host_statuses": [
+    {
+     "address": {
+      "socket_address": {
+       "address": "10.46.6.88",
+       "port_value": 13833
+      }
+     },
+     "stats": [
+      {
+       "name": "cx_connect_fail"
+      },
+      {
+       "name": "cx_total"
+      },
+      {
+       "name": "rq_error"
+      },
+      {
+       "name": "rq_success"
+      },
+      {
+       "name": "rq_timeout"
+      },
+      {
+       "name": "rq_total"
+      },
+      {
+       "type": "GAUGE",
+       "name": "cx_active"
+      },
+      {
+       "type": "GAUGE",
+       "name": "rq_active"
+      }
+     ],
+     "health_status": {
+      "eds_health_status": "HEALTHY"
+     },
+     "weight": 1
+    }
+   ]
+  },
+  {
+   "name": "service1.main.egress_cluster",
+   "added_via_api": true,
+   "host_statuses": [
+    {
+     "address": {
+      "socket_address": {
+       "address": "10.46.6.90",
+       "port_value": 13833
+      }
+     },
+     "stats": [
+      {
+       "name": "cx_connect_fail"
+      },
+      {
+       "name": "cx_total"
+      },
+      {
+       "name": "rq_error"
+      },
+      {
+       "name": "rq_success"
+      },
+      {
+       "name": "rq_timeout"
+      },
+      {
+       "name": "rq_total"
+      },
+      {
+       "type": "GAUGE",
+       "name": "cx_active"
+      },
+      {
+       "type": "GAUGE",
+       "name": "rq_active"
+      }
+     ],
+     "health_status": {
+      "eds_health_status": "HEALTHY"
+     },
+     "weight": 1
+    }
+   ]
+  },
+  {
+   "name": "some_service7.main.egress_cluster",
+   "added_via_api": true,
+   "host_statuses": [
+    {
+     "address": {
+      "socket_address": {
+       "address": "10.46.6.88",
+       "port_value": 13833
+      }
+     },
+     "stats": [
+      {
+       "name": "cx_connect_fail"
+      },
+      {
+       "name": "cx_total"
+      },
+      {
+       "name": "rq_error"
+      },
+      {
+       "name": "rq_success"
+      },
+      {
+       "name": "rq_timeout"
+      },
+      {
+       "name": "rq_total"
+      },
+      {
+       "type": "GAUGE",
+       "name": "cx_active"
+      },
+      {
+       "type": "GAUGE",
+       "name": "rq_active"
+      }
+     ],
+     "health_status": {
+      "eds_health_status": "UNHEALTHY"
+     },
+     "weight": 1
+    }
+   ]
+  },
+  {
+   "name": "service2.main.egress_cluster",
+   "added_via_api": true,
+   "host_statuses": [
+    {
+     "address": {
+      "socket_address": {
+       "address": "10.46.6.103",
+       "port_value": 13810
+      }
+     },
+     "stats": [
+      {
+       "name": "cx_connect_fail"
+      },
+      {
+       "name": "cx_total"
+      },
+      {
+       "name": "rq_error"
+      },
+      {
+       "name": "rq_success"
+      },
+      {
+       "name": "rq_timeout"
+      },
+      {
+       "name": "rq_total"
+      },
+      {
+       "type": "GAUGE",
+       "name": "cx_active"
+      },
+      {
+       "type": "GAUGE",
+       "name": "rq_active"
+      }
+     ],
+     "health_status": {
+      "eds_health_status": "HEALTHY"
+     },
+     "weight": 1
+    }
+   ]
+  },
+{
+   "name": "spectre.main.egress_cluster",
+   "added_via_api": true,
+   "host_statuses": [
+    {
+     "address": {
+      "socket_address": {
+       "address": "10.46.6.106",
+       "port_value": 13819
+      }
+     },
+     "stats": [
+      {
+       "name": "cx_connect_fail"
+      },
+      {
+       "name": "cx_total"
+      },
+      {
+       "name": "rq_error"
+      },
+      {
+       "name": "rq_success"
+      },
+      {
+       "name": "rq_timeout"
+      },
+      {
+       "name": "rq_total"
+      },
+      {
+       "type": "GAUGE",
+       "name": "cx_active"
+      },
+      {
+       "type": "GAUGE",
+       "name": "rq_active"
+      }
+     ],
+     "health_status": {
+      "eds_health_status": "HEALTHY"
+     },
+     "weight": 1
+    }
+   ]
+  }
+ ]
+}

--- a/tests/test_envoy_tools.py
+++ b/tests/test_envoy_tools.py
@@ -1,0 +1,160 @@
+# Copyright 2015-2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import os
+
+import mock
+import pytest
+import requests
+
+from paasta_tools.envoy_tools import get_backends
+from paasta_tools.envoy_tools import get_casper_endpoints
+from paasta_tools.envoy_tools import match_backends_and_tasks
+
+
+@pytest.fixture
+def mock_paasta_tools_settings(system_paasta_config):
+    with mock.patch(
+        "paasta_tools.envoy_tools.settings", autospec=True
+    ) as mock_settings:
+        mock_settings.system_paasta_config = system_paasta_config
+        yield
+
+
+def test_get_backends(mock_paasta_tools_settings):
+    testdir = os.path.dirname(os.path.realpath(__file__))
+    testdata = os.path.join(testdir, "envoy_admin_clusters_snapshot.txt")
+    with open(testdata, "r") as fd:
+        mock_envoy_admin_clusters_data = json.load(fd)
+
+    mock_response = mock.Mock()
+    mock_response.json.return_value = mock_envoy_admin_clusters_data
+    mock_get = mock.Mock(return_value=(mock_response))
+
+    hosts = {
+        "10.46.6.90": ("host2.two.com", None, None),
+        "10.46.6.88": ("host3.three.com", None, None),
+        "10.46.6.103": ("host4.four.com", None, None),
+    }
+
+    with mock.patch.object(requests.Session, "get", mock_get):
+        with mock.patch(
+            "socket.gethostbyaddr", side_effect=lambda x: hosts[x], autospec=True,
+        ):
+            expected = [
+                (
+                    {
+                        "address": "10.46.6.88",
+                        "port_value": 13833,
+                        "hostname": "host3",
+                        "eds_health_status": "HEALTHY",
+                        "weight": 1,
+                    },
+                    False,
+                ),
+                (
+                    {
+                        "address": "10.46.6.90",
+                        "port_value": 13833,
+                        "hostname": "host2",
+                        "eds_health_status": "HEALTHY",
+                        "weight": 1,
+                    },
+                    False,
+                ),
+            ]
+            assert expected == get_backends("service1.main", "host", 123)
+
+
+def test_get_casper_endpoints():
+    testdir = os.path.dirname(os.path.realpath(__file__))
+    testdata = os.path.join(testdir, "envoy_admin_clusters_snapshot.txt")
+    with open(testdata, "r") as fd:
+        mock_envoy_admin_clusters_data = json.load(fd)
+
+    expected = frozenset([("10.46.6.106", 13819)])
+
+    assert expected == get_casper_endpoints(mock_envoy_admin_clusters_data)
+
+
+def test_match_backends_and_tasks():
+    backends = [
+        {
+            "address": "10.50.2.4",
+            "port_value": 31000,
+            "eds_health_status": "HEALTHY",
+            "weight": 1,
+            "has_associated_task": False,
+        },
+        {
+            "address": "10.50.2.5",
+            "port_value": 31001,
+            "eds_health_status": "HEALTHY",
+            "weight": 1,
+            "has_associated_task": False,
+        },
+        {
+            "address": "10.50.2.6",
+            "port_value": 31001,
+            "eds_health_status": "HEALTHY",
+            "weight": 1,
+            "has_associated_task": False,
+        },
+        {
+            "address": "10.50.2.6",
+            "port_value": 31002,
+            "eds_health_status": "HEALTHY",
+            "weight": 1,
+            "has_associated_task": False,
+        },
+        {
+            "address": "10.50.2.8",
+            "port_value": 31000,
+            "eds_health_status": "HEALTHY",
+            "weight": 1,
+            "has_associated_task": False,
+        },
+    ]
+    good_task1 = mock.Mock(host="box4", ports=[31000])
+    good_task2 = mock.Mock(host="box5", ports=[31001])
+    bad_task = mock.Mock(host="box7", ports=[31000])
+    tasks = [good_task1, good_task2, bad_task]
+
+    hostnames = {
+        "box4": "10.50.2.4",
+        "box5": "10.50.2.5",
+        "box6": "10.50.2.6",
+        "box7": "10.50.2.7",
+        "box8": "10.50.2.8",
+    }
+
+    with mock.patch(
+        "paasta_tools.envoy_tools.socket.gethostbyname",
+        side_effect=lambda x: hostnames[x],
+        autospec=True,
+    ):
+        expected = [
+            (backends[0], good_task1),
+            (backends[1], good_task2),
+            (None, bad_task),
+            (backends[2], None),
+            (backends[3], None),
+            (backends[4], None),
+        ]
+        actual = match_backends_and_tasks(backends, tasks)
+
+        def keyfunc(t):
+            return tuple(sorted((t[0] or {}).items())), t[1]
+
+        assert sorted(actual, key=keyfunc) == sorted(expected, key=keyfunc)


### PR DESCRIPTION
This reverts commit ced20ed9a12e3757eaf8c75d7c8b97717a12c663 which was created by #2640 which was a revert of #2595. This effectively restores #2595 . No new changes are introduced in this PR.

We've fixed the issues which were caused by missing envoy configuration.