### PR TITLE
change kubernetes service autoscaling target metrics units

### DIFF
--- a/docs/source/hpa.rst
+++ b/docs/source/hpa.rst
@@ -53,7 +53,7 @@ Here is an example that includes all configuration
        max_replicas: 3
        min_replicas: 1
        uwsgi:
-         target_average_value: 53
+         target_average_value: 0.53
          dimensions:
              paasta_yelp_com_instance: main_uswest1_autoscaling
              some_unique_signalfx_dimension: value_of_dimension
@@ -61,9 +61,9 @@ Here is an example that includes all configuration
        http:
          target_average_value: 53
        cpu:
-         target_average_value: 70
+         target_average_value: 0.7
        memory:
-         target_average_value: 70
+         target_average_value: 0.7
        your-own-sfx-metrics:
          target_value: 2333
          signalflow_metrics_query: "data('your_own_sfx_metrics', filter('some_dimension', 'value')).mean(over="30m").publish()"
@@ -92,7 +92,7 @@ cpu
 Please check here for `algorthm detail <https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details>`_
 
 :target_average_value (required):
-  An Integer from 0 (exclusive) to 100 (inclusive), (0 - 100].
+  A number from 0 (exclusive) to 1 (inclusive), (0 - 1].
   This is the percentage of cpu used.
 
 memory
@@ -117,8 +117,7 @@ You can achieve the same function with your own custom metrics.
 Any suggestions/demands are welcome.
 
 :target_average_value (required):
-  An Integer from 0 (exclusive) to 100 (inclusive), (0 - 100].
-  This is 100 times of the average value exposed by your http endpoint.
+  A number
 
 :dimensions:
   Any number of custom key value pairs that are strings.

--- a/general_itests/fake_soa_configs_validate/fake_valid_service/kubernetes-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_valid_service/kubernetes-test-cluster.yaml
@@ -11,9 +11,9 @@ main2:
       max_replicas: 100
       min_replicas: 1
       cpu:
-          target_average_value: 7
+          target_average_value: 0.7
       memory:
-          target_average_value: 7
+          target_average_value: 0.7
       uwsgi:
           target_average_value: 4
       http:

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -208,10 +208,10 @@
                             "additionalProperties": false,
                             "properties": {
                                 "target_average_value": {
-                                    "type": "integer",
-                                    "default": 70,
+                                    "type": "number",
+                                    "default": 0.7,
                                     "minimum": 0,
-                                    "maximum": 100,
+                                    "maximum": 1,
                                     "exclusiveMinimum": true,
                                     "exclusiveMaximum": false
                                 }
@@ -225,10 +225,10 @@
                             "additionalProperties": false,
                             "properties": {
                                 "target_average_value": {
-                                    "type": "integer",
-                                    "default": 70,
+                                    "type": "number",
+                                    "default": 0.7,
                                     "minimum": 0,
-                                    "maximum": 100,
+                                    "maximum": 1,
                                     "exclusiveMinimum": true,
                                     "exclusiveMaximum": false
                                 }
@@ -242,12 +242,7 @@
                             "additionalProperties": false,
                             "properties": {
                                 "target_average_value": {
-                                    "type": "integer",
-                                    "default": 70,
-                                    "minimum": 0,
-                                    "maximum": 100,
-                                    "exclusiveMinimum": true,
-                                    "exclusiveMaximum": false
+                                    "type": "number"
                                 },
                                 "dimensions": {
                                     "type": "object",
@@ -268,12 +263,7 @@
                             "additionalProperties": false,
                             "properties": {
                                 "target_average_value": {
-                                    "type": "number",
-                                    "default": 70,
-                                    "minimum": 0,
-                                    "maximum": 100,
-                                    "exclusiveMinimum": true,
-                                    "exclusiveMaximum": false
+                                    "type": "number"
                                 },
                                 "dimensions": {
                                     "type": "object",

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -412,8 +412,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                         type="Resource",
                         resource=V2beta1ResourceMetricSource(
                             name=metric_name,
-                            target_average_utilization=value["target_average_value"]
-                            * 100,
+                            target_average_utilization=int(
+                                value["target_average_value"] * 100
+                            ),
                         ),
                     )
                 )

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -412,7 +412,8 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                         type="Resource",
                         resource=V2beta1ResourceMetricSource(
                             name=metric_name,
-                            target_average_utilization=value["target_average_value"],
+                            target_average_utilization=value["target_average_value"]
+                            * 100,
                         ),
                     )
                 )
@@ -489,7 +490,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         autoscaling_params = self.get_autoscaling_params()
         metrics_provider = autoscaling_params["metrics_provider"]
         metrics = []
-        target = autoscaling_params["setpoint"] * 100
+        target = autoscaling_params["setpoint"]
         annotations: Dict[str, str] = {}
         selector = V1LabelSelector(match_labels={"kubernetes_cluster": cluster})
         if autoscaling_params["decision_policy"] == "bespoke":
@@ -503,7 +504,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 V2beta1MetricSpec(
                     type="Resource",
                     resource=V2beta1ResourceMetricSource(
-                        name="cpu", target_average_utilization=int(target)
+                        name="cpu", target_average_utilization=int(target * 100)
                     ),
                 )
             )

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -235,11 +235,11 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
         hpa_config = {
             "min_replicas": 1,
             "max_replicas": 3,
-            "cpu": {"target_average_value": 70},
-            "memory": {"target_average_value": 70},
-            "uwsgi": {"target_average_value": 70},
-            "http": {"target_average_value": 70, "dimensions": {"any": "random"}},
-            "external": {"target_value": 70, "signalflow_metrics_query": "fake_query"},
+            "cpu": {"target_average_value": 0.7},
+            "memory": {"target_average_value": 0.7},
+            "uwsgi": {"target_average_value": 0.7},
+            "http": {"target_average_value": 0.7, "dimensions": {"any": "random"}},
+            "external": {"target_value": 0.7, "signalflow_metrics_query": "fake_query"},
         }
         mock_config_dict = KubernetesDeploymentConfigDict(
             bounce_method="crossover", instances=3, horizontal_autoscaling=hpa_config,
@@ -1105,12 +1105,12 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             "horizontal_autoscaling": {
                 "min_replicas": 1,
                 "max_replicas": 3,
-                "cpu": {"target_average_value": 70},
-                "memory": {"target_average_value": 70},
-                "uwsgi": {"target_average_value": 70},
-                "http": {"target_average_value": 70, "dimensions": {"any": "random"}},
+                "cpu": {"target_average_value": 0.7},
+                "memory": {"target_average_value": 0.7},
+                "uwsgi": {"target_average_value": 0.7},
+                "http": {"target_average_value": 0.7, "dimensions": {"any": "random"}},
                 "external": {
-                    "target_value": 70,
+                    "target_value": 0.7,
                     "signalflow_metrics_query": "fake_query",
                 },
             }
@@ -1155,7 +1155,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                         type="Pods",
                         pods=V2beta1PodsMetricSource(
                             metric_name="uwsgi",
-                            target_average_value=70,
+                            target_average_value=0.7,
                             selector=V1LabelSelector(
                                 match_labels={"kubernetes_cluster": "cluster"}
                             ),
@@ -1164,13 +1164,13 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     V2beta1MetricSpec(
                         type="External",
                         external=V2beta1ExternalMetricSource(
-                            metric_name="http", target_value=70,
+                            metric_name="http", target_value=0.7,
                         ),
                     ),
                     V2beta1MetricSpec(
                         type="External",
                         external=V2beta1ExternalMetricSource(
-                            metric_name="external", target_value=70,
+                            metric_name="external", target_value=0.7,
                         ),
                     ),
                 ],
@@ -1253,7 +1253,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                         type="Pods",
                         pods=V2beta1PodsMetricSource(
                             metric_name="http",
-                            target_average_value=50.0,
+                            target_average_value=0.5,
                             selector=V1LabelSelector(
                                 match_labels={"kubernetes_cluster": "cluster"}
                             ),
@@ -1298,7 +1298,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                         type="Pods",
                         pods=V2beta1PodsMetricSource(
                             metric_name="uwsgi",
-                            target_average_value=50.0,
+                            target_average_value=0.5,
                             selector=V1LabelSelector(
                                 match_labels={"kubernetes_cluster": "cluster"}
                             ),


### PR DESCRIPTION
I changed how target_average_value in kuberentes is set (for uwsgi and http metrics). It was originally timed 100 and is not anymore. cpu and memory metrics is timed by 100 as required. 