### PR TITLE
fix error messaage violates swag format error

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1377,10 +1377,10 @@ def list_deployments(
 async def get_tail_lines_for_kubernetes_pod(
     kube_client: KubeClient, pod: V1Pod, num_tail_lines: int
 ) -> MutableMapping[str, List[str]]:
-    tail_lines_dict: MutableMapping[str, List[str]] = {
+    tail_lines_dict: MutableMapping[str, Any] = {
         "stdout": [],
         "stderr": [],
-        "error_message": [],
+        "error_message": "",
     }
     for container in pod.spec.containers:
         if container.name != HACHECK_POD_NAME:
@@ -1394,9 +1394,9 @@ async def get_tail_lines_for_kubernetes_pod(
                     )
                 )
             except ApiException as e:
-                tail_lines_dict["error_message"].append(
-                    f"couldn't read stdout/stderr because {e.getResponseBody()}"
-                )
+                tail_lines_dict[
+                    "error_message"
+                ] = f"couldn't read stdout/stderr because {e.getResponseBody()}"
 
     return tail_lines_dict
 


### PR DESCRIPTION
The error messages said it violdates the swagger format:
https://fluffy.yelpcorp.com/i/fg0MF8L3tHTkPVKl9wGvhjfJdzQwK7wS.html

And it turns out the error message should be string rather than list:
https://sourcegraph.yelpcorp.com/mirrors/Yelp/paasta/-/blob/paasta_tools/api/api_docs/swagger.json#L885