### PR TITLE
Default hostname when getting envoy status to raw IP address if lookup fails

### DIFF
--- a/paasta_tools/envoy_tools.py
+++ b/paasta_tools/envoy_tools.py
@@ -146,16 +146,18 @@ def get_multiple_backends(
                                 casper_endpoint_found = True
                                 continue
 
+                        try:
+                            hostname = socket.gethostbyaddr(address)[0].split(".")[0]
+                        except socket.herror:
+                            # Default to the raw IP address if we can't lookup the hostname
+                            hostname = address
+
                         cluster_backends.append(
                             (
                                 EnvoyBackend(
                                     address=address,
                                     port_value=port_value,
-                                    hostname=socket.gethostbyaddr(
-                                        host_status["address"]["socket_address"][
-                                            "address"
-                                        ]
-                                    )[0].split(".")[0],
+                                    hostname=hostname,
                                     eds_health_status=host_status["health_status"][
                                         "eds_health_status"
                                     ],


### PR DESCRIPTION
paasta status would error when retrieving envoy status if socket.gethostbyaddr failed on a k8s pod IP. The hostname is only used for display purposes, so this defaults the hostname to the raw IP if socket.gethostbyaddr fails.