### PR TITLE
Refactor instance listing into a single function

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -26,6 +26,7 @@ from typing import Tuple
 
 import yaml
 from service_configuration_lib import pick_random_port
+from service_configuration_lib import read_extra_service_information
 from service_configuration_lib import read_yaml_file
 from service_configuration_lib.spark_config import get_mesos_spark_env
 from service_configuration_lib.spark_config import stringify_spark_env
@@ -48,8 +49,7 @@ from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import paasta_print
-from paasta_tools.utils import load_tron_yaml
-from paasta_tools.utils import extract_jobs_from_tron_yaml
+from paasta_tools.utils import filter_templates_from_config
 from paasta_tools.spark_tools import get_spark_resource_requirements
 from paasta_tools.spark_tools import get_webui_url
 from paasta_tools.spark_tools import inject_spark_conf_str
@@ -672,8 +672,10 @@ def load_tron_service_config(
     service, cluster, load_deployments=True, soa_dir=DEFAULT_SOA_DIR
 ):
     """Load all configured jobs for a service, and any additional config values."""
-    config = load_tron_yaml(service=service, cluster=cluster, soa_dir=soa_dir)
-    jobs = extract_jobs_from_tron_yaml(config)
+    config = read_extra_service_information(
+        service_name=service, extra_info=f"tron-{cluster}", soa_dir=soa_dir
+    )
+    jobs = filter_templates_from_config(config)
     job_configs = [
         TronJobConfig(
             name=name,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2637,68 +2637,30 @@ def list_all_instances_for_service(
     return instances
 
 
-def get_tron_instance_list_from_yaml(
-    service: str, cluster: str, soa_dir: str
-) -> Collection[Tuple[str, str]]:
-    instance_list = []
-    try:
-        tron_config_content = load_tron_yaml(
-            service=service, cluster=cluster, soa_dir=soa_dir
-        )
-    except NoConfigurationForServiceError:
-        return []
-    jobs = extract_jobs_from_tron_yaml(config=tron_config_content)
-    for job_name, job in jobs.items():
-        action_names = get_action_names_from_job(job=job)
-        for name in action_names:
-            instance = f"{job_name}.{name}"
-            instance_list.append((service, instance))
-    return instance_list
-
-
-def get_action_names_from_job(job: dict) -> Collection[str]:
-    # Warning: This duplicates some logic from TronActionConfig, but can't be imported here
-    # dute to circular imports
-    actions = job.get("actions", {})
-    if isinstance(actions, dict):
-        return list(actions.keys())
-    elif actions is None:
-        return []
-    else:
-        raise TypeError("Tron actions must be a dictionary")
-
-
-def load_tron_yaml(service: str, cluster: str, soa_dir: str) -> Dict[str, Any]:
-    config = service_configuration_lib.read_extra_service_information(
-        service_name=service, extra_info=f"tron-{cluster}", soa_dir=soa_dir
-    )
-    if not config:
-        raise NoConfigurationForServiceError(
-            "No Tron configuration found for service %s" % service
-        )
-    return config
-
-
-def extract_jobs_from_tron_yaml(config: Dict) -> Dict[str, Any]:
+def filter_templates_from_config(config: Dict) -> Dict[str, Any]:
     config = {
         key: value for key, value in config.items() if not key.startswith("_")
     }  # filter templates
     return config or {}
 
 
-def get_instance_list_from_yaml(
-    service: str, conf_file: str, soa_dir: str
+def read_service_instance_names(
+    service: str, instance_type: str, cluster: str, soa_dir: str
 ) -> Collection[Tuple[str, str]]:
     instance_list = []
-    instances = service_configuration_lib.read_extra_service_information(
+    conf_file = f"{instance_type}-{cluster}"
+    config = service_configuration_lib.read_extra_service_information(
         service, conf_file, soa_dir=soa_dir
     )
-    for instance in instances:
-        if instance.startswith("_"):
-            log.debug(
-                f"Ignoring {service}.{instance} as instance name begins with '_'."
-            )
-        else:
+    config = filter_templates_from_config(config)
+    if instance_type == "tron":
+        for job_name, job in config.items():
+            action_names = list(job.get("actions", {}).keys())
+            for name in action_names:
+                instance = f"{job_name}.{name}"
+                instance_list.append((service, instance))
+    else:
+        for instance in config:
             instance_list.append((service, instance))
     return instance_list
 
@@ -2740,22 +2702,14 @@ def get_service_instance_list_no_cache(
 
     instance_list: List[Tuple[str, str]] = []
     for srv_instance_type in instance_types:
-        conf_file = f"{srv_instance_type}-{cluster}"
-        log.debug(
-            f"Enumerating all instances for config file: {soa_dir}/*/{conf_file}.yaml"
+        instance_list.extend(
+            read_service_instance_names(
+                service=service,
+                instance_type=srv_instance_type,
+                cluster=cluster,
+                soa_dir=soa_dir,
+            )
         )
-        if srv_instance_type == "tron":
-            instance_list.extend(
-                get_tron_instance_list_from_yaml(
-                    service=service, cluster=cluster, soa_dir=soa_dir
-                )
-            )
-        else:
-            instance_list.extend(
-                get_instance_list_from_yaml(
-                    service=service, conf_file=conf_file, soa_dir=soa_dir
-                )
-            )
     log.debug("Enumerated the following instances: %s", instance_list)
     return instance_list
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2753,17 +2753,9 @@ def get_services_for_cluster(
     )
     instance_list: List[Tuple[str, str]] = []
     for srv_dir in os.listdir(rootdir):
-        service_instance_list = get_service_instance_list(
-            srv_dir, cluster, instance_type, soa_dir
+        instance_list.extend(
+            get_service_instance_list(srv_dir, cluster, instance_type, soa_dir)
         )
-        for service_instance in service_instance_list:
-            service, instance = service_instance
-            if instance.startswith("_"):
-                log.debug(
-                    f"Ignoring {service}.{instance} as instance name begins with '_'."
-                )
-            else:
-                instance_list.append(service_instance)
     return instance_list
 
 

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -734,24 +734,9 @@ class TestTronTools:
         assert result["env"]["SHELL"] == "/bin/bash"
         assert isinstance(result["docker_parameters"], list)
 
-    @mock.patch(
-        "service_configuration_lib.read_extra_service_information", autospec=True
-    )
-    def test_load_tron_yaml_picks_service_dir(
-        self, mock_read_extra_service_configuration
-    ):
-        config = "test"
-        mock_read_extra_service_configuration.return_value = config
-        assert config == tron_tools.load_tron_yaml(
-            service="foo", cluster="bar", soa_dir="test"
-        )
-        mock_read_extra_service_configuration.assert_called_once_with(
-            service_name="foo", extra_info="tron-bar", soa_dir="test"
-        )
-
-    @mock.patch("paasta_tools.tron_tools.load_tron_yaml", autospec=True)
-    def test_load_tron_service_config(self, mock_load_tron_yaml):
-        mock_load_tron_yaml.return_value = {
+    @mock.patch("paasta_tools.tron_tools.read_extra_service_information", autospec=True)
+    def test_load_tron_service_config(self, mock_read_extra_service_information):
+        mock_read_extra_service_information.return_value = {
             "_template": {"actions": {"action1": {}}},
             "job1": {"actions": {"action1": {}}},
         }
@@ -771,13 +756,13 @@ class TestTronTools:
                 soa_dir="fake",
             )
         ]
-        mock_load_tron_yaml.assert_called_once_with(
-            service="service", cluster="test-cluster", soa_dir="fake"
+        mock_read_extra_service_information.assert_called_once_with(
+            service_name="service", extra_info="tron-test-cluster", soa_dir="fake"
         )
 
-    @mock.patch("paasta_tools.tron_tools.load_tron_yaml", autospec=True)
-    def test_load_tron_service_config_empty(self, mock_load_tron_yaml):
-        mock_load_tron_yaml.return_value = {}
+    @mock.patch("paasta_tools.tron_tools.read_extra_service_information", autospec=True)
+    def test_load_tron_service_config_empty(self, mock_read_extra_service_information):
+        mock_read_extra_service_information.return_value = {}
         job_configs = tron_tools.load_tron_service_config(
             service="service",
             cluster="test-cluster",
@@ -785,8 +770,8 @@ class TestTronTools:
             soa_dir="fake",
         )
         assert job_configs == []
-        mock_load_tron_yaml.assert_called_once_with(
-            service="service", cluster="test-cluster", soa_dir="fake"
+        mock_read_extra_service_information.assert_called_once_with(
+            service_name="service", extra_info="tron-test-cluster", soa_dir="fake"
         )
 
     @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -961,35 +961,6 @@ def test_get_services_for_cluster():
         assert get_instances_patch.call_count == 2
 
 
-def test_get_services_for_cluster_ignores_underscore():
-    cluster = "honey_bunches_of_oats"
-    soa_dir = "completely_wholesome"
-    instances = [
-        [
-            ("fake_service1", "this_is_testing"),
-            ("fake_service1", "all_the_things"),
-            ("fake_service1", "_ignore_me"),
-        ],
-        [("fake_service2", "my_nerf_broke")],
-    ]
-    expected = [
-        ("fake_service2", "my_nerf_broke"),
-        ("fake_service1", "this_is_testing"),
-        ("fake_service1", "all_the_things"),
-    ]
-    with mock.patch(
-        "os.path.abspath", autospec=True, return_value="chex_mix"
-    ), mock.patch(
-        "os.listdir", autospec=True, return_value=["dir1", "dir2"]
-    ), mock.patch(
-        "paasta_tools.utils.get_service_instance_list",
-        side_effect=lambda a, b, c, d: instances.pop(),
-        autospec=True,
-    ):
-        actual = utils.get_services_for_cluster(cluster, soa_dir=soa_dir)
-        assert expected == actual
-
-
 def test_color_text():
     expected = f"{utils.PaastaColors.RED}hi{utils.PaastaColors.DEFAULT}"
     actual = utils.PaastaColors.color_text(utils.PaastaColors.RED, "hi")


### PR DESCRIPTION
We can simplify the tron logic because we don't have to worry about
jobs and actions being lists. They are always dicts now.

This is in preparation for changing the way we read instance configs
(PAASTA-16300). Ideally that would be a single function, e.g.
read_instance_configs, that all other tools can use.