### PR TITLE
PAASTA-15540 Fix duplicated log lines on `paasta logs -f`

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1031,7 +1031,7 @@ class PaastaColors:
         return PaastaColors.color_text(PaastaColors.DEFAULT, text)
 
 
-LOG_COMPONENTS = OrderedDict(
+LOG_COMPONENTS: Mapping[str, Mapping[str, Any]] = OrderedDict(
     [
         (
             "build",


### PR DESCRIPTION
`run_code_over_scribe_envs()` invokes the `callback()` function for every logging component. But callback() ignores the `component` param and uses `components` instead.  This gets passed down to the log filtering functions, which end up matching log lines more than once.

This bug affects print_last_n_logs, print_logs_by_time and tail_logs. But the first two do not expose the problem thanks to [paasta/pull/2322](https://github.com/Yelp/paasta/pull/2322). 
Note that we still need to keep the fix on pull/2322 as scribe is still duplicating log lines when pulling data in non-streaming mode.