### PR TITLE
Initial paasta support for tron on k8s

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -152,6 +152,12 @@
                 },
                 "aws_credentials_yaml": {
                     "type": "string"
+                },
+                "spark_cluster_manager": {
+                    "enum": [
+                        "mesos",
+                        "kubernetes"
+                    ]
                 }
             }
         },

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -45,7 +45,7 @@ requests-cache >= 0.4.10,<= 0.5.0
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.2.0
+service-configuration-lib >= 2.3.0
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ rsa==3.4.2
 ruamel.yaml==0.15.96
 s3transfer==0.1.13
 sensu-plugin==0.3.1
-service-configuration-lib==2.2.0
+service-configuration-lib==2.3.0
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0


### PR DESCRIPTION
This PR also fixes an issue of `executor: spark` on mesos, where `spark.mesos.executor.docker.volumes` need to have lower-cased file modes, like `ro` and `rw`.