### PR TITLE
Load instance configs everywhere with utils function that includes automated config

### DIFF
--- a/paasta_tools/adhoc_tools.py
+++ b/paasta_tools/adhoc_tools.py
@@ -20,6 +20,7 @@ from paasta_tools.long_running_service_tools import LongRunningServiceConfigDict
 from paasta_tools.utils import BranchDictV2
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import load_service_instance_config
 from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
@@ -35,18 +36,15 @@ def load_adhoc_job_config(
     general_config = service_configuration_lib.read_service_configuration(
         service, soa_dir=soa_dir
     )
-    adhoc_conf_file = "adhoc-%s" % cluster
-    instance_configs = service_configuration_lib.read_extra_service_information(
-        service_name=service, extra_info=adhoc_conf_file, soa_dir=soa_dir
+    instance_config = load_service_instance_config(
+        service=service,
+        instance=instance,
+        instance_type="adhoc",
+        cluster=cluster,
+        soa_dir=soa_dir,
     )
-
-    if instance not in instance_configs:
-        raise NoConfigurationForServiceError(
-            f"{instance} not found in config file {soa_dir}/{service}/{adhoc_conf_file}.yaml."
-        )
-
     general_config = deep_merge_dictionaries(
-        overrides=instance_configs[instance], defaults=general_config
+        overrides=instance_config, defaults=general_config
     )
 
     branch_dict = None

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -20,14 +20,13 @@ import requests
 import service_configuration_lib
 from mypy_extensions import TypedDict
 
-from paasta_tools.kubernetes_tools import InvalidJobNameError
-from paasta_tools.kubernetes_tools import NoConfigurationForServiceError
 from paasta_tools.kubernetes_tools import sanitised_cr_name
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
 from paasta_tools.long_running_service_tools import LongRunningServiceConfigDict
 from paasta_tools.utils import BranchDictV2
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import load_service_instance_config
 from paasta_tools.utils import load_v2_deployments_json
 
 
@@ -113,22 +112,11 @@ def load_flink_instance_config(
     general_config = service_configuration_lib.read_service_configuration(
         service, soa_dir=soa_dir
     )
-    flink_conf_file = "flink-%s" % cluster
-    instance_configs = service_configuration_lib.read_extra_service_information(
-        service, flink_conf_file, soa_dir=soa_dir
+    instance_config = load_service_instance_config(
+        service, instance, "flink", cluster, soa_dir=soa_dir
     )
-
-    if instance.startswith("_"):
-        raise InvalidJobNameError(
-            f"Unable to load kubernetes job config for {service}.{instance} as instance name starts with '_'"
-        )
-    if instance not in instance_configs:
-        raise NoConfigurationForServiceError(
-            f"{instance} not found in config file {soa_dir}/{service}/{flink_conf_file}.yaml."
-        )
-
     general_config = deep_merge_dictionaries(
-        overrides=instance_configs[instance], defaults=general_config
+        overrides=instance_config, defaults=general_config
     )
 
     branch_dict: Optional[BranchDictV2] = None

--- a/paasta_tools/frameworks/native_scheduler.py
+++ b/paasta_tools/frameworks/native_scheduler.py
@@ -27,6 +27,7 @@ from paasta_tools.frameworks.constraints import ConstraintState
 from paasta_tools.frameworks.constraints import update_constraint_state
 from paasta_tools.frameworks.native_service_config import load_paasta_native_job_config
 from paasta_tools.frameworks.native_service_config import NativeServiceConfig
+from paasta_tools.frameworks.native_service_config import NativeServiceConfigDict
 from paasta_tools.frameworks.native_service_config import TaskInfo
 from paasta_tools.frameworks.task_store import MesosTaskParameters
 from paasta_tools.frameworks.task_store import TaskStore
@@ -74,7 +75,7 @@ class NativeScheduler(Scheduler):
         service_config: Optional[NativeServiceConfig] = None,
         reconcile_backoff: float = 30,
         instance_type: str = "paasta_native",
-        service_config_overrides: Optional[Dict] = None,
+        service_config_overrides: Optional[NativeServiceConfigDict] = None,
         reconcile_start_time: float = float("inf"),
         task_store_type=ZKTaskStore,
     ) -> None:

--- a/paasta_tools/frameworks/native_service_config.py
+++ b/paasta_tools/frameworks/native_service_config.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import copy
 from typing import Any
+from typing import cast
 from typing import List
 from typing import Optional
 
@@ -245,20 +246,23 @@ class NativeServiceConfig(LongRunningServiceConfig):
 
 
 def load_paasta_native_job_config(
-    service,
-    instance,
-    cluster,
-    load_deployments=True,
-    soa_dir=DEFAULT_SOA_DIR,
-    instance_type="paasta_native",
-    config_overrides=None,
+    service: str,
+    instance: str,
+    cluster: str,
+    load_deployments: bool = True,
+    soa_dir: str = DEFAULT_SOA_DIR,
+    instance_type: str = "paasta_native",
+    config_overrides: Optional[NativeServiceConfigDict] = None,
 ) -> NativeServiceConfig:
-    instance_config_dict = load_service_instance_config(
-        service=service,
-        instance=instance,
-        instance_type=instance_type,
-        cluster=cluster,
-        soa_dir=soa_dir,
+    instance_config_dict = cast(
+        NativeServiceConfigDict,
+        load_service_instance_config(
+            service=service,
+            instance=instance,
+            instance_type=instance_type,
+            cluster=cluster,
+            soa_dir=soa_dir,
+        ),
     )
     branch_dict: Optional[BranchDictV2] = None
     instance_config_dict.update(config_overrides or {})

--- a/paasta_tools/kafkacluster_tools.py
+++ b/paasta_tools/kafkacluster_tools.py
@@ -16,14 +16,13 @@ from typing import Optional
 
 import service_configuration_lib
 
-from paasta_tools.kubernetes_tools import InvalidJobNameError
-from paasta_tools.kubernetes_tools import NoConfigurationForServiceError
 from paasta_tools.kubernetes_tools import sanitised_cr_name
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
 from paasta_tools.long_running_service_tools import LongRunningServiceConfigDict
 from paasta_tools.utils import BranchDictV2
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import load_service_instance_config
 from paasta_tools.utils import load_v2_deployments_json
 
 
@@ -101,22 +100,11 @@ def load_kafkacluster_instance_config(
     general_config = service_configuration_lib.read_service_configuration(
         service, soa_dir=soa_dir
     )
-    kafkacluster_conf_file = "kafkacluster-%s" % cluster
-    instance_configs = service_configuration_lib.read_extra_service_information(
-        service, kafkacluster_conf_file, soa_dir=soa_dir
+    instance_config = load_service_instance_config(
+        service, instance, "kafka", cluster, soa_dir=soa_dir
     )
-
-    if instance.startswith("_"):
-        raise InvalidJobNameError(
-            f"Unable to load kubernetes job config for {service}.{instance} as instance name starts with '_'"
-        )
-    if instance not in instance_configs:
-        raise NoConfigurationForServiceError(
-            f"{instance} not found in config file {soa_dir}/{service}/{kafkacluster_conf_file}.yaml."
-        )
-
     general_config = deep_merge_dictionaries(
-        overrides=instance_configs[instance], defaults=general_config
+        overrides=instance_config, defaults=general_config
     )
 
     branch_dict: Optional[BranchDictV2] = None

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -115,10 +115,9 @@ from paasta_tools.utils import DeployWhitelist
 from paasta_tools.utils import DockerVolume
 from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_git_sha_from_dockerurl
-from paasta_tools.utils import InvalidJobNameError
+from paasta_tools.utils import load_service_instance_config
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import load_v2_deployments_json
-from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import PersistentVolume
@@ -245,22 +244,11 @@ def load_kubernetes_service_config_no_cache(
     general_config = service_configuration_lib.read_service_configuration(
         service, soa_dir=soa_dir
     )
-    kubernetes_conf_file = "kubernetes-%s" % cluster
-    instance_configs = service_configuration_lib.read_extra_service_information(
-        service, kubernetes_conf_file, soa_dir=soa_dir
+    instance_config = load_service_instance_config(
+        service, instance, "kubernetes", cluster, soa_dir=soa_dir
     )
-
-    if instance.startswith("_"):
-        raise InvalidJobNameError(
-            f"Unable to load kubernetes job config for {service}.{instance} as instance name starts with '_'"
-        )
-    if instance not in instance_configs:
-        raise NoConfigurationForServiceError(
-            f"{instance} not found in config file {soa_dir}/{service}/{kubernetes_conf_file}.yaml."
-        )
-
     general_config = deep_merge_dictionaries(
-        overrides=instance_configs[instance], defaults=general_config
+        overrides=instance_config, defaults=general_config
     )
 
     branch_dict: Optional[BranchDictV2] = None

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -74,7 +74,7 @@ from paasta_tools.utils import DockerVolume
 from paasta_tools.utils import get_code_sha_from_dockerurl
 from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_user_agent
-from paasta_tools.utils import InvalidJobNameError
+from paasta_tools.utils import load_service_instance_config
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import MarathonConfigDict
@@ -366,22 +366,11 @@ def load_marathon_service_config_no_cache(
     general_config = service_configuration_lib.read_service_configuration(
         service, soa_dir=soa_dir
     )
-    marathon_conf_file = "marathon-%s" % cluster
-    instance_configs = service_configuration_lib.read_extra_service_information(
-        service, marathon_conf_file, soa_dir=soa_dir
+    instance_config = load_service_instance_config(
+        service, instance, "marathon", cluster, soa_dir=soa_dir
     )
-
-    if instance.startswith("_"):
-        raise InvalidJobNameError(
-            f"Unable to load marathon job config for {service}.{instance} as instance name starts with '_'"
-        )
-    if instance not in instance_configs:
-        raise NoConfigurationForServiceError(
-            f"{instance} not found in config file {soa_dir}/{service}/{marathon_conf_file}.yaml."
-        )
-
     general_config = deep_merge_dictionaries(
-        overrides=instance_configs[instance], defaults=general_config
+        overrides=instance_config, defaults=general_config
     )
 
     branch_dict: Optional[BranchDictV2] = None

--- a/paasta_tools/paasta_service_config_loader.py
+++ b/paasta_tools/paasta_service_config_loader.py
@@ -18,7 +18,6 @@ from typing import List
 from typing import Tuple
 from typing import Type
 
-from service_configuration_lib import read_extra_service_information
 from service_configuration_lib import read_service_configuration
 
 from paasta_tools import utils
@@ -26,6 +25,7 @@ from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import InstanceConfig_T
 from paasta_tools.utils import list_clusters
+from paasta_tools.utils import load_service_instance_configs
 from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoDeploymentsAvailable
 
@@ -132,10 +132,11 @@ class PaastaServiceConfigLoader:
     def _refresh_framework_config(
         self, cluster: str, instance_type_class: Type[InstanceConfig_T]
     ):
-        conf_name = self._framework_config_filename(cluster, instance_type_class)
-        log.info("Reading configuration file: %s.yaml", conf_name)
-        instances = read_extra_service_information(
-            service_name=self._service, extra_info=conf_name, soa_dir=self._soa_dir
+        instances = load_service_instance_configs(
+            service=self._service,
+            instance_type=instance_type_class.config_filename_prefix,
+            cluster=cluster,
+            soa_dir=self._soa_dir,
         )
         self._framework_configs[(cluster, instance_type_class)] = instances
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2773,7 +2773,7 @@ def get_services_for_cluster(
 
 def load_service_instance_configs(
     service: str, instance_type: str, cluster: str, soa_dir: str = DEFAULT_SOA_DIR,
-) -> Dict[str, Dict[str, Any]]:
+) -> Dict[str, InstanceConfigDict]:
     conf_file = f"{instance_type}-{cluster}"
     user_configs = service_configuration_lib.read_extra_service_information(
         service, conf_file, soa_dir=soa_dir
@@ -2797,7 +2797,7 @@ def load_service_instance_config(
     instance_type: str,
     cluster: str,
     soa_dir: str = DEFAULT_SOA_DIR,
-) -> Dict[str, Any]:
+) -> InstanceConfigDict:
     if instance.startswith("_"):
         raise InvalidJobNameError(
             f"Unable to load {instance_type} config for {service}.{instance} as instance name starts with '_'"

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -1189,6 +1189,8 @@ def test_autoscale_services_ignores_non_deployed_services():
         "paasta_tools.autoscaling.autoscaling_service_lib.PaastaServiceConfigLoader._create_service_config",
         autospec=True,
         side_effect=NoDeploymentsAvailable,
+    ), mock.patch(
+        "paasta_tools.utils.load_system_paasta_config", autospec=True,
     ):
         configs = autoscaling_service_lib.get_configs_of_services_to_scale(
             cluster="fake_cluster", services=["fake-service"]

--- a/tests/test_firewall_update.py
+++ b/tests/test_firewall_update.py
@@ -65,6 +65,9 @@ def test_parse_args_default_cron():
     assert not args.verbose
 
 
+@mock.patch(
+    "paasta_tools.utils.load_system_paasta_config", autospec=True,
+)
 @mock.patch.object(
     firewall_update,
     "load_system_paasta_config",
@@ -77,7 +80,7 @@ def test_parse_args_default_cron():
     autospec=True,
     return_value=(("myservice", "hassecurity", "02:42:a9:fe:00:0a", "1.1.1.1"),),
 )
-def test_smartstack_dependencies_of_running_firewalled_services(_, __, tmpdir):
+def test_smartstack_dependencies_of_running_firewalled_services(_, __, ___, tmpdir):
     soa_dir = tmpdir.mkdir("yelpsoa")
     myservice_dir = soa_dir.mkdir("myservice")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2412,8 +2412,13 @@ def test_suggest_possibilities_one():
 
 def test_filter_templates_from_config_with_empty_dict():
     assert utils.filter_templates_from_config({}) == {}
+<<<<<<< HEAD
 
 
+=======
+
+
+>>>>>>> Refactor instance listing into a single function
 def test_filter_templates_from_config():
     config = {"_template": "foo", "instance0": "bar", "instance1": "baz"}
     assert utils.filter_templates_from_config(config) == {


### PR DESCRIPTION
The design in PAASTA-16256 specifies that configuration from automated sources can be stored in a new subdirectory in each service's yelpsoa-configs. For example,
```
foo_service/
  marathon-norcal-devc.yaml
  service.yaml
  deploy.yaml
  auto/
    marathon-norcal-devc.yaml
```

The regular instance config in `marathon-norcal-devc.yaml` is deep-merged with `auto/marathon-norcal-devc.yaml`, such that keys are only used from `auto` if they are not specified in the regular file.

For example, given
```
marathon-norcal-devc.yaml
----
foo:
  cpus: 1
  mem: 20
bar:
  cpus: 2

auto/marathon-norcal-devc.yaml
----
foo:
  mem: 30
bar:
  mem: 30
```
The result would be `mem: 20` for `foo` and `mem: 30` for `bar`.

I've implemented this in `utils.load_service_instance_config(s)` and replaced all the places that we load instance configs with it. I only anticipate enabling auto configs for stateless marathon/kubernetes services this quarter, but I would like to keep the way we load instance configs consistent everywhere.

The next step is helpers to write the `auto/` values, which will include validating them. No instance types will be enabled anywhere except in mesosstage/kubestage for now, which I think makes this safe to release even before validation.
