### PR TITLE
Add k8s deployment errors to paasta status (-vv or -vvv)

### DIFF
--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -1292,9 +1292,25 @@
                     "type": "string",
                     "description": "The status of the pod"
                 },
+                "containers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/KubernetesContainer",
+                        "description": "List of containers in the pod"
+                    }
+                }
+            }
+        },
+        "KubernetesContainer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the container"
+                },
                 "tail_lines": {
                     "$ref": "#/definitions/TaskTailLines",
-                    "description": "Stdout and stderr tail of the task"
+                    "description": "Stdout and stderr tail of the container"
                 }
             }
         },

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -55,6 +55,7 @@ from paasta_tools.cli.utils import NoSuchService
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.flink_tools import FlinkDeploymentConfig
 from paasta_tools.kafkacluster_tools import KafkaClusterDeploymentConfig
+from paasta_tools.kubernetes_tools import format_tail_lines_for_kubernetes_pod
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.kubernetes_tools import KubernetesDeployStatus
 from paasta_tools.kubernetes_tools import paasta_prefixed
@@ -646,7 +647,8 @@ def format_kubernetes_pod_table(pods):
         )
         if pod.message is not None:
             rows.append(PaastaColors.grey(f"  {pod.message}"))
-        rows.extend(format_tail_lines_for_mesos_task(pod.tail_lines, pod.name))
+        if pod.containers is not None:
+            rows.extend(format_tail_lines_for_kubernetes_pod(pod.containers, pod.name))
 
     return format_table(rows)
 

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -16,7 +16,7 @@ from paasta_tools import kubernetes_tools
 from paasta_tools import marathon_tools
 from paasta_tools import smartstack_tools
 from paasta_tools.cli.utils import LONG_RUNNING_INSTANCE_TYPE_HANDLERS
-from paasta_tools.kubernetes_tools import get_tail_lines_for_kubernetes_pod
+from paasta_tools.kubernetes_tools import get_tail_lines_for_kubernetes_container
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
 from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
@@ -91,20 +91,22 @@ async def job_status(
         num_tail_lines = calculate_tail_lines(verbose)
 
         for pod in pod_list:
-            if num_tail_lines > 0:
-                tail_lines = await get_tail_lines_for_kubernetes_pod(
-                    client, pod, num_tail_lines
+            containers = [
+                dict(
+                    name=container.name,
+                    tail_lines=await get_tail_lines_for_kubernetes_container(
+                        client, pod, container, num_tail_lines,
+                    ),
                 )
-            else:
-                tail_lines = {}
-
+                for container in pod.status.container_statuses
+            ]
             kstatus["pods"].append(
                 {
                     "name": pod.metadata.name,
                     "host": pod.spec.node_name,
                     "deployed_timestamp": pod.metadata.creation_timestamp.timestamp(),
                     "phase": pod.status.phase,
-                    "tail_lines": tail_lines,
+                    "containers": containers,
                     "reason": pod.status.reason,
                     "message": pod.status.message,
                 }

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -46,6 +46,7 @@ from kubernetes.client import V1Capabilities
 from kubernetes.client import V1ConfigMap
 from kubernetes.client import V1Container
 from kubernetes.client import V1ContainerPort
+from kubernetes.client import V1ContainerStatus
 from kubernetes.client import V1DeleteOptions
 from kubernetes.client import V1Deployment
 from kubernetes.client import V1DeploymentSpec
@@ -118,6 +119,7 @@ from paasta_tools.utils import InvalidJobNameError
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError
+from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import PersistentVolume
 from paasta_tools.utils import SystemPaastaConfig
@@ -1376,31 +1378,70 @@ def list_deployments(
 
 
 @async_timeout()
-async def get_tail_lines_for_kubernetes_pod(
-    kube_client: KubeClient, pod: V1Pod, num_tail_lines: int
-) -> MutableMapping[str, List[str]]:
-    tail_lines_dict: MutableMapping[str, Any] = {
+async def get_tail_lines_for_kubernetes_container(
+    kube_client: KubeClient,
+    pod: V1Pod,
+    container: V1ContainerStatus,
+    num_tail_lines: int,
+) -> MutableMapping[str, Any]:
+    tail_lines: MutableMapping[str, Any] = {
         "stdout": [],
         "stderr": [],
         "error_message": "",
     }
-    for container in pod.spec.containers:
-        if container.name != HACHECK_POD_NAME:
-            try:
-                tail_lines_dict["stdout"].append(
-                    kube_client.core.read_namespaced_pod_log(
-                        name=pod.metadata.name,
-                        namespace="paasta",
-                        container=container.name,
-                        tail_lines=num_tail_lines,
+
+    if container.name != HACHECK_POD_NAME:
+        if container.state.waiting:
+            error = container.state.waiting.message
+        elif container.state.terminated:
+            error = container.state.terminated.message
+        error = error or ""  # if no errors, message will be None. convert to ""
+        tail_lines["error_message"] = error
+
+        try:
+            if num_tail_lines > 0:
+                log = kube_client.core.read_namespaced_pod_log(
+                    name=pod.metadata.name,
+                    namespace=pod.metadata.namespace,
+                    container=container.name,
+                    tail_lines=num_tail_lines,
+                )
+                tail_lines["stdout"].extend(log.split("\n"))
+        except ApiException as e:
+            # there is a potential race condition in which a pod's containers
+            # have not failed, but have when we get the container's logs. in this
+            # case, use the error from the exception, though it is less accurate.
+            if error == "":
+                body = json.loads(e.body)
+                error = body.get("message", "")
+            tail_lines["error_message"] = f"couldn't read stdout/stderr: '{error}'"
+
+    return tail_lines
+
+
+def format_tail_lines_for_kubernetes_pod(
+    pod_containers: Sequence, pod_name: str,
+) -> List[str]:
+    rows: List[str] = []
+    for container in pod_containers:
+        if container.tail_lines.error_message is not None:
+            rows.append(
+                PaastaColors.blue(
+                    f"errors for container {container.name} in pod {pod_name}"
+                )
+            )
+            rows.append(PaastaColors.red(f"  {container.tail_lines.error_message}"))
+
+        for stream_name in ("stdout", "stderr"):
+            stream_lines = getattr(container.tail_lines, stream_name, [])
+            if len(stream_lines) > 0:
+                rows.append(
+                    PaastaColors.blue(
+                        f"{stream_name} tail for {container.name} in pod {pod_name}"
                     )
                 )
-            except ApiException as e:
-                tail_lines_dict[
-                    "error_message"
-                ] = f"couldn't read stdout/stderr because {e.getResponseBody()}"
-
-    return tail_lines_dict
+                rows.extend(f"  {line}" for line in stream_lines)
+    return rows
 
 
 def create_custom_resource(

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1181,7 +1181,7 @@ class TestPrintKubernetesStatus:
                 host="fake_host1",
                 deployed_timestamp=1562963508,
                 phase="Running",
-                tail_lines=Struct(),
+                containers=[],
                 message=None,
             ),
             Struct(
@@ -1189,7 +1189,7 @@ class TestPrintKubernetesStatus:
                 host="fake_host2",
                 deployed_timestamp=1562963510,
                 phase="Running",
-                tail_lines=Struct(),
+                containers=[],
                 message=None,
             ),
             Struct(
@@ -1197,7 +1197,7 @@ class TestPrintKubernetesStatus:
                 host="fake_host3",
                 deployed_timestamp=1562963511,
                 phase="Failed",
-                tail_lines=Struct(),
+                containers=[],
                 message="Disk quota exceeded",
                 reason="Evicted",
             ),
@@ -1388,7 +1388,7 @@ class TestFormatKubernetesPodTable:
             host="paasta.cloud",
             deployed_timestamp=1565648600,
             phase="Running",
-            tail_lines=Struct(),
+            containers=[],
             message=None,
             reason=None,
         )


### PR DESCRIPTION
### Description
I've made it so that when using -vv or -vvv with `paasta status` for a k8s service, k8s errors will be included, in addition to any stdout or stderr. It looks like [this] (https://gist.github.com/kawaiwanyelp/5bfd63bbfd1c7d440099af4ff838b1ac).

The errors and instance output are per container per pod. Pods themselves don't record any aggregated error states for its containers. So, even if a container is in a crash loop, the pod may still be "healthy" (we show this in `paasta status`, and I'd like to fix that in a separate PR).

### Testing done
`make test`
manual testing by making a local `paasta-api` process talk to a real dev k8s cluster