### PR TITLE
allow 0 bounce margin factor for k8s

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -180,7 +180,7 @@
                     "default": 1,
                     "minimum": 0,
                     "maximum": 1,
-                    "exclusiveMinimum": true,
+                    "exclusiveMinimum": false,
                     "exclusiveMaximum": false
                 },
                 "bounce_priority": {


### PR DESCRIPTION
So, in paasta_tools we just set the pod disruption budget to (1 - bounce_margin_factor).  For services that only have 1 replica, if we want them to be able to be bounced or evicted, we need to have a PDB of 1, which means we need a bounce_marge_factor of 0, but this is currently disallowed.