### PR TITLE
Show real hostname for k8s pods in paasta status

### DIFF
--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -103,7 +103,7 @@ async def job_status(
             kstatus["pods"].append(
                 {
                     "name": pod.metadata.name,
-                    "host": pod.spec.node_name,
+                    "host": kubernetes_tools.get_pod_hostname(client, pod),
                     "deployed_timestamp": pod.metadata.creation_timestamp.timestamp(),
                     "phase": pod.status.phase,
                     "containers": containers,

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2014,3 +2014,14 @@ def set_cr_desired_state(
     kube_client.custom.replace_namespaced_custom_object(**cr_id, body=cr)
     status = cr.get("status")
     return status
+
+
+def get_pod_hostname(kube_client: KubeClient, pod: V1Pod) -> str:
+    """Gets the hostname of a pod's node from labels"""
+    try:
+        node = kube_client.core.read_node(name=pod.spec.node_name)
+    except ApiException:
+        # fall back to node name (which has the IP) if node somehow doesnt exist
+        return pod.spec.node_name
+    # if label has disappeared (say we changed it), default to node name
+    return node.metadata.labels.get("yelp.com/hostname", pod.spec.node_name)

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2498,3 +2498,25 @@ def test_warning_big_bounce():
             ]
             == "config3b06ff5f"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
+
+
+@pytest.mark.parametrize(
+    "node,expected",
+    [
+        (
+            mock.Mock(metadata=mock.Mock(labels={"yelp.com/hostname": "a_hostname"})),
+            "a_hostname",
+        ),
+        (mock.Mock(metadata=mock.Mock(labels={})), "a_node_name",),
+        (ApiException(), "a_node_name",),
+    ],
+)
+def test_get_pod_hostname(node, expected):
+    client = mock.MagicMock()
+    client.core.read_node.side_effect = [node]
+    pod = mock.MagicMock()
+    pod.spec.node_name = "a_node_name"
+
+    hostname = kubernetes_tools.get_pod_hostname(client, pod)
+
+    assert hostname == expected


### PR DESCRIPTION
### Description
Currently, we just show pod hostnames in `paasta status` like `ip-00-00-00-00.us-west-1.compute.internal`, but this review makes it so that real hostnames are shown instead, making them directly copyable for SSH-ing.

### Testing
`make test`
Manual testing with a local paasta-api connected to a test k8s cluster