### PR TITLE
Implement deploy_whitelist and deploy_blacklist for k8s pods as node affinities

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -39,6 +39,7 @@ from humanfriendly import parse_size
 from kubernetes import client as kube_client
 from kubernetes import config as kube_config
 from kubernetes.client import models
+from kubernetes.client import V1Affinity
 from kubernetes.client import V1AWSElasticBlockStoreVolumeSource
 from kubernetes.client import V1beta1PodDisruptionBudget
 from kubernetes.client import V1beta1PodDisruptionBudgetSpec
@@ -61,6 +62,10 @@ from kubernetes.client import V1LabelSelector
 from kubernetes.client import V1Lifecycle
 from kubernetes.client import V1Namespace
 from kubernetes.client import V1Node
+from kubernetes.client import V1NodeAffinity
+from kubernetes.client import V1NodeSelector
+from kubernetes.client import V1NodeSelectorRequirement
+from kubernetes.client import V1NodeSelectorTerm
 from kubernetes.client import V1ObjectFieldSelector
 from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1PersistentVolumeClaim
@@ -1156,6 +1161,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 ),
                 share_process_namespace=True,
                 node_selector=self.get_node_selector(),
+                affinity=V1Affinity(node_affinity=self.get_node_affinity()),
                 restart_policy="Always",
                 volumes=self.get_pod_volumes(
                     docker_volumes=docker_volumes,
@@ -1165,7 +1171,47 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         )
 
     def get_node_selector(self) -> Mapping[str, str]:
+        """Converts simple node restrictions into node selectors. Unlike node
+        affinities, selectors will show up in `kubectl describe`.
+        """
         return {"yelp.com/pool": self.get_pool()}
+
+    def get_node_affinity(self) -> V1NodeAffinity:
+        """Converts deploy_whitelist and deploy_blacklist in node affinities.
+
+        note: At the time of writing, `kubectl describe` does not show affinities,
+        only selectors. To see affinities, use `kubectl get pod -o json` instead.
+        """
+        requirements = []
+        # convert whitelist into a node selector req
+        whitelist = self.get_deploy_whitelist()
+        if whitelist:
+            location_type, alloweds = whitelist
+            requirements.append((f"yelp.com/{location_type}", "In", alloweds))
+        # convert blacklist into multiple node selector reqs
+        blacklist = self.get_deploy_blacklist()
+        if blacklist:
+            # not going to prune for duplicates, or group blacklist items for
+            # same location_type. makes testing easier and k8s can handle it.
+            for location_type, not_allowed in blacklist:
+                requirements.append(
+                    (f"yelp.com/{location_type}", "NotIn", [not_allowed])
+                )
+        # package everything into a node affinity - lots of layers :P
+        term = V1NodeSelectorTerm(
+            match_expressions=[
+                V1NodeSelectorRequirement(key=key, operator=op, values=vs,)
+                for key, op, vs in requirements
+            ]
+        )
+        selector = V1NodeSelector(node_selector_terms=[term])
+        return V1NodeAffinity(
+            # this means that the selectors are only used during scheduling.
+            # changing it while the pod is running will not cause an eviction.
+            # this should be fine since if there are whitelist/blacklist config
+            # changes, we will bounce anyway.
+            required_during_scheduling_ignored_during_execution=selector,
+        )
 
     def sanitize_for_config_hash(
         self, config: Union[V1Deployment, V1StatefulSet]

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1,4 +1,3 @@
-import unittest
 from typing import Any
 from typing import Dict
 from typing import Sequence
@@ -8,6 +7,7 @@ import pytest
 from hypothesis import given
 from hypothesis.strategies import floats
 from hypothesis.strategies import integers
+from kubernetes.client import V1Affinity
 from kubernetes.client import V1AWSElasticBlockStoreVolumeSource
 from kubernetes.client import V1beta1PodDisruptionBudget
 from kubernetes.client import V1Capabilities
@@ -25,6 +25,10 @@ from kubernetes.client import V1HostPathVolumeSource
 from kubernetes.client import V1HTTPGetAction
 from kubernetes.client import V1LabelSelector
 from kubernetes.client import V1Lifecycle
+from kubernetes.client import V1NodeAffinity
+from kubernetes.client import V1NodeSelector
+from kubernetes.client import V1NodeSelectorRequirement
+from kubernetes.client import V1NodeSelectorTerm
 from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1PersistentVolumeClaim
 from kubernetes.client import V1PersistentVolumeClaimSpec
@@ -220,8 +224,8 @@ def test_load_kubernetes_service_config():
         assert ret == mock_load_kubernetes_service_config_no_cache.return_value
 
 
-class TestKubernetesDeploymentConfig(unittest.TestCase):
-    def setUp(self):
+class TestKubernetesDeploymentConfig:
+    def setup_method(self, method):
         hpa_config = {
             "min_replicas": 1,
             "max_replicas": 3,
@@ -963,6 +967,9 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             autospec=True,
             return_value=[],
         ) as mock_get_pod_volumes, mock.patch(
+            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_node_affinity",
+            autospec=True,
+        ) as mock_get_node_affinity, mock.patch(
             "paasta_tools.kubernetes_tools.load_service_namespace_config",
             autospec=True,
         ) as mock_load_service_namespace_config:
@@ -978,7 +985,6 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             assert mock_service_namespace_config.is_in_smartstack.called
             assert mock_get_pod_volumes.called
             assert mock_get_volumes.called
-            print(ret.metadata.annotations)
             assert ret == V1PodTemplateSpec(
                 metadata=V1ObjectMeta(
                     labels={
@@ -1001,6 +1007,9 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     containers=mock_get_kubernetes_containers.return_value,
                     share_process_namespace=True,
                     node_selector={"yelp.com/pool": "default"},
+                    affinity=V1Affinity(
+                        node_affinity=mock_get_node_affinity.return_value,
+                    ),
                     restart_policy="Always",
                     volumes=[],
                 ),
@@ -1024,6 +1033,9 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             autospec=True,
             return_value=[],
         ) as mock_get_pod_volumes, mock.patch(
+            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_node_affinity",
+            autospec=True,
+        ) as mock_get_node_affinity, mock.patch(
             "paasta_tools.kubernetes_tools.load_service_namespace_config",
             autospec=True,
         ) as mock_load_service_namespace_config:
@@ -1039,7 +1051,6 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             assert mock_service_namespace_config.is_in_smartstack.called
             assert mock_get_pod_volumes.called
             assert mock_get_volumes.called
-            print(ret.metadata.annotations)
             assert ret == V1PodTemplateSpec(
                 metadata=V1ObjectMeta(
                     labels={
@@ -1062,10 +1073,72 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     containers=mock_get_kubernetes_containers.return_value,
                     share_process_namespace=True,
                     node_selector={"yelp.com/pool": "default"},
+                    affinity=V1Affinity(
+                        node_affinity=mock_get_node_affinity.return_value,
+                    ),
                     restart_policy="Always",
                     volumes=[],
                 ),
             )
+
+    @pytest.mark.parametrize(
+        "whitelist,blacklist,expected",
+        [
+            # no blacklist or whitelist, only node affinity should be pool
+            (None, [], []),
+            (  # whitelist only
+                ("habitat", ["habitat_a", "habitat_b"]),
+                [],
+                [
+                    V1NodeSelectorRequirement(
+                        key="yelp.com/habitat",
+                        operator="In",
+                        values=["habitat_a", "habitat_b"],
+                    ),
+                ],
+            ),
+            (  # blacklist only
+                None,
+                [("habitat", "habitat_a"), ("habitat", "habitat_b")],
+                [
+                    V1NodeSelectorRequirement(
+                        key="yelp.com/habitat", operator="NotIn", values=["habitat_a"]
+                    ),
+                    V1NodeSelectorRequirement(
+                        key="yelp.com/habitat", operator="NotIn", values=["habitat_b"]
+                    ),
+                ],
+            ),
+            (  # whitelist and blacklist
+                ("habitat", ["habitat_a", "habitat_b"]),
+                [("region", "region_a"), ("habitat", "habitat_c")],
+                [
+                    V1NodeSelectorRequirement(
+                        key="yelp.com/habitat",
+                        operator="In",
+                        values=["habitat_a", "habitat_b"],
+                    ),
+                    V1NodeSelectorRequirement(
+                        key="yelp.com/region", operator="NotIn", values=["region_a"]
+                    ),
+                    V1NodeSelectorRequirement(
+                        key="yelp.com/habitat", operator="NotIn", values=["habitat_c"]
+                    ),
+                ],
+            ),
+        ],
+    )
+    def test_get_node_affinity(self, whitelist, blacklist, expected):
+        self.deployment.config_dict["deploy_whitelist"] = whitelist
+        self.deployment.config_dict["deploy_blacklist"] = blacklist
+
+        node_affinity = self.deployment.get_node_affinity()
+
+        assert node_affinity == V1NodeAffinity(
+            required_during_scheduling_ignored_during_execution=V1NodeSelector(
+                node_selector_terms=[V1NodeSelectorTerm(match_expressions=expected,)],
+            ),
+        )
 
     def test_get_kubernetes_metadata(self):
         with mock.patch(
@@ -2486,7 +2559,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config3b06ff5f"
+            == "configc7d4fe91"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 


### PR DESCRIPTION
### Description
To support `deploy_blacklist` and `deploy_whitelist` for k8s instances, I've implemented logic to convert those configs to node affinities. I've also taken the liberty of converting the pool selector (previously implemented as a node selector) into a node affinity so that it's all unified.

### Testing
`make test`
Manual testing using `setup_kubernetes_job` to create test pods with the new node affinities

### Notes
While testing, I found out that `kubectl describe pod` _does not_  show affinities, only selectors. However, it will still show failures if the affinities result in no scheduleable nodes, which can be confusing. It is possible to see them using `kubectl get pod -o json`, which shows the raw pod configs, and I've documented this in the code. I haven't seen any reported issues so it doesn't seem like anyone is going to get around to "fixing" this issue.

Also, given that I changed the `test_warning_big_bounce` SHA, it appears that releasing this will cause a big bounce, at least for k8s instances.