### PR TITLE
Fix docker registry permission issue

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -225,6 +225,7 @@ class TronActionConfig(InstanceConfig):
                     service=self.get_service(),
                     aws_credentials_yaml=self.config_dict.get("aws_credentials_yaml"),
                 ),
+                needs_docker_cfg=True,
             )
         else:
             spark_env = get_k8s_spark_env(
@@ -286,6 +287,8 @@ class TronActionConfig(InstanceConfig):
         if self.get_executor() == "spark":
             env["EXECUTOR_CLUSTER"] = self.get_spark_paasta_cluster()
             env["EXECUTOR_POOL"] = self.get_spark_paasta_pool()
+            # Run spark (and mesos framework) as root.
+            env["SPARK_USER"] = "root"
             env["SPARK_OPTS"] = stringify_spark_env(self.get_spark_config_dict())
             env.update(get_mesos_spark_auth_env())
             env["CLUSTERMAN_RESOURCES"] = json.dumps(

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -119,6 +119,7 @@ class TestTronActionConfig:
                 spark_ui_port=12345,
                 user_spark_opts={"spark.eventLog.enabled": "false"},
                 volumes=["/nail/tmp:/nail/tmp:rw"],
+                needs_docker_cfg=True,
             )
 
     def test_get_spark_config_dict_k8s(self, spark_action_config):
@@ -189,6 +190,7 @@ class TestTronActionConfig:
                 assert env["AWS_DEFAULT_REGION"] == "us-west-2"
                 assert env["SPARK_MESOS_PRINCIPAL"] == "spark"
                 assert env["SPARK_MESOS_SECRET"] == "SHARED_SECRET(SPARK_MESOS_SECRET)"
+                assert env["SPARK_USER"] == "root"
             else:
                 assert not any([env.get("SPARK_OPTS"), env.get("CLUSTERMAN_RESOURCES")])
 


### PR DESCRIPTION
This PR adds root priviledge to both driver and executor containers as
well as specifying `spark.mesos.uri` configuration. These 2 in
combiniation should fix the issue where spark executors cannot be
created on mesos slaves due to 401 to private docker registry.