### PR TITLE
allow min_instance to be 0

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -473,7 +473,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             return self.get_hpa_metric_spec(name, cluster, namespace)
         min_replicas = self.get_min_instances()
         max_replicas = self.get_max_instances()
-        if min_replicas is not None or max_replicas is not None:
+        if min_replicas is None or max_replicas is None:
             log.error(
                 f"Please specify min_instances and max_instances for autoscaling to work: {min_replicas}, {max_replicas}"
             )

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -473,7 +473,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             return self.get_hpa_metric_spec(name, cluster, namespace)
         min_replicas = self.get_min_instances()
         max_replicas = self.get_max_instances()
-        if not min_replicas or not max_replicas:
+        if min_replicas is not None or max_replicas is not None:
             log.error(
                 f"Please specify min_instances and max_instances for autoscaling to work: {min_replicas}, {max_replicas}"
             )


### PR DESCRIPTION
Right now, if min_instance is 0, HPA won't be created. 