### PR TITLE
Make get_pod_hostname return NotScheduled if pod has not yet been scheduled

### DIFF
--- a/paasta_tools/contrib/get_running_task_allocation.py
+++ b/paasta_tools/contrib/get_running_task_allocation.py
@@ -159,7 +159,8 @@ def get_kubernetes_task_allocation_info() -> Iterable[TaskAllocationInfo]:
                 "resources": get_kubernetes_resource_request(container.resources),
                 "container_type": get_container_type(container.name, instance),
             }
-        for container in pod.status.container_statuses:
+        container_statuses = pod.status.container_statuses or []
+        for container in container_statuses:
             if not container.state.running:
                 continue
             # docker://abcdef

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -91,6 +91,7 @@ async def job_status(
         num_tail_lines = calculate_tail_lines(verbose)
 
         for pod in pod_list:
+            container_statuses = pod.status.container_statuses or []
             containers = [
                 dict(
                     name=container.name,
@@ -98,7 +99,7 @@ async def job_status(
                         client, pod, container, num_tail_lines,
                     ),
                 )
-                for container in pod.status.container_statuses
+                for container in container_statuses
             ]
             kstatus["pods"].append(
                 {

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2005,6 +2005,8 @@ def set_cr_desired_state(
 
 def get_pod_hostname(kube_client: KubeClient, pod: V1Pod) -> str:
     """Gets the hostname of a pod's node from labels"""
+    if not pod.spec.node_name:  # can be none, if pod not yet scheduled
+        return "NotScheduled"
     try:
         node = kube_client.core.read_node(name=pod.spec.node_name)
     except ApiException:


### PR DESCRIPTION
### Description
In #2684, I made `paasta status` check the pod container statuses for error messages. And in #2694, I made `paasta status` get the real hostname for pods, instead of the node names. In both cases, if there were no containers yet (i.e. the pod hasn't been scheduled yet), it would cause an Exception because `pod.status.container_statuses` and `pod.spec.node_name` would be `None`. This PR fixes the issue by checking if they are `None` first before doing anything with them.

### Testing
`make test`
manual testing on a test cluster with a node the had to run on a non-existent pool (couldn't be scheduled)

### Notes
On a broader note, when inspecting k8s objects, it is important to check that whether or not they are `None` or not. Most properties are optional, according to the k8s documentation. 