### PR TITLE
Ensure a k8s affinity object is added to pods only if there are affinities to set

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -39,6 +39,7 @@ from humanfriendly import parse_size
 from kubernetes import client as kube_client
 from kubernetes import config as kube_config
 from kubernetes.client import models
+from kubernetes.client import V1Affinity
 from kubernetes.client import V1AWSElasticBlockStoreVolumeSource
 from kubernetes.client import V1beta1PodDisruptionBudget
 from kubernetes.client import V1beta1PodDisruptionBudgetSpec
@@ -61,6 +62,10 @@ from kubernetes.client import V1LabelSelector
 from kubernetes.client import V1Lifecycle
 from kubernetes.client import V1Namespace
 from kubernetes.client import V1Node
+from kubernetes.client import V1NodeAffinity
+from kubernetes.client import V1NodeSelector
+from kubernetes.client import V1NodeSelectorRequirement
+from kubernetes.client import V1NodeSelectorTerm
 from kubernetes.client import V1ObjectFieldSelector
 from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1PersistentVolumeClaim
@@ -1156,6 +1161,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 ),
                 share_process_namespace=True,
                 node_selector=self.get_node_selector(),
+                affinity=V1Affinity(node_affinity=self.get_node_affinity()),
                 restart_policy="Always",
                 volumes=self.get_pod_volumes(
                     docker_volumes=docker_volumes,
@@ -1165,7 +1171,47 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         )
 
     def get_node_selector(self) -> Mapping[str, str]:
+        """Converts simple node restrictions into node selectors. Unlike node
+        affinities, selectors will show up in `kubectl describe`.
+        """
         return {"yelp.com/pool": self.get_pool()}
+
+    def get_node_affinity(self) -> V1NodeAffinity:
+        """Converts deploy_whitelist and deploy_blacklist in node affinities.
+
+        note: At the time of writing, `kubectl describe` does not show affinities,
+        only selectors. To see affinities, use `kubectl get pod -o json` instead.
+        """
+        requirements = []
+        # convert whitelist into a node selector req
+        whitelist = self.get_deploy_whitelist()
+        if whitelist:
+            location_type, alloweds = whitelist
+            requirements.append((f"yelp.com/{location_type}", "In", alloweds))
+        # convert blacklist into multiple node selector reqs
+        blacklist = self.get_deploy_blacklist()
+        if blacklist:
+            # not going to prune for duplicates, or group blacklist items for
+            # same location_type. makes testing easier and k8s can handle it.
+            for location_type, not_allowed in blacklist:
+                requirements.append(
+                    (f"yelp.com/{location_type}", "NotIn", [not_allowed])
+                )
+        # package everything into a node affinity - lots of layers :P
+        term = V1NodeSelectorTerm(
+            match_expressions=[
+                V1NodeSelectorRequirement(key=key, operator=op, values=vs,)
+                for key, op, vs in requirements
+            ]
+        )
+        selector = V1NodeSelector(node_selector_terms=[term])
+        return V1NodeAffinity(
+            # this means that the selectors are only used during scheduling.
+            # changing it while the pod is running will not cause an eviction.
+            # this should be fine since if there are whitelist/blacklist config
+            # changes, we will bounce anyway.
+            required_during_scheduling_ignored_during_execution=selector,
+        )
 
     def sanitize_for_config_hash(
         self, config: Union[V1Deployment, V1StatefulSet]

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -949,143 +949,107 @@ class TestKubernetesDeploymentConfig:
                 in ret.spec.template.metadata.labels.__setitem__.mock_calls
             )
 
-    def test_get_pod_template_spec_non_smartstack_service(self):
-        with mock.patch(
-            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_volumes",
-            autospec=True,
-        ) as mock_get_volumes, mock.patch(
-            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_service",
-            autospec=True,
-        ) as mock_get_service, mock.patch(
-            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_instance",
-            autospec=True,
-        ) as mock_get_instance, mock.patch(
-            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_kubernetes_containers",
-            autospec=True,
-        ) as mock_get_kubernetes_containers, mock.patch(
-            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_pod_volumes",
-            autospec=True,
-            return_value=[],
-        ) as mock_get_pod_volumes, mock.patch(
-            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_node_affinity",
-            autospec=True,
-        ) as mock_get_node_affinity, mock.patch(
-            "paasta_tools.kubernetes_tools.load_service_namespace_config",
-            autospec=True,
-        ) as mock_load_service_namespace_config:
-            mock_service_namespace_config = mock.Mock()
-            mock_load_service_namespace_config.return_value = (
-                mock_service_namespace_config
-            )
-            mock_service_namespace_config.is_in_smartstack.return_value = False
-            ret = self.deployment.get_pod_template_spec(
-                git_sha="aaaa123", system_paasta_config=mock.Mock()
-            )
-            assert mock_load_service_namespace_config.called
-            assert mock_service_namespace_config.is_in_smartstack.called
-            assert mock_get_pod_volumes.called
-            assert mock_get_volumes.called
-            assert ret == V1PodTemplateSpec(
-                metadata=V1ObjectMeta(
-                    labels={
-                        "yelp.com/paasta_git_sha": "aaaa123",
-                        "yelp.com/paasta_instance": mock_get_instance.return_value,
-                        "yelp.com/paasta_service": mock_get_service.return_value,
-                        "paasta.yelp.com/git_sha": "aaaa123",
-                        "paasta.yelp.com/instance": mock_get_instance.return_value,
-                        "paasta.yelp.com/service": mock_get_service.return_value,
-                    },
-                    annotations={
-                        "smartstack_registrations": '["kurupt.fm"]',
-                        "paasta.yelp.com/routable_ip": "false",
-                        "hpa": '{"http": {"any": "random"}, "uwsgi": {}}',
-                        "iam.amazonaws.com/role": "",
-                    },
-                ),
-                spec=V1PodSpec(
-                    service_account_name=None,
-                    containers=mock_get_kubernetes_containers.return_value,
-                    share_process_namespace=True,
-                    node_selector={"yelp.com/pool": "default"},
-                    affinity=V1Affinity(
-                        node_affinity=mock_get_node_affinity.return_value,
-                    ),
-                    restart_policy="Always",
-                    volumes=[],
-                ),
-            )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_volumes",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_service",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_instance",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_kubernetes_containers",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_pod_volumes",
+        autospec=True,
+        return_value=[],
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_node_affinity",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.load_service_namespace_config", autospec=True,
+    )
+    @pytest.mark.parametrize(
+        "in_smtstk,routable_ip,node_affinity,spec_affinity",
+        [
+            (True, "true", None, {}),
+            (False, "false", None, {}),
+            # an affinity obj is only added if there is a node affinity
+            (
+                False,
+                "false",
+                "a_node_affinity",
+                {"affinity": V1Affinity(node_affinity="a_node_affinity")},
+            ),
+        ],
+    )
+    def test_get_pod_template_spec(
+        self,
+        mock_load_service_namespace_config,
+        mock_get_node_affinity,
+        mock_get_pod_volumes,
+        mock_get_kubernetes_containers,
+        mock_get_instance,
+        mock_get_service,
+        mock_get_volumes,
+        in_smtstk,
+        routable_ip,
+        node_affinity,
+        spec_affinity,
+    ):
+        mock_service_namespace_config = mock.Mock()
+        mock_load_service_namespace_config.return_value = mock_service_namespace_config
+        mock_service_namespace_config.is_in_smartstack.return_value = in_smtstk
+        mock_get_node_affinity.return_value = node_affinity
 
-    def test_get_pod_template_spec_smartstack_service(self):
-        with mock.patch(
-            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_volumes",
-            autospec=True,
-        ) as mock_get_volumes, mock.patch(
-            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_service",
-            autospec=True,
-        ) as mock_get_service, mock.patch(
-            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_instance",
-            autospec=True,
-        ) as mock_get_instance, mock.patch(
-            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_kubernetes_containers",
-            autospec=True,
-        ) as mock_get_kubernetes_containers, mock.patch(
-            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_pod_volumes",
-            autospec=True,
-            return_value=[],
-        ) as mock_get_pod_volumes, mock.patch(
-            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_node_affinity",
-            autospec=True,
-        ) as mock_get_node_affinity, mock.patch(
-            "paasta_tools.kubernetes_tools.load_service_namespace_config",
-            autospec=True,
-        ) as mock_load_service_namespace_config:
-            mock_service_namespace_config = mock.Mock()
-            mock_load_service_namespace_config.return_value = (
-                mock_service_namespace_config
-            )
-            mock_service_namespace_config.is_in_smartstack.return_value = True
-            ret = self.deployment.get_pod_template_spec(
-                git_sha="aaaa123", system_paasta_config=mock.Mock()
-            )
-            assert mock_load_service_namespace_config.called
-            assert mock_service_namespace_config.is_in_smartstack.called
-            assert mock_get_pod_volumes.called
-            assert mock_get_volumes.called
-            assert ret == V1PodTemplateSpec(
-                metadata=V1ObjectMeta(
-                    labels={
-                        "yelp.com/paasta_git_sha": "aaaa123",
-                        "yelp.com/paasta_instance": mock_get_instance.return_value,
-                        "yelp.com/paasta_service": mock_get_service.return_value,
-                        "paasta.yelp.com/git_sha": "aaaa123",
-                        "paasta.yelp.com/instance": mock_get_instance.return_value,
-                        "paasta.yelp.com/service": mock_get_service.return_value,
-                    },
-                    annotations={
-                        "smartstack_registrations": '["kurupt.fm"]',
-                        "paasta.yelp.com/routable_ip": "true",
-                        "hpa": '{"http": {"any": "random"}, "uwsgi": {}}',
-                        "iam.amazonaws.com/role": "",
-                    },
-                ),
-                spec=V1PodSpec(
-                    service_account_name=None,
-                    containers=mock_get_kubernetes_containers.return_value,
-                    share_process_namespace=True,
-                    node_selector={"yelp.com/pool": "default"},
-                    affinity=V1Affinity(
-                        node_affinity=mock_get_node_affinity.return_value,
-                    ),
-                    restart_policy="Always",
-                    volumes=[],
-                ),
-            )
+        ret = self.deployment.get_pod_template_spec(
+            git_sha="aaaa123", system_paasta_config=mock.Mock()
+        )
+
+        assert mock_load_service_namespace_config.called
+        assert mock_service_namespace_config.is_in_smartstack.called
+        assert mock_get_pod_volumes.called
+        assert mock_get_volumes.called
+        pod_spec_kwargs = dict(
+            service_account_name=None,
+            containers=mock_get_kubernetes_containers.return_value,
+            share_process_namespace=True,
+            node_selector={"yelp.com/pool": "default"},
+            restart_policy="Always",
+            volumes=[],
+        )
+        pod_spec_kwargs.update(spec_affinity)
+        assert ret == V1PodTemplateSpec(
+            metadata=V1ObjectMeta(
+                labels={
+                    "yelp.com/paasta_git_sha": "aaaa123",
+                    "yelp.com/paasta_instance": mock_get_instance.return_value,
+                    "yelp.com/paasta_service": mock_get_service.return_value,
+                    "paasta.yelp.com/git_sha": "aaaa123",
+                    "paasta.yelp.com/instance": mock_get_instance.return_value,
+                    "paasta.yelp.com/service": mock_get_service.return_value,
+                },
+                annotations={
+                    "smartstack_registrations": '["kurupt.fm"]',
+                    "paasta.yelp.com/routable_ip": routable_ip,
+                    "hpa": '{"http": {"any": "random"}, "uwsgi": {}}',
+                    "iam.amazonaws.com/role": "",
+                },
+            ),
+            spec=V1PodSpec(**pod_spec_kwargs),
+        )
 
     @pytest.mark.parametrize(
         "whitelist,blacklist,expected",
         [
-            # no blacklist or whitelist, only node affinity should be pool
-            (None, [], []),
             (  # whitelist only
                 ("habitat", ["habitat_a", "habitat_b"]),
                 [],
@@ -1139,6 +1103,11 @@ class TestKubernetesDeploymentConfig:
                 node_selector_terms=[V1NodeSelectorTerm(match_expressions=expected,)],
             ),
         )
+
+    def test_get_node_affinity_no_blacklist_or_whitelist(self):
+        self.deployment.config_dict["deploy_whitelist"] = None
+        self.deployment.config_dict["deploy_blacklist"] = []
+        assert self.deployment.get_node_affinity() is None
 
     def test_get_kubernetes_metadata(self):
         with mock.patch(
@@ -2559,7 +2528,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "configc7d4fe91"
+            == "config3b06ff5f"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1,4 +1,3 @@
-import unittest
 from typing import Any
 from typing import Dict
 from typing import Sequence
@@ -8,6 +7,7 @@ import pytest
 from hypothesis import given
 from hypothesis.strategies import floats
 from hypothesis.strategies import integers
+from kubernetes.client import V1Affinity
 from kubernetes.client import V1AWSElasticBlockStoreVolumeSource
 from kubernetes.client import V1beta1PodDisruptionBudget
 from kubernetes.client import V1Capabilities
@@ -25,6 +25,10 @@ from kubernetes.client import V1HostPathVolumeSource
 from kubernetes.client import V1HTTPGetAction
 from kubernetes.client import V1LabelSelector
 from kubernetes.client import V1Lifecycle
+from kubernetes.client import V1NodeAffinity
+from kubernetes.client import V1NodeSelector
+from kubernetes.client import V1NodeSelectorRequirement
+from kubernetes.client import V1NodeSelectorTerm
 from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1PersistentVolumeClaim
 from kubernetes.client import V1PersistentVolumeClaimSpec
@@ -220,8 +224,8 @@ def test_load_kubernetes_service_config():
         assert ret == mock_load_kubernetes_service_config_no_cache.return_value
 
 
-class TestKubernetesDeploymentConfig(unittest.TestCase):
-    def setUp(self):
+class TestKubernetesDeploymentConfig:
+    def setup_method(self, method):
         hpa_config = {
             "min_replicas": 1,
             "max_replicas": 3,
@@ -963,6 +967,9 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             autospec=True,
             return_value=[],
         ) as mock_get_pod_volumes, mock.patch(
+            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_node_affinity",
+            autospec=True,
+        ) as mock_get_node_affinity, mock.patch(
             "paasta_tools.kubernetes_tools.load_service_namespace_config",
             autospec=True,
         ) as mock_load_service_namespace_config:
@@ -978,7 +985,6 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             assert mock_service_namespace_config.is_in_smartstack.called
             assert mock_get_pod_volumes.called
             assert mock_get_volumes.called
-            print(ret.metadata.annotations)
             assert ret == V1PodTemplateSpec(
                 metadata=V1ObjectMeta(
                     labels={
@@ -1001,6 +1007,9 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     containers=mock_get_kubernetes_containers.return_value,
                     share_process_namespace=True,
                     node_selector={"yelp.com/pool": "default"},
+                    affinity=V1Affinity(
+                        node_affinity=mock_get_node_affinity.return_value,
+                    ),
                     restart_policy="Always",
                     volumes=[],
                 ),
@@ -1024,6 +1033,9 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             autospec=True,
             return_value=[],
         ) as mock_get_pod_volumes, mock.patch(
+            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_node_affinity",
+            autospec=True,
+        ) as mock_get_node_affinity, mock.patch(
             "paasta_tools.kubernetes_tools.load_service_namespace_config",
             autospec=True,
         ) as mock_load_service_namespace_config:
@@ -1039,7 +1051,6 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
             assert mock_service_namespace_config.is_in_smartstack.called
             assert mock_get_pod_volumes.called
             assert mock_get_volumes.called
-            print(ret.metadata.annotations)
             assert ret == V1PodTemplateSpec(
                 metadata=V1ObjectMeta(
                     labels={
@@ -1062,10 +1073,72 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                     containers=mock_get_kubernetes_containers.return_value,
                     share_process_namespace=True,
                     node_selector={"yelp.com/pool": "default"},
+                    affinity=V1Affinity(
+                        node_affinity=mock_get_node_affinity.return_value,
+                    ),
                     restart_policy="Always",
                     volumes=[],
                 ),
             )
+
+    @pytest.mark.parametrize(
+        "whitelist,blacklist,expected",
+        [
+            # no blacklist or whitelist, only node affinity should be pool
+            (None, [], []),
+            (  # whitelist only
+                ("habitat", ["habitat_a", "habitat_b"]),
+                [],
+                [
+                    V1NodeSelectorRequirement(
+                        key="yelp.com/habitat",
+                        operator="In",
+                        values=["habitat_a", "habitat_b"],
+                    ),
+                ],
+            ),
+            (  # blacklist only
+                None,
+                [("habitat", "habitat_a"), ("habitat", "habitat_b")],
+                [
+                    V1NodeSelectorRequirement(
+                        key="yelp.com/habitat", operator="NotIn", values=["habitat_a"]
+                    ),
+                    V1NodeSelectorRequirement(
+                        key="yelp.com/habitat", operator="NotIn", values=["habitat_b"]
+                    ),
+                ],
+            ),
+            (  # whitelist and blacklist
+                ("habitat", ["habitat_a", "habitat_b"]),
+                [("region", "region_a"), ("habitat", "habitat_c")],
+                [
+                    V1NodeSelectorRequirement(
+                        key="yelp.com/habitat",
+                        operator="In",
+                        values=["habitat_a", "habitat_b"],
+                    ),
+                    V1NodeSelectorRequirement(
+                        key="yelp.com/region", operator="NotIn", values=["region_a"]
+                    ),
+                    V1NodeSelectorRequirement(
+                        key="yelp.com/habitat", operator="NotIn", values=["habitat_c"]
+                    ),
+                ],
+            ),
+        ],
+    )
+    def test_get_node_affinity(self, whitelist, blacklist, expected):
+        self.deployment.config_dict["deploy_whitelist"] = whitelist
+        self.deployment.config_dict["deploy_blacklist"] = blacklist
+
+        node_affinity = self.deployment.get_node_affinity()
+
+        assert node_affinity == V1NodeAffinity(
+            required_during_scheduling_ignored_during_execution=V1NodeSelector(
+                node_selector_terms=[V1NodeSelectorTerm(match_expressions=expected,)],
+            ),
+        )
 
     def test_get_kubernetes_metadata(self):
         with mock.patch(
@@ -2486,7 +2559,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config3b06ff5f"
+            == "configc7d4fe91"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 


### PR DESCRIPTION
### Description
I previously merged and reverted #2696 after discovering that having an empty affinity object on a pod resulted in all nodes being deselected from deployment. This PR reverts that revert and accounts for the "no affinities" case by only adding an affinity object to a pod spec if there are node affinities to add. I've also added a number of tests to account for that case.

### Testing
`make test`
Tested by scheduling a pod with no deploy whitelists or blacklists on a test cluster

### Notes
Since releasing #2696 caused an incident, I'd like to make a release and test it in kubestage before unpinning everywhere.