### PR TITLE
Also allow extraordinarily high boost values when --force is passed

### DIFF
--- a/paasta_tools/autoscaling/load_boost.py
+++ b/paasta_tools/autoscaling/load_boost.py
@@ -145,7 +145,7 @@ def set_boost_factor(
         log.error(f"Cannot set a boost factor smaller than {MIN_BOOST_FACTOR}")
         return False
 
-    if factor > MAX_BOOST_FACTOR:
+    if not override and factor > MAX_BOOST_FACTOR:
         log.warning(
             "Boost factor {} does not sound reasonable. Defaulting to {}".format(
                 factor, MAX_BOOST_FACTOR

--- a/paasta_tools/cli/cmds/boost.py
+++ b/paasta_tools/cli/cmds/boost.py
@@ -26,7 +26,7 @@ def add_subparser(subparsers):
         "boost",
         help="Set, print the status, or clear a capacity boost for a given region in a PaaSTA cluster",
         description=(
-            "'paasta boost' is used to temporary provision more capacity in a given cluster "
+            "'paasta boost' is used to temporarily provision more capacity in a given cluster "
             "It operates by ssh'ing to a Mesos master of a remote cluster, and "
             "interacting with the boost in the local zookeeper cluster. If you set or clear "
             "a boost, you may want to run the cluster autoscaler manually afterward."

--- a/yelp_package/dockerfiles/itest/api/Dockerfile
+++ b/yelp_package/dockerfiles/itest/api/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update > /dev/null && \
 WORKDIR /work
 
 ADD requirements.txt /work/
-RUN virtualenv /venv -ppython3.6
+RUN virtualenv /venv -ppython3.6 --no-download
 ENV PATH=/venv/bin:$PATH
 RUN pip install -r requirements.txt
 


### PR DESCRIPTION
Some users may need to set boost above 3.0, allow that if they set --force already. For clusters scaled by clusterman, they will not exceed max_capacity in any case.