### PR TITLE
Bump service-configuration-lib version to 2.4.1

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -235,6 +235,7 @@ class TronActionConfig(InstanceConfig):
                 paasta_service=self.get_service(),
                 paasta_instance=self.get_instance(),
                 docker_img=self.get_docker_url(),
+                volumes=self.get_volumes(load_system_paasta_config().get_volumes()),
                 user_spark_opts=self.config_dict.get("spark_args", {}),
                 event_log_dir=get_default_event_log_dir(
                     service=self.get_service(),

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -45,7 +45,7 @@ requests-cache >= 0.4.10,<= 0.5.0
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.3.0
+service-configuration-lib >= 2.4.1
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ rsa==3.4.2
 ruamel.yaml==0.15.96
 s3transfer==0.1.13
 sensu-plugin==0.3.1
-service-configuration-lib==2.3.0
+service-configuration-lib==2.4.1
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -145,6 +145,18 @@ class TestTronActionConfig:
                 paasta_service="my_service",
                 spark_app_name="tron_spark_my_service_cool_job.print",
                 spark_ui_port=12345,
+                volumes=[
+                    {
+                        "hostPath": "/etc/pki/spark",
+                        "containerPath": "/etc/spark_k8s_secrets",
+                        "mode": "RO",
+                    },
+                    {
+                        "containerPath": "/nail/tmp",
+                        "hostPath": "/nail/tmp",
+                        "mode": "RW",
+                    },
+                ],
                 user_spark_opts={"spark.eventLog.enabled": "false"},
             )
 


### PR DESCRIPTION
This includes multiple enhancements and bug fixes of
service-configuration-lib 2.4.1, including attaching volumes to spark
executor pods.