### PR TITLE
Fix `check_orphans.py` uses unsafe yaml loader

### DIFF
--- a/paasta_tools/contrib/check_orphans.py
+++ b/paasta_tools/contrib/check_orphans.py
@@ -36,7 +36,7 @@ class ExitCode(Enum):
 
 def get_zk_hosts(path: str) -> List[str]:
     with open(path) as f:
-        x = yaml.load(f)
+        x = yaml.safe_load(f)
     return [f"{host}:{port}" for host, port in x]
 
 


### PR DESCRIPTION
```
paasta-mesos-master::10-81-63-228-uswest2bdevc.dev.yelpcorp.com :
check_orphan_registrations : True
/opt/venvs/paasta-tools/bin/check_orphans.py:39: YAMLLoadWarning:
calling yaml.load() without Loader=... is deprecated, as the default
Loader is unsafe. Please read https://msg.pyyaml.org/load for full
details.   x = yaml.load(f) WARNING:check_orphans:error getting file
from 10.144.177.10 WARNING:ch
```