### PR TITLE
Pin setuptools<46.0.0 in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=py36-linux
 tox_pip_extensions_ext_pip_custom_platform = true
 tox_pip_extensions_ext_venv_update = true
 docker_compose_version = 1.18.0
+requires = setuptools < 46.0.0
 
 [testenv]
 # The Makefile and .travis.yml override the indexserver to the public one when


### PR DESCRIPTION
http-parser 0.8.3 (the latest version) uses Features from setuptools,
which was deprecated starting in 46.0.0