### PR TITLE
Add requirements-bootstrap to install setuptools<46.0.0

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,4 +18,4 @@ override_dh_auto_test:
 	true
 
 override_dh_virtualenv:
-	dh_virtualenv -i $(PIP_INDEX_URL) --python=/usr/bin/python3.6 --preinstall no-manylinux1 --preinstall pip==18.1 --preinstall pip-custom-platform --pip-tool pip-custom-platform
+	dh_virtualenv -i $(PIP_INDEX_URL) --python=/usr/bin/python3.6 --preinstall no-manylinux1 --preinstall=-rrequirements-bootstrap.txt --pip-tool pip-custom-platform

--- a/requirements-bootstrap.txt
+++ b/requirements-bootstrap.txt
@@ -1,0 +1,5 @@
+pip==18.1
+pip-custom-platform>=0.3.1
+setuptools==39.0.1
+venv-update>=2.1.3
+wheel==0.32.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ choice==0.1
 click==6.6
 cookiecutter==1.4.0
 croniter==0.3.20
+cryptography==2.3.1
 decorator==4.1.2
 docker-py==1.2.3
 docutils==0.12

--- a/yelp_package/dockerfiles/mesos-paasta/Dockerfile
+++ b/yelp_package/dockerfiles/mesos-paasta/Dockerfile
@@ -16,10 +16,11 @@ RUN mkdir -p /nail/etc
 RUN ln -s /etc/mesos-slave-secret /nail/etc/mesos-slave-secret
 RUN ln -s /etc/paasta/mesos-cli.json /nail/etc/mesos-cli.json
 
-ADD requirements.txt requirements-dev.txt /paasta/
+ADD requirements.txt requirements-dev.txt requirements-bootstrap.txt /paasta/
 RUN pip install virtualenv==15.1.0
 RUN virtualenv /venv -ppython3.6
 ENV PATH=/venv/bin:$PATH
+RUN pip install -r /paasta/requirements-bootstrap.txt
 RUN pip install -r /paasta/requirements.txt
 
 ADD ./yelp_package/dockerfiles/mesos-paasta/cron.d /etc/cron.d

--- a/yelp_package/dockerfiles/playground/Dockerfile
+++ b/yelp_package/dockerfiles/playground/Dockerfile
@@ -13,9 +13,10 @@ RUN mkdir -p /var/log/paasta_logs /var/run/sshd /nail/etc
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 RUN ln -s /etc/paasta/mesos-cli.json /nail/etc/mesos-cli.json
 
-ADD requirements.txt requirements-dev.txt /paasta/
+ADD requirements.txt requirements-dev.txt requirements-bootstrap.txt /paasta/
 RUN virtualenv /venv -ppython3.6
 ENV PATH=/venv/bin:$PATH
+RUN pip install -r /paasta/requirements-bootstrap.txt
 RUN pip install -r /paasta/requirements.txt
 
 ADD ./yelp_package/dockerfiles/playground/start.sh /start.sh


### PR DESCRIPTION
### Description
setuptools v46.0.0 was released 2 days ago and removed Features, which http-parser requires. To get around this issue, I added `requirements-bootstrap.txt`, which includes the current version of setuptools PaaSTA uses, which tox installs before it installs other dependencies for tox. I also patched the debian rules to use `requirements-bootstrap.txt`. This should fix the Travis errors we've been seeing recently.

### Testing
Reproduced the Travis issue locally by using the public PyPI instead of Yelp's internal PyPI (since it doesn't have the latest version of setuptools. Verified that `requirements-bootstrap.txt` resolves the bug and updates to `debian/rules` fixes the builds.