### PR TITLE
Make requirements-bootstrap reqs hard pins to fix yelp-internal build

### DIFF
--- a/requirements-bootstrap.txt
+++ b/requirements-bootstrap.txt
@@ -1,5 +1,6 @@
-pip==18.1
-pip-custom-platform>=0.3.1
+pip==9.0.3
+pip-custom-platform==0.5.0
+pymonkey==0.3.1
 setuptools==39.0.1
-venv-update>=2.1.3
+venv-update==3.0.0
 wheel==0.32.3


### PR DESCRIPTION
### Description
I merged #2712 not too long ago, and while it fixed the Travis tests, it broke Yelp's internal Jenkins build.  This PR fixes the issue by making `requirements-bootstrap.txt`reqs hard pins.

### Testing
`make test` with a Yelp-y env, and non-Yelp-y env.