### PR TITLE
Kube state metrics collector

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
     rev: 3.7.7
     hooks:
     -   id: flake8
+        args: ['--ignore', 'E231']
         exclude: ^docs/source/conf.py$
 -   repo: https://github.com/Yelp/detect-secrets
     rev: 0.9.1

--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -23,6 +23,7 @@ opt/venvs/paasta-tools/bin/generate_services_file.py usr/bin/generate_services_f
 opt/venvs/paasta-tools/bin/generate_services_yaml.py usr/bin/generate_services_yaml
 opt/venvs/paasta-tools/bin/get_mesos_leader.py usr/bin/get_mesos_leader
 opt/venvs/paasta-tools/bin/kill_orphaned_docker_containers.py usr/bin/kill_orphaned_docker_containers
+opt/venvs/paasta-tools/bin/kube_state_metrics_collector.py usr/bin/kube_state_metrics_collector
 opt/venvs/paasta-tools/bin/kubernetes_remove_evicted_pods.py usr/bin/kubernetes_remove_evicted_pods
 opt/venvs/paasta-tools/bin/list_marathon_service_instances.py usr/bin/list_marathon_service_instances
 opt/venvs/paasta-tools/bin/paasta-api usr/bin/paasta-api

--- a/paasta_tools/kubernetes/bin/kube_state_metrics_collector.py
+++ b/paasta_tools/kubernetes/bin/kube_state_metrics_collector.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+# Copyright 2015-2020 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import defaultdict
+from typing import Any
+from typing import Dict
+from typing import Iterator
+from typing import List
+from typing import Mapping
+from typing import Optional
+from typing import Tuple
+
+import requests
+from prometheus_client.parser import text_string_to_metric_families
+
+from paasta_tools.metrics.metrics_lib import get_metrics_interface
+from paasta_tools.utils import KubeStateMetricsCollectorConfigDict
+from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import paasta_print
+
+
+def collect_and_emit_metrics() -> None:
+    kube_state_metrics_url = _get_kube_state_metrics_url()
+    if kube_state_metrics_url is None:
+        paasta_print("kube-state-metrics is not running on this machine; exiting")
+        return
+
+    system_paasta_config = load_system_paasta_config()
+    collector_config = system_paasta_config.get_kube_state_metrics_collector_config()
+
+    kube_state_metrics_response = requests.get(kube_state_metrics_url)
+    metric_family_name_to_family: Dict[str, Any] = {
+        family.name: family
+        for family in text_string_to_metric_families(kube_state_metrics_response.text)
+    }
+
+    metrics_interface = get_metrics_interface("kubernetes.kube-state-metrics")
+    cluster = system_paasta_config.get_cluster()
+    default_dimensions = {
+        "paasta_cluster": cluster,
+        "kubernetes_cluster": cluster,  # required so HPA can find these metrics
+    }
+
+    for name, dimensions, value in _yield_metrics(
+        metric_family_name_to_family, collector_config,
+    ):
+        dimensions.update(default_dimensions)
+        gauge = metrics_interface.create_gauge(name, **dimensions)
+        gauge.set(value)
+
+
+def _get_kube_state_metrics_url() -> Optional[str]:
+    try:
+        pods = requests.get("http://127.0.0.1:10255/pods").json()
+    except requests.ConnectionError:
+        return None
+
+    for pod in pods["items"]:
+        if pod["metadata"]["namespace"] != "kube-system":
+            pass
+
+        for container in pod["spec"]["containers"]:
+            if container["name"] == "kube-state-metrics":
+                for port_metadata in container["ports"]:
+                    if port_metadata["name"] == "http-metrics":
+                        ip = pod["status"]["podIP"]
+                        port = port_metadata["containerPort"]
+                        return f"http://{ip}:{port}/metrics"
+    return None
+
+
+def _yield_metrics(
+    metric_family_name_to_family: Dict[str, Any],
+    collector_config: KubeStateMetricsCollectorConfigDict,
+) -> Iterator[Tuple[str, Dict[str, str], float]]:
+    label_key_to_labels = _extract_label_key_to_labels(
+        metric_family_name_to_family,
+        collector_config.get("label_metric_to_label_key", {}),
+    )
+    label_renames = collector_config.get("label_renames", {})
+
+    for metric_name in collector_config.get("unaggregated_metrics", []):
+        if metric_name in metric_family_name_to_family:
+            family = metric_family_name_to_family[metric_name]
+            for sample in family.samples:
+                final_dimensions = _update_dimensions(
+                    sample.labels, label_key_to_labels, label_renames,
+                )
+                yield sample.name, final_dimensions, sample.value
+
+    summed_metric_to_group_keys = collector_config.get(
+        "summed_metric_to_group_keys", {}
+    )
+    for metric_name in summed_metric_to_group_keys:
+        if metric_name in metric_family_name_to_family:
+            yield from _sum_metrics(
+                metric_family_name_to_family[metric_name],
+                summed_metric_to_group_keys[metric_name],
+                label_key_to_labels,
+                label_renames,
+            )
+
+
+def _extract_label_key_to_labels(
+    metric_family_name_to_family: Dict[str, Any],
+    label_metric_to_label_key: Dict[str, List[str]],
+) -> Dict[str, Dict[str, Dict[str, str]]]:
+    label_key_to_labels: Dict[str, Dict[str, Dict[str, str]]] = defaultdict(
+        lambda: defaultdict(dict)
+    )
+    for label_metric, (label_key, dest_key) in label_metric_to_label_key.items():
+        family = metric_family_name_to_family[label_metric]
+        for sample in family.samples:
+            label_key_value = sample.labels.pop(label_key)
+            label_key_to_labels[dest_key][label_key_value].update(sample.labels)
+
+    return label_key_to_labels
+
+
+def _sum_metrics(
+    family: Any,
+    group_keys: List[str],
+    label_key_to_labels: Dict[str, Dict[str, Dict[str, str]]],
+    label_renames: Dict[str, str],
+) -> Iterator[Tuple[str, Dict[str, str], float]]:
+    sums: Dict[Tuple, float] = defaultdict(float)
+    for sample in family.samples:
+        updated_labels = _update_dimensions(
+            sample.labels, label_key_to_labels, label_renames,
+        )
+        group_values = tuple(updated_labels.get(key, "None") for key in group_keys)
+        sums[group_values] += sample.value
+
+    for group_values, metric_value in sums.items():
+        dimensions = dict(zip(group_keys, group_values))
+        yield family.name, dimensions, metric_value
+
+
+def _update_dimensions(
+    dimensions: Dict[str, str],
+    label_key_to_labels: Dict[str, Dict[str, Dict[str, str]]],
+    label_renames: Dict[str, str],
+) -> Dict[str, str]:
+    final_dimensions = dict(dimensions)
+    for label_key, label_key_value_to_dims in label_key_to_labels.items():
+        if label_key in dimensions:
+            label_key_value = dimensions[label_key]
+            extra_dims: Mapping[str, str] = label_key_value_to_dims.get(
+                label_key_value, {}
+            )
+            final_dimensions.update(extra_dims)
+
+    for label_name, label_new_name in label_renames.items():
+        if label_name in final_dimensions:
+            final_dimensions[label_new_name] = final_dimensions.pop(label_name)
+
+    return final_dimensions
+
+
+if __name__ == "__main__":
+    collect_and_emit_metrics()

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1713,6 +1713,13 @@ class KubeCustomResourceDict(TypedDict, total=False):
     group: str
 
 
+class KubeStateMetricsCollectorConfigDict(TypedDict, total=False):
+    unaggregated_metrics: List[str]
+    summed_metric_to_group_keys: Dict[str, List[str]]
+    label_metric_to_label_key: Dict[str, List[str]]
+    label_renames: Dict[str, str]
+
+
 class SystemPaastaConfigDict(TypedDict, total=False):
     api_endpoints: Dict[str, str]
     auth_certificate_ttl: str
@@ -1751,6 +1758,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     filter_bogus_mesos_cputime_enabled: bool
     fsm_template: str
     hacheck_sidecar_image_url: str
+    kube_state_metrics_collector: KubeStateMetricsCollectorConfigDict
     kubernetes_custom_resources: List[KubeCustomResourceDict]
     kubernetes_use_hacheck_sidecar: bool
     local_run_config: LocalRunConfig
@@ -2312,6 +2320,11 @@ class SystemPaastaConfig:
 
     def get_boost_regions(self) -> List[str]:
         return self.config_dict.get("boost_regions", [])
+
+    def get_kube_state_metrics_collector_config(
+        self,
+    ) -> KubeStateMetricsCollectorConfigDict:
+        return self.config_dict.get("kube_state_metrics_collector", {})
 
 
 def _run(

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -30,6 +30,7 @@ mypy-extensions >= 0.3.0
 objgraph
 ply
 progressbar2 >= 3.10.0
+prometheus-client
 pymesos >= 0.2.0
 pyramid >= 1.8
 pyramid-swagger >= 2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,6 +59,7 @@ PasteDeploy==1.5.2
 ply==3.4
 poyo==0.4.0
 progressbar2==3.10.1
+prometheus-client==0.7.1
 protobuf==3.7.1
 py==1.5.2
 pyasn1==0.4.2

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "paasta_tools/get_mesos_leader.py",
         "paasta_tools/kubernetes/bin/paasta_secrets_sync.py",
         "paasta_tools/kubernetes/bin/paasta_cleanup_stale_nodes.py",
+        "paasta_tools/kubernetes/bin/kube_state_metrics_collector.py",
         "paasta_tools/kubernetes/bin/kubernetes_remove_evicted_pods.py",
         "paasta_tools/list_marathon_service_instances.py",
         "paasta_tools/log_task_lifecycle_events.py",

--- a/tests/kubernetes/bin/test_kube_state_metrics_collector.py
+++ b/tests/kubernetes/bin/test_kube_state_metrics_collector.py
@@ -1,0 +1,222 @@
+from collections import defaultdict
+from collections import namedtuple
+
+import mock
+import pytest
+
+from paasta_tools.kubernetes.bin.kube_state_metrics_collector import (
+    collect_and_emit_metrics,
+)
+
+
+Family = namedtuple("Family", ["name", "samples"])
+
+Sample = namedtuple("Sample", ["name", "labels", "value"])
+
+
+@pytest.fixture
+def mock_metrics_interface():
+    with mock.patch(
+        "paasta_tools.kubernetes.bin.kube_state_metrics_collector.get_metrics_interface",
+        autospec=True,
+    ) as _mock_get_metrics_interface:
+        mock_metrics_interface = _mock_get_metrics_interface.return_value
+        yield mock_metrics_interface
+
+
+@pytest.fixture
+def mock_system_paasta_config():
+    with mock.patch(
+        "paasta_tools.kubernetes.bin.kube_state_metrics_collector.load_system_paasta_config",
+        autospec=True,
+    ) as _mock_load_system_paasta_config:
+        mock_system_paasta_config = mock.Mock()
+        mock_system_paasta_config.get_cluster.return_value = "westeros-prod"
+        _mock_load_system_paasta_config.return_value = mock_system_paasta_config
+        yield mock_system_paasta_config
+
+
+@pytest.fixture(autouse=True)
+def mock_requests_get():
+    with mock.patch("requests.get", autospec=True) as mock_requests_get:
+        mock_requests_get.return_value.text = ""
+        yield
+
+
+@pytest.fixture
+def mock_get_kube_state_metrics_url():
+    with mock.patch(
+        "paasta_tools.kubernetes.bin.kube_state_metrics_collector._get_kube_state_metrics_url",
+        autospec=True,
+    ) as _mock_get_kube_state_metrics_url:
+        _mock_get_kube_state_metrics_url.return_value = "http://abc.def"
+        yield _mock_get_kube_state_metrics_url
+
+
+@pytest.fixture
+def mock_text_string_to_metric_families():
+    with mock.patch(
+        "paasta_tools.kubernetes.bin.kube_state_metrics_collector.text_string_to_metric_families",
+        autospec=True,
+    ) as _mock_text_string_to_metric_families:
+        yield _mock_text_string_to_metric_families
+
+
+def test_exit_if_no_kube_state_metrics(
+    mock_get_kube_state_metrics_url, mock_metrics_interface,
+):
+    mock_get_kube_state_metrics_url.return_value = None
+    collect_and_emit_metrics()
+    assert not mock_metrics_interface.create_gauge.called
+
+
+def test_empty_config(
+    mock_get_kube_state_metrics_url, mock_system_paasta_config, mock_metrics_interface
+):
+    mock_system_paasta_config.get_kube_state_metrics_collector_config.return_value = {}
+    collect_and_emit_metrics()
+    assert not mock_metrics_interface.create_gauge.called
+
+
+def test_unaggregated_metric(
+    mock_get_kube_state_metrics_url,
+    mock_text_string_to_metric_families,
+    mock_system_paasta_config,
+    mock_metrics_interface,
+):
+    mock_system_paasta_config.get_kube_state_metrics_collector_config.return_value = {
+        "unaggregated_metrics": ["test_metric"]
+    }
+    mock_text_string_to_metric_families.return_value = [
+        Family(
+            name="test_metric",
+            samples=[Sample(name="test_metric", labels={"label": "value"}, value=1),],
+        ),
+        Family(
+            name="other_metric",
+            samples=[Sample(name="other_metric", labels={}, value=5),],
+        ),
+    ]
+    collect_and_emit_metrics()
+    mock_metrics_interface.create_gauge.assert_called_once_with(
+        "test_metric",
+        label="value",
+        paasta_cluster="westeros-prod",
+        kubernetes_cluster="westeros-prod",
+    )
+    mock_metrics_interface.create_gauge.return_value.set.assert_called_once_with(1)
+
+
+def test_aggregated_metric(
+    mock_get_kube_state_metrics_url,
+    mock_text_string_to_metric_families,
+    mock_system_paasta_config,
+    mock_metrics_interface,
+):
+    mock_system_paasta_config.get_kube_state_metrics_collector_config.return_value = {
+        "summed_metric_to_group_keys": {"test_metric": ["sum_key"],}
+    }
+    mock_text_string_to_metric_families.return_value = [
+        Family(
+            name="test_metric",
+            samples=[
+                Sample(name="test_metric", labels={"sum_key": "a"}, value=1),
+                Sample(name="test_metric", labels={"sum_key": "a"}, value=2),
+                Sample(name="test_metric", labels={"sum_key": "a"}, value=3),
+                Sample(name="test_metric", labels={"sum_key": "b"}, value=9),
+                Sample(name="test_metric", labels={"sum_key": "b"}, value=11),
+            ],
+        )
+    ]
+    gauges = defaultdict(mock.Mock)
+    mock_metrics_interface.create_gauge.side_effect = lambda name, **dimensions: gauges[
+        (name, dimensions["sum_key"])
+    ]
+
+    collect_and_emit_metrics()
+    mock_metrics_interface.create_gauge.assert_has_calls(
+        [
+            mock.call(
+                "test_metric",
+                paasta_cluster="westeros-prod",
+                kubernetes_cluster="westeros-prod",
+                sum_key="a",
+            ),
+            mock.call(
+                "test_metric",
+                paasta_cluster="westeros-prod",
+                kubernetes_cluster="westeros-prod",
+                sum_key="b",
+            ),
+        ]
+    )
+    assert mock_metrics_interface.create_gauge.call_count == 2
+    gauges["test_metric", "a"].set.assert_called_once_with(1 + 2 + 3)
+    gauges["test_metric", "b"].set.assert_called_once_with(9 + 11)
+
+
+def test_label_joining(
+    mock_get_kube_state_metrics_url,
+    mock_text_string_to_metric_families,
+    mock_system_paasta_config,
+    mock_metrics_interface,
+):
+    mock_system_paasta_config.get_kube_state_metrics_collector_config.return_value = {
+        "unaggregated_metrics": ["test_metric"],
+        "label_metric_to_label_key": {"test_labels": ["source", "dest"],},
+    }
+    mock_text_string_to_metric_families.return_value = [
+        Family(
+            name="test_metric",
+            samples=[Sample(name="test_metric", labels={"dest": "abc"}, value=4),],
+        ),
+        Family(
+            name="test_labels",
+            samples=[
+                Sample(
+                    name="test_labels",
+                    labels={"source": "abc", "is_good": "true",},
+                    value=1,
+                ),
+            ],
+        ),
+    ]
+
+    collect_and_emit_metrics()
+    mock_metrics_interface.create_gauge.assert_called_once_with(
+        "test_metric",
+        paasta_cluster="westeros-prod",
+        kubernetes_cluster="westeros-prod",
+        dest="abc",
+        is_good="true",
+    )
+    mock_metrics_interface.create_gauge.return_value.set.assert_called_once_with(4)
+
+
+def test_label_renaming(
+    mock_get_kube_state_metrics_url,
+    mock_text_string_to_metric_families,
+    mock_system_paasta_config,
+    mock_metrics_interface,
+):
+    mock_system_paasta_config.get_kube_state_metrics_collector_config.return_value = {
+        "unaggregated_metrics": ["test_metric"],
+        "label_renames": {"constantinople": "istanbul",},
+    }
+    mock_text_string_to_metric_families.return_value = [
+        Family(
+            name="test_metric",
+            samples=[
+                Sample(name="test_metric", labels={"constantinople": "xyz"}, value=6)
+            ],
+        ),
+    ]
+
+    collect_and_emit_metrics()
+    mock_metrics_interface.create_gauge.assert_called_once_with(
+        "test_metric",
+        paasta_cluster="westeros-prod",
+        kubernetes_cluster="westeros-prod",
+        istanbul="xyz",
+    )
+    mock_metrics_interface.create_gauge.return_value.set.assert_called_once_with(6)


### PR DESCRIPTION
Example of the config I'm imagining we'd use: https://fluffy.yelpcorp.com/i/fJhPH6pQnBrK8xqvjbg2j3NFkRB31lNJ.html

I have tested this and it does indeed output the expected data and sends data to signalfx.  I am still not super convinced that this is better than using prometheus, but I wanted to finish it at the very least to use as a backup.