### PR TITLE
Un-revert #2712 and add hard pins in requirements-bootstrap.txt

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,4 +18,4 @@ override_dh_auto_test:
 	true
 
 override_dh_virtualenv:
-	dh_virtualenv -i $(PIP_INDEX_URL) --python=/usr/bin/python3.6 --preinstall no-manylinux1 --preinstall pip==18.1 --preinstall pip-custom-platform --pip-tool pip-custom-platform
+	dh_virtualenv -i $(PIP_INDEX_URL) --python=/usr/bin/python3.6 --preinstall no-manylinux1 --preinstall=-rrequirements-bootstrap.txt --pip-tool pip-custom-platform

--- a/requirements-bootstrap.txt
+++ b/requirements-bootstrap.txt
@@ -1,0 +1,5 @@
+pip==18.1
+pip-custom-platform>=0.3.1
+setuptools==39.0.1
+venv-update>=2.1.3
+wheel==0.32.3

--- a/requirements-bootstrap.txt
+++ b/requirements-bootstrap.txt
@@ -1,5 +1,5 @@
 pip==18.1
-pip-custom-platform>=0.3.1
+pip-custom-platform==0.5.0
 setuptools==39.0.1
-venv-update>=2.1.3
+venv-update==3.2.4
 wheel==0.32.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ choice==0.1
 click==6.6
 cookiecutter==1.4.0
 croniter==0.3.20
+cryptography==2.3.1
 decorator==4.1.2
 docker-py==1.2.3
 docutils==0.12

--- a/yelp_package/dockerfiles/mesos-paasta/Dockerfile
+++ b/yelp_package/dockerfiles/mesos-paasta/Dockerfile
@@ -16,10 +16,11 @@ RUN mkdir -p /nail/etc
 RUN ln -s /etc/mesos-slave-secret /nail/etc/mesos-slave-secret
 RUN ln -s /etc/paasta/mesos-cli.json /nail/etc/mesos-cli.json
 
-ADD requirements.txt requirements-dev.txt /paasta/
+ADD requirements.txt requirements-dev.txt requirements-bootstrap.txt /paasta/
 RUN pip install virtualenv==15.1.0
 RUN virtualenv /venv -ppython3.6
 ENV PATH=/venv/bin:$PATH
+RUN pip install -r /paasta/requirements-bootstrap.txt
 RUN pip install -r /paasta/requirements.txt
 
 ADD ./yelp_package/dockerfiles/mesos-paasta/cron.d /etc/cron.d

--- a/yelp_package/dockerfiles/playground/Dockerfile
+++ b/yelp_package/dockerfiles/playground/Dockerfile
@@ -13,9 +13,10 @@ RUN mkdir -p /var/log/paasta_logs /var/run/sshd /nail/etc
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 RUN ln -s /etc/paasta/mesos-cli.json /nail/etc/mesos-cli.json
 
-ADD requirements.txt requirements-dev.txt /paasta/
+ADD requirements.txt requirements-dev.txt requirements-bootstrap.txt /paasta/
 RUN virtualenv /venv -ppython3.6
 ENV PATH=/venv/bin:$PATH
+RUN pip install -r /paasta/requirements-bootstrap.txt
 RUN pip install -r /paasta/requirements.txt
 
 ADD ./yelp_package/dockerfiles/playground/start.sh /start.sh


### PR DESCRIPTION
### Description
I previously merged #2712 to unblock Travis, but it wound up blocking Yelp's internal PaaSTA build. I then created #2714 to fix that issue, but @vkhromov pointed out that we had previously run into performance issues (#2638). As a result, I've bumped the hard pins in `requirements-bootstrap.txt` to be in line with what PaaSTA currently uses.

### Testing
ran `make itest` on both Yelp and external PyPIs. Packages were able to install successfully after I added `venv-update==3.2.4` to Yelp's internal PyPI. 