### PR TITLE
use paasta_cluster intead of kubernetes_cluster for HPA

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -391,7 +391,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         hpa_config = self.config_dict["horizontal_autoscaling"]
         min_replicas = hpa_config.get("min_replicas", 0)
         max_replicas = hpa_config["max_replicas"]
-        selector = V1LabelSelector(match_labels={"kubernetes_cluster": cluster})
+        selector = V1LabelSelector(match_labels={"paasta_cluster": cluster})
         annotations = {"signalfx.com.custom.metrics": ""}
         metrics = []
         for metric_name, value in hpa_config.items():
@@ -484,7 +484,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         metrics = []
         target = autoscaling_params["setpoint"]
         annotations: Dict[str, str] = {}
-        selector = V1LabelSelector(match_labels={"kubernetes_cluster": cluster})
+        selector = V1LabelSelector(match_labels={"paasta_cluster": cluster})
         if autoscaling_params["decision_policy"] == "bespoke":
             log.error(
                 f"Sorry, bespoke is not implemented yet. Please use a different decision \

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1148,7 +1148,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                             metric_name="uwsgi",
                             target_average_value=0.7,
                             selector=V1LabelSelector(
-                                match_labels={"kubernetes_cluster": "cluster"}
+                                match_labels={"paasta_cluster": "cluster"}
                             ),
                         ),
                     ),
@@ -1246,7 +1246,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                             metric_name="http",
                             target_average_value=0.5,
                             selector=V1LabelSelector(
-                                match_labels={"kubernetes_cluster": "cluster"}
+                                match_labels={"paasta_cluster": "cluster"}
                             ),
                         ),
                     )
@@ -1291,7 +1291,7 @@ class TestKubernetesDeploymentConfig(unittest.TestCase):
                             metric_name="uwsgi",
                             target_average_value=0.5,
                             selector=V1LabelSelector(
-                                match_labels={"kubernetes_cluster": "cluster"}
+                                match_labels={"paasta_cluster": "cluster"}
                             ),
                         ),
                     )


### PR DESCRIPTION
I decide to correct all labels. These label selectors are used to select metrics with dimensions [here](https://reviewboard.yelpcorp.com/r/490904/)