### PR TITLE
Add option to pass in attribution for rightsizing changes

### DIFF
--- a/paasta_tools/contrib/rightsizer_soaconfigs_update.py
+++ b/paasta_tools/contrib/rightsizer_soaconfigs_update.py
@@ -67,6 +67,13 @@ def parse_args():
         dest="local_dir",
     )
     parser.add_argument(
+        "--source-id",
+        help="String to attribute the changes in the commit message. Defaults to csv report name",
+        required=False,
+        default=None,
+        dest="source_id",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         help="Logging verbosity",
@@ -112,10 +119,11 @@ def main(args):
         args.splunk_creds, args.splunk_app, args.csv_report, args.criteria_filter
     )
     extra_message = get_extra_message(report["search"])
+    config_source = args.source_id or args.csv_report
 
     results = get_recommendations_by_service_file(report["results"])
     updater = AutoConfigUpdater(
-        config_source=args.csv_report,
+        config_source=config_source,
         git_remote=args.git_remote,
         branch=args.branch,
         working_dir=args.local_dir or "/nail/tmp",


### PR DESCRIPTION
With the current default of `config_source=args.csv_report`, commit messages look like
```
Update to autotuned_defaults configs from paasta_rightsizer_memory_recs.csv
    
This review is based on results from the following Splunk search:
    
    | inputlookup paasta_rightsizer_memory_recs.csv | ...
```

With this change, we could do `--source-id=$BUILD_URL` in jenkins and get
```
Update to autotuned_defaults configs from https://jenkins-deploy.yelpcorp.com/job/paasta_rightsizer/137/
    
This review is based on results from the following Splunk search:
    
    | inputlookup paasta_rightsizer_memory_recs.csv | ...
```
The csv report name is still in the detail message.