### PR TITLE
paasta validate for specific instance type

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -354,25 +354,31 @@ def validate_unique_instance_names(service_path):
     check_passed = True
 
     for cluster in list_clusters(service, soa_dir):
-        service_instances = get_service_instance_list(
-            service=service, cluster=cluster, soa_dir=soa_dir
-        )
-        instance_names = [service_instance[1] for service_instance in service_instances]
-        instance_name_to_count = Counter(instance_names)
-        duplicate_instance_names = [
-            instance_name
-            for instance_name, count in instance_name_to_count.items()
-            if count > 1
-        ]
-        if duplicate_instance_names:
-            check_passed = False
-            paasta_print(
-                duplicate_instance_names_message(
-                    service, cluster, duplicate_instance_names
-                )
+        for instance_type in ["marathon", "kubernetes"]:
+            service_instances = get_service_instance_list(
+                service=service,
+                cluster=cluster,
+                instance_type=instance_type,
+                soa_dir=soa_dir,
             )
-        else:
-            paasta_print(no_duplicate_instance_names_message(service, cluster))
+            instance_names = [
+                service_instance[1] for service_instance in service_instances
+            ]
+            instance_name_to_count = Counter(instance_names)
+            duplicate_instance_names = [
+                instance_name
+                for instance_name, count in instance_name_to_count.items()
+                if count > 1
+            ]
+            if duplicate_instance_names:
+                check_passed = False
+                paasta_print(
+                    duplicate_instance_names_message(
+                        service, cluster, duplicate_instance_names
+                    )
+                )
+            else:
+                paasta_print(no_duplicate_instance_names_message(service, cluster))
 
     return check_passed
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2750,7 +2750,7 @@ def get_service_instance_list(
 
     :param service: The service name
     :param cluster: The cluster to read the configuration for
-    :param instance_type: The type of instances to examine: 'marathon', 'tron', or None (default) for both
+    :param instance_type: The type of instances to examine: 'marathon', 'kubernetes', 'tron', or None (default) for both
     :param soa_dir: The SOA config directory to read from
     :returns: A list of tuples of (name, instance) for each instance defined for the service name
     """


### PR DESCRIPTION
I have tested this against local yelpsoa-configs repo. And the pre-receive hook just calls "paasta validate".