### PR TITLE
Include all schemas and fix key error for autotuned_defaults

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 recursive-include paasta_tools/cli/fsm/template *
-include paasta_tools/cli/schemas/*.json
+recursive-include paasta_tools/cli/schemas *.json
 include paasta_tools/api/api_docs/*.json
 include requirements-minimal.txt
 include paasta_tools/py.typed

--- a/paasta_tools/contrib/paasta_update_soa_memcpu.py
+++ b/paasta_tools/contrib/paasta_update_soa_memcpu.py
@@ -130,7 +130,7 @@ def cwd(path):
 def get_report_from_splunk(creds, app, filename, criteria_filter):
     """ Expect a table containing at least the following fields:
     criteria (<service> [marathon|kubernetes]-<cluster_name> <instance>)
-    service_owner
+    service_owner (Optional)
     project (Required to create tickets)
     estimated_monthly_savings (Optional)
     search_time (Unix time)
@@ -161,7 +161,7 @@ def get_report_from_splunk(creds, app, filename, criteria_filter):
         serv["service"] = criteria.split(" ")[0]
         serv["cluster"] = criteria.split(" ")[1]
         serv["instance"] = criteria.split(" ")[2]
-        serv["owner"] = d["result"]["service_owner"]
+        serv["owner"] = d["result"].get("service_owner", "Unavailable")
         serv["date"] = d["result"]["_time"].split(" ")[0]
         serv["money"] = d["result"].get("estimated_monthly_savings", 0)
         serv["project"] = d["result"].get("project", "Unavailable")


### PR DESCRIPTION
The actual installed package only includes the top level of schemas/, we need to add recursively now that autotuned_defaults exists.
```
$ ls /opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/cli/schemas
adhoc_schema.json  kubernetes_schema.json  marathon_schema.json  tron_schema.json
```
service_owner is only used in the review description, so it should be optional like the other keys.
https://github.com/Yelp/paasta/blob/master/paasta_tools/contrib/paasta_update_soa_memcpu.py#L364