### PR TITLE
Fix example cluser. Fixes #2702

### DIFF
--- a/example_cluster/docker-compose.override.yml
+++ b/example_cluster/docker-compose.override.yml
@@ -78,7 +78,7 @@ services:
   registry:
     image: registry:2
     ports:
-      - '5000:5000'
+      - '15000:5000'
   git:
     build: ../yelp_package/dockerfiles/gitremote/
     command: /usr/sbin/sshd -D

--- a/example_cluster/example-services/hello-world/marathon-testcluster.yaml
+++ b/example_cluster/example-services/hello-world/marathon-testcluster.yaml
@@ -5,3 +5,4 @@ main:
   mem: 100
   deploy_group: testcluster.everything
   disk: 40
+  cap_add: ["DAC_OVERRIDE", "CHOWN", "SETGID", "SETUID"]


### PR DESCRIPTION
This adds new CAP_ADD for nginx to run properly in a secure environment.
Additionally it puts the docker registry on a higher port, as often 5000
is already taken.