### PR TITLE
Expose k8s node selectors and node affinities for Kubernetes apps

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -173,16 +173,16 @@ These options are only applicable to tasks scheduled on Kubernetes.
             - operator: NotIn
               values: ["c3.8xlarge"]
 
-    * Requires that a node have the ``vip`` label::
+    * Requires that a node have the ``ssd`` label::
 
         node_selectors:
-          vip:
+          ssd:
             - operator: Exists
 
-    * Requires that a node not have the ``vip`` label::
+    * Requires that a node not have the ``ssd`` label::
 
         node_selectors:
-          vip:
+          ssd:
             - operator: DoesNotExist
 
     * Requires that a node have a label ``priority`` with a value greater than 1

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -170,35 +170,30 @@ These options are only applicable to tasks scheduled on Kubernetes.
 
         node_selectors:
           instance_type:
-            operator: NotIn
-            values: ["c3.8xlarge"]
+            - operator: NotIn
+              values: ["c3.8xlarge"]
 
     * Requires that a node have the ``vip`` label::
 
         node_selectors:
           vip:
-            operator: Exists
+            - operator: Exists
 
     * Requires that a node not have the ``vip`` label::
 
         node_selectors:
           vip:
-            operator: DoesNotExist
+            - operator: DoesNotExist
 
     * Requires that a node have a label ``priority`` with a value greater than 1
       and less than 5::
 
         node_selectors:
           priority:
-            operator: Gt
-            value: 3
-
-    * Requires that a node have a priority less than 3::
-
-        node_selectors:
-          priority:
-            operator: Lt
-            value: 3
+            - operator: Gt
+              value: 1
+            - operator: Lt
+              value: 5
 
     .. note::
 

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -106,11 +106,19 @@ specify the following options:
     validate that the bind mounts are "safe".
 
 
-``Placement Options (Constraints)``
------------------------------------
+Placement Options
+-----------------
 
-Constraint options control how Mesos schedules a task, whether it is scheduled by
-Marathon, Tron, or ``paasta remote-run``.
+Placement options provide control over how PaaSTA schedules a task, whether it
+is scheduled by Marathon (on Mesos), Kubernetes, Tron, or ``paasta remote-run``.
+Most commonly, it is used to restrict tasks to specific locations.
+
+.. _general-placement-options:
+
+General
+^^^^^^^
+
+These options are applicable to tasks scheduled through Mesos or Kubernetes.
 
   * ``deploy_blacklist``: A list of lists indicating a set of locations to *not* deploy to. For example:
 
@@ -126,6 +134,88 @@ Marathon, Tron, or ``paasta remote-run``.
     is empty (the default), then deployment is allowed anywhere.  This is superseded by the blacklist; if
     a host is both whitelisted and blacklisted, the blacklist will take precedence.  Only one location type
     of whitelisting may be specified.
+
+  * ``pool``: The pool of machines a PaaSTA app runs in. If no pool is set,
+    an app will automatically be set to run in ``default`` pool.
+
+    Warning: In order for an service to be launched in a particular pool, there
+    *must* exist some nodes that already exist with that particular
+    pool attribute set.
+
+.. _k8s-placement-options:
+
+Kubernetes
+^^^^^^^^^^
+
+These options are only applicable to tasks scheduled on Kubernetes.
+
+  * ``node_selectors``: A map of labels a node is required to have for a task
+    to be launched on said node. There are several ways to define a selector.
+    The simplest is a key-value pair. For example, this selector restricts a
+    task to c3.8xlarge instances::
+
+      node_selectors:
+        instance_type: c3.8xlarge
+
+    The value can also be a list of multiple values. For example, this selector
+    restricts a task to both c3.8xlarge and m5.2xlarge instances::
+
+      node_selectors:
+        instance_type: ["c3.8xlarge", "m5.2xlarge"]
+
+    For more complex cases, an operator, and optionally a value (or values) must
+    be set. Here are some examples:
+
+    * Restricts a task to instances that are not c3.8xlarges::
+
+        node_selectors:
+          instance_type:
+            operator: NotIn
+            values: ["c3.8xlarge"]
+
+    * Requires that a node have the ``vip`` label::
+
+        node_selectors:
+          vip:
+            operator: Exists
+
+    * Requires that a node not have the ``vip`` label::
+
+        node_selectors:
+          vip:
+            operator: DoesNotExist
+
+    * Requires that a node have a label ``priority`` with a value greater than 1
+      and less than 5::
+
+        node_selectors:
+          priority:
+            operator: Gt
+            value: 3
+
+    * Requires that a node have a priority less than 3::
+
+        node_selectors:
+          priority:
+            operator: Lt
+            value: 3
+
+    .. note::
+
+      The label ``instance_type`` is special. If set as a node selector,
+      PaaSTA will automatically convert it to a canonical version set by
+      Kubernetes on all AWS nodes.
+
+For more information on selector operators, see the official Kubernetes
+documentation on `node affinities
+<https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity>`_.
+
+.. _mesos-placement-options:
+
+Mesos
+^^^^^
+
+These options are applicable only to tasks scheduled on Mesos.
 
   * ``constraints``: Overrides the default placement constraints for services.
     Should be defined as an array of arrays (E.g ``[["habitat", "GROUP_BY"]]``
@@ -145,18 +235,6 @@ Marathon, Tron, or ``paasta remote-run``.
     constraints instead of replacing them. See ``constraints`` for details on
     format and the default constraints.
 
-  * ``pool``: Changes the "pool" constrained automatically added to all PaaSTA
-    Marathon apps. The default pool is ``default``, which equates to::
-
-       ["pool", "LIKE", "default"]
-
-    This constraint is automatically appended to the list of constraints for
-    a service unless overridden with the ``constraints`` input.
-
-    Warning: In order for an service to be launched in a particular pool, there
-    *must* exist some Mesos slaves that already exist with that particular
-    pool attribute set.
-
 ``kubernetes-[clustername].yaml``
 -------------------------------
 
@@ -173,7 +251,8 @@ instance MAY have:
 
   * Anything in the `Common Settings`_.
 
-  * Only ``pool`` from `Placement Options (Constraints)`_.
+  * Anything from :ref:`General Placement Options <general-placement-options>`
+    and :ref:`Kubernetes Placement Options <k8s-placement-options>`.
 
   * ``cap_add``: List of capabilities that are passed to Docker. Defaults
     to empty list. Example::
@@ -338,7 +417,8 @@ instance MAY have:
 
   * Anything in the `Common Settings`_.
 
-  * Anything in the `Placement Options (Constraints)`_.
+  * Anything from :ref:`General Placement Options <general-placement-options>`
+    and :ref:`Mesos Placement Options <mesos-placement-options>`.
 
   * ``cap_add``: List of capabilities that are passed to Docker. Defaults
     to empty list. Example::
@@ -590,7 +670,9 @@ Each Tron **action** of a job MAY specify the following:
 
   * Anything in the `Common Settings`_.
 
-  * Anything in the `Placement Options (Constraints)`_.
+  * Anything from :ref:`General Placement Options <general-placement-options>`
+    and :ref:`Mesos Placement Options <mesos-placement-options>` (currently, Tron
+    only supports Mesos workloads).
 
   * ``service``: Uses a docker image from different service. When ``service`` is set
     for an action, that setting takes precedence over what is set for the job.

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -353,61 +353,68 @@
                                     "uniqueItems": true
                                 },
                                 {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "operator": {
-                                            "enum": [
-                                                "In",
-                                                "NotIn"
-                                            ]
-                                        },
-                                        "values": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
+                                    "type": "array",
+                                    "items": {
+                                        "anyOf": [
+                                            {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "operator": {
+                                                        "enum": [
+                                                            "In",
+                                                            "NotIn"
+                                                        ]
+                                                    },
+                                                    "values": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "uniqueItems": true
+                                                    }
+                                                },
+                                                "required": [
+                                                    "operator",
+                                                    "values"
+                                                ]
                                             },
-                                            "uniqueItems": true
-                                        }
-                                    },
-                                    "required": [
-                                        "operator",
-                                        "values"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "operator": {
-                                            "enum": [
-                                                "Exists",
-                                                "DoesNotExist"
-                                            ]
-                                        }
-                                    },
-                                    "required": [
-                                        "operator"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "operator": {
-                                            "enum": [
-                                                "Gt",
-                                                "Lt"
-                                            ]
-                                        },
-                                        "value": {
-                                            "type": "integer"
-                                        }
-                                    },
-                                    "required": [
-                                        "operator",
-                                        "value"
-                                    ]
+                                            {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "operator": {
+                                                        "enum": [
+                                                            "Exists",
+                                                            "DoesNotExist"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "operator"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "operator": {
+                                                        "enum": [
+                                                            "Gt",
+                                                            "Lt"
+                                                        ]
+                                                    },
+                                                    "value": {
+                                                        "type": "integer"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "operator",
+                                                    "value"
+                                                ]
+                                            }
+                                        ]
+                                    }
                                 }
                             ]
                         }

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -347,6 +347,7 @@
                                 },
                                 {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "operator": {
                                             "enum": [
@@ -360,6 +361,40 @@
                                                 "type": "string"
                                             },
                                             "uniqueItems": true
+                                        }
+                                    },
+                                    "required": [
+                                        "operator",
+                                        "values"
+                                    ]
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "operator": {
+                                            "enum": [
+                                                "Exists",
+                                                "DoesNotExist"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "operator"
+                                    ]
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "operator": {
+                                            "enum": [
+                                                "Gt",
+                                                "Lt"
+                                            ]
+                                        },
+                                        "value": {
+                                            "type": "integer"
                                         }
                                     },
                                     "required": [

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -336,6 +336,41 @@
                     },
                     "uniqueItems": true
                 },
+                "node_selectors": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+[a-zA-Z0-9-_./]*[a-zA-Z0-9]+$": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "operator": {
+                                            "enum": [
+                                                "In",
+                                                "NotIn"
+                                            ]
+                                        },
+                                        "values": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "uniqueItems": true
+                                        }
+                                    },
+                                    "required": [
+                                        "operator",
+                                        "value"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
                 "pool": {
                     "type": "string"
                 },

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -346,6 +346,13 @@
                                     "type": "string"
                                 },
                                 {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "uniqueItems": true
+                                },
+                                {
                                     "type": "object",
                                     "additionalProperties": false,
                                     "properties": {

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2267,7 +2267,6 @@ def get_pod_hostname(kube_client: KubeClient, pod: V1Pod) -> str:
 def to_node_label(label: str) -> str:
     """k8s-ifies certain special node labels"""
     if label in {"instance_type", "instance-type"}:
-        # kube_client is assumed to already be configured
         version_info = kube_client.VersionApi().get_code()
         if int(version_info.major) == 1 and int(version_info.minor) < 17:
             # the beta instance-type label is deprecated as of k8s v1.17

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2270,12 +2270,7 @@ def get_pod_hostname(kube_client: KubeClient, pod: V1Pod) -> str:
 def to_node_label(label: str) -> str:
     """k8s-ifies certain special node labels"""
     if label in {"instance_type", "instance-type"}:
-        version_info = kube_client.VersionApi().get_code()
-        if int(version_info.major) == 1 and int(version_info.minor) < 17:
-            # the beta instance-type label is deprecated as of k8s v1.17
-            return "beta.kubernetes.io/instance-type"
-        else:
-            return "node.kubernetes.io/instance-type"
+        return "node.kubernetes.io/instance-type"
     elif label in {
         "datacenter",
         "ecosystem",

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1274,7 +1274,11 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
         for label, config in raw_selectors.items():
             # non-dict raw selectors become node selectors, not affinities
-            if type(config) is not dict:
+            if type(config) is list:
+                # specifying an array/list value for a label is shorthand for
+                # the "In" operator
+                config = {"operator": "In", "values": config}
+            elif type(config) is not dict:
                 continue
             if config["operator"] in {"In", "NotIn"}:
                 values = config["values"]

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1141,21 +1141,23 @@ class TestKubernetesDeploymentConfig:
                 {
                     "select_key": "select_value",  # simple item, excluded
                     "implicit_in_key": ["implicit_value"],  # shorthand "In" case
-                    "in_key": {"operator": "In", "values": ["a_value"]},
-                    "out_key": {"operator": "NotIn", "values": ["a_value"]},
-                    "exists_key": {"operator": "Exists"},
-                    "dne_key": {"operator": "DoesNotExist"},
-                    "gt_key": {"operator": "Gt", "value": 100},
-                    "lt_key": {"operator": "Lt", "value": 200},
+                    "a_key": [
+                        {"operator": "In", "values": ["a_value"]},
+                        {"operator": "NotIn", "values": ["a_value"]},
+                        {"operator": "Exists"},
+                        {"operator": "DoesNotExist"},
+                        {"operator": "Gt", "value": 100},
+                        {"operator": "Lt", "value": 200},
+                    ],
                 },
                 [
                     ("implicit_in_key", "In", ["implicit_value"]),
-                    ("in_key", "In", ["a_value"]),
-                    ("out_key", "NotIn", ["a_value"]),
-                    ("exists_key", "Exists", []),
-                    ("dne_key", "DoesNotExist", []),
-                    ("gt_key", "Gt", ["100"]),
-                    ("lt_key", "Lt", ["200"]),
+                    ("a_key", "In", ["a_value"]),
+                    ("a_key", "NotIn", ["a_value"]),
+                    ("a_key", "Exists", []),
+                    ("a_key", "DoesNotExist", []),
+                    ("a_key", "Gt", ["100"]),
+                    ("a_key", "Lt", ["200"]),
                 ],
             ),
         ],
@@ -1166,7 +1168,7 @@ class TestKubernetesDeploymentConfig:
 
     def test_raw_selectors_to_requirements_error(self):
         self.deployment.config_dict["node_selectors"] = {
-            "error_key": {"operator": "BadOperator"},
+            "error_key": [{"operator": "BadOperator"}],
         }
         with pytest.raises(ValueError):
             self.deployment._raw_selectors_to_requirements()

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2665,26 +2665,13 @@ def test_get_pod_hostname(pod_node_name, node, expected):
     assert hostname == expected
 
 
-@mock.patch("paasta_tools.kubernetes_tools.kube_client", autospec=True)
 @pytest.mark.parametrize(
-    "label,version_info,expected",
+    "label,expected",
     [
-        ("a_random_label", None, "a_random_label"),  # non-special case
-        (  # instance_type -> beta k8s label
-            "instance_type",
-            mock.Mock(major="1", minor="16"),
-            "beta.kubernetes.io/instance-type",
-        ),
-        (  # instance_type -> non-beta k8s label
-            "instance_type",
-            mock.Mock(major="1", minor="17"),
-            "node.kubernetes.io/instance-type",
-        ),
-        ("habitat", None, "yelp.com/habitat"),  # hiera case
+        ("a_random_label", "a_random_label"),  # non-special case
+        ("instance_type", "node.kubernetes.io/instance-type"),  # instance_type
+        ("habitat", "yelp.com/habitat"),  # hiera case
     ],
 )
-def test_to_node_label(mock_client, label, version_info, expected):
-    mock_client.VersionApi.return_value = mock.Mock(
-        get_code=mock.Mock(return_value=version_info)
-    )
+def test_to_node_label(label, expected):
     assert kubernetes_tools.to_node_label(label) == expected

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1139,7 +1139,8 @@ class TestKubernetesDeploymentConfig:
             ({}, []),  # no node_selectors case
             (  # node_selectors config case, complex items become requirements
                 {
-                    "select_key": "select_value",
+                    "select_key": "select_value",  # simple item, excluded
+                    "implicit_in_key": ["implicit_value"],  # shorthand "In" case
                     "in_key": {"operator": "In", "values": ["a_value"]},
                     "out_key": {"operator": "NotIn", "values": ["a_value"]},
                     "exists_key": {"operator": "Exists"},
@@ -1148,6 +1149,7 @@ class TestKubernetesDeploymentConfig:
                     "lt_key": {"operator": "Lt", "value": 200},
                 },
                 [
+                    ("implicit_in_key", "In", ["implicit_value"]),
                     ("in_key", "In", ["a_value"]),
                     ("out_key", "NotIn", ["a_value"]),
                     ("exists_key", "Exists", []),


### PR DESCRIPTION
### Description
In an effort to give devs more control over how their nodes are scheduled, as well as offer a limited equivalent for (Marathon) constraints to k8s tasks, I've exposed node selectors and affinities under a `node_selectors` config value in soa-configs. 

This is not intended to provide a functional replacement to Marathon constraints for  k8s apps. The Kubernetes scheduler already tries to spread pods out, much better than Marathon, so we shouldn't need as strong controls. However, if a dev wants to, say, only run their instances on specific instance types, then it is possible with this feature.

I've added comments and updated the soa-configs documentation to provide an explanation on how it's supposed to work.

### Testing
- `make test
- Manual testing on a test cluster
  - Status quo, no `node_selectors`
  - `node_selectors` test cases with string value (becomes a node selector), list of strings value (becomes an "in" node affinity), and each operator config value (becomes a node affinity)

### Notes
The k8s schema allows the `constraints` and `extra_constraints` keys, likely because it was initially copied from the Marathon one. I *have not* deprecated these because some existing configs for k8s service instances do set them, again likely because they were converted from Marathon ones, even though they aren't supported. 