### PR TITLE
pause HPA for kubernetes services using zk

### DIFF
--- a/paasta_tools/api/views/pause_autoscaler.py
+++ b/paasta_tools/api/views/pause_autoscaler.py
@@ -22,7 +22,6 @@ from pyramid.view import view_config
 
 from paasta_tools.api.views.exception import ApiFailure
 from paasta_tools.long_running_service_tools import ZK_PAUSE_AUTOSCALE_PATH
-from paasta_tools.long_running_service_tools import ZK_RESUME_AUTOSCALE_PATH
 from paasta_tools.utils import ZookeeperPool
 
 
@@ -52,8 +51,6 @@ def update_service_autoscaler_pause(request):
         try:
             zk.ensure_path(ZK_PAUSE_AUTOSCALE_PATH)
             zk.set(ZK_PAUSE_AUTOSCALE_PATH, str(expiry_time).encode("utf-8"))
-            zk.ensure_path(ZK_RESUME_AUTOSCALE_PATH)
-            zk.set(ZK_RESUME_AUTOSCALE_PATH, str("False").encode("utf-8"))
         except Exception as e:
             raise ApiFailure(e, 500)
     return
@@ -69,8 +66,6 @@ def delete_service_autoscaler_pause(request):
         try:
             zk.ensure_path(ZK_PAUSE_AUTOSCALE_PATH)
             zk.delete(ZK_PAUSE_AUTOSCALE_PATH)
-            zk.ensure_path(ZK_RESUME_AUTOSCALE_PATH)
-            zk.delete(ZK_RESUME_AUTOSCALE_PATH)
         except Exception as e:
             raise ApiFailure(e, 500)
     return

--- a/paasta_tools/api/views/pause_autoscaler.py
+++ b/paasta_tools/api/views/pause_autoscaler.py
@@ -22,6 +22,7 @@ from pyramid.view import view_config
 
 from paasta_tools.api.views.exception import ApiFailure
 from paasta_tools.long_running_service_tools import ZK_PAUSE_AUTOSCALE_PATH
+from paasta_tools.long_running_service_tools import ZK_RESUME_AUTOSCALE_PATH
 from paasta_tools.utils import ZookeeperPool
 
 
@@ -51,9 +52,10 @@ def update_service_autoscaler_pause(request):
         try:
             zk.ensure_path(ZK_PAUSE_AUTOSCALE_PATH)
             zk.set(ZK_PAUSE_AUTOSCALE_PATH, str(expiry_time).encode("utf-8"))
+            zk.ensure_path(ZK_RESUME_AUTOSCALE_PATH)
+            zk.set(ZK_RESUME_AUTOSCALE_PATH, str("False").encode("utf-8"))
         except Exception as e:
             raise ApiFailure(e, 500)
-
     return
 
 
@@ -67,6 +69,8 @@ def delete_service_autoscaler_pause(request):
         try:
             zk.ensure_path(ZK_PAUSE_AUTOSCALE_PATH)
             zk.delete(ZK_PAUSE_AUTOSCALE_PATH)
+            zk.ensure_path(ZK_RESUME_AUTOSCALE_PATH)
+            zk.delete(ZK_RESUME_AUTOSCALE_PATH)
         except Exception as e:
             raise ApiFailure(e, 500)
     return

--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -29,11 +29,14 @@ from typing import Mapping
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
+from typing import Union
 
 import a_sync
 import aiohttp
 from kazoo.client import KazooClient
 from kazoo.exceptions import NoNodeError
+from kubernetes.client import V1Deployment
+from kubernetes.client import V1StatefulSet
 from marathon.models.app import MarathonApp
 from marathon.models.app import MarathonTask
 
@@ -44,9 +47,11 @@ from paasta_tools.bounce_lib import filter_tasks_in_smartstack
 from paasta_tools.bounce_lib import LockHeldException
 from paasta_tools.bounce_lib import LockTimeout
 from paasta_tools.bounce_lib import ZK_LOCK_CONNECT_TIMEOUT_S
+from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
+from paasta_tools.kubernetes_tools import write_annotation_for_kubernetes_service
 from paasta_tools.long_running_service_tools import load_service_namespace_config
 from paasta_tools.long_running_service_tools import ZK_PAUSE_AUTOSCALE_PATH
-from paasta_tools.long_running_service_tools import ZK_RESUME_AUTOSCALE_PATH
 from paasta_tools.marathon_tools import AutoscalingParamsDict
 from paasta_tools.marathon_tools import compose_autoscaling_zookeeper_root
 from paasta_tools.marathon_tools import format_job_id
@@ -841,24 +846,23 @@ def autoscaling_is_paused():
         return False
 
 
-def is_autoscaling_resumed():
-    with ZookeeperPool() as zk:
-        try:
-            resumed = zk.get(ZK_RESUME_AUTOSCALE_PATH)[0].decode("utf8")
-        except (NoNodeError, ValueError, AttributeError):
-            resumed = "True"
-
-    return True if resumed == "True" else False
+def is_autoscaling_resumed(formatted_application: Union[V1Deployment, V1StatefulSet]):
+    if formatted_application.metadata.annotations:
+        if "is_paused" in formatted_application.metadata.annotations:
+            return formatted_application.metadata.annotations["is_paused"] == "False"
+    return True
 
 
-def write_autoscaling_resumed():
-    with ZookeeperPool() as zk:
-        try:
-            zk.ensure_path(ZK_RESUME_AUTOSCALE_PATH)
-            zk.set(ZK_RESUME_AUTOSCALE_PATH, "True".encode("utf-8"))
-        except Exception as e:
-            error_msg = f"Could not update zk resume state: {e} "
-            log.error(error_msg)
+def write_autoscaling_paused(
+    kube_client: KubeClient,
+    service_config: KubernetesDeploymentConfig,
+    formatted_application: Union[V1Deployment, V1StatefulSet],
+    paused: bool,
+) -> None:
+    annotation = {"is_paused": str(paused)}
+    write_annotation_for_kubernetes_service(
+        kube_client, service_config, formatted_application, annotation
+    )
 
 
 def autoscale_services(

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1035,7 +1035,19 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 "paasta.yelp.com/instance": self.get_instance(),
                 "paasta.yelp.com/git_sha": git_sha,
             },
+            annotations=self.get_annotations(),
         )
+
+    def get_annotations(self) -> Optional[Dict]:
+        # fetches annotations if k8s deployments already exists
+        try:
+            kube_client = KubeClient()
+            deployment = kube_client.deployments.read_namespaced_deployment(
+                name=self.get_sanitised_deployment_name(), namespace="paasta"
+            )
+            return deployment.metadata.annotations
+        except Exception:
+            return None
 
     def get_sanitised_deployment_name(self) -> str:
         return get_kubernetes_app_name(self.get_service(), self.get_instance())
@@ -1634,6 +1646,25 @@ def set_instances_for_kubernetes_service(
         )
 
 
+def write_annotation_for_kubernetes_service(
+    kube_client: KubeClient,
+    service_config: KubernetesDeploymentConfig,
+    formatted_application: Union[V1Deployment, V1StatefulSet],
+    annotation: Dict,
+) -> None:
+    name = formatted_application.metadata.name
+    formatted_application.metadata.annotations = annotation
+    print(annotation)
+    if service_config.get_persistent_volumes():
+        kube_client.deployments.patch_namespaced_stateful_set(
+            name=name, namespace="paasta", body=formatted_application
+        )
+    else:
+        kube_client.deployments.patch_namespaced_deployment(
+            name=name, namespace="paasta", body=formatted_application
+        )
+
+
 def list_all_deployments(kube_client: KubeClient) -> Sequence[KubeDeployment]:
     return list_deployments(kube_client)
 
@@ -1839,6 +1870,16 @@ def update_deployment(
     kube_client: KubeClient, formatted_deployment: V1Deployment
 ) -> None:
     return kube_client.deployments.replace_namespaced_deployment(
+        name=formatted_deployment.metadata.name,
+        namespace="paasta",
+        body=formatted_deployment,
+    )
+
+
+def patch_deployment(
+    kube_client: KubeClient, formatted_deployment: V1Deployment
+) -> None:
+    return kube_client.deployments.patch_namespaced_deployment(
         name=formatted_deployment.metadata.name,
         namespace="paasta",
         body=formatted_deployment,

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -512,13 +512,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         target = autoscaling_params["setpoint"]
         annotations: Dict[str, str] = {}
         selector = V1LabelSelector(match_labels={"paasta_cluster": cluster})
-        if autoscaling_params["decision_policy"] == "bespoke":
-            log.error(
-                f"Sorry, bespoke is not implemented yet. Please use a different decision \
-                policy if possible for {name}/name in namespace{namespace}"
-            )
-            return None
-        elif metrics_provider == "mesos_cpu":
+        if metrics_provider == "mesos_cpu":
             metrics.append(
                 V2beta1MetricSpec(
                     type="Resource",

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -24,7 +24,6 @@ log = logging.getLogger(__name__)
 logging.getLogger("marathon").setLevel(logging.WARNING)
 
 ZK_PAUSE_AUTOSCALE_PATH = "/autoscaling/paused"
-ZK_RESUME_AUTOSCALE_PATH = "/autoscaling/resumed"
 DEFAULT_CONTAINER_PORT = 8888
 
 
@@ -291,7 +290,7 @@ class LongRunningServiceConfig(InstanceConfig):
     def get_max_instances(self) -> Optional[int]:
         return self.config_dict.get("max_instances", None)
 
-    def set_min_instances(self, instance_count):
+    def set_min_instances(self, instance_count: int) -> None:
         if "min_instances" in self.config_dict:
             self.config_dict["min_instances"] = instance_count
 

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 logging.getLogger("marathon").setLevel(logging.WARNING)
 
 ZK_PAUSE_AUTOSCALE_PATH = "/autoscaling/paused"
+ZK_RESUME_AUTOSCALE_PATH = "/autoscaling/resumed"
 DEFAULT_CONTAINER_PORT = 8888
 
 

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -290,6 +290,10 @@ class LongRunningServiceConfig(InstanceConfig):
     def get_max_instances(self) -> Optional[int]:
         return self.config_dict.get("max_instances", None)
 
+    def set_min_instances(self, instance_count):
+        if "min_instances" in self.config_dict:
+            self.config_dict["min_instances"] = instance_count
+
     def get_desired_instances(self) -> int:
         """Get the number of instances specified in zookeeper or the service's marathon configuration.
         If the number of instances in zookeeper is less than min_instances, returns min_instances.

--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -29,7 +29,6 @@ from typing import Tuple
 
 from paasta_tools.autoscaling.autoscaling_service_lib import autoscaling_is_paused
 from paasta_tools.autoscaling.autoscaling_service_lib import is_autoscaling_resumed
-from paasta_tools.autoscaling.autoscaling_service_lib import write_autoscaling_resumed
 from paasta_tools.kubernetes.application.controller_wrappers import Application
 from paasta_tools.kubernetes.application.controller_wrappers import (
     get_application_wrapper,
@@ -135,29 +134,23 @@ def setup_kube_deployments(
         )
         for service_instance in service_instances_with_valid_names
     ]
-    resumed_autoscaler = False
 
     for _, app in applications:
-        if (
-            app
-            and (app.kube_deployment.service, app.kube_deployment.instance)
-            not in existing_apps
-        ):
-            app.create(kube_client)
-        elif (
-            app
-            and (app.kube_deployment not in existing_kube_deployments)
-            or autoscaling_is_paused()
-        ):
-            app.update(kube_client)
-        elif not autoscaling_is_paused() and not is_autoscaling_resumed():
-            resumed_autoscaler = True
-            app.update(kube_client)
-        else:
-            log.debug(f"{app} is up to date, no action taken")
-
-    if resumed_autoscaler:
-        write_autoscaling_resumed()
+        if app:
+            if (
+                app.kube_deployment.service,
+                app.kube_deployment.instance,
+            ) not in existing_apps:
+                app.create(kube_client)
+            elif (
+                app.kube_deployment not in existing_kube_deployments
+                or autoscaling_is_paused()
+            ):
+                app.update(kube_client)
+            elif not autoscaling_is_paused() and not is_autoscaling_resumed(app.item):
+                app.update(kube_client)
+            else:
+                log.debug(f"{app} is up to date, no action taken")
 
     return (False, None) not in applications and len(
         service_instances_with_valid_names

--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -27,6 +27,7 @@ from typing import Optional
 from typing import Sequence
 from typing import Tuple
 
+from paasta_tools.autoscaling.autoscaling_service_lib import autoscaling_is_paused
 from paasta_tools.kubernetes.application.controller_wrappers import Application
 from paasta_tools.kubernetes.application.controller_wrappers import (
     get_application_wrapper,
@@ -140,7 +141,10 @@ def setup_kube_deployments(
             not in existing_apps
         ):
             app.create(kube_client)
-        elif app and app.kube_deployment not in existing_kube_deployments:
+        elif app and (
+            app.kube_deployment not in existing_kube_deployments
+            or autoscaling_is_paused()
+        ):
             app.update(kube_client)
         else:
             log.debug(f"{app} is up to date, no action taken")

--- a/tests/api/test_pause_autoscaler.py
+++ b/tests/api/test_pause_autoscaler.py
@@ -49,9 +49,8 @@ def test_update_autoscaler_pause():
         mock_time.time = mock.Mock(return_value=0)
 
         response = pause_autoscaler.update_service_autoscaler_pause(request)
-        assert mock_zk_ensure.call_count == 2
-        mock_zk_set.assert_any_call("/autoscaling/paused", b"6000")
-        mock_zk_set.assert_any_call("/autoscaling/resumed", b"False")
+        assert mock_zk_ensure.call_count == 1
+        mock_zk_set.assert_called_once_with("/autoscaling/paused", b"6000")
         assert response is None
 
 
@@ -71,7 +70,6 @@ def test_delete_autoscaler_pause():
         mock_time.time = mock.Mock(return_value=0)
 
         response = pause_autoscaler.delete_service_autoscaler_pause(request)
-        assert mock_zk_ensure.call_count == 2
-        mock_zk_del.assert_any_call("/autoscaling/paused")
-        mock_zk_del.assert_any_call("/autoscaling/resumed")
+        assert mock_zk_ensure.call_count == 1
+        mock_zk_del.assert_called_once_with("/autoscaling/paused")
         assert response is None

--- a/tests/api/test_pause_autoscaler.py
+++ b/tests/api/test_pause_autoscaler.py
@@ -49,8 +49,9 @@ def test_update_autoscaler_pause():
         mock_time.time = mock.Mock(return_value=0)
 
         response = pause_autoscaler.update_service_autoscaler_pause(request)
-        mock_zk_ensure.assert_called_once_with("/autoscaling/paused")
-        mock_zk_set.assert_called_once_with("/autoscaling/paused", b"6000")
+        assert mock_zk_ensure.call_count == 2
+        mock_zk_set.assert_any_call("/autoscaling/paused", b"6000")
+        mock_zk_set.assert_any_call("/autoscaling/resumed", b"False")
         assert response is None
 
 
@@ -70,6 +71,7 @@ def test_delete_autoscaler_pause():
         mock_time.time = mock.Mock(return_value=0)
 
         response = pause_autoscaler.delete_service_autoscaler_pause(request)
-        mock_zk_ensure.assert_called_once_with("/autoscaling/paused")
-        mock_zk_del.assert_called_once_with("/autoscaling/paused")
+        assert mock_zk_ensure.call_count == 2
+        mock_zk_del.assert_any_call("/autoscaling/paused")
+        mock_zk_del.assert_any_call("/autoscaling/resumed")
         assert response is None

--- a/tests/kubernetes/application/test_controller_wrapper.py
+++ b/tests/kubernetes/application/test_controller_wrapper.py
@@ -209,11 +209,15 @@ def test_sync_horizontal_pod_autoscaler_delete_hpa_when_no_autoscaling(
 
 
 @mock.patch(
+    "paasta_tools.kubernetes.application.controller_wrappers.is_autoscaling_resumed",
+    autospec=True,
+)
+@mock.patch(
     "paasta_tools.kubernetes.application.controller_wrappers.autoscaling_is_paused",
     autospec=True,
 )
 def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_paused(
-    mock_autoscaling_is_paused,
+    mock_autoscaling_is_paused, mock_is_autoscaling_resumed,
 ):
     mock_client = mock.MagicMock()
     config_dict = {"max_instances": 3, "min_instances": 1}
@@ -221,8 +225,45 @@ def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_paused(
     app.item.spec.replicas = 2
 
     mock_autoscaling_is_paused.return_value = True
+    mock_is_autoscaling_resumed.return_value = False
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
     assert app.soa_config.get_min_instances() == 2
+    assert (
+        mock_client.autoscaling.create_namespaced_horizontal_pod_autoscaler.call_count
+        == 0
+    )
+    assert (
+        mock_client.autoscaling.replace_namespaced_horizontal_pod_autoscaler.call_count
+        == 1
+    )
+
+
+@mock.patch(
+    "paasta_tools.kubernetes.application.controller_wrappers.write_autoscaling_paused",
+    autospec=True,
+)
+@mock.patch(
+    "paasta_tools.kubernetes.application.controller_wrappers.is_autoscaling_resumed",
+    autospec=True,
+)
+@mock.patch(
+    "paasta_tools.kubernetes.application.controller_wrappers.autoscaling_is_paused",
+    autospec=True,
+)
+def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_resumed(
+    mock_autoscaling_is_paused,
+    mock_is_autoscaling_resumed,
+    mock_write_autoscaling_paused,
+):
+    mock_client = mock.MagicMock()
+    config_dict = {"max_instances": 3, "min_instances": 1}
+    app = setup_app(config_dict, True)
+    app.item.spec.replicas = 2
+
+    mock_autoscaling_is_paused.return_value = False
+    mock_is_autoscaling_resumed.return_value = False
+    app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
+    assert mock_write_autoscaling_paused.call_count == 1
     assert (
         mock_client.autoscaling.create_namespaced_horizontal_pod_autoscaler.call_count
         == 0

--- a/tests/kubernetes/application/test_controller_wrapper.py
+++ b/tests/kubernetes/application/test_controller_wrapper.py
@@ -162,12 +162,16 @@ def setup_app(config_dict, exists_hpa):
     return app
 
 
-def test_sync_horizontal_pod_autoscaler_no_autoscaling():
+@mock.patch(
+    "paasta_tools.kubernetes.application.controller_wrappers.autoscaling_is_paused",
+    autospec=True,
+)
+def test_sync_horizontal_pod_autoscaler_no_autoscaling(mock_autoscaling_is_paused):
     mock_client = mock.MagicMock()
     # Do nothing
     config_dict = {"instances": 1}
     app = setup_app(config_dict, False)
-    app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
+    mock_autoscaling_is_paused.return_value = False
     assert (
         mock_client.autoscaling.create_namespaced_horizontal_pod_autoscaler.call_count
         == 0
@@ -179,11 +183,19 @@ def test_sync_horizontal_pod_autoscaler_no_autoscaling():
     assert app.delete_horizontal_pod_autoscaler.call_count == 0
 
 
-def test_sync_horizontal_pod_autoscaler_delete_hpa_when_no_autoscaling():
+@mock.patch(
+    "paasta_tools.kubernetes.application.controller_wrappers.autoscaling_is_paused",
+    autospec=True,
+)
+def test_sync_horizontal_pod_autoscaler_delete_hpa_when_no_autoscaling(
+    mock_autoscaling_is_paused,
+):
     mock_client = mock.MagicMock()
     # old HPA got removed so delete
     config_dict = {"instances": 1}
     app = setup_app(config_dict, True)
+
+    mock_autoscaling_is_paused.return_value = False
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
     assert (
         mock_client.autoscaling.create_namespaced_horizontal_pod_autoscaler.call_count
@@ -196,12 +208,44 @@ def test_sync_horizontal_pod_autoscaler_delete_hpa_when_no_autoscaling():
     assert app.delete_horizontal_pod_autoscaler.call_count == 1
 
 
-def test_sync_horizontal_pod_autoscaler_create_hpa():
+@mock.patch(
+    "paasta_tools.kubernetes.application.controller_wrappers.autoscaling_is_paused",
+    autospec=True,
+)
+def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_paused(
+    mock_autoscaling_is_paused,
+):
+    mock_client = mock.MagicMock()
+    config_dict = {"max_instances": 3, "min_instances": 1}
+    app = setup_app(config_dict, True)
+    app.item.spec.replicas = 2
+
+    mock_autoscaling_is_paused.return_value = True
+    app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
+    assert app.soa_config.get_min_instances() == 2
+    assert (
+        mock_client.autoscaling.create_namespaced_horizontal_pod_autoscaler.call_count
+        == 0
+    )
+    assert (
+        mock_client.autoscaling.replace_namespaced_horizontal_pod_autoscaler.call_count
+        == 1
+    )
+
+
+@mock.patch(
+    "paasta_tools.kubernetes.application.controller_wrappers.autoscaling_is_paused",
+    autospec=True,
+)
+def test_sync_horizontal_pod_autoscaler_create_hpa(mock_autoscaling_is_paused):
     mock_client = mock.MagicMock()
     # Create
     config_dict = {"max_instances": 3}
     app = setup_app(config_dict, False)
+
+    mock_autoscaling_is_paused.return_value = False
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
+
     assert (
         mock_client.autoscaling.replace_namespaced_horizontal_pod_autoscaler.call_count
         == 0
@@ -216,11 +260,17 @@ def test_sync_horizontal_pod_autoscaler_create_hpa():
     )
 
 
-def test_sync_horizontal_pod_autoscaler_update_hpa():
+@mock.patch(
+    "paasta_tools.kubernetes.application.controller_wrappers.autoscaling_is_paused",
+    autospec=True,
+)
+def test_sync_horizontal_pod_autoscaler_update_hpa(mock_autoscaling_is_paused):
     mock_client = mock.MagicMock()
     # Update
     config_dict = {"max_instances": 3}
     app = setup_app(config_dict, True)
+
+    mock_autoscaling_is_paused.return_value = False
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
     assert (
         mock_client.autoscaling.create_namespaced_horizontal_pod_autoscaler.call_count
@@ -235,21 +285,3 @@ def test_sync_horizontal_pod_autoscaler_update_hpa():
         ),
         pretty=True,
     )
-
-
-def test_sync_horizontal_pod_autoscaler_bespoke_autoscaler():
-    mock_client = mock.MagicMock()
-
-    # Do nothing
-    config_dict = {"max_instances": 3, "autoscaling": {"decision_policy": "bespoke"}}
-    app = setup_app(config_dict, False)
-    app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
-    assert (
-        mock_client.autoscaling.create_namespaced_horizontal_pod_autoscaler.call_count
-        == 0
-    )
-    assert (
-        mock_client.autoscaling.replace_namespaced_horizontal_pod_autoscaler.call_count
-        == 0
-    )
-    assert app.delete_horizontal_pod_autoscaler.call_count == 0

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1123,6 +1123,7 @@ class TestKubernetesDeploymentConfig:
                     "paasta.yelp.com/service": mock_get_service.return_value,
                 },
                 name="kurupt-fm",
+                annotations=None,
             )
 
     def test_get_hpa_metric_spec(self):

--- a/tests/test_setup_kubernetes_job.py
+++ b/tests/test_setup_kubernetes_job.py
@@ -199,10 +199,13 @@ def test_setup_kube_deployment_create_update():
         side_effect=simple_create_application_object,
     ) as mock_create_application_object, mock.patch(
         "paasta_tools.setup_kubernetes_job.list_all_deployments", autospec=True
-    ) as mock_list_all_deployments:
+    ) as mock_list_all_deployments, mock.patch(
+        "paasta_tools.setup_kubernetes_job.autoscaling_is_paused", autospec=True
+    ) as mock_autoscaling_is_paused:
         mock_client = mock.Mock()
         # No instances created
         mock_service_instances: Sequence[str] = []
+        mock_autoscaling_is_paused.return_value = False
         setup_kube_deployments(
             kube_client=mock_client,
             service_instances=mock_service_instances,

--- a/tests/test_setup_kubernetes_job.py
+++ b/tests/test_setup_kubernetes_job.py
@@ -191,6 +191,7 @@ def test_setup_kube_deployment_create_update():
         )
         fake_app.create = fake_create
         fake_app.update = fake_update
+        fake_app.item = None
         return True, fake_app
 
     with mock.patch(
@@ -203,15 +204,12 @@ def test_setup_kube_deployment_create_update():
         "paasta_tools.setup_kubernetes_job.autoscaling_is_paused", autospec=True
     ) as mock_autoscaling_is_paused, mock.patch(
         "paasta_tools.setup_kubernetes_job.is_autoscaling_resumed", autospec=True
-    ) as mock_is_autoscaling_resumed, mock.patch(
-        "paasta_tools.setup_kubernetes_job.write_autoscaling_resumed", autospec=True
-    ) as mock_write_autoscaling_resumed:
+    ) as mock_is_autoscaling_resumed:
         mock_client = mock.Mock()
         # No instances created
         mock_service_instances: Sequence[str] = []
         mock_autoscaling_is_paused.return_value = False
         mock_is_autoscaling_resumed.return_value = True
-        mock_write_autoscaling_resumed.return_value = None
         setup_kube_deployments(
             kube_client=mock_client,
             service_instances=mock_service_instances,


### PR DESCRIPTION
The following code is used to pause HPA when a user has specified `paasta pause_service_autoscaler`. Currently, if a user runs pause autoscaler, the paasta api will write to zk `time_until` in minutes and `resumed` which is a bool. 

On a cron job, `setup_kubernetes_job` will update the k8s deployment which updates HPA and makes min_instanes = current replicas. This restricts the service from scaling down, but still allows it to scale up. Note that the `update` is only ran on two conditions: if service is paused OR if service is not paused and has not been resumed yet. 

Testing Done:
* make test
* added units tests