### PR TITLE
Add option in list_kubernetes_service_instances to show sanitised names

### DIFF
--- a/paasta_tools/kubernetes/application/tools.py
+++ b/paasta_tools/kubernetes/application/tools.py
@@ -10,7 +10,6 @@ from paasta_tools.kubernetes.application.controller_wrappers import DeploymentWr
 from paasta_tools.kubernetes.application.controller_wrappers import StatefulSetWrapper
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import paasta_prefixed
-from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
 
 log = logging.getLogger(__name__)
 
@@ -74,7 +73,3 @@ def list_namespaced_applications(
         elif application_type == V1StatefulSet:
             apps.extend(list_namespaced_stateful_sets(kube_client, namespace))
     return apps
-
-
-def get_app_name(service: str, instance: str):
-    return sanitise_kubernetes_name(f"{service}-{instance}")

--- a/paasta_tools/list_kubernetes_service_instances.py
+++ b/paasta_tools/list_kubernetes_service_instances.py
@@ -29,6 +29,7 @@ Command line options:
 import argparse
 import sys
 
+from paasta_tools import kubernetes_tools
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_services_for_cluster
@@ -55,6 +56,14 @@ def parse_args():
         default=DEFAULT_SOA_DIR,
         help="define a different soa config directory",
     )
+    parser.add_argument(
+        "--sanitise",
+        action="store_true",
+        help=(
+            "Whether or not to sanitise service instance names before displaying "
+            "them. Kubernets apps created by PaaSTA use sanitised names."
+        ),
+    )
     args = parser.parse_args()
     return args
 
@@ -68,7 +77,11 @@ def main():
     )
     service_instances = []
     for name, instance in instances:
-        service_instances.append(compose_job_id(name, instance))
+        if args.sanitise:
+            app_name = kubernetes_tools.get_kubernetes_app_name(name, instance)
+        else:
+            app_name = compose_job_id(name, instance)
+        service_instances.append(app_name)
     paasta_print("\n".join(service_instances))
     sys.exit(0)
 

--- a/tests/test_list_kubernetes_service_instances.py
+++ b/tests/test_list_kubernetes_service_instances.py
@@ -1,5 +1,5 @@
 import mock
-from pytest import raises
+import pytest
 
 from paasta_tools.list_kubernetes_service_instances import main
 from paasta_tools.list_kubernetes_service_instances import parse_args
@@ -13,22 +13,34 @@ def test_parse_args():
         assert parse_args() == mock_parser.return_value.parse_args()
 
 
-def test_main():
-    with mock.patch(
-        "paasta_tools.list_kubernetes_service_instances.parse_args", autospec=True
-    ) as mock_parse_args, mock.patch(
-        "paasta_tools.list_kubernetes_service_instances.get_services_for_cluster",
-        autospec=True,
-        return_value=[("service1", "instance1"), ("service2", "instance1")],
-    ) as mock_get_services_for_cluster, mock.patch(
-        "paasta_tools.list_kubernetes_service_instances.paasta_print", autospec=True
-    ) as mock_print:
-        with raises(SystemExit) as e:
-            main()
-        assert e.value.code == 0
-        mock_get_services_for_cluster.assert_called_with(
+@mock.patch("paasta_tools.list_kubernetes_service_instances.parse_args", autospec=True)
+@mock.patch(
+    "paasta_tools.list_kubernetes_service_instances.get_services_for_cluster",
+    autospec=True,
+    return_value=[("service_1", "instance1"), ("service_2", "instance1")],
+)
+@mock.patch(
+    "paasta_tools.list_kubernetes_service_instances.paasta_print", autospec=True
+)
+@pytest.mark.parametrize(
+    "sanitise,expected",
+    [
+        (False, "service_1.instance1\nservice_2.instance1"),
+        (True, "service--1-instance1\nservice--2-instance1"),
+    ],
+)
+def test_main(mock_print, mock_get_services, mock_parse_args, sanitise, expected):
+    mock_parse_args.return_value = mock.Mock(sanitise=sanitise)
+
+    with pytest.raises(SystemExit) as e:
+        main()
+
+    assert e.value.code == 0
+    assert mock_get_services.call_args_list == [
+        mock.call(
             cluster=mock_parse_args.return_value.cluster,
             instance_type="kubernetes",
             soa_dir=mock_parse_args.return_value.soa_dir,
         )
-        mock_print.assert_called_with("service1.instance1\nservice2.instance1")
+    ]
+    assert mock_print.call_args_list == [mock.call(expected)]


### PR DESCRIPTION
### Description
list_kubernetes_service_instances currently shows service and instance names composed with a dot. I'm adding an option to show k8s sanitised names instead, i.e. the names deployments and statefulsets use when created by PaaSTA. I'm doing this so i can grep for the name of the paasta-contract-monitor's deployment from the source of truth (PaaSTA), and delete the deployment periodically so the PCM actually properly tests scheduling.

### Testing
`make test`
manual testing on a test cluster

### Notes
@drmorr0, I noticed that the Pd Disruption Budgets created by PaaSTA do not use any sanitised names. However, in the interest of not deleting the budgets that we have now, I'm not going to properly sanitise them in this review. I've added a TODO. 