### PR TITLE
Add ability for services to opt out of inbound network traffic

### DIFF
--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -351,6 +351,12 @@
                 "security": {
                     "type": "object",
                     "properties": {
+                        "inbound_network_mode": {
+                            "enum": [
+                                "full",
+                                "restrict"
+                            ]
+                        },
                         "outbound_firewall": {
                             "enum": [
                                 "block",

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -327,9 +327,9 @@ def _dns_servers():
                 yield parts[1]
 
 
-def ensure_shared_chains(conf):
+def ensure_shared_chains(conf=None):
     _ensure_dns_chain()
-    if conf.get_network_mode() != "local":
+    if conf is None or conf.get_network_mode() != "local":
         _ensure_internet_chain()
         _ensure_common_chain()
 

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -327,10 +327,11 @@ def _dns_servers():
                 yield parts[1]
 
 
-def ensure_shared_chains():
+def ensure_shared_chains(conf):
     _ensure_dns_chain()
-    _ensure_internet_chain()
-    _ensure_common_chain()
+    if conf.get_network_mode() != "local":
+        _ensure_internet_chain()
+        _ensure_common_chain()
 
 
 def _ensure_common_chain():

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -181,6 +181,7 @@ def _yocalhost_rule(port, comment, protocol="tcp"):
         target_parameters=(),
     )
 
+
 def _reject_remaining_inbound_traffic_rule(port, protocol="tcp"):
     """Return an iptables rule denying all other traffic.
 
@@ -191,9 +192,7 @@ def _reject_remaining_inbound_traffic_rule(port, protocol="tcp"):
         src="0.0.0.0/0.0.0.0",
         dst="0.0.0.0/0.0.0.0",
         target="REJECT",
-        matches=(
-            (protocol, (("dport", (str(port),)),)),
-        ),
+        matches=((protocol, (("dport", (str(port),)),)),),
         target_parameters=((("reject-with", ("icmp-port-unreachable",))),),
     )
 

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -84,6 +84,7 @@ class ServiceGroup(collections.namedtuple("ServiceGroup", ("service", "instance"
         rules.extend(_well_known_rules(conf))
         rules.extend(_smartstack_rules(conf, soa_dir, synapse_service_dir))
         rules.extend(_cidr_rules(conf))
+
         return tuple(rules)
 
     def update_rules(self, soa_dir, synapse_service_dir):
@@ -180,6 +181,22 @@ def _yocalhost_rule(port, comment, protocol="tcp"):
         target_parameters=(),
     )
 
+def _reject_remaining_inbound_traffic_rule(port, protocol="tcp"):
+    """Return an iptables rule denying all other traffic.
+
+    This should eventually be turned into a deny-allow,
+    but is opt-in at the service level for now."""
+    return iptables.Rule(
+        protocol=protocol,
+        src="0.0.0.0/0.0.0.0",
+        dst="0.0.0.0/0.0.0.0",
+        target="REJECT",
+        matches=(
+            (protocol, (("dport", (str(port),)),)),
+        ),
+        target_parameters=((("reject-with", ("icmp-port-unreachable",))),),
+    )
+
 
 def _smartstack_rules(conf, soa_dir, synapse_service_dir):
     for dep in conf.get_dependencies() or ():
@@ -215,6 +232,10 @@ def _smartstack_rules(conf, soa_dir, synapse_service_dir):
         service_namespaces = get_all_namespaces_for_service(service, soa_dir=soa_dir)
         port = dict(service_namespaces)[namespace]["proxy_port"]
         yield _yocalhost_rule(port, "proxy_port " + namespace)
+
+        # Allow services to opt out of network visibility beyond localhost
+        if conf.get_inbound_network_mode() == "restrict":
+            yield _reject_remaining_inbound_traffic_rule(port)
 
 
 def _ports_valid(ports):
@@ -327,11 +348,10 @@ def _dns_servers():
                 yield parts[1]
 
 
-def ensure_shared_chains(conf=None):
+def ensure_shared_chains():
     _ensure_dns_chain()
-    if conf is None or conf.get_network_mode() != "local":
-        _ensure_internet_chain()
-        _ensure_common_chain()
+    _ensure_internet_chain()
+    _ensure_common_chain()
 
 
 def _ensure_common_chain():

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -43,6 +43,7 @@ class LongRunningServiceConfigDict(InstanceConfigDict, total=False):
     max_instances: int
     min_instances: int
     nerve_ns: str
+    network_mode: str
     registrations: List[str]
     replication_threshold: int
     bounce_start_deadline: float
@@ -172,6 +173,17 @@ class LongRunningServiceConfig(InstanceConfig):
     # FIXME(jlynch|2016-08-02, PAASTA-4964): DEPRECATE nerve_ns and remove it
     def get_nerve_namespace(self) -> str:
         return decompose_job_id(self.get_registrations()[0])[1]
+
+    def get_network_mode(self) -> str:
+        """Retrieve the requested network mode for the given service.
+
+        Setting this to a value other than `full` is uncommon, as doing so will restrict the
+        availability of your service.
+
+        This option exists primarily for sensitive services that wish to opt into this functionality.
+        """
+        default = "full"
+        return self.config_dict.get("network_mode", default)
 
     def get_registrations(self) -> List[str]:
         registrations = self.config_dict.get("registrations", [])

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -184,7 +184,12 @@ class LongRunningServiceConfig(InstanceConfig):
         This option exists primarily for sensitive services that wish to opt into this functionality.
         """
         default = "full"
-        return self.config_dict.get("inbound_network_mode", default)
+        security = self.config_dict.get("security")
+
+        if security is None:
+            return default
+
+        return security.get("inbound_network_mode", default)
 
     def get_registrations(self) -> List[str]:
         registrations = self.config_dict.get("registrations", [])

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -184,7 +184,7 @@ class LongRunningServiceConfig(InstanceConfig):
         This option exists primarily for sensitive services that wish to opt into this functionality.
         """
         default = "full"
-        return self.config_dict.get("network_mode", default)
+        return self.config_dict.get("inbound_network_mode", default)
 
     def get_registrations(self) -> List[str]:
         registrations = self.config_dict.get("registrations", [])

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -174,11 +174,12 @@ class LongRunningServiceConfig(InstanceConfig):
     def get_nerve_namespace(self) -> str:
         return decompose_job_id(self.get_registrations()[0])[1]
 
-    def get_network_mode(self) -> str:
-        """Retrieve the requested network mode for the given service.
+    def get_inbound_network_mode(self) -> str:
+        """Retrieve the requested inbound network mode for the given service.
 
         Setting this to a value other than `full` is uncommon, as doing so will restrict the
-        availability of your service.
+        availability of your service. The only other supported value is `restrict` currently,
+        which will reject all remaining inbound traffic to the service port after all other rules.
 
         This option exists primarily for sensitive services that wish to opt into this functionality.
         """

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -707,19 +707,28 @@ class InstanceConfig:
         if inbound_network_mode is None and outbound_firewall is None:
             return True, ""
 
-        if inbound_network_mode is not None and inbound_network_mode not in ("full", "restrict"):
+        if inbound_network_mode is not None and inbound_network_mode not in (
+            "full",
+            "restrict",
+        ):
             return (
                 False,
                 'Unrecognized inbound_network_mode value "%s"' % inbound_network_mode,
             )
 
-        if outbound_firewall is not None and outbound_firewall not in ("block", "monitor"):
+        if outbound_firewall is not None and outbound_firewall not in (
+            "block",
+            "monitor",
+        ):
             return (
                 False,
                 'Unrecognized outbound_firewall value "%s"' % outbound_firewall,
             )
 
-        unknown_keys = set(security.keys()) - {"inbound_network_mode", "outbound_firewall"}
+        unknown_keys = set(security.keys()) - {
+            "inbound_network_mode",
+            "outbound_firewall",
+        }
         if unknown_keys:
             return (
                 False,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -701,17 +701,25 @@ class InstanceConfig:
         if security is None:
             return True, ""
 
+        inbound_network_mode = security.get("inbound_network_mode")
         outbound_firewall = security.get("outbound_firewall")
-        if outbound_firewall is None:
+
+        if inbound_network_mode is None and outbound_firewall is None:
             return True, ""
 
-        if outbound_firewall not in ("block", "monitor"):
+        if inbound_network_mode is not None and inbound_network_mode not in ("full", "restrict"):
+            return (
+                False,
+                'Unrecognized inbound_network_mode value "%s"' % inbound_network_mode,
+            )
+
+        if outbound_firewall is not None and outbound_firewall not in ("block", "monitor"):
             return (
                 False,
                 'Unrecognized outbound_firewall value "%s"' % outbound_firewall,
             )
 
-        unknown_keys = set(security.keys()) - {"outbound_firewall"}
+        unknown_keys = set(security.keys()) - {"inbound_network_mode", "outbound_firewall"}
         if unknown_keys:
             return (
                 False,
@@ -863,6 +871,17 @@ class InstanceConfig:
             return None
         dependency_ref = self.get_dependencies_reference() or "main"
         return dependencies.get(dependency_ref)
+
+    def get_inbound_firewall_mode(self) -> Optional[str]:
+        """Return 'full', 'restrict', or None as configured in security->inbound_firewall_mode
+
+        Defaults to None if not specified in the config
+
+        :returns: A string specified in the config, None if not specified"""
+        security = self.config_dict.get("security")
+        if not security:
+            return None
+        return security.get("inbound_firewall_mode")
 
     def get_outbound_firewall(self) -> Optional[str]:
         """Return 'block', 'monitor', or None as configured in security->outbound_firewall

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -425,11 +425,13 @@ def test_ensure_internet_chain():
 @mock.patch.object(firewall, "_default_rules", return_value=[])
 @mock.patch.object(firewall, "_well_known_rules", return_value=[])
 @mock.patch.object(firewall, "_cidr_rules", return_value=[])
-def test_restrict_inbound_network_traffic(mock_cidr_rules,
-                                          mock_well_known_rules,
-                                          mock_default_rules,
-                                          mock_service_config,
-                                          service_group):
+def test_restrict_inbound_network_traffic(
+    mock_cidr_rules,
+    mock_well_known_rules,
+    mock_default_rules,
+    mock_service_config,
+    service_group,
+):
     mock_service_config.return_value.get_inbound_network_mode.return_value = "restrict"
     assert service_group.get_rules(
         DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR
@@ -466,9 +468,7 @@ def test_restrict_inbound_network_traffic(mock_cidr_rules,
             target="REJECT",
             src="0.0.0.0/0.0.0.0",
             dst="0.0.0.0/0.0.0.0",
-            matches=(
-                ("tcp", (("dport", ("20000",)),)),
-            ),
+            matches=(("tcp", (("dport", ("20000",)),)),),
             target_parameters=((("reject-with", ("icmp-port-unreachable",))),),
         ),
     )

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -422,6 +422,58 @@ def test_ensure_internet_chain():
     )
 
 
+@mock.patch.object(firewall, "_default_rules", return_value=[])
+@mock.patch.object(firewall, "_well_known_rules", return_value=[])
+@mock.patch.object(firewall, "_cidr_rules", return_value=[])
+def test_restrict_inbound_network_traffic(mock_cidr_rules,
+                                          mock_well_known_rules,
+                                          mock_default_rules,
+                                          mock_service_config,
+                                          service_group):
+    mock_service_config.return_value.get_inbound_network_mode.return_value = "restrict"
+    assert service_group.get_rules(
+        DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR
+    ) == (
+        EMPTY_RULE._replace(
+            protocol="tcp",
+            target="ACCEPT",
+            dst="1.2.3.4/255.255.255.255",
+            matches=(
+                ("comment", (("comment", ("backend example_happyhour.main",)),)),
+                ("tcp", (("dport", ("123",)),)),
+            ),
+        ),
+        EMPTY_RULE._replace(
+            protocol="tcp",
+            target="ACCEPT",
+            dst="5.6.7.8/255.255.255.255",
+            matches=(
+                ("comment", (("comment", ("backend example_happyhour.main",)),)),
+                ("tcp", (("dport", ("567",)),)),
+            ),
+        ),
+        EMPTY_RULE._replace(
+            protocol="tcp",
+            target="ACCEPT",
+            dst="169.254.255.254/255.255.255.255",
+            matches=(
+                ("comment", (("comment", ("proxy_port example_happyhour.main",)),)),
+                ("tcp", (("dport", ("20000",)),)),
+            ),
+        ),
+        EMPTY_RULE._replace(
+            protocol="tcp",
+            target="REJECT",
+            src="0.0.0.0/0.0.0.0",
+            dst="0.0.0.0/0.0.0.0",
+            matches=(
+                ("tcp", (("dport", ("20000",)),)),
+            ),
+            target_parameters=((("reject-with", ("icmp-port-unreachable",))),),
+        ),
+    )
+
+
 @pytest.fixture
 def mock_active_service_groups():
     groups = {


### PR DESCRIPTION
Adds a new soa configuration variable, `inbound_network_mode` that accepts the following attributes:

* `full`: the default. No change versus existing behavior.
* `restrict`: adds a single iptables rule to `REJECT` all traffic for the service's `dport` at the end of the chain.

Advice welcome on testing this to verify the iptables chain works as expected. Unit tests otherwise added and pass as expected.

Context: PAASTA-16455