### PR TITLE
Make k8s_itests run in docker containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
   - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-ce=18.03.1~ce-0~ubuntu devscripts golang-1.13 --force-yes
   - 'if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" -a "$DOCKER_USERNAME" != "" ]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi'
 install:
-  - pip install coveralls tox==3.2 tox-pip-extensions==1.3.0
+  - pip install coveralls tox==3.2 tox-pip-extensions==1.3.0 ephemeral-port-reserve
   # There's some weird breakage between travis, python, virtualenvs, and eggs that I don't really
   # understand, but it was causing the build to fail because of ContextualVersionConflicts.
   # It seems as though we're hitting https://github.com/pypa/pip/issues/6275

--- a/k8s_itests/Makefile
+++ b/k8s_itests/Makefile
@@ -6,7 +6,7 @@ export KUBE_RESOURCE_DIR=$(CWD)/deployments/kind/resources
 export KIND_CLUSTER=$(CLUSTER)
 export SOA_DIR=$(PAASTA_CONFIG_DIR)/fake_soa_config
 export PAASTA_SYSTEM_CONFIG_DIR=$(PAASTA_CONFIG_DIR)/fake_etc_paasta
-export PAASTA_API_PORT= `ephemeral-port-reserve`
+export PAASTA_API_PORT=$(shell ephemeral-port-reserve)
 export KUBECONFIG=$(shell ./kind get kubeconfig-path --name=$(KIND_CLUSTER))
 
 ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)

--- a/k8s_itests/deployments/paasta/fake_etc_paasta/api_endpoints.json
+++ b/k8s_itests/deployments/paasta/fake_etc_paasta/api_endpoints.json
@@ -1,5 +1,5 @@
 {
     "api_endpoints": {
-        "<%cluster%>": "http://localhost:$(PAASTA_API_PORT)"
+        "<%cluster%>": "http://0.0.0.0:$(PAASTA_API_PORT)"
     }
 }

--- a/k8s_itests/deployments/paasta/fake_soa_config/compute-infra-test-service/deployments.json
+++ b/k8s_itests/deployments/paasta/fake_soa_config/compute-infra-test-service/deployments.json
@@ -1,4 +1,11 @@
 {
+    "v1": {
+        "compute-infra-test-service:<%cluster%>.autoscaling": {
+            "docker_image": "services-compute-infra-test-service:paasta-a0ec9b362e29123022e5cebb6612aedc58a0889b",
+            "desired_state": "start",
+            "force_bounce": null
+        }
+    },
     "v2": {
         "deployments": {
             "<%cluster%>.autoscaling": {

--- a/k8s_itests/docker-compose.yml
+++ b/k8s_itests/docker-compose.yml
@@ -4,7 +4,7 @@ volumes:
   nail-etc:
 
 services:
-  paastatools:
+  paasta_tools:
     build:
       context: ../
       dockerfile: ./yelp_package/dockerfiles/itest/k8s/Dockerfile

--- a/k8s_itests/docker-compose.yml
+++ b/k8s_itests/docker-compose.yml
@@ -1,0 +1,54 @@
+version: '2.3'
+
+volumes:
+  nail-etc:
+
+services:
+  paastatools:
+    build:
+      context: ../
+      dockerfile: ./yelp_package/dockerfiles/itest/k8s/Dockerfile
+    network_mode: host
+    environment:
+      KIND_CLUSTER: ${KIND_CLUSTER}
+      KUBECONTEXT: kubernetes-admin@${KIND_CLUSTER}
+      KUBECONFIG: ${KUBECONFIG}
+      KUBE_RESOURCE_DIR: ${KUBE_RESOURCE_DIR}
+      USER: ${USER}
+      PAASTA_API_PORT: ${PAASTA_API_PORT}
+    volumes:
+      - ../:/work:rw
+      - nail-etc:/nail/etc
+      - /etc/boto:/etc/boto:rw
+      - /etc/kubernetes:/etc/kubernetes:rw
+      - ${KUBECONFIG}:${KUBECONFIG}:rw
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${SOA_DIR}:/nail/etc/services:rw
+      - ./deployments/.tmp/fake_etc_paasta:/etc/paasta:rw
+    command:
+      bash -c "/venv/bin/wait_paasta_api.sh -- pytest ./k8s_itests -s"
+    depends_on:
+      - paasta_api
+
+  paasta_api:
+    build:
+      context: ../
+      dockerfile: ./yelp_package/dockerfiles/itest/api/Dockerfile
+    command: bash -c 'pip install -e /work && exec paasta-api -D -c ${KIND_CLUSTER} ${PAASTA_API_PORT}'
+    network_mode: host
+    environment:
+      KIND_CLUSTER: ${KIND_CLUSTER}
+      KUBECONTEXT: kubernetes-admin@${KIND_CLUSTER}
+      KUBECONFIG: ${KUBECONFIG}
+      KUBE_RESOURCE_DIR: ${KUBE_RESOURCE_DIR}
+      USER: ${USER}
+      PAASTA_API_PORT: ${PAASTA_API_PORT}
+    volumes:
+      - ../:/work:rw
+      - nail-etc:/nail/etc
+      - /etc/boto:/etc/boto:rw
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${KUBECONFIG}:${KUBECONFIG}:rw
+      - /etc/kubernetes:/etc/kubernetes:rw
+      - ${SOA_DIR}:/nail/etc/services:rw
+      - ./deployments/.tmp/fake_etc_paasta:/etc/paasta:rw

--- a/k8s_itests/test_autoscaling.py
+++ b/k8s_itests/test_autoscaling.py
@@ -1,3 +1,5 @@
+import os
+
 from k8s_itests.utils import cmd
 from k8s_itests.utils import init_all
 
@@ -11,3 +13,11 @@ def setup_module(module):
 class TestSetupKubernetesJobs:
     def test_autoscaling(self):
         cmd("kubectl get hpa -n paasta", False)
+
+    def test_paasta_status(self):
+        instance = "autoscaling"
+        service = "compute-infra-test-service"
+        cmd(
+            f"python -m paasta_tools.cli.cli status  -c {os.environ['KIND_CLUSTER']} -s {service} -i {instance}",
+            False,
+        )

--- a/k8s_itests/test_autoscaling.py
+++ b/k8s_itests/test_autoscaling.py
@@ -5,13 +5,7 @@ terminate_on_exit = []
 
 
 def setup_module(module):
-    # Kill paasta api server on exit
-    terminate_on_exit.append(init_all())
-
-
-def teardown_module(module):
-    for p in terminate_on_exit:
-        p.kill()
+    init_all()
 
 
 class TestSetupKubernetesJobs:

--- a/k8s_itests/utils.py
+++ b/k8s_itests/utils.py
@@ -25,14 +25,10 @@ def start_paasta_api():
 
 def paasta_apply():
     print("Applying SOA configurations")
-    service_instances = cmd(
-        "python -m paasta_tools.list_kubernetes_service_instances -d {}".format(
-            os.environ["SOA_DIR"]
-        ),
-    )
+    service_instances = cmd("python -m paasta_tools.list_kubernetes_service_instances")
     cmd(
-        "python -m paasta_tools.setup_kubernetes_job {} -v -d {}".format(
-            service_instances.stdout.strip(), os.environ["SOA_DIR"]
+        "python -m paasta_tools.setup_kubernetes_job {} -v".format(
+            service_instances.stdout.strip()
         ),
         False,
     )
@@ -40,4 +36,3 @@ def paasta_apply():
 
 def init_all():
     paasta_apply()
-    return start_paasta_api()

--- a/tox.ini
+++ b/tox.ini
@@ -79,29 +79,9 @@ commands =
     # Run paasta-tools k8s_itests in docker
     docker-compose down
     docker-compose --verbose build
-    docker-compose up
-
-[testenv:run_k8s_itest]
-basepython = python3.6
-whitelist_externals = bash
-deps =
-    {[testenv]deps}
-passenv =
-    KIND_CLUSTER
-    KUBECONFIG
-    KUBECONTEXT
-    PAASTA_SYSTEM_CONFIG_DIR
-    SOA_DIR
-    PAASTA_API_PORT
-    KUBE_RESOURCE_DIR
-    USER
-    PAASTA_CONFIG_DIR
-    DOCKER_TLS_VERIFY
-    DOCKER_HOST
-    DOCKER_CERT_PATH
-changedir=k8s_itests/
-commands =
-    pytest * -s
+    docker-compose up \
+        --abort-on-container-exit \
+        --exit-code-from paasta_tools
 
 [testenv:example_cluster]
 changedir=example_cluster/

--- a/tox.ini
+++ b/tox.ini
@@ -80,8 +80,7 @@ commands =
     docker-compose down
     docker-compose --verbose build
     docker-compose up \
-        --abort-on-container-exit \
-        --exit-code-from paasta_tools
+        --abort-on-container-exit
 
 [testenv:example_cluster]
 changedir=example_cluster/

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,8 @@ commands =
 [testenv:k8s_itests]
 basepython = python3.6
 whitelist_externals = bash
+deps =
+    docker-compose=={[tox]docker_compose_version}
 setenv =
 passenv =
     KIND_CLUSTER
@@ -67,12 +69,39 @@ passenv =
     KUBE_RESOURCE_DIR
     USER
     PAASTA_CONFIG_DIR
+    DOCKER_TLS_VERIFY
+    DOCKER_HOST
+    DOCKER_CERT_PATH
 changedir=k8s_itests/
+commands =
+    # Build /etc/paasta used by docker-compose
+	{toxinidir}/k8s_itests/scripts/setup.sh
+    # Run paasta-tools k8s_itests in docker
+    docker-compose down
+    docker-compose --verbose build
+    docker-compose up
+
+[testenv:run_k8s_itest]
+basepython = python3.6
+whitelist_externals = bash
 deps =
     {[testenv]deps}
+passenv =
+    KIND_CLUSTER
+    KUBECONFIG
+    KUBECONTEXT
+    PAASTA_SYSTEM_CONFIG_DIR
+    SOA_DIR
+    PAASTA_API_PORT
+    KUBE_RESOURCE_DIR
+    USER
+    PAASTA_CONFIG_DIR
+    DOCKER_TLS_VERIFY
+    DOCKER_HOST
+    DOCKER_CERT_PATH
+changedir=k8s_itests/
 commands =
-	{toxinidir}/k8s_itests/scripts/setup.sh
-    pytest {toxinidir}/k8s_itests -s
+    pytest * -s
 
 [testenv:example_cluster]
 changedir=example_cluster/

--- a/yelp_package/dockerfiles/itest/k8s/Dockerfile
+++ b/yelp_package/dockerfiles/itest/k8s/Dockerfile
@@ -42,10 +42,9 @@ WORKDIR /work
 ADD requirements.txt /work/
 RUN virtualenv /venv -ppython3.6 --no-download
 ENV PATH=/venv/bin:$PATH
-RUN pip install -U pip
 RUN pip install -r requirements.txt
 ADD yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh /venv/bin
 
 ADD . /work/
 RUN pip install -e /work/
-RUN pip install -U pytest
+RUN pip install pytest

--- a/yelp_package/dockerfiles/itest/k8s/Dockerfile
+++ b/yelp_package/dockerfiles/itest/k8s/Dockerfile
@@ -17,7 +17,7 @@ RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sou
 
 # Need Python 3.6
 RUN apt-get update > /dev/null && \
-    apt-get install -y --no-install-recommends software-properties-common && \
+    apt-get install -y --no-install-recommends curl software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa
 
 RUN apt-get update > /dev/null && \
@@ -32,16 +32,20 @@ RUN apt-get update > /dev/null && \
         virtualenv > /dev/null \
     && apt-get clean > /dev/null
 
+# Install kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+RUN chmod +x ./kubectl
+RUN mv ./kubectl /usr/local/bin/kubectl
+
 WORKDIR /work
 
 ADD requirements.txt /work/
 RUN virtualenv /venv -ppython3.6 --no-download
 ENV PATH=/venv/bin:$PATH
+RUN pip install -U pip
 RUN pip install -r requirements.txt
-
-COPY yelp_package/dockerfiles/xenial/mesos-slave-secret /etc/
-COPY yelp_package/dockerfiles/itest/api/mesos-cli.json yelp_package/dockerfiles/xenial/mesos-slave-secret /nail/etc/
-COPY yelp_package/dockerfiles/itest/api/*.json /etc/paasta/
+ADD yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh /venv/bin
 
 ADD . /work/
 RUN pip install -e /work/
+RUN pip install -U pytest

--- a/yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh
+++ b/yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh
@@ -9,7 +9,7 @@ shift
 cmd="$@"
 
 until [ $(curl -o /dev/null -s -w %{http_code} http://127.0.0.1:${PAASTA_API_PORT}/v1/version) = 200 ]; do
-      >&2 echo "PaaSTA APi is unavailable."
+      >&2 echo "PaaSTA API is unavailable."
         sleep 1
         count=$((${count}+1))
         if [ ${count} -gt 9 ]; then

--- a/yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh
+++ b/yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+count=1
+
+host="("
+shift
+cmd="$@"
+
+until [ $(curl -o /dev/null -s -w %{http_code} http://127.0.0.1:${PAASTA_API_PORT}/v1/version) = 200 ]; do
+      >&2 echo "PaaSTA APi is unavailable."
+        sleep 1
+        count=$((${count}+1))
+        if [ ${count} -gt 9 ]; then
+            echo "Timeout after trying ${count} times"
+            exit 1
+        fi
+    done
+
+    >&2 echo "PaaSTA API is up."
+    exec $cmd
+")"

--- a/yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh
+++ b/yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh
@@ -4,20 +4,18 @@ set -e
 
 count=1
 
-host="("
 shift
-cmd="$@"
+cmd=("$@")
 
-until [ $(curl -o /dev/null -s -w %{http_code} http://127.0.0.1:${PAASTA_API_PORT}/v1/version) = 200 ]; do
-      >&2 echo "PaaSTA API is unavailable."
-        sleep 1
-        count=$((${count}+1))
-        if [ ${count} -gt 9 ]; then
-            echo "Timeout after trying ${count} times"
-            exit 1
-        fi
-    done
+until [ "$(curl -o /dev/null -s -w "%{http_code}" http://127.0.0.1:"${PAASTA_API_PORT}"/v1/version)" = 200 ]; do
+    >&2 echo "PaaSTA API is unavailable."
+    sleep 1
+    count=$((count+1))
+    if [ ${count} -gt 9 ]; then
+        echo "Timeout after trying ${count} times"
+        exit 1
+    fi
+done
 
-    >&2 echo "PaaSTA API is up."
-    exec $cmd
-")"
+>&2 echo "PaaSTA API is up."
+exec "${cmd[@]}"


### PR DESCRIPTION
I didn't really want to do this since it's slow. But there are more refactoring than I thought to run it outside a container. I give up. 
I'll add a local docker registry later if I can. It's hard as kind runs in docker network, so it cannot talk to host network.  