### PR TITLE
Turn off pod eviction alerts for stateless services

### DIFF
--- a/paasta_tools/kubernetes/bin/kubernetes_remove_evicted_pods.py
+++ b/paasta_tools/kubernetes/bin/kubernetes_remove_evicted_pods.py
@@ -148,7 +148,7 @@ def main() -> None:
     kube_client = KubeClient()
 
     evicted_pods = evicted_pods_per_service(kube_client)
-    notify_service_owners(evicted_pods, args.soa_dir, args.dry_run)
+    # notify_service_owners(evicted_pods, args.soa_dir, args.dry_run)
     remove_pods(kube_client, evicted_pods, args.dry_run)
 
 

--- a/paasta_tools/kubernetes/bin/kubernetes_remove_evicted_pods.py
+++ b/paasta_tools/kubernetes/bin/kubernetes_remove_evicted_pods.py
@@ -148,7 +148,6 @@ def main() -> None:
     kube_client = KubeClient()
 
     evicted_pods = evicted_pods_per_service(kube_client)
-    # notify_service_owners(evicted_pods, args.soa_dir, args.dry_run)
     remove_pods(kube_client, evicted_pods, args.dry_run)
 
 


### PR DESCRIPTION
I just commented it out for all services because I think this should not happen on stateful sets. They all use ebs volumes.