### PR TITLE
Expose HPA status and SFX metrics in paasta status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
   - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-ce=18.03.1~ce-0~ubuntu devscripts golang-1.13 --force-yes
   - 'if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" -a "$DOCKER_USERNAME" != "" ]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi'
 install:
-  - pip install coveralls tox==3.2 tox-pip-extensions==1.3.0
+  - pip install coveralls tox==3.2 tox-pip-extensions==1.3.0 ephemeral-port-reserve
   # There's some weird breakage between travis, python, virtualenvs, and eggs that I don't really
   # understand, but it was causing the build to fail because of ContextualVersionConflicts.
   # It seems as though we're hitting https://github.com/pypa/pip/issues/6275

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 recursive-include paasta_tools/cli/fsm/template *
-include paasta_tools/cli/schemas/*.json
+recursive-include paasta_tools/cli/schemas *.json
 include paasta_tools/api/api_docs/*.json
 include requirements-minimal.txt
 include paasta_tools/py.typed

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+paasta-tools (0.95.6) xenial; urgency=medium
+
+  * 0.95.6 tagged with 'make release'
+    Commit: Added new page_for_expected_runtime tron option
+
+ -- Qui Nguyen <qui@yelp.com>  Tue, 17 Mar 2020 11:02:21 -0700
+
 paasta-tools (0.95.5) xenial; urgency=medium
 
   * 0.95.5 tagged with 'make release'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+paasta-tools (0.95.8) xenial; urgency=medium
+
+  * 0.95.8 tagged with 'make release'
+    Commit: Merge pull request #2723 from Yelp/rightsizer-keys-optional
+    Include all schemas and fix key error for autotuned_defaults
+
+ -- Qui Nguyen <qui@yelp.com>  Tue, 17 Mar 2020 18:18:41 -0700
+
 paasta-tools (0.95.7) xenial; urgency=medium
 
   * 0.95.7 tagged with 'make release'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+paasta-tools (0.95.7) xenial; urgency=medium
+
+  * 0.95.7 tagged with 'make release'
+    Commit: Merge pull request #2718 from Yelp/u/siruitan/PAASTA-16402-
+    avoid_connecting_mesos_leader_in_paasta_validate  Avoid connecting
+    to mesos leader during paasta validate
+
+ -- Aaron Tan <siruitan@yelp.com>  Tue, 17 Mar 2020 14:04:31 -0700
+
 paasta-tools (0.95.6) xenial; urgency=medium
 
   * 0.95.6 tagged with 'make release'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+paasta-tools (0.95.9) xenial; urgency=medium
+
+  * 0.95.9 tagged with 'make release'
+    Commit: Merge pull request #2722 from Yelp/u/enocht/PAASTA-
+    15842_k8s_bespoke_policy  Implement k8s bespoke policies for paasta
+    API
+
+ -- Mingqi Zhu <mingqiz@yelp.com>  Thu, 19 Mar 2020 14:41:55 -0700
+
 paasta-tools (0.95.8) xenial; urgency=medium
 
   * 0.95.8 tagged with 'make release'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+paasta-tools (0.95.11) xenial; urgency=medium
+
+  * 0.95.11 tagged with 'make release'
+    Commit: Merge pull request #2733 from Yelp/u/kawaiwan/list-sanitized-
+    k8s-instances  Add option in list_kubernetes_service_instances to
+    show sanitised names
+
+ -- Ka Wai Wan <kawaiwan@yelp.com>  Fri, 20 Mar 2020 13:37:08 -0700
+
 paasta-tools (0.95.10) xenial; urgency=medium
 
   * 0.95.10 tagged with 'make release'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+paasta-tools (0.95.10) xenial; urgency=medium
+
+  * 0.95.10 tagged with 'make release'
+    Commit: Make suffixed_number_value understand basic SI suffixes too.
+    PAASTA-16370
+
+ -- Evan Krall <krall@yelp.com>  Fri, 20 Mar 2020 11:50:15 -0700
+
 paasta-tools (0.95.9) xenial; urgency=medium
 
   * 0.95.9 tagged with 'make release'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+paasta-tools (0.95.5) xenial; urgency=medium
+
+  * 0.95.5 tagged with 'make release'
+    Commit: Merge branch "PAASTA-16066"
+
+ -- Evan Krall <krall@yelp.com>  Fri, 13 Mar 2020 11:48:36 -0700
+
 paasta-tools (0.95.4) xenial; urgency=medium
 
   * 0.95.4 tagged with 'make release'

--- a/docs/source/generated/paasta_tools.autoscaling.max_all_k8s_services.rst
+++ b/docs/source/generated/paasta_tools.autoscaling.max_all_k8s_services.rst
@@ -1,0 +1,7 @@
+paasta\_tools.autoscaling.max\_all\_k8s\_services module
+========================================================
+
+.. automodule:: paasta_tools.autoscaling.max_all_k8s_services
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.autoscaling.rst
+++ b/docs/source/generated/paasta_tools.autoscaling.rst
@@ -11,6 +11,7 @@ Submodules
    paasta_tools.autoscaling.ec2_fitness
    paasta_tools.autoscaling.forecasting
    paasta_tools.autoscaling.load_boost
+   paasta_tools.autoscaling.max_all_k8s_services
    paasta_tools.autoscaling.pause_service_autoscaler
    paasta_tools.autoscaling.utils
 

--- a/docs/source/generated/paasta_tools.config_utils.rst
+++ b/docs/source/generated/paasta_tools.config_utils.rst
@@ -1,0 +1,7 @@
+paasta\_tools.config\_utils module
+==================================
+
+.. automodule:: paasta_tools.config_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.kubernetes.bin.kube_state_metrics_collector.rst
+++ b/docs/source/generated/paasta_tools.kubernetes.bin.kube_state_metrics_collector.rst
@@ -1,0 +1,7 @@
+paasta\_tools.kubernetes.bin.kube\_state\_metrics\_collector module
+===================================================================
+
+.. automodule:: paasta_tools.kubernetes.bin.kube_state_metrics_collector
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/k8s_itests/Makefile
+++ b/k8s_itests/Makefile
@@ -6,7 +6,7 @@ export KUBE_RESOURCE_DIR=$(CWD)/deployments/kind/resources
 export KIND_CLUSTER=$(CLUSTER)
 export SOA_DIR=$(PAASTA_CONFIG_DIR)/fake_soa_config
 export PAASTA_SYSTEM_CONFIG_DIR=$(PAASTA_CONFIG_DIR)/fake_etc_paasta
-export PAASTA_API_PORT= `ephemeral-port-reserve`
+export PAASTA_API_PORT=$(shell ephemeral-port-reserve)
 export KUBECONFIG=$(shell ./kind get kubeconfig-path --name=$(KIND_CLUSTER))
 
 ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)

--- a/k8s_itests/deployments/paasta/fake_etc_paasta/api_endpoints.json
+++ b/k8s_itests/deployments/paasta/fake_etc_paasta/api_endpoints.json
@@ -1,5 +1,5 @@
 {
     "api_endpoints": {
-        "<%cluster%>": "http://localhost:$(PAASTA_API_PORT)"
+        "<%cluster%>": "http://0.0.0.0:$(PAASTA_API_PORT)"
     }
 }

--- a/k8s_itests/deployments/paasta/fake_soa_config/compute-infra-test-service/deployments.json
+++ b/k8s_itests/deployments/paasta/fake_soa_config/compute-infra-test-service/deployments.json
@@ -1,4 +1,11 @@
 {
+    "v1": {
+        "compute-infra-test-service:<%cluster%>.autoscaling": {
+            "docker_image": "services-compute-infra-test-service:paasta-a0ec9b362e29123022e5cebb6612aedc58a0889b",
+            "desired_state": "start",
+            "force_bounce": null
+        }
+    },
     "v2": {
         "deployments": {
             "<%cluster%>.autoscaling": {

--- a/k8s_itests/docker-compose.yml
+++ b/k8s_itests/docker-compose.yml
@@ -4,7 +4,7 @@ volumes:
   nail-etc:
 
 services:
-  paastatools:
+  paasta_tools:
     build:
       context: ../
       dockerfile: ./yelp_package/dockerfiles/itest/k8s/Dockerfile

--- a/k8s_itests/docker-compose.yml
+++ b/k8s_itests/docker-compose.yml
@@ -1,0 +1,54 @@
+version: '2.3'
+
+volumes:
+  nail-etc:
+
+services:
+  paastatools:
+    build:
+      context: ../
+      dockerfile: ./yelp_package/dockerfiles/itest/k8s/Dockerfile
+    network_mode: host
+    environment:
+      KIND_CLUSTER: ${KIND_CLUSTER}
+      KUBECONTEXT: kubernetes-admin@${KIND_CLUSTER}
+      KUBECONFIG: ${KUBECONFIG}
+      KUBE_RESOURCE_DIR: ${KUBE_RESOURCE_DIR}
+      USER: ${USER}
+      PAASTA_API_PORT: ${PAASTA_API_PORT}
+    volumes:
+      - ../:/work:rw
+      - nail-etc:/nail/etc
+      - /etc/boto:/etc/boto:rw
+      - /etc/kubernetes:/etc/kubernetes:rw
+      - ${KUBECONFIG}:${KUBECONFIG}:rw
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${SOA_DIR}:/nail/etc/services:rw
+      - ./deployments/.tmp/fake_etc_paasta:/etc/paasta:rw
+    command:
+      bash -c "/venv/bin/wait_paasta_api.sh -- pytest ./k8s_itests -s"
+    depends_on:
+      - paasta_api
+
+  paasta_api:
+    build:
+      context: ../
+      dockerfile: ./yelp_package/dockerfiles/itest/api/Dockerfile
+    command: bash -c 'pip install -e /work && exec paasta-api -D -c ${KIND_CLUSTER} ${PAASTA_API_PORT}'
+    network_mode: host
+    environment:
+      KIND_CLUSTER: ${KIND_CLUSTER}
+      KUBECONTEXT: kubernetes-admin@${KIND_CLUSTER}
+      KUBECONFIG: ${KUBECONFIG}
+      KUBE_RESOURCE_DIR: ${KUBE_RESOURCE_DIR}
+      USER: ${USER}
+      PAASTA_API_PORT: ${PAASTA_API_PORT}
+    volumes:
+      - ../:/work:rw
+      - nail-etc:/nail/etc
+      - /etc/boto:/etc/boto:rw
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${KUBECONFIG}:${KUBECONFIG}:rw
+      - /etc/kubernetes:/etc/kubernetes:rw
+      - ${SOA_DIR}:/nail/etc/services:rw
+      - ./deployments/.tmp/fake_etc_paasta:/etc/paasta:rw

--- a/k8s_itests/test_autoscaling.py
+++ b/k8s_itests/test_autoscaling.py
@@ -1,3 +1,5 @@
+import os
+
 from k8s_itests.utils import cmd
 from k8s_itests.utils import init_all
 
@@ -11,3 +13,11 @@ def setup_module(module):
 class TestSetupKubernetesJobs:
     def test_autoscaling(self):
         cmd("kubectl get hpa -n paasta", False)
+
+    def test_paasta_status(self):
+        instance = "autoscaling"
+        service = "compute-infra-test-service"
+        cmd(
+            f"python -m paasta_tools.cli.cli status  -c {os.environ['KIND_CLUSTER']} -s {service} -i {instance}",
+            False,
+        )

--- a/k8s_itests/test_autoscaling.py
+++ b/k8s_itests/test_autoscaling.py
@@ -5,13 +5,7 @@ terminate_on_exit = []
 
 
 def setup_module(module):
-    # Kill paasta api server on exit
-    terminate_on_exit.append(init_all())
-
-
-def teardown_module(module):
-    for p in terminate_on_exit:
-        p.kill()
+    init_all()
 
 
 class TestSetupKubernetesJobs:

--- a/k8s_itests/utils.py
+++ b/k8s_itests/utils.py
@@ -25,14 +25,10 @@ def start_paasta_api():
 
 def paasta_apply():
     print("Applying SOA configurations")
-    service_instances = cmd(
-        "python -m paasta_tools.list_kubernetes_service_instances -d {}".format(
-            os.environ["SOA_DIR"]
-        ),
-    )
+    service_instances = cmd("python -m paasta_tools.list_kubernetes_service_instances")
     cmd(
-        "python -m paasta_tools.setup_kubernetes_job {} -v -d {}".format(
-            service_instances.stdout.strip(), os.environ["SOA_DIR"]
+        "python -m paasta_tools.setup_kubernetes_job {} -v".format(
+            service_instances.stdout.strip()
         ),
         False,
     )
@@ -40,4 +36,3 @@ def paasta_apply():
 
 def init_all():
     paasta_apply()
-    return start_paasta_api()

--- a/paasta_tools/__init__.py
+++ b/paasta_tools/__init__.py
@@ -17,4 +17,4 @@
 # setup phase, the dependencies may not exist on disk yet.
 #
 # Don't bump version manually. See `make release` docs in ./Makefile
-__version__ = "0.95.9"
+__version__ = "0.95.10"

--- a/paasta_tools/__init__.py
+++ b/paasta_tools/__init__.py
@@ -17,4 +17,4 @@
 # setup phase, the dependencies may not exist on disk yet.
 #
 # Don't bump version manually. See `make release` docs in ./Makefile
-__version__ = "0.95.7"
+__version__ = "0.95.8"

--- a/paasta_tools/__init__.py
+++ b/paasta_tools/__init__.py
@@ -17,4 +17,4 @@
 # setup phase, the dependencies may not exist on disk yet.
 #
 # Don't bump version manually. See `make release` docs in ./Makefile
-__version__ = "0.95.6"
+__version__ = "0.95.7"

--- a/paasta_tools/__init__.py
+++ b/paasta_tools/__init__.py
@@ -17,4 +17,4 @@
 # setup phase, the dependencies may not exist on disk yet.
 #
 # Don't bump version manually. See `make release` docs in ./Makefile
-__version__ = "0.95.8"
+__version__ = "0.95.9"

--- a/paasta_tools/__init__.py
+++ b/paasta_tools/__init__.py
@@ -17,4 +17,4 @@
 # setup phase, the dependencies may not exist on disk yet.
 #
 # Don't bump version manually. See `make release` docs in ./Makefile
-__version__ = "0.95.10"
+__version__ = "0.95.11"

--- a/paasta_tools/__init__.py
+++ b/paasta_tools/__init__.py
@@ -17,4 +17,4 @@
 # setup phase, the dependencies may not exist on disk yet.
 #
 # Don't bump version manually. See `make release` docs in ./Makefile
-__version__ = "0.95.4"
+__version__ = "0.95.5"

--- a/paasta_tools/__init__.py
+++ b/paasta_tools/__init__.py
@@ -17,4 +17,4 @@
 # setup phase, the dependencies may not exist on disk yet.
 #
 # Don't bump version manually. See `make release` docs in ./Makefile
-__version__ = "0.95.5"
+__version__ = "0.95.6"

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -1253,6 +1253,35 @@
                         "$ref": "#/definitions/KubernetesPod"
                     }
                 },
+                "autoscaling_status": {
+                    "type": "object",
+                    "description": "HPA associated to this app",
+                    "properties": {
+                        "min_instances": {
+                            "type": "integer",
+                            "description": "min_instances as specified in yelpsoa_configs"
+                        },
+                        "max_instances": {
+                            "type": "integer",
+                            "description": "min_instances as specified in yelpsoa_configs"
+                        },
+                        "desired_replicas": {
+                            "type": "integer",
+                            "description": "desired number of _instances as calculated by HPA"
+                        },
+                        "last_scale_time": {
+                            "type": "string",
+                            "description": "timestamp of last autoscale"
+                        },
+                        "metrics": {
+                            "type": "array",
+                            "description": "Current metrics",
+                            "items": {
+                                "$ref": "#/definitions/HPAMetric"
+                            }
+                        }
+                    }
+                },
                 "error_message": {
                     "type": "string",
                     "description": "Error message when a kubernetes object (Deployment/Statefulset) cannot be found"
@@ -1263,6 +1292,23 @@
                 "app_count",
                 "bounce_method"
             ]
+        },
+        "HPAMetric": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "name of the metric"
+                },
+                "target_value": {
+                    "type": "string",
+                    "description": "setpoint/target_value as specified in yelpsoa_configs"
+                },
+                "current_value": {
+                    "type": "string",
+                    "description": "setpoint/target_value as specified in yelpsoa_configs"
+                }
+            }
         },
         "KubernetesReplicaSet": {
             "type": "object",

--- a/paasta_tools/api/client.py
+++ b/paasta_tools/api/client.py
@@ -40,11 +40,11 @@ def get_paasta_api_client(
 ) -> Any:
     if not system_paasta_config:
         system_paasta_config = load_system_paasta_config()
-
     if not cluster:
         cluster = system_paasta_config.get_cluster()
-
-    api_endpoints = system_paasta_config.get_api_endpoints()
+    # api_endpoints = system_paasta_config.get_api_endpoints()
+    api_endpoints = {'kubestage': 'http://localhost:56123', 'mesosstage': 'http://localhost:56123'}
+    print(api_endpoints)
     if cluster not in api_endpoints:
         log.error("Cluster %s not in paasta-api endpoints config", cluster)
         return None

--- a/paasta_tools/api/client.py
+++ b/paasta_tools/api/client.py
@@ -40,11 +40,11 @@ def get_paasta_api_client(
 ) -> Any:
     if not system_paasta_config:
         system_paasta_config = load_system_paasta_config()
+
     if not cluster:
         cluster = system_paasta_config.get_cluster()
-    # api_endpoints = system_paasta_config.get_api_endpoints()
-    api_endpoints = {'kubestage': 'http://localhost:56123', 'mesosstage': 'http://localhost:56123'}
-    print(api_endpoints)
+
+    api_endpoints = system_paasta_config.get_api_endpoints()
     if cluster not in api_endpoints:
         log.error("Cluster %s not in paasta-api endpoints config", cluster)
         return None

--- a/paasta_tools/api/views/autoscaler.py
+++ b/paasta_tools/api/views/autoscaler.py
@@ -20,8 +20,8 @@ from pyramid.view import view_config
 
 from paasta_tools.api import settings
 from paasta_tools.api.views.exception import ApiFailure
-from paasta_tools.long_running_service_tools import set_instances_for_marathon_service
 from paasta_tools.marathon_tools import load_marathon_service_config
+from paasta_tools.marathon_tools import set_instances_for_marathon_service
 
 
 @view_config(route_name="service.autoscaler.get", request_method="GET", renderer="json")

--- a/paasta_tools/api/views/autoscaler.py
+++ b/paasta_tools/api/views/autoscaler.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2015-2016 Yelp Inc.
 #
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -84,8 +83,6 @@ def get_autoscaler_count(request):
 
     instance_type = get_instance_type(service, instance, cluster, soa_dir)
     service_config = get_service_config(instance_type, service, instance, cluster, soa_dir)
-    print(service_config)
-    print(service_config.get_sanitised_deployment_name())
 
     response_body = {
         "desired_instances": service_config.get_instances(),
@@ -131,8 +128,6 @@ def update_autoscaler_count(request):
         )
 
     if instance_type == 'marathon':
-        # Dump whatever number from the client to zk. get_instances() will limit
-        # readings from zk to [min_instances, max_instances].
         set_instances_for_marathon_service(service=service, instance=instance, instance_count=desired_instances)
     elif instance_type == 'kubernetes':
         kube_client = KubeClient()

--- a/paasta_tools/api/views/autoscaler.py
+++ b/paasta_tools/api/views/autoscaler.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright 2015-2016 Yelp Inc.
 #
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -15,16 +16,20 @@
 """
 PaaSTA service list (instances) etc.
 """
+from kubernetes.client import V1Deployment
+from kubernetes.client import V1DeploymentSpec
+from kubernetes.client import V1LabelSelector
+
 from pyramid.response import Response
 from pyramid.view import view_config
 
 from paasta_tools.api import settings
 from paasta_tools.api.views.exception import ApiFailure
+from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.kubernetes_tools import load_kubernetes_service_config
+from paasta_tools.kubernetes_tools import set_instances_for_kubernetes_service
 from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.marathon_tools import set_instances_for_marathon_service
-from paasta_tools.kubernetes_tools import load_kubernetes_service_config
-from paasta_tools.long_running_service_tools import set_instances_for_marathon_service
-from paasta_tools.marathon_tools import load_marathon_service_config
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import validate_service_instance
 
@@ -50,7 +55,7 @@ def get_service_config(instance_type, service, instance, cluster, soa_dir):
                 instance=instance,
                 cluster=cluster,
                 soa_dir=soa_dir,
-                load_deployments=False,
+                load_deployments=True,
             )
         elif instance_type == 'kubernetes':
             service_config = load_kubernetes_service_config(
@@ -58,7 +63,7 @@ def get_service_config(instance_type, service, instance, cluster, soa_dir):
                 instance=instance,
                 cluster=cluster,
                 soa_dir=soa_dir,
-                load_deployments=False,
+                load_deployments=True,
             )
         else:
             error_message = f"Autoscaling is not supported for {service}.{instance} because instance type is neither " \
@@ -79,6 +84,8 @@ def get_autoscaler_count(request):
 
     instance_type = get_instance_type(service, instance, cluster, soa_dir)
     service_config = get_service_config(instance_type, service, instance, cluster, soa_dir)
+    print(service_config)
+    print(service_config.get_sanitised_deployment_name())
 
     response_body = {
         "desired_instances": service_config.get_instances(),
@@ -93,6 +100,8 @@ def get_autoscaler_count(request):
 def update_autoscaler_count(request):
     service = request.swagger_data.get("service")
     instance = request.swagger_data.get("instance")
+    cluster = settings.cluster
+    soa_dir = settings.soa_dir
     desired_instances = request.swagger_data.get("json_body")["desired_instances"]
     if not isinstance(desired_instances, int):
         error_message = 'The provided body does not have an integer value for "desired_instances": {}'.format(
@@ -109,31 +118,31 @@ def update_autoscaler_count(request):
         raise ApiFailure(error_message, 404)
     min_instances = service_config.get_min_instances()
 
-    if instance_type == 'marathon':
-        # Dump whatever number from the client to zk. get_instances() will limit
-        # readings from zk to [min_instances, max_instances].
-        set_instances_for_marathon_service(
-            service=service, instance=instance, instance_count=desired_instances
-        )
-    elif instance_type == 'kubernetes':
-        # TODO: implement kubernetes instance scaling here
-        pass
-    else:
-        error_message = f"Autoscaling is not supported for {service}.{instance} because instance type is neither " \
-                        f"marathon or kubernetes."
-        raise ApiFailure(error_message, 404)
-
     status = "SUCCESS"
     if desired_instances > max_instances:
         desired_instances = max_instances
         status = (
-            "WARNING desired_instances is greater than max_instances %d" % max_instances
+                "WARNING desired_instances is greater than max_instances %d" % max_instances
         )
     elif desired_instances < min_instances:
         desired_instances = min_instances
         status = (
-            "WARNING desired_instances is less than min_instances %d" % min_instances
+                "WARNING desired_instances is less than min_instances %d" % min_instances
         )
+
+    if instance_type == 'marathon':
+        # Dump whatever number from the client to zk. get_instances() will limit
+        # readings from zk to [min_instances, max_instances].
+        set_instances_for_marathon_service(service=service, instance=instance, instance_count=desired_instances)
+    elif instance_type == 'kubernetes':
+        kube_client = KubeClient()
+        set_instances_for_kubernetes_service(kube_client=kube_client,
+                                             service_config=service_config,
+                                             instance_count=desired_instances)
+    else:
+        error_message = f"Autoscaling is not supported for {service}.{instance} because instance type is neither " \
+                        f"marathon or kubernetes."
+        raise ApiFailure(error_message, 404)
 
     response_body = {"desired_instances": desired_instances, "status": status}
     return Response(json_body=response_body, status_code=202)

--- a/paasta_tools/api/views/autoscaler.py
+++ b/paasta_tools/api/views/autoscaler.py
@@ -20,47 +20,9 @@ from pyramid.view import view_config
 
 from paasta_tools.api import settings
 from paasta_tools.api.views.exception import ApiFailure
-from paasta_tools.kubernetes_tools import load_kubernetes_service_config
-from paasta_tools.marathon_tools import load_marathon_service_config
-from paasta_tools.utils import NoConfigurationForServiceError
-from paasta_tools.utils import validate_service_instance
-
-
-SERVICE_CONFIG_MAP = {
-    "marathon": load_marathon_service_config,
-    "kubernetes": load_kubernetes_service_config,
-}
-
-
-def get_instance_type(service, instance, cluster, soa_dir):
-    try:
-        return validate_service_instance(service, instance, cluster, soa_dir)
-    except NoConfigurationForServiceError:
-        error_message = (
-                "Deployment key %s not found. Try to execute the corresponding pipeline if it's a fresh instance"
-                % ".".join([settings.cluster, instance])
-        )
-        raise ApiFailure(error_message, 404)
-    except Exception as e:
-        raise ApiFailure(e, 500)
-
-
-def get_service_config(instance_type, service, instance, cluster, soa_dir):
-    try:
-        if instance_type in SERVICE_CONFIG_MAP:
-            service_config = SERVICE_CONFIG_MAP[instance_type](service=service,
-                                                               instance=instance,
-                                                               cluster=cluster,
-                                                               soa_dir=soa_dir,
-                                                               load_deployments=True,)
-        else:
-            error_message = f"Autoscaling is not supported for {service}.{instance} because instance type is neither " \
-                            f"marathon or kubernetes."
-            raise ApiFailure(error_message, 404)
-    except Exception:
-        error_message = f"Unable to load service config for {service}.{instance}"
-        raise ApiFailure(error_message, 404)
-    return service_config
+from paasta_tools.cli.utils import get_instance_config
+from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
+from paasta_tools.marathon_tools import MarathonServiceConfig
 
 
 @view_config(route_name="service.autoscaler.get", request_method="GET", renderer="json")
@@ -70,12 +32,19 @@ def get_autoscaler_count(request):
     cluster = settings.cluster
     soa_dir = settings.soa_dir
 
-    instance_type = get_instance_type(service, instance, cluster, soa_dir)
-    service_config = get_service_config(instance_type, service, instance, cluster, soa_dir)
+    instance_config = get_instance_config(service, instance, cluster, soa_dir)
+    if not isinstance(
+        instance_config, (KubernetesDeploymentConfig, MarathonServiceConfig)
+    ):
+        error_message = (
+            f"Autoscaling is not supported for {service}.{instance} because instance type is not "
+            f"marathon or kubernetes."
+        )
+        raise ApiFailure(error_message, 501)
 
     response_body = {
-        "desired_instances": service_config.get_instances(),
-        "calculated_instances": service_config.get_instances(with_limit=False),
+        "desired_instances": instance_config.get_instances(),
+        "calculated_instances": instance_config.get_instances(with_limit=False),
     }
     return Response(json_body=response_body, status_code=200)
 
@@ -95,14 +64,21 @@ def update_autoscaler_count(request):
         )
         raise ApiFailure(error_message, 500)
 
-    instance_type = get_instance_type(service, instance, cluster, soa_dir)
-    service_config = get_service_config(instance_type, service, instance, cluster, soa_dir)
+    instance_config = get_instance_config(service, instance, cluster, soa_dir, True)
+    if not isinstance(
+        instance_config, (KubernetesDeploymentConfig, MarathonServiceConfig)
+    ):
+        error_message = (
+            f"Autoscaling is not supported for {service}.{instance} because instance type is not "
+            f"marathon or kubernetes."
+        )
+        raise ApiFailure(error_message, 501)
 
-    max_instances = service_config.get_max_instances()
+    max_instances = instance_config.get_max_instances()
     if max_instances is None:
         error_message = f"Autoscaling is not enabled for {service}.{instance}"
         raise ApiFailure(error_message, 404)
-    min_instances = service_config.get_min_instances()
+    min_instances = instance_config.get_min_instances()
 
     status = "SUCCESS"
     if desired_instances > max_instances:
@@ -115,13 +91,15 @@ def update_autoscaler_count(request):
         status = (
             "WARNING desired_instances is less than min_instances %d" % min_instances
         )
-
-    if instance_type in SERVICE_CONFIG_MAP:
-        service_config.set_autoscaled_instances(instance_count=desired_instances)
-    else:
-        error_message = f"Autoscaling is not supported for {service}.{instance} because instance type is neither " \
-                        f"marathon or kubernetes."
-        raise ApiFailure(error_message, 404)
+    try:
+        if isinstance(instance_config, KubernetesDeploymentConfig):
+            instance_config.set_autoscaled_instances(
+                instance_count=desired_instances, kube_client=settings.kubernetes_client
+            )
+        else:
+            instance_config.set_autoscaled_instances(instance_count=desired_instances)
+    except Exception as err:
+        raise ApiFailure(err, 500)
 
     response_body = {"desired_instances": desired_instances, "status": status}
     return Response(json_body=response_body, status_code=202)

--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -44,11 +44,10 @@ from paasta_tools.bounce_lib import filter_tasks_in_smartstack
 from paasta_tools.bounce_lib import LockHeldException
 from paasta_tools.bounce_lib import LockTimeout
 from paasta_tools.bounce_lib import ZK_LOCK_CONNECT_TIMEOUT_S
-from paasta_tools.long_running_service_tools import compose_autoscaling_zookeeper_root
 from paasta_tools.long_running_service_tools import load_service_namespace_config
-from paasta_tools.long_running_service_tools import set_instances_for_marathon_service
 from paasta_tools.long_running_service_tools import ZK_PAUSE_AUTOSCALE_PATH
 from paasta_tools.marathon_tools import AutoscalingParamsDict
+from paasta_tools.marathon_tools import compose_autoscaling_zookeeper_root
 from paasta_tools.marathon_tools import format_job_id
 from paasta_tools.marathon_tools import get_marathon_apps_with_clients
 from paasta_tools.marathon_tools import get_marathon_clients
@@ -57,6 +56,7 @@ from paasta_tools.marathon_tools import is_old_task_missing_healthchecks
 from paasta_tools.marathon_tools import is_task_healthy
 from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.marathon_tools import MESOS_TASK_SPACER
+from paasta_tools.marathon_tools import set_instances_for_marathon_service
 from paasta_tools.mesos.task import Task
 from paasta_tools.mesos_tools import get_all_running_tasks
 from paasta_tools.mesos_tools import get_cached_list_of_running_tasks_from_frameworks

--- a/paasta_tools/autoscaling/max_all_k8s_services.py
+++ b/paasta_tools/autoscaling/max_all_k8s_services.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+from paasta_tools.kubernetes.application.controller_wrappers import (
+    get_application_wrapper,
+)
+from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
+from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
+from paasta_tools.utils import get_services_for_cluster
+from paasta_tools.utils import load_system_paasta_config
+
+
+def main() -> None:
+    system_paasta_config = load_system_paasta_config()
+
+    kube_client = KubeClient()
+
+    services = {
+        service
+        for service, instance in get_services_for_cluster(
+            cluster=system_paasta_config.get_cluster(), instance_type="kubernetes"
+        )
+    }
+
+    for service in services:
+        pscl = PaastaServiceConfigLoader(service=service, load_deployments=False)
+        for instance_config in pscl.instance_configs(
+            cluster=system_paasta_config.get_cluster(),
+            instance_type_class=KubernetesDeploymentConfig,
+        ):
+            # Force min_instances = max_instances so that we scale up.
+            max_instances = instance_config.get_max_instances()
+            if max_instances is not None:
+                instance_config.config_dict["min_instances"] = max_instances
+                formatted_application = instance_config.format_kubernetes_app()
+                wrapper = get_application_wrapper(formatted_application)
+                wrapper.soa_config = instance_config
+                print(f"Scaling up {service}.{instance_config.instance}")
+                wrapper.update(kube_client)
+
+
+if __name__ == "__main__":
+    main()

--- a/paasta_tools/autoscaling/max_all_k8s_services.py
+++ b/paasta_tools/autoscaling/max_all_k8s_services.py
@@ -27,11 +27,10 @@ def main() -> None:
             cluster=system_paasta_config.get_cluster(),
             instance_type_class=KubernetesDeploymentConfig,
         ):
-            # Force min_instances = max_instances so that we scale up.
             max_instances = instance_config.get_max_instances()
             if max_instances is not None:
-                instance_config.config_dict["min_instances"] = max_instances
                 formatted_application = instance_config.format_kubernetes_app()
+                formatted_application.spec.replicas = max_instances
                 wrapper = get_application_wrapper(formatted_application)
                 wrapper.soa_config = instance_config
                 print(f"Scaling up {service}.{instance_config.instance}")

--- a/paasta_tools/check_kubernetes_services_replication.py
+++ b/paasta_tools/check_kubernetes_services_replication.py
@@ -46,6 +46,7 @@ from paasta_tools.smartstack_tools import KubeSmartstackReplicationChecker
 
 
 log = logging.getLogger(__name__)
+DEFAULT_ALERT_AFTER = "5m"
 
 
 def check_healthy_kubernetes_tasks_for_service_instance(
@@ -73,6 +74,7 @@ def check_kubernetes_pod_replication(
     instance_config: KubernetesDeploymentConfig,
     all_tasks_or_pods: Sequence[V1Pod],
     smartstack_replication_checker: KubeSmartstackReplicationChecker,
+    default_alert_after: Optional[str] = DEFAULT_ALERT_AFTER,
 ) -> Optional[bool]:
     """Checks a service's replication levels based on how the service's replication
     should be monitored. (smartstack or k8s)
@@ -87,6 +89,13 @@ def check_kubernetes_pod_replication(
     proxy_port = get_proxy_port_for_instance(instance_config)
 
     registrations = instance_config.get_registrations()
+    if "monitoring" not in instance_config.config_dict:
+        instance_config.config_dict["monitoring"] = {}
+    instance_config.config_dict["monitoring"][
+        "alert_after"
+    ] = instance_config.config_dict["monitoring"].get(
+        "alert_after", default_alert_after
+    )
     # if the primary registration does not match the service_instance name then
     # the best we can do is check k8s for replication (for now).
     if proxy_port is not None and registrations[0] == instance_config.job_id:

--- a/paasta_tools/cli/cmds/autoscale.py
+++ b/paasta_tools/cli/cmds/autoscale.py
@@ -78,6 +78,7 @@ def paasta_autoscale(args):
             res, http = api.autoscaler.update_autoscaler_count(
                 service=service, instance=args.instance, json_body=body
             ).result()
+
             _log_audit(
                 action="manual-scale",
                 action_details=body,

--- a/paasta_tools/cli/cmds/autoscale.py
+++ b/paasta_tools/cli/cmds/autoscale.py
@@ -66,38 +66,38 @@ def paasta_autoscale(args):
             "Could not connect to paasta api. Maybe you misspelled the cluster?"
         )
         return 1
-    # try:
-    if args.set is None:
-        log.debug("Getting the current autoscaler count...")
-        res, http = api.autoscaler.get_autoscaler_count(
-            service=service, instance=args.instance
-        ).result()
-    else:
-        log.debug(f"Setting desired instances to {args.set}.")
-        body = {"desired_instances": int(args.set)}
-        res, http = api.autoscaler.update_autoscaler_count(
-            service=service, instance=args.instance, json_body=body
-        ).result()
-        _log_audit(
-            action="manual-scale",
-            action_details=body,
-            service=service,
-            instance=args.instance,
-            cluster=args.cluster,
+    try:
+        if args.set is None:
+            log.debug("Getting the current autoscaler count...")
+            res, http = api.autoscaler.get_autoscaler_count(
+                service=service, instance=args.instance
+            ).result()
+        else:
+            log.debug(f"Setting desired instances to {args.set}.")
+            body = {"desired_instances": int(args.set)}
+            res, http = api.autoscaler.update_autoscaler_count(
+                service=service, instance=args.instance, json_body=body
+            ).result()
+            _log_audit(
+                action="manual-scale",
+                action_details=body,
+                service=service,
+                instance=args.instance,
+                cluster=args.cluster,
+            )
+    except HTTPNotFound:
+        paasta_print(
+            PaastaColors.red(
+                f"ERROR: '{args.instance}' is not configured to autoscale, "
+                f"so paasta autoscale could not scale it up on demand. "
+                f"If you want to be able to boost this service, please configure autoscaling for the service "
+                f"in its config file by setting min and max instances. Example: \n"
+                f"{args.instance}:\n"
+                f"     min_instances: 5\n"
+                f"     max_instances: 50"
+            )
         )
-    # except HTTPNotFound:
-    #     paasta_print(
-    #         PaastaColors.red(
-    #             f"ERROR: '{args.instance}' is not configured to autoscale, "
-    #             f"so paasta autoscale could not scale it up on demand. "
-    #             f"If you want to be able to boost this service, please configure autoscaling for the service "
-    #             f"in its config file by setting min and max instances. Example: \n"
-    #             f"{args.instance}:\n"
-    #             f"     min_instances: 5\n"
-    #             f"     max_instances: 50"
-    #         )
-    #     )
-    #     return 0
+        return 0
 
     log.debug(f"Res: {res} Http: {http}")
     print(res["desired_instances"])

--- a/paasta_tools/cli/cmds/autoscale.py
+++ b/paasta_tools/cli/cmds/autoscale.py
@@ -66,39 +66,38 @@ def paasta_autoscale(args):
             "Could not connect to paasta api. Maybe you misspelled the cluster?"
         )
         return 1
-    try:
-        if args.set is None:
-            log.debug("Getting the current autoscaler count...")
-            res, http = api.autoscaler.get_autoscaler_count(
-                service=service, instance=args.instance
-            ).result()
-        else:
-            log.debug(f"Setting desired instances to {args.set}.")
-            body = {"desired_instances": int(args.set)}
-            res, http = api.autoscaler.update_autoscaler_count(
-                service=service, instance=args.instance, json_body=body
-            ).result()
-
-            _log_audit(
-                action="manual-scale",
-                action_details=body,
-                service=service,
-                instance=args.instance,
-                cluster=args.cluster,
-            )
-    except HTTPNotFound:
-        paasta_print(
-            PaastaColors.red(
-                f"ERROR: '{args.instance}' is not configured to autoscale, "
-                f"so paasta autoscale could not scale it up on demand. "
-                f"If you want to be able to boost this service, please configure autoscaling for the service "
-                f"in its config file by setting min and max instances. Example: \n"
-                f"{args.instance}:\n"
-                f"     min_instances: 5\n"
-                f"     max_instances: 50"
-            )
+    # try:
+    if args.set is None:
+        log.debug("Getting the current autoscaler count...")
+        res, http = api.autoscaler.get_autoscaler_count(
+            service=service, instance=args.instance
+        ).result()
+    else:
+        log.debug(f"Setting desired instances to {args.set}.")
+        body = {"desired_instances": int(args.set)}
+        res, http = api.autoscaler.update_autoscaler_count(
+            service=service, instance=args.instance, json_body=body
+        ).result()
+        _log_audit(
+            action="manual-scale",
+            action_details=body,
+            service=service,
+            instance=args.instance,
+            cluster=args.cluster,
         )
-        return 0
+    # except HTTPNotFound:
+    #     paasta_print(
+    #         PaastaColors.red(
+    #             f"ERROR: '{args.instance}' is not configured to autoscale, "
+    #             f"so paasta autoscale could not scale it up on demand. "
+    #             f"If you want to be able to boost this service, please configure autoscaling for the service "
+    #             f"in its config file by setting min and max instances. Example: \n"
+    #             f"{args.instance}:\n"
+    #             f"     min_instances: 5\n"
+    #             f"     max_instances: 50"
+    #         )
+    #     )
+    #     return 0
 
     log.debug(f"Res: {res} Http: {http}")
     print(res["desired_instances"])

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1364,8 +1364,7 @@ def clusters_data_to_wait_for(service, deploy_group, git_sha, soa_dir):
 
     total_instances = 0
     clusters_data = []
-    # api_endpoints = load_system_paasta_config().get_api_endpoints()
-    api_endpoints = {'kubestage': 'http://localhost:56123', 'mesosstage': 'http://localhost:56123'}
+    api_endpoints = load_system_paasta_config().get_api_endpoints()
     for cluster in service_configs.clusters:
         if cluster not in api_endpoints:
             paasta_print(

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1364,7 +1364,8 @@ def clusters_data_to_wait_for(service, deploy_group, git_sha, soa_dir):
 
     total_instances = 0
     clusters_data = []
-    api_endpoints = load_system_paasta_config().get_api_endpoints()
+    # api_endpoints = load_system_paasta_config().get_api_endpoints()
+    api_endpoints = {'kubestage': 'http://localhost:56123', 'mesosstage': 'http://localhost:56123'}
     for cluster in service_configs.clusters:
         if cluster not in api_endpoints:
             paasta_print(

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1069,7 +1069,11 @@ def print_flink_status(
                 start_time=f"{str(start_time)} ({humanize.naturaltime(start_time)})",
                 dashboard_url=PaastaColors.grey(f"{dashboard_url}/#/jobs/{job_id}"),
             )
-            color_fn = PaastaColors.green if job.get("state") and job.get("state") == "RUNNING" else PaastaColors.red
+            color_fn = (
+                PaastaColors.green
+                if job.get("state") and job.get("state") == "RUNNING"
+                else PaastaColors.red
+            )
             output.append(color_fn(job_info_str))
 
         if verbose and job_id in status.exceptions:

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -16,7 +16,6 @@ import concurrent.futures
 import difflib
 import shutil
 import sys
-import traceback
 from collections import defaultdict
 from collections import OrderedDict
 from datetime import datetime
@@ -255,10 +254,9 @@ def paasta_status_on_api_endpoint(
             PaastaColors.red(f"Could not connect to API: {exc.__class__.__name__}")
         )
         return 1
-    except Exception:
-        tb = sys.exc_info()[2]
+    except Exception as e:
         output.append(PaastaColors.red(f"Exception when talking to the API:"))
-        output.extend(line.strip() for line in traceback.format_tb(tb))
+        output.append(e)
         return 1
 
     if status.git_sha != "":

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -270,6 +270,9 @@
                         "check_that_every_day_has_a_successful_run": {
                             "type": "boolean"
                         },
+                        "page_for_expected_runtime": {
+                            "type": "boolean"
+                        },
                         "priority": {
                             "type": "string"
                         }

--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -83,6 +83,10 @@ class PushNotFastForwardError(Exception):
     pass
 
 
+class ValidationError(Exception):
+    pass
+
+
 def _push_to_remote(branch: str) -> None:
     try:
         subprocess.check_output(
@@ -191,7 +195,7 @@ class AutoConfigUpdater:
     def commit_to_remote(self, extra_message: str = ""):
         if not self.validate():
             log.error("Files failed validation, not committing changes")
-            return
+            raise ValidationError
 
         # TODO: more identifying information, like hostname or paasta_tools version?
         message = f"Update to {AUTO_SOACONFIG_SUBDIR} configs from {self.config_source}"

--- a/paasta_tools/contrib/paasta_update_soa_memcpu.py
+++ b/paasta_tools/contrib/paasta_update_soa_memcpu.py
@@ -130,7 +130,7 @@ def cwd(path):
 def get_report_from_splunk(creds, app, filename, criteria_filter):
     """ Expect a table containing at least the following fields:
     criteria (<service> [marathon|kubernetes]-<cluster_name> <instance>)
-    service_owner
+    service_owner (Optional)
     project (Required to create tickets)
     estimated_monthly_savings (Optional)
     search_time (Unix time)
@@ -161,7 +161,7 @@ def get_report_from_splunk(creds, app, filename, criteria_filter):
         serv["service"] = criteria.split(" ")[0]
         serv["cluster"] = criteria.split(" ")[1]
         serv["instance"] = criteria.split(" ")[2]
-        serv["owner"] = d["result"]["service_owner"]
+        serv["owner"] = d["result"].get("service_owner", "Unavailable")
         serv["date"] = d["result"]["_time"].split(" ")[0]
         serv["money"] = d["result"].get("estimated_monthly_savings", 0)
         serv["project"] = d["result"].get("project", "Unavailable")

--- a/paasta_tools/contrib/rightsizer_soaconfigs_update.py
+++ b/paasta_tools/contrib/rightsizer_soaconfigs_update.py
@@ -67,6 +67,13 @@ def parse_args():
         dest="local_dir",
     )
     parser.add_argument(
+        "--source-id",
+        help="String to attribute the changes in the commit message. Defaults to csv report name",
+        required=False,
+        default=None,
+        dest="source_id",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         help="Logging verbosity",
@@ -112,10 +119,11 @@ def main(args):
         args.splunk_creds, args.splunk_app, args.csv_report, args.criteria_filter
     )
     extra_message = get_extra_message(report["search"])
+    config_source = args.source_id or args.csv_report
 
     results = get_recommendations_by_service_file(report["results"])
     updater = AutoConfigUpdater(
-        config_source=args.csv_report,
+        config_source=config_source,
         git_remote=args.git_remote,
         branch=args.branch,
         working_dir=args.local_dir or "/nail/tmp",

--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -23,7 +23,7 @@ from paasta_tools.deployd.common import get_marathon_clients_from_config
 from paasta_tools.deployd.common import get_service_instances_needing_update
 from paasta_tools.deployd.common import PaastaThread
 from paasta_tools.deployd.common import ServiceInstance
-from paasta_tools.long_running_service_tools import AUTOSCALING_ZK_ROOT
+from paasta_tools.marathon_tools import AUTOSCALING_ZK_ROOT
 from paasta_tools.marathon_tools import DEFAULT_SOA_DIR
 from paasta_tools.marathon_tools import deformat_job_id
 from paasta_tools.marathon_tools import get_marathon_apps_with_clients

--- a/paasta_tools/instance/hpa_metrics_parser.py
+++ b/paasta_tools/instance/hpa_metrics_parser.py
@@ -1,4 +1,4 @@
-class HPAMetricsParser():
+class HPAMetricsParser:
     def __init__(self, hpa):
         self.NAME = "name"
         self.TARGET = "target_value"
@@ -9,15 +9,16 @@ class HPAMetricsParser():
         Parse target metrics.
         """
         metric_spec = getattr(metric, metric.type.lower())
+        print(metric_spec)
         status = {}
         switchers = {
-            'Pods': self.parse_pod_metric,
-            'External': self.parse_external_metric,
-            'Resource': self.parse_resource_metric,
+            "Pods": self.parse_pod_metric,
+            "External": self.parse_external_metric,
+            "Resource": self.parse_resource_metric,
         }
         switchers[metric.type](metric_spec, status)
+        status[self.TARGET] = str(status[self.TARGET]) if status[self.TARGET] else "N/A"
         return status
-
 
     def parse_current(self, metric):
         """
@@ -27,21 +28,32 @@ class HPAMetricsParser():
         status = {}
         status[self.NAME] = metric_spec.metric_name
         switchers = {
-            'Pods': self.parse_pod_metric_current,
-            'External': self.parse_external_metric_current,
-            'Resource': self.parse_resource_metric_current,
+            "Pods": self.parse_pod_metric_current,
+            "External": self.parse_external_metric_current,
+            "Resource": self.parse_resource_metric_current,
         }
         switchers[metric.type](metric_spec, status)
+        status[self.CURRENT] = (
+            str(status[self.CURRENT]) if status[self.CURRENT] else "N/A"
+        )
         return status
 
-    #External metrics
+    # External metrics
     def parse_external_metric(self, metric_spec, status):
         status[self.NAME] = metric_spec.metric_name
-        status[self.TARGET] = metric_spec.target_average_value if hasattr(metric_spec, "target_average_value") else metric_spec.target_value
+        status[self.TARGET] = (
+            metric_spec.target_average_value
+            if getattr(metric_spec, "target_average_value")
+            else metric_spec.target_value
+        )
 
     def parse_external_metric_current(self, metric_spec, status):
         status[self.NAME] = metric_spec.metric_name
-        status[self.CURRENT] =metric_spec.current_average_value if hasattr(metric_spec, "current_average_value") else metric_spec.current_value
+        status[self.CURRENT] = (
+            metric_spec.current_average_value
+            if getattr(metric_spec, "current_average_value")
+            else metric_spec.current_value
+        )
 
     # Pod metrics
     def parse_pod_metric(self, metric_spec, status):
@@ -55,8 +67,16 @@ class HPAMetricsParser():
     # Resource metrics
     def parse_resource_metric(self, metric_spec, status):
         status[self.NAME] = metric_spec.name
-        status[self.TARGET] = metric_spec.target_average_value if hasattr(metric_spec, "target_average_value") else metric_spec.target_average_utilization
+        status[self.TARGET] = (
+            metric_spec.target_average_value
+            if getattr(metric_spec, "target_average_value")
+            else metric_spec.target_average_utilization
+        )
 
     def parse_resource_metric_current(self, metric_spec, status):
         status[self.NAME] = metric_spec.name
-        status[self.CURRENT] =metric_spec.current_average_value if hasattr(metric_spec, "current_average_value") else metric_spec.current_average_utilization
+        status[self.CURRENT] = (
+            metric_spec.current_average_value
+            if getattr(metric_spec, "current_average_value")
+            else metric_spec.current_average_utilization
+        )

--- a/paasta_tools/instance/hpa_metrics_parser.py
+++ b/paasta_tools/instance/hpa_metrics_parser.py
@@ -1,0 +1,62 @@
+class HPAMetricsParser():
+    def __init__(self, hpa):
+        self.NAME = "name"
+        self.TARGET = "target_value"
+        self.CURRENT = "current_value"
+
+    def parse_target(self, metric):
+        """
+        Parse target metrics.
+        """
+        metric_spec = getattr(metric, metric.type.lower())
+        status = {}
+        switchers = {
+            'Pods': self.parse_pod_metric,
+            'External': self.parse_external_metric,
+            'Resource': self.parse_resource_metric,
+        }
+        switchers[metric.type](metric_spec, status)
+        return status
+
+
+    def parse_current(self, metric):
+        """
+        Parse current metrics
+        """
+        metric_spec = getattr(metric, metric.type)
+        status = {}
+        status[self.NAME] = metric_spec.metric_name
+        switchers = {
+            'Pods': self.parse_pod_metric_current,
+            'External': self.parse_external_metric_current,
+            'Resource': self.parse_resource_metric_current,
+        }
+        switchers[metric.type](metric_spec, status)
+        return status
+
+    #External metrics
+    def parse_external_metric(self, metric_spec, status):
+        status[self.NAME] = metric_spec.metric_name
+        status[self.TARGET] = metric_spec.target_average_value if hasattr(metric_spec, "target_average_value") else metric_spec.target_value
+
+    def parse_external_metric_current(self, metric_spec, status):
+        status[self.NAME] = metric_spec.metric_name
+        status[self.CURRENT] =metric_spec.current_average_value if hasattr(metric_spec, "current_average_value") else metric_spec.current_value
+
+    # Pod metrics
+    def parse_pod_metric(self, metric_spec, status):
+        status[self.NAME] = metric_spec.metric_name
+        status[self.TARGET] = metric_spec.target_average_value
+
+    def parse_pod_metric_current(self, metric_spec, status):
+        status[self.NAME] = metric_spec.metric_name
+        status[self.CURRENT] = metric_spec.current_value
+
+    # Resource metrics
+    def parse_resource_metric(self, metric_spec, status):
+        status[self.NAME] = metric_spec.name
+        status[self.TARGET] = metric_spec.target_average_value if hasattr(metric_spec, "target_average_value") else metric_spec.target_average_utilization
+
+    def parse_resource_metric_current(self, metric_spec, status):
+        status[self.NAME] = metric_spec.name
+        status[self.CURRENT] =metric_spec.current_average_value if hasattr(metric_spec, "current_average_value") else metric_spec.current_average_utilization

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -5,6 +5,7 @@ from typing import MutableMapping
 from typing import Sequence
 
 import a_sync
+import pytz
 from kubernetes.client import V1Pod
 from kubernetes.client import V1ReplicaSet
 from kubernetes.client.rest import ApiException
@@ -16,6 +17,7 @@ from paasta_tools import kubernetes_tools
 from paasta_tools import marathon_tools
 from paasta_tools import smartstack_tools
 from paasta_tools.cli.utils import LONG_RUNNING_INSTANCE_TYPE_HANDLERS
+from paasta_tools.instance.hpa_metrics_parser import HPAMetricsParser
 from paasta_tools.kubernetes_tools import get_tail_lines_for_kubernetes_container
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
@@ -71,6 +73,44 @@ def set_cr_desired_state(
             f"{service}.{instance}: {e}"
         )
         raise RuntimeError(error_message)
+
+
+def autoscaling_status(
+    kube_client: kubernetes_tools.KubeClient,
+    job_config: LongRunningServiceConfig,
+    namespace: str,
+):
+    status = {}
+    try:
+        hpa = kube_client.autoscaling.read_namespaced_horizontal_pod_autoscaler(
+            name=job_config.get_sanitised_deployment_name(), namespace=namespace
+        )
+        status["min_instances"] = hpa.spec.min_replicas
+        status["max_instances"] = hpa.spec.max_replicas
+        # Parse metrics sources, based on
+        # https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V2beta1ExternalMetricSource.md#v2beta1externalmetricsource
+        metric_stats = []
+        parser = HPAMetricsParser(hpa)
+        if hpa.spec.metrics is not None:
+            for metric_spec in hpa.spec.metrics:
+                metric_stats.append(parser.parse_target(metric_spec))
+        if hpa.status.current_metrics is not None:
+            for metric_spec in hpa.status.current_metrics:
+                metric_stats.append(parser.parse_current(metric_spec))
+        status["metrics"] = metric_stats
+        status["desired_replicas"] = hpa.status.desired_replicas
+        status["last_scale_time"] = (
+            hpa.status.last_scale_time.replace(tzinfo=pytz.UTC).isoformat()
+            if getattr(hpa.status, "last_scale_time")
+            else "N/A"
+        )
+    except ApiException as e:
+        if e.status == 404:
+            # This means that HPA doesn't exist. Return nothing.
+            return {}
+        error_message = f"Error while reading autoscaling information: {e}"
+        raise RuntimeError(error_message)
+    return status
 
 
 @a_sync.to_blocking
@@ -282,6 +322,10 @@ def kubernetes_status(
         verbose=verbose,
         pod_list=pod_list,
         replicaset_list=replicaset_list,
+    )
+
+    kstatus["autoscaling_status"] = autoscaling_status(
+        kube_client, job_config, job_config.get_kubernetes_namespace()
     )
 
     evicted_count = 0

--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -267,6 +267,7 @@ class DeploymentWrapper(Application):
             )
             # with bespoke autoscaler, setup_kubernetes_job sets the number of instances directly; no HPA is required.
             and self.soa_config.get_autoscaling_params()["decision_policy"] != "bespoke"
+            and self.soa_config.get_desired_state() != "stop"
         )
 
     def sync_horizontal_pod_autoscaler(self, kube_client: KubeClient) -> None:

--- a/paasta_tools/kubernetes/application/tools.py
+++ b/paasta_tools/kubernetes/application/tools.py
@@ -10,7 +10,6 @@ from paasta_tools.kubernetes.application.controller_wrappers import DeploymentWr
 from paasta_tools.kubernetes.application.controller_wrappers import StatefulSetWrapper
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import paasta_prefixed
-from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
 
 log = logging.getLogger(__name__)
 
@@ -74,7 +73,3 @@ def list_namespaced_applications(
         elif application_type == V1StatefulSet:
             apps.extend(list_namespaced_stateful_sets(kube_client, namespace))
     return apps
-
-
-def get_app_name(service: str, instance: str):
-    return sanitise_kubernetes_name(f"{service}-{instance}")

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -944,7 +944,11 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             return None
 
     def set_autoscaled_instances(self, instance_count: int) -> None:
-        raise NotImplementedError()
+        """Set the number of instances in the same way that the autoscaler does."""
+        kube_client = KubeClient()
+        set_instances_for_kubernetes_service(kube_client=kube_client,
+                                             service_config=self,
+                                             instance_count=instance_count)
 
     def get_desired_instances(self) -> int:
         """ For now if we have an EBS instance it means we can only have 1 instance

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -150,8 +150,6 @@ DISCOVERY_ATTRIBUTES = {"region", "superregion", "ecosystem", "habitat"}
 # For detail, https://github.com/kubernetes-client/python/issues/553
 # This hack should be removed when the issue got fixed.
 # This is no better way to work around rn.
-
-
 class MonkeyPatchAutoScalingConditions(V2beta1HorizontalPodAutoscalerStatus):
     @property
     def conditions(self) -> Sequence[V2beta1HorizontalPodAutoscalerCondition]:
@@ -461,7 +459,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     )
                     annotations[
                         f"signalfx.com.external.metric/{metric_name}"
-                    ] = f'data("{metric_name}", filter={filters}).mean(by="paasta_yelp_com_instance").mean(over="15m").publish()'
+                    ] = f'data("{metric_name}", filter={filters}).mean(by="paasta_instance").mean(over="15m").publish()'
             else:
                 metrics.append(
                     V2beta1MetricSpec(
@@ -1803,6 +1801,10 @@ def get_kubernetes_app_by_name(
     name: str, kube_client: KubeClient, namespace: str = "paasta"
 ) -> Union[V1Deployment, V1StatefulSet]:
     try:
+        print("==666666666666666666666666666666666")
+        print(name)
+        print(namespace)
+        print("==666666666666666666666666666666666")
         app = kube_client.deployments.read_namespaced_deployment_status(
             name=name, namespace=namespace
         )

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -317,6 +317,26 @@ class InvalidKubernetesConfig(Exception):
         )
 
 
+class KubeClient:
+    def __init__(self) -> None:
+        kube_config.load_kube_config(
+            config_file=os.environ.get("KUBECONFIG", KUBE_CONFIG_PATH),
+            context=os.environ.get("KUBECONTEXT"),
+        )
+        models.V1beta1PodDisruptionBudgetStatus.disrupted_pods = property(
+            fget=lambda *args, **kwargs: models.V1beta1PodDisruptionBudgetStatus.disrupted_pods(
+                *args, **kwargs
+            ),
+            fset=_set_disrupted_pods,
+        )
+        self.deployments = kube_client.AppsV1Api()
+        self.core = kube_client.CoreV1Api()
+        self.policy = kube_client.PolicyV1beta1Api()
+        self.apiextensions = kube_client.ApiextensionsV1beta1Api()
+        self.custom = kube_client.CustomObjectsApi()
+        self.autoscaling = kube_client.AutoscalingV2beta1Api()
+
+
 class KubernetesDeploymentConfig(LongRunningServiceConfig):
     config_dict: KubernetesDeploymentConfigDict
 
@@ -925,15 +945,24 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
     def get_sanitised_instance_name(self) -> str:
         return sanitise_kubernetes_name(self.get_instance())
 
-    def get_autoscaled_instances(self) -> int:
+    def get_autoscaled_instances(self) -> Optional[int]:
         try:
-            return (
-                KubeClient()
-                .deployments.read_namespaced_deployment(
-                    name=self.get_sanitised_deployment_name(), namespace="paasta"
+            if self.get_persistent_volumes():
+                return (
+                    KubeClient()
+                    .deployments.read_namespaced_stateful_set(
+                        name=self.get_sanitised_deployment_name(), namespace="paasta"
+                    )
+                    .spec.replicas
                 )
-                .spec.replicas
-            )
+            else:
+                return (
+                    KubeClient()
+                    .deployments.read_namespaced_deployment(
+                        name=self.get_sanitised_deployment_name(), namespace="paasta"
+                    )
+                    .spec.replicas
+                )
         except ApiException as e:
             log.error(e)
             log.debug(
@@ -943,12 +972,13 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             )
             return None
 
-    def set_autoscaled_instances(self, instance_count: int) -> None:
+    def set_autoscaled_instances(
+        self, instance_count: int, kube_client: KubeClient
+    ) -> None:
         """Set the number of instances in the same way that the autoscaler does."""
-        kube_client = KubeClient()
-        set_instances_for_kubernetes_service(kube_client=kube_client,
-                                             service_config=self,
-                                             instance_count=instance_count)
+        set_instances_for_kubernetes_service(
+            kube_client=kube_client, service_config=self, instance_count=instance_count
+        )
 
     def get_desired_instances(self) -> int:
         """ For now if we have an EBS instance it means we can only have 1 instance
@@ -1336,26 +1366,6 @@ def get_kubernetes_services_running_here_for_nerve(
     return nerve_list
 
 
-class KubeClient:
-    def __init__(self) -> None:
-        kube_config.load_kube_config(
-            config_file=os.environ.get("KUBECONFIG", KUBE_CONFIG_PATH),
-            context=os.environ.get("KUBECONTEXT"),
-        )
-        models.V1beta1PodDisruptionBudgetStatus.disrupted_pods = property(
-            fget=lambda *args, **kwargs: models.V1beta1PodDisruptionBudgetStatus.disrupted_pods(
-                *args, **kwargs
-            ),
-            fset=_set_disrupted_pods,
-        )
-        self.deployments = kube_client.AppsV1Api()
-        self.core = kube_client.CoreV1Api()
-        self.policy = kube_client.PolicyV1beta1Api()
-        self.apiextensions = kube_client.ApiextensionsV1beta1Api()
-        self.custom = kube_client.CustomObjectsApi()
-        self.autoscaling = kube_client.AutoscalingV2beta1Api()
-
-
 def force_delete_pods(
     service: str,
     paasta_service: str,
@@ -1604,15 +1614,21 @@ def create_pod_disruption_budget(
 
 
 def set_instances_for_kubernetes_service(
-    kube_client: KubeClient, service_config: KubernetesDeploymentConfig, instance_count: int
+    kube_client: KubeClient,
+    service_config: KubernetesDeploymentConfig,
+    instance_count: int,
 ) -> None:
-    deployment_name = service_config.get_sanitised_deployment_name()
-    scale_deployment_body = service_config.format_kubernetes_app()
-    scale_deployment_body.spec.replicas = instance_count
-
-    kube_client.deployments.patch_namespaced_deployment_scale(name=deployment_name,
-                                                              namespace="paasta",
-                                                              body=scale_deployment_body)
+    name = service_config.get_sanitised_deployment_name()
+    formatted_application = service_config.format_kubernetes_app()
+    formatted_application.spec.replicas = instance_count
+    if service_config.get_persistent_volumes():
+        kube_client.deployments.patch_namespaced_stateful_set_scale(
+            name=name, namespace="paasta", body=formatted_application
+        )
+    else:
+        kube_client.deployments.patch_namespaced_deployment_scale(
+            name=name, namespace="paasta", body=formatted_application
+        )
 
 
 def list_all_deployments(kube_client: KubeClient) -> Sequence[KubeDeployment]:

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1016,10 +1016,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
     def get_kubernetes_metadata(self, git_sha: str) -> V1ObjectMeta:
         return V1ObjectMeta(
-            name="{service}-{instance}".format(
-                service=self.get_sanitised_service_name(),
-                instance=self.get_sanitised_instance_name(),
-            ),
+            name=self.get_sanitised_deployment_name(),
             labels={
                 "yelp.com/paasta_service": self.get_service(),
                 "yelp.com/paasta_instance": self.get_instance(),
@@ -1031,10 +1028,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         )
 
     def get_sanitised_deployment_name(self) -> str:
-        return "{service}-{instance}".format(
-            service=self.get_sanitised_service_name(),
-            instance=self.get_sanitised_instance_name(),
-        )
+        return get_kubernetes_app_name(self.get_service(), self.get_instance())
 
     def get_min_task_uptime(self) -> int:
         return self.config_dict.get("bounce_health_params", {}).get(
@@ -1062,10 +1056,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     kind="StatefulSet",
                     metadata=self.get_kubernetes_metadata(git_sha),
                     spec=V1StatefulSetSpec(
-                        service_name="{service}-{instance}".format(
-                            service=self.get_sanitised_service_name(),
-                            instance=self.get_sanitised_instance_name(),
-                        ),
+                        service_name=self.get_sanitised_deployment_name(),
                         volume_claim_templates=self.get_volume_claim_templates(),
                         replicas=self.get_desired_instances(),
                         revision_history_limit=0,
@@ -1592,7 +1583,9 @@ def pod_disruption_budget_for_service_instance(
     service: str, instance: str, max_unavailable: Union[str, int],
 ) -> V1beta1PodDisruptionBudget:
     return V1beta1PodDisruptionBudget(
-        metadata=V1ObjectMeta(name=f"{service}-{instance}", namespace="paasta"),
+        metadata=V1ObjectMeta(
+            name=get_kubernetes_app_name(service, instance), namespace="paasta",
+        ),
         spec=V1beta1PodDisruptionBudgetSpec(
             max_unavailable=max_unavailable,
             selector=V1LabelSelector(
@@ -1797,6 +1790,13 @@ def get_nodes_grouped_by_attribute(
         )
         if key
     }
+
+
+def get_kubernetes_app_name(service: str, instance: str) -> str:
+    return "{service}-{instance}".format(
+        service=sanitise_kubernetes_name(service),
+        instance=sanitise_kubernetes_name(instance),
+    )
 
 
 def get_kubernetes_app_by_name(

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1599,6 +1599,18 @@ def create_pod_disruption_budget(
     )
 
 
+def set_instances_for_kubernetes_service(
+    kube_client: KubeClient, service_config: KubernetesDeploymentConfig, instance_count: int
+) -> None:
+    deployment_name = service_config.get_sanitised_deployment_name()
+    scale_deployment_body = service_config.format_kubernetes_app()
+    scale_deployment_body.spec.replicas = instance_count
+
+    kube_client.deployments.patch_namespaced_deployment_scale(name=deployment_name,
+                                                              namespace="paasta",
+                                                              body=scale_deployment_body)
+
+
 def list_all_deployments(kube_client: KubeClient) -> Sequence[KubeDeployment]:
     return list_deployments(kube_client)
 

--- a/paasta_tools/list_kubernetes_service_instances.py
+++ b/paasta_tools/list_kubernetes_service_instances.py
@@ -29,6 +29,7 @@ Command line options:
 import argparse
 import sys
 
+from paasta_tools import kubernetes_tools
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_services_for_cluster
@@ -55,6 +56,14 @@ def parse_args():
         default=DEFAULT_SOA_DIR,
         help="define a different soa config directory",
     )
+    parser.add_argument(
+        "--sanitise",
+        action="store_true",
+        help=(
+            "Whether or not to sanitise service instance names before displaying "
+            "them. Kubernets apps created by PaaSTA use sanitised names."
+        ),
+    )
     args = parser.parse_args()
     return args
 
@@ -68,7 +77,11 @@ def main():
     )
     service_instances = []
     for name, instance in instances:
-        service_instances.append(compose_job_id(name, instance))
+        if args.sanitise:
+            app_name = kubernetes_tools.get_kubernetes_app_name(name, instance)
+        else:
+            app_name = compose_job_id(name, instance)
+        service_instances.append(app_name)
     paasta_print("\n".join(service_instances))
     sys.exit(0)
 

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -20,6 +20,7 @@ from paasta_tools.utils import InstanceConfigDict
 from paasta_tools.utils import InvalidInstanceConfig
 from paasta_tools.utils import InvalidJobNameError
 
+
 log = logging.getLogger(__name__)
 logging.getLogger("marathon").setLevel(logging.WARNING)
 

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -20,7 +20,6 @@ from paasta_tools.utils import InstanceConfigDict
 from paasta_tools.utils import InvalidInstanceConfig
 from paasta_tools.utils import InvalidJobNameError
 
-
 log = logging.getLogger(__name__)
 logging.getLogger("marathon").setLevel(logging.WARNING)
 

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -7,7 +7,6 @@ from typing import Optional
 from typing import Tuple
 
 import service_configuration_lib
-from kazoo.exceptions import NoNodeError
 from mypy_extensions import TypedDict
 
 from paasta_tools.utils import BranchDictV2
@@ -20,12 +19,10 @@ from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import InstanceConfigDict
 from paasta_tools.utils import InvalidInstanceConfig
 from paasta_tools.utils import InvalidJobNameError
-from paasta_tools.utils import ZookeeperPool
 
 log = logging.getLogger(__name__)
 logging.getLogger("marathon").setLevel(logging.WARNING)
 
-AUTOSCALING_ZK_ROOT = "/autoscaling"
 ZK_PAUSE_AUTOSCALE_PATH = "/autoscaling/paused"
 DEFAULT_CONTAINER_PORT = 8888
 
@@ -245,21 +242,10 @@ class LongRunningServiceConfig(InstanceConfig):
         return self.config_dict.get("bounce_start_deadline", 0)
 
     def get_autoscaled_instances(self) -> int:
-        try:
-            zk_instances = get_instances_from_zookeeper(
-                service=self.service, instance=self.instance
-            )
-            log.debug("Got %d instances out of zookeeper" % zk_instances)
-            return zk_instances
-        except NoNodeError:
-            log.debug("No zookeeper data, returning None")
-            return None
+        raise NotImplementedError()
 
     def set_autoscaled_instances(self, instance_count: int) -> None:
-        """Set the number of instances in the same way that the autoscaler does."""
-        set_instances_for_marathon_service(
-            service=self.service, instance=self.instance, instance_count=instance_count,
-        )
+        raise NotImplementedError()
 
     def get_instances(self, with_limit: bool = True) -> int:
         """Gets the number of instances for a service, ignoring whether the user has requested
@@ -437,29 +423,6 @@ def load_service_namespace_config(
 
 class InvalidSmartstackMode(Exception):
     pass
-
-
-def get_instances_from_zookeeper(service: str, instance: str) -> int:
-    with ZookeeperPool() as zookeeper_client:
-        (instances, _) = zookeeper_client.get(
-            "%s/instances" % compose_autoscaling_zookeeper_root(service, instance)
-        )
-        return int(instances)
-
-
-def compose_autoscaling_zookeeper_root(service: str, instance: str) -> str:
-    return f"{AUTOSCALING_ZK_ROOT}/{service}/{instance}"
-
-
-def set_instances_for_marathon_service(
-    service: str, instance: str, instance_count: int, soa_dir: str = DEFAULT_SOA_DIR
-) -> None:
-    zookeeper_path = "%s/instances" % compose_autoscaling_zookeeper_root(
-        service, instance
-    )
-    with ZookeeperPool() as zookeeper_client:
-        zookeeper_client.ensure_path(zookeeper_path)
-        zookeeper_client.set(zookeeper_path, str(instance_count).encode("utf8"))
 
 
 def get_proxy_port_for_instance(

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -244,9 +244,6 @@ class LongRunningServiceConfig(InstanceConfig):
     def get_autoscaled_instances(self) -> int:
         raise NotImplementedError()
 
-    def set_autoscaled_instances(self, instance_count: int) -> None:
-        raise NotImplementedError()
-
     def get_instances(self, with_limit: bool = True) -> int:
         """Gets the number of instances for a service, ignoring whether the user has requested
         the service to be started or stopped"""

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -41,6 +41,7 @@ from typing import TypeVar
 import pytz
 import requests
 import service_configuration_lib
+from kazoo.exceptions import NoNodeError
 from marathon import MarathonClient
 from marathon import MarathonHttpError
 from marathon import NotFoundError
@@ -83,6 +84,8 @@ from paasta_tools.utils import paasta_print
 from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import time_cache
+from paasta_tools.utils import ZookeeperPool
+
 
 # Marathon creates Mesos tasks with an id composed of the app's full name, a
 # spacer, and a UUID. This variable is that spacer. Note that we don't control
@@ -90,6 +93,7 @@ from paasta_tools.utils import time_cache
 # with you. We need to know what it is so we can decompose Mesos task ids.
 MESOS_TASK_SPACER = "."
 PUPPET_SERVICE_DIR = "/etc/nerve/puppet_services.d"
+AUTOSCALING_ZK_ROOT = "/autoscaling"
 
 
 # A set of config attributes that don't get included in the hash of the config.
@@ -886,6 +890,23 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         Useful for graceful shard migrations. Defaults to None"""
         return self.config_dict.get("previous_marathon_shards", None)
 
+    def get_autoscaled_instances(self) -> int:
+        try:
+            zk_instances = get_instances_from_zookeeper(
+                service=self.service, instance=self.instance
+            )
+            log.debug("Got %d instances out of zookeeper" % zk_instances)
+            return zk_instances
+        except NoNodeError:
+            log.debug("No zookeeper data, returning None")
+            return None
+
+    def set_autoscaled_instances(self, instance_count: int) -> None:
+        """Set the number of instances in the same way that the autoscaler does."""
+        set_instances_for_marathon_service(
+            service=self.service, instance=self.instance, instance_count=instance_count,
+        )
+
 
 class MarathonDeployStatus:
     """ An enum to represent Marathon app deploy status.
@@ -1603,3 +1624,26 @@ def take_up_slack(client: MarathonClient, app: MarathonApp) -> None:
 def get_short_task_id(task_id: str) -> str:
     """Return just the Marathon-generated UUID of a Mesos task id."""
     return task_id.split(MESOS_TASK_SPACER)[-1]
+
+
+def get_instances_from_zookeeper(service: str, instance: str) -> int:
+    with ZookeeperPool() as zookeeper_client:
+        (instances, _) = zookeeper_client.get(
+            "%s/instances" % compose_autoscaling_zookeeper_root(service, instance)
+        )
+        return int(instances)
+
+
+def compose_autoscaling_zookeeper_root(service: str, instance: str) -> str:
+    return f"{AUTOSCALING_ZK_ROOT}/{service}/{instance}"
+
+
+def set_instances_for_marathon_service(
+    service: str, instance: str, instance_count: int, soa_dir: str = DEFAULT_SOA_DIR
+) -> None:
+    zookeeper_path = "%s/instances" % compose_autoscaling_zookeeper_root(
+        service, instance
+    )
+    with ZookeeperPool() as zookeeper_client:
+        zookeeper_client.ensure_path(zookeeper_path)
+        zookeeper_client.set(zookeeper_path, str(instance_count).encode("utf8"))

--- a/paasta_tools/metrics/metastatus_lib.py
+++ b/paasta_tools/metrics/metastatus_lib.py
@@ -15,6 +15,7 @@
 import copy
 import itertools
 import math
+import re
 from collections import Counter
 from collections import namedtuple
 from collections import OrderedDict
@@ -659,6 +660,11 @@ def calculate_resource_utilization_for_slaves(
 
 
 _IEC_NUMBER_SUFFIXES = {
+    "k": 1000,
+    "M": 1000 ** 2,
+    "G": 1000 ** 3,
+    "T": 1000 ** 4,
+    "P": 1000 ** 5,
     "Ki": 1024,
     "Mi": 1024 ** 2,
     "Gi": 1024 ** 3,
@@ -668,11 +674,14 @@ _IEC_NUMBER_SUFFIXES = {
 
 
 def suffixed_number_value(s: str) -> int:
-    suff = s[-2:]
+    pattern = r"(?P<number>\d+)(?P<suff>\w*)"
+    match = re.match(pattern, s)
+    number, suff = match.groups()
+
     if suff in _IEC_NUMBER_SUFFIXES:
-        return int(s[:-2]) * _IEC_NUMBER_SUFFIXES[suff]
+        return int(number) * _IEC_NUMBER_SUFFIXES[suff]
     else:
-        return int(s)
+        return int(number)
 
 
 def suffixed_number_dict_values(d: Mapping[Any, str]) -> Mapping[Any, int]:

--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -27,12 +27,10 @@ from typing import Optional
 from typing import Sequence
 from typing import Tuple
 
-from kubernetes.client import V1Deployment
-from kubernetes.client import V1StatefulSet
-
 from paasta_tools.kubernetes.application.controller_wrappers import Application
-from paasta_tools.kubernetes.application.controller_wrappers import DeploymentWrapper
-from paasta_tools.kubernetes.application.controller_wrappers import StatefulSetWrapper
+from paasta_tools.kubernetes.application.controller_wrappers import (
+    get_application_wrapper,
+)
 from paasta_tools.kubernetes_tools import ensure_namespace
 from paasta_tools.kubernetes_tools import InvalidKubernetesConfig
 from paasta_tools.kubernetes_tools import KubeClient
@@ -179,14 +177,7 @@ def create_application_object(
         log.error(str(e))
         return False, None
 
-    app: Optional[Application] = None
-    if isinstance(formatted_application, V1Deployment):
-        app = DeploymentWrapper(formatted_application)
-    elif isinstance(formatted_application, V1StatefulSet):
-        app = StatefulSetWrapper(formatted_application)
-    else:
-        raise Exception("Unknown kubernetes object to update")
-
+    app = get_application_wrapper(formatted_application)
     app.load_local_config(soa_dir, cluster)
     return True, app
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1920,8 +1920,7 @@ class SystemPaastaConfig:
         :returns: The name of the cluster defined in the paasta configuration
         """
         try:
-            # return self.config_dict["cluster"]
-            return 'kubestage'
+            return self.config_dict["cluster"]
         except KeyError:
             raise PaastaNotConfiguredError(
                 "Could not find cluster in configuration directory: %s" % self.directory

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1920,7 +1920,8 @@ class SystemPaastaConfig:
         :returns: The name of the cluster defined in the paasta configuration
         """
         try:
-            return self.config_dict["cluster"]
+            # return self.config_dict["cluster"]
+            return 'kubestage'
         except KeyError:
             raise PaastaNotConfiguredError(
                 "Could not find cluster in configuration directory: %s" % self.directory

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2997,7 +2997,12 @@ def load_deployments_json(
     deployment_file = os.path.join(soa_dir, service, "deployments.json")
     if os.path.isfile(deployment_file):
         with open(deployment_file) as f:
-            return DeploymentsJsonV1(json.load(f)["v1"])
+            config_dict = json.load(f)
+            return (
+                DeploymentsJsonV1(config_dict["v1"])
+                if "v1" in config_dict
+                else DeploymentsJsonV2(service=service, config_dict=config_dict["v2"])
+            )
     else:
         e = f"{deployment_file} was not found. 'generate_deployments_for_service --service {service}' must be run first"
         raise NoDeploymentsAvailable(e)

--- a/tests/api/test_autoscaler.py
+++ b/tests/api/test_autoscaler.py
@@ -23,7 +23,7 @@ def test_get_autoscaler_count(mock_get_service_config, mock_get_instance_type):
     request = testing.DummyRequest()
     request.swagger_data = {"service": "fake_service", "instance": "fake_instance"}
 
-    mock_get_instance_type.return_value = 'kubernetes'
+    mock_get_instance_type.return_value = "kubernetes"
     mock_get_service_config.return_value = mock.MagicMock(
         get_instances=mock.MagicMock(return_value=123)
     )
@@ -34,7 +34,9 @@ def test_get_autoscaler_count(mock_get_service_config, mock_get_instance_type):
 
 @mock.patch("paasta_tools.api.views.autoscaler.get_instance_type", autospec=True)
 @mock.patch("paasta_tools.api.views.autoscaler.get_service_config", autospec=True)
-def test_update_autoscaler_count_marathon(mock_get_service_config, mock_get_instance_type):
+def test_update_autoscaler_count_marathon(
+    mock_get_service_config, mock_get_instance_type
+):
     request = testing.DummyRequest()
     request.swagger_data = {
         "service": "fake_marathon_service",
@@ -42,7 +44,7 @@ def test_update_autoscaler_count_marathon(mock_get_service_config, mock_get_inst
         "json_body": {"desired_instances": 123},
     }
 
-    mock_get_instance_type.return_value = 'marathon'
+    mock_get_instance_type.return_value = "marathon"
     mock_get_service_config.return_value = mock.MagicMock(
         get_min_instances=mock.MagicMock(return_value=100),
         get_max_instances=mock.MagicMock(return_value=200),
@@ -55,7 +57,9 @@ def test_update_autoscaler_count_marathon(mock_get_service_config, mock_get_inst
 
 @mock.patch("paasta_tools.api.views.autoscaler.get_instance_type", autospec=True)
 @mock.patch("paasta_tools.api.views.autoscaler.get_service_config", autospec=True)
-def test_update_autoscaler_count_kubernetes(mock_get_service_config, mock_get_instance_type):
+def test_update_autoscaler_count_kubernetes(
+    mock_get_service_config, mock_get_instance_type
+):
     request = testing.DummyRequest()
     request.swagger_data = {
         "service": "fake_kubernetes_service",
@@ -63,7 +67,7 @@ def test_update_autoscaler_count_kubernetes(mock_get_service_config, mock_get_in
         "json_body": {"desired_instances": 155},
     }
 
-    mock_get_instance_type.return_value = 'kubernetes'
+    mock_get_instance_type.return_value = "kubernetes"
     mock_get_service_config.return_value = mock.MagicMock(
         get_min_instances=mock.MagicMock(return_value=100),
         get_max_instances=mock.MagicMock(return_value=200),
@@ -76,7 +80,9 @@ def test_update_autoscaler_count_kubernetes(mock_get_service_config, mock_get_in
 
 @mock.patch("paasta_tools.api.views.autoscaler.get_instance_type", autospec=True)
 @mock.patch("paasta_tools.api.views.autoscaler.get_service_config", autospec=True)
-def test_update_autoscaler_count_warning(mock_get_service_config, mock_get_instance_type):
+def test_update_autoscaler_count_warning(
+    mock_get_service_config, mock_get_instance_type
+):
     request = testing.DummyRequest()
     request.swagger_data = {
         "service": "fake_service",
@@ -84,7 +90,7 @@ def test_update_autoscaler_count_warning(mock_get_service_config, mock_get_insta
         "json_body": {"desired_instances": 123},
     }
 
-    mock_get_instance_type.return_value = 'kubernetes'
+    mock_get_instance_type.return_value = "kubernetes"
     mock_get_service_config.return_value = mock.MagicMock(
         get_min_instances=mock.MagicMock(return_value=10),
         get_max_instances=mock.MagicMock(return_value=100),

--- a/tests/api/test_autoscaler.py
+++ b/tests/api/test_autoscaler.py
@@ -17,58 +17,66 @@ from pyramid import testing
 from paasta_tools.api.views import autoscaler
 
 
-def test_get_autoscaler_count():
+@mock.patch("paasta_tools.api.views.autoscaler.get_instance_type", autospec=True)
+@mock.patch("paasta_tools.api.views.autoscaler.get_service_config", autospec=True)
+def test_get_autoscaler_count(mock_get_service_config, mock_get_instance_type):
     request = testing.DummyRequest()
     request.swagger_data = {"service": "fake_service", "instance": "fake_instance"}
 
-    with mock.patch(
-        "paasta_tools.api.views.autoscaler.load_marathon_service_config", autospec=True
-    ) as mock_load_marathon_service_config:
-        mock_load_marathon_service_config.return_value = mock.MagicMock(
-            get_instances=mock.MagicMock(return_value=123)
-        )
-        response = autoscaler.get_autoscaler_count(request)
-        assert response.json_body["desired_instances"] == 123
-        assert response.json_body["calculated_instances"] == 123
+    mock_get_instance_type.return_value = 'kubernetes'
+    mock_get_service_config.return_value = mock.MagicMock(
+        get_instances=mock.MagicMock(return_value=123)
+    )
+    response = autoscaler.get_autoscaler_count(request)
+    assert response.json_body["desired_instances"] == 123
+    assert response.json_body["calculated_instances"] == 123
 
 
-@mock.patch(
-    "paasta_tools.api.views.autoscaler.load_marathon_service_config", autospec=True
-)
-def test_update_autoscaler_count(mock_load_marathon_service_config):
+@mock.patch("paasta_tools.api.views.autoscaler.get_instance_type", autospec=True)
+@mock.patch("paasta_tools.api.views.autoscaler.get_service_config", autospec=True)
+def test_update_autoscaler_count_marathon(mock_get_service_config, mock_get_instance_type):
     request = testing.DummyRequest()
     request.swagger_data = {
-        "service": "fake_service",
-        "instance": "fake_instance",
+        "service": "fake_marathon_service",
+        "instance": "fake_marathon_instance",
         "json_body": {"desired_instances": 123},
     }
 
-    mock_load_marathon_service_config.return_value = mock.MagicMock(
+    mock_get_instance_type.return_value = 'marathon'
+    mock_get_service_config.return_value = mock.MagicMock(
         get_min_instances=mock.MagicMock(return_value=100),
         get_max_instances=mock.MagicMock(return_value=200),
     )
 
-    with mock.patch(
-        "paasta_tools.api.views.autoscaler.set_instances_for_marathon_service",
-        autospec=True,
-    ) as mock_set_instances:
-        response = autoscaler.update_autoscaler_count(request)
-        assert response.json_body["desired_instances"] == 123
-        mock_set_instances.assert_called_once_with(
-            service="fake_service", instance="fake_instance", instance_count=123
-        )
+    response = autoscaler.update_autoscaler_count(request)
+    assert response.json_body["desired_instances"] == 123
+    assert response.status_code == 202
 
 
-@mock.patch(
-    "paasta_tools.api.views.autoscaler.load_marathon_service_config", autospec=True
-)
-@mock.patch(
-    "paasta_tools.api.views.autoscaler.set_instances_for_marathon_service",
-    autospec=True,
-)
-def test_update_autoscaler_count_warning(
-    mock_set_instances_for_marathon_service, mock_load_marathon_service_config
-):
+@mock.patch("paasta_tools.api.views.autoscaler.get_instance_type", autospec=True)
+@mock.patch("paasta_tools.api.views.autoscaler.get_service_config", autospec=True)
+def test_update_autoscaler_count_kubernetes(mock_get_service_config, mock_get_instance_type):
+    request = testing.DummyRequest()
+    request.swagger_data = {
+        "service": "fake_kubernetes_service",
+        "instance": "fake__kubernetes_instance",
+        "json_body": {"desired_instances": 155},
+    }
+
+    mock_get_instance_type.return_value = 'kubernetes'
+    mock_get_service_config.return_value = mock.MagicMock(
+        get_min_instances=mock.MagicMock(return_value=100),
+        get_max_instances=mock.MagicMock(return_value=200),
+    )
+
+    response = autoscaler.update_autoscaler_count(request)
+    assert response.json_body["desired_instances"] == 155
+    assert response.status_code == 202
+
+
+@mock.patch("paasta_tools.api.views.autoscaler.get_instance_type", autospec=True)
+@mock.patch("paasta_tools.api.views.autoscaler.get_service_config", autospec=True)
+def test_update_autoscaler_count_warning(mock_get_service_config, mock_get_instance_type):
     request = testing.DummyRequest()
     request.swagger_data = {
         "service": "fake_service",
@@ -76,7 +84,8 @@ def test_update_autoscaler_count_warning(
         "json_body": {"desired_instances": 123},
     }
 
-    mock_load_marathon_service_config.return_value = mock.MagicMock(
+    mock_get_instance_type.return_value = 'kubernetes'
+    mock_get_service_config.return_value = mock.MagicMock(
         get_min_instances=mock.MagicMock(return_value=10),
         get_max_instances=mock.MagicMock(return_value=100),
     )

--- a/tests/cli/test_cmds_autoscale.py
+++ b/tests/cli/test_cmds_autoscale.py
@@ -17,12 +17,16 @@ from paasta_tools.cli.cmds.autoscale import paasta_autoscale
 
 
 @mock.patch("paasta_tools.cli.cmds.autoscale.figure_out_service_name", autospec=True)
-@mock.patch("paasta_tools.cli.cmds.autoscale.client.get_paasta_api_client", autospec=True)
+@mock.patch(
+    "paasta_tools.cli.cmds.autoscale.client.get_paasta_api_client", autospec=True
+)
 @mock.patch("paasta_tools.cli.cmds.autoscale._log_audit", autospec=True)
-def test_paasta_autoscale(mock__log_audit, mock_get_paasta_api_client, mock_figure_out_service_name):
-    service = 'fake_service'
-    instance = 'fake_instance'
-    cluster = 'fake_cluster'
+def test_paasta_autoscale(
+    mock__log_audit, mock_get_paasta_api_client, mock_figure_out_service_name
+):
+    service = "fake_service"
+    instance = "fake_instance"
+    cluster = "fake_cluster"
 
     mock_figure_out_service_name.return_value = service
     mock_get_paasta_api_client.return_value = mock.MagicMock()
@@ -35,8 +39,13 @@ def test_paasta_autoscale(mock__log_audit, mock_get_paasta_api_client, mock_figu
 
     fake_result = mock.MagicMock()
     fake_result.result.return_value = {"desired_instances": 14}, mock.Mock()
-    mock_get_paasta_api_client.return_value.autoscaler.update_autoscaler_count.return_value = fake_result
+    mock_get_paasta_api_client.return_value.autoscaler.update_autoscaler_count.return_value = (
+        fake_result
+    )
     mock__log_audit.return_value = None
 
     paasta_autoscale(args)
-    assert mock_get_paasta_api_client.return_value.autoscaler.update_autoscaler_count.call_count == 1
+    assert (
+        mock_get_paasta_api_client.return_value.autoscaler.update_autoscaler_count.call_count
+        == 1
+    )

--- a/tests/cli/test_cmds_autoscale.py
+++ b/tests/cli/test_cmds_autoscale.py
@@ -11,5 +11,32 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# from paasta_tools.cli.cmds import bespoke_autoscale
+import mock
+
+from paasta_tools.cli.cmds.autoscale import paasta_autoscale
+
+
+@mock.patch("paasta_tools.cli.cmds.autoscale.figure_out_service_name", autospec=True)
+@mock.patch("paasta_tools.cli.cmds.autoscale.client.get_paasta_api_client", autospec=True)
+@mock.patch("paasta_tools.cli.cmds.autoscale._log_audit", autospec=True)
+def test_paasta_autoscale(mock__log_audit, mock_get_paasta_api_client, mock_figure_out_service_name):
+    service = 'fake_service'
+    instance = 'fake_instance'
+    cluster = 'fake_cluster'
+
+    mock_figure_out_service_name.return_value = service
+    mock_get_paasta_api_client.return_value = mock.MagicMock()
+
+    args = mock.MagicMock()
+    args.service = service
+    args.clusters = cluster
+    args.instances = instance
+    args.set = 14
+
+    fake_result = mock.MagicMock()
+    fake_result.result.return_value = {"desired_instances": 14}, mock.Mock()
+    mock_get_paasta_api_client.return_value.autoscaler.update_autoscaler_count.return_value = fake_result
+    mock__log_audit.return_value = None
+
+    paasta_autoscale(args)
+    assert mock_get_paasta_api_client.return_value.autoscaler.update_autoscaler_count.call_count == 1

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -894,3 +894,16 @@ def test_reserved_maintenence_resources_ignores_non_maintenance():
         }
     )
     assert all([actual[x] == 5 for x in ["cpus", "mem", "disk"]])
+
+
+def test_suffixed_number_value():
+    assert metastatus_lib.suffixed_number_value("5k") == 5 * 1000
+    assert metastatus_lib.suffixed_number_value("5M") == 5 * 1000 ** 2
+    assert metastatus_lib.suffixed_number_value("5G") == 5 * 1000 ** 3
+    assert metastatus_lib.suffixed_number_value("5T") == 5 * 1000 ** 4
+    assert metastatus_lib.suffixed_number_value("5P") == 5 * 1000 ** 5
+    assert metastatus_lib.suffixed_number_value("5Ki") == 5 * 1024
+    assert metastatus_lib.suffixed_number_value("5Mi") == 5 * 1024 ** 2
+    assert metastatus_lib.suffixed_number_value("5Gi") == 5 * 1024 ** 3
+    assert metastatus_lib.suffixed_number_value("5Ti") == 5 * 1024 ** 4
+    assert metastatus_lib.suffixed_number_value("5Pi") == 5 * 1024 ** 5

--- a/tests/test_check_kubernetes_services_replication.py
+++ b/tests/test_check_kubernetes_services_replication.py
@@ -33,6 +33,7 @@ def instance_config():
         cluster="fake_cluster",
         soa_dir="fake_soa_dir",
         job_id=job_id,
+        config_dict={},
     )
     mock_instance_config.get_replication_crit_percentage.return_value = 90
     mock_instance_config.get_registrations.return_value = [job_id]

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1904,13 +1904,29 @@ def test_update_deployment():
 
 
 @mock.patch("paasta_tools.kubernetes_tools.KubernetesDeploymentConfig", autospec=True)
-def test_set_instances_for_kubernetes_service(mock_kube_deploy_config):
+def test_set_instances_for_kubernetes_service_deployment(mock_kube_deploy_config):
     replicas = 5
     mock_client = mock.Mock()
-    mock_kube_deploy_config.get_sanitised_deployment_name.return_value = 'fake_deployment'
+    mock_kube_deploy_config.get_sanitised_deployment_name.return_value = (
+        "fake_deployment"
+    )
+    mock_kube_deploy_config.get_persistent_volumes.return_value = False
     mock_kube_deploy_config.format_kubernetes_app.return_value = mock.Mock()
     set_instances_for_kubernetes_service(mock_client, mock_kube_deploy_config, replicas)
     assert mock_client.deployments.patch_namespaced_deployment_scale.call_count == 1
+
+
+@mock.patch("paasta_tools.kubernetes_tools.KubernetesDeploymentConfig", autospec=True)
+def test_set_instances_for_kubernetes_service_statefulset(mock_kube_deploy_config):
+    replicas = 5
+    mock_client = mock.Mock()
+    mock_kube_deploy_config.get_sanitised_deployment_name.return_value = (
+        "fake_stateful_set"
+    )
+    mock_kube_deploy_config.get_persistent_volumes.return_value = True
+    mock_kube_deploy_config.format_kubernetes_app.return_value = mock.Mock()
+    set_instances_for_kubernetes_service(mock_client, mock_kube_deploy_config, replicas)
+    assert mock_client.deployments.patch_namespaced_stateful_set_scale.call_count == 1
 
 
 def test_create_custom_resource():

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -94,6 +94,7 @@ from paasta_tools.kubernetes_tools import paasta_prefixed
 from paasta_tools.kubernetes_tools import pod_disruption_budget_for_service_instance
 from paasta_tools.kubernetes_tools import pods_for_service_instance
 from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
+from paasta_tools.kubernetes_tools import set_instances_for_kubernetes_service
 from paasta_tools.kubernetes_tools import update_custom_resource
 from paasta_tools.kubernetes_tools import update_deployment
 from paasta_tools.kubernetes_tools import update_kubernetes_secret_signature
@@ -1900,6 +1901,16 @@ def test_update_deployment():
     mock_client.deployments.create_namespaced_deployment.assert_called_with(
         namespace="paasta", body=V1Deployment(api_version="some")
     )
+
+
+@mock.patch("paasta_tools.kubernetes_tools.KubernetesDeploymentConfig", autospec=True)
+def test_set_instances_for_kubernetes_service(mock_kube_deploy_config):
+    replicas = 5
+    mock_client = mock.Mock()
+    mock_kube_deploy_config.get_sanitised_deployment_name.return_value = 'fake_deployment'
+    mock_kube_deploy_config.format_kubernetes_app.return_value = mock.Mock()
+    set_instances_for_kubernetes_service(mock_client, mock_kube_deploy_config, replicas)
+    assert mock_client.deployments.patch_namespaced_deployment_scale.call_count == 1
 
 
 def test_create_custom_resource():

--- a/tests/test_list_kubernetes_service_instances.py
+++ b/tests/test_list_kubernetes_service_instances.py
@@ -1,5 +1,5 @@
 import mock
-from pytest import raises
+import pytest
 
 from paasta_tools.list_kubernetes_service_instances import main
 from paasta_tools.list_kubernetes_service_instances import parse_args
@@ -13,22 +13,34 @@ def test_parse_args():
         assert parse_args() == mock_parser.return_value.parse_args()
 
 
-def test_main():
-    with mock.patch(
-        "paasta_tools.list_kubernetes_service_instances.parse_args", autospec=True
-    ) as mock_parse_args, mock.patch(
-        "paasta_tools.list_kubernetes_service_instances.get_services_for_cluster",
-        autospec=True,
-        return_value=[("service1", "instance1"), ("service2", "instance1")],
-    ) as mock_get_services_for_cluster, mock.patch(
-        "paasta_tools.list_kubernetes_service_instances.paasta_print", autospec=True
-    ) as mock_print:
-        with raises(SystemExit) as e:
-            main()
-        assert e.value.code == 0
-        mock_get_services_for_cluster.assert_called_with(
+@mock.patch("paasta_tools.list_kubernetes_service_instances.parse_args", autospec=True)
+@mock.patch(
+    "paasta_tools.list_kubernetes_service_instances.get_services_for_cluster",
+    autospec=True,
+    return_value=[("service_1", "instance1"), ("service_2", "instance1")],
+)
+@mock.patch(
+    "paasta_tools.list_kubernetes_service_instances.paasta_print", autospec=True
+)
+@pytest.mark.parametrize(
+    "sanitise,expected",
+    [
+        (False, "service_1.instance1\nservice_2.instance1"),
+        (True, "service--1-instance1\nservice--2-instance1"),
+    ],
+)
+def test_main(mock_print, mock_get_services, mock_parse_args, sanitise, expected):
+    mock_parse_args.return_value = mock.Mock(sanitise=sanitise)
+
+    with pytest.raises(SystemExit) as e:
+        main()
+
+    assert e.value.code == 0
+    assert mock_get_services.call_args_list == [
+        mock.call(
             cluster=mock_parse_args.return_value.cluster,
             instance_type="kubernetes",
             soa_dir=mock_parse_args.return_value.soa_dir,
         )
-        mock_print.assert_called_with("service1.instance1\nservice2.instance1")
+    ]
+    assert mock_print.call_args_list == [mock.call(expected)]

--- a/tests/test_setup_kubernetes_job.py
+++ b/tests/test_setup_kubernetes_job.py
@@ -82,9 +82,11 @@ def test_create_application_object():
         "paasta_tools.kubernetes.application.controller_wrappers.Application.load_local_config",
         autospec=True,
     ), mock.patch(
-        "paasta_tools.setup_kubernetes_job.DeploymentWrapper", autospec=True
+        "paasta_tools.kubernetes.application.controller_wrappers.DeploymentWrapper",
+        autospec=True,
     ) as mock_deployment_wrapper, mock.patch(
-        "paasta_tools.setup_kubernetes_job.StatefulSetWrapper", autospec=True
+        "paasta_tools.kubernetes.application.controller_wrappers.StatefulSetWrapper",
+        autospec=True,
     ) as mock_stateful_set_wrapper:
         mock_kube_client = mock.Mock()
         mock_deploy = mock.MagicMock(spec=V1Deployment)

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -88,9 +88,16 @@ class TestTronActionConfig:
         assert action_config.get_action_name() == "print"
         assert action_config.get_cluster() == "fake-cluster"
 
-    def test_get_spark_config_dict(self, spark_action_config):
+    @pytest.mark.parametrize(
+        "for_validation, mesos_leader_arg",
+        [(True, "N/A"), (False, "mesos.leader.com"),],
+    )
+    def test_get_spark_config_dict(
+        self, spark_action_config, for_validation, mesos_leader_arg
+    ):
         spark_action_config.config_dict["spark_cluster_manager"] = "mesos"
         spark_action_config.spark_ui_port = 12345
+        spark_action_config.for_validation = for_validation
         with mock.patch(
             "paasta_tools.tron_tools.get_mesos_spark_env",
             autospec=True,
@@ -110,7 +117,7 @@ class TestTronActionConfig:
             mock_get_mesos_spark_env.assert_called_once_with(
                 docker_img="",
                 event_log_dir="/nail/etc",
-                mesos_leader="mesos.leader.com",
+                mesos_leader=mesos_leader_arg,
                 paasta_cluster="fake-spark-cluster",
                 paasta_instance="cool_job.print",
                 paasta_pool="fake-spark-pool",

--- a/tox.ini
+++ b/tox.ini
@@ -79,29 +79,9 @@ commands =
     # Run paasta-tools k8s_itests in docker
     docker-compose down
     docker-compose --verbose build
-    docker-compose up
-
-[testenv:run_k8s_itest]
-basepython = python3.6
-whitelist_externals = bash
-deps =
-    {[testenv]deps}
-passenv =
-    KIND_CLUSTER
-    KUBECONFIG
-    KUBECONTEXT
-    PAASTA_SYSTEM_CONFIG_DIR
-    SOA_DIR
-    PAASTA_API_PORT
-    KUBE_RESOURCE_DIR
-    USER
-    PAASTA_CONFIG_DIR
-    DOCKER_TLS_VERIFY
-    DOCKER_HOST
-    DOCKER_CERT_PATH
-changedir=k8s_itests/
-commands =
-    pytest * -s
+    docker-compose up \
+        --abort-on-container-exit \
+        --exit-code-from paasta_tools
 
 [testenv:example_cluster]
 changedir=example_cluster/

--- a/tox.ini
+++ b/tox.ini
@@ -80,8 +80,7 @@ commands =
     docker-compose down
     docker-compose --verbose build
     docker-compose up \
-        --abort-on-container-exit \
-        --exit-code-from paasta_tools
+        --abort-on-container-exit
 
 [testenv:example_cluster]
 changedir=example_cluster/

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,8 @@ commands =
 [testenv:k8s_itests]
 basepython = python3.6
 whitelist_externals = bash
+deps =
+    docker-compose=={[tox]docker_compose_version}
 setenv =
 passenv =
     KIND_CLUSTER
@@ -67,12 +69,39 @@ passenv =
     KUBE_RESOURCE_DIR
     USER
     PAASTA_CONFIG_DIR
+    DOCKER_TLS_VERIFY
+    DOCKER_HOST
+    DOCKER_CERT_PATH
 changedir=k8s_itests/
+commands =
+    # Build /etc/paasta used by docker-compose
+	{toxinidir}/k8s_itests/scripts/setup.sh
+    # Run paasta-tools k8s_itests in docker
+    docker-compose down
+    docker-compose --verbose build
+    docker-compose up
+
+[testenv:run_k8s_itest]
+basepython = python3.6
+whitelist_externals = bash
 deps =
     {[testenv]deps}
+passenv =
+    KIND_CLUSTER
+    KUBECONFIG
+    KUBECONTEXT
+    PAASTA_SYSTEM_CONFIG_DIR
+    SOA_DIR
+    PAASTA_API_PORT
+    KUBE_RESOURCE_DIR
+    USER
+    PAASTA_CONFIG_DIR
+    DOCKER_TLS_VERIFY
+    DOCKER_HOST
+    DOCKER_CERT_PATH
+changedir=k8s_itests/
 commands =
-	{toxinidir}/k8s_itests/scripts/setup.sh
-    pytest {toxinidir}/k8s_itests -s
+    pytest * -s
 
 [testenv:example_cluster]
 changedir=example_cluster/

--- a/tox.ini
+++ b/tox.ini
@@ -79,8 +79,9 @@ commands =
     # Run paasta-tools k8s_itests in docker
     docker-compose down
     docker-compose --verbose build
+    docker-compose up
     docker-compose up \
-        --abort-on-container-exit
+      --abort-on-container-exit
 
 [testenv:example_cluster]
 changedir=example_cluster/

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Edit this release and run "make release"
-RELEASE=0.95.4
+RELEASE=0.95.5
 
 SHELL=/bin/bash
 

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Edit this release and run "make release"
-RELEASE=0.95.7
+RELEASE=0.95.8
 
 SHELL=/bin/bash
 

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Edit this release and run "make release"
-RELEASE=0.95.8
+RELEASE=0.95.9
 
 SHELL=/bin/bash
 

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Edit this release and run "make release"
-RELEASE=0.95.6
+RELEASE=0.95.7
 
 SHELL=/bin/bash
 

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Edit this release and run "make release"
-RELEASE=0.95.5
+RELEASE=0.95.6
 
 SHELL=/bin/bash
 

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Edit this release and run "make release"
-RELEASE=0.95.10
+RELEASE=0.95.11
 
 SHELL=/bin/bash
 

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Edit this release and run "make release"
-RELEASE=0.95.9
+RELEASE=0.95.10
 
 SHELL=/bin/bash
 

--- a/yelp_package/dockerfiles/itest/k8s/Dockerfile
+++ b/yelp_package/dockerfiles/itest/k8s/Dockerfile
@@ -42,10 +42,9 @@ WORKDIR /work
 ADD requirements.txt /work/
 RUN virtualenv /venv -ppython3.6 --no-download
 ENV PATH=/venv/bin:$PATH
-RUN pip install -U pip
 RUN pip install -r requirements.txt
 ADD yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh /venv/bin
 
 ADD . /work/
 RUN pip install -e /work/
-RUN pip install -U pytest
+RUN pip install pytest

--- a/yelp_package/dockerfiles/itest/k8s/Dockerfile
+++ b/yelp_package/dockerfiles/itest/k8s/Dockerfile
@@ -17,7 +17,7 @@ RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sou
 
 # Need Python 3.6
 RUN apt-get update > /dev/null && \
-    apt-get install -y --no-install-recommends software-properties-common && \
+    apt-get install -y --no-install-recommends curl software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa
 
 RUN apt-get update > /dev/null && \
@@ -32,16 +32,20 @@ RUN apt-get update > /dev/null && \
         virtualenv > /dev/null \
     && apt-get clean > /dev/null
 
+# Install kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+RUN chmod +x ./kubectl
+RUN mv ./kubectl /usr/local/bin/kubectl
+
 WORKDIR /work
 
 ADD requirements.txt /work/
 RUN virtualenv /venv -ppython3.6 --no-download
 ENV PATH=/venv/bin:$PATH
+RUN pip install -U pip
 RUN pip install -r requirements.txt
-
-COPY yelp_package/dockerfiles/xenial/mesos-slave-secret /etc/
-COPY yelp_package/dockerfiles/itest/api/mesos-cli.json yelp_package/dockerfiles/xenial/mesos-slave-secret /nail/etc/
-COPY yelp_package/dockerfiles/itest/api/*.json /etc/paasta/
+ADD yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh /venv/bin
 
 ADD . /work/
 RUN pip install -e /work/
+RUN pip install -U pytest

--- a/yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh
+++ b/yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh
@@ -9,7 +9,7 @@ shift
 cmd="$@"
 
 until [ $(curl -o /dev/null -s -w %{http_code} http://127.0.0.1:${PAASTA_API_PORT}/v1/version) = 200 ]; do
-      >&2 echo "PaaSTA APi is unavailable."
+      >&2 echo "PaaSTA API is unavailable."
         sleep 1
         count=$((${count}+1))
         if [ ${count} -gt 9 ]; then

--- a/yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh
+++ b/yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+count=1
+
+host="("
+shift
+cmd="$@"
+
+until [ $(curl -o /dev/null -s -w %{http_code} http://127.0.0.1:${PAASTA_API_PORT}/v1/version) = 200 ]; do
+      >&2 echo "PaaSTA APi is unavailable."
+        sleep 1
+        count=$((${count}+1))
+        if [ ${count} -gt 9 ]; then
+            echo "Timeout after trying ${count} times"
+            exit 1
+        fi
+    done
+
+    >&2 echo "PaaSTA API is up."
+    exec $cmd
+")"


### PR DESCRIPTION
This branch is based on PAASTA-16313. 
This is the api part of implementation for HPA added. There will be anotehr PR for the client part. 
Tested with itest. More tests will be added in the client part. 
```
 $ curl http://0.0.0.0:33222/v1/services/compute-infra-test-service/autoscaling/status
{"service": "compute-infra-test-service", "instance": "autoscaling", "git_sha": "a0ec9b36", "kubernetes": {"app_count": 1, "desired_state": "start", "bounce_method": "crossover", "app_id": "compute-infra-test-service-autoscaling", "pods": [], "replicasets": [], "expected_instance_count": 1, "deploy_status": "Waiting", "running_instance_count": 0, "create_timestamp": 1584934018.0, "namespace": "paasta", "autoscaling_status": {"min_instances": 1, "max_instances": 10, "metrics": [{"name": "memory", "target_value": "7000"}, {"name": "http", "target_value": "70"}, {"name": "uwsgi", "target_value": "70"}, {"name": "external", "target_value": "20"}, {"name": "cpu", "target_value": "7000"}], "desired_replicas": 0, "last_scale_time": "N/A"}, "evicted_count": 0}}(py36-linux)```