### PR TITLE
Fix service name in deployd for autotuned_defaults changes

### DIFF
--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -29,6 +29,7 @@ from paasta_tools.marathon_tools import deformat_job_id
 from paasta_tools.marathon_tools import get_marathon_apps_with_clients
 from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.mesos_maintenance import get_draining_hosts
+from paasta_tools.utils import AUTO_SOACONFIG_SUBDIR
 from paasta_tools.utils import get_services_for_cluster
 from paasta_tools.utils import list_all_instances_for_service
 from paasta_tools.utils import load_system_paasta_config
@@ -369,7 +370,12 @@ class YelpSoaEventHandler(pyinotify.ProcessEvent):
         returns None if it is not an event we're interested in"""
         starts_with = ["marathon-", "deployments.json"]
         if any([event.name.startswith(x) for x in starts_with]):
-            service_name = event.path.split("/")[-1]
+            dir_name = event.path.split("/")[-1]
+            # we also have a subdir for autotuned_defaults
+            if dir_name == AUTO_SOACONFIG_SUBDIR:
+                service_name = event.path.split("/")[-2]
+            else:
+                service_name = dir_name
         elif event.name.endswith(".json") and event.path.split("/")[-1] == "secrets":
             # this is needed because we put the secrets json files in a
             # subdirectory so the service name would be "secrets" otherwise

--- a/tests/deployd/test_watchers.py
+++ b/tests/deployd/test_watchers.py
@@ -6,6 +6,7 @@ from pytest import raises
 from requests.exceptions import RequestException
 
 from paasta_tools.deployd.common import ServiceInstance
+from paasta_tools.utils import AUTO_SOACONFIG_SUBDIR
 
 
 class FakePyinotify:  # pragma: no cover
@@ -575,6 +576,12 @@ class TestYelpSoaEventHandler(unittest.TestCase):
         name = mock.PropertyMock(return_value="marathon-cluster.yaml")
         type(mock_event).name = name
         mock_event.path = "/blah/test-service"
+        assert "test-service" == self.handler.get_service_name_from_event(mock_event)
+
+        mock_event = mock.Mock()
+        name = mock.PropertyMock(return_value="marathon-cluster.yaml")
+        type(mock_event).name = name
+        mock_event.path = f"/blah/test-service/{AUTO_SOACONFIG_SUBDIR}"
         assert "test-service" == self.handler.get_service_name_from_event(mock_event)
 
         name = mock.PropertyMock(return_value="deployments.json")


### PR DESCRIPTION
This is wrong:
```
paasta_tools.deployd.watchers.YelpSoaEventHandler:Looking for things to bounce for autotuned_defaults because /nail/etc/services/spectre_buster/autotuned_defaults/marathon-norcal-prod.yaml changed.
```