### PR TITLE
FLINK-2303 further changes

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1096,6 +1096,10 @@ def print_flink_status(
                     )
     if verbose > 1 and len(status.pod_status) > 0:
         append_pod_status(status.pod_status, output)
+    if verbose == 1:
+        output.append(
+            PaastaColors.yellow(f"    Use -vv to view pod information and exceptions")
+        )
     return 0
 
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1105,9 +1105,7 @@ def print_flink_status(
     if verbose and len(status.pod_status) > 0:
         append_pod_status(status.pod_status, output)
     if verbose == 1 and status.exceptions:
-        output.append(
-            PaastaColors.yellow(f"    Use -vv to view pod information and exceptions")
-        )
+        output.append(PaastaColors.yellow(f"    Use -vv to view exceptions"))
     return 0
 
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -916,7 +916,9 @@ def append_pod_status(pod_status, output: List[str]):
             PaastaColors.green
             if pod["phase"] == "Running" and pod["container_state"] == "Running"
             else PaastaColors.red
-            if pod["phase"] in ("Failed", "CrashLoopBackOff")
+            # pods can get stuck in phase: Running and state: CrashLoopBackOff, so check for that
+            if pod["phase"] == "Failed"
+            or pod["container_state_reason"] == "CrashLoopBackOff"
             else PaastaColors.yellow
         )
 
@@ -1036,7 +1038,7 @@ def print_flink_status(
     )
 
     output.append(f"    Jobs:")
-    if verbose:
+    if verbose > 1:
         output.append(
             f'      {"Job Name": <{allowed_max_job_name_length}} State       Job ID                           Started'
         )

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -912,11 +912,19 @@ def append_pod_status(pod_status, output: List[str]):
         ("Pod Name", "Host", "Phase", "Uptime")
     ]
     for pod in pod_status:
+        color_fn = (
+            PaastaColors.green
+            if pod["phase"] == "Running" and pod["container_state"] == "Running"
+            else PaastaColors.red
+            if pod["phase"] in ("Failed", "CrashLoopBackOff")
+            else PaastaColors.yellow
+        )
+
         rows.append(
             (
                 pod["name"],
                 pod["host"],
-                pod["phase"],
+                color_fn(pod["phase"]),
                 get_pod_uptime(pod["deployed_timestamp"]),
             )
         )
@@ -1094,9 +1102,9 @@ def print_flink_status(
                     output.append(
                         f"            {str(exc_ts)} ({humanize.naturaltime(exc_ts)})"
                     )
-    if verbose > 1 and len(status.pod_status) > 0:
+    if verbose and len(status.pod_status) > 0:
         append_pod_status(status.pod_status, output)
-    if verbose == 1:
+    if verbose == 1 and status.exceptions:
         output.append(
             PaastaColors.yellow(f"    Use -vv to view pod information and exceptions")
         )

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1076,7 +1076,11 @@ def print_flink_status(
             )
             output.append(job_info_str)
         else:
-            output.append(PaastaColors.yellow(f"    Only showing {allowed_max_jobs_printed} Flink jobs, use -v to show all"))
+            output.append(
+                PaastaColors.yellow(
+                    f"    Only showing {allowed_max_jobs_printed} Flink jobs, use -v to show all"
+                )
+            )
             break
 
         if verbose > 1 and job_id in status.exceptions:


### PR DESCRIPTION
- if not all jobs are being shown, print a warning to use -v to see them all
- -v option now shows all jobs, -vv needed to see pods, exceptions etc
- only color the status, rather than the whole line

Note: I planned to put Sofya on this PR too but she doesn't seem to be a member of the Yelp GH org, I'll send the PR to her for an unofficial review

Screenshots:
- normal usage (no -v), showing warning: https://yelp-shootie.appspot.com/shot/4582659305504768
- with -v, showing all jobs: https://yelp-shootie.appspot.com/shot/5166412535431168
- with -vv, showing all jobs and pods, exceptions etc: https://yelp-shootie.appspot.com/shot/4884504471666688
- with <3 jobs available, warning isn't shown: https://yelp-shootie.appspot.com/shot/4503976779710464