### PR TITLE
Pin aspy.refactor_imports in pre-commit to get a reproducible build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     hooks:
     -   id: reorder-python-imports
         args: [--py3-plus]
+        additional_dependencies: [aspy.refactor_imports==0.5.3]
 -   repo: https://github.com/asottile/pyupgrade
     rev: v1.12.0
     hooks:


### PR DESCRIPTION
A bump in this package broke our build, so I would like to stop that.
I'm also investigating how we can freeze all the things.