### PR TITLE
Expose HPA status and SFX metrics in paasta status

### DIFF
--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -1253,6 +1253,35 @@
                         "$ref": "#/definitions/KubernetesPod"
                     }
                 },
+                "autoscaling_status": {
+                    "type": "object",
+                    "description": "HPA associated to this app",
+                    "properties": {
+                        "min_instances": {
+                            "type": "integer",
+                            "description": "min_instances as specified in yelpsoa_configs"
+                        },
+                        "max_instances": {
+                            "type": "integer",
+                            "description": "min_instances as specified in yelpsoa_configs"
+                        },
+                        "desired_replicas": {
+                            "type": "integer",
+                            "description": "desired number of _instances as calculated by HPA"
+                        },
+                        "last_scale_time": {
+                            "type": "string",
+                            "description": "timestamp of last autoscale"
+                        },
+                        "metrics": {
+                            "type": "array",
+                            "description": "Current metrics",
+                            "items": {
+                                "$ref": "#/definitions/HPAMetric"
+                            }
+                        }
+                    }
+                },
                 "error_message": {
                     "type": "string",
                     "description": "Error message when a kubernetes object (Deployment/Statefulset) cannot be found"
@@ -1263,6 +1292,23 @@
                 "app_count",
                 "bounce_method"
             ]
+        },
+        "HPAMetric": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "name of the metric"
+                },
+                "target_value": {
+                    "type": "string",
+                    "description": "setpoint/target_value as specified in yelpsoa_configs"
+                },
+                "current_value": {
+                    "type": "string",
+                    "description": "setpoint/target_value as specified in yelpsoa_configs"
+                }
+            }
         },
         "KubernetesReplicaSet": {
             "type": "object",

--- a/paasta_tools/check_kubernetes_services_replication.py
+++ b/paasta_tools/check_kubernetes_services_replication.py
@@ -93,7 +93,7 @@ def check_kubernetes_pod_replication(
     # If this instance does not autoscale and only has 1 instance, set alert after to 20m.
     # Otherwise, set it to 10 min.
     if (
-        instance_config.get_max_instances() is None
+        not instance_config.is_autoscaling_enabled()
         and instance_config.get_instances() == 1
     ):
         default_alert_after = "20m"

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -256,7 +256,7 @@ def paasta_status_on_api_endpoint(
         return 1
     except Exception as e:
         output.append(PaastaColors.red(f"Exception when talking to the API:"))
-        output.append(e)
+        output.append(str(e))
         return 1
 
     if status.git_sha != "":

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -16,7 +16,6 @@ import concurrent.futures
 import difflib
 import shutil
 import sys
-import traceback
 from collections import defaultdict
 from collections import OrderedDict
 from datetime import datetime
@@ -255,10 +254,9 @@ def paasta_status_on_api_endpoint(
             PaastaColors.red(f"Could not connect to API: {exc.__class__.__name__}")
         )
         return 1
-    except Exception:
-        tb = sys.exc_info()[2]
+    except Exception as e:
         output.append(PaastaColors.red(f"Exception when talking to the API:"))
-        output.extend(line.strip() for line in traceback.format_tb(tb))
+        output.append(e)
         return 1
 
     if status.git_sha != "":

--- a/paasta_tools/instance/hpa_metrics_parser.py
+++ b/paasta_tools/instance/hpa_metrics_parser.py
@@ -9,7 +9,6 @@ class HPAMetricsParser:
         Parse target metrics.
         """
         metric_spec = getattr(metric, metric.type.lower())
-        print(metric_spec)
         status = {}
         switchers = {
             "Pods": self.parse_pod_metric,
@@ -38,7 +37,6 @@ class HPAMetricsParser:
         )
         return status
 
-    # External metrics
     def parse_external_metric(self, metric_spec, status):
         status[self.NAME] = metric_spec.metric_name
         status[self.TARGET] = (
@@ -55,7 +53,6 @@ class HPAMetricsParser:
             else metric_spec.current_value
         )
 
-    # Pod metrics
     def parse_pod_metric(self, metric_spec, status):
         status[self.NAME] = metric_spec.metric_name
         status[self.TARGET] = metric_spec.target_average_value
@@ -64,7 +61,6 @@ class HPAMetricsParser:
         status[self.NAME] = metric_spec.metric_name
         status[self.CURRENT] = metric_spec.current_value
 
-    # Resource metrics
     def parse_resource_metric(self, metric_spec, status):
         status[self.NAME] = metric_spec.name
         status[self.TARGET] = (

--- a/paasta_tools/instance/hpa_metrics_parser.py
+++ b/paasta_tools/instance/hpa_metrics_parser.py
@@ -1,0 +1,82 @@
+class HPAMetricsParser:
+    def __init__(self, hpa):
+        self.NAME = "name"
+        self.TARGET = "target_value"
+        self.CURRENT = "current_value"
+
+    def parse_target(self, metric):
+        """
+        Parse target metrics.
+        """
+        metric_spec = getattr(metric, metric.type.lower())
+        print(metric_spec)
+        status = {}
+        switchers = {
+            "Pods": self.parse_pod_metric,
+            "External": self.parse_external_metric,
+            "Resource": self.parse_resource_metric,
+        }
+        switchers[metric.type](metric_spec, status)
+        status[self.TARGET] = str(status[self.TARGET]) if status[self.TARGET] else "N/A"
+        return status
+
+    def parse_current(self, metric):
+        """
+        Parse current metrics
+        """
+        metric_spec = getattr(metric, metric.type)
+        status = {}
+        status[self.NAME] = metric_spec.metric_name
+        switchers = {
+            "Pods": self.parse_pod_metric_current,
+            "External": self.parse_external_metric_current,
+            "Resource": self.parse_resource_metric_current,
+        }
+        switchers[metric.type](metric_spec, status)
+        status[self.CURRENT] = (
+            str(status[self.CURRENT]) if status[self.CURRENT] else "N/A"
+        )
+        return status
+
+    # External metrics
+    def parse_external_metric(self, metric_spec, status):
+        status[self.NAME] = metric_spec.metric_name
+        status[self.TARGET] = (
+            metric_spec.target_average_value
+            if getattr(metric_spec, "target_average_value")
+            else metric_spec.target_value
+        )
+
+    def parse_external_metric_current(self, metric_spec, status):
+        status[self.NAME] = metric_spec.metric_name
+        status[self.CURRENT] = (
+            metric_spec.current_average_value
+            if getattr(metric_spec, "current_average_value")
+            else metric_spec.current_value
+        )
+
+    # Pod metrics
+    def parse_pod_metric(self, metric_spec, status):
+        status[self.NAME] = metric_spec.metric_name
+        status[self.TARGET] = metric_spec.target_average_value
+
+    def parse_pod_metric_current(self, metric_spec, status):
+        status[self.NAME] = metric_spec.metric_name
+        status[self.CURRENT] = metric_spec.current_value
+
+    # Resource metrics
+    def parse_resource_metric(self, metric_spec, status):
+        status[self.NAME] = metric_spec.name
+        status[self.TARGET] = (
+            metric_spec.target_average_value
+            if getattr(metric_spec, "target_average_value")
+            else metric_spec.target_average_utilization
+        )
+
+    def parse_resource_metric_current(self, metric_spec, status):
+        status[self.NAME] = metric_spec.name
+        status[self.CURRENT] = (
+            metric_spec.current_average_value
+            if getattr(metric_spec, "current_average_value")
+            else metric_spec.current_average_utilization
+        )

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -322,9 +322,11 @@ def kubernetes_status(
             kstatus["autoscaling_status"] = autoscaling_status(
                 kube_client, job_config, job_config.get_kubernetes_namespace()
             )
-        except Exception as e:
-            error_message = f"Error while reading autoscaling information: {e}"
-            kstatus["error_message"] = error_message
+        except ApiException as e:
+            error_message = (
+                f"Error while reading autoscaling information: {e.getResponseBody()}"
+            )
+            kstatus["error_message"].append(error_message)
 
     evicted_count = 0
     for pod in pod_list:

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -104,10 +104,7 @@ def autoscaling_status(
             if getattr(hpa.status, "last_scale_time")
             else "N/A"
         )
-    except ApiException as e:
-        if e.status == 404:
-            # This means that HPA doesn't exist. Return nothing.
-            return {}
+    except Exception as e:
         error_message = f"Error while reading autoscaling information: {e}"
         raise RuntimeError(error_message)
     return status

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -324,9 +324,10 @@ def kubernetes_status(
         replicaset_list=replicaset_list,
     )
 
-    kstatus["autoscaling_status"] = autoscaling_status(
-        kube_client, job_config, job_config.get_kubernetes_namespace()
-    )
+    if job_config.is_autoscaling_enabled() is True:
+        kstatus["autoscaling_status"] = autoscaling_status(
+            kube_client, job_config, job_config.get_kubernetes_namespace()
+        )
 
     evicted_count = 0
     for pod in pod_list:

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -5,6 +5,7 @@ from typing import MutableMapping
 from typing import Sequence
 
 import a_sync
+import pytz
 from kubernetes.client import V1Pod
 from kubernetes.client import V1ReplicaSet
 from kubernetes.client.rest import ApiException
@@ -16,6 +17,7 @@ from paasta_tools import kubernetes_tools
 from paasta_tools import marathon_tools
 from paasta_tools import smartstack_tools
 from paasta_tools.cli.utils import LONG_RUNNING_INSTANCE_TYPE_HANDLERS
+from paasta_tools.instance.hpa_metrics_parser import HPAMetricsParser
 from paasta_tools.kubernetes_tools import get_tail_lines_for_kubernetes_container
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
@@ -71,6 +73,44 @@ def set_cr_desired_state(
             f"{service}.{instance}: {e}"
         )
         raise RuntimeError(error_message)
+
+
+def autoscaling_status(
+    kube_client: kubernetes_tools.KubeClient,
+    job_config: LongRunningServiceConfig,
+    namespace: str,
+):
+    status = {}
+    try:
+        hpa = kube_client.autoscaling.read_namespaced_horizontal_pod_autoscaler(
+            name=job_config.get_sanitised_deployment_name(), namespace=namespace
+        )
+        status["min_instances"] = hpa.spec.min_replicas
+        status["max_instances"] = hpa.spec.max_replicas
+        # Parse metrics sources, based on
+        # https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V2beta1ExternalMetricSource.md#v2beta1externalmetricsource
+        metric_stats = []
+        parser = HPAMetricsParser(hpa)
+        if hpa.spec.metrics is not None:
+            for metric_spec in hpa.spec.metrics:
+                metric_stats.append(parser.parse_target(metric_spec))
+        if hpa.status.current_metrics is not None:
+            for metric_spec in hpa.status.current_metrics:
+                metric_stats.append(parser.parse_current(metric_spec))
+        status["metrics"] = metric_stats
+        status["desired_replicas"] = hpa.status.desired_replicas
+        status["last_scale_time"] = (
+            hpa.status.last_scale_time.replace(tzinfo=pytz.UTC).isoformat()
+            if getattr(hpa.status, "last_scale_time")
+            else "N/A"
+        )
+    except ApiException as e:
+        if e.status == 404:
+            # This means that HPA doesn't exist. Return nothing.
+            return {}
+        error_message = f"Error while reading autoscaling information: {e}"
+        raise RuntimeError(error_message)
+    return status
 
 
 @a_sync.to_blocking
@@ -282,6 +322,10 @@ def kubernetes_status(
         verbose=verbose,
         pod_list=pod_list,
         replicaset_list=replicaset_list,
+    )
+
+    kstatus["autoscaling_status"] = autoscaling_status(
+        kube_client, job_config, job_config.get_kubernetes_namespace()
     )
 
     evicted_count = 0

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -150,8 +150,6 @@ DISCOVERY_ATTRIBUTES = {"region", "superregion", "ecosystem", "habitat"}
 # For detail, https://github.com/kubernetes-client/python/issues/553
 # This hack should be removed when the issue got fixed.
 # This is no better way to work around rn.
-
-
 class MonkeyPatchAutoScalingConditions(V2beta1HorizontalPodAutoscalerStatus):
     @property
     def conditions(self) -> Sequence[V2beta1HorizontalPodAutoscalerCondition]:
@@ -461,7 +459,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     )
                     annotations[
                         f"signalfx.com.external.metric/{metric_name}"
-                    ] = f'data("{metric_name}", filter={filters}).mean(by="paasta_yelp_com_instance").mean(over="15m").publish()'
+                    ] = f'data("{metric_name}", filter={filters}).mean(by="paasta_instance").mean(over="15m").publish()'
             else:
                 metrics.append(
                     V2beta1MetricSpec(
@@ -1803,6 +1801,10 @@ def get_kubernetes_app_by_name(
     name: str, kube_client: KubeClient, namespace: str = "paasta"
 ) -> Union[V1Deployment, V1StatefulSet]:
     try:
+        print("==666666666666666666666666666666666")
+        print(name)
+        print(namespace)
+        print("==666666666666666666666666666666666")
         app = kube_client.deployments.read_namespaced_deployment_status(
             name=name, namespace=namespace
         )

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1801,10 +1801,6 @@ def get_kubernetes_app_by_name(
     name: str, kube_client: KubeClient, namespace: str = "paasta"
 ) -> Union[V1Deployment, V1StatefulSet]:
     try:
-        print("==666666666666666666666666666666666")
-        print(name)
-        print(namespace)
-        print("==666666666666666666666666666666666")
         app = kube_client.deployments.read_namespaced_deployment_status(
             name=name, namespace=namespace
         )

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -247,7 +247,7 @@ class LongRunningServiceConfig(InstanceConfig):
     def get_instances(self, with_limit: bool = True) -> int:
         """Gets the number of instances for a service, ignoring whether the user has requested
         the service to be started or stopped"""
-        if self.get_max_instances() is not None:
+        if self.is_autoscaling_enabled():
             autoscaled_instances = self.get_autoscaled_instances()
             if autoscaled_instances is None:
                 return self.get_max_instances()
@@ -265,6 +265,9 @@ class LongRunningServiceConfig(InstanceConfig):
 
     def get_min_instances(self) -> int:
         return self.config_dict.get("min_instances", 1)
+
+    def is_autoscaling_enabled(self) -> bool:
+        return self.get_max_instances() is not None
 
     def get_max_instances(self) -> Optional[int]:
         return self.config_dict.get("max_instances", None)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2991,9 +2991,7 @@ class DeploymentsJsonV2:
             raise NoDeploymentsAvailable(e)
 
 
-def load_deployments_json(
-    service: str, soa_dir: str = DEFAULT_SOA_DIR
-) -> DeploymentsJsonV1:
+def load_deployments_json(service: str, soa_dir: str = DEFAULT_SOA_DIR) -> Any:
     deployment_file = os.path.join(soa_dir, service, "deployments.json")
     if os.path.isfile(deployment_file):
         with open(deployment_file) as f:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2997,7 +2997,12 @@ def load_deployments_json(
     deployment_file = os.path.join(soa_dir, service, "deployments.json")
     if os.path.isfile(deployment_file):
         with open(deployment_file) as f:
-            return DeploymentsJsonV1(json.load(f)["v1"])
+            config_dict = json.load(f)
+            return (
+                DeploymentsJsonV1(config_dict["v1"])
+                if "v1" in config_dict
+                else DeploymentsJsonV2(service=service, config_dict=config_dict["v2"])
+            )
     else:
         e = f"{deployment_file} was not found. 'generate_deployments_for_service --service {service}' must be run first"
         raise NoDeploymentsAvailable(e)

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -786,9 +786,6 @@ class TestKubernetesDeploymentConfig:
             "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_aws_ebs_volumes",
             autospec=True,
         ) as mock_get_aws_ebs_volumes:
-            mock_get_aws_ebs_volumes.return_value = []
-            assert self.deployment.get_desired_instances() == 3
-
             mock_get_aws_ebs_volumes.return_value = ["some-ebs-vol"]
             with pytest.raises(Exception):
                 self.deployment.get_desired_instances()


### PR DESCRIPTION
This branch is based on PAASTA-16313. 
This is the api part of implementation for HPA added. There will be anotehr PR for the client part. 
Tested with itest. More tests will be added in the client part. 
```
 $ curl http://0.0.0.0:33222/v1/services/compute-infra-test-service/autoscaling/status
{"service": "compute-infra-test-service", "instance": "autoscaling", "git_sha": "a0ec9b36", "kubernetes": {"app_count": 1, "desired_state": "start", "bounce_method": "crossover", "app_id": "compute-infra-test-service-autoscaling", "pods": [], "replicasets": [], "expected_instance_count": 1, "deploy_status": "Waiting", "running_instance_count": 0, "create_timestamp": 1584934018.0, "namespace": "paasta", "autoscaling_status": {"min_instances": 1, "max_instances": 10, "metrics": [{"name": "memory", "target_value": "7000"}, {"name": "http", "target_value": "70"}, {"name": "uwsgi", "target_value": "70"}, {"name": "external", "target_value": "20"}, {"name": "cpu", "target_value": "7000"}], "desired_replicas": 0, "last_scale_time": "N/A"}, "evicted_count": 0}}(py36-linux)
```

Note that the tests depend on #2737 . So I'll add them after that is merged. 