### PR TITLE
Log mesos container id and memory limit with OOMkills

### DIFF
--- a/paasta_tools/oom_logger.py
+++ b/paasta_tools/oom_logger.py
@@ -65,6 +65,8 @@ LogLine = namedtuple(
         "service",
         "instance",
         "process_name",
+        "mesos_container_id",
+        "mem_limit",
     ],
 )
 
@@ -113,7 +115,8 @@ def log_to_scribe(logger, log_line):
     """Send the event to 'tmp_paasta_oom_events'."""
     line = (
         '{"timestamp": %d, "hostname": "%s", "container_id": "%s", "cluster": "%s", '
-        '"service": "%s", "instance": "%s", "process_name": "%s"}'
+        '"service": "%s", "instance": "%s", "process_name": "%s", '
+        '"mesos_container_id": "%s", "mem_limit": "%s"}'
         % (
             log_line.timestamp,
             log_line.hostname,
@@ -122,6 +125,8 @@ def log_to_scribe(logger, log_line):
             log_line.service,
             log_line.instance,
             log_line.process_name,
+            log_line.mesos_container_id,
+            log_line.mem_limit,
         )
     )
     logger.log_line("tmp_paasta_oom_events", line)
@@ -184,6 +189,8 @@ def main():
         env_vars = get_container_env_as_dict(docker_inspect)
         service = env_vars.get("PAASTA_SERVICE", "unknown")
         instance = env_vars.get("PAASTA_INSTANCE", "unknown")
+        mesos_container_id = env_vars.get("MESOS_CONTAINER_NAME", "mesos-null")
+        mem_limit = env_vars.get("PAASTA_RESOURCE_MEM", "unknown")
         log_line = LogLine(
             timestamp=timestamp,
             hostname=hostname,
@@ -192,6 +199,8 @@ def main():
             service=service,
             instance=instance,
             process_name=process_name,
+            mesos_container_id=mesos_container_id,
+            mem_limit=mem_limit,
         )
         log_to_scribe(scribe_logger, log_line)
         log_to_paasta(log_line)

--- a/tests/test_oom_logger.py
+++ b/tests/test_oom_logger.py
@@ -102,7 +102,12 @@ def sys_stdin_without_process_name():
 def docker_inspect():
     return {
         "Config": {
-            "Env": ["PAASTA_SERVICE=fake_service", "PAASTA_INSTANCE=fake_instance"]
+            "Env": [
+                "PAASTA_SERVICE=fake_service",
+                "PAASTA_INSTANCE=fake_instance",
+                "PAASTA_RESOURCE_MEM=512",
+                "MESOS_CONTAINER_NAME=mesos-a04c14a6-83ea-4047-a802-92b850b1624e",
+            ]
         }
     }
 
@@ -117,6 +122,8 @@ def log_line():
         service="fake_service",
         instance="fake_instance",
         process_name="apache2",
+        mesos_container_id="a04c14a6-83ea-4047-a802-92b850b1624e",
+        mem_limit="512",
     )
 
 
@@ -197,6 +204,8 @@ def test_log_to_scribe(log_line):
                 "service": log_line.service,
                 "instance": log_line.instance,
                 "process_name": log_line.process_name,
+                "mesos_container_id": log_line.mesos_container_id,
+                "mem_limit": log_line.mem_limit,
             }
         ),
     )


### PR DESCRIPTION
For autotune, we want to be able to join the oomkill logs with tmp_paastaallocations logs.
However currently the oomkill log only contains the docker id while paasta alllocation only contains docker id (when running on k8s) or mesos_task_id (when running on mesos)
This PR adds mesos_task_id to the log. If running on kubernetes, it will have the value 'null'


Also adding the useful memory limit of the container at the time of the OOM