### PR TITLE
Double the default requested disk for services to 2g

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -57,7 +57,7 @@ specify the following options:
     met, other than a ``TASK_FAILED`` message. For more a more detailed read on
     how this works, see the docs on `isolation <isolation.html>`_
 
-  * ``disk``: Disk (in MB) an instance needs. Defaults to 1024 (1GB). Disk limits
+  * ``disk``: Disk (in MB) an instance needs. Defaults to 2048 (2GB). Disk limits
     may or may not be enforced, but services should set their ``disk`` setting
     regardless to ensure the scheduler has adequate information for distributing
     tasks.

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -493,14 +493,13 @@ class InstanceConfig:
     def get_docker_init(self) -> Iterable[DockerParameter]:
         return [{"key": "init", "value": "true"}]
 
-    def get_disk(self, default: float = 1024) -> float:
+    def get_disk(self, default: float = 2048) -> float:
         """Gets the amount of disk space in MiB required from the service's configuration.
 
-        Defaults to 1024 (1GiB) if no value is specified in the config.
+        Defaults to 2048 (2GiB) if no value is specified in the config.
 
-        :returns: The amount of disk space specified by the config, 1024 MiB if not specified"""
-        disk = self.config_dict.get("disk", default)
-        return disk
+        :returns: The amount of disk space specified by the config, 2048 MiB if not specified"""
+        return self.config_dict.get("disk", default)
 
     def get_gpus(self) -> Optional[int]:
         """Gets the number of gpus required from the service's configuration.


### PR DESCRIPTION
I get it, we are trying to cram as much as we can on our servers.

But the thing is, our docker images for many of our services are over 1g, and it causes constant pages and evictions.

I think this is one place where we need to be a bit more honest about how big our docker images are.