### PR TITLE
Add --strip-headers option to paasta logs (PAASTA-16280)

### DIFF
--- a/general_itests/steps/tail_paasta_logs.py
+++ b/general_itests/steps/tail_paasta_logs.py
@@ -97,8 +97,8 @@ def step_impl(context):
     # thread's work deposited in the shared queue.
     assert context.print_log_patch.call_count == 2
     context.print_log_patch.assert_any_call(
-        "fake log line added for env1", context.levels, False
+        "fake log line added for env1", context.levels, False, False
     )
     context.print_log_patch.assert_any_call(
-        "fake log line added for env2", context.levels, False
+        "fake log line added for env2", context.levels, False, False
     )

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -170,7 +170,7 @@ def add_subparser(subparsers) -> None:
         type=int,
     )
     status_parser.add_argument(
-        "-sh",
+        "-S",
         "--strip-headers",
         dest="strip_headers",
         help="Print log lines without header information.",


### PR DESCRIPTION
This PR adds --strip-headers, which causes paasta logs to just print the timestamp and message, skipping cluster, instance, log level and component. This was requested by Connectors, because the long headers make Flink logs quite difficult to read.

**Examples**
without strip-headers: https://yelp-shootie.appspot.com/shot/4643532397084672
with strip-headers: https://yelp-shootie.appspot.com/shot/4551395315810304

I would quite like to remove the 

This was requested for Flink services, but works equally well for regular PaaSTA services. Here it is for Apollo:
without strip-headers: https://yelp-shootie.appspot.com/shot/4594127790931968
with strip-headers: https://yelp-shootie.appspot.com/shot/4594127790931968

I'd like to strip the hostname and commit too, but those are part of the `message` field in the JSON and not guaranteed to be present, so I'm leaving them for now.

@Rob-Johnson assigning to you as CI onpoint, feel free to reassign.