### PR TITLE
Add autoscaling status in paasta client

### DIFF
--- a/k8s_itests/test_autoscaling.py
+++ b/k8s_itests/test_autoscaling.py
@@ -18,6 +18,6 @@ class TestSetupKubernetesJobs:
         instance = "autoscaling"
         service = "compute-infra-test-service"
         cmd(
-            f"python -m paasta_tools.cli.cli status  -c {os.environ['KIND_CLUSTER']} -s {service} -i {instance}",
+            f"python -m paasta_tools.cli.cli status  -c {os.environ['KIND_CLUSTER']} -s {service} -i {instance} -v",
             False,
         )

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1168,8 +1168,11 @@ def print_kubernetes_status(
         )
         output.extend([f"        {line}" for line in replicasets_table])
 
-    if kubernetes_status.autoscaling_status and verbose > 0:
+    try:
         autoscaling_status = kubernetes_status.autoscaling_status
+    except AttributeError:
+        autoscaling_status = None
+    if autoscaling_status and verbose > 0:
         output.append("    Autoscaling status:")
         output.append(f"       min_instances: {autoscaling_status['min_instances']}")
         output.append(f"       max_instances: {autoscaling_status['min_instances']}")

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1174,11 +1174,12 @@ def print_kubernetes_status(
         output.append(f"       min_instances: {autoscaling_status['min_instances']}")
         output.append(f"       max_instances: {autoscaling_status['min_instances']}")
         output.append(
-            f"       desired instances: {autoscaling_status['desired_replicas']}"
+            f"       Desired instances: {autoscaling_status['desired_replicas']}"
         )
         output.append(
-            f"       last scale time: {autoscaling_status['last_scale_time']}"
+            f"       Last scale time: {autoscaling_status['last_scale_time']}"
         )
+        output.append(f"       Dashboard: y/sfx-autoscaling")
         NA = PaastaColors.red("N/A")
         if len(autoscaling_status["metrics"]) > 0:
             output.append(f"       Metrics:")

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1186,15 +1186,16 @@ def print_kubernetes_status(
         NA = PaastaColors.red("N/A")
         if len(autoscaling_status["metrics"]) > 0:
             output.append(f"       Metrics:")
+
+        metrics_table: List[List[str]] = [["Metric", "Current", "Target"]]
         for metric in autoscaling_status["metrics"]:
-            output.append(f"         {metric['name']}:")
             current_metric = (
                 NA
                 if getattr(metric, "current_value") is None
                 else getattr(metric, "current_value")
             )
-            output.append(f"           Current Value: {current_metric}")
-            output.append(f"           Target Value: {metric.target_value}")
+            metrics_table.append([metric["name"], current_metric, metric.target_value])
+        output.extend(["         " + s for s in format_table(metrics_table)])
 
     if kubernetes_status.smartstack is not None:
         smartstack_status_human = get_smartstack_status_human(


### PR DESCRIPTION
WIth verbose 1
```
paasta_tools_1  | .
paasta_tools_1  | service: compute-infra-test-service
paasta_tools_1  | cluster: mingqiz-k8s-test
paasta_tools_1  |     instance: autoscaling
paasta_tools_1  |     Git sha:    a0ec9b36 (desired)
paasta_tools_1  |     State:      Configured - Desired state: Started
paasta_tools_1  |     Kubernetes:   Critical - up with (0/10) instances (0 evicted). Status: Waiting (new tasks waiting for capacity to become available)
paasta_tools_1  |       App created: 2020-03-30 21:04:05 (2 seconds ago). Namespace: paasta
paasta_tools_1  |     Autoscaling status:
paasta_tools_1  |        min_instances: 1
paasta_tools_1  |        max_instances: 1
paasta_tools_1  |        desired instances: 0
paasta_tools_1  |        last scale time: N/A
paasta_tools_1  |        Metrics:
paasta_tools_1  |          memory:
paasta_tools_1  |            Current Value: N/A
paasta_tools_1  |            Target Value: 7000
paasta_tools_1  |          http:
paasta_tools_1  |            Current Value: N/A
paasta_tools_1  |            Target Value: 70
paasta_tools_1  |          uwsgi:
paasta_tools_1  |            Current Value: N/A
paasta_tools_1  |            Target Value: 70
paasta_tools_1  |          external:
paasta_tools_1  |            Current Value: N/A
paasta_tools_1  |            Target Value: 20
paasta_tools_1  |          cpu:
paasta_tools_1  |            Current Value: N/A
paasta_tools_1  |            Target Value: 7000
paasta_tools_1  |
paasta_tools_1  | /work/paasta_tools/utils.py:1487: UserWarning: clog is unavailable
paasta_tools_1  |   warnings.warn("clog is unavailable")
paasta_tools_1  | .
paasta_tools_1  |
paasta_tools_1  | ============================== 2 passed in 2.87s ===============================
k8sitests_paasta_tools_1 exited with code 0
Aborting on container exit...
Stopping k8sitests_paasta_api_1 ... done
```