### PR TITLE
PAASTA-16466 Fix `paasta status` regression with evicted pods

### DIFF
--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -1366,17 +1366,13 @@
                     }
                 },
                 "reason": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
+                    "type": "string",
+                    "x-nullable": true,
                     "description": "short message explaining the pod's state"
                 },
                 "message": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
+                    "type": "string",
+                    "x-nullable": true,
                     "description": "long message explaining the pod's state"
                 }
             }


### PR DESCRIPTION
Our swagger definition declares `pod.status.reason` and `pod.status.message`
with the types `['string','null']`. But Swagger 2.0 doesn't support null
as a data type. Luckily [bravado-core offers](https://bravado-core.readthedocs.io/en/stable/models.html#allowing-null-values-for-properties) the `x-nullable` extension
which can be used on this situation.

Manual tests:
- `paasta status -v` working when pod.status.reason and pod.status.message are both null
```
$ PAASTA_SYSTEM_CONFIG_DIR=~/etc-paasta paasta status -s compute-infra-test-service -c cluster -i main_k8s -v

service: compute-infra-test-service
cluster: cluster
    instance: main_k8s
    Git sha:    41a908ac (desired)
    State:      Configured - Desired state: Started
    Kubernetes:   Healthy - up with (10/10) instances (0 evicted). Status: Running
      App created: 2020-03-19 05:10:03 (13 days ago). Namespace: paasta
      Pods:
        Pod ID                                                 Host deployed to
...
```
- `paasta status -v` working when pod.status.reason and pod.status.message contain strings.
```
$ PAASTA_SYSTEM_CONFIG_DIR=~/etc-paasta paasta status -s compute-infra-test-service -c cluster -i main_k8s -v

service: compute-infra-test-service
cluster: cluster
    instance: main_k8s
    Git sha:    41a908ac (desired)
    State:      Configured - Desired state: Started
    Kubernetes:   Warning - up with (9/10) instances (1 evicted). Status: Waiting (new tasks waiting for capacity to become available)
      App created: 2020-03-19 05:10:03 (13 days ago). Namespace: paasta
      Pods:
        Pod ID                                                 Host deployed to                                           Deployed at what localtime         Health
        compute-infra-test-service-main--k8s-7bc999b7db-nn7xc  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  2020-03-30T11:20 (a day ago)       Evicted
          Pod ephemeral local storage usage exceeds the total limit of containers 1280Mi.
...
```