### PR TITLE
PAASTA-16510 fix k8s oom regex

### DIFF
--- a/paasta_tools/oom_logger.py
+++ b/paasta_tools/oom_logger.py
@@ -77,7 +77,14 @@ def capture_oom_events_from_stdin():
         r"^(\d+)\s([a-zA-Z0-9\-]+)\s.*Task in /docker/(\w{12})\w+ killed as a"
     )
     oom_regex_kubernetes = re.compile(
-        r"^(\d+)\s([a-zA-Z0-9\-]+)\s.*Task in /kubepods/[a-zA-Z]+/pod[-\w]+/(\w{12})\w+ killed as a"
+        r"""
+        ^(\d+)\s # timestamp
+        ([a-zA-Z0-9\-]+) # hostname
+        \s.*Task\sin\s/kubepods/(?:[a-zA-Z]+/)? # start of message; non capturing, optional group for the qos cgroup
+        pod[-\w]+/(\w{12})\w+\s # containerid
+        killed\sas\sa*  # eom
+        """,
+        re.VERBOSE,
     )
     process_name = ""
 


### PR DESCRIPTION
kubernetes has different hierarchies of cgroups depending on the qos for
the pod. for burstable and best effort QoS, a seperate namespace is
created under the /kubepods namespace (/kubepods/besteffort or
/kubepods/burstable), but for guaranteed qos the task is placed in the
/kubepods cgroup.
this fixes the regex we use to parse info from syslog output about the
pod that's killed by using an optional, non-capturing group to mark the
qos class used