### PR TITLE
Make paasta status display k8s event log for pods

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -55,6 +55,7 @@ from paasta_tools.cli.utils import NoSuchService
 from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.flink_tools import FlinkDeploymentConfig
 from paasta_tools.kafkacluster_tools import KafkaClusterDeploymentConfig
+from paasta_tools.kubernetes_tools import format_pod_event_messages
 from paasta_tools.kubernetes_tools import format_tail_lines_for_kubernetes_pod
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.kubernetes_tools import KubernetesDeployStatus
@@ -670,6 +671,8 @@ def format_kubernetes_pod_table(pods):
                 health_check_status,
             )
         )
+        if pod.events:
+            rows.extend(format_pod_event_messages(pod.events, pod.name))
         if pod.message is not None:
             rows.append(PaastaColors.grey(f"  {pod.message}"))
         if len(pod.containers) > 0:

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -18,6 +18,7 @@ from paasta_tools import marathon_tools
 from paasta_tools import smartstack_tools
 from paasta_tools.cli.utils import LONG_RUNNING_INSTANCE_TYPE_HANDLERS
 from paasta_tools.instance.hpa_metrics_parser import HPAMetricsParser
+from paasta_tools.kubernetes_tools import get_pod_event_messages
 from paasta_tools.kubernetes_tools import get_tail_lines_for_kubernetes_container
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
@@ -125,6 +126,7 @@ async def job_status(
 
         for pod in pod_list:
             container_statuses = pod.status.container_statuses or []
+            pod_event_messages = await get_pod_event_messages(client, pod)
             containers = [
                 dict(
                     name=container.name,
@@ -144,6 +146,7 @@ async def job_status(
                     "containers": containers,
                     "reason": pod.status.reason,
                     "message": pod.status.message,
+                    "events": pod_event_messages,
                 }
             )
         for replicaset in replicaset_list:

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -54,6 +54,7 @@ from kubernetes.client import V1DeploymentSpec
 from kubernetes.client import V1DeploymentStrategy
 from kubernetes.client import V1EnvVar
 from kubernetes.client import V1EnvVarSource
+from kubernetes.client import V1Event
 from kubernetes.client import V1ExecAction
 from kubernetes.client import V1Handler
 from kubernetes.client import V1HostPathVolumeSource
@@ -1459,6 +1460,41 @@ async def get_tail_lines_for_kubernetes_container(
     return tail_lines
 
 
+def get_pod_events(kube_client: KubeClient, pod: V1Pod) -> List[V1Event]:
+    try:
+        pod_events = kube_client.core.list_namespaced_event(
+            namespace=pod.metadata.namespace,
+            field_selector=f"involvedObject.name={pod.metadata.name}",
+        )
+        return pod_events.items if pod_events else []
+    except ApiException:
+        return []
+
+
+@async_timeout()
+async def get_pod_event_messages(kube_client: KubeClient, pod: V1Pod) -> List[Dict]:
+    pod_events = get_pod_events(kube_client, pod)
+    pod_event_messages = []
+    if pod_events:
+        for event in pod_events:
+            message = {
+                "message": event.message,
+                "timeStamp": str(event.last_timestamp),
+            }
+            pod_event_messages.append(message)
+    return pod_event_messages
+
+
+def format_pod_event_messages(
+    pod_event_messages: List[Dict], pod_name: str
+) -> List[str]:
+    rows: List[str] = list()
+    rows.append(PaastaColors.blue(f"Pod Events for {pod_name}"))
+    for message in pod_event_messages:
+        rows.append(f"   Event at {message['timeStamp']}: {message['message']}")
+    return rows
+
+
 def format_tail_lines_for_kubernetes_pod(
     pod_containers: Sequence, pod_name: str,
 ) -> List[str]:
@@ -1472,7 +1508,7 @@ def format_tail_lines_for_kubernetes_pod(
             )
             rows.append(PaastaColors.red(f"  {container.tail_lines.error_message}"))
 
-        for stream_name in ("stdout", "stderr"):
+        for stream_name in ("Stdout", "stderr"):
             stream_lines = getattr(container.tail_lines, stream_name, [])
             if len(stream_lines) > 0:
                 rows.append(

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1242,6 +1242,7 @@ class TestPrintKubernetesStatus:
                 ready=True,
                 containers=[],
                 message=None,
+                events=[],
             ),
             Struct(
                 name="app_2",
@@ -1251,6 +1252,7 @@ class TestPrintKubernetesStatus:
                 ready=True,
                 containers=[],
                 message=None,
+                events=[],
             ),
             Struct(
                 name="app_3",
@@ -1261,6 +1263,7 @@ class TestPrintKubernetesStatus:
                 containers=[],
                 message="Disk quota exceeded",
                 reason="Evicted",
+                events=[],
             ),
         ]
         mock_kubernetes_status.replicasets = [
@@ -1511,12 +1514,13 @@ class TestFormatKubernetesPodTable:
             containers=[],
             message=None,
             reason=None,
+            events=[],
         )
 
     @pytest.fixture
     def mock_kubernetes_replicaset(self):
         return Struct(
-            name="abc123", replicas=3, ready_replicas=3, create_timestamp=1565648600
+            name="abc123", replicas=3, ready_replicas=3, create_timestamp=1565648600,
         )
 
     def test_format_kubernetes_pod_table(
@@ -1555,6 +1559,7 @@ class TestFormatKubernetesPodTable:
         mock_kubernetes_pod,
     ):
         mock_kubernetes_pod.host = None
+        mock_kubernetes_pod.events = []
         output = format_kubernetes_pod_table([mock_kubernetes_pod])
         pod_table_dict = _formatted_table_to_dict(output)
         assert pod_table_dict["Host deployed to"] == "Unknown"
@@ -1570,6 +1575,7 @@ class TestFormatKubernetesPodTable:
     ):
         mock_kubernetes_pod.phase = phase
         mock_kubernetes_pod.ready = ready
+        mock_kubernetes_pod.events = []
         output = format_kubernetes_pod_table([mock_kubernetes_pod])
         pod_table_dict = _formatted_table_to_dict(output)
         assert pod_table_dict["Health"] == PaastaColors.red("Unhealthy")
@@ -1582,6 +1588,7 @@ class TestFormatKubernetesPodTable:
     ):
         mock_kubernetes_pod.phase = "Failed"
         mock_kubernetes_pod.reason = "Evicted"
+        mock_kubernetes_pod.events = []
         output = format_kubernetes_pod_table([mock_kubernetes_pod])
         pod_table_dict = _formatted_table_to_dict(output)
         assert pod_table_dict["Health"] == PaastaColors.red("Evicted")
@@ -1593,6 +1600,7 @@ class TestFormatKubernetesPodTable:
         mock_kubernetes_pod,
     ):
         mock_kubernetes_pod.phase = None
+        mock_kubernetes_pod.events = []
         output = format_kubernetes_pod_table([mock_kubernetes_pod])
         pod_table_dict = _formatted_table_to_dict(output)
         assert pod_table_dict["Health"] == PaastaColors.grey("N/A")


### PR DESCRIPTION
### Summary
Currently, `paasta status <service>.<instance> -vv` shows us the stdout/stderr for a specific container (`docker logs`). However, most pod errors are not caused on the application level, but usually caused by the kubernetes scheduler itself (ie, failed to pull image, pod is stuck in scheduler, etc). Therefore, on top of displaying app logs, we also want to display the k8s event logs to our users so they can figure out why their pods aren't scheduling and debug.

Here is an example output with event logs: https://fluffy.yelpcorp.com/i/LZczNbLmMhDDF503xPSL6Z0nb5JtCHq2.html#L15-17

Note that some of this code may be reused in https://github.com/Yelp/paasta/pull/2761 and vice versa. 

### Testing done:
* make test
* manually tested on various pods in kubestage