### PR TITLE
Make is easy for devs to find smartstack.yaml config options

### DIFF
--- a/paasta_tools/cli/fsm/template/{{cookiecutter.service}}/smartstack.yaml
+++ b/paasta_tools/cli/fsm/template/{{cookiecutter.service}}/smartstack.yaml
@@ -1,3 +1,4 @@
 ---
+# See y/smartstack-config
 main:
   proxy_port: {{cookiecutter.proxy_port}}


### PR DESCRIPTION
I'm not to concerned about the fact that the url is internal only :)