### PR TITLE
fix the traceback when metric value is None

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1194,7 +1194,12 @@ def print_kubernetes_status(
                 if getattr(metric, "current_value") is None
                 else getattr(metric, "current_value")
             )
-            metrics_table.append([metric["name"], current_metric, metric.target_value])
+            target_metric = (
+                NA
+                if getattr(metric, "target_value") is None
+                else getattr(metric, "target_value")
+            )
+            metrics_table.append([metric["name"], current_metric, target_metric])
         output.extend(["         " + s for s in format_table(metrics_table)])
 
     if kubernetes_status.smartstack is not None:


### PR DESCRIPTION
The bug happens when the target_value of the metric is None:

Sample output is here: https://fluffy.yelpcorp.com/i/rm1q9mRVzNkJlnm2hls5G1nmxsSVpfSv.html