### PR TITLE
Added aio speedups packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 a-sync==0.5.0
 addict==2.1.0
+aiodns==2.0.0
 aiohttp==3.5.4
 argcomplete==0.8.1
 argparse==1.4.0
@@ -13,7 +14,9 @@ boto3-type-annotations==0.3.1
 botocore==1.7.21
 bravado==10.4.1
 bravado-core==5.12.1
+brotlipy==0.7.0
 cachetools==2.0.1
+cchardet==2.1.6
 certifi==2017.11.5
 chardet==3.0.4
 choice==0.1


### PR DESCRIPTION
Although this didn't seem to improve our situation, the aiohttp docs recommend installing these "speedup" packages to get better performance when doing lots of aio http requests.

I'm particularly interested in aiodns, which should be used automatically when available (again, didn't help our particular issue)