### PR TITLE
Stop using the deprecated dict instead of string for marathon healthchecks

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -248,7 +248,7 @@ class HealthcheckDict(TypedDict, total=False):
     timeoutSeconds: float
     maxConsecutiveFailures: int
     path: str
-    command: CommandDict
+    command: str
 
 
 # These are more-or-less duplicated from native_service_config, but this code uses camelCase, not snake_case.
@@ -845,7 +845,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
                 HealthcheckDict(
                     {
                         "protocol": "COMMAND",
-                        "command": {"value": self.get_healthcheck_cmd()},
+                        "command": self.get_healthcheck_cmd(),
                         "gracePeriodSeconds": graceperiodseconds,
                         "intervalSeconds": intervalseconds,
                         "timeoutSeconds": timeoutseconds,

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -2201,7 +2201,7 @@ class TestMarathonServiceConfig:
         expected = [
             {
                 "protocol": "COMMAND",
-                "command": {"value": fake_command},
+                "command": fake_command,
                 "gracePeriodSeconds": 60,
                 "intervalSeconds": 10,
                 "timeoutSeconds": 10,
@@ -2233,7 +2233,7 @@ class TestMarathonServiceConfig:
         expected = [
             {
                 "protocol": "COMMAND",
-                "command": {"value": fake_command},
+                "command": fake_command,
                 "gracePeriodSeconds": 60,
                 "intervalSeconds": 10,
                 "timeoutSeconds": fake_timeout,


### PR DESCRIPTION
The client lib expects just a string now and does this dict for you.
This removes a ton of deprecation warnings when you run certain paasta commands that interact with marathon