### PR TITLE
Remove annotations from metadata spec and improve pause HPA

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -47,6 +47,7 @@ from paasta_tools.bounce_lib import filter_tasks_in_smartstack
 from paasta_tools.bounce_lib import LockHeldException
 from paasta_tools.bounce_lib import LockTimeout
 from paasta_tools.bounce_lib import ZK_LOCK_CONNECT_TIMEOUT_S
+from paasta_tools.kubernetes_tools import get_annotations_for_deployment
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.kubernetes_tools import write_annotation_for_kubernetes_service
@@ -846,10 +847,12 @@ def autoscaling_is_paused():
         return False
 
 
-def is_autoscaling_resumed(formatted_application: Union[V1Deployment, V1StatefulSet]):
-    if formatted_application.metadata.annotations:
-        if "is_paused" in formatted_application.metadata.annotations:
-            return formatted_application.metadata.annotations["is_paused"] == "False"
+def is_autoscaling_resumed(service_config: KubernetesDeploymentConfig):
+    kube_client = KubeClient()
+    annotations = get_annotations_for_deployment(kube_client, service_config)
+    if annotations:
+        if "is_paused" in annotations:
+            return annotations["is_paused"] == "False"
     return True
 
 

--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -847,16 +847,14 @@ def autoscaling_is_paused():
         return False
 
 
-def is_autoscaling_resumed(service_config: KubernetesDeploymentConfig):
-    kube_client = KubeClient()
+def is_deployment_marked_paused(
+    kube_client: KubeClient, service_config: KubernetesDeploymentConfig
+):
     annotations = get_annotations_for_deployment(kube_client, service_config)
-    if annotations:
-        if "is_paused" in annotations:
-            return annotations["is_paused"] == "False"
-    return True
+    return annotations.get("is_paused", "False") == "True"
 
 
-def write_autoscaling_paused(
+def mark_deployment_as_paused(
     kube_client: KubeClient,
     service_config: KubernetesDeploymentConfig,
     formatted_application: Union[V1Deployment, V1StatefulSet],

--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -294,7 +294,7 @@ class DeploymentWrapper(Application):
                 )
                 self.soa_config.set_min_instances(self.item.spec.replicas)
                 write_autoscaling_paused(kube_client, self.soa_config, self.item, True)
-            elif not is_autoscaling_resumed(self.item):
+            elif not is_autoscaling_resumed(self.soa_config):
                 write_autoscaling_paused(kube_client, self.soa_config, self.item, False)
 
         body = self.soa_config.get_autoscaling_metric_spec(

--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -28,7 +28,7 @@ from typing import Sequence
 from typing import Tuple
 
 from paasta_tools.autoscaling.autoscaling_service_lib import autoscaling_is_paused
-from paasta_tools.autoscaling.autoscaling_service_lib import is_autoscaling_resumed
+from paasta_tools.autoscaling.autoscaling_service_lib import is_deployment_marked_paused
 from paasta_tools.kubernetes.application.controller_wrappers import Application
 from paasta_tools.kubernetes.application.controller_wrappers import (
     get_application_wrapper,
@@ -146,11 +146,13 @@ def setup_kube_deployments(
             elif app.kube_deployment not in existing_kube_deployments:
                 log.debug(f"Updating {app} because configs have changed.")
                 app.update(kube_client)
-            elif autoscaling_is_paused() and is_autoscaling_resumed(app.soa_config):
+            elif autoscaling_is_paused() and not is_deployment_marked_paused(
+                kube_client, app.soa_config
+            ):
                 log.debug(f"Updating {app} because autoscaler needs to be paused.")
                 app.update(kube_client)
-            elif not autoscaling_is_paused() and not is_autoscaling_resumed(
-                app.soa_config
+            elif not autoscaling_is_paused() and is_deployment_marked_paused(
+                kube_client, app.soa_config
             ):
                 log.debug(f"Updating {app} because autoscaler needs to be resumed.")
                 app.update(kube_client)

--- a/tests/kubernetes/application/test_controller_wrapper.py
+++ b/tests/kubernetes/application/test_controller_wrapper.py
@@ -209,7 +209,7 @@ def test_sync_horizontal_pod_autoscaler_delete_hpa_when_no_autoscaling(
 
 
 @mock.patch(
-    "paasta_tools.kubernetes.application.controller_wrappers.is_autoscaling_resumed",
+    "paasta_tools.kubernetes.application.controller_wrappers.is_deployment_marked_paused",
     autospec=True,
 )
 @mock.patch(
@@ -217,7 +217,7 @@ def test_sync_horizontal_pod_autoscaler_delete_hpa_when_no_autoscaling(
     autospec=True,
 )
 def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_paused(
-    mock_autoscaling_is_paused, mock_is_autoscaling_resumed,
+    mock_autoscaling_is_paused, mock_is_deployment_marked_paused,
 ):
     mock_client = mock.MagicMock()
     config_dict = {"max_instances": 3, "min_instances": 1}
@@ -225,7 +225,7 @@ def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_paused(
     app.item.spec.replicas = 2
 
     mock_autoscaling_is_paused.return_value = True
-    mock_is_autoscaling_resumed.return_value = False
+    mock_is_deployment_marked_paused.return_value = False
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
     assert app.soa_config.get_min_instances() == 2
     assert (
@@ -239,11 +239,11 @@ def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_paused(
 
 
 @mock.patch(
-    "paasta_tools.kubernetes.application.controller_wrappers.write_autoscaling_paused",
+    "paasta_tools.kubernetes.application.controller_wrappers.mark_deployment_as_paused",
     autospec=True,
 )
 @mock.patch(
-    "paasta_tools.kubernetes.application.controller_wrappers.is_autoscaling_resumed",
+    "paasta_tools.kubernetes.application.controller_wrappers.is_deployment_marked_paused",
     autospec=True,
 )
 @mock.patch(
@@ -252,8 +252,8 @@ def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_paused(
 )
 def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_resumed(
     mock_autoscaling_is_paused,
-    mock_is_autoscaling_resumed,
-    mock_write_autoscaling_paused,
+    mock_is_deployment_marked_paused,
+    mock_mark_deployment_as_paused,
 ):
     mock_client = mock.MagicMock()
     config_dict = {"max_instances": 3, "min_instances": 1}
@@ -261,9 +261,9 @@ def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_resumed(
     app.item.spec.replicas = 2
 
     mock_autoscaling_is_paused.return_value = False
-    mock_is_autoscaling_resumed.return_value = False
+    mock_is_deployment_marked_paused.return_value = True
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
-    assert mock_write_autoscaling_paused.call_count == 1
+    assert mock_mark_deployment_as_paused.call_count == 1
     assert (
         mock_client.autoscaling.create_namespaced_horizontal_pod_autoscaler.call_count
         == 0
@@ -275,7 +275,7 @@ def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_resumed(
 
 
 @mock.patch(
-    "paasta_tools.kubernetes.application.controller_wrappers.is_autoscaling_resumed",
+    "paasta_tools.kubernetes.application.controller_wrappers.is_deployment_marked_paused",
     autospec=True,
 )
 @mock.patch(
@@ -283,7 +283,7 @@ def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_resumed(
     autospec=True,
 )
 def test_sync_horizontal_pod_autoscaler_create_hpa(
-    mock_autoscaling_is_paused, mock_is_autoscaling_resumed
+    mock_autoscaling_is_paused, mock_is_deployment_marked_paused
 ):
     mock_client = mock.MagicMock()
     # Create
@@ -291,7 +291,7 @@ def test_sync_horizontal_pod_autoscaler_create_hpa(
     app = setup_app(config_dict, False)
 
     mock_autoscaling_is_paused.return_value = False
-    mock_is_autoscaling_resumed.return_value = True
+    mock_is_deployment_marked_paused.return_value = False
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
 
     assert (
@@ -309,7 +309,7 @@ def test_sync_horizontal_pod_autoscaler_create_hpa(
 
 
 @mock.patch(
-    "paasta_tools.kubernetes.application.controller_wrappers.is_autoscaling_resumed",
+    "paasta_tools.kubernetes.application.controller_wrappers.is_deployment_marked_paused",
     autospec=True,
 )
 @mock.patch(
@@ -317,7 +317,7 @@ def test_sync_horizontal_pod_autoscaler_create_hpa(
     autospec=True,
 )
 def test_sync_horizontal_pod_autoscaler_update_hpa(
-    mock_autoscaling_is_paused, mock_is_autoscaling_resumed
+    mock_autoscaling_is_paused, mock_is_deployment_marked_paused
 ):
     mock_client = mock.MagicMock()
     # Update
@@ -325,7 +325,7 @@ def test_sync_horizontal_pod_autoscaler_update_hpa(
     app = setup_app(config_dict, True)
 
     mock_autoscaling_is_paused.return_value = False
-    mock_is_autoscaling_resumed.return_value = True
+    mock_is_deployment_marked_paused.return_value = False
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
     assert (
         mock_client.autoscaling.create_namespaced_horizontal_pod_autoscaler.call_count

--- a/tests/kubernetes/application/test_controller_wrapper.py
+++ b/tests/kubernetes/application/test_controller_wrapper.py
@@ -275,16 +275,23 @@ def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_resumed(
 
 
 @mock.patch(
+    "paasta_tools.kubernetes.application.controller_wrappers.is_autoscaling_resumed",
+    autospec=True,
+)
+@mock.patch(
     "paasta_tools.kubernetes.application.controller_wrappers.autoscaling_is_paused",
     autospec=True,
 )
-def test_sync_horizontal_pod_autoscaler_create_hpa(mock_autoscaling_is_paused):
+def test_sync_horizontal_pod_autoscaler_create_hpa(
+    mock_autoscaling_is_paused, mock_is_autoscaling_resumed
+):
     mock_client = mock.MagicMock()
     # Create
     config_dict = {"max_instances": 3}
     app = setup_app(config_dict, False)
 
     mock_autoscaling_is_paused.return_value = False
+    mock_is_autoscaling_resumed.return_value = True
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
 
     assert (
@@ -302,16 +309,23 @@ def test_sync_horizontal_pod_autoscaler_create_hpa(mock_autoscaling_is_paused):
 
 
 @mock.patch(
+    "paasta_tools.kubernetes.application.controller_wrappers.is_autoscaling_resumed",
+    autospec=True,
+)
+@mock.patch(
     "paasta_tools.kubernetes.application.controller_wrappers.autoscaling_is_paused",
     autospec=True,
 )
-def test_sync_horizontal_pod_autoscaler_update_hpa(mock_autoscaling_is_paused):
+def test_sync_horizontal_pod_autoscaler_update_hpa(
+    mock_autoscaling_is_paused, mock_is_autoscaling_resumed
+):
     mock_client = mock.MagicMock()
     # Update
     config_dict = {"max_instances": 3}
     app = setup_app(config_dict, True)
 
     mock_autoscaling_is_paused.return_value = False
+    mock_is_autoscaling_resumed.return_value = True
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
     assert (
         mock_client.autoscaling.create_namespaced_horizontal_pod_autoscaler.call_count

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1195,7 +1195,6 @@ class TestKubernetesDeploymentConfig:
                     "paasta.yelp.com/service": mock_get_service.return_value,
                 },
                 name="kurupt-fm",
-                annotations=None,
             )
 
     def test_get_hpa_metric_spec(self):

--- a/tests/test_setup_kubernetes_job.py
+++ b/tests/test_setup_kubernetes_job.py
@@ -192,6 +192,7 @@ def test_setup_kube_deployment_create_update():
         fake_app.create = fake_create
         fake_app.update = fake_update
         fake_app.item = None
+        fake_app.soa_config = None
         return True, fake_app
 
     with mock.patch(
@@ -330,7 +331,7 @@ def test_setup_kube_deployment_create_update():
 
         # update because autoscaler has been paused
         mock_autoscaling_is_paused.return_value = True
-        mock_is_autoscaling_resumed.return_value = False
+        mock_is_autoscaling_resumed.return_value = True
         fake_create.reset_mock()
         fake_update.reset_mock()
         mock_service_instances = ["kurupt.garage"]

--- a/tests/test_setup_kubernetes_job.py
+++ b/tests/test_setup_kubernetes_job.py
@@ -204,13 +204,13 @@ def test_setup_kube_deployment_create_update():
     ) as mock_list_all_deployments, mock.patch(
         "paasta_tools.setup_kubernetes_job.autoscaling_is_paused", autospec=True
     ) as mock_autoscaling_is_paused, mock.patch(
-        "paasta_tools.setup_kubernetes_job.is_autoscaling_resumed", autospec=True
-    ) as mock_is_autoscaling_resumed:
+        "paasta_tools.setup_kubernetes_job.is_deployment_marked_paused", autospec=True
+    ) as mock_is_deployment_marked_paused:
         mock_client = mock.Mock()
         # No instances created
         mock_service_instances: Sequence[str] = []
         mock_autoscaling_is_paused.return_value = False
-        mock_is_autoscaling_resumed.return_value = True
+        mock_is_deployment_marked_paused.return_value = False
         setup_kube_deployments(
             kube_client=mock_client,
             service_instances=mock_service_instances,
@@ -331,7 +331,7 @@ def test_setup_kube_deployment_create_update():
 
         # update because autoscaler has been paused
         mock_autoscaling_is_paused.return_value = True
-        mock_is_autoscaling_resumed.return_value = True
+        mock_is_deployment_marked_paused.return_value = False
         fake_create.reset_mock()
         fake_update.reset_mock()
         mock_service_instances = ["kurupt.garage"]
@@ -354,7 +354,7 @@ def test_setup_kube_deployment_create_update():
 
         # update because autoscaler has been resumed
         mock_autoscaling_is_paused.return_value = False
-        mock_is_autoscaling_resumed.return_value = False
+        mock_is_deployment_marked_paused.return_value = True
         fake_create.reset_mock()
         fake_update.reset_mock()
         mock_service_instances = ["kurupt.garage"]


### PR DESCRIPTION
### Summary
The following code is responsible for fixing the update deployment feedback loop caused by the revision annotation being bump after each iteration of `setup_kubernetes_job`. This code removes the need for pause_service_autoscaler to depend on annotations in the metadata spec. Instead, in order to determine whether the deployment has been paused, it manually just queries the k8s API, and check the annotations on the object directly.

In addition, we've also added an extra check so deployments will not continually be updated when paused. Conditions for `setup_kubernetes_job` to run `update()`:
- If k8s deployment config sha is different than existing one.
- If HPA is paused AND the deployment has not been paused yet.
- If HPA is resumed AND the deployment is still paused.

### Testing Done
* make test
* manually tested on kubestage. This time, we ensured that deployments are only updated once after being paused.