### PR TITLE
Fix kwarg name in oom count metric and add tests

### DIFF
--- a/paasta_tools/oom_logger.py
+++ b/paasta_tools/oom_logger.py
@@ -46,13 +46,18 @@ from paasta_tools.utils import get_docker_client
 from paasta_tools.utils import load_system_paasta_config
 
 
+# Sorry to any non-yelpers but this won't
+# do much as our metrics and logging libs
+# are not open source
 try:
     import yelp_meteorite
 except ImportError:
-    # Sorry to any non-yelpers but you won't
-    # get metrics emitted as our metrics lib
-    # is currently not open source
     yelp_meteorite = None
+
+try:
+    from clog.loggers import ScribeLogger
+except ImportError:
+    ScribeLogger = None
 
 
 LogLine = namedtuple(
@@ -179,11 +184,10 @@ def send_sfx_event(service, instance, cluster):
 
 
 def main():
-    try:
-        from clog.loggers import ScribeLogger
-    except ImportError:
+    if ScribeLogger is None:
         print("Scribe logger unavailable, exiting.", file=sys.stderr)
         sys.exit(1)
+
     scribe_logger = ScribeLogger(host="169.254.255.254", port=1463, retry_interval=5)
     cluster = load_system_paasta_config().get_cluster()
     client = get_docker_client()

--- a/paasta_tools/oom_logger.py
+++ b/paasta_tools/oom_logger.py
@@ -178,7 +178,7 @@ def send_sfx_event(service, instance, cluster):
             "paasta.service.oom_events", dimensions=dimensions,
         )
         counter = yelp_meteorite.create_counter(
-            "paasta.service.oom_count", dimensions=dimensions,
+            "paasta.service.oom_count", default_dimensions=dimensions,
         )
         counter.count()
 

--- a/tests/test_oom_logger.py
+++ b/tests/test_oom_logger.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-import warnings
 
 import pytest
 from mock import Mock
@@ -154,7 +153,7 @@ def log_line():
         service="fake_service",
         instance="fake_instance",
         process_name="apache2",
-        mesos_container_id="a04c14a6-83ea-4047-a802-92b850b1624e",
+        mesos_container_id="mesos-a04c14a6-83ea-4047-a802-92b850b1624e",
         mem_limit="512",
     )
 
@@ -252,40 +251,33 @@ def test_log_to_scribe(log_line):
     )
 
 
-try:
-    from paasta_tools.oom_logger import ScribeLogger  # noqa: F401
+@patch("paasta_tools.oom_logger.sys.stdin", autospec=True)
+@patch("paasta_tools.oom_logger.ScribeLogger", autospec=None)
+@patch("paasta_tools.oom_logger.load_system_paasta_config", autospec=True)
+@patch("paasta_tools.oom_logger.log_to_scribe", autospec=True)
+@patch("paasta_tools.oom_logger.log_to_paasta", autospec=True)
+@patch("paasta_tools.oom_logger.get_docker_client", autospec=True)
+def test_main(
+    mock_get_docker_client,
+    mock_log_to_paasta,
+    mock_log_to_scribe,
+    mock_load_system_paasta_config,
+    mock_scribelogger,
+    mock_sys_stdin,
+    sys_stdin,
+    docker_inspect,
+    log_line,
+):
 
-    @patch("paasta_tools.oom_logger.sys.stdin", autospec=True)
-    @patch("paasta_tools.oom_logger.ScribeLogger", autospec=True)
-    @patch("paasta_tools.oom_logger.load_system_paasta_config", autospec=True)
-    @patch("paasta_tools.oom_logger.log_to_scribe", autospec=True)
-    @patch("paasta_tools.oom_logger.log_to_paasta", autospec=True)
-    @patch("paasta_tools.oom_logger.get_docker_client", autospec=True)
-    def test_main(
-        mock_get_docker_client,
-        mock_log_to_paasta,
-        mock_log_to_scribe,
-        mock_load_system_paasta_config,
-        mock_scribelogger,
-        mock_sys_stdin,
-        sys_stdin,
-        docker_inspect,
-        log_line,
-    ):
+    mock_sys_stdin.readline.side_effect = sys_stdin
+    docker_client = Mock(inspect_container=Mock(return_value=docker_inspect))
+    mock_get_docker_client.return_value = docker_client
+    mock_load_system_paasta_config.return_value.get_cluster.return_value = (
+        "fake_cluster"
+    )
+    scribe_logger = Mock()
+    mock_scribelogger.return_value = scribe_logger
 
-        mock_sys_stdin.readline.side_effect = sys_stdin
-        docker_client = Mock(inspect_container=Mock(return_value=docker_inspect))
-        mock_get_docker_client.return_value = docker_client
-        mock_load_system_paasta_config.return_value.get_cluster.return_value = (
-            "fake_cluster"
-        )
-        scribe_logger = Mock()
-        mock_scribelogger.return_value = scribe_logger
-
-        main()
-        mock_log_to_paasta.assert_called_once_with(log_line)
-        mock_log_to_scribe.assert_called_once_with(scribe_logger, log_line)
-
-
-except ImportError:
-    warnings.warn("ScribeLogger is unavailable")
+    main()
+    mock_log_to_paasta.assert_called_once_with(log_line)
+    mock_log_to_scribe.assert_called_once_with(scribe_logger, log_line)


### PR DESCRIPTION
The main change is just L176 in oom_logger.py. Probably spent more time on the tests than I should have, but I wanted to make sure they would catch any similar typos next time. 

test_main was never being run after https://github.com/Yelp/paasta/pull/2346 because that change moved the import of ScribeLogger into main() itself, so `from paasta_tools.oom_logger import ScribeLogger` would fail even if clog was in the venv. Since we are mocking ScribeLogger anyway, we can run the tests regardless of whether it is in the venv or not.

After I made that change, I fixed the mesos container id mock and added tests for the sfx method.