### PR TITLE
Paasta 16560 check oom events thresholds

### DIFF
--- a/paasta_tools/check_oom_events.py
+++ b/paasta_tools/check_oom_events.py
@@ -65,6 +65,20 @@ def parse_args(args):
         help="Sensu 'realert_every' to use.",
     )
     parser.add_argument(
+        "--check-interval",
+        dest="check_interval",
+        type=int,
+        default=1,
+        help="How often this check runs, in minutes.",
+    )
+    parser.add_argument(
+        "--alert-threshold",
+        dest="alert_threshold",
+        type=int,
+        default=1,
+        help="Number of OOM kills required in the check interval to send an alert.",
+    )
+    parser.add_argument(
         "-s",
         "--superregion",
         dest="superregion",
@@ -114,39 +128,37 @@ def latest_oom_events(cluster, superregion, interval=60):
     return res
 
 
-def compose_sensu_status(instance, oom_events, is_check_enabled):
+def compose_sensu_status(
+    instance, oom_events, is_check_enabled, alert_threshold, check_interval
+):
     """
     :param instance: InstanceConfig
     :param oom_events: a list of OOMEvents
     :param is_check_enabled: boolean to indicate whether the check enabled for the instance
     """
+    interval_string = f"{check_interval} minute(s)"
+    instance_name = f"{instance.service}.{instance.instance}"
     if not is_check_enabled:
-        return (
-            Status.OK,
-            "This check is disabled for {}.{}.".format(
-                instance.service, instance.instance
-            ),
-        )
+        return (Status.OK, f"This check is disabled for {instance_name}.")
     if len(oom_events) == 0:
         return (
             Status.OK,
-            "No oom events for %s.%s in the last minute."
-            % (instance.service, instance.instance),
+            f"No oom events for {instance_name} in the last {interval_string}.",
         )
-    else:
+    elif len(oom_events) >= alert_threshold:
+        process_names = ",".join(
+            sorted({e.process_name for e in oom_events if e.process_name})
+        )
         return (
             Status.CRITICAL,
-            "The Out Of Memory killer killed %d processes (%s) "
-            "in the last minute in %s.%s containers."
-            % (
-                len(oom_events),
-                ",".join(
-                    sorted({e.process_name for e in oom_events if e.process_name})
-                ),
-                instance.service,
-                instance.instance,
-            ),
+            f"The Out Of Memory killer killed {len(oom_events)} processes ({process_names}) "
+            f"in the last {interval_string} in {instance_name} containers.",
         )
+    else:
+        # If the number of OOM kills isn't above the alert threshold,
+        # don't send anything. This will keep an alert open if it's already open,
+        # but won't start a new alert if there wasn't one yet
+        return None
 
 
 def send_sensu_event(instance, oom_events, args):
@@ -162,7 +174,12 @@ def send_sensu_event(instance, oom_events, args):
         instance=instance,
         oom_events=oom_events,
         is_check_enabled=monitoring_overrides.get("check_oom_events", True),
+        alert_threshold=args.alert_threshold,
+        check_interval=args.check_interval,
     )
+    if not status:
+        return
+
     memory_limit = instance.get_mem()
     try:
         memory_limit_str = f"{int(memory_limit)}MB"
@@ -191,7 +208,9 @@ def send_sensu_event(instance, oom_events, args):
 def main(sys_argv):
     args = parse_args(sys_argv[1:])
     cluster = load_system_paasta_config().get_cluster()
-    victims = latest_oom_events(cluster, args.superregion)
+    victims = latest_oom_events(
+        cluster, args.superregion, interval=(60 * args.check_interval)
+    )
     for (service, instance) in get_services_for_cluster(cluster, soa_dir=args.soa_dir):
         try:
             instance_config = get_instance_config(

--- a/paasta_tools/check_oom_events.py
+++ b/paasta_tools/check_oom_events.py
@@ -131,7 +131,7 @@ def compose_sensu_status(
     instance_name = f"{instance.service}.{instance.instance}"
     if not is_check_enabled:
         return (Status.OK, f"This check is disabled for {instance_name}.")
-    if len(oom_events) == 0:
+    if not oom_events:
         return (
             Status.OK,
             f"No oom events for {instance_name} in the last {interval_string}.",

--- a/tests/test_check_oom_events.py
+++ b/tests/test_check_oom_events.py
@@ -8,7 +8,6 @@ from pysensu_yelp import Status
 from paasta_tools.check_oom_events import compose_sensu_status
 from paasta_tools.check_oom_events import latest_oom_events
 from paasta_tools.check_oom_events import main
-from paasta_tools.check_oom_events import OOMEvent
 from paasta_tools.check_oom_events import read_oom_events_from_scribe
 
 
@@ -21,10 +20,21 @@ def scribereader_output():
             ' "cluster": "fake_cluster", "service": "fake_service1", '
             '"instance": "fake_instance1", "process_name": "uwsgi"}' % (time_now - 20)
         ),
+        #  Same container, different process
+        (
+            '{"timestamp": %d, "hostname": "hostname1", "container_id": "baaab5a3a9fa",'
+            ' "cluster": "fake_cluster", "service": "fake_service1", '
+            '"instance": "fake_instance1", "process_name": "python"}' % (time_now - 20)
+        ),
         (
             '{"timestamp": %d, "hostname": "hostname2", "container_id": "8dc8b9aeebbe",'
             ' "cluster": "fake_cluster", "service": "fake_service2", '
             '"instance": "fake_instance2", "process_name": "uwsgi"}' % (time_now - 15)
+        ),
+        (
+            '{"timestamp": %d, "hostname": "hostname2", "container_id": "7dc8b9ffffff",'
+            ' "cluster": "fake_cluster", "service": "fake_service2", '
+            '"instance": "fake_instance2", "process_name": "uwsgi"}' % (time_now - 14)
         ),
         ("Non-JSON lines must be ignored."),
     )
@@ -64,19 +74,14 @@ def test_compose_sensu_status_unknown(instance_config):
 def test_compose_sensu_status_not_ok(instance_config):
     assert compose_sensu_status(
         instance=instance_config,
-        oom_events=[
-            OOMEvent("hostname1", "container_id1", "proc_A"),
-            OOMEvent("hostname3", "container_id3", "proc_C"),
-            OOMEvent("hostname2", "container_id2", "proc_B"),
-            OOMEvent("hostname2", "container_id2", ""),
-        ],
+        oom_events={"container_id1", "container_id2", "container_id3"},
         is_check_enabled=True,
         alert_threshold=2,
         check_interval=1,
     ) == (
         Status.CRITICAL,
-        "The Out Of Memory killer killed 4 processes (proc_A,proc_B,proc_C)"
-        " in the last 1 minute(s) in fake_service.fake_instance containers.",
+        "The Out Of Memory killer killed processes for fake_service.fake_instance"
+        " in the last 1 minute(s).",
     )
 
 
@@ -84,12 +89,7 @@ def test_compose_sensu_status_below_threshold(instance_config):
     assert (
         compose_sensu_status(
             instance=instance_config,
-            oom_events=[
-                OOMEvent("hostname1", "container_id1", "proc_A"),
-                OOMEvent("hostname3", "container_id3", "proc_C"),
-                OOMEvent("hostname2", "container_id2", "proc_B"),
-                OOMEvent("hostname2", "container_id2", ""),
-            ],
+            oom_events={"container_id1", "container_id2", "container_id3"},
             is_check_enabled=True,
             alert_threshold=5,
             check_interval=1,
@@ -106,7 +106,7 @@ def test_read_oom_events_from_scribe(mock_scribereader, scribereader_output):
         len(
             [x for x in read_oom_events_from_scribe("fake_cluster", "fake_superregion")]
         )
-        == 2
+        == 4
     )
 
 
@@ -115,8 +115,9 @@ def test_latest_oom_events(mock_scribereader, scribereader_output):
     mock_scribereader.get_default_scribe_hosts.return_value = [{"host": "", "port": ""}]
     mock_scribereader.get_stream_tailer.return_value = scribereader_output
     events = latest_oom_events("fake_cluster", "fake_superregion")
+    # Events from the same container count as one
     assert len(events.get(("fake_service1", "fake_instance1"), [])) == 1
-    assert len(events.get(("fake_service2", "fake_instance2"), [])) == 1
+    assert len(events.get(("fake_service2", "fake_instance2"), [])) == 2
     assert len(events.get(("fake_service3", "fake_instance3"), [])) == 0
 
 


### PR DESCRIPTION
With autotuned_defaults running services with smaller margins on resources, we expect occasional OOMs. We want to keep these OOM alerts actionable, and don't want service owners to disable autotuned_defaults every time an OOM occurs. Even if a service isn't using autotuned_defaults, they don't necessarily need to bump memory on every OOM.

We will still be showing every OOM in dashboards and logs, and the rightsizer will take them into account - we just want to give the rightsizer some time to adjust. 

At the same time, the alert should still show serious issues with the memory value. We can explore different settings, but I'm thinking we can start with something conservative like alert_threshold=2 and check_every=5, so it will alert if any 2 containers in the same service instance OOM within a 5 min period.
