### PR TITLE
Fix paasta metastatus reports incorrect resource usage

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1749,6 +1749,12 @@ def pods_for_service_instance(
     ).items
 
 
+def get_pods_by_node(kube_client: KubeClient, node: V1Node) -> Sequence[V1Pod]:
+    return kube_client.core.list_pod_for_all_namespaces(
+        field_selector=f"spec.nodeName={node.metadata.name}"
+    ).items
+
+
 def get_all_pods(kube_client: KubeClient, namespace: str = "paasta") -> Sequence[V1Pod]:
     return kube_client.core.list_namespaced_pod(namespace=namespace).items
 

--- a/paasta_tools/metrics/metastatus_lib.py
+++ b/paasta_tools/metrics/metastatus_lib.py
@@ -109,15 +109,15 @@ def get_mesos_cpu_status(
     return total, used, available
 
 
-def get_kube_cpu_status(nodes: Sequence[V1Node],) -> Tuple[int, int, int]:
+def get_kube_cpu_status(nodes: Sequence[V1Node],) -> Tuple[float, float, float]:
     """Takes in the list of Kubernetes nodes and analyzes them, returning the status.
 
     :param nodes: list of Kubernetes nodes.
     :returns: Tuple of total, used, and available CPUs.
     """
 
-    total = 0
-    available = 0
+    total = 0.0
+    available = 0.0
     for node in nodes:
         available += suffixed_number_value(node.status.allocatable["cpu"])
         total += suffixed_number_value(node.status.capacity["cpu"])
@@ -146,14 +146,14 @@ def get_mesos_memory_status(
     return total, used, available
 
 
-def get_kube_memory_status(nodes: Sequence[V1Node],) -> Tuple[int, int, int]:
+def get_kube_memory_status(nodes: Sequence[V1Node],) -> Tuple[float, float, float]:
     """Takes in the list of Kubernetes nodes and analyzes them, returning the status.
 
     :param nodes: list of Kubernetes nodes.
     :returns: Tuple of total, used, and available memory in Mi.
     """
-    total = 0
-    available = 0
+    total = 0.0
+    available = 0.0
     for node in nodes:
         available += suffixed_number_value(node.status.allocatable["memory"])
         total += suffixed_number_value(node.status.capacity["memory"])
@@ -184,15 +184,15 @@ def get_mesos_disk_status(
     return total, used, available
 
 
-def get_kube_disk_status(nodes: Sequence[V1Node],) -> Tuple[int, int, int]:
+def get_kube_disk_status(nodes: Sequence[V1Node],) -> Tuple[float, float, float]:
     """Takes in the list of Kubernetes nodes and analyzes them, returning the status.
 
     :param nodes: list of Kubernetes nodes.
     :returns: Tuple of total, used, and available disk space in Mi.
     """
 
-    total = 0
-    available = 0
+    total = 0.0
+    available = 0.0
     for node in nodes:
         available += suffixed_number_value(node.status.allocatable["ephemeral-storage"])
         total += suffixed_number_value(node.status.capacity["ephemeral-storage"])
@@ -222,15 +222,15 @@ def get_mesos_gpu_status(
     return total, used, available
 
 
-def get_kube_gpu_status(nodes: Sequence[V1Node],) -> Tuple[int, int, int]:
+def get_kube_gpu_status(nodes: Sequence[V1Node],) -> Tuple[float, float, float]:
     """Takes in the list of Kubernetes nodes and analyzes them, returning the status.
 
     :param nodes: list of Kubernetes nodes.
     :returns: Tuple of total, used, and available GPUs.
     """
 
-    total = 0
-    available = 0
+    total = 0.0
+    available = 0.0
     for node in nodes:
         available += suffixed_number_value(
             node.status.allocatable.get("nvidia.com/gpu", "0")
@@ -329,7 +329,7 @@ def percent_used(total: float, used: float) -> float:
 
 
 def assert_cpu_health(
-    cpu_status: Tuple[int, int, int], threshold: int = 10
+    cpu_status: Tuple[float, float, float], threshold: int = 10
 ) -> HealthCheckResult:
     total, used, available = cpu_status
     try:
@@ -354,7 +354,7 @@ def assert_cpu_health(
 
 
 def assert_memory_health(
-    memory_status: Tuple[int, int, int], threshold: int = 10
+    memory_status: Tuple[float, float, float], threshold: int = 10
 ) -> HealthCheckResult:
     total: float
     used: float
@@ -385,7 +385,7 @@ def assert_memory_health(
 
 
 def assert_disk_health(
-    disk_status: Tuple[int, int, int], threshold: int = 10
+    disk_status: Tuple[float, float, float], threshold: int = 10
 ) -> HealthCheckResult:
     total: float
     used: float
@@ -416,7 +416,7 @@ def assert_disk_health(
 
 
 def assert_gpu_health(
-    gpu_status: Tuple[int, int, int], threshold: int = 0
+    gpu_status: Tuple[float, float, float], threshold: int = 0
 ) -> HealthCheckResult:
     total, used, available = gpu_status
 
@@ -719,18 +719,18 @@ _IEC_NUMBER_SUFFIXES = {
 }
 
 
-def suffixed_number_value(s: str) -> int:
+def suffixed_number_value(s: str) -> float:
     pattern = r"(?P<number>\d+)(?P<suff>\w*)"
     match = re.match(pattern, s)
     number, suff = match.groups()
 
     if suff in _IEC_NUMBER_SUFFIXES:
-        return int(int(number) * _IEC_NUMBER_SUFFIXES[suff])
+        return float(number) * _IEC_NUMBER_SUFFIXES[suff]
     else:
-        return int(number)
+        return float(number)
 
 
-def suffixed_number_dict_values(d: Mapping[Any, str]) -> Mapping[Any, int]:
+def suffixed_number_dict_values(d: Mapping[Any, str]) -> Mapping[Any, float]:
     return {k: suffixed_number_value(v) for k, v in d.items()}
 
 

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -917,7 +917,7 @@ def test_reserved_maintenence_resources_ignores_non_maintenance():
 
 def test_suffixed_number_value():
     assert metastatus_lib.suffixed_number_value("5k") == 5 * 1000
-    assert metastatus_lib.suffixed_number_value("5m") == int(5 * 1000 ** -1)
+    assert metastatus_lib.suffixed_number_value("5m") == 5 * 1000 ** -1
     assert metastatus_lib.suffixed_number_value("5M") == 5 * 1000 ** 2
     assert metastatus_lib.suffixed_number_value("5G") == 5 * 1000 ** 3
     assert metastatus_lib.suffixed_number_value("5T") == 5 * 1000 ** 4

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -684,8 +684,8 @@ def test_calculate_resource_utilization_for_kube_nodes():
     )["free"]
 
     assert free.cpus == 480
-    assert int(free.mem) == 730
-    assert int(free.disk) == 180
+    assert free.mem == 730
+    assert free.disk == 180
 
 
 def test_healthcheck_result_for_resource_utilization_ok():
@@ -917,6 +917,7 @@ def test_reserved_maintenence_resources_ignores_non_maintenance():
 
 def test_suffixed_number_value():
     assert metastatus_lib.suffixed_number_value("5k") == 5 * 1000
+    assert metastatus_lib.suffixed_number_value("5m") == int(5 * 1000 ** -1)
     assert metastatus_lib.suffixed_number_value("5M") == 5 * 1000 ** 2
     assert metastatus_lib.suffixed_number_value("5G") == 5 * 1000 ** 3
     assert metastatus_lib.suffixed_number_value("5T") == 5 * 1000 ** 4

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -17,10 +17,14 @@ import re
 
 import mock
 import pytest
+from kubernetes.client import V1Container
 from kubernetes.client import V1Node
 from kubernetes.client import V1NodeStatus
+from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1Pod
+from kubernetes.client import V1PodSpec
 from kubernetes.client import V1PodStatus
+from kubernetes.client import V1ResourceRequirements
 from mock import Mock
 from mock import patch
 
@@ -643,30 +647,45 @@ def test_calculate_resource_utilization_for_slaves():
 def test_calculate_resource_utilization_for_kube_nodes():
     fake_nodes = [
         V1Node(
+            metadata=V1ObjectMeta(name="fake_node1"),
             status=V1NodeStatus(
                 allocatable={
-                    "cpu": "480",
-                    "ephemeral-storage": "180Mi",
-                    "memory": "730Mi",
-                    "nvidia.com/gpu": "2",
-                },
-                capacity={
                     "cpu": "500",
                     "ephemeral-storage": "200Mi",
                     "memory": "750Mi",
-                    "nvidia.com/gpu": "5",
                 },
-            )
+            ),
         )
     ]
+    fake_pods_by_node = {
+        "fake_node1": [
+            V1Pod(
+                metadata=V1ObjectMeta(name="pod1"),
+                status=V1PodStatus(phase="Running"),
+                spec=V1PodSpec(
+                    containers=[
+                        V1Container(
+                            name="container1",
+                            resources=V1ResourceRequirements(
+                                requests={
+                                    "cpu": "20",
+                                    "ephemeral-storage": "20Mi",
+                                    "memory": "20Mi",
+                                }
+                            ),
+                        )
+                    ]
+                ),
+            )
+        ]
+    }
     free = metastatus_lib.calculate_resource_utilization_for_kube_nodes(
-        nodes=fake_nodes
+        nodes=fake_nodes, pods_by_node=fake_pods_by_node
     )["free"]
 
     assert free.cpus == 480
-    assert free.mem == 730
-    assert free.disk == 180
-    assert free.gpus == 2
+    assert int(free.mem) == 730
+    assert int(free.disk) == 180
 
 
 def test_healthcheck_result_for_resource_utilization_ok():


### PR DESCRIPTION
Allocatable resource from k8s nodes describes the total resource can be allocated.
The value will not changed if the resource is allocated to the pods. To get the value
for allocated resource, we need to aggregate the resource requirement from all pods.

The sample output is here: https://fluffy.yelpcorp.com/i/7gw50nz68qbQnKhXRczwPXwl1NmGbkL2.html
I have confirmed the number matches the number reported by `kubectl describe nodes`

I don't implement the gpu part since we are not using that now.