### PR TITLE
Do not attempt to update HPA configs of a stateful set

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -47,7 +47,7 @@ from paasta_tools.bounce_lib import filter_tasks_in_smartstack
 from paasta_tools.bounce_lib import LockHeldException
 from paasta_tools.bounce_lib import LockTimeout
 from paasta_tools.bounce_lib import ZK_LOCK_CONNECT_TIMEOUT_S
-from paasta_tools.kubernetes_tools import get_annotations_for_deployment
+from paasta_tools.kubernetes_tools import get_annotations_for_kubernetes_service
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.kubernetes_tools import write_annotation_for_kubernetes_service
@@ -861,7 +861,7 @@ def autoscaling_is_paused():
 def is_deployment_marked_paused(
     kube_client: KubeClient, service_config: KubernetesDeploymentConfig
 ):
-    annotations = get_annotations_for_deployment(kube_client, service_config)
+    annotations = get_annotations_for_kubernetes_service(kube_client, service_config)
     return annotations.get("is_paused", "False") == "True"
 
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1753,14 +1753,19 @@ def set_instances_for_kubernetes_service(
         )
 
 
-def get_annotations_for_deployment(
+def get_annotations_for_kubernetes_service(
     kube_client: KubeClient, service_config: KubernetesDeploymentConfig
 ) -> Dict:
     name = service_config.get_sanitised_deployment_name()
-    deployment = kube_client.deployments.read_namespaced_deployment(
-        name=name, namespace="paasta"
-    )
-    return deployment.metadata.annotations if deployment.metadata.annotations else {}
+    if service_config.get_persistent_volumes():
+        k8s_service = kube_client.deployments.read_namespaced_stateful_set(
+            name=name, namespace="paasta"
+        )
+    else:
+        k8s_service = kube_client.deployments.read_namespaced_deployment(
+            name=name, namespace="paasta"
+        )
+    return k8s_service.metadata.annotations if k8s_service.metadata.annotations else {}
 
 
 def write_annotation_for_kubernetes_service(

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -24,6 +24,7 @@ from paasta_tools import marathon_tools
 from paasta_tools.autoscaling import autoscaling_service_lib
 from paasta_tools.autoscaling.autoscaling_service_lib import autoscaling_is_paused
 from paasta_tools.autoscaling.autoscaling_service_lib import filter_autoscaling_tasks
+from paasta_tools.autoscaling.autoscaling_service_lib import is_deployment_marked_paused
 from paasta_tools.autoscaling.autoscaling_service_lib import MAX_TASK_DELTA
 from paasta_tools.autoscaling.autoscaling_service_lib import MetricsProviderNoDataError
 from paasta_tools.utils import NoDeploymentsAvailable
@@ -1889,3 +1890,15 @@ def test_autoscale_service_configs():
             mock_marathon_tasks,
             mock_mesos_tasks,
         )
+
+
+@pytest.mark.parametrize(
+    "given_annotations, is_marked_paused", [({"is_paused": "True"}, True), ({}, False),]
+)
+def test_is_deployment_marked_paused(given_annotations, is_marked_paused):
+    with mock.patch(
+        "paasta_tools.autoscaling.autoscaling_service_lib.get_annotations_for_kubernetes_service",
+        autospec=True,
+        return_value=given_annotations,
+    ):
+        assert is_deployment_marked_paused(mock.Mock(), mock.Mock()) is is_marked_paused


### PR DESCRIPTION
Currently our HPA-related logic only applies to k8s deployments, but in the context of setup_kubernetes_job, a paasta service instance can also be a k8s stateful set. Apply HPA config update against a stateful set can lead to issues.

For example, `is_deployment_marked_paused` method assumes a deployment with name 'foo' already exists and attempts to fetch annotations of it. In the case of a stateful set, a deployment with the same name does not exist and k8s API server will return 404, which crashes setup_kubernetes_job run.