### PR TITLE
Up the timeout for aio session for autoscaling

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -335,7 +335,7 @@ async def get_http_utilization_for_all_tasks(
     # hundreds of unique sessions seems to increase (timeout) errors.
     # However, using 1 session is slower because the default number of connections
     # is 100, but still seems to be a sane amount.
-    async with aiohttp.ClientSession(conn_timeout=2, read_timeout=2) as session:
+    async with aiohttp.ClientSession(conn_timeout=10, read_timeout=10) as session:
         futures = [
             asyncio.ensure_future(
                 get_http_utilization_for_a_task(


### PR DESCRIPTION
Apparently this was the "real" fix. Previously in my tests I just made a session, but left default timeouts. After taking @Rob-Johnson 's feedback I added the 2 second timeout back in, but didn't test in prod again.

Well, the errors were still there :(

Patching in this timeout in prod makes the errors go away, so I guess I'll patch it back in here. 
If you want I'll undo my other changes and make a session per request? But I don't think a single session isn't such a bad idea.