### PR TITLE
Never flood the bounce queue upon deployd restart

### DIFF
--- a/tests/deployd/test_deployd_master.py
+++ b/tests/deployd/test_deployd_master.py
@@ -87,8 +87,6 @@ class TestDeployDaemon(unittest.TestCase):
             "paasta_tools.deployd.master.DeployDaemon.prioritise_bouncing_services",
             autospec=True,
         ) as mock_prioritise_bouncing_services, mock.patch(
-            "paasta_tools.deployd.master.DeployDaemon.add_all_services", autospec=True
-        ) as mock_add_all_services, mock.patch(
             "paasta_tools.deployd.master.DeployDaemon.start_workers",
             autospec=True,
             side_effect=lambda self: setattr(
@@ -108,7 +106,6 @@ class TestDeployDaemon(unittest.TestCase):
             )
             assert mock_q_metrics.return_value.start.called
             assert mock_start_watchers.called
-            assert mock_add_all_services.called
             assert not mock_prioritise_bouncing_services.called
             assert mock_start_workers.called
             assert mock_main_loop.called


### PR DESCRIPTION
Since our queue is persistent now, I don't think we need to flood the bounce queue every time we restart deployd.