### PR TITLE
Bump scribereader to 0.8.0

### DIFF
--- a/extra-linux-requirements.txt
+++ b/extra-linux-requirements.txt
@@ -1,1 +1,1 @@
-cryptography==2.3.1
+cryptography==2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ choice==0.1
 click==6.6
 cookiecutter==1.4.0
 croniter==0.3.20
-cryptography==2.3.1
+cryptography==2.8
 decorator==4.1.2
 docker-py==1.2.3
 docutils==0.12

--- a/tests/cli/test_cmds_logs.py
+++ b/tests/cli/test_cmds_logs.py
@@ -742,6 +742,7 @@ def test_scribereader_print_last_n_logs():
     ) as determine_scribereader_envs_patch:
 
         determine_scribereader_envs_patch.return_value = ["env1", "env2"]
+        mock_scribereader.get_tail_host_and_port.return_value = "fake_host", "fake_port"
         fake_iter = mock.MagicMock()
         fake_iter.__iter__.return_value = (
             [
@@ -792,6 +793,7 @@ def test_scribereader_print_logs_by_time():
     ) as determine_scribereader_envs_patch:
 
         determine_scribereader_envs_patch.return_value = ["env1", "env2"]
+        mock_scribereader.get_tail_host_and_port.return_value = "fake_host", "fake_port"
         fake_iter = mock.MagicMock()
         fake_iter.__iter__.return_value = (
             [

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -8,14 +8,14 @@ inflection==0.3.1
 markdown==2.4
 monk==1.1.1
 python-jsonschema-objects==0.3.1
-scribereader==0.2.6
+scribereader==0.8.0
 signalform-tools==0.0.16
 slo-transcoder==3.2.3
 smmap2==2.0.3
 sticht[yelp_internal]==1.1.1
 vault-tools==0.7.34
 yelp-cgeom==1.3.1
-yelp-clog==5.0.0
+yelp-clog==4.1.1  # scribereader requires <5.0.0
 yelp-logging==1.0.37
 yelp_meteorite
 yelp_paasta_helpers


### PR DESCRIPTION
### Description
scribereader 0.2.6 is over 3 years old, and data streams core is deprecating things. I'm bumping it to 0.8.0, instead of 0.8.1 (which is the latest version), because 0.8.1 removes support for uswest1. However, our logs config still have uswest1 (see `/etc/paasta/logs.json`), and I can't change it to uswest2 ahead of this fix because the current version of scribereader PaaSTA uses doesn't know about uswest2. Version 0.8.0 supports both uswest1 and uswest2, so it's a stopgap version.

### Testing
- make test
- make itest_xenial
- Various `paasta logs` test runs:
  - `paasta logs -s clusterman -i cluster_metrics -c pnw-prod -C app_output -v -f`
  - `paasta logs -s clusterman -i cluster_metrics -c pnw-prod -C app_output -v -n 1000`
  - `paasta logs -s clusterman -i cluster_metrics -c pnw-prod -C app_output -v -a 1h`
  - `paasta logs -s clusterman -i cluster_metrics -c norcal-devc,norcal-stagef -C app_output -v -f`
  - `paasta logs -s clusterman -i cluster_metrics -c norcal-devc,norcal-stagef  -C app_output -v -n 1000`
  - `paasta logs -s clusterman -i cluster_metrics -c norcal-devc,norcal-stagef  -C app_output -v -a 1h`