### PR TITLE
Add support for logging to Monk

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1421,20 +1421,9 @@ try:
     # again after importing it.
     warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-    @register_log_writer("scribe")
-    class ScribeLogWriter(LogWriter):
-        def __init__(
-            self,
-            scribe_host: str = "169.254.255.254",
-            scribe_port: int = 1463,
-            scribe_disable: bool = False,
-            **kwargs: Any,
-        ) -> None:
-            clog.config.configure(
-                scribe_host=scribe_host,
-                scribe_port=scribe_port,
-                scribe_disable=scribe_disable,
-            )
+    class CLogWriter(LogWriter):
+        def __init__(self, **kwargs: Any):
+            clog.config.configure(**kwargs)
 
         def log(
             self,
@@ -1481,6 +1470,34 @@ try:
                 instance=instance,
             )
             clog.log_line(log_name, formatted_line)
+
+    @register_log_writer("monk")
+    class MonkLogWriter(CLogWriter):
+        def __init__(
+            self,
+            monk_host: str = "169.254.255.254",
+            monk_port: int = 1473,
+            monk_disable: bool = False,
+            **kwargs: Any,
+        ) -> None:
+            super().__init__(
+                monk_host=monk_host, monk_port=monk_port, monk_disable=monk_disable,
+            )
+
+    @register_log_writer("scribe")
+    class ScribeLogWriter(CLogWriter):
+        def __init__(
+            self,
+            scribe_host: str = "169.254.255.254",
+            scribe_port: int = 1463,
+            scribe_disable: bool = False,
+            **kwargs: Any,
+        ) -> None:
+            super().__init__(
+                scribe_host=scribe_host,
+                scribe_port=scribe_port,
+                scribe_disable=scribe_disable,
+            )
 
 
 except ImportError:

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -6,7 +6,7 @@ gitdb2==2.0.3
 gitpython==2.1.9
 inflection==0.3.1
 markdown==2.4
-monk==0.7.0
+monk==1.1.1
 python-jsonschema-objects==0.3.1
 scribereader==0.2.6
 signalform-tools==0.0.16
@@ -15,7 +15,7 @@ smmap2==2.0.3
 sticht[yelp_internal]==1.1.1
 vault-tools==0.7.34
 yelp-cgeom==1.3.1
-yelp-clog==3.3.1
+yelp-clog==5.0.0
 yelp-logging==1.0.37
 yelp_meteorite
 yelp_paasta_helpers


### PR DESCRIPTION
Monk is the recommended way of logging at Yelp, this commit adds support
to log to Monk as well as Scribe.
Newer versions of yelp_clog support both Monk and Scribe as a backend,
depending on configuration values.

Also make the oom_logger use clog.log_line (which supports Monk and
Scribe) rather than forcing Scribe.

-----

### Testing Done

* `make {test,itest,itest_xenial}` all pass
* Tested the `MonkLogWriter` locally (as well as ensured the updated `ScribeLogWriter` was still working), by changing `/etc/paasta/logs.json`

```
{
 "log_writer": {
   "driver": "monk",
   "monk_host": "169.254.255.254",
   "monk_port": 1473,
   "monk_disable": false,
   "options": {
     "monk_host": "169.254.255.254",
     "monk_port": 1473,
     "monk_disable": false
   }
 }
...
}
```

```python
>> ./.tox/py36-linux/bin/python
Python 3.6.0 (default, Jan 13 2017, 20:56:47)
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from paasta_tools.utils import configure_log
>>> configure_log()
>>> from paasta_tools.utils import _log_writer
>>> _log_writer.log(service='flavr', line='monk integration test', component='monitoring')
[service flavr] monk integration test
>>> _log_writer
<paasta_tools.utils.MonkLogWriter object at 0x7ff48dc0f7b8>
```