### PR TITLE
PaaSTA swagger.json is invalid

### DIFF
--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -207,7 +207,8 @@
                                 "services": {
                                     "type": "array",
                                     "items": {
-                                        "type": "array"
+                                        "type": "array",
+                                        "items": {}
                                     }
                                 }
                             }


### PR DESCRIPTION
According to go-swagger:

```
The swagger spec at "/nail/home/maksym/paasta-tools-go/swagger.json" is invalid against swagger specification 2.0. see errors :
- "paths./services.get.responses.200" must validate one and only one schema (oneOf). Found none valid
- "paths./services.get.responses.200.schema" must validate one and only one schema (oneOf). Found none valid
- "paths./services.get.responses.200.schema.properties.services.items" must validate at least one schema (anyOf)                            
- "paths./services.get.responses.200.schema.properties.services.items.items" must validate at least one schema (anyOf)
- paths./services.get.responses.200.schema.properties.services.items.items in body must be of type object: "string"
```