### PR TITLE
Remove ServiceInstances from the deploy queue if they fail too many t…

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1785,6 +1785,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     deployd_big_bounce_deadline: float
     deployd_log_level: str
     deployd_maintenance_polling_frequency: int
+    deployd_max_service_instance_failures: int
     deployd_metrics_provider: str
     deployd_number_workers: int
     deployd_startup_bounce_deadline: float
@@ -2085,6 +2086,14 @@ class SystemPaastaConfig:
         :returns: A boolean
         """
         return self.config_dict.get("deployd_startup_oracle_enabled", True)
+
+    def get_deployd_max_service_instance_failures(self) -> int:
+        """Determines how many times a service instance entry in deployd's queue
+        can fail before it will be removed from the queue.
+
+        :returns: An integer
+        """
+        return self.config_dict.get("deployd_max_service_instance_failures", 20)
 
     def get_sensu_host(self) -> str:
         """Get the host that we should send sensu events to.

--- a/tests/deployd/test_workers.py
+++ b/tests/deployd/test_workers.py
@@ -28,6 +28,7 @@ class TestPaastaDeployWorker(unittest.TestCase):
             self.worker = PaastaDeployWorker(
                 1, self.mock_instances_to_bounce, mock_config, self.mock_metrics
             )
+            self.worker.max_failures = 20
 
     def test_setup(self):
         with mock.patch(


### PR DESCRIPTION
…imes.

Now that we have a persistent queue, we don't want to keep failing entries in there indefinitely.