### PR TITLE
Ensure inbound_network_mode propagates smartstack iptables dependencies

### DIFF
--- a/paasta_tools/firewall_update.py
+++ b/paasta_tools/firewall_update.py
@@ -146,8 +146,9 @@ def smartstack_dependencies_of_running_firewalled_services(soa_dir=DEFAULT_SOA_D
             load_deployments=False,
             soa_dir=soa_dir,
         )
+        inbound_network_mode = config.get_inbound_network_mode()
         outbound_firewall = config.get_outbound_firewall()
-        if not outbound_firewall:
+        if not inbound_network_mode and not outbound_firewall:
             continue
 
         dependencies = config.get_dependencies() or ()

--- a/tests/test_firewall_update.py
+++ b/tests/test_firewall_update.py
@@ -78,14 +78,19 @@ def test_parse_args_default_cron():
     firewall,
     "services_running_here",
     autospec=True,
-    return_value=(("myservice", "hassecurity", "02:42:a9:fe:00:0a", "1.1.1.1"),),
+    return_value=(("myservice", "hassecurityinbound", "02:42:a9:fe:00:0a", "1.1.1.1"),
+                  ("myservice", "hassecurityoutbound", "02:42:a9:fe:00:0a", "1.1.1.1"),),
 )
 def test_smartstack_dependencies_of_running_firewalled_services(_, __, ___, tmpdir):
     soa_dir = tmpdir.mkdir("yelpsoa")
     myservice_dir = soa_dir.mkdir("myservice")
 
     marathon_config = {
-        "hassecurity": {
+        "hassecurityinbound": {
+            "dependencies_reference": "my_ref",
+            "security": {"inbound_network_mode": "restrict"},
+        },
+        "hassecurityoutbound": {
             "dependencies_reference": "my_ref",
             "security": {"outbound_firewall": "block"},
         },
@@ -106,8 +111,10 @@ def test_smartstack_dependencies_of_running_firewalled_services(_, __, ___, tmpd
         soa_dir=str(soa_dir)
     )
     assert dict(result) == {
-        "mydependency.depinstance": {("myservice", "hassecurity")},
-        "another.one": {("myservice", "hassecurity")},
+        "mydependency.depinstance": {("myservice", "hassecurityinbound"),
+                                     ("myservice", "hassecurityoutbound"),},
+        "another.one": {("myservice", "hassecurityinbound"),
+                        ("myservice", "hassecurityoutbound"),},
     }
 
 

--- a/tests/test_firewall_update.py
+++ b/tests/test_firewall_update.py
@@ -78,8 +78,10 @@ def test_parse_args_default_cron():
     firewall,
     "services_running_here",
     autospec=True,
-    return_value=(("myservice", "hassecurityinbound", "02:42:a9:fe:00:0a", "1.1.1.1"),
-                  ("myservice", "hassecurityoutbound", "02:42:a9:fe:00:0a", "1.1.1.1"),),
+    return_value=(
+        ("myservice", "hassecurityinbound", "02:42:a9:fe:00:0a", "1.1.1.1"),
+        ("myservice", "hassecurityoutbound", "02:42:a9:fe:00:0a", "1.1.1.1"),
+    ),
 )
 def test_smartstack_dependencies_of_running_firewalled_services(_, __, ___, tmpdir):
     soa_dir = tmpdir.mkdir("yelpsoa")
@@ -111,10 +113,14 @@ def test_smartstack_dependencies_of_running_firewalled_services(_, __, ___, tmpd
         soa_dir=str(soa_dir)
     )
     assert dict(result) == {
-        "mydependency.depinstance": {("myservice", "hassecurityinbound"),
-                                     ("myservice", "hassecurityoutbound"),},
-        "another.one": {("myservice", "hassecurityinbound"),
-                        ("myservice", "hassecurityoutbound"),},
+        "mydependency.depinstance": {
+            ("myservice", "hassecurityinbound"),
+            ("myservice", "hassecurityoutbound"),
+        },
+        "another.one": {
+            ("myservice", "hassecurityinbound"),
+            ("myservice", "hassecurityoutbound"),
+        },
     }
 
 


### PR DESCRIPTION
Currently, firewall_update.py only checks for outbound_firewall rules when determining whether to include smartstack mapping information (consumed downstream by iptables rules).

This change ensures that inbound_network_mode is also checked to ensure this information is made available.