### PR TITLE
Fix name of get_inbound_network_mode method

### DIFF
--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -174,23 +174,6 @@ class LongRunningServiceConfig(InstanceConfig):
     def get_nerve_namespace(self) -> str:
         return decompose_job_id(self.get_registrations()[0])[1]
 
-    def get_inbound_network_mode(self) -> str:
-        """Retrieve the requested inbound network mode for the given service.
-
-        Setting this to a value other than `full` is uncommon, as doing so will restrict the
-        availability of your service. The only other supported value is `restrict` currently,
-        which will reject all remaining inbound traffic to the service port after all other rules.
-
-        This option exists primarily for sensitive services that wish to opt into this functionality.
-        """
-        default = "full"
-        security = self.config_dict.get("security")
-
-        if security is None:
-            return default
-
-        return security.get("inbound_network_mode", default)
-
     def get_registrations(self) -> List[str]:
         registrations = self.config_dict.get("registrations", [])
         for registration in registrations:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -881,8 +881,8 @@ class InstanceConfig:
         dependency_ref = self.get_dependencies_reference() or "main"
         return dependencies.get(dependency_ref)
 
-    def get_inbound_firewall_mode(self) -> Optional[str]:
-        """Return 'full', 'restrict', or None as configured in security->inbound_firewall_mode
+    def get_inbound_network_mode(self) -> Optional[str]:
+        """Return 'full', 'restrict', or None as configured in security->inbound_network_mode
 
         Defaults to None if not specified in the config
 
@@ -890,7 +890,7 @@ class InstanceConfig:
         security = self.config_dict.get("security")
         if not security:
             return None
-        return security.get("inbound_firewall_mode")
+        return security.get("inbound_network_mode")
 
     def get_outbound_firewall(self) -> Optional[str]:
         """Return 'block', 'monitor', or None as configured in security->outbound_firewall

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -883,8 +883,13 @@ class InstanceConfig:
 
     def get_inbound_network_mode(self) -> Optional[str]:
         """Return 'full', 'restrict', or None as configured in security->inbound_network_mode
-
         Defaults to None if not specified in the config
+
+        Setting this to a value other than `full` is uncommon, as doing so will restrict the
+        availability of your service. The only other supported value is `restrict` currently,
+        which will reject all remaining inbound traffic to the service port after all other rules.
+
+        This option exists primarily for sensitive services that wish to opt into this functionality.
 
         :returns: A string specified in the config, None if not specified"""
         security = self.config_dict.get("security")


### PR DESCRIPTION
This method was improperly named from the outset, preventing `inbound_network_mode` from being read properly. This also did not appear to result in a crash during configuration, possibly due to use of config proxying behavior by paasta.

Renaming this should fix inbound_network_mode behavior. No test changes are necessary since the test class is already named properly (and, unfortunately, uses mocks as its strategy).