### PR TITLE
Extend Kubernetes Custom Resources with general yelpsoa-configs

### DIFF
--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -121,12 +121,21 @@ def test_setup_all_custom_resources():
 
 def test_load_all_configs():
     with mock.patch(
-        "paasta_tools.kubernetes_tools.service_configuration_lib.read_extra_service_information",
-        autospec=True,
-    ) as mock_read_info, mock.patch("os.listdir", autospec=True) as mock_oslist:
+        "paasta_tools.utils.read_service_configuration", autospec=True,
+    ) as mock_read_service, mock.patch(
+        "paasta_tools.utils.read_extra_service_information", autospec=True,
+    ) as mock_read_info, mock.patch(
+        "os.listdir", autospec=True
+    ) as mock_oslist:
         mock_oslist.return_value = ["kurupt", "mc"]
         ret = setup_kubernetes_cr.load_all_configs(
             cluster="westeros-prod", file_prefix="thing", soa_dir="/nail/soa"
+        )
+        mock_read_service.assert_has_calls(
+            [
+                mock.call("kurupt", soa_dir="/nail/soa"),
+                mock.call("mc", soa_dir="/nail/soa"),
+            ]
         )
         mock_read_info.assert_has_calls(
             [


### PR DESCRIPTION
This commit extends the configuration/custom resources submitted to Kubernetes for services deployed there (this is targetting resources managed by operators).

Re-using the logic used in [marathon_tools.py](https://github.com/Yelp/paasta/blob/master/paasta_tools/marathon_tools.py#L349), reading the "general" service configuration (`monitoring.yaml`, `smartstack.yaml`, etc...) and merging it with every instance configuration found in `kubernetes-{cluster}` files.

Shipping this change will cause the `paasta.yelp.com/config_sha` label to be updated even if the CRs themselves will not change. Not sure whether that is an issue for existing operators?

-----

* `make test` passes
* Tested on a local run of the `kafka-operator` (`setup_kubernetes_cr`)
  * New CR spec [here](https://fluffy.yelpcorp.com/i/DklZT5WCGCgqpbK2Rsw6pxCjKQbBFXmT.html#L48-90)
  * The CR specs do not change after applying with the "extended" resource (extra fields are ignored by the operator as they are not in the CRD). ([Before](https://fluffy.yelpcorp.com/i/rbMXjw5hc39W6Qpzk26KbNNkNCggkX6n.html) – [After](https://fluffy.yelpcorp.com/i/T0L8FKSdKF8l9KhVBH99btP5wLNDrm35.html))