### PR TITLE
make pool constraint 'EQUALS' instead of 'LIKE'

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -835,7 +835,7 @@ class InstanceConfig:
 
     def get_pool_constraints(self) -> List[Constraint]:
         pool = self.get_pool()
-        return [["pool", "LIKE", pool]]
+        return [["pool", "EQUALS", pool]]
 
     def get_constraints(self) -> Optional[List[Constraint]]:
         return stringify_constraints(self.config_dict.get("constraints", None))

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1051,7 +1051,10 @@ class TestMarathonTools:
                 "type": "DOCKER",
                 "volumes": fake_volumes,
             },
-            "constraints": [["habitat", "GROUP_BY", "1"], ["pool", "LIKE", "default"]],
+            "constraints": [
+                ["habitat", "GROUP_BY", "1"],
+                ["pool", "EQUALS", "default"],
+            ],
             "uris": ["file:///root/.dockercfg"],
             "mem": fake_mem,
             "env": expected_env,
@@ -1352,7 +1355,7 @@ class TestMarathonTools:
         fake_system_paasta_config = SystemPaastaConfig(
             {"auto_hostname_unique_size": 3}, "/foo"
         )
-        expected_constraints = [["pool", "LIKE", "default"], ["hostname", "UNIQUE"]]
+        expected_constraints = [["pool", "EQUALS", "default"], ["hostname", "UNIQUE"]]
         actual = fake_conf.get_calculated_constraints(
             service_namespace_config=fake_service_namespace_config,
             system_paasta_config=fake_system_paasta_config,
@@ -1371,7 +1374,7 @@ class TestMarathonTools:
             branch_dict=None,
         )
         fake_system_paasta_config = SystemPaastaConfig({}, "/foo")
-        expected_constraints = [["pool", "LIKE", "default"]]
+        expected_constraints = [["pool", "EQUALS", "default"]]
         actual = fake_conf.get_calculated_constraints(
             service_namespace_config=fake_service_namespace_config,
             system_paasta_config=fake_system_paasta_config,
@@ -1392,7 +1395,7 @@ class TestMarathonTools:
         fake_system_paasta_config = SystemPaastaConfig(
             {"auto_hostname_unique_size": 3}, "/foo"
         )
-        expected_constraints = [["pool", "LIKE", "default"]]
+        expected_constraints = [["pool", "EQUALS", "default"]]
         actual = fake_conf.get_calculated_constraints(
             service_namespace_config=fake_service_namespace_config,
             system_paasta_config=fake_system_paasta_config,
@@ -1413,7 +1416,7 @@ class TestMarathonTools:
             branch_dict=None,
         )
 
-        expected_constraints = [["pool", "LIKE", "default"]]
+        expected_constraints = [["pool", "EQUALS", "default"]]
         actual = fake_conf.get_calculated_constraints(
             service_namespace_config=fake_service_namespace_config,
             system_paasta_config=system_paasta_config,
@@ -1437,7 +1440,7 @@ class TestMarathonTools:
 
         expected_constraints = [
             ["region", "GROUP_BY", "1"],
-            ["pool", "LIKE", "default"],
+            ["pool", "EQUALS", "default"],
         ]
         actual = fake_conf.get_calculated_constraints(
             service_namespace_config=fake_service_namespace_config,
@@ -1457,7 +1460,7 @@ class TestMarathonTools:
             branch_dict=None,
         )
 
-        expected_constraints = [["foo", "1"], ["pool", "LIKE", "default"]]
+        expected_constraints = [["foo", "1"], ["pool", "EQUALS", "default"]]
         actual = fake_conf.get_calculated_constraints(
             service_namespace_config=fake_service_namespace_config,
             system_paasta_config=system_paasta_config,
@@ -1476,7 +1479,7 @@ class TestMarathonTools:
             branch_dict=None,
         )
 
-        expected_constraints = [["extra", "constraint"], ["pool", "LIKE", "default"]]
+        expected_constraints = [["extra", "constraint"], ["pool", "EQUALS", "default"]]
         actual = fake_conf.get_calculated_constraints(
             service_namespace_config=fake_service_namespace_config,
             system_paasta_config=system_paasta_config,
@@ -1500,7 +1503,7 @@ class TestMarathonTools:
         )
         expected_constraints = [
             ["habitat", "GROUP_BY", "2"],
-            ["pool", "LIKE", "default"],
+            ["pool", "EQUALS", "default"],
         ]
         actual = fake_conf.get_calculated_constraints(
             service_namespace_config=fake_service_namespace_config,
@@ -1524,7 +1527,7 @@ class TestMarathonTools:
         )
         expected_constraints = [
             ["region", "UNLIKE", "fake_blacklisted_region"],
-            ["pool", "LIKE", "default"],
+            ["pool", "EQUALS", "default"],
         ]
         actual = fake_conf.get_calculated_constraints(
             service_namespace_config=fake_service_namespace_config,
@@ -1548,7 +1551,7 @@ class TestMarathonTools:
         )
         expected_constraints = [
             ["region", "LIKE", "fake_whitelisted_region"],
-            ["pool", "LIKE", "default"],
+            ["pool", "EQUALS", "default"],
         ]
         actual = fake_conf.get_calculated_constraints(
             service_namespace_config=fake_service_namespace_config,
@@ -1577,7 +1580,7 @@ class TestMarathonTools:
         expected_constraints = [
             ["region", "GROUP_BY", "1"],
             ["region", "LIKE", "foo"],
-            ["pool", "LIKE", "default"],
+            ["pool", "EQUALS", "default"],
         ]
         actual = fake_conf.get_calculated_constraints(
             service_namespace_config=fake_service_namespace_config,
@@ -1606,7 +1609,7 @@ class TestMarathonTools:
         expected_constraints = [
             ["region", "GROUP_BY", "1"],
             ["region", "LIKE", "foo"],
-            ["pool", "LIKE", "default"],
+            ["pool", "EQUALS", "default"],
         ]
         actual = fake_conf.get_calculated_constraints(
             service_namespace_config=fake_service_namespace_config,
@@ -2355,7 +2358,7 @@ class TestMarathonServiceConfig:
         ):
             assert (
                 marathon_config.format_marathon_app_dict()["id"]
-                == "service.instance.gitabcdef.configb402f7ff"
+                == "service.instance.gitabcdef.configa925251a"
             ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 
@@ -2459,7 +2462,7 @@ def test_format_marathon_app_dict_no_smartstack():
             "health_checks": [],
             "env": mock.ANY,
             "id": fake_job_id,
-            "constraints": [["region", "GROUP_BY", "1"], ["pool", "LIKE", "default"]],
+            "constraints": [["region", "GROUP_BY", "1"], ["pool", "EQUALS", "default"]],
         }
         assert actual == expected
 
@@ -2571,7 +2574,7 @@ def test_format_marathon_app_dict_with_smartstack():
             ],
             "env": mock.ANY,
             "id": fake_job_id,
-            "constraints": [["region", "GROUP_BY", "1"], ["pool", "LIKE", "default"]],
+            "constraints": [["region", "GROUP_BY", "1"], ["pool", "EQUALS", "default"]],
         }
         assert actual == expected
 
@@ -2735,7 +2738,7 @@ def test_format_marathon_app_dict_utilizes_extra_volumes():
             "health_checks": [],
             "env": mock.ANY,
             "id": fake_job_id,
-            "constraints": [["region", "GROUP_BY", "1"], ["pool", "LIKE", "default"]],
+            "constraints": [["region", "GROUP_BY", "1"], ["pool", "EQUALS", "default"]],
         }
         assert actual == expected
 

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -772,7 +772,7 @@ class TestTronTools:
             ],
             "docker_parameters": mock.ANY,
             "constraints": [
-                {"attribute": "pool", "operator": "LIKE", "value": "special_pool"}
+                {"attribute": "pool", "operator": "EQUALS", "value": "special_pool"}
             ],
             "trigger_downstreams": True,
             "triggered_by": ["foo.bar.{shortdate}"],
@@ -832,7 +832,7 @@ class TestTronTools:
             ],
             "docker_parameters": mock.ANY,
             "constraints": [
-                {"attribute": "pool", "operator": "LIKE", "value": "special_pool"}
+                {"attribute": "pool", "operator": "EQUALS", "value": "special_pool"}
             ],
         }
         assert result["env"]["SHELL"] == "/bin/bash"
@@ -963,7 +963,7 @@ class TestTronTools:
             "extra_volumes": expected_extra_volumes,
             "docker_parameters": mock.ANY,
             "constraints": [
-                {"attribute": "pool", "operator": "LIKE", "value": "special_pool"}
+                {"attribute": "pool", "operator": "EQUALS", "value": "special_pool"}
             ],
             "trigger_downstreams": True,
             "triggered_by": ["foo.bar.{shortdate}"],


### PR DESCRIPTION
(COMPINFRA-333) We have a "stable" pool and a "stable_batch" pool, and
jobs that are supposed to run on the "stable" pool are getting scheduled
on the "stable_batch" pool because the constraint is too open.  This
change should make it so that stuff only gets scheduled on the pool they
specify.

Note that this will cause a big bounce, and will affect all Marathon and
Tron jobs, even though the issue we saw was only for Tron.