### PR TITLE
Rename inbound_network_mode to inbound_firewall

### DIFF
--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -351,7 +351,7 @@
                 "security": {
                     "type": "object",
                     "properties": {
-                        "inbound_network_mode": {
+                        "inbound_firewall": {
                             "enum": [
                                 "full",
                                 "restrict"

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -233,7 +233,7 @@ def _smartstack_rules(conf, soa_dir, synapse_service_dir):
         yield _yocalhost_rule(port, "proxy_port " + namespace)
 
         # Allow services to opt out of network visibility beyond localhost
-        if conf.get_inbound_firewall() == "restrict":
+        if conf.get_inbound_firewall() == "reject":
             yield _reject_remaining_inbound_traffic_rule(port)
 
 

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -233,7 +233,7 @@ def _smartstack_rules(conf, soa_dir, synapse_service_dir):
         yield _yocalhost_rule(port, "proxy_port " + namespace)
 
         # Allow services to opt out of network visibility beyond localhost
-        if conf.get_inbound_network_mode() == "restrict":
+        if conf.get_inbound_firewall() == "restrict":
             yield _reject_remaining_inbound_traffic_rule(port)
 
 

--- a/paasta_tools/firewall_update.py
+++ b/paasta_tools/firewall_update.py
@@ -146,9 +146,9 @@ def smartstack_dependencies_of_running_firewalled_services(soa_dir=DEFAULT_SOA_D
             load_deployments=False,
             soa_dir=soa_dir,
         )
-        inbound_network_mode = config.get_inbound_network_mode()
+        inbound_firewall = config.get_inbound_firewall()
         outbound_firewall = config.get_outbound_firewall()
-        if not inbound_network_mode and not outbound_firewall:
+        if not inbound_firewall and not outbound_firewall:
             continue
 
         dependencies = config.get_dependencies() or ()

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -701,19 +701,19 @@ class InstanceConfig:
         if security is None:
             return True, ""
 
-        inbound_network_mode = security.get("inbound_network_mode")
+        inbound_firewall = security.get("inbound_firewall")
         outbound_firewall = security.get("outbound_firewall")
 
-        if inbound_network_mode is None and outbound_firewall is None:
+        if inbound_firewall is None and outbound_firewall is None:
             return True, ""
 
-        if inbound_network_mode is not None and inbound_network_mode not in (
-            "full",
-            "restrict",
+        if inbound_firewall is not None and inbound_firewall not in (
+            "allow",
+            "reject",
         ):
             return (
                 False,
-                'Unrecognized inbound_network_mode value "%s"' % inbound_network_mode,
+                'Unrecognized inbound_firewall value "%s"' % inbound_firewall,
             )
 
         if outbound_firewall is not None and outbound_firewall not in (
@@ -726,7 +726,7 @@ class InstanceConfig:
             )
 
         unknown_keys = set(security.keys()) - {
-            "inbound_network_mode",
+            "inbound_firewall",
             "outbound_firewall",
         }
         if unknown_keys:
@@ -881,21 +881,22 @@ class InstanceConfig:
         dependency_ref = self.get_dependencies_reference() or "main"
         return dependencies.get(dependency_ref)
 
-    def get_inbound_network_mode(self) -> Optional[str]:
-        """Return 'full', 'restrict', or None as configured in security->inbound_network_mode
+    def get_inbound_firewall(self) -> Optional[str]:
+        """Return 'allow', 'reject', or None as configured in security->inbound_firewall
         Defaults to None if not specified in the config
 
-        Setting this to a value other than `full` is uncommon, as doing so will restrict the
-        availability of your service. The only other supported value is `restrict` currently,
+        Setting this to a value other than `allow` is uncommon, as doing so will restrict the
+        availability of your service. The only other supported value is `reject` currently,
         which will reject all remaining inbound traffic to the service port after all other rules.
 
         This option exists primarily for sensitive services that wish to opt into this functionality.
 
         :returns: A string specified in the config, None if not specified"""
+        default_inbound_rule = "allow"
         security = self.config_dict.get("security")
         if not security:
             return None
-        return security.get("inbound_network_mode")
+        return security.get("inbound_firewall", default_inbound_rule)
 
     def get_outbound_firewall(self) -> Optional[str]:
         """Return 'block', 'monitor', or None as configured in security->outbound_firewall

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -892,11 +892,10 @@ class InstanceConfig:
         This option exists primarily for sensitive services that wish to opt into this functionality.
 
         :returns: A string specified in the config, None if not specified"""
-        default_inbound_rule = "allow"
         security = self.config_dict.get("security")
         if not security:
             return None
-        return security.get("inbound_firewall", default_inbound_rule)
+        return security.get("inbound_firewall")
 
     def get_outbound_firewall(self) -> Optional[str]:
         """Return 'block', 'monitor', or None as configured in security->outbound_firewall

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -425,7 +425,7 @@ def test_ensure_internet_chain():
 @mock.patch.object(firewall, "_default_rules", return_value=[])
 @mock.patch.object(firewall, "_well_known_rules", return_value=[])
 @mock.patch.object(firewall, "_cidr_rules", return_value=[])
-def test_restrict_inbound_network_traffic(
+def test_reject_inbound_network_traffic(
     mock_cidr_rules,
     mock_well_known_rules,
     mock_default_rules,

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -432,7 +432,7 @@ def test_restrict_inbound_network_traffic(
     mock_service_config,
     service_group,
 ):
-    mock_service_config.return_value.get_inbound_network_mode.return_value = "restrict"
+    mock_service_config.return_value.get_inbound_firewall.return_value = "reject"
     assert service_group.get_rules(
         DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR
     ) == (

--- a/tests/test_firewall_update.py
+++ b/tests/test_firewall_update.py
@@ -90,7 +90,7 @@ def test_smartstack_dependencies_of_running_firewalled_services(_, __, ___, tmpd
     marathon_config = {
         "hassecurityinbound": {
             "dependencies_reference": "my_ref",
-            "security": {"inbound_network_mode": "restrict"},
+            "security": {"inbound_firewall": "reject"},
         },
         "hassecurityoutbound": {
             "dependencies_reference": "my_ref",


### PR DESCRIPTION
For consistency with `outbound_firewall` and its collection of options. This also renames the config parameters to `accept` and `reject` to indicate what they'll do in iptables.