### PR TITLE
log the marathon app-id in deployd so we can better track bounce timings

### DIFF
--- a/paasta_tools/deployd/common.py
+++ b/paasta_tools/deployd/common.py
@@ -85,7 +85,7 @@ def get_service_instances_needing_update(
     marathon_clients: MarathonClients,
     instances: Collection[Tuple[str, str]],
     cluster: str,
-) -> List[Tuple[str, str, MarathonServiceConfig]]:
+) -> List[Tuple[str, str, MarathonServiceConfig, str]]:
     marathon_apps = {}
     for marathon_client in marathon_clients.get_all_clients():
         marathon_apps.update(
@@ -111,10 +111,11 @@ def get_service_instances_needing_update(
                 "ERROR: Skipping {}.{} because: '{}'".format(service, instance, str(e))
             )
             continue
-        if app_id not in marathon_app_ids:
-            service_instances.append((service, instance, config))
-        elif marathon_apps[app_id].instances != config_app["instances"]:
-            service_instances.append((service, instance, config))
+        if (
+            app_id not in marathon_app_ids
+            or marathon_apps[app_id].instances != config_app["instances"]
+        ):
+            service_instances.append((service, instance, config, app_id))
     return service_instances
 
 

--- a/paasta_tools/deployd/watchers.py
+++ b/paasta_tools/deployd/watchers.py
@@ -320,7 +320,9 @@ class PublicConfigEventHandler(pyinotify.ProcessEvent):
             except ValueError:
                 self.log.error("Couldn't load public config, the JSON is invalid!")
                 return
-            service_instance_configs: List[Tuple[str, str, MarathonServiceConfig]] = []
+            service_instance_configs: List[
+                Tuple[str, str, MarathonServiceConfig, str]
+            ] = []
             if new_config != self.public_config:
                 self.log.info(
                     "Public config has changed, now checking if it affects any services config shas."
@@ -340,7 +342,7 @@ class PublicConfigEventHandler(pyinotify.ProcessEvent):
                 self.log.info(
                     f"{len(service_instance_configs)} service instances affected. Doing a staggered bounce."
                 )
-                for service, instance, config in service_instance_configs:
+                for service, instance, config, _ in service_instance_configs:
                     self.filewatcher.instances_to_bounce.put(
                         ServiceInstance(
                             service=service,
@@ -423,9 +425,9 @@ class YelpSoaEventHandler(pyinotify.ProcessEvent):
             [(service_name, instance) for instance in instances],
             self.filewatcher.cluster,
         )
-        for service, instance, config in service_instance_configs:
+        for service, instance, config, app_id in service_instance_configs:
             self.log.info(
-                f"{service}.{instance} has a new marathon app ID. Enqueuing it to be bounced."
+                f"{service}.{instance} has a new marathon app ID ({app_id}). Enqueuing it to be bounced."
             )
             now = time.time()
             self.filewatcher.instances_to_bounce.put(

--- a/tests/deployd/test_common.py
+++ b/tests/deployd/test_common.py
@@ -178,7 +178,7 @@ def test_get_service_instances_needing_update():
             ),
         ]
         mock_load_marathon_service_config.assert_has_calls(calls)
-        assert ret == [("universe", "c138", mock.ANY)]
+        assert ret == [("universe", "c138", mock.ANY, "/universe.c138.c2.g2")]
 
         mock_configs = [
             mock.Mock(
@@ -198,7 +198,10 @@ def test_get_service_instances_needing_update():
         ret = get_service_instances_needing_update(
             fake_clients, mock_service_instances, "westeros-prod"
         )
-        assert ret == [("universe", "c137", mock.ANY), ("universe", "c138", mock.ANY)]
+        assert ret == [
+            ("universe", "c137", mock.ANY, "/universe.c137.c1.g1"),
+            ("universe", "c138", mock.ANY, "/universe.c138.c2.g2"),
+        ]
 
         mock_configs = [
             mock.Mock(
@@ -216,7 +219,7 @@ def test_get_service_instances_needing_update():
         ret = get_service_instances_needing_update(
             fake_clients, mock_service_instances, "westeros-prod"
         )
-        assert ret == [("universe", "c138", mock.ANY)]
+        assert ret == [("universe", "c138", mock.ANY, "/universe.c138.c2.g2")]
 
         mock_configs = [
             mock.Mock(
@@ -234,7 +237,7 @@ def test_get_service_instances_needing_update():
         ret = get_service_instances_needing_update(
             fake_clients, mock_service_instances, "westeros-prod"
         )
-        assert ret == [("universe", "c138", mock.ANY)]
+        assert ret == [("universe", "c138", mock.ANY, "/universe.c138.c2.g2")]
 
         mock_configs = [
             mock.Mock(
@@ -252,7 +255,7 @@ def test_get_service_instances_needing_update():
         ret = get_service_instances_needing_update(
             fake_clients, mock_service_instances, "westeros-prod"
         )
-        assert ret == [("universe", "c138", mock.ANY)]
+        assert ret == [("universe", "c138", mock.ANY, "/universe.c138.c2.g2")]
 
         mock_configs = [
             mock.Mock(
@@ -270,8 +273,7 @@ def test_get_service_instances_needing_update():
         ret = get_service_instances_needing_update(
             fake_clients, mock_service_instances, "westeros-prod"
         )
-        assert ret == [("universe", "c138", mock.ANY)]
-
+        assert ret == [("universe", "c138", mock.ANY, "/universe.c138.c2.g2")]
         mock_configs = [
             mock.Mock(format_marathon_app_dict=mock.Mock(side_effect=Exception)),
             mock.Mock(
@@ -286,7 +288,7 @@ def test_get_service_instances_needing_update():
         ret = get_service_instances_needing_update(
             fake_clients, mock_service_instances, "westeros-prod"
         )
-        assert ret == [("universe", "c138", mock.ANY)]
+        assert ret == [("universe", "c138", mock.ANY, "/universe.c138.c2.g2")]
 
 
 def test_get_marathon_clients_from_config():

--- a/tests/deployd/test_watchers.py
+++ b/tests/deployd/test_watchers.py
@@ -538,7 +538,12 @@ class TestPublicConfigEventHandler(unittest.TestCase):
             mock_load_system_config.return_value = mock.Mock(
                 get_deployd_big_bounce_deadline=mock.Mock(return_value=100.0)
             )
-            fake_si = ("someservice", "someinstance", mock.Mock())
+            fake_si = (
+                "someservice",
+                "someinstance",
+                mock.Mock(),
+                "someservice.someinstance.stuff.otherstuff",
+            )
             mock_get_service_instances_needing_update.return_value = [fake_si]
             self.handler.process_default(mock_event)
             assert mock_load_system_config.called
@@ -677,6 +682,7 @@ class TestYelpSoaEventHandler(unittest.TestCase):
                     "universe",
                     "c137",
                     mock.Mock(get_bounce_start_deadline=mock.Mock(return_value=0)),
+                    "/universe.c137.c1.g1",
                 )
             ]
             self.handler.bounce_service("universe")


### PR DESCRIPTION
I'm trying to make it easier to figure out how long it takes deployd to bounce something by matching the marathon app ids in Splunk.  