### PR TITLE
Update inbound_firewall schema to reflect the changed variable names

### DIFF
--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -353,8 +353,8 @@
                     "properties": {
                         "inbound_firewall": {
                             "enum": [
-                                "full",
-                                "restrict"
+                                "accept",
+                                "reject"
                             ]
                         },
                         "outbound_firewall": {


### PR DESCRIPTION
Fixes this issue in config validation:

> remote:   Validation Message: 'reject' is not one of ['full', 'restrict']    