### PR TITLE
Refactor inbound_firewall to not depend on smartstack dependencies

### DIFF
--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -218,7 +218,6 @@ def _inbound_traffic_rule(conf, service_name, instance_name, protocol="tcp"):
             )
 
 
-
 def _smartstack_rules(conf, soa_dir, synapse_service_dir):
     for dep in conf.get_dependencies() or ():
         namespace = dep.get("smartstack")

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -77,13 +77,19 @@ class ServiceGroup(collections.namedtuple("ServiceGroup", ("service", "instance"
             # for several minutes after the directory disappears from soa-configs.
             return ()
 
-        if not conf.get_outbound_firewall():
+        if not conf.get_inbound_firewall() and not conf.get_outbound_firewall():
             return ()
 
-        rules = list(_default_rules(conf, self.log_prefix))
-        rules.extend(_well_known_rules(conf))
-        rules.extend(_smartstack_rules(conf, soa_dir, synapse_service_dir))
-        rules.extend(_cidr_rules(conf))
+        rules = list()
+
+        if conf.get_inbound_firewall():
+            rules.extend(_inbound_traffic_rule(conf, self.service, self.instance))
+
+        if conf.get_outbound_firewall():
+            rules.extend(_default_rules(conf, self.log_prefix))
+            rules.extend(_well_known_rules(conf))
+            rules.extend(_smartstack_rules(conf, soa_dir, synapse_service_dir))
+            rules.extend(_cidr_rules(conf))
 
         return tuple(rules)
 
@@ -182,19 +188,29 @@ def _yocalhost_rule(port, comment, protocol="tcp"):
     )
 
 
-def _reject_remaining_inbound_traffic_rule(port, protocol="tcp"):
-    """Return an iptables rule denying all other traffic.
+def _inbound_traffic_rule(conf, service_name, instance_name, protocol="tcp"):
+    """Return iptables rules for inbound traffic
 
-    This should eventually be turned into a deny-allow,
-    but is opt-in at the service level for now."""
-    return iptables.Rule(
-        protocol=protocol,
-        src="0.0.0.0/0.0.0.0",
-        dst="0.0.0.0/0.0.0.0",
-        target="REJECT",
-        matches=((protocol, (("dport", (str(port),)),)),),
-        target_parameters=((("reject-with", ("icmp-port-unreachable",))),),
-    )
+    If this is set to "reject", this is limited only to traffic from localhost"""
+    policy = conf.get_inbound_firewall()
+    if policy == "reject":
+        port = conf.get_proxy_port(service_name, instance_name)
+        yield iptables.Rule(
+            protocol=protocol,
+            src="0.0.0.0/0.0.0.0",
+            dst="0.0.0.0/0.0.0.0",
+            target="REJECT",
+            matches=((protocol, (("dport", (str(port),)),)),),
+            target_parameters=((("reject-with", ("icmp-port-unreachable",))),),
+        )
+        yield iptables.Rule(
+            protocol=protocol,
+            src="127.0.0.1/255.255.255.255",
+            dst="0.0.0.0/0.0.0.0",
+            target="ALLOW",
+            matches=((protocol, (("dport", (str(port),)),)),),
+            target_parameters=(),
+        )
 
 
 def _smartstack_rules(conf, soa_dir, synapse_service_dir):
@@ -231,10 +247,6 @@ def _smartstack_rules(conf, soa_dir, synapse_service_dir):
         service_namespaces = get_all_namespaces_for_service(service, soa_dir=soa_dir)
         port = dict(service_namespaces)[namespace]["proxy_port"]
         yield _yocalhost_rule(port, "proxy_port " + namespace)
-
-        # Allow services to opt out of network visibility beyond localhost
-        if conf.get_inbound_firewall() == "reject":
-            yield _reject_remaining_inbound_traffic_rule(port)
 
 
 def _ports_valid(ports):

--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -81,9 +81,6 @@ class ServiceGroup(collections.namedtuple("ServiceGroup", ("service", "instance"
             # for several minutes after the directory disappears from soa-configs.
             return ()
 
-        if not conf.get_inbound_firewall() and not conf.get_outbound_firewall():
-            return ()
-
         rules = list()
 
         if conf.get_inbound_firewall():

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -448,7 +448,15 @@ def test_reject_inbound_network_traffic(
         EMPTY_RULE._replace(
             protocol="tcp",
             target="ALLOW",
-            src="127.0.0.1/255.255.255.255",
+            src="127.0.0.0/255.0.0.0",
+            dst="0.0.0.0/0.0.0.0",
+            matches=(("tcp", (("dport", ("20000",)),)),),
+            target_parameters=(),
+        ),
+        EMPTY_RULE._replace(
+            protocol="tcp",
+            target="ALLOW",
+            src="169.254.0.0/255.255.0.0",
             dst="0.0.0.0/0.0.0.0",
             matches=(("tcp", (("dport", ("20000",)),)),),
             target_parameters=(),

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -433,9 +433,26 @@ def test_reject_inbound_network_traffic(
     service_group,
 ):
     mock_service_config.return_value.get_inbound_firewall.return_value = "reject"
+    mock_service_config.return_value.get_proxy_port.return_value = "20000"
     assert service_group.get_rules(
         DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR
     ) == (
+        EMPTY_RULE._replace(
+            protocol="tcp",
+            target="REJECT",
+            src="0.0.0.0/0.0.0.0",
+            dst="0.0.0.0/0.0.0.0",
+            matches=(("tcp", (("dport", ("20000",)),)),),
+            target_parameters=((("reject-with", ("icmp-port-unreachable",))),),
+        ),
+        EMPTY_RULE._replace(
+            protocol="tcp",
+            target="ALLOW",
+            src="127.0.0.1/255.255.255.255",
+            dst="0.0.0.0/0.0.0.0",
+            matches=(("tcp", (("dport", ("20000",)),)),),
+            target_parameters=(),
+        ),
         EMPTY_RULE._replace(
             protocol="tcp",
             target="ACCEPT",
@@ -462,14 +479,6 @@ def test_reject_inbound_network_traffic(
                 ("comment", (("comment", ("proxy_port example_happyhour.main",)),)),
                 ("tcp", (("dport", ("20000",)),)),
             ),
-        ),
-        EMPTY_RULE._replace(
-            protocol="tcp",
-            target="REJECT",
-            src="0.0.0.0/0.0.0.0",
-            dst="0.0.0.0/0.0.0.0",
-            matches=(("tcp", (("dport", ("20000",)),)),),
-            target_parameters=((("reject-with", ("icmp-port-unreachable",))),),
         ),
     )
 


### PR DESCRIPTION
Previously, this was placed at the end of `_smartstack_rules`, placing inbound filters after rules established to allow smartstack traffic. When envoy is used, this doesn't make sense. It also doesn't make sense to require a dependencies file for this filtering behavior, either.

As such, this has been moved upwards one layer and refactored accordingly. I've also included an allow for traffic from localhost, should other rules not propagate it to this location.

Including Krall as CC, due to some chatter about healthcheck traffic today. This is an opt-in feature, so this should only impact services that include it.