### PR TITLE
Add tween to log request info to CLog

### DIFF
--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -30,6 +30,7 @@ import paasta_tools.api
 from paasta_tools import kubernetes_tools
 from paasta_tools import marathon_tools
 from paasta_tools.api import settings
+from paasta_tools.api.tweens import request_logger
 from paasta_tools.utils import load_system_paasta_config
 
 
@@ -83,6 +84,7 @@ def make_app(global_config=None):
     )
 
     config.include("pyramid_swagger")
+    config.include(request_logger)
     config.add_route("resources.utilization", "/v1/resources/utilization")
     config.add_route(
         "service.instance.status", "/v1/services/{service}/{instance}/status"

--- a/paasta_tools/api/settings.py
+++ b/paasta_tools/api/settings.py
@@ -17,6 +17,7 @@ Settings of the paasta-api server.
 import os
 from typing import Optional
 
+from paasta_tools import utils
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.marathon_tools import MarathonClients
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -28,6 +29,7 @@ soa_dir: str = os.environ.get("PAASTA_API_SOA_DIR", DEFAULT_SOA_DIR)
 # juro have `Optional[T]` type, but de facto are always initialized to a value
 # of the corresponding type after the application is started.
 cluster: str = None  # type: ignore
+hostname: str = utils.get_hostname()
 marathon_clients: MarathonClients = None  # type: ignore
 kubernetes_client: Optional[KubeClient] = None
 system_paasta_config: Optional[SystemPaastaConfig]

--- a/paasta_tools/api/tweens/request_logger.py
+++ b/paasta_tools/api/tweens/request_logger.py
@@ -1,0 +1,113 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Creates a tween that logs information about requests.
+"""
+import json
+import logging
+import time
+import traceback
+
+import pyramid
+
+from paasta_tools import utils
+from paasta_tools.api import settings
+
+try:
+    import clog
+except ImportError:
+    clog = None
+
+
+DEFAULT_REQUEST_LOG_NAME = "tmp_paasta_requests"
+
+
+def includeme(config):
+    if clog is not None:
+        config.add_tween(
+            "paasta_tools.api.tweens.request_logger.request_logger_tween_factory",
+            under=pyramid.tweens.INGRESS,
+        )
+
+
+class request_logger_tween_factory:
+    """Tween that logs information about requests"""
+
+    def __init__(self, handler, registry):
+        self.handler = handler
+        self.registry = registry
+        self.log_name = registry.settings.get(
+            "request_log_name", DEFAULT_REQUEST_LOG_NAME,
+        )
+
+    def _log(
+        self, endpoint, level=logging.INFO, additional_fields=None,
+    ):
+        if clog is not None:
+            dct = {
+                "timestamp": time.time(),
+                "hostname": utils.get_hostname(),
+                "level": logging.getLevelName(level),
+                "cluster": settings.cluster,
+                "endpoint": endpoint,
+            }
+            if additional_fields is not None:
+                dct.update(additional_fields)
+            line = json.dumps(dct, sort_keys=True)
+            clog.log_line(self.log_name, line)
+
+    def __call__(self, request):
+        start_time = time.time()  # start clock for response time
+        request_fields = {
+            "path": request.path,
+            "params": request.params.mixed(),
+        }
+        response_fields = {}
+        log_level = logging.INFO
+
+        try:
+            response = self.handler(request)
+
+            response_fields["status_code"] = response.status_int
+            if 300 <= response.status_int < 400:
+                log_level = logging.WARNING
+            elif 400 <= response.status_int < 600:
+                log_level = logging.ERROR
+                response_fields["body"] = response.body.decode("utf-8")
+
+            return response
+
+        except Exception as e:
+            log_level = logging.ERROR
+            response_fields.update(
+                {
+                    "status_code": 500,
+                    "exc_type": type(e).__name__,
+                    "exc_info": traceback.format_exc(),
+                }
+            )
+            raise
+
+        finally:
+            response_time_ms = (time.time() - start_time) * 1000
+            response_fields["response_time_ms"] = response_time_ms
+
+            self._log(
+                endpoint=request.matched_route.name if request.matched_route else None,
+                level=log_level,
+                additional_fields={
+                    "request": request_fields,
+                    "response": response_fields,
+                },
+            )

--- a/paasta_tools/api/tweens/request_logger.py
+++ b/paasta_tools/api/tweens/request_logger.py
@@ -28,7 +28,7 @@ except ImportError:
     clog = None
 
 
-DEFAULT_REQUEST_LOG_NAME = "tmp_paasta_requests"
+DEFAULT_REQUEST_LOG_NAME = "tmp_paasta_api_requests"
 
 
 def includeme(config):
@@ -73,6 +73,9 @@ class request_logger_tween_factory:
         request_fields = {
             "path": request.path,
             "params": request.params.mixed(),
+            "client_addr": request.client_addr,
+            "http_method": request.method,
+            "headers": dict(request.headers),  # incls user agent
         }
         response_fields = {}
         log_level = "INFO"

--- a/tests/api/tweens/test_request_logger.py
+++ b/tests/api/tweens/test_request_logger.py
@@ -117,8 +117,6 @@ def test_request_logger_tween_factory_call(
     extra_expected_response,
 ):
     req = Request.blank("/path/to/something")
-    req.matched_route = mock.Mock()
-    req.matched_route.name = "some.random.endpoint"
     mock_handler.return_value = Response(body="a_body", status=status_code,)
     if exc is not None:
         mock_handler.side_effect = exc
@@ -143,7 +141,14 @@ def test_request_logger_tween_factory_call(
             timestamp=datetime.fromtimestamp(0),
             level=expected_lvl,
             additional_fields={
-                "request": {"path": "/path/to/something", "params": {},},
+                # most of these are default for a blank request
+                "request": {
+                    "path": "/path/to/something",
+                    "params": {},
+                    "client_addr": None,
+                    "http_method": "GET",
+                    "headers": {"Host": "localhost:80"},
+                },
                 "response": expected_response,
             },
         ),

--- a/tests/api/tweens/test_request_logger.py
+++ b/tests/api/tweens/test_request_logger.py
@@ -1,0 +1,133 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import itertools
+import logging
+
+import mock
+import pytest
+from pyramid.request import Request
+from pyramid.response import Response
+
+from paasta_tools.api.tweens import request_logger
+
+
+@pytest.fixture
+def mock_clog():
+    with mock.patch.object(request_logger, "clog", autospec=True) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_handler():
+    return mock.Mock()
+
+
+@pytest.fixture
+def mock_registry():
+    reg = mock.Mock()
+    reg.settings = {}
+    yield reg
+    reg.settings.clear()
+
+
+@pytest.fixture
+def mock_factory(mock_handler, mock_registry):
+    mock_registry.settings = {"request_log_name": "request_logs"}
+    yield request_logger.request_logger_tween_factory(
+        mock_handler, mock_registry,
+    )
+
+
+def test_request_logger_tween_factory_init(mock_factory):
+    assert mock_factory.log_name == "request_logs"
+
+
+@mock.patch("time.time", mock.Mock(return_value="a_time"), autospec=False)
+@mock.patch(
+    "paasta_tools.utils.get_hostname",
+    mock.Mock(return_value="a_hostname"),
+    autospec=False,
+)
+@mock.patch("paasta_tools.api.settings.cluster", "a_cluster", autospec=False)
+def test_request_logger_tween_factory_log(mock_clog, mock_factory):
+    mock_factory._log(
+        endpoint="/path/to/something",
+        level=logging.ERROR,
+        additional_fields={"additional_key": "additional_value"},
+    )
+    assert mock_clog.log_line.call_args_list == [
+        mock.call(
+            "request_logs",
+            (
+                '{"additional_key": "additional_value", '
+                '"cluster": "a_cluster", "endpoint": "/path/to/something", '
+                '"hostname": "a_hostname", "level": "ERROR", '
+                '"timestamp": "a_time"}'
+            ),
+        ),
+    ]
+
+
+@mock.patch(
+    "time.time", mock.Mock(side_effect=itertools.cycle([0, 57])), autospec=False,
+)
+@mock.patch(
+    "traceback.format_exc", mock.Mock(return_value="an_exc_body"), autospec=False,
+)
+@pytest.mark.parametrize(
+    "status_code,exc,expected_lvl,extra_expected_response",
+    [
+        (200, None, logging.INFO, {}),
+        (300, None, logging.WARNING, {}),
+        (400, None, logging.ERROR, {"body": "a_body"}),
+        (
+            500,
+            Exception(),
+            logging.ERROR,
+            {"exc_type": "Exception", "exc_info": "an_exc_body"},
+        ),
+    ],
+)
+def test_request_logger_tween_factory_call(
+    mock_handler, mock_factory, status_code, exc, expected_lvl, extra_expected_response,
+):
+    req = Request.blank("/path/to/something")
+    req.matched_route = mock.Mock()
+    req.matched_route.name = "some.random.endpoint"
+    mock_handler.return_value = Response(body="a_body", status=status_code,)
+    if exc is not None:
+        mock_handler.side_effect = exc
+    mock_factory._log = mock.Mock()
+
+    try:
+        mock_factory(req)
+    except Exception as e:
+        if exc is None:
+            pytest.fail(f"Got unexpected exception: {e}")
+
+    expected_response = {
+        "status_code": status_code,
+        "response_time_ms": 57000,
+    }
+    expected_response.update(extra_expected_response)
+    assert mock_factory._log.call_args_list == [
+        mock.call(
+            endpoint="some.random.endpoint",
+            level=expected_lvl,
+            additional_fields={
+                "request": {"path": "/path/to/something", "params": {},},
+                "response": expected_response,
+            },
+        ),
+    ]


### PR DESCRIPTION
### Description
This PR adds the a tween to the PaaSTA API to make it log response times, status codes, and exception information for requests made to clog (if available). We aren't really logging this elsewhere; once we get this into scribe, we can start processing it to see how our API is performing.

### Testing
make test
Ran the API locally against the kubestage cluster with the tween set up. Had it print to the console instead of actually logging to clog.