### PR TITLE
Reduce timeouts in setup_marathon_job from get_draining_hosts

### DIFF
--- a/paasta_tools/mesos_maintenance.py
+++ b/paasta_tools/mesos_maintenance.py
@@ -32,6 +32,7 @@ from paasta_tools.mesos_tools import get_count_running_tasks_on_slave
 from paasta_tools.mesos_tools import get_mesos_leader
 from paasta_tools.mesos_tools import get_mesos_master
 from paasta_tools.mesos_tools import MESOS_MASTER_PORT
+from paasta_tools.utils import time_cache
 from paasta_tools.utils import to_bytes
 
 
@@ -169,6 +170,7 @@ def get_maintenance_schedule():
     return client_fn(data={"type": "GET_MAINTENANCE_SCHEDULE"})
 
 
+@time_cache(ttl=10)
 def get_maintenance_status():
     """Makes a GET_MAINTENANCE_STATUS request to the operator api
 

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -673,8 +673,12 @@ def deploy_service(
     try:
         draining_hosts = get_draining_hosts()
     except ReadTimeout as e:
-        errormsg = "ReadTimeout encountered trying to get draining hosts: %s" % e
-        return (1, errormsg, 60)
+        errormsg = (
+            "ReadTimeout encountered trying to get draining hosts: %s. Continuing with bounce assuming no tasks at-risk"
+            % e
+        )
+        log_deploy_error(errormsg)
+        draining_hosts = []
 
     (
         old_app_live_happy_tasks,


### PR DESCRIPTION
This 1) logs the ReadTimeout but keeps going, and 2) adds a cache on get_maintenance_status. We can see if the cache helps by checking the deployd logs for the timeout lines.

I tested the cache manually on a Mesos master by making a copy of mesos maintenance, making this change there, and then running a script that calls it a few times.