### PR TITLE
Also update scribereader in check_oom_events

### DIFF
--- a/extra-linux-requirements.txt
+++ b/extra-linux-requirements.txt
@@ -1,1 +1,1 @@
-cryptography==2.3.1
+cryptography==2.8

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -983,7 +983,7 @@ class ScribeLogReader(LogReader):
     ) -> ContextManager:
         # Scribe connection details
         host, port = scribereader.get_tail_host_and_port(
-            **self.scribe_env_to_locations(scribe_env),
+            **scribe_env_to_locations(scribe_env),
         )
 
         # Recent logs might not be archived yet. Log warning message.
@@ -1017,7 +1017,7 @@ class ScribeLogReader(LogReader):
     ) -> ContextManager:
         # Scribe connection details
         host, port = scribereader.get_tail_host_and_port(
-            **self.scribe_env_to_locations(scribe_env),
+            **scribe_env_to_locations(scribe_env),
         )
 
         # The reason we need a fake context here is because scribereader is a bit inconsistent in its
@@ -1063,7 +1063,7 @@ class ScribeLogReader(LogReader):
         try:
             log.debug(f"Going to tail {stream_name} scribe stream in {scribe_env}")
             host, port = scribereader.get_tail_host_and_port(
-                **self.scribe_env_to_locations(scribe_env),
+                **scribe_env_to_locations(scribe_env),
             )
             tailer = scribereader.get_stream_tailer(stream_name, host, port)
             for line in tailer:
@@ -1126,18 +1126,19 @@ class ScribeLogReader(LogReader):
         else:
             return env
 
-    def scribe_env_to_locations(self, scribe_env):
-        """Converts a scribe environment to a dictionary of locations. The
-        return value is meant to be used as kwargs for `scribereader.get_tail_host_and_port`.
-        """
-        locations = {"ecosystem": None, "region": None, "superregion": None}
-        if scribe_env in scribereader.PROD_REGIONS:
-            locations["region"] = scribe_env
-        elif scribe_env in scribereader.PROD_SUPERREGIONS:
-            locations["superregion"] = scribe_env
-        else:  # non-prod envs are expressed as ecosystems
-            locations["ecosystem"] = scribe_env
-        return locations
+
+def scribe_env_to_locations(scribe_env):
+    """Converts a scribe environment to a dictionary of locations. The
+    return value is meant to be used as kwargs for `scribereader.get_tail_host_and_port`.
+    """
+    locations = {"ecosystem": None, "region": None, "superregion": None}
+    if scribe_env in scribereader.PROD_REGIONS:
+        locations["region"] = scribe_env
+    elif scribe_env in scribereader.PROD_SUPERREGIONS:
+        locations["superregion"] = scribe_env
+    else:  # non-prod envs are expressed as ecosystems
+        locations["ecosystem"] = scribe_env
+    return locations
 
 
 def generate_start_end_time(

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ choice==0.1
 click==6.6
 cookiecutter==1.4.0
 croniter==0.3.20
-cryptography==2.3.1
+cryptography==2.8
 decorator==4.1.2
 docker-py==1.2.3
 docutils==0.12

--- a/tests/cli/test_cmds_logs.py
+++ b/tests/cli/test_cmds_logs.py
@@ -742,6 +742,7 @@ def test_scribereader_print_last_n_logs():
     ) as determine_scribereader_envs_patch:
 
         determine_scribereader_envs_patch.return_value = ["env1", "env2"]
+        mock_scribereader.get_tail_host_and_port.return_value = "fake_host", "fake_port"
         fake_iter = mock.MagicMock()
         fake_iter.__iter__.return_value = (
             [
@@ -792,6 +793,7 @@ def test_scribereader_print_logs_by_time():
     ) as determine_scribereader_envs_patch:
 
         determine_scribereader_envs_patch.return_value = ["env1", "env2"]
+        mock_scribereader.get_tail_host_and_port.return_value = "fake_host", "fake_port"
         fake_iter = mock.MagicMock()
         fake_iter.__iter__.return_value = (
             [

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -8,14 +8,14 @@ inflection==0.3.1
 markdown==2.4
 monk==1.1.1
 python-jsonschema-objects==0.3.1
-scribereader==0.2.6
+scribereader==0.8.0
 signalform-tools==0.0.16
 slo-transcoder==3.2.3
 smmap2==2.0.3
 sticht[yelp_internal]==1.1.1
 vault-tools==0.7.34
 yelp-cgeom==1.3.1
-yelp-clog==5.0.0
+yelp-clog==4.1.1  # scribereader requires <5.0.0
 yelp-logging==1.0.37
 yelp_meteorite
 yelp_paasta_helpers


### PR DESCRIPTION
### Description
Previously I updated scribereader to 0.8.0 but that was reverted because I didn't also update certain outdated calls in `check_oom_events` as well. This PR un-reverts the update and also updates `check_oom_events` to match as well.

### Testing
`make test`
Locally ran `check_oom_events` against the `norcal-devc` cluster