### PR TITLE
Notify sysgit deploymentsd watcher to create a new deployments.json o…

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -51,6 +51,7 @@ from paasta_tools.cli.cmds.push_to_registry import is_docker_image_already_in_re
 from paasta_tools.cli.utils import get_jenkins_build_output_url
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
+from paasta_tools.cli.utils import trigger_deploys
 from paasta_tools.cli.utils import validate_git_sha
 from paasta_tools.cli.utils import validate_given_deploy_groups
 from paasta_tools.cli.utils import validate_service_name
@@ -211,17 +212,6 @@ def add_subparser(subparsers):
     )
 
     list_parser.set_defaults(command=paasta_mark_for_deployment)
-
-
-def trigger_deploys(service):
-    """Connects to the deploymentsd watcher on sysgit, which is an extremely simple
-    service that listens for a service string and then generates a service deployment"""
-    logline = f"Notifying sysgit to generate a deployment for {service}"
-    _log(service=service, line=logline, component="deploy", level="event")
-    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    client.connect(("sysgit.yelpcorp.com", 5049))
-    client.send(f"{service}\n".encode("utf-8"))
-    client.close()
 
 
 def mark_for_deployment(git_url, deploy_group, service, commit):

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -28,6 +28,7 @@ from paasta_tools.api.client import get_paasta_api_client
 from paasta_tools.cli.cmds.status import add_instance_filter_arguments
 from paasta_tools.cli.cmds.status import apply_args_filters
 from paasta_tools.cli.utils import get_instance_config
+from paasta_tools.cli.utils import trigger_deploys
 from paasta_tools.flink_tools import FlinkDeploymentConfig
 from paasta_tools.generate_deployments_for_service import get_latest_deployment_tag
 from paasta_tools.marathon_tools import MarathonServiceConfig
@@ -126,9 +127,10 @@ def issue_state_change_for_service(service_config, force_bounce, desired_state):
         force_bounce=force_bounce,
         desired_state=desired_state,
     )
-    remote_git.create_remote_refs(
-        utils.get_git_url(service_config.get_service()), ref_mutator
-    )
+    git_url = utils.get_git_url(service_config.get_service())
+    remote_git.create_remote_refs(git_url, ref_mutator)
+    if "yelpcorp.com" in git_url:
+        trigger_deploys(service_config.get_service())
     log_event(service_config=service_config, desired_state=desired_state)
 
 

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -27,13 +27,14 @@ def test_format_tag():
     assert actual == expected
 
 
+@mock.patch("paasta_tools.cli.cmds.start_stop_restart.trigger_deploys", autospec=True)
 @mock.patch("paasta_tools.utils.get_git_url", autospec=True)
 @mock.patch("dulwich.client.get_transport_and_path", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.start_stop_restart.log_event", autospec=True)
 def test_issue_state_change_for_service(
-    mock_log_event, get_transport_and_path, get_git_url
+    mock_log_event, get_transport_and_path, get_git_url, mock_trigger_deploys,
 ):
-    fake_git_url = "BLOORGRGRGRGR"
+    fake_git_url = "BLOORGRGRGRGR.yelpcorp.com"
     fake_path = "somepath"
 
     get_git_url.return_value = fake_git_url
@@ -56,6 +57,7 @@ def test_issue_state_change_for_service(
     get_transport_and_path.assert_called_once_with(fake_git_url)
     mock_git_client.send_pack.assert_called_once_with(fake_path, mock.ANY, mock.ANY)
     assert mock_log_event.call_count == 1
+    mock_trigger_deploys.assert_called_once_with("fake_service")
 
 
 def test_make_mutate_refs_func():

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -27,7 +27,7 @@ from paasta_tools.cli import utils
 from paasta_tools.marathon_tools import MarathonServiceConfig
 
 
-@patch("paasta_tools.cli.utils.gethostbyname_ex", autospec=True)
+@patch("socket.gethostbyname_ex", autospec=True)
 def test_bad_calculate_remote_master(mock_get_by_hostname, system_paasta_config):
     mock_get_by_hostname.side_effect = gaierror(42, "bar")
     ips, output = utils.calculate_remote_masters("myhost", system_paasta_config)
@@ -35,7 +35,7 @@ def test_bad_calculate_remote_master(mock_get_by_hostname, system_paasta_config)
     assert "ERROR while doing DNS lookup of paasta-myhost.yelp:\nbar\n" in output
 
 
-@patch("paasta_tools.cli.utils.gethostbyname_ex", autospec=True)
+@patch("socket.gethostbyname_ex", autospec=True)
 def test_ok_remote_masters(mock_get_by_hostname, system_paasta_config):
     mock_get_by_hostname.return_value = ("myhost", [], ["1.2.3.4", "1.2.3.5"])
     ips, output = utils.calculate_remote_masters("myhost", system_paasta_config)


### PR DESCRIPTION
…n paasta start/stop/restart

Previously this was handled by a gitolite hook, but that went away when services moved off gitolite. This is the same approach used by mark-for-deployment; we just missed that we needed it on start/stop/restart as well.

See PAASTA-16512

---

I ran this locally and it triggered a restart of compute-infra-test-service essentially immediately.