### PR TITLE
yelp_clog 4.1.1 requires scribe host and port

### DIFF
--- a/paasta_tools/oom_logger.py
+++ b/paasta_tools/oom_logger.py
@@ -188,7 +188,9 @@ def main():
         print("CLog logger unavailable, exiting.", file=sys.stderr)
         sys.exit(1)
 
-    clog.config.configure(monk_disable=False)
+    clog.config.configure(
+        scribe_host="169.254.255.254", scribe_port=1463, monk_disable=False
+    )
 
     cluster = load_system_paasta_config().get_cluster()
     client = get_docker_client()


### PR DESCRIPTION
Apparently we needed to downgrade yelp_clog for the scribereader update here: https://github.com/Yelp/paasta/pull/2815/files#diff-238a62906b32a2556199a125adf97658L18

But 4.1.1 requires these as positional args, they only became optional in 5.0.0.
```
Traceback (most recent call last):
  File "/usr/bin/paasta_oom_logger", line 11, in <module>
    sys.exit(main())
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/paasta_tools/oom_logger.py", line 191, in main
    clog.config.configure(monk_disable=False)
TypeError: configure() missing 2 required positional arguments: 'scribe_host' and 'scribe_port'
```