### PR TITLE
PAASTA-16499 `paasta validate` now checks if vault secrets are defined

### DIFF
--- a/general_itests/fake_etc_paasta/vault.json
+++ b/general_itests/fake_etc_paasta/vault.json
@@ -1,0 +1,5 @@
+{
+    "vault_cluster_map": {
+        "test-cluster": "test-vault-env"
+    }
+}


### PR DESCRIPTION
This change adds a new test to `paasta validate` so that operators will know if any of their service instances reference a secret that doesn't exist.

The reason for this change is that mesos would allow such situations, but kubernetes would fail to bring up the service.
So an early check will help to avoid these situations.

More info on PAASTA-16499