### PR TITLE
yelp_clog 4.1.1 doesn't create any logger if scribe_disable is True

### DIFF
--- a/paasta_tools/oom_logger.py
+++ b/paasta_tools/oom_logger.py
@@ -189,7 +189,10 @@ def main():
         sys.exit(1)
 
     clog.config.configure(
-        scribe_host="169.254.255.254", scribe_port=1463, monk_disable=False
+        scribe_host="169.254.255.254",
+        scribe_port=1463,
+        monk_disable=False,
+        scribe_disable=False,
     )
 
     cluster = load_system_paasta_config().get_cluster()


### PR DESCRIPTION
https://github.com/Yelp/paasta/pull/2819 made oom_logger stop crashing, but the lines still weren't showing up. Turns out 5.0.0 will create a monk logger if scribe_disable is True, but 4.1.1 won't, so we need to explicitly pass scribe_disable=False.

This time I created a logger with these settings and confirmed that they show up.
```
clog.config.configure(scribe_host="169.254.255.254", scribe_port=1463, monk_disable=False, scribe_disable=False)
clog.log_line('tmp_test', f'test {time.time()}')

$ scribereader -e devc tmp_test -n 10
test 1590691290.7611883
```