### PR TITLE
Add disk recos support 

### DIFF
--- a/paasta_tools/cli/schemas/autotuned_defaults/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/autotuned_defaults/kubernetes_schema.json
@@ -15,6 +15,11 @@
                     "minimum": 0,
                     "exclusiveMinimum": true
                 },
+                "disk": {
+                    "type": "number",
+                    "minimum": 128,
+                    "exclusiveMinimum": true
+                },
                 "mem": {
                     "type": "number",
                     "minimum": 32,

--- a/paasta_tools/cli/schemas/autotuned_defaults/marathon_schema.json
+++ b/paasta_tools/cli/schemas/autotuned_defaults/marathon_schema.json
@@ -15,6 +15,11 @@
                     "minimum": 0,
                     "exclusiveMinimum": true
                 },
+                "disk": {
+                    "type": "number",
+                    "minimum": 128,
+                    "exclusiveMinimum": true
+                },
                 "mem": {
                     "type": "number",
                     "minimum": 32,

--- a/paasta_tools/contrib/rightsizer_soaconfigs_update.py
+++ b/paasta_tools/contrib/rightsizer_soaconfigs_update.py
@@ -91,6 +91,9 @@ def get_recommendation_from_result(result):
     mem = result.get("mem")
     if mem and mem != NULL:
         rec["mem"] = max(128, round(float(mem)))
+    disk = result.get("disk")
+    if disk and disk != NULL:
+        rec["disk"] = max(128, round(float(disk)))
     return rec
 
 

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -98,6 +98,9 @@ def test_validate_auto_config_file_unknown_type(mock_validate, tmpdir):
         ({"instance": {"cpus": "bad_string_value"}}, False),
         ({"instance": {"cpus": 1, "invalid_key": 2}}, False),
         ({"instance": {"cpus": 1.2, "mem": 100}}, True),
+        ({"instance": {"cpus": 1.2, "mem": 100, "disk": "very big"}}, False),
+        ({"instance": {"cpus": 1.2, "mem": 100, "disk": 0}}, False),
+        ({"instance": {"cpus": 1.2, "mem": 100, "disk": 1000}}, True),
     ],
 )
 def test_validate_auto_config_file_e2e(data, is_valid, tmpdir):


### PR DESCRIPTION
1) Added disk support to the original rightsizer (not autotuned_defaults) and tested a local bulk update:
`/opt/venvs/paasta-tools/bin/python ~/git/paasta/paasta_tools/contrib/paasta_update_soa_memcpu.py -s ********:**************** -y ~/git/yelpsoa-configs --csv-report paasta_rightsizer_disk_recs.csv -f '*stageg*' --app yelp_computeinfra -v -l`
Fluffy of the diff
https://fluffy.yelpcorp.com/i/WGd8WMW65bZhQj8wRXr56Kn5THSxX95z.html

2) Added support to paasta_tools.contrib.rightsizer_soaconfigs_update
Tested it manually before:
```│(py36-linux) dev42-uswest1adevc:~/git/paasta/paasta_tools/contrib % /opt/venvs/paasta-tools/bin/python -m paasta_tools.contrib.rightsizer_soaconfigs_update -c paasta_rightsizer_disk_recs.csv --git-remote git@sysgit.yelpcorp.com:yelpsoa-configs -v -s *******:******************* --branch mathieu_test_PAASTA-16518_d --push-to-remote
│INFO:root:Found 6562 services to rightsize
│Cloning into '/nail/tmp/tmprxiz6i9y'...
│remote: Counting objects: 531056, done.
│remote: Compressing objects: 100% (459999/459999), done.
│Receiving objects: 100% (531056/531056), 99.37 MiB | 5.01 MiB/s, done.
│remote: Total 531056 (delta 360042), reused 99939 (delta 68167)
│Resolving deltas: 100% (360042/360042), done.
│Switched to a new branch 'mathieu_test_PAASTA-16518_d'
│Nothing specified, nothing added.
│Maybe you wanted to say 'git add .'?
│INFO:paasta_tools.config_utils:No files changed, no push required.
```

With this change:
```
sudo dpkg -i paasta-tools_0.96.4-mathieudev~xenial1_amd64.deb
/opt/venvs/paasta-tools/bin/python -m paasta_tools.contrib.rightsizer_soaconfigs_update -c paasta_rightsizer_disk_recs.csv --git-remote git@sysgit.yelpcorp.com:yelpsoa-configs -v -s ******:******** --branch mathieu_test_7 --local-dir /nail/home/mathieu/git/yelpsoa-configs
dev42-uswest1adevc:~/git/yelpsoa-configs % git diff |head -10                                                                                                                               (git)-[mathieu_test_7]
diff --git a/abu/autotuned_defaults/marathon-pnw-prod.yaml b/abu/autotuned_defaults/marathon-pnw-prod.yaml                                                                                                        
index 4ebca3e779..a4499a6df8 100644                                                                                                                                                                               
--- a/abu/autotuned_defaults/marathon-pnw-prod.yaml                                                                                                                                                               
+++ b/abu/autotuned_defaults/marathon-pnw-prod.yaml                                                                                                                                                               
@@ -10,3 +10,4 @@                                                                                                                                                                                                 
 main:                                                                                                                                                                                                            
   cpus: 0.1                                                                                                                                                                                                      
   mem: 143                                                                                                                                                                                                       
+  disk: 1024                                                                                                                                                                                                                                                      ```

3) Added to the schema for validation
Added unittest