### PR TITLE
Make is_pod_healthy_in_smartstack report an error message when it fails

### DIFF
--- a/paasta_tools/contrib/is_pod_healthy_in_smartstack.py
+++ b/paasta_tools/contrib/is_pod_healthy_in_smartstack.py
@@ -36,4 +36,8 @@ if are_services_up_on_ip_port(
 ):
     sys.exit(0)
 else:
+    print(
+        f"Could not find backend {host_ip}:{port} for service {services} "
+        f"on Synapse at {synapse_host}:{synapse_port}"
+    )
     sys.exit(1)


### PR DESCRIPTION
This should be picked up by the kubelet and displayed in the pod's events log, which should lead to more helpful error messages in the output of paasta status when the readiness probe fails

Messing with the hacheck sidecar seems potentially scary -- I might test this on kubestage first?