### PR TITLE
Bump sticht to 1.1.9 to get SCRIBE_ENV fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -97,7 +97,7 @@ simplejson==3.10.0
 six==1.11.0
 slackclient==1.2.1
 sseclient-py==1.7
-sticht==1.1.8
+sticht==1.1.9
 strict-rfc3339==0.7
 swagger-spec-validator==2.1.0
 syslogmp==0.2.2

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -12,7 +12,7 @@ scribereader==0.8.0
 signalform-tools==0.0.16
 slo-transcoder==3.2.3
 smmap2==2.0.3
-sticht[yelp_internal]==1.1.8
+sticht[yelp_internal]==1.1.9
 vault-tools==0.7.34
 yelp-cgeom==1.3.1
 yelp-clog==4.1.1  # scribereader requires <5.0.0


### PR DESCRIPTION
somehow I didn't actually include the `**` as recommended by @kawaiwanyelp [here](https://github.com/Yelp/sticht/pull/15#discussion_r432034870) -- I've fixed this in sticht 1.1.9