### PR TITLE
Fix the call to get_proxy_port for inbound firewall mode

### DIFF
--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -10,6 +10,7 @@ import re
 from contextlib import contextmanager
 
 from paasta_tools import iptables
+from paasta_tools.contrib.graceful_container_drain import get_proxy_port
 from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.marathon_tools import get_all_namespaces_for_service
 from paasta_tools.utils import get_running_mesos_docker_containers
@@ -195,7 +196,7 @@ def _inbound_traffic_rule(conf, service_name, instance_name, protocol="tcp"):
     If this is set to "reject", this is limited only to traffic from localhost"""
     policy = conf.get_inbound_firewall()
     if policy == "reject":
-        port = conf.get_proxy_port(service_name, instance_name)
+        port = get_proxy_port(service_name, instance_name)
         yield iptables.Rule(
             protocol=protocol,
             src="0.0.0.0/0.0.0.0",

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -422,6 +422,7 @@ def test_ensure_internet_chain():
     )
 
 
+@mock.patch.object(firewall, "get_proxy_port", return_value="20000")
 @mock.patch.object(firewall, "_default_rules", return_value=[])
 @mock.patch.object(firewall, "_well_known_rules", return_value=[])
 @mock.patch.object(firewall, "_cidr_rules", return_value=[])
@@ -429,11 +430,11 @@ def test_reject_inbound_network_traffic(
     mock_cidr_rules,
     mock_well_known_rules,
     mock_default_rules,
+    mock_get_proxy_port,
     mock_service_config,
     service_group,
 ):
     mock_service_config.return_value.get_inbound_firewall.return_value = "reject"
-    mock_service_config.return_value.get_proxy_port.return_value = "20000"
     assert service_group.get_rules(
         DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR
     ) == (


### PR DESCRIPTION
This currently lives in contrib/graceful_container_drain, not as a config accessor. Updated the call and test accordingly.