### PR TITLE
Speed up generate deployments a third time

### DIFF
--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -177,7 +177,7 @@ def see_it_in_list(context, shard_number=None):
             )
         )
 
-        assert context.app_id in full_list, (context.app_id, full_list)
+    assert context.app_id in full_list, (context.app_id, full_list)
 
 
 @then("we should not see it in the list of apps on shard {shard_number:d}")

--- a/paasta_itests/steps/setup_marathon_job_steps.py
+++ b/paasta_itests/steps/setup_marathon_job_steps.py
@@ -177,7 +177,7 @@ def see_it_in_list(context, shard_number=None):
             )
         )
 
-    assert context.app_id in full_list
+        assert context.app_id in full_list, (context.app_id, full_list)
 
 
 @then("we should not see it in the list of apps on shard {shard_number:d}")

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -38,12 +38,14 @@ Command line options:
 - -v, --verbose: Verbose output
 """
 import argparse
+import concurrent.futures
 import json
 import logging
 import os
 import re
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Tuple
 
 from mypy_extensions import TypedDict
@@ -145,6 +147,15 @@ def get_deploy_group_mappings(
     """
     mappings: Dict[str, V1_Mapping] = {}
     v2_mappings: V2_Mappings = {"deployments": {}, "controls": {}}
+    git_url = get_git_url(service=service, soa_dir=soa_dir)
+
+    # Most of the time of this function is in two parts:
+    # 1. getting remote refs from git. (Mostly IO, just waiting for git to get back to us.)
+    # 2. loading instance configs. (Mostly CPU, copy.deepcopying yaml over and over again)
+    # Let's do these two things in parallel.
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    remote_refs_future = executor.submit(remote_git.list_remote_refs, git_url)
 
     service_configs = get_instance_configs_for_service(soa_dir=soa_dir, service=service)
 
@@ -155,20 +166,23 @@ def get_deploy_group_mappings(
         log.info("Service %s has no valid deploy groups. Skipping.", service)
         return mappings, v2_mappings
 
-    git_url = get_git_url(service=service, soa_dir=soa_dir)
-    remote_refs = remote_git.list_remote_refs(git_url)
+    remote_refs = remote_refs_future.result()
+
+    tag_by_deploy_group = {
+        dg: get_latest_deployment_tag(remote_refs, dg)
+        for dg in set(deploy_group_branch_mappings.values())
+    }
+    state_by_branch_and_sha = get_desired_state_by_branch_and_sha(remote_refs)
 
     for control_branch, deploy_group in deploy_group_branch_mappings.items():
-        (deploy_ref_name, _) = get_latest_deployment_tag(remote_refs, deploy_group)
+        (deploy_ref_name, deploy_ref_sha) = tag_by_deploy_group[deploy_group]
         if deploy_ref_name in remote_refs:
             commit_sha = remote_refs[deploy_ref_name]
             control_branch_alias = f"{service}:paasta-{control_branch}"
             control_branch_alias_v2 = f"{service}:{control_branch}"
             docker_image = build_docker_image_name(service, commit_sha)
-            desired_state, force_bounce = get_desired_state(
-                branch=control_branch,
-                remote_refs=remote_refs,
-                deploy_group=deploy_group,
+            desired_state, force_bounce = state_by_branch_and_sha.get(
+                (control_branch, deploy_ref_sha), ("start", None)
             )
             log.info("Mapping %s to docker image %s", control_branch, docker_image)
 
@@ -203,37 +217,25 @@ def get_service_from_docker_image(image_name: str) -> str:
     return matches.group(1)
 
 
-def get_desired_state(
-    branch: str, remote_refs: Dict[str, str], deploy_group: str
-) -> Tuple[str, Any]:
-    """Gets the desired state (start or stop) from the given repo, as well as
-    an arbitrary value (which may be None) that will change when a restart is
-    desired.
-    """
-    # (?:paasta-){1,2} supports a previous mistake where some tags would be called
-    # paasta-paasta-cluster.instance
-    tag_pattern = (
-        r"^refs/tags/(?:paasta-){0,2}%s-(?P<force_bounce>[^-]+)-(?P<state>(start|stop))$"
-        % branch
-    )
+def get_desired_state_by_branch_and_sha(
+    remote_refs: Dict[str, str]
+) -> Dict[Tuple[str, str], Tuple[str, Any]]:
+    tag_pattern = r"^refs/tags/(?:paasta-){0,2}(?P<branch>[a-zA-Z0-9-_.]+)-(?P<force_bounce>[^-]+)-(?P<state>(start|stop))$"
 
-    states = []
-    (_, head_sha) = get_latest_deployment_tag(remote_refs, deploy_group)
+    states_by_branch_and_sha: Dict[Tuple[str, str], List[Tuple[str, Any]]] = {}
 
     for ref_name, sha in remote_refs.items():
-        if sha == head_sha:
-            match = re.match(tag_pattern, ref_name)
-            if match:
-                gd = match.groupdict()
-                states.append((gd["state"], gd["force_bounce"]))
+        match = re.match(tag_pattern, ref_name)
+        if match:
+            gd = match.groupdict()
+            states_by_branch_and_sha.setdefault((gd["branch"], sha), []).append(
+                (gd["state"], gd["force_bounce"])
+            )
 
-    if states:
-        # there may be more than one that matches, so take the one that sorts
-        # last by the force_bounce key.
-        sorted_states = sorted(states, key=lambda x: x[1])
-        return sorted_states[-1]
-    else:
-        return ("start", None)
+    return {
+        (branch, sha): sorted(states, key=lambda x: x[1])[-1]
+        for ((branch, sha), states) in states_by_branch_and_sha.items()
+    }
 
 
 def get_deployments_dict_from_deploy_group_mappings(

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -369,7 +369,7 @@ def load_marathon_service_config_no_cache(
         service, soa_dir=soa_dir
     )
     instance_config = load_service_instance_config(
-        service, instance, "marathon", cluster, soa_dir=soa_dir, use_cache=False,
+        service, instance, "marathon", cluster, soa_dir=soa_dir,
     )
     general_config = deep_merge_dictionaries(
         overrides=instance_config, defaults=general_config

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -352,7 +352,6 @@ def load_marathon_service_config_no_cache(
     cluster: str,
     load_deployments: bool = True,
     soa_dir: str = DEFAULT_SOA_DIR,
-    use_cache: bool = False,
 ) -> "MarathonServiceConfig":
     """Read a service instance's configuration for marathon.
 
@@ -370,7 +369,7 @@ def load_marathon_service_config_no_cache(
         service, soa_dir=soa_dir
     )
     instance_config = load_service_instance_config(
-        service, instance, "marathon", cluster, soa_dir=soa_dir, use_cache=use_cache,
+        service, instance, "marathon", cluster, soa_dir=soa_dir, use_cache=False,
     )
     general_config = deep_merge_dictionaries(
         overrides=instance_config, defaults=general_config
@@ -427,7 +426,6 @@ def load_marathon_service_config(
         cluster=cluster,
         load_deployments=load_deployments,
         soa_dir=soa_dir,
-        use_cache=True,
     )
 
 

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -352,6 +352,7 @@ def load_marathon_service_config_no_cache(
     cluster: str,
     load_deployments: bool = True,
     soa_dir: str = DEFAULT_SOA_DIR,
+    use_cache: bool = False,
 ) -> "MarathonServiceConfig":
     """Read a service instance's configuration for marathon.
 
@@ -369,7 +370,7 @@ def load_marathon_service_config_no_cache(
         service, soa_dir=soa_dir
     )
     instance_config = load_service_instance_config(
-        service, instance, "marathon", cluster, soa_dir=soa_dir
+        service, instance, "marathon", cluster, soa_dir=soa_dir, use_cache=use_cache,
     )
     general_config = deep_merge_dictionaries(
         overrides=instance_config, defaults=general_config
@@ -426,6 +427,7 @@ def load_marathon_service_config(
         cluster=cluster,
         load_deployments=load_deployments,
         soa_dir=soa_dir,
+        use_cache=True,
     )
 
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -55,6 +55,7 @@ from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
+from paasta_tools.utils import time_cache
 from paasta_tools.utils import paasta_print
 from paasta_tools.utils import filter_templates_from_config
 from paasta_tools.spark_tools import get_spark_resource_requirements
@@ -743,7 +744,20 @@ def load_tron_instance_config(
     )
 
 
+@time_cache(ttl=5)
 def load_tron_service_config(
+    service,
+    cluster,
+    load_deployments=True,
+    soa_dir=DEFAULT_SOA_DIR,
+    for_validation=False,
+):
+    return load_tron_service_config_no_cache(
+        service, cluster, load_deployments, soa_dir, for_validation,
+    )
+
+
+def load_tron_service_config_no_cache(
     service,
     cluster,
     load_deployments=True,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2728,7 +2728,7 @@ def read_service_instance_names(
 ) -> Collection[Tuple[str, str]]:
     instance_list = []
     conf_file = f"{instance_type}-{cluster}"
-    config = service_configuration_lib.read_extra_service_information(
+    config = __read_extra_service_information_cached(
         service, conf_file, soa_dir=soa_dir
     )
     config = filter_templates_from_config(config)
@@ -2842,7 +2842,7 @@ def load_service_instance_configs(
     service: str, instance_type: str, cluster: str, soa_dir: str = DEFAULT_SOA_DIR,
 ) -> Dict[str, InstanceConfigDict]:
     conf_file = f"{instance_type}-{cluster}"
-    user_configs = service_configuration_lib.read_extra_service_information(
+    user_configs = __read_extra_service_information_cached(
         service, conf_file, soa_dir=soa_dir
     )
     user_configs = filter_templates_from_config(user_configs)
@@ -2858,21 +2858,38 @@ def load_service_instance_configs(
     return merged
 
 
+# be extremely sure you do not modify the return value of this.
+@time_cache(ttl=5)
+def __read_extra_service_information_cached(*args: Any, **kwargs: Any) -> Dict:
+    return service_configuration_lib.read_extra_service_information(*args, **kwargs)
+
+
 def load_service_instance_config(
     service: str,
     instance: str,
     instance_type: str,
     cluster: str,
     soa_dir: str = DEFAULT_SOA_DIR,
+    use_cache: bool = True,
 ) -> InstanceConfigDict:
     if instance.startswith("_"):
         raise InvalidJobNameError(
             f"Unable to load {instance_type} config for {service}.{instance} as instance name starts with '_'"
         )
     conf_file = f"{instance_type}-{cluster}"
-    user_config = service_configuration_lib.read_extra_service_information(
-        service, conf_file, soa_dir=soa_dir
-    ).get(instance)
+
+    if use_cache:
+        read_extra_service_information = __read_extra_service_information_cached
+    else:
+        read_extra_service_information = (
+            service_configuration_lib.read_extra_service_information
+        )
+
+    user_config = copy.deepcopy(
+        read_extra_service_information(service, conf_file, soa_dir=soa_dir).get(
+            instance
+        )
+    )
     if user_config is None:
         raise NoConfigurationForServiceError(
             f"{instance} not found in config file {soa_dir}/{service}/{conf_file}.yaml."
@@ -2890,7 +2907,7 @@ def load_service_instance_auto_configs(
     enabled_types = load_system_paasta_config().get_auto_config_instance_types_enabled()
     conf_file = f"{instance_type}-{cluster}"
     if enabled_types.get(instance_type):
-        return service_configuration_lib.read_extra_service_information(
+        return __read_extra_service_information_cached(
             service, f"{AUTO_SOACONFIG_SUBDIR}/{conf_file}", soa_dir=soa_dir
         )
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -90,7 +90,7 @@ rsa==3.4.2
 ruamel.yaml==0.15.96
 s3transfer==0.1.13
 sensu-plugin==0.3.1
-service-configuration-lib==2.4.3
+service-configuration-lib==2.4.4
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -216,28 +216,10 @@ def test_get_desired_state_understands_tags():
         "refs/tags/paasta-cluster2.someinstance-20160308T053933-deploy": "9085FD67ED1BB5FADAFA7F2AFAF8DEDEE7342711",
     }
     branch = "cluster2.someinstance"
-    deploy_group = branch
+    sha = "9085FD67ED1BB5FADAFA7F2AFAF8DEDEE7342711"
     expected_desired_state = ("stop", "20160205T182601")
-    actual = generate_deployments_for_service.get_desired_state(
-        branch, remote_refs, deploy_group
-    )
-
-    assert actual == expected_desired_state
-
-
-def test_get_desired_state_fails_gracefully_with_start():
-    remote_refs = {
-        "refs/heads/master": "7894E99E6805E9DC8C1D8EB26229E3E2243878C9",
-        "refs/remotes/origin/HEAD": "EE8796C4E4295B7D4087E3EB73662B99218DAD94",
-        "refs/remotes/origin/master": "5F7C10B320A4EDBC4773C5FEFB1CD7B7A84FCB69",
-        "refs/heads/paasta-cluster.instance": "4EF01B5A574B519AB546309E89F72972A33B6B75",
-        "refs/heads/paasta-cluster2.someinstance": "9085FD67ED1BB5FADAFA7F2AFAF8DEDEE7342711",
-    }
-    branch = "cluster.instance"
-    deploy_group = branch
-    expected_desired_state = ("start", None)
-    actual = generate_deployments_for_service.get_desired_state(
-        branch, remote_refs, deploy_group
-    )
+    actual = generate_deployments_for_service.get_desired_state_by_branch_and_sha(
+        remote_refs
+    )[(branch, sha)]
 
     assert actual == expected_desired_state

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -138,7 +138,12 @@ class TestMarathonTools:
             )
             assert load_service_instance_config_patch.call_count == 1
             load_service_instance_config_patch.assert_any_call(
-                fake_name, fake_instance, "marathon", fake_cluster, soa_dir=fake_dir
+                fake_name,
+                fake_instance,
+                "marathon",
+                fake_cluster,
+                soa_dir=fake_dir,
+                use_cache=True,
             )
 
     def test_read_service_config_and_deployments(self):
@@ -209,7 +214,12 @@ class TestMarathonTools:
             )
             assert load_service_instance_config_patch.call_count == 1
             load_service_instance_config_patch.assert_any_call(
-                fake_name, fake_instance, "marathon", fake_cluster, soa_dir=fake_dir
+                fake_name,
+                fake_instance,
+                "marathon",
+                fake_cluster,
+                soa_dir=fake_dir,
+                use_cache=True,
             )
 
     def test_get_all_namespaces_for_service(self):

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -143,7 +143,7 @@ class TestMarathonTools:
                 "marathon",
                 fake_cluster,
                 soa_dir=fake_dir,
-                use_cache=True,
+                use_cache=False,
             )
 
     def test_read_service_config_and_deployments(self):
@@ -219,7 +219,7 @@ class TestMarathonTools:
                 "marathon",
                 fake_cluster,
                 soa_dir=fake_dir,
-                use_cache=True,
+                use_cache=False,
             )
 
     def test_get_all_namespaces_for_service(self):

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -138,12 +138,7 @@ class TestMarathonTools:
             )
             assert load_service_instance_config_patch.call_count == 1
             load_service_instance_config_patch.assert_any_call(
-                fake_name,
-                fake_instance,
-                "marathon",
-                fake_cluster,
-                soa_dir=fake_dir,
-                use_cache=False,
+                fake_name, fake_instance, "marathon", fake_cluster, soa_dir=fake_dir,
             )
 
     def test_read_service_config_and_deployments(self):
@@ -214,12 +209,7 @@ class TestMarathonTools:
             )
             assert load_service_instance_config_patch.call_count == 1
             load_service_instance_config_patch.assert_any_call(
-                fake_name,
-                fake_instance,
-                "marathon",
-                fake_cluster,
-                soa_dir=fake_dir,
-                use_cache=False,
+                fake_name, fake_instance, "marathon", fake_cluster, soa_dir=fake_dir,
             )
 
     def test_get_all_namespaces_for_service(self):

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -844,7 +844,7 @@ class TestTronTools:
             "_template": {"actions": {"action1": {}}},
             "job1": {"actions": {"action1": {}}},
         }
-        job_configs = tron_tools.load_tron_service_config(
+        job_configs = tron_tools.load_tron_service_config_no_cache(
             service="service",
             cluster="test-cluster",
             load_deployments=False,
@@ -980,7 +980,7 @@ class TestTronTools:
     @mock.patch("paasta_tools.tron_tools.read_extra_service_information", autospec=True)
     def test_load_tron_service_config_empty(self, mock_read_extra_service_information):
         mock_read_extra_service_information.return_value = {}
-        job_configs = tron_tools.load_tron_service_config(
+        job_configs = tron_tools.load_tron_service_config_no_cache(
             service="service",
             cluster="test-cluster",
             load_deployments=False,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -892,7 +892,7 @@ def test_read_service_instance_names_ignores_underscore():
         (fake_name, fake_instance_1),
     ]
     with mock.patch(
-        "paasta_tools.utils.service_configuration_lib.read_extra_service_information",
+        "paasta_tools.utils.__read_extra_service_information_cached",
         autospec=True,
         return_value=fake_job_config,
     ):
@@ -918,7 +918,7 @@ def test_read_service_instance_names_tron():
         ("fake_service", "job2.actionD"),
     ]
     with mock.patch(
-        "paasta_tools.utils.service_configuration_lib.read_extra_service_information",
+        "paasta_tools.utils.__read_extra_service_information_cached",
         autospec=True,
         return_value=fake_tron_job_config,
     ):
@@ -935,8 +935,7 @@ def test_read_service_instance_names_tron():
     "paasta_tools.utils.load_service_instance_auto_configs", autospec=True,
 )
 @mock.patch(
-    "paasta_tools.utils.service_configuration_lib.read_extra_service_information",
-    autospec=True,
+    "paasta_tools.utils.__read_extra_service_information_cached", autospec=True,
 )
 def test_load_service_instance_configs(
     mock_read_extra_service_information, mock_load_auto_configs
@@ -961,7 +960,7 @@ def test_load_service_instance_configs(
     )
     assert result == expected
     mock_read_extra_service_information.assert_called_with(
-        service_name="fake_service", extra_info="kubernetes-fake", soa_dir="fake_dir",
+        "fake_service", "kubernetes-fake", soa_dir="fake_dir",
     )
     mock_load_auto_configs.assert_called_with(
         service="fake_service",
@@ -983,8 +982,7 @@ def test_load_service_instance_config_underscore():
 
 
 @mock.patch(
-    "paasta_tools.utils.service_configuration_lib.read_extra_service_information",
-    autospec=True,
+    "paasta_tools.utils.__read_extra_service_information_cached", autospec=True,
 )
 def test_load_service_instance_config_not_found(mock_read_service_information):
     mock_read_service_information.return_value = {"bar": {"cpus": 10}}
@@ -1002,8 +1000,7 @@ def test_load_service_instance_config_not_found(mock_read_service_information):
     "paasta_tools.utils.load_service_instance_auto_configs", autospec=True,
 )
 @mock.patch(
-    "paasta_tools.utils.service_configuration_lib.read_extra_service_information",
-    autospec=True,
+    "paasta_tools.utils.__read_extra_service_information_cached", autospec=True,
 )
 @pytest.mark.parametrize(
     "user_config,auto_config,expected_config",
@@ -1034,7 +1031,7 @@ def test_load_service_instance_config(
     )
     assert result == expected_config
     mock_read_extra_service_information.assert_called_with(
-        service_name="fake_service", extra_info="kubernetes-fake", soa_dir="fake_dir",
+        "fake_service", "kubernetes-fake", soa_dir="fake_dir",
     )
     mock_load_auto_configs.assert_called_with(
         service="fake_service",
@@ -1045,8 +1042,7 @@ def test_load_service_instance_config(
 
 
 @mock.patch(
-    "paasta_tools.utils.service_configuration_lib.read_extra_service_information",
-    autospec=True,
+    "paasta_tools.utils.__read_extra_service_information_cached", autospec=True,
 )
 @mock.patch(
     "paasta_tools.utils.load_system_paasta_config", autospec=True,
@@ -1068,8 +1064,8 @@ def test_load_service_instance_auto_configs(
     )
     if instance_type_enabled:
         mock_read_extra_service_information.assert_called_with(
-            service_name="fake_service",
-            extra_info=f"{utils.AUTO_SOACONFIG_SUBDIR}/marathon-fake",
+            "fake_service",
+            f"{utils.AUTO_SOACONFIG_SUBDIR}/marathon-fake",
             soa_dir="fake_dir",
         )
         assert result == mock_read_extra_service_information.return_value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -892,7 +892,7 @@ def test_read_service_instance_names_ignores_underscore():
         (fake_name, fake_instance_1),
     ]
     with mock.patch(
-        "paasta_tools.utils.__read_extra_service_information_cached",
+        "paasta_tools.utils.service_configuration_lib.read_extra_service_information",
         autospec=True,
         return_value=fake_job_config,
     ):
@@ -918,7 +918,7 @@ def test_read_service_instance_names_tron():
         ("fake_service", "job2.actionD"),
     ]
     with mock.patch(
-        "paasta_tools.utils.__read_extra_service_information_cached",
+        "paasta_tools.utils.service_configuration_lib.read_extra_service_information",
         autospec=True,
         return_value=fake_tron_job_config,
     ):
@@ -935,7 +935,8 @@ def test_read_service_instance_names_tron():
     "paasta_tools.utils.load_service_instance_auto_configs", autospec=True,
 )
 @mock.patch(
-    "paasta_tools.utils.__read_extra_service_information_cached", autospec=True,
+    "paasta_tools.utils.service_configuration_lib.read_extra_service_information",
+    autospec=True,
 )
 def test_load_service_instance_configs(
     mock_read_extra_service_information, mock_load_auto_configs
@@ -960,7 +961,7 @@ def test_load_service_instance_configs(
     )
     assert result == expected
     mock_read_extra_service_information.assert_called_with(
-        "fake_service", "kubernetes-fake", soa_dir="fake_dir",
+        "fake_service", "kubernetes-fake", soa_dir="fake_dir", deepcopy=False,
     )
     mock_load_auto_configs.assert_called_with(
         service="fake_service",
@@ -982,7 +983,8 @@ def test_load_service_instance_config_underscore():
 
 
 @mock.patch(
-    "paasta_tools.utils.__read_extra_service_information_cached", autospec=True,
+    "paasta_tools.utils.service_configuration_lib.read_extra_service_information",
+    autospec=True,
 )
 def test_load_service_instance_config_not_found(mock_read_service_information):
     mock_read_service_information.return_value = {"bar": {"cpus": 10}}
@@ -1000,7 +1002,8 @@ def test_load_service_instance_config_not_found(mock_read_service_information):
     "paasta_tools.utils.load_service_instance_auto_configs", autospec=True,
 )
 @mock.patch(
-    "paasta_tools.utils.__read_extra_service_information_cached", autospec=True,
+    "paasta_tools.utils.service_configuration_lib.read_extra_service_information",
+    autospec=True,
 )
 @pytest.mark.parametrize(
     "user_config,auto_config,expected_config",
@@ -1031,7 +1034,7 @@ def test_load_service_instance_config(
     )
     assert result == expected_config
     mock_read_extra_service_information.assert_called_with(
-        "fake_service", "kubernetes-fake", soa_dir="fake_dir",
+        "fake_service", "kubernetes-fake", soa_dir="fake_dir", deepcopy=False,
     )
     mock_load_auto_configs.assert_called_with(
         service="fake_service",
@@ -1042,7 +1045,8 @@ def test_load_service_instance_config(
 
 
 @mock.patch(
-    "paasta_tools.utils.__read_extra_service_information_cached", autospec=True,
+    "paasta_tools.utils.service_configuration_lib.read_extra_service_information",
+    autospec=True,
 )
 @mock.patch(
     "paasta_tools.utils.load_system_paasta_config", autospec=True,
@@ -1067,6 +1071,7 @@ def test_load_service_instance_auto_configs(
             "fake_service",
             f"{utils.AUTO_SOACONFIG_SUBDIR}/marathon-fake",
             soa_dir="fake_dir",
+            deepcopy=False,
         )
         assert result == mock_read_extra_service_information.return_value
     else:


### PR DESCRIPTION
original attempt: #2814
second attempt: #2821

This time relies on https://github.com/Yelp/service_configuration_lib/pull/48 which allows me to  bypass deepcopy altogether instead of trying to cache the result of it.