### PR TITLE
U/tingyenl/coreml 1401 get a meaningful spark app name

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -602,6 +602,21 @@ def run_docker_container(
     return 0
 
 
+def get_spark_app_name(original_docker_cmd):
+    # Use submitted batch name as default spark_run job name
+    if "spark-submit" in original_docker_cmd:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("cmd", choices=["spark-submit"])
+        parser.add_argument("others", nargs="+")
+        args, _ = parser.parse_known_args(original_docker_cmd)
+        scripts = [arg for arg in args.others if arg.endswith(".py")]
+        if len(scripts) > 0:
+            batch_name = scripts[0].split("/")[-1].replace(".py", "")
+            spark_app_name = "spark_run_{}_{}".format(batch_name, get_username())
+            return spark_app_name
+    return "paasta_spark_run_{}".format(get_username())
+
+
 def configure_and_run_docker_container(
     args: argparse.Namespace,
     docker_img: str,
@@ -625,13 +640,13 @@ def configure_and_run_docker_container(
                 file=sys.stderr,
             )
 
-    spark_ui_port = pick_random_port(args.service + str(os.getpid()))
-    spark_app_name = "paasta_spark_run_{}".format(get_username())
-    container_name = spark_app_name + "_" + str(spark_ui_port)
     original_docker_cmd = args.cmd or instance_config.get_cmd()
+    spark_ui_port = pick_random_port(args.service + str(os.getpid()))
+    spark_app_name = get_spark_app_name(original_docker_cmd)
+
+    container_name = spark_app_name + "_" + str(spark_ui_port)
     if "jupyter" not in original_docker_cmd:
         spark_app_name = container_name
-
     access_key, secret_key = get_aws_credentials(
         service=args.service,
         no_aws_credentials=args.no_aws_credentials,

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import socket
 import sys
 import time
@@ -609,14 +610,14 @@ def run_docker_container(
     return 0
 
 
-def get_spark_app_name(original_docker_cmd, spark_ui_port):
+def get_spark_app_name(original_docker_cmd: str, spark_ui_port: int) -> str:
     # Use submitted batch name as default spark_run job name
     spark_app_name = "paasta_spark_run"
     if "spark-submit" in original_docker_cmd:
         parser = argparse.ArgumentParser()
         parser.add_argument("cmd", choices=["spark-submit"])
         parser.add_argument("others", nargs="+")
-        args, _ = parser.parse_known_args(original_docker_cmd)
+        args, _ = parser.parse_known_args(shlex.split(original_docker_cmd))
         scripts = [arg for arg in args.others if arg.endswith(".py")]
         # if we are able to find the running script from cmd, update
         # the app name to be the first batch name we found

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import socket
 import sys
 import time
@@ -302,6 +303,11 @@ def add_subparser(subparsers):
     list_parser.set_defaults(command=paasta_spark_run)
 
 
+def sanitize_container_name(container_name):
+    # container_name only allows [a-zA-Z0-9][a-zA-Z0-9_.-]
+    return re.sub("[^a-zA-Z0-9_.-]", "_", re.sub("^[^a-zA-Z0-9]+", "", container_name))
+
+
 def get_docker_run_cmd(container_name, volumes, env, docker_img, docker_cmd, nvidia):
     cmd = ["paasta_docker_wrapper", "run"]
     cmd.append("--rm")
@@ -316,7 +322,7 @@ def get_docker_run_cmd(container_name, volumes, env, docker_img, docker_cmd, nvi
             cmd.append("--tty=true")
 
     cmd.append("--user=%d:%d" % (os.geteuid(), os.getegid()))
-    cmd.append("--name=%s" % container_name)
+    cmd.append("--name=%s" % sanitize_container_name(container_name))
     for k, v in env.items():
         cmd.append("--env")
         if k in SENSITIVE_ENV:
@@ -584,6 +590,7 @@ def parse_constraints_string(constraints_string: str) -> Mapping[str, str]:
 def run_docker_container(
     container_name, volumes, environment, docker_img, docker_cmd, dry_run, nvidia
 ) -> int:
+
     docker_run_args = dict(
         container_name=container_name,
         volumes=volumes,
@@ -602,19 +609,26 @@ def run_docker_container(
     return 0
 
 
-def get_spark_app_name(original_docker_cmd):
+def get_spark_app_name(original_docker_cmd, spark_ui_port):
     # Use submitted batch name as default spark_run job name
+    spark_app_name = "paasta_spark_run"
     if "spark-submit" in original_docker_cmd:
         parser = argparse.ArgumentParser()
         parser.add_argument("cmd", choices=["spark-submit"])
         parser.add_argument("others", nargs="+")
         args, _ = parser.parse_known_args(original_docker_cmd)
         scripts = [arg for arg in args.others if arg.endswith(".py")]
+        # if we are able to find the running script from cmd, update
+        # the app name to be the first batch name we found
         if len(scripts) > 0:
             batch_name = scripts[0].split("/")[-1].replace(".py", "")
-            spark_app_name = "spark_run_{}_{}".format(batch_name, get_username())
-            return spark_app_name
-    return "paasta_spark_run_{}".format(get_username())
+            spark_app_name = "paasta_" + batch_name
+
+    if "jupyter-lab" in original_docker_cmd:
+        spark_app_name = "paasta_jupyter"
+
+    spark_app_name += "_{}_{}".format(get_username(), spark_ui_port)
+    return spark_app_name
 
 
 def configure_and_run_docker_container(
@@ -642,11 +656,8 @@ def configure_and_run_docker_container(
 
     original_docker_cmd = args.cmd or instance_config.get_cmd()
     spark_ui_port = pick_random_port(args.service + str(os.getpid()))
-    spark_app_name = get_spark_app_name(original_docker_cmd)
+    spark_app_name = get_spark_app_name(original_docker_cmd, spark_ui_port)
 
-    container_name = spark_app_name + "_" + str(spark_ui_port)
-    if "jupyter" not in original_docker_cmd:
-        spark_app_name = container_name
     access_key, secret_key = get_aws_credentials(
         service=args.service,
         no_aws_credentials=args.no_aws_credentials,
@@ -703,7 +714,7 @@ def configure_and_run_docker_container(
                 raise
 
     return run_docker_container(
-        container_name=container_name,
+        container_name=spark_app_name,
         volumes=volumes,
         environment=environment,
         docker_img=docker_img,

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -24,6 +24,7 @@ from paasta_tools.cli.cmds.spark_run import emit_resource_requirements
 from paasta_tools.cli.cmds.spark_run import get_docker_cmd
 from paasta_tools.cli.cmds.spark_run import get_docker_run_cmd
 from paasta_tools.cli.cmds.spark_run import get_smart_paasta_instance_name
+from paasta_tools.cli.cmds.spark_run import get_spark_app_name
 from paasta_tools.cli.cmds.spark_run import get_spark_config
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import SystemPaastaConfig
@@ -551,6 +552,22 @@ def test_emit_resource_requirements(tmpdir):
             ],
             any_order=True,
         )
+
+
+@pytest.mark.parametrize(
+    "cmd,expected_name",
+    [
+        (
+            ["spark-submit", "path/to/my-script.py", "--some-configs", "values"],
+            "spark_run_my-script_fake_user",
+        ),
+        (["jupyterlab"], "paasta_spark_run_fake_user"),
+    ],
+)
+def test_get_spark_app_name(cmd, expected_name):
+    with mock.patch("paasta_tools.cli.cmds.spark_run.get_username", autospec=True) as m:
+        m.return_value = "fake_user"
+        assert get_spark_app_name(cmd) == expected_name
 
 
 def test_get_docker_cmd_add_spark_conf_str():

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -26,6 +26,7 @@ from paasta_tools.cli.cmds.spark_run import get_docker_run_cmd
 from paasta_tools.cli.cmds.spark_run import get_smart_paasta_instance_name
 from paasta_tools.cli.cmds.spark_run import get_spark_app_name
 from paasta_tools.cli.cmds.spark_run import get_spark_config
+from paasta_tools.cli.cmds.spark_run import sanitize_container_name
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import SystemPaastaConfig
 
@@ -62,6 +63,19 @@ def test_get_docker_run_cmd(mock_getegid, mock_geteuid):
         "pyspark",
         {},
     ]
+
+
+@pytest.mark.parametrize(
+    "container_name,expected",
+    [
+        # name should always start with [a-zA-Z0-9]
+        ("~!.abcde", "abcde"),
+        # name with none supported chars will be replace with _
+        ("to~be?or not to be!", "to_be_or_not_to_be_"),
+    ],
+)
+def test_sanitize_container_name(container_name, expected):
+    assert sanitize_container_name(container_name) == expected
 
 
 @pytest.mark.parametrize("mrjob", [True, False])
@@ -557,17 +571,25 @@ def test_emit_resource_requirements(tmpdir):
 @pytest.mark.parametrize(
     "cmd,expected_name",
     [
+        # spark-submit use first batch name append user name and port
         (
-            ["spark-submit", "path/to/my-script.py", "--some-configs", "values"],
-            "spark_run_my-script_fake_user",
+            ["spark-submit", "path/to/my-script.py", "--some-configs", "a.py"],
+            "paasta_my-script_fake_user_1234",
         ),
-        (["jupyterlab"], "paasta_spark_run_fake_user"),
+        # spark-submit that is unable to find .py script, use the default name
+        # with user name and port
+        (["spark-submit", "path/to/my-script.jar"], "paasta_spark_run_fake_user_1234"),
+        # non jupyter-lab cmd use the default name and append user name and port
+        (["pyspark"], "paasta_spark_run_fake_user_1234",),
+        # jupyterlab we have a different name
+        (["jupyter-lab"], "paasta_jupyter_fake_user_1234"),
     ],
 )
 def test_get_spark_app_name(cmd, expected_name):
+    spark_ui_port = 1234
     with mock.patch("paasta_tools.cli.cmds.spark_run.get_username", autospec=True) as m:
         m.return_value = "fake_user"
-        assert get_spark_app_name(cmd) == expected_name
+        assert get_spark_app_name(cmd, spark_ui_port) == expected_name
 
 
 def test_get_docker_cmd_add_spark_conf_str():

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -573,16 +573,16 @@ def test_emit_resource_requirements(tmpdir):
     [
         # spark-submit use first batch name append user name and port
         (
-            ["spark-submit", "path/to/my-script.py", "--some-configs", "a.py"],
+            "spark-submit path/to/my-script.py --some-configs a.py",
             "paasta_my-script_fake_user_1234",
         ),
         # spark-submit that is unable to find .py script, use the default name
         # with user name and port
-        (["spark-submit", "path/to/my-script.jar"], "paasta_spark_run_fake_user_1234"),
+        ("spark-submit path/to/my-script.jar", "paasta_spark_run_fake_user_1234"),
         # non jupyter-lab cmd use the default name and append user name and port
-        (["pyspark"], "paasta_spark_run_fake_user_1234",),
+        ("pyspark", "paasta_spark_run_fake_user_1234",),
         # jupyterlab we have a different name
-        (["jupyter-lab"], "paasta_jupyter_fake_user_1234"),
+        ("jupyter-lab", "paasta_jupyter_fake_user_1234"),
     ],
 )
 def test_get_spark_app_name(cmd, expected_name):


### PR DESCRIPTION
clean up for  https://github.com/Yelp/paasta/pull/2730

make test pass locally 
also test running with adhoc spark batch seems to work, and have the correct app name being configured: http://history.spark.paasta-pnw-devc.yelp/history/fc21f809-33fc-48c7-a034-69c195279885-19660/jobs/ (The filename I tested is s3.py, and correctly set the app name to be paasta_s3_tingyenl_53434 ) 