### PR TITLE
Fix typo in ACCEPT rules (should be ACCEPT, not ALLOW)

### DIFF
--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -210,7 +210,7 @@ def _inbound_traffic_rule(conf, service_name, instance_name, protocol="tcp"):
                 protocol=protocol,
                 src=ip_range,
                 dst="0.0.0.0/0.0.0.0",
-                target="ALLOW",
+                target="ACCEPT",
                 matches=((protocol, (("dport", (str(port),)),)),),
                 target_parameters=(),
             )

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -448,7 +448,7 @@ def test_reject_inbound_network_traffic(
         ),
         EMPTY_RULE._replace(
             protocol="tcp",
-            target="ALLOW",
+            target="ACCEPT",
             src="127.0.0.0/255.0.0.0",
             dst="0.0.0.0/0.0.0.0",
             matches=(("tcp", (("dport", ("20000",)),)),),
@@ -456,7 +456,7 @@ def test_reject_inbound_network_traffic(
         ),
         EMPTY_RULE._replace(
             protocol="tcp",
-            target="ALLOW",
+            target="ACCEPT",
             src="169.254.0.0/255.255.0.0",
             dst="0.0.0.0/0.0.0.0",
             matches=(("tcp", (("dport", ("20000",)),)),),


### PR DESCRIPTION
Fixes a typo I introduced in inbound_firewall rules. These should be `ACCEPT`; `ALLOW` is not the correct keyword.