### PR TITLE
Fix error where setup.py was trying to install paasta_tools/contrib/_…

### DIFF
--- a/paasta_tools/firewall.py
+++ b/paasta_tools/firewall.py
@@ -11,7 +11,6 @@ from contextlib import contextmanager
 
 from paasta_tools import iptables
 from paasta_tools.cli.utils import get_instance_config
-from paasta_tools.contrib.graceful_container_drain import get_proxy_port
 from paasta_tools.marathon_tools import get_all_namespaces_for_service
 from paasta_tools.native_mesos_scheduler import paasta_native_services_running_here
 from paasta_tools.utils import get_running_mesos_docker_containers

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         "paasta_tools/setup_marathon_job.py",
         "paasta_tools/synapse_srv_namespaces_fact.py",
     ]
-    + glob.glob("paasta_tools/contrib/*"),
+    + glob.glob("paasta_tools/contrib/*.py"),
     entry_points={
         "console_scripts": [
             "paasta=paasta_tools.cli.cli:main",


### PR DESCRIPTION
…`_pycache__` as a script.

The import from a contrib script in firewall.py causes python to create a pyc file under paasta_tools/contrib/__pycache__.
On the next run of setup.py, this __pycache__ directory would be passed in the scripts parameter to setup().
setup() would then fail to install a directory as a script with:

    error: [Errno 21] Is a directory: '/nail/home/krall/pg/paasta/paasta_tools/contrib/__pycache__'

As it turns out, this import shouldn't be here anyway -- it was removed in e9fdebcf2, but in a different branch it was moved in eae9a97a2.
The merge commit, 78e57cf35, ended up with the import still existing in the end.