### PR TITLE
Also include shell scripts from contrib dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         "paasta_tools/setup_marathon_job.py",
         "paasta_tools/synapse_srv_namespaces_fact.py",
     ]
+    + glob.glob("paasta_tools/contrib/*.sh")
     + glob.glob("paasta_tools/contrib/*.py"),
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
In 1e23c51170e70ed3db0bb4acf99823af2c545f5a I restricted the glob to *.py to avoid including the __pycache__ directory, but this had the effect of also omitting shell scripts.