### PR TITLE
fix the bug that spark-run failed to parse the environment variable in command

### DIFF
--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -576,6 +576,11 @@ def test_emit_resource_requirements(tmpdir):
             "spark-submit path/to/my-script.py --some-configs a.py",
             "paasta_my-script_fake_user_1234",
         ),
+        # spark-submit with env settings
+        (
+            "USER=TEST spark-submit path/to/my-script.py --some-configs a.py",
+            "paasta_my-script_fake_user_1234",
+        ),
         # spark-submit that is unable to find .py script, use the default name
         # with user name and port
         ("spark-submit path/to/my-script.jar", "paasta_spark_run_fake_user_1234"),


### PR DESCRIPTION
Just noticed that the spark batch will failed if people had environment settings on the batch name. 

fixed the unit tests and also tested it manually. It successfully give the correct job name with or without the environment variables in the commands. 