### PR TITLE
Refactor inbound firewall rules to mark traffic in PREFILTER, then act during later chains

### DIFF
--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -354,6 +354,7 @@
                         "inbound_firewall": {
                             "enum": [
                                 "accept",
+                                "monitor",
                                 "reject"
                             ]
                         },

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -710,6 +710,7 @@ class InstanceConfig:
 
         if inbound_firewall is not None and inbound_firewall not in (
             "allow",
+            "monitor",
             "reject",
         ):
             return (

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -429,247 +429,252 @@ def test_ensure_internet_chain():
 def test_reject_inbound_network_traffic(
     mock_ensure_chain, mock_get_nerve_ports, mock_service_config, service_group,
 ):
-    mock_service_config.return_value.get_inbound_firewall.return_value = "reject"
-    assert service_group.get_rules(
-        DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR
-    ) == (
-        EMPTY_RULE._replace(
-            protocol="ip",
-            src="0.0.0.0/0.0.0.0",
-            dst="0.0.0.0/0.0.0.0",
-            target="LOG",
-            matches=(("limit", (("limit", ("1/sec",)), ("limit-burst", ("1",)))),),
-            target_parameters=(("log-prefix", ("paasta.my_cool_service ",)),),
-        ),
-        EMPTY_RULE._replace(
-            protocol="ip",
-            src="0.0.0.0/0.0.0.0",
-            dst="0.0.0.0/0.0.0.0",
-            target="PAASTA-COMMON",
-            matches=(),
-            target_parameters=(),
-        ),
-        EMPTY_RULE._replace(
-            protocol="ip",
-            src="0.0.0.0/0.0.0.0",
-            dst="0.0.0.0/0.0.0.0",
-            target="PAASTA-INTERNET",
-            matches=(),
-            target_parameters=(),
-        ),
-        EMPTY_RULE._replace(
-            protocol="tcp",
-            src="0.0.0.0/0.0.0.0",
-            dst="1.2.3.4/255.255.255.255",
-            target="ACCEPT",
-            matches=(
-                ("comment", (("comment", ("backend example_happyhour.main",)),)),
-                ("tcp", (("dport", ("123",)),)),
+    for inbound_firewall_rule, inbound_firewall_target, inbound_firewall_target_parameters in [
+            ("reject", "REJECT", ((("reject-with", ("icmp-port-unreachable",))),)),
+            ("monitor", "LOG", ()),
+    ]:
+        mock_ensure_chain.reset_mock()
+        mock_service_config.return_value.get_inbound_firewall.return_value = inbound_firewall_rule
+        assert service_group.get_rules(
+            DEFAULT_SOA_DIR, firewall.DEFAULT_SYNAPSE_SERVICE_DIR
+        ) == (
+            EMPTY_RULE._replace(
+                protocol="ip",
+                src="0.0.0.0/0.0.0.0",
+                dst="0.0.0.0/0.0.0.0",
+                target="LOG",
+                matches=(("limit", (("limit", ("1/sec",)), ("limit-burst", ("1",)))),),
+                target_parameters=(("log-prefix", ("paasta.my_cool_service ",)),),
             ),
-            target_parameters=(),
-        ),
-        EMPTY_RULE._replace(
-            protocol="tcp",
-            src="0.0.0.0/0.0.0.0",
-            dst="5.6.7.8/255.255.255.255",
-            target="ACCEPT",
-            matches=(
-                ("comment", (("comment", ("backend example_happyhour.main",)),)),
-                ("tcp", (("dport", ("567",)),)),
+            EMPTY_RULE._replace(
+                protocol="ip",
+                src="0.0.0.0/0.0.0.0",
+                dst="0.0.0.0/0.0.0.0",
+                target="PAASTA-COMMON",
+                matches=(),
+                target_parameters=(),
             ),
-            target_parameters=(),
-        ),
-        EMPTY_RULE._replace(
-            protocol="tcp",
-            src="0.0.0.0/0.0.0.0",
-            dst="169.254.255.254/255.255.255.255",
-            target="ACCEPT",
-            matches=(
-                ("comment", (("comment", ("proxy_port example_happyhour.main",)),)),
-                ("tcp", (("dport", ("20000",)),)),
+            EMPTY_RULE._replace(
+                protocol="ip",
+                src="0.0.0.0/0.0.0.0",
+                dst="0.0.0.0/0.0.0.0",
+                target="PAASTA-INTERNET",
+                matches=(),
+                target_parameters=(),
             ),
-            target_parameters=(),
-        ),
-        EMPTY_RULE._replace(
-            protocol="ip",
-            src="0.0.0.0/0.0.0.0",
-            dst="169.229.226.0/255.255.255.0",
-            target="ACCEPT",
-            matches=(("comment", (("comment", ("allow 169.229.226.0/24:*",)),)),),
-            target_parameters=(),
-        ),
-        EMPTY_RULE._replace(
-            protocol="tcp",
-            src="0.0.0.0/0.0.0.0",
-            dst="8.8.8.8/255.255.255.255",
-            target="ACCEPT",
-            matches=(
-                ("comment", (("comment", ("allow 8.8.8.8/32:53",)),)),
-                ("tcp", (("dport", ("53",)),)),
+            EMPTY_RULE._replace(
+                protocol="tcp",
+                src="0.0.0.0/0.0.0.0",
+                dst="1.2.3.4/255.255.255.255",
+                target="ACCEPT",
+                matches=(
+                    ("comment", (("comment", ("backend example_happyhour.main",)),)),
+                    ("tcp", (("dport", ("123",)),)),
+                ),
+                target_parameters=(),
             ),
-            target_parameters=(),
-        ),
-        EMPTY_RULE._replace(
-            protocol="udp",
-            src="0.0.0.0/0.0.0.0",
-            dst="8.8.8.8/255.255.255.255",
-            target="ACCEPT",
-            matches=(
-                ("comment", (("comment", ("allow 8.8.8.8/32:53",)),)),
-                ("udp", (("dport", ("53",)),)),
+            EMPTY_RULE._replace(
+                protocol="tcp",
+                src="0.0.0.0/0.0.0.0",
+                dst="5.6.7.8/255.255.255.255",
+                target="ACCEPT",
+                matches=(
+                    ("comment", (("comment", ("backend example_happyhour.main",)),)),
+                    ("tcp", (("dport", ("567",)),)),
+                ),
+                target_parameters=(),
             ),
-            target_parameters=(),
-        ),
-        EMPTY_RULE._replace(
-            protocol="tcp",
-            src="0.0.0.0/0.0.0.0",
-            dst="8.8.4.4/255.255.255.255",
-            target="ACCEPT",
-            matches=(
-                ("comment", (("comment", ("allow 8.8.4.4/32:1024:65535",)),)),
-                ("tcp", (("dport", ("1024:65535",)),)),
+            EMPTY_RULE._replace(
+                protocol="tcp",
+                src="0.0.0.0/0.0.0.0",
+                dst="169.254.255.254/255.255.255.255",
+                target="ACCEPT",
+                matches=(
+                    ("comment", (("comment", ("proxy_port example_happyhour.main",)),)),
+                    ("tcp", (("dport", ("20000",)),)),
+                ),
+                target_parameters=(),
             ),
-            target_parameters=(),
-        ),
-        EMPTY_RULE._replace(
-            protocol="udp",
-            src="0.0.0.0/0.0.0.0",
-            dst="8.8.4.4/255.255.255.255",
-            target="ACCEPT",
-            matches=(
-                ("comment", (("comment", ("allow 8.8.4.4/32:1024:65535",)),)),
-                ("udp", (("dport", ("1024:65535",)),)),
+            EMPTY_RULE._replace(
+                protocol="ip",
+                src="0.0.0.0/0.0.0.0",
+                dst="169.229.226.0/255.255.255.0",
+                target="ACCEPT",
+                matches=(("comment", (("comment", ("allow 169.229.226.0/24:*",)),)),),
+                target_parameters=(),
             ),
-            target_parameters=(),
-        ),
-    )
-
-    assert mock_ensure_chain.mock_calls == [
-        mock.call(
-            "PAASTA.my_cool_se.f031797563.30000",
-            [
-                EMPTY_RULE._replace(
-                    protocol="tcp",
-                    src="0.0.0.0/0.0.0.0",
-                    dst="0.0.0.0/0.0.0.0",
-                    target="RETURN",
-                    matches=(("tcp", (("dport", ("! 30000",)),)),),
-                    target_parameters=(),
+            EMPTY_RULE._replace(
+                protocol="tcp",
+                src="0.0.0.0/0.0.0.0",
+                dst="8.8.8.8/255.255.255.255",
+                target="ACCEPT",
+                matches=(
+                    ("comment", (("comment", ("allow 8.8.8.8/32:53",)),)),
+                    ("tcp", (("dport", ("53",)),)),
                 ),
-                EMPTY_RULE._replace(
-                    protocol="tcp",
-                    src="127.0.0.0/255.0.0.0",
-                    dst="0.0.0.0/0.0.0.0",
-                    target="RETURN",
-                    matches=(("tcp", (("dport", ("! 30000",)),)),),
-                    target_parameters=(),
+                target_parameters=(),
+            ),
+            EMPTY_RULE._replace(
+                protocol="udp",
+                src="0.0.0.0/0.0.0.0",
+                dst="8.8.8.8/255.255.255.255",
+                target="ACCEPT",
+                matches=(
+                    ("comment", (("comment", ("allow 8.8.8.8/32:53",)),)),
+                    ("udp", (("dport", ("53",)),)),
                 ),
-                EMPTY_RULE._replace(
-                    protocol="tcp",
-                    src="169.254.0.0/255.255.0.0",
-                    dst="0.0.0.0/0.0.0.0",
-                    target="RETURN",
-                    matches=(("tcp", (("dport", ("! 30000",)),)),),
-                    target_parameters=(),
+                target_parameters=(),
+            ),
+            EMPTY_RULE._replace(
+                protocol="tcp",
+                src="0.0.0.0/0.0.0.0",
+                dst="8.8.4.4/255.255.255.255",
+                target="ACCEPT",
+                matches=(
+                    ("comment", (("comment", ("allow 8.8.4.4/32:1024:65535",)),)),
+                    ("tcp", (("dport", ("1024:65535",)),)),
                 ),
-                EMPTY_RULE._replace(
-                    protocol="tcp",
-                    src="0.0.0.0/0.0.0.0",
-                    dst="0.0.0.0/0.0.0.0",
-                    target="MARK",
-                    matches=(("mark", (("mark", ("30000",)),)),),
-                    target_parameters=(),
+                target_parameters=(),
+            ),
+            EMPTY_RULE._replace(
+                protocol="udp",
+                src="0.0.0.0/0.0.0.0",
+                dst="8.8.4.4/255.255.255.255",
+                target="ACCEPT",
+                matches=(
+                    ("comment", (("comment", ("allow 8.8.4.4/32:1024:65535",)),)),
+                    ("udp", (("dport", ("1024:65535",)),)),
                 ),
-            ],
-            table_name="nat",
-        ),
-        mock.call(
-            "PAASTA.my_cool_se.f031797563.30001",
-            [
-                EMPTY_RULE._replace(
-                    protocol="tcp",
-                    src="0.0.0.0/0.0.0.0",
-                    dst="0.0.0.0/0.0.0.0",
-                    target="RETURN",
-                    matches=(("tcp", (("dport", ("! 30001",)),)),),
-                    target_parameters=(),
-                ),
-                EMPTY_RULE._replace(
-                    protocol="tcp",
-                    src="127.0.0.0/255.0.0.0",
-                    dst="0.0.0.0/0.0.0.0",
-                    target="RETURN",
-                    matches=(("tcp", (("dport", ("! 30001",)),)),),
-                    target_parameters=(),
-                ),
-                EMPTY_RULE._replace(
-                    protocol="tcp",
-                    src="169.254.0.0/255.255.0.0",
-                    dst="0.0.0.0/0.0.0.0",
-                    target="RETURN",
-                    matches=(("tcp", (("dport", ("! 30001",)),)),),
-                    target_parameters=(),
-                ),
-                EMPTY_RULE._replace(
-                    protocol="tcp",
-                    src="0.0.0.0/0.0.0.0",
-                    dst="0.0.0.0/0.0.0.0",
-                    target="MARK",
-                    matches=(("mark", (("mark", ("30001",)),)),),
-                    target_parameters=(),
-                ),
-            ],
-            table_name="nat",
-        ),
-        mock.call(
-            "PAASTA.my_cool_se.f031797563",
-            [
-                EMPTY_RULE._replace(
-                    protocol="tcp",
-                    src="0.0.0.0/0.0.0.0",
-                    dst="0.0.0.0/0.0.0.0",
-                    target="PAASTA.my_cool_se.f031797563.30000",
-                    matches=(),
-                    target_parameters=(),
-                ),
-                EMPTY_RULE._replace(
-                    protocol="tcp",
-                    src="0.0.0.0/0.0.0.0",
-                    dst="0.0.0.0/0.0.0.0",
-                    target="PAASTA.my_cool_se.f031797563.30001",
-                    matches=(),
-                    target_parameters=(),
-                ),
-            ],
-            table_name="nat",
-        ),
-        mock.call(
-            "PAASTA.my_cool_se.f031797563-INBOUND-FILTER",
-            [
-                EMPTY_RULE._replace(
-                    protocol="tcp",
-                    src="0.0.0.0/0.0.0.0",
-                    dst="0.0.0.0/0.0.0.0",
-                    target="REJECT",
-                    matches=(("mark", (("mark", ("30000",)),)),),
-                    target_parameters=(("reject-with", ("icmp-port-unreachable",)),),
-                ),
-            ],
-        ),
-        mock.call(
-            "PAASTA.my_cool_se.f031797563-INBOUND-FILTER",
-            [
-                EMPTY_RULE._replace(
-                    protocol="tcp",
-                    src="0.0.0.0/0.0.0.0",
-                    dst="0.0.0.0/0.0.0.0",
-                    target="REJECT",
-                    matches=(("mark", (("mark", ("30001",)),)),),
-                    target_parameters=(("reject-with", ("icmp-port-unreachable",)),),
-                ),
-            ],
-        ),
-    ]
+                target_parameters=(),
+            ),
+        )
+    
+        assert mock_ensure_chain.mock_calls == [
+            mock.call(
+                "PAASTA.my_cool_se.f031797563.30000",
+                [
+                    EMPTY_RULE._replace(
+                        protocol="tcp",
+                        src="0.0.0.0/0.0.0.0",
+                        dst="0.0.0.0/0.0.0.0",
+                        target="RETURN",
+                        matches=(("tcp", (("dport", ("! 30000",)),)),),
+                        target_parameters=(),
+                    ),
+                    EMPTY_RULE._replace(
+                        protocol="tcp",
+                        src="127.0.0.0/255.0.0.0",
+                        dst="0.0.0.0/0.0.0.0",
+                        target="RETURN",
+                        matches=(("tcp", (("dport", ("! 30000",)),)),),
+                        target_parameters=(),
+                    ),
+                    EMPTY_RULE._replace(
+                        protocol="tcp",
+                        src="169.254.0.0/255.255.0.0",
+                        dst="0.0.0.0/0.0.0.0",
+                        target="RETURN",
+                        matches=(("tcp", (("dport", ("! 30000",)),)),),
+                        target_parameters=(),
+                    ),
+                    EMPTY_RULE._replace(
+                        protocol="tcp",
+                        src="0.0.0.0/0.0.0.0",
+                        dst="0.0.0.0/0.0.0.0",
+                        target="MARK",
+                        matches=(("mark", (("mark", ("30000",)),)),),
+                        target_parameters=(),
+                    ),
+                ],
+                table_name="nat",
+            ),
+            mock.call(
+                "PAASTA.my_cool_se.f031797563.30001",
+                [
+                    EMPTY_RULE._replace(
+                        protocol="tcp",
+                        src="0.0.0.0/0.0.0.0",
+                        dst="0.0.0.0/0.0.0.0",
+                        target="RETURN",
+                        matches=(("tcp", (("dport", ("! 30001",)),)),),
+                        target_parameters=(),
+                    ),
+                    EMPTY_RULE._replace(
+                        protocol="tcp",
+                        src="127.0.0.0/255.0.0.0",
+                        dst="0.0.0.0/0.0.0.0",
+                        target="RETURN",
+                        matches=(("tcp", (("dport", ("! 30001",)),)),),
+                        target_parameters=(),
+                    ),
+                    EMPTY_RULE._replace(
+                        protocol="tcp",
+                        src="169.254.0.0/255.255.0.0",
+                        dst="0.0.0.0/0.0.0.0",
+                        target="RETURN",
+                        matches=(("tcp", (("dport", ("! 30001",)),)),),
+                        target_parameters=(),
+                    ),
+                    EMPTY_RULE._replace(
+                        protocol="tcp",
+                        src="0.0.0.0/0.0.0.0",
+                        dst="0.0.0.0/0.0.0.0",
+                        target="MARK",
+                        matches=(("mark", (("mark", ("30001",)),)),),
+                        target_parameters=(),
+                    ),
+                ],
+                table_name="nat",
+            ),
+            mock.call(
+                "PAASTA.my_cool_se.f031797563",
+                [
+                    EMPTY_RULE._replace(
+                        protocol="tcp",
+                        src="0.0.0.0/0.0.0.0",
+                        dst="0.0.0.0/0.0.0.0",
+                        target="PAASTA.my_cool_se.f031797563.30000",
+                        matches=(),
+                        target_parameters=(),
+                    ),
+                    EMPTY_RULE._replace(
+                        protocol="tcp",
+                        src="0.0.0.0/0.0.0.0",
+                        dst="0.0.0.0/0.0.0.0",
+                        target="PAASTA.my_cool_se.f031797563.30001",
+                        matches=(),
+                        target_parameters=(),
+                    ),
+                ],
+                table_name="nat",
+            ),
+            mock.call(
+                "PAASTA.my_cool_se.f031797563-INBOUND-FILTER",
+                [
+                    EMPTY_RULE._replace(
+                        protocol="tcp",
+                        src="0.0.0.0/0.0.0.0",
+                        dst="0.0.0.0/0.0.0.0",
+                        target=inbound_firewall_target,
+                        matches=(("mark", (("mark", ("30000",)),)),),
+                        target_parameters=inbound_firewall_target_parameters,
+                    ),
+                ],
+            ),
+            mock.call(
+                "PAASTA.my_cool_se.f031797563-INBOUND-FILTER",
+                [
+                    EMPTY_RULE._replace(
+                        protocol="tcp",
+                        src="0.0.0.0/0.0.0.0",
+                        dst="0.0.0.0/0.0.0.0",
+                        target=inbound_firewall_target,
+                        matches=(("mark", (("mark", ("30001",)),)),),
+                        target_parameters=inbound_firewall_target_parameters,
+                    ),
+                ],
+            ),
+        ]
 
 
 @pytest.fixture

--- a/tests/test_iptables.py
+++ b/tests/test_iptables.py
@@ -140,6 +140,7 @@ def test_ensure_chain():
         mock.call(
             "PAASTA.service",
             EMPTY_RULE._replace(target="ACCEPT", src="2.0.0.0/255.255.255.0"),
+            table_name="filter",
         )
     ]
 
@@ -148,6 +149,7 @@ def test_ensure_chain():
         mock.call(
             "PAASTA.service",
             {EMPTY_RULE._replace(target="ACCEPT", src="1.0.0.0/255.255.255.0")},
+            table_name="filter",
         )
     ]
 
@@ -158,7 +160,9 @@ def test_ensure_chain_creates_chain_if_doesnt_exist():
     ), mock.patch.object(iptables, "create_chain", autospec=True) as mock_create_chain:
         iptables.ensure_chain("PAASTA.service", ())
 
-    assert mock_create_chain.mock_calls == [mock.call("PAASTA.service")]
+    assert mock_create_chain.mock_calls == [
+        mock.call("PAASTA.service", table_name="filter")
+    ]
 
 
 def test_ensure_rule_does_not_exist():
@@ -173,7 +177,12 @@ def test_ensure_rule_does_not_exist():
         iptables.ensure_rule("PAASTA.service", EMPTY_RULE._replace(target="DROP"))
 
     assert mock_insert_rule.mock_calls == [
-        mock.call("PAASTA.service", EMPTY_RULE._replace(target="DROP"))
+        mock.call(
+            "PAASTA.service",
+            EMPTY_RULE._replace(target="DROP"),
+            position=0,
+            table_name="filter",
+        )
     ]
 
 


### PR DESCRIPTION
After debugging my previous inbound filter changes, it was clear that getting traffic passed through to the `PAASTA` service chain was going to be cumbersome and buggy after the traffic was already routed to Docker.

So I tried a new strategy:
```
sudo iptables -t nat -I DOCKER 1 -p tcp ! -s 127.0.0.1 --dport $DPORT -j MARK --set-mark $DPORT
sudo iptables -I DOCKER-USER 1 -m mark --mark $DPORT -j REJECT
```
And this worked much better.

This change intercepts inbound traffic very early -- specifically, in the nat `PREFILTER` chain of iptables -- and marks it for later operations (in this change, log or reject). This has the benefit of identifying the source of traffic before it gets to the `MASQUERADE` actions in prefiltering. This in turn makes it substantially easier to identify the source of traffic _and_ to tidy up these rules in conveniently named `PAASTA` chains.

This change is long because, to do this, I needed to push the table definition down through paasta_tools/iptables.py. I also added two new chains (`PAASTA-PREFILTER` and `PAASTA-MARK`) to keep the new rules legible and easy to find in manual debugging.

Tests will be added before this ships. This should be considered a WIP until they've been added as noted in the comments below.