### PR TITLE
Optimize deployd workers

### DIFF
--- a/paasta_itests/steps/bounces_steps.py
+++ b/paasta_itests/steps/bounces_steps.py
@@ -227,7 +227,11 @@ def when_setup_service_initiated(context):
         "paasta_tools.mesos_maintenance.get_principal", autospec=True
     ) as mock_get_principal, mock.patch(
         "paasta_tools.mesos_maintenance.get_secret", autospec=True
-    ) as mock_get_secret:
+    ) as mock_get_secret, mock.patch(
+        "paasta_tools.mesos_maintenance.get_mesos_leader",
+        autospec=True,
+        return_value="mesosmaster",
+    ):
         credentials = mesos_maintenance.load_credentials(
             mesos_secrets="/etc/mesos-slave-secret"
         )

--- a/paasta_tools/bounce_lib.py
+++ b/paasta_tools/bounce_lib.py
@@ -27,6 +27,7 @@ from typing import Any
 from typing import Callable
 from typing import Collection
 from typing import Dict
+from typing import Iterator
 from typing import List
 from typing import Mapping
 from typing import Optional
@@ -129,14 +130,17 @@ def bounce_lock(name):
 
 
 @contextmanager
-def bounce_lock_zookeeper(name):
+def bounce_lock_zookeeper(
+    name: str, system_paasta_config: Optional[SystemPaastaConfig] = None
+) -> Iterator:
     """Acquire a bounce lock in zookeeper for the name given. The name should
     generally be the service namespace being bounced.
     This is a contextmanager. Please use it via 'with bounce_lock(name):'.
     :param name: The lock name to acquire"""
+    if system_paasta_config is None:
+        system_paasta_config = load_system_paasta_config()
     zk = KazooClient(
-        hosts=load_system_paasta_config().get_zk_hosts(),
-        timeout=ZK_LOCK_CONNECT_TIMEOUT_S,
+        hosts=system_paasta_config.get_zk_hosts(), timeout=ZK_LOCK_CONNECT_TIMEOUT_S,
     )
     zk.start()
     lock = zk.Lock(f"{ZK_LOCK_PATH}/{name}")

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -19,6 +19,7 @@ from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import InstanceConfigDict
 from paasta_tools.utils import InvalidInstanceConfig
 from paasta_tools.utils import InvalidJobNameError
+from paasta_tools.utils import SystemPaastaConfig
 
 log = logging.getLogger(__name__)
 logging.getLogger("marathon").setLevel(logging.WARNING)
@@ -139,8 +140,10 @@ class LongRunningServiceConfig(InstanceConfig):
         """
         return self.get_service()
 
-    def get_env(self) -> Dict[str, str]:
-        env = super().get_env()
+    def get_env(
+        self, system_paasta_config: Optional[SystemPaastaConfig] = None
+    ) -> Dict[str, str]:
+        env = super().get_env(system_paasta_config=system_paasta_config)
         env["PAASTA_PORT"] = str(self.get_container_port())
         return env
 

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -373,10 +373,10 @@ def load_service_namespace_config(
     :returns: A dict of the above keys, if they were defined
     """
 
-    service_config = service_configuration_lib.read_service_configuration(
-        service_name=service, soa_dir=soa_dir
+    smartstack_config = service_configuration_lib.read_extra_service_information(
+        service_name=service, extra_info="smartstack", soa_dir=soa_dir, deepcopy=False,
     )
-    smartstack_config = service_config.get("smartstack", {})
+
     namespace_config_from_file = smartstack_config.get(namespace, {})
 
     service_namespace_config = ServiceNamespaceConfig()

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1405,7 +1405,7 @@ def get_matching_appids(
     Useful for fuzzy matching if you think there are marathon
     apps running but you don't know the full instance id"""
     marathon_apps = get_all_marathon_apps(
-        client, service_name=service, embed_tasks=embed_tasks
+        client, service_name=service, instance_name=instance, embed_tasks=embed_tasks
     )
     return [
         app.id for app in marathon_apps if does_app_id_match(service, instance, app.id)
@@ -1444,12 +1444,14 @@ def does_app_id_match(service: str, instance: str, app_id: str) -> bool:
 def get_all_marathon_apps(
     client: MarathonClient,
     service_name: Optional[str] = None,
+    instance_name: Optional[str] = None,
     embed_tasks: bool = False,
 ) -> List[MarathonApp]:
     if service_name:
         return client.list_apps(
             embed_tasks=embed_tasks,
-            app_id="/" + format_job_id(service=service_name, instance=""),
+            app_id="/"
+            + format_job_id(service=service_name, instance=(instance_name or "")),
         )
     else:
         # Ignore apps inside a folder
@@ -1463,11 +1465,14 @@ def get_all_marathon_apps(
 def get_marathon_apps_with_clients(
     clients: Sequence[MarathonClient],
     service_name: Optional[str] = None,
+    instance_name: Optional[str] = None,
     embed_tasks: bool = False,
 ) -> Sequence[Tuple[MarathonApp, MarathonClient]]:
     marathon_apps_with_clients: List[Tuple[MarathonApp, MarathonClient]] = []
     for client in clients:
-        for app in get_all_marathon_apps(client, service_name, embed_tasks=embed_tasks):
+        for app in get_all_marathon_apps(
+            client, service_name, instance_name=instance_name, embed_tasks=embed_tasks
+        ):
             marathon_apps_with_clients.append((app, client))
     return marathon_apps_with_clients
 

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -663,7 +663,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
 
         if system_paasta_config is None:
             system_paasta_config = load_system_paasta_config()
-        docker_url = self.get_docker_url()
+        docker_url = self.get_docker_url(system_paasta_config=system_paasta_config)
         service_namespace_config = load_service_namespace_config(
             service=self.service, namespace=self.get_nerve_namespace()
         )
@@ -703,7 +703,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
             "health_checks": self.get_healthchecks(
                 service_namespace_config=service_namespace_config
             ),
-            "env": self.get_env(),
+            "env": self.get_env(system_paasta_config=system_paasta_config),
             "mem": float(self.get_mem()),
             "cpus": float(self.get_cpus()),
             "disk": float(self.get_disk()),
@@ -772,7 +772,9 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         }
         ahash["container"]["docker"][  # type: ignore
             "parameters"
-        ] = self.format_docker_parameters(with_labels=False)
+        ] = self.format_docker_parameters(
+            with_labels=False, system_paasta_config=system_paasta_config
+        )
         secret_hashes = get_secret_hashes(
             environment_variables=config["env"],
             secret_environment=system_paasta_config.get_vault_environment(),

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -406,6 +406,7 @@ def load_marathon_service_config(
     cluster: str,
     load_deployments: bool = True,
     soa_dir: str = DEFAULT_SOA_DIR,
+    # system_paasta_config: Optional[SystemPaastaConfig] = None
 ) -> "MarathonServiceConfig":
     """Read a service instance's configuration for marathon.
 
@@ -631,7 +632,9 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         ]
         return routing_constraints
 
-    def format_marathon_app_dict(self) -> FormattedMarathonAppDict:
+    def format_marathon_app_dict(
+        self, system_paasta_config: Optional[SystemPaastaConfig] = None
+    ) -> FormattedMarathonAppDict:
         """Create the configuration that will be passed to the Marathon REST API.
 
         Currently compiles the following keys into one nice dict:
@@ -658,7 +661,8 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         :param service_namespace_config: The service instance's configuration dict
         :returns: A dict containing all of the keys listed above"""
 
-        system_paasta_config = load_system_paasta_config()
+        if system_paasta_config is None:
+            system_paasta_config = load_system_paasta_config()
         docker_url = self.get_docker_url()
         service_namespace_config = load_service_namespace_config(
             service=self.service, namespace=self.get_nerve_namespace()
@@ -674,7 +678,9 @@ class MarathonServiceConfig(LongRunningServiceConfig):
                 "docker": {
                     "image": docker_url,
                     "network": net,
-                    "parameters": self.format_docker_parameters(),
+                    "parameters": self.format_docker_parameters(
+                        system_paasta_config=system_paasta_config
+                    ),
                 },
                 "type": "DOCKER",
                 "volumes": docker_volumes,

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -406,7 +406,6 @@ def load_marathon_service_config(
     cluster: str,
     load_deployments: bool = True,
     soa_dir: str = DEFAULT_SOA_DIR,
-    # system_paasta_config: Optional[SystemPaastaConfig] = None
 ) -> "MarathonServiceConfig":
     """Read a service instance's configuration for marathon.
 

--- a/paasta_tools/mesos_maintenance.py
+++ b/paasta_tools/mesos_maintenance.py
@@ -19,6 +19,7 @@ import logging
 from socket import gaierror
 from socket import getfqdn
 from socket import gethostbyname
+from typing import List
 from typing import NamedTuple
 from typing import Optional
 
@@ -30,6 +31,7 @@ from requests import Session
 from requests.exceptions import HTTPError
 
 from paasta_tools.mesos_tools import get_count_running_tasks_on_slave
+from paasta_tools.mesos_tools import get_mesos_config_path
 from paasta_tools.mesos_tools import get_mesos_leader
 from paasta_tools.mesos_tools import get_mesos_master
 from paasta_tools.mesos_tools import MESOS_MASTER_PORT
@@ -60,12 +62,12 @@ class Resource(NamedTuple):
 MAINTENANCE_ROLE = "maintenance"
 
 
-def base_api(system_paasta_config: Optional[SystemPaastaConfig] = None):
+def base_api(mesos_config_path: Optional[str] = None):
     """Helper function for making all API requests
 
     :returns: a function that can be called to make a request
     """
-    leader = get_mesos_leader(system_paasta_config=system_paasta_config)
+    leader = get_mesos_leader(mesos_config_path)
 
     def execute_request(method, endpoint, timeout=(3, 2), **kwargs):
         url = "http://%s:%d%s" % (leader, MESOS_MASTER_PORT, endpoint)
@@ -83,22 +85,22 @@ def base_api(system_paasta_config: Optional[SystemPaastaConfig] = None):
     return execute_request
 
 
-def master_api(system_paasta_config: Optional[SystemPaastaConfig] = None):
+def master_api(mesos_config_path: Optional[str] = None):
     """Helper function for making API requests to the /master API endpoints
 
     :returns: a function that can be called to make a request to /master
     """
 
     def execute_master_api_request(method, endpoint, **kwargs):
-        base_api_client = base_api(system_paasta_config=system_paasta_config)
+        base_api_client = base_api(mesos_config_path=mesos_config_path)
         return base_api_client(method, "/master%s" % endpoint, **kwargs)
 
     return execute_master_api_request
 
 
-def operator_api(system_paasta_config: Optional[SystemPaastaConfig] = None):
+def operator_api(mesos_config_path: Optional[str] = None):
     def execute_operator_api_request(**kwargs):
-        base_api_client = base_api(system_paasta_config=system_paasta_config)
+        base_api_client = base_api(mesos_config_path=mesos_config_path)
         if "headers" in kwargs:
             kwargs["headers"]["Content-Type"] = "application/json"
         else:
@@ -173,12 +175,12 @@ def get_maintenance_schedule():
 
 
 @time_cache(ttl=10)
-def get_maintenance_status(system_paasta_config: Optional[SystemPaastaConfig] = None):
+def get_maintenance_status(mesos_config_path: Optional[str] = None):
     """Makes a GET_MAINTENANCE_STATUS request to the operator api
 
     :returns: a GET_MAINTENANCE_STATUS response
     """
-    client_fn = operator_api(system_paasta_config=system_paasta_config)
+    client_fn = operator_api(mesos_config_path=mesos_config_path)
     return client_fn(data={"type": "GET_MAINTENANCE_STATUS"})
 
 
@@ -195,15 +197,17 @@ def schedule():
 
 def get_hosts_with_state(
     state, system_paasta_config: Optional[SystemPaastaConfig] = None
-):
+) -> List[str]:
     """Helper function to check the maintenance status and return all hosts
     listed as being in a current state
 
     :param state: State we are interested in ('down_machines' or 'draining_machines')
     :returns: A list of hostnames in the specified state or an empty list if no machines
     """
+
+    mesos_config_path = get_mesos_config_path(system_paasta_config)
     try:
-        status = get_maintenance_status().json()
+        status = get_maintenance_status(mesos_config_path).json()
         status = status["get_maintenance_status"]["status"]
     except HTTPError:
         raise HTTPError("Error getting maintenance status.")

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -97,14 +97,16 @@ def get_mesos_config_path(
     )
 
 
-def get_mesos_config(system_paasta_config: Optional[SystemPaastaConfig] = None) -> Dict:
-    return load_mesos_config(get_mesos_config_path(system_paasta_config))
+def get_mesos_config(mesos_config_path: Optional[str] = None) -> Dict:
+    if mesos_config_path is None:
+        mesos_config_path = get_mesos_config_path()
+    return load_mesos_config(mesos_config_path)
 
 
 def get_mesos_master(
-    system_paasta_config: Optional[SystemPaastaConfig] = None, **overrides: Any
+    mesos_config_path: Optional[str] = None, **overrides: Any
 ) -> MesosMaster:
-    config = get_mesos_config(system_paasta_config)
+    config = get_mesos_config(mesos_config_path)
     for k, v in overrides.items():
         config[k] = v
     return MesosMaster(config)
@@ -125,13 +127,13 @@ class MesosTailLines(NamedTuple):
     error_message: str
 
 
-def get_mesos_leader(system_paasta_config: Optional[SystemPaastaConfig] = None) -> str:
+def get_mesos_leader(mesos_config_path: Optional[str] = None) -> str:
     """Get the current mesos-master leader's hostname.
     Attempts to determine this by using mesos.cli to query ZooKeeper.
 
     :returns: The current mesos-master hostname"""
     try:
-        url = get_mesos_master(system_paasta_config).host
+        url = get_mesos_master(mesos_config_path).host
     except mesos_exceptions.MasterNotAvailableException:
         log.debug("mesos.cli failed to provide the master host")
         raise

--- a/paasta_tools/mesos_tools.py
+++ b/paasta_tools/mesos_tools.py
@@ -59,6 +59,7 @@ from paasta_tools.utils import format_table
 from paasta_tools.utils import get_user_agent
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import PaastaColors
+from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import TimeoutError
 
 MARATHON_FRAMEWORK_NAME_PREFIX = "marathon"
@@ -82,23 +83,28 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-def get_mesos_config_path():
+def get_mesos_config_path(
+    system_paasta_config: Optional[SystemPaastaConfig] = None,
+) -> str:
     """
     Determine where to find the configuration for mesos-cli.
     """
-    return (
-        load_system_paasta_config()
-        .get_mesos_cli_config()
-        .get("path", DEFAULT_MESOS_CLI_CONFIG_LOCATION)
+    if system_paasta_config is None:
+        system_paasta_config = load_system_paasta_config()
+
+    return system_paasta_config.get_mesos_cli_config().get(
+        "path", DEFAULT_MESOS_CLI_CONFIG_LOCATION
     )
 
 
-def get_mesos_config():
-    return load_mesos_config(get_mesos_config_path())
+def get_mesos_config(system_paasta_config: Optional[SystemPaastaConfig] = None) -> Dict:
+    return load_mesos_config(get_mesos_config_path(system_paasta_config))
 
 
-def get_mesos_master(**overrides: Any) -> MesosMaster:
-    config = get_mesos_config()
+def get_mesos_master(
+    system_paasta_config: Optional[SystemPaastaConfig] = None, **overrides: Any
+) -> MesosMaster:
+    config = get_mesos_config(system_paasta_config)
     for k, v in overrides.items():
         config[k] = v
     return MesosMaster(config)
@@ -119,13 +125,13 @@ class MesosTailLines(NamedTuple):
     error_message: str
 
 
-def get_mesos_leader() -> str:
+def get_mesos_leader(system_paasta_config: Optional[SystemPaastaConfig] = None) -> str:
     """Get the current mesos-master leader's hostname.
     Attempts to determine this by using mesos.cli to query ZooKeeper.
 
     :returns: The current mesos-master hostname"""
     try:
-        url = get_mesos_master().host
+        url = get_mesos_master(system_paasta_config).host
     except mesos_exceptions.MasterNotAvailableException:
         log.debug("mesos.cli failed to provide the master host")
         raise

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -327,7 +327,9 @@ def print_output(argv: Optional[Sequence[str]] = None) -> None:
         if args.use_mesos_cache:
             master_kwargs["use_mesos_cache"] = True
 
-        master = get_mesos_master(**master_kwargs)
+        master = get_mesos_master(
+            system_paasta_config=system_paasta_config, **master_kwargs
+        )
 
         marathon_servers = get_marathon_servers(system_paasta_config)
         marathon_clients = all_marathon_clients(get_marathon_clients(marathon_servers))

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -39,6 +39,7 @@ from paasta_tools.marathon_tools import MarathonClients
 from paasta_tools.mesos.exceptions import MasterNotAvailableException
 from paasta_tools.mesos.master import MesosMaster
 from paasta_tools.mesos.master import MesosState
+from paasta_tools.mesos_tools import get_mesos_config_path
 from paasta_tools.mesos_tools import get_mesos_leader
 from paasta_tools.mesos_tools import get_mesos_master
 from paasta_tools.mesos_tools import is_mesos_available
@@ -328,7 +329,8 @@ def print_output(argv: Optional[Sequence[str]] = None) -> None:
             master_kwargs["use_mesos_cache"] = True
 
         master = get_mesos_master(
-            system_paasta_config=system_paasta_config, **master_kwargs
+            mesos_config_path=get_mesos_config_path(system_paasta_config),
+            **master_kwargs,
         )
 
         marathon_servers = get_marathon_servers(system_paasta_config)

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -168,7 +168,13 @@ def send_event(
     monitoring_overrides["alert_after"] = "10m"
     check_name = "setup_marathon_job.%s" % compose_job_id(name, instance)
     monitoring_tools.send_event(
-        name, check_name, monitoring_overrides, status, output, soa_dir
+        name,
+        check_name,
+        monitoring_overrides,
+        status,
+        output,
+        soa_dir,
+        system_paasta_config=system_paasta_config,
     )
 
 

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -133,7 +133,13 @@ def parse_args() -> argparse.Namespace:
 
 
 def send_event(
-    name: str, instance: str, soa_dir: str, status: int, output: str
+    name: str,
+    instance: str,
+    soa_dir: str,
+    status: int,
+    output: str,
+    system_paasta_config: SystemPaastaConfig,
+    marathon_service_config: marathon_tools.MarathonServiceConfig,
 ) -> None:
     """Send an event to sensu via pysensu_yelp with the given information.
 
@@ -143,10 +149,15 @@ def send_event(
     :param status: The status to emit for this event
     :param output: The output to emit for this event
     """
-    cluster = load_system_paasta_config().get_cluster()
-    monitoring_overrides = marathon_tools.load_marathon_service_config(
-        name, instance, cluster, soa_dir=soa_dir, load_deployments=False
-    ).get_monitoring()
+    if system_paasta_config is None:
+        system_paasta_config = load_system_paasta_config()
+    cluster = system_paasta_config.get_cluster()
+
+    if marathon_service_config is None:
+        marathon_service_config = marathon_tools.load_marathon_service_config(
+            name, instance, cluster, soa_dir=soa_dir, load_deployments=False
+        )
+    monitoring_overrides = marathon_service_config.get_monitoring()
     # In order to let sensu know how often to expect this check to fire,
     # we need to set the ``check_every`` to the frequency of our cron job, which
     # is 10s.
@@ -592,6 +603,7 @@ def deploy_service(
     bounce_health_params: Dict[str, Any],
     soa_dir: str,
     job_config: marathon_tools.MarathonServiceConfig,
+    system_paasta_config: Optional[SystemPaastaConfig] = None,
     bounce_margin_factor: float = 1.0,
 ) -> Tuple[int, str, Optional[float]]:
     """Deploy the service to marathon, either directly or via a bounce if needed.
@@ -619,7 +631,9 @@ def deploy_service(
             instance=instance,
         )
 
-    system_paasta_config = load_system_paasta_config()
+    if system_paasta_config is None:
+        system_paasta_config = load_system_paasta_config()
+
     cluster = system_paasta_config.get_cluster()
     existing_apps_with_clients = marathon_tools.get_matching_apps_with_clients(
         service=service,
@@ -671,7 +685,7 @@ def deploy_service(
         return (1, errormsg, None)
 
     try:
-        draining_hosts = get_draining_hosts()
+        draining_hosts = get_draining_hosts(system_paasta_config=system_paasta_config)
     except ReadTimeout as e:
         errormsg = (
             "ReadTimeout encountered trying to get draining hosts: %s. Continuing with bounce assuming no tasks at-risk"
@@ -845,6 +859,7 @@ def setup_service(
     job_config: marathon_tools.MarathonServiceConfig,
     marathon_apps_with_clients: Sequence[Tuple[MarathonApp, MarathonClient]],
     soa_dir: str,
+    system_paasta_config: Optional[SystemPaastaConfig] = None,
 ) -> Tuple[int, str, Optional[float]]:
     """Setup the service instance given and attempt to deploy it, if possible.
     Doesn't do anything if the service is already in Marathon and hasn't changed.
@@ -858,7 +873,9 @@ def setup_service(
 
     log.info("Setting up instance %s for service %s", instance, service)
     try:
-        marathon_app_dict = job_config.format_marathon_app_dict()
+        marathon_app_dict = job_config.format_marathon_app_dict(
+            system_paasta_config=system_paasta_config
+        )
     except NoDockerImageError:
         error_msg = (
             "Docker image for {0}.{1} not in deployments.json. Exiting. Has Jenkins deployed it?\n"
@@ -891,6 +908,7 @@ def setup_service(
         ),
         soa_dir=soa_dir,
         job_config=job_config,
+        system_paasta_config=system_paasta_config,
         bounce_margin_factor=job_config.get_bounce_margin_factor(),
     )
 
@@ -958,6 +976,7 @@ def deploy_marathon_service(
     clients: marathon_tools.MarathonClients,
     soa_dir: str,
     marathon_apps_with_clients: Optional[Sequence[Tuple[MarathonApp, MarathonClient]]],
+    system_paasta_config: Optional[SystemPaastaConfig] = None,
 ) -> Tuple[int, float]:
     """deploy the service instance given and process return code
     if there was an error we send a sensu alert.
@@ -971,26 +990,31 @@ def deploy_marathon_service(
         bounce_in_seconds instructs how long until the deployd should try another bounce
         None means that it is in a steady state and doesn't need to bounce again
     """
+    if system_paasta_config is None:
+        system_paasta_config = load_system_paasta_config()
+
     short_id = marathon_tools.format_job_id(service, instance)
     try:
-        with bounce_lib.bounce_lock_zookeeper(short_id):
+        with bounce_lib.bounce_lock_zookeeper(
+            short_id, system_paasta_config=system_paasta_config
+        ):
             try:
                 service_instance_config = marathon_tools.load_marathon_service_config_no_cache(
                     service,
                     instance,
-                    load_system_paasta_config().get_cluster(),
+                    system_paasta_config.get_cluster(),
                     soa_dir=soa_dir,
                 )
             except NoDeploymentsAvailable:
                 log.debug(
                     "No deployments found for %s.%s in cluster %s. Skipping."
-                    % (service, instance, load_system_paasta_config().get_cluster())
+                    % (service, instance, system_paasta_config.get_cluster())
                 )
                 return 0, None
             except NoConfigurationForServiceError:
                 error_msg = (
                     "Could not read marathon configuration file for %s.%s in cluster %s"
-                    % (service, instance, load_system_paasta_config().get_cluster())
+                    % (service, instance, system_paasta_config.get_cluster())
                 )
                 log.error(error_msg)
                 return 1, None
@@ -1014,11 +1038,20 @@ def deploy_marathon_service(
                         job_config=service_instance_config,
                         marathon_apps_with_clients=marathon_apps_with_clients,
                         soa_dir=soa_dir,
+                        system_paasta_config=system_paasta_config,
                     )
                 sensu_status = (
                     pysensu_yelp.Status.CRITICAL if status else pysensu_yelp.Status.OK
                 )
-                send_event(service, instance, soa_dir, sensu_status, output)
+                send_event(
+                    service,
+                    instance,
+                    soa_dir,
+                    sensu_status,
+                    output,
+                    system_paasta_config,
+                    service_instance_config,
+                )
                 return 0, bounce_again_in_seconds
             except (
                 KeyError,
@@ -1030,7 +1063,13 @@ def deploy_marathon_service(
                 error_str = traceback.format_exc()
                 log.error(error_str)
                 send_event(
-                    service, instance, soa_dir, pysensu_yelp.Status.CRITICAL, error_str
+                    service,
+                    instance,
+                    soa_dir,
+                    pysensu_yelp.Status.CRITICAL,
+                    error_str,
+                    system_paasta_config,
+                    service_instance_config,
                 )
                 return 1, None
     except bounce_lib.LockHeldException:

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -1000,6 +1000,8 @@ def deploy_marathon_service(
                     clients=clients.get_all_clients_for_service(
                         job_config=service_instance_config
                     ),
+                    service_name=service,
+                    instance_name=instance,
                     embed_tasks=True,
                 )
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -349,8 +349,12 @@ class InstanceConfig:
     def job_id(self) -> str:
         return self._job_id
 
-    def get_docker_registry(self) -> str:
-        return get_service_docker_registry(self.service, self.soa_dir)
+    def get_docker_registry(
+        self, system_paasta_config: Optional["SystemPaastaConfig"] = None
+    ) -> str:
+        return get_service_docker_registry(
+            self.service, self.soa_dir, system_config=system_paasta_config
+        )
 
     def get_branch(self) -> str:
         return get_paasta_branch(
@@ -452,7 +456,9 @@ class InstanceConfig:
             yield {"key": "cap-drop", "value": cap}
 
     def format_docker_parameters(
-        self, with_labels: bool = True
+        self,
+        with_labels: bool = True,
+        system_paasta_config: Optional["SystemPaastaConfig"] = None,
     ) -> List[DockerParameter]:
         """Formats extra flags for running docker.  Will be added in the format
         `["--%s=%s" % (e['key'], e['value']) for e in list]` to the `docker run` command
@@ -465,7 +471,7 @@ class InstanceConfig:
             {"key": "cpu-period", "value": "%s" % int(self.get_cpu_period())},
             {"key": "cpu-quota", "value": "%s" % int(self.get_cpu_quota())},
         ]
-        if self.use_docker_disk_quota():
+        if self.use_docker_disk_quota(system_paasta_config=system_paasta_config):
             parameters.append(
                 {
                     "key": "storage-opt",
@@ -488,8 +494,12 @@ class InstanceConfig:
         parameters.extend(self.get_cap_drop())
         return parameters
 
-    def use_docker_disk_quota(self) -> bool:
-        return load_system_paasta_config().get_enforce_disk_quota()
+    def use_docker_disk_quota(
+        self, system_paasta_config: Optional["SystemPaastaConfig"] = None
+    ) -> bool:
+        if system_paasta_config is None:
+            system_paasta_config = load_system_paasta_config()
+        return system_paasta_config.get_enforce_disk_quota()
 
     def get_docker_init(self) -> Iterable[DockerParameter]:
         return [{"key": "init", "value": "true"}]
@@ -634,11 +644,15 @@ class InstanceConfig:
         else:
             return ""
 
-    def get_docker_url(self) -> str:
+    def get_docker_url(
+        self, system_paasta_config: Optional["SystemPaastaConfig"] = None
+    ) -> str:
         """Compose the docker url.
         :returns: '<registry_uri>/<docker_image>'
         """
-        registry_uri = self.get_docker_registry()
+        registry_uri = self.get_docker_registry(
+            system_paasta_config=system_paasta_config
+        )
         docker_image = self.get_docker_image()
         if not docker_image:
             raise NoDockerImageError(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -545,7 +545,9 @@ class InstanceConfig:
     def get_instance_type(self) -> Optional[str]:
         return getattr(self, "config_filename_prefix", None)
 
-    def get_env_dictionary(self) -> Dict[str, str]:
+    def get_env_dictionary(
+        self, system_paasta_config: Optional["SystemPaastaConfig"] = None
+    ) -> Dict[str, str]:
         """A dictionary of key/value pairs that represent environment variables
         to be injected to the container environment"""
         env = {
@@ -561,7 +563,9 @@ class InstanceConfig:
         if self.get_gpus() is not None:
             env["PAASTA_RESOURCE_GPUS"] = str(self.get_gpus())
         try:
-            env["PAASTA_GIT_SHA"] = get_git_sha_from_dockerurl(self.get_docker_url())
+            env["PAASTA_GIT_SHA"] = get_git_sha_from_dockerurl(
+                self.get_docker_url(system_paasta_config=system_paasta_config)
+            )
         except Exception:
             pass
         team = self.get_team()
@@ -574,11 +578,13 @@ class InstanceConfig:
         env.update(user_env)
         return {str(k): str(v) for (k, v) in env.items()}
 
-    def get_env(self) -> Dict[str, str]:
+    def get_env(
+        self, system_paasta_config: Optional["SystemPaastaConfig"] = None
+    ) -> Dict[str, str]:
         """Basic get_env that simply returns the basic env, other classes
         might need to override this getter for more implementation-specific
         env getting"""
-        return self.get_env_dictionary()
+        return self.get_env_dictionary(system_paasta_config=system_paasta_config)
 
     def get_args(self) -> Optional[List[str]]:
         """Get the docker args specified in the service's configuration.

--- a/tests/cli/test_cmds_info.py
+++ b/tests/cli/test_cmds_info.py
@@ -29,6 +29,8 @@ def test_get_service_info():
     ) as mock_read_service_configuration, mock.patch(
         "service_configuration_lib.read_service_configuration", autospec=True
     ) as mock_scl_read_service_configuration, mock.patch(
+        "service_configuration_lib.read_extra_service_information", autospec=True
+    ) as mock_read_extra_service_information, mock.patch(
         "paasta_tools.cli.cmds.info.get_actual_deployments", autospec=True
     ) as mock_get_actual_deployments, mock.patch(
         "paasta_tools.cli.cmds.info.get_smartstack_endpoints", autospec=True
@@ -40,11 +42,13 @@ def test_get_service_info():
             "external_link": "http://bla",
             "smartstack": {"main": {"proxy_port": 9001}},
         }
-        mock_scl_read_service_configuration.return_value = {
-            "description": "a fake service that does stuff",
-            "external_link": "http://bla",
-            "smartstack": {"main": {"proxy_port": 9001}},
-        }
+        mock_scl_read_service_configuration.return_value = (
+            mock_read_service_configuration.return_value
+        )
+        mock_read_extra_service_information.return_value = mock_read_service_configuration.return_value[
+            "smartstack"
+        ]
+
         mock_get_actual_deployments.return_value = ["clusterA.main", "clusterB.main"]
         mock_get_smartstack_endpoints.return_value = [
             "http://foo:1234",
@@ -121,12 +125,13 @@ def test_get_deployments_strings_default_case_with_smartstack():
     with mock.patch(
         "paasta_tools.cli.cmds.info.get_actual_deployments", autospec=True
     ) as mock_get_actual_deployments, mock.patch(
-        "service_configuration_lib.read_service_configuration", autospec=True
-    ) as mock_read_service_configuration:
+        "service_configuration_lib.read_extra_service_information", autospec=True
+    ) as mock_read_extra_service_information:
         mock_get_actual_deployments.return_value = ["clusterA.main", "clusterB.main"]
-        mock_read_service_configuration.return_value = {
-            "smartstack": {"main": {"proxy_port": 9001}}
+        mock_read_extra_service_information.return_value = {
+            "main": {"proxy_port": 9001}
         }
+
         actual = info.get_deployments_strings("fake_service", "/fake/soa/dir")
         assert (
             " - clusterA (%s)"

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -298,7 +298,6 @@ class TestMarathonTools:
             "extra_advertise": {"alpha": ["beta"], "gamma": ["delta", "epsilon"]},
             "extra_healthcheck_headers": {"Host": "example.com"},
         }
-        fake_config = {"smartstack": {namespace: fake_info}}
         expected = {
             "healthcheck_mode": fake_healthcheck_mode,
             "healthcheck_uri": fake_uri,
@@ -326,14 +325,16 @@ class TestMarathonTools:
             "extra_healthcheck_headers": {"Host": "example.com"},
         }
         with mock.patch(
-            "service_configuration_lib.read_service_configuration",
+            "service_configuration_lib.read_extra_service_information",
             autospec=True,
-            return_value=fake_config,
-        ) as read_service_configuration_patch:
+            return_value={namespace: fake_info},
+        ) as read_extra_service_information_patch:
             actual = marathon_tools.load_service_namespace_config(
                 name, namespace, soa_dir
             )
-            read_service_configuration_patch.assert_called_once_with(name, soa_dir)
+            read_extra_service_information_patch.assert_called_once_with(
+                name, extra_info="smartstack", soa_dir=soa_dir, deepcopy=False
+            )
             assert sorted(actual) == sorted(expected)
 
     def test_read_service_namespace_config_no_mode_with_no_smartstack(self):
@@ -342,30 +343,34 @@ class TestMarathonTools:
         soa_dir = "rid_aos"
         fake_config: Dict = {}
         with mock.patch(
-            "service_configuration_lib.read_service_configuration",
+            "service_configuration_lib.read_extra_service_information",
             autospec=True,
             return_value=fake_config,
-        ) as read_service_configuration_patch:
+        ) as read_extra_service_information_patch:
             actual = marathon_tools.load_service_namespace_config(
                 name, namespace, soa_dir
             )
-            read_service_configuration_patch.assert_called_once_with(name, soa_dir)
+            read_extra_service_information_patch.assert_called_once_with(
+                name, extra_info="smartstack", soa_dir=soa_dir, deepcopy=False
+            )
             assert actual.get("mode") is None
 
     def test_read_service_namespace_config_no_mode_with_smartstack(self):
         name = "eman"
         namespace = "ecapseman"
         soa_dir = "rid_aos"
-        fake_config = {"smartstack": {namespace: {"proxy_port": 9001}}}
+        fake_smartstack_config = {namespace: {"proxy_port": 9001}}
         with mock.patch(
-            "service_configuration_lib.read_service_configuration",
+            "service_configuration_lib.read_extra_service_information",
             autospec=True,
-            return_value=fake_config,
-        ) as read_service_configuration_patch:
+            return_value=fake_smartstack_config,
+        ) as read_extra_service_information_patch:
             actual = marathon_tools.load_service_namespace_config(
                 name, namespace, soa_dir
             )
-            read_service_configuration_patch.assert_called_once_with(name, soa_dir)
+            read_extra_service_information_patch.assert_called_once_with(
+                name, extra_info="smartstack", soa_dir=soa_dir, deepcopy=False
+            )
             assert actual.get("mode") == "http"
 
     def test_read_service_namespace_config_no_file(self):
@@ -374,13 +379,15 @@ class TestMarathonTools:
         soa_dir = "an_adventure"
 
         with mock.patch(
-            "service_configuration_lib.read_service_configuration",
+            "service_configuration_lib.read_extra_service_information",
             side_effect=Exception,
             autospec=True,
-        ) as read_service_configuration_patch:
+        ) as read_extra_service_information_patch:
             with raises(Exception):
                 marathon_tools.load_service_namespace_config(name, namespace, soa_dir)
-            read_service_configuration_patch.assert_called_once_with(name, soa_dir)
+            read_extra_service_information_patch.assert_called_once_with(
+                name, extra_info="smartstack", soa_dir=soa_dir, deepcopy=False
+            )
 
     @mock.patch("paasta_tools.mesos_tools.get_local_slave_state", autospec=True)
     def test_marathon_services_running_here(self, mock_get_local_slave_state):

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1119,12 +1119,13 @@ class TestMarathonTools:
                 },
                 "/foo",
             ),
-        ):
+        ) as load_system_paasta_config_patch:
             actual = config.format_marathon_app_dict()
             assert actual == expected_conf
 
             # Assert that the complete config can be inserted into the MarathonApp model
             assert MarathonApp(**actual)
+            assert load_system_paasta_config_patch.call_count == 1
 
     def test_get_desired_instances_is_zero_when_desired_state_is_stop(self):
         fake_conf = marathon_tools.MarathonServiceConfig(

--- a/tests/test_mesos_maintenance.py
+++ b/tests/test_mesos_maintenance.py
@@ -627,16 +627,23 @@ def test_schedule(mock_get_maintenance_schedule,):
     assert mock_get_maintenance_schedule.call_count == 1
 
 
+@mock.patch("paasta_tools.mesos_maintenance.get_mesos_config_path", autospec=True)
 @mock.patch("paasta_tools.mesos_maintenance.get_maintenance_status", autospec=True)
-def test_get_hosts_with_state_none(mock_get_maintenance_status,):
+def test_get_hosts_with_state_none(
+    mock_get_maintenance_status, mock_get_mesos_config_path
+):
+    mock_get_mesos_config_path.return_value = "/dev/null"
     fake_status = {"get_maintenance_status": {"status": {}}}
     mock_get_maintenance_status.return_value = mock.Mock()
     mock_get_maintenance_status.return_value.json.return_value = fake_status
     assert get_hosts_with_state(state="fake_state") == []
 
 
+@mock.patch("paasta_tools.mesos_maintenance.get_mesos_config_path", autospec=True)
 @mock.patch("paasta_tools.mesos_maintenance.get_maintenance_status", autospec=True)
-def test_get_hosts_with_state_draining(mock_get_maintenance_status,):
+def test_get_hosts_with_state_draining(
+    mock_get_maintenance_status, mock_get_mesos_config_path
+):
     fake_status = {
         "type": "GET_MAINTENANCE_STATUS",
         "get_maintenance_status": {
@@ -656,8 +663,11 @@ def test_get_hosts_with_state_draining(mock_get_maintenance_status,):
     assert sorted(get_hosts_with_state(state="draining_machines")) == expected
 
 
+@mock.patch("paasta_tools.mesos_maintenance.get_mesos_config_path", autospec=True)
 @mock.patch("paasta_tools.mesos_maintenance.get_maintenance_status", autospec=True)
-def test_get_hosts_with_state_down(mock_get_maintenance_status,):
+def test_get_hosts_with_state_down(
+    mock_get_maintenance_status, mock_get_mesos_config_path
+):
     fake_status = {
         "type": "GET_MAINTENANCE_STATUS",
         "get_maintenance_status": {

--- a/tests/test_mesos_maintenance.py
+++ b/tests/test_mesos_maintenance.py
@@ -681,7 +681,7 @@ def test_get_hosts_with_state_down(mock_get_maintenance_status,):
 def test_get_draining_hosts(mock_get_hosts_with_state,):
     get_draining_hosts()
     assert mock_get_hosts_with_state.call_count == 1
-    expected_args = mock.call(state="draining_machines")
+    expected_args = mock.call(state="draining_machines", system_paasta_config=None)
     assert mock_get_hosts_with_state.call_args == expected_args
 
 

--- a/tests/test_monitoring_tools.py
+++ b/tests/test_monitoring_tools.py
@@ -203,7 +203,7 @@ class TestMonitoring_Tools:
     def test_get_monitoring_config_value_with_monitor_config(self):
         expected = "monitor_test_team"
         with mock.patch(
-            "service_configuration_lib.read_service_configuration",
+            "paasta_tools.monitoring_tools._cached_read_service_configuration",
             autospec=True,
             return_value=self.fake_general_service_config,
         ) as service_configuration_lib_patch, mock.patch(
@@ -230,7 +230,7 @@ class TestMonitoring_Tools:
     def test_get_monitoring_config_value_with_service_config(self):
         expected = "general_test_team"
         with mock.patch(
-            "service_configuration_lib.read_service_configuration",
+            "paasta_tools.monitoring_tools._cached_read_service_configuration",
             autospec=True,
             return_value=self.fake_general_service_config,
         ) as service_configuration_lib_patch, mock.patch(
@@ -257,7 +257,7 @@ class TestMonitoring_Tools:
     def test_get_monitoring_config_value_with_defaults(self):
         expected = None
         with mock.patch(
-            "service_configuration_lib.read_service_configuration",
+            "paasta_tools.monitoring_tools._cached_read_service_configuration",
             autospec=True,
             return_value=self.empty_job_config,
         ) as service_configuration_lib_patch, mock.patch(

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -277,6 +277,7 @@ class TestSetupMarathonJob:
                 fake_status,
                 fake_output,
                 fake_soa_dir,
+                system_paasta_config=fake_system_paasta_config,
             )
             assert load_marathon_service_config_patch.call_count == 0
             assert load_system_paasta_config_patch.call_count == 0

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -131,6 +131,7 @@ class TestSetupMarathonJob:
                 job_config=self.fake_marathon_service_config,
                 marathon_apps_with_clients=[],
                 soa_dir="no_more",
+                system_paasta_config=load_system_paasta_config_patch(),
             )
             sys_exit_patch.assert_called_once_with(0)
 
@@ -190,6 +191,7 @@ class TestSetupMarathonJob:
                 job_config=self.fake_marathon_service_config,
                 marathon_apps_with_clients=[],
                 soa_dir="no_more",
+                system_paasta_config=load_system_paasta_config_patch(),
             )
             sys_exit_patch.assert_called_once_with(0)
 
@@ -246,6 +248,10 @@ class TestSetupMarathonJob:
         expected_check_name = "setup_marathon_job.%s" % compose_job_id(
             fake_service, fake_instance
         )
+        fake_job_config = mock.Mock()
+        fake_job_config.get_monitoring.return_value = {}
+        fake_system_paasta_config = mock.Mock()
+
         with mock.patch(
             "paasta_tools.monitoring_tools.send_event", autospec=True
         ) as send_event_patch, mock.patch(
@@ -253,15 +259,15 @@ class TestSetupMarathonJob:
         ) as load_marathon_service_config_patch, mock.patch(
             "paasta_tools.setup_marathon_job.load_system_paasta_config", autospec=True
         ) as load_system_paasta_config_patch:
-            load_system_paasta_config_patch.return_value.get_cluster = mock.Mock(
-                return_value="fake_cluster"
-            )
-            load_marathon_service_config_patch.return_value.get_monitoring.return_value = (
-                {}
-            )
 
             setup_marathon_job.send_event(
-                fake_service, fake_instance, fake_soa_dir, fake_status, fake_output
+                fake_service,
+                fake_instance,
+                fake_soa_dir,
+                fake_status,
+                fake_output,
+                fake_system_paasta_config,
+                fake_job_config,
             )
 
             send_event_patch.assert_called_once_with(
@@ -272,13 +278,8 @@ class TestSetupMarathonJob:
                 fake_output,
                 fake_soa_dir,
             )
-            load_marathon_service_config_patch.assert_called_once_with(
-                fake_service,
-                fake_instance,
-                load_system_paasta_config_patch.return_value.get_cluster.return_value,
-                load_deployments=False,
-                soa_dir=fake_soa_dir,
-            )
+            assert load_marathon_service_config_patch.call_count == 0
+            assert load_system_paasta_config_patch.call_count == 0
 
     def test_do_bounce_when_create_app_and_new_app_not_running_but_already_created(
         self,
@@ -1402,7 +1403,9 @@ class TestSetupMarathonJob:
                 marathon_apps_with_clients=None,
                 soa_dir=None,
             )
-            format_marathon_app_dict_patch.assert_called_once_with()
+            format_marathon_app_dict_patch.assert_called_once_with(
+                system_paasta_config=None
+            )
             assert deploy_service_patch.call_count == 1
 
     def test_setup_service_srv_does_not_exist(self):
@@ -1488,7 +1491,9 @@ class TestSetupMarathonJob:
 
             get_bounce_patch.assert_called_once_with()
             get_bounce_margin_factor_patch.assert_called_once_with()
-            format_marathon_app_dict_patch.assert_called_once_with()
+            format_marathon_app_dict_patch.assert_called_once_with(
+                system_paasta_config=None
+            )
             get_drain_method_patch.assert_called_once_with(
                 read_namespace_conf_patch.return_value
             )
@@ -1510,6 +1515,7 @@ class TestSetupMarathonJob:
                 soa_dir=None,
                 bounce_margin_factor=fake_bounce_margin_factor,
                 job_config=self.fake_marathon_service_config,
+                system_paasta_config=None,
             )
 
     def test_setup_service_srv_complete_config_raises(self):

--- a/tests/test_setup_marathon_job.py
+++ b/tests/test_setup_marathon_job.py
@@ -2034,6 +2034,7 @@ class TestSetupMarathonJob:
             side_effect=bounce_lib.LockHeldException,
         ):
             mock_clients: marathon_tools.MarathonClients = mock.Mock()
+            mock_system_paasta_config = mock.Mock()
             mock_marathon_apps_with_clients: List[
                 Tuple[MarathonApp, MarathonClient]
             ] = []
@@ -2043,6 +2044,7 @@ class TestSetupMarathonJob:
                 mock_clients,
                 "fake_soa",
                 mock_marathon_apps_with_clients,
+                mock_system_paasta_config,
             )
             assert not mock_setup_service.called
             assert ret == (0, None)


### PR DESCRIPTION
These changes drastically decrease the amount of CPU time needed by deployd's workers / setup_marathon_job.

The first commit, 546cc64, makes it so we only request information about apps that matter from Marathon.

The second and third commits, 30b7371 and 700784c, aim to reduce the number of times `load_system_paasta_config` is called by passing around SystemPaastaConfig objects to almost everything that needs it that ends up being called by deployd. (The one exception remaining in my pyflame charts is https://github.com/Yelp/paasta/blob/766c25dcf3bba640e51a4e9ba8091f63910b79bf/paasta_tools/utils.py#L2915 -- removing this would give a further 20% CPU time improvement). It turns out that even though `load_system_paasta_configs` tries very hard not to re-parse YAML, the code that determines whether the files have changed takes a nontrivial amount of time, especially if you call it dozens of times.

(I could be convinced to optimize load_system_paasta_config a different way -- honestly I think it might be a lot cleaner to lean on the caching / singleton-y behavior of load_system_paasta_config, but don't have it bother to check whether the files need reloading most of the time. Instead we'd have some method to force reloading.)

The last commit makes load_service_namespace_config faster by making it only read smartstack.yaml instead of reading [seven files](https://github.com/Yelp/service_configuration_lib/blob/02b8b297b53efbedbae30ad929765d1a6cbd5c18/service_configuration_lib/__init__.py#L139) and then immediately discarding most of that information.

It's a little hard to tell _exactly_ how much faster this makes deployd, since we don't have graphs of throughput numbers or CPU time consumed by workers, but I estimate that all these changes together seems to make it roughly 10x faster.