### PR TITLE
Pod defaults from system paasta config

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1163,7 +1163,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             if "hpa" in annotations:
                 annotations["hpa"] = json.dumps(annotations["hpa"])
 
-        pod_spec_kwargs = dict(
+        pod_spec_kwargs = {}
+        pod_spec_kwargs.update(system_paasta_config.get_pod_defaults())
+        pod_spec_kwargs.update(
             service_account_name=self.get_kubernetes_service_account_name(),
             containers=self.get_kubernetes_containers(
                 docker_volumes=docker_volumes,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2380,6 +2380,9 @@ class SystemPaastaConfig:
     def get_boost_regions(self) -> List[str]:
         return self.config_dict.get("boost_regions", [])
 
+    def get_pod_defaults(self) -> Dict[str, Any]:
+        return self.config_dict.get("pod_defaults", {})
+
 
 def _run(
     command: Union[str, List[str]],

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1825,6 +1825,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     pdb_max_unavailable: Union[str, int]
     pki_backend: str
     previous_marathon_servers: List[MarathonConfigDict]
+    pod_defaults: Dict[str, Any]
     register_k8s_pods: bool
     register_marathon_services: bool
     register_native_services: bool

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1002,9 +1002,11 @@ class TestKubernetesDeploymentConfig:
         mock_load_service_namespace_config.return_value = mock_service_namespace_config
         mock_service_namespace_config.is_in_smartstack.return_value = in_smtstk
         mock_get_node_affinity.return_value = node_affinity
+        mock_system_paasta_config = mock.Mock()
+        mock_system_paasta_config.get_pod_defaults.return_value = dict(dns_policy="foo")
 
         ret = self.deployment.get_pod_template_spec(
-            git_sha="aaaa123", system_paasta_config=mock.Mock()
+            git_sha="aaaa123", system_paasta_config=mock_system_paasta_config
         )
 
         assert mock_load_service_namespace_config.called
@@ -1018,6 +1020,7 @@ class TestKubernetesDeploymentConfig:
             node_selector={"yelp.com/pool": "default"},
             restart_policy="Always",
             volumes=[],
+            dns_policy="foo",
         )
         pod_spec_kwargs.update(spec_affinity)
         assert ret == V1PodTemplateSpec(


### PR DESCRIPTION
Seems like a good idea to be able to configure things like pod's dns policy from system paasta configs.