### PR TITLE
u/clan/BATCHPROC-65-run-spark-container-as-non-root

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -236,7 +236,6 @@ class TronActionConfig(InstanceConfig):
                     service=self.get_service(),
                     aws_credentials_yaml=self.config_dict.get("aws_credentials_yaml"),
                 ),
-                needs_docker_cfg=True,
             )
         else:
             spark_env = get_k8s_spark_env(
@@ -299,8 +298,6 @@ class TronActionConfig(InstanceConfig):
         if self.get_executor() == "spark":
             env["EXECUTOR_CLUSTER"] = self.get_spark_paasta_cluster()
             env["EXECUTOR_POOL"] = self.get_spark_paasta_pool()
-            # Run spark (and mesos framework) as root.
-            env["SPARK_USER"] = "root"
             env["SPARK_OPTS"] = stringify_spark_env(self.get_spark_config_dict())
             env.update(get_mesos_spark_auth_env())
             env["CLUSTERMAN_RESOURCES"] = json.dumps(
@@ -434,11 +431,6 @@ class TronActionConfig(InstanceConfig):
         parameters = super().format_docker_parameters(with_labels=with_labels)
         if self.get_executor() == "spark":
             parameters.append({"key": "net", "value": "host"})
-            if self.get_spark_cluster_manager() == "kubernetes":
-                # TODO: this is a temprary solution to circumvent permission issue of reading
-                # SSL ceritficates of k8s clusters. We should remove this clause once a stable
-                # solution is available.
-                parameters.append({"key": "user", "value": "root"})
         return parameters
 
 

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -126,7 +126,6 @@ class TestTronActionConfig:
                 spark_ui_port=12345,
                 user_spark_opts={"spark.eventLog.enabled": "false"},
                 volumes=["/nail/tmp:/nail/tmp:rw"],
-                needs_docker_cfg=True,
             )
 
     def test_get_spark_config_dict_k8s(self, spark_action_config):
@@ -209,7 +208,6 @@ class TestTronActionConfig:
                 assert env["AWS_DEFAULT_REGION"] == "us-west-2"
                 assert env["SPARK_MESOS_PRINCIPAL"] == "spark"
                 assert env["SPARK_MESOS_SECRET"] == "SHARED_SECRET(SPARK_MESOS_SECRET)"
-                assert env["SPARK_USER"] == "root"
             else:
                 assert not any([env.get("SPARK_OPTS"), env.get("CLUSTERMAN_RESOURCES")])
 


### PR DESCRIPTION
Spark certs now have permission of 0644; we no longer need to run the containers as root.

Make test passed. 

In progress to manually test in dev cluster.