### PR TITLE
BATCHPROC-65-add-back-docker-cfg

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -237,6 +237,7 @@ class TronActionConfig(InstanceConfig):
                     service=self.get_service(),
                     aws_credentials_yaml=self.config_dict.get("aws_credentials_yaml"),
                 ),
+                needs_docker_cfg=True,
             )
         else:
             spark_env = get_k8s_spark_env(

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -126,6 +126,7 @@ class TestTronActionConfig:
                 spark_ui_port=12345,
                 user_spark_opts={"spark.eventLog.enabled": "false"},
                 volumes=["/nail/tmp:/nail/tmp:rw"],
+                needs_docker_cfg=True,
             )
 
     def test_get_spark_config_dict_k8s(self, spark_action_config):


### PR DESCRIPTION
referring to my change from yesterday: https://sourcegraph.yelpcorp.com/mirrors/Yelp/paasta/-/commit/2f3e04b355f20a63708378c081c3a240bb62aa23

I don't think I needed to remove this line to run spark containers as root. Although we are able to run spark jobs as usually without it.

Make test pass.