### PR TITLE
Use paasta-tools-go/cmd/paasta as entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ example_cluster/paasta/docker_registry.json
 general_itests/fake_etc_paasta/clusters.json
 pip-wheel-metadata
 debian/debhelper-build-stamp
+/bin

--- a/.gitignore
+++ b/.gitignore
@@ -35,10 +35,10 @@ paasta_itests/mesos-cli.json
 paasta_itests/fake_etc_paasta/chronos.json
 paasta_itests/fake_etc_paasta/marathon.json
 yelp_package/bintray.json
+yelp_package/gopath
 .mypy_cache/
 debian/.debhelper
 example_cluster/paasta/docker_registry.json
 general_itests/fake_etc_paasta/clusters.json
 pip-wheel-metadata
 debian/debhelper-build-stamp
-/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,6 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-ce=18.03.1~ce-0~ubuntu devscripts --force-yes
   - eval "$(gimme 1.13.1)"
-  - which go
-  - go version
   - 'if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" -a "$DOCKER_USERNAME" != "" ]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi'
 install:
   - pip install coveralls tox==3.2 tox-pip-extensions==1.3.0 ephemeral-port-reserve
@@ -50,7 +48,7 @@ install:
   # It seems as though we're hitting https://github.com/pypa/pip/issues/6275
   # I also don't understand why but running setup.py egg_info is a workaround that appears to fix things
   - python setup.py egg_info
-script: which go; go version; if [[ -n "$MAKE_TARGET" ]]; then make "$MAKE_TARGET"; else tox -i https://pypi.python.org/simple; fi
+script: if [[ -n "$MAKE_TARGET" ]]; then make "$MAKE_TARGET"; else tox -i https://pypi.python.org/simple; fi
 after_success:
   - coveralls
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
 
   - sudo apt-get update
   - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-ce=18.03.1~ce-0~ubuntu devscripts --force-yes
-  - eval "$(gimme 1.13.1)"
+  - eval "$(gimme 1.13)"
   - 'if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" -a "$DOCKER_USERNAME" != "" ]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi'
 install:
   - pip install coveralls tox==3.2 tox-pip-extensions==1.3.0 ephemeral-port-reserve

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
 
   - sudo apt-get update
   - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-ce=18.03.1~ce-0~ubuntu devscripts --force-yes
-  - eval "$(gimme 1.13)"
+  - eval "$(gimme 1.14)"
   - 'if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" -a "$DOCKER_USERNAME" != "" ]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi'
 install:
   - pip install coveralls tox==3.2 tox-pip-extensions==1.3.0 ephemeral-port-reserve

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,11 @@ before_install:
   - sudo bash -c 'echo "deb http://download.docker.com/linux/ubuntu xenial stable" > /etc/apt/sources.list.d/docker.list'
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 
-  # Go repos
-  - sudo add-apt-repository ppa:longsleep/golang-backports -y
-
   - sudo apt-get update
-  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-ce=18.03.1~ce-0~ubuntu devscripts golang-1.13 --force-yes
+  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-ce=18.03.1~ce-0~ubuntu devscripts --force-yes
+  - eval "$(gimme 1.13.1)"
+  - which go
+  - go version
   - 'if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" -a "$DOCKER_USERNAME" != "" ]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi'
 install:
   - pip install coveralls tox==3.2 tox-pip-extensions==1.3.0 ephemeral-port-reserve
@@ -50,7 +50,7 @@ install:
   # It seems as though we're hitting https://github.com/pypa/pip/issues/6275
   # I also don't understand why but running setup.py egg_info is a workaround that appears to fix things
   - python setup.py egg_info
-script: if [[ -n "$MAKE_TARGET" ]]; then make "$MAKE_TARGET"; else tox -i https://pypi.python.org/simple; fi
+script: which go; go version; if [[ -n "$MAKE_TARGET" ]]; then make "$MAKE_TARGET"; else tox -i https://pypi.python.org/simple; fi
 after_success:
   - coveralls
 before_deploy:

--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -47,7 +47,7 @@ opt/venvs/paasta-tools/bin/paasta_remote_run.py usr/bin/paasta_remote_run
 opt/venvs/paasta-tools/bin/paasta_secrets_sync.py usr/bin/paasta_secrets_sync
 opt/venvs/paasta-tools/bin/paasta_setup_tron_namespace usr/bin/paasta_setup_tron_namespace
 opt/venvs/paasta-tools/bin/paasta_tabcomplete.sh usr/share/bash-completion/completions/paasta
-opt/venvs/paasta-tools/bin/paasta usr/bin/paasta
+opt/venvs/paasta-tools/bin/paasta_go usr/bin/paasta
 opt/venvs/paasta-tools/bin/setup_marathon_job.py usr/bin/setup_marathon_job
 opt/venvs/paasta-tools/bin/setup_kubernetes_job.py usr/bin/setup_kubernetes_job
 opt/venvs/paasta-tools/bin/setup_kubernetes_crd.py usr/bin/setup_kubernetes_crd

--- a/debian/rules
+++ b/debian/rules
@@ -26,4 +26,4 @@ override_dh_virtualenv:
 		--preinstall no-manylinux1 \
 		--preinstall=-rrequirements-bootstrap.txt \
 		--pip-tool pip-custom-platform
-	cp bin/paasta $(DH_VENV_DIR)/bin/paasta_go
+	cp yelp_package/gopath/paasta_go $(DH_VENV_DIR)/bin/paasta_go

--- a/debian/rules
+++ b/debian/rules
@@ -17,5 +17,13 @@ override_dh_auto_build:
 override_dh_auto_test:
 	true
 
+PACKAGE=$(shell dh_listpackages)
+DH_VIRTUALENV_INSTALL_ROOT=/opt/venvs
+DH_VENV_DIR=debian/$(PACKAGE)$(DH_VIRTUALENV_INSTALL_ROOT)/$(PACKAGE)
 override_dh_virtualenv:
-	dh_virtualenv -i $(PIP_INDEX_URL) --python=/usr/bin/python3.6 --preinstall no-manylinux1 --preinstall=-rrequirements-bootstrap.txt --pip-tool pip-custom-platform
+	dh_virtualenv -i $(PIP_INDEX_URL) \
+		--python=/usr/bin/python3.6 \
+		--preinstall no-manylinux1 \
+		--preinstall=-rrequirements-bootstrap.txt \
+		--pip-tool pip-custom-platform
+	cp bin/paasta $(DH_VENV_DIR)/bin/paasta_go

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -49,12 +49,14 @@ itest_%: package_$$* bintray_$$*
 	$(DOCKER_RUN) /work/yelp_package/itest/ubuntu.sh paasta-tools_$(ACTUAL_PACKAGE_VERSION)_amd64.deb
 
 GOPATH=$(CURDIR)/gopath
+GOCMD=GOPATH=$(GOPATH) GO111MODULE=on go
 go_entrypoint:
 	mkdir -p $(GOPATH)
-	GOPATH=$(GOPATH) GO111MODULE=on go get -d github.com/Yelp/paasta-tools-go/cmd/paasta@v0.0.4-rc1
+	$(GOCMD) get -d github.com/Yelp/paasta-tools-go/cmd/paasta@v0.0.4-rc1
+	chmod -R +rw $(GOPATH)
 	cd $(GOPATH)/pkg/mod/github.com/\!yelp/paasta-tools-go@v0.0.4-rc1 && \
-		GOPATH=$(GOPATH) go build $(GO_BUILD_FLAGS) -v -o $(GOPATH)/paasta_go ./cmd/paasta
-	test -x paasta
+		$(GOCMD) build $(GO_BUILD_FLAGS) -v -o $(GOPATH)/paasta_go ./cmd/paasta
+	test -x $(GOPATH)/paasta_go
 
 package_%: build_$$*_docker go_entrypoint
 	# Copy these files to .old before maybe clobbering them

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -52,9 +52,9 @@ GOPATH=$(CURDIR)/gopath
 GOCMD=GOPATH=$(GOPATH) GO111MODULE=on go
 go_entrypoint:
 	mkdir -p $(GOPATH)
-	$(GOCMD) get -d github.com/Yelp/paasta-tools-go/cmd/paasta@v0.0.4-rc1
+	$(GOCMD) get -d github.com/Yelp/paasta-tools-go/cmd/paasta@v0.0.4
 	chmod -R +rw $(GOPATH)
-	cd $(GOPATH)/pkg/mod/github.com/\!yelp/paasta-tools-go@v0.0.4-rc1 && \
+	cd $(GOPATH)/pkg/mod/github.com/\!yelp/paasta-tools-go@v0.0.4 && \
 		$(GOCMD) build $(GO_BUILD_FLAGS) -v -o $(GOPATH)/paasta_go ./cmd/paasta
 	test -x $(GOPATH)/paasta_go
 

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -26,10 +26,12 @@ ifeq ($(PAASTA_ENV),YELP)
 	ADD_MISSING_DEPS_MAYBE:=-diff --unchanged-line-format= --old-line-format= --new-line-format='%L' ../requirements.txt ./extra_requirements_yelp.txt >> ../requirements.txt
 	ACTUAL_PACKAGE_VERSION=$(RELEASE)-yelp1
 	ADD_VERSION_SUFFIX=dch -v $(ACTUAL_PACKAGE_VERSION) --force-distribution --distribution $* --changelog ../debian/changelog 'Build for yelp: add scribereader to virtualenv'
+	GO_BUILD_FLAGS=-tags yelp -modfile int.mod
 else
 	ADD_MISSING_DEPS_MAYBE:=$(NOOP)
 	ACTUAL_PACKAGE_VERSION=$(RELEASE)~$*1
 	ADD_VERSION_SUFFIX=dch -b -v $(ACTUAL_PACKAGE_VERSION) --force-distribution --distribution $* --changelog ../debian/changelog 'Build for $*'
+	GO_BUILD_FLAGS=
 endif
 
 build_%_docker:
@@ -46,12 +48,15 @@ build_%_docker:
 itest_%: package_$$* bintray_$$*
 	$(DOCKER_RUN) /work/yelp_package/itest/ubuntu.sh paasta-tools_$(ACTUAL_PACKAGE_VERSION)_amd64.deb
 
-package_%: build_$$*_docker
-	rm -rf ../bin
-	mkdir -p ../bin
-	GO111MODULE=on GOBIN=`pwd`/../bin go get -v github.com/Yelp/paasta-tools-go/cmd/paasta@v0.0.3
-	test -x ../bin/paasta
+GOPATH=$(CURDIR)/gopath
+go_entrypoint:
+	mkdir -p $(GOPATH)
+	GOPATH=$(GOPATH) GO111MODULE=on go get -d github.com/Yelp/paasta-tools-go/cmd/paasta@v0.0.4-rc1
+	cd $(GOPATH)/pkg/mod/github.com/\!yelp/paasta-tools-go@v0.0.4-rc1 && \
+		GOPATH=$(GOPATH) go build $(GO_BUILD_FLAGS) -v -o $(GOPATH)/paasta_go ./cmd/paasta
+	test -x paasta
 
+package_%: build_$$*_docker go_entrypoint
 	# Copy these files to .old before maybe clobbering them
 	cp ../requirements.txt ../requirements.txt.old
 	cp ../debian/changelog ../debian/changelog.old

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -47,6 +47,11 @@ itest_%: package_$$* bintray_$$*
 	$(DOCKER_RUN) /work/yelp_package/itest/ubuntu.sh paasta-tools_$(ACTUAL_PACKAGE_VERSION)_amd64.deb
 
 package_%: build_$$*_docker
+	rm -rf ../bin && \
+	mkdir -p ../bin && \
+	GO111MODULE=on GOBIN=`pwd`/../bin go get -v github.com/Yelp/paasta-tools-go/cmd/paasta@v0.0.3 && \
+	test -x ../bin/paasta
+
 	# Copy these files to .old before maybe clobbering them
 	cp ../requirements.txt ../requirements.txt.old
 	cp ../debian/changelog ../debian/changelog.old
@@ -56,11 +61,10 @@ package_%: build_$$*_docker
 
 	# noddebs to work around https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=897569
 	$(DOCKER_RUN) /bin/bash -c "DEB_BUILD_OPTIONS=noddebs dpkg-buildpackage -d && mv ../*.deb dist/"
+	$(DOCKER_RUN) chown -R $(UID):$(GID) /work
 	# then move them back
 	mv ../requirements.txt.old ../requirements.txt
 	mv ../debian/changelog.old ../debian/changelog
-	$(DOCKER_RUN) chown -R $(UID):$(GID) /work
-
 
 DATE := $(shell date +'%Y-%m-%d' -d "`dpkg-parsechangelog -l../debian/changelog | sed -n 's/^Date: //p'`")
 PAASTAVERSION := $(shell dpkg-parsechangelog -l../debian/changelog | sed -n 's/^Version: //p')

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -47,9 +47,9 @@ itest_%: package_$$* bintray_$$*
 	$(DOCKER_RUN) /work/yelp_package/itest/ubuntu.sh paasta-tools_$(ACTUAL_PACKAGE_VERSION)_amd64.deb
 
 package_%: build_$$*_docker
-	rm -rf ../bin && \
-	mkdir -p ../bin && \
-	GO111MODULE=on GOBIN=`pwd`/../bin go get -v github.com/Yelp/paasta-tools-go/cmd/paasta@v0.0.3 && \
+	rm -rf ../bin
+	mkdir -p ../bin
+	GO111MODULE=on GOBIN=`pwd`/../bin go get -v github.com/Yelp/paasta-tools-go/cmd/paasta@v0.0.3
 	test -x ../bin/paasta
 
 	# Copy these files to .old before maybe clobbering them


### PR DESCRIPTION
The binary is shipped with paasta-tools deb to avoid having to deal with multiple packages providing same usr/bin/paasta link.