### PR TITLE
Fix name of stdout stream for k8s status

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1591,7 +1591,7 @@ def format_tail_lines_for_kubernetes_pod(
             )
             rows.append(PaastaColors.red(f"  {container.tail_lines.error_message}"))
 
-        for stream_name in ("Stdout", "stderr"):
+        for stream_name in ("stdout", "stderr"):
             stream_lines = getattr(container.tail_lines, stream_name, [])
             if len(stream_lines) > 0:
                 rows.append(


### PR DESCRIPTION
I think stdout/stderr for k8s instances was broken in this review: https://github.com/Yelp/paasta/commit/7ac9f14e143b926d7a7672b63ba50fc7016f7914#diff-8099076c2ecaf9f1a063335425abd3c1R1511

There's no clear reason why that line was changed in that review. 

When we put the log lines into the API response, it's with a lowercase "stdout": https://github.com/Yelp/paasta/blob/master/paasta_tools/kubernetes_tools.py#L1533

I manually tested this by making this change on the paasta master in pnw-prod (I think this was relatively low-risk because it only affects the CLI side of paasta status on that box). With this change, I got tracebacks from a recently failed container through -vv, which I wasn't getting before. https://fluffy.yelpcorp.com/i/sv8Qpb2xVfsGVv8qblLT8HLRljFHWdvM.html

Let me know if you have ideas for adding a unit test - I would like to add one, but I don't know of a way to generate an object corresponding to the swagger response spec.