### PR TITLE
Always sync HPAs and Pod Disruption Budgets in setup_kubernetes_job

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -29,14 +29,11 @@ from typing import Mapping
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
-from typing import Union
 
 import a_sync
 import aiohttp
 from kazoo.client import KazooClient
 from kazoo.exceptions import NoNodeError
-from kubernetes.client import V1Deployment
-from kubernetes.client import V1StatefulSet
 from marathon.models.app import MarathonApp
 from marathon.models.app import MarathonTask
 
@@ -47,10 +44,6 @@ from paasta_tools.bounce_lib import filter_tasks_in_smartstack
 from paasta_tools.bounce_lib import LockHeldException
 from paasta_tools.bounce_lib import LockTimeout
 from paasta_tools.bounce_lib import ZK_LOCK_CONNECT_TIMEOUT_S
-from paasta_tools.kubernetes_tools import get_annotations_for_kubernetes_service
-from paasta_tools.kubernetes_tools import KubeClient
-from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
-from paasta_tools.kubernetes_tools import write_annotation_for_kubernetes_service
 from paasta_tools.long_running_service_tools import load_service_namespace_config
 from paasta_tools.long_running_service_tools import ZK_PAUSE_AUTOSCALE_PATH
 from paasta_tools.marathon_tools import AutoscalingParamsDict
@@ -856,25 +849,6 @@ def autoscaling_is_paused():
         return True
     else:
         return False
-
-
-def is_deployment_marked_paused(
-    kube_client: KubeClient, service_config: KubernetesDeploymentConfig
-):
-    annotations = get_annotations_for_kubernetes_service(kube_client, service_config)
-    return annotations.get("is_paused", "False") == "True"
-
-
-def mark_deployment_as_paused(
-    kube_client: KubeClient,
-    service_config: KubernetesDeploymentConfig,
-    formatted_application: Union[V1Deployment, V1StatefulSet],
-    paused: bool,
-) -> None:
-    annotation = {"is_paused": str(paused)}
-    write_annotation_for_kubernetes_service(
-        kube_client, service_config, formatted_application, annotation
-    )
 
 
 def autoscale_services(

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -24,7 +24,6 @@ from paasta_tools import marathon_tools
 from paasta_tools.autoscaling import autoscaling_service_lib
 from paasta_tools.autoscaling.autoscaling_service_lib import autoscaling_is_paused
 from paasta_tools.autoscaling.autoscaling_service_lib import filter_autoscaling_tasks
-from paasta_tools.autoscaling.autoscaling_service_lib import is_deployment_marked_paused
 from paasta_tools.autoscaling.autoscaling_service_lib import MAX_TASK_DELTA
 from paasta_tools.autoscaling.autoscaling_service_lib import MetricsProviderNoDataError
 from paasta_tools.utils import NoDeploymentsAvailable
@@ -1890,15 +1889,3 @@ def test_autoscale_service_configs():
             mock_marathon_tasks,
             mock_mesos_tasks,
         )
-
-
-@pytest.mark.parametrize(
-    "given_annotations, is_marked_paused", [({"is_paused": "True"}, True), ({}, False),]
-)
-def test_is_deployment_marked_paused(given_annotations, is_marked_paused):
-    with mock.patch(
-        "paasta_tools.autoscaling.autoscaling_service_lib.get_annotations_for_kubernetes_service",
-        autospec=True,
-        return_value=given_annotations,
-    ):
-        assert is_deployment_marked_paused(mock.Mock(), mock.Mock()) is is_marked_paused

--- a/tests/kubernetes/application/test_controller_wrapper.py
+++ b/tests/kubernetes/application/test_controller_wrapper.py
@@ -209,15 +209,11 @@ def test_sync_horizontal_pod_autoscaler_delete_hpa_when_no_autoscaling(
 
 
 @mock.patch(
-    "paasta_tools.kubernetes.application.controller_wrappers.is_deployment_marked_paused",
-    autospec=True,
-)
-@mock.patch(
     "paasta_tools.kubernetes.application.controller_wrappers.autoscaling_is_paused",
     autospec=True,
 )
 def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_paused(
-    mock_autoscaling_is_paused, mock_is_deployment_marked_paused,
+    mock_autoscaling_is_paused,
 ):
     mock_client = mock.MagicMock()
     config_dict = {"max_instances": 3, "min_instances": 1}
@@ -225,7 +221,6 @@ def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_paused(
     app.item.spec.replicas = 2
 
     mock_autoscaling_is_paused.return_value = True
-    mock_is_deployment_marked_paused.return_value = False
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
     assert app.soa_config.get_min_instances() == 2
     assert (
@@ -239,21 +234,11 @@ def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_paused(
 
 
 @mock.patch(
-    "paasta_tools.kubernetes.application.controller_wrappers.mark_deployment_as_paused",
-    autospec=True,
-)
-@mock.patch(
-    "paasta_tools.kubernetes.application.controller_wrappers.is_deployment_marked_paused",
-    autospec=True,
-)
-@mock.patch(
     "paasta_tools.kubernetes.application.controller_wrappers.autoscaling_is_paused",
     autospec=True,
 )
 def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_resumed(
     mock_autoscaling_is_paused,
-    mock_is_deployment_marked_paused,
-    mock_mark_deployment_as_paused,
 ):
     mock_client = mock.MagicMock()
     config_dict = {"max_instances": 3, "min_instances": 1}
@@ -261,9 +246,7 @@ def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_resumed(
     app.item.spec.replicas = 2
 
     mock_autoscaling_is_paused.return_value = False
-    mock_is_deployment_marked_paused.return_value = True
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
-    assert mock_mark_deployment_as_paused.call_count == 1
     assert (
         mock_client.autoscaling.create_namespaced_horizontal_pod_autoscaler.call_count
         == 0
@@ -275,23 +258,16 @@ def test_sync_horizontal_pod_autoscaler_when_autoscaling_is_resumed(
 
 
 @mock.patch(
-    "paasta_tools.kubernetes.application.controller_wrappers.is_deployment_marked_paused",
-    autospec=True,
-)
-@mock.patch(
     "paasta_tools.kubernetes.application.controller_wrappers.autoscaling_is_paused",
     autospec=True,
 )
-def test_sync_horizontal_pod_autoscaler_create_hpa(
-    mock_autoscaling_is_paused, mock_is_deployment_marked_paused
-):
+def test_sync_horizontal_pod_autoscaler_create_hpa(mock_autoscaling_is_paused):
     mock_client = mock.MagicMock()
     # Create
     config_dict = {"max_instances": 3}
     app = setup_app(config_dict, False)
 
     mock_autoscaling_is_paused.return_value = False
-    mock_is_deployment_marked_paused.return_value = False
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
 
     assert (
@@ -309,23 +285,16 @@ def test_sync_horizontal_pod_autoscaler_create_hpa(
 
 
 @mock.patch(
-    "paasta_tools.kubernetes.application.controller_wrappers.is_deployment_marked_paused",
-    autospec=True,
-)
-@mock.patch(
     "paasta_tools.kubernetes.application.controller_wrappers.autoscaling_is_paused",
     autospec=True,
 )
-def test_sync_horizontal_pod_autoscaler_update_hpa(
-    mock_autoscaling_is_paused, mock_is_deployment_marked_paused
-):
+def test_sync_horizontal_pod_autoscaler_update_hpa(mock_autoscaling_is_paused):
     mock_client = mock.MagicMock()
     # Update
     config_dict = {"max_instances": 3}
     app = setup_app(config_dict, True)
 
     mock_autoscaling_is_paused.return_value = False
-    mock_is_deployment_marked_paused.return_value = False
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)
     assert (
         mock_client.autoscaling.create_namespaced_horizontal_pod_autoscaler.call_count


### PR DESCRIPTION
Previously we only synced these if we determined that the Deployment needed to be updated, but there are cases where users change autoscaling settings (which only affect the HPA) without changing anything that affects the Deployment.

See PAASTA-16675

---

Note that I am also getting rid of the `is_paused` annotation we were putting on deployments.  This really was just so that we would know we needed to call `app.update()` so that the HPA got updated when autoscaling transitions between paused and resumed.  However, because of what I'm describing above, we actually need to check these every time, so we don't need this extra bit of coordination.

I also considered just having us update the deployment every time, since it seems like that is fine -- if no fields have changed it just bumps the `resourceVersion` and `generation` fields, but the pods seem to be unaffected.  Let me know if you think that'd be better.

