### PR TITLE
Add support to emit task allocation metrics for all namespaces with matching given prefix

### DIFF
--- a/paasta_tools/contrib/get_running_task_allocation.py
+++ b/paasta_tools/contrib/get_running_task_allocation.py
@@ -142,7 +142,9 @@ def get_container_type(container_name: str, instance_name: str) -> str:
     """
     To differentiate between main service containers and sidecars
     """
-    if instance_name and container_name == kubernetes_tools.sanitise_kubernetes_name(instance_name):
+    if instance_name and container_name == kubernetes_tools.sanitise_kubernetes_name(
+        instance_name
+    ):
         return MAIN_CONTAINER_TYPE
     else:
         return container_name
@@ -214,8 +216,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--namespace-prefix",
-        help="prefix of the namespace to fetch the logs for" \
-	    "Used only when scheduler is kubernetes",
+        help="prefix of the namespace to fetch the logs for"
+        "Used only when scheduler is kubernetes",
         dest="namespace_prefix",
         default="paasta",
     )
@@ -229,7 +231,7 @@ def main(args: argparse.Namespace) -> None:
     else:
         client = KubeClient()
         all_namespaces = kubernetes_tools.get_all_namespaces(client)
-        matching_namespaces = [n for n in all_namespaces if args.namespace_prefix in n]
+        matching_namespaces = [n for n in all_namespaces if n.startswith(args.namespace_prefix)]
         for matching_namespace in matching_namespaces:
             display_task_allocation_info(cluster, args.scheduler, matching_namespace)
 

--- a/paasta_tools/contrib/get_running_task_allocation.py
+++ b/paasta_tools/contrib/get_running_task_allocation.py
@@ -231,7 +231,9 @@ def main(args: argparse.Namespace) -> None:
     else:
         client = KubeClient()
         all_namespaces = kubernetes_tools.get_all_namespaces(client)
-        matching_namespaces = [n for n in all_namespaces if n.startswith(args.namespace_prefix)]
+        matching_namespaces = [
+            n for n in all_namespaces if n.startswith(args.namespace_prefix)
+        ]
         for matching_namespace in matching_namespaces:
             display_task_allocation_info(cluster, args.scheduler, matching_namespace)
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1469,6 +1469,11 @@ def force_delete_pods(
         )
 
 
+def get_all_namespaces(kube_client: KubeClient) -> List[str]:
+    namespaces = kube_client.core.list_namespace()
+    return [item.metadata.name for item in namespaces.items]
+
+
 def ensure_namespace(kube_client: KubeClient, namespace: str) -> None:
     paasta_namespace = V1Namespace(
         metadata=V1ObjectMeta(name=namespace, labels={"name": namespace})
@@ -2283,6 +2288,8 @@ def create_kubernetes_secret_signature(
 
 
 def sanitise_kubernetes_name(service: str,) -> str:
+    if not service:
+        return service
     name = service.replace("_", "--")
     if name.startswith("--"):
         name = name.replace("--", "underscore-", 1)

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2288,8 +2288,6 @@ def create_kubernetes_secret_signature(
 
 
 def sanitise_kubernetes_name(service: str,) -> str:
-    if not service:
-        return service
     name = service.replace("_", "--")
     if name.startswith("--"):
         name = name.replace("--", "underscore-", 1)


### PR DESCRIPTION
Current state: [get_running_task_allocation](https://sourcegraph.yelpcorp.com/mirrors/Yelp/paasta@ace761b252ddc14ebce9b98f19c12cbf1a7f0305/-/blob/paasta_tools/contrib/get_running_task_allocation.py#L222:26) is currently hard-coded to fetch task allocation metrics from kubernetes pods only for [paasta](https://sourcegraph.yelpcorp.com/mirrors/Yelp/paasta@ace761b252ddc14ebce9b98f19c12cbf1a7f0305/-/blob/paasta_tools/kubernetes_tools.py#L1828:1) namespace.
Ideal state is to emit task allocation metrics for all namespaces prefixed as `paasta`. This will eventually be used in cost reports to report cost allocation for all kubernetes pods.

The code change is backwards compatible (i.e. no need to change to the [puppet](https://sourcegraph.yelpcorp.com/sysgit/puppet@45039da539c1efac674dff4dd075424b205fd1a9/-/blob/modules/profile_kube/manifests/master_monitoring.pp#L56:84) deployment to emit metrics to scribe topic).

By default, task allocation metrics are emitted for all namespaces prefixed as `paasta`. User could provide different prefix using `--namespace-prefix`.