### PR TITLE
Support moving_average forecast_policy and offset fields in autoscali…

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -218,6 +218,9 @@ class AutoscalingParamsDict(TypedDict, total=False):
     metrics_provider: str
     decision_policy: str
     setpoint: float
+    forecast_policy: Optional[str]
+    offset: Optional[float]
+    moving_average_window_seconds: Optional[int]
 
 
 class MarathonServiceConfigDict(LongRunningServiceConfigDict, total=False):

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1413,6 +1413,62 @@ class TestKubernetesDeploymentConfig:
         )
         assert expected_res == return_value
 
+    def test_get_autoscaling_metric_spec_offset_and_averaging(self):
+        config_dict = {
+            "min_instances": 1,
+            "max_instances": 3,
+            "autoscaling": {
+                "metrics_provider": "uwsgi",
+                "setpoint": 0.5,
+                "offset": 0.1,
+                "forecast_policy": "moving_average",
+                "moving_average_window_seconds": 300,
+            },
+        }
+        mock_config = KubernetesDeploymentConfig(  # type: ignore
+            service="service",
+            cluster="cluster",
+            instance="instance",
+            config_dict=config_dict,
+            branch_dict=None,
+        )
+        return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
+            mock_config, "fake_name", "cluster"
+        )
+        expected_res = V2beta1HorizontalPodAutoscaler(
+            kind="HorizontalPodAutoscaler",
+            metadata=V1ObjectMeta(
+                name="fake_name",
+                namespace="paasta",
+                annotations={
+                    "signalfx.com.custom.metrics": "",
+                    "signalfx.com.external.metric/service-instance-uwsgi": (
+                        "(data('uwsgi', filter=filter('paasta_cluster', 'cluster') "
+                        "and filter('paasta_service', 'service') and "
+                        "filter('paasta_instance', 'instance')).mean().mean(over=300s) - 0.1).publish()"
+                    ),
+                },
+            ),
+            spec=V2beta1HorizontalPodAutoscalerSpec(
+                max_replicas=3,
+                min_replicas=1,
+                metrics=[
+                    V2beta1MetricSpec(
+                        type="External",
+                        external=V2beta1ExternalMetricSource(
+                            metric_name="service-instance-uwsgi",
+                            target_value=0.5 - 0.1,
+                        ),
+                    )
+                ],
+                scale_target_ref=V2beta1CrossVersionObjectReference(
+                    api_version="apps/v1", kind="Deployment", name="fake_name",
+                ),
+            ),
+        )
+
+        assert expected_res == return_value
+
     def test_get_autoscaling_metric_spec_bespoke(self):
         config_dict = {
             "min_instances": 1,


### PR DESCRIPTION
…ng section for Kubernetes.

Previously if instances had these fields set we were just ignoring them.

See PAASTA-16756 and PAASTA-16755