### PR TITLE
Correctly quote duration passed to mean() in signalfow generated for …

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -607,7 +607,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         signalflow = f"data('{signalfx_metric_name}', filter={filters}).mean()"
 
         if moving_average_window_seconds is not None:
-            signalflow += f".mean(over={moving_average_window_seconds}s)"
+            signalflow += f".mean(over='{moving_average_window_seconds}s')"
         if offset is not None:
             signalflow = f"({signalflow} - {offset})"
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1446,7 +1446,7 @@ class TestKubernetesDeploymentConfig:
                     "signalfx.com.external.metric/service-instance-uwsgi": (
                         "(data('uwsgi', filter=filter('paasta_cluster', 'cluster') "
                         "and filter('paasta_service', 'service') and "
-                        "filter('paasta_instance', 'instance')).mean().mean(over=300s) - 0.1).publish()"
+                        "filter('paasta_instance', 'instance')).mean().mean(over='300s') - 0.1).publish()"
                     ),
                 },
             ),


### PR DESCRIPTION
…kubernetes instances using moving_average forecast_policy

See PAASTA-16756