### PR TITLE
Emulate the legacy autoscaler's approach to windowed averaging for HPAs.

### DIFF
--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1514,11 +1514,7 @@ class TestKubernetesDeploymentConfig:
                 namespace="paasta",
                 annotations={
                     "signalfx.com.custom.metrics": "",
-                    "signalfx.com.external.metric/service-instance-uwsgi": (
-                        "(data('uwsgi', filter=filter('paasta_cluster', 'cluster') "
-                        "and filter('paasta_service', 'service') and "
-                        "filter('paasta_instance', 'instance')).mean().mean(over='300s') - 0.1).publish()"
-                    ),
+                    "signalfx.com.external.metric/service-instance-uwsgi": mock.ANY,
                 },
             ),
             spec=V2beta1HorizontalPodAutoscalerSpec(
@@ -1528,8 +1524,7 @@ class TestKubernetesDeploymentConfig:
                     V2beta1MetricSpec(
                         type="External",
                         external=V2beta1ExternalMetricSource(
-                            metric_name="service-instance-uwsgi",
-                            target_value=0.5 - 0.1,
+                            metric_name="service-instance-uwsgi", target_value=1,
                         ),
                     )
                 ],


### PR DESCRIPTION
Our previous attempt looked at the average load seen by each instance, which led to oscillations what the HPA wanted to scale to (see DAR-920).  This approach was found to be more stable.

See PAASTA-16756

---
The one change I made to the custom signalflow that you wrote this weekend was to add a `max(results, 0)` so we don't return something less than 0.

I tested this by running it for compute-infra-test-service.downthenup on norcal-stagef.  Here are the results that show it works: https://fluffy.yelpcorp.com/i/M4NqNV3hrjhMQCbQSPGbRKlCB9rx2FCt.html