### PR TITLE
SEC-12874: Add prototypical authz to mark-for-deployment

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -218,10 +218,11 @@ def add_subparser(subparsers):
 def mark_for_deployment(git_url, deploy_group, service, commit, allowed_groups=None):
     """Mark a docker image for deployment"""
     username = get_username()
-    if allowed_groups is not None and username not in ldap_user_search(allowed_groups):
-        logline = f"current user is not authorized to perform this action (should be in one of {allowed_groups})"
-        _log(service=service, line=logline, component="deploy", level="event")
-        return 1
+    if allowed_groups is not None:
+        if not any([username in ldap_user_search(group) for group in allowed_groups]):
+            logline = f"current user is not authorized to perform this action (should be in one of {allowed_groups})"
+            _log(service=service, line=logline, component="deploy", level="event")
+            return 1
 
     tag = get_paasta_tag_from_deploy_group(
         identifier=deploy_group, desired_state="deploy"

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -219,7 +219,7 @@ def mark_for_deployment(git_url, deploy_group, service, commit, allowed_groups=N
     """Mark a docker image for deployment"""
     username = get_username()
     if allowed_groups is not None and username not in ldap_user_search(allowed_groups):
-        logline = f"current user is not authorized to perform this action (must be in one of {allowed_groups})"
+        logline = f"current user is not authorized to perform this action (should be in one of {allowed_groups})"
         _log(service=service, line=logline, component="deploy", level="event")
         return 1
 

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -216,7 +216,9 @@ def add_subparser(subparsers):
     list_parser.set_defaults(command=paasta_mark_for_deployment)
 
 
-def mark_for_deployment(git_url, deploy_group, service, commit, allowed_groups=DEFAULT_ALLOWED_PUSH_GROUPS):
+def mark_for_deployment(
+    git_url, deploy_group, service, commit, allowed_groups=DEFAULT_ALLOWED_PUSH_GROUPS
+):
     """Mark a docker image for deployment"""
     username = get_username()
     if allowed_groups is not None:

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -79,6 +79,7 @@ from paasta_tools.utils import TimeoutError
 DEFAULT_DEPLOYMENT_TIMEOUT = 3600  # seconds
 DEFAULT_AUTO_CERTIFY_DELAY = 600  # seconds
 DEFAULT_SLACK_CHANNEL = "#deploy"
+DEFAULT_ALLOWED_PUSH_GROUPS = os.environ.get("PAASTA_SECRET_ALLOWED_PUSH_GROUPS", None)
 
 log = logging.getLogger(__name__)
 
@@ -215,7 +216,7 @@ def add_subparser(subparsers):
     list_parser.set_defaults(command=paasta_mark_for_deployment)
 
 
-def mark_for_deployment(git_url, deploy_group, service, commit, allowed_groups=None):
+def mark_for_deployment(git_url, deploy_group, service, commit, allowed_groups=DEFAULT_ALLOWED_PUSH_GROUPS):
     """Mark a docker image for deployment"""
     username = get_username()
     if allowed_groups is not None:

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -67,6 +67,8 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import format_tag
 from paasta_tools.utils import get_git_url
 from paasta_tools.utils import get_paasta_tag_from_deploy_group
+from paasta_tools.utils import get_username
+from paasta_tools.utils import ldap_user_search
 from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import PaastaColors
@@ -213,8 +215,12 @@ def add_subparser(subparsers):
     list_parser.set_defaults(command=paasta_mark_for_deployment)
 
 
-def mark_for_deployment(git_url, deploy_group, service, commit):
+def mark_for_deployment(git_url, deploy_group, service, commit, allowed_groups=None):
     """Mark a docker image for deployment"""
+    username = get_username()
+    if allowed_groups is not None and username not in ldap_user_search(allowed_groups):
+        raise UnauthorizedException("user is not authorized to perform this action")
+
     tag = get_paasta_tag_from_deploy_group(
         identifier=deploy_group, desired_state="deploy"
     )

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -222,7 +222,21 @@ def mark_for_deployment(
     """Mark a docker image for deployment"""
     username = get_username()
     if allowed_groups is not None:
-        if not any([username in ldap_user_search(group) for group in allowed_groups]):
+        system_paasta_config = load_system_paasta_config()
+        search_base = system_paasta_config.get_ldap_search_base()
+        search_ou = system_paasta_config.get_ldap_search_ou()
+        host = system_paasta_config.get_ldap_host()
+        username = system_paasta_config.get_ldap_reader_username()
+        password = system_paasta_config.get_ldap_reader_password()
+        if not any(
+            [
+                username
+                in ldap_user_search(
+                    group, search_base, search_ou, host, username, password
+                )
+                for group in allowed_groups
+            ]
+        ):
             logline = f"current user is not authorized to perform this action (should be in one of {allowed_groups})"
             _log(service=service, line=logline, component="deploy", level="event")
             return 1

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -79,7 +79,6 @@ from paasta_tools.utils import TimeoutError
 DEFAULT_DEPLOYMENT_TIMEOUT = 3600  # seconds
 DEFAULT_AUTO_CERTIFY_DELAY = 600  # seconds
 DEFAULT_SLACK_CHANNEL = "#deploy"
-DEFAULT_ALLOWED_PUSH_GROUPS = os.environ.get("PAASTA_SECRET_ALLOWED_PUSH_GROUPS", None)
 
 log = logging.getLogger(__name__)
 
@@ -216,13 +215,16 @@ def add_subparser(subparsers):
     list_parser.set_defaults(command=paasta_mark_for_deployment)
 
 
-def mark_for_deployment(
-    git_url, deploy_group, service, commit, allowed_groups=DEFAULT_ALLOWED_PUSH_GROUPS
-):
+def mark_for_deployment(git_url, deploy_group, service, commit, allowed_groups=None):
     """Mark a docker image for deployment"""
     username = get_username()
+    system_paasta_config = load_system_paasta_config()
+    allowed_groups = (
+        allowed_groups
+        if allowed_groups is not None
+        else system_paasta_config.get_default_push_groups()
+    )
     if allowed_groups is not None:
-        system_paasta_config = load_system_paasta_config()
         search_base = system_paasta_config.get_ldap_search_base()
         search_ou = system_paasta_config.get_ldap_search_ou()
         host = system_paasta_config.get_ldap_host()

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -219,7 +219,9 @@ def mark_for_deployment(git_url, deploy_group, service, commit, allowed_groups=N
     """Mark a docker image for deployment"""
     username = get_username()
     if allowed_groups is not None and username not in ldap_user_search(allowed_groups):
-        raise UnauthorizedException("user is not authorized to perform this action")
+        logline = f"current user is not authorized to perform this action (must be in one of {allowed_groups})"
+        _log(service=service, line=logline, component="deploy", level="event")
+        return 1
 
     tag = get_paasta_tag_from_deploy_group(
         identifier=deploy_group, desired_state="deploy"

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -22,7 +22,6 @@ import glob
 import hashlib
 import io
 import json
-import ldap3
 import logging
 import math
 import os
@@ -31,8 +30,8 @@ import queue
 import re
 import shlex
 import signal
-import ssl
 import socket
+import ssl
 import sys
 import tempfile
 import threading
@@ -69,6 +68,7 @@ from typing import Union
 
 import choice
 import dateutil.tz
+import ldap3
 import requests_cache
 import service_configuration_lib
 from docker import Client
@@ -3558,11 +3558,17 @@ def load_all_configs(
     return config_dicts
 
 
-def ldap_user_search(cn: str, search_base: str = LDAP_SEARCH_BASE, ou: str = LDAP_SEARCH_OU) -> Set[str]:
+def ldap_user_search(
+    cn: str, search_base: str = LDAP_SEARCH_BASE, ou: str = LDAP_SEARCH_OU
+) -> Set[str]:
     """Connects to LDAP and raises a subclass of LDAPOperationResult when it fails"""
-    tls_config = ldap3.Tls(validate=ssl.CERT_REQUIRED, ca_certs_file="/etc/ssl/certs/ca-certificates.crt")
+    tls_config = ldap3.Tls(
+        validate=ssl.CERT_REQUIRED, ca_certs_file="/etc/ssl/certs/ca-certificates.crt"
+    )
     server = ldap3.Server(LDAP_HOST, use_ssl=True, tls=tls_config)
-    conn = ldap3.Connection(server, user=LDAP_USERNAME, password=LDAP_PASSWORD, raise_exceptions=True)
+    conn = ldap3.Connection(
+        server, user=LDAP_USERNAME, password=LDAP_PASSWORD, raise_exceptions=True
+    )
     conn.bind()
 
     search_filter = f"(memberOf=CN={cn},{ou})"

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1808,6 +1808,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     cluster_fqdn_format: str
     clusters: Sequence[str]
     dashboard_links: Dict[str, Dict[str, str]]
+    default_push_groups: List
     deploy_blacklist: UnsafeDeployBlacklist
     deploy_whitelist: UnsafeDeployWhitelist
     deployd_big_bounce_deadline: float
@@ -2425,6 +2426,9 @@ class SystemPaastaConfig:
 
     def get_ldap_reader_password(self) -> str:
         return self.config_dict.get("ldap_reader_password", None)
+
+    def get_default_push_groups(self) -> List:
+        return self.config_dict.get("default_push_groups", None)
 
 
 def _run(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -31,6 +31,7 @@ import queue
 import re
 import shlex
 import signal
+import ssl
 import socket
 import sys
 import tempfile
@@ -3557,14 +3558,14 @@ def load_all_configs(
     return config_dicts
 
 
-def ldap_user_search(search_base: str = LDAP_SEARCH_BASE, ou: str = LDAP_SEARCH_OU) -> Set[str]:
+def ldap_user_search(cn: str, search_base: str = LDAP_SEARCH_BASE, ou: str = LDAP_SEARCH_OU) -> Set[str]:
     """Connects to LDAP and raises a subclass of LDAPOperationResult when it fails"""
     tls_config = ldap3.Tls(validate=ssl.CERT_REQUIRED, ca_certs_file="/etc/ssl/certs/ca-certificates.crt")
     server = ldap3.Server(LDAP_HOST, use_ssl=True, tls=tls_config)
     conn = ldap3.Connection(server, user=LDAP_USERNAME, password=LDAP_PASSWORD, raise_exceptions=True)
     conn.bind()
 
-    search_filter = f"(memberOf=CN={team},{ou})"
+    search_filter = f"(memberOf=CN={cn},{ou})"
     entries = conn.extend.standard.paged_search(
         search_base=search_base,
         search_scope=ldap3.SUBTREE,

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ jsonref==0.1
 jsonschema==2.5.1
 kazoo==2.4.0
 kubernetes==10.0.1
+ldap3==2.6.0
 manhole==1.5.0
 marathon==0.12.0
 MarkupSafe==1.0

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -53,7 +53,13 @@ def mock_periodically_update_slack():
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log_audit", autospec=True)
 @patch("paasta_tools.remote_git.create_remote_refs", autospec=True)
-def test_mark_for_deployment_happy(mock_create_remote_refs, mock__log_audit, mock__log):
+@patch(
+    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
+)
+def test_mark_for_deployment_happy(mock_load_system_paasta_config, mock_create_remote_refs, mock__log_audit, mock__log):
+    config_mock = mock.Mock()
+    config_mock.get_default_push_groups.return_value = None
+    mock_load_system_paasta_config.return_value = config_mock
     actual = mark_for_deployment.mark_for_deployment(
         git_url="fake_git_url",
         deploy_group="fake_deploy_group",
@@ -74,7 +80,13 @@ def test_mark_for_deployment_happy(mock_create_remote_refs, mock__log_audit, moc
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log_audit", autospec=True)
 @patch("paasta_tools.remote_git.create_remote_refs", autospec=True)
-def test_mark_for_deployment_sad(mock_create_remote_refs, mock__log_audit, mock__log):
+@patch(
+    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
+)
+def test_mark_for_deployment_sad(mock_load_system_paasta_config, mock_create_remote_refs, mock__log_audit, mock__log):
+    config_mock = mock.Mock()
+    config_mock.get_default_push_groups.return_value = None
+    mock_load_system_paasta_config.return_value = config_mock
     mock_create_remote_refs.side_effect = Exception("something bad")
     with patch("time.sleep", autospec=True):
         actual = mark_for_deployment.mark_for_deployment(
@@ -226,7 +238,13 @@ def test_paasta_mark_for_deployment_with_good_rollback(
 
 @patch("paasta_tools.remote_git.create_remote_refs", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.trigger_deploys", autospec=True)
-def test_mark_for_deployment_yelpy_repo(mock_trigger_deploys, mock_create_remote_refs):
+@patch(
+    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
+)
+def test_mark_for_deployment_yelpy_repo(mock_load_system_paasta_config, mock_trigger_deploys, mock_create_remote_refs):
+    config_mock = mock.Mock()
+    config_mock.get_default_push_groups.return_value = None
+    mock_load_system_paasta_config.return_value = config_mock
     mark_for_deployment.mark_for_deployment(
         git_url="git://false.repo.yelpcorp.com/services/test_services",
         deploy_group="fake_deploy_group",
@@ -238,9 +256,15 @@ def test_mark_for_deployment_yelpy_repo(mock_trigger_deploys, mock_create_remote
 
 @patch("paasta_tools.remote_git.create_remote_refs", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.trigger_deploys", autospec=True)
+@patch(
+    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
+)
 def test_mark_for_deployment_nonyelpy_repo(
-    mock_trigger_deploys, mock_create_remote_refs
+        mock_load_system_paasta_config, mock_trigger_deploys, mock_create_remote_refs
 ):
+    config_mock = mock.Mock()
+    config_mock.get_default_push_groups.return_value = None
+    mock_load_system_paasta_config.return_value = config_mock
     mark_for_deployment.mark_for_deployment(
         git_url="git://false.repo/services/test_services",
         deploy_group="fake_deploy_group",

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -56,7 +56,9 @@ def mock_periodically_update_slack():
 @patch(
     "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
 )
-def test_mark_for_deployment_happy(mock_load_system_paasta_config, mock_create_remote_refs, mock__log_audit, mock__log):
+def test_mark_for_deployment_happy(
+    mock_load_system_paasta_config, mock_create_remote_refs, mock__log_audit, mock__log
+):
     config_mock = mock.Mock()
     config_mock.get_default_push_groups.return_value = None
     mock_load_system_paasta_config.return_value = config_mock
@@ -83,7 +85,9 @@ def test_mark_for_deployment_happy(mock_load_system_paasta_config, mock_create_r
 @patch(
     "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
 )
-def test_mark_for_deployment_sad(mock_load_system_paasta_config, mock_create_remote_refs, mock__log_audit, mock__log):
+def test_mark_for_deployment_sad(
+    mock_load_system_paasta_config, mock_create_remote_refs, mock__log_audit, mock__log
+):
     config_mock = mock.Mock()
     config_mock.get_default_push_groups.return_value = None
     mock_load_system_paasta_config.return_value = config_mock
@@ -241,7 +245,9 @@ def test_paasta_mark_for_deployment_with_good_rollback(
 @patch(
     "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
 )
-def test_mark_for_deployment_yelpy_repo(mock_load_system_paasta_config, mock_trigger_deploys, mock_create_remote_refs):
+def test_mark_for_deployment_yelpy_repo(
+    mock_load_system_paasta_config, mock_trigger_deploys, mock_create_remote_refs
+):
     config_mock = mock.Mock()
     config_mock.get_default_push_groups.return_value = None
     mock_load_system_paasta_config.return_value = config_mock
@@ -260,7 +266,7 @@ def test_mark_for_deployment_yelpy_repo(mock_load_system_paasta_config, mock_tri
     "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
 )
 def test_mark_for_deployment_nonyelpy_repo(
-        mock_load_system_paasta_config, mock_trigger_deploys, mock_create_remote_refs
+    mock_load_system_paasta_config, mock_trigger_deploys, mock_create_remote_refs
 ):
     config_mock = mock.Mock()
     config_mock.get_default_push_groups.return_value = None


### PR DESCRIPTION
WIP.

The purpose of this review is to allow for separate authz on mark-for-deployment, while allowing for other paasta commands to be executed by unprivileged paasta users. This is needed because certain git hosts (ie, Github) are unable to protect tags or implement this behavior in githooks, preventing this behavior to be enforced by git itself.

