### PR TITLE
Use deploy.yaml for push groups when performing m-f-d authz check

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -380,8 +380,8 @@ def paasta_mark_for_deployment(args):
     username = get_username()
     system_paasta_config = load_system_paasta_config()
     allowed_groups = (
-        deploy_info['allowed_push_groups']
-        if deploy_info.get('allowed_push_groups') is not None
+        deploy_info["allowed_push_groups"]
+        if deploy_info.get("allowed_push_groups") is not None
         else system_paasta_config.get_default_push_groups()
     )
     if allowed_groups is not None:

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -253,6 +253,34 @@ def mark_for_deployment(git_url, deploy_group, service, commit):
     return 1
 
 
+def deploy_authz_check(deploy_info):
+    username = get_username()
+    system_paasta_config = load_system_paasta_config()
+    allowed_groups = (
+        deploy_info["allowed_push_groups"]
+        if deploy_info.get("allowed_push_groups") is not None
+        else system_paasta_config.get_default_push_groups()
+    )
+    if allowed_groups is not None:
+        search_base = system_paasta_config.get_ldap_search_base()
+        search_ou = system_paasta_config.get_ldap_search_ou()
+        host = system_paasta_config.get_ldap_host()
+        username = system_paasta_config.get_ldap_reader_username()
+        password = system_paasta_config.get_ldap_reader_password()
+        if not any(
+            [
+                username
+                in ldap_user_search(
+                    group, search_base, search_ou, host, username, password
+                )
+                for group in allowed_groups
+            ]
+        ):
+            logline = f"current user is not authorized to perform this action (should be in one of {allowed_groups})"
+            _log(service=service, line=logline, component="deploy", level="event")
+            raise ValueError(logline)
+
+
 def report_waiting_aborted(service, deploy_group):
     print(
         PaastaColors.red(
@@ -375,33 +403,7 @@ def paasta_mark_for_deployment(args):
             )
 
     deploy_info = get_deploy_info(service=service, soa_dir=args.soa_dir)
-
-    # Authz check based on deploy.yaml settings
-    username = get_username()
-    system_paasta_config = load_system_paasta_config()
-    allowed_groups = (
-        deploy_info["allowed_push_groups"]
-        if deploy_info.get("allowed_push_groups") is not None
-        else system_paasta_config.get_default_push_groups()
-    )
-    if allowed_groups is not None:
-        search_base = system_paasta_config.get_ldap_search_base()
-        search_ou = system_paasta_config.get_ldap_search_ou()
-        host = system_paasta_config.get_ldap_host()
-        username = system_paasta_config.get_ldap_reader_username()
-        password = system_paasta_config.get_ldap_reader_password()
-        if not any(
-            [
-                username
-                in ldap_user_search(
-                    group, search_base, search_ou, host, username, password
-                )
-                for group in allowed_groups
-            ]
-        ):
-            logline = f"current user is not authorized to perform this action (should be in one of {allowed_groups})"
-            _log(service=service, line=logline, component="deploy", level="event")
-            raise ValueError(logline)
+    deploy_authz_check(deploy_info)
 
     deploy_process = MarkForDeploymentProcess(
         service=service,

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -399,9 +399,9 @@ def paasta_mark_for_deployment(args):
                 for group in allowed_groups
             ]
         ):
-            raise ValueError(
-                f"current user is not authorized to perform this action (should be in one of {allowed_groups})"
-            )
+            logline = f"current user is not authorized to perform this action (should be in one of {allowed_groups})"
+            _log(service=service, line=logline, component="deploy", level="event")
+            raise ValueError(logline)
 
     deploy_process = MarkForDeploymentProcess(
         service=service,

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -253,7 +253,7 @@ def mark_for_deployment(git_url, deploy_group, service, commit):
     return 1
 
 
-def deploy_authz_check(deploy_info):
+def deploy_authz_check(deploy_info, service):
     username = get_username()
     system_paasta_config = load_system_paasta_config()
     allowed_groups = (
@@ -403,7 +403,7 @@ def paasta_mark_for_deployment(args):
             )
 
     deploy_info = get_deploy_info(service=service, soa_dir=args.soa_dir)
-    deploy_authz_check(deploy_info)
+    deploy_authz_check(deploy_info, service)
 
     deploy_process = MarkForDeploymentProcess(
         service=service,

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 from humanize import naturaltime
 
+from paasta_tools.cli.cmds.mark_for_deployment import deploy_authz_check
+from paasta_tools.cli.cmds.mark_for_deployment import get_deploy_info
 from paasta_tools.cli.cmds.mark_for_deployment import mark_for_deployment
 from paasta_tools.cli.utils import extract_tags
 from paasta_tools.cli.utils import figure_out_service_name
@@ -160,6 +162,9 @@ def paasta_rollback(args):
     """
     soa_dir = args.soa_dir
     service = figure_out_service_name(args, soa_dir)
+
+    deploy_info = get_deploy_info(service=service, soa_dir=args.soa_dir)
+    deploy_authz_check(deploy_info)
 
     git_url = get_git_url(service, soa_dir)
     given_deploy_groups = {

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -164,7 +164,7 @@ def paasta_rollback(args):
     service = figure_out_service_name(args, soa_dir)
 
     deploy_info = get_deploy_info(service=service, soa_dir=args.soa_dir)
-    deploy_authz_check(deploy_info)
+    deploy_authz_check(deploy_info, service)
 
     git_url = get_git_url(service, soa_dir)
     given_deploy_groups = {

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -195,6 +195,9 @@ def test_paasta_mark_for_deployment_with_good_rollback(
         timeout = 600
 
     mock_list_deploy_groups.return_value = ["test_deploy_groups"]
+    config_mock = mock.Mock()
+    config_mock.get_default_push_groups.return_value = None
+    mock_load_system_paasta_config.return_value = config_mock
     mock_mark_for_deployment.return_value = 0
 
     def do_wait_for_deployment_side_effect(self, target_commit):

--- a/tests/cli/test_cmds_rollback.py
+++ b/tests/cli/test_cmds_rollback.py
@@ -31,7 +31,9 @@ from paasta_tools.utils import RollbackTypes
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.deploy_authz_check", autospec=True)
 def test_paasta_rollback_mark_for_deployment_simple_invocation(
+    mock_deploy_authz_check,
     mock_get_git_shas_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,
@@ -89,7 +91,9 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.deploy_authz_check", autospec=True)
 def test_paasta_rollback_with_force(
+    mock_deploy_authz_check,
     mock_get_git_shas_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,
@@ -155,7 +159,9 @@ def test_paasta_rollback_with_force(
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.deploy_authz_check", autospec=True)
 def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
+    mock_deploy_authz_check,
     mock_get_git_shas_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,
@@ -225,7 +231,9 @@ def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
 @patch("paasta_tools.cli.cmds.rollback.figure_out_service_name", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.deploy_authz_check", autospec=True)
 def test_paasta_rollback_mark_for_deployment_wrong_deploy_group_args(
+    mock_deploy_authz_check,
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_figure_out_service_name,
@@ -251,7 +259,9 @@ def test_paasta_rollback_mark_for_deployment_wrong_deploy_group_args(
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.deploy_authz_check", autospec=True)
 def test_paasta_rollback_git_sha_was_not_marked_before(
+    mock_deploy_authz_check,
     mock_get_git_shas_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,
@@ -285,7 +295,9 @@ def test_paasta_rollback_git_sha_was_not_marked_before(
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.deploy_authz_check", autospec=True)
 def test_paasta_rollback_mark_for_deployment_multiple_deploy_group_args(
+    mock_deploy_authz_check,
     mock_get_git_shas_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,


### PR DESCRIPTION
Instead of specifying authz on the call to mark-for-deployment, this instead uses settings made available by deploy.yaml. 

Since this setting can be used by other tooling (and does not require a code rewrite to enable), this is preferred vs the previous approach.