### PR TITLE
Adding support for anti-affinity in PaaSTA

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -201,6 +201,37 @@ These options are only applicable to tasks scheduled on Kubernetes.
       PaaSTA will automatically convert it to a canonical version set by
       Kubernetes on all AWS nodes.
 
+  * ``anti_affinity``: A set of rules define when a node *should not* be
+    selected for spawning a task in terms of task running on the node.
+    This can be used to schedule a single task per node and provide better
+    resource isolation for resource intensive tasks. For example::
+
+      anti_affinity:
+        service: acron
+
+    for a service ``acron`` indicates to not schedule any 2 instances
+    ``acron`` service on the same host. This can be extended to
+    service ``instances`` also. For example::
+
+      anti_affinity:
+        service: acron
+        instance: test
+
+    would indicate to not schedule any 2 instances with name ``test``
+    of service ``acron`` on the same host.
+    Multiple anti_affinities rules can also be used which will result
+    ``AND-ing`` of all the rules. For example::
+
+      anti_affinity:
+        - service: acron
+        - service: kafka-k8s
+
+    would indicate the scheduler to not select a node when both
+    ``acron`` and ``kafka-k8s`` is running on the node
+    **Note:** ``anti_affinity`` rules should be used with judiciously
+    and with caution as they require substantial processing and
+    may slow down scheduling significantly in large clusters
+
 For more information on selector operators, see the official Kubernetes
 documentation on `node affinities
 <https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity>`_.

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -639,6 +639,36 @@
                             }
                         }
                     }
+                },
+                "anti_affinity": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "service": {
+                                    "type": "string"
+                                },
+                                "instance": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "service": {
+                                        "type": "string"
+                                    },
+                                    "instance": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "uniqueItems": true
+                        }
+                    ]
                 }
             }
         }


### PR DESCRIPTION
## Description
Adding support for pod anti-affinity on `service` and `instance` in PaaSTA with the following DSL
```yaml
anti_affinity:
    service: "service"
    instance: "instance"
```

```yaml
anti_affinity:
    - service: "service"
       instance: "instance"
    - service: "service_2"
       instance: "instance_2"
```

## Testing
`make test` passes