### PR TITLE
Fix redefinition of username during ldap check, make failed checks more friendly

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -278,7 +278,7 @@ def deploy_authz_check(deploy_info, service):
         ):
             logline = f"current user is not authorized to perform this action (should be in one of {allowed_groups})"
             _log(service=service, line=logline, component="deploy", level="event")
-            print(logline)
+            print(logline, file=sys.stderr)
             sys.exit(1)
 
 

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -254,7 +254,7 @@ def mark_for_deployment(git_url, deploy_group, service, commit):
 
 
 def deploy_authz_check(deploy_info, service):
-    username = get_username()
+    deploy_username = get_username()
     system_paasta_config = load_system_paasta_config()
     allowed_groups = (
         deploy_info["allowed_push_groups"]
@@ -265,20 +265,21 @@ def deploy_authz_check(deploy_info, service):
         search_base = system_paasta_config.get_ldap_search_base()
         search_ou = system_paasta_config.get_ldap_search_ou()
         host = system_paasta_config.get_ldap_host()
-        username = system_paasta_config.get_ldap_reader_username()
-        password = system_paasta_config.get_ldap_reader_password()
+        ldap_username = system_paasta_config.get_ldap_reader_username()
+        ldap_password = system_paasta_config.get_ldap_reader_password()
         if not any(
             [
-                username
+                deploy_username
                 in ldap_user_search(
-                    group, search_base, search_ou, host, username, password
+                    group, search_base, search_ou, host, ldap_username, ldap_password
                 )
                 for group in allowed_groups
             ]
         ):
             logline = f"current user is not authorized to perform this action (should be in one of {allowed_groups})"
             _log(service=service, line=logline, component="deploy", level="event")
-            raise ValueError(logline)
+            print(logline)
+            sys.exit(1)
 
 
 def report_waiting_aborted(service, deploy_group):


### PR DESCRIPTION
This fixes as bug introduced due to variable name confusion, and presents the user with a friendly error instead of a traceback when they're not authorized to continue `mark-for-deployment` or `rollback`.

This was tested manually by trying `paasta mark-for-deployment -c <sha> -l <deploy_target> -s <service> -d <soa_dir>` locally with `allowed_push_groups` set in deploy.yaml. I verified both the success case (with a user in the appropriate group) and the deny case (using my own user, which did not have the appropriate groups) manually.

Previous reviews should have sufficient testing coverage, but happy to add more here as needed.