### PR TITLE
Adding prometheus port support in PaaSTA

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -409,6 +409,9 @@ instance MAY have:
     Defaults to the same uri specified in ``smartstack.yaml``, but can be
     set to something different here.
 
+ * ``prometheus_port``: Optional port, not equal to ``container_port``, to
+    expose for prometheus scraping
+
 **Note**: Although many of these settings are inherited from ``smartstack.yaml``,
 their thresholds are not the same. The reason for this has to do with control
 loops and infrastructure stability. The load balancer tier can be pickier

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -669,6 +669,10 @@
                             "uniqueItems": true
                         }
                     ]
+                },
+                "prometheus_port": {
+                    "type": "integer",
+                    "minimum": 0
                 }
             }
         }


### PR DESCRIPTION
## Description
Adding `prometheus_port` support in `yelpsoa_config` to expose extra ports for prometheus metrics scraping

## Testing
`make test` passes