### PR TITLE
Tron 1553: reduce spark reconfiguration

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -13,6 +13,7 @@
 import datetime
 import difflib
 import glob
+import hashlib
 import json
 import logging
 import os
@@ -25,7 +26,6 @@ from typing import List
 from typing import Tuple
 
 import yaml
-from service_configuration_lib import pick_random_port
 from service_configuration_lib import read_extra_service_information
 from service_configuration_lib import read_yaml_file
 from service_configuration_lib.spark_config import get_k8s_spark_env
@@ -183,6 +183,15 @@ def parse_time_variables(command: str, parse_time: datetime.datetime = None) -> 
     return StringFormatter(job_context).format(command)
 
 
+def pick_spark_ui_port(service, instance):
+    # We don't know what ports will be available on the agent that the driver
+    # will be scheduled on, so we just try to make them unique per service / instance.
+    hash_key = f"{service} {instance}".encode()
+    hash_number = int(hashlib.sha1(hash_key).hexdigest(), 16)
+    preferred_port = 33000 + (hash_number % 25000)
+    return preferred_port
+
+
 class TronActionConfig(InstanceConfig):
     config_filename_prefix = "tron"
 
@@ -205,11 +214,7 @@ class TronActionConfig(InstanceConfig):
             soa_dir=soa_dir,
         )
         self.job, self.action = decompose_instance(instance)
-        self.spark_ui_port = (
-            pick_random_port(f"{self.get_service()}{self.get_instance()}".encode())
-            if not for_validation
-            else "2333"
-        )
+        self.spark_ui_port = pick_spark_ui_port(service, instance)
         # Indicate whether this config object is created for validation
         self.for_validation = for_validation
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -43,7 +43,6 @@ except ImportError:  # pragma: no cover (no libyaml-dev / pypy)
 
 from paasta_tools.spark_tools import get_aws_credentials
 from paasta_tools.spark_tools import get_default_event_log_dir
-from paasta_tools.mesos_tools import find_mesos_leader
 from paasta_tools.tron.client import TronClient
 from paasta_tools.tron import tron_command_context
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -224,7 +223,7 @@ class TronActionConfig(InstanceConfig):
                 spark_app_name=f"tron_spark_{self.get_service()}_{self.get_instance()}",
                 spark_ui_port=self.spark_ui_port,
                 mesos_leader=(
-                    find_mesos_leader(self.get_spark_paasta_cluster())
+                    f"zk://{load_system_paasta_config().get_zk_hosts()}"
                     if not self.for_validation
                     else "N/A"
                 ),

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -175,7 +175,7 @@ class TestTronActionConfig:
             autospec=True,
             return_value={"foo": "bar"},
         ), mock.patch(
-            "paasta_tools.tron_tools.pick_random_port", autospec=True,
+            "paasta_tools.tron_tools.pick_spark_ui_port", autospec=True,
         ), mock.patch(
             "paasta_tools.tron_tools.find_mesos_leader", autospec=True,
         ), mock.patch(
@@ -219,7 +219,7 @@ class TestTronActionConfig:
             autospec=True,
             return_value={"spark.master": "mesos://host:port"},
         ), mock.patch(
-            "paasta_tools.tron_tools.pick_random_port", autospec=True,
+            "paasta_tools.tron_tools.pick_spark_ui_port", autospec=True,
         ), mock.patch(
             "paasta_tools.tron_tools.find_mesos_leader", autospec=True,
         ), mock.patch(


### PR DESCRIPTION
2 changes to make setup_tron_namespace more efficient.

### Using ZK for the mesos leader
You can just give Spark the zk string and it will find the leader itself: https://spark.apache.org/docs/latest/running-on-mesos.html#using-a-mesos-master-url
So we don't need to run find_mesos_leader and reconfigure each time the mesos leader changes. I've tested this in Mesosstage and the driver was able to find the leader.

But I don't think this is the cause of the slowness on tron sync deploy, because we actually don't have any jobs with `executor: spark` and `spark_cluster_manager: mesos`. They are all scheduling using k8s.

### Picking a deterministic UI port
I'm not sure this is the cause of the slowness either, but it's definitely inefficient. I noticed spark and ad_targeting_batches (the namespaces with `executor: spark` jobs) are getting re-configured constantly, basically every 10 minutes, even if there's no yelpsoa-configs change or code push.

I copied the tronfigs on the master before and after one of these reconfigurations, and found the only difference was the ui port:
```
228c228
<           --conf spark.ui.port=35363 --conf spark.executorEnv.PAASTA_SERVICE=spark
---
>           --conf spark.ui.port=41266 --conf spark.executorEnv.PAASTA_SERVICE=spark
```

The reason is pick_random_port (https://github.com/Yelp/service_configuration_lib/blob/master/service_configuration_lib/__init__.py#L322) actually reserves the port on the box where the code is running (the tron master) and ensures the port is available on that box. But the driver won't be running on the Tron master, so we don't need to do that. The new approach doesn't guarantee the port will be available for the spark drive on the paasta agent, but neither does the current one 🤷‍♀️ 