### PR TITLE
minor improvements to setup_kubernetes_job

### DIFF
--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -264,7 +264,6 @@ class DeploymentWrapper(Application):
             ).start()
             return
         update_deployment(kube_client=kube_client, formatted_deployment=self.item)
-        self.update_related_api_objects(kube_client)
 
     def update_related_api_objects(self, kube_client: KubeClient) -> None:
         super().update_related_api_objects(kube_client)
@@ -405,7 +404,6 @@ class StatefulSetWrapper(Application):
 
     def update(self, kube_client: KubeClient):
         update_stateful_set(kube_client=kube_client, formatted_stateful_set=self.item)
-        self.update_related_api_objects(kube_client)
 
 
 def get_application_wrapper(


### PR DESCRIPTION
1) We don't log a JSON-ified list of service-instances updated at the
end, because we can already get that information and it just gets split
up weirdly in syslog, which would make Splunk ingestion worse.

2) Suppress logs from kazoo because these are noisy and useless most of
the time

3) Make sure that we update "related" API objects every time the script
runs (it actually did this before too, but it was less clear, because
the update was called in two different places)