### PR TITLE
Support iam_role using AWS pod identity solution

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -539,6 +539,9 @@
                         "aws"
                     ]
                 },
+                "fs_group": {
+                    "type": "int"
+                },
                 "healthcheck_mode": {
                     "enum": [
                         "cmd",

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -31,6 +31,7 @@ DEFAULT_CONTAINER_PORT = 8888
 class LongRunningServiceConfigDict(InstanceConfigDict, total=False):
     drain_method: str
     iam_role: str
+    iam_role_provider: str
     container_port: int
     drain_method_params: Dict
     healthcheck_cmd: str
@@ -202,6 +203,9 @@ class LongRunningServiceConfig(InstanceConfig):
 
     def get_iam_role(self) -> str:
         return self.config_dict.get("iam_role", "")
+
+    def get_iam_role_provider(self) -> str:
+        return self.config_dict.get("iam_role_provider", "kiam")
 
     def get_healthcheck_uri(
         self, service_namespace_config: ServiceNamespaceConfig

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -32,6 +32,7 @@ class LongRunningServiceConfigDict(InstanceConfigDict, total=False):
     drain_method: str
     iam_role: str
     iam_role_provider: str
+    fs_group: int
     container_port: int
     drain_method_params: Dict
     healthcheck_cmd: str
@@ -206,6 +207,9 @@ class LongRunningServiceConfig(InstanceConfig):
 
     def get_iam_role_provider(self) -> str:
         return self.config_dict.get("iam_role_provider", "kiam")
+
+    def get_fs_group(self) -> Optional[int]:
+        return self.config_dict.get("fs_group")
 
     def get_healthcheck_uri(
         self, service_namespace_config: ServiceNamespaceConfig


### PR DESCRIPTION
## Support iam_role using AWS pod identity solution

Added `iam_role_provider` parameter for services which can be set to
either `kiam` (default) or `aws`.  If it's set to `aws` then PaaSTA uses
the AWS pod identity solution [1] instead of `kiam` to support per-pod
IAM profiles.

[1] https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/

## Workaround for AWS pod identity and non-root programs

AWS pod identity creates a token with `0600` permissions and
`root:root`:
```
-rw------- 1 root root 1498 Aug 13 12:47 /run/secrets/eks.amazonaws.com/serviceaccount/..2020_08_13_12_47_11.793276204/token
```
This prevents programs running inside containers using a non-root
account to read the token.  See [1] for details.

This CR working around that by adding
```
  securityContext:
›         fsGroup: 65534
```
into the pod spec.
After that the token is owned by the given group and has `0640`
permissions:
```
-rw-r----- 1 root nobody 1498 Aug 13 14:20 /run/secrets/eks.amazonaws.com/serviceaccount/..2020_08_13_14_20_31.793276204/token      ```

The id of the group can be changed via the `fs_group` service parameter.

[1] https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8