### PR TITLE
Show Kafka Zookeeper connection string in paasta status

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1267,6 +1267,8 @@ def print_kafka_status(
     if "kafka_view_url" in status and status.kafka_view_url is not None:
         output.append(f"    Kafka View Url: {status.kafka_view_url}")
 
+    output.append(f"    Zookeeper: {status.zookeeper}")
+
     annotations = kafka_status.get("metadata").annotations
     desired_state = annotations.get(paasta_prefixed("desired_state"))
     if desired_state is None:

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1030,6 +1030,7 @@ def mock_kafka_status() -> Mapping[str, Any]:
                 "under_replicated_partitions": 1,
             },
             kafka_view_url="https://kafkaview.com",
+            zookeeper="0.0.0.0:2181/kafka",
         ),
     )
 
@@ -1359,6 +1360,7 @@ class TestPrintKafkaStatus:
         status = mock_kafka_status["status"]
         expected_output = [
             f"    Kafka View Url: {status.kafka_view_url}",
+            f"    Zookeeper: {status.zookeeper}",
             f"    State: testing",
             f"    Ready: {str(status.cluster_ready).lower()}",
             f"    Health: {PaastaColors.red('unhealthy')}",


### PR DESCRIPTION
This has been added to the `status` of a KafkaCluster custom resource and is not optional.