### PR TITLE
PaaSTA instance Envoy replication checks

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -78,3 +78,6 @@ disallow_untyped_defs = True
 
 [mypy-paasta_tools.deployd.*]
 disallow_untyped_defs = True
+
+[mypy-paasta_tools.envoy_tools]
+disallow_untyped_defs = True

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -370,14 +370,20 @@ def _build_envoy_location_dict_for_backends(
         registration,
         envoy_host=envoy_host,
         envoy_admin_port=settings.system_paasta_config.get_envoy_admin_port(),
+        envoy_admin_endpoint_format=settings.system_paasta_config.get_envoy_admin_endpoint_format(),
     )
     sorted_envoy_backends = sorted(
-        [backend[0] for backend in backends],
+        [
+            backend[0]
+            for _, service_backends in backends.items()
+            for backend in service_backends
+        ],
         key=lambda backend: backend["eds_health_status"],
     )
     casper_proxied_backends = {
         (backend["address"], backend["port_value"])
-        for backend, is_casper_proxied_backend in backends
+        for _, service_backends in backends.items()
+        for backend, is_casper_proxied_backend in service_backends
         if is_casper_proxied_backend
     }
 

--- a/paasta_tools/check_flink_services_health.py
+++ b/paasta_tools/check_flink_services_health.py
@@ -30,7 +30,7 @@ from paasta_tools.kubernetes_tools import is_pod_ready
 from paasta_tools.kubernetes_tools import V1Pod
 from paasta_tools.monitoring_tools import check_under_replication
 from paasta_tools.monitoring_tools import send_replication_event
-from paasta_tools.smartstack_tools import KubeSmartstackReplicationChecker
+from paasta_tools.smartstack_tools import KubeSmartstackEnvoyReplicationChecker
 from paasta_tools.utils import is_under_replicated
 
 
@@ -108,7 +108,7 @@ Things you can do:
 def check_flink_service_health(
     instance_config: FlinkDeploymentConfig,
     all_tasks_or_pods: Sequence[V1Pod],
-    smartstack_replication_checker: KubeSmartstackReplicationChecker,
+    replication_checker: KubeSmartstackEnvoyReplicationChecker,
 ) -> None:
     si_pods = filter_pods_by_service_instance(
         pod_list=all_tasks_or_pods,

--- a/paasta_tools/drain_lib.py
+++ b/paasta_tools/drain_lib.py
@@ -19,8 +19,8 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Set
-from typing import Tuple
 from typing import Type
 from typing import TypeVar
 
@@ -201,7 +201,7 @@ class HacheckDrainMethod(DrainMethod):
 
     async def for_each_registration(
         self, task: DrainTask, func: Callable[..., Awaitable[T]]
-    ) -> Tuple[T, ...]:
+    ) -> Sequence[T]:
         if task.ports == []:
             return None
         futures = [func(url) for url in self.spool_urls(task)]

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -30,7 +30,7 @@ from paasta_tools.kubernetes_tools import get_tail_lines_for_kubernetes_containe
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
 from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
-from paasta_tools.smartstack_tools import KubeSmartstackReplicationChecker
+from paasta_tools.smartstack_tools import KubeSmartstackEnvoyReplicationChecker
 from paasta_tools.smartstack_tools import match_backends_and_pods
 from paasta_tools.utils import calculate_tail_lines
 
@@ -249,11 +249,11 @@ def smartstack_status(
     registration = job_config.get_registrations()[0]
     instance_pool = job_config.get_pool()
 
-    smartstack_replication_checker = KubeSmartstackReplicationChecker(
+    replication_checker = KubeSmartstackEnvoyReplicationChecker(
         nodes=kubernetes_tools.get_all_nodes(settings.kubernetes_client),
         system_paasta_config=settings.system_paasta_config,
     )
-    node_hostname_by_location = smartstack_replication_checker.get_allowed_locations_and_hosts(
+    node_hostname_by_location = replication_checker.get_allowed_locations_and_hosts(
         job_config
     )
 
@@ -273,9 +273,7 @@ def smartstack_status(
     }
 
     for location, hosts in node_hostname_by_location.items():
-        synapse_host = smartstack_replication_checker.get_first_host_in_pool(
-            hosts, instance_pool
-        )
+        synapse_host = replication_checker.get_first_host_in_pool(hosts, instance_pool)
         sorted_backends = sorted(
             smartstack_tools.get_backends(
                 registration,

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2523,7 +2523,7 @@ def load_custom_resource_definitions(
         kube_kind = KubeKind(**custom_resource_dict.pop("kube_kind"))  # type: ignore
         custom_resources.append(
             CustomResourceDefinition(  # type: ignore
-                kube_kind=kube_kind, **custom_resource_dict
+                kube_kind=kube_kind, **custom_resource_dict  # type: ignore
             )
         )
     return custom_resources

--- a/paasta_tools/monitoring_tools.py
+++ b/paasta_tools/monitoring_tools.py
@@ -20,10 +20,12 @@ on the framework that is asking, and still allows you to set your team
 
 Everything in here is private, and you shouldn't worry about it.
 """
+import abc
 import json
 import logging
 import os
 from typing import Dict
+from typing import Mapping
 from typing import Optional
 from typing import Tuple
 
@@ -37,6 +39,14 @@ from paasta_tools.utils import is_under_replicated
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import time_cache
+
+
+class ReplicationChecker(abc.ABC):
+    @abc.abstractmethod
+    def get_replication_for_instance(
+        self, instance_config: LongRunningServiceConfig
+    ) -> Dict[str, Dict[str, Dict[str, int]]]:
+        ...
 
 
 try:
@@ -210,7 +220,9 @@ def send_event(
     :param status: The status to emit for this event
     :param output: The output to emit for this event
     :param soa_dir: The service directory to read monitoring information from
+    :param ttl: TTL (optional)
     :param cluster: The cluster name (optional)
+    :param system_paasta_config: A SystemPaastaConfig object representing the system
     """
     # This function assumes the input is a string like "mumble.main"
     team = get_team(overrides, service, soa_dir)
@@ -273,7 +285,7 @@ def read_monitoring_config(service, soa_dir=DEFAULT_SOA_DIR):
     return monitor_conf
 
 
-def list_teams(**kwargs):
+def list_teams():
     """Loads team data from the system. Returns a set of team names (or empty
     set).
     """
@@ -318,167 +330,179 @@ def send_replication_event(instance_config, status, output):
 
 
 def emit_replication_metrics(
-    smartstack_replication_info: Dict[str, Dict[str, int]],
+    replication_infos: Mapping[str, Mapping[str, Mapping[str, int]]],
     instance_config: LongRunningServiceConfig,
     expected_count: int,
 ) -> None:
-    meteorite_dims = {
-        "paasta_service": instance_config.service,
-        "paasta_cluster": instance_config.cluster,
-        "paasta_instance": instance_config.instance,
-        "paasta_pool": instance_config.get_pool(),
-    }
+    for provider, replication_info in replication_infos.items():
+        meteorite_dims = {
+            "paasta_service": instance_config.service,
+            "paasta_cluster": instance_config.cluster,
+            "paasta_instance": instance_config.instance,
+            "paasta_pool": instance_config.get_pool(),
+            "service_discovery_provider": provider,
+        }
 
-    num_available_backends = 0
-    for available_backends in smartstack_replication_info.values():
-        num_available_backends += available_backends.get(instance_config.job_id, 0)
-    available_backends_gauge = yelp_meteorite.create_gauge(
-        "paasta.service.available_backends", meteorite_dims
-    )
-    available_backends_gauge.set(num_available_backends)
+        num_available_backends = 0
+        for available_backends in replication_info.values():
+            num_available_backends += available_backends.get(instance_config.job_id, 0)
+        available_backends_gauge = yelp_meteorite.create_gauge(
+            "paasta.service.available_backends", meteorite_dims
+        )
+        available_backends_gauge.set(num_available_backends)
 
-    critical_percentage = instance_config.get_replication_crit_percentage()
-    num_critical_backends = critical_percentage * expected_count / 100.0
-    critical_backends_gauge = yelp_meteorite.create_gauge(
-        "paasta.service.critical_backends", meteorite_dims
-    )
-    critical_backends_gauge.set(num_critical_backends)
+        critical_percentage = instance_config.get_replication_crit_percentage()
+        num_critical_backends = critical_percentage * expected_count / 100.0
+        critical_backends_gauge = yelp_meteorite.create_gauge(
+            "paasta.service.critical_backends", meteorite_dims
+        )
+        critical_backends_gauge.set(num_critical_backends)
 
-    expected_backends_gauge = yelp_meteorite.create_gauge(
-        "paasta.service.expected_backends", meteorite_dims
-    )
-    expected_backends_gauge.set(expected_count)
+        expected_backends_gauge = yelp_meteorite.create_gauge(
+            "paasta.service.expected_backends", meteorite_dims
+        )
+        expected_backends_gauge.set(expected_count)
 
 
-def check_smartstack_replication_for_instance(
-    instance_config, expected_count, smartstack_replication_checker
+def check_replication_for_instance(
+    instance_config: LongRunningServiceConfig,
+    expected_count: int,
+    replication_checker: ReplicationChecker,
 ) -> bool:
     """Check a set of namespaces to see if their number of available backends is too low,
     emitting events to Sensu based on the fraction available and the thresholds defined in
     the corresponding yelpsoa config.
 
     :param instance_config: an instance of MarathonServiceConfig
-    :param smartstack_replication_checker: an instance of SmartstackReplicationChecker
+    :param replication_checker: an instance of ReplicationChecker
     """
 
     crit_threshold = instance_config.get_replication_crit_percentage()
 
-    log.info("Checking instance %s in smartstack", instance_config.job_id)
-    smartstack_replication_info = smartstack_replication_checker.get_replication_for_instance(
+    log.info(
+        "Checking instance %s in service discovery providers", instance_config.job_id
+    )
+    replication_infos = replication_checker.get_replication_for_instance(
         instance_config
     )
 
-    log.debug(
-        "Got smartstack replication info for %s: %s"
-        % (instance_config.job_id, smartstack_replication_info)
-    )
+    log.debug(f"Got replication info for {instance_config.job_id}: {replication_infos}")
     if yelp_meteorite is not None:
         emit_replication_metrics(
-            smartstack_replication_info, instance_config, expected_count,
+            replication_infos, instance_config, expected_count,
         )
 
-    if len(smartstack_replication_info) == 0:
-        status = pysensu_yelp.Status.CRITICAL
-        output = (
-            "Service %s has no Smartstack replication info. Make sure the discover key in your smartstack.yaml "
-            "is valid!\n"
-        ) % instance_config.job_id
-        log.error(output)
-        service_is_under_replicated = True
-    else:
-        expected_count_per_location = int(
-            expected_count / len(smartstack_replication_info)
-        )
-        output = ""
-        output_critical = ""
-        output_ok = ""
-        under_replication_per_location = []
-
-        for location, available_backends in sorted(smartstack_replication_info.items()):
-            num_available_in_location = available_backends.get(
-                instance_config.job_id, 0
-            )
-            under_replicated, ratio = is_under_replicated(
-                num_available_in_location, expected_count_per_location, crit_threshold
-            )
-            if under_replicated:
-                output_critical += (
-                    "- Service %s has %d out of %d expected instances in %s (CRITICAL: %d%%)\n"
-                    % (
-                        instance_config.job_id,
-                        num_available_in_location,
-                        expected_count_per_location,
-                        location,
-                        ratio,
-                    )
-                )
-            else:
-                output_ok += (
-                    "- Service %s has %d out of %d expected instances in %s (OK: %d%%)\n"
-                    % (
-                        instance_config.job_id,
-                        num_available_in_location,
-                        expected_count_per_location,
-                        location,
-                        ratio,
-                    )
-                )
-            under_replication_per_location.append(under_replicated)
-
-        output += output_critical
-        if output_critical and output_ok:
-            output += "\n\n"
-            output += "The following locations are OK:\n"
-        output += output_ok
-
-        service_is_under_replicated = any(under_replication_per_location)
-        if service_is_under_replicated:
-            status = pysensu_yelp.Status.CRITICAL
-            output += (
-                "\n\n"
-                "What this alert means:\n"
-                "\n"
-                "  This replication alert means that a SmartStack powered loadbalancer (haproxy)\n"
-                "  doesn't have enough healthy backends. Not having enough healthy backends\n"
-                "  means that clients of that service will get 503s (http) or connection refused\n"
-                "  (tcp) when trying to connect to it.\n"
-                "\n"
-                "Reasons this might be happening:\n"
-                "\n"
-                "  The service may simply not have enough copies or it could simply be\n"
-                "  unhealthy in that location. There also may not be enough resources\n"
-                "  in the cluster to support the requested instance count.\n"
-                "\n"
-                "Things you can do:\n"
-                "\n"
-                "  * You can view the logs for the job with:\n"
-                "      paasta logs -s %(service)s -i %(instance)s -c %(cluster)s\n"
-                "\n"
-                "  * Fix the cause of the unhealthy service. Try running:\n"
-                "\n"
-                "      paasta status -s %(service)s -i %(instance)s -c %(cluster)s -vv\n"
-                "\n"
-                "  * Widen SmartStack discovery settings\n"
-                "  * Increase the instance count\n"
-                "\n"
-            ) % {
-                "service": instance_config.service,
-                "instance": instance_config.instance,
-                "cluster": instance_config.cluster,
-            }
+    combined_output = ""
+    service_is_under_replicated = False
+    for service_discovery_provider, replication_info in replication_infos.items():
+        if len(replication_info) == 0:
+            output = (
+                "Service %s has no %s replication info. Make sure the discover key in the corresponding config (e.g. smartstack.yaml for Smartstack) is valid!\n"
+            ) % (instance_config.job_id, service_discovery_provider)
             log.error(output)
+            service_is_under_replicated = True
         else:
-            status = pysensu_yelp.Status.OK
-            log.info(output)
+            expected_count_per_location = int(expected_count / len(replication_info))
+            output = ""
+            output_critical = ""
+            output_ok = ""
+            under_replication_per_location = []
+
+            for location, available_backends in sorted(replication_info.items()):
+                num_available_in_location = available_backends.get(
+                    instance_config.job_id, 0
+                )
+                under_replicated, ratio = is_under_replicated(
+                    num_available_in_location,
+                    expected_count_per_location,
+                    crit_threshold,
+                )
+                if under_replicated:
+                    output_critical += (
+                        "- Service %s has %d out of %d expected instances in %s according to %s (CRITICAL: %d%%)\n"
+                        % (
+                            instance_config.job_id,
+                            num_available_in_location,
+                            expected_count_per_location,
+                            location,
+                            service_discovery_provider,
+                            ratio,
+                        )
+                    )
+                else:
+                    output_ok += (
+                        "- Service %s has %d out of %d expected instances in %s according to %s (OK: %d%%)\n"
+                        % (
+                            instance_config.job_id,
+                            num_available_in_location,
+                            expected_count_per_location,
+                            location,
+                            service_discovery_provider,
+                            ratio,
+                        )
+                    )
+                under_replication_per_location.append(under_replicated)
+
+            output += output_critical
+            if output_critical and output_ok:
+                output += "\n\n"
+                output += "The following locations are OK:\n"
+            output += output_ok
+
+            service_is_under_replicated_anywhere = any(under_replication_per_location)
+            service_is_under_replicated |= service_is_under_replicated_anywhere
+            if service_is_under_replicated_anywhere:
+                output += (
+                    "\n\n"
+                    "What this alert means:\n"
+                    "\n"
+                    "  This replication alert means that a %(service_discovery_provider)s powered loadbalancer\n"
+                    "  doesn't have enough healthy backends. Not having enough healthy backends\n"
+                    "  means that clients of that service will get 503s (http) or connection refused\n"
+                    "  (tcp) when trying to connect to it.\n"
+                    "\n"
+                    "Reasons this might be happening:\n"
+                    "\n"
+                    "  The service may simply not have enough copies or it could simply be\n"
+                    "  unhealthy in that location. There also may not be enough resources\n"
+                    "  in the cluster to support the requested instance count.\n"
+                    "\n"
+                    "Things you can do:\n"
+                    "\n"
+                    "  * You can view the logs for the job with:\n"
+                    "      paasta logs -s %(service)s -i %(instance)s -c %(cluster)s\n"
+                    "\n"
+                    "  * Fix the cause of the unhealthy service. Try running:\n"
+                    "\n"
+                    "      paasta status -s %(service)s -i %(instance)s -c %(cluster)s -vv\n"
+                    "\n"
+                    "  * Widen %(service_discovery_provider)s discovery settings\n"
+                    "  * Increase the instance count\n"
+                    "\n"
+                ) % {
+                    "service": instance_config.service,
+                    "instance": instance_config.instance,
+                    "cluster": instance_config.cluster,
+                    "service_discovery_provider": service_discovery_provider,
+                }
+                log.error(output)
+            else:
+                log.info(output)
+        combined_output += output
+    status = (
+        pysensu_yelp.Status.CRITICAL
+        if service_is_under_replicated
+        else pysensu_yelp.Status.OK
+    )
     send_replication_event(
-        instance_config=instance_config, status=status, output=output
+        instance_config=instance_config, status=status, output=combined_output
     )
 
     return not service_is_under_replicated
 
 
 def check_under_replication(
-    instance_config,
+    instance_config: LongRunningServiceConfig,
     expected_count: int,
     num_available: int,
     sub_component: Optional[str] = None,
@@ -530,11 +554,11 @@ def check_under_replication(
             "instance": instance_config.instance,
             "cluster": instance_config.cluster,
         }
-    return (under_replicated, output)
+    return under_replicated, output
 
 
 def send_replication_event_if_under_replication(
-    instance_config,
+    instance_config: LongRunningServiceConfig,
     expected_count: int,
     num_available: int,
     sub_component: Optional[str] = None,

--- a/paasta_tools/setup_marathon_job.py
+++ b/paasta_tools/setup_marathon_job.py
@@ -51,6 +51,7 @@ from typing import Callable
 from typing import Collection
 from typing import Dict
 from typing import List
+from typing import Mapping
 from typing import Optional
 from typing import Sequence
 from typing import Set
@@ -264,7 +265,7 @@ def drain_tasks_and_find_tasks_to_kill(
 
 
 def old_app_tasks_to_task_client_pairs(
-    old_app_tasks: Dict[Tuple[str, MarathonClient], Set[MarathonTask]],
+    old_app_tasks: Mapping[Tuple[str, MarathonClient], Set[MarathonTask]],
 ) -> Set[Tuple[MarathonTask, MarathonClient]]:
     ret: Set[Tuple[MarathonTask, MarathonClient]] = set()
     for (app, client), tasks in old_app_tasks.items():
@@ -278,11 +279,11 @@ def do_bounce(
     drain_method: drain_lib.DrainMethod,
     config: marathon_tools.FormattedMarathonAppDict,
     new_app_running: bool,
-    happy_new_tasks: List[MarathonTask],
-    old_app_live_happy_tasks: Dict[Tuple[str, MarathonClient], Set[MarathonTask]],
-    old_app_live_unhappy_tasks: Dict[Tuple[str, MarathonClient], Set[MarathonTask]],
-    old_app_draining_tasks: Dict[Tuple[str, MarathonClient], Set[MarathonTask]],
-    old_app_at_risk_tasks: Dict[Tuple[str, MarathonClient], Set[MarathonTask]],
+    happy_new_tasks: Sequence[MarathonTask],
+    old_app_live_happy_tasks: Mapping[Tuple[str, MarathonClient], Set[MarathonTask]],
+    old_app_live_unhappy_tasks: Mapping[Tuple[str, MarathonClient], Set[MarathonTask]],
+    old_app_draining_tasks: Mapping[Tuple[str, MarathonClient], Set[MarathonTask]],
+    old_app_at_risk_tasks: Mapping[Tuple[str, MarathonClient], Set[MarathonTask]],
     service: str,
     bounce_method: str,
     serviceinstance: str,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1796,10 +1796,9 @@ class KubeStateMetricsCollectorConfigDict(TypedDict, total=False):
 class SystemPaastaConfigDict(TypedDict, total=False):
     api_endpoints: Dict[str, str]
     auth_certificate_ttl: str
-    auto_hostname_unique_size: int
     auto_config_instance_types_enabled: Dict[str, bool]
+    auto_hostname_unique_size: int
     boost_regions: List[str]
-    cluster: str
     cluster_autoscaler_max_decrease: float
     cluster_autoscaler_max_increase: float
     cluster_autoscaling_draining_enabled: bool
@@ -1807,10 +1806,10 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     cluster_boost_enabled: bool
     cluster_fqdn_format: str
     clusters: Sequence[str]
+    cluster: str
     dashboard_links: Dict[str, Dict[str, str]]
     default_push_groups: List
     deploy_blacklist: UnsafeDeployBlacklist
-    deploy_whitelist: UnsafeDeployWhitelist
     deployd_big_bounce_deadline: float
     deployd_log_level: str
     deployd_maintenance_polling_frequency: int
@@ -1819,11 +1818,12 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     deployd_number_workers: int
     deployd_startup_bounce_deadline: float
     deployd_startup_oracle_enabled: bool
-    deployd_worker_failure_backoff_factor: int
     deployd_use_zk_queue: bool
+    deployd_worker_failure_backoff_factor: int
+    deploy_whitelist: UnsafeDeployWhitelist
     disabled_watchers: List
-    docker_registry: str
     dockercfg_location: str
+    docker_registry: str
     enable_client_cert_auth: bool
     enable_nerve_readiness_check: bool
     enforce_disk_quota: bool
@@ -1835,11 +1835,11 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     hacheck_sidecar_image_url: str
     kubernetes_custom_resources: List[KubeCustomResourceDict]
     kubernetes_use_hacheck_sidecar: bool
+    ldap_host: str
+    ldap_reader_password: str
+    ldap_reader_username: str
     ldap_search_base: str
     ldap_search_ou: str
-    ldap_host: str
-    ldap_reader_username: str
-    ldap_reader_password: str
     local_run_config: LocalRunConfig
     log_reader: LogReaderConfig
     log_writer: LogWriterConfig
@@ -1852,8 +1852,8 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     paasta_native: PaastaNativeConfig
     pdb_max_unavailable: Union[str, int]
     pki_backend: str
-    previous_marathon_servers: List[MarathonConfigDict]
     pod_defaults: Dict[str, Any]
+    previous_marathon_servers: List[MarathonConfigDict]
     register_k8s_pods: bool
     register_marathon_services: bool
     register_native_services: bool
@@ -1863,6 +1863,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     security_check_command: str
     sensu_host: str
     sensu_port: int
+    service_discovery_providers: Dict[str, Any]
     slack: Dict[str, str]
     spark_run_config: SparkRunConfig
     synapse_haproxy_url_format: str
@@ -2171,6 +2172,9 @@ class SystemPaastaConfig:
         return self.config_dict.get(
             "synapse_haproxy_url_format", DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT
         )
+
+    def get_service_discovery_providers(self) -> Dict[str, Any]:
+        return self.config_dict.get("service_discovery_providers", {})
 
     def get_cluster_autoscaling_resources(self) -> IdToClusterAutoscalingResourcesDict:
         return self.config_dict.get("cluster_autoscaling_resources", {})

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ kubernetes==10.0.1
 ldap3==2.6.0
 manhole==1.5.0
 marathon==0.12.0
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 monotonic==1.4
 msgpack-python==0.5.6
 multidict==4.1.0

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -33,8 +33,8 @@ from paasta_tools.marathon_tools import get_short_task_id
 from paasta_tools.mesos.exceptions import SlaveDoesNotExist
 from paasta_tools.mesos.slave import MesosSlave
 from paasta_tools.mesos.task import Task
+from paasta_tools.smartstack_tools import DiscoveredHost
 from paasta_tools.smartstack_tools import HaproxyBackend
-from paasta_tools.smartstack_tools import SmartstackHost
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import TimeoutError
@@ -521,7 +521,7 @@ def test_marathon_service_mesh_status(
     "paasta_tools.api.views.instance.pik.smartstack_tools.get_backends", autospec=True
 )
 @mock.patch(
-    "paasta_tools.api.views.instance.pik.KubeSmartstackReplicationChecker",
+    "paasta_tools.api.views.instance.pik.KubeSmartstackEnvoyReplicationChecker",
     autospec=True,
 )
 @mock.patch(
@@ -543,7 +543,7 @@ def test_kubernetes_smartstack_status(
     ]
 
     mock_kube_smartstack_replication_checker.return_value.get_allowed_locations_and_hosts.return_value = {
-        "us-north-3": [SmartstackHost(hostname="host1.paasta.party", pool="default")]
+        "us-north-3": [DiscoveredHost(hostname="host1.paasta.party", pool="default")]
     }
 
     mock_get_expected_instance_count_for_namespace.return_value = 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ def system_paasta_config():
                     "mode": "RO",
                 }
             ],
+            "service_discovery_providers": {"smartstack": {}, "envoy": {}},
         },
         "/fake_dir/",
     )

--- a/tests/test_check_flink_services_health.py
+++ b/tests/test_check_flink_services_health.py
@@ -120,7 +120,7 @@ def test_check_flink_service_health_healthy(instance_config):
         check_flink_services_health.check_flink_service_health(
             instance_config=instance_config,
             all_tasks_or_pods=all_pods,
-            smartstack_replication_checker=None,
+            replication_checker=None,
         )
         expected = [
             mock.call(
@@ -182,7 +182,7 @@ def test_check_flink_service_health_too_few_taskmanagers(instance_config):
         check_flink_services_health.check_flink_service_health(
             instance_config=instance_config,
             all_tasks_or_pods=all_pods,
-            smartstack_replication_checker=None,
+            replication_checker=None,
         )
         expected = [
             mock.call(
@@ -236,7 +236,7 @@ def test_check_flink_service_health_under_registered_taskamanagers(instance_conf
         check_flink_services_health.check_flink_service_health(
             instance_config=instance_config,
             all_tasks_or_pods=all_pods,
-            smartstack_replication_checker=None,
+            replication_checker=None,
         )
         expected = [
             mock.call(

--- a/tests/test_check_kubernetes_services_replication.py
+++ b/tests/test_check_kubernetes_services_replication.py
@@ -48,18 +48,17 @@ def test_check_service_replication_for_normal_smartstack(instance_config):
         autospec=True,
         return_value=666,
     ), mock.patch(
-        "paasta_tools.monitoring_tools.check_smartstack_replication_for_instance",
-        autospec=True,
-    ) as mock_check_smartstack_replication_for_service:
+        "paasta_tools.monitoring_tools.check_replication_for_instance", autospec=True,
+    ) as mock_check_replication_for_service:
         check_kubernetes_services_replication.check_kubernetes_pod_replication(
             instance_config=instance_config,
             all_tasks_or_pods=all_pods,
-            smartstack_replication_checker=None,
+            replication_checker=None,
         )
-        mock_check_smartstack_replication_for_service.assert_called_once_with(
+        mock_check_replication_for_service.assert_called_once_with(
             instance_config=instance_config,
             expected_count=100,
-            smartstack_replication_checker=None,
+            replication_checker=None,
         )
 
 
@@ -73,9 +72,8 @@ def test_check_service_replication_for_smartstack_with_different_namespace(
         autospec=True,
         return_value=666,
     ), mock.patch(
-        "paasta_tools.monitoring_tools.check_smartstack_replication_for_instance",
-        autospec=True,
-    ) as mock_check_smartstack_replication_for_service, mock.patch(
+        "paasta_tools.monitoring_tools.check_replication_for_instance", autospec=True,
+    ) as mock_check_replication_for_service, mock.patch(
         "paasta_tools.check_kubernetes_services_replication.check_healthy_kubernetes_tasks_for_service_instance",
         autospec=True,
     ) as mock_check_healthy_kubernetes_tasks:
@@ -83,9 +81,9 @@ def test_check_service_replication_for_smartstack_with_different_namespace(
         check_kubernetes_services_replication.check_kubernetes_pod_replication(
             instance_config=instance_config,
             all_tasks_or_pods=all_pods,
-            smartstack_replication_checker=None,
+            replication_checker=None,
         )
-        assert not mock_check_smartstack_replication_for_service.called
+        assert not mock_check_replication_for_service.called
         mock_check_healthy_kubernetes_tasks.assert_called_once_with(
             instance_config=instance_config, expected_count=100, all_pods=[]
         )
@@ -105,7 +103,7 @@ def test_check_service_replication_for_non_smartstack(instance_config):
         check_kubernetes_services_replication.check_kubernetes_pod_replication(
             instance_config=instance_config,
             all_tasks_or_pods=[],
-            smartstack_replication_checker=None,
+            replication_checker=None,
         )
         mock_check_healthy_kubernetes_tasks.assert_called_once_with(
             instance_config=instance_config, expected_count=100, all_pods=[]

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -49,18 +49,17 @@ def test_check_service_replication_for_normal_smartstack(instance_config):
         autospec=True,
         return_value=666,
     ), mock.patch(
-        "paasta_tools.monitoring_tools.check_smartstack_replication_for_instance",
-        autospec=True,
-    ) as mock_check_smartstack_replication_for_service:
+        "paasta_tools.monitoring_tools.check_replication_for_instance", autospec=True,
+    ) as mock_check_replication_for_service:
         check_marathon_services_replication.check_service_replication(
             instance_config=instance_config,
             all_tasks_or_pods=all_tasks,
-            smartstack_replication_checker=None,
+            replication_checker=None,
         )
-        mock_check_smartstack_replication_for_service.assert_called_once_with(
+        mock_check_replication_for_service.assert_called_once_with(
             instance_config=instance_config,
             expected_count=100,
-            smartstack_replication_checker=None,
+            replication_checker=None,
         )
 
 
@@ -74,9 +73,8 @@ def test_check_service_replication_for_smartstack_with_different_namespace(
         autospec=True,
         return_value=666,
     ), mock.patch(
-        "paasta_tools.monitoring_tools.check_smartstack_replication_for_instance",
-        autospec=True,
-    ) as mock_check_smartstack_replication_for_service, mock.patch(
+        "paasta_tools.monitoring_tools.check_replication_for_instance", autospec=True,
+    ) as mock_check_replication_for_service, mock.patch(
         "paasta_tools.check_marathon_services_replication.check_healthy_marathon_tasks_for_service_instance",
         autospec=True,
     ) as mock_check_healthy_marathon_tasks:
@@ -84,9 +82,9 @@ def test_check_service_replication_for_smartstack_with_different_namespace(
         check_marathon_services_replication.check_service_replication(
             instance_config=instance_config,
             all_tasks_or_pods=all_tasks,
-            smartstack_replication_checker=None,
+            replication_checker=None,
         )
-        assert not mock_check_smartstack_replication_for_service.called
+        assert not mock_check_replication_for_service.called
         mock_check_healthy_marathon_tasks.assert_called_once_with(
             instance_config=instance_config, expected_count=100, all_tasks=[]
         )
@@ -106,7 +104,7 @@ def test_check_service_replication_for_non_smartstack(instance_config):
         check_marathon_services_replication.check_service_replication(
             instance_config=instance_config,
             all_tasks_or_pods=[],
-            smartstack_replication_checker=None,
+            replication_checker=None,
         )
         mock_check_healthy_marathon_tasks.assert_called_once_with(
             instance_config=instance_config, expected_count=100, all_tasks=[]

--- a/tests/test_check_service_replication_tools.py
+++ b/tests/test_check_service_replication_tools.py
@@ -133,6 +133,6 @@ def test_check_services_replication():
         mock_check_service_replication.assert_called_once_with(
             instance_config=instance_config,
             all_tasks_or_pods=mock_pods,
-            smartstack_replication_checker=mock_replication_checker,
+            replication_checker=mock_replication_checker,
         )
         assert pct_under_replicated == 0

--- a/tests/test_envoy_tools.py
+++ b/tests/test_envoy_tools.py
@@ -15,7 +15,6 @@ import json
 import os
 
 import mock
-import pytest
 import requests
 
 from paasta_tools.envoy_tools import get_backends
@@ -23,16 +22,7 @@ from paasta_tools.envoy_tools import get_casper_endpoints
 from paasta_tools.envoy_tools import match_backends_and_tasks
 
 
-@pytest.fixture
-def mock_paasta_tools_settings(system_paasta_config):
-    with mock.patch(
-        "paasta_tools.envoy_tools.settings", autospec=True
-    ) as mock_settings:
-        mock_settings.system_paasta_config = system_paasta_config
-        yield
-
-
-def test_get_backends(mock_paasta_tools_settings):
+def test_get_backends():
     testdir = os.path.dirname(os.path.realpath(__file__))
     testdata = os.path.join(testdir, "envoy_admin_clusters_snapshot.txt")
     with open(testdata, "r") as fd:
@@ -52,29 +42,31 @@ def test_get_backends(mock_paasta_tools_settings):
         with mock.patch(
             "socket.gethostbyaddr", side_effect=lambda x: hosts[x], autospec=True,
         ):
-            expected = [
-                (
-                    {
-                        "address": "10.46.6.88",
-                        "port_value": 13833,
-                        "hostname": "host3",
-                        "eds_health_status": "HEALTHY",
-                        "weight": 1,
-                    },
-                    False,
-                ),
-                (
-                    {
-                        "address": "10.46.6.90",
-                        "port_value": 13833,
-                        "hostname": "host2",
-                        "eds_health_status": "HEALTHY",
-                        "weight": 1,
-                    },
-                    False,
-                ),
-            ]
-            assert expected == get_backends("service1.main", "host", 123)
+            expected = {
+                "service1.main": [
+                    (
+                        {
+                            "address": "10.46.6.88",
+                            "port_value": 13833,
+                            "hostname": "host3",
+                            "eds_health_status": "HEALTHY",
+                            "weight": 1,
+                        },
+                        False,
+                    ),
+                    (
+                        {
+                            "address": "10.46.6.90",
+                            "port_value": 13833,
+                            "hostname": "host2",
+                            "eds_health_status": "HEALTHY",
+                            "weight": 1,
+                        },
+                        False,
+                    ),
+                ]
+            }
+            assert expected == get_backends("service1.main", "host", 123, "something")
 
 
 def test_get_casper_endpoints():

--- a/tests/test_monitoring_tools.py
+++ b/tests/test_monitoring_tools.py
@@ -636,22 +636,22 @@ def instance_config():
     return mock_instance_config
 
 
-def test_check_smartstack_replication_for_instance_ok_when_expecting_zero(
-    instance_config,
-):
+def test_check_replication_for_instance_ok_when_expecting_zero(instance_config,):
     expected_replication_count = 0
     mock_smartstack_replication_checker = mock.Mock()
     mock_smartstack_replication_checker.get_replication_for_instance.return_value = {
-        "fake_region": {"test.main": 1, "test.three": 4, "test.four": 8}
+        "fake_provider": {
+            "fake_region": {"test.main": 1, "test.three": 4, "test.four": 8}
+        }
     }
 
     with mock.patch(
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
     ) as mock_send_replication_event:
-        monitoring_tools.check_smartstack_replication_for_instance(
+        monitoring_tools.check_replication_for_instance(
             instance_config=instance_config,
             expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
+            replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
@@ -660,19 +660,21 @@ def test_check_smartstack_replication_for_instance_ok_when_expecting_zero(
         )
 
 
-def test_check_smartstack_replication_for_instance_crit_when_absent(instance_config):
+def test_check_replication_for_instance_crit_when_absent(instance_config):
     expected_replication_count = 8
     mock_smartstack_replication_checker = mock.Mock()
     mock_smartstack_replication_checker.get_replication_for_instance.return_value = {
-        "fake_region": {"test.two": 1, "test.three": 4, "test.four": 8}
+        "fake_provider": {
+            "fake_region": {"test.two": 1, "test.three": 4, "test.four": 8}
+        }
     }
     with mock.patch(
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
     ) as mock_send_replication_event:
-        monitoring_tools.check_smartstack_replication_for_instance(
+        monitoring_tools.check_replication_for_instance(
             instance_config=instance_config,
             expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
+            replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
@@ -681,25 +683,25 @@ def test_check_smartstack_replication_for_instance_crit_when_absent(instance_con
         )
 
 
-def test_check_smartstack_replication_for_instance_crit_when_zero_replication(
-    instance_config,
-):
+def test_check_replication_for_instance_crit_when_zero_replication(instance_config,):
     expected_replication_count = 8
     mock_smartstack_replication_checker = mock.Mock()
     mock_smartstack_replication_checker.get_replication_for_instance.return_value = {
-        "fake_region": {
-            "fake_service.fake_instance": 0,
-            "test.main": 8,
-            "test.fully_replicated": 8,
+        "fake_provider": {
+            "fake_region": {
+                "fake_service.fake_instance": 0,
+                "test.main": 8,
+                "test.fully_replicated": 8,
+            }
         }
     }
     with mock.patch(
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
     ) as mock_send_replication_event:
-        monitoring_tools.check_smartstack_replication_for_instance(
+        monitoring_tools.check_replication_for_instance(
             instance_config=instance_config,
             expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
+            replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
@@ -722,25 +724,25 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication(
         ) in alert_output
 
 
-def test_check_smartstack_replication_for_instance_crit_when_low_replication(
-    instance_config,
-):
+def test_check_replication_for_instance_crit_when_low_replication(instance_config,):
     expected_replication_count = 8
     mock_smartstack_replication_checker = mock.Mock()
     mock_smartstack_replication_checker.get_replication_for_instance.return_value = {
-        "fake_region": {
-            "test.canary": 1,
-            "fake_service.fake_instance": 4,
-            "test.fully_replicated": 8,
+        "fake_provider": {
+            "fake_region": {
+                "test.canary": 1,
+                "fake_service.fake_instance": 4,
+                "test.fully_replicated": 8,
+            }
         }
     }
     with mock.patch(
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
     ) as mock_send_replication_event:
-        monitoring_tools.check_smartstack_replication_for_instance(
+        monitoring_tools.check_replication_for_instance(
             instance_config=instance_config,
             expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
+            replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
@@ -763,25 +765,25 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication(
         ) in alert_output
 
 
-def test_check_smartstack_replication_for_instance_ok_with_enough_replication(
-    instance_config,
-):
+def test_check_replication_for_instance_ok_with_enough_replication(instance_config,):
     expected_replication_count = 8
     mock_smartstack_replication_checker = mock.Mock()
     mock_smartstack_replication_checker.get_replication_for_instance.return_value = {
-        "fake_region": {
-            "test.canary": 1,
-            "test.low_replication": 4,
-            "fake_service.fake_instance": 8,
+        "fake_provider": {
+            "fake_region": {
+                "test.canary": 1,
+                "test.low_replication": 4,
+                "fake_service.fake_instance": 8,
+            }
         }
     }
     with mock.patch(
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
     ) as mock_send_replication_event:
-        monitoring_tools.check_smartstack_replication_for_instance(
+        monitoring_tools.check_replication_for_instance(
             instance_config=instance_config,
             expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
+            replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
@@ -791,28 +793,30 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication(
         _, send_replication_event_kwargs = mock_send_replication_event.call_args
         alert_output = send_replication_event_kwargs["output"]
         assert (
-            "{} has 8 out of 8 expected instances in fake_region (OK: 100%)".format(
+            "{} has 8 out of 8 expected instances in fake_region according to fake_provider (OK: 100%)".format(
                 instance_config.job_id
             )
         ) in alert_output
 
 
-def test_check_smartstack_replication_for_instance_ok_with_enough_replication_multilocation(
+def test_check_replication_for_instance_ok_with_enough_replication_multilocation(
     instance_config,
 ):
     expected_replication_count = 2
     mock_smartstack_replication_checker = mock.Mock()
     mock_smartstack_replication_checker.get_replication_for_instance.return_value = {
-        "fake_region": {"fake_service.fake_instance": 1},
-        "fake_other_region": {"fake_service.fake_instance": 1},
+        "fake_provider": {
+            "fake_region": {"fake_service.fake_instance": 1},
+            "fake_other_region": {"fake_service.fake_instance": 1},
+        }
     }
     with mock.patch(
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
     ) as mock_send_replication_event:
-        monitoring_tools.check_smartstack_replication_for_instance(
+        monitoring_tools.check_replication_for_instance(
             instance_config=instance_config,
             expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
+            replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
@@ -833,22 +837,24 @@ def test_check_smartstack_replication_for_instance_ok_with_enough_replication_mu
         ) in alert_output
 
 
-def test_check_smartstack_replication_for_instance_crit_when_low_replication_multilocation(
+def test_check_replication_for_instance_crit_when_low_replication_multilocation(
     instance_config,
 ):
     expected_replication_count = 2
     mock_smartstack_replication_checker = mock.Mock()
     mock_smartstack_replication_checker.get_replication_for_instance.return_value = {
-        "fake_region": {"fake_service.fake_instance": 1},
-        "fake_other_region": {"fake_service.fake_instance": 0},
+        "fake_provider": {
+            "fake_region": {"fake_service.fake_instance": 1},
+            "fake_other_region": {"fake_service.fake_instance": 0},
+        }
     }
     with mock.patch(
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
     ) as mock_send_replication_event:
-        monitoring_tools.check_smartstack_replication_for_instance(
+        monitoring_tools.check_replication_for_instance(
             instance_config=instance_config,
             expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
+            replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
@@ -876,22 +882,24 @@ def test_check_smartstack_replication_for_instance_crit_when_low_replication_mul
         ) in alert_output
 
 
-def test_check_smartstack_replication_for_instance_crit_when_zero_replication_multilocation(
+def test_check_replication_for_instance_crit_when_zero_replication_multilocation(
     instance_config,
 ):
     expected_replication_count = 2
     mock_smartstack_replication_checker = mock.Mock()
     mock_smartstack_replication_checker.get_replication_for_instance.return_value = {
-        "fake_region": {"fake_service.fake_instance": 0},
-        "fake_other_region": {"fake_service.fake_instance": 0},
+        "fake_provider": {
+            "fake_region": {"fake_service.fake_instance": 0},
+            "fake_other_region": {"fake_service.fake_instance": 0},
+        }
     }
     with mock.patch(
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
     ) as mock_send_replication_event:
-        monitoring_tools.check_smartstack_replication_for_instance(
+        monitoring_tools.check_replication_for_instance(
             instance_config=instance_config,
             expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
+            replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
@@ -919,22 +927,24 @@ def test_check_smartstack_replication_for_instance_crit_when_zero_replication_mu
         ) in alert_output
 
 
-def test_check_smartstack_replication_for_instance_crit_when_missing_replication_multilocation(
+def test_check_replication_for_instance_crit_when_missing_replication_multilocation(
     instance_config,
 ):
     expected_replication_count = 2
     mock_smartstack_replication_checker = mock.Mock()
     mock_smartstack_replication_checker.get_replication_for_instance.return_value = {
-        "fake_region": {"test.main": 0},
-        "fake_other_region": {"test.main": 0},
+        "fake_provider": {
+            "fake_region": {"test.main": 0},
+            "fake_other_region": {"test.main": 0},
+        }
     }
     with mock.patch(
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
     ) as mock_send_replication_event:
-        monitoring_tools.check_smartstack_replication_for_instance(
+        monitoring_tools.check_replication_for_instance(
             instance_config=instance_config,
             expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
+            replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
@@ -955,19 +965,19 @@ def test_check_smartstack_replication_for_instance_crit_when_missing_replication
         ) in alert_output
 
 
-def test_check_smartstack_replication_for_instance_crit_when_no_smartstack_info(
-    instance_config,
-):
+def test_check_replication_for_instance_crit_when_no_smartstack_info(instance_config,):
     expected_replication_count = 2
     mock_smartstack_replication_checker = mock.Mock()
-    mock_smartstack_replication_checker.get_replication_for_instance.return_value = {}
+    mock_smartstack_replication_checker.get_replication_for_instance.return_value = {
+        "fake_provider": {}
+    }
     with mock.patch(
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
     ) as mock_send_replication_event:
-        monitoring_tools.check_smartstack_replication_for_instance(
+        monitoring_tools.check_replication_for_instance(
             instance_config=instance_config,
             expected_count=expected_replication_count,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
+            replication_checker=mock_smartstack_replication_checker,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
@@ -977,7 +987,7 @@ def test_check_smartstack_replication_for_instance_crit_when_no_smartstack_info(
         _, send_replication_event_kwargs = mock_send_replication_event.call_args
         alert_output = send_replication_event_kwargs["output"]
         assert (
-            f"{instance_config.job_id} has no Smartstack replication info."
+            f"{instance_config.job_id} has no fake_provider replication info."
         ) in alert_output
 
 
@@ -986,11 +996,13 @@ def test_emit_replication_metrics(instance_config):
         "paasta_tools.monitoring_tools.yelp_meteorite", autospec=True
     ) as mock_yelp_meteorite:
         mock_smartstack_replication_info = {
-            "fake_region_1": {
-                "fake_service.fake_instance": 2,
-                "other_service.other_instance": 5,
-            },
-            "fake_region_2": {"fake_service.fake_instance": 4},
+            "fake_provider": {
+                "fake_region_1": {
+                    "fake_service.fake_instance": 2,
+                    "other_service.other_instance": 5,
+                },
+                "fake_region_2": {"fake_service.fake_instance": 4},
+            }
         }
         mock_gauges = {
             "paasta.service.available_backends": mock.Mock(),
@@ -1002,6 +1014,7 @@ def test_emit_replication_metrics(instance_config):
             "paasta_cluster": "fake_cluster",
             "paasta_instance": "fake_instance",
             "paasta_pool": "fake_pool",
+            "service_discovery_provider": "fake_provider",
         }
 
         mock_yelp_meteorite.create_gauge.side_effect = lambda name, dims: mock_gauges[
@@ -1023,7 +1036,7 @@ def test_emit_replication_metrics(instance_config):
         mock_gauges["paasta.service.expected_backends"].set.assert_called_once_with(10)
 
 
-def test_check_smartstack_replication_for_instance_emits_metrics(instance_config):
+def test_check_replication_for_instance_emits_metrics(instance_config):
     with mock.patch(
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
     ), mock.patch(
@@ -1033,13 +1046,13 @@ def test_check_smartstack_replication_for_instance_emits_metrics(instance_config
     ) as mock_emit_replication_metrics:
         mock_smartstack_replication_checker = mock.Mock()
         mock_smartstack_replication_checker.get_replication_for_instance.return_value = {
-            "fake_region": {"fake_service.fake_instance": 10}
+            "fake_provider": {"fake_region": {"fake_service.fake_instance": 10}}
         }
 
-        monitoring_tools.check_smartstack_replication_for_instance(
+        monitoring_tools.check_replication_for_instance(
             instance_config=instance_config,
             expected_count=10,
-            smartstack_replication_checker=mock_smartstack_replication_checker,
+            replication_checker=mock_smartstack_replication_checker,
         )
         mock_emit_replication_metrics.assert_called_once_with(
             mock_smartstack_replication_checker.get_replication_for_instance.return_value,

--- a/tests/test_smartstack_tools.py
+++ b/tests/test_smartstack_tools.py
@@ -504,8 +504,13 @@ def mock_replication_checker():
 @pytest.fixture
 def mock_kube_replication_checker():
     mock_nodes = [mock.Mock()]
+    mock_system_paasta_config = mock.Mock()
+    mock_system_paasta_config.get_service_discovery_providers.return_value = {
+        "smartstack": {},
+        "envoy": {},
+    }
     return smartstack_tools.KubeSmartstackEnvoyReplicationChecker(
-        nodes=mock_nodes, system_paasta_config=mock.Mock()
+        nodes=mock_nodes, system_paasta_config=mock_system_paasta_config,
     )
 
 

--- a/tests/test_smartstack_tools.py
+++ b/tests/test_smartstack_tools.py
@@ -19,12 +19,12 @@ import requests
 
 from paasta_tools import smartstack_tools
 from paasta_tools.smartstack_tools import backend_is_up
+from paasta_tools.smartstack_tools import DiscoveredHost
 from paasta_tools.smartstack_tools import get_registered_marathon_tasks
 from paasta_tools.smartstack_tools import get_replication_for_services
 from paasta_tools.smartstack_tools import ip_port_hostname_from_svname
 from paasta_tools.smartstack_tools import match_backends_and_pods
 from paasta_tools.smartstack_tools import match_backends_and_tasks
-from paasta_tools.smartstack_tools import SmartstackHost
 from paasta_tools.utils import DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT
 
 
@@ -340,15 +340,24 @@ def test_get_replication_for_all_services(mock_get_multiple_backends):
 
 
 @mock.patch(
+    "paasta_tools.utils.socket.getservbyname", autospec=True,
+)
+@mock.patch(
     "paasta_tools.smartstack_tools.marathon_tools.load_service_namespace_config",
     autospec=True,
 )
 @mock.patch(
     "paasta_tools.smartstack_tools.get_replication_for_all_services", autospec=True
 )
+@mock.patch(
+    "paasta_tools.smartstack_tools.envoy_tools.get_replication_for_all_services",
+    autospec=True,
+)
 def test_get_replication_for_instance_mesos(
-    mock_get_replication_for_all_services,
+    mock_envoy_tools_get_replication_for_all_services,
+    mock_smartstack_tools_get_replication_for_all_services,
     mock_load_service_namespace_config,
+    mock_socket_getservbyname,
     system_paasta_config,
 ):
     mock_mesos_slaves = [
@@ -363,20 +372,30 @@ def test_get_replication_for_instance_mesos(
     ]
     instance_config = mock.Mock(service="fake_service", instance="fake_instance")
     instance_config.get_pool.return_value = "cool_pool"
-    mock_get_replication_for_all_services.return_value = {
+    mock_smartstack_tools_get_replication_for_all_services.return_value = {
+        "fake_service.fake_instance": 20
+    }
+    mock_envoy_tools_get_replication_for_all_services.return_value = {
         "fake_service.fake_instance": 20
     }
     mock_load_service_namespace_config.return_value.get_discover.return_value = "region"
-    checker = smartstack_tools.MesosSmartstackReplicationChecker(
+    mock_socket_getservbyname.return_value = mock.Mock()
+    checker = smartstack_tools.MesosSmartstackEnvoyReplicationChecker(
         mesos_slaves=mock_mesos_slaves, system_paasta_config=system_paasta_config
     )
     assert checker.get_replication_for_instance(instance_config) == {
-        "fake_region1": {"fake_service.fake_instance": 20}
+        "Smartstack": {"fake_region1": {"fake_service.fake_instance": 20}},
+        "Envoy": {"fake_region1": {"fake_service.fake_instance": 20}},
     }
-    mock_get_replication_for_all_services.assert_called_once_with(
+    mock_smartstack_tools_get_replication_for_all_services.assert_called_once_with(
         synapse_host="host2",
         synapse_port=system_paasta_config.get_synapse_port(),
         synapse_haproxy_url_format=system_paasta_config.get_synapse_haproxy_url_format(),
+    )
+    mock_envoy_tools_get_replication_for_all_services.assert_called_once_with(
+        envoy_host="host2",
+        envoy_admin_port=system_paasta_config.get_envoy_admin_port(),
+        envoy_admin_endpoint_format=system_paasta_config.get_envoy_admin_endpoint_format(),
     )
 
 
@@ -470,16 +489,22 @@ def test_are_services_up_on_port():
 
 @pytest.fixture
 def mock_replication_checker():
-    smartstack_tools.SmartstackReplicationChecker.__abstractmethods__ = frozenset()
-    return smartstack_tools.SmartstackReplicationChecker(
-        system_paasta_config=mock.Mock()
+    smartstack_tools.BaseReplicationChecker.__abstractmethods__ = frozenset()
+    system_paasta_config = mock.Mock()
+    return smartstack_tools.BaseReplicationChecker(
+        system_paasta_config=system_paasta_config,
+        service_discovery_providers=[
+            smartstack_tools.SmartstackServiceDiscovery(
+                system_paasta_config=system_paasta_config
+            )
+        ],
     )
 
 
 @pytest.fixture
 def mock_kube_replication_checker():
     mock_nodes = [mock.Mock()]
-    return smartstack_tools.KubeSmartstackReplicationChecker(
+    return smartstack_tools.KubeSmartstackEnvoyReplicationChecker(
         nodes=mock_nodes, system_paasta_config=mock.Mock()
     )
 
@@ -514,8 +539,8 @@ def test_kube_get_allowed_locations_and_hosts(mock_kube_replication_checker):
         )
         assert ret == {
             "us-west-1": [
-                SmartstackHost(hostname="foo1", pool="default"),
-                SmartstackHost(hostname="foo2", pool="default"),
+                DiscoveredHost(hostname="foo1", pool="default"),
+                DiscoveredHost(hostname="foo2", pool="default"),
             ]
         }
 
@@ -528,13 +553,13 @@ def test_get_allowed_locations_and_hosts(mock_replication_checker):
 
 def test_get_replication_for_instance(mock_replication_checker):
     with mock.patch(
-        "paasta_tools.smartstack_tools.SmartstackReplicationChecker.get_allowed_locations_and_hosts",
+        "paasta_tools.smartstack_tools.BaseReplicationChecker.get_allowed_locations_and_hosts",
         autospec=True,
     ) as mock_get_allowed_locations_and_hosts, mock.patch(
-        "paasta_tools.smartstack_tools.SmartstackReplicationChecker.get_first_host_in_pool",
+        "paasta_tools.smartstack_tools.BaseReplicationChecker.get_first_host_in_pool",
         autospec=True,
     ) as mock_get_first_host_in_pool, mock.patch(
-        "paasta_tools.smartstack_tools.SmartstackReplicationChecker._get_replication_info",
+        "paasta_tools.smartstack_tools.BaseReplicationChecker._get_replication_info",
         autospec=True,
     ) as mock_get_replication_info:
         mock_get_allowed_locations_and_hosts.return_value = {
@@ -542,8 +567,10 @@ def test_get_replication_for_instance(mock_replication_checker):
             "middleearth-prod": [mock.Mock(), mock.Mock()],
         }
         expected = {
-            "westeros-prod": mock_get_replication_info.return_value,
-            "middleearth-prod": mock_get_replication_info.return_value,
+            "Smartstack": {
+                "westeros-prod": mock_get_replication_info.return_value,
+                "middleearth-prod": mock_get_replication_info.return_value,
+            }
         }
         assert (
             mock_replication_checker.get_replication_for_instance(mock.Mock())
@@ -567,19 +594,20 @@ def test_get_first_host_in_pool(mock_replication_checker):
 
 
 def test_get_replication_info(mock_replication_checker):
-    with mock.patch(
-        "paasta_tools.smartstack_tools.get_replication_for_all_services", autospec=True
-    ) as mock_get_replication_for_all_services:
-        mock_replication_checker._cache = {}
-        mock_instance_config = mock.Mock(service="thing", instance="main")
-        ret = mock_replication_checker._get_replication_info(
-            "westeros-prod", "host1", mock_instance_config
-        )
-        assert ret == {
-            "thing.main": mock_get_replication_for_all_services.return_value[
-                "thing.main"
-            ]
-        }
-        assert mock_replication_checker._cache == {
-            "westeros-prod": mock_get_replication_for_all_services.return_value
-        }
+    mock_replication_checker._cache = {}
+    mock_instance_config = mock.Mock(service="thing", instance="main")
+    mock_service_discovery_provider = mock.MagicMock()
+    ret = mock_replication_checker._get_replication_info(
+        "westeros-prod", "host1", mock_instance_config, mock_service_discovery_provider
+    )
+    assert ret == {
+        "thing.main": mock_service_discovery_provider.get_replication_for_all_services.return_value[
+            "thing.main"
+        ]
+    }
+    assert mock_replication_checker._cache == {
+        (
+            "westeros-prod",
+            mock_service_discovery_provider.NAME,
+        ): mock_service_discovery_provider.get_replication_for_all_services.return_value
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2532,7 +2532,7 @@ def test_timed_flock_inner_timeout_ok(mock_flock, tmpdir):
     my_file = tmpdir.join("my-file")
     with open(str(my_file), "w") as f:
         with utils.timed_flock(f, seconds=1):
-            time.true_slow_sleep(0.1)
+            time.true_slow_sleep(0.1)  # type: ignore
         assert mock_flock.mock_calls == [
             mock.call(f.fileno(), utils.fcntl.LOCK_EX),
             mock.call(f.fileno(), utils.fcntl.LOCK_UN),


### PR DESCRIPTION
In addition to getting replication information from Smartstack, get the
same information from Envoy, and use both of them to send notifications
about underreplicated services.

While here I also cleaned up some `mypy` stuff.