### PR TITLE
Print instance name in lighter blue so it's easier to read

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -237,7 +237,7 @@ def paasta_status_on_api_endpoint(
     system_paasta_config: SystemPaastaConfig,
     verbose: int,
 ) -> int:
-    output.append("    instance: %s" % PaastaColors.blue(instance))
+    output.append("    instance: %s" % PaastaColors.cyan(instance))
     client = get_paasta_api_client(cluster, system_paasta_config)
     if not client:
         print("Cannot get a paasta-api client")


### PR DESCRIPTION
Trivial change for PAASTA-16917: the dark blue text is pretty difficult to read, cyan is easier.

Before:
![Screenshot 2020-08-14 at 17 40 48](https://user-images.githubusercontent.com/1771291/90273283-a11ff000-de56-11ea-8205-e3a4965af040.png)

After:
![Screenshot 2020-08-14 at 17 40 30](https://user-images.githubusercontent.com/1771291/90273300-a846fe00-de56-11ea-83b4-decabaf00c5f.png)

`make test` and `make acceptance` pass. Tested on Mesos and k8s services.