### PR TITLE
MESH-857 Pod readiness checks supporting Envoy / Smartstack

### DIFF
--- a/paasta_tools/contrib/is_pod_healthy_in_proxy.py
+++ b/paasta_tools/contrib/is_pod_healthy_in_proxy.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# Copyright 2015-2018 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import os
+import sys
+
+from paasta_tools.envoy_tools import are_services_up_in_pod as is_envoy_ready
+from paasta_tools.smartstack_tools import (
+    are_services_up_on_ip_port as is_smartstack_ready,
+)
+from paasta_tools.utils import load_system_paasta_config
+
+
+system_paasta_config = load_system_paasta_config()
+
+synapse_port = system_paasta_config.get_synapse_port()
+synapse_host = "169.254.255.254"
+synapse_haproxy_url_format = system_paasta_config.get_synapse_haproxy_url_format()
+
+envoy_host = os.environ["PAASTA_HOST"]
+envoy_admin_port = system_paasta_config.get_envoy_admin_port()
+envoy_admin_endpoint_format = system_paasta_config.get_envoy_admin_endpoint_format()
+pod_ip = os.environ["PAASTA_POD_IP"]
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--enable-smartstack",
+        dest="smartstack_readiness_check_enabled",
+        action="store_true",
+        help="Check smartstack readiness",
+    )
+
+    parser.add_argument(
+        "--enable-envoy",
+        action="store_true",
+        dest="envoy_readiness_check_enabled",
+        help="Check envoy readiness",
+    )
+
+    parser.add_argument(
+        "pod_port", help="Pod Port", type=int,
+    )
+
+    parser.add_argument(
+        "services", nargs="+", help="List of service.instance names",
+    )
+
+    return parser
+
+
+def main() -> None:
+    args = get_parser().parse_args()
+
+    if args.smartstack_readiness_check_enabled:
+        smartstack_ready = is_smartstack_ready(
+            synapse_host=synapse_host,
+            synapse_port=synapse_port,
+            synapse_haproxy_url_format=synapse_haproxy_url_format,
+            services=args.services,
+            host_ip=pod_ip,
+            host_port=args.pod_port,
+        )
+    else:
+        smartstack_ready = True
+
+    if args.envoy_readiness_check_enabled:
+        envoy_ready = is_envoy_ready(
+            envoy_host=envoy_host,
+            envoy_admin_port=envoy_admin_port,
+            envoy_admin_endpoint_format=envoy_admin_endpoint_format,
+            registrations=args.services,
+            pod_ip=pod_ip,
+            pod_port=args.pod_port,
+        )
+    else:
+        envoy_ready = True
+
+    if smartstack_ready and envoy_ready:
+        sys.exit(0)
+    else:
+        if not smartstack_ready:
+            print(
+                f"Could not find backend {pod_ip}:{args.pod_port} for service {args.services} "
+                f"on Haproxy at {synapse_host}:{synapse_port}"
+            )
+        if not envoy_ready:
+            print(
+                f"Could not find backend {pod_ip}:{args.pod_port} for service {args.services} "
+                f"on Envoy at {envoy_host}:{envoy_admin_port}"
+            )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1826,9 +1826,12 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     docker_registry: str
     enable_client_cert_auth: bool
     enable_nerve_readiness_check: bool
+    enable_envoy_readiness_check: bool
     enforce_disk_quota: bool
     envoy_admin_domain_name: str
     envoy_admin_endpoint_format: str
+    envoy_nerve_readiness_check_script: str
+    envoy_readiness_check_script: str
     expected_slave_attributes: ExpectedSlaveAttributes
     filter_bogus_mesos_cputime_enabled: bool
     fsm_template: str
@@ -2031,6 +2034,34 @@ class SystemPaastaConfig:
         If enabled present a client certificate from ~/.paasta/pki/<cluster>.crt and ~/.paasta/pki/<cluster>.key
         """
         return self.config_dict.get("enable_client_cert_auth", True)
+
+    def get_enable_nerve_readiness_check(self) -> bool:
+        """
+        If enabled perform readiness checks on nerve
+        """
+        return self.config_dict.get("enable_nerve_readiness_check", True)
+
+    def get_enable_envoy_readiness_check(self) -> bool:
+        """
+        If enabled perform readiness checks on envoy
+        """
+        return self.config_dict.get("enable_envoy_readiness_check", False)
+
+    def get_nerve_readiness_check_script(self) -> str:
+        return self.config_dict.get(
+            "nerve_readiness_check_script", "/check_smartstack_up.sh"
+        )
+
+    def get_envoy_readiness_check_script(self) -> str:
+        return self.config_dict.get(
+            "envoy_readiness_check_script", "/check_proxy_up.sh --enable-envoy"
+        )
+
+    def get_envoy_nerve_readiness_check_script(self) -> str:
+        return self.config_dict.get(
+            "envoy_nerve_readiness_check_script",
+            "/check_proxy_up.sh --enable-smartstack --enable-envoy",
+        )
 
     def get_enforce_disk_quota(self) -> bool:
         """
@@ -2354,12 +2385,6 @@ class SystemPaastaConfig:
     def get_register_native_services(self) -> bool:
         """Enable registration of native paasta services in nerve"""
         return self.config_dict.get("register_native_services", False)
-
-    def get_nerve_readiness_check_script(self) -> str:
-        """Script to check service is up in smartstack"""
-        return self.config_dict.get(
-            "nerve_readiness_check_script", "/check_smartstack_up.sh"
-        )
 
     def get_taskproc(self) -> Dict:
         return self.config_dict.get("taskproc", {})

--- a/yelp_package/dockerfiles/hacheck-sidecar/Dockerfile
+++ b/yelp_package/dockerfiles/hacheck-sidecar/Dockerfile
@@ -3,9 +3,10 @@ FROM docker-dev.yelpcorp.com/xenial_yelp
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
 
-RUN apt-get update && apt-get install -y hacheck python paasta-tools=0.81.14-yelp1
+RUN apt-get update && apt-get install -y hacheck python paasta-tools
 RUN mkdir -p /etc/paasta
 ADD ./check_smartstack_up.sh /check_smartstack_up.sh
+ADD ./check_proxy_up.sh /check_proxy_up.sh
 ADD ./hacheck.conf.yaml /etc/hacheck.conf.yaml
 ENTRYPOINT ["/usr/bin/hacheck"]
 CMD ["-p", "6666", "-c", "/etc/hacheck.conf.yaml", "--spool-root", "/var/spool/hacheck"]

--- a/yelp_package/dockerfiles/hacheck-sidecar/check_proxy_up.sh
+++ b/yelp_package/dockerfiles/hacheck-sidecar/check_proxy_up.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+if [ -f /var/ready ]; then
+	exit 0
+else
+	/opt/venvs/paasta-tools/bin/is_pod_healthy_in_proxy.py $@ && touch /var/ready
+	exit $?
+fi


### PR DESCRIPTION
Adds a new pod readiness script (`/check_proxy_up.sh`) that supports both Envoy and Smartstack.

For now, this readiness script won't be enabled on any service, meaning that we won't have any bounces after merging.

To enable the new readiness check on a single service, we can add the following to yelpsoa-configs (`KubernetesDeploymentConfigDict`):
```
bounce_health_params:
  check_envoy
```
`check_haproxy` can be set as well to check smartstack (and can coexist with `check_envoy`).

To enable the new readiness check on every service, the following param can be added to `SystemPaastaConfigDict`
```
enable_envoy_readiness_check: true
```
`enable_nerve_readiness_check` can be set as well to check smartstack (and can coexist with `enable_envoy_readiness_check`)

### Tests:
- Multiple manual tests on a k8s node:
```
# PAASTA_HOST="XXXXXXXX" PAASTA_POD_IP=YYYYYY python paasta_tools/contrib/is_pod_healthy_in_proxy.py --enable-smartstack --enable-envoy 8888 [service].[instance1] [service].[instance2] [service].[instance3]
UserWarning: clog is unavailable
  warnings.warn("clog is unavailable")
# echo $?
0
``` 
- Built paasta_tools and rolled it out to kubestage.
  - No bounces detected
  - New deployments still use /check_smartstack_up.sh as expected 

Note: At some point after making a new paasta-tools release (and before using the new readiness check on any service), I'll have to update the hacheck-sidecar docker image to get the latest paasta-tools pkg and the new check script.