### PR TITLE
improve healthcheck_grace_period_seconds docs

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -391,9 +391,9 @@ instance MAY have:
     is treated as a failure. This is a required field if ``healthcheck_mode``
     is ``cmd``.
 
-  * ``healthcheck_grace_period_seconds``: Kubernetes will wait this long for a
-    service to come up before counting failed healthchecks. Defaults to 60
-    seconds.
+  * ``healthcheck_grace_period_seconds``: Kubernetes will wait this long
+    after the container has started before liveness or readiness probes are
+    initiated. Defaults to 60 seconds.
 
   * ``healthcheck_interval_seconds``: Kubernetes will wait this long between
     healthchecks. Defaults to 10 seconds.

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -228,7 +228,12 @@ class LongRunningServiceConfig(InstanceConfig):
             return cmd
 
     def get_healthcheck_grace_period_seconds(self) -> float:
-        """How long Marathon should give a service to come up before counting failed healthchecks."""
+        """
+        Grace periods indicate different things on kubernetes/marathon: on
+        marathon, it indicates how long marathon will tolerate failing
+        healthchecks; on kubernetes, how long before kubernetes will start
+        sending healthcheck and liveness probes.
+        """
         return self.config_dict.get("healthcheck_grace_period_seconds", 60)
 
     def get_healthcheck_interval_seconds(self) -> float:


### PR DESCRIPTION
there are subtle differences in what this field means for k8s and
marathon.