### PR TITLE
MESH-857 Adds volume_mounts to the hacheck sidecar container

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -874,11 +874,7 @@ class InstanceConfig:
 
     def get_volumes(self, system_volumes: Sequence[DockerVolume]) -> List[DockerVolume]:
         volumes = list(system_volumes) + list(self.get_extra_volumes())
-        deduped = {
-            v["containerPath"].rstrip("/") + v["hostPath"].rstrip("/"): v
-            for v in volumes
-        }.values()
-        return sort_dicts(deduped)
+        return _reorder_docker_volumes(volumes)
 
     def get_persistent_volumes(self) -> Sequence[PersistentVolume]:
         return self.config_dict.get("persistent_volumes", [])
@@ -1836,6 +1832,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     filter_bogus_mesos_cputime_enabled: bool
     fsm_template: str
     hacheck_sidecar_image_url: str
+    hacheck_sidecar_volumes: List[DockerVolume]
     kubernetes_custom_resources: List[KubeCustomResourceDict]
     kubernetes_use_hacheck_sidecar: bool
     ldap_host: str
@@ -1985,6 +1982,20 @@ class SystemPaastaConfig:
                 "Could not find docker registry in configuration directory: %s"
                 % self.directory
             )
+
+    def get_hacheck_sidecar_volumes(self) -> List[DockerVolume]:
+        """Get the hacheck sidecar volumes defined in this host's hacheck_sidecar_volumes config file.
+
+        :returns: The list of volumes specified in the paasta configuration
+        """
+        try:
+            volumes = self.config_dict["hacheck_sidecar_volumes"]
+        except KeyError:
+            raise PaastaNotConfiguredError(
+                "Could not find hacheck_sidecar_volumes in configuration directory: %s"
+                % self.directory
+            )
+        return _reorder_docker_volumes(list(volumes))
 
     def get_volumes(self) -> Sequence[DockerVolume]:
         """Get the volumes defined in this host's volumes config file.
@@ -3633,3 +3644,10 @@ def ldap_user_search(
         time_limit=10,
     )
     return {entry["attributes"]["sAMAccountName"] for entry in entries}
+
+
+def _reorder_docker_volumes(volumes: List[DockerVolume]) -> List[DockerVolume]:
+    deduped = {
+        v["containerPath"].rstrip("/") + v["hostPath"].rstrip("/"): v for v in volumes
+    }.values()
+    return sort_dicts(deduped)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -420,6 +420,22 @@ def test_SystemPaastaConfig_get_volumes():
     assert actual == expected
 
 
+def test_SystemPaastaConfig_get_hacheck_sidecar_volumes():
+    fake_config = utils.SystemPaastaConfig(
+        {
+            "hacheck_sidecar_volumes": [
+                {"hostPath": "fake_other_path", "containerPath": "/blurp", "mode": "ro"}
+            ]
+        },
+        "/some/fake/dir",
+    )
+    expected = [
+        {"hostPath": "fake_other_path", "containerPath": "/blurp", "mode": "ro"}
+    ]
+    actual = fake_config.get_hacheck_sidecar_volumes()
+    assert actual == expected
+
+
 def test_SystemPaastaConfig_get_volumes_dne():
     fake_config = utils.SystemPaastaConfig({}, "/some/fake/dir")
     with raises(utils.PaastaNotConfiguredError):


### PR DESCRIPTION
Add the `hacheck_sidecar_volumes` paasta config key to mount volumes into the hacheck sidecar container:
Eg:
```
$ cat /etc/paasta/hacheck_sidecar_volumes.json
{
  "hacheck_sidecar_volumes": [
    {
      "hostPath": "/etc/services",
      "containerPath": "/etc/services",
      "mode": "RO"
    }
  ]
}
```
I did this independently from the existing `volumes` key as it might not be a good idea to mount every volume on that list into the sidecar container.

We need this feature so we can mount `/etc/services` into the hacheck-sidecar container. Without this file present, [get_envoy_admin_port()](https://github.com/Yelp/paasta/blob/22a35e16672d1afbf20a3c09cd90de4db59e5241/paasta_tools/utils.py#L2428) doesn't work.

Note that this change will bounce every service.

### Tests:
- Manually deployed the config file `/etc/paasta/hacheck_sidecar_volumes.json` in to the kubestage k8s masters
- Manually built and installed paasta-tools into kubestage
- All the services under the paasta namespace bounced as expected
- the hacheck sidecar container now has /etc/services mounted:
```
$ kubectl-kubestage describe pod XXXXXXXXXX -n paasta
    Mounts:
      /etc/services from host--slash-etcslash-services (ro)
    Mounts:
      /etc/services from host--slash-etcslash-services (ro)
```