### PR TITLE
Use service-configuration-lib 2.4.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -90,7 +90,7 @@ rsa==3.4.2
 ruamel.yaml==0.15.96
 s3transfer==0.1.13
 sensu-plugin==0.3.1
-service-configuration-lib==2.4.6
+service-configuration-lib==2.4.7
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0


### PR DESCRIPTION
### Description
This is to have `paasta validate` pick up a fix from [this PR](https://github.com/Yelp/service_configuration_lib/pull/53). 

### Testing done
manual testing that errors related to `eventLog.dir` seen in the previous version of `service_configuration_lib` are gone