### PR TITLE
Filter disabled users via user account control flags

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -3623,7 +3623,7 @@ def ldap_user_search(
     )
     conn.bind()
 
-    search_filter = f"(memberOf=CN={cn},{search_ou})"
+    search_filter = f"(&(memberOf=CN={cn},{search_ou})(!(userAccountControl=514)))"
     entries = conn.extend.standard.paged_search(
         search_base=search_base,
         search_scope=ldap3.SUBTREE,


### PR DESCRIPTION
Not entirely happy with this filter, but I can't find a better place to put this currently.

This covers an implementation-specific edge case for user access control. Displaying this in the public repository does not reveal terribly much (this isn't Yelp-specific; it's a standard described [here](https://support.microsoft.com/en-us/help/305144/how-to-use-useraccountcontrol-to-manipulate-user-account-properties)), but I don't like making this part of the hardcoded portion of the LDAP query, nor recommend open source users adopt this particular user access strategy for all LDAP services.

I'm open to suggestions on how to templatize this better (eg, making this part of the config, or providing a more generic template for the filter). In the meantime, this isn't especially urgent, and will work if we desire to use it.