### PR TITLE
Separate git server from primary server in git config

### DIFF
--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -1125,7 +1125,7 @@ def trigger_deploys(
     if not system_config:
         system_config = load_system_paasta_config()
     server = system_config.get_git_repo_config("yelpsoa-configs").get(
-        "git_server", DEFAULT_SOA_CONFIGS_GIT_URL,
+        "deploy_server", DEFAULT_SOA_CONFIGS_GIT_URL,
     )
 
     client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2493,6 +2493,7 @@ class SystemPaastaConfig:
                     "yelpsoa-configs": {
                         "repo_name": "yelpsoa-configs",
                         "git_server": DEFAULT_SOA_CONFIGS_GIT_URL,
+                        "deploy_server": DEFAULT_SOA_CONFIGS_GIT_URL,
                     },
                 },
             },

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -587,23 +587,35 @@ def test_SystemPaastaConfig_get_deployd_log_level():
 
 
 @pytest.mark.parametrize(
-    "config,expected_server",
+    "config,expected_git,expected_primary",
     [
-        ({}, "sysgit.yelpcorp.com"),
+        ({}, "sysgit.yelpcorp.com", "sysgit.yelpcorp.com"),
         (
-            {"git_config": {"repos": {"yelpsoa-configs": {"git_server": "a_server"}}}},
+            {
+                "git_config": {
+                    "repos": {
+                        "yelpsoa-configs": {
+                            "git_server": "a_server",
+                            "deploy_server": "b_server",
+                        },
+                    },
+                },
+            },
             "a_server",
+            "b_server",
         ),
     ],
 )
-def test_SystemPaastaConfig_get_git_config(config, expected_server):
+def test_SystemPaastaConfig_get_git_config(config, expected_git, expected_primary):
     fake_config = utils.SystemPaastaConfig(config, "/some/fake/dir")
 
     actual_git = fake_config.get_git_config()
     actual_repo = fake_config.get_git_repo_config("yelpsoa-configs")
 
-    assert actual_git["repos"]["yelpsoa-configs"]["git_server"] == expected_server
-    assert actual_repo["git_server"] == expected_server
+    assert actual_git["repos"]["yelpsoa-configs"]["git_server"] == expected_git
+    assert actual_repo["git_server"] == expected_git
+    assert actual_git["repos"]["yelpsoa-configs"]["deploy_server"] == expected_primary
+    assert actual_repo["deploy_server"] == expected_primary
 
 
 @pytest.yield_fixture


### PR DESCRIPTION
### Description
I realized when trying to make a git config file that the server we trigger deploys on and the server clone soa-configs from will be different, but are the same right now. So, the two need different keys in the git config.

### Testing done
`make test`