### PR TITLE
Fix pip fails to retry after network errors

### DIFF
--- a/yelp_package/dockerfiles/bionic/Dockerfile
+++ b/yelp_package/dockerfiles/bionic/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update > /dev/null && \
         zsh > /dev/null \
     && rm -rf /var/lib/apt/lists/*
 
+RUN python -m pip install --upgrade pip==20.0.2
 RUN pip install virtualenv==16.0.0
 RUN cd /tmp && \
     wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \

--- a/yelp_package/dockerfiles/mesos-paasta/Dockerfile
+++ b/yelp_package/dockerfiles/mesos-paasta/Dockerfile
@@ -20,6 +20,7 @@ RUN ln -s /etc/mesos-slave-secret /nail/etc/mesos-slave-secret
 RUN ln -s /etc/paasta/mesos-cli.json /nail/etc/mesos-cli.json
 
 ADD requirements.txt requirements-dev.txt requirements-bootstrap.txt /paasta/
+RUN python -m pip install --upgrade pip==20.0.2
 RUN pip install virtualenv==15.1.0
 RUN virtualenv /venv -ppython3.6
 ENV PATH=/venv/bin:$PATH

--- a/yelp_package/dockerfiles/trusty/Dockerfile
+++ b/yelp_package/dockerfiles/trusty/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update && cd /tmp && \
     gdebi -n dh-virtualenv*.deb && \
     rm dh-virtualenv_*.deb
 
+RUN python -m pip install --upgrade pip==20.0.2
 RUN pip install virtualenv==15.1.0 tox-pip-extensions==1.2.1 tox==3.1.3
 
 ADD mesos-slave-secret /etc/mesos-slave-secret

--- a/yelp_package/dockerfiles/xenial/Dockerfile
+++ b/yelp_package/dockerfiles/xenial/Dockerfile
@@ -52,6 +52,7 @@ RUN cd /tmp && \
 ADD mesos-slave-secret /etc/mesos-slave-secret
 
 COPY requirements.txt requirements.txt
+RUN python -m pip install --upgrade pip==20.0.2
 RUN pip install virtualenv==16.7.7
 RUN virtualenv --python=python3.6 venv && venv/bin/pip install -r requirements.txt
 


### PR DESCRIPTION
Ubuntu `python-pip` package contains an ancient version of `pip`, which
fails to retry after network error with the following message:
```
  File
  "/venv/share/python-wheels/urllib3-1.13.1-py2.py3-none-any.whl/urllib3/util/retry.py",
  line 228, in increment
      total -= 1
      TypeError: unsupported operand type(s) for -=: 'Retry' and 'int'
```

As a result, most of our Travis jobs fail on initial runs and need several manual retries.

This PR fixes that by upgrading `pip` to a more recent version.

## Testing
Run Travis tests a couple of times with no failures, see https://travis-ci.org/github/Yelp/paasta/builds/720948239 and https://travis-ci.org/github/Yelp/paasta/builds/720955289