### PR TITLE
MESH-857 Fix hacheck-sidecar command path

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -726,7 +726,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
     def get_readiness_check_script(
         self, system_paasta_config: SystemPaastaConfig
-    ) -> str:
+    ) -> List[str]:
         """Script to check if a service is up in smartstack / envoy"""
         enable_envoy_check = self.get_enable_envoy_readiness_check(system_paasta_config)
         enable_nerve_check = self.get_enable_nerve_readiness_check(system_paasta_config)
@@ -753,10 +753,8 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         ):
             readiness_probe = V1Probe(
                 _exec=V1ExecAction(
-                    command=[
-                        self.get_readiness_check_script(system_paasta_config),
-                        str(self.get_container_port()),
-                    ]
+                    command=self.get_readiness_check_script(system_paasta_config)
+                    + [str(self.get_container_port())]
                     + self.get_registrations()
                 ),
                 initial_delay_seconds=10,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1835,8 +1835,8 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     enforce_disk_quota: bool
     envoy_admin_domain_name: str
     envoy_admin_endpoint_format: str
-    envoy_nerve_readiness_check_script: str
-    envoy_readiness_check_script: str
+    envoy_nerve_readiness_check_script: List[str]
+    envoy_readiness_check_script: List[str]
     expected_slave_attributes: ExpectedSlaveAttributes
     filter_bogus_mesos_cputime_enabled: bool
     fsm_template: str
@@ -1858,7 +1858,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     mesos_config: Dict
     metrics_provider: str
     monitoring_config: Dict
-    nerve_readiness_check_script: str
+    nerve_readiness_check_script: List[str]
     paasta_native: PaastaNativeConfig
     pdb_max_unavailable: Union[str, int]
     pki_backend: str
@@ -2068,20 +2068,20 @@ class SystemPaastaConfig:
         """
         return self.config_dict.get("enable_envoy_readiness_check", False)
 
-    def get_nerve_readiness_check_script(self) -> str:
+    def get_nerve_readiness_check_script(self) -> List[str]:
         return self.config_dict.get(
-            "nerve_readiness_check_script", "/check_smartstack_up.sh"
+            "nerve_readiness_check_script", ["/check_smartstack_up.sh"]
         )
 
-    def get_envoy_readiness_check_script(self) -> str:
+    def get_envoy_readiness_check_script(self) -> List[str]:
         return self.config_dict.get(
-            "envoy_readiness_check_script", "/check_proxy_up.sh --enable-envoy"
+            "envoy_readiness_check_script", ["/check_proxy_up.sh", "--enable-envoy"]
         )
 
-    def get_envoy_nerve_readiness_check_script(self) -> str:
+    def get_envoy_nerve_readiness_check_script(self) -> List[str]:
         return self.config_dict.get(
             "envoy_nerve_readiness_check_script",
-            "/check_proxy_up.sh --enable-smartstack --enable-envoy",
+            ["/check_proxy_up.sh", "--enable-smartstack", "--enable-envoy"],
         )
 
     def get_enforce_disk_quota(self) -> bool:

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -398,9 +398,13 @@ class TestKubernetesDeploymentConfig:
     @pytest.mark.parametrize(
         "enable_envoy_check, enable_nerve_check, expected_cmd",
         [
-            (True, True, "/check_proxy_up.sh --enable-smartstack --enable-envoy"),
-            (True, False, "/check_proxy_up.sh --enable-envoy"),
-            (False, True, "/check_smartstack_up.sh"),
+            (
+                True,
+                True,
+                ["/check_proxy_up.sh", "--enable-smartstack", "--enable-envoy"],
+            ),
+            (True, False, ["/check_proxy_up.sh", "--enable-envoy"]),
+            (False, True, ["/check_smartstack_up.sh"]),
         ],
     )
     def test_get_readiness_check_script(
@@ -445,7 +449,7 @@ class TestKubernetesDeploymentConfig:
         ), mock.patch(
             "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_readiness_check_script",
             autospec=True,
-            return_value="/nail/blah.sh",
+            return_value=["/nail/blah.sh"],
         ):
             mock_system_config = mock.Mock(
                 get_hacheck_sidecar_image_url=mock.Mock(


### PR DESCRIPTION
`get_readiness_check_script()` and `get_envoy_nerve_readiness_check_script()` will return a string such as `/check_proxy_up.sh --enable-smartstack --enable-envoy` instead of returning a List of arguments (which is what V1ExecAction expects).

This triggers the following errors when enabling Envoy readiness checks:
```
  Warning  Unhealthy  60s (x29 over 5m40s)  kubelet, ip-10-114-45-230.us-west-1.compute.internal  Readiness probe failed: OCI runtime exec failed: exec failed: container_linux.go:346: starting container process caused "exec: \"/check_proxy_up.sh --enable-smartstack --enable-envoy\": stat /check_proxy_up.sh --enable-smartstack --enable-envoy: no such file or directory": unknown
```

So I'm amending the command passed to V1ExecAction, providing each argument as a list item.
Note that this isn't affecting any service as Envoy readiness checks are currently disabled.

### Tests:
- Manually built and installed a new paasta-tools version on kubestage
- No services where bounced as expected
- Enabling envoy checks don't produce the error mentioned above anymore, and the hacheck sidecar gets to the 'ready' status
- Tested this while enabling envoy checks, smartstack checks, and both checks at the same time on a single service.