### PR TITLE
Fix check_orphans.py to handle k8s instances

### DIFF
--- a/paasta_tools/contrib/check_orphans.py
+++ b/paasta_tools/contrib/check_orphans.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 import argparse
 import asyncio
+import functools
 import json
 import logging
 import os.path
+import re
+import socket
 import sys
 from collections import defaultdict
 from enum import Enum
@@ -71,6 +74,10 @@ def get_zk_data(ignored_services: Set[str]) -> SmartstackData:
 
 
 class InstanceTuple(NamedTuple):
+    # paasta_host may be different from the service's host if running on k8s.
+    # We need the actual PaaSTA host because the k8s pod does not listen for
+    # xinetd connections.
+    paasta_host: str
     host: str
     port: int
     service: str
@@ -78,10 +85,39 @@ class InstanceTuple(NamedTuple):
 
 def read_from_zk_data(registrations: SmartstackData) -> Set[InstanceTuple]:
     return {
-        InstanceTuple(instance_data["host"], instance_data["port"], service)
+        InstanceTuple(
+            host_to_ip(instance_data["name"], instance_data["host"]),
+            instance_data["host"],
+            instance_data["port"],
+            service,
+        )
         for service, instance in registrations.items()
         for instance_data in instance.values()
     }
+
+
+@functools.lru_cache()
+def host_to_ip(host: str, fallback: str) -> str:
+    """Try to resolve a host to an IP with a fallback.
+
+    Because DNS resolution is relatively slow and can't be easily performed
+    using asyncio, we cheat a little and use a regex for well-formed hostnames
+    to try to guess the IP without doing real resolution.
+
+    A fallback is needed because in some cases the nerve registration does not
+    match an actual hostname (e.g. "prod-db15" or "prod-splunk-master").
+    """
+    for match in (
+        re.match(r"^(\d+)-(\d+)-(\d+)-(\d+)-", host),
+        re.match(r"^ip-(\d+)-(\d+)-(\d+)-(\d+)", host),
+    ):
+        if match:
+            return ".".join(match.groups())
+    else:
+        try:
+            return socket.gethostbyname(host)
+        except socket.gaierror:
+            return fallback
 
 
 async def transfer_one_file(
@@ -93,8 +129,8 @@ async def transfer_one_file(
             asyncio.open_connection(host=host, port=port, limit=2 ** 32), timeout=1.0
         )
         resp = await asyncio.wait_for(reader.read(), timeout=1.0)
-    except (asyncio.TimeoutError, ConnectionRefusedError):
-        logger.warning(f"error getting file from {host}")
+    except (asyncio.TimeoutError, ConnectionRefusedError) as ex:
+        logger.warning(f"error getting file from {host}: {ex!r}")
         return (host, None)
 
     return (host, resp.decode())
@@ -113,12 +149,20 @@ async def gather_files(hosts: Set[str]) -> Dict[str, str]:
 
 
 def read_one_nerve_file(nerve_config: str) -> Set[InstanceTuple]:
-    services = json.loads(nerve_config)["services"]
+    nerve_config = json.loads(nerve_config)
     return {
         InstanceTuple(
-            service["host"], service["port"], service["zk_path"][len(PREFIX) :]
+            # The "instance_id" configured in nerve's config file is the same
+            # as the "name" attribute in a zookeeper registration (i.e. for
+            # PaaSTA hosts, it will be the hostname of the machine running
+            # nerve). To be able to easily compare the tuples using set
+            # operations, we resolve it to an IP in both places.
+            host_to_ip(nerve_config["instance_id"], service["host"]),
+            service["host"],
+            service["port"],
+            service["zk_path"][len(PREFIX) :],
         )
-        for service in services.values()
+        for service in nerve_config["services"].values()
         if service["zk_path"].startswith(PREFIX)
     }
 


### PR DESCRIPTION
k8s instances have their own IP address and always run on port 8888; we can't use the instance's IP to talk to the host's xinetd anymore to find its nerve registrations.

Instead, we use the `name` field from the nerve registration, which for PaaSTA instances is the hostname of the PaaSTA host which we can use to fetch the configured nerve registrations. This is the same as the `instance_id` in the nerve config.

After this change, the number of hosts which fail to fetch registrations drops from 1658 to 32 (all timeout errors). I spot-checked a bunch of those and confirmed that it is checking the right IP, but that those hosts aren't running xinetd because they are not PaaSTA hosts at all (just some other host type using nerve for service discovery).

Note that I had to introduce DNS resolution because we don't put the host IP in the zookeeper registration, only its name. This seems like the pragmatic approach for now as opposed to a larger change to service registration.

I tested this on prod, stagef, stageg, and devc. It discovered a few orphans on stageg which I confirmed were real problems and which aren't being caught with the current (master) version of the script.