### PR TITLE
Update Spark Run To Work with Session Token and Credential Process

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -672,20 +672,12 @@ def configure_and_run_docker_container(
     spark_ui_port = pick_random_port(args.service + str(os.getpid()))
     spark_app_name = get_spark_app_name(original_docker_cmd, spark_ui_port)
 
-    command = f"echo 'hola\n'"
-    retcode, _ = _run(command, stream=True)
-    # Uncomment this code to update the credentials file to define the session token/key/id inline
-    # command = f"aws-okta -a Dev -r read-only -k --session-duration 900"
-    # retcode, _ = _run(command, stream=True)
-
     access_key, secret_key, session_token = get_aws_credentials(
         service=args.service,
         no_aws_credentials=args.no_aws_credentials,
         aws_credentials_yaml=args.aws_credentials_yaml,
         profile_name=args.aws_profile,
     )
-    # Debuging access key so I can see which profile is used
-    print('>>>>>' + access_key + "<<<<<<\n")
     spark_config_dict = get_spark_config(
         args=args,
         spark_app_name=spark_app_name,

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -429,9 +429,7 @@ def get_spark_config(
     }
 
     default_event_log_dir = get_default_event_log_dir(
-        access_key=access_key,
-        secret_key=secret_key,
-        session_token=session_token,
+        access_key=access_key, secret_key=secret_key, session_token=session_token,
     )
     if default_event_log_dir is not None:
         user_args["spark.eventLog.enabled"] = "true"

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -71,7 +71,6 @@ def get_aws_credentials(
                 )
             )
 
-    
     creds = Session(profile_name=profile_name).get_credentials()
     return (
         creds.access_key,
@@ -82,9 +81,13 @@ def get_aws_credentials(
 
 def get_default_event_log_dir(**kwargs) -> str:
     if "access_key" not in kwargs or "secret_key" not in kwargs:
-        access_key, secret_key, session_token  = get_aws_credentials(**kwargs)
+        access_key, secret_key, session_token = get_aws_credentials(**kwargs)
     else:
-        access_key, secret_key, session_token = kwargs["access_key"], kwargs["secret_key"], kwargs.get("session_token", None)
+        access_key, secret_key, session_token = (
+            kwargs["access_key"],
+            kwargs["secret_key"],
+            kwargs.get("session_token", None),
+        )
     if access_key is None:
         log.warning(
             "Since no AWS credentials were provided, spark event logging "
@@ -101,12 +104,16 @@ def get_default_event_log_dir(**kwargs) -> str:
         spark_run_conf = {}
 
     try:
-        account_id = boto3.client(
-            "sts",
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-            aws_session_token=session_token,
-        ).get_caller_identity().get("Account")
+        account_id = (
+            boto3.client(
+                "sts",
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+                aws_session_token=session_token,
+            )
+            .get_caller_identity()
+            .get("Account")
+        )
     except Exception as e:
         log.warning("Failed to identify account ID, error: {}".format(str(e)))
         return None

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -81,7 +81,10 @@ def get_aws_credentials(
 
 
 def get_default_event_log_dir(**kwargs) -> str:
-    access_key, secret_key, session_token = kwargs["access_key"], kwargs["secret_key"], kwargs["session_token"]
+    if "access_key" not in kwargs or "secret_key" not in kwargs:
+        access_key, secret_key, session_token  = get_aws_credentials(**kwargs)
+    else:
+        access_key, secret_key, session_token = kwargs["access_key"], kwargs["secret_key"], kwargs.get("session_token", None)
     if access_key is None:
         log.warning(
             "Since no AWS credentials were provided, spark event logging "

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -101,7 +101,7 @@ def get_default_event_log_dir(**kwargs) -> str:
         spark_run_conf = {}
 
     try:
-        return boto3.client(
+        account_id = boto3.client(
             "sts",
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ async-timeout==3.0.0
 attrs==17.4.0
 binaryornot==0.4.4
 boto==2.48.0
-boto3==1.4.7
+boto3==1.11.11
 boto3-type-annotations==0.3.1
-botocore==1.7.21
+botocore==1.14.11
 bravado==10.4.1
 bravado-core==5.12.1
 cachetools==2.0.1
@@ -88,7 +88,7 @@ retry==0.9.2
 rfc3987==1.3.7
 rsa==3.4.2
 ruamel.yaml==0.15.96
-s3transfer==0.1.13
+s3transfer==0.3.3
 sensu-plugin==0.3.1
 service-configuration-lib==2.4.6
 setuptools==39.0.1

--- a/script.py
+++ b/script.py
@@ -1,0 +1,4 @@
+import boto3
+session = boto3.Session(profile_name='dev-read-only')
+client = session.client('s3')
+client.list_buckets()

--- a/script.py
+++ b/script.py
@@ -1,4 +1,0 @@
-import boto3
-session = boto3.Session(profile_name='dev-read-only')
-client = session.client('s3')
-client.list_buckets()

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -180,6 +180,7 @@ class TestGetSparkConfig:
             volumes=["v1:v1:rw", "v2:v2:rw"],
             access_key="test_access_key",
             secret_key="test_secret_key",
+            session_token=None,
         )
 
     def test_find_master(self):
@@ -293,7 +294,7 @@ class TestConfigureAndRunDockerContainer:
         mock_get_username.return_value = "fake_user"
         mock_get_spark_config.return_value = {"spark.app.name": "fake_app"}
         mock_run_docker_container.return_value = 0
-        mock_get_aws_credentials.return_value = ("id", "secret")
+        mock_get_aws_credentials.return_value = ("id", "secret", "token")
 
         args = mock.MagicMock()
         args.aws_region = "fake_region"
@@ -361,7 +362,7 @@ class TestConfigureAndRunDockerContainer:
         mock_os_path_exists,
         mock_get_aws_credentials,
     ):
-        mock_get_aws_credentials.return_value = ("id", "secret")
+        mock_get_aws_credentials.return_value = ("id", "secret", "token")
         with mock.patch(
             "paasta_tools.cli.cmds.spark_run.emit_resource_requirements", autospec=True
         ) as mock_emit_resource_requirements, mock.patch(
@@ -394,7 +395,7 @@ class TestConfigureAndRunDockerContainer:
         mock_os_path_exists,
         mock_get_aws_credentials,
     ):
-        mock_get_aws_credentials.return_value = ("id", "secret")
+        mock_get_aws_credentials.return_value = ("id", "secret", "token")
         with mock.patch(
             "paasta_tools.cli.cmds.spark_run.emit_resource_requirements", autospec=True
         ) as mock_emit_resource_requirements, mock.patch(
@@ -431,7 +432,7 @@ class TestConfigureAndRunDockerContainer:
         mock_get_aws_credentials,
         mock_create_spark_config_str,
     ):
-        mock_get_aws_credentials.return_value = ("id", "secret")
+        mock_get_aws_credentials.return_value = ("id", "secret", "token")
 
         with mock.patch(
             "paasta_tools.cli.cmds.spark_run.emit_resource_requirements", autospec=True
@@ -472,7 +473,7 @@ class TestConfigureAndRunDockerContainer:
         mock_get_aws_credentials,
         mock_create_spark_config_str,
     ):
-        mock_get_aws_credentials.return_value = ("id", "secret")
+        mock_get_aws_credentials.return_value = ("id", "secret", "token")
         with mock.patch(
             "paasta_tools.cli.cmds.spark_run.emit_resource_requirements", autospec=True
         ) as mock_emit_resource_requirements, mock.patch(

--- a/tests/test_spark_tools.py
+++ b/tests/test_spark_tools.py
@@ -18,9 +18,11 @@ def test_load_aws_credentials_from_yaml(tmpdir):
         f'aws_secret_access_key: "{fake_secret_access_key}"'
     )
 
-    aws_access_key_id, aws_secret_access_key, aws_session_token  = _load_aws_credentials_from_yaml(
-        yaml_file
-    )
+    (
+        aws_access_key_id,
+        aws_secret_access_key,
+        aws_session_token,
+    ) = _load_aws_credentials_from_yaml(yaml_file)
     assert aws_access_key_id == fake_access_key_id
     assert aws_secret_access_key == fake_secret_access_key
     assert aws_session_token is None
@@ -137,7 +139,9 @@ class TestStuff:
     def test_get_default_event_log_dir(self, mock_account_id, account_id, expected_dir):
         mock_account_id.return_value = account_id
         ret = get_default_event_log_dir(
-            access_key="test_access_key", secret_key="test_secret_key", session_token="test_token"
+            access_key="test_access_key",
+            secret_key="test_secret_key",
+            session_token="test_token",
         )
         assert ret == expected_dir
 


### PR DESCRIPTION
This PR does the following:

- updates the version of boto3 and botocore to support when a credential_process is defined for a profile
- updates `get_aws_credentials` method and helper functions so that it no longer fails if a a profile configured with either a `credential_process` or a `aws_session_token`. For the former, the boto3 API returns the values as expected. In the case where a profile is configure with the session token inline, added support to handle loading and reading this key from a yaml file.

**Testing**
Automated testing
`make itest` passes

Added two new tests:

1. Check for `aws_session_token` when reading from a passed yaml file
2. Verify that we read the correct profile name when passing `profile_name` to `get_aws_credentials` rather than falling back to the default profile

I also had to fix the tests because the `args` getting passed to `get_aws_credentials` were not being respected.


Manual testing
_profile that has credential process_
`paasta spark-run --cmd /bin/bash --aws-profile dev-read-only` works when I have a credential process defined in my `~/.aws/credentials`

I get authed via the credential process as spark-run starts.

_manually specifying the aws yaml file (parsing the keys)_
`paasta spark-run --cmd /bin/bash --aws-credentials-yaml /etc/boto_cfg/mrjob.yaml`

Keys are statically defined inline and the correct identity is used