### PR TITLE
Add hacheck sidecar cpu righsizing

### DIFF
--- a/paasta_tools/cli/schemas/autotuned_defaults/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/autotuned_defaults/kubernetes_schema.json
@@ -24,6 +24,49 @@
                     "type": "number",
                     "minimum": 32,
                     "exclusiveMinimum": true
+                },
+                "sidecar_resource_requirements": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "hacheck": {
+                            "type": "object",
+                            "properties": {
+                                "requests": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "number",
+                                            "minimum": 0.0
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        },
+                                        "ephemeral-storage": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "limits": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "number",
+                                            "minimum": 0.0
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        },
+                                        "ephemeral-storage": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/paasta_tools/contrib/paasta_update_soa_memcpu.py
+++ b/paasta_tools/contrib/paasta_update_soa_memcpu.py
@@ -178,6 +178,7 @@ def get_report_from_splunk(creds, app, filename, criteria_filter):
         serv["old_mem"] = d["result"].get("current_mem")
         serv["disk"] = d["result"].get("suggested_disk")
         serv["old_disk"] = d["result"].get("current_disk")
+        serv["hacheck_cpus"] = d["result"].get("suggested_hacheck_cpus")
         services_to_update[criteria] = serv
 
     return {

--- a/paasta_tools/contrib/rightsizer_soaconfigs_update.py
+++ b/paasta_tools/contrib/rightsizer_soaconfigs_update.py
@@ -94,6 +94,15 @@ def get_recommendation_from_result(result):
     disk = result.get("disk")
     if disk and disk != NULL:
         rec["disk"] = max(128, round(float(disk)))
+    hacheck_cpus = result.get("hacheck_cpus")
+    if hacheck_cpus and hacheck_cpus != NULL:
+        hacheck_cpus_value = max(0.1, min(float(hacheck_cpus), 1))
+        rec["sidecar_resource_requirements"] = {
+            "hacheck": {
+                "requests": {"cpu": hacheck_cpus_value,},
+                "limits": {"cpu": hacheck_cpus_value,},
+            },
+        }
     return rec
 
 


### PR DESCRIPTION
This expects a splunk field named "suggested_hacheck_cpus", and uses
that to set the request and limit for the hacheck sidecar

This results in diffs like:
```
diff --git a/ad_admin/autotuned_defaults/kubernetes-norcal-stagef.yaml b/ad_admin/autotuned_defaults/kubernetes-norcal-stagef.yaml
index 3a27aa526e..020748b927 100644
--- a/ad_admin/autotuned_defaults/kubernetes-norcal-stagef.yaml
+++ b/ad_admin/autotuned_defaults/kubernetes-norcal-stagef.yaml
@@ -11,3 +11,9 @@ main:
   cpus: 0.4
   mem: 466
   disk: 256
+  sidecar_resource_requirements:
+    hacheck:
+      requests:
+        cpu: 0.1
+      limits:
+        cpu: 0.1
(many, many more services here)
```