### PR TITLE
Fix tron_tools to work with aws access token

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -322,7 +322,7 @@ class TronActionConfig(InstanceConfig):
             )
             if "AWS_ACCESS_KEY_ID" not in env or "AWS_SECRET_ACCESS_KEY" not in env:
                 try:
-                    access_key, secret_key = get_aws_credentials(
+                    access_key, secret_key, session_token = get_aws_credentials(
                         service=self.get_service(),
                         aws_credentials_yaml=self.config_dict.get(
                             "aws_credentials_yaml"

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -195,7 +195,7 @@ class TestTronActionConfig:
         ), mock.patch(
             "paasta_tools.tron_tools.get_aws_credentials",
             autospec=True,
-            return_value=("access", "secret"),
+            return_value=("access", "secret", "token"),
         ):
             env = action_config.get_env()
             if executor == "spark":
@@ -235,7 +235,7 @@ class TestTronActionConfig:
         ), mock.patch(
             "paasta_tools.tron_tools.get_aws_credentials",
             autospec=True,
-            return_value=("access", "secret"),
+            return_value=("access", "secret", "token"),
         ):
             assert (
                 action_config.get_cmd()


### PR DESCRIPTION
it looks like last time we modified the get_aws_credentials, we forget to update tron_tools. This changes fixed the issue. 

I've ensure: 
- make test pass
- `git grep get_aws_credentials` and ensured everything in the repo is expecting three output instead of two. 