### PR TITLE
MESH-848 Add Envoy support on `paasta status` for k8s services

### DIFF
--- a/paasta_tools/api/api_docs/oapi.yaml
+++ b/paasta_tools/api/api_docs/oapi.yaml
@@ -315,6 +315,9 @@ components:
         smartstack:
           $ref: '#/components/schemas/SmartstackStatus'
           description: Status of the service in smartstack
+        envoy:
+          $ref: '#/components/schemas/EnvoyStatus'
+          description: Status of the service in Envoy
       required:
       - desired_state
       - app_count

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -1240,6 +1240,10 @@
                     "$ref": "#/definitions/SmartstackStatus",
                     "description": "Status of the service in smartstack"
                 },
+                "envoy": {
+                    "$ref": "#/definitions/EnvoyStatus",
+                    "description": "Status of the service in Envoy"
+                },
                 "namespace": {
                     "type": "string",
                     "description": "The namespace this app is running"

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -20,7 +20,6 @@ import datetime
 import logging
 import re
 import traceback
-from enum import Enum
 from typing import Any
 from typing import Dict
 from typing import List
@@ -183,7 +182,7 @@ def marathon_instance_status(
             if include_smartstack:
                 mstatus["smartstack"] = marathon_service_mesh_status(
                     service,
-                    ServiceMesh.SMARTSTACK,
+                    pik.ServiceMesh.SMARTSTACK,
                     instance,
                     job_config,
                     service_namespace_config,
@@ -193,7 +192,7 @@ def marathon_instance_status(
             if include_envoy:
                 mstatus["envoy"] = marathon_service_mesh_status(
                     service,
-                    ServiceMesh.ENVOY,
+                    pik.ServiceMesh.ENVOY,
                     instance,
                     job_config,
                     service_namespace_config,
@@ -327,11 +326,6 @@ def build_marathon_task_dict(marathon_task: MarathonTask) -> MutableMapping[str,
     return task_dict
 
 
-class ServiceMesh(Enum):
-    SMARTSTACK = "smartstack"
-    ENVOY = "envoy"
-
-
 def _build_smartstack_location_dict_for_backends(
     synapse_host: str,
     registration: str,
@@ -401,7 +395,7 @@ def _build_envoy_location_dict_for_backends(
 
 def marathon_service_mesh_status(
     service: str,
-    service_mesh: ServiceMesh,
+    service_mesh: pik.ServiceMesh,
     instance: str,
     job_config: marathon_tools.MarathonServiceConfig,
     service_namespace_config: ServiceNamespaceConfig,
@@ -434,7 +428,7 @@ def marathon_service_mesh_status(
     }
 
     for location, hosts in slave_hostname_by_location.items():
-        if service_mesh == ServiceMesh.SMARTSTACK:
+        if service_mesh == pik.ServiceMesh.SMARTSTACK:
             service_mesh_status["locations"].append(
                 _build_smartstack_location_dict_for_backends(
                     synapse_host=hosts[0],
@@ -444,7 +438,7 @@ def marathon_service_mesh_status(
                     should_return_individual_backends=should_return_individual_backends,
                 )
             )
-        elif service_mesh == ServiceMesh.ENVOY:
+        elif service_mesh == pik.ServiceMesh.ENVOY:
             service_mesh_status["locations"].append(
                 _build_envoy_location_dict_for_backends(
                     envoy_host=hosts[0],
@@ -676,6 +670,7 @@ def instance_status(request):
                     instance=instance,
                     verbose=verbose,
                     include_smartstack=include_smartstack,
+                    include_envoy=include_envoy,
                     instance_type=instance_type,
                     settings=settings,
                 )

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1219,6 +1219,14 @@ def print_kubernetes_status(
             kubernetes_status.smartstack.locations,
         )
         output.extend([f"    {line}" for line in smartstack_status_human])
+
+    if kubernetes_status.envoy is not None:
+        envoy_status_human = get_envoy_status_human(
+            kubernetes_status.envoy.registration,
+            kubernetes_status.envoy.expected_backends_per_location,
+            kubernetes_status.envoy.locations,
+        )
+        output.extend([f"    {line}" for line in envoy_status_human])
     return 0
 
 

--- a/paasta_tools/paastaapi/models/instance_status_kubernetes.py
+++ b/paasta_tools/paastaapi/models/instance_status_kubernetes.py
@@ -48,7 +48,8 @@ class InstanceStatusKubernetes(object):
         'pods': 'list[KubernetesPod]',
         'replicasets': 'list[KubernetesReplicaSet]',
         'running_instance_count': 'int',
-        'smartstack': 'SmartstackStatus'
+        'smartstack': 'SmartstackStatus',
+        'envoy': 'EnvoyStatus'
     }
 
     attribute_map = {
@@ -67,10 +68,11 @@ class InstanceStatusKubernetes(object):
         'pods': 'pods',
         'replicasets': 'replicasets',
         'running_instance_count': 'running_instance_count',
-        'smartstack': 'smartstack'
+        'smartstack': 'smartstack',
+        'envoy': 'envoy'
     }
 
-    def __init__(self, app_count=None, app_id=None, autoscaling_status=None, backoff_seconds=None, bounce_method=None, create_timestamp=None, deploy_status=None, deploy_status_message=None, desired_state=None, error_message=None, expected_instance_count=None, namespace=None, pods=None, replicasets=None, running_instance_count=None, smartstack=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, app_count=None, app_id=None, autoscaling_status=None, backoff_seconds=None, bounce_method=None, create_timestamp=None, deploy_status=None, deploy_status_message=None, desired_state=None, error_message=None, expected_instance_count=None, namespace=None, pods=None, replicasets=None, running_instance_count=None, smartstack=None, envoy=None, local_vars_configuration=None):  # noqa: E501
         """InstanceStatusKubernetes - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -92,6 +94,7 @@ class InstanceStatusKubernetes(object):
         self._replicasets = None
         self._running_instance_count = None
         self._smartstack = None
+        self._envoy = None
         self.discriminator = None
 
         self.app_count = app_count
@@ -123,6 +126,8 @@ class InstanceStatusKubernetes(object):
             self.running_instance_count = running_instance_count
         if smartstack is not None:
             self.smartstack = smartstack
+        if envoy is not None:
+            self.envoy = envoy
 
     @property
     def app_count(self):
@@ -511,6 +516,27 @@ class InstanceStatusKubernetes(object):
         """
 
         self._smartstack = smartstack
+
+    @property
+    def envoy(self):
+        """Gets the envoy of this InstanceStatusKubernetes.  # noqa: E501
+
+
+        :return: The envoy of this InstanceStatusKubernetes.  # noqa: E501
+        :rtype: EnvoyStatus
+        """
+        return self._envoy
+
+    @envoy.setter
+    def envoy(self, envoy):
+        """Sets the envoy of this InstanceStatusKubernetes.
+
+
+        :param envoy: The envoy of this InstanceStatusKubernetes.  # noqa: E501
+        :type envoy: EnvoyStatus
+        """
+
+        self._envoy = envoy
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -28,6 +28,7 @@ from paasta_tools.api import settings
 from paasta_tools.api.views import instance
 from paasta_tools.autoscaling.autoscaling_service_lib import ServiceAutoscalingInfo
 from paasta_tools.envoy_tools import EnvoyBackend
+from paasta_tools.instance.kubernetes import ServiceMesh
 from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
 from paasta_tools.marathon_tools import get_short_task_id
 from paasta_tools.mesos.exceptions import SlaveDoesNotExist
@@ -148,7 +149,7 @@ def test_instance_status_marathon(
         expected_marathon_service_mesh_status_calls.append(
             mock.call(
                 "fake_service",
-                instance.ServiceMesh.SMARTSTACK,
+                ServiceMesh.SMARTSTACK,
                 "fake_instance",
                 mock_service_config,
                 mock_load_service_namespace_config.return_value,
@@ -160,7 +161,7 @@ def test_instance_status_marathon(
         expected_marathon_service_mesh_status_calls.append(
             mock.call(
                 "fake_service",
-                instance.ServiceMesh.ENVOY,
+                ServiceMesh.ENVOY,
                 "fake_instance",
                 mock_service_config,
                 mock_load_service_namespace_config.return_value,
@@ -441,7 +442,7 @@ def test_marathon_service_mesh_status(
 
     smartstack_status = instance.marathon_service_mesh_status(
         "fake_service",
-        instance.ServiceMesh.SMARTSTACK,
+        ServiceMesh.SMARTSTACK,
         "fake_instance",
         mock_service_config,
         mock_service_namespace_config,
@@ -484,7 +485,7 @@ def test_marathon_service_mesh_status(
     ]
     envoy_status = instance.marathon_service_mesh_status(
         "fake_service",
-        instance.ServiceMesh.ENVOY,
+        ServiceMesh.ENVOY,
         "fake_instance",
         mock_service_config,
         mock_service_namespace_config,
@@ -568,8 +569,9 @@ def test_kubernetes_smartstack_status(
     mock_service_namespace_config = ServiceNamespaceConfig()
     mock_settings = mock.Mock()
 
-    smartstack_status = instance.pik.smartstack_status(
+    smartstack_status = instance.pik.mesh_status(
         service="fake_service",
+        service_mesh=ServiceMesh.SMARTSTACK,
         instance="fake_instance",
         job_config=mock_job_config,
         service_namespace_config=mock_service_namespace_config,
@@ -1087,6 +1089,7 @@ def test_kubernetes_instance_status_bounce_method(
         instance_type="kubernetes",
         verbose=0,
         include_smartstack=False,
+        include_envoy=False,
         settings=settings,
     )
     assert actual["bounce_method"] == mock_job_config.get_bounce_method()
@@ -1121,6 +1124,7 @@ def test_kubernetes_instance_status_evicted_nodes(
         instance_type="kubernetes",
         verbose=0,
         include_smartstack=False,
+        include_envoy=False,
         settings=mock_settings,
     )
     assert instance_status["evicted_count"] == 1

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -986,6 +986,11 @@ def mock_kubernetes_status():
             expected_backends_per_location=1,
             locations=[],
         ),
+        envoy=Struct(
+            registration="fake_service.fake_instance",
+            expected_backends_per_location=1,
+            locations=[],
+        ),
         evicted_count=1,
     )
 
@@ -1224,6 +1229,7 @@ class TestPrintKubernetesStatus:
         "paasta_tools.cli.cmds.status.format_tail_lines_for_mesos_task", autospec=True
     )
     @patch("paasta_tools.cli.cmds.status.get_smartstack_status_human", autospec=True)
+    @patch("paasta_tools.cli.cmds.status.get_envoy_status_human", autospec=True)
     @patch("paasta_tools.cli.cmds.status.humanize.naturaltime", autospec=True)
     @patch(
         "paasta_tools.cli.cmds.status.kubernetes_app_deploy_status_human", autospec=True
@@ -1236,6 +1242,7 @@ class TestPrintKubernetesStatus:
         mock_desired_state,
         mock_kubernetes_app_deploy_status_human,
         mock_naturaltime,
+        mock_get_envoy_status_human,
         mock_get_smartstack_status_human,
         mock_format_tail_lines_for_mesos_task,
         mock_kubernetes_status,

--- a/tests/instance/test_kubernetes.py
+++ b/tests/instance/test_kubernetes.py
@@ -32,6 +32,7 @@ def instance_status_kwargs():
         instance_type="",
         verbose=0,
         include_smartstack=False,
+        include_envoy=False,
         settings=mock.Mock(),
     )
 
@@ -102,6 +103,7 @@ def test_kubernetes_status(
         instance="",
         verbose=0,
         include_smartstack=False,
+        include_envoy=False,
         instance_type="flink",
         settings=mock.Mock(),
     )


### PR DESCRIPTION
### Tests:
```
$ PAASTA_SYSTEM_CONFIG_DIR=~/etc-paasta paasta status -s compute-infra-test-service -c XXXXXX -i main_k8s -vv
...
    Envoy:
      Service Name: compute-infra-test-service.main
      Backends:
        XXXXXX - Healthy - in BackendType.ENVOY with (2/2) total backends UP in this namespace.
          Proxied through Casper: False
          Hostname:Port              Weight  Status
          XXXXXX:8888               10         HEALTHY
          XXXXXX:8888               10         HEALTHY
```
