### PR TITLE
Use `extrapolation="last_value"` for custom signalflow used by HPA

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -176,8 +176,8 @@ setpoint = {setpoint}
 moving_average_window = '{moving_average_window_seconds}s'
 filters = filter('paasta_service', '{paasta_service}') and filter('paasta_instance', '{paasta_instance}') and filter('paasta_cluster', '{paasta_cluster}')
 
-current_replicas = data('kube_hpa_status_current_replicas', filter=filters).sum(by=['paasta_cluster'])
-load_per_instance = data('{signalfx_metric_name}', filter=filters)
+current_replicas = data('kube_hpa_status_current_replicas', filter=filters, extrapolation="last_value").sum(by=['paasta_cluster'])
+load_per_instance = data('{signalfx_metric_name}', filter=filters, extrapolation="last_value")
 
 desired_instances_at_each_point_in_time = (load_per_instance - offset).sum() / (setpoint - offset)
 desired_instances = desired_instances_at_each_point_in_time.mean(over=moving_average_window)


### PR DESCRIPTION
Without this, missing data can cause the signalfx metrics adapter to request 0 instances