### PR TITLE
Stop fetching events in paasta status because it is slowing down etcd

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2370,17 +2370,6 @@ async def get_kubernetes_app_deploy_status(
     kube_client: KubeClient,
     desired_instances: int,
 ) -> Tuple[int, str]:
-    # Try to get a real status message but we don't ever want to crash if this fails
-    try:
-        event_stream = await get_all_events_for_service(app, kube_client)
-        if not event_stream:
-            # events only stick around for so long
-            deploy_message = "Unknown; no recent events"
-        else:
-            deploy_message = event_stream[-1]["message"]
-    except Exception as e:
-        deploy_message = f"Error getting status message: {str(e)}"
-
     if app.status.ready_replicas is None:
         if desired_instances == 0:
             deploy_status = KubernetesDeployStatus.Stopped
@@ -2398,6 +2387,9 @@ async def get_kubernetes_app_deploy_status(
         deploy_status = KubernetesDeployStatus.Stopped
     else:
         deploy_status = KubernetesDeployStatus.Running
+    # Temporarily removing the message because the events query it used was overloading etcd
+    # TODO: change the implementation or remove the deploy message entirely
+    deploy_message = ""
     return deploy_status, deploy_message
 
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2565,45 +2565,40 @@ def test_update_stateful_set():
 
 @pytest.mark.asyncio
 async def test_get_kubernetes_app_deploy_status():
-    with asynctest.patch(
-        "paasta_tools.kubernetes_tools.get_all_events_for_service", autospec=True
-    ) as mock_get_events:
-        mock_get_events.return_value = [{"message": "some kubernetes message"}]
+    mock_client = mock.Mock()
+    mock_status = mock.Mock(replicas=1, ready_replicas=1, updated_replicas=1)
+    mock_app = mock.Mock(status=mock_status)
+    assert await get_kubernetes_app_deploy_status(
+        mock_app, mock_client, desired_instances=1
+    ) == (KubernetesDeployStatus.Running, "")
 
-        mock_client = mock.Mock()
-        mock_status = mock.Mock(replicas=1, ready_replicas=1, updated_replicas=1)
-        mock_app = mock.Mock(status=mock_status)
-        assert await get_kubernetes_app_deploy_status(
-            mock_app, mock_client, desired_instances=1
-        ) == (KubernetesDeployStatus.Running, "some kubernetes message")
+    assert await get_kubernetes_app_deploy_status(
+        mock_app, mock_client, desired_instances=2
+    ) == (KubernetesDeployStatus.Waiting, "")
 
-        assert await get_kubernetes_app_deploy_status(
-            mock_app, mock_client, desired_instances=2
-        ) == (KubernetesDeployStatus.Waiting, "some kubernetes message")
+    mock_status = mock.Mock(replicas=1, ready_replicas=2, updated_replicas=1)
+    mock_app = mock.Mock(status=mock_status)
+    assert await get_kubernetes_app_deploy_status(
+        mock_app, mock_client, desired_instances=2
+    ) == (KubernetesDeployStatus.Deploying, "")
 
-        mock_status = mock.Mock(replicas=1, ready_replicas=2, updated_replicas=1)
-        mock_app = mock.Mock(status=mock_status)
-        assert await get_kubernetes_app_deploy_status(
-            mock_app, mock_client, desired_instances=2
-        ) == (KubernetesDeployStatus.Deploying, "some kubernetes message")
+    mock_status = mock.Mock(replicas=0, ready_replicas=None, updated_replicas=0)
+    mock_app = mock.Mock(status=mock_status)
+    assert await get_kubernetes_app_deploy_status(
+        mock_app, mock_client, desired_instances=0
+    ) == (KubernetesDeployStatus.Stopped, "")
 
-        mock_status = mock.Mock(replicas=0, ready_replicas=None, updated_replicas=0)
-        mock_app = mock.Mock(status=mock_status)
-        assert await get_kubernetes_app_deploy_status(
-            mock_app, mock_client, desired_instances=0
-        ) == (KubernetesDeployStatus.Stopped, "some kubernetes message")
+    mock_status = mock.Mock(replicas=0, ready_replicas=0, updated_replicas=0)
+    mock_app = mock.Mock(status=mock_status)
+    assert await get_kubernetes_app_deploy_status(
+        mock_app, mock_client, desired_instances=0
+    ) == (KubernetesDeployStatus.Stopped, "")
 
-        mock_status = mock.Mock(replicas=0, ready_replicas=0, updated_replicas=0)
-        mock_app = mock.Mock(status=mock_status)
-        assert await get_kubernetes_app_deploy_status(
-            mock_app, mock_client, desired_instances=0
-        ) == (KubernetesDeployStatus.Stopped, "some kubernetes message")
-
-        mock_status = mock.Mock(replicas=1, ready_replicas=None, updated_replicas=None)
-        mock_app = mock.Mock(status=mock_status)
-        assert await get_kubernetes_app_deploy_status(
-            mock_app, mock_client, desired_instances=1
-        ) == (KubernetesDeployStatus.Waiting, "some kubernetes message")
+    mock_status = mock.Mock(replicas=1, ready_replicas=None, updated_replicas=None)
+    mock_app = mock.Mock(status=mock_status)
+    assert await get_kubernetes_app_deploy_status(
+        mock_app, mock_client, desired_instances=1
+    ) == (KubernetesDeployStatus.Waiting, "")
 
 
 def test_parse_container_resources():


### PR DESCRIPTION
I didn't remove all the code, to leave open the possibility of adding this info back in once we understand what's going on and see if we can optimize the query. I'll add a ticket to the postmortem about making a decision on that.