### PR TITLE
Do not return hpa if min or max is 0

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -576,6 +576,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         if self.get_desired_state() == "stop":
             return None
 
+        if not self.is_autoscaling_enabled():
+            return None
+
         # use new autoscaling configuration if it exists.
         if "horizontal_autoscaling" in self.config_dict:
             return self.get_hpa_metric_spec(name, cluster, namespace)
@@ -586,7 +589,10 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
         min_replicas = self.get_min_instances()
         max_replicas = self.get_max_instances()
-        if not min_replicas or not max_replicas:
+        if min_replicas == 0 or max_replicas == 0:
+            log.error(
+                f"Invalid value for min or max_instances: {min_replicas}, {max_replicas}"
+            )
             return None
 
         metrics_provider = autoscaling_params["metrics_provider"]

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -586,7 +586,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
         min_replicas = self.get_min_instances()
         max_replicas = self.get_max_instances()
-        if min_replicas is None or max_replicas is None:
+        if not min_replicas or not max_replicas:
             return None
 
         metrics_provider = autoscaling_params["metrics_provider"]


### PR DESCRIPTION
error from setup_kubernetes_job:

```
"message": "HorizontalPodAutoscaler.autoscaling \"ad--landscape-main\" is invalid: [spec.minReplicas: Invalid value: 0: must be greater than or equal to 1, spec.maxReplicas: Invalid value: 0: must be greater than 0, spec.metrics: Forbidden: must specify at least one Object or External metric to support scaling to zero replicas]",
```

I just changed this yesterday for no good reason, we can change it back.
