### PR TITLE
Support PaaSTA secrets as files

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -505,6 +505,50 @@
                     },
                     "uniqueItems": true
                 },
+                "secret_volumes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "container_path": {
+                                "type": "string"
+                            },
+                            "secret_name": {
+                                "type": "string"
+                            },
+                            "default_mode": {
+                                "type": "string"
+                            },
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "key": {
+                                            "type": "string"
+                                        },
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "mode": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "key",
+                                        "path"
+                                    ]
+                                },
+                                "uniqueItems": true
+                            }
+                        },
+                        "required": [
+                            "container_path",
+                            "secret_name"
+                        ]
+                    },
+                    "uniqueItems": true
+                },
                 "replication_threshold": {
                     "type": "integer",
                     "minimum": 0

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -228,6 +228,19 @@ class PersistentVolume(VolumeWithMode):
     storage_class_name: str
 
 
+class SecretVolumeItem(TypedDict, total=False):
+    key: str
+    path: str
+    mode: Union[str, int]
+
+
+class SecretVolume(TypedDict, total=False):
+    secret_name: str
+    container_path: str
+    default_mode: Union[str, int]
+    items: List[SecretVolumeItem]
+
+
 class InstanceConfigDict(TypedDict, total=False):
     deploy_group: str
     mem: float
@@ -247,6 +260,7 @@ class InstanceConfigDict(TypedDict, total=False):
     role: str
     extra_volumes: List[DockerVolume]
     aws_ebs_volumes: List[AwsEbsVolume]
+    secret_volumes: List[SecretVolume]
     security: SecurityConfigDict
     dependencies_reference: str
     dependencies: Dict[str, Dict]
@@ -841,6 +855,9 @@ class InstanceConfig:
 
     def get_aws_ebs_volumes(self) -> List[AwsEbsVolume]:
         return self.config_dict.get("aws_ebs_volumes", [])
+
+    def get_secret_volumes(self) -> List[SecretVolume]:
+        return self.config_dict.get("secret_volumes", [])
 
     def get_role(self) -> Optional[str]:
         """Which mesos role of nodes this job should run on.


### PR DESCRIPTION
Add `secret_volume` option into yelpsoa, which allows to mount an                                                      
existing secret as a file into an instance.                                                                            
                                                                                                                       
Example:                                                                                                               
```                                                                                                                    
main:                                                                                                                  
  secret_volumes:                                                                                                      
  - container_path: /home/nobody/.ssh                                                                                  
    secret_name: zzz_password                                                                                          
    default_mode: 0444                                                                                                 
    items:                                                                                                             
    - key: rsa-private                                                                                                 
      path: id_rsa                                                                                                     
    - key: rsa-public                                                                                                  
      path: id_rsa.pub                                                                                                 
      mode: 0666                                                                                                       
```                                                                                                                    
                                                                                                                       
As a result, the content of the `rsa-private` key from the
`zzz_password` secret will be accessible via the
`/home/nobody/.ssh/id_rsa` file with `0444` mode, and the content of
`rsa-public` key from the same secret will be accessible via
`/home/nobody/.ssh/id_rsa.pub` file with `0666` mode.