### PR TITLE
script to track and auto-apply Puppet-created kubernetes resources

### DIFF
--- a/paasta_tools/apply_external_resources.py
+++ b/paasta_tools/apply_external_resources.py
@@ -1,0 +1,76 @@
+#!/opt/venvs/paasta-tools/bin/python
+import os
+import sys
+from filecmp import cmp
+from shutil import copy
+from subprocess import CalledProcessError
+from subprocess import run
+from traceback import print_exc
+
+APPLIED_DIRECTORY = ".applied"
+
+
+# This script expects the KUBECONFIG environment variable to be set correctly
+def main(puppet_resource_root: str) -> int:
+    exit_code = 0
+    applied_resource_root = os.path.join(puppet_resource_root, APPLIED_DIRECTORY)
+
+    # Loop through everything in the puppet resource path
+    for root, dirs, files in os.walk(puppet_resource_root):
+        # modifying the 'dirs' variable in-place will update the order that os.walk visits things
+        if APPLIED_DIRECTORY in dirs:
+            dirs.remove(APPLIED_DIRECTORY)
+        dirs.sort()  # Need to apply things in the correct order
+
+        # Check to see if there's a difference between what Puppet created and
+        # what's been previously applied
+        for filename in sorted([f for f in files if f.endswith(".yaml")]):
+            path = os.path.join(root, filename)
+            applied_path = os.path.join(
+                applied_resource_root, os.path.relpath(path, puppet_resource_root)
+            )
+            print(f"comparing {path} and {applied_path}")
+            if not os.path.exists(applied_path) or not cmp(
+                path, applied_path, shallow=False
+            ):
+                # This is idempotent; if something gets out of sync and a resource gets applied
+                # a second time, kubectl just won't make any changes
+                try:
+                    run(["kubectl", "apply", "-f", path], check=True)
+                    os.makedirs(os.path.dirname(applied_path), exist_ok=True)
+                    copy(path, applied_path)
+                except CalledProcessError:
+                    print(f"There was a problem applying {path}:\n")
+                    print_exc(
+                        file=sys.stdout
+                    )  # keep all messages on the same stream so they're in order
+                    exit_code = 1
+                    continue
+
+    # Loop through all the files that have been previously applied and see
+    # if Puppet has removed any of them
+    for root, dirs, files in os.walk(applied_resource_root):
+        dirs.sort(reverse=True)  # for deleting things, we need to go in reverse order
+        for filename in sorted([f for f in files if f.endswith(".yaml")], reverse=True):
+            path = os.path.join(root, filename)
+            puppet_path = os.path.join(
+                puppet_resource_root, os.path.relpath(path, applied_resource_root)
+            )
+            if not os.path.exists(puppet_path):
+                print(f"Deleting resource {path}...")
+                try:
+                    run(["kubectl", "delete", "-f", path], check=True)
+                    os.remove(path)
+                except CalledProcessError:
+                    print(f"There was a problem deleting {path}:\n")
+                    print_exc(
+                        file=sys.stdout
+                    )  # keep all messages on the same stream so they're in order
+                    exit_code = 1
+                    continue
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1]))

--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -8,6 +8,7 @@ mock
 path.py
 pep8
 pre-commit
+pyfakefs
 pylint
 pytest
 pytest-asyncio

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,6 +22,7 @@ pep8==1.5.7
 pluggy==0.6.0
 pre-commit==1.18.0
 pycodestyle==2.3.1
+pyfakefs==4.1.0
 pyflakes==1.6.0
 Pygments==2.2.0
 pylint==1.7.2

--- a/tests/test_apply_external_resources.py
+++ b/tests/test_apply_external_resources.py
@@ -1,0 +1,150 @@
+import os
+from subprocess import CalledProcessError
+
+import mock
+import pytest
+
+from paasta_tools.apply_external_resources import main
+
+
+@pytest.fixture
+def mock_run():
+    with mock.patch(
+        "paasta_tools.apply_external_resources.run", autospec=True
+    ) as mock_runner:
+        yield mock_runner
+
+
+@pytest.fixture(autouse=True)
+def setup_external_files(fs):
+    fs.create_file(
+        "/external_resources/00-common/10-foo/10-deployment.yaml", contents="foo: bar",
+    )
+    fs.create_file(
+        "/external_resources/00-common/10-foo/20-service.yaml", contents="fizz: buzz",
+    )
+    fs.create_file(
+        "/external_resources/20-common/10-foo/20-deployment.yaml", contents="baz: biz",
+    )
+    fs.create_file(
+        "/external_resources/.applied/00-common/10-foo/10-deployment.yaml",
+        contents="foo: bar",
+    )
+    fs.create_file(
+        "/external_resources/.applied/00-common/10-foo/20-service.yaml",
+        contents="fizz: buzz",
+    )
+    fs.create_file(
+        "/external_resources/.applied/20-common/10-foo/20-deployment.yaml",
+        contents="baz: biz",
+    )
+
+
+def test_no_changes(mock_run):
+    assert main("/external_resources") == 0
+    assert mock_run.call_count == 0
+
+
+def test_resources_added_in_order(mock_run, fs):
+    fs.create_file(
+        "/external_resources/00-common/10-foo/30-hpa.yaml", contents="blah: blah",
+    )
+    fs.create_file(
+        "/external_resources/00-common/10-foo/40-service.yaml", contents="blah: blah",
+    )
+    fs.create_file(
+        "/external_resources/00-common/30-foo/10-deployment.yaml",
+        contents="blah: blah",
+    )
+    assert main("/external_resources") == 0
+    assert mock_run.call_args_list == [
+        mock.call(
+            [
+                "kubectl",
+                "apply",
+                "-f",
+                "/external_resources/00-common/10-foo/30-hpa.yaml",
+            ],
+            check=True,
+        ),
+        mock.call(
+            [
+                "kubectl",
+                "apply",
+                "-f",
+                "/external_resources/00-common/10-foo/40-service.yaml",
+            ],
+            check=True,
+        ),
+        mock.call(
+            [
+                "kubectl",
+                "apply",
+                "-f",
+                "/external_resources/00-common/30-foo/10-deployment.yaml",
+            ],
+            check=True,
+        ),
+    ]
+    assert os.path.exists("/external_resources/.applied/00-common/10-foo/30-hpa.yaml")
+    assert os.path.exists(
+        "/external_resources/.applied/00-common/10-foo/40-service.yaml"
+    )
+    assert os.path.exists(
+        "/external_resources/.applied/00-common/30-foo/10-deployment.yaml"
+    )
+
+
+def test_resources_deleted_in_reverse_order(mock_run, fs):
+    fs.create_file(
+        "/external_resources/.applied/00-common/10-foo/30-hpa.yaml",
+        contents="blah: blah",
+    )
+    fs.create_file(
+        "/external_resources/.applied/00-common/10-foo/40-service.yaml",
+        contents="blah: blah",
+    )
+    assert main("/external_resources") == 0
+    assert mock_run.call_args_list == [
+        mock.call(
+            [
+                "kubectl",
+                "delete",
+                "-f",
+                "/external_resources/.applied/00-common/10-foo/40-service.yaml",
+            ],
+            check=True,
+        ),
+        mock.call(
+            [
+                "kubectl",
+                "delete",
+                "-f",
+                "/external_resources/.applied/00-common/10-foo/30-hpa.yaml",
+            ],
+            check=True,
+        ),
+    ]
+    assert not os.path.exists(
+        "/external_resources/.applied/00-common/10-foo/30-hpa.yaml"
+    )
+    assert not os.path.exists(
+        "/external_resources/.applied/00-common/10-foo/40-service.yaml"
+    )
+
+
+def test_kubectl_fails(mock_run, fs):
+    mock_run.side_effect = [CalledProcessError(cmd="kubectl", returncode=1), None]
+    fs.create_file(
+        "/external_resources/00-common/10-foo/30-hpa.yaml", contents="blah: blah",
+    )
+    fs.create_file(
+        "/external_resources/00-common/10-foo/40-service.yaml", contents="blah: blah",
+    )
+    assert main("/external_resources") == 1
+    assert not os.path.exists(
+        "/external_resources/.applied/00-common/10-foo/30-hpa.yaml"
+    )
+    assert os.path.exists(
+        "/external_resources/.applied/00-common/10-foo/40-service.yaml"
+    )


### PR DESCRIPTION
## Description

The goal here is to replace the cron'ed `kubectl apply` in puppet with something a little bit more intelligent.  This script creates a `.applied` directory inside `/etc/kubernetes/puppet_resources`, which tracks what's previously been applied to the cluster.  New files or changed files will get re-applied.  Things that have previously been deleted will thus exist in `.applied` but not in `puppet_resources`, and the script will run `kubectl delete` on such objects.

The script will only run on the kubernetes leader, and will rsync the `.applied` folder to the other masters.

All the operations in here are idempotent (e.g., if `kubectl apply` runs a second time, then it just won't make any changes), so this should be robust in case something goes wrong.  If the script _does_ find some errors it will exit 1, which I'll configure puppet to create a ticket for someone to manually investigate.

## Testing done

Ran manually on kubestage
Added some tests via `pyfakefs`