### PR TITLE
Unify error interface between bravado and oapi clients

### DIFF
--- a/paasta_itests/steps/paasta_api_steps.py
+++ b/paasta_itests/steps/paasta_api_steps.py
@@ -39,7 +39,7 @@ def service_instance_status_error(context, error_code, job_id):
         response = context.paasta_api_client.service.status_instance(
             instance=instance, service=service
         ).result()
-    except context.paasta_api_client.exception as exc:
+    except context.paasta_api_client.api_error as exc:
         assert exc.status_code == int(error_code)
 
     assert not response

--- a/paasta_itests/steps/paasta_api_steps.py
+++ b/paasta_itests/steps/paasta_api_steps.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from behave import then
-from bravado import exception as bexception
 
 from paasta_tools.cli.cmds.status import paasta_status_on_api_endpoint
 from paasta_tools.utils import decompose_job_id
@@ -40,7 +39,7 @@ def service_instance_status_error(context, error_code, job_id):
         response = context.paasta_api_client.service.status_instance(
             instance=instance, service=service
         ).result()
-    except bexception.HTTPError as exc:
+    except context.paasta_api_client.exception as exc:
         assert exc.status_code == int(error_code)
 
     assert not response

--- a/paasta_tools/api/auth_decorator.py
+++ b/paasta_tools/api/auth_decorator.py
@@ -53,8 +53,10 @@ class AuthResourceDecorator:
 
 
 class AuthClientDecorator:
-    """
-    """
+    api_error: type
+    connection_error: type
+    timeout_error: type
+    request_error: type
 
     def __init__(self, client, cluster_name):
         """ Create a auth client decorator.

--- a/paasta_tools/api/auth_decorator.py
+++ b/paasta_tools/api/auth_decorator.py
@@ -1,7 +1,10 @@
 import functools
 
 from bravado.docstring_property import docstring_property
+from bravado.exception import BravadoConnectionError
+from bravado.exception import BravadoTimeoutError
 from bravado.exception import HTTPBadRequest
+from bravado.exception import HTTPError
 
 import paasta_tools.api
 from paasta_tools.utils import load_system_paasta_config
@@ -61,6 +64,10 @@ class AuthClientDecorator:
         :return: A wrapped swagger client that should be used in place of a
             plain swagger client.
         """
+        self.api_error = HTTPError
+        self.connection_error = BravadoConnectionError
+        self.timeout_error = BravadoTimeoutError
+        self.request_error = HTTPBadRequest
         self.client = client
         self.cluster_name = cluster_name
 

--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -22,8 +22,8 @@ import sys
 import warnings
 
 import argcomplete
-import pkg_resources
 
+import paasta_tools
 from paasta_tools.cli import cmds
 from paasta_tools.cli.utils import load_method
 from paasta_tools.cli.utils import modules_in_pkg as paasta_commands_dir
@@ -106,9 +106,7 @@ def get_argparser():
         "-V",
         "--version",
         action="version",
-        version="paasta-tools {}".format(
-            pkg_resources.get_distribution("paasta-tools").version
-        ),
+        version=f"paasta-tools {paasta_tools.__version__}",
     )
 
     subparsers = parser.add_subparsers(

--- a/paasta_tools/cli/cmds/list_deploy_queue.py
+++ b/paasta_tools/cli/cmds/list_deploy_queue.py
@@ -19,10 +19,6 @@ import traceback
 from typing import List
 from typing import Union
 
-from bravado.exception import BravadoConnectionError
-from bravado.exception import BravadoTimeoutError
-from bravado.exception import HTTPError
-
 from paasta_tools.api.client import get_paasta_api_client
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -82,10 +78,10 @@ def list_deploy_queue(args,) -> int:
 
     try:
         deploy_queues, raw_response = client.deploy_queue.deploy_queue().result()
-    except HTTPError as exc:
+    except client.api_error as exc:
         print(PaastaColors.red(exc.response.text))
         return exc.status_code
-    except (BravadoConnectionError, BravadoTimeoutError) as exc:
+    except (client.connection_error, client.timeout_error) as exc:
         print(PaastaColors.red(f"Could not connect to API: {exc.__class__.__name__}"))
         return 1
     except Exception:

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -37,7 +37,6 @@ from typing import Optional
 
 import humanize
 import progressbar
-from bravado.exception import HTTPError
 from requests.exceptions import ConnectionError
 from service_configuration_lib import read_deploy
 from slackclient import SlackClient
@@ -1197,7 +1196,7 @@ def _run_instance_worker(cluster_data, instances_out, green_light):
                 include_envoy=False,
                 include_mesos=False,
             ).result()
-        except HTTPError as e:
+        except api.api_error as e:
             if e.response.status_code == 404:
                 log.warning(
                     "Can't get status for instance {}, service {} in "

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -20,7 +20,6 @@ from typing import Dict
 from typing import List
 
 import choice
-from bravado.exception import HTTPError
 
 from paasta_tools import remote_git
 from paasta_tools import utils
@@ -301,7 +300,7 @@ def paasta_start_or_stop(args, desired_state):
                             instance=instance,
                             desired_state=desired_state,
                         ).result()
-                    except HTTPError as exc:
+                    except client.api_error as exc:
                         print(exc.response.text)
                         return exc.status_code
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -37,9 +37,6 @@ from typing import Type
 from typing import Union
 
 import humanize
-from bravado.exception import BravadoConnectionError
-from bravado.exception import BravadoTimeoutError
-from bravado.exception import HTTPError
 from mypy_extensions import Arg
 from service_configuration_lib import read_deploy
 
@@ -246,10 +243,10 @@ def paasta_status_on_api_endpoint(
         status = client.service.status_instance(
             service=service, instance=instance, verbose=verbose
         ).result()
-    except HTTPError as exc:
+    except client.api_error as exc:
         output.append(PaastaColors.red(exc.response.text))
         return exc.status_code
-    except (BravadoConnectionError, BravadoTimeoutError) as exc:
+    except (client.connection_error, client.timeout_error) as exc:
         output.append(
             PaastaColors.red(f"Could not connect to API: {exc.__class__.__name__}")
         )

--- a/paasta_tools/monitoring/check_capacity.py
+++ b/paasta_tools/monitoring/check_capacity.py
@@ -17,8 +17,6 @@ import json
 import sys
 from collections import defaultdict
 
-from bravado.exception import HTTPError
-
 from paasta_tools.api.client import get_paasta_api_client
 from paasta_tools.utils import load_system_paasta_config
 
@@ -140,7 +138,7 @@ def run_capacity_check():
 
     try:
         resource_use = client.resources.resources(groupings=attributes).result()
-    except HTTPError as e:
+    except client.api_error as e:
         print("UNKNOWN received exception from paasta api:\n\t%s" % e)
         sys.exit(3)
 


### PR DESCRIPTION
- remove pkg_resources for version lookup because we have version constant in paasta_tools module
- add error type objects to oapi and swagger api clients
- remove explicit imports of bravado for error types