### PR TITLE
Add label to Kubernetes services if supplied in yelpsoa-config

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -409,8 +409,12 @@ instance MAY have:
     Defaults to the same uri specified in ``smartstack.yaml``, but can be
     set to something different here.
 
+ * ``prometheus_shard``: Optional name of Prometheus shard to be configured to
+   scrape the service. This shard should already exist and will not be
+   automatically created.
+
  * ``prometheus_port``: Optional port, not equal to ``container_port``, to
-    expose for prometheus scraping
+   expose for prometheus scraping.
 
 **Note**: Although many of these settings are inherited from ``smartstack.yaml``,
 their thresholds are not the same. The reason for this has to do with control

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -679,6 +679,9 @@
                         }
                     ]
                 },
+                "prometheus_shard": {
+                    "type": "string"
+                },
                 "prometheus_port": {
                     "type": "integer",
                     "minimum": 0

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1287,8 +1287,12 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
             prometheus_shard = self.get_prometheus_shard()
             if prometheus_shard:
-                complete_config.metadata.labels["yelp.com/paasta_prometheus_shard"] = prometheus_shard
-                complete_config.metadata.labels["paasta.yelp.com/config_prometheus_shard"] = prometheus_shard
+                complete_config.metadata.labels[
+                    "yelp.com/paasta_prometheus_shard"
+                ] = prometheus_shard
+                complete_config.metadata.labels[
+                    "paasta.yelp.com/config_prometheus_shard"
+                ] = prometheus_shard
 
             complete_config.spec.template.metadata.labels[
                 "yelp.com/paasta_config_sha"

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -290,6 +290,7 @@ class KubernetesDeploymentConfigDict(LongRunningServiceConfigDict, total=False):
     sidecar_resource_requirements: Dict[str, SidecarResourceRequirements]
     lifecycle: KubeLifecycleDict
     anti_affinity: Union[KubeAffinityCondition, List[KubeAffinityCondition]]
+    prometheus_shard: str
     prometheus_port: int
 
 
@@ -1283,6 +1284,12 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             )
             complete_config.metadata.labels["yelp.com/paasta_config_sha"] = config_hash
             complete_config.metadata.labels["paasta.yelp.com/config_sha"] = config_hash
+
+            prometheus_shard = self.get_prometheus_shard()
+            if prometheus_shard:
+                complete_config.metadata.labels["yelp.com/paasta_prometheus_shard"] = prometheus_shard
+                complete_config.metadata.labels["paasta.yelp.com/config_prometheus_shard"] = prometheus_shard
+
             complete_config.spec.template.metadata.labels[
                 "yelp.com/paasta_config_sha"
             ] = config_hash
@@ -1574,6 +1581,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         return self.config_dict.get("lifecycle", KubeLifecycleDict({})).get(
             "termination_grace_period_seconds"
         )
+
+    def get_prometheus_shard(self) -> Optional[str]:
+        return self.config_dict.get("prometheus_shard")
 
     def get_prometheus_port(self) -> Optional[int]:
         return self.config_dict.get("prometheus_port")

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1288,10 +1288,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             prometheus_shard = self.get_prometheus_shard()
             if prometheus_shard:
                 complete_config.metadata.labels[
-                    "yelp.com/paasta_prometheus_shard"
-                ] = prometheus_shard
-                complete_config.metadata.labels[
-                    "paasta.yelp.com/config_prometheus_shard"
+                    "paasta.yelp.com/prometheus_shard"
                 ] = prometheus_shard
 
             complete_config.spec.template.metadata.labels[

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Edit this release and run "make release"
-RELEASE=0.97.5
+RELEASE=0.97.6
 
 SHELL=/bin/bash
 

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Edit this release and run "make release"
-RELEASE=0.97.6
+RELEASE=0.97.5
 
 SHELL=/bin/bash
 


### PR DESCRIPTION
If a `prometheus_shard` option is specified in the yelpsoa-config file, set `yelp.com/paasta_prometheus_shard` and `paasta.yelp.com/config_prometheus_shard` labels to the provided shard.

This label will be used by the Prometheus Service Monitor for the given shard to discover and scrape the service.

Snippet from `sudo setup_kubernetes_job -v compute-infra-test-service.main_k8s`:
```bash
DEBUG:paasta_tools.kubernetes_tools:Complete configuration for instance is: {'api_version': 'apps/v1',
 'kind': 'Deployment',
 'metadata': {'annotations': None,
              'cluster_name': None,
              'creation_timestamp': None,
              'deletion_grace_period_seconds': None,
              'deletion_timestamp': None,
              'finalizers': None,
              'generate_name': None,
              'generation': None,
              'initializers': None,
              'labels': {'paasta.yelp.com/config_sha': 'configad75e987',
                         'paasta.yelp.com/git_sha': '191a485cce034b076748ff6fd054ade1726ea619',
                         'paasta.yelp.com/instance': 'main_k8s',
                         'paasta.yelp.com/prometheus_shard': 'edge',
                         'paasta.yelp.com/service': 'compute-infra-test-service',
```