### PR TITLE
Only show kubernetes pod events with multiple -v's

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -641,11 +641,11 @@ def format_marathon_task_table(tasks):
     return format_table(rows)
 
 
-def format_kubernetes_pod_table(pods):
+def format_kubernetes_pod_table(pods, verbose: int):
     rows = [("Pod ID", "Host deployed to", "Deployed at what localtime", "Health")]
     for pod in pods:
         local_deployed_datetime = datetime.fromtimestamp(pod.deployed_timestamp)
-        hostname = f"{pod.host}" if pod.host is not None else "Unknown"
+        hostname = f"{pod.host}" if pod.host is not None else PaastaColors.grey("N/A")
         if pod.phase is None or pod.phase == "Pending":
             health_check_status = PaastaColors.grey("N/A")
         elif pod.phase == "Running":
@@ -667,7 +667,7 @@ def format_kubernetes_pod_table(pods):
                 health_check_status,
             )
         )
-        if pod.events:
+        if pod.events and verbose > 1:
             rows.extend(format_pod_event_messages(pod.events, pod.name))
         if pod.message is not None:
             rows.append(PaastaColors.grey(f"  {pod.message}"))
@@ -1166,7 +1166,7 @@ def print_kubernetes_status(
 
     if kubernetes_status.pods and len(kubernetes_status.pods) > 0:
         output.append("      Pods:")
-        pods_table = format_kubernetes_pod_table(kubernetes_status.pods)
+        pods_table = format_kubernetes_pod_table(kubernetes_status.pods, verbose)
         output.extend([f"        {line}" for line in pods_table])
 
     if kubernetes_status.replicasets and len(kubernetes_status.replicasets) > 0:

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1551,7 +1551,7 @@ class TestFormatKubernetesPodTable:
         mock_format_tail_lines_for_mesos_task,
         mock_kubernetes_pod,
     ):
-        output = format_kubernetes_pod_table([mock_kubernetes_pod])
+        output = format_kubernetes_pod_table([mock_kubernetes_pod], verbose=0)
         pod_table_dict = _formatted_table_to_dict(output)
         assert pod_table_dict == {
             "Pod ID": "abc123",
@@ -1582,9 +1582,9 @@ class TestFormatKubernetesPodTable:
     ):
         mock_kubernetes_pod.host = None
         mock_kubernetes_pod.events = []
-        output = format_kubernetes_pod_table([mock_kubernetes_pod])
+        output = format_kubernetes_pod_table([mock_kubernetes_pod], verbose=0)
         pod_table_dict = _formatted_table_to_dict(output)
-        assert pod_table_dict["Host deployed to"] == "Unknown"
+        assert pod_table_dict["Host deployed to"] == PaastaColors.grey("N/A")
 
     @pytest.mark.parametrize("phase,ready", [("Failed", False), ("Running", False)])
     def test_unhealthy(
@@ -1598,7 +1598,7 @@ class TestFormatKubernetesPodTable:
         mock_kubernetes_pod.phase = phase
         mock_kubernetes_pod.ready = ready
         mock_kubernetes_pod.events = []
-        output = format_kubernetes_pod_table([mock_kubernetes_pod])
+        output = format_kubernetes_pod_table([mock_kubernetes_pod], verbose=0)
         pod_table_dict = _formatted_table_to_dict(output)
         assert pod_table_dict["Health"] == PaastaColors.red("Unhealthy")
 
@@ -1611,7 +1611,7 @@ class TestFormatKubernetesPodTable:
         mock_kubernetes_pod.phase = "Failed"
         mock_kubernetes_pod.reason = "Evicted"
         mock_kubernetes_pod.events = []
-        output = format_kubernetes_pod_table([mock_kubernetes_pod])
+        output = format_kubernetes_pod_table([mock_kubernetes_pod], verbose=0)
         pod_table_dict = _formatted_table_to_dict(output)
         assert pod_table_dict["Health"] == PaastaColors.red("Evicted")
 
@@ -1623,7 +1623,7 @@ class TestFormatKubernetesPodTable:
     ):
         mock_kubernetes_pod.phase = None
         mock_kubernetes_pod.events = []
-        output = format_kubernetes_pod_table([mock_kubernetes_pod])
+        output = format_kubernetes_pod_table([mock_kubernetes_pod], verbose=0)
         pod_table_dict = _formatted_table_to_dict(output)
         assert pod_table_dict["Health"] == PaastaColors.grey("N/A")
 


### PR DESCRIPTION
I'm tired of the pod table in `paasta status -v` being impossible to read because the rows for each pod are separated by a bunch of lines of pod events.

Isn't https://fluffy.yelpcorp.com/i/HPM4HsRzsx6mz5LBSvmfcM1bHlPJk0nx.png much nicer than https://fluffy.yelpcorp.com/i/jlvVnQqhjB3rfxwdZd8SxLFNcrtN6WDW.png?