### PR TITLE
Bump scribreader to 0.10.0 from 0.8.0

### DIFF
--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -8,14 +8,14 @@ inflection==0.3.1
 markdown==2.4
 monk==1.1.1
 python-jsonschema-objects==0.3.1
-scribereader==0.8.0
+scribereader==0.10.0
 signalform-tools==0.0.16
 slo-transcoder==3.2.3
 smmap2==2.0.3
 sticht[yelp_internal]==1.1.12
 vault-tools==0.7.34
 yelp-cgeom==1.3.1
-yelp-clog==4.1.1  # scribereader requires <5.0.0
+yelp-clog==5.0.0
 yelp-logging==1.0.37
 yelp_meteorite
 yelp_paasta_helpers


### PR DESCRIPTION
### Description
Scribereader >0.9.0 has support for corp clusters so we need to bump to at least that version to fix `paasta logs`, which is currently broken in our corp clusters. I'm bumping it to 0.10.0, which is the latest available version.

### Testing
manually tested `paasta logs -n 1000` on a service and got the logs successfully
`make test`
`make yelpy` - made sure all yelpy packages installed with no dep issues