### PR TITLE
Add prometheus_shard and prometheus_path to Pod spec

### DIFF
--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -24,7 +24,7 @@ DOCKER_RUN=docker run -t -v $(CURDIR)/../:/work:rw -e PIP_INDEX_URL=$(PIP_INDEX_
 NOOP = true
 ifeq ($(PAASTA_ENV),YELP)
 	ADD_MISSING_DEPS_MAYBE:=-diff --unchanged-line-format= --old-line-format= --new-line-format='%L' ../requirements.txt ./extra_requirements_yelp.txt >> ../requirements.txt
-	ACTUAL_PACKAGE_VERSION=$(RELEASE)-yelp2
+	ACTUAL_PACKAGE_VERSION=$(RELEASE)-yelp1
 	ADD_VERSION_SUFFIX=dch -v $(ACTUAL_PACKAGE_VERSION) --force-distribution --distribution $* --changelog ../debian/changelog 'Build for yelp: add scribereader to virtualenv'
 else
 	ADD_MISSING_DEPS_MAYBE:=$(NOOP)

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -24,7 +24,7 @@ DOCKER_RUN=docker run -t -v $(CURDIR)/../:/work:rw -e PIP_INDEX_URL=$(PIP_INDEX_
 NOOP = true
 ifeq ($(PAASTA_ENV),YELP)
 	ADD_MISSING_DEPS_MAYBE:=-diff --unchanged-line-format= --old-line-format= --new-line-format='%L' ../requirements.txt ./extra_requirements_yelp.txt >> ../requirements.txt
-	ACTUAL_PACKAGE_VERSION=$(RELEASE)-yelp1
+	ACTUAL_PACKAGE_VERSION=$(RELEASE)-yelp2
 	ADD_VERSION_SUFFIX=dch -v $(ACTUAL_PACKAGE_VERSION) --force-distribution --distribution $* --changelog ../debian/changelog 'Build for yelp: add scribereader to virtualenv'
 else
 	ADD_MISSING_DEPS_MAYBE:=$(NOOP)


### PR DESCRIPTION
This branch adds the `prometheus_shard` label to the Deployment's PodTemplateSpec so that Pods created as part of the Deployment also have the label.

It also moves the `prometheus_path` label to a Pod annotation. This is because the prometheus_path can be any valid URL path string (e.g. `/my_test/path`) which can include characters which are not valid for Kubernetes labels
```
a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character
```
As the prometheus_path is only required by Prometheus once the pod has already been discovered, it does not require indexing by Kubernetes and therefore does not need to be a Label.