### PR TITLE
Limit the number of extrapolations on the service load timeseries in …

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -642,7 +642,9 @@ def format_marathon_task_table(tasks):
 
 
 def format_kubernetes_pod_table(pods, verbose: int):
-    rows = [("Pod ID", "Host deployed to", "Deployed at what localtime", "Health")]
+    rows: List[Union[str, Sequence[str]]] = [
+        ("Pod ID", "Host deployed to", "Deployed at what localtime", "Health")
+    ]
     for pod in pods:
         local_deployed_datetime = datetime.fromtimestamp(pod.deployed_timestamp)
         hostname = f"{pod.host}" if pod.host is not None else PaastaColors.grey("N/A")

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -177,7 +177,7 @@ moving_average_window = '{moving_average_window_seconds}s'
 filters = filter('paasta_service', '{paasta_service}') and filter('paasta_instance', '{paasta_instance}') and filter('paasta_cluster', '{paasta_cluster}')
 
 current_replicas = data('kube_hpa_status_current_replicas', filter=filters, extrapolation="last_value").sum(by=['paasta_cluster'])
-load_per_instance = data('{signalfx_metric_name}', filter=filters, extrapolation="last_value")
+load_per_instance = data('{signalfx_metric_name}', filter=filters, extrapolation="last_value", maxExtrapolations=10)
 
 desired_instances_at_each_point_in_time = (load_per_instance - offset).sum() / (setpoint - offset)
 desired_instances = desired_instances_at_each_point_in_time.mean(over=moving_average_window)


### PR DESCRIPTION
…legacy autoscaling signalflow.

Without this, when instances die we'll keep the service load timeseries (e.g. uwsgi) pegged at its last value for some time.

See PAASTA-17043 for details.

---

I chose 10 kind of arbitrarily, but it looks alright when I update the graph.