### PR TITLE
make wait-for-deployment check the actually-running git SHAs, not just what's in deployments.json

### DIFF
--- a/paasta_tools/api/api_docs/oapi.yaml
+++ b/paasta_tools/api/api_docs/oapi.yaml
@@ -233,6 +233,15 @@ components:
       type: object
     InstanceStatusKubernetes:
       properties:
+        active_shas:
+          type: array
+          description: List of git/config SHAs running.
+          items:
+            type: array
+            items:
+              type: string
+            minItems: 2
+            maxItems: 2
         app_count:
           description: The number of different running versions of the same service
             (0 for stopped, 1 for running and 1+ for bouncing)
@@ -339,6 +348,15 @@ components:
       type: object
     InstanceStatusMarathon:
       properties:
+        active_shas:
+          type: array
+          description: List of git/config SHAs running.
+          items:
+            type: array
+            items:
+              type: string
+            minItems: 2
+            maxItems: 2
         app_count:
           description: The number of different running versions of the same service
             (0 for stopped, 1 for running and 1+ for bouncing)

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -766,6 +766,18 @@
                 "error_message": {
                     "type": "string",
                     "description": "Error message when a marathon job ID cannot be found"
+                },
+                "active_shas": {
+                    "type": "array",
+                    "description": "List of git/config SHAs running.",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                    }
                 }
             },
             "required": [
@@ -1288,6 +1300,18 @@
                 "error_message": {
                     "type": "string",
                     "description": "Error message when a kubernetes object (Deployment/Statefulset) cannot be found"
+                },
+                "active_shas": {
+                    "type": "array",
+                    "description": "List of git/config SHAs running.",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                    }
                 }
             },
             "required": [

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -181,6 +181,8 @@ async def pod_info(
         "reason": pod.status.reason,
         "message": pod.status.message,
         "events": pod_event_messages,
+        "git_sha": pod.metadata.labels.get("paasta.yelp.com/git_sha"),
+        "config_sha": pod.metadata.labels.get("paasta.yelp.com/config_sha"),
     }
 
 
@@ -219,6 +221,12 @@ async def job_status(
                     "replicas": replicaset.spec.replicas,
                     "ready_replicas": ready_replicas,
                     "create_timestamp": replicaset.metadata.creation_timestamp.timestamp(),
+                    "git_sha": replicaset.metadata.labels.get(
+                        "paasta.yelp.com/git_sha"
+                    ),
+                    "config_sha": replicaset.metadata.labels.get(
+                        "paasta.yelp.com/config_sha"
+                    ),
                 }
             )
 
@@ -441,11 +449,10 @@ def kubernetes_status(
     active_shas = kubernetes_tools.get_active_shas_for_service(
         [app, *pod_list, *replicaset_list]
     )
-    kstatus["app_count"] = max(
-        len(active_shas["config_sha"]), len(active_shas["git_sha"])
-    )
+    kstatus["app_count"] = len(active_shas)
     kstatus["desired_state"] = job_config.get_desired_state()
     kstatus["bounce_method"] = job_config.get_bounce_method()
+    kstatus["active_shas"] = list(active_shas)
 
     job_status(
         kstatus=kstatus,

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2235,15 +2235,19 @@ def parse_container_resources(resources: Mapping[str, str]) -> KubeContainerReso
 
 def get_active_shas_for_service(
     obj_list: Sequence[Union[V1Pod, V1ReplicaSet, V1Deployment, V1StatefulSet]],
-) -> Mapping[str, Set[str]]:
-    ret: MutableMapping[str, Set[str]] = {"config_sha": set(), "git_sha": set()}
+) -> Set[Tuple[str, str]]:
+    ret = set()
+
     for obj in obj_list:
         config_sha = obj.metadata.labels.get("paasta.yelp.com/config_sha")
-        if config_sha is not None:
-            ret["config_sha"].add(config_sha)
+        if config_sha.startswith("config"):
+            config_sha = config_sha[len("config") :]
+
         git_sha = obj.metadata.labels.get("paasta.yelp.com/git_sha")
-        if git_sha is not None:
-            ret["git_sha"].add(git_sha)
+        if git_sha.startswith("git"):
+            git_sha = git_sha[len("git") :]
+
+        ret.add((git_sha, config_sha))
     return ret
 
 

--- a/paasta_tools/paastaapi/model/instance_status_kubernetes.py
+++ b/paasta_tools/paastaapi/model/instance_status_kubernetes.py
@@ -110,6 +110,7 @@ class InstanceStatusKubernetes(ModelNormal):
             'app_count': (int,),  # noqa: E501
             'bounce_method': (str,),  # noqa: E501
             'desired_state': (str,),  # noqa: E501
+            'active_shas': ([[str]],),  # noqa: E501
             'app_id': (str,),  # noqa: E501
             'autoscaling_status': (InstanceStatusKubernetesAutoscalingStatus,),  # noqa: E501
             'backoff_seconds': (int,),  # noqa: E501
@@ -136,6 +137,7 @@ class InstanceStatusKubernetes(ModelNormal):
         'app_count': 'app_count',  # noqa: E501
         'bounce_method': 'bounce_method',  # noqa: E501
         'desired_state': 'desired_state',  # noqa: E501
+        'active_shas': 'active_shas',  # noqa: E501
         'app_id': 'app_id',  # noqa: E501
         'autoscaling_status': 'autoscaling_status',  # noqa: E501
         'backoff_seconds': 'backoff_seconds',  # noqa: E501
@@ -204,6 +206,7 @@ class InstanceStatusKubernetes(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            active_shas ([[str]]): List of git/config SHAs running.. [optional]  # noqa: E501
             app_id (str): ID of the desired version of a service instance. [optional]  # noqa: E501
             autoscaling_status (InstanceStatusKubernetesAutoscalingStatus): [optional]  # noqa: E501
             backoff_seconds (int): backoff in seconds before launching the next task. [optional]  # noqa: E501

--- a/paasta_tools/paastaapi/model/instance_status_marathon.py
+++ b/paasta_tools/paastaapi/model/instance_status_marathon.py
@@ -111,6 +111,7 @@ class InstanceStatusMarathon(ModelNormal):
             'app_count': (int,),  # noqa: E501
             'bounce_method': (str,),  # noqa: E501
             'desired_state': (str,),  # noqa: E501
+            'active_shas': ([[str]],),  # noqa: E501
             'app_statuses': ([MarathonAppStatus],),  # noqa: E501
             'autoscaling_info': (MarathonAutoscalingInfo,),  # noqa: E501
             'backoff_seconds': (int,),  # noqa: E501
@@ -133,6 +134,7 @@ class InstanceStatusMarathon(ModelNormal):
         'app_count': 'app_count',  # noqa: E501
         'bounce_method': 'bounce_method',  # noqa: E501
         'desired_state': 'desired_state',  # noqa: E501
+        'active_shas': 'active_shas',  # noqa: E501
         'app_statuses': 'app_statuses',  # noqa: E501
         'autoscaling_info': 'autoscaling_info',  # noqa: E501
         'backoff_seconds': 'backoff_seconds',  # noqa: E501
@@ -197,6 +199,7 @@ class InstanceStatusMarathon(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            active_shas ([[str]]): List of git/config SHAs running.. [optional]  # noqa: E501
             app_statuses ([MarathonAppStatus]): Statuses of each app of the service. [optional]  # noqa: E501
             autoscaling_info (MarathonAutoscalingInfo): [optional]  # noqa: E501
             backoff_seconds (int): backoff in seconds before launching the next task. [optional]  # noqa: E501

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -204,7 +204,9 @@ def test_marathon_job_status(
     mock_marathon_app_status,
     mock_service_config,
 ):
-    mock_service_config.format_marathon_app_dict = lambda: {"id": "foo"}
+    mock_service_config.format_marathon_app_dict = lambda: {
+        "id": "foo.bar.gitabc.config123"
+    }
     settings.system_paasta_config = mock.create_autospec(SystemPaastaConfig)
 
     mock_get_marathon_app_deploy_status.return_value = 0  # Running status
@@ -216,7 +218,7 @@ def test_marathon_job_status(
         target_instances=3,
     )
 
-    mock_app = mock.Mock(id="/foo", tasks_running=2)
+    mock_app = mock.Mock(id="/foo.bar.gitabc.config123", tasks_running=2)
     job_status = instance.marathon_job_status(
         "fake_service",
         "fake_instance",
@@ -234,10 +236,11 @@ def test_marathon_job_status(
         "desired_state": "start",
         "bounce_method": "fake_bounce",
         "expected_instance_count": 1,
-        "desired_app_id": "foo",
+        "desired_app_id": "foo.bar.gitabc.config123",
         "deploy_status": "Running",
         "running_instance_count": 2,
         "autoscaling_info": expected_autoscaling_info,
+        "active_shas": [("abc", "123")],
     }
 
     assert mock_marathon_app_status.call_count == 1
@@ -273,10 +276,12 @@ def test_marathon_job_status_no_dashboard_links(
     mock_marathon_app_status,
     mock_service_config,
 ):
-    mock_service_config.format_marathon_app_dict = lambda: {"id": "foo"}
+    mock_service_config.format_marathon_app_dict = lambda: {
+        "id": "foo.bar.gitabc.config123"
+    }
     settings.system_paasta_config = mock.create_autospec(SystemPaastaConfig)
     mock_get_marathon_app_deploy_status.return_value = 0  # Running status
-    mock_app = mock.Mock(id="/foo", tasks_running=2)
+    mock_app = mock.Mock(id="/foo.bar.gitabc.config123", tasks_running=2)
 
     mock_get_marathon_dashboard_links.return_value = None
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2741,8 +2741,8 @@ def test_get_active_shas_for_service():
         ),
     ]
     assert get_active_shas_for_service(mock_pod_list) == {
-        "git_sha": {"b456", "b456!!!"},
-        "config_sha": {"a123", "a123!!!"},
+        ("b456!!!", "a123!!!"),
+        ("b456", "a123"),
     }
 
 


### PR DESCRIPTION
PAASTA-17026

We've got a race condition currently with wait-for-deployment, which leads to it thinking deployments are done before they've really started.

If wait-for-deployment polls for status after the `yelpsoa-configs` cron updates deployments.json, but before the `setup_kubernetes_job` runs, and the old version is fully deployed, then:

- the app_count check on line 1247 will pass. (There's exactly one app -- the old app).
- the git_sha check on line 1260 will pass (since that only checks deployments.json)
- the deploy_status check on line 1272-1275 will pass (since the old version is still Running)
- the required_instance_count check on line 1297 will pass (since the old version is fully deployed).

This patch adds a new `active_shas` property to the status response, and checks this in wait-for-deployment.