### PR TITLE
Add pod_name and pod_ip to tmp_paasta_allocation

### DIFF
--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -115,6 +115,7 @@ from paasta_tools.utils import PersistentVolume
 from paasta_tools.utils import SecretVolume
 from paasta_tools.utils import SecretVolumeItem
 from paasta_tools.utils import SystemPaastaConfig
+from paasta_tools.contrib.get_running_task_allocation import get_kubernetes_metadata as task_allocation_get_kubernetes_metadata
 
 
 def test_force_delete_pods():
@@ -3179,3 +3180,20 @@ def test_mode_to_int():
     assert mode_to_int(None) is None
     assert mode_to_int(0o123) == 0o123
     assert mode_to_int("0123") == 0o123
+
+
+def test_running_task_allocation_get_kubernetes_metadata():
+    mock_pod = mock.MagicMock()
+    mock_pod.metadata.labels={
+        "yelp.com/paasta_service": "srv1",
+        "yelp.com/paasta_instance": "instance1",
+        "paasta.yelp.com/service": "srv1",
+        "paasta.yelp.com/instance": "instance1",
+    }
+    mock_pod.spec.node_selector={
+        'yelp.com/pool': 'default'
+    }
+    mock_pod.metadata.name = "pod_1"
+    mock_pod.status.pod_ip = "10.10.10.10"
+    ret = task_allocation_get_kubernetes_metadata(mock_pod)
+    assert ret == ('srv1', 'instance1', 'default', 'pod_1', '10.10.10.10')


### PR DESCRIPTION
Add pod_name and pod_ip to tmp_paasta_allocation to create a direct mapping between service / instance and pod name / ip

[Example get_running_task_allocation output](https://fluffy.yelpcorp.com/i/QjhwT9X7W7MR8zntcx9QsPDP99HSzkmK.html)