### PR TITLE
Add host_ip to get_running_task_allocation output

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+paasta-tools (0.97.19) xenial; urgency=medium
+
+  * 0.97.19 tagged with 'make release'
+    Commit: Run get_running_task_allocation.py using paasta_tools Python
+    Run get_running_task_allocation.py using paasta_tools Python
+
+ -- Serg Shevchenko <sergs@yelp.com>  Mon, 26 Oct 2020 12:22:40 -0700
+
 paasta-tools (0.97.18) xenial; urgency=medium
 
   * 0.97.18 tagged with 'make release'

--- a/docs/source/generated/paasta_tools.contrib.add_to_deploy_queue.rst
+++ b/docs/source/generated/paasta_tools.contrib.add_to_deploy_queue.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.add\_to\_deploy\_queue module
+===================================================
+
+.. automodule:: paasta_tools.contrib.add_to_deploy_queue
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.bounce_log_latency_parser.rst
+++ b/docs/source/generated/paasta_tools.contrib.bounce_log_latency_parser.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.bounce\_log\_latency\_parser module
+=========================================================
+
+.. automodule:: paasta_tools.contrib.bounce_log_latency_parser
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.check_orphans.rst
+++ b/docs/source/generated/paasta_tools.contrib.check_orphans.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.check\_orphans module
+===========================================
+
+.. automodule:: paasta_tools.contrib.check_orphans
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.create_dynamodb_table.rst
+++ b/docs/source/generated/paasta_tools.contrib.create_dynamodb_table.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.create\_dynamodb\_table module
+====================================================
+
+.. automodule:: paasta_tools.contrib.create_dynamodb_table
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.delete_old_marathon_deployments.rst
+++ b/docs/source/generated/paasta_tools.contrib.delete_old_marathon_deployments.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.delete\_old\_marathon\_deployments module
+===============================================================
+
+.. automodule:: paasta_tools.contrib.delete_old_marathon_deployments
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.emit_allocated_cpu_metrics.rst
+++ b/docs/source/generated/paasta_tools.contrib.emit_allocated_cpu_metrics.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.emit\_allocated\_cpu\_metrics module
+==========================================================
+
+.. automodule:: paasta_tools.contrib.emit_allocated_cpu_metrics
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.get_running_task_allocation.rst
+++ b/docs/source/generated/paasta_tools.contrib.get_running_task_allocation.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.get\_running\_task\_allocation module
+===========================================================
+
+.. automodule:: paasta_tools.contrib.get_running_task_allocation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.graceful_container_drain.rst
+++ b/docs/source/generated/paasta_tools.contrib.graceful_container_drain.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.graceful\_container\_drain module
+=======================================================
+
+.. automodule:: paasta_tools.contrib.graceful_container_drain
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.is_pod_healthy_in_proxy.rst
+++ b/docs/source/generated/paasta_tools.contrib.is_pod_healthy_in_proxy.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.is\_pod\_healthy\_in\_proxy module
+========================================================
+
+.. automodule:: paasta_tools.contrib.is_pod_healthy_in_proxy
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.is_pod_healthy_in_smartstack.rst
+++ b/docs/source/generated/paasta_tools.contrib.is_pod_healthy_in_smartstack.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.is\_pod\_healthy\_in\_smartstack module
+=============================================================
+
+.. automodule:: paasta_tools.contrib.is_pod_healthy_in_smartstack
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.kill_bad_containers.rst
+++ b/docs/source/generated/paasta_tools.contrib.kill_bad_containers.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.kill\_bad\_containers module
+==================================================
+
+.. automodule:: paasta_tools.contrib.kill_bad_containers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.mock_patch_checker.rst
+++ b/docs/source/generated/paasta_tools.contrib.mock_patch_checker.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.mock\_patch\_checker module
+=================================================
+
+.. automodule:: paasta_tools.contrib.mock_patch_checker
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.paasta_get_num_deployments.rst
+++ b/docs/source/generated/paasta_tools.contrib.paasta_get_num_deployments.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.paasta\_get\_num\_deployments module
+==========================================================
+
+.. automodule:: paasta_tools.contrib.paasta_get_num_deployments
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.paasta_update_soa_memcpu.rst
+++ b/docs/source/generated/paasta_tools.contrib.paasta_update_soa_memcpu.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.paasta\_update\_soa\_memcpu module
+========================================================
+
+.. automodule:: paasta_tools.contrib.paasta_update_soa_memcpu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.rightsizer_soaconfigs_update.rst
+++ b/docs/source/generated/paasta_tools.contrib.rightsizer_soaconfigs_update.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.rightsizer\_soaconfigs\_update module
+===========================================================
+
+.. automodule:: paasta_tools.contrib.rightsizer_soaconfigs_update
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.rst
+++ b/docs/source/generated/paasta_tools.contrib.rst
@@ -1,0 +1,33 @@
+paasta\_tools.contrib package
+=============================
+
+Submodules
+----------
+
+.. toctree::
+
+   paasta_tools.contrib.add_to_deploy_queue
+   paasta_tools.contrib.bounce_log_latency_parser
+   paasta_tools.contrib.check_orphans
+   paasta_tools.contrib.create_dynamodb_table
+   paasta_tools.contrib.delete_old_marathon_deployments
+   paasta_tools.contrib.emit_allocated_cpu_metrics
+   paasta_tools.contrib.get_running_task_allocation
+   paasta_tools.contrib.graceful_container_drain
+   paasta_tools.contrib.is_pod_healthy_in_proxy
+   paasta_tools.contrib.is_pod_healthy_in_smartstack
+   paasta_tools.contrib.kill_bad_containers
+   paasta_tools.contrib.mock_patch_checker
+   paasta_tools.contrib.paasta_get_num_deployments
+   paasta_tools.contrib.paasta_update_soa_memcpu
+   paasta_tools.contrib.rightsizer_soaconfigs_update
+   paasta_tools.contrib.shared_ip_check
+   paasta_tools.contrib.utilization_check
+
+Module contents
+---------------
+
+.. automodule:: paasta_tools.contrib
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.shared_ip_check.rst
+++ b/docs/source/generated/paasta_tools.contrib.shared_ip_check.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.shared\_ip\_check module
+==============================================
+
+.. automodule:: paasta_tools.contrib.shared_ip_check
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.contrib.utilization_check.rst
+++ b/docs/source/generated/paasta_tools.contrib.utilization_check.rst
@@ -1,0 +1,7 @@
+paasta\_tools.contrib.utilization\_check module
+===============================================
+
+.. automodule:: paasta_tools.contrib.utilization_check
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/paasta_tools.rst
+++ b/docs/source/generated/paasta_tools.rst
@@ -9,6 +9,7 @@ Subpackages
    paasta_tools.api
    paasta_tools.autoscaling
    paasta_tools.cli
+   paasta_tools.contrib
    paasta_tools.deployd
    paasta_tools.frameworks
    paasta_tools.instance

--- a/paasta_tools/__init__.py
+++ b/paasta_tools/__init__.py
@@ -17,4 +17,4 @@
 # setup phase, the dependencies may not exist on disk yet.
 #
 # Don't bump version manually. See `make release` docs in ./Makefile
-__version__ = "0.97.18"
+__version__ = "0.97.19"

--- a/paasta_tools/api/client.py
+++ b/paasta_tools/api/client.py
@@ -18,14 +18,13 @@ Client interface for the Paasta rest api.
 import json
 import logging
 import os
+from dataclasses import dataclass
 from typing import Any
 from typing import Mapping
 from typing import Optional
 from typing import Type
 from urllib.parse import ParseResult
 from urllib.parse import urlparse
-
-from dataclasses import dataclass
 
 import paasta_tools.paastaapi.apis as paastaapis
 from paasta_tools import paastaapi

--- a/paasta_tools/contrib/get_running_task_allocation.py
+++ b/paasta_tools/contrib/get_running_task_allocation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/venvs/paasta-tools/bin/python
 import argparse
 import time
 from typing import Any

--- a/paasta_tools/contrib/get_running_task_allocation.py
+++ b/paasta_tools/contrib/get_running_task_allocation.py
@@ -35,6 +35,7 @@ class TaskAllocationInfo(NamedTuple):
     docker_id: str
     pod_name: str
     pod_ip: str
+    host_ip: str
     mesos_container_id: str  # Because Mesos task info does not have docker id
 
 
@@ -99,6 +100,7 @@ async def get_mesos_task_allocation_info() -> Iterable[TaskAllocationInfo]:
                 docker_id=None,
                 pod_name=None,
                 pod_ip=None,
+                host_ip=None,
                 mesos_container_id=mesos_container_id,
             )
         )
@@ -133,15 +135,23 @@ def get_kubernetes_resource_request(
 
 def get_kubernetes_metadata(
     pod: V1Pod,
-) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]]:
+) -> Tuple[
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[str],
+]:
     labels = pod.metadata.labels or {}
     node_selectors = pod.spec.node_selector or {}
     pod_name = pod.metadata.name
     pod_ip = pod.status.pod_ip
+    host_ip = pod.status.host_ip
     service = labels.get("paasta.yelp.com/service")
     instance = labels.get("paasta.yelp.com/instance")
     pool = node_selectors.get("yelp.com/pool", "default")
-    return service, instance, pool, pod_name, pod_ip
+    return service, instance, pool, pod_name, pod_ip, host_ip
 
 
 def get_container_type(container_name: str, instance_name: str) -> str:
@@ -161,7 +171,9 @@ def get_kubernetes_task_allocation_info(namespace: str) -> Iterable[TaskAllocati
     pods = get_all_running_kubernetes_pods(client, namespace)
     info_list = []
     for pod in pods:
-        service, instance, pool, pod_name, pod_ip = get_kubernetes_metadata(pod)
+        service, instance, pool, pod_name, pod_ip, host_ip = get_kubernetes_metadata(
+            pod
+        )
         name_to_info: MutableMapping[str, Any] = {}
         for container in pod.spec.containers:
             name_to_info[container.name] = {
@@ -169,6 +181,7 @@ def get_kubernetes_task_allocation_info(namespace: str) -> Iterable[TaskAllocati
                 "container_type": get_container_type(container.name, instance),
                 "pod_name": pod_name,
                 "pod_ip": pod_ip,
+                "host_ip": host_ip,
             }
         container_statuses = pod.status.container_statuses or []
         for container in container_statuses:
@@ -197,6 +210,7 @@ def get_kubernetes_task_allocation_info(namespace: str) -> Iterable[TaskAllocati
                     docker_id=info.get("docker_id"),
                     pod_name=info.get("pod_name"),
                     pod_ip=info.get("pod_ip"),
+                    host_ip=info.get("host_ip"),
                     mesos_container_id=None,
                 )
             )

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -3195,5 +3195,13 @@ def test_running_task_allocation_get_kubernetes_metadata():
     mock_pod.spec.node_selector = {"yelp.com/pool": "default"}
     mock_pod.metadata.name = "pod_1"
     mock_pod.status.pod_ip = "10.10.10.10"
+    mock_pod.status.host_ip = "10.10.10.11"
     ret = task_allocation_get_kubernetes_metadata(mock_pod)
-    assert ret == ("srv1", "instance1", "default", "pod_1", "10.10.10.10")
+    assert ret == (
+        "srv1",
+        "instance1",
+        "default",
+        "pod_1",
+        "10.10.10.10",
+        "10.10.10.11",
+    )

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Edit this release and run "make release"
-RELEASE=0.97.18
+RELEASE=0.97.19
 
 SHELL=/bin/bash
 


### PR DESCRIPTION
Add host_ip to get_running_task_allocation script output to simplify mapping of a running pod to a host.

Change in api/client.py is caused by an automated import reordering.