### PR TITLE
Have status API return full-length git SHAs in active_shas for marath…

### DIFF
--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -69,6 +69,7 @@ from paasta_tools.mesos_tools import results_or_unknown
 from paasta_tools.mesos_tools import select_tasks_by_id
 from paasta_tools.mesos_tools import TaskNotFound
 from paasta_tools.utils import calculate_tail_lines
+from paasta_tools.utils import get_git_sha_from_dockerurl
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import TimeoutError
@@ -212,9 +213,8 @@ def get_active_shas_for_marathon_apps(
 ) -> Set[Tuple[str, str]]:
     ret = set()
     for (app, client) in marathon_apps_with_clients:
-        _, _, git_sha, config_sha = marathon_tools.deformat_job_id(app.id)
-        if git_sha.startswith("git"):
-            git_sha = git_sha[len("git") :]
+        git_sha = get_git_sha_from_dockerurl(app.container.docker.image, long=True)
+        _, _, _, config_sha = marathon_tools.deformat_job_id(app.id)
         if config_sha.startswith("config"):
             config_sha = config_sha[len("config") :]
         ret.add((git_sha, config_sha))

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -205,7 +205,7 @@ def test_marathon_job_status(
     mock_service_config,
 ):
     mock_service_config.format_marathon_app_dict = lambda: {
-        "id": "foo.bar.gitabc.config123"
+        "id": "foo.bar.gitabc.config123",
     }
     settings.system_paasta_config = mock.create_autospec(SystemPaastaConfig)
 
@@ -219,6 +219,7 @@ def test_marathon_job_status(
     )
 
     mock_app = mock.Mock(id="/foo.bar.gitabc.config123", tasks_running=2)
+    mock_app.container.docker.image = "registry.yelp/servicename-abc"
     job_status = instance.marathon_job_status(
         "fake_service",
         "fake_instance",
@@ -282,6 +283,7 @@ def test_marathon_job_status_no_dashboard_links(
     settings.system_paasta_config = mock.create_autospec(SystemPaastaConfig)
     mock_get_marathon_app_deploy_status.return_value = 0  # Running status
     mock_app = mock.Mock(id="/foo.bar.gitabc.config123", tasks_running=2)
+    mock_app.container.docker.image = "registry.yelp/servicename-abc"
 
     mock_get_marathon_dashboard_links.return_value = None
 


### PR DESCRIPTION
…on apps, to be consistent with kubernetes. PAASTA-17026

This should fix the `{service}.{instance} on {cluster} not yet running {full git SHA}` bug we saw earlier.