### PR TITLE
fix spark-run with mrjob

### DIFF
--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -222,19 +222,18 @@ def test_get_spark_env(
     extra_expected,
     aws,
     expected_aws,
-    mock_create_spark_config_str,
     mock_get_possible_launced_by_user_variable_from_env,
 ):
-    spark_opts = {"spark.ui.port": "1234"}
+    spark_conf_str = "--conf spark.ui.port=1234"
     expected_output = {
         "SPARK_USER": "root",
-        "SPARK_OPTS": mock_create_spark_config_str.return_value,
+        "SPARK_OPTS": "--conf spark.ui.port=1234",
         "PAASTA_LAUNCHED_BY": mock_get_possible_launced_by_user_variable_from_env.return_value,
         "PAASTA_INSTANCE_TYPE": "spark",
         **extra_expected,
         **expected_aws,
     }
-    assert spark_run.get_spark_env(args, spark_opts, aws) == expected_output
+    assert spark_run.get_spark_env(args, spark_conf_str, aws, "1234") == expected_output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description
- fixed the issue that triggers `spark.master` key not exist error when use with `--mrjob` 

The original spark job called `create_spark_conf_str` twice, and unfortunately the create_spark_conf_str will drop the `spark.master`if `--mrjob` is set.  Therefore the second time we called the function will raise the error. 
The fix updates:
1.  create_spark_conf_str is called only once
2. also update create_spark_conf_str doesn't modify the passing argument spark_conf dict to ensure the stability. 

# Test: 
- make test pass
- manually run with with `paasta spark-run --mrjob` works on ads devc batch` also works! 