### PR TITLE
Two separate try/excepts for two separate attribute lookups

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1214,10 +1214,11 @@ def _run_instance_worker(cluster_data, instances_out, green_light):
         long_running_status = None
         if status:
             try:
-                if status.marathon:
-                    long_running_status = status.marathon
-                elif status.kubernetes:
-                    long_running_status = status.kubernetes
+                long_running_status = status.marathon
+            except ApiAttributeError:
+                pass
+            try:
+                long_running_status = status.kubernetes
             except ApiAttributeError:
                 pass
         if not status:

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1214,11 +1214,13 @@ def _run_instance_worker(cluster_data, instances_out, green_light):
         long_running_status = None
         if status:
             try:
-                long_running_status = status.marathon
+                if status.marathon:
+                    long_running_status = status.marathon
             except ApiAttributeError:
                 pass
             try:
-                long_running_status = status.kubernetes
+                if status.kubernetes:
+                    long_running_status = status.kubernetes
             except ApiAttributeError:
                 pass
         if not status:


### PR DESCRIPTION
For k8s instances, the `if status.marathon` line would raise ApiAttributeError so we'd never hit the `elif status.kubernetes` line -- this causes wait-for-deployment to think that this instance is neither marathon nor kubernetes, so it doesn't bother waiting for it.