### PR TITLE
Make mypy not complain about imports from contrib in test_kubernetes_…

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -84,3 +84,6 @@ disallow_untyped_defs = True
 
 [mypy-paasta_tools.envoy_tools]
 disallow_untyped_defs = True
+
+[mypy-paasta_tools.contrib.*]
+ignore_errors = True


### PR DESCRIPTION
…tools.py

Looks like this broke in https://github.com/Yelp/paasta/pull/2942 -- paasta_tools/contrib needed a `__init__.py` for imports to work properly from it, at least for mypy. I'm not sure how pytest was able to import.