### PR TITLE
Pin cryptography version to 2.8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=py36-linux
 tox_pip_extensions_ext_pip_custom_platform = true
 tox_pip_extensions_ext_venv_update = true
 docker_compose_version = 1.26.2
+cryptography_version = 2.8
 
 [testenv]
 # The Makefile and .travis.yml override the indexserver to the public one when
@@ -37,6 +38,7 @@ changedir=paasta_itests/
 passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
 deps =
     docker-compose=={[tox]docker_compose_version}
+    cryptography==[{tox]cryptography_version}
 commands =
     docker-compose down
     docker-compose --verbose build --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
@@ -59,6 +61,7 @@ basepython = python3.6
 whitelist_externals = bash
 deps =
     docker-compose=={[tox]docker_compose_version}
+    cryptography==[{tox]cryptography_version}
 setenv =
 passenv =
     KIND_CLUSTER
@@ -88,6 +91,7 @@ changedir=example_cluster/
 passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
 deps =
     docker-compose=={[tox]docker_compose_version}
+    cryptography==[{tox]cryptography_version}
 commands =
     docker-compose down
     docker-compose --verbose build --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}


### PR DESCRIPTION
Newer versions of cryptography python package do not support
openssl 1.0.2 and fail tests. This change pins cryptography version to 2.8.