### PR TITLE
PAASTA-17084 Don't fail to remove resources if they are already gone

### DIFF
--- a/paasta_tools/apply_external_resources.py
+++ b/paasta_tools/apply_external_resources.py
@@ -59,7 +59,10 @@ def main(puppet_resource_root: str) -> int:
             if not os.path.exists(puppet_path):
                 print(f"Deleting resource {path}...")
                 try:
-                    run(["kubectl", "delete", "-f", path], check=True)
+                    run(
+                        ["kubectl", "delete", "--ignore-not-found=true", "-f", path],
+                        check=True,
+                    )
                     os.remove(path)
                 except CalledProcessError:
                     print(f"There was a problem deleting {path}:\n")

--- a/tests/test_apply_external_resources.py
+++ b/tests/test_apply_external_resources.py
@@ -110,6 +110,7 @@ def test_resources_deleted_in_reverse_order(mock_run, fs):
             [
                 "kubectl",
                 "delete",
+                "--ignore-not-found=true",
                 "-f",
                 "/external_resources/.applied/00-common/10-foo/40-service.yaml",
             ],
@@ -119,6 +120,7 @@ def test_resources_deleted_in_reverse_order(mock_run, fs):
             [
                 "kubectl",
                 "delete",
+                "--ignore-not-found=true",
                 "-f",
                 "/external_resources/.applied/00-common/10-foo/30-hpa.yaml",
             ],


### PR DESCRIPTION
This PR tries to address the issue identified on https://fluffy.yelpcorp.com/i/rSQd5DxlJxqt75X5VRhlDgxTWFt9m6X6.html where **apply_external_resources.py** fails to remove resources that are already gone.

- Manual invocation:
```
# kubectl delete -f xxxxx/10-nvidia-device-plugin-daemonset.yaml
Error from server (NotFound): error when deleting "xxxxx/10-nvidia-device-plugin-daemonset.yaml": daemonsets.apps "nvidia-device-plugin-daemonset" not found

# kubectl delete --ignore-not-found=true -f xxxxx/10-nvidia-device-plugin-daemonset.yaml
# echo $?
0
```