### PR TITLE
Only exit non-zero if there is a critical failure for replication scr…

### DIFF
--- a/paasta_tools/check_services_replication_tools.py
+++ b/paasta_tools/check_services_replication_tools.py
@@ -75,14 +75,6 @@ def parse_args() -> argparse.Namespace:
         help="define a different soa config directory",
     )
     parser.add_argument(
-        "--warn",
-        dest="under_replicated_warn_pct",
-        type=float,
-        default=5,
-        help="The percentage of under replicated service instances past which "
-        "the script will return a warning status",
-    )
-    parser.add_argument(
         "--crit",
         dest="under_replicated_crit_pct",
         type=float,
@@ -218,12 +210,6 @@ def main(
             f"are under replicated (past {args.under_replicated_crit_pct} is critical)!"
         )
         sys.exit(2)
-    elif pct_under_replicated >= args.under_replicated_warn_pct:
-        log.warning(
-            f"{pct_under_replicated}% of instances ({count_under_replicated}/{total}) "
-            f"are under replicated (past {args.under_replicated_warn_pct} is a warning)!"
-        )
-        sys.exit(1)
     else:
         sys.exit(0)
 

--- a/tests/test_check_service_replication_tools.py
+++ b/tests/test_check_service_replication_tools.py
@@ -21,8 +21,8 @@ def test_main_kubernetes():
     ) as mock_yelp_meteorite, mock.patch(
         "paasta_tools.check_services_replication_tools.sys.exit", autospec=True,
     ) as mock_sys_exit:
-        mock_parse_args.return_value.under_replicated_crit_pct = 10
-        mock_parse_args.return_value.under_replicated_warn_pct = 5
+        mock_parse_args.return_value.under_replicated_crit_pct = 5
+        mock_parse_args.return_value.min_count_critical = 1
         mock_check_services_replication.return_value = (6, 100)
 
         check_services_replication_tools.main(
@@ -40,7 +40,7 @@ def test_main_kubernetes():
         mock_gauge = mock_yelp_meteorite.create_gauge.return_value
         mock_gauge.set.assert_called_once_with(6)
 
-        mock_sys_exit.assert_called_once_with(1)
+        mock_sys_exit.assert_called_once_with(2)
 
 
 def test_main_mesos():
@@ -61,8 +61,8 @@ def test_main_mesos():
     ) as mock_yelp_meteorite, mock.patch(
         "paasta_tools.check_services_replication_tools.sys.exit", autospec=True,
     ) as mock_sys_exit:
-        mock_parse_args.return_value.under_replicated_crit_pct = 10
-        mock_parse_args.return_value.under_replicated_warn_pct = 5
+        mock_parse_args.return_value.under_replicated_crit_pct = 5
+        mock_parse_args.return_value.min_count_critical = 1
         mock_check_services_replication.return_value = (6, 100)
 
         check_services_replication_tools.main(
@@ -83,7 +83,7 @@ def test_main_mesos():
         mock_gauge = mock_yelp_meteorite.create_gauge.return_value
         mock_gauge.set.assert_called_once_with(6)
 
-        mock_sys_exit.assert_called_once_with(1)
+        mock_sys_exit.assert_called_once_with(2)
 
 
 def test_check_services_replication():


### PR DESCRIPTION
…ipts

The alert for this script is the cron staleness check, which will alert if the exit code of the command is anything other than 0.

I thought about adding `test $? -lt 2` to the end of the command so that would only alert if the exit code of the script were 2, but if the script encounters any Python exceptions, it will exit 1, and I think we should probably still alert in that case.