### PR TITLE
Update status for HPA objects in v2beta2

### DIFF
--- a/paasta_tools/instance/hpa_metrics_parser.py
+++ b/paasta_tools/instance/hpa_metrics_parser.py
@@ -48,41 +48,41 @@ class HPAMetricsParser:
         return status
 
     def parse_external_metric(self, metric_spec, status: HPAMetricsDict):
-        status["name"] = metric_spec.metric_name
+        status["name"] = metric_spec.metric.name
         status["target_value"] = (
-            metric_spec.target_average_value
-            if getattr(metric_spec, "target_average_value")
-            else metric_spec.target_value
+            metric_spec.target.average_value
+            if getattr(metric_spec.target, "average_value")
+            else metric_spec.target.value
         )
 
     def parse_external_metric_current(self, metric_spec, status: HPAMetricsDict):
-        status["name"] = metric_spec.metric_name
+        status["name"] = metric_spec.metric.name
         status["current_value"] = (
-            metric_spec.current_average_value
-            if getattr(metric_spec, "current_average_value")
-            else metric_spec.current_value
+            metric_spec.current.average_value
+            if getattr(metric_spec.current, "average_value")
+            else metric_spec.current.value
         )
 
     def parse_pod_metric(self, metric_spec, status: HPAMetricsDict):
-        status["name"] = metric_spec.metric_name
-        status["target_value"] = metric_spec.target_average_value
+        status["name"] = metric_spec.metric.name
+        status["target_value"] = metric_spec.target.average_value
 
     def parse_pod_metric_current(self, metric_spec, status: HPAMetricsDict):
-        status["name"] = metric_spec.metric_name
-        status["current_value"] = metric_spec.current_average_value
+        status["name"] = metric_spec.metric.name
+        status["current_value"] = metric_spec.current.average_value
 
     def parse_resource_metric(self, metric_spec, status: HPAMetricsDict):
         status["name"] = metric_spec.name
         status["target_value"] = (
-            metric_spec.target_average_value
-            if getattr(metric_spec, "target_average_value")
-            else metric_spec.target_average_utilization
+            metric_spec.target.average_value
+            if getattr(metric_spec.target, "average_value")
+            else metric_spec.target.average_utilization
         )
 
     def parse_resource_metric_current(self, metric_spec, status: HPAMetricsDict):
         status["name"] = metric_spec.name
         status["current_value"] = (
-            metric_spec.current_average_value
-            if getattr(metric_spec, "current_average_value")
-            else metric_spec.current_average_utilization
+            metric_spec.current.average_value
+            if getattr(metric_spec.current, "average_value")
+            else metric_spec.current.average_utilization
         )

--- a/tests/instance/test_hpa_metrics_parser.py
+++ b/tests/instance/test_hpa_metrics_parser.py
@@ -1,0 +1,126 @@
+import pytest
+from kubernetes.client import V2beta2ExternalMetricSource
+from kubernetes.client import V2beta2ExternalMetricStatus
+from kubernetes.client import V2beta2MetricIdentifier
+from kubernetes.client import V2beta2MetricSpec
+from kubernetes.client import V2beta2MetricStatus
+from kubernetes.client import V2beta2MetricTarget
+from kubernetes.client import V2beta2MetricValueStatus
+from kubernetes.client import V2beta2PodsMetricSource
+from kubernetes.client import V2beta2PodsMetricStatus
+from kubernetes.client import V2beta2ResourceMetricSource
+from kubernetes.client import V2beta2ResourceMetricStatus
+
+from paasta_tools.instance.hpa_metrics_parser import HPAMetricsParser
+
+
+@pytest.fixture
+def parser():
+    return HPAMetricsParser(hpa=None)
+
+
+def test_parse_target_external_metric_value(parser):
+    metric_spec = V2beta2MetricSpec(
+        type="External",
+        external=V2beta2ExternalMetricSource(
+            metric=V2beta2MetricIdentifier(name="foo"),
+            target=V2beta2MetricTarget(type="Value", average_value=12,),
+        ),
+    )
+    status = parser.parse_target(metric_spec)
+    assert status["name"] == "foo"
+    assert status["target_value"] == "12"
+
+
+def test_parse_target_external_metric_average_value(parser):
+    # The parser handles this case, but it's not currently
+    # used in kubernetes_tools
+    metric_spec = V2beta2MetricSpec(
+        type="External",
+        external=V2beta2ExternalMetricSource(
+            metric=V2beta2MetricIdentifier(name="foo"),
+            target=V2beta2MetricTarget(type="AverageValue", average_value=0.5,),
+        ),
+    )
+    status = parser.parse_target(metric_spec)
+    assert status["name"] == "foo"
+    assert status["target_value"] == "0.5"
+
+
+def test_parse_target_pod_metric(parser):
+    metric_spec = V2beta2MetricSpec(
+        type="Pods",
+        pods=V2beta2PodsMetricSource(
+            metric=V2beta2MetricIdentifier(name="foo"),
+            target=V2beta2MetricTarget(type="AverageValue", average_value=0.5,),
+        ),
+    )
+    status = parser.parse_target(metric_spec)
+    assert status["name"] == "foo"
+    assert status["target_value"] == "0.5"
+
+
+def test_parse_target_resource_metric(parser):
+    metric_spec = V2beta2MetricSpec(
+        type="Resource",
+        resource=V2beta2ResourceMetricSource(
+            name="cpu",
+            target=V2beta2MetricTarget(type="Utilization", average_utilization=0.5,),
+        ),
+    )
+    status = parser.parse_target(metric_spec)
+    assert status["name"] == "cpu"
+    assert status["target_value"] == "0.5"
+
+
+def test_parse_current_external_metric_value(parser):
+    metric_status = V2beta2MetricStatus(
+        type="External",
+        external=V2beta2ExternalMetricStatus(
+            current=V2beta2MetricValueStatus(value=4,),
+            metric=V2beta2MetricIdentifier(name="foo"),
+        ),
+    )
+    status = parser.parse_current(metric_status)
+    assert status["name"] == "foo"
+    assert status["current_value"] == "4"
+
+
+def test_parse_current_external_metric_average_value(parser):
+    # The parser handles this case, but it's not currently
+    # used in kubernetes_tools
+    metric_status = V2beta2MetricStatus(
+        type="External",
+        external=V2beta2ExternalMetricStatus(
+            current=V2beta2MetricValueStatus(average_value=0.4,),
+            metric=V2beta2MetricIdentifier(name="foo"),
+        ),
+    )
+    status = parser.parse_current(metric_status)
+    assert status["name"] == "foo"
+    assert status["current_value"] == "0.4"
+
+
+def test_parse_current_pod_metric(parser):
+    metric_status = V2beta2MetricStatus(
+        type="Pods",
+        pods=V2beta2PodsMetricStatus(
+            current=V2beta2MetricValueStatus(average_value=0.4,),
+            metric=V2beta2MetricIdentifier(name="foo"),
+        ),
+    )
+    status = parser.parse_current(metric_status)
+    assert status["name"] == "foo"
+    assert status["current_value"] == "0.4"
+
+
+def test_parse_current_resource_metric(parser):
+    metric_status = V2beta2MetricStatus(
+        type="Resource",
+        resource=V2beta2ResourceMetricStatus(
+            current=V2beta2MetricValueStatus(average_utilization=0.4,), name="cpu",
+        ),
+    )
+    status = parser.parse_current(metric_status)
+    assert status["name"] == "cpu"
+    assert status["current_value"] == "0.4"


### PR DESCRIPTION
This is causing errors in `paasta status -v` for services with HPAs, after https://github.com/Yelp/paasta/pull/2968 changed the response API object. `'V2beta2ExternalMetricSource' object has no attribute 'metric_name'`