### PR TITLE
Revert Yelp/paasta#2970

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -25,7 +25,7 @@ ipaddress >= 1.0.22
 isodate >= 0.5.0
 jsonschema[format]
 kazoo >= 2.0.0
-kubernetes >= 12.0.0
+kubernetes
 manhole
 marathon >= 0.12.0
 mypy-extensions >= 0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ jmespath==0.9.3
 jsonref==0.1
 jsonschema==2.5.1
 kazoo==2.8.0
-kubernetes==12.0.0
+kubernetes==10.0.1
 ldap3==2.6.0
 manhole==1.5.0
 marathon==0.12.0

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -49,15 +49,13 @@ from kubernetes.client import V1StatefulSetSpec
 from kubernetes.client import V1TCPSocketAction
 from kubernetes.client import V1Volume
 from kubernetes.client import V1VolumeMount
-from kubernetes.client import V2beta2CrossVersionObjectReference
-from kubernetes.client import V2beta2ExternalMetricSource
-from kubernetes.client import V2beta2HorizontalPodAutoscaler
-from kubernetes.client import V2beta2HorizontalPodAutoscalerSpec
-from kubernetes.client import V2beta2MetricIdentifier
-from kubernetes.client import V2beta2MetricSpec
-from kubernetes.client import V2beta2MetricTarget
-from kubernetes.client import V2beta2PodsMetricSource
-from kubernetes.client import V2beta2ResourceMetricSource
+from kubernetes.client import V2beta1CrossVersionObjectReference
+from kubernetes.client import V2beta1ExternalMetricSource
+from kubernetes.client import V2beta1HorizontalPodAutoscaler
+from kubernetes.client import V2beta1HorizontalPodAutoscalerSpec
+from kubernetes.client import V2beta1MetricSpec
+from kubernetes.client import V2beta1PodsMetricSource
+from kubernetes.client import V2beta1ResourceMetricSource
 from kubernetes.client.rest import ApiException
 
 from paasta_tools import kubernetes_tools
@@ -1597,67 +1595,51 @@ class TestKubernetesDeploymentConfig:
             "signalfx.com.external.metric/service-instance-external": "fake_query",
             "signalfx.com.external.metric/service-instance-http": 'data("http", filter=filter("any", "random")).mean(by="paasta_yelp_com_instance").mean(over="15m").publish()',
         }
-        expected_res = V2beta2HorizontalPodAutoscaler(
+        expected_res = V2beta1HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
                 name="fake_name", namespace="paasta", annotations=annotations
             ),
-            spec=V2beta2HorizontalPodAutoscalerSpec(
+            spec=V2beta1HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
                 metrics=[
-                    V2beta2MetricSpec(
+                    V2beta1MetricSpec(
                         type="Resource",
-                        resource=V2beta2ResourceMetricSource(
-                            name="cpu",
-                            target=V2beta2MetricTarget(
-                                type="Utilization", average_utilization=70,
-                            ),
+                        resource=V2beta1ResourceMetricSource(
+                            name="cpu", target_average_utilization=70
                         ),
                     ),
-                    V2beta2MetricSpec(
+                    V2beta1MetricSpec(
                         type="Resource",
-                        resource=V2beta2ResourceMetricSource(
-                            name="memory",
-                            target=V2beta2MetricTarget(
-                                type="Utilization", average_utilization=70,
-                            ),
+                        resource=V2beta1ResourceMetricSource(
+                            name="memory", target_average_utilization=70
                         ),
                     ),
-                    V2beta2MetricSpec(
+                    V2beta1MetricSpec(
                         type="Pods",
-                        pods=V2beta2PodsMetricSource(
-                            metric=V2beta2MetricIdentifier(
-                                name="uwsgi",
-                                selector=V1LabelSelector(
-                                    match_labels={"paasta_cluster": "cluster"}
-                                ),
-                            ),
-                            target=V2beta2MetricTarget(
-                                type="AverageValue", average_value=0.7,
+                        pods=V2beta1PodsMetricSource(
+                            metric_name="uwsgi",
+                            target_average_value=0.7,
+                            selector=V1LabelSelector(
+                                match_labels={"paasta_cluster": "cluster"}
                             ),
                         ),
                     ),
-                    V2beta2MetricSpec(
+                    V2beta1MetricSpec(
                         type="External",
-                        external=V2beta2ExternalMetricSource(
-                            metric=V2beta2MetricIdentifier(
-                                name="service-instance-http",
-                            ),
-                            target=V2beta2MetricTarget(type="Value", value=0.7,),
+                        external=V2beta1ExternalMetricSource(
+                            metric_name="service-instance-http", target_value=0.7,
                         ),
                     ),
-                    V2beta2MetricSpec(
+                    V2beta1MetricSpec(
                         type="External",
-                        external=V2beta2ExternalMetricSource(
-                            metric=V2beta2MetricIdentifier(
-                                name="service-instance-external",
-                            ),
-                            target=V2beta2MetricTarget(type="Value", value=0.7,),
+                        external=V2beta1ExternalMetricSource(
+                            metric_name="service-instance-external", target_value=0.7,
                         ),
                     ),
                 ],
-                scale_target_ref=V2beta2CrossVersionObjectReference(
+                scale_target_ref=V2beta1CrossVersionObjectReference(
                     api_version="apps/v1", kind="Deployment", name="fake_name",
                 ),
             ),
@@ -1684,26 +1666,23 @@ class TestKubernetesDeploymentConfig:
             mock_config, "fake_name", "cluster"
         )
         annotations: Dict[Any, Any] = {}
-        expected_res = V2beta2HorizontalPodAutoscaler(
+        expected_res = V2beta1HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
                 name="fake_name", namespace="paasta", annotations=annotations
             ),
-            spec=V2beta2HorizontalPodAutoscalerSpec(
+            spec=V2beta1HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
                 metrics=[
-                    V2beta2MetricSpec(
+                    V2beta1MetricSpec(
                         type="Resource",
-                        resource=V2beta2ResourceMetricSource(
-                            name="cpu",
-                            target=V2beta2MetricTarget(
-                                type="Utilization", average_utilization=50.0,
-                            ),
+                        resource=V2beta1ResourceMetricSource(
+                            name="cpu", target_average_utilization=50.0
                         ),
                     )
                 ],
-                scale_target_ref=V2beta2CrossVersionObjectReference(
+                scale_target_ref=V2beta1CrossVersionObjectReference(
                     api_version="apps/v1", kind="Deployment", name="fake_name",
                 ),
             ),
@@ -1730,31 +1709,27 @@ class TestKubernetesDeploymentConfig:
             mock_config, "fake_name", "cluster"
         )
         annotations = {"signalfx.com.custom.metrics": ""}
-        expected_res = V2beta2HorizontalPodAutoscaler(
+        expected_res = V2beta1HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
                 name="fake_name", namespace="paasta", annotations=annotations
             ),
-            spec=V2beta2HorizontalPodAutoscalerSpec(
+            spec=V2beta1HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
                 metrics=[
-                    V2beta2MetricSpec(
+                    V2beta1MetricSpec(
                         type="Pods",
-                        pods=V2beta2PodsMetricSource(
-                            metric=V2beta2MetricIdentifier(
-                                name="http",
-                                selector=V1LabelSelector(
-                                    match_labels={"paasta_cluster": "cluster"}
-                                ),
-                            ),
-                            target=V2beta2MetricTarget(
-                                type="AverageValue", average_value=0.5,
+                        pods=V2beta1PodsMetricSource(
+                            metric_name="http",
+                            target_average_value=0.5,
+                            selector=V1LabelSelector(
+                                match_labels={"paasta_cluster": "cluster"}
                             ),
                         ),
                     )
                 ],
-                scale_target_ref=V2beta2CrossVersionObjectReference(
+                scale_target_ref=V2beta1CrossVersionObjectReference(
                     api_version="apps/v1", kind="Deployment", name="fake_name",
                 ),
             ),
@@ -1781,31 +1756,27 @@ class TestKubernetesDeploymentConfig:
         )
 
         annotations = {"signalfx.com.custom.metrics": ""}
-        expected_res = V2beta2HorizontalPodAutoscaler(
+        expected_res = V2beta1HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
                 name="fake_name", namespace="paasta", annotations=annotations
             ),
-            spec=V2beta2HorizontalPodAutoscalerSpec(
+            spec=V2beta1HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
                 metrics=[
-                    V2beta2MetricSpec(
+                    V2beta1MetricSpec(
                         type="Pods",
-                        pods=V2beta2PodsMetricSource(
-                            metric=V2beta2MetricIdentifier(
-                                name="uwsgi",
-                                selector=V1LabelSelector(
-                                    match_labels={"paasta_cluster": "cluster"}
-                                ),
-                            ),
-                            target=V2beta2MetricTarget(
-                                type="AverageValue", average_value=0.5,
+                        pods=V2beta1PodsMetricSource(
+                            metric_name="uwsgi",
+                            target_average_value=0.5,
+                            selector=V1LabelSelector(
+                                match_labels={"paasta_cluster": "cluster"}
                             ),
                         ),
                     )
                 ],
-                scale_target_ref=V2beta2CrossVersionObjectReference(
+                scale_target_ref=V2beta1CrossVersionObjectReference(
                     api_version="apps/v1", kind="Deployment", name="fake_name",
                 ),
             ),
@@ -1836,7 +1807,7 @@ class TestKubernetesDeploymentConfig:
         return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
             mock_config, "fake_name", "cluster"
         )
-        expected_res = V2beta2HorizontalPodAutoscaler(
+        expected_res = V2beta1HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
                 name="fake_name",
@@ -1846,21 +1817,18 @@ class TestKubernetesDeploymentConfig:
                     "signalfx.com.external.metric/service-instance-uwsgi": mock.ANY,
                 },
             ),
-            spec=V2beta2HorizontalPodAutoscalerSpec(
+            spec=V2beta1HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
                 metrics=[
-                    V2beta2MetricSpec(
+                    V2beta1MetricSpec(
                         type="External",
-                        external=V2beta2ExternalMetricSource(
-                            metric=V2beta2MetricIdentifier(
-                                name="service-instance-uwsgi",
-                            ),
-                            target=V2beta2MetricTarget(type="Value", value=1,),
+                        external=V2beta1ExternalMetricSource(
+                            metric_name="service-instance-uwsgi", target_value=1,
                         ),
                     )
                 ],
-                scale_target_ref=V2beta2CrossVersionObjectReference(
+                scale_target_ref=V2beta1CrossVersionObjectReference(
                     api_version="apps/v1", kind="Deployment", name="fake_name",
                 ),
             ),
@@ -3167,7 +3135,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config33f02c03"
+            == "config3836dd19"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 


### PR DESCRIPTION
### Description
Yelp/paasta#2970 seems to be causing issues with setup_kubernetes_job by making it fail for a bit whenever a new HPA for a service needs to be created, though it does eventually succeed those services (then it fails for another service :P). This in turn blocks service deployments. So, this PR just reverts the change. We'll revisit it again later.