### PR TITLE
Update to v2beta2 API for HPA, try #2

### DIFF
--- a/paasta_tools/instance/hpa_metrics_parser.py
+++ b/paasta_tools/instance/hpa_metrics_parser.py
@@ -48,41 +48,41 @@ class HPAMetricsParser:
         return status
 
     def parse_external_metric(self, metric_spec, status: HPAMetricsDict):
-        status["name"] = metric_spec.metric_name
+        status["name"] = metric_spec.metric.name
         status["target_value"] = (
-            metric_spec.target_average_value
-            if getattr(metric_spec, "target_average_value")
-            else metric_spec.target_value
+            metric_spec.target.average_value
+            if getattr(metric_spec.target, "average_value")
+            else metric_spec.target.value
         )
 
     def parse_external_metric_current(self, metric_spec, status: HPAMetricsDict):
-        status["name"] = metric_spec.metric_name
+        status["name"] = metric_spec.metric.name
         status["current_value"] = (
-            metric_spec.current_average_value
-            if getattr(metric_spec, "current_average_value")
-            else metric_spec.current_value
+            metric_spec.current.average_value
+            if getattr(metric_spec.current, "average_value")
+            else metric_spec.current.value
         )
 
     def parse_pod_metric(self, metric_spec, status: HPAMetricsDict):
-        status["name"] = metric_spec.metric_name
-        status["target_value"] = metric_spec.target_average_value
+        status["name"] = metric_spec.metric.name
+        status["target_value"] = metric_spec.target.average_value
 
     def parse_pod_metric_current(self, metric_spec, status: HPAMetricsDict):
-        status["name"] = metric_spec.metric_name
-        status["current_value"] = metric_spec.current_average_value
+        status["name"] = metric_spec.metric.name
+        status["current_value"] = metric_spec.current.average_value
 
     def parse_resource_metric(self, metric_spec, status: HPAMetricsDict):
         status["name"] = metric_spec.name
         status["target_value"] = (
-            metric_spec.target_average_value
-            if getattr(metric_spec, "target_average_value")
-            else metric_spec.target_average_utilization
+            metric_spec.target.average_value
+            if getattr(metric_spec.target, "average_value")
+            else metric_spec.target.average_utilization
         )
 
     def parse_resource_metric_current(self, metric_spec, status: HPAMetricsDict):
         status["name"] = metric_spec.name
         status["current_value"] = (
-            metric_spec.current_average_value
-            if getattr(metric_spec, "current_average_value")
-            else metric_spec.current_average_utilization
+            metric_spec.current.average_value
+            if getattr(metric_spec.current, "average_value")
+            else metric_spec.current.average_utilization
         )

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -122,7 +122,7 @@ def autoscaling_status(
             raise
 
     # Parse metrics sources, based on
-    # https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V2beta1ExternalMetricSource.md#v2beta1externalmetricsource
+    # https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V2beta2ExternalMetricSource.md#v2beta2externalmetricsource
     parser = HPAMetricsParser(hpa)
 
     # https://github.com/python/mypy/issues/7217

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -95,16 +95,16 @@ from kubernetes.client import V1StatefulSetSpec
 from kubernetes.client import V1TCPSocketAction
 from kubernetes.client import V1Volume
 from kubernetes.client import V1VolumeMount
-from kubernetes.client import V2beta1CrossVersionObjectReference
-from kubernetes.client import V2beta1ExternalMetricSource
-from kubernetes.client import V2beta1HorizontalPodAutoscaler
-from kubernetes.client import V2beta1HorizontalPodAutoscalerCondition
-from kubernetes.client import V2beta1HorizontalPodAutoscalerSpec
-from kubernetes.client import V2beta1MetricSpec
-from kubernetes.client import V2beta1PodsMetricSource
-from kubernetes.client import V2beta1ResourceMetricSource
+from kubernetes.client import V2beta2CrossVersionObjectReference
+from kubernetes.client import V2beta2ExternalMetricSource
+from kubernetes.client import V2beta2HorizontalPodAutoscaler
+from kubernetes.client import V2beta2HorizontalPodAutoscalerSpec
+from kubernetes.client import V2beta2MetricIdentifier
+from kubernetes.client import V2beta2MetricSpec
+from kubernetes.client import V2beta2MetricTarget
+from kubernetes.client import V2beta2PodsMetricSource
+from kubernetes.client import V2beta2ResourceMetricSource
 from kubernetes.client.configuration import Configuration as KubeConfiguration
-from kubernetes.client.models import V2beta1HorizontalPodAutoscalerStatus
 from kubernetes.client.rest import ApiException
 from mypy_extensions import TypedDict
 
@@ -189,24 +189,6 @@ desired_instances = desired_instances_at_each_point_in_time.mean(over=moving_ave
 
 max(desired_instances / current_replicas, 0).publish()
 """
-
-
-# For detail, https://github.com/kubernetes-client/python/issues/553
-# This hack should be removed when the issue got fixed.
-# This is no better way to work around rn.
-class MonkeyPatchAutoScalingConditions(V2beta1HorizontalPodAutoscalerStatus):
-    @property
-    def conditions(self) -> Sequence[V2beta1HorizontalPodAutoscalerCondition]:
-        return super().conditions()
-
-    @conditions.setter
-    def conditions(
-        self, conditions: Optional[Sequence[V2beta1HorizontalPodAutoscalerCondition]]
-    ) -> None:
-        self._conditions = list() if conditions is None else conditions
-
-
-models.V2beta1HorizontalPodAutoscalerStatus = MonkeyPatchAutoScalingConditions
 
 
 class KubeKind(NamedTuple):
@@ -407,7 +389,7 @@ class KubeClient:
         self.policy = kube_client.PolicyV1beta1Api()
         self.apiextensions = kube_client.ApiextensionsV1beta1Api()
         self.custom = kube_client.CustomObjectsApi()
-        self.autoscaling = kube_client.AutoscalingV2beta1Api()
+        self.autoscaling = kube_client.AutoscalingV2beta2Api()
         self.request = kube_client.ApiClient().request
 
 
@@ -486,7 +468,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
     def get_hpa_metric_spec(
         self, name: str, cluster: str, namespace: str = "paasta"
-    ) -> Optional[V2beta1HorizontalPodAutoscaler]:
+    ) -> Optional[V2beta2HorizontalPodAutoscaler]:
         hpa_config = self.config_dict["horizontal_autoscaling"]
         min_replicas = hpa_config.get("min_replicas", 1)
         max_replicas = hpa_config["max_replicas"]
@@ -498,12 +480,15 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 continue
             if metric_name in {"cpu", "memory"}:
                 metrics.append(
-                    V2beta1MetricSpec(
+                    V2beta2MetricSpec(
                         type="Resource",
-                        resource=V2beta1ResourceMetricSource(
+                        resource=V2beta2ResourceMetricSource(
                             name=metric_name,
-                            target_average_utilization=int(
-                                value["target_average_value"] * 100
+                            target=V2beta2MetricTarget(
+                                type="Utilization",
+                                average_utilization=int(
+                                    value["target_average_value"] * 100
+                                ),
                             ),
                         ),
                     )
@@ -511,12 +496,16 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             elif metric_name in {"http", "uwsgi"}:
                 if "dimensions" not in value:
                     metrics.append(
-                        V2beta1MetricSpec(
+                        V2beta2MetricSpec(
                             type="Pods",
-                            pods=V2beta1PodsMetricSource(
-                                metric_name=metric_name,
-                                target_average_value=value["target_average_value"],
-                                selector=selector,
+                            pods=V2beta2PodsMetricSource(
+                                metric=V2beta2MetricIdentifier(
+                                    name=metric_name, selector=selector,
+                                ),
+                                target=V2beta2MetricTarget(
+                                    type="AverageValue",
+                                    average_value=value["target_average_value"],
+                                ),
                             ),
                         )
                     )
@@ -525,11 +514,15 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                         metric_name
                     )
                     metrics.append(
-                        V2beta1MetricSpec(
+                        V2beta2MetricSpec(
                             type="External",
-                            external=V2beta1ExternalMetricSource(
-                                metric_name=namespaced_metric_name,
-                                target_value=value["target_average_value"],
+                            external=V2beta2ExternalMetricSource(
+                                metric=V2beta2MetricIdentifier(
+                                    name=namespaced_metric_name,
+                                ),
+                                target=V2beta2MetricTarget(
+                                    type="Value", value=value["target_average_value"],
+                                ),
                             ),
                         )
                     )
@@ -544,11 +537,15 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     metric_name
                 )
                 metrics.append(
-                    V2beta1MetricSpec(
+                    V2beta2MetricSpec(
                         type="External",
-                        external=V2beta1ExternalMetricSource(
-                            metric_name=namespaced_metric_name,
-                            target_value=value["target_value"],
+                        external=V2beta2ExternalMetricSource(
+                            metric=V2beta2MetricIdentifier(
+                                name=namespaced_metric_name,
+                            ),
+                            target=V2beta2MetricTarget(
+                                type="Value", value=value["target_value"],
+                            ),
                         ),
                     )
                 )
@@ -556,16 +553,16 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     f"signalfx.com.external.metric/{namespaced_metric_name}"
                 ] = value["signalflow_metrics_query"]
 
-        return V2beta1HorizontalPodAutoscaler(
+        return V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
                 name=name, namespace=namespace, annotations=annotations
             ),
-            spec=V2beta1HorizontalPodAutoscalerSpec(
+            spec=V2beta2HorizontalPodAutoscalerSpec(
                 max_replicas=max_replicas,
                 min_replicas=min_replicas,
                 metrics=metrics,
-                scale_target_ref=V2beta1CrossVersionObjectReference(
+                scale_target_ref=V2beta2CrossVersionObjectReference(
                     api_version="apps/v1", kind="Deployment", name=name
                 ),
             ),
@@ -576,7 +573,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
     def get_autoscaling_metric_spec(
         self, name: str, cluster: str, namespace: str = "paasta"
-    ) -> Optional[V2beta1HorizontalPodAutoscaler]:
+    ) -> Optional[V2beta2HorizontalPodAutoscaler]:
         # Returns None if an HPA should not be attached based on the config,
         # or the config is invalid.
 
@@ -609,10 +606,13 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         selector = V1LabelSelector(match_labels={"paasta_cluster": cluster})
         if metrics_provider == "mesos_cpu":
             metrics.append(
-                V2beta1MetricSpec(
+                V2beta2MetricSpec(
                     type="Resource",
-                    resource=V2beta1ResourceMetricSource(
-                        name="cpu", target_average_utilization=int(target * 100)
+                    resource=V2beta2ResourceMetricSource(
+                        name="cpu",
+                        target=V2beta2MetricTarget(
+                            type="Utilization", average_utilization=int(target * 100),
+                        ),
                     ),
                 )
             )
@@ -639,22 +639,28 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 ] = signalflow
 
                 metrics.append(
-                    V2beta1MetricSpec(
+                    V2beta2MetricSpec(
                         type="External",
-                        external=V2beta1ExternalMetricSource(
-                            metric_name=hpa_metric_name,
-                            target_value=1,  # see comments on signalflow template above
+                        external=V2beta2ExternalMetricSource(
+                            metric=V2beta2MetricIdentifier(name=hpa_metric_name,),
+                            target=V2beta2MetricTarget(
+                                type="Value",
+                                value=1,  # see comments on signalflow template above
+                            ),
                         ),
                     )
                 )
             else:
                 metrics.append(
-                    V2beta1MetricSpec(
+                    V2beta2MetricSpec(
                         type="Pods",
-                        pods=V2beta1PodsMetricSource(
-                            metric_name=metrics_provider,
-                            target_average_value=target,
-                            selector=selector,
+                        pods=V2beta2PodsMetricSource(
+                            metric=V2beta2MetricIdentifier(
+                                name=metrics_provider, selector=selector,
+                            ),
+                            target=V2beta2MetricTarget(
+                                type="AverageValue", average_value=target,
+                            ),
                         ),
                     )
                 )
@@ -666,16 +672,16 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             )
             return None
 
-        return V2beta1HorizontalPodAutoscaler(
+        return V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
                 name=name, namespace=namespace, annotations=annotations
             ),
-            spec=V2beta1HorizontalPodAutoscalerSpec(
+            spec=V2beta2HorizontalPodAutoscalerSpec(
                 max_replicas=max_replicas,
                 min_replicas=min_replicas,
                 metrics=metrics,
-                scale_target_ref=V2beta1CrossVersionObjectReference(
+                scale_target_ref=V2beta2CrossVersionObjectReference(
                     api_version="apps/v1", kind="Deployment", name=name
                 ),
             ),

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -25,7 +25,7 @@ ipaddress >= 1.0.22
 isodate >= 0.5.0
 jsonschema[format]
 kazoo >= 2.0.0
-kubernetes
+kubernetes >= 12.0.0
 manhole
 marathon >= 0.12.0
 mypy-extensions >= 0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ jmespath==0.9.3
 jsonref==0.1
 jsonschema==2.5.1
 kazoo==2.8.0
-kubernetes==10.0.1
+kubernetes==12.0.0
 ldap3==2.6.0
 manhole==1.5.0
 marathon==0.12.0

--- a/tests/instance/test_hpa_metrics_parser.py
+++ b/tests/instance/test_hpa_metrics_parser.py
@@ -1,0 +1,126 @@
+import pytest
+from kubernetes.client import V2beta2ExternalMetricSource
+from kubernetes.client import V2beta2ExternalMetricStatus
+from kubernetes.client import V2beta2MetricIdentifier
+from kubernetes.client import V2beta2MetricSpec
+from kubernetes.client import V2beta2MetricStatus
+from kubernetes.client import V2beta2MetricTarget
+from kubernetes.client import V2beta2MetricValueStatus
+from kubernetes.client import V2beta2PodsMetricSource
+from kubernetes.client import V2beta2PodsMetricStatus
+from kubernetes.client import V2beta2ResourceMetricSource
+from kubernetes.client import V2beta2ResourceMetricStatus
+
+from paasta_tools.instance.hpa_metrics_parser import HPAMetricsParser
+
+
+@pytest.fixture
+def parser():
+    return HPAMetricsParser(hpa=None)
+
+
+def test_parse_target_external_metric_value(parser):
+    metric_spec = V2beta2MetricSpec(
+        type="External",
+        external=V2beta2ExternalMetricSource(
+            metric=V2beta2MetricIdentifier(name="foo"),
+            target=V2beta2MetricTarget(type="Value", average_value=12,),
+        ),
+    )
+    status = parser.parse_target(metric_spec)
+    assert status["name"] == "foo"
+    assert status["target_value"] == "12"
+
+
+def test_parse_target_external_metric_average_value(parser):
+    # The parser handles this case, but it's not currently
+    # used in kubernetes_tools
+    metric_spec = V2beta2MetricSpec(
+        type="External",
+        external=V2beta2ExternalMetricSource(
+            metric=V2beta2MetricIdentifier(name="foo"),
+            target=V2beta2MetricTarget(type="AverageValue", average_value=0.5,),
+        ),
+    )
+    status = parser.parse_target(metric_spec)
+    assert status["name"] == "foo"
+    assert status["target_value"] == "0.5"
+
+
+def test_parse_target_pod_metric(parser):
+    metric_spec = V2beta2MetricSpec(
+        type="Pods",
+        pods=V2beta2PodsMetricSource(
+            metric=V2beta2MetricIdentifier(name="foo"),
+            target=V2beta2MetricTarget(type="AverageValue", average_value=0.5,),
+        ),
+    )
+    status = parser.parse_target(metric_spec)
+    assert status["name"] == "foo"
+    assert status["target_value"] == "0.5"
+
+
+def test_parse_target_resource_metric(parser):
+    metric_spec = V2beta2MetricSpec(
+        type="Resource",
+        resource=V2beta2ResourceMetricSource(
+            name="cpu",
+            target=V2beta2MetricTarget(type="Utilization", average_utilization=0.5,),
+        ),
+    )
+    status = parser.parse_target(metric_spec)
+    assert status["name"] == "cpu"
+    assert status["target_value"] == "0.5"
+
+
+def test_parse_current_external_metric_value(parser):
+    metric_status = V2beta2MetricStatus(
+        type="External",
+        external=V2beta2ExternalMetricStatus(
+            current=V2beta2MetricValueStatus(value=4,),
+            metric=V2beta2MetricIdentifier(name="foo"),
+        ),
+    )
+    status = parser.parse_current(metric_status)
+    assert status["name"] == "foo"
+    assert status["current_value"] == "4"
+
+
+def test_parse_current_external_metric_average_value(parser):
+    # The parser handles this case, but it's not currently
+    # used in kubernetes_tools
+    metric_status = V2beta2MetricStatus(
+        type="External",
+        external=V2beta2ExternalMetricStatus(
+            current=V2beta2MetricValueStatus(average_value=0.4,),
+            metric=V2beta2MetricIdentifier(name="foo"),
+        ),
+    )
+    status = parser.parse_current(metric_status)
+    assert status["name"] == "foo"
+    assert status["current_value"] == "0.4"
+
+
+def test_parse_current_pod_metric(parser):
+    metric_status = V2beta2MetricStatus(
+        type="Pods",
+        pods=V2beta2PodsMetricStatus(
+            current=V2beta2MetricValueStatus(average_value=0.4,),
+            metric=V2beta2MetricIdentifier(name="foo"),
+        ),
+    )
+    status = parser.parse_current(metric_status)
+    assert status["name"] == "foo"
+    assert status["current_value"] == "0.4"
+
+
+def test_parse_current_resource_metric(parser):
+    metric_status = V2beta2MetricStatus(
+        type="Resource",
+        resource=V2beta2ResourceMetricStatus(
+            current=V2beta2MetricValueStatus(average_utilization=0.4,), name="cpu",
+        ),
+    )
+    status = parser.parse_current(metric_status)
+    assert status["name"] == "cpu"
+    assert status["current_value"] == "0.4"

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -49,13 +49,15 @@ from kubernetes.client import V1StatefulSetSpec
 from kubernetes.client import V1TCPSocketAction
 from kubernetes.client import V1Volume
 from kubernetes.client import V1VolumeMount
-from kubernetes.client import V2beta1CrossVersionObjectReference
-from kubernetes.client import V2beta1ExternalMetricSource
-from kubernetes.client import V2beta1HorizontalPodAutoscaler
-from kubernetes.client import V2beta1HorizontalPodAutoscalerSpec
-from kubernetes.client import V2beta1MetricSpec
-from kubernetes.client import V2beta1PodsMetricSource
-from kubernetes.client import V2beta1ResourceMetricSource
+from kubernetes.client import V2beta2CrossVersionObjectReference
+from kubernetes.client import V2beta2ExternalMetricSource
+from kubernetes.client import V2beta2HorizontalPodAutoscaler
+from kubernetes.client import V2beta2HorizontalPodAutoscalerSpec
+from kubernetes.client import V2beta2MetricIdentifier
+from kubernetes.client import V2beta2MetricSpec
+from kubernetes.client import V2beta2MetricTarget
+from kubernetes.client import V2beta2PodsMetricSource
+from kubernetes.client import V2beta2ResourceMetricSource
 from kubernetes.client.rest import ApiException
 
 from paasta_tools import kubernetes_tools
@@ -1595,51 +1597,67 @@ class TestKubernetesDeploymentConfig:
             "signalfx.com.external.metric/service-instance-external": "fake_query",
             "signalfx.com.external.metric/service-instance-http": 'data("http", filter=filter("any", "random")).mean(by="paasta_yelp_com_instance").mean(over="15m").publish()',
         }
-        expected_res = V2beta1HorizontalPodAutoscaler(
+        expected_res = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
                 name="fake_name", namespace="paasta", annotations=annotations
             ),
-            spec=V2beta1HorizontalPodAutoscalerSpec(
+            spec=V2beta2HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
                 metrics=[
-                    V2beta1MetricSpec(
+                    V2beta2MetricSpec(
                         type="Resource",
-                        resource=V2beta1ResourceMetricSource(
-                            name="cpu", target_average_utilization=70
-                        ),
-                    ),
-                    V2beta1MetricSpec(
-                        type="Resource",
-                        resource=V2beta1ResourceMetricSource(
-                            name="memory", target_average_utilization=70
-                        ),
-                    ),
-                    V2beta1MetricSpec(
-                        type="Pods",
-                        pods=V2beta1PodsMetricSource(
-                            metric_name="uwsgi",
-                            target_average_value=0.7,
-                            selector=V1LabelSelector(
-                                match_labels={"paasta_cluster": "cluster"}
+                        resource=V2beta2ResourceMetricSource(
+                            name="cpu",
+                            target=V2beta2MetricTarget(
+                                type="Utilization", average_utilization=70,
                             ),
                         ),
                     ),
-                    V2beta1MetricSpec(
-                        type="External",
-                        external=V2beta1ExternalMetricSource(
-                            metric_name="service-instance-http", target_value=0.7,
+                    V2beta2MetricSpec(
+                        type="Resource",
+                        resource=V2beta2ResourceMetricSource(
+                            name="memory",
+                            target=V2beta2MetricTarget(
+                                type="Utilization", average_utilization=70,
+                            ),
                         ),
                     ),
-                    V2beta1MetricSpec(
+                    V2beta2MetricSpec(
+                        type="Pods",
+                        pods=V2beta2PodsMetricSource(
+                            metric=V2beta2MetricIdentifier(
+                                name="uwsgi",
+                                selector=V1LabelSelector(
+                                    match_labels={"paasta_cluster": "cluster"}
+                                ),
+                            ),
+                            target=V2beta2MetricTarget(
+                                type="AverageValue", average_value=0.7,
+                            ),
+                        ),
+                    ),
+                    V2beta2MetricSpec(
                         type="External",
-                        external=V2beta1ExternalMetricSource(
-                            metric_name="service-instance-external", target_value=0.7,
+                        external=V2beta2ExternalMetricSource(
+                            metric=V2beta2MetricIdentifier(
+                                name="service-instance-http",
+                            ),
+                            target=V2beta2MetricTarget(type="Value", value=0.7,),
+                        ),
+                    ),
+                    V2beta2MetricSpec(
+                        type="External",
+                        external=V2beta2ExternalMetricSource(
+                            metric=V2beta2MetricIdentifier(
+                                name="service-instance-external",
+                            ),
+                            target=V2beta2MetricTarget(type="Value", value=0.7,),
                         ),
                     ),
                 ],
-                scale_target_ref=V2beta1CrossVersionObjectReference(
+                scale_target_ref=V2beta2CrossVersionObjectReference(
                     api_version="apps/v1", kind="Deployment", name="fake_name",
                 ),
             ),
@@ -1666,23 +1684,26 @@ class TestKubernetesDeploymentConfig:
             mock_config, "fake_name", "cluster"
         )
         annotations: Dict[Any, Any] = {}
-        expected_res = V2beta1HorizontalPodAutoscaler(
+        expected_res = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
                 name="fake_name", namespace="paasta", annotations=annotations
             ),
-            spec=V2beta1HorizontalPodAutoscalerSpec(
+            spec=V2beta2HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
                 metrics=[
-                    V2beta1MetricSpec(
+                    V2beta2MetricSpec(
                         type="Resource",
-                        resource=V2beta1ResourceMetricSource(
-                            name="cpu", target_average_utilization=50.0
+                        resource=V2beta2ResourceMetricSource(
+                            name="cpu",
+                            target=V2beta2MetricTarget(
+                                type="Utilization", average_utilization=50.0,
+                            ),
                         ),
                     )
                 ],
-                scale_target_ref=V2beta1CrossVersionObjectReference(
+                scale_target_ref=V2beta2CrossVersionObjectReference(
                     api_version="apps/v1", kind="Deployment", name="fake_name",
                 ),
             ),
@@ -1709,27 +1730,31 @@ class TestKubernetesDeploymentConfig:
             mock_config, "fake_name", "cluster"
         )
         annotations = {"signalfx.com.custom.metrics": ""}
-        expected_res = V2beta1HorizontalPodAutoscaler(
+        expected_res = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
                 name="fake_name", namespace="paasta", annotations=annotations
             ),
-            spec=V2beta1HorizontalPodAutoscalerSpec(
+            spec=V2beta2HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
                 metrics=[
-                    V2beta1MetricSpec(
+                    V2beta2MetricSpec(
                         type="Pods",
-                        pods=V2beta1PodsMetricSource(
-                            metric_name="http",
-                            target_average_value=0.5,
-                            selector=V1LabelSelector(
-                                match_labels={"paasta_cluster": "cluster"}
+                        pods=V2beta2PodsMetricSource(
+                            metric=V2beta2MetricIdentifier(
+                                name="http",
+                                selector=V1LabelSelector(
+                                    match_labels={"paasta_cluster": "cluster"}
+                                ),
+                            ),
+                            target=V2beta2MetricTarget(
+                                type="AverageValue", average_value=0.5,
                             ),
                         ),
                     )
                 ],
-                scale_target_ref=V2beta1CrossVersionObjectReference(
+                scale_target_ref=V2beta2CrossVersionObjectReference(
                     api_version="apps/v1", kind="Deployment", name="fake_name",
                 ),
             ),
@@ -1756,27 +1781,31 @@ class TestKubernetesDeploymentConfig:
         )
 
         annotations = {"signalfx.com.custom.metrics": ""}
-        expected_res = V2beta1HorizontalPodAutoscaler(
+        expected_res = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
                 name="fake_name", namespace="paasta", annotations=annotations
             ),
-            spec=V2beta1HorizontalPodAutoscalerSpec(
+            spec=V2beta2HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
                 metrics=[
-                    V2beta1MetricSpec(
+                    V2beta2MetricSpec(
                         type="Pods",
-                        pods=V2beta1PodsMetricSource(
-                            metric_name="uwsgi",
-                            target_average_value=0.5,
-                            selector=V1LabelSelector(
-                                match_labels={"paasta_cluster": "cluster"}
+                        pods=V2beta2PodsMetricSource(
+                            metric=V2beta2MetricIdentifier(
+                                name="uwsgi",
+                                selector=V1LabelSelector(
+                                    match_labels={"paasta_cluster": "cluster"}
+                                ),
+                            ),
+                            target=V2beta2MetricTarget(
+                                type="AverageValue", average_value=0.5,
                             ),
                         ),
                     )
                 ],
-                scale_target_ref=V2beta1CrossVersionObjectReference(
+                scale_target_ref=V2beta2CrossVersionObjectReference(
                     api_version="apps/v1", kind="Deployment", name="fake_name",
                 ),
             ),
@@ -1807,7 +1836,7 @@ class TestKubernetesDeploymentConfig:
         return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
             mock_config, "fake_name", "cluster"
         )
-        expected_res = V2beta1HorizontalPodAutoscaler(
+        expected_res = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
                 name="fake_name",
@@ -1817,18 +1846,21 @@ class TestKubernetesDeploymentConfig:
                     "signalfx.com.external.metric/service-instance-uwsgi": mock.ANY,
                 },
             ),
-            spec=V2beta1HorizontalPodAutoscalerSpec(
+            spec=V2beta2HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
                 metrics=[
-                    V2beta1MetricSpec(
+                    V2beta2MetricSpec(
                         type="External",
-                        external=V2beta1ExternalMetricSource(
-                            metric_name="service-instance-uwsgi", target_value=1,
+                        external=V2beta2ExternalMetricSource(
+                            metric=V2beta2MetricIdentifier(
+                                name="service-instance-uwsgi",
+                            ),
+                            target=V2beta2MetricTarget(type="Value", value=1,),
                         ),
                     )
                 ],
-                scale_target_ref=V2beta1CrossVersionObjectReference(
+                scale_target_ref=V2beta2CrossVersionObjectReference(
                     api_version="apps/v1", kind="Deployment", name="fake_name",
                 ),
             ),
@@ -3135,7 +3167,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config3836dd19"
+            == "config33f02c03"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 


### PR DESCRIPTION
There were a couple issues with https://github.com/Yelp/paasta/pull/2968:
* creating an HPA raised an error: `ValueError: Invalid value for `conditions`, must not be `None` (my tests didn't catch this because this only occurs when creating a new HPA, not updating an existing one)
* paasta status was erroring because it still expected v2beta1 objects (fix copied from https://github.com/Yelp/paasta/pull/2970)