### PR TITLE
Use above() in HPA signalflow so we do not replace null with 0

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -187,7 +187,7 @@ load_per_instance = data('{signalfx_metric_name}', filter=filters, extrapolation
 desired_instances_at_each_point_in_time = (load_per_instance - offset).sum() / (setpoint - offset)
 desired_instances = desired_instances_at_each_point_in_time.mean(over=moving_average_window)
 
-max(desired_instances / current_replicas, 0).publish()
+(desired_instances / current_replicas).above(0).publish()
 """
 
 


### PR DESCRIPTION
If desired_instances or current_replicas is null, the final metric will be null instead of 0. I think that would result in FailedGetExternalMetric errors instead of scaling to min for the HPA.

https://app.signalfx.com/#/temp/chart/EmkLzKRAYAA shows the result for internalapi during the DAR yesterday.