### PR TITLE
Improve metastatus performance by pulling all pods at once & caching

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2169,6 +2169,14 @@ def get_all_pods(kube_client: KubeClient, namespace: str = "paasta") -> Sequence
     return kube_client.core.list_namespaced_pod(namespace=namespace).items
 
 
+@time_cache(ttl=300)
+def get_all_pods_cached(
+    kube_client: KubeClient, namespace: str = "paasta"
+) -> Sequence[V1Pod]:
+    pods: Sequence[V1Pod] = get_all_pods(kube_client, namespace)
+    return pods
+
+
 def filter_pods_by_service_instance(
     pod_list: Sequence[V1Pod], service: str, instance: str
 ) -> Sequence[V1Pod]:
@@ -2257,6 +2265,12 @@ def get_active_shas_for_service(
 
 def get_all_nodes(kube_client: KubeClient,) -> Sequence[V1Node]:
     return kube_client.core.list_node().items
+
+
+@time_cache(ttl=300)
+def get_all_nodes_cached(kube_client: KubeClient) -> Sequence[V1Node]:
+    nodes: Sequence[V1Node] = get_all_nodes(kube_client)
+    return nodes
 
 
 def filter_nodes_by_blacklist(

--- a/paasta_tools/metrics/metastatus_lib.py
+++ b/paasta_tools/metrics/metastatus_lib.py
@@ -56,6 +56,7 @@ from paasta_tools.mesos_tools import is_task_terminal
 from paasta_tools.mesos_tools import MesosResources
 from paasta_tools.mesos_tools import MesosTask
 from paasta_tools.utils import PaastaColors
+from paasta_tools.utils import time_cache
 from paasta_tools.utils import print_with_indent
 
 
@@ -452,7 +453,7 @@ def assert_mesos_tasks_running(metrics: MesosMetrics,) -> HealthCheckResult:
 
 
 def assert_kube_pods_running(kube_client: KubeClient,) -> HealthCheckResult:
-    statuses = [get_pod_status(pod) for pod in get_all_pods(kube_client)]
+    statuses = [get_pod_status(pod) for pod in get_kube_all_pods(kube_client)]
     running = statuses.count(PodStatus.RUNNING)
     pending = statuses.count(PodStatus.PENDING)
     failed = statuses.count(PodStatus.FAILED)
@@ -856,6 +857,15 @@ def get_resource_utilization_by_grouping(
         for attribute_value, slaves in slave_groupings.items()
     }
 
+@time_cache(ttl=300)
+def get_kube_all_nodes(kube_client: KubeClient) -> Sequence[V1Node]:
+    nodes: Sequence[V1Node] = get_all_nodes(kube_client)
+    return nodes
+
+@time_cache(ttl=300)
+def get_kube_all_pods(kube_client: KubeClient) -> Sequence[V1Pod]:
+    pods:  Sequence[V1Pod] = get_all_pods(kube_client)
+    return pods
 
 def get_resource_utilization_by_grouping_kube(
     grouping_func: _GenericNodeGroupingFunctionT,
@@ -877,16 +887,18 @@ def get_resource_utilization_by_grouping_kube(
     is the dict returned by ``calculate_resource_utilization_for_kube_nodes`` for
     nodes grouped by attribute value.
     """
-    nodes: Sequence[V1Node] = get_all_nodes(kube_client)
+    nodes = get_kube_all_nodes(kube_client)
     nodes = filter_slaves(nodes, filters)
     if len(nodes) == 0:
         raise ValueError("There are no nodes registered in the Kubernetes.")
 
     node_groupings = group_slaves_by_key_func(grouping_func, nodes, sort_func)
 
+    pods = get_kube_all_pods(kube_client)
+
     pods_by_node = {}
     for node in nodes:
-        pods_by_node[node.metadata.name] = get_pods_by_node(kube_client, node)
+        pods_by_node[node.metadata.name] = [pod for pod in pods if pod.spec.node_name == node.metadata.name]
     return {
         attribute_value: calculate_resource_utilization_for_kube_nodes(
             nodes, pods_by_node
@@ -946,7 +958,7 @@ def get_kube_resource_utilization_health(
     :returns: a list of HealthCheckResult tuples
     """
 
-    nodes = get_all_nodes(kube_client)
+    nodes = get_kube_all_nodes(kube_client)
 
     return [
         assert_cpu_health(get_kube_cpu_status(nodes)),

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -228,6 +228,7 @@ def utilization_table_by_grouping_from_kube(
     service_instance_stats: Optional[ServiceInstanceStats] = None,
 ) -> Tuple[Sequence[MutableSequence[str]], bool]:
     grouping_function = metastatus_lib.key_func_for_attribute_multi_kube(groupings)
+
     resource_info_dict_grouped = metastatus_lib.get_resource_utilization_by_grouping_kube(
         grouping_function, kube_client
     )

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -272,7 +272,7 @@ def test_assert_kube_deployments():
 
 def test_assert_kube_pods_running():
     with mock.patch(
-        "paasta_tools.metrics.metastatus_lib.get_all_pods", autospec=True
+        "paasta_tools.metrics.metastatus_lib.get_all_pods_cached", autospec=True
     ) as mock_get_all_pods:
         client = Mock()
         mock_get_all_pods.return_value = [


### PR DESCRIPTION
Currently in prod, metastatus is timing out when requesting any resources with groupings (aka when verbosity>1)

This adds 2 improvements:
1. Cache any requests to ~~`kuberetes.client.get_all_nodes`~~ `kubernetes_tools.get_all_nodes` or ~~`kubernetes.client.get_all_pods`~~ `kubernetes_tools.get_all_pods`
2. Reduce `# pods` API requests to a single `get_all_pods` API request and filter in memory instead. 
  - With the original code, each `get_pods_by_node` query took 1-2 seconds themselves, and there are over 599 nodes in pnw-prod. This went well over the 120 timeout for the api.

With this change, running `paasta_metastatus -vvv` returns in 1m35s, where previously it was taking >30m (I never was able to get it to finish).  As a result, running the API, it was able to return successfully even with `--max-request-seconds 120`, where in prod we're currently just getting an empty status after 120s.
