### PR TITLE
Cache things in redis

### DIFF
--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -28,6 +28,9 @@ from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import SystemPaastaConfig
 
 
+redcache.setup()
+
+
 def add_subparser(subparsers,) -> None:
     status_parser = subparsers.add_parser(
         "metastatus",
@@ -114,12 +117,13 @@ def add_subparser(subparsers,) -> None:
 
 
 @redcache.d(
-    res=120,
-    selector=lambda *_, **kwds: [
-        item for item in kwds.items() if item[0] != "system_paasta_config"
-    ],
+    resolution=120,
+    selector=lambda **k: filter(
+        lambda item: item[0] != "system_paasta_config", k.items()
+    ),
 )
 def paasta_metastatus_on_api_endpoint(
+    *,
     cluster: str,
     system_paasta_config: SystemPaastaConfig,
     groupings: Sequence[str],

--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -16,6 +16,7 @@ from typing import Sequence
 from typing import Tuple
 
 from paasta_tools import paastaapi
+from paasta_tools import redcache
 from paasta_tools.api.client import get_paasta_oapi_client
 from paasta_tools.cli.utils import get_paasta_metastatus_cmd_args
 from paasta_tools.cli.utils import lazy_choices_completer
@@ -112,6 +113,12 @@ def add_subparser(subparsers,) -> None:
     status_parser.set_defaults(command=paasta_metastatus)
 
 
+@redcache.d(
+    res=120,
+    selector=lambda *_, **kwds: [
+        item for item in kwds.items() if item[0] != "system_paasta_config"
+    ],
+)
 def paasta_metastatus_on_api_endpoint(
     cluster: str,
     system_paasta_config: SystemPaastaConfig,

--- a/paasta_tools/cli/cmds/metastatus.py
+++ b/paasta_tools/cli/cmds/metastatus.py
@@ -28,9 +28,6 @@ from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import SystemPaastaConfig
 
 
-redcache.setup()
-
-
 def add_subparser(subparsers,) -> None:
     status_parser = subparsers.add_parser(
         "metastatus",
@@ -214,6 +211,7 @@ def paasta_metastatus(args,) -> int:
     """Print the status of a PaaSTA clusters"""
     soa_dir = args.soa_dir
     system_paasta_config = load_system_paasta_config()
+    redcache.setup()
 
     all_clusters = list_clusters(soa_dir=soa_dir)
     clusters_to_inspect = figure_out_clusters_to_inspect(args, all_clusters)

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2166,8 +2166,12 @@ def get_pods_by_node(kube_client: KubeClient, node: V1Node) -> Sequence[V1Pod]:
     ).items
 
 
-@redcache.d(skip=1)
-def get_all_pods(kube_client: KubeClient, namespace: str = "paasta") -> Sequence[V1Pod]:
+@redcache.d(
+    selector=lambda **k: filter(lambda item: item[0] != "kube_client", k.items())
+)
+def get_all_pods(
+    *, kube_client: KubeClient, namespace: str = "paasta"
+) -> Sequence[V1Pod]:
     return kube_client.core.list_namespaced_pod(namespace=namespace).items
 
 
@@ -2175,7 +2179,7 @@ def get_all_pods(kube_client: KubeClient, namespace: str = "paasta") -> Sequence
 def get_all_pods_cached(
     kube_client: KubeClient, namespace: str = "paasta"
 ) -> Sequence[V1Pod]:
-    pods: Sequence[V1Pod] = get_all_pods(kube_client, namespace)
+    pods: Sequence[V1Pod] = get_all_pods(kube_client=kube_client, namespace=namespace)
     return pods
 
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -108,6 +108,7 @@ from kubernetes.client.models import V2beta1HorizontalPodAutoscalerStatus
 from kubernetes.client.rest import ApiException
 from mypy_extensions import TypedDict
 
+from paasta_tools import redcache
 from paasta_tools.async_utils import async_timeout
 from paasta_tools.long_running_service_tools import host_passes_blacklist
 from paasta_tools.long_running_service_tools import host_passes_whitelist
@@ -2165,6 +2166,7 @@ def get_pods_by_node(kube_client: KubeClient, node: V1Node) -> Sequence[V1Pod]:
     ).items
 
 
+@redcache.d(skip=1)
 def get_all_pods(kube_client: KubeClient, namespace: str = "paasta") -> Sequence[V1Pod]:
     return kube_client.core.list_namespaced_pod(namespace=namespace).items
 

--- a/paasta_tools/redcache/__init__.py
+++ b/paasta_tools/redcache/__init__.py
@@ -1,0 +1,65 @@
+import pickle
+import time
+from functools import wraps
+
+from redis.client import Redis
+
+cache_server: Redis = None
+
+
+def hashable(data):
+    if isinstance(data, dict):
+        return frozenset((key, hashable(val)) for key, val in data.items())
+    elif "__iter__" in dir(data):
+        return tuple(hashable(item) for item in data)
+    elif "__hash__" in dir(data):
+        return data
+    else:
+        raise f"{type(data)}({data!r}) is not hashable"
+
+
+def d(res=60, selector=lambda *args, **kwds: (args, kwds)):
+    def dd(f):
+        @wraps(f)
+        def wrapper(*args, **kwds):
+            if cache_server is None:
+                return f(*args, **kwds)
+
+            data_hash = hash(hashable(selector(args, kwds)))
+            ts = int(time.time())
+            ts_res = ts - ts % res
+            key = f"{f.__module__}.{f.__name__}:{ts_res}:{data_hash}"
+
+            # check if key exists
+            exists = cache_server.get(key)
+            if exists is None:
+                # try grabbing a lock for the key
+                if cache_server.set(key, pickle.dumps(dict(ts=ts)), nx=True):
+                    print("updating cache")
+                    val = f(*args, **kwds)
+                    # set the value for others
+                    cache_server.set(key, pickle.dumps(dict(ts=ts, val=val)))
+                    return val
+                else:
+                    # re-fetch the key locked by somebody else
+                    exists = cache_server.get(key)
+
+            # re-fetch in a loop until `val` shows up
+            while time.time() < ts_res + res:
+                exists = pickle.loads(exists)
+                if "val" in exists:
+                    return exists["val"]
+                time.sleep(0.5)
+                exists = cache_server.get(key)
+
+            # key we're looking for is already stale
+            return f(*args, **kwds)
+
+        return wrapper
+
+    return dd
+
+
+def setup():
+    global cache_server
+    cache_server = Redis(host="localhost", port=6379)

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -18,6 +18,7 @@ dulwich >= 0.17.3
 ephemeral-port-reserve >= 1.0.1
 graphviz
 gunicorn
+hiredis
 humanfriendly
 humanize >= 0.5.1
 inotify >= 0.2.8
@@ -44,6 +45,7 @@ python-dateutil >= 2.4.0
 python-iptables
 pytimeparse >= 1.1.0
 pytz >= 2014.10
+redis
 requests >= 2.18.4
 requests-cache >= 0.4.10,<= 0.5.0
 retry

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ future==0.16.0
 google-auth==1.2.0
 graphviz==0.8.2
 gunicorn==19.8.1
+hiredis==0.2.0
 humanfriendly==4.18
 humanize==0.5.1
 hupper==1.0
@@ -81,6 +82,7 @@ python-utils==2.0.1
 pytimeparse==1.1.5
 pytz==2016.10
 pyyaml==5.1
+redis==3.4.1
 repoze.lru==0.6
 requests==2.21.0
 requests-cache==0.4.10


### PR DESCRIPTION
`redcache.d` is a decorator that fetches function result from redis cache if one is configured, otherwise (or upon error or timeout) will call the cached function directly.

takes two arguments:

- `resolution` is the time resolution to look for cached fragments, eg for `resolution=60`, the cache key will be calculated as `timestamp - timestamp % 60`.
- `selector` is a function that receives cached function's arguments and returns a hashable subset that will be used to derive cache key, should be used for things like skipping stateful objects, like network connections etc.

the decorator must only be used for pure functions(no side-effects) that take long time to run, it's not practical to use for anything that runs in less than 100-200ms.