### PR TITLE
[cli] Only load the required subcommand

### DIFF
--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -205,6 +205,8 @@ def parse_args(argv):
              from sys.argv
     """
     parser = get_argparser(commands=[])
+    argcomplete.autocomplete(parser)
+
     args, _ = parser.parse_known_args(argv)
     if args.command:
         parser = get_argparser(commands=[args.command])

--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -122,7 +122,7 @@ PAASTA_SUBCOMMANDS = {
     "logs": "logs",
     "mark-for-deployment": "mark_for_deployment",
     "metastatus": "metastatus",
-    "pauise_service_autoscaler": "pauise_service_autoscaler",
+    "pause_service_autoscaler": "pause_service_autoscaler",
     "performance-check": "performance_check",
     "push-to-registry": "push_to_registry",
     "remote-run": "remote_run",

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -17,7 +17,6 @@ import getpass
 import hashlib
 import logging
 import os
-import pkgutil
 import random
 import re
 import socket
@@ -64,29 +63,6 @@ from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import validate_service_instance
 
 log = logging.getLogger(__name__)
-
-
-def load_method(module_name, method_name):
-    """Return a function given a module and method name.
-
-    :param module_name: a string
-    :param method_name: a string
-    :return: a function
-    """
-    module = __import__(module_name, fromlist=[method_name])
-    method = getattr(module, method_name)
-    return method
-
-
-def modules_in_pkg(pkg):
-    """Return the list of modules in a python package (a module with a
-    __init__.py file.)
-
-    :return: a list of strings such as `['list', 'check']` that correspond to
-             the module names in the package.
-    """
-    for _, module_name, _ in pkgutil.walk_packages(pkg.__path__):
-        yield module_name
 
 
 def is_file_in_dir(file_name, path):

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -239,15 +239,6 @@ def test_lazy_choices_completer():
     assert completer(prefix="") == ["1", "2", "3"]
 
 
-def test_modules_in_pkg():
-    from paasta_tools.cli import cmds
-
-    ret = tuple(utils.modules_in_pkg(cmds))
-    assert "__init__" not in ret
-    assert "cook_image" in ret
-    assert "list_clusters" in ret
-
-
 @mock.patch("paasta_tools.cli.utils.INSTANCE_TYPE_HANDLERS", dict(), autospec=None)
 @mock.patch("paasta_tools.cli.utils.validate_service_instance", autospec=True)
 def test_get_instance_config_by_instance_type(mock_validate_service_instance,):

--- a/yelp_package/itest/tab_complete.sh
+++ b/yelp_package/itest/tab_complete.sh
@@ -36,7 +36,7 @@ tab_complete_fail() {
 # This test will need to be modified if we add any new subcommands that start with
 # with the provided pre_typed:
 pre_typed='st'
-expected=`echo -e "start\vstop\vstatus"`
+expected=`echo -e "start\vstatus\vstop"`
 # We feed the special env variables available at tab completion time
 # to the paasta command to make it return back the tab completion output to
 # fd 8, which we redirect to 1 so we can capture it

--- a/yelp_package/itest/ubuntu.sh
+++ b/yelp_package/itest/ubuntu.sh
@@ -147,6 +147,7 @@ do
 done
 
 # Tab completion tests
+echo Testing tab completion
 "$(dirname "$0")/tab_complete.sh"
 
 


### PR DESCRIPTION
Due to inconssistencies in current paasta cli implementation, we're preloading all subcommand modules to find actual subcommands and populate the argument parser.

This PR (for the time being) hardcodes existing subcommands, uses stripped down arg parser to find the subcommand we want to run, loads that subcommand and prepares the arg parser for it.

Drops the total overhead from 2.5s to 0.2s, though the impact won't be as large for actual subcommands because most of load time is spent in `util` modules which is used by all of them.