### PR TITLE
PAASTA-17145: handle a missing ecosystem in vault data gracefully

### DIFF
--- a/paasta_tools/secret_providers/vault.py
+++ b/paasta_tools/secret_providers/vault.py
@@ -149,7 +149,7 @@ class SecretProvider(BaseSecretProvider):
 
     def get_secret_signature_from_data(self, data: Mapping[str, Any]) -> Optional[str]:
         ecosystem = self.ecosystems[0]
-        if data["environments"][ecosystem]:
+        if data["environments"].get(ecosystem):
             return data["environments"][ecosystem]["signature"]
         else:
             return None

--- a/tests/secret_providers/test_vault.py
+++ b/tests/secret_providers/test_vault.py
@@ -6,11 +6,11 @@ from paasta_tools.secret_providers.vault import SecretProvider
 
 
 @fixture
-def mock_secret_provider(ecosystems=["devc"]):
+def mock_secret_provider():
     with mock.patch(
         "paasta_tools.secret_providers.vault.SecretProvider.get_vault_ecosystems_for_clusters",
         autospec=True,
-        return_value=ecosystems,
+        return_value=["devc"],
     ), mock.patch(
         "paasta_tools.secret_providers.vault.get_vault_client", autospec=True
     ):


### PR DESCRIPTION
We can occasionally get some vault jsonsecret data with only a subset of 'valid' ecosystems listed in the `environments` data.

When a new service that has an old jsonsecret file like this is deployed to a kubernetes cluster, even if the instance to be scheduled in the new ecosystem does not actually depend on this particular jsonsecret file, `paasta_secrets_sync` will not only fail to sync this broken secret, but all following secrets and services.

Instead, I think we should treat missing ecosystems in `environments` as we do an ecosystem without encrypted data.  This way `paasta_secrets_sync` will continue on to other, correctly-generated secrets, and if the service owner really does need to fix that data they will be able to see that there is an issue with the instance not deployed due to a missing secret on the k8s side.

The new test failed with the original code as expected:
```
========================================================================================= FAILURES ==========================================================================================
________________________________________________________________________ test_get_secret_signature_from_data_missing ________________________________________________________________________

mock_secret_provider = <paasta_tools.secret_providers.vault.SecretProvider object at 0x7f4c3cbd1160>

    def test_get_secret_signature_from_data_missing(mock_secret_provider):
        mock_secret_provider.cluster_names = ["mesosstage", "devc", "prod"]
        mock_secret_provider.vault_cluster_config = {
            "mesosstage": "devc",
            "devc": "devc",
            "prod": "prod",
        }
        with mock.patch(
            "paasta_tools.secret_providers.vault.get_plaintext", autospec=False
        ):
            # Should not raise errors
>           assert not mock_secret_provider.get_secret_signature_from_data(
                {"environments": {"westeros": {}}}
            )

tests/secret_providers/test_vault.py:163:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <paasta_tools.secret_providers.vault.SecretProvider object at 0x7f4c3cbd1160>, data = {'environments': {'westeros': {}}}

    def get_secret_signature_from_data(self, data: Mapping[str, Any]) -> Optional[str]:
        ecosystem = self.ecosystems[0]
        #if data["environments"].get(ecosystem):
>       if data["environments"][ecosystem]:
E       KeyError: 'devc'

paasta_tools/secret_providers/vault.py:153: KeyError
============================================================================ 1 failed, 8 passed in 0.11 seconds =============================================================================
```
but passes for the new code. 

