### PR TITLE
allow tagging secret as shared across environments

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -105,6 +105,16 @@ def add_subparser(subparsers):
         default=False,
         help="Optionally pass the plaintext from stdin",
     )
+    secret_parser.add_argument(
+        "--cross_environment",
+        required=False,
+        type=str,
+        help=(
+            "Provide motivation in case the same value is being duplicated "
+            "across multiple runtime environments when adding or updating a secret"
+        ),
+        metavar="MOTIVATION",
+    )
     secret_parser.set_defaults(command=paasta_secret)
 
 
@@ -209,7 +219,10 @@ def paasta_secret(args):
         if not plaintext:
             print("Warning: Given plaintext is an empty string.")
         secret_provider.write_secret(
-            action=args.action, secret_name=args.secret_name, plaintext=plaintext
+            action=args.action,
+            secret_name=args.secret_name,
+            plaintext=plaintext,
+            cross_environment_motivation=args.cross_environment,
         )
         secret_path = os.path.join(
             secret_provider.secret_dir, f"{args.secret_name}.json"

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -106,7 +106,7 @@ def add_subparser(subparsers):
         help="Optionally pass the plaintext from stdin",
     )
     secret_parser.add_argument(
-        "--cross_environment",
+        "--cross-env-motivation",
         required=False,
         type=str,
         help=(
@@ -222,7 +222,7 @@ def paasta_secret(args):
             action=args.action,
             secret_name=args.secret_name,
             plaintext=plaintext,
-            cross_environment_motivation=args.cross_environment,
+            cross_environment_motivation=args.cross_env_motivation,
         )
         secret_path = os.path.join(
             secret_provider.secret_dir, f"{args.secret_name}.json"

--- a/paasta_tools/secret_providers/__init__.py
+++ b/paasta_tools/secret_providers/__init__.py
@@ -29,7 +29,13 @@ class BaseSecretProvider:
     ) -> Dict[str, str]:
         raise NotImplementedError
 
-    def write_secret(self, action: str, secret_name: str, plaintext: bytes) -> None:
+    def write_secret(
+        self,
+        action: str,
+        secret_name: str,
+        plaintext: bytes,
+        cross_environment_motivation: Optional[str] = None,
+    ) -> None:
         raise NotImplementedError
 
     def decrypt_secret(self, secret_name: str) -> str:

--- a/paasta_tools/secret_providers/vault.py
+++ b/paasta_tools/secret_providers/vault.py
@@ -106,7 +106,13 @@ class SecretProvider(BaseSecretProvider):
             )
             raise
 
-    def write_secret(self, action: str, secret_name: str, plaintext: bytes) -> None:
+    def write_secret(
+        self,
+        action: str,
+        secret_name: str,
+        plaintext: bytes,
+        cross_environment_motivation: Optional[str] = None,
+    ) -> None:
         with TempGpgKeyring(overwrite=True):
             for ecosystem in self.ecosystems:
                 client = self.clients[ecosystem]
@@ -119,6 +125,7 @@ class SecretProvider(BaseSecretProvider):
                     plaintext=plaintext,
                     service_name=self.service_name,
                     transit_key=self.encryption_key,
+                    cross_environment_motivation=cross_environment_motivation,
                 )
 
     def decrypt_secret(self, secret_name: str) -> str:

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -152,6 +152,7 @@ def test_paasta_secret():
             service="middleearth",
             clusters="mesosstage",
             shared=False,
+            cross_environment="because ...",
         )
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(
@@ -161,6 +162,7 @@ def test_paasta_secret():
             action="add",
             secret_name="theonering",
             plaintext=mock_get_plaintext_input.return_value,
+            cross_environment_motivation="because ...",
         )
         mock_log_audit.assert_called_with(
             action="add-secret",
@@ -174,6 +176,7 @@ def test_paasta_secret():
             service="middleearth",
             clusters="mesosstage",
             shared=False,
+            cross_environment=None,
         )
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(
@@ -183,6 +186,7 @@ def test_paasta_secret():
             action="update",
             secret_name="theonering",
             plaintext=mock_get_plaintext_input.return_value,
+            cross_environment_motivation=None,
         )
         mock_log_audit.assert_called_with(
             action="update-secret",

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -152,7 +152,7 @@ def test_paasta_secret():
             service="middleearth",
             clusters="mesosstage",
             shared=False,
-            cross_environment="because ...",
+            cross_env_motivation="because ...",
         )
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(
@@ -176,7 +176,7 @@ def test_paasta_secret():
             service="middleearth",
             clusters="mesosstage",
             shared=False,
-            cross_environment=None,
+            cross_env_motivation=None,
         )
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(

--- a/tests/secret_providers/test_vault.py
+++ b/tests/secret_providers/test_vault.py
@@ -73,7 +73,10 @@ def test_write_secret(mock_secret_provider):
         "paasta_tools.secret_providers.vault.encrypt_secret", autospec=False
     ) as mock_encrypt_secret:
         mock_secret_provider.write_secret(
-            action="add", secret_name="mysecret", plaintext=b"SECRETSQUIRREL"
+            action="add",
+            secret_name="mysecret",
+            plaintext=b"SECRETSQUIRREL",
+            cross_environment_motivation="because ...",
         )
         mock_encrypt_secret.assert_called_with(
             client=mock_secret_provider.clients["devc"],
@@ -84,6 +87,7 @@ def test_write_secret(mock_secret_provider):
             service_name="universe",
             soa_dir="/nail/blah",
             transit_key="paasta",
+            cross_environment_motivation="because ...",
         )
 
         mock_secret_provider.encryption_key = "special-key"
@@ -99,6 +103,7 @@ def test_write_secret(mock_secret_provider):
             service_name="universe",
             soa_dir="/nail/blah",
             transit_key="special-key",
+            cross_environment_motivation=None,
         )
 
 

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -13,7 +13,7 @@ signalform-tools==0.0.16
 slo-transcoder==3.3.0
 smmap2==2.0.3
 sticht[yelp_internal]==1.1.12
-vault-tools==0.7.34
+vault-tools==0.9.2
 yelp-cgeom==1.3.1
 yelp-clog==5.0.0
 yelp-logging==1.0.37


### PR DESCRIPTION
This change allows to add a metadata string when creating or updating a secret which is meant to have the same value across multiple environments. This is done to allow developers to provide context about why a secret has been duplicated instead of following the best practice of using different secret value in different runtime environments. This ultimately allows to create catalogue of secrets which are meant to be replicated and detect when new duplicated secrets are added not following the convention.

The additional parameter has been implemented in the latest version of `vault-tools` (0.9.2). I recognise this is a pretty large bump for the dependency, so I'd ask reviewers to look at the library changelog for potentially breaking changes introduced in the meantime (cause I don't have enough knowledge of this codebase to catch possible edge cases).

Also, please point me to any bit of documentation which may need updating from this.