### PR TITLE
Monkey-patch default HPA scaling policy into HPA spec

### DIFF
--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -277,6 +277,7 @@ class DeploymentWrapper(Application):
         desired_hpa_spec = self.soa_config.get_autoscaling_metric_spec(
             name=self.item.metadata.name,
             cluster=self.soa_config.cluster,
+            kube_client=kube_client,
             namespace=self.item.metadata.namespace,
         )
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -404,13 +404,22 @@ class KubeClient:
             ),
             fset=_set_disrupted_pods,
         )
+
         self.deployments = kube_client.AppsV1Api()
         self.core = kube_client.CoreV1Api()
         self.policy = kube_client.PolicyV1beta1Api()
         self.apiextensions = kube_client.ApiextensionsV1beta1Api()
         self.custom = kube_client.CustomObjectsApi()
         self.autoscaling = kube_client.AutoscalingV2beta2Api()
-        self.request = kube_client.ApiClient().request
+
+        self.api_client = kube_client.ApiClient()
+        self.request = self.api_client.request
+        # This function is used by the k8s client to serialize OpenAPI objects
+        # into JSON before posting to the api. The JSON output can be used
+        # in place of OpenAPI objects in client function calls. This allows us
+        # to monkey-patch the JSON data with configs the api supports, but the
+        # Python client lib may not yet.
+        self.jsonify = self.api_client.sanitize_for_serialization
 
 
 class KubernetesDeploymentConfig(LongRunningServiceConfig):
@@ -486,12 +495,44 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             defaults=default_params,
         )
 
+    # TODO: move the default scaling policy to system paasta configs
+    def get_autoscaling_scaling_policy(self, max_replicas: int) -> Dict:
+        """Returns the k8s HPA scaling policy in raw JSON. Requires k8s v1.18
+        to work.
+        """
+        # The HPA scaling algorithm is as follows. Every sync period (default:
+        # 15 seconds), the HPA will:
+        #   1. determine what the desired capacity is from metrics
+        #   2. apply min/max replica scaling limits
+        #   3. rate-limit the scaling magnitude (e.g. scale down by no more than
+        #      30% of current replicas)
+        #   4. constrain the scaling magnitude by the period seconds (e.g. scale
+        #      down by no more than 30% of current replicas per 60 seconds)
+        #   5. record the desired capacity, then pick the highest capacity from
+        #      the stabilization window (default: last 300 seconds) as the final
+        #      desired capacity.
+        #      - the idea is to stabilize scaling against (heavily) fluctuating
+        #        metrics
+        return {
+            "scaleDown": {
+                "stabilizationWindowSeconds": 300,
+                # the policy in a human-readable way: scale down every 60s by
+                # at most 30% of current replicas.
+                "selectPolicy": "Max",
+                "policies": [{"type": "Percent", "value": 30, "periodSeconds": 60}],
+            }
+        }
+
     def namespace_external_metric_name(self, metric_name: str) -> str:
         return f"{self.get_sanitised_deployment_name()}-{metric_name}"
 
     def get_autoscaling_metric_spec(
-        self, name: str, cluster: str, namespace: str = "paasta"
-    ) -> Optional[V2beta2HorizontalPodAutoscaler]:
+        self,
+        name: str,
+        cluster: str,
+        kube_client: KubeClient,
+        namespace: str = "paasta",
+    ) -> Optional[Union[V2beta2HorizontalPodAutoscaler, Dict]]:
         # Returns None if an HPA should not be attached based on the config,
         # or the config is invalid.
 
@@ -587,7 +628,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             )
             return None
 
-        return V2beta2HorizontalPodAutoscaler(
+        hpa = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
                 name=name, namespace=namespace, annotations=annotations
@@ -601,6 +642,17 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 ),
             ),
         )
+
+        # In k8s v1.18, HPA scaling policies can be set:
+        #   https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
+        # However, the python client library currently only supports v1.17, so
+        # we need to monkey-patch scaling policies until the library is updated
+        # v1.18.
+        scaling_policy = self.get_autoscaling_scaling_policy(max_replicas)
+        if scaling_policy:
+            hpa = kube_client.jsonify(hpa)  # this is a hack, see KubeClient class
+            hpa["spec"]["behavior"] = scaling_policy
+        return hpa
 
     def get_deployment_strategy_config(self) -> V1DeploymentStrategy:
         # get soa defined bounce_method

--- a/tests/kubernetes/application/test_controller_wrapper.py
+++ b/tests/kubernetes/application/test_controller_wrapper.py
@@ -278,7 +278,7 @@ def test_sync_horizontal_pod_autoscaler_create_hpa(mock_autoscaling_is_paused):
     mock_client.autoscaling.create_namespaced_horizontal_pod_autoscaler.assert_called_once_with(
         namespace="faasta",
         body=app.soa_config.get_autoscaling_metric_spec(
-            "fake_name", "cluster", "faasta"
+            "fake_name", "cluster", mock_client, namespace="faasta",
         ),
         pretty=True,
     )
@@ -331,7 +331,7 @@ def test_sync_horizontal_pod_autoscaler_update_hpa(mock_autoscaling_is_paused):
         namespace="faasta",
         name="fake_name",
         body=app.soa_config.get_autoscaling_metric_spec(
-            "fake_name", "cluster", "faasta"
+            "fake_name", "cluster", mock_client, namespace="faasta",
         ),
         pretty=True,
     )

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -241,6 +241,13 @@ def test_load_kubernetes_service_config():
 
 
 class TestKubernetesDeploymentConfig:
+    @pytest.fixture(autouse=True)
+    def mock_load_kube_config(self):
+        with mock.patch(
+            "paasta_tools.kubernetes_tools.kube_config.load_kube_config", autospec=True,
+        ) as m:
+            yield m
+
     def setup_method(self, method):
         mock_config_dict = KubernetesDeploymentConfigDict(
             bounce_method="crossover", instances=3,
@@ -253,6 +260,19 @@ class TestKubernetesDeploymentConfig:
             branch_dict=None,
             soa_dir="/nail/blah",
         )
+
+    # TODO: remove once hpa scaling policy patch is removed
+    def patch_expected_autoscaling_spec(self, obj, deployment, max_replicas=3):
+        """Currently, HPA scaling policies are monkey-patched onto the HPA
+        OpenAPI objects. This function does the same thing so that any assertions
+        we do will pass.
+        """
+        if isinstance(obj, V2beta2HorizontalPodAutoscaler):
+            obj = KubeClient().jsonify(obj)
+            obj["spec"]["behavior"] = deployment.get_autoscaling_scaling_policy(
+                max_replicas,
+            )
+        return obj
 
     def test_copy(self):
         assert self.deployment.copy() == self.deployment
@@ -1569,7 +1589,7 @@ class TestKubernetesDeploymentConfig:
             branch_dict=None,
         )
         return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
-            mock_config, "fake_name", "cluster"
+            mock_config, "fake_name", "cluster", KubeClient(),
         )
         annotations: Dict[Any, Any] = {}
         expected_res = V2beta2HorizontalPodAutoscaler(
@@ -1596,7 +1616,10 @@ class TestKubernetesDeploymentConfig:
                 ),
             ),
         )
-        assert expected_res == return_value
+        assert (
+            self.patch_expected_autoscaling_spec(expected_res, mock_config)
+            == return_value
+        )
 
     def test_get_autoscaling_metric_spec_http(self):
         # with http
@@ -1622,7 +1645,7 @@ class TestKubernetesDeploymentConfig:
             autospec=True,
         ):
             return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
-                mock_config, "fake_name", "cluster"
+                mock_config, "fake_name", "cluster", KubeClient(),
             )
         annotations = {"signalfx.com.custom.metrics": ""}
         expected_res = V2beta2HorizontalPodAutoscaler(
@@ -1654,7 +1677,10 @@ class TestKubernetesDeploymentConfig:
                 ),
             ),
         )
-        assert expected_res == return_value
+        assert (
+            self.patch_expected_autoscaling_spec(expected_res, mock_config)
+            == return_value
+        )
 
     def test_get_autoscaling_metric_spec_uwsgi(self):
         config_dict = KubernetesDeploymentConfigDict(
@@ -1679,7 +1705,7 @@ class TestKubernetesDeploymentConfig:
             autospec=True,
         ):
             return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
-                mock_config, "fake_name", "cluster"
+                mock_config, "fake_name", "cluster", KubeClient(),
             )
 
         annotations = {"signalfx.com.custom.metrics": ""}
@@ -1712,7 +1738,10 @@ class TestKubernetesDeploymentConfig:
                 ),
             ),
         )
-        assert expected_res == return_value
+        assert (
+            self.patch_expected_autoscaling_spec(expected_res, mock_config)
+            == return_value
+        )
 
     def test_get_autoscaling_metric_spec_offset_and_averaging(self):
         config_dict = KubernetesDeploymentConfigDict(
@@ -1736,7 +1765,7 @@ class TestKubernetesDeploymentConfig:
             branch_dict=None,
         )
         return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
-            mock_config, "fake_name", "cluster"
+            mock_config, "fake_name", "cluster", KubeClient(),
         )
         expected_res = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
@@ -1745,7 +1774,15 @@ class TestKubernetesDeploymentConfig:
                 namespace="paasta",
                 annotations={
                     "signalfx.com.custom.metrics": "",
-                    "signalfx.com.external.metric/service-instance-uwsgi": mock.ANY,
+                    "signalfx.com.external.metric/service-instance-uwsgi": kubernetes_tools.LEGACY_AUTOSCALING_SIGNALFLOW.format(
+                        setpoint=0.5,
+                        offset=0.1,
+                        moving_average_window_seconds=300,
+                        paasta_service="service",
+                        paasta_instance="instance",
+                        paasta_cluster="cluster",
+                        signalfx_metric_name="uwsgi",
+                    ),
                 },
             ),
             spec=V2beta2HorizontalPodAutoscalerSpec(
@@ -1768,7 +1805,10 @@ class TestKubernetesDeploymentConfig:
             ),
         )
 
-        assert expected_res == return_value
+        assert (
+            self.patch_expected_autoscaling_spec(expected_res, mock_config)
+            == return_value
+        )
 
     def test_get_autoscaling_metric_spec_bespoke(self):
         config_dict = KubernetesDeploymentConfigDict(
@@ -1786,7 +1826,7 @@ class TestKubernetesDeploymentConfig:
             branch_dict=None,
         )
         return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
-            mock_config, "fake_name", "cluster"
+            mock_config, "fake_name", "cluster", KubeClient(),
         )
         expected_res = None
         assert expected_res == return_value


### PR DESCRIPTION
### Description
This is a first attempt at support HPA scaling policies that were newly introduced in Kubernetes v1.18 in PaaSTA to control how quickly we scale down. Couple of things to note:

- I've had to monkey-patch the scaling policies configs into the JSON data the k8s client posts to get this to work, because the k8s client library only supports v1.17. 
- I've only created (what I think is) a sensible default so far, but the next step will be to make the defaults configurable in system paasta configs or on a per-instance basis from soa-configs.
- The sensible default is to at most per minute scale down by either 30% of current replicas or 5% of max replicas, whichever is highest. Essentially, this means we only scale down at most by 30% of max replicas, and the rate of scale down plateaus to 5% of max replicas as we scale down. 
- I have not touched the scale up policy. The default scale up policy is [here](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#scaling-policies).

### Testing
`make test`
Updating an HPA in kubestage with these changes yields the following alpha annotation (I pretty-formatted it for readability) visible in `kubectl get hpa`:
```
"autoscaling.alpha.kubernetes.io/behavior": "{
  \"ScaleUp\": {
    \"StabilizationWindowSeconds\": 0,
    \"SelectPolicy\": \"Max\",
    \"Policies\": [
      {
        \"Type\": \"Pods\",
        \"Value\": 4,
        \"PeriodSeconds\": 15
      },
      {
        \"Type\": \"Percent\",
        \"Value\": 100,
        \"PeriodSeconds\": 15
      }
    ]
  },
  \"ScaleDown\": {
    \"StabilizationWindowSeconds\": 300,
    \"SelectPolicy\": \"Max\",
    \"Policies\": [
      {
        \"Type\": \"Percent\",
        \"Value\": 30,
        \"PeriodSeconds\": 60
      },
      {
        \"Type\": \"Pods\",
        \"Value\": 1,
        \"PeriodSeconds\": 60
      }
    ]
  }
}"
```

### Notes
- I could make the policy a little more safe, by decreasing the percent scale down value, and/or increasing the `periodSeconds` parameter, which is the scale-down interval.
- Not sure I want to make this configurable on the first pass. I want to see if this helps before I go further. We should be able to see more controlled scale-downs.