### PR TITLE
Use -1 to get the last element of list

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -895,7 +895,7 @@ def status_kubernetes_job_human(
 
 
 def get_flink_job_name(flink_job):
-    return flink_job["name"].split(".", 2)[2]
+    return flink_job["name"].split(".", 2)[-1]
 
 
 def should_job_info_be_shown(cluster_state):


### PR DESCRIPTION
As opposed to assuming that all jobs will have name like `{service_name}.{instance}.{job_name}` and getting 2nd element after splitting. Use -1 to get the last element so that the function works for cases where job names are defined without service and instance names.