### PR TITLE
Read supported storage classes from system_paasta_config

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -134,6 +134,7 @@ from paasta_tools.utils import DeployWhitelist
 from paasta_tools.utils import DockerVolume
 from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_git_sha_from_dockerurl
+from paasta_tools.utils import get_supported_storage_classes
 from paasta_tools.utils import load_service_instance_config
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import load_v2_deployments_json
@@ -168,7 +169,6 @@ DISCOVERY_ATTRIBUTES = {
     "pool",
     "hostname",
 }
-SUPPORTED_STORAGE_CLASSES = {"ebs", "ebs-slow", "ebs-retain"}
 
 GPU_RESOURCE_NAME = "nvidia.com/gpu"
 
@@ -1145,8 +1145,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         ]
 
     def get_storage_class_name(self, volume: PersistentVolume) -> str:
+        supported_storage_classes = get_supported_storage_classes()
         storage_class_name = volume.get("storage_class_name", "ebs")
-        if storage_class_name not in SUPPORTED_STORAGE_CLASSES:
+        if storage_class_name not in supported_storage_classes:
             log.warning(f"storage class {storage_class_name} is not supported")
             storage_class_name = "ebs"
         return storage_class_name

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1152,6 +1152,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             )
         except (PaastaNotConfiguredError):
             log.warning("No PaaSTA configuration was found, returning default value")
+            supported_storage_classes = []
         storage_class_name = volume.get("storage_class_name", "ebs")
         if storage_class_name not in supported_storage_classes:
             log.warning(f"storage class {storage_class_name} is not supported")

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -134,7 +134,6 @@ from paasta_tools.utils import DeployWhitelist
 from paasta_tools.utils import DockerVolume
 from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_git_sha_from_dockerurl
-from paasta_tools.utils import get_supported_storage_classes
 from paasta_tools.utils import load_service_instance_config
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import load_v2_deployments_json
@@ -1145,7 +1144,8 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         ]
 
     def get_storage_class_name(self, volume: PersistentVolume) -> str:
-        supported_storage_classes = get_supported_storage_classes()
+        system_paasta_config = load_system_paasta_config()
+        supported_storage_classes = system_paasta_config.get_supported_storage_classes()
         storage_class_name = volume.get("storage_class_name", "ebs")
         if storage_class_name not in supported_storage_classes:
             log.warning(f"storage class {storage_class_name} is not supported")

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1150,12 +1150,11 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             supported_storage_classes = (
                 system_paasta_config.get_supported_storage_classes()
             )
-            storage_class_name = volume.get("storage_class_name", "ebs")
-            if storage_class_name not in supported_storage_classes:
-                log.warning(f"storage class {storage_class_name} is not supported")
-                storage_class_name = DEFAULT_STORAGE_CLASS_NAME
         except (PaastaNotConfiguredError):
             log.warning("No PaaSTA configuration was found, returning default value")
+        storage_class_name = volume.get("storage_class_name", "ebs")
+        if storage_class_name not in supported_storage_classes:
+            log.warning(f"storage class {storage_class_name} is not supported")
             storage_class_name = DEFAULT_STORAGE_CLASS_NAME
         return storage_class_name
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1894,6 +1894,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     service_discovery_providers: Dict[str, Any]
     slack: Dict[str, str]
     spark_run_config: SparkRunConfig
+    supported_storage_classes: Sequence[str]
     synapse_haproxy_url_format: str
     synapse_host: str
     synapse_port: int
@@ -2457,6 +2458,9 @@ class SystemPaastaConfig:
 
     def get_clusters(self) -> Sequence[str]:
         return self.config_dict.get("clusters", [])
+
+    def get_supported_storage_classes(self) -> Sequence[str]:
+        return self.config_dict.get("supported_storage_classes", [])
 
     def get_envoy_admin_endpoint_format(self) -> str:
         """ Get the format string for Envoy's admin interface. """

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1897,8 +1897,9 @@ class TestKubernetesDeploymentConfig:
         ) as mock_load_system_config:
             mock_load_system_config.side_effect = None
             mock_load_system_config.return_value = mock.Mock(
-                get_supported_storage_classes=mock.Mock(return_value=["ebs", "ebs-slow", "ebs-retain"]),
-                get_register_k8s_pods=mock.Mock(return_value=False),
+                get_supported_storage_classes=mock.Mock(
+                    return_value=["ebs", "ebs-slow", "ebs-retain"]
+                ),
             )
             pv = PersistentVolume(
                 storage_class_name=storage_class_name,


### PR DESCRIPTION
## Description
This change makes `paasta_tools` read the set of supported storage classes from `system_paasta_config` rather than relying on hard-coded values. We can then manage these configs in Puppet which will be useful for allowing users to experiment with new StorageClasses (e.g. ones with the new `gp3` volume type).

## Testing Done
`make test` passes

## Release Strategy
`patch` release