### PR TITLE
PAASTA-17119 Replace kube_hpa_status_current_replicas uwsgi hpa metric

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2544,7 +2544,7 @@ setpoint = {setpoint}
 moving_average_window = '{moving_average_window_seconds}s'
 filters = filter('paasta_service', '{paasta_service}') and filter('paasta_instance', '{paasta_instance}') and filter('paasta_cluster', '{paasta_cluster}')
 
-current_replicas = data('kube_hpa_status_current_replicas', filter=filters, extrapolation="last_value").sum(by=['paasta_cluster'])
+current_replicas = data('kube_deployment_spec_replicas', filter=filters, extrapolation="last_value").sum(by=['paasta_cluster'])
 load_per_instance = data('{signalfx_metric_name}', filter=filters, extrapolation="last_value", maxExtrapolations=10).below(1, clamp=True)
 
 desired_instances_at_each_point_in_time = (load_per_instance - offset).sum() / (setpoint - offset)


### PR DESCRIPTION
I'm replacing the metric **kube_hpa_status_current_replicas** with **kube_deployment_spec_replicas** on the signalflow code for the uwsgi HPA.

For details on this new metric please check PAASTA-17119.

I'm also moving the signalflow code to a paasta config variable, so that we can override it if needed.

### Tests:
- Installed a paasta_tools version to kubestage and confirmed that the signalflow code was updated on different HPA objects.
- This change didn't bounce any pod as the signalflow code lives on HPA objects (as an annotation).