### PR TITLE
fix vault secret provider (s/do_renew/do_cert_renew)

### DIFF
--- a/paasta_tools/secret_providers/vault.py
+++ b/paasta_tools/secret_providers/vault.py
@@ -11,7 +11,7 @@ try:
     from vault_tools.paasta_secret import get_vault_client
     from vault_tools.gpg import TempGpgKeyring
     from vault_tools.paasta_secret import encrypt_secret
-    from vault_tools.cert_tools import do_renew
+    from vault_tools.cert_tools import do_cert_renew
     import hvac
 except ImportError:
 
@@ -26,7 +26,7 @@ except ImportError:
     def encrypt_secret(*args: Any, **kwargs: Any) -> None:
         return None
 
-    def do_renew(*args: Any, **kwargs: Any) -> None:
+    def do_cert_renew(*args: Any, **kwargs: Any) -> None:
         return None
 
 
@@ -165,7 +165,7 @@ class SecretProvider(BaseSecretProvider):
         client = self.clients[self.ecosystems[0]]
         user = getpass.getuser()
         pki_dir = os.path.expanduser("~/.paasta/pki")
-        do_renew(
+        do_cert_renew(
             client=client,
             pki_backend=pki_backend,
             role=user,

--- a/tests/secret_providers/test_vault.py
+++ b/tests/secret_providers/test_vault.py
@@ -174,7 +174,7 @@ def test_get_secret_signature_from_data_missing(mock_secret_provider):
 
 def test_renew_issue_cert(mock_secret_provider):
     with mock.patch(
-        "paasta_tools.secret_providers.vault.do_renew", autospec=True
-    ) as mock_do_renew:
+        "paasta_tools.secret_providers.vault.do_cert_renew", autospec=True
+    ) as mock_do_cert_renew:
         mock_secret_provider.renew_issue_cert("paasta", "30m")
-        assert mock_do_renew.called
+        assert mock_do_cert_renew.called


### PR DESCRIPTION
In https://github.com/Yelp/paasta/pull/2983 I broke the Vault secret provider by bumping the version of `vault-tools` because in the latest versions the `do_renew` function of the `cert_tools` module has been renamed to `do_cert_renew`. The function signature has remained the same so no other adjustment should be required.