### PR TITLE
Stricter schema checking for persistent_volumes, to catch containerPa…

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -388,8 +388,12 @@
                             },
                             "mode": {
                                 "type": "string"
+                            },
+                            "storage_class_name": {
+                                "type": "string"
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     },
                     "uniqueItems": true
                 },


### PR DESCRIPTION
…th instead of container_path

This catches the recent typo when run locally. I'm currently running this against locally against the rest of yelpsoa-configs to make sure I'm not going to block anybody's changes.