### PR TITLE
set rescue_failures parameter in Vault provider decryption

### DIFF
--- a/paasta_tools/secret_providers/vault.py
+++ b/paasta_tools/secret_providers/vault.py
@@ -86,6 +86,7 @@ class SecretProvider(BaseSecretProvider):
                 cache_dir=None,
                 cache_key=None,
                 context=self.service_name,
+                rescue_failures=False,
             ).decode("utf-8")
             secret_environment[k] = secret
         return secret_environment
@@ -139,6 +140,7 @@ class SecretProvider(BaseSecretProvider):
             cache_key=None,
             cache_dir=None,
             context=self.service_name,
+            rescue_failures=False,
         ).decode("utf-8")
 
     def decrypt_secret_raw(self, secret_name: str) -> bytes:
@@ -152,6 +154,7 @@ class SecretProvider(BaseSecretProvider):
             cache_key=None,
             cache_dir=None,
             context=self.service_name,
+            rescue_failures=False,
         )
 
     def get_secret_signature_from_data(self, data: Mapping[str, Any]) -> Optional[str]:

--- a/tests/secret_providers/test_vault.py
+++ b/tests/secret_providers/test_vault.py
@@ -121,6 +121,7 @@ def test_decrypt_secret(mock_secret_provider):
             cache_key=None,
             cache_dir=None,
             context="universe",
+            rescue_failures=False,
         )
 
 
@@ -138,6 +139,7 @@ def test_decrypt_secret_raw(mock_secret_provider):
             cache_key=None,
             cache_dir=None,
             context="universe",
+            rescue_failures=False,
         )
 
 


### PR DESCRIPTION
I'm sorry I had to burn through 3 released just to make this work, but this should be the final one.
This parameter makes `vault-tools` not swallow exceptions in the decryption process (which was the behaviour previous to the version bump in https://github.com/Yelp/paasta/pull/2983).