### PR TITLE
Add signalflow for hpa to system paasta configs

### DIFF
--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1714,7 +1714,16 @@ class TestKubernetesDeploymentConfig:
         )
         assert expected_res == return_value
 
-    def test_get_autoscaling_metric_spec_offset_and_averaging(self):
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.load_system_paasta_config",
+        autospec=True,
+        return_value=mock.Mock(
+            get_legacy_autoscaling_signalflow=lambda: "fake_signalflow_query"
+        ),
+    )
+    def test_get_autoscaling_metric_spec_offset_and_averaging(
+        self, fake_system_paasta_config
+    ):
         config_dict = KubernetesDeploymentConfigDict(
             {
                 "min_instances": 1,


### PR DESCRIPTION
I cherry-picked the commit from https://github.com/Yelp/paasta/pull/2987 and just changed the metric back to status quo, kube_hpa_status_current_replicas. That means this shouldn't change anything except make it possible to change though system paasta configs.

I'm doing this to make it easier to experiment on the Signalflow in general - we have a few tickets related to that to make HPA more stable, including PAASTA-17143.