### PR TITLE
PAASTA-17176 Add rate limit param for s_k_j

### DIFF
--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -67,7 +67,16 @@ def parse_args() -> argparse.Namespace:
         "-c", "--cluster", dest="cluster", help="paasta cluster",
     )
     parser.add_argument(
-        "-v", "--verbose", action="store_true", dest="verbose", default=False
+        "-v", "--verbose", action="store_true", dest="verbose", default=False,
+    )
+    parser.add_argument(
+        "-l",
+        "--rate-limit",
+        dest="rate_limit",
+        default=0,
+        metavar="LIMIT",
+        type=int,
+        help="Update or create up to this number of service instances. Default is 0 (no limit).",
     )
     args = parser.parse_args()
     return args
@@ -92,6 +101,7 @@ def main() -> None:
         service_instances=args.service_instance_list,
         soa_dir=soa_dir,
         cluster=args.cluster or load_system_paasta_config().get_cluster(),
+        rate_limit=args.rate_limit,
     )
     sys.exit(0 if setup_kube_succeeded else 1)
 
@@ -111,6 +121,7 @@ def setup_kube_deployments(
     kube_client: KubeClient,
     service_instances: Sequence[str],
     cluster: str,
+    rate_limit: int = 0,
     soa_dir: str = DEFAULT_SOA_DIR,
 ) -> bool:
     if service_instances:
@@ -135,6 +146,7 @@ def setup_kube_deployments(
         for service_instance in service_instances_with_valid_names
     ]
 
+    api_updates = 0
     for _, app in applications:
         if app:
             if (
@@ -143,14 +155,21 @@ def setup_kube_deployments(
             ) not in existing_apps:
                 log.info(f"Creating {app} because it does not exist yet.")
                 app.create(kube_client)
+                api_updates += 1
             elif app.kube_deployment not in existing_kube_deployments:
                 log.info(f"Updating {app} because configs have changed.")
                 app.update(kube_client)
+                api_updates += 1
             else:
                 log.info(f"{app} is up-to-date!")
 
             log.info(f"Ensuring related API objects for {app} are in sync")
             app.update_related_api_objects(kube_client)
+        if rate_limit > 0 and api_updates >= rate_limit:
+            log.info(
+                f"Not doing any further updates as we reached the limit ({api_updates})"
+            )
+            break
 
     return (False, None) not in applications and len(
         service_instances_with_valid_names


### PR DESCRIPTION
This change adds a `--rate-limit` param to `setup_kubernetes_job` so that we can control how many updates are sent to the k8s API on every cronjob run.
The intention is to limit the damage that big bounces cause on our biggest clusters.

### Tests:
- Manually executed `setup_kubernetes_job` while removing some of the existing deployments on kubestage.