### PR TITLE
Add additional labels for Prometheus use

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1442,8 +1442,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "paasta.yelp.com/service": self.get_service(),
             "paasta.yelp.com/instance": self.get_instance(),
             "paasta.yelp.com/git_sha": git_sha,
-            "paasta.yelp.com/deploy_group": self.get_deploy_group(),
-            "paasta.yelp.com/docker_image": self.get_docker_image(),
         }
 
         # Allow the Prometheus Operator's Pod Service Monitor for specified
@@ -1459,6 +1457,11 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         ):
             # this is kinda silly, but k8s labels must be strings
             labels["paasta.yelp.com/scrape_uwsgi_prometheus"] = "true"
+
+            # these should probably eventually be made into default labels,
+            # but for now we're fine with these being behind this feature toggle
+            labels["paasta.yelp.com/deploy_group"] = self.get_deploy_group()
+            labels["paasta.yelp.com/docker_image"] = self.get_docker_image()
 
         return V1PodTemplateSpec(
             metadata=V1ObjectMeta(labels=labels, annotations=annotations,),

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1237,8 +1237,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 "paasta.yelp.com/service": self.get_service(),
                 "paasta.yelp.com/instance": self.get_instance(),
                 "paasta.yelp.com/git_sha": git_sha,
-                "paasta.yelp.com/deploy_group": self.get_deploy_group(),
-                "paasta.yelp.com/docker_image": self.get_docker_image(),
             },
         )
 
@@ -1324,16 +1322,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 complete_config.metadata.labels[
                     "paasta.yelp.com/prometheus_shard"
                 ] = prometheus_shard
-
-            # not all services use uwsgi autoscaling, so we label those that do in order to have
-            # prometheus selectively discover/scrape them
-            if self.should_run_uwsgi_exporter_sidecar(
-                system_paasta_config=system_paasta_config
-            ):
-                # this is kinda silly, but k8s labels must be strings
-                complete_config.metadata.labels[
-                    "paasta.yelp.com/scrape_uwsgi_prometheus"
-                ] = "true"
 
             # DO NOT ADD LABELS AFTER THIS LINE
             config_hash = get_config_hash(

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1237,6 +1237,8 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 "paasta.yelp.com/service": self.get_service(),
                 "paasta.yelp.com/instance": self.get_instance(),
                 "paasta.yelp.com/git_sha": git_sha,
+                "paasta.yelp.com/deploy_group": self.get_deploy_group(),
+                "paasta.yelp.com/docker_image": self.get_docker_image(),
             },
         )
 
@@ -1322,6 +1324,16 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 complete_config.metadata.labels[
                     "paasta.yelp.com/prometheus_shard"
                 ] = prometheus_shard
+
+            # not all services use uwsgi autoscaling, so we label those that do in order to have
+            # prometheus selectively discover/scrape them
+            if self.should_run_uwsgi_exporter_sidecar(
+                system_paasta_config=system_paasta_config
+            ):
+                # this is kinda silly, but k8s labels must be strings
+                complete_config.metadata.labels[
+                    "paasta.yelp.com/scrape_uwsgi_prometheus"
+                ] = "true"
 
             # DO NOT ADD LABELS AFTER THIS LINE
             config_hash = get_config_hash(
@@ -1442,6 +1454,8 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "paasta.yelp.com/service": self.get_service(),
             "paasta.yelp.com/instance": self.get_instance(),
             "paasta.yelp.com/git_sha": git_sha,
+            "paasta.yelp.com/deploy_group": self.get_deploy_group(),
+            "paasta.yelp.com/docker_image": self.get_docker_image(),
         }
 
         # Allow the Prometheus Operator's Pod Service Monitor for specified
@@ -1449,6 +1463,14 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         prometheus_shard = self.get_prometheus_shard()
         if prometheus_shard:
             labels["paasta.yelp.com/prometheus_shard"] = prometheus_shard
+
+        # not all services use uwsgi autoscaling, so we label those that do in order to have
+        # prometheus selectively discover/scrape them
+        if self.should_run_uwsgi_exporter_sidecar(
+            system_paasta_config=system_paasta_config
+        ):
+            # this is kinda silly, but k8s labels must be strings
+            labels["paasta.yelp.com/scrape_uwsgi_prometheus"] = "true"
 
         return V1PodTemplateSpec(
             metadata=V1ObjectMeta(labels=labels, annotations=annotations,),


### PR DESCRIPTION
deploy_group and docker_image are existing dimensions that we can't use
relabeling to include in metric scraping since they're only present in
the k8s container spec and Prometheus doesn't expose that.

most importantly, scrape_uwsgi_prometheus will be how we filter down the
set of pods that Prometheus should actually scrape - the idea is
currently that this label is only set when someone has opted into using
the uwsgi exporter, but in the future this label should be set if a
service has chosen to use uwsgi autoscaling instead of checking this
feature toggle