### PR TITLE
Paasta 16369 validate instance name paasta logs

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -1386,7 +1386,7 @@ def paasta_logs(args: argparse.Namespace) -> int:
         instances = None
     else:
         instances = args.instances.split(",")
-        
+
         if not verify_instances(args.instances, service, clusters):
             return 1
 

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -23,7 +23,6 @@ from collections import namedtuple
 from contextlib import contextmanager
 from multiprocessing import Process
 from multiprocessing import Queue
-from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.utils import list_all_instances_for_service
 from queue import Empty
 from time import sleep

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -15,15 +15,14 @@
 """PaaSTA log reader for humans"""
 import argparse
 import datetime
+import difflib
 import logging
 import re
 import sys
-import difflib
 from collections import namedtuple
 from contextlib import contextmanager
 from multiprocessing import Process
 from multiprocessing import Queue
-from paasta_tools.utils import list_all_instances_for_service
 from queue import Empty
 from time import sleep
 from typing import Any
@@ -43,6 +42,8 @@ import isodate
 import pytz
 import ujson as json
 from dateutil import tz
+
+from paasta_tools.utils import list_all_instances_for_service
 
 try:
     from scribereader import scribereader
@@ -1318,6 +1319,7 @@ def pick_default_log_mode(
         return 0
     return 1
 
+
 def verify_instances(
     args_instances: str, service: str, clusters: Sequence[str]
 ) -> Sequence[str]:
@@ -1336,7 +1338,7 @@ def verify_instances(
     misspelled_instances: Sequence[str] = [
         i for i in unverified_instances if i not in service_instances
     ]
-    
+
     if misspelled_instances:
         suggestions: List[str] = []
         for instance in misspelled_instances:
@@ -1363,20 +1365,20 @@ def verify_instances(
             print("Did you mean any of these?")
             for instance in sorted(suggestions):
                 print("  %s" % instance)
-        
+
     return misspelled_instances
+
 
 def paasta_logs(args: argparse.Namespace) -> int:
     """Print the logs for as Paasta service.
     :param args: argparse.Namespace obj created from sys.args by cli"""
     soa_dir = args.soa_dir
     service = figure_out_service_name(args, soa_dir)
-    
+
     if args.clusters is None:
         clusters = list_clusters(service, soa_dir=soa_dir)
     else:
         clusters = args.clusters.split(",")
-
 
     if args.instances is None:
         instances = None

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -42,8 +42,6 @@ import pytz
 import ujson as json
 from dateutil import tz
 
-from paasta_tools.utils import list_all_instances_for_service
-
 try:
     from scribereader import scribereader
     from scribereader.scribereader import StreamTailerSetupError
@@ -1318,6 +1316,7 @@ def pick_default_log_mode(
         )
         return 0
     return 1
+
 
 def paasta_logs(args: argparse.Namespace) -> int:
     """Print the logs for as Paasta service.

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -18,7 +18,6 @@ import datetime
 import logging
 import re
 import sys
-import pdb
 import difflib
 from collections import namedtuple
 from contextlib import contextmanager
@@ -1366,9 +1365,7 @@ def verify_instances(
             for instance in sorted(suggestions):
                 print("  %s" % instance)
         
-        return False
-
-    return True
+    return misspelled_instances
 
 def paasta_logs(args: argparse.Namespace) -> int:
     """Print the logs for as Paasta service.
@@ -1387,7 +1384,7 @@ def paasta_logs(args: argparse.Namespace) -> int:
     else:
         instances = args.instances.split(",")
 
-        if not verify_instances(args.instances, service, clusters):
+        if verify_instances(args.instances, service, clusters):
             return 1
 
     if args.components is not None:

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -49,6 +49,7 @@ from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import NoSuchService
 from paasta_tools.cli.utils import validate_service_name
+from paasta_tools.cli.utils import verify_instances
 from paasta_tools.flink_tools import FlinkDeploymentConfig
 from paasta_tools.kafkacluster_tools import KafkaClusterDeploymentConfig
 from paasta_tools.kubernetes_tools import format_pod_event_messages
@@ -1447,56 +1448,7 @@ def report_invalid_whitelist_values(
             "\n" "Warning: This service does not have any %s matching these names:\n%s"
         ) % (item_type, ",".join(bogus_entries))
     return return_string
-
-
-def verify_instances(
-    args_instances: str, service: str, clusters: Sequence[str]
-) -> Sequence[str]:
-    """Verify that a list of instances specified by user is correct for this service.
-
-    :param args_instances: a list of instances.
-    :param service: the service name
-    :param cluster: a list of clusters
-    :returns: a list of instances specified in args_instances without any exclusions.
-    """
-    unverified_instances = args_instances.split(",")
-    service_instances: Set[str] = list_all_instances_for_service(
-        service, clusters=clusters
-    )
-
-    misspelled_instances: Sequence[str] = [
-        i for i in unverified_instances if i not in service_instances
-    ]
-
-    if misspelled_instances:
-        suggestions: List[str] = []
-        for instance in misspelled_instances:
-            matches = difflib.get_close_matches(
-                instance, service_instances, n=5, cutoff=0.5
-            )
-            suggestions.extend(matches)  # type: ignore
-        suggestions = list(set(suggestions))
-
-        if clusters:
-            message = "{} doesn't have any instances matching {} on {}.".format(
-                service,
-                ", ".join(sorted(misspelled_instances)),
-                ", ".join(sorted(clusters)),
-            )
-        else:
-            message = "{} doesn't have any instances matching {}.".format(
-                service, ", ".join(sorted(misspelled_instances))
-            )
-
-        print(PaastaColors.red(message))
-
-        if suggestions:
-            print("Did you mean any of these?")
-            for instance in sorted(suggestions):
-                print("  %s" % instance)
-
-    return unverified_instances
-
+    
 
 def normalize_registrations(
     service: str, registrations: Sequence[str]

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -30,7 +30,6 @@ from typing import Iterable
 from typing import List
 from typing import Mapping
 from typing import Sequence
-from typing import Set
 from typing import Tuple
 from typing import Type
 from typing import Union
@@ -69,7 +68,6 @@ from paasta_tools.utils import format_table
 from paasta_tools.utils import get_soa_cluster_deploy_files
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import is_under_replicated
-from paasta_tools.utils import list_all_instances_for_service
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
 from paasta_tools.utils import load_deployments_json
@@ -1448,7 +1446,7 @@ def report_invalid_whitelist_values(
             "\n" "Warning: This service does not have any %s matching these names:\n%s"
         ) % (item_type, ",".join(bogus_entries))
     return return_string
-    
+
 
 def normalize_registrations(
     service: str, registrations: Sequence[str]

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -1046,6 +1046,7 @@ def trigger_deploys(
     finally:
         client.close()
 
+
 def verify_instances(
     args_instances: str, service: str, clusters: Sequence[str]
 ) -> Sequence[str]:

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import difflib
 import fnmatch
 import getpass
 import hashlib
@@ -1044,3 +1045,51 @@ def trigger_deploys(
         client.send(f"{service}\n".encode("utf-8"))
     finally:
         client.close()
+
+def verify_instances(
+    args_instances: str, service: str, clusters: Sequence[str]
+) -> Sequence[str]:
+    """Verify that a list of instances specified by user is correct for this service.
+
+    :param args_instances: a list of instances.
+    :param service: the service name
+    :param cluster: a list of clusters
+    :returns: a list of instances specified in args_instances without any exclusions.
+    """
+    unverified_instances = args_instances.split(",")
+    service_instances: Set[str] = list_all_instances_for_service(
+        service, clusters=clusters
+    )
+
+    misspelled_instances: Sequence[str] = [
+        i for i in unverified_instances if i not in service_instances
+    ]
+
+    if misspelled_instances:
+        suggestions: List[str] = []
+        for instance in misspelled_instances:
+            matches = difflib.get_close_matches(
+                instance, service_instances, n=5, cutoff=0.5
+            )
+            suggestions.extend(matches)  # type: ignore
+        suggestions = list(set(suggestions))
+
+        if clusters:
+            message = "{} doesn't have any instances matching {} on {}.".format(
+                service,
+                ", ".join(sorted(misspelled_instances)),
+                ", ".join(sorted(clusters)),
+            )
+        else:
+            message = "{} doesn't have any instances matching {}.".format(
+                service, ", ".join(sorted(misspelled_instances))
+            )
+
+        print(PaastaColors.red(message))
+
+        if suggestions:
+            print("Did you mean any of these?")
+            for instance in sorted(suggestions):
+                print("  %s" % instance)
+
+    return misspelled_instances

--- a/tests/cli/test_cmds_logs.py
+++ b/tests/cli/test_cmds_logs.py
@@ -20,8 +20,8 @@ from queue import Empty
 import isodate
 import mock
 import pytest
-from pytest import raises
 from mock import call
+from pytest import raises
 
 from paasta_tools.cli.cli import parse_args
 from paasta_tools.cli.cmds import logs
@@ -1300,11 +1300,12 @@ def test_pick_default_log_mode():
         # Supports tailing , time and line counts. Line counts should be prioritized
         assert logs_by_lines.call_count == 1
 
+
 @mock.patch("paasta_tools.cli.cmds.logs.list_all_instances_for_service", autospec=True)
 @mock.patch("builtins.print", autospec=True)
 def test_verify_instances(mock_print, mock_list_all_instances_for_service):
     mock_list_all_instances_for_service.return_value = ["east", "west", "north"]
-    
+
     assert logs.verify_instances("esst,west", "fake_service", []) == ["esst"]
     assert mock_print.called
     mock_print.assert_has_calls(

--- a/tests/cli/test_cmds_logs.py
+++ b/tests/cli/test_cmds_logs.py
@@ -20,7 +20,6 @@ from queue import Empty
 import isodate
 import mock
 import pytest
-from mock import call
 from pytest import raises
 
 from paasta_tools.cli.cli import parse_args
@@ -1299,22 +1298,3 @@ def test_pick_default_log_mode():
 
         # Supports tailing , time and line counts. Line counts should be prioritized
         assert logs_by_lines.call_count == 1
-
-
-@mock.patch("paasta_tools.cli.cmds.logs.list_all_instances_for_service", autospec=True)
-@mock.patch("builtins.print", autospec=True)
-def test_verify_instances(mock_print, mock_list_all_instances_for_service):
-    mock_list_all_instances_for_service.return_value = ["east", "west", "north"]
-
-    assert logs.verify_instances("esst,west", "fake_service", []) == ["esst"]
-    assert mock_print.called
-    mock_print.assert_has_calls(
-        [
-            call(
-                "\x1b[31mfake_service doesn't have any instances matching esst.\x1b[0m"
-            ),
-            call("Did you mean any of these?"),
-            call("  east"),
-            call("  west"),
-        ]
-    )

--- a/tests/cli/test_cmds_logs.py
+++ b/tests/cli/test_cmds_logs.py
@@ -21,6 +21,7 @@ import isodate
 import mock
 import pytest
 from pytest import raises
+from mock import call
 
 from paasta_tools.cli.cli import parse_args
 from paasta_tools.cli.cmds import logs
@@ -1298,3 +1299,21 @@ def test_pick_default_log_mode():
 
         # Supports tailing , time and line counts. Line counts should be prioritized
         assert logs_by_lines.call_count == 1
+
+@mock.patch("paasta_tools.cli.cmds.logs.list_all_instances_for_service", autospec=True)
+@mock.patch("builtins.print", autospec=True)
+def test_verify_instances(mock_print, mock_list_all_instances_for_service):
+    mock_list_all_instances_for_service.return_value = ["east", "west", "north"]
+    
+    assert logs.verify_instances("esst,west", "fake_service", []) == ["esst"]
+    assert mock_print.called
+    mock_print.assert_has_calls(
+        [
+            call(
+                "\x1b[31mfake_service doesn't have any instances matching esst.\x1b[0m"
+            ),
+            call("Did you mean any of these?"),
+            call("  east"),
+            call("  west"),
+        ]
+    )

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -50,7 +50,6 @@ from paasta_tools.cli.cmds.status import print_kafka_status
 from paasta_tools.cli.cmds.status import print_kubernetes_status
 from paasta_tools.cli.cmds.status import print_marathon_status
 from paasta_tools.cli.cmds.status import report_invalid_whitelist_values
-from paasta_tools.cli.cmds.status import verify_instances
 from paasta_tools.cli.utils import NoSuchService
 from paasta_tools.cli.utils import PaastaColors
 from paasta_tools.paastaapi import ApiException
@@ -665,7 +664,7 @@ def test_apply_args_filters_bad_service_name(mock_list_services, capfd):
     assert "  fake_service" in output
 
 
-@patch("paasta_tools.cli.cmds.status.list_all_instances_for_service", autospec=True)
+@patch("paasta_tools.cli.utils.list_all_instances_for_service", autospec=True)
 @patch("paasta_tools.cli.cmds.status.get_instance_configs_for_service", autospec=True)
 @patch("paasta_tools.cli.cmds.status.list_services", autospec=True)
 @patch("paasta_tools.cli.cmds.status.figure_out_service_name", autospec=True)
@@ -715,52 +714,10 @@ def test_apply_args_filters_no_instances_found(
         "fake_service doesn't have any instances matching instance4, instance5 on cluster1."
         in output
     )
+    
     assert "Did you mean any of these?" in output
     for i in ["instance1", "instance2", "instance3"]:
         assert i in output
-
-
-@patch("paasta_tools.cli.cmds.status.list_all_instances_for_service", autospec=True)
-@patch("builtins.print", autospec=True)
-def test_verify_instances(mock_print, mock_list_all_instances_for_service):
-    mock_list_all_instances_for_service.return_value = ["east", "west", "north"]
-
-    assert verify_instances("west,esst", "fake_service", []) == ["west", "esst"]
-    assert mock_print.called
-    mock_print.assert_has_calls(
-        [
-            call(
-                "\x1b[31mfake_service doesn't have any instances matching esst.\x1b[0m"
-            ),
-            call("Did you mean any of these?"),
-            call("  east"),
-            call("  west"),
-        ]
-    )
-
-
-@patch("paasta_tools.cli.cmds.status.list_all_instances_for_service", autospec=True)
-@patch("builtins.print", autospec=True)
-def test_verify_instances_with_clusters(
-    mock_print, mock_list_all_instances_for_service
-):
-    mock_list_all_instances_for_service.return_value = ["east", "west", "north"]
-
-    assert verify_instances(
-        "west,esst,fake", "fake_service", ["fake_cluster1", "fake_cluster2"]
-    ) == ["west", "esst", "fake"]
-    assert mock_print.called
-    mock_print.assert_has_calls(
-        [
-            call(
-                "\x1b[31mfake_service doesn't have any instances matching esst,"
-                " fake on fake_cluster1, fake_cluster2.\x1b[0m"
-            ),
-            call("Did you mean any of these?"),
-            call("  east"),
-            call("  west"),
-        ]
-    )
 
 
 @patch("paasta_tools.cli.cmds.status.get_instance_configs_for_service", autospec=True)

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -20,7 +20,6 @@ from typing import Set
 import mock
 import pytest
 from mock import ANY
-from mock import call
 from mock import MagicMock
 from mock import Mock
 from mock import patch
@@ -498,7 +497,7 @@ def test_apply_args_filters_clusters_return_none_when_cluster_not_in_deploy_grou
 @patch("paasta_tools.cli.cmds.status.list_services", autospec=True)
 @patch("paasta_tools.cli.cmds.status.figure_out_service_name", autospec=True)
 @patch("paasta_tools.cli.cmds.status.list_clusters", autospec=True)
-@patch("paasta_tools.cli.cmds.status.list_all_instances_for_service", autospec=True)
+@patch("paasta_tools.cli.utils.list_all_instances_for_service", autospec=True)
 def test_apply_args_filters_clusters_return_none_when_instance_not_in_deploy_group(
     mock_list_clusters,
     mock_figure_out_service_name,
@@ -714,7 +713,7 @@ def test_apply_args_filters_no_instances_found(
         "fake_service doesn't have any instances matching instance4, instance5 on cluster1."
         in output
     )
-    
+
     assert "Did you mean any of these?" in output
     for i in ["instance1", "instance2", "instance3"]:
         assert i in output

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -17,15 +17,15 @@ from socket import gaierror
 
 import ephemeral_port_reserve
 import mock
-from mock import patch
 from mock import call
+from mock import patch
 from pytest import mark
 from pytest import raises
 
 from paasta_tools.cli import utils
+from paasta_tools.cli.utils import verify_instances
 from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.utils import SystemPaastaConfig
-from paasta_tools.cli.utils import verify_instances
 
 
 @patch("socket.gethostbyname_ex", autospec=True)
@@ -431,6 +431,7 @@ def test_trigger_deploys(mock_socket, mock_load_config):
     assert mock_client.send.call_args_list == [mock.call("a_service\n".encode("utf-8"))]
     assert mock_client.close.call_count == 1
 
+
 @patch("paasta_tools.cli.utils.list_all_instances_for_service", autospec=True)
 @patch("builtins.print", autospec=True)
 def test_verify_instances(mock_print, mock_list_all_instances_for_service):
@@ -448,6 +449,7 @@ def test_verify_instances(mock_print, mock_list_all_instances_for_service):
             call("  west"),
         ]
     )
+
 
 @patch("paasta_tools.cli.utils.list_all_instances_for_service", autospec=True)
 @patch("builtins.print", autospec=True)


### PR DESCRIPTION
### Description

When running `paasta logs` with an invalid instance, you will be met with an error and possible suggestions to the instance name entered.

### Testing Done

- `make test - PASSED` 