### PR TITLE
[WIP] Add support for k8s secret sync to namespaces

### DIFF
--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -30,6 +30,7 @@ from paasta_tools.utils import load_service_instance_config
 from paasta_tools.utils import load_v2_deployments_json
 
 
+KUBERNETES_NAMESPACE = "paasta-flinks"
 FLINK_INGRESS_PORT = 31080
 FLINK_DASHBOARD_TIMEOUT_SECONDS = 5
 

--- a/paasta_tools/kafkacluster_tools.py
+++ b/paasta_tools/kafkacluster_tools.py
@@ -25,6 +25,8 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import load_service_instance_config
 from paasta_tools.utils import load_v2_deployments_json
 
+KUBERNETES_NAMESPACE = "paasta-kafkaclusters"
+
 
 class KafkaClusterDeploymentConfigDict(LongRunningServiceConfigDict, total=False):
     replicas: int

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2526,11 +2526,12 @@ def create_secret(
     secret: str,
     service: str,
     secret_provider: BaseSecretProvider,
+    namespace="paasta",
 ) -> None:
     service = sanitise_kubernetes_name(service)
     sanitised_secret = sanitise_kubernetes_name(secret)
     kube_client.core.create_namespaced_secret(
-        namespace="paasta",
+        namespace=namespace,
         body=V1Secret(
             metadata=V1ObjectMeta(
                 name=f"paasta-secret-{service}-{sanitised_secret}",
@@ -2553,12 +2554,13 @@ def update_secret(
     secret: str,
     service: str,
     secret_provider: BaseSecretProvider,
+    namespace="paasta",
 ) -> None:
     service = sanitise_kubernetes_name(service)
     sanitised_secret = sanitise_kubernetes_name(secret)
     kube_client.core.replace_namespaced_secret(
         name=f"paasta-secret-{service}-{sanitised_secret}",
-        namespace="paasta",
+        namespace=namespace,
         body=V1Secret(
             metadata=V1ObjectMeta(
                 name=f"paasta-secret-{service}-{sanitised_secret}",
@@ -2577,13 +2579,13 @@ def update_secret(
 
 
 def get_kubernetes_secret_signature(
-    kube_client: KubeClient, secret: str, service: str
+    kube_client: KubeClient, secret: str, service: str, namespace="paasta",
 ) -> Optional[str]:
     service = sanitise_kubernetes_name(service)
     secret = sanitise_kubernetes_name(secret)
     try:
         signature = kube_client.core.read_namespaced_config_map(
-            name=f"paasta-secret-{service}-{secret}-signature", namespace="paasta"
+            name=f"paasta-secret-{service}-{secret}-signature", namespace=namespace
         )
     except ApiException as e:
         if e.status == 404:
@@ -2597,13 +2599,17 @@ def get_kubernetes_secret_signature(
 
 
 def update_kubernetes_secret_signature(
-    kube_client: KubeClient, secret: str, service: str, secret_signature: str
+    kube_client: KubeClient,
+    secret: str,
+    service: str,
+    secret_signature: str,
+    namespace="paasta",
 ) -> None:
     service = sanitise_kubernetes_name(service)
     secret = sanitise_kubernetes_name(secret)
     kube_client.core.replace_namespaced_config_map(
         name=f"paasta-secret-{service}-{secret}-signature",
-        namespace="paasta",
+        namespace=namespace,
         body=V1ConfigMap(
             metadata=V1ObjectMeta(
                 name=f"paasta-secret-{service}-{secret}-signature",
@@ -2618,12 +2624,16 @@ def update_kubernetes_secret_signature(
 
 
 def create_kubernetes_secret_signature(
-    kube_client: KubeClient, secret: str, service: str, secret_signature: str
+    kube_client: KubeClient,
+    secret: str,
+    service: str,
+    secret_signature: str,
+    namespace="paasta",
 ) -> None:
     service = sanitise_kubernetes_name(service)
     secret = sanitise_kubernetes_name(secret)
     kube_client.core.create_namespaced_config_map(
-        namespace="paasta",
+        namespace=namespace,
         body=V1ConfigMap(
             metadata=V1ObjectMeta(
                 name=f"paasta-secret-{service}-{secret}-signature",

--- a/paasta_tools/nrtsearchservice_tools.py
+++ b/paasta_tools/nrtsearchservice_tools.py
@@ -25,6 +25,8 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import load_service_instance_config
 from paasta_tools.utils import load_v2_deployments_json
 
+KUBERNETES_NAMESPACE = "paasta-nrtsearchservices"
+
 
 class NrtsearchServiceDeploymentConfigDict(LongRunningServiceConfigDict, total=False):
     replicas: int

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -2,6 +2,7 @@ import socket
 
 
 DEFAULT_SPARK_SERVICE = "spark"
+KUBERNETES_NAMESPACE = "paasta-spark"
 
 
 def get_webui_url(port: str) -> str:


### PR DESCRIPTION
Putting this up early for some feedback, probably some tests need fixing and I need to test the script manually since we don't have an integration test. Mostly want opinions on `INSTANCE_TYPE_TO_K8S_NAMESPACE`, we don't seem to have this map anywhere so I'm relying on some conventions to work it out, kinda ugly, other ideas welcome.

To support paasta secrets in operator workloads we need to sync secrets
for services that run in other namespaces into those namespaces. This
adds mapping for workloads to k8s namespaces and changes the sync script
to list all services and find any instance types and sync to those
instance type's namespaces.