### PR TITLE
Make get_kubernetes_metadata use actual node pool

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2707,6 +2707,17 @@ def get_pod_hostname(kube_client: KubeClient, pod: V1Pod) -> str:
     return node.metadata.labels.get("yelp.com/hostname", pod.spec.node_name)
 
 
+def get_pod_node(
+    kube_client: KubeClient, pod: V1Pod, cache_nodes: bool = False
+) -> Optional[V1Node]:
+    if cache_nodes:
+        nodes = get_all_nodes_cached(kube_client)
+    else:
+        nodes = get_all_nodes(kube_client)
+    running_node = [node for node in nodes if node.metadata.name == pod.spec.node_name]
+    return running_node[0] if running_node else None
+
+
 def to_node_label(label: str) -> str:
     """k8s-ifies certain special node labels"""
     if label in {"instance_type", "instance-type"}:


### PR DESCRIPTION
This fixes an assumption that pods use just a node selector. Some of the
cassandra Pods use node affinity and in practice a lot of things can
impact the node/pool that a Pod actually ends up on. This checks the Pod
to see what node it is scheduled on and gets the pool from the Nodes
labels (which I think is more reliable).

Note I tested this on kubestage but I don't know the impact if this
breaks something so please warn me if I need to be careful.