### PR TITLE
Pass AWS_SESSION_TOKEN During Spark Environment Creation

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -409,6 +409,9 @@ def get_spark_env(
     spark_env = {}
 
     access_key, secret_key, token = aws_creds
+    print(">>>> HELLO")
+    print(access_key)
+    print(token)
     if access_key:
         spark_env["AWS_ACCESS_KEY_ID"] = access_key
         spark_env["AWS_SECRET_ACCESS_KEY"] = secret_key
@@ -443,6 +446,7 @@ def get_spark_env(
         spark_env["SPARK_DAEMON_CLASSPATH"] = "/opt/spark/extra_jars/*"
         spark_env["SPARK_NO_DAEMONIZE"] = "true"
 
+    print(spark_env)
     return spark_env
 
 
@@ -597,6 +601,8 @@ def configure_and_run_docker_container(
             else:
                 raise
 
+    print('>>> ENVIRONEMNT')
+    print(environment)
     return run_docker_container(
         container_name=spark_conf["spark.app.name"],
         volumes=volumes,

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -15,7 +15,6 @@ from typing import Tuple
 from typing import Union
 
 from boto3.exceptions import Boto3Error
-from boto3 import Session as Boto3Session
 from service_configuration_lib.spark_config import get_aws_credentials
 from service_configuration_lib.spark_config import get_history_url
 from service_configuration_lib.spark_config import get_signalfx_url
@@ -445,7 +444,6 @@ def get_spark_env(
         spark_env["SPARK_DAEMON_CLASSPATH"] = "/opt/spark/extra_jars/*"
         spark_env["SPARK_NO_DAEMONIZE"] = "true"
 
-    print(spark_env)
     return spark_env
 
 
@@ -600,8 +598,6 @@ def configure_and_run_docker_container(
             else:
                 raise
 
-    print('>>> ENVIRONEMNT')
-    print(environment)
     return run_docker_container(
         container_name=spark_conf["spark.app.name"],
         volumes=volumes,
@@ -760,12 +756,10 @@ def paasta_spark_run(args):
         )
         return 1
 
-    session = Boto3Session(profile_name=args.aws_profile)
     aws_creds = get_aws_credentials(
         service=args.service,
         no_aws_credentials=args.no_aws_credentials,
         aws_credentials_yaml=args.aws_credentials_yaml,
-        session=session,
         profile_name=args.aws_profile,
     )
     docker_image = get_docker_image(args, instance_config)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -408,10 +408,11 @@ def get_spark_env(
 
     spark_env = {}
 
-    access_key, secret_key, _ = aws_creds
+    access_key, secret_key, token = aws_creds
     if access_key:
         spark_env["AWS_ACCESS_KEY_ID"] = access_key
         spark_env["AWS_SECRET_ACCESS_KEY"] = secret_key
+        spark_env["AWS_SESSION_TOKEN"] = token
         spark_env["AWS_DEFAULT_REGION"] = args.aws_region
     spark_env["PAASTA_LAUNCHED_BY"] = get_possible_launched_by_user_variable_from_env()
     spark_env["PAASTA_INSTANCE_TYPE"] = "spark"

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -594,6 +594,8 @@ class InstanceConfig:
             env["PAASTA_INSTANCE_TYPE"] = instance_type
         user_env = self.config_dict.get("env", {})
         env.update(user_env)
+        print('instance config')
+        print(env.items())
         return {str(k): str(v) for (k, v) in env.items()}
 
     def get_env(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -594,8 +594,6 @@ class InstanceConfig:
             env["PAASTA_INSTANCE_TYPE"] = instance_type
         user_env = self.config_dict.get("env", {})
         env.update(user_env)
-        print('instance config')
-        print(env.items())
         return {str(k): str(v) for (k, v) in env.items()}
 
     def get_env(

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ rsa==3.4.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.5.2
+service-configuration-lib==2.5.3
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -208,10 +208,11 @@ def mock_get_possible_launced_by_user_variable_from_env():
     [
         ((None, None, None), {}),
         (
-            ("access-key", "secret-key", None),
+            ("access-key", "secret-key", "token"),
             {
                 "AWS_ACCESS_KEY_ID": "access-key",
                 "AWS_SECRET_ACCESS_KEY": "secret-key",
+                "AWS_SESSION_TOKEN": "token",
                 "AWS_DEFAULT_REGION": "test-region",
             },
         ),
@@ -411,6 +412,7 @@ class TestConfigureAndRunDockerContainer:
                 "env1": "val1",
                 "AWS_ACCESS_KEY_ID": "id",
                 "AWS_SECRET_ACCESS_KEY": "secret",
+                "AWS_SESSION_TOKEN": "token",
                 "AWS_DEFAULT_REGION": "fake_region",
                 "SPARK_OPTS": mock_create_spark_config_str.return_value,
                 "SPARK_USER": "root",


### PR DESCRIPTION
When creating a spark session, we need to also pass in the AWS_SESSION_TOKEN in order to be able to properly use the AWS creds. This PR adds the session token to the environment, and updates corresponding tests to expect this value.

Bumps the version of `service-configuration-lib` to `v2.5.3` wich has the updates in https://github.com/Yelp/service_configuration_lib/pull/60 lands which is needed to automatically use the temp aws provider.

**Testing**

Federate cred testing all done using a spark3/hadoop3 built image via https://github.yelpcorp.com/services/spark/pull/10/files

_pyspark w/ Federated Creds on Hadoop 3 image_
```
(py36-linux) srojas@dev2-uswest2adevc:~/paasta(u/srojas/SEC-13906-pass-session-token-to-spark-env○) » paasta spark-run -C pyspark --image docker-dev.ye
lpcorp.com/spark-dev-srojas --aws-profile security --spark-args "spark.eventLog.dir=s3a://yelp-spark-event-logs-dev-us-west-2/srojas/"
/nail/home/srojas/paasta/paasta_tools/utils.py:1554: UserWarning: clog is unavailable
  warnings.warn("clog is unavailable")
Password for srojas:
Give me your best Yubi sneeze (empty to get mobile push): eidfcckifgjhejlllgfkvjutlkbgcbhjkgchvfektedu
spark.sql.shuffle.partitions has been set to 8 to be equal to twice the number of requested cores, but you should consider setting a higher value if ne
cessary. Follow y/spark for help on partition sizing

Spark monitoring URL http://dev2-uswest2adevc.uswest2-devc.yelpcorp.com:37279
...
I0208 20:53:11.768925   173 sched.cpp:744] Framework registered with aba8bfb3-839f-41c1-9455-f40738e18a5c-33346
21/02/08 20:53:12 WARN MetricsConfig: Cannot locate configuration: tried hadoop-metrics2-s3a-file-system.properties,hadoop-metrics2.properties
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /__ / .__/\_,_/_/ /_/\_\   version 3.0.1
      /_/

Using Python version 3.6.9 (default, Oct  8 2020 12:12:24)
SparkSession available as 'spark'.
>>>
```
_spark-submit w/ Federated Creds on Hadoop 3 image_
```
(py36-linux) srojas@dev2-uswest2adevc:~/paasta(u/srojas/SEC-13906-pass-session-token-to-spark-env○) » paasta spark-run --image docker-dev.yelpcorp.com/
spark-dev-srojas --aws-profile security --cmd "spark-submit  --deploy-mode client --name s3-srojas --conf spark.eventLog.dir=s3a://yelp-spark-event-log
s-dev-us-west-2/srojas/ --conf spark.executor.instances=2 --conf spark.driver.memory=512m --conf spark.executor.memory=512m  file:///work/integration_t
ests/s3.py"
/nail/home/srojas/paasta/paasta_tools/utils.py:1554: UserWarning: clog is unavailable
  warnings.warn("clog is unavailable")
spark.sql.shuffle.partitions has been set to 8 to be equal to twice the number of requested cores, but you should consider setting a higher value if ne
cessary. Follow y/spark for help on partition sizing

Spark monitoring URL http://dev2-uswest2adevc.uswest2-devc.yelpcorp.com:34749
After the job is finished, you can find the spark UI from http://history.spark.paasta-pnw-devc.yelp/

21/02/08 21:00:02 INFO SparkContext: Running Spark version 3.0.1
21/02/08 21:00:02 INFO ResourceUtils: ==============================================================
21/02/08 21:00:02 INFO ResourceUtils: Resources for spark.driver:
...
```
<img width="1133" alt="Screen Shot 2021-02-08 at 2 02 22 PM" src="https://user-images.githubusercontent.com/22459773/107280977-eab85480-6a0d-11eb-9685-5c738d59445e.png">


User cred testing all done using default spark service image to verify that hadoop v2.7 still works with the changes

_spark-submit w/ User Creds on Hadoop 2.7 image_
```
paasta spark-run --cmd "spark-submit  --deploy-mo
de client --name s3-srojas --conf spark.eventLog.dir=s3a://yelp-spark-event-logs-dev-us-west-2/srojas/ --conf spark.executor.instances=2 --conf spark.d
river.memory=512m --conf spark.executor.memory=512m  file:///work/integration_tests/s3.py"
Status: Downloaded newer image for docker-paasta.yelpcorp.com:443/services-spark:paasta-8d51d1eeec3ac20a2eb31c85488280409084d3a8
spark.sql.shuffle.partitions has been set to 8 to be equal to twice the number of requested cores, but you should consider setting a higher value if ne
cessary. Follow y/spark for help on partition sizing

Spark monitoring URL http://dev2-uswest2adevc.uswest2-devc.yelpcorp.com:33696


Signalfx dashboard: https://app.signalfx.com/#/dashboard/DJzYJDkAcAA?density=4&variables%5B%5D=Instance%3Dinstance_name:&variables%5B%5D=Service%3Dser$
ice_name:%5B%22spark%22%5D&variables%5B%5D=PaaSTA%20Cluster%3Dpaasta_cluster:pnw-devc&variables%5B%5D=PaaSTA%20Service%3Dpaasta_service:spark&variables
%5B%5D=PaaSTA%20Instance%3Dpaasta_instance:adhoc_srojas_spark-submit&startTime=-6h&endTime=Now


After the job is finished, you can find the spark UI from http://history.spark.paasta-pnw-devc.yelp/
...
```
<img width="1137" alt="Screen Shot 2021-02-08 at 2 05 10 PM" src="https://user-images.githubusercontent.com/22459773/107281277-4da9eb80-6a0e-11eb-9ba9-c4c73c4384ae.png">


_pyspark w/ User Creds on Hadoop 2.7 image_
```
(py36-linux) srojas@dev2-uswest2adevc:~/paasta(u/srojas/SEC-13906-pass-session-token-to-spark-env○) » paasta spark-run -C pyspark --aws-profile dev /na
il/home/srojas/paasta/paasta_tools/utils.py:1554: UserWarning: clog is unavailable
  warnings.warn("clog is unavailable")
Please wait while the image (docker-paasta.yelpcorp.com:443/services-spark:paasta-8d51d1eeec3ac20a2eb31c85488280409084d3a8) is pulled (times out after
5m)...
paasta-8d51d1eeec3ac20a2eb31c85488280409084d3a8: Pulling from services-spark
Digest: sha256:38ad564cd2eac734d1cb33455a17801384280296f6697128a1a7a5e64ec35893
Status: Image is up to date for docker-paasta.yelpcorp.com:443/services-spark:paasta-8d51d1eeec3ac20a2eb31c85488280409084d3a8
spark.sql.shuffle.partitions has been set to 8 to be equal to twice the number of requested cores, but you should consider setting a higher value if ne
cessary. Follow y/spark for help on partition sizing

Spark monitoring URL http://dev2-uswest2adevc.uswest2-devc.yelpcorp.com:41613
...
I0208 21:07:37.339687   165 sched.cpp:744] Framework registered with aba8bfb3-839f-41c1-9455-f40738e18a5c-33358
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /__ / .__/\_,_/_/ /_/\_\   version 2.4.6
      /_/

Using Python version 3.6.9 (default, Oct  8 2020 12:12:24)
SparkSession available as 'spark'.
>>>
```