### PR TITLE
Add support for auto-configuring cpu_burst_add (PAASTA-17172)

### DIFF
--- a/paasta_tools/cli/schemas/autotuned_defaults/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/autotuned_defaults/kubernetes_schema.json
@@ -15,6 +15,11 @@
                     "minimum": 0,
                     "exclusiveMinimum": true
                 },
+                "cpu_burst_add": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "exclusiveMinimum": false
+                },
                 "disk": {
                     "type": "number",
                     "minimum": 128,

--- a/paasta_tools/cli/schemas/autotuned_defaults/marathon_schema.json
+++ b/paasta_tools/cli/schemas/autotuned_defaults/marathon_schema.json
@@ -15,6 +15,11 @@
                     "minimum": 0,
                     "exclusiveMinimum": true
                 },
+                "cpu_burst_add": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "exclusiveMinimum": false
+                },
                 "disk": {
                     "type": "number",
                     "minimum": 128,

--- a/paasta_tools/contrib/paasta_update_soa_memcpu.py
+++ b/paasta_tools/contrib/paasta_update_soa_memcpu.py
@@ -179,6 +179,7 @@ def get_report_from_splunk(creds, app, filename, criteria_filter):
         serv["disk"] = d["result"].get("suggested_disk")
         serv["old_disk"] = d["result"].get("current_disk")
         serv["hacheck_cpus"] = d["result"].get("suggested_hacheck_cpus")
+        serv["cpu_burst_add"] = d["result"].get("suggested_cpu_burst_add")
         services_to_update[criteria] = serv
 
     return {

--- a/paasta_tools/contrib/rightsizer_soaconfigs_update.py
+++ b/paasta_tools/contrib/rightsizer_soaconfigs_update.py
@@ -9,6 +9,7 @@ from paasta_tools.utils import format_git_url
 from paasta_tools.utils import load_system_paasta_config
 
 NULL = "null"
+SUPPORTED_CSV_KEYS = ("cpus", "mem", "disk", "hacheck_cpus")
 
 
 def parse_args():
@@ -34,6 +35,15 @@ def parse_args():
         help="Splunk csv file from which to pull data.",
         required=True,
         dest="csv_report",
+    )
+    parser.add_argument(
+        "--csv-key",
+        help="Key(s) to apply to config from the csv. If not specified, applies all supported keys.",
+        choices=SUPPORTED_CSV_KEYS,
+        required=False,
+        nargs="*",
+        default=None,
+        dest="csv_keys",
     )
     parser.add_argument(
         "--app",
@@ -96,37 +106,37 @@ def get_default_git_remote():
     return default_git_remote
 
 
-def get_recommendation_from_result(result):
+def get_recommendation_from_result(result, keys_to_apply):
     rec = {}
-    cpus = result.get("cpus")
-    if cpus and cpus != NULL:
-        rec["cpus"] = float(cpus)
-    mem = result.get("mem")
-    if mem and mem != NULL:
-        rec["mem"] = max(128, round(float(mem)))
-    disk = result.get("disk")
-    if disk and disk != NULL:
-        rec["disk"] = max(128, round(float(disk)))
-    hacheck_cpus = result.get("hacheck_cpus")
-    if hacheck_cpus and hacheck_cpus != NULL:
-        hacheck_cpus_value = max(0.1, min(float(hacheck_cpus), 1))
-        rec["sidecar_resource_requirements"] = {
-            "hacheck": {
-                "requests": {"cpu": hacheck_cpus_value,},
-                "limits": {"cpu": hacheck_cpus_value,},
-            },
-        }
+    for key in keys_to_apply:
+        val = result.get(key)
+        if not val or val == NULL:
+            continue
+        if key == "cpus":
+            rec["cpus"] = float(val)
+        elif key == "mem":
+            rec["mem"] = max(128, round(float(val)))
+        elif key == "disk":
+            rec["disk"] = max(128, round(float(val)))
+        elif key == "hacheck_cpus":
+            hacheck_cpus_value = max(0.1, min(float(val), 1))
+            rec["sidecar_resource_requirements"] = {
+                "hacheck": {
+                    "requests": {"cpu": hacheck_cpus_value,},
+                    "limits": {"cpu": hacheck_cpus_value,},
+                },
+            }
     return rec
 
 
-def get_recommendations_by_service_file(results):
+def get_recommendations_by_service_file(results, keys_to_apply):
     results_by_service_file = defaultdict(dict)
     for result in results.values():
         key = (
             result["service"],
             result["cluster"],
         )  # e.g. (foo, marathon-norcal-stagef)
-        rec = get_recommendation_from_result(result)
+        rec = get_recommendation_from_result(result, keys_to_apply)
         if not rec:
             continue
         results_by_service_file[key][result["instance"]] = rec
@@ -146,7 +156,8 @@ def main(args):
     extra_message = get_extra_message(report["search"])
     config_source = args.source_id or args.csv_report
 
-    results = get_recommendations_by_service_file(report["results"])
+    keys_to_apply = args.csv_keys or SUPPORTED_CSV_KEYS
+    results = get_recommendations_by_service_file(report["results"], keys_to_apply)
     updater = AutoConfigUpdater(
         config_source=config_source,
         git_remote=args.git_remote or get_default_git_remote(),


### PR DESCRIPTION
This makes `cpu_burst_add` a valid key in AutoConfigUpdater and fetches it from the Splunk CSV, but doesn't actually write cpu_burst_add in the rightsizer batch. This should be a no-op in terms of the configs updated in the daily cpu job.

Since we're adding suggested_cpu_burst_add to the existing cpu CSV, the `--csv-key` option will allow us to roll out the burst changes more slowly. My plan:
1. Release this change
2. Add `--csv-key cpus` to the existing Jenkins job for the cpu CSV.
3. Add cpu_burst_add to the rightsizer batch in a follow-up PR.
4. Add a new job with `--csv-key cpu_burst_add` that can be selectively applied to different clusters via the criteria filter (`-f`).
5. Once we're happy with the burst changes, we can eventually merge the two jobs back together.

I've tested the rightsizer batch manually to check that the `--csv-key` option works as expected.