### PR TITLE
Make pods with a prometheus_port routable

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1345,6 +1345,19 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
     def get_kubernetes_service_account_name(self) -> Optional[str]:
         return self.config_dict.get("service_account_name", None)
 
+    def has_routable_ip(
+        self,
+        service_namespace_config: ServiceNamespaceConfig,
+    ) -> str:
+        """Return whether the routable_ip label should be true or false.
+
+        Services with a `prometheus_port` defined must have a routable IP
+        address to allow Prometheus shards to scrape metrics.
+        """
+        if service_namespace_config.is_in_smartstack() or self.get_prometheus_port() is not None:
+            return "true"
+        return "false"
+
     def get_pod_template_spec(
         self, git_sha: str, system_paasta_config: SystemPaastaConfig
     ) -> V1PodTemplateSpec:
@@ -1355,11 +1368,10 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             system_volumes=system_paasta_config.get_volumes()
         )
         hacheck_sidecar_volumes = system_paasta_config.get_hacheck_sidecar_volumes()
+        has_routable_ip = self.has_routable_ip(service_namespace_config)
         annotations: Dict[str, Any] = {
             "smartstack_registrations": json.dumps(self.get_registrations()),
-            "paasta.yelp.com/routable_ip": "true"
-            if service_namespace_config.is_in_smartstack()
-            else "false",
+            "paasta.yelp.com/routable_ip": has_routable_ip,
         }
         metrics_provider = self.get_autoscaling_params()["metrics_provider"]
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1345,16 +1345,16 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
     def get_kubernetes_service_account_name(self) -> Optional[str]:
         return self.config_dict.get("service_account_name", None)
 
-    def has_routable_ip(
-        self,
-        service_namespace_config: ServiceNamespaceConfig,
-    ) -> str:
+    def has_routable_ip(self, service_namespace_config: ServiceNamespaceConfig) -> str:
         """Return whether the routable_ip label should be true or false.
 
         Services with a `prometheus_port` defined must have a routable IP
         address to allow Prometheus shards to scrape metrics.
         """
-        if service_namespace_config.is_in_smartstack() or self.get_prometheus_port() is not None:
+        if (
+            service_namespace_config.is_in_smartstack()
+            or self.get_prometheus_port() is not None
+        ):
             return "true"
         return "false"
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1444,14 +1444,10 @@ class TestKubernetesDeploymentConfig:
             (False, 8888, "true"),
             (True, None, "true"),
             (False, None, "false"),
-        ]
+        ],
     )
     def test_routable_ip(
-        self,
-        mock_get_prometheus_port,
-        in_smtstk,
-        prometheus_port,
-        expected,
+        self, mock_get_prometheus_port, in_smtstk, prometheus_port, expected,
     ):
         mock_get_prometheus_port.return_value = prometheus_port
         mock_service_namespace_config = mock.Mock()

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1433,6 +1433,34 @@ class TestKubernetesDeploymentConfig:
             spec=V1PodSpec(**pod_spec_kwargs),
         )
 
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_prometheus_port",
+        autospec=True,
+    )
+    @pytest.mark.parametrize(
+        "in_smtstk,prometheus_port,expected",
+        [
+            (True, 8888, "true"),
+            (False, 8888, "true"),
+            (True, None, "true"),
+            (False, None, "false"),
+        ]
+    )
+    def test_routable_ip(
+        self,
+        mock_get_prometheus_port,
+        in_smtstk,
+        prometheus_port,
+        expected,
+    ):
+        mock_get_prometheus_port.return_value = prometheus_port
+        mock_service_namespace_config = mock.Mock()
+        mock_service_namespace_config.is_in_smartstack.return_value = in_smtstk
+
+        ret = self.deployment.has_routable_ip(mock_service_namespace_config)
+
+        assert ret == expected
+
     @pytest.mark.parametrize(
         "raw_selectors,expected",
         [


### PR DESCRIPTION
Prometheus shards (currently deployed outside of PaaSTA) that need to
scrape metrics from a service need to be able to contact that service.

The only way to do so currently is to add a port in Smartstack in order
to make the pod ip routable (via the `paasta.yelp.com/routable_ip`
label). That port is unused and just serves to enable this behaviour.

While reserving unused ports in Smartstack is not too big a deal,
Smartstack/PaaSTA will launch a hacheck sidecar container which will run
extra healthchecks and use extra resources.
For Kubernetes operator pods, only one pod per deployment (the leader)
will have a Prometheus endpoint running (and able to accept
healthchecks). The other pods are therefore incorrectly considered
unhealthy, while they are just waiting for the lock to become leader.

This commit makes pods with a `prometheus_port` have their ip routable,
to remove the need for an unused Smartstack port and healthchecks.
Prometheus shards are able to gracefully deal with pods that do not
return a response (e.g: non-leader pods in an operator).

## Testing done

Additional unit test, `make test` still passes.