### PR TITLE
PAASTA-16376: Add a config option for kubernetes services to get a ro…

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -625,6 +625,9 @@
                     "type": "integer",
                     "minimum": 0
                 },
+                "routable_ip": {
+                    "type": "boolean"
+                },
                 "lifecycle": {
                     "type": "object",
                     "properties": {

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1352,7 +1352,8 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         address to allow Prometheus shards to scrape metrics.
         """
         if (
-            service_namespace_config.is_in_smartstack()
+            self.config_dict.get("routable_ip", False)
+            or service_namespace_config.is_in_smartstack()
             or self.get_prometheus_port() is not None
         ):
             return "true"

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -279,6 +279,7 @@ class KubernetesDeploymentConfigDict(LongRunningServiceConfigDict, total=False):
     prometheus_shard: str
     prometheus_path: str
     prometheus_port: int
+    routable_ip: bool
 
 
 def load_kubernetes_service_config_no_cache(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1438,21 +1438,27 @@ class TestKubernetesDeploymentConfig:
         autospec=True,
     )
     @pytest.mark.parametrize(
-        "in_smtstk,prometheus_port,expected",
+        "ip_configured,in_smtstk,prometheus_port,expected",
         [
-            (True, 8888, "true"),
-            (False, 8888, "true"),
-            (True, None, "true"),
-            (False, None, "false"),
+            (False, True, 8888, "true"),
+            (False, False, 8888, "true"),
+            (False, True, None, "true"),
+            (True, False, None, "true"),
+            (False, False, None, "false"),
         ],
     )
     def test_routable_ip(
-        self, mock_get_prometheus_port, in_smtstk, prometheus_port, expected,
+        self,
+        mock_get_prometheus_port,
+        ip_configured,
+        in_smtstk,
+        prometheus_port,
+        expected,
     ):
         mock_get_prometheus_port.return_value = prometheus_port
         mock_service_namespace_config = mock.Mock()
         mock_service_namespace_config.is_in_smartstack.return_value = in_smtstk
-
+        self.deployment.config_dict["routable_ip"] = ip_configured
         ret = self.deployment.has_routable_ip(mock_service_namespace_config)
 
         assert ret == expected


### PR DESCRIPTION
…utable IP even if not in smartstack or used for prometheus scraping

This simply extends the work done in #3014 to allow for services to explicitly require a routable IP, rather than implied via smartstack or prometheus configurations.

Originally, *only* service instances which registered to smartstack would be assigned a routable IP.  In #3014 we also added the logic to give a routable IP to pods which needed to be exposed so prometheus could scrape their metrics.

There may be other usecases to expose a service (e.g. perhaps it needs to be accessible, but not through our service mesh, nor does it need to be scraped by prometheus), so it seems useful to give service owners the option to explicitly request a routable IP via their configuration when needed.  

See PAASTA-16376 for more info including pending usecases for this feature.  I've held off on adding to the documentation to verify the functionality internally first.

## Testing done
`make test` still passes