### PR TITLE
PAASTA-16376: document routable_ip option on k8s

### DIFF
--- a/docs/source/soa_configs.rst
+++ b/docs/source/soa_configs.rst
@@ -14,18 +14,20 @@ directory. There is one folder per service. Here is an example tree::
   soa-configs
   ├── web
   │   ├── deploy.yaml
-  │   ├── marathon-dev.yaml
-  │   ├── marathon-prod.yaml
+  │   ├── kubernetes-dev.yaml
+  │   ├── kubernetes-prod.yaml
   │   ├── monitoring.yaml
   │   ├── service.yaml
   │   └── smartstack.yaml
   ├── api
+  │   ├── adhoc-prod.yaml
   │   ├── deploy.yaml
   │   ├── marathon-dev.yaml
   │   ├── marathon-prod.yaml
   │   ├── monitoring.yaml
   │   ├── service.yaml
-  │   └── smartstack.yaml
+  │   ├── smartstack.yaml
+  │   └── tron-prod.yaml
   ...
 
 See the `paasta-specific soa-configs documentation <yelpsoa_configs.html>`_ for more information

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -409,16 +409,20 @@ instance MAY have:
     Defaults to the same uri specified in ``smartstack.yaml``, but can be
     set to something different here.
 
- * ``prometheus_shard``: Optional name of Prometheus shard to be configured to
-   scrape the service. This shard should already exist and will not be
-   automatically created.
+  * ``prometheus_shard``: Optional name of Prometheus shard to be configured to
+    scrape the service. This shard should already exist and will not be
+    automatically created.
 
- * ``prometheus_path``: Optional path the Prometheus shard to be configured with
-   to scrape the service. This shard should already exist and will not be
-   automatically created.
+  * ``prometheus_path``: Optional path the Prometheus shard to be configured with
+    to scrape the service. This shard should already exist and will not be
+    automatically created.
 
- * ``prometheus_port``: Optional port, not equal to ``container_port``, to
-   expose for prometheus scraping.
+  * ``prometheus_port``: Optional port, not equal to ``container_port``, to
+    expose for prometheus scraping.
+
+  * ``routable_ip``: Optionally assign this instance a routable IP so it can be
+    accessed externally. This option is implied when registered to smartstack or
+    when specifying a ``prometheus_port``. Defaults to ``false``
 
 **Note**: Although many of these settings are inherited from ``smartstack.yaml``,
 their thresholds are not the same. The reason for this has to do with control


### PR DESCRIPTION
This is strictly a doc update -- `routable_ip` is working as intended so we can document it.   I also noticed the `prometheus_(shard|path|port)` sections were indented incorrectly; these have been fixed.

In addition, show other examples of yelpsoa files in our top level `soa-configs` documentation, to make it clear files don't _need_ to be only `marathon-$cluster.yaml`

`make docs` succeeds and generates the expected changes.

`soa_configs.html` Before: ![Screen Shot 2021-01-26 at 5 43 47 PM](https://user-images.githubusercontent.com/2119545/105930650-cb2d2f00-5ffe-11eb-94d9-4bd603c5abee.png)

`soa_configs.html` after: 
![Screen Shot 2021-01-26 at 5 40 08 PM](https://user-images.githubusercontent.com/2119545/105930704-da13e180-5ffe-11eb-9dbc-131eb1e7cef1.png)

`yelpsoa_configs.html` `kubernetes-clustename-yaml` before: 
![Screen Shot 2021-01-26 at 5 44 02 PM](https://user-images.githubusercontent.com/2119545/105930790-f283fc00-5ffe-11eb-9d82-5be59c28d395.png)

`yelpsoa_configs.html` `kubernetes-clustername-haml` after: 
![Screen Shot 2021-01-26 at 5 47 50 PM](https://user-images.githubusercontent.com/2119545/105930819-00398180-5fff-11eb-8984-ead217aa0f11.png)


