### PR TITLE
Shows replicaset table in nonverbose request

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1136,7 +1136,7 @@ def print_kubernetes_status(
     if error_message:
         output.append(error_message)
         return 1
-    import pdb; pdb.set_trace()
+
     bouncing_status = bouncing_status_human(
         kubernetes_status.app_count, kubernetes_status.bounce_method
     )

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1136,7 +1136,7 @@ def print_kubernetes_status(
     if error_message:
         output.append(error_message)
         return 1
-
+    import pdb; pdb.set_trace()
     bouncing_status = bouncing_status_human(
         kubernetes_status.app_count, kubernetes_status.bounce_method
     )
@@ -1164,7 +1164,7 @@ def print_kubernetes_status(
             )
         )
     )
-    if kubernetes_status.create_timestamp:
+    if kubernetes_status.create_timestamp and verbose > 0:
         create_datetime = datetime.fromtimestamp(kubernetes_status.create_timestamp)
         output.append(
             "      App created: {} ({}). Namespace: {}".format(

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -200,10 +200,12 @@ async def job_status(
     kstatus["app_id"] = app_id
     kstatus["pods"] = []
     kstatus["replicasets"] = []
-    num_tail_lines = calculate_tail_lines(verbose)
-    kstatus["pods"] = await asyncio.gather(
-        *[pod_info(pod, client, num_tail_lines) for pod in pod_list]
-    )
+
+    if verbose > 0:
+        num_tail_lines = calculate_tail_lines(verbose)
+        kstatus["pods"] = await asyncio.gather(
+            *[pod_info(pod, client, num_tail_lines) for pod in pod_list]
+        )
 
     for replicaset in replicaset_list:
         kstatus["replicasets"].append(

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1036,6 +1036,34 @@ def test_paasta_status_exception(system_paasta_config):
             verbose=False,
         )
 
+def test_format_kubernetes_replicaset_table_in_non_verbose():
+    with mock.patch(
+        "paasta_tools.cli.cmds.status.print_kubernetes_status", autospec=True
+    ) as mock_print_kubernetes_status, mock.patch(
+        "paasta_tools.cli.cmds.status.format_kubernetes_replicaset_table", autospec=True
+    ) as mock_format_kubernetes_replicaset_table:
+        mock_kubernetes_status.replicasets = [
+            paastamodels.KubernetesReplicaSet(
+                name="replicaset_1",
+                replicas=3,
+                ready_replicas=2,
+                create_timestamp=1562963508.0,
+                git_sha=None,
+                config_sha=None,
+            )
+        ]
+        
+        mock_print_kubernetes_status(
+            cluster="fake_cluster",
+            service="fake_service",
+            instance="fake_instance",
+            output=[],
+            kubernetes_status=mock_kubernetes_status,
+            verbose=0
+        )
+
+        assert mock_format_kubernetes_replicaset_table.called == True
+        
 
 class TestPrintMarathonStatus:
     def test_error(self, mock_marathon_status):

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1036,34 +1036,35 @@ def test_paasta_status_exception(system_paasta_config):
             verbose=False,
         )
 
-def test_format_kubernetes_replicaset_table_in_non_verbose():
+
+def test_format_kubernetes_replicaset_table_in_non_verbose(mock_kubernetes_status):
     with mock.patch(
-        "paasta_tools.cli.cmds.status.print_kubernetes_status", autospec=True
-    ) as mock_print_kubernetes_status, mock.patch(
         "paasta_tools.cli.cmds.status.format_kubernetes_replicaset_table", autospec=True
-    ) as mock_format_kubernetes_replicaset_table:
+    ) as mock_format_kubernetes_replicaset_table, mock.patch(
+        "paasta_tools.cli.cmds.status.bouncing_status_human", autospec=True
+    ):
         mock_kubernetes_status.replicasets = [
             paastamodels.KubernetesReplicaSet(
                 name="replicaset_1",
                 replicas=3,
                 ready_replicas=2,
                 create_timestamp=1562963508.0,
-                git_sha=None,
-                config_sha=None,
+                git_sha="fake_git_sha",
+                config_sha="fake_config_sha",
             )
         ]
-        
-        mock_print_kubernetes_status(
+        mock_kubernetes_status.error_message = ""
+        status.print_kubernetes_status(
             cluster="fake_cluster",
             service="fake_service",
             instance="fake_instance",
             output=[],
             kubernetes_status=mock_kubernetes_status,
-            verbose=0
+            verbose=0,
         )
 
-        assert mock_format_kubernetes_replicaset_table.called == True
-        
+        assert mock_format_kubernetes_replicaset_table.called
+
 
 class TestPrintMarathonStatus:
     def test_error(self, mock_marathon_status):

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1284,7 +1284,6 @@ class TestPrintKubernetesStatus:
             f"    Kubernetes:   {PaastaColors.green('Healthy')} - up with {PaastaColors.green('(2/2)')} instances ({PaastaColors.red('1')} evicted). Status: {mock_kubernetes_app_deploy_status_human.return_value}",
         ]
         expected_output += [
-            f"      App created: 2019-07-12 20:31:48 ({mock_naturaltime.return_value}). Namespace: paasta",
             f"      Pods:",
             f"        Pod ID  Host deployed to  Deployed at what localtime      Health",
             f"        app_1   fake_host1        2019-07-12T20:31 ({mock_naturaltime.return_value})  {PaastaColors.green('Healthy')}",

--- a/tests/instance/test_kubernetes.py
+++ b/tests/instance/test_kubernetes.py
@@ -113,6 +113,22 @@ def test_kubernetes_status(
     assert "desired_state" in status
 
 
+@mock.patch("paasta_tools.kubernetes_tools.get_kubernetes_app_by_name", autospec=True)
+def test_job_status_include_replicaset_non_verbose(mock_get_kubernetes_app_by_name):
+    kstatus = {}
+    pik.job_status(
+        kstatus=kstatus,
+        client=mock.Mock(),
+        job_config=mock.Mock(),
+        pod_list=[],
+        replicaset_list=[mock.Mock(), mock.Mock(), mock.Mock()],
+        verbose=0,
+        namespace=mock.Mock(),
+    )
+
+    assert len(kstatus["replicasets"]) == 3
+
+
 @mock.patch("paasta_tools.instance.kubernetes.job_status", autospec=True)
 @mock.patch(
     "paasta_tools.kubernetes_tools.load_service_namespace_config", autospec=True


### PR DESCRIPTION
Modified the API request to retrieve the replicaset data without having to use the verbose option when running `paasta status`.

**Verbose Option Deactivated**
![image](https://user-images.githubusercontent.com/16994361/106205155-e15bfc00-6172-11eb-9d4e-82f8c02e4a60.png)

**Verbose Option Activated**
![image](https://user-images.githubusercontent.com/16994361/106205227-06506f00-6173-11eb-83e6-75ab62767ac9.png)
