### PR TITLE
PAASTA-16562: Use the oldest replicaset for 'app' timestamp rather than deployment

### DIFF
--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -241,7 +241,9 @@ async def job_status(
     kstatus["running_instance_count"] = (
         app.status.ready_replicas if app.status.ready_replicas else 0
     )
-    kstatus["create_timestamp"] = app.metadata.creation_timestamp.timestamp()
+    kstatus["create_timestamp"] = min(
+        [rs.metadata.creation_timestamp.timestamp() for rs in replicaset_list]
+    )
     kstatus["namespace"] = app.metadata.namespace
 
 


### PR DESCRIPTION
Currently we use deployment creation for the `paasta status` output for `App created` timestamp.  Since we don't recreate deployments or statefulsets on code or config changes (unless `bounce_method` is `brutal`), this timestamp is less relevant to developers.

Instead, we should make it reflect the latest change caused by a deployment, either via a restart, a service change, or a yelpsoa-configs change. 

We create new `replicasets` for any of the aforementioned changes, so this just replaces the current `create_timestamp` with the oldest replicaset creation timestamp.

Verified this is showing the expected timestamp after a `paasta restart` of paasta-contract-monitor:
## Old status
```
      App created: 2021-01-06 06:33:05 (26 days ago). Namespace: paasta
...
    ReplicaSets:
        ReplicaSet Name                               Ready / Desired  Created at what localtime       Service git SHA                           Config hash
        paasta-contract-monitor-main--k8s-576f67445b  10/10            2021-02-01T10:30 (2 hours ago)  d2b2a34706cd44404c6e95c88d831271dac98cb3  configfc5c0db5
```

## New status
```
      App created: 2021-02-01 10:30:05 (2 hours ago). Namespace: paasta
...
    ReplicaSets:
        ReplicaSet Name                               Ready / Desired  Created at what localtime       Service git SHA                           Config hash
        paasta-contract-monitor-main--k8s-576f67445b  10/10            2021-02-01T10:30 (2 hours ago)  d2b2a34706cd44404c6e95c88d831271dac98cb3  configfc5c0db5
```

