### PR TITLE
Add support for parsing HPAs with Object metrics

### DIFF
--- a/paasta_tools/instance/hpa_metrics_parser.py
+++ b/paasta_tools/instance/hpa_metrics_parser.py
@@ -1,3 +1,6 @@
+from kubernetes.client.models.v2beta2_object_metric_status import (
+    V2beta2ObjectMetricStatus,
+)
 from mypy_extensions import TypedDict
 
 
@@ -23,6 +26,7 @@ class HPAMetricsParser:
             "Pods": self.parse_pod_metric,
             "External": self.parse_external_metric,
             "Resource": self.parse_resource_metric,
+            "Object": self.parse_object_metric,
         }
         switchers[metric.type](metric_spec, status)
         status["target_value"] = (
@@ -40,6 +44,7 @@ class HPAMetricsParser:
             "Pods": self.parse_pod_metric_current,
             "External": self.parse_external_metric_current,
             "Resource": self.parse_resource_metric_current,
+            "Object": self.parse_object_metric_current,
         }
         switchers[metric.type](metric_spec, status)
         status["current_value"] = (
@@ -85,4 +90,24 @@ class HPAMetricsParser:
             metric_spec.current.average_value
             if getattr(metric_spec.current, "average_value")
             else metric_spec.current.average_utilization
+        )
+
+    def parse_object_metric(
+        self, metric_spec: V2beta2ObjectMetricStatus, status: HPAMetricsDict
+    ) -> None:
+        status["name"] = metric_spec.metric.name
+        status["target_value"] = (
+            metric_spec.target.average_value
+            if getattr(metric_spec.target, "average_value")
+            else metric_spec.target.value
+        )
+
+    def parse_object_metric_current(
+        self, metric_spec: V2beta2ObjectMetricStatus, status: HPAMetricsDict
+    ) -> None:
+        status["name"] = metric_spec.metric.name
+        status["current_value"] = (
+            metric_spec.current.average_value
+            if getattr(metric_spec.current, "average_value")
+            else metric_spec.current.value
         )


### PR DESCRIPTION
We'll be using Object metrics to support Prometheus-backed HPAs, so lets
set some groundwork and make sure that we can parse said HPAs once we've
actually created some.