### PR TITLE
Stop adding SFX custom metrics annotation

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -541,7 +541,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 )
             )
         elif metrics_provider in ("http", "uwsgi"):
-            annotations = {"signalfx.com.custom.metrics": ""}
             if (
                 autoscaling_params.get("forecast_policy") == "moving_average"
                 or "offset" in autoscaling_params

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -103,7 +103,6 @@ from kubernetes.client import V2beta2HorizontalPodAutoscalerSpec
 from kubernetes.client import V2beta2MetricIdentifier
 from kubernetes.client import V2beta2MetricSpec
 from kubernetes.client import V2beta2MetricTarget
-from kubernetes.client import V2beta2PodsMetricSource
 from kubernetes.client import V2beta2ResourceMetricSource
 from kubernetes.client.configuration import Configuration as KubeConfiguration
 from kubernetes.client.models import V2beta2HorizontalPodAutoscalerStatus
@@ -527,7 +526,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         metrics = []
         target = autoscaling_params["setpoint"]
         annotations: Dict[str, str] = {}
-        selector = V1LabelSelector(match_labels={"paasta_cluster": cluster})
         if metrics_provider == "mesos_cpu":
             metrics.append(
                 V2beta2MetricSpec(
@@ -577,21 +575,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                         ),
                     )
                 )
-            else:
-                metrics.append(
-                    V2beta2MetricSpec(
-                        type="Pods",
-                        pods=V2beta2PodsMetricSource(
-                            metric=V2beta2MetricIdentifier(
-                                name=metrics_provider, selector=selector,
-                            ),
-                            target=V2beta2MetricTarget(
-                                type="AverageValue", average_value=target,
-                            ),
-                        ),
-                    )
-                )
-
         else:
             log.error(
                 f"Unknown metrics_provider specified: {metrics_provider} for\

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1758,12 +1758,9 @@ class TestKubernetesDeploymentConfig:
             return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
                 mock_config, "fake_name", "cluster", KubeClient(),
             )
-        annotations = {"signalfx.com.custom.metrics": ""}
         expected_res = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
-            metadata=V1ObjectMeta(
-                name="fake_name", namespace="paasta", annotations=annotations
-            ),
+            metadata=V1ObjectMeta(name="fake_name", namespace="paasta", annotations={}),
             spec=V2beta2HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
@@ -1819,12 +1816,9 @@ class TestKubernetesDeploymentConfig:
                 mock_config, "fake_name", "cluster", KubeClient(),
             )
 
-        annotations = {"signalfx.com.custom.metrics": ""}
         expected_res = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
-            metadata=V1ObjectMeta(
-                name="fake_name", namespace="paasta", annotations=annotations
-            ),
+            metadata=V1ObjectMeta(name="fake_name", namespace="paasta", annotations={}),
             spec=V2beta2HorizontalPodAutoscalerSpec(
                 max_replicas=3,
                 min_replicas=1,
@@ -1893,7 +1887,6 @@ class TestKubernetesDeploymentConfig:
                 name="fake_name",
                 namespace="paasta",
                 annotations={
-                    "signalfx.com.custom.metrics": "",
                     "signalfx.com.external.metric/service-instance-uwsgi": "fake_signalflow_query",
                 },
             ),

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -56,7 +56,6 @@ from kubernetes.client import V2beta2HorizontalPodAutoscalerSpec
 from kubernetes.client import V2beta2MetricIdentifier
 from kubernetes.client import V2beta2MetricSpec
 from kubernetes.client import V2beta2MetricTarget
-from kubernetes.client import V2beta2PodsMetricSource
 from kubernetes.client import V2beta2ResourceMetricSource
 from kubernetes.client.rest import ApiException
 
@@ -1718,122 +1717,6 @@ class TestKubernetesDeploymentConfig:
                             name="cpu",
                             target=V2beta2MetricTarget(
                                 type="Utilization", average_utilization=50.0,
-                            ),
-                        ),
-                    )
-                ],
-                scale_target_ref=V2beta2CrossVersionObjectReference(
-                    api_version="apps/v1", kind="Deployment", name="fake_name",
-                ),
-            ),
-        )
-        assert (
-            self.patch_expected_autoscaling_spec(expected_res, mock_config)
-            == return_value
-        )
-
-    def test_get_autoscaling_metric_spec_http(self):
-        # with http
-        config_dict = KubernetesDeploymentConfigDict(
-            {
-                "min_instances": 1,
-                "max_instances": 3,
-                "autoscaling": {"metrics_provider": "http", "setpoint": 0.5},
-            }
-        )
-        mock_config = KubernetesDeploymentConfig(  # type: ignore
-            service="service",
-            cluster="cluster",
-            instance="instance",
-            config_dict=config_dict,
-            branch_dict=None,
-        )
-        with mock.patch(
-            "paasta_tools.kubernetes_tools.load_system_paasta_config",
-            return_value=mock.Mock(
-                get_hpa_always_uses_external_for_signalfx=lambda: False
-            ),
-            autospec=True,
-        ):
-            return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
-                mock_config, "fake_name", "cluster", KubeClient(),
-            )
-        expected_res = V2beta2HorizontalPodAutoscaler(
-            kind="HorizontalPodAutoscaler",
-            metadata=V1ObjectMeta(name="fake_name", namespace="paasta", annotations={}),
-            spec=V2beta2HorizontalPodAutoscalerSpec(
-                max_replicas=3,
-                min_replicas=1,
-                metrics=[
-                    V2beta2MetricSpec(
-                        type="Pods",
-                        pods=V2beta2PodsMetricSource(
-                            metric=V2beta2MetricIdentifier(
-                                name="http",
-                                selector=V1LabelSelector(
-                                    match_labels={"paasta_cluster": "cluster"}
-                                ),
-                            ),
-                            target=V2beta2MetricTarget(
-                                type="AverageValue", average_value=0.5,
-                            ),
-                        ),
-                    )
-                ],
-                scale_target_ref=V2beta2CrossVersionObjectReference(
-                    api_version="apps/v1", kind="Deployment", name="fake_name",
-                ),
-            ),
-        )
-        assert (
-            self.patch_expected_autoscaling_spec(expected_res, mock_config)
-            == return_value
-        )
-
-    def test_get_autoscaling_metric_spec_uwsgi(self):
-        config_dict = KubernetesDeploymentConfigDict(
-            {
-                "min_instances": 1,
-                "max_instances": 3,
-                "autoscaling": {"metrics_provider": "uwsgi", "setpoint": 0.5},
-            }
-        )
-        mock_config = KubernetesDeploymentConfig(  # type: ignore
-            service="service",
-            cluster="cluster",
-            instance="instance",
-            config_dict=config_dict,
-            branch_dict=None,
-        )
-        with mock.patch(
-            "paasta_tools.kubernetes_tools.load_system_paasta_config",
-            return_value=mock.Mock(
-                get_hpa_always_uses_external_for_signalfx=lambda: False
-            ),
-            autospec=True,
-        ):
-            return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
-                mock_config, "fake_name", "cluster", KubeClient(),
-            )
-
-        expected_res = V2beta2HorizontalPodAutoscaler(
-            kind="HorizontalPodAutoscaler",
-            metadata=V1ObjectMeta(name="fake_name", namespace="paasta", annotations={}),
-            spec=V2beta2HorizontalPodAutoscalerSpec(
-                max_replicas=3,
-                min_replicas=1,
-                metrics=[
-                    V2beta2MetricSpec(
-                        type="Pods",
-                        pods=V2beta2PodsMetricSource(
-                            metric=V2beta2MetricIdentifier(
-                                name="uwsgi",
-                                selector=V1LabelSelector(
-                                    match_labels={"paasta_cluster": "cluster"}
-                                ),
-                            ),
-                            target=V2beta2MetricTarget(
-                                type="AverageValue", average_value=0.5,
                             ),
                         ),
                     )


### PR DESCRIPTION
This will cause issues once we add additional metrics to the HPA since
the SFX adapter will try to act on those metrics and, predictably, fail.

**NOTE: this is using https://github.com/Yelp/paasta/pull/3023 as a base to make it easier to break things up into multiple PRs - my plan is to merge the base PR and then merge this into master**