### PR TITLE
Implement setup_prometheus_adapter_config.py stubs

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -19,12 +19,16 @@ import logging
 import re
 import sys
 from pathlib import Path
+from typing import cast
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
 
 import ruamel.yaml as yaml
+from kubernetes.client import V1ConfigMap
+from kubernetes.client import V1ObjectMeta
+from kubernetes.client.rest import ApiException
 from mypy_extensions import TypedDict
 
 from paasta_tools.kubernetes_tools import ensure_namespace
@@ -37,6 +41,10 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_services_for_cluster
 
 log = logging.getLogger(__name__)
+
+PROMETHEUS_ADAPTER_CONFIGMAP_NAMESPACE = "custom-metrics"
+PROMETHEUS_ADAPTER_CONFIGMAP_NAME = "adapter-config"
+PROMETHEUS_ADAPTER_CONFIGMAP_FILENAME = "config.yaml"
 
 
 class PrometheusAdapterRule(TypedDict):
@@ -218,19 +226,61 @@ def create_prometheus_adapter_config(
 def update_prometheus_adapter_configmap(
     kube_client: KubeClient, config: PrometheusAdapterConfig
 ) -> None:
-    pass
+    kube_client.core.replace_namespaced_config_map(
+        name=PROMETHEUS_ADAPTER_CONFIGMAP_NAME,
+        namespace=PROMETHEUS_ADAPTER_CONFIGMAP_NAMESPACE,
+        body=V1ConfigMap(
+            metadata=V1ObjectMeta(name=PROMETHEUS_ADAPTER_CONFIGMAP_NAME),
+            data={
+                PROMETHEUS_ADAPTER_CONFIGMAP_FILENAME: yaml.dump(
+                    config,
+                    default_flow_style=False,
+                    explicit_start=True,
+                    width=sys.maxsize,
+                )
+            },
+        ),
+    )
 
 
 def create_prometheus_adapter_configmap(
     kube_client: KubeClient, config: PrometheusAdapterConfig
 ) -> None:
-    pass
+    kube_client.core.create_namespaced_config_map(
+        namespace=PROMETHEUS_ADAPTER_CONFIGMAP_NAMESPACE,
+        body=V1ConfigMap(
+            metadata=V1ObjectMeta(name=PROMETHEUS_ADAPTER_CONFIGMAP_NAME),
+            data={
+                PROMETHEUS_ADAPTER_CONFIGMAP_FILENAME: yaml.dump(
+                    config, default_flow_style=False, explicit_start=True
+                )
+            },
+        ),
+    )
 
 
 def get_prometheus_adapter_configmap(
     kube_client: KubeClient,
 ) -> Optional[PrometheusAdapterConfig]:
-    return {"rules": []}
+    try:
+        config = cast(
+            # we cast since mypy infers the wrong type since the k8s clientlib is untyped
+            V1ConfigMap,
+            kube_client.core.read_namespaced_config_map(
+                name=PROMETHEUS_ADAPTER_CONFIGMAP_NAME,
+                namespace=PROMETHEUS_ADAPTER_CONFIGMAP_NAMESPACE,
+            ),
+        )
+    except ApiException as e:
+        if e.status == 404:
+            return None
+        else:
+            raise
+
+    if not config:
+        return None
+
+    return yaml.safe_load(config.data[PROMETHEUS_ADAPTER_CONFIGMAP_FILENAME])
 
 
 def restart_prometheus_adapter(kube_client: KubeClient) -> None:

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -1,40 +1,49 @@
+from pathlib import Path
+import json
 from typing import Any
 from typing import Dict
 
 import pytest
+import ruamel.yaml as yaml
+from py._path.local import LocalPath
+from paasta_tools.long_running_service_tools import AutoscalingParamsDict
 
+from paasta_tools.setup_prometheus_adapter_config import (
+    create_instance_uwsgi_scaling_rule,
+)
+from paasta_tools.setup_prometheus_adapter_config import (
+    create_prometheus_adapter_config,
+)
 from paasta_tools.setup_prometheus_adapter_config import (
     should_create_uwsgi_scaling_rule,
 )
 
 
 @pytest.mark.parametrize(
-    "instance_name, instance_config,expected",
+    "instance_name,autoscaling_config,expected",
     [
-        ("_not_a_real_instance", {}, False),
-        ("not_autoscaled", {}, False),
         (
             "not_uwsgi_autoscaled",
-            {"autoscaling": {"decision_policy": "bespoke"}},
+            {"metrics_provider": "mesos_cpu", "decision_policy": "bespoke", "moving_average_window_seconds": 123, "setpoint": .653},
             False,
         ),
         (
             "uwsgi_autoscaled_no_prometheus",
-            {"autoscaling": {"metrics_provider": "uwsgi"}},
+            {"metrics_provider": "uwsgi", "moving_average_window_seconds": 124, "setpoint": .425},
             False,
         ),
         (
             "uwsgi_autoscaled_prometheus",
-            {"autoscaling": {"metrics_provider": "uwsgi", "use_prometheus": True}},
+            {"metrics_provider": "uwsgi", "use_prometheus": True, "moving_average_window_seconds": 544, "setpoint": .764},
             True,
         ),
     ],
 )
 def test_should_create_uswgi_scaling_rule(
-    instance_name: str, instance_config: Dict[str, Any], expected: bool
+    instance_name: str, autoscaling_config: AutoscalingParamsDict, expected: bool
 ) -> None:
     should_create, reason = should_create_uwsgi_scaling_rule(
-        instance=instance_name, instance_config=instance_config
+        instance=instance_name, autoscaling_config=autoscaling_config
     )
 
     assert should_create == expected
@@ -42,3 +51,99 @@ def test_should_create_uswgi_scaling_rule(
         assert reason is None
     else:
         assert reason is not None
+
+
+def test_create_instance_uwsgi_scaling_rule() -> None:
+    service_name = "test_service"
+    instance_name = "test_instance"
+    paasta_cluster = "test_cluster"
+    autoscaling_config = {
+        "metrics_provider": "uwsgi",
+        "setpoint": 0.1234567890,
+        "moving_average_window_seconds": 20120302,
+        "use_prometheus": True,
+    }
+
+    rule = create_instance_uwsgi_scaling_rule(
+        service=service_name,
+        instance=instance_name,
+        paasta_cluster=paasta_cluster,
+        autoscaling_config=autoscaling_config,
+    )
+
+    # we test that the format of the dictionary is as expected with mypy
+    # and we don't want to test the full contents of the retval since then
+    # we're basically just writting a change-detector test - instead, we test
+    # that we're actually using our inputs
+    assert service_name in rule["seriesQuery"]
+    assert instance_name in rule["seriesQuery"]
+    assert paasta_cluster in rule["seriesQuery"]
+    # these two numbers are distinctive and unlikely to be used as constants
+    assert str(autoscaling_config["setpoint"]) in rule["metricsQuery"]
+    assert (
+        str(autoscaling_config["moving_average_window_seconds"])
+        in rule["metricsQuery"]
+    )
+
+
+def test_create_prometheus_adapter_config(tmpdir: LocalPath) -> None:
+    # TODO: if we upgrade to pytest>=3.9, we can use their tmp_path fixture directly
+    tmp_path = Path(str(tmpdir))
+    service_config = {
+        "_shared_env": {"env": {"PAASTA_IS_GREAT": True}},
+        "test_instance": {
+            "deploy_group": "some-group",
+            "min_instances": 1,
+            "max_instances": 3,
+            "registrations": ["test_service.test_instance"],
+            "autoscaling": {
+                "metrics_provider": "uwsgi",
+                "setpoint": 0.45,
+                "use_prometheus": True,
+            }
+        },
+        "another_test_instance": {
+            "deploy_group": "some-group",
+            "min_instances": 1,
+            "max_instances": 3,
+            "registrations": ["test_service.another_test_instance"],
+            "autoscaling": {
+                "metrics_provider": "uwsgi",
+                "setpoint": 0.45,
+                "use_prometheus": True,
+            }
+        },
+    }
+    deployments = {
+        "v2": {
+            "deployments": {
+                "some-group": {
+                    "docker_image": "image",
+                    "git_sha": "sha",
+                }
+            },
+            "controls": {
+                "test_service:some-cluster.test_instance": {
+                    "desired_state": "start",
+                    "force_bounce": "20210129T005338",
+                },
+                "test_service:some-cluster.another_test_instance": {
+                    "desired_state": "start",
+                    "force_bounce": "20210129T005338",
+                },
+            }
+        },
+    }
+
+    (tmp_path / "test_service").mkdir()
+    (tmp_path / "test_service" / "kubernetes-some-cluster.yaml").write_text(
+        yaml.dump(service_config), encoding="utf-8"
+    )
+    (tmp_path / "test_service" / "deployments.json").write_text(
+        json.dumps(deployments), encoding="utf-8"
+    )
+    config = create_prometheus_adapter_config(
+        paasta_cluster="some-cluster", soa_dir=tmp_path
+    )
+
+    assert len(config["rules"]) == len(service_config.keys()) - 1

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import mock
 import pytest
 import ruamel.yaml as yaml
 from py._path.local import LocalPath
@@ -148,8 +149,11 @@ def test_create_prometheus_adapter_config(tmpdir: LocalPath) -> None:
     (tmp_path / "test_service" / "deployments.json").write_text(
         json.dumps(deployments), encoding="utf-8"
     )
-    config = create_prometheus_adapter_config(
-        paasta_cluster="some-cluster", soa_dir=tmp_path
-    )
+    with mock.patch(
+        "paasta_tools.utils.load_system_paasta_config", autospec=True,
+    ):
+        config = create_prometheus_adapter_config(
+            paasta_cluster="some-cluster", soa_dir=tmp_path
+        )
 
     assert len(config["rules"]) == len(service_config.keys()) - 1

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -1,13 +1,11 @@
-from pathlib import Path
 import json
-from typing import Any
-from typing import Dict
+from pathlib import Path
 
 import pytest
 import ruamel.yaml as yaml
 from py._path.local import LocalPath
-from paasta_tools.long_running_service_tools import AutoscalingParamsDict
 
+from paasta_tools.long_running_service_tools import AutoscalingParamsDict
 from paasta_tools.setup_prometheus_adapter_config import (
     create_instance_uwsgi_scaling_rule,
 )
@@ -24,17 +22,31 @@ from paasta_tools.setup_prometheus_adapter_config import (
     [
         (
             "not_uwsgi_autoscaled",
-            {"metrics_provider": "mesos_cpu", "decision_policy": "bespoke", "moving_average_window_seconds": 123, "setpoint": .653},
+            {
+                "metrics_provider": "mesos_cpu",
+                "decision_policy": "bespoke",
+                "moving_average_window_seconds": 123,
+                "setpoint": 0.653,
+            },
             False,
         ),
         (
             "uwsgi_autoscaled_no_prometheus",
-            {"metrics_provider": "uwsgi", "moving_average_window_seconds": 124, "setpoint": .425},
+            {
+                "metrics_provider": "uwsgi",
+                "moving_average_window_seconds": 124,
+                "setpoint": 0.425,
+            },
             False,
         ),
         (
             "uwsgi_autoscaled_prometheus",
-            {"metrics_provider": "uwsgi", "use_prometheus": True, "moving_average_window_seconds": 544, "setpoint": .764},
+            {
+                "metrics_provider": "uwsgi",
+                "use_prometheus": True,
+                "moving_average_window_seconds": 544,
+                "setpoint": 0.764,
+            },
             True,
         ),
     ],
@@ -57,7 +69,7 @@ def test_create_instance_uwsgi_scaling_rule() -> None:
     service_name = "test_service"
     instance_name = "test_instance"
     paasta_cluster = "test_cluster"
-    autoscaling_config = {
+    autoscaling_config: AutoscalingParamsDict = {
         "metrics_provider": "uwsgi",
         "setpoint": 0.1234567890,
         "moving_average_window_seconds": 20120302,
@@ -81,8 +93,7 @@ def test_create_instance_uwsgi_scaling_rule() -> None:
     # these two numbers are distinctive and unlikely to be used as constants
     assert str(autoscaling_config["setpoint"]) in rule["metricsQuery"]
     assert (
-        str(autoscaling_config["moving_average_window_seconds"])
-        in rule["metricsQuery"]
+        str(autoscaling_config["moving_average_window_seconds"]) in rule["metricsQuery"]
     )
 
 
@@ -100,7 +111,7 @@ def test_create_prometheus_adapter_config(tmpdir: LocalPath) -> None:
                 "metrics_provider": "uwsgi",
                 "setpoint": 0.45,
                 "use_prometheus": True,
-            }
+            },
         },
         "another_test_instance": {
             "deploy_group": "some-group",
@@ -111,17 +122,12 @@ def test_create_prometheus_adapter_config(tmpdir: LocalPath) -> None:
                 "metrics_provider": "uwsgi",
                 "setpoint": 0.45,
                 "use_prometheus": True,
-            }
+            },
         },
     }
     deployments = {
         "v2": {
-            "deployments": {
-                "some-group": {
-                    "docker_image": "image",
-                    "git_sha": "sha",
-                }
-            },
+            "deployments": {"some-group": {"docker_image": "image", "git_sha": "sha",}},
             "controls": {
                 "test_service:some-cluster.test_instance": {
                     "desired_state": "start",
@@ -131,7 +137,7 @@ def test_create_prometheus_adapter_config(tmpdir: LocalPath) -> None:
                     "desired_state": "start",
                     "force_bounce": "20210129T005338",
                 },
-            }
+            },
         },
     }
 

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -1,0 +1,44 @@
+from typing import Any
+from typing import Dict
+
+import pytest
+
+from paasta_tools.setup_prometheus_adapter_config import (
+    should_create_uwsgi_scaling_rule,
+)
+
+
+@pytest.mark.parametrize(
+    "instance_name, instance_config,expected",
+    [
+        ("_not_a_real_instance", {}, False),
+        ("not_autoscaled", {}, False),
+        (
+            "not_uwsgi_autoscaled",
+            {"autoscaling": {"decision_policy": "bespoke"}},
+            False,
+        ),
+        (
+            "uwsgi_autoscaled_no_prometheus",
+            {"autoscaling": {"metrics_provider": "uwsgi"}},
+            False,
+        ),
+        (
+            "uwsgi_autoscaled_prometheus",
+            {"autoscaling": {"metrics_provider": "uwsgi", "use_prometheus": True}},
+            True,
+        ),
+    ],
+)
+def test_should_create_uswgi_scaling_rule(
+    instance_name: str, instance_config: Dict[str, Any], expected: bool
+) -> None:
+    should_create, reason = should_create_uwsgi_scaling_rule(
+        instance=instance_name, instance_config=instance_config
+    )
+
+    assert should_create == expected
+    if expected:
+        assert reason is None
+    else:
+        assert reason is not None

--- a/tox.ini
+++ b/tox.ini
@@ -171,6 +171,7 @@ mypy_paths =
     tests/test_marathon_tools.py
     tests/test_setup_kubernetes_job.py
     tests/test_setup_marathon_job.py
+    tests/test_setup_prometheus_adapter_config.py
     tests/test_secret_tools.py
     tests/secret_providers/test_secret_providers.py
     tests/secret_providers/test_vault.py


### PR DESCRIPTION
It's probably easiest to review this commit by commit.

output from `python -m paasta_tools.setup_prometheus_adapter_config -c kubestage --dry-run --verbose`: https://fluffy.yelpcorp.com/i/Zp9G7XK51LtsZ8jrJZQ56bc1SQqZ10pP.html


**NOTE: this is using #3026 as a base to make it easier to break things up into multiple PRs - my plan is to merge the base PR and then merge this into master**