### PR TITLE
Released 0.97.64 via make release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+paasta-tools (0.97.64) xenial; urgency=medium
+
+  * 0.97.64 tagged with 'make release'
+    Commit: Merge pull request #3011 from Yelp/u/srojas/SEC-13906-pass-
+    session-token-to-spark-env  Pass AWS_SESSION_TOKEN During Spark
+    Environment Creation
+
+ -- Skyler Rojas <srojas@yelp.com>  Mon, 08 Feb 2021 14:38:33 -0800
+
 paasta-tools (0.97.63) xenial; urgency=medium
 
   * 0.97.63 tagged with 'make release'

--- a/paasta_tools/__init__.py
+++ b/paasta_tools/__init__.py
@@ -17,4 +17,4 @@
 # setup phase, the dependencies may not exist on disk yet.
 #
 # Don't bump version manually. See `make release` docs in ./Makefile
-__version__ = "0.97.63"
+__version__ = "0.97.64"

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Edit this release and run "make release"
-RELEASE=0.97.63
+RELEASE=0.97.64
 
 SHELL=/bin/bash
 


### PR DESCRIPTION
Version tag + bump via `make release`. Turns out bumping the version in `yelp_package/Makefile` and running `make release` was easy enough to follow