### PR TITLE
Stop returning non-zero when no rules are generated

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -375,7 +375,7 @@ def main() -> int:
 
     if not config["rules"]:
         log.error("Got empty rule configuration - refusing to continue.")
-        return 1
+        return 0
 
     kube_client = KubeClient()
     if not args.dry_run:


### PR DESCRIPTION
This is a fail-safe to stop us from deleting all rules, but this is
currently tripping up our alerting on clusters that don't have
Prometheus-enabled HPAs