### PR TITLE
PAASTA-17261-Paasta-Logs-Support-Tron-Instance-Names

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -1334,9 +1334,6 @@ def paasta_logs(args: argparse.Namespace) -> int:
         instances = None
     else:
         instances = args.instances.split(",")
-        # Check for instance inputs with suffixes (i.e. Flink instances)
-        instances_without_suffixes = [x.split(".")[0] for x in instances]
-        args.instances = ",".join(instances_without_suffixes)
 
         if verify_instances(args.instances, service, clusters):
             return 1

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -1071,8 +1071,8 @@ def verify_instances(
 
     # Check for instances with suffixes other than Tron instances (i.e. Flink instances)
     instances_without_suffixes = [x.split(".")[0] for x in unverified_instances]
-    misspelled_instances.clear()
-    misspelled_instances: Sequence[str] = [
+
+    misspelled_instances = [
         i for i in instances_without_suffixes if i not in service_instances
     ]
 

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -1066,6 +1066,16 @@ def verify_instances(
         i for i in unverified_instances if i not in service_instances
     ]
 
+    if len(misspelled_instances) == 0:
+        return misspelled_instances
+
+    # Check for instances with suffixes other than Tron instances (i.e. Flink instances)
+    instances_without_suffixes = [x.split(".")[0] for x in unverified_instances]
+    misspelled_instances.clear()
+    misspelled_instances: Sequence[str] = [
+        i for i in instances_without_suffixes if i not in service_instances
+    ]
+
     if misspelled_instances:
         suggestions: List[str] = []
         for instance in misspelled_instances:

--- a/tests/cli/test_cmds_logs.py
+++ b/tests/cli/test_cmds_logs.py
@@ -388,23 +388,6 @@ def test_extract_utc_timestamp_from_log_line_when_invalid_date_format():
     assert not logs.extract_utc_timestamp_from_log_line(line)
 
 
-def test_verify_instances_for_instances_with_suffixes():
-    with mock.patch(
-        "paasta_tools.cli.cmds.logs.verify_instances", autospec=True
-    ) as mock_verify_instances, mock.patch(
-        "paasta_tools.cli.cmds.logs.figure_out_service_name", autospec=True
-    ):
-        mock_args = mock.Mock(
-            service="fake_service",
-            clusters="fake_cluster1",
-            instances="fake_instance.container",
-        )
-
-        logs.paasta_logs(mock_args)
-
-        assert mock_verify_instances.call_args[0][0] == "fake_instance"
-
-
 def test_parse_marathon_log_line_fail():
     assert "" == logs.parse_marathon_log_line("fake timestamp", None, None)
 

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -473,3 +473,22 @@ def test_verify_instances_with_clusters(
             call("  west"),
         ]
     )
+
+
+@patch("paasta_tools.cli.utils.list_all_instances_for_service", autospec=True)
+def test_verify_instances_with_suffixes(mock_list_all_instances_for_service):
+    mock_list_all_instances_for_service.return_value = [
+        "fake_instance1",
+        "fake_instance2.jobname",
+    ]
+
+    assert (
+        verify_instances(
+            "fake_instance1.containername", "fake_service", ["fake_cluster"]
+        )
+        == []
+    )
+    assert (
+        verify_instances("fake_instance2.jobname", "fake_service", ["fake_cluster"])
+        == []
+    )


### PR DESCRIPTION
### Description
PAASTA-17231 validated instances with suffixes in a way where it only will validate the string before the suffix. This was a great fix for Flink instances for example.

`paasta logs -s stream_sql -i main.SUPERVISOR`

In this case, verify_instances will only validate `main`.

However, this fix excluded tron instance names which required the strings before and after the suffix to be validated. 

`paasta logs -s reminder -i compute-infrastructure-oncall-us.compute-infrastructure-oncall-us`

In this case, verify_instances will validate the entire string `compute-infrastructure-oncall-us.compute-infrastructure-oncall-us`.

This change allows for both instances with suffixes to be validated correctly.

### Tests
`make test` - PASSED