### PR TITLE
bump yelp-clog to 5.1.0

### DIFF
--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -15,7 +15,7 @@ smmap2==2.0.3
 sticht[yelp_internal]==1.1.12
 vault-tools==0.9.2
 yelp-cgeom==1.3.1
-yelp-clog==5.0.0
+yelp-clog==5.1.0
 yelp-logging==1.0.37
 yelp_meteorite
 yelp_paasta_helpers


### PR DESCRIPTION
new version is loading various logging dependencies lazily, which shaves some 600ms off loading time of various subcommands

```
before:
paasta list-clusters  1.06s user 0.14s system 98% cpu 1.219 total

after:
paasta list-clusters  0.45s user 0.14s system 97% cpu 0.607 total
```