### PR TITLE
MESH-1070 Cleanup readiness check settings

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2097,7 +2097,8 @@ class SystemPaastaConfig:
 
     def get_envoy_readiness_check_script(self) -> List[str]:
         return self.config_dict.get(
-            "envoy_readiness_check_script", ["/check_proxy_up.sh", "--enable-envoy"]
+            "envoy_readiness_check_script",
+            ["/check_proxy_up.sh", "--enable-envoy", "--envoy-check-mode", "eds-dir"],
         )
 
     def get_envoy_nerve_readiness_check_script(self) -> List[str]:
@@ -2405,10 +2406,7 @@ class SystemPaastaConfig:
 
     def get_hacheck_sidecar_image_url(self) -> str:
         """Get the docker image URL for the hacheck sidecar container"""
-        return self.config_dict.get(
-            "hacheck_sidecar_image_url",
-            "docker-paasta.yelpcorp.com:443/hacheck-k8s-sidecar",
-        )
+        return self.config_dict.get("hacheck_sidecar_image_url")
 
     def get_register_k8s_pods(self) -> bool:
         """Enable registration of k8s services in nerve"""

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -426,7 +426,16 @@ class TestKubernetesDeploymentConfig:
                 True,
                 ["/check_proxy_up.sh", "--enable-smartstack", "--enable-envoy"],
             ),
-            (True, False, ["/check_proxy_up.sh", "--enable-envoy"]),
+            (
+                True,
+                False,
+                [
+                    "/check_proxy_up.sh",
+                    "--enable-envoy",
+                    "--envoy-check-mode",
+                    "eds-dir",
+                ],
+            ),
             (False, True, ["/check_smartstack_up.sh"]),
         ],
     )

--- a/yelp_package/dockerfiles/hacheck-sidecar/Dockerfile
+++ b/yelp_package/dockerfiles/hacheck-sidecar/Dockerfile
@@ -3,7 +3,7 @@ FROM docker-dev.yelpcorp.com/xenial_yelp
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
 
-RUN apt-get update && apt-get install -y hacheck python paasta-tools
+RUN apt-get update && apt-get install -y hacheck python paasta-tools=0.97.72-yelp1
 RUN mkdir -p /etc/paasta
 ADD ./check_smartstack_up.sh /check_smartstack_up.sh
 ADD ./check_proxy_up.sh /check_proxy_up.sh

--- a/yelp_package/dockerfiles/hacheck-sidecar/Makefile
+++ b/yelp_package/dockerfiles/hacheck-sidecar/Makefile
@@ -1,7 +1,12 @@
-all: build push
+DOCKER_TAG_VERSION:=$(shell git rev-parse HEAD)
+DOCKER_HOST:=docker-paasta.yelpcorp.com:443
+DOCKER_IMG_NAME:=hacheck-k8s-sidecar
 
+
+.PHONY: build
 build:
-	docker build -t docker-paasta.yelpcorp.com:443/hacheck-k8s-sidecar .
+	docker build -t $(DOCKER_HOST)/$(DOCKER_IMG_NAME):$(DOCKER_TAG_VERSION) .
 
-push:
-	sudo -i bash -c 'docker push docker-paasta.yelpcorp.com:443/hacheck-k8s-sidecar'
+.PHONY: push
+push: build
+	sudo -i bash -c 'docker push $(DOCKER_HOST)/$(DOCKER_IMG_NAME):$(DOCKER_TAG_VERSION)'


### PR DESCRIPTION
Doing some housekeeping on the readiness check settings:
- pin paasta-tools on the hacheck sidecar image. The pinned version is the one that's currently installed on the latest hacheck image.
- hacheck Makefile now includes the latest commit SHA when tagging new images.
- remove the default for hacheck_sidecar_image_url as we rely on the value set on /etc/paasta. If /etc/paasta isn't setting any value, I'd rather have s_k_j failling than bouncing things with the wrong hacheck img.
- adjust the default value for envoy_readiness_check_script

This is a noop: envoy_readiness_check_script and hacheck_sidecar_image_url are managed through puppet at the moment.