### PR TITLE
Sort Prometheus rulesets for easier comparison

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -262,7 +262,7 @@ def create_prometheus_adapter_config(
             )
 
     return {
-        "rules": rules,
+        "rules": sorted(rules, key=lambda rule: rule["name"]["as"]),
     }
 
 

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -262,6 +262,10 @@ def create_prometheus_adapter_config(
             )
 
     return {
+        # we sort our rules so that we can easily compare between two different configmaps
+        # as otherwise we'd need to do fancy order-independent comparisons between the two
+        # sets of rules later due to the fact that we're not iterating in a deterministic
+        # way and can add rules in any arbitrary order
         "rules": sorted(rules, key=lambda rule: rule["name"]["as"]),
     }
 


### PR DESCRIPTION
Previously we were just doing strict dictionary equality, but this
breaks down when your values are lists and those lists aren't in the
same order.