### PR TITLE
Allow HPA scaledown policies to be overridden from soa configs

### DIFF
--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -41,6 +41,7 @@ class AutoscalingParamsDict(TypedDict, total=False):
     moving_average_window_seconds: Optional[int]
     use_prometheus: bool
     uwsgi_stats_port: int
+    scaledown_policies: Optional[dict]
 
 
 class LongRunningServiceConfigDict(InstanceConfigDict, total=False):


### PR DESCRIPTION
See PAASTA-17257

---

Because this is very Kubernetes-specific behavior, I've opted to try to expose the fields without modification (including leaving them camel cased).  I am also slightly worried that this is a bit brittle because we don't currently validate the autoscaling section of soa-configs, and it might be easy to get it wrong which could mess up setup_kubernetes_job...but I also don't expect this to be commonly-used behavior and we need it now so I kind of vote we just do it?