### PR TITLE
Add --volume parameter to local-run. PAASTA-1262, PAASTA-16089

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -466,6 +466,17 @@ def add_subparser(subparsers):
         required=False,
         default=None,
     )
+    list_parser.add_argument(
+        "--volume",
+        dest="volumes",
+        action="append",
+        type=str,
+        default=[],
+        required=False,
+        help=(
+            "Same as the -v / --volume parameter to docker run: hostPath:containerPath[:mode]"
+        ),
+    )
 
     list_parser.set_defaults(command=paasta_local_run)
 
@@ -873,7 +884,7 @@ def configure_and_run_docker_container(
         return 1
 
     soa_dir = args.yelpsoa_config_root
-    volumes = list()
+    volumes = args.volumes
     load_deployments = (docker_url is None or pull_image) and not docker_sha
     interactive = args.interactive
 

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -383,6 +383,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
     args.vault_auth_method = "ldap"
     args.vault_token_file = "/blah/token"
     args.skip_secrets = False
+    args.volumes = []
 
     mock_secret_provider_kwargs = {
         "vault_cluster_config": {},
@@ -450,6 +451,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
     args.vault_auth_method = "ldap"
     args.vault_token_file = "/blah/token"
     args.skip_secrets = False
+    args.volumes = []
 
     return_code = configure_and_run_docker_container(
         docker_client=mock_docker_client,
@@ -522,6 +524,7 @@ def test_configure_and_run_pulls_image_when_asked(
     args.vault_auth_method = "ldap"
     args.vault_token_file = "/blah/token"
     args.skip_secrets = False
+    args.volumes = []
 
     return_code = configure_and_run_docker_container(
         docker_client=mock_docker_client,
@@ -592,6 +595,7 @@ def test_configure_and_run_docker_container_defaults_to_interactive_instance(
         args.vault_auth_method = "ldap"
         args.vault_token_file = "/blah/token"
         args.skip_secrets = False
+        args.volumes = []
 
         mock_config = mock.create_autospec(AdhocJobConfig)
         mock_get_default_interactive_config.return_value = mock_config
@@ -1890,7 +1894,7 @@ def test_volumes_are_deduped(mock_exists):
                 },
                 "/etc/paasta",
             ),
-            args=mock.Mock(yelpsoa_config_root="/blurp/durp"),
+            args=mock.Mock(yelpsoa_config_root="/blurp/durp", volumes=[]),
         )
         args, kwargs = mock_run_docker_container.call_args
         assert kwargs["volumes"] == ["/hostPath:/containerPath:ro"]
@@ -1945,7 +1949,7 @@ def test_missing_volumes_skipped(mock_exists):
                 },
                 "/etc/paasta",
             ),
-            args=mock.Mock(yelpsoa_config_root="/blurp/durp"),
+            args=mock.Mock(yelpsoa_config_root="/blurp/durp", volumes=[]),
         )
         args, kwargs = mock_run_docker_container.call_args
         assert kwargs["volumes"] == []


### PR DESCRIPTION
We suggest people use `paasta local-run` for ad-hoc batch jobs, but currently there's no way to add arbitrary volume mounts. This means our best advice for users who want to pass an input file to a batch job is to make a yelpsoa-configs change with an `extra_volumes` entry, which is pretty clunky.

This change adds a `--volume` parameter. (Note that `-v` already exists and means verbose.)