### PR TITLE
Implement CPU-based moving average window autoscaling

### DIFF
--- a/paasta_tools/autoscaling/forecasting.py
+++ b/paasta_tools/autoscaling/forecasting.py
@@ -1,7 +1,7 @@
 from paasta_tools.autoscaling.utils import get_autoscaling_component
 from paasta_tools.autoscaling.utils import register_autoscaling_component
 from paasta_tools.long_running_service_tools import (
-    DEFAULT_AUTOSCALING_MOVING_AVERAGE_WINDOW,
+    DEFAULT_UWSGI_AUTOSCALING_MOVING_AVERAGE_WINDOW,
 )
 
 
@@ -43,7 +43,7 @@ def trailing_window_historical_load(historical_load, window_size):
 @register_autoscaling_component("moving_average", FORECAST_POLICY_KEY)
 def moving_average_forecast_policy(
     historical_load,
-    moving_average_window_seconds=DEFAULT_AUTOSCALING_MOVING_AVERAGE_WINDOW,
+    moving_average_window_seconds=DEFAULT_UWSGI_AUTOSCALING_MOVING_AVERAGE_WINDOW,
     **kwargs,
 ):
     """Does a simple average of all historical load data points within the moving average window. Weights all data

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -112,6 +112,9 @@ from mypy_extensions import TypedDict
 
 from paasta_tools.async_utils import async_timeout
 from paasta_tools.long_running_service_tools import AutoscalingParamsDict
+from paasta_tools.long_running_service_tools import (
+    DEFAULT_UWSGI_AUTOSCALING_MOVING_AVERAGE_WINDOW,
+)
 from paasta_tools.long_running_service_tools import host_passes_blacklist
 from paasta_tools.long_running_service_tools import host_passes_whitelist
 from paasta_tools.long_running_service_tools import InvalidHealthcheckMode
@@ -603,9 +606,10 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             signalflow = legacy_autoscaling_signalflow.format(
                 setpoint=target,
                 offset=autoscaling_params.get("offset", 0),
-                moving_average_window_seconds=autoscaling_params[
-                    "moving_average_window_seconds"
-                ],
+                moving_average_window_seconds=autoscaling_params.get(
+                    "moving_average_window_seconds",
+                    DEFAULT_UWSGI_AUTOSCALING_MOVING_AVERAGE_WINDOW,
+                ),
                 paasta_service=self.get_service(),
                 paasta_instance=self.get_instance(),
                 paasta_cluster=self.get_cluster(),

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -29,7 +29,11 @@ ZK_PAUSE_AUTOSCALE_PATH = "/autoscaling/paused"
 DEFAULT_CONTAINER_PORT = 8888
 
 DEFAULT_AUTOSCALING_SETPOINT = 0.8
-DEFAULT_AUTOSCALING_MOVING_AVERAGE_WINDOW = 1800
+DEFAULT_UWSGI_AUTOSCALING_MOVING_AVERAGE_WINDOW = 1800
+# we set a different default moving average window so that we can reuse our existing PromQL
+# without having to write a different query for existing users that want to autoscale on
+# instantaneous CPU
+DEFAULT_CPU_AUTOSCALING_MOVING_AVERAGE_WINDOW = 60
 
 
 class AutoscalingParamsDict(TypedDict, total=False):
@@ -335,7 +339,6 @@ class LongRunningServiceConfig(InstanceConfig):
             "metrics_provider": "mesos_cpu",
             "decision_policy": "proportional",
             "setpoint": DEFAULT_AUTOSCALING_SETPOINT,
-            "moving_average_window_seconds": DEFAULT_AUTOSCALING_MOVING_AVERAGE_WINDOW,
         }
         return deep_merge_dictionaries(
             overrides=self.config_dict.get("autoscaling", AutoscalingParamsDict({})),

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -292,9 +292,9 @@ def create_instance_cpu_scaling_rule(
         avg(
             irate(
                 container_cpu_usage_seconds_total{{
-                    namespace="paasta",
-                    container="{sanitized_instance_name}",
-                    paasta_cluster="{paasta_cluster}"
+                    namespace='paasta',
+                    container='{sanitized_instance_name}',
+                    paasta_cluster='{paasta_cluster}'
                 }}[1m]
             )
         ) by (pod, container)
@@ -303,13 +303,13 @@ def create_instance_cpu_scaling_rule(
     cpus_available = f"""
         sum(
             container_spec_cpu_quota{{
-                namespace="paasta",
-                container="{sanitized_instance_name}",
-                paasta_cluster="{paasta_cluster}"
+                namespace='paasta',
+                container='{sanitized_instance_name}',
+                paasta_cluster='{paasta_cluster}'
             }}
             / container_spec_cpu_period{{
-                namespace="paasta",
-                paasta_cluster="{paasta_cluster}"
+                namespace='paasta',
+                paasta_cluster='{paasta_cluster}'
             }}
         ) by (pod, container)
     """
@@ -321,10 +321,10 @@ def create_instance_cpu_scaling_rule(
     # {{deployment}}-{{10 character hex string}}) so that our query only considers the
     # service that we want to autoscale - without this we're only filtering by instance
     # name and these are very much not unique
+    # k8s:pod:info is an internal recording rule that joins kube_pod_info with
+    # kube_pod_status_phase
     pod_info_join = f"""
         on (pod) group_left(kube_deployment) label_replace(
-            # k8s:pod:info is an internal recording rule that joins kube_pod_info with
-            # kube_pod_status_phase
             k8s:pod:info{{
                 created_by_name=~'{deployment_name}.*',
                 created_by_kind='ReplicaSet',

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -326,16 +326,16 @@ def create_instance_cpu_scaling_rule(
             # k8s:pod:info is an internal recording rule that joins kube_pod_info with
             # kube_pod_status_phase
             k8s:pod:info{{
-                created_by_name=~"{deployment_name}.*",
-                created_by_kind="ReplicaSet",
-                namespace="paasta",
-                paasta_cluster="{paasta_cluster}",
-                phase="Running"
+                created_by_name=~'{deployment_name}.*',
+                created_by_kind='ReplicaSet',
+                namespace='paasta',
+                paasta_cluster='{paasta_cluster}',
+                phase='Running'
             }},
-            "kube_deployment",
-            "$1",
-            "created_by_name",
-            "(.+)-[a-f0-9]{{10}}"
+            'kube_deployment',
+            '$1',
+            'created_by_name',
+            '(.+)-[a-f0-9]{{10}}'
         )
     """
 

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -265,7 +265,6 @@ def create_instance_cpu_scaling_rule(
     """
     Creates a Prometheus adapter rule config for a given service instance.
     """
-    metrics_query = f""""""
     deployment_name = get_kubernetes_app_name(service=service, instance=instance)
     sanitized_instance_name = sanitise_kubernetes_name(instance)
     metric_name = f"{deployment_name}-cpu-prom"

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -39,6 +39,12 @@ from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
 from paasta_tools.kubernetes_tools import V1Pod
 from paasta_tools.long_running_service_tools import AutoscalingParamsDict
+from paasta_tools.long_running_service_tools import (
+    DEFAULT_CPU_AUTOSCALING_MOVING_AVERAGE_WINDOW,
+)
+from paasta_tools.long_running_service_tools import (
+    DEFAULT_UWSGI_AUTOSCALING_MOVING_AVERAGE_WINDOW,
+)
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_services_for_cluster
@@ -194,7 +200,9 @@ def create_instance_uwsgi_scaling_rule(
     Creates a Prometheus adapter rule config for a given service instance.
     """
     setpoint = autoscaling_config["setpoint"]
-    moving_average_window = autoscaling_config["moving_average_window_seconds"]
+    moving_average_window = autoscaling_config.get(
+        "moving_average_window_seconds", DEFAULT_UWSGI_AUTOSCALING_MOVING_AVERAGE_WINDOW
+    )
     # this should always be set, but we default to 0 for safety as the worst thing that would happen
     # is that we take a couple more iterations than required to hit the desired setpoint
     offset = autoscaling_config.get("offset", 0)
@@ -261,7 +269,9 @@ def create_instance_cpu_scaling_rule(
     deployment_name = get_kubernetes_app_name(service=service, instance=instance)
     sanitized_instance_name = sanitise_kubernetes_name(instance)
     metric_name = f"{deployment_name}-cpu-prom"
-    moving_average_window = autoscaling_config["moving_average_window_seconds"]
+    moving_average_window = autoscaling_config.get(
+        "moving_average_window_seconds", DEFAULT_CPU_AUTOSCALING_MOVING_AVERAGE_WINDOW
+    )
     # this series query is a bit of a hack: we don't use the Prometheus adapter as expected (i.e., very generic rules)
     # but we still need to give it a query that returns something even though we're not going to use the series/label
     # templates that are auto-extracted for us. That said: we still need this query to return labels that can be tied

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -126,7 +126,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def should_create_uwsgi_scaling_rule(
-    instance: str, autoscaling_config: AutoscalingParamsDict,
+    autoscaling_config: AutoscalingParamsDict,
 ) -> Tuple[bool, Optional[str]]:
     """
     Determines whether we should configure the prometheus adapter for a given service.
@@ -205,7 +205,7 @@ def get_rules_for_service_instance(
     rules: List[PrometheusAdapterRule] = []
 
     should_create_uwsgi, skip_uwsgi_reason = should_create_uwsgi_scaling_rule(
-        instance=instance_name, autoscaling_config=autoscaling_config,
+        autoscaling_config=autoscaling_config,
     )
     if should_create_uwsgi:
         rules.append(

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -11,10 +11,9 @@ from paasta_tools.setup_prometheus_adapter_config import (
 
 
 @pytest.mark.parametrize(
-    "instance_name,autoscaling_config,expected",
+    "autoscaling_config,expected",
     [
         (
-            "not_uwsgi_autoscaled",
             {
                 "metrics_provider": "mesos_cpu",
                 "decision_policy": "bespoke",
@@ -24,7 +23,6 @@ from paasta_tools.setup_prometheus_adapter_config import (
             False,
         ),
         (
-            "uwsgi_autoscaled_no_prometheus",
             {
                 "metrics_provider": "uwsgi",
                 "moving_average_window_seconds": 124,
@@ -33,7 +31,6 @@ from paasta_tools.setup_prometheus_adapter_config import (
             False,
         ),
         (
-            "uwsgi_autoscaled_prometheus",
             {
                 "metrics_provider": "uwsgi",
                 "use_prometheus": True,
@@ -45,10 +42,10 @@ from paasta_tools.setup_prometheus_adapter_config import (
     ],
 )
 def test_should_create_uswgi_scaling_rule(
-    instance_name: str, autoscaling_config: AutoscalingParamsDict, expected: bool
+    autoscaling_config: AutoscalingParamsDict, expected: bool
 ) -> None:
     should_create, reason = should_create_uwsgi_scaling_rule(
-        instance=instance_name, autoscaling_config=autoscaling_config
+        autoscaling_config=autoscaling_config
     )
 
     assert should_create == expected

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -2,9 +2,13 @@ import pytest
 
 from paasta_tools.long_running_service_tools import AutoscalingParamsDict
 from paasta_tools.setup_prometheus_adapter_config import (
+    create_instance_cpu_scaling_rule,
+)
+from paasta_tools.setup_prometheus_adapter_config import (
     create_instance_uwsgi_scaling_rule,
 )
 from paasta_tools.setup_prometheus_adapter_config import get_rules_for_service_instance
+from paasta_tools.setup_prometheus_adapter_config import should_create_cpu_scaling_rule
 from paasta_tools.setup_prometheus_adapter_config import (
     should_create_uwsgi_scaling_rule,
 )
@@ -88,6 +92,101 @@ def test_create_instance_uwsgi_scaling_rule() -> None:
 
 
 @pytest.mark.parametrize(
+    "autoscaling_config,expected",
+    [
+        (
+            {
+                "metrics_provider": "mesos_cpu",
+                "use_prometheus": True,
+                "moving_average_window_seconds": 123,
+                "setpoint": 0.653,
+            },
+            True,
+        ),
+        (
+            {
+                "metrics_provider": "cpu",
+                "use_prometheus": True,
+                "moving_average_window_seconds": 123,
+                "setpoint": 0.653,
+            },
+            True,
+        ),
+        (
+            {
+                "metrics_provider": "mesos_cpu",
+                "moving_average_window_seconds": 123,
+                "setpoint": 0.653,
+            },
+            False,
+        ),
+        (
+            {
+                "metrics_provider": "cpu",
+                "moving_average_window_seconds": 123,
+                "setpoint": 0.653,
+            },
+            False,
+        ),
+        (
+            {
+                "metrics_provider": "uwsgi",
+                "moving_average_window_seconds": 124,
+                "setpoint": 0.425,
+            },
+            False,
+        ),
+        (
+            {
+                "metrics_provider": "uwsgi",
+                "use_prometheus": True,
+                "moving_average_window_seconds": 544,
+                "setpoint": 0.764,
+            },
+            False,
+        ),
+    ],
+)
+def test_should_create_cpu_scaling_rule(
+    autoscaling_config: AutoscalingParamsDict, expected: bool
+) -> None:
+    should_create, reason = should_create_cpu_scaling_rule(
+        autoscaling_config=autoscaling_config
+    )
+
+    assert should_create == expected
+    if expected:
+        assert reason is None
+    else:
+        assert reason is not None
+
+
+def test_create_instance_cpu_scaling_rule() -> None:
+    service_name = "test_service"
+    instance_name = "test_instance"
+    paasta_cluster = "test_cluster"
+    autoscaling_config: AutoscalingParamsDict = {
+        "metrics_provider": "cpu",
+        "setpoint": 0.1234567890,
+        "moving_average_window_seconds": 20120302,
+        "use_prometheus": True,
+    }
+
+    rule = create_instance_cpu_scaling_rule(
+        service=service_name,
+        instance=instance_name,
+        paasta_cluster=paasta_cluster,
+        autoscaling_config=autoscaling_config,
+    )
+
+    # our query doesn't include the setpoint as we'll just give the HPA the current CPU usage and
+    # let the HPA compare that to the setpoint directly
+    assert (
+        str(autoscaling_config["moving_average_window_seconds"]) in rule["metricsQuery"]
+    )
+
+
+@pytest.mark.parametrize(
     "autoscaling_config,expected_rules",
     [
         (
@@ -115,7 +214,25 @@ def test_create_instance_uwsgi_scaling_rule() -> None:
                 "moving_average_window_seconds": 20120302,
                 "use_prometheus": True,
             },
+            1,
+        ),
+        (
+            {
+                "metrics_provider": "cpu",
+                "setpoint": 0.1234567890,
+                "moving_average_window_seconds": 20120302,
+                "use_prometheus": False,
+            },
             0,
+        ),
+        (
+            {
+                "metrics_provider": "cpu",
+                "setpoint": 0.1234567890,
+                "moving_average_window_seconds": 20120302,
+                "use_prometheus": True,
+            },
+            1,
         ),
         (
             {


### PR DESCRIPTION
This additionally allows us to use `cpu` as a metrics provider instead of continuing to propagate `mesos_cpu` when we're not using Mesos anymore.

NOTE: we'll still continue to use the built-in CPU scaling that k8s provides for safety.