### PR TITLE
Make HPAMetricsParser.parse_current return None when type is an empty…

### DIFF
--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -138,7 +138,8 @@ def autoscaling_status(
     if hpa.status.current_metrics is not None:
         for metric_spec in hpa.status.current_metrics:
             parsed = parser.parse_current(metric_spec)
-            metrics_by_name[parsed["name"]].update(parsed)
+            if parsed is not None:
+                metrics_by_name[parsed["name"]].update(parsed)
 
     metric_stats = list(metrics_by_name.values())
 

--- a/tests/instance/test_hpa_metrics_parser.py
+++ b/tests/instance/test_hpa_metrics_parser.py
@@ -162,3 +162,10 @@ def test_parse_current_object_metric(parser):
     status = parser.parse_current(metric_status)
     assert status["name"] == "some-metric"
     assert status["current_value"] == "0.1"
+
+
+def test_parse_current_empty_string_metric(parser):
+    metric_status = V2beta2MetricStatus(type="",)
+
+    status = parser.parse_current(metric_status)
+    assert status is None


### PR DESCRIPTION
… string. PAASTA-17298

This makes paasta status happy with no client-side changes (the client already handles when the current metrics are missing from the response); the HPA section looks like:

```       Metrics:
         Metric                               Current  Target
         example--happyhour-envoy-uwsgi-prom  N/A      1
         example--happyhour-envoy-uwsgi       8m       1
```
