### PR TITLE
Use discover: habitat and advertise: [habitat, region] in fsm for smartstack

### DIFF
--- a/paasta_tools/cli/fsm/template/{{cookiecutter.service}}/smartstack.yaml
+++ b/paasta_tools/cli/fsm/template/{{cookiecutter.service}}/smartstack.yaml
@@ -2,3 +2,5 @@
 # See y/smartstack-config
 main:
   proxy_port: {{cookiecutter.proxy_port}}
+  advertise: [habitat, region]
+  discover: habitat


### PR DESCRIPTION
Make the default smartstack.yaml for new services use discover: habitat and advertise: [habitat, region] so new services take advantage of az aware routing