### PR TITLE
Don't print bytes objects when tailing local-run container stdout/stderr

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -829,7 +829,11 @@ def run_docker_container(
             for line in docker_client.attach(
                 container_id, stderr=True, stream=True, logs=True
             ):
-                print(line, flush=True)
+                # writing to sys.stdout.buffer lets us write the raw bytes we
+                # get from the docker client without having to convert them to
+                # a utf-8 string
+                sys.stdout.buffer.write(line)
+                sys.stdout.flush()
         else:
             _output_exit_code()
             returncode = 3


### PR DESCRIPTION
I think this probably has been messed up since the transition to python3?

See PAASTA-17039

---

I tested that this works with a local-run.  The `end=""` is needed so that we don't add extra newlines since the stdout/err already has newlines (I figure this is slightly better than `.strip()`?)