### PR TITLE
For services not in the mesh, set a readiness check that is the same …

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1089,6 +1089,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             ),
             name=self.get_sanitised_instance_name(),
             liveness_probe=self.get_liveness_probe(service_namespace_config),
+            readiness_probe=self.get_readiness_probe(service_namespace_config),
             ports=[V1ContainerPort(container_port=port) for port in ports],
             security_context=self.get_security_context(),
             volume_mounts=self.get_volume_mounts(
@@ -1104,6 +1105,14 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             hacheck_sidecar_volumes=hacheck_sidecar_volumes,
         )
         return containers
+
+    def get_readiness_probe(
+        self, service_namespace_config: ServiceNamespaceConfig
+    ) -> Optional[V1Probe]:
+        if service_namespace_config.is_in_smartstack():
+            return None
+        else:
+            return self.get_liveness_probe(service_namespace_config)
 
     def get_kubernetes_container_termination_action(self) -> V1Handler:
         command = self.config_dict.get("lifecycle", KubeLifecycleDict({})).get(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -917,6 +917,7 @@ class TestKubernetesDeploymentConfig:
                         period_seconds=10,
                         timeout_seconds=10,
                     ),
+                    readiness_probe=None,
                     name="fm",
                     ports=ports,
                     volume_mounts=mock_get_volume_mounts.return_value,
@@ -1017,6 +1018,21 @@ class TestKubernetesDeploymentConfig:
             self.deployment.get_liveness_probe(service_namespace_config)
             == liveness_probe
         )
+
+    def test_get_readiness_probe_in_mesh(self):
+        service_namespace_config = mock.Mock()
+        service_namespace_config.is_in_smartstack.return_value = True
+        assert self.deployment.get_readiness_probe(service_namespace_config) is None
+
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_liveness_probe",
+        autospec=True,
+    )
+    def test_get_readiness_probe_not_in_mesh(self, mock_get_liveness_probe):
+        service_namespace_config = mock.Mock()
+        service_namespace_config.is_in_smartstack.return_value = False
+        readiness_probe = self.deployment.get_readiness_probe(service_namespace_config)
+        assert readiness_probe == mock_get_liveness_probe.return_value
 
     def test_get_security_context_without_cap_add(self):
         expected_security_context = V1SecurityContext(


### PR DESCRIPTION
…as their liveness check (which is configured by settings in soa configs)

Without this, services not in the mesh that set a healthcheck might get restarted for failing their liveness check, but Kubernetes will think they are ready for the purposes of bouncing.  This also means that we won't send replication alerts to the owning team.

See PAASTA-17303

---

I probably want to test this on kubestage before deploying it.