### PR TITLE
PAASTA-17227 - Bump Sticht Version to Resolve Key Errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -99,7 +99,7 @@ simplejson==3.10.0
 six==1.11.0
 slackclient==1.2.1
 sseclient-py==1.7
-sticht==1.1.12
+sticht==1.1.13
 strict-rfc3339==0.7
 swagger-spec-validator==2.1.0
 syslogmp==0.2.2


### PR DESCRIPTION
### Description
Bumping the Paasta's version of Sticht to v1.1.13 to add fix to the Key Errors involving slo watchers.

### Test
`make test` - PASSED