### PR TITLE
Make paasta validate check that service mesh registrations are decomp…

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -816,16 +816,15 @@ class InstanceConfig:
                 'Your service config specifies "%s", an unsupported parameter.' % param,
             )
 
-    def validate(
-        self,
-        params: List[str] = [
-            "cpus",
-            "mem",
-            "security",
-            "dependencies_reference",
-            "deploy_group",
-        ],
-    ) -> List[str]:
+    def validate(self, params: Optional[List[str]] = None,) -> List[str]:
+        if params is None:
+            params = [
+                "cpus",
+                "mem",
+                "security",
+                "dependencies_reference",
+                "deploy_group",
+            ]
         error_msgs = []
         for param in params:
             check_passed, check_msg = self.check(param)

--- a/tests/test_long_running_service_tools.py
+++ b/tests/test_long_running_service_tools.py
@@ -262,6 +262,20 @@ class TestLongRunningServiceConfig:
         )
         assert fake_conf.get_instances() == 0
 
+    def test_validate_with_bad_registration(self):
+        fake_conf = long_running_service_tools.LongRunningServiceConfig(
+            service="fake_name",
+            cluster="fake_cluster",
+            instance="fake_instance",
+            config_dict={
+                "registrations": ["fake_name.fake_instance", "bad_registration"],
+                "deploy_group": None,
+            },
+            branch_dict=None,
+        )
+        error_messages = fake_conf.validate()
+        assert "bad_registration" in error_messages[0]
+
 
 class TestServiceNamespaceConfig:
     def test_get_mode_default(self):


### PR DESCRIPTION
…osable via decompose_job_id

See PAASTA-17314

---

Wasn't sure if we still needed warning logging in `get_registrations` (since validate should hopefully catch most of this and it obviously didn't help stop the issue I saw yesterday), but I figured why not.