### PR TITLE
Add support for min and max instances in autotuned_defaults

### DIFF
--- a/paasta_tools/cli/schemas/autotuned_defaults/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/autotuned_defaults/kubernetes_schema.json
@@ -30,6 +30,16 @@
                     "minimum": 32,
                     "exclusiveMinimum": true
                 },
+                "min_instances": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": false
+                },
+                "max_instances": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": false
+                },
                 "sidecar_resource_requirements": {
                     "type": "object",
                     "additionalProperties": false,

--- a/paasta_tools/cli/schemas/autotuned_defaults/marathon_schema.json
+++ b/paasta_tools/cli/schemas/autotuned_defaults/marathon_schema.json
@@ -25,6 +25,16 @@
                     "minimum": 128,
                     "exclusiveMinimum": true
                 },
+               "min_instances": {
+                   "type": "integer",
+                   "minimum": 0,
+                   "exclusiveMinimum": false
+               },
+               "max_instances": {
+                   "type": "integer",
+                   "minimum": 0,
+                   "exclusiveMinimum": false
+               },
                 "mem": {
                     "type": "number",
                     "minimum": 32,

--- a/paasta_tools/cli/schemas/autotuned_defaults/marathon_schema.json
+++ b/paasta_tools/cli/schemas/autotuned_defaults/marathon_schema.json
@@ -25,16 +25,16 @@
                     "minimum": 128,
                     "exclusiveMinimum": true
                 },
-               "min_instances": {
-                   "type": "integer",
-                   "minimum": 0,
-                   "exclusiveMinimum": false
-               },
-               "max_instances": {
-                   "type": "integer",
-                   "minimum": 0,
-                   "exclusiveMinimum": false
-               },
+                "min_instances": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": false
+                },
+                "max_instances": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": false
+                },
                 "mem": {
                     "type": "number",
                     "minimum": 32,

--- a/paasta_tools/contrib/paasta_update_soa_memcpu.py
+++ b/paasta_tools/contrib/paasta_update_soa_memcpu.py
@@ -139,12 +139,13 @@ def get_report_from_splunk(creds, app, filename, criteria_filter):
     estimated_monthly_savings (Optional)
     search_time (Unix time)
     one of the following pairs:
-    - current_cpus
-    suggested_cpus
-    - current_mem
-    suggested_mem
-    - current_disk
-    suggested_disk
+    - current_cpus and suggested_cpus
+    - current_mem and suggested_mem
+    - current_disk and suggested_disk
+    - suggested_hacheck_cpus
+    - suggested_cpu_burst_add
+    - suggested_min_instances
+    - suggested_max_instances
     """
     url = f"https://splunk-api.yelpcorp.com/servicesNS/nobody/{app}/search/jobs/export"
     search = (
@@ -178,6 +179,8 @@ def get_report_from_splunk(creds, app, filename, criteria_filter):
         serv["old_mem"] = d["result"].get("current_mem")
         serv["disk"] = d["result"].get("suggested_disk")
         serv["old_disk"] = d["result"].get("current_disk")
+        serv["min_instances"] = d["result"].get("suggested_min_instances")
+        serv["max_instances"] = d["result"].get("suggested_max_instances")
         serv["hacheck_cpus"] = d["result"].get("suggested_hacheck_cpus")
         serv["cpu_burst_add"] = d["result"].get("suggested_cpu_burst_add")
         services_to_update[criteria] = serv

--- a/paasta_tools/contrib/rightsizer_soaconfigs_update.py
+++ b/paasta_tools/contrib/rightsizer_soaconfigs_update.py
@@ -9,7 +9,7 @@ from paasta_tools.utils import format_git_url
 from paasta_tools.utils import load_system_paasta_config
 
 NULL = "null"
-SUPPORTED_CSV_KEYS = ("cpus", "mem", "disk", "hacheck_cpus", "cpu_burst_add")
+SUPPORTED_CSV_KEYS = ("cpus", "mem", "disk", "hacheck_cpus", "cpu_burst_add", "min_instances", "max_instances")
 
 
 def parse_args():
@@ -120,6 +120,10 @@ def get_recommendation_from_result(result, keys_to_apply):
             rec["mem"] = max(128, round(float(val)))
         elif key == "disk":
             rec["disk"] = max(128, round(float(val)))
+        elif key == "min_instances":
+            rec["min_instances"] = int(val)
+        elif key == "max_instances":
+            rec["max_instances"] = int(val)
         elif key == "hacheck_cpus":
             hacheck_cpus_value = max(0.1, min(float(val), 1))
             rec["sidecar_resource_requirements"] = {

--- a/paasta_tools/contrib/rightsizer_soaconfigs_update.py
+++ b/paasta_tools/contrib/rightsizer_soaconfigs_update.py
@@ -9,7 +9,15 @@ from paasta_tools.utils import format_git_url
 from paasta_tools.utils import load_system_paasta_config
 
 NULL = "null"
-SUPPORTED_CSV_KEYS = ("cpus", "mem", "disk", "hacheck_cpus", "cpu_burst_add", "min_instances", "max_instances")
+SUPPORTED_CSV_KEYS = (
+    "cpus",
+    "mem",
+    "disk",
+    "hacheck_cpus",
+    "cpu_burst_add",
+    "min_instances",
+    "max_instances",
+)
 
 
 def parse_args():

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -101,6 +101,8 @@ def test_validate_auto_config_file_unknown_type(mock_validate, tmpdir):
         ({"instance": {"cpus": 1.2, "mem": 100, "disk": "very big"}}, False),
         ({"instance": {"cpus": 1.2, "mem": 100, "disk": 0}}, False),
         ({"instance": {"cpus": 1.2, "mem": 100, "disk": 1000}}, True),
+        ({"instance": {"min_instances": 1.2}}, False),
+        ({"instance": {"min_instances": 1}}, True),
     ],
 )
 def test_validate_auto_config_file_e2e(data, is_valid, tmpdir):


### PR DESCRIPTION
Just appending to already autotunable resources. At some point I would love to refactor this a bit and maybe delete old cruft in paasta_update_soa_memcpu.py but it's not really an emergency for now.