### PR TITLE
Build and upload deb for focal

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ yproperties() // Sets releng approved global properties (SCM polling, build log 
 CHANNELS = ['paasta']
 GIT_SERVER = 'git@github.com'
 PACKAGE_NAME = 'mirrors/Yelp/paasta'
-DIST = ['xenial', 'bionic']
+DIST = ['xenial', 'bionic', 'focal']
 
 commit = ''
 


### PR DESCRIPTION
I want to start building focal packages for py-gitolite, but it depends on paasta-tools.

Debs are already built in github actions (https://github.com/Yelp/paasta/blob/master/.github/workflows/ci.yml#L42), so I just need to update the jenkins job to build + upload them.

# Verification
`make itest_focal` succeeds