### PR TITLE
Make prometheus uwsgi query use k8s:deployment:pods_status_ready inst…

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -232,6 +232,18 @@ def create_instance_uwsgi_scaling_rule(
             )
         ) by (kube_deployment)
     """
+    # k8s:deployment:pods_status_ready is a metric created by summing kube_pod_status_ready
+    # over paasta service/instance/cluster. it counts the number of ready pods in a paasta
+    # deployment.
+    ready_pods = f"""
+        (
+            k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
+            or
+            max_over_time(
+                k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
+            )
+        )
+    """
     load_per_instance = f"""
         avg(
             uwsgi_worker_busy{{{worker_filter_terms}}}
@@ -239,7 +251,7 @@ def create_instance_uwsgi_scaling_rule(
     """
     missing_instances = f"""
         clamp_min(
-            {current_replicas} - count({load_per_instance}) by (kube_deployment),
+            {ready_pods} - count({load_per_instance}) by (kube_deployment),
             0
         )
     """


### PR DESCRIPTION
…ead of kube_spec_deployment_replicas

## Description
`kube_deployment_spec_replicas` isn't good as a fallback metric because it doesn't actually measure responsive instances actually running in the cluster; instead it is what the current replicas should be. I'm replacing it with `k8s:deployment:pods_status_ready`, which sums `kube_pods_status_ready`, which is more accurate.

## Testing
We're already using it in our signalflow override and it's been shown to help.
I've also tested the final uwsgi query in prometheus and it works fine