### PR TITLE
Shorten replication alert output, and add tip + runbook, and add OOM alert tip

### DIFF
--- a/paasta_tools/check_flink_services_health.py
+++ b/paasta_tools/check_flink_services_health.py
@@ -129,6 +129,7 @@ def check_flink_service_health(
     instance_config: FlinkDeploymentConfig,
     all_tasks_or_pods: Sequence[V1Pod],
     replication_checker: KubeSmartstackEnvoyReplicationChecker,
+    dry_run: bool = False,
 ) -> None:
     si_pods = filter_pods_by_service_instance(
         pod_list=all_tasks_or_pods,
@@ -177,7 +178,7 @@ def check_flink_service_health(
         log.info(output)
         status = pysensu_yelp.Status.OK
     send_replication_event(
-        instance_config=instance_config, status=status, output=output
+        instance_config=instance_config, status=status, output=output, dry_run=dry_run,
     )
 
 

--- a/paasta_tools/check_kubernetes_services_replication.py
+++ b/paasta_tools/check_kubernetes_services_replication.py
@@ -53,6 +53,7 @@ def check_healthy_kubernetes_tasks_for_service_instance(
     instance_config: KubernetesDeploymentConfig,
     expected_count: int,
     all_pods: Sequence[V1Pod],
+    dry_run: bool = False,
 ) -> None:
     si_pods = filter_pods_by_service_instance(
         pod_list=all_pods,
@@ -67,6 +68,7 @@ def check_healthy_kubernetes_tasks_for_service_instance(
         instance_config=instance_config,
         expected_count=expected_count,
         num_available=num_healthy_tasks,
+        dry_run=dry_run,
     )
 
 
@@ -74,6 +76,7 @@ def check_kubernetes_pod_replication(
     instance_config: KubernetesDeploymentConfig,
     all_tasks_or_pods: Sequence[V1Pod],
     replication_checker: KubeSmartstackEnvoyReplicationChecker,
+    dry_run: bool = False,
 ) -> Optional[bool]:
     """Checks a service's replication levels based on how the service's replication
     should be monitored. (smartstack/envoy or k8s)
@@ -112,6 +115,7 @@ def check_kubernetes_pod_replication(
             instance_config=instance_config,
             expected_count=expected_count,
             replication_checker=replication_checker,
+            dry_run=dry_run,
         )
         return is_well_replicated
     else:
@@ -119,6 +123,7 @@ def check_kubernetes_pod_replication(
             instance_config=instance_config,
             expected_count=expected_count,
             all_pods=all_tasks_or_pods,
+            dry_run=dry_run,
         )
         return None
 

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -68,7 +68,7 @@ def filter_healthy_marathon_instances_for_short_app_id(all_tasks, app_id):
 
 
 def check_healthy_marathon_tasks_for_service_instance(
-    instance_config, expected_count, all_tasks
+    instance_config, expected_count, all_tasks, dry_run=False,
 ):
     app_id = format_job_id(instance_config.service, instance_config.instance)
     num_healthy_tasks = filter_healthy_marathon_instances_for_short_app_id(
@@ -79,6 +79,7 @@ def check_healthy_marathon_tasks_for_service_instance(
         instance_config=instance_config,
         expected_count=expected_count,
         num_available=num_healthy_tasks,
+        dry_run=dry_run,
     )
 
 
@@ -86,6 +87,7 @@ def check_service_replication(
     instance_config: MarathonServiceConfig,
     all_tasks_or_pods: Sequence[MarathonTask],
     replication_checker: MesosSmartstackEnvoyReplicationChecker,
+    dry_run: bool = False,
 ) -> Optional[bool]:
     """Checks a service's replication levels based on how the service's replication
     should be monitored. (smartstack/envoy or mesos)
@@ -107,6 +109,7 @@ def check_service_replication(
             instance_config=instance_config,
             expected_count=expected_count,
             replication_checker=replication_checker,
+            dry_run=dry_run,
         )
         return is_well_replicated
     else:
@@ -114,6 +117,7 @@ def check_service_replication(
             instance_config=instance_config,
             expected_count=expected_count,
             all_tasks=all_tasks_or_pods,
+            dry_run=dry_run,
         )
         return None
 

--- a/paasta_tools/check_oom_events.py
+++ b/paasta_tools/check_oom_events.py
@@ -201,7 +201,10 @@ def send_sensu_event(instance, oom_events, args):
             "alert_after": "0m",
             "realert_every": args.realert_every,
             "runbook": "y/check-oom-events",
-            "tip": "Try bumping the memory limit past %s" % memory_limit_str,
+            "tip": (
+                "Follow the runbook to investigate and rightsize memory usage "
+                f"(curr: {memory_limit_str})"
+            ),
         }
     )
     return monitoring_tools.send_event(

--- a/paasta_tools/check_oom_events.py
+++ b/paasta_tools/check_oom_events.py
@@ -83,6 +83,12 @@ def parse_args(args):
         required=True,
         help="The superregion to read OOM events from.",
     )
+    parser.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        help="Print Sensu alert events instead of sending them",
+    )
     return parser.parse_args(args)
 
 
@@ -205,6 +211,7 @@ def send_sensu_event(instance, oom_events, args):
         status=status[0],
         output=status[1],
         soa_dir=instance.soa_dir,
+        dry_run=args.dry_run,
     )
 
 
@@ -214,6 +221,7 @@ def main(sys_argv):
     victims = latest_oom_events(
         cluster, args.superregion, interval=(60 * args.check_interval)
     )
+
     for (service, instance) in get_services_for_cluster(cluster, soa_dir=args.soa_dir):
         try:
             instance_config = get_instance_config(

--- a/paasta_tools/monitoring_tools.py
+++ b/paasta_tools/monitoring_tools.py
@@ -210,6 +210,7 @@ def send_event(
     ttl=None,
     cluster=None,
     system_paasta_config=None,
+    dry_run=False,
 ):
     """Send an event to sensu via pysensu_yelp with the given information.
 
@@ -268,7 +269,16 @@ def send_event(
         "description": get_description(overrides, service, soa_dir),
     }
 
-    if result_dict.get("sensu_host"):
+    if dry_run:
+        if status == pysensu_yelp.Status.OK:
+            print(f"Would've sent an OK event for check '{check_name}'")
+        else:
+            from pprint import pprint  # only import during testing
+
+            print(f"Would've sent the following alert for check '{check_name}':")
+            pprint(result_dict)
+
+    elif result_dict.get("sensu_host"):
         pysensu_yelp.send_event(**result_dict)
 
 

--- a/paasta_tools/monitoring_tools.py
+++ b/paasta_tools/monitoring_tools.py
@@ -304,7 +304,7 @@ def list_teams():
     return teams
 
 
-def send_replication_event(instance_config, status, output):
+def send_replication_event(instance_config, status, output, dry_run=False):
     """Send an event to sensu via pysensu_yelp with the given information.
 
     :param instance_config: an instance of LongRunningServiceConfig
@@ -328,6 +328,7 @@ def send_replication_event(instance_config, status, output):
         output=output,
         soa_dir=instance_config.soa_dir,
         cluster=instance_config.cluster,
+        dry_run=dry_run,
     )
     _log(
         service=instance_config.service,
@@ -378,6 +379,7 @@ def check_replication_for_instance(
     instance_config: LongRunningServiceConfig,
     expected_count: int,
     replication_checker: ReplicationChecker,
+    dry_run: bool = False,
 ) -> bool:
     """Check a set of namespaces to see if their number of available backends is too low,
     emitting events to Sensu based on the fraction available and the thresholds defined in
@@ -512,7 +514,10 @@ def check_replication_for_instance(
         status = pysensu_yelp.Status.OK
 
     send_replication_event(
-        instance_config=instance_config, status=status, output=combined_output
+        instance_config=instance_config,
+        status=status,
+        output=combined_output,
+        dry_run=dry_run,
     )
 
     return not service_is_under_replicated
@@ -577,6 +582,7 @@ def send_replication_event_if_under_replication(
     expected_count: int,
     num_available: int,
     sub_component: Optional[str] = None,
+    dry_run: bool = False,
 ):
     under_replicated, output = check_under_replication(
         instance_config, expected_count, num_available, sub_component
@@ -588,5 +594,5 @@ def send_replication_event_if_under_replication(
         log.info(output)
         status = pysensu_yelp.Status.OK
     send_replication_event(
-        instance_config=instance_config, status=status, output=output
+        instance_config=instance_config, status=status, output=output, dry_run=dry_run,
     )

--- a/paasta_tools/monitoring_tools.py
+++ b/paasta_tools/monitoring_tools.py
@@ -55,6 +55,8 @@ except ImportError:
     yelp_meteorite = None
 
 
+DEFAULT_REPLICATION_RUNBOOK = "y/unhealthy-paasta-instances"
+
 log = logging.getLogger(__name__)
 
 
@@ -320,8 +322,22 @@ def send_replication_event(
     if "alert_after" not in monitoring_overrides:
         monitoring_overrides["alert_after"] = "2m"
     monitoring_overrides["check_every"] = "1m"
-    monitoring_overrides["runbook"] = get_runbook(
-        monitoring_overrides, instance_config.service, soa_dir=instance_config.soa_dir
+    monitoring_overrides["runbook"] = __get_monitoring_config_value(
+        "runbook",
+        monitoring_overrides,
+        instance_config.service,
+        soa_dir=instance_config.soa_dir,
+        monitoring_defaults=lambda _: DEFAULT_REPLICATION_RUNBOOK,
+    )
+    monitoring_overrides["tip"] = __get_monitoring_config_value(
+        "tip",
+        monitoring_overrides,
+        instance_config.service,
+        soa_dir=instance_config.soa_dir,
+        monitoring_defaults=lambda _: (
+            f"Check the instance with: `paasta status -s {instance_config.service} "
+            f"-i {instance_config.instance} -c {instance_config.cluster} -vv`"
+        ),
     )
     monitoring_overrides["description"] = description
 

--- a/tests/test_check_flink_services_health.py
+++ b/tests/test_check_flink_services_health.py
@@ -48,15 +48,15 @@ def instance_config():
     return_value={"taskmanagers": 3},
 )
 def test_check_under_registered_taskmanagers_ok(mock_overview, instance_config):
-    under, output = check_under_registered_taskmanagers(
+    under, output, description = check_under_registered_taskmanagers(
         instance_config, expected_count=3, cr_name="fake--service-575c857546"
     )
     assert not under
     assert (
-        "Service fake_service.fake_instance has 3 out of 3 expected instances of "
-        "taskmanager reported by dashboard!\n"
-        "(threshold: 100%)"
+        "fake_service.fake_instance has 3/3 taskmanagers "
+        "reported by dashboard (threshold: 100%)"
     ) in output
+    assert "fake_service.fake_instance taskmanager is available" in description
 
 
 @mock.patch(
@@ -65,17 +65,17 @@ def test_check_under_registered_taskmanagers_ok(mock_overview, instance_config):
     return_value={"taskmanagers": 2},
 )
 def test_check_under_registered_taskmanagers_under(mock_overview, instance_config):
-    under, output = check_under_registered_taskmanagers(
+    under, output, description = check_under_registered_taskmanagers(
         instance_config, expected_count=3, cr_name="fake--service-575c857546"
     )
     assert under
     assert (
-        "Service fake_service.fake_instance has 2 out of 3 expected instances of "
-        "taskmanager reported by dashboard!\n"
-        "(threshold: 100%)"
+        "fake_service.fake_instance has 2/3 taskmanagers "
+        "reported by dashboard (threshold: 100%)"
     ) in output
     assert (
-        "paasta status -s fake_service -i fake_instance -c fake_cluster -vv" in output
+        "paasta status -s fake_service -i fake_instance -c fake_cluster -vv"
+        in description
     )
 
 
@@ -85,17 +85,17 @@ def test_check_under_registered_taskmanagers_under(mock_overview, instance_confi
     side_effect=ValueError("dummy exception"),
 )
 def test_check_under_registered_taskmanagers_error(mock_overview, instance_config):
-    under, output = check_under_registered_taskmanagers(
+    under, output, description = check_under_registered_taskmanagers(
         instance_config, expected_count=3, cr_name="fake--service-575c857546"
     )
     assert under
     assert (
-        "Dashboard of service fake_service.fake_instance is not available!\n"
-        "(dummy exception)\n"
-        "What this alert"
+        "Dashboard of service fake_service.fake_instance is not available "
+        "(dummy exception)"
     ) in output
     assert (
-        "paasta status -s fake_service -i fake_instance -c fake_cluster -vv" in output
+        "paasta status -s fake_service -i fake_instance -c fake_cluster -vv"
+        in description
     )
 
 
@@ -108,11 +108,11 @@ def test_check_flink_service_health_healthy(instance_config):
     ), mock.patch(
         "paasta_tools.check_flink_services_health.check_under_replication",
         autospec=True,
-        return_value=(False, "OK"),
+        return_value=(False, "OK", "check_rep"),
     ) as mock_check_under_replication, mock.patch(
         "paasta_tools.check_flink_services_health.check_under_registered_taskmanagers",
         autospec=True,
-        return_value=(False, "OK"),
+        return_value=(False, "OK", "check_task"),
     ) as mock_check_under_registered_taskmanagers, mock.patch(
         "paasta_tools.check_flink_services_health.send_replication_event", autospec=True
     ) as mock_send_replication_event:
@@ -150,7 +150,8 @@ def test_check_flink_service_health_healthy(instance_config):
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
             status=pysensu_yelp.Status.OK,
-            output="OK\n########\nOK\n########\nOK\n########\nOK",
+            output="OK, OK, OK, OK",
+            description="check_rep\n########\ncheck_rep\n########\ncheck_rep\n########\ncheck_task",
             dry_run=True,
         )
 
@@ -158,11 +159,11 @@ def test_check_flink_service_health_healthy(instance_config):
 def test_check_flink_service_health_too_few_taskmanagers(instance_config):
     def check_under_replication_side_effect(*args, **kwargs):
         if kwargs["sub_component"] == "supervisor":
-            return False, "OK"
+            return False, "OK", "check_rep"
         if kwargs["sub_component"] == "jobmanager":
-            return False, "OK"
+            return False, "OK", "check_rep"
         if kwargs["sub_component"] == "taskmanager":
-            return True, "NOPE"
+            return True, "NOPE", "check_rep"
 
     all_pods = []
     with mock.patch(
@@ -172,7 +173,7 @@ def test_check_flink_service_health_too_few_taskmanagers(instance_config):
     ), mock.patch(
         "paasta_tools.check_flink_services_health.check_under_registered_taskmanagers",
         autospec=True,
-        return_value=(True, "NOPE"),
+        return_value=(True, "NOPE", "check_task"),
     ) as mock_check_under_registered_taskmanagers, mock.patch(
         "paasta_tools.check_flink_services_health.check_under_replication",
         autospec=True,
@@ -214,7 +215,8 @@ def test_check_flink_service_health_too_few_taskmanagers(instance_config):
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
             status=pysensu_yelp.Status.CRITICAL,
-            output="OK\n########\nOK\n########\nNOPE\n########\nNOPE",
+            output="OK, OK, NOPE, NOPE",
+            description="check_rep\n########\ncheck_rep\n########\ncheck_rep\n########\ncheck_task",
             dry_run=True,
         )
 
@@ -228,11 +230,11 @@ def test_check_flink_service_health_under_registered_taskamanagers(instance_conf
     ), mock.patch(
         "paasta_tools.check_flink_services_health.check_under_replication",
         autospec=True,
-        return_value=(False, "OK"),
+        return_value=(False, "OK", "check_rep"),
     ) as mock_check_under_replication, mock.patch(
         "paasta_tools.check_flink_services_health.check_under_registered_taskmanagers",
         autospec=True,
-        return_value=(True, "NOPE"),
+        return_value=(True, "NOPE", "check_task"),
     ) as mock_check_under_registered_taskmanagers, mock.patch(
         "paasta_tools.check_flink_services_health.send_replication_event", autospec=True
     ) as mock_send_replication_event:
@@ -270,6 +272,7 @@ def test_check_flink_service_health_under_registered_taskamanagers(instance_conf
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
             status=pysensu_yelp.Status.CRITICAL,
-            output="OK\n########\nOK\n########\nOK\n########\nNOPE",
+            output="OK, OK, OK, NOPE",
+            description="check_rep\n########\ncheck_rep\n########\ncheck_rep\n########\ncheck_task",
             dry_run=True,
         )

--- a/tests/test_check_flink_services_health.py
+++ b/tests/test_check_flink_services_health.py
@@ -121,6 +121,7 @@ def test_check_flink_service_health_healthy(instance_config):
             instance_config=instance_config,
             all_tasks_or_pods=all_pods,
             replication_checker=None,
+            dry_run=True,
         )
         expected = [
             mock.call(
@@ -150,6 +151,7 @@ def test_check_flink_service_health_healthy(instance_config):
             instance_config=instance_config,
             status=pysensu_yelp.Status.OK,
             output="OK\n########\nOK\n########\nOK\n########\nOK",
+            dry_run=True,
         )
 
 
@@ -183,6 +185,7 @@ def test_check_flink_service_health_too_few_taskmanagers(instance_config):
             instance_config=instance_config,
             all_tasks_or_pods=all_pods,
             replication_checker=None,
+            dry_run=True,
         )
         expected = [
             mock.call(
@@ -212,6 +215,7 @@ def test_check_flink_service_health_too_few_taskmanagers(instance_config):
             instance_config=instance_config,
             status=pysensu_yelp.Status.CRITICAL,
             output="OK\n########\nOK\n########\nNOPE\n########\nNOPE",
+            dry_run=True,
         )
 
 
@@ -237,6 +241,7 @@ def test_check_flink_service_health_under_registered_taskamanagers(instance_conf
             instance_config=instance_config,
             all_tasks_or_pods=all_pods,
             replication_checker=None,
+            dry_run=True,
         )
         expected = [
             mock.call(
@@ -266,4 +271,5 @@ def test_check_flink_service_health_under_registered_taskamanagers(instance_conf
             instance_config=instance_config,
             status=pysensu_yelp.Status.CRITICAL,
             output="OK\n########\nOK\n########\nOK\n########\nNOPE",
+            dry_run=True,
         )

--- a/tests/test_check_kubernetes_services_replication.py
+++ b/tests/test_check_kubernetes_services_replication.py
@@ -54,11 +54,13 @@ def test_check_service_replication_for_normal_smartstack(instance_config):
             instance_config=instance_config,
             all_tasks_or_pods=all_pods,
             replication_checker=None,
+            dry_run=True,
         )
         mock_check_replication_for_service.assert_called_once_with(
             instance_config=instance_config,
             expected_count=100,
             replication_checker=None,
+            dry_run=True,
         )
 
 
@@ -82,10 +84,14 @@ def test_check_service_replication_for_smartstack_with_different_namespace(
             instance_config=instance_config,
             all_tasks_or_pods=all_pods,
             replication_checker=None,
+            dry_run=True,
         )
         assert not mock_check_replication_for_service.called
         mock_check_healthy_kubernetes_tasks.assert_called_once_with(
-            instance_config=instance_config, expected_count=100, all_pods=[]
+            instance_config=instance_config,
+            expected_count=100,
+            all_pods=[],
+            dry_run=True,
         )
 
 
@@ -104,9 +110,13 @@ def test_check_service_replication_for_non_smartstack(instance_config):
             instance_config=instance_config,
             all_tasks_or_pods=[],
             replication_checker=None,
+            dry_run=True,
         )
         mock_check_healthy_kubernetes_tasks.assert_called_once_with(
-            instance_config=instance_config, expected_count=100, all_pods=[]
+            instance_config=instance_config,
+            expected_count=100,
+            all_pods=[],
+            dry_run=True,
         )
 
 
@@ -128,7 +138,7 @@ def test_check_healthy_kubernetes_tasks_for_service_instance():
         mock_pod_2 = mock.Mock()
         mock_filter_pods_by_service_instance.return_value = [mock_pod_1, mock_pod_2]
         check_kubernetes_services_replication.check_healthy_kubernetes_tasks_for_service_instance(
-            mock_instance_config, 5, mock_pods
+            mock_instance_config, 5, mock_pods, dry_run=True,
         )
         mock_filter_pods_by_service_instance.assert_called_with(
             pod_list=mock_pods,
@@ -136,5 +146,8 @@ def test_check_healthy_kubernetes_tasks_for_service_instance():
             instance=mock_instance_config.instance,
         )
         mock_send_replication_event_if_under_replication.assert_called_with(
-            instance_config=mock_instance_config, expected_count=5, num_available=1
+            instance_config=mock_instance_config,
+            expected_count=5,
+            num_available=1,
+            dry_run=True,
         )

--- a/tests/test_check_marathon_services_replication.py
+++ b/tests/test_check_marathon_services_replication.py
@@ -55,11 +55,13 @@ def test_check_service_replication_for_normal_smartstack(instance_config):
             instance_config=instance_config,
             all_tasks_or_pods=all_tasks,
             replication_checker=None,
+            dry_run=True,
         )
         mock_check_replication_for_service.assert_called_once_with(
             instance_config=instance_config,
             expected_count=100,
             replication_checker=None,
+            dry_run=True,
         )
 
 
@@ -83,10 +85,14 @@ def test_check_service_replication_for_smartstack_with_different_namespace(
             instance_config=instance_config,
             all_tasks_or_pods=all_tasks,
             replication_checker=None,
+            dry_run=True,
         )
         assert not mock_check_replication_for_service.called
         mock_check_healthy_marathon_tasks.assert_called_once_with(
-            instance_config=instance_config, expected_count=100, all_tasks=[]
+            instance_config=instance_config,
+            expected_count=100,
+            all_tasks=[],
+            dry_run=True,
         )
 
 
@@ -105,9 +111,13 @@ def test_check_service_replication_for_non_smartstack(instance_config):
             instance_config=instance_config,
             all_tasks_or_pods=[],
             replication_checker=None,
+            dry_run=True,
         )
         mock_check_healthy_marathon_tasks.assert_called_once_with(
-            instance_config=instance_config, expected_count=100, all_tasks=[]
+            instance_config=instance_config,
+            expected_count=100,
+            all_tasks=[],
+            dry_run=True,
         )
 
 
@@ -175,8 +185,14 @@ def test_check_healthy_marathon_tasks_for_service_instance(
 ):
     mock_healthy_instances.return_value = 2
     check_marathon_services_replication.check_healthy_marathon_tasks_for_service_instance(
-        instance_config=instance_config, expected_count=10, all_tasks=mock.Mock()
+        instance_config=instance_config,
+        expected_count=10,
+        all_tasks=mock.Mock(),
+        dry_run=True,
     )
     mock_send_replication_event_if_under_replication.assert_called_once_with(
-        instance_config=instance_config, expected_count=10, num_available=2
+        instance_config=instance_config,
+        expected_count=10,
+        num_available=2,
+        dry_run=True,
     )

--- a/tests/test_check_service_replication_tools.py
+++ b/tests/test_check_service_replication_tools.py
@@ -23,6 +23,7 @@ def test_main_kubernetes():
     ) as mock_sys_exit:
         mock_parse_args.return_value.under_replicated_crit_pct = 5
         mock_parse_args.return_value.min_count_critical = 1
+        mock_parse_args.return_value.dry_run = False
         mock_check_services_replication.return_value = (6, 100)
 
         check_services_replication_tools.main(
@@ -63,6 +64,7 @@ def test_main_mesos():
     ) as mock_sys_exit:
         mock_parse_args.return_value.under_replicated_crit_pct = 5
         mock_parse_args.return_value.min_count_critical = 1
+        mock_parse_args.return_value.dry_run = False
         mock_check_services_replication.return_value = (6, 100)
 
         check_services_replication_tools.main(

--- a/tests/test_check_service_replication_tools.py
+++ b/tests/test_check_service_replication_tools.py
@@ -124,6 +124,7 @@ def test_check_services_replication():
             check_service_replication=mock_check_service_replication,
             replication_checker=mock_replication_checker,
             all_tasks_or_pods=mock_pods,
+            dry_run=True,
         )
         mock_paasta_service_config_loader.assert_called_once_with(
             service="a", soa_dir=soa_dir
@@ -133,6 +134,7 @@ def test_check_services_replication():
             instance_config=instance_config,
             all_tasks_or_pods=mock_pods,
             replication_checker=mock_replication_checker,
+            dry_run=True,
         )
         assert count_under_replicated == 0
         assert total == 1

--- a/tests/test_monitoring_tools.py
+++ b/tests/test_monitoring_tools.py
@@ -537,7 +537,8 @@ def test_send_event_users_monitoring_tools_send_event_properly(instance_config):
             check_name=expected_check_name,
             overrides={
                 "fake_key": "fake_value",
-                "runbook": "y/runbook",
+                "runbook": mock.ANY,
+                "tip": mock.ANY,
                 "alert_after": "2m",
                 "check_every": "1m",
                 "description": fake_description,
@@ -582,7 +583,8 @@ def test_send_replication_event_users_monitoring_tools_send_event_properly(
             check_name=expected_check_name,
             overrides={
                 "fake_key": "fake_value",
-                "runbook": "y/runbook",
+                "runbook": mock.ANY,
+                "tip": mock.ANY,
                 "alert_after": "2m",
                 "check_every": "1m",
                 "description": fake_description,
@@ -626,7 +628,8 @@ def test_send_replication_event_users_monitoring_tools_send_event_respects_alert
             service=instance_config.service,
             check_name=expected_check_name,
             overrides={
-                "runbook": "y/runbook",
+                "runbook": mock.ANY,
+                "tip": mock.ANY,
                 "alert_after": "666m",
                 "check_every": "1m",
                 "description": fake_description,

--- a/tests/test_monitoring_tools.py
+++ b/tests/test_monitoring_tools.py
@@ -525,7 +525,10 @@ def test_send_event_users_monitoring_tools_send_event_properly(instance_config):
         return_value="y/runbook",
     ):
         monitoring_tools.send_replication_event(
-            instance_config=instance_config, status=fake_status, output=fake_output
+            instance_config=instance_config,
+            status=fake_status,
+            output=fake_output,
+            dry_run=True,
         )
         send_event_patch.assert_called_once_with(
             service=instance_config.service,
@@ -540,6 +543,7 @@ def test_send_event_users_monitoring_tools_send_event_properly(instance_config):
             output=fake_output,
             soa_dir=instance_config.soa_dir,
             cluster=instance_config.cluster,
+            dry_run=True,
         )
 
 
@@ -563,7 +567,10 @@ def test_send_replication_event_users_monitoring_tools_send_event_properly(
         return_value="y/runbook",
     ):
         monitoring_tools.send_replication_event(
-            instance_config=instance_config, status=fake_status, output=fake_output
+            instance_config=instance_config,
+            status=fake_status,
+            output=fake_output,
+            dry_run=True,
         )
         send_event_patch.assert_called_once_with(
             service=instance_config.service,
@@ -578,6 +585,7 @@ def test_send_replication_event_users_monitoring_tools_send_event_properly(
             output=fake_output,
             soa_dir=instance_config.soa_dir,
             cluster=instance_config.cluster,
+            dry_run=True,
         )
 
 
@@ -600,7 +608,10 @@ def test_send_replication_event_users_monitoring_tools_send_event_respects_alert
         return_value="y/runbook",
     ):
         monitoring_tools.send_replication_event(
-            instance_config=instance_config, status=fake_status, output=fake_output
+            instance_config=instance_config,
+            status=fake_status,
+            output=fake_output,
+            dry_run=True,
         )
         send_event_patch.call_count == 1
         send_event_patch.assert_called_once_with(
@@ -615,6 +626,7 @@ def test_send_replication_event_users_monitoring_tools_send_event_respects_alert
             output=fake_output,
             soa_dir=instance_config.soa_dir,
             cluster=instance_config.cluster,
+            dry_run=True,
         )
 
 
@@ -652,11 +664,13 @@ def test_check_replication_for_instance_ok_when_expecting_zero(instance_config,)
             instance_config=instance_config,
             expected_count=expected_replication_count,
             replication_checker=mock_smartstack_replication_checker,
+            dry_run=True,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
             status=pysensu_yelp.Status.OK,
             output=mock.ANY,
+            dry_run=True,
         )
 
 
@@ -675,11 +689,13 @@ def test_check_replication_for_instance_crit_when_absent(instance_config):
             instance_config=instance_config,
             expected_count=expected_replication_count,
             replication_checker=mock_smartstack_replication_checker,
+            dry_run=True,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
             status=pysensu_yelp.Status.CRITICAL,
             output=mock.ANY,
+            dry_run=True,
         )
 
 
@@ -702,11 +718,13 @@ def test_check_replication_for_instance_crit_when_zero_replication(instance_conf
             instance_config=instance_config,
             expected_count=expected_replication_count,
             replication_checker=mock_smartstack_replication_checker,
+            dry_run=True,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
             status=pysensu_yelp.Status.CRITICAL,
             output=mock.ANY,
+            dry_run=True,
         )
         _, send_replication_event_kwargs = mock_send_replication_event.call_args
         alert_output = send_replication_event_kwargs["output"]
@@ -743,11 +761,13 @@ def test_check_replication_for_instance_crit_when_low_replication(instance_confi
             instance_config=instance_config,
             expected_count=expected_replication_count,
             replication_checker=mock_smartstack_replication_checker,
+            dry_run=True,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
             status=pysensu_yelp.Status.CRITICAL,
             output=mock.ANY,
+            dry_run=True,
         )
         _, send_replication_event_kwargs = mock_send_replication_event.call_args
         alert_output = send_replication_event_kwargs["output"]
@@ -784,11 +804,13 @@ def test_check_replication_for_instance_ok_with_enough_replication(instance_conf
             instance_config=instance_config,
             expected_count=expected_replication_count,
             replication_checker=mock_smartstack_replication_checker,
+            dry_run=True,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
             status=pysensu_yelp.Status.OK,
             output=mock.ANY,
+            dry_run=True,
         )
         _, send_replication_event_kwargs = mock_send_replication_event.call_args
         alert_output = send_replication_event_kwargs["output"]
@@ -817,11 +839,13 @@ def test_check_replication_for_instance_ok_with_enough_replication_multilocation
             instance_config=instance_config,
             expected_count=expected_replication_count,
             replication_checker=mock_smartstack_replication_checker,
+            dry_run=True,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
             status=pysensu_yelp.Status.OK,
             output=mock.ANY,
+            dry_run=True,
         )
         _, send_replication_event_kwargs = mock_send_replication_event.call_args
         alert_output = send_replication_event_kwargs["output"]
@@ -855,11 +879,13 @@ def test_check_replication_for_instance_crit_when_low_replication_multilocation(
             instance_config=instance_config,
             expected_count=expected_replication_count,
             replication_checker=mock_smartstack_replication_checker,
+            dry_run=True,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
             status=pysensu_yelp.Status.CRITICAL,
             output=mock.ANY,
+            dry_run=True,
         )
         _, send_replication_event_kwargs = mock_send_replication_event.call_args
         alert_output = send_replication_event_kwargs["output"]
@@ -900,11 +926,13 @@ def test_check_replication_for_instance_crit_when_zero_replication_multilocation
             instance_config=instance_config,
             expected_count=expected_replication_count,
             replication_checker=mock_smartstack_replication_checker,
+            dry_run=True,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
             status=pysensu_yelp.Status.CRITICAL,
             output=mock.ANY,
+            dry_run=True,
         )
         _, send_replication_event_kwargs = mock_send_replication_event.call_args
         alert_output = send_replication_event_kwargs["output"]
@@ -945,11 +973,13 @@ def test_check_replication_for_instance_crit_when_missing_replication_multilocat
             instance_config=instance_config,
             expected_count=expected_replication_count,
             replication_checker=mock_smartstack_replication_checker,
+            dry_run=True,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
             status=pysensu_yelp.Status.CRITICAL,
             output=mock.ANY,
+            dry_run=True,
         )
         _, send_replication_event_kwargs = mock_send_replication_event.call_args
         alert_output = send_replication_event_kwargs["output"]
@@ -978,11 +1008,13 @@ def test_check_replication_for_instance_crit_when_no_smartstack_info(instance_co
             instance_config=instance_config,
             expected_count=expected_replication_count,
             replication_checker=mock_smartstack_replication_checker,
+            dry_run=True,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
             status=pysensu_yelp.Status.CRITICAL,
             output=mock.ANY,
+            dry_run=True,
         )
         _, send_replication_event_kwargs = mock_send_replication_event.call_args
         alert_output = send_replication_event_kwargs["output"]
@@ -1068,10 +1100,13 @@ def test_send_replication_event_if_under_replication_handles_0_expected(
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
     ) as mock_send_event:
         monitoring_tools.send_replication_event_if_under_replication(
-            instance_config=instance_config, expected_count=0, num_available=0
+            instance_config=instance_config,
+            expected_count=0,
+            num_available=0,
+            dry_run=True,
         )
         mock_send_event.assert_called_once_with(
-            instance_config=instance_config, status=0, output=mock.ANY
+            instance_config=instance_config, status=0, output=mock.ANY, dry_run=True,
         )
         _, send_event_kwargs = mock_send_event.call_args
         alert_output = send_event_kwargs["output"]
@@ -1087,10 +1122,13 @@ def test_send_replication_event_if_under_replication_good(instance_config):
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
     ) as mock_send_event:
         monitoring_tools.send_replication_event_if_under_replication(
-            instance_config=instance_config, expected_count=100, num_available=100
+            instance_config=instance_config,
+            expected_count=100,
+            num_available=100,
+            dry_run=True,
         )
         mock_send_event.assert_called_once_with(
-            instance_config=instance_config, status=0, output=mock.ANY
+            instance_config=instance_config, status=0, output=mock.ANY, dry_run=True,
         )
         _, send_event_kwargs = mock_send_event.call_args
         alert_output = send_event_kwargs["output"]
@@ -1106,10 +1144,13 @@ def test_send_replication_event_if_under_replication_critical(instance_config):
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
     ) as mock_send_event:
         monitoring_tools.send_replication_event_if_under_replication(
-            instance_config=instance_config, expected_count=100, num_available=89
+            instance_config=instance_config,
+            expected_count=100,
+            num_available=89,
+            dry_run=True,
         )
         mock_send_event.assert_called_once_with(
-            instance_config=instance_config, status=2, output=mock.ANY
+            instance_config=instance_config, status=2, output=mock.ANY, dry_run=True,
         )
         _, send_event_kwargs = mock_send_event.call_args
         alert_output = send_event_kwargs["output"]

--- a/tests/test_monitoring_tools.py
+++ b/tests/test_monitoring_tools.py
@@ -1068,6 +1068,28 @@ def test_emit_replication_metrics(instance_config):
         mock_gauges["paasta.service.expected_backends"].set.assert_called_once_with(10)
 
 
+def test_emit_replication_metrics_dry_run(instance_config):
+    with mock.patch(
+        "paasta_tools.monitoring_tools.yelp_meteorite", autospec=True
+    ) as mock_yelp_meteorite:
+        mock_smartstack_replication_info = {
+            "fake_provider": {
+                "fake_region_1": {
+                    "fake_service.fake_instance": 2,
+                    "other_service.other_instance": 5,
+                },
+                "fake_region_2": {"fake_service.fake_instance": 4},
+            }
+        }
+        monitoring_tools.emit_replication_metrics(
+            mock_smartstack_replication_info,
+            instance_config,
+            expected_count=10,
+            dry_run=True,
+        )
+        mock_yelp_meteorite.create_gauge.call_count = 0
+
+
 def test_check_replication_for_instance_emits_metrics(instance_config):
     with mock.patch(
         "paasta_tools.monitoring_tools.send_replication_event", autospec=True
@@ -1085,11 +1107,13 @@ def test_check_replication_for_instance_emits_metrics(instance_config):
             instance_config=instance_config,
             expected_count=10,
             replication_checker=mock_smartstack_replication_checker,
+            dry_run=True,
         )
         mock_emit_replication_metrics.assert_called_once_with(
             mock_smartstack_replication_checker.get_replication_for_instance.return_value,
             instance_config,
             10,
+            dry_run=True,
         )
 
 


### PR DESCRIPTION
## Description
This PR does a number of things:

- Adds `--dry-run` for the oom and replication event checker
- Updates the tip for the oom checker
- Moves a lot of context from the output to the description of replication alert events. This is because the output was so long that it would prevent the tip and runbook from showing up in Slack alerts (400 char limit). The description was also not well-used. 
- Changes the default replication alert runbook to y/paastatools for help debugging services (we should probably create a dedicated runbook or section for this)

## Testing
`make test`
manual testing using `--dry-run` to see the sensu events
manual testing and seeing slack alert messages