### PR TITLE
Do not run file-based oapi check during itests

### DIFF
--- a/paasta_tools/contrib/check_manual_oapi_changes.sh
+++ b/paasta_tools/contrib/check_manual_oapi_changes.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
 set -uo pipefail
 
-diff_names=$(git diff origin/master --name-only)
-schema_touched=$(echo "$diff_names" | grep 'paasta_tools/api/api_docs/oapi.yaml')
-api_touched=$(echo "$diff_names" | grep 'paasta_tools/paastaapi')
+if ! [[ "${PAASTA_SYSTEM_CONFIG_DIR:-}" =~ ^.*/general_itests/fake_etc_paasta ]] ; then
+    # Do not run during general_itests
+    diff_names=$(git diff origin/master --name-only)
+    schema_touched=$(echo "$diff_names" | grep 'paasta_tools/api/api_docs/oapi.yaml')
+    api_touched=$(echo "$diff_names" | grep 'paasta_tools/paastaapi')
 
-if [ ! -z "$api_touched" -a -z "$schema_touched" ]; then
-    echo "paasta_tools/paastaapi must not be modified manually" >&2
-    echo "Please revert your changes:" >&2
-    echo -e "$api_touched" >&2
-    exit 1
+    if [ ! -z "$api_touched" -a -z "$schema_touched" ]; then
+        echo "paasta_tools/paastaapi must not be modified manually" >&2
+        echo "Please revert your changes:" >&2
+        echo -e "$api_touched" >&2
+        exit 1
+    fi
 fi
 
 make openapi-codegen &>/dev/null


### PR DESCRIPTION
This fixes our internal jenkins build which runs `tox -e general_itests`, which in turn runs `pre-commit run --all-files`.  general_itests were broken after removing pre-commit's global exclusion of all `paasta_tools/paastaapi` files in #3081. 

This changes the script to skip the file-based check since *all* files will be returned during `pre-commit run --all-files`, but still catches situations where `make openapi-codegen` generates a diff that has not yet been committed, which should be caught. 

Verified a commit with a manual modification to `paasta_tools/paastaapi/model/kubernetes_pod.py` fails the precommit:
```
check that oapi.yaml is updated if paastaapi changes.......................Failed
hookid: check-oapi-schema

paasta_tools/paastaapi must not be modified manually
Please revert your changes:
paasta_tools/paastaapi/model/kubernetes_pod.py
```

while `tox -e general_itests` passes the pre-commit step without issue:
```
general_itests runtests: commands[2] | pre-commit run --all-files
Trim Trailing Whitespace...................................................Passed
Fix End of Files...........................................................Passed
Check docstring is first...................................................Passed
Check JSON.................................................................Passed
Check Yaml.................................................................Passed
Debug Statements (Python)..................................................Passed
Tests should end in _test.py...............................................Passed
Fix requirements.txt.......................................................Passed
Fix python encoding pragma.................................................Passed
Pretty format JSON.........................................................Passed
Reorder python imports.....................................................Passed
pyupgrade..................................................................Passed
black......................................................................Passed
flake8.....................................................................Passed
Detect secrets.............................................................Passed
mock.patch enforce autospec................................................Passed
check that oapi.yaml is updated if paastaapi changes.......................Passed
```
