### PR TITLE
Wrap ready_pods query in sum(...) by (kube_deployment) …

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -236,13 +236,13 @@ def create_instance_uwsgi_scaling_rule(
     # over paasta service/instance/cluster. it counts the number of ready pods in a paasta
     # deployment.
     ready_pods = f"""
-        (
+        (sum(
             k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
             or
             max_over_time(
                 k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
             )
-        )
+        ) by (kube_deployment))
     """
     load_per_instance = f"""
         avg(

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -232,6 +232,18 @@ def create_instance_uwsgi_scaling_rule(
             )
         ) by (kube_deployment)
     """
+    # k8s:deployment:pods_status_ready is a metric created by summing kube_pod_status_ready
+    # over paasta service/instance/cluster. it counts the number of ready pods in a paasta
+    # deployment.
+    ready_pods = f"""
+        (
+            k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
+            or
+            max_over_time(
+                k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
+            )
+        )
+    """
     load_per_instance = f"""
         avg(
             uwsgi_worker_busy{{{worker_filter_terms}}}
@@ -239,7 +251,7 @@ def create_instance_uwsgi_scaling_rule(
     """
     missing_instances = f"""
         clamp_min(
-            {current_replicas} - count({load_per_instance}) by (kube_deployment),
+            {ready_pods} - count({load_per_instance}) by (kube_deployment),
             0
         )
     """


### PR DESCRIPTION
… so it has the same labels as the count() in missing_instances. PAASTA-17220

Also reverts #3086, which means it un-reverts #3070.