### PR TITLE
In make release: add files before committing, because…

### DIFF
--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -108,7 +108,8 @@ release:
 	dch -v $(RELEASE) --distribution xenial --changelog ../debian/changelog $$'$(VERSION) tagged with \'make release\'\rCommit: $(LAST_COMMIT_MSG)'
 	sed -i -e "s/__version__ = .*/__version__ = \"$(VERSION)\"/" ../paasta_tools/__init__.py
 	cd .. && make docs || true
-	git commit -m "Released $(RELEASE) via make release" ./Makefile ../debian/changelog ../paasta_tools/__init__.py ../docs/source/generated/
+	git add ./Makefile ../debian/changelog ../paasta_tools/__init__.py ../docs/source/generated/
+	git commit -m "Released $(RELEASE) via make release"
 	if [[ "$$(git status --porcelain --untracked-files=all)" != "$$(<$(untracked_files_tmpfile))" ]]; then echo "Error: automatic git commit left some files uncommitted. Fix the git commit command in yelp_package/Makefile to include any automatically generated files that it is currently missing."; exit 1; fi
 	git tag v$(VERSION)
 	git push --atomic origin master v$(VERSION)


### PR DESCRIPTION
… passing ../docs/source/generated as an argument to commit doesn't result in new files being committed.