### PR TITLE
Add cpus_limit to paasta allocation

### DIFF
--- a/paasta_tools/contrib/get_running_task_allocation.py
+++ b/paasta_tools/contrib/get_running_task_allocation.py
@@ -126,14 +126,18 @@ def get_kubernetes_resource_request(
 ) -> Mapping[str, float]:
     if not resources:
         requests: Mapping[str, str] = {}
+        limits: Mapping[str, str] = {}
     else:
         requests = resources.requests or {}
+        limits = resources.limits or {}
 
-    parsed = kubernetes_tools.parse_container_resources(requests)
+    parsed_requests = kubernetes_tools.parse_container_resources(requests)
+    parsed_limits = kubernetes_tools.parse_container_resources(limits)
     return {
-        "cpus": parsed.cpus,
-        "mem": parsed.mem,
-        "disk": parsed.disk,
+        "cpus": parsed_requests.cpus,
+        "mem": parsed_requests.mem,
+        "disk": parsed_requests.disk,
+        "cpus_limit": parsed_limits.cpus,
     }
 
 

--- a/paasta_tools/contrib/get_running_task_allocation.py
+++ b/paasta_tools/contrib/get_running_task_allocation.py
@@ -2,8 +2,8 @@
 import argparse
 import time
 from typing import Any
-from typing import Iterable
 from typing import Dict
+from typing import Iterable
 from typing import Mapping
 from typing import MutableMapping
 from typing import NamedTuple

--- a/paasta_tools/contrib/get_running_task_allocation.py
+++ b/paasta_tools/contrib/get_running_task_allocation.py
@@ -3,6 +3,7 @@ import argparse
 import time
 from typing import Any
 from typing import Iterable
+from typing import Dict
 from typing import Mapping
 from typing import MutableMapping
 from typing import NamedTuple
@@ -123,10 +124,10 @@ def get_all_running_kubernetes_pods(
 
 def get_kubernetes_resource_request(
     resources: V1ResourceRequirements,
-) -> Mapping[str, float]:
+) -> Dict[str, float]:
     if not resources:
-        requests: Mapping[str, str] = {}
-        limits: Mapping[str, str] = {}
+        requests: Dict[str, str] = {}
+        limits: Dict[str, str] = {}
     else:
         requests = resources.requests or {}
         limits = resources.limits or {}

--- a/paasta_tools/contrib/get_running_task_allocation.py
+++ b/paasta_tools/contrib/get_running_task_allocation.py
@@ -122,7 +122,7 @@ def get_all_running_kubernetes_pods(
     return running
 
 
-def get_kubernetes_resource_request(
+def get_kubernetes_resource_request_limit(
     resources: V1ResourceRequirements,
 ) -> Dict[str, float]:
     if not resources:
@@ -204,7 +204,7 @@ def get_kubernetes_task_allocation_info(namespace: str) -> Iterable[TaskAllocati
         name_to_info: MutableMapping[str, Any] = {}
         for container in pod.spec.containers:
             name_to_info[container.name] = {
-                "resources": get_kubernetes_resource_request(container.resources),
+                "resources": get_kubernetes_resource_request_limit(container.resources),
                 "container_type": get_container_type(container.name, instance),
                 "pod_name": pod_name,
                 "pod_ip": pod_ip,

--- a/tests/contrib/test_get_running_task_allocation.py
+++ b/tests/contrib/test_get_running_task_allocation.py
@@ -1,0 +1,18 @@
+from paasta_tools.contrib.get_running_task_allocation import get_kubernetes_resource_request
+from kubernetes.client import V1ResourceRequirements
+
+def test_get_kubernetes_resource_request():
+    test_resource_req = V1ResourceRequirements(
+                limits={
+                    "cpu": "1.3",
+                    "memory": "2048Mi",
+                    "ephemeral-storage": "4096Mi"
+                },
+                requests={
+                    "cpu": "0.3",
+                    "memory": "2048Mi",
+                    "ephemeral-storage": "4096Mi",
+                },
+            )
+
+    assert get_kubernetes_resource_request(test_resource_req) == {'cpus': 0.3, 'cpus_limit': 1.3, 'disk': 4096.0, 'mem': 2048.0}

--- a/tests/contrib/test_get_running_task_allocation.py
+++ b/tests/contrib/test_get_running_task_allocation.py
@@ -1,18 +1,19 @@
-from paasta_tools.contrib.get_running_task_allocation import get_kubernetes_resource_request
 from kubernetes.client import V1ResourceRequirements
+
+from paasta_tools.contrib.get_running_task_allocation import (
+    get_kubernetes_resource_request,
+)
+
 
 def test_get_kubernetes_resource_request():
     test_resource_req = V1ResourceRequirements(
-                limits={
-                    "cpu": "1.3",
-                    "memory": "2048Mi",
-                    "ephemeral-storage": "4096Mi"
-                },
-                requests={
-                    "cpu": "0.3",
-                    "memory": "2048Mi",
-                    "ephemeral-storage": "4096Mi",
-                },
-            )
+        limits={"cpu": "1.3", "memory": "2048Mi", "ephemeral-storage": "4096Mi"},
+        requests={"cpu": "0.3", "memory": "2048Mi", "ephemeral-storage": "4096Mi",},
+    )
 
-    assert get_kubernetes_resource_request(test_resource_req) == {'cpus': 0.3, 'cpus_limit': 1.3, 'disk': 4096.0, 'mem': 2048.0}
+    assert get_kubernetes_resource_request(test_resource_req) == {
+        "cpus": 0.3,
+        "cpus_limit": 1.3,
+        "disk": 4096.0,
+        "mem": 2048.0,
+    }

--- a/tests/contrib/test_get_running_task_allocation.py
+++ b/tests/contrib/test_get_running_task_allocation.py
@@ -1,17 +1,17 @@
 from kubernetes.client import V1ResourceRequirements
 
 from paasta_tools.contrib.get_running_task_allocation import (
-    get_kubernetes_resource_request,
+    get_kubernetes_resource_request_limit,
 )
 
 
-def test_get_kubernetes_resource_request():
+def test_get_kubernetes_resource_request_limit():
     test_resource_req = V1ResourceRequirements(
         limits={"cpu": "1.3", "memory": "2048Mi", "ephemeral-storage": "4096Mi"},
         requests={"cpu": "0.3", "memory": "2048Mi", "ephemeral-storage": "4096Mi",},
     )
 
-    assert get_kubernetes_resource_request(test_resource_req) == {
+    assert get_kubernetes_resource_request_limit(test_resource_req) == {
         "cpus": 0.3,
         "cpus_limit": 1.3,
         "disk": 4096.0,


### PR DESCRIPTION
Currently, cpu recommendations are not super accurate because we don't know how much CPU a task can really use before getting throttled ([cpus + cpu_burst_add](https://github.com/Yelp/paasta/blob/master/paasta_tools/kubernetes_tools.py#L987) AKA cpus limit in k8s). We currently only keep track of the requested cpus.
We could get that info out of band in the hourly report we are using for autotuned_defaults by parsing the configuration directly but we would lose time accuracy. I am OK to do that if you have strong opinion against this change.

This PR adds cpus_limit to the allocation log which will enable us to track this accurately and ultimately make better recommendations.

I know this file is in contrib but I felt like it deserved some unit tests, so I added a test directory and one puny test.
A couple of things to note:
- I did not bother doing this for Mesos, should I ?
- I could have done the reverse calculation and logged the cpu_burst_add but I felt like maybe it's just better to log the actual limit
