### PR TITLE
MONK-2327 Add pod management policy support to StatefuleSets

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -236,6 +236,14 @@ For more information on selector operators, see the official Kubernetes
 documentation on `node affinities
 <https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity>`_.
 
+  * ``pod_management_policy``: An option for applications managed with `StatefulSets <https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/>`_ to determine if the pods are managed in parallel or in order.
+
+    The default value is `OrderedReady <https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#orderedready-pod-management>`_.
+    It can be set to `Parallel <https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#parallel-pod-management>`_. For example::
+
+      pod_management_policy: Parallel
+
+
 .. _mesos-placement-options:
 
 Mesos

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -649,6 +649,12 @@
                             ]
                         }
                     }
+                },
+                "pod_management_policy": {
+                    "enum": [
+                        "OrderedReady",
+                        "Parallel"
+                    ]
                 }
             }
         }

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -296,6 +296,7 @@ class KubernetesDeploymentConfigDict(LongRunningServiceConfigDict, total=False):
     prometheus_path: str
     prometheus_port: int
     routable_ip: bool
+    pod_management_policy: str
 
 
 def load_kubernetes_service_config_no_cache(
@@ -1370,6 +1371,10 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "check_envoy", system_paasta_config.get_enable_envoy_readiness_check()
         )
 
+    def get_pod_management_policy(self) -> str:
+        """Get sts pod_management_policy from config, default to 'OrderedReady'"""
+        return self.config_dict.get("pod_management_policy", "OrderedReady")
+
     def format_kubernetes_app(self) -> Union[V1Deployment, V1StatefulSet]:
         """Create the configuration that will be passed to the Kubernetes REST API."""
 
@@ -1397,6 +1402,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                         template=self.get_pod_template_spec(
                             git_sha=git_sha, system_paasta_config=system_paasta_config
                         ),
+                        pod_management_policy=self.get_pod_management_policy(),
                     ),
                 )
             else:

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1361,6 +1361,7 @@ class TestKubernetesDeploymentConfig:
                     revision_history_limit=0,
                     template=mock_get_pod_template_spec.return_value,
                     volume_claim_templates=mock_get_volumes_claim_templates.return_value,
+                    pod_management_policy="OrderedReady",
                 ),
             )
             assert ret == expected
@@ -3404,3 +3405,27 @@ def test_running_task_allocation_get_pod_pool():
 
         ret = task_allocation_get_pod_pool(mock.Mock(), mock.Mock())
         assert ret == "default"
+
+    @pytest.mark.parametrize(
+        "config_dict, expected_management_policy",
+        [
+            ({"pod_management_policy": "Parallel"}, "Parallel"),
+            ({}, "OrderedReady"),
+        ],
+    )
+    def test_get_pod_management_policy(
+        self, config_dict, expected_management_policy
+    ):
+        deployment = KubernetesDeploymentConfig(
+            service="my-service",
+            instance="my-instance",
+            cluster="mega-cluster",
+            config_dict=config_dict,
+            branch_dict=None,
+            soa_dir="/nail/blah",
+        )
+        mock_system_paasta_config = mock.Mock()
+        assert (
+            deployment.get_pod_management_policy()
+            == expected_management_policy
+        )


### PR DESCRIPTION
### Summary
Adding `pod_management_policy` to StatefulSets spec to make it configurable, right now without this option we are using the default [OrderedReady](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#orderedready-pod-management) option, it would be helpful for monk to adopt the [Parallel](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#parallel-pod-management) policy when scaling up during an incident.

The config required in yelpsoa-config would be something like
```
pod_management_policy: Parallel
```

### Testing
`make test` passed

### Note
I reckon rolling out this change should not lead to sts restart existing pods, as the default config is `OrderedReady` but please let me know if there is anything I have missed or if there is any other concern about this change.