### PR TITLE
Paasta Validate - Validates max_instances is higher than min_instance…

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -439,9 +439,9 @@ def validate_min_max_instances(service_path):
                         returncode = False
                         print(
                             failure(
-                                f"Instance {instance} on cluster {cluster} has an invalid number of min_instances."
-                                + f"The number of min_instances ({min_instances}) must not be higher than the max_instances ({max_instances}).",
-                                "http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html",
+                                f"Instance {instance} on cluster {cluster} has a greater number of min_instances than max_instances."
+                                + f"The number of min_instances ({min_instances}) cannot be greater than the max_instances ({max_instances}).",
+                                "",
                             )
                         )
 

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -26,6 +26,7 @@ from paasta_tools.cli.cmds.validate import SCHEMA_INVALID
 from paasta_tools.cli.cmds.validate import SCHEMA_VALID
 from paasta_tools.cli.cmds.validate import UNKNOWN_SERVICE
 from paasta_tools.cli.cmds.validate import validate_instance_names
+from paasta_tools.cli.cmds.validate import validate_min_max_instances
 from paasta_tools.cli.cmds.validate import validate_paasta_objects
 from paasta_tools.cli.cmds.validate import validate_schema
 from paasta_tools.cli.cmds.validate import validate_secrets
@@ -130,6 +131,39 @@ def test_validate_unknown_service_service_path():
     service = "unused"
 
     assert not paasta_validate_soa_configs(service, service_path)
+
+
+@patch("paasta_tools.cli.cmds.validate.get_instance_config", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.list_all_instances_for_service", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
+def test_validate_min_max_instances_success(
+    mock_path_to_soa_dir_service,
+    mock_list_clusters,
+    mock_list_all_instances_for_service,
+    mock_get_instance_config,
+    capsys,
+):
+    mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
+    mock_list_clusters.return_value = ["fake_cluster"]
+    mock_list_all_instances_for_service.return_value = {"fake_instance1"}
+    mock_get_instance_config.return_value = mock.Mock(
+        get_instance=mock.Mock(return_value="fake_instance1"),
+        get_instance_type=mock.Mock(return_value="fake_type"),
+        get_min_instances=mock.Mock(return_value=3),
+        get_max_instances=mock.Mock(return_value=1),
+    )
+
+    assert validate_min_max_instances("fake-service-path") is False
+    output, _ = capsys.readouterr()
+    assert (
+        "Instance fake_instance1 on cluster fake_cluster has an invalid number of min_instances."
+        in output
+    )
+    assert (
+        "The number of min_instances (3) must not be higher than the max_instances (1)."
+        in output
+    )
 
 
 @patch("paasta_tools.cli.cmds.validate.os.path.isdir", autospec=True)

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -160,11 +160,11 @@ def test_validate_min_max_instances_success(
     assert validate_min_max_instances("fake-service-path") is False
     output, _ = capsys.readouterr()
     assert (
-        "Instance fake_instance1 on cluster fake_cluster has an invalid number of min_instances."
+        "Instance fake_instance1 on cluster fake_cluster has a greater number of min_instances than max_instances."
         in output
     )
     assert (
-        "The number of min_instances (3) must not be higher than the max_instances (1)."
+        "The number of min_instances (3) cannot be greater than the max_instances (1)."
         in output
     )
 

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -35,6 +35,7 @@ from paasta_tools.cli.cmds.validate import validate_unique_instance_names
 
 
 @patch("paasta_tools.cli.cmds.validate.validate_unique_instance_names", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.validate_min_max_instances", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_paasta_objects", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_all_schemas", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_tron", autospec=True)
@@ -49,6 +50,7 @@ def test_paasta_validate_calls_everything(
     mock_validate_all_schemas,
     mock_validate_paasta_objects,
     mock_validate_unique_instance_names,
+    mock_validate_min_max_instances,
 ):
     # Ensure each check in 'paasta_validate' is called
 
@@ -59,6 +61,7 @@ def test_paasta_validate_calls_everything(
     mock_validate_tron.return_value = True
     mock_validate_paasta_objects.return_value = True
     mock_validate_unique_instance_names.return_value = True
+    mock_validate_min_max_instances.return_value = True
 
     args = mock.MagicMock()
     args.service = "test"


### PR DESCRIPTION
…s in a service.

### Description
As `paasta validate runs` on a yelp-soaconfigs service, it will validate if the configuration is compliant with the paasta contract.

```
(py37-linux) lancelei@dev54-uswest1adevc:~/Repos/yelpsoa-configs/compute-infra-test-service$ paasta validate
✓ Successfully validated schema: kubernetes-kubestage.yaml
✓ Successfully validated schema: kubernetes-infrastage.yaml
✓ Successfully validated schema: kubernetes-pnw-devc.yaml
✓ Successfully validated schema: kubernetes-norcal-stagef.yaml
✓ Successfully validated schema: tron-mesosstage.yaml
✓ Successfully validated schema: marathon-mesosstage.yaml
✓ Successfully validated schema: tron-norcal-devc.yaml
✓ Successfully validated schema: kubernetes-norcal-devc.yaml
✓ Successfully validated schema: kubernetes-nova-prod.yaml
✓ Successfully validated schema: kubernetes-pnw-prod.yaml
✓ Successfully validated schema: tron-spam-pnw-prod.yaml
✓ Successfully validated schema: kubernetes-norcal-corp.yaml
✓ Successfully validated schema: kubernetes-norcal-stageg.yaml
✓ Successfully validated schema: tron-pnw-prod.yaml
✓ Successfully validated schema: adhoc-mesosstage.yaml
✓ tron-mesosstage.yaml is valid.
✓ tron-norcal-devc.yaml is valid.
✓ tron-spam-pnw-prod.yaml is valid.
✓ tron-pnw-prod.yaml is valid.
✓ All PaaSTA Instances for are valid for all clusters
✓ All compute-infra-test-service's instance names in cluster infrastage are unique
✓ All compute-infra-test-service's instance names in cluster kubestage are unique
✓ All compute-infra-test-service's instance names in cluster mesosstage are unique
✓ All compute-infra-test-service's instance names in cluster norcal-corp are unique
✓ All compute-infra-test-service's instance names in cluster norcal-devc are unique
✓ All compute-infra-test-service's instance names in cluster norcal-stagef are unique
✓ All compute-infra-test-service's instance names in cluster norcal-stageg are unique
✓ All compute-infra-test-service's instance names in cluster nova-prod are unique
✓ All compute-infra-test-service's instance names in cluster pnw-devc are unique
✓ All compute-infra-test-service's instance names in cluster pnw-prod are unique
✓ All compute-infra-test-service's instance names in cluster spam-pnw-prod are unique
✓ No orphan secrets found

✗ Instance crossover on cluster norcal-stagef has an invalid number of min_instances.The number of min_instances (3) must not be higher than the max_instances (1). http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html
```

### Test
`make test` - PASSED