### PR TITLE
Fixing the documentation for the alert_after value

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -1090,7 +1090,7 @@ Here is a list of options that PaaSTA will pass through:
    the ``tip`` option.
 
  * ``alert_after``: Time string that represents how long a a check should be
-   failing before an actual alert should be fired. Currently defaults to ``2m``
+   failing before an actual alert should be fired. Currently defaults to ``10m``
    for the replication alert.
 
  * ``realert_every``: An integer (not a time unit) representing how many checks

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -374,7 +374,7 @@ instance MAY have:
 
   * ``replication_threshold``: An integer representing the percentage of instances that
     need to be available for monitoring purposes. If less than ``replication_threshold``
-    percent instances of a service's backends are not available, the monitoring
+    percent instances of a service's backends are available, the monitoring
     scripts will send a CRITICAL alert.
 
   * ``healthcheck_mode``: One of ``cmd``, ``tcp``, ``http``, or ``https``.


### PR DESCRIPTION
The default value seems to be as 10mins in the source code (https://github.com/Yelp/paasta/blob/master/paasta_tools/check_kubernetes_services_replication.py#L49)