### PR TITLE
Annotation values my be strings

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1567,7 +1567,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         # prometheus_port is used to override the default scrape port in Prometheus
         prometheus_port = self.get_prometheus_port()
         if prometheus_port:
-            annotations["paasta.yelp.com/prometheus_port"] = prometheus_port
+            annotations["paasta.yelp.com/prometheus_port"] = str(prometheus_port)
 
         # Default Pod labels
         labels: Dict[str, Any] = {
@@ -1603,7 +1603,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         return V1PodTemplateSpec(
             metadata=V1ObjectMeta(labels=labels, annotations=annotations,),
             spec=V1PodSpec(**pod_spec_kwargs),
-        )
+        )prometheus_port
 
     def get_node_selector(self) -> Mapping[str, str]:
         """Converts simple node restrictions into node selectors. Unlike node

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1603,7 +1603,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         return V1PodTemplateSpec(
             metadata=V1ObjectMeta(labels=labels, annotations=annotations,),
             spec=V1PodSpec(**pod_spec_kwargs),
-        )prometheus_port
+        )
 
     def get_node_selector(self) -> Mapping[str, str]:
         """Converts simple node restrictions into node selectors. Unlike node


### PR DESCRIPTION
Annotation values have to be strings. This patch has been tested on kube1-uswest1astagef:
```
paasta-tools:
  Installed: 0.98.00-yelp2
  Candidate: 0.98.00-yelp2
  Version table:
 *** 0.98.00-yelp2 100
        100 /var/lib/dpkg/status
        
davent@kube1-uswest1astagef:~$ sudo setup_kubernetes_job statsite.main
INFO:__main__:Updating statsite-main-619eca5e0c3e96c5a12299eff0ce7ab2e087ea52-configa4a38a09 because configs have changed.
INFO:__main__:Ensuring related API objects for statsite-main-619eca5e0c3e96c5a12299eff0ce7ab2e087ea52-configa4a38a09 are in sync
INFO:root:poddisruptionbudget statsite-main up to date
INFO:paasta_tools.kubernetes.application.controller_wrappers:No HPA required for statsite-main/name in paasta
```

Result applied as expected:
```
metadata:
  annotations:
    iam.amazonaws.com/role: ""
    paasta.yelp.com/prometheus_path: /metrics
    paasta.yelp.com/prometheus_port: "9102"
 ```