### PR TITLE
Update pyyaml to 5.4.1 for CLoader support internally

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ python-iptables==0.14.0
 python-utils==2.0.1
 pytimeparse==1.1.5
 pytz==2016.10
-pyyaml==5.4
+pyyaml==5.4.1
 repoze.lru==0.6
 requests==2.21.0
 requests-cache==0.4.10


### PR DESCRIPTION
5.4.0 in our internal pypi index was built without CLoader support. 5.4.1 has it (and we fixed this problem for future uploads of pyyaml, context at https://yelp.slack.com/archives/CDBRTGJF8/p1614211751114300). Having CLoader available should make all yaml parsing much faster.

I noticed this when I was running the .tools/generate-historical-infrastructure-stats.py script in yelpsoa-configs, which uses the paasta venv and assumes that CSafeLoader is available.