### PR TITLE
RFC: Optionally mounting in service specific keys to /etc/boto_cfg

### DIFF
--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -74,6 +74,12 @@
                         "type": "string"
                     }
                 },
+                "boto_keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "cfs_period_us": {
                     "type": "integer",
                     "minimum": 1000,

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -342,6 +342,12 @@
                         "type": "string"
                     }
                 },
+                "boto_keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "extra_volumes": {
                     "type": "array",
                     "items": {

--- a/paasta_tools/cli/schemas/marathon_schema.json
+++ b/paasta_tools/cli/schemas/marathon_schema.json
@@ -321,6 +321,12 @@
                         "type": "string"
                     }
                 },
+                "boto_keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "cfs_period_us": {
                     "type": "integer",
                     "minimum": 1000,

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -64,6 +64,12 @@
                         "type": "string"
                     }
                 },
+                "boto_keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "mem": {
                     "type": "number",
                     "minimum": 32,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -3723,7 +3723,5 @@ def ldap_user_search(
 
 
 def _reorder_docker_volumes(volumes: List[DockerVolume]) -> List[DockerVolume]:
-    deduped = {
-        v["containerPath"].rstrip("/") + v["hostPath"].rstrip("/"): v for v in volumes
-    }.values()
+    deduped = {v["containerPath"].rstrip("/"): v for v in volumes}.values()
     return sort_dicts(deduped)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1869,7 +1869,7 @@ class TestInstanceConfig:
             {"containerPath": "/a", "hostPath": "/a", "mode": "RO"}
         ]
 
-    def test_get_volumes_dedupes_respects_hostpath(self):
+    def test_get_volumes_dedupes_by_containerpath(self):
         fake_conf = utils.InstanceConfig(
             service="",
             cluster="",
@@ -1883,10 +1883,9 @@ class TestInstanceConfig:
             branch_dict=None,
         )
         system_volumes: List[utils.DockerVolume] = [
-            {"containerPath": "/a", "hostPath": "/a", "mode": "RO"}
+            {"containerPath": "/a", "hostPath": "/yet_another_a", "mode": "RO"}
         ]
         assert fake_conf.get_volumes(system_volumes) == [
-            {"containerPath": "/a", "hostPath": "/a", "mode": "RO"},
             {"containerPath": "/a", "hostPath": "/other_a", "mode": "RO"},
         ]
 


### PR DESCRIPTION
This is mostly experimental at this point. What I'm hoping to achieve is that services can specify which keys they will need to use, and then those keys will be sourced out of a folder, put into a new folder, and have that mounted in as /etc/boto_cfg. This goes along with https://github.yelpcorp.com/sysgit/puppet/pull/3370/files.

We first expect /etc/boto_cfg_private to exist and have keys inside it (see other PR)

Then you add an entry into the service configuration for which boto_keys you will need

When the service is launched, if the boto_keys setting is found, it will attempt to create a new folder within boto_cfg_private for the service, link in the source keys that match the entries, and then add that as another volume.

I updated the volume deduplication code to dedupe based on containerPath only, such that the extra volume added above will trump the default /etc/boto_cfg one. (Note: I don't think it's valid to have two mounts with the same containerPath anyway, this should probably get shipped regardless)

Thus, the service will see /etc/boto_cfg as only the subset of keys it needs. If no boto_keys is specified, no extra volume is added, and the default boto_cfg mount will remain as is.

When the keys get updated, similar code in puppet (see linked review) will update the keys to their new values, and consequently the new keys will appear to the service. The reason this code exists in two places is to prevent race conditions (see linked review discussion).

This isn't super polished at this point, I'm mostly seeking feedback first. There's still some open questions as to whether we want to seriously pursue this. Any and all feedback is welcome.

To test this, I ran a paasta local-run with custom configs:
https://fluffy.yelpcorp.com/i/DPgHNlmPczdb7q1Gzpj5QJqwNR3WcQb4.html