### PR TITLE
Fix new paasta status tip for crashloopbackoff containers with no sta…

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1465,17 +1465,19 @@ def create_replica_table(
 
         main_container = get_main_container(pod)
         if main_container:
-            # If container has no timestamp, use pod's creation
-            timestamp = (
-                datetime.fromtimestamp(main_container.timestamp)
-                if main_container.timestamp
-                else start_datetime
-            )
+            if main_container.timestamp:
+                timestamp = datetime.fromtimestamp(main_container.timestamp)
+            elif main_container.last_timestamp:
+                timestamp = datetime.fromtimestamp(main_container.last_timestamp)
+            else:
+                # if no container timestamps are found, use pod's creation
+                timestamp = start_datetime
+
             humanized_timestamp = humanize.naturaltime(timestamp)
             if recent_container_restart(main_container):
                 table.append(
                     PaastaColors.red(
-                        f"  Restarted at {humanized_timestamp}. {main_container.restart_count} restarts since starting"
+                        f"  Restarted {humanized_timestamp}. {main_container.restart_count} restarts since starting"
                     )
                 )
             if (


### PR DESCRIPTION
…rt time

Right now new status is supposed to display when a container last restarted, however for containers that are not currently running (which is typical for things stuck in `CrashLoopBackoff`), we will display the _pod_ creation time rather than the last restart.

This changes to fetch the last restart time from the container's `last_state` status.

This also fixes the slightly grammatical awkwardness of `Restarted at one minute ago` since `humanize.naturaltime` will always report the time in reference to current time. 

before this change:  (note `at` and bad "Restarted at" time)
https://fluffy.yelpcorp.com/i/SjCr1tlq9KPn8n1T42bgJzJkH14V50H7.html

after this change:
https://fluffy.yelpcorp.com/i/D2hsCPXg630JjzQvT7WCsLWMc13Q8dH5.html