### PR TITLE
PAASTA-17375 - yelpsoa-configs does not validate that registrations are valid

### DIFF
--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -74,6 +74,7 @@ class LongRunningServiceConfigDict(InstanceConfigDict, total=False):
     registrations: List[str]
     replication_threshold: int
     bounce_start_deadline: float
+    smartstack: dict
 
 
 # Defined here to avoid import cycles -- this gets used in bounce_lib and subclassed in marathon_tools.
@@ -226,7 +227,6 @@ class LongRunningServiceConfig(InstanceConfig):
         smartstack = self.config_dict.get("smartstack", {})
         invalid_registrations: List[str] = []
         if smartstack:
-            invalid_registrations: List[str] = []
             for registration in registrations:
                 try:
                     check_registration_in_smartstack(registration, smartstack)
@@ -241,8 +241,10 @@ class LongRunningServiceConfig(InstanceConfig):
         invalid_registrations: List[str] = []
         for registration in registrations:
             try:
-                if decompose_job_id(registration)[2] is not None and \
-                        decompose_job_id(registration)[3] is not None:
+                if (
+                    decompose_job_id(registration)[2] is not None
+                    and decompose_job_id(registration)[3] is not None
+                ):
                     invalid_registrations.append(registration)
             except InvalidJobNameError:
                 invalid_registrations.append(registration)
@@ -347,7 +349,7 @@ class LongRunningServiceConfig(InstanceConfig):
 
         :returns: The number of instances specified in the config, 0 if not
                   specified or if desired_state is not 'start'.
-                  """
+        """
         if self.get_desired_state() == "start":
             return self.get_instances()
         else:

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -74,7 +74,7 @@ class LongRunningServiceConfigDict(InstanceConfigDict, total=False):
     registrations: List[str]
     replication_threshold: int
     bounce_start_deadline: float
-    smartstack: dict
+    smartstack: Dict
 
 
 # Defined here to avoid import cycles -- this gets used in bounce_lib and subclassed in marathon_tools.
@@ -241,10 +241,10 @@ class LongRunningServiceConfig(InstanceConfig):
         invalid_registrations: List[str] = []
         for registration in registrations:
             try:
-                if (
-                    decompose_job_id(registration)[2] is not None
-                    and decompose_job_id(registration)[3] is not None
-                ):
+                service, instance, git_hash, config_hash = decompose_job_id(
+                    registration
+                )
+                if git_hash is not None and config_hash is not None:
                     invalid_registrations.append(registration)
             except InvalidJobNameError:
                 invalid_registrations.append(registration)

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -391,7 +391,7 @@ class LongRunningServiceConfig(InstanceConfig):
             service_instance = compose_job_id(self.service, self.instance)
             registrations_str = ", ".join(registrations_not_in_smartstack)
             error_messages.append(
-                f"Service registrations must exist in the smartstack. "
+                f"Service registrations must exist in smartstack.yaml. "
                 f"The following registrations for {service_instance} are "
                 f"invalid: {registrations_str}"
             )

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -76,6 +76,7 @@ from docker.utils import kwargs_from_env
 from kazoo.client import KazooClient
 from mypy_extensions import TypedDict
 from service_configuration_lib import read_service_configuration
+from service_configuration_lib import ServiceInfoDict
 
 import paasta_tools.cli.fsm
 
@@ -258,7 +259,7 @@ class SecretVolume(TypedDict, total=False):
     items: List[SecretVolumeItem]
 
 
-class InstanceConfigDict(TypedDict, total=False):
+class InstanceConfigDict(ServiceInfoDict, total=False):
     deploy_group: str
     mem: float
     cpus: float

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2739,7 +2739,9 @@ class RegistrationNotInSmartstackError(Exception):
     pass
 
 
-def check_registration_in_smartstack(registration: str, smartstack: dict, spacer: str = SPACER) -> bool:
+def check_registration_in_smartstack(
+    registration: str, smartstack: dict, spacer: str = SPACER
+) -> bool:
     """Checks if a registration is defined in the smartstack.
 
     :param registration: A str from a registration
@@ -2747,7 +2749,9 @@ def check_registration_in_smartstack(registration: str, smartstack: dict, spacer
     :returns: true if the registration exist on the smartstack
     """
     if spacer in registration and registration.split(spacer)[1] not in smartstack:
-        raise RegistrationNotInSmartstackError("Registration %s does not exist in smartstack" % registration)
+        raise RegistrationNotInSmartstackError(
+            "Registration %s does not exist in smartstack" % registration
+        )
     return True
 
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2735,6 +2735,22 @@ def decompose_job_id(job_id: str, spacer: str = SPACER) -> Tuple[str, str, str, 
     return (decomposed[0], decomposed[1], git_hash, config_hash)
 
 
+class RegistrationNotInSmartstackError(Exception):
+    pass
+
+
+def check_registration_in_smartstack(registration: str, smartstack: dict, spacer: str = SPACER) -> bool:
+    """Checks if a registration is defined in the smartstack.
+
+    :param registration: A str from a registration
+    :param smartstack: The smartstack dict
+    :returns: true if the registration exist on the smartstack
+    """
+    if spacer in registration and registration.split(spacer)[1] not in smartstack:
+        raise RegistrationNotInSmartstackError("Registration %s does not exist in smartstack" % registration)
+    return True
+
+
 def build_docker_image_name(service: str) -> str:
     """docker-paasta.yelpcorp.com:443 is the URL for the Registry where PaaSTA
     will look for your images.

--- a/tests/test_long_running_service_tools.py
+++ b/tests/test_long_running_service_tools.py
@@ -282,14 +282,20 @@ class TestLongRunningServiceConfig:
             cluster="fake_cluster",
             instance="fake_instance",
             config_dict={
-                "registrations": ["fake_name.fake_instance.something.something", "valid.valid"],
+                "registrations": [
+                    "fake_name.fake_instance.something.something",
+                    "valid.valid",
+                ],
                 "deploy_group": None,
             },
             branch_dict=None,
         )
         error_messages = fake_conf.validate()
-        assert 'Service registrations must be of the form service.registration. The following registrations for ' \
-               'fake_name.fake_instance are invalid: fake_name.fake_instance.something.something' in error_messages[0]
+        assert (
+            "Service registrations must be of the form service.registration. The following registrations for "
+            "fake_name.fake_instance are invalid: fake_name.fake_instance.something.something"
+            in error_messages[0]
+        )
 
     def test_validate_registration_not_in_smartstack(self):
         fake_conf = long_running_service_tools.LongRunningServiceConfig(
@@ -299,18 +305,29 @@ class TestLongRunningServiceConfig:
             config_dict={
                 "registrations": ["fake_name.fake_instance"],
                 "deploy_group": None,
-                'smartstack': {'fake_smartstack': {'proxy_port': 20783, 'timeout_client_ms': 60000,
-                                                'timeout_server_ms': 60000, 'is_proxy': True,
-                                                'advertise': ['habitat', 'region'], 'discover': 'habitat',
-                                                'extra_advertise': {
-                                                    'ecosystem:devc': ['ecosystem:devc', 'ecosystem:testopia'],
-                                                    'region:uswest2-prod': ['superregion:pnw-yrprod']}}}
+                "smartstack": {
+                    "fake_smartstack": {
+                        "proxy_port": 20783,
+                        "timeout_client_ms": 60000,
+                        "timeout_server_ms": 60000,
+                        "is_proxy": True,
+                        "advertise": ["habitat", "region"],
+                        "discover": "habitat",
+                        "extra_advertise": {
+                            "ecosystem:devc": ["ecosystem:devc", "ecosystem:testopia"],
+                            "region:uswest2-prod": ["superregion:pnw-yrprod"],
+                        },
+                    }
+                },
             },
             branch_dict=None,
         )
         error_messages = fake_conf.validate()
-        assert 'Service registrations must exist in the smartstack. The following registrations for ' \
-               'fake_name.fake_instance are invalid: fake_name.fake_instance' in error_messages[0]
+        assert (
+            "Service registrations must exist in the smartstack. The following registrations for "
+            "fake_name.fake_instance are invalid: fake_name.fake_instance"
+            in error_messages[0]
+        )
 
 
 class TestServiceNamespaceConfig:

--- a/tests/test_long_running_service_tools.py
+++ b/tests/test_long_running_service_tools.py
@@ -324,7 +324,7 @@ class TestLongRunningServiceConfig:
         )
         error_messages = fake_conf.validate()
         assert (
-            "Service registrations must exist in the smartstack. The following registrations for "
+            "Service registrations must exist in smartstack.yaml. The following registrations for "
             "fake_name.fake_instance are invalid: fake_name.fake_instance"
             in error_messages[0]
         )

--- a/tests/test_long_running_service_tools.py
+++ b/tests/test_long_running_service_tools.py
@@ -276,6 +276,42 @@ class TestLongRunningServiceConfig:
         error_messages = fake_conf.validate()
         assert "bad_registration" in error_messages[0]
 
+    def test_validate_with_bad_spaced_registration(self):
+        fake_conf = long_running_service_tools.LongRunningServiceConfig(
+            service="fake_name",
+            cluster="fake_cluster",
+            instance="fake_instance",
+            config_dict={
+                "registrations": ["fake_name.fake_instance.something.something", "valid.valid"],
+                "deploy_group": None,
+            },
+            branch_dict=None,
+        )
+        error_messages = fake_conf.validate()
+        assert 'Service registrations must be of the form service.registration. The following registrations for ' \
+               'fake_name.fake_instance are invalid: fake_name.fake_instance.something.something' in error_messages[0]
+
+    def test_validate_registration_not_in_smartstack(self):
+        fake_conf = long_running_service_tools.LongRunningServiceConfig(
+            service="fake_name",
+            cluster="fake_cluster",
+            instance="fake_instance",
+            config_dict={
+                "registrations": ["fake_name.fake_instance"],
+                "deploy_group": None,
+                'smartstack': {'fake_smartstack': {'proxy_port': 20783, 'timeout_client_ms': 60000,
+                                                'timeout_server_ms': 60000, 'is_proxy': True,
+                                                'advertise': ['habitat', 'region'], 'discover': 'habitat',
+                                                'extra_advertise': {
+                                                    'ecosystem:devc': ['ecosystem:devc', 'ecosystem:testopia'],
+                                                    'region:uswest2-prod': ['superregion:pnw-yrprod']}}}
+            },
+            branch_dict=None,
+        )
+        error_messages = fake_conf.validate()
+        assert 'Service registrations must exist in the smartstack. The following registrations for ' \
+               'fake_name.fake_instance are invalid: fake_name.fake_instance' in error_messages[0]
+
 
 class TestServiceNamespaceConfig:
     def test_get_mode_default(self):


### PR DESCRIPTION
Some services contained registrations that were not declared in smartstack.yaml at all.

This was not caught when the service was on marathon, as we only checked the first registration, but now on kubernetes a service will fail to be deployed if registrations are not valid.

This PR also makes sure that registration meet the `service.registration` format

Note: This PR have [a dependency with this other PR](https://github.com/Yelp/service_configuration_lib/pull/69) to be released