### PR TITLE
Make new paasta status report OOM kills when it is the last state of …

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1478,14 +1478,25 @@ def create_replica_table(
                         f"  Restarted at {humanized_timestamp}. {main_container.restart_count} restarts since starting"
                     )
                 )
-            if main_container.reason == "OOMKilled":
+            if (
+                main_container.reason == "OOMKilled"
+                or main_container.last_reason == "OOMKilled"
+            ):
+                if main_container.reason == "OOMKilled":
+                    oom_kill_timestamp = timestamp
+                    human_oom_kill_timestamp = humanized_timestamp
+                elif main_container.last_reason == "OOMKilled":
+                    oom_kill_timestamp = datetime.fromtimestamp(
+                        main_container.last_timestamp
+                    )
+                    human_oom_kill_timestamp = humanize.naturaltime(oom_kill_timestamp)
                 table.extend(
                     [
                         PaastaColors.red(
-                            f"  OOM Killed at {humanized_timestamp}.  {main_container.restart_count} restarts since starting"
+                            f"  OOM Killed {human_oom_kill_timestamp} ({oom_kill_timestamp})."
                         ),
                         PaastaColors.red(
-                            f"  Check y/check-oom-events and consider increasing memory in yelpsoa_configs"
+                            f"    Check y/check-oom-events and consider increasing memory in yelpsoa_configs"
                         ),
                     ]
                 )


### PR DESCRIPTION
…the container, too

example:
```
service: yelp-main-code-debt
cluster: norcal-devc
    instance: main
    Git sha:    2ce39357 (desired)
    State: Launching replicas
    Running versions:
      Rerun with -v to see all replicas
      2ce39357 - Started 2021-05-21 22:57:52 (5 days ago)
        Replica States: 3 Healthy / 2 Not Running
          Unhealthy Replicas:
            ID                                         IP/Port            Host deployed to  Started at what localtime  State
            yelp-main-code-debt-main-6cd748879c-brpj5  10.93.189.64:8888  10.40.10.46       a day ago                  Not Running
              Restarted at a day ago. 26 restarts since starting
              OOM Killed 17 seconds ago (2021-05-27 17:45:40).
                Check y/check-oom-events and consider increasing memory in yelpsoa_configs
              Consider checking logs with `paasta logs -c norcal-devc -s yelp-main-code-debt -i main -p yelp-main-code-debt-main-6cd748879c-brpj5`
            yelp-main-code-debt-main-6cd748879c-g49kr  10.93.253.51:8888  10.40.22.87       3 hours ago                Not Running
              Restarted at 3 hours ago. 48 restarts since starting
              OOM Killed a minute ago (2021-05-27 17:44:30).
                Check y/check-oom-events and consider increasing memory in yelpsoa_configs
              Consider checking logs with `paasta logs -c norcal-devc -s yelp-main-code-debt -i main -p yelp-main-code-debt-main-6cd748879c-g49kr`
```