### PR TITLE
Scaffold out the k8s toggles for tronjobs

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -169,6 +169,9 @@
             ],
             "additionalProperties": false,
             "properties": {
+                "use_k8s": {
+                    "type": "boolean"
+                },
                 "name": {
                     "$ref": "#definitions/name"
                 },

--- a/paasta_tools/setup_tron_namespace.py
+++ b/paasta_tools/setup_tron_namespace.py
@@ -24,6 +24,8 @@ import argparse
 import logging
 import sys
 
+import ruamel.yaml as yaml
+
 from paasta_tools import tron_tools
 from paasta_tools.tron_tools import MASTER_NAMESPACE
 
@@ -110,10 +112,16 @@ def main():
             skipped.append(MASTER_NAMESPACE)
             log.debug(f"Skipped {MASTER_NAMESPACE}")
 
+    k8s_enabled_for_cluster = (
+        yaml.safe_load(master_config).get("k8s_options", {}).get("enabled", False)
+    )
     for service in sorted(services):
         try:
             new_config = tron_tools.create_complete_config(
-                cluster=args.cluster, service=service, soa_dir=args.soa_dir
+                cluster=args.cluster,
+                service=service,
+                soa_dir=args.soa_dir,
+                k8s_enabled=k8s_enabled_for_cluster,
             )
             if args.dry_run:
                 log.info(f"Would update {service} to:")

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -753,8 +753,13 @@ def format_tron_job_dict(job_config: TronJobConfig, k8s_enabled: bool = False):
         "max_runtime": job_config.get_max_runtime(),
         "time_zone": job_config.get_time_zone(),
         "expected_runtime": job_config.get_expected_runtime(),
-        "use_k8s": job_config.get_use_k8s(),
     }
+    # TODO: this should be directly inlined, but we need to update tron everywhere first so it'll
+    # be slightly less tedious to just conditionally send this now until we clean things up on the
+    # removal of all the Mesos code
+    if job_config.get_use_k8s():
+        result["use_k8s"] = job_config.get_use_k8s()
+
     cleanup_config = job_config.get_cleanup_action()
     if cleanup_config:
         cleanup_action = format_tron_action_dict(

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -4,10 +4,20 @@ import mock
 import pytest
 
 from paasta_tools import tron_tools
+from paasta_tools import utils
 from paasta_tools.tron_tools import MASTER_NAMESPACE
 from paasta_tools.tron_tools import MESOS_EXECUTOR_NAMES
 from paasta_tools.utils import InvalidInstanceConfig
 from paasta_tools.utils import NoDeploymentsAvailable
+
+MOCK_SYSTEM_PAASTA_CONFIG = utils.SystemPaastaConfig(
+    {
+        "docker_registry": "mock_registry",
+        "volumes": [],
+        "dockercfg_location": "/mock/dockercfg",
+    },
+    "/mock/system/configs",
+)
 
 
 class TestTronConfig:
@@ -1091,7 +1101,12 @@ class TestTronTools:
             returncode=1, stdout="tronfig error", stderr=""
         )
 
-        result = tron_tools.validate_complete_config("a_service", "a-cluster")
+        with mock.patch(
+            "paasta_tools.tron_tools.load_system_paasta_config",
+            autospec=True,
+            return_value=MOCK_SYSTEM_PAASTA_CONFIG,
+        ):
+            result = tron_tools.validate_complete_config("a_service", "a-cluster")
 
         assert mock_load_config.call_count == 1
         assert mock_format_job.call_count == 1
@@ -1102,7 +1117,7 @@ class TestTronTools:
     @mock.patch("paasta_tools.tron_tools.format_tron_job_dict", autospec=True)
     @mock.patch("subprocess.run", autospec=True)
     def test_validate_complete_config_passes(
-        self, mock_run, mock_format_job, mock_load_config
+        self, mock_run, mock_format_job, mock_load_config,
     ):
         job_config = mock.Mock(spec_set=tron_tools.TronJobConfig)
         job_config.get_name.return_value = "my_job"
@@ -1111,7 +1126,12 @@ class TestTronTools:
         mock_format_job.return_value = {}
         mock_run.return_value = mock.Mock(returncode=0, stdout="OK", stderr="")
 
-        result = tron_tools.validate_complete_config("a_service", "a-cluster")
+        with mock.patch(
+            "paasta_tools.tron_tools.load_system_paasta_config",
+            autospec=True,
+            return_value=MOCK_SYSTEM_PAASTA_CONFIG,
+        ):
+            result = tron_tools.validate_complete_config("a_service", "a-cluster")
 
         assert mock_load_config.call_count == 1
         assert mock_format_job.call_count == 1

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -394,7 +394,6 @@ class TestTronJobConfig:
             },
             "expected_runtime": "1h",
             "monitoring": {"team": "noop"},
-            "use_k8s": False,
         }
 
     @mock.patch(
@@ -482,7 +481,6 @@ class TestTronJobConfig:
             },
             "cleanup_action": mock_format_action.return_value,
             "monitoring": {"team": "noop"},
-            "use_k8s": False,
         }
 
     @mock.patch("paasta_tools.utils.get_pipeline_deploy_groups", autospec=True)


### PR DESCRIPTION
We're handling the toggles in PaaSTA rather than Tron since the
cluster-level config isn't easily available when setting up an
ActionRun, so we will instead use setup_tron_namespace to configure Tron
to use either Mesos or Kubernetes.

Additionally, we'll need to add some translation layers for things like
Mesos constraints/Docker parameters, so we might as well centralize that
here rather than setup Mesos here and Kubernetes in Tron.

The general idea here is that we want our config sync to handle toggling the 
use of k8s - disabling k8s for an entire cluster will lead to this sync setting
`use_k8s` to false for all jobs and therefore set the executor back to `mesos`
for everything