### PR TITLE
Define proper type for monitoring key in InstanceConfigDict.

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -258,6 +258,25 @@ class SecretVolume(TypedDict, total=False):
     items: List[SecretVolumeItem]
 
 
+class MonitoringDict(TypedDict, total=False):
+    alert_after: Union[str, float]
+    check_every: str
+    check_oom_events: bool
+    component: str
+    description: str
+    notification_email: Union[str, bool]
+    page: bool
+    priority: str
+    project: str
+    realert_every: float
+    runbook: str
+    slack_channels: Union[str, List[str]]
+    tags: List[str]
+    team: str
+    ticket: bool
+    tip: str
+
+
 class InstanceConfigDict(TypedDict, total=False):
     deploy_group: str
     mem: float
@@ -269,7 +288,7 @@ class InstanceConfigDict(TypedDict, total=False):
     cpu_burst_add: float
     cap_add: List
     env: Dict[str, str]
-    monitoring: Dict[str, str]
+    monitoring: MonitoringDict
     deploy_blacklist: UnsafeDeployBlacklist
     deploy_whitelist: UnsafeDeployWhitelist
     pool: str
@@ -628,7 +647,7 @@ class InstanceConfig:
                     "Instance configuration can specify cmd or args, but not both."
                 )
 
-    def get_monitoring(self) -> Dict[str, Any]:
+    def get_monitoring(self) -> MonitoringDict:
         """Get monitoring overrides defined for the given instance"""
         return self.config_dict.get("monitoring", {})
 

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1627,10 +1627,10 @@ class TestMarathonTools:
             service="fake_name",
             cluster="fake_cluster",
             instance="fake_instance",
-            config_dict={"monitoring": {"test": "foo"}},
+            config_dict={"monitoring": {"notification_email": "foo"}},
             branch_dict=None,
         )
-        assert fake_conf.get_monitoring() == {"test": "foo"}
+        assert fake_conf.get_monitoring() == {"notification_email": "foo"}
 
     def test_get_marathon_client(self):
         fake_url = ["nothing_for_me_to_do_but_dance"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1291,7 +1291,7 @@ class TestInstanceConfig:
         assert actual == expect
 
     def test_get_monitoring(self):
-        fake_info = {"fake_key": "fake_value"}
+        fake_info: utils.MonitoringDict = {"notification_email": "fake_value"}
         assert (
             utils.InstanceConfig(
                 service="",


### PR DESCRIPTION
For the benefit of mypy in yelpsoa-configs templating.