### PR TITLE
PAASTA-17337 - capturing instance misconfiguration exceptions for setup_kubernetes_job

### DIFF
--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -168,8 +168,7 @@ def setup_kube_deployments(
                 log.info(f"Ensuring related API objects for {app} are in sync")
                 app.update_related_api_objects(kube_client)
             except Exception:
-                log.error(f"Error while processing: {app}")
-                log.error(traceback.format_exc())
+                log.exception(f"Error while processing: {app}")
         if rate_limit > 0 and api_updates >= rate_limit:
             log.info(
                 f"Not doing any further updates as we reached the limit ({api_updates})"

--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -23,7 +23,6 @@ Command line options:
 import argparse
 import logging
 import sys
-import traceback
 from typing import Optional
 from typing import Sequence
 from typing import Tuple

--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -23,6 +23,7 @@ Command line options:
 import argparse
 import logging
 import sys
+import traceback
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
@@ -149,22 +150,26 @@ def setup_kube_deployments(
     api_updates = 0
     for _, app in applications:
         if app:
-            if (
-                app.kube_deployment.service,
-                app.kube_deployment.instance,
-            ) not in existing_apps:
-                log.info(f"Creating {app} because it does not exist yet.")
-                app.create(kube_client)
-                api_updates += 1
-            elif app.kube_deployment not in existing_kube_deployments:
-                log.info(f"Updating {app} because configs have changed.")
-                app.update(kube_client)
-                api_updates += 1
-            else:
-                log.info(f"{app} is up-to-date!")
+            try:
+                if (
+                    app.kube_deployment.service,
+                    app.kube_deployment.instance,
+                ) not in existing_apps:
+                    log.info(f"Creating {app} because it does not exist yet.")
+                    app.create(kube_client)
+                    api_updates += 1
+                elif app.kube_deployment not in existing_kube_deployments:
+                    log.info(f"Updating {app} because configs have changed.")
+                    app.update(kube_client)
+                    api_updates += 1
+                else:
+                    log.info(f"{app} is up-to-date!")
 
-            log.info(f"Ensuring related API objects for {app} are in sync")
-            app.update_related_api_objects(kube_client)
+                log.info(f"Ensuring related API objects for {app} are in sync")
+                app.update_related_api_objects(kube_client)
+            except Exception:
+                log.error(f"Error while processing: {app}")
+                log.error(traceback.format_exc())
         if rate_limit > 0 and api_updates >= rate_limit:
             log.info(
                 f"Not doing any further updates as we reached the limit ({api_updates})"


### PR DESCRIPTION
If one instance is misconfigured and hits an exception, it will cause the entire run to fail and will not progress to the other service instances that have yet to be setup.