### PR TITLE
Configure GHA to upload an sdist+wheel to public pypi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 ---
 name: paasta-ci
-on: [push, release]
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  release:
+
 jobs:
   tox:
     runs-on: ubuntu-20.04

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,46 @@
+---
+name: paasta-pypi
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  tox:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        toxenv:
+          - py37-linux,docs,mypy,tests
+          - general_itests
+          - paasta_itests
+          - example_cluster
+    env:
+      PIP_INDEX_URL: https://pypi.python.org/simple
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - run: python -m pip install --upgrade pip
+      - run: pip install coveralls tox==3.2 tox-pip-extensions==1.3.0 ephemeral-port-reserve
+      - run: tox -i https://pypi.python.org/simple -e ${{ matrix.toxenv }}
+  pypi:
+    # lets run tests before we push anything to pypi, much like we do internally
+    needs: tox
+    runs-on: ubuntu-20.04
+    env:
+      PIP_INDEX_URL: https://pypi.python.org/simple
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      # this will create a .tar.gz with all the code (i.e., an sdist)
+      - run: python setup.py sdist
+      # and finally, upload the above sdist to public PyPI
+      - uses: pypa/gh-action-pypi-publish@v1.2.2
+        with:
+          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
nerve-tools uses paasta as a dependency, so without doing this we can't
use any new paasta features there.

we only stopped uploading sdists with the migration to GHA since we
wanted to focus on getting public CI back up and public PyPI uploads
could wait a bit.

lastly, I've also added back wheel uploads since it seems like we had
stopped doing that for a while in travis (and i'm assuming that wasn't
on purpose).