### PR TITLE
Add registration labels to pods

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1570,6 +1570,12 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         if prometheus_shard:
             labels["paasta.yelp.com/prometheus_shard"] = prometheus_shard
 
+        if system_paasta_config.get_kubernetes_add_registration_labels():
+            # Allow Kubernetes Services to easily find
+            # pods belonging to a certain smartstack namespace
+            for registration in self.get_registrations():
+                labels[f"paasta.yelp.com/registrations/{registration}"] = "true"  # type: ignore
+
         # not all services use uwsgi autoscaling, so we label those that do in order to have
         # prometheus selectively discover/scrape them
         if self.should_run_uwsgi_exporter_sidecar(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1889,6 +1889,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     git_config: Dict
     hacheck_sidecar_image_url: str
     hacheck_sidecar_volumes: List[DockerVolume]
+    kubernetes_add_registration_labels: bool
     kubernetes_custom_resources: List[KubeCustomResourceDict]
     kubernetes_use_hacheck_sidecar: bool
     ldap_host: str
@@ -2437,6 +2438,9 @@ class SystemPaastaConfig:
     def get_register_k8s_pods(self) -> bool:
         """Enable registration of k8s services in nerve"""
         return self.config_dict.get("register_k8s_pods", False)
+
+    def get_kubernetes_add_registration_labels(self) -> bool:
+        return self.config_dict.get("kubernetes_add_registration_labels", False)
 
     def get_kubernetes_custom_resources(self) -> Sequence[KubeCustomResourceDict]:
         """List of custom resources that should be synced by setup_kubernetes_cr """

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1480,6 +1480,9 @@ class TestKubernetesDeploymentConfig:
         mock_get_node_affinity.return_value = node_affinity
         mock_get_pod_anti_affinity.return_value = anti_affinity
         mock_system_paasta_config = mock.Mock()
+        mock_system_paasta_config.get_kubernetes_add_registration_labels.return_value = (
+            True
+        )
         mock_system_paasta_config.get_pod_defaults.return_value = dict(dns_policy="foo")
         mock_get_termination_grace_period.return_value = termination_grace_period
 
@@ -1511,6 +1514,7 @@ class TestKubernetesDeploymentConfig:
                     "paasta.yelp.com/git_sha": "aaaa123",
                     "paasta.yelp.com/instance": mock_get_instance.return_value,
                     "paasta.yelp.com/service": mock_get_service.return_value,
+                    "paasta.yelp.com/registrations/kurupt.fm": "true",
                 },
                 annotations={
                     "smartstack_registrations": '["kurupt.fm"]',


### PR DESCRIPTION
Since rolling this out in one go will bounce all services, we need to roll it out carefully and slowly.