### PR TITLE
Change the label keys for registrations

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1579,7 +1579,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             # Allow Kubernetes Services to easily find
             # pods belonging to a certain smartstack namespace
             for registration in self.get_registrations():
-                labels[f"paasta.yelp.com/registrations/{registration}"] = "true"  # type: ignore
+                labels[f"registrations.paasta.yelp.com/{registration}"] = "true"  # type: ignore
 
         if self.is_istio_sidecar_injection_enabled():
             labels["sidecar.istio.io/inject"] = "true"

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1514,7 +1514,7 @@ class TestKubernetesDeploymentConfig:
                     "paasta.yelp.com/git_sha": "aaaa123",
                     "paasta.yelp.com/instance": mock_get_instance.return_value,
                     "paasta.yelp.com/service": mock_get_service.return_value,
-                    "paasta.yelp.com/registrations/kurupt.fm": "true",
+                    "registrations.paasta.yelp.com/kurupt.fm": "true",
                 },
                 annotations={
                     "smartstack_registrations": '["kurupt.fm"]',


### PR DESCRIPTION
According to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/, labels can only have one /. I'm using registrations.paasta instead of something like paasta.yelp.com/registrations_service_name because there's also a maximum of 63 characters allowed to the label's name section, which is whatever follows the slash, so using a subdomain seems to be a wiser solution.

Also tested this manually by running it on kubestage's k8s CM leader