### PR TITLE
TRON-1625: Support adding paasta default_volumes to tron master k8s config

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -650,6 +650,15 @@ def format_master_config(master_config, default_volumes, dockercfg_location):
         }
     )
     master_config["mesos_options"] = mesos_options
+
+    k8s_options = master_config.get("k8s_options", {})
+    if k8s_options:
+        # Only add default volumes if we already have k8s_options
+        # TODO: Gate this on whether k8s on tron is enabled
+        k8s_options.update(
+            {"default_volumes": format_volumes(default_volumes),}
+        )
+        master_config["k8s_options"] = k8s_options
     return master_config
 
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -654,7 +654,6 @@ def format_master_config(master_config, default_volumes, dockercfg_location):
     k8s_options = master_config.get("k8s_options", {})
     if k8s_options:
         # Only add default volumes if we already have k8s_options
-        # TODO: Gate this on whether k8s on tron is enabled
         k8s_options.update(
             {"default_volumes": format_volumes(default_volumes),}
         )

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -641,6 +641,25 @@ class TestTronTools:
             },
         }
 
+        master_config["k8s_options"] = {
+            "kubeconfig_path": "/var/lib/tron/kubeconfig.conf"
+        }
+
+        result = tron_tools.format_master_config(
+            master_config, paasta_volumes, dockercfg
+        )
+
+        assert result["k8s_options"] == {
+            "kubeconfig_path": "/var/lib/tron/kubeconfig.conf",
+            "default_volumes": [
+                {
+                    "container_path": "/nail/other",
+                    "host_path": "/other/home",
+                    "mode": "RW",
+                }
+            ],
+        }
+
     def test_format_tron_action_dict_default_executor(self):
         action_dict = {
             "command": "echo something",


### PR DESCRIPTION
This change adds support for updating/adding the `default_volumes` key into MASTER config, using the paasta system-level default volumes (i.e. /etc/paasta/volumes.json).

A manual dry-run of `setup_tron_namespace` shows it would generate the expected config: https://fluffy.yelpcorp.com/i/zqDppdXcs5zTqjzXBxX3Lv2DdBg3t7Pd.html

Note that this currently only _updates_ the `k8s_options` key if it already exists in MASTER config (i.e. we've already specified it manually in yelpsoa-configs ourselves), to allow us to gate this only to tron servers that have already been updated with k8s support.