### PR TITLE
Fix GHA pypi workflow's DOCKER_REGISTRY

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,6 +19,7 @@ jobs:
           - example_cluster
     env:
       PIP_INDEX_URL: https://pypi.python.org/simple
+      DOCKER_REGISTRY: ""
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -33,6 +34,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       PIP_INDEX_URL: https://pypi.python.org/simple
+      DOCKER_REGISTRY: ""
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
https://github.com/Yelp/paasta/pull/3138/files made our default docker registry our internal yelpcorp.com one, but for github actions we need to override back to DockerHub.

This just adds the empty `DOCKER_REGISTRY`  envvar to both jobs in the `pypi` workflow, just as we configured in the `ci` workflow in #3138. 