### PR TITLE
Refactor wait-for-deployment to use asyncio and futures instead of a …

### DIFF
--- a/paasta_tools/cassandracluster_tools.py
+++ b/paasta_tools/cassandracluster_tools.py
@@ -37,7 +37,6 @@ log.addHandler(logging.NullHandler())
 
 
 class CassandraClusterDeploymentConfigDict(LongRunningServiceConfigDict, total=False):
-    bounce_margin_factor: float
     replicas: int
 
 
@@ -111,9 +110,6 @@ class CassandraClusterDeploymentConfig(LongRunningServiceConfig):
         crossover is the closest
         """
         return "crossover"
-
-    def get_bounce_margin_factor(self) -> float:
-        return self.config_dict.get("bounce_margin_factor", 1.0)
 
     def get_sanitised_service_name(self) -> str:
         return sanitise_kubernetes_name(self.get_service())

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1405,9 +1405,9 @@ async def wait_for_deployment(
                 for coro in asyncio.as_completed(
                     instance_done_futures, timeout=timeout
                 ):
+                    cluster, instance = await coro
                     finished_instances += 1
                     bar.update(finished_instances)
-                    cluster, instance = await coro
                     if progress is not None:
                         progress.percent = bar.percentage
                         remaining_instances[cluster].remove(instance)

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1401,6 +1401,15 @@ async def wait_for_deployment(
             }
             finished_instances = 0
 
+            async def periodically_update_progressbar():
+                while True:
+                    await asyncio.sleep(60)
+                    bar.update(finished_instances)
+
+            periodically_update_progressbar_task = asyncio.create_task(
+                periodically_update_progressbar()
+            )
+
             try:
                 for coro in asyncio.as_completed(
                     instance_done_futures, timeout=timeout
@@ -1428,6 +1437,8 @@ async def wait_for_deployment(
                     progress.percent = 100.0
                     progress.waiting_on = None
                 return 0
+            finally:
+                periodically_update_progressbar_task.cancel()
 
 
 def compose_timeout_message(

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -36,6 +36,7 @@ from typing import Iterator
 from typing import List
 from typing import Mapping
 from typing import Optional
+from typing import Set
 from typing import Tuple
 
 import a_sync
@@ -1113,7 +1114,7 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
 
 
 async def wait_until_instance_is_done(
-    pool,
+    executor: concurrent.futures.Executor,
     service: str,
     instance: str,
     cluster: str,
@@ -1122,7 +1123,7 @@ async def wait_until_instance_is_done(
 ) -> Tuple[str, str]:
     loop = asyncio.get_running_loop()
     while not await loop.run_in_executor(
-        pool,
+        executor,
         functools.partial(
             check_if_instance_is_done,
             service,
@@ -1320,7 +1321,7 @@ def get_instance_configs_for_service_in_deploy_group_all_clusters(
         service=service, soa_dir=soa_dir, load_deployments=False
     )
 
-    ret = {}
+    instance_configs_per_cluster = {}
 
     api_endpoints = load_system_paasta_config().get_api_endpoints()
     for cluster in service_configs.clusters:
@@ -1332,13 +1333,13 @@ def get_instance_configs_for_service_in_deploy_group_all_clusters(
             )
             raise NoSuchCluster
 
-        ret[cluster] = list(
+        instance_configs_per_cluster[cluster] = list(
             get_instance_configs_for_service_in_cluster_and_deploy_group(
                 service_configs, cluster, deploy_group
             )
         )
 
-    return ret
+    return instance_configs_per_cluster
 
 
 @a_sync.to_blocking
@@ -1379,13 +1380,13 @@ async def wait_for_deployment(
 
     with progressbar.ProgressBar(maxval=total_instances) as bar:
         instance_done_futures = []
-        with concurrent.futures.ThreadPoolExecutor() as pool:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             for cluster, instance_configs in instance_configs_per_cluster.items():
                 for instance_config in instance_configs:
                     instance_done_futures.append(
                         asyncio.ensure_future(
                             wait_until_instance_is_done(
-                                pool,
+                                executor,
                                 service,
                                 instance_config.get_instance(),
                                 cluster,
@@ -1395,8 +1396,8 @@ async def wait_for_deployment(
                         )
                     )
 
-            remaining_instances: Dict[str, List[str]] = {
-                cluster: [ic.get_instance() for ic in instance_configs]
+            remaining_instances: Dict[str, Set[str]] = {
+                cluster: {ic.get_instance() for ic in instance_configs}
                 for cluster, instance_configs in instance_configs_per_cluster.items()
             }
             finished_instances = 0
@@ -1442,7 +1443,11 @@ async def wait_for_deployment(
 
 
 def compose_timeout_message(
-    remaining_instances: Dict[str, List[str]], timeout, deploy_group, service, git_sha
+    remaining_instances: Mapping[str, Collection[str]],
+    timeout,
+    deploy_group,
+    service,
+    git_sha,
 ):
     paasta_status = []
     paasta_logs = []

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -309,7 +309,6 @@ KubePodLabels = TypedDict(
 
 class KubernetesDeploymentConfigDict(LongRunningServiceConfigDict, total=False):
     bounce_method: str
-    bounce_margin_factor: float
     bounce_health_params: Dict[str, Any]
     service_account_name: str
     node_selectors: Dict[str, Union[str, Dict[str, Any]]]
@@ -1764,9 +1763,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             service=self.get_service(), environment_variables=self.get_env()
         )
         return ahash
-
-    def get_bounce_margin_factor(self) -> float:
-        return self.config_dict.get("bounce_margin_factor", 1.0)
 
     def get_termination_grace_period(self) -> Optional[int]:
         return self.config_dict.get("lifecycle", KubeLifecycleDict({})).get(

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -73,6 +73,7 @@ class LongRunningServiceConfigDict(InstanceConfigDict, total=False):
     registrations: List[str]
     replication_threshold: int
     bounce_start_deadline: float
+    bounce_margin_factor: float
 
 
 # Defined here to avoid import cycles -- this gets used in bounce_lib and subclassed in marathon_tools.
@@ -367,6 +368,9 @@ class LongRunningServiceConfig(InstanceConfig):
                 f"invalid: {registrations_str}"
             )
         return error_messages
+
+    def get_bounce_margin_factor(self) -> float:
+        return self.config_dict.get("bounce_margin_factor", 1.0)
 
 
 class InvalidHealthcheckMode(Exception):

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -219,7 +219,6 @@ class MarathonServiceConfigDict(LongRunningServiceConfigDict, total=False):
     max_launch_delay_seconds: float
     bounce_method: str
     bounce_health_params: Dict[str, Any]
-    bounce_margin_factor: float
     accepted_resource_roles: Optional[List[str]]
     host_port: int
     marathon_shard: int
@@ -855,9 +854,6 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         if service_namespace_config.is_in_smartstack():
             default = {"check_haproxy": True}
         return self.config_dict.get("bounce_health_params", default)
-
-    def get_bounce_margin_factor(self) -> float:
-        return self.config_dict.get("bounce_margin_factor", 1.0)
 
     def get_accepted_resource_roles(self) -> Optional[List[str]]:
         return self.config_dict.get("accepted_resource_roles", None)

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from queue import Queue
-from threading import Event
+import asyncio
 
 from mock import Mock
 from mock import patch
@@ -40,217 +39,188 @@ class fake_args:
     verbose = False
 
 
-def mock_status_instance_side_effect(
-    service, instance, include_smartstack, include_envoy, include_mesos
-):
-    if instance in ["instance1", "instance6", "notaninstance", "api_error"]:
-        # valid completed instance
-        mock_mstatus = Mock(
-            app_count=1,
-            deploy_status="Running",
-            expected_instance_count=2,
-            running_instance_count=2,
-        )
-    if instance == "instance2":
-        # too many marathon apps
-        mock_mstatus = Mock(
-            app_count=2,
-            deploy_status="Running",
-            expected_instance_count=2,
-            running_instance_count=2,
-        )
-    if instance == "instance3":
-        # too many running instances
-        mock_mstatus = Mock(
-            app_count=1,
-            deploy_status="Running",
-            expected_instance_count=2,
-            running_instance_count=4,
-        )
-    if instance == "instance4":
-        # still Deploying
-        mock_mstatus = Mock(
-            app_count=1,
-            deploy_status="Deploying",
-            expected_instance_count=2,
-            running_instance_count=2,
-        )
-    if instance == "instance4.1":
-        # still Deploying
-        mock_mstatus = Mock(
-            app_count=1,
-            deploy_status="Waiting",
-            expected_instance_count=2,
-            running_instance_count=2,
-        )
-    if instance == "instance5":
-        # not a marathon instance
-        mock_mstatus = None
-    if instance == "instance7":
-        # paasta stop'd
-        mock_mstatus = Mock(
-            app_count=1,
-            deploy_status="Stopped",
-            expected_instance_count=0,
-            running_instance_count=0,
-            desired_state="stop",
-        )
-    if instance == "instance8":
-        # paasta has autoscaled to 0
-        mock_mstatus = Mock(
-            app_count=1,
-            deploy_status="Stopped",
-            expected_instance_count=0,
-            running_instance_count=0,
-        )
-    mock_status = Mock()
-    mock_status.git_sha = "somesha"
-    if instance == "instance6":
-        # running the wrong version
-        mock_status.git_sha = "anothersha"
-    mock_status.marathon = mock_mstatus
-    mock_status.kubernetes = None
-
-    if instance == "notaninstance":
-        # not an instance paasta can find
-        raise ApiException(status=404, reason="")
-    if instance == "api_error":
-        # not an instance paasta can find
-        raise ApiException(status=500, reason="")
-
-    return mock_status
-
-
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log", autospec=True)
 @patch(
     "paasta_tools.cli.cmds.mark_for_deployment.client.get_paasta_oapi_client",
     autospec=True,
 )
-def test_instances_deployed(mock_get_paasta_oapi_client, mock__log):
+def test_check_if_instance_is_done(mock_get_paasta_oapi_client, mock__log):
     mock_paasta_api_client = Mock()
     mock_paasta_api_client.api_error = ApiException
     mock_get_paasta_oapi_client.return_value = mock_paasta_api_client
-    mock_paasta_api_client.service.status_instance.side_effect = (
-        mock_status_instance_side_effect
-    )
 
-    f = mark_for_deployment.instances_deployed
-    e = Event()
-    e.set()
-    cluster_data = mark_for_deployment.ClusterData(
-        cluster="cluster",
-        service="service1",
+    def check_instance(instance_config):
+        return mark_for_deployment.check_if_instance_is_done(
+            service="service1",
+            instance=instance_config.get_instance(),
+            cluster="cluster",
+            git_sha="somesha",
+            instance_config=instance_config,
+        )
+
+    # valid completed instance
+    mock_paasta_api_client.service.status_instance.return_value = Mock(
         git_sha="somesha",
-        instances_queue=Queue(),
+        kubernetes=None,
+        marathon=Mock(
+            app_count=1,
+            active_shas=None,
+            deploy_status="Running",
+            expected_instance_count=2,
+            running_instance_count=2,
+        ),
     )
-    cluster_data.instances_queue.put(mock_marathon_instance_config("instance1"))
-    instances_out = Queue()
-    f(cluster_data, instances_out, e)
-    assert cluster_data.instances_queue.empty()
-    assert instances_out.empty()
+    assert check_instance(mock_marathon_instance_config("instance1"))
 
-    cluster_data.instances_queue = Queue()
-    cluster_data.instances_queue.put(mock_marathon_instance_config("instance1"))
-    cluster_data.instances_queue.put(mock_marathon_instance_config("instance2"))
-    instances_out = Queue()
-    f(cluster_data, instances_out, e)
-    assert cluster_data.instances_queue.empty()
-    assert instances_out.get(block=False).get_instance() == "instance2"
+    # too many marathon apps
+    mock_paasta_api_client.service.status_instance.return_value = Mock(
+        git_sha="somesha",
+        kubernetes=None,
+        marathon=Mock(
+            app_count=2,
+            active_shas=None,
+            deploy_status="Running",
+            expected_instance_count=2,
+            running_instance_count=2,
+        ),
+    )
+    assert not check_instance(mock_marathon_instance_config("instance2"))
 
-    cluster_data.instances_queue = Queue()
-    cluster_data.instances_queue.put("instance3")
-    instances_out = Queue()
-    f(cluster_data, instances_out, e)
-    assert cluster_data.instances_queue.empty()
-    assert instances_out.empty()
+    # too many running instances
+    mock_paasta_api_client.service.status_instance.return_value = Mock(
+        git_sha="somesha",
+        kubernetes=None,
+        marathon=Mock(
+            app_count=1,
+            active_shas=None,
+            deploy_status="Running",
+            expected_instance_count=2,
+            running_instance_count=4,
+        ),
+    )
+    assert check_instance(mock_marathon_instance_config("instance3"))
 
-    cluster_data.instances_queue = Queue()
-    cluster_data.instances_queue.put(mock_marathon_instance_config("instance4"))
-    instances_out = Queue()
-    f(cluster_data, instances_out, e)
-    assert cluster_data.instances_queue.empty()
-    assert instances_out.empty()
+    # still Deploying
+    mock_paasta_api_client.service.status_instance.return_value = Mock(
+        git_sha="somesha",
+        kubernetes=None,
+        marathon=Mock(
+            app_count=1,
+            active_shas=None,
+            deploy_status="Deploying",
+            expected_instance_count=2,
+            running_instance_count=2,
+        ),
+    )
+    assert check_instance(mock_marathon_instance_config("instance4"))
 
-    cluster_data.instances_queue = Queue()
-    cluster_data.instances_queue.put(mock_marathon_instance_config("instance4.1"))
-    instances_out = Queue()
-    f(cluster_data, instances_out, e)
-    assert cluster_data.instances_queue.empty()
-    assert instances_out.empty()
+    # still Deploying
+    mock_paasta_api_client.service.status_instance.return_value = Mock(
+        git_sha="somesha",
+        kubernetes=None,
+        marathon=Mock(
+            app_count=1,
+            active_shas=None,
+            deploy_status="Waiting",
+            expected_instance_count=2,
+            running_instance_count=2,
+        ),
+    )
+    assert check_instance(mock_marathon_instance_config("instance4.1"))
 
-    cluster_data.instances_queue = Queue()
-    cluster_data.instances_queue.put(mock_marathon_instance_config("instance5"))
-    cluster_data.instances_queue.put(mock_marathon_instance_config("instance1"))
-    instances_out = Queue()
-    f(cluster_data, instances_out, e)
-    assert cluster_data.instances_queue.empty()
-    assert instances_out.empty()
+    # not a marathon instance
+    mock_paasta_api_client.service.status_instance.return_value = Mock(
+        git_sha="somesha", kubernetes=None, marathon=None,
+    )
+    assert check_instance(mock_marathon_instance_config("instance5"))
 
-    cluster_data.instances_queue = Queue()
-    cluster_data.instances_queue.put(mock_marathon_instance_config("instance6"))
-    instances_out = Queue()
-    f(cluster_data, instances_out, e)
-    assert cluster_data.instances_queue.empty()
-    assert instances_out.get(block=False).get_instance() == "instance6"
+    # wrong sha
+    mock_paasta_api_client.service.status_instance.return_value = Mock(
+        git_sha="anothersha",
+        kubernetes=None,
+        marathon=Mock(
+            app_count=1,
+            active_shas=None,
+            deploy_status="Running",
+            expected_instance_count=2,
+            running_instance_count=2,
+        ),
+    )
+    assert not check_instance(mock_marathon_instance_config("instance6"))
 
-    cluster_data.instances_queue = Queue()
-    cluster_data.instances_queue.put(mock_marathon_instance_config("notaninstance"))
-    instances_out = Queue()
-    f(cluster_data, instances_out, e)
-    assert cluster_data.instances_queue.empty()
-    assert instances_out.get(block=False).get_instance() == "notaninstance"
+    # paasta stop'd
+    mock_paasta_api_client.service.status_instance.return_value = Mock(
+        git_sha="somesha",
+        kubernetes=None,
+        marathon=Mock(
+            app_count=1,
+            active_shas=None,
+            deploy_status="Stopped",
+            expected_instance_count=0,
+            running_instance_count=0,
+            desired_state="stop",
+        ),
+    )
+    assert check_instance(mock_marathon_instance_config("instance7"))
 
-    cluster_data.instances_queue = Queue()
-    cluster_data.instances_queue.put(mock_marathon_instance_config("api_error"))
-    instances_out = Queue()
-    f(cluster_data, instances_out, e)
-    assert cluster_data.instances_queue.empty()
-    assert instances_out.get(block=False).get_instance() == "api_error"
+    # paasta has autoscaled to 0
+    mock_paasta_api_client.service.status_instance.return_value = Mock(
+        git_sha="somesha",
+        kubernetes=None,
+        marathon=Mock(
+            app_count=1,
+            active_shas=None,
+            deploy_status="Stopped",
+            expected_instance_count=0,
+            running_instance_count=0,
+        ),
+    )
+    assert check_instance(mock_marathon_instance_config("instance8"))
 
-    cluster_data.instances_queue = Queue()
-    cluster_data.instances_queue.put(mock_marathon_instance_config("instance7"))
-    instances_out = Queue()
-    f(cluster_data, instances_out, e)
-    assert cluster_data.instances_queue.empty()
-    assert instances_out.empty()
+    # not found -> maybe this is the first time we're deploying it, and it's not up yet.
+    mock_paasta_api_client.service.status_instance.side_effect = ApiException(
+        status=404, reason=""
+    )
+    assert not check_instance(mock_marathon_instance_config("notaninstance"))
 
-    cluster_data.instances_queue = Queue()
-    cluster_data.instances_queue.put(mock_marathon_instance_config("instance8"))
-    instances_out = Queue()
-    f(cluster_data, instances_out, e)
-    assert cluster_data.instances_queue.empty()
-    assert instances_out.empty()
-
-
-def instances_deployed_side_effect(cluster_data, instances_out, green_light):
-    while not cluster_data.instances_queue.empty():
-        instance_config = cluster_data.instances_queue.get()
-        if instance_config.get_instance() not in ["instance1", "instance2"]:
-            instances_out.put(instance_config)
-        cluster_data.instances_queue.task_done()
+    # crash -> consider it not done yet, hope it stops crashing later
+    mock_paasta_api_client.service.status_instance.side_effect = ApiException(
+        status=500, reason=""
+    )
+    assert not check_instance(mock_marathon_instance_config("api_error"))
 
 
 @patch(
     "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
 )
 @patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.PaastaServiceConfigLoader", autospec=True
+    "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+    autospec=True,
 )
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log", autospec=True)
-@patch("paasta_tools.cli.cmds.mark_for_deployment.instances_deployed", autospec=True)
+@patch(
+    "paasta_tools.cli.cmds.mark_for_deployment.check_if_instance_is_done", autospec=True
+)
 def test_wait_for_deployment(
-    mock_instances_deployed,
+    mock_check_if_instance_is_done,
     mock__log,
-    mock_paasta_service_config_loader,
+    mock_get_instance_configs_for_service_in_deploy_group_all_clusters,
     mock_load_system_paasta_config,
 ):
-    mock_paasta_service_config_loader.return_value.clusters = ["cluster1"]
-    mock_paasta_service_config_loader.return_value.instance_configs.return_value = [
-        mock_marathon_instance_config("instance1"),
-        mock_marathon_instance_config("instance2"),
-        mock_marathon_instance_config("instance3"),
-    ]
-    mock_instances_deployed.side_effect = instances_deployed_side_effect
+    mock_get_instance_configs_for_service_in_deploy_group_all_clusters.return_value = {
+        "cluster1": [
+            mock_marathon_instance_config("instance1"),
+            mock_marathon_instance_config("instance2"),
+            mock_marathon_instance_config("instance3"),
+        ],
+    }
+
+    def check_if_instance_is_done_side_effect(
+        service, instance, cluster, git_sha, instance_config, api=None
+    ):
+        return instance in ["instance1", "instance2"]
+
+    mock_check_if_instance_is_done.side_effect = check_if_instance_is_done_side_effect
 
     mock_load_system_paasta_config.return_value.get_api_endpoints.return_value = {
         "cluster1": "some_url_1",
@@ -258,28 +228,23 @@ def test_wait_for_deployment(
     }
 
     with raises(TimeoutError):
-        with patch("time.time", side_effect=[0, 0, 2], autospec=True):
-            with patch("time.sleep", autospec=True):
-                mark_for_deployment.wait_for_deployment(
-                    "service", "fake_deploy_group", "somesha", "/nail/soa", 1
-                )
+        with patch(
+            "asyncio.as_completed", side_effect=[asyncio.TimeoutError], autospec=True
+        ):
+            mark_for_deployment.wait_for_deployment(
+                "service", "fake_deploy_group", "somesha", "/nail/soa", 1
+            )
 
-    mock_paasta_service_config_loader.return_value.clusters = ["cluster1", "cluster2"]
-    # TODO: mock clusters_data_to_wait_for instead of this
-    mock_paasta_service_config_loader.return_value.instance_configs.side_effect = [
-        [
+    mock_get_instance_configs_for_service_in_deploy_group_all_clusters.return_value = {
+        "cluster1": [
             mock_marathon_instance_config("instance1"),
             mock_marathon_instance_config("instance2"),
         ],
-        [
+        "cluster2": [
             mock_marathon_instance_config("instance1"),
             mock_marathon_instance_config("instance2"),
         ],
-        [],
-        [],
-        [],
-        [],
-    ]
+    }
     with patch("sys.stdout", autospec=True, flush=Mock()):
         assert (
             mark_for_deployment.wait_for_deployment(
@@ -288,22 +253,16 @@ def test_wait_for_deployment(
             == 0
         )
 
-    mock_paasta_service_config_loader.return_value.clusters = ["cluster1", "cluster2"]
-    # TODO: mock clusters_data_to_wait_for instead of this
-    mock_paasta_service_config_loader.return_value.instance_configs.side_effect = [
-        [
+    mock_get_instance_configs_for_service_in_deploy_group_all_clusters.return_value = {
+        "cluster1": [
             mock_marathon_instance_config("instance1"),
             mock_marathon_instance_config("instance2"),
         ],
-        [
+        "cluster2": [
             mock_marathon_instance_config("instance1"),
             mock_marathon_instance_config("instance3"),
         ],
-        [],
-        [],
-        [],
-        [],
-    ]
+    }
     with raises(TimeoutError):
         mark_for_deployment.wait_for_deployment(
             "service", "fake_deploy_group", "somesha", "/nail/soa", 0
@@ -317,12 +276,8 @@ def test_wait_for_deployment(
     "paasta_tools.cli.cmds.mark_for_deployment.PaastaServiceConfigLoader", autospec=True
 )
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log", autospec=True)
-@patch("paasta_tools.cli.cmds.mark_for_deployment.instances_deployed", autospec=True)
 def test_wait_for_deployment_raise_no_such_cluster(
-    mock_instances_deployed,
-    mock__log,
-    mock_paasta_service_config_loader,
-    mock_load_system_paasta_config,
+    mock__log, mock_paasta_service_config_loader, mock_load_system_paasta_config,
 ):
     mock_load_system_paasta_config.return_value.get_api_endpoints.return_value = {
         "cluster1": "some_url_1",
@@ -442,36 +397,14 @@ def mock_marathon_instance_config(fake_name) -> "MarathonServiceConfig":
 
 
 def test_compose_timeout_message():
-    clusters_data = []
-    clusters_data.append(
-        mark_for_deployment.ClusterData(
-            cluster="cluster1",
-            service="someservice",
-            git_sha="somesha",
-            instances_queue=Queue(),
-        )
-    )
-    clusters_data[0].instances_queue.put(mock_marathon_instance_config("instance1"))
-    clusters_data[0].instances_queue.put(mock_marathon_instance_config("instance2"))
-    clusters_data.append(
-        mark_for_deployment.ClusterData(
-            cluster="cluster2",
-            service="someservice",
-            git_sha="somesha",
-            instances_queue=Queue(),
-        )
-    )
-    clusters_data[1].instances_queue.put(mock_marathon_instance_config("instance3"))
-    clusters_data.append(
-        mark_for_deployment.ClusterData(
-            cluster="cluster3",
-            service="someservice",
-            git_sha="somesha",
-            instances_queue=Queue(),
-        )
-    )
+    remaining_instances = {
+        "cluster1": ["instance1", "instance2"],
+        "cluster2": ["instance3"],
+        "cluster3": [],
+    }
+
     message = mark_for_deployment.compose_timeout_message(
-        clusters_data, 1, "fake_group", "someservice", "some_git_sha"
+        remaining_instances, 1, "fake_group", "someservice", "some_git_sha"
     )
     assert (
         "  paasta status -c cluster1 -s someservice -i instance1,instance2" in message


### PR DESCRIPTION
…bespoke thread pool implementation.

This is a refactor I've wanted to do for a while, and IMO it's much more readable. Don't forget to load the diff on mark_for_deployment.py.