### PR TITLE
PAASTA-17414 make paasta status --new the default

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -131,13 +131,24 @@ def add_subparser(subparsers,) -> None:
         default=DEFAULT_SOA_DIR,
         help="define a different soa config directory",
     )
-    status_parser.add_argument(
+
+    version = status_parser.add_mutually_exclusive_group()
+
+    version.add_argument(
         "--new",
         dest="new",
         action="store_true",
         default=False,
         help="Use experimental new version of paasta status for services",
     )
+    version.add_argument(
+        "--old",
+        dest="old",
+        default=False,
+        action="store_true",
+        help="Use the old version of paasta status for services",
+    )
+
     add_instance_filter_arguments(status_parser)
     status_parser.set_defaults(command=paasta_status)
 
@@ -2092,6 +2103,7 @@ def paasta_status(args) -> int:
                 actual_deployments = get_actual_deployments(service, soa_dir)
             if all_flink or actual_deployments:
                 deploy_pipeline = list(get_planned_deployments(service, soa_dir))
+                new = _get_paasta_status_version(args, system_paasta_config)
                 tasks.append(
                     (
                         report_status_for_cluster,
@@ -2103,7 +2115,7 @@ def paasta_status(args) -> int:
                             instance_whitelist=instances,
                             system_paasta_config=system_paasta_config,
                             verbose=args.verbose,
-                            new=args.new,
+                            new=new,
                         ),
                     )
                 )
@@ -2239,6 +2251,20 @@ def status_marathon_job_human(
         return "Marathon:   {} - {} (app {}) is not configured in Marathon yet (waiting for bounce)".format(
             status, name, desired_app_id
         )
+
+
+def _get_paasta_status_version(args, system_paasta_config) -> bool:
+    if args.new:
+        return True
+    elif args.old:
+        return False
+    else:
+        if system_paasta_config.get_paasta_status_version() == "old":
+            return False
+        elif system_paasta_config.get_paasta_status_version() == "new":
+            return True
+        else:
+            return True
 
 
 # Add other custom status writers here

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -2103,7 +2103,7 @@ def paasta_status(args) -> int:
                 actual_deployments = get_actual_deployments(service, soa_dir)
             if all_flink or actual_deployments:
                 deploy_pipeline = list(get_planned_deployments(service, soa_dir))
-                new = _get_paasta_status_version(args, system_paasta_config)
+                new = _use_new_paasta_status(args, system_paasta_config)
                 tasks.append(
                     (
                         report_status_for_cluster,
@@ -2253,7 +2253,7 @@ def status_marathon_job_human(
         )
 
 
-def _get_paasta_status_version(args, system_paasta_config) -> bool:
+def _use_new_paasta_status(args, system_paasta_config) -> bool:
     if args.new:
         return True
     elif args.old:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1906,6 +1906,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     monitoring_config: Dict
     nerve_readiness_check_script: List[str]
     paasta_native: PaastaNativeConfig
+    paasta_status_version: str
     pdb_max_unavailable: Union[str, int]
     pki_backend: str
     pod_defaults: Dict[str, Any]
@@ -2328,6 +2329,12 @@ class SystemPaastaConfig:
 
     def get_previous_marathon_servers(self) -> List[MarathonConfigDict]:
         return self.config_dict.get("previous_marathon_servers", [])
+
+    def get_paasta_status_version(self) -> str:
+        """Get paasta status version string (new | old). Defaults to 'old'.
+
+        :returns: A string with the version desired version of paasta status."""
+        return self.config_dict.get("paasta_status_version", "old")
 
     def get_local_run_config(self) -> LocalRunConfig:
         """Get the local-run config

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -355,6 +355,7 @@ class StatusArgs:
         verbose,
         service_instance=None,
         new=False,
+        old=False,
     ):
         self.service = service
         self.soa_dir = soa_dir
@@ -366,6 +367,7 @@ class StatusArgs:
         self.verbose = verbose
         self.service_instance = service_instance
         self.new = new
+        self.old = old
 
 
 @patch("paasta_tools.cli.cmds.status.get_instance_configs_for_service", autospec=True)


### PR DESCRIPTION
After having a new and more helpful paasta status, it's hidden behind an obscure flag. This PR adds support for `paasta status --old` and for setting the `paasta_status_version` in `etc/paasta`



Note:  `paasta_status_version` needs to be set in `etc/paasta` to make the --new version the default one