### PR TITLE
Update paasta secret sync to support other namespaces

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2637,14 +2637,15 @@ def create_secret(
     secret: str,
     service: str,
     secret_provider: BaseSecretProvider,
+    namespace: str = "paasta",
 ) -> None:
     service = sanitise_kubernetes_name(service)
     sanitised_secret = sanitise_kubernetes_name(secret)
     kube_client.core.create_namespaced_secret(
-        namespace="paasta",
+        namespace=namespace,
         body=V1Secret(
             metadata=V1ObjectMeta(
-                name=f"paasta-secret-{service}-{sanitised_secret}",
+                name=f"{namespace}-secret-{service}-{sanitised_secret}",
                 labels={
                     "yelp.com/paasta_service": service,
                     "paasta.yelp.com/service": service,
@@ -2664,15 +2665,16 @@ def update_secret(
     secret: str,
     service: str,
     secret_provider: BaseSecretProvider,
+    namespace: str = "paasta",
 ) -> None:
     service = sanitise_kubernetes_name(service)
     sanitised_secret = sanitise_kubernetes_name(secret)
     kube_client.core.replace_namespaced_secret(
-        name=f"paasta-secret-{service}-{sanitised_secret}",
-        namespace="paasta",
+        name=f"{namespace}-secret-{service}-{sanitised_secret}",
+        namespace=namespace,
         body=V1Secret(
             metadata=V1ObjectMeta(
-                name=f"paasta-secret-{service}-{sanitised_secret}",
+                name=f"{namespace}-secret-{service}-{sanitised_secret}",
                 labels={
                     "yelp.com/paasta_service": service,
                     "paasta.yelp.com/service": service,
@@ -2688,13 +2690,13 @@ def update_secret(
 
 
 def get_kubernetes_secret_signature(
-    kube_client: KubeClient, secret: str, service: str
+    kube_client: KubeClient, secret: str, service: str, namespace: str = "paasta",
 ) -> Optional[str]:
     service = sanitise_kubernetes_name(service)
     secret = sanitise_kubernetes_name(secret)
     try:
         signature = kube_client.core.read_namespaced_config_map(
-            name=f"paasta-secret-{service}-{secret}-signature", namespace="paasta"
+            name=f"{namespace}-secret-{service}-{secret}-signature", namespace=namespace
         )
     except ApiException as e:
         if e.status == 404:
@@ -2708,16 +2710,20 @@ def get_kubernetes_secret_signature(
 
 
 def update_kubernetes_secret_signature(
-    kube_client: KubeClient, secret: str, service: str, secret_signature: str
+    kube_client: KubeClient,
+    secret: str,
+    service: str,
+    secret_signature: str,
+    namespace: str = "paasta",
 ) -> None:
     service = sanitise_kubernetes_name(service)
     secret = sanitise_kubernetes_name(secret)
     kube_client.core.replace_namespaced_config_map(
-        name=f"paasta-secret-{service}-{secret}-signature",
-        namespace="paasta",
+        name=f"{namespace}-secret-{service}-{secret}-signature",
+        namespace=namespace,
         body=V1ConfigMap(
             metadata=V1ObjectMeta(
-                name=f"paasta-secret-{service}-{secret}-signature",
+                name=f"{namespace}-secret-{service}-{secret}-signature",
                 labels={
                     "yelp.com/paasta_service": service,
                     "paasta.yelp.com/service": service,
@@ -2729,15 +2735,19 @@ def update_kubernetes_secret_signature(
 
 
 def create_kubernetes_secret_signature(
-    kube_client: KubeClient, secret: str, service: str, secret_signature: str
+    kube_client: KubeClient,
+    secret: str,
+    service: str,
+    secret_signature: str,
+    namespace: str = "paasta",
 ) -> None:
     service = sanitise_kubernetes_name(service)
     secret = sanitise_kubernetes_name(secret)
     kube_client.core.create_namespaced_config_map(
-        namespace="paasta",
+        namespace=namespace,
         body=V1ConfigMap(
             metadata=V1ObjectMeta(
-                name=f"paasta-secret-{service}-{secret}-signature",
+                name=f"{namespace}-secret-{service}-{secret}-signature",
                 labels={
                     "yelp.com/paasta_service": service,
                     "paasta.yelp.com/service": service,

--- a/tests/kubernetes/bin/test_paasta_secrets_sync.py
+++ b/tests/kubernetes/bin/test_paasta_secrets_sync.py
@@ -38,7 +38,8 @@ def test_main():
             assert e.value.code == 1
 
 
-def test_sync_all_secrets():
+@pytest.mark.parametrize("namespace", [None, "tron"])
+def test_sync_all_secrets(namespace):
     with mock.patch(
         "paasta_tools.kubernetes.bin.paasta_secrets_sync.sync_secrets", autospec=True
     ) as mock_sync_secrets:
@@ -50,6 +51,7 @@ def test_sync_all_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
+            namespace=namespace,
         )
 
         mock_sync_secrets.side_effect = [True, False]
@@ -60,6 +62,7 @@ def test_sync_all_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
+            namespace=namespace,
         )
 
         mock_sync_secrets.side_effect = None
@@ -70,10 +73,12 @@ def test_sync_all_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
+            namespace=namespace,
         )
 
 
-def test_sync_secrets():
+@pytest.mark.parametrize("namespace", [None, "tron"])
+def test_sync_secrets(namespace):
     with mock.patch(
         "paasta_tools.kubernetes.bin.paasta_secrets_sync.get_secret_provider",
         autospec=True,
@@ -110,6 +115,7 @@ def test_sync_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
+            namespace=namespace,
         )
 
         mock_scandir.return_value.__enter__.return_value = [mock.Mock(path="some_file")]
@@ -121,6 +127,7 @@ def test_sync_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
+            namespace=namespace,
         )
 
         mock_get_secret_provider.return_value = mock.Mock(
@@ -138,8 +145,11 @@ def test_sync_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
+            namespace=namespace,
         )
         assert mock_get_kubernetes_secret_signature.called
+        _, kwargs = mock_get_kubernetes_secret_signature.call_args_list[-1]
+        assert kwargs.get("namespace") == namespace
         assert not mock_create_secret.called
         assert not mock_update_secret.called
         assert not mock_create_kubernetes_secret_signature.called
@@ -153,12 +163,17 @@ def test_sync_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
+            namespace=namespace,
         )
         assert mock_get_kubernetes_secret_signature.called
         assert not mock_create_secret.called
         assert mock_update_secret.called
+        _, kwargs = mock_update_secret.call_args_list[-1]
+        assert kwargs.get("namespace") == namespace
         assert not mock_create_kubernetes_secret_signature.called
         assert mock_update_kubernetes_secret_signature.called
+        _, kwargs = mock_update_kubernetes_secret_signature.call_args_list[-1]
+        assert kwargs.get("namespace") == namespace
         mock_update_kubernetes_secret_signature.reset_mock()
         mock_update_secret.reset_mock()
 
@@ -170,11 +185,16 @@ def test_sync_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
+            namespace=namespace,
         )
         assert mock_get_kubernetes_secret_signature.called
         assert mock_create_secret.called
+        _, kwargs = mock_create_secret.call_args_list[-1]
+        assert kwargs.get("namespace") == namespace
         assert not mock_update_secret.called
         assert mock_create_kubernetes_secret_signature.called
+        _, kwargs = mock_create_kubernetes_secret_signature.call_args_list[-1]
+        assert kwargs.get("namespace") == namespace
         assert not mock_update_kubernetes_secret_signature.called
         mock_update_kubernetes_secret_signature.reset_mock()
         mock_update_secret.reset_mock()
@@ -187,6 +207,7 @@ def test_sync_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
+            namespace=namespace,
         )
         assert mock_get_kubernetes_secret_signature.called
         assert mock_create_secret.called
@@ -203,4 +224,5 @@ def test_sync_secrets():
                 secret_provider_name="vaulty",
                 vault_cluster_config={},
                 soa_dir="/nail/blah",
+                namespace=namespace,
             )

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -3134,6 +3134,18 @@ def test_create_kubernetes_secret_signature():
         secret_signature="ab1234",
     )
     assert mock_client.core.create_namespaced_config_map.called
+    _, kwargs = mock_client.core.create_namespaced_config_map.call_args_list[0]
+    assert kwargs.get("namespace") == "paasta"
+
+    create_kubernetes_secret_signature(
+        kube_client=mock_client,
+        secret="mortys-fate",
+        service="universe",
+        secret_signature="ab1234",
+        namespace="tron",
+    )
+    _, kwargs = mock_client.core.create_namespaced_config_map.call_args_list[1]
+    assert kwargs.get("namespace") == "tron"
 
 
 def test_update_kubernetes_secret_signature():
@@ -3145,6 +3157,18 @@ def test_update_kubernetes_secret_signature():
         secret_signature="ab1234",
     )
     assert mock_client.core.replace_namespaced_config_map.called
+    _, kwargs = mock_client.core.replace_namespaced_config_map.call_args_list[0]
+    assert kwargs.get("namespace") == "paasta"
+
+    update_kubernetes_secret_signature(
+        kube_client=mock_client,
+        secret="mortys-fate",
+        service="universe",
+        secret_signature="ab1234",
+        namespace="tron",
+    )
+    _, kwargs = mock_client.core.replace_namespaced_config_map.call_args_list[1]
+    assert kwargs.get("namespace") == "tron"
 
 
 def test_get_kubernetes_secret_signature():
@@ -3152,12 +3176,24 @@ def test_get_kubernetes_secret_signature():
     mock_client.core.read_namespaced_config_map.return_value = mock.Mock(
         data={"signature": "hancock"}
     )
-    assert (
-        get_kubernetes_secret_signature(
-            kube_client=mock_client, secret="mortys-morty", service="universe"
-        )
-        == "hancock"
+
+    secret_sig = get_kubernetes_secret_signature(
+        kube_client=mock_client, secret="mortys-morty", service="universe"
     )
+    _, kwargs = mock_client.core.read_namespaced_config_map.call_args_list[0]
+    assert kwargs.get("namespace") == "paasta"
+    assert secret_sig == "hancock"
+
+    secret_sig = get_kubernetes_secret_signature(
+        kube_client=mock_client,
+        secret="mortys-morty",
+        service="universe",
+        namespace="tron",
+    )
+    _, kwargs = mock_client.core.read_namespaced_config_map.call_args_list[1]
+    assert kwargs.get("namespace") == "tron"
+    assert secret_sig == "hancock"
+
     mock_client.core.read_namespaced_config_map.side_effect = ApiException(404)
     assert (
         get_kubernetes_secret_signature(
@@ -3183,6 +3219,8 @@ def test_create_secret():
         secret_provider=mock_secret_provider,
     )
     assert mock_client.core.create_namespaced_secret.called
+    _, kwargs = mock_client.core.create_namespaced_secret.call_args_list[0]
+    assert kwargs.get("namespace") == "paasta"
     mock_secret_provider.decrypt_secret_raw.assert_called_with("mortys-fate")
 
     create_secret(
@@ -3191,6 +3229,17 @@ def test_create_secret():
         secret="mortys_fate",
         secret_provider=mock_secret_provider,
     )
+    mock_secret_provider.decrypt_secret_raw.assert_called_with("mortys_fate")
+
+    create_secret(
+        kube_client=mock_client,
+        service="universe",
+        secret="mortys_fate",
+        secret_provider=mock_secret_provider,
+        namespace="tron",
+    )
+    _, kwargs = mock_client.core.create_namespaced_secret.call_args_list[2]
+    assert kwargs.get("namespace") == "tron"
     mock_secret_provider.decrypt_secret_raw.assert_called_with("mortys_fate")
 
 
@@ -3206,6 +3255,8 @@ def test_update_secret():
         secret_provider=mock_secret_provider,
     )
     assert mock_client.core.replace_namespaced_secret.called
+    _, kwargs = mock_client.core.replace_namespaced_secret.call_args_list[0]
+    assert kwargs.get("namespace") == "paasta"
     mock_secret_provider.decrypt_secret_raw.assert_called_with("mortys-fate")
 
     update_secret(
@@ -3214,6 +3265,17 @@ def test_update_secret():
         secret="mortys_fate",
         secret_provider=mock_secret_provider,
     )
+    mock_secret_provider.decrypt_secret_raw.assert_called_with("mortys_fate")
+
+    update_secret(
+        kube_client=mock_client,
+        service="universe",
+        secret="mortys_fate",
+        secret_provider=mock_secret_provider,
+        namespace="tron",
+    )
+    _, kwargs = mock_client.core.replace_namespaced_secret.call_args_list[2]
+    assert kwargs.get("namespace") == "tron"
     mock_secret_provider.decrypt_secret_raw.assert_called_with("mortys_fate")
 
 


### PR DESCRIPTION
This updates the paasta secret sync to optionally sync yelpsoa-config specified secrets into a namespace different than `paasta`, but leaves the default as `paasta`.

In addition to creating the resources in the new namespace, the naming convention changes from `paasta-` prefixed to `{namespace}-` prefixed.

I have added tests to verify leaving namespace unspecified results in reading from/writing to the `paasta` namespace.

Manual test runs against kubestage also work as expected:
```
$  KUBECONFIG=./etc_paasta_for_development/admin.conf PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_for_development/ python paasta_tools/kubernetes/bin/paasta_secrets_sync.py -n tron compute-infra-test-service -v
INFO:__main__:new-test-secret for compute-infra-test-service not found, creating

$  KUBECONFIG=./etc_paasta_for_development/admin.conf PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_for_development/ python paasta_tools/kubernetes/bin/paasta_secrets_sync.py -n tron compute-infra-test-service -v
INFO:__main__:new-test-secret for compute-infra-test-service up to date

$ kubectl-kubestage get cm -n tron
INFO: You are using an Okta authenticated kubectl wrapper
NAME                                                               DATA   AGE
istio-ca-root-cert                                                 1      3d20h
tron-secret-compute-infra-test-service-new-test-secret-signature   1      92s

 $ kubectl-kubestage get secret -n tron
INFO: You are using an Okta authenticated kubectl wrapper
NAME                                                     TYPE                                  DATA   AGE
default-token-9llsl                                      kubernetes.io/service-account-token   3      3d20h
tron-secret-compute-infra-test-service-new-test-secret   Opaque                                1      104s
```

I also verified this new version continues to work without specifying namespace on kubestage for noops, updates, and creating secrets.

The intent of this change is to sync paasta secrets that have tronjobs configured into th `tron` namespace to maintain parity with paasta secrets on mesos. 
