### PR TITLE
Make wait-for-deployment warn pct time configurable

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -75,6 +75,7 @@ from paasta_tools.utils import TimeoutError
 
 
 DEFAULT_DEPLOYMENT_TIMEOUT = 3600  # seconds
+DEFAULT_WARN_PERCENT = 50
 DEFAULT_AUTO_CERTIFY_DELAY = 600  # seconds
 DEFAULT_SLACK_CHANNEL = "#deploy"
 DEFAULT_STUCK_BOUNCE_RUNBOOK = "y/stuckbounce"
@@ -154,6 +155,18 @@ def add_subparser(subparsers):
             "Time in seconds to wait for paasta to deploy the service. "
             "If the timeout is exceeded we return 1. "
             "Default is %(default)s seconds."
+        ),
+    )
+    list_parser.add_argument(
+        "-w",
+        "--warn",
+        dest="warn",
+        type=int,
+        default=DEFAULT_WARN_PERCENT,
+        help=(
+            "Percent of timeout to warn at if the deployment hasn't finished. "
+            "For example, --warn=75 will warn at 75%% of the timeout. "
+            "Defaults to %(default)s."
         ),
     )
     list_parser.add_argument(
@@ -416,6 +429,7 @@ def paasta_mark_for_deployment(args):
         block=args.block,
         soa_dir=args.soa_dir,
         timeout=args.timeout,
+        warn_pct=args.warn,
         auto_certify_delay=args.auto_certify_delay,
         auto_abandon_delay=args.auto_abandon_delay,
         auto_rollback_delay=args.auto_rollback_delay,
@@ -456,7 +470,6 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
     rollback_states = ["start_rollback", "rolling_back", "rolled_back"]
     rollforward_states = ["start_deploy", "deploying", "deployed"]
     default_slack_channel = DEFAULT_SLACK_CHANNEL
-    timeout_percentage_before_reminding = 75
 
     def __init__(
         self,
@@ -470,6 +483,7 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
         block,
         soa_dir,
         timeout,
+        warn_pct,
         auto_certify_delay,
         auto_abandon_delay,
         auto_rollback_delay,
@@ -488,6 +502,7 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
         self.block = block
         self.soa_dir = soa_dir
         self.timeout = timeout
+        self.warn_pct = warn_pct
         self.mark_for_deployment_return_code = -1
         self.auto_certify_delay = auto_certify_delay
         self.auto_abandon_delay = auto_abandon_delay
@@ -639,7 +654,7 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
 
                     self.notify_users(
                         (
-                            f"It has been {self.timeout_percentage_before_reminding}% of the "
+                            f"It has been {self.warn_pct}% of the "
                             f"maximum deploy time ({human_max_deploy_time}), "
                             "which means the deployment may be stuck. "
                             "Here are some things you can try:\n\n"
@@ -655,9 +670,7 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
                 )
 
         def schedule_callback():
-            time_to_notify = self.timeout * (
-                self.timeout_percentage_before_reminding / 100
-            )
+            time_to_notify = self.timeout * self.warn_pct / 100
             self.paasta_status_reminder_handle = self.event_loop.call_later(
                 time_to_notify, times_up
             )

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -193,6 +193,7 @@ def test_paasta_mark_for_deployment_with_good_rollback(
         auto_rollback = True
         block = True
         timeout = 600
+        warn = 80  # % of timeout to warn at
 
     mock_list_deploy_groups.return_value = ["test_deploy_groups"]
     config_mock = mock.Mock()
@@ -314,6 +315,7 @@ def test_MarkForDeployProcess_handles_wait_for_deployment_failure(
         git_url="git@git.yelpcorp.com:services/repo",
         soa_dir=None,
         timeout=None,
+        warn_pct=None,
         auto_certify_delay=1,
         auto_abandon_delay=1,
         auto_rollback_delay=1,
@@ -358,6 +360,7 @@ def test_MarkForDeployProcess_handles_first_time_deploys(
         git_url="git@git.yelpcorp.com:services/repo",
         soa_dir=None,
         timeout=None,
+        warn_pct=None,
         auto_certify_delay=1,
         auto_abandon_delay=1,
         auto_rollback_delay=1,
@@ -398,6 +401,7 @@ def test_MarkForDeployProcess_get_authors_diffs_against_prod_deploy_group(
         git_url="git@git.yelpcorp.com:services/repo",
         soa_dir=None,
         timeout=None,
+        warn_pct=None,
         auto_certify_delay=1,
         auto_abandon_delay=1,
         auto_rollback_delay=1,
@@ -436,6 +440,7 @@ def test_MarkForDeployProcess_get_authors_falls_back_to_current_deploy_group(
         git_url="git@git.yelpcorp.com:services/repo1",
         soa_dir=None,
         timeout=None,
+        warn_pct=None,
         auto_certify_delay=1,
         auto_abandon_delay=1,
         auto_rollback_delay=1,
@@ -478,6 +483,7 @@ def test_MarkForDeployProcess_handles_wait_for_deployment_cancelled(
         git_url="git@git.yelpcorp.com:services/repo1",
         soa_dir=None,
         timeout=None,
+        warn_pct=None,
         auto_certify_delay=1,
         auto_abandon_delay=1,
         auto_rollback_delay=1,
@@ -523,6 +529,7 @@ def test_MarkForDeployProcess_skips_wait_for_deployment_when_block_is_False(
         git_url="git@git.yelpcorp.com:services/repo1",
         soa_dir=None,
         timeout=None,
+        warn_pct=None,
         auto_certify_delay=1,
         auto_abandon_delay=1,
         auto_rollback_delay=1,
@@ -566,6 +573,7 @@ def test_MarkForDeployProcess_goes_to_mfd_failed_when_mark_for_deployment_fails(
         git_url="git@git.yelpcorp.com:services/repo1",
         soa_dir=None,
         timeout=None,
+        warn_pct=None,
         auto_certify_delay=1,
         auto_abandon_delay=1,
         auto_rollback_delay=1,
@@ -639,6 +647,7 @@ def test_MarkForDeployProcess_happy_path(
         block=True,
         soa_dir="soa_dir",
         timeout=3600,
+        warn_pct=50,
         auto_certify_delay=None,
         auto_abandon_delay=600,
         auto_rollback_delay=30,
@@ -684,6 +693,7 @@ def test_MarkForDeployProcess_happy_path_skips_complete_if_no_auto_rollback(
         block=True,
         soa_dir="soa_dir",
         timeout=3600,
+        warn_pct=50,
         auto_certify_delay=None,
         auto_abandon_delay=600,
         auto_rollback_delay=30,


### PR DESCRIPTION
### Description
Currently, we warn users when their deployment has reached 75% of the mfd timeout. This 75% is hardcoded, which isn't great. So, I've added an option to mfd to make the warn percentage configurable.

I've also lowered the default pct to 50% to leave more time for stuck bounce debugging. At 75% with a default 1hr/3600s timeout, we only get 15m of debugging time, which means by the time we've taken action, the deploy has already timed out, forcing users to restart Jenkins. 50% or 30m is better. If we find that some services naturally deploy slower, we can raise the warn pct for their mfd since it is now configurable.

### Testing
`make test` passes
manual test on `compute-infra-test-service` works. i ran the following command, and got a warning at 15s, after which it timed out at 30s, as expected:
```
paasta mark-for-deployment --commit <commit> --deploy-group dev-stage.everything -s compute-infra-test-service --wait-for-deployment -t 30 -w 50
```

### Notes
Assuming this is released, we'd need to make another change in our internal jenkins libraries so that `--warn` is configurable through `deploy.yaml`. 