### PR TITLE
TRON-1738: Setup k8s env secrets in setup_tron_namespace

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -362,7 +362,7 @@ class TronActionConfig(InstanceConfig):
                 )
                 sanitised_service = sanitise_kubernetes_name(service)
                 secret_env[k] = {
-                    "secret": f"tron-secret-{sanitised_service}-{sanitised_secret}",
+                    "secret_name": f"tron-secret-{sanitised_service}-{sanitised_secret}",
                     "key": secret,
                 }
         return secret_env

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -201,7 +201,7 @@ class TestTronActionConfig:
                 },
                 {
                     "TEST_SECRET": {
-                        "secret": "tron-secret-my--service-a--service--secret",
+                        "secret_name": "tron-secret-my--service-a--service--secret",
                         "key": "a_service_secret",
                     }
                 },
@@ -210,7 +210,7 @@ class TestTronActionConfig:
                 {"TEST_SECRET": "SHARED_SECRET(a_shared_secret)"},
                 {
                     "TEST_SECRET": {
-                        "secret": "tron-secret-underscore-shared-a--shared--secret",
+                        "secret_name": "tron-secret-underscore-shared-a--shared--secret",
                         "key": "a_shared_secret",
                     }
                 },
@@ -911,7 +911,7 @@ class TestTronTools:
             "env": mock.ANY,
             "secret_env": {
                 "SOME_SECRET": {
-                    "secret": "tron-secret-my--service-secret--name",
+                    "secret_name": "tron-secret-my--service-secret--name",
                     "key": "secret_name",
                 }
             },


### PR DESCRIPTION
*Note*: This branch is based off of #3121 and will not be merged until that PR has been merged to master. 

We now need to create a separate `secret_env` key in generated tronfig for paasta secrets in tron k8s jobs so we can correctly pull from k8s Secret resources created by our `paasta_secrets_sync` job.

This change will do the generation of the `secrets_env` key only if k8s is enabled at both the cluster and job level.

tests pass cleanly, and a manual run against a test job (`compute-infra-test-service.test_frequent`) with `use_k8s: true` and  a `MASTER` config with `k8s_options` with `enabled: true` generates the expected tronfig: https://fluffy.yelpcorp.com/i/xl2mlTChtNJk37TMqGCkpxlpNwDdDlLP.html#L162-187
(Note the new `secret_env` section and the lack of a `TEST_SECRET` key in the standard `env` section).