### PR TITLE
Send cap_{add,drop} for k8s tronjobs

### DIFF
--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -7,6 +7,7 @@ from paasta_tools import tron_tools
 from paasta_tools import utils
 from paasta_tools.tron_tools import MASTER_NAMESPACE
 from paasta_tools.tron_tools import MESOS_EXECUTOR_NAMES
+from paasta_tools.utils import CAPS_DROP
 from paasta_tools.utils import InvalidInstanceConfig
 from paasta_tools.utils import NoDeploymentsAvailable
 
@@ -908,6 +909,8 @@ class TestTronTools:
             "cpus": 2,
             "mem": 1200,
             "disk": 42,
+            "cap_add": [],
+            "cap_drop": CAPS_DROP,
             "env": mock.ANY,
             "secret_env": {
                 "SOME_SECRET": {


### PR DESCRIPTION
This requires https://github.com/Yelp/Tron/pull/827 to be
merged/deployed before this can be merged/deployed itself

Verified by running `paasta_setup_tron_namespace -a --cluster norcal-corp --dry-run -d ~/pg/sysgit/yelpsoa-configs/` locally on a checkout modified to have k8s enabled on norcal-corp on a job using `cap_add`:

```yaml
    actions:
      run:
        cap_add:
        - NET_RAW
        cap_drop:
        - SETPCAP
        - MKNOD
        - AUDIT_WRITE
        - CHOWN
        - NET_RAW
        - DAC_OVERRIDE
        - FOWNER
        - FSETID
        - KILL
        - SETGID
        - SETUID
        - NET_BIND_SERVICE
        - SYS_CHROOT
        - SETFCAP
```
and, on a job with no added caps:
```yaml
        cap_add: []
        cap_drop:
        - SETPCAP
        - MKNOD
        - AUDIT_WRITE
        - CHOWN
        - NET_RAW
        - DAC_OVERRIDE
        - FOWNER
        - FSETID
        - KILL
        - SETGID
        - SETUID
        - NET_BIND_SERVICE
        - SYS_CHROOT
        - SETFCAP
        ```