### PR TITLE
Add logspout feature flag to all tron on k8s containers

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -726,7 +726,6 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
         result["executor"] = "kubernetes"
 
         result["secret_env"] = action_config.get_secret_env()
-
         all_env = action_config.get_env(use_k8s=True)
         # For k8s, we do not want secret envvars to be duplicated in both `env` and `secret_env`
         result["env"] = {k: v for k, v in all_env.items() if not is_secret_ref(v)}

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -726,7 +726,7 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
         # for Tron-on-K8s, we want to ship tronjob output through logspout
         # such that this output eventually makes it into our per-instance
         # log streams automatically
-        result["env"]["TRON_ENABLE_LOGSPOUT"] = "1"
+        result["env"]["TRON_ENABLE_PER_INSTANCE_LOGSPOUT"] = "1"
 
     elif executor in MESOS_EXECUTOR_NAMES:
         result["executor"] = "mesos"

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -306,8 +306,14 @@ class TronActionConfig(InstanceConfig):
     def get_spark_cluster_manager(self):
         return self.config_dict.get("spark_cluster_manager", "mesos")
 
-    def get_env(self):
+    def get_env(self, use_k8s: bool = False) -> Dict[str, str]:
         env = super().get_env()
+        # for Tron-on-K8s, we want to ship tronjob output through logspout
+        # such that this output eventually makes it into our per-instance
+        # log streams automatically
+        if use_k8s:
+            env["TRON_ENABLE_LOGSPOUT"] = "1"
+
         if self.get_executor() == "spark":
             spark_config_dict = self.get_spark_config_dict()
             env["EXECUTOR_CLUSTER"] = self.get_spark_paasta_cluster()
@@ -718,9 +724,11 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
     # whatever is in soaconfigs to the k8s equivalent here as well.
     if executor in KUBERNETES_EXECUTOR_NAMES and use_k8s:
         result["executor"] = "kubernetes"
+
         result["secret_env"] = action_config.get_secret_env()
+
+        all_env = action_config.get_env(use_k8s=True)
         # For k8s, we do not want secret envvars to be duplicated in both `env` and `secret_env`
-        all_env = action_config.get_env()
         result["env"] = {k: v for k, v in all_env.items() if not is_secret_ref(v)}
 
     elif executor in MESOS_EXECUTOR_NAMES:

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -927,7 +927,7 @@ class TestTronTools:
         )
         assert result["docker_image"] == expected_docker
         assert result["env"]["SHELL"] == "/bin/bash"
-        assert result["env"]["TRON_ENABLE_LOGSPOUT"] == "1"
+        assert result["env"]["TRON_ENABLE_PER_INSTANCE_LOGSPOUT"] == "1"
         assert "SOME_SECRET" not in result["env"]
 
     def test_format_tron_action_dict_paasta_no_branch_dict(self):

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -191,31 +191,6 @@ class TestTronActionConfig:
             else:
                 assert not any([env.get("SPARK_OPTS"), env.get("CLUSTERMAN_RESOURCES")])
 
-    def test_get_env_kubernetes(self, action_config, monkeypatch):
-        monkeypatch.setattr(tron_tools, "clusterman_metrics", mock.Mock())
-        action_config.config_dict["executor"] = "paasta"
-        with mock.patch(
-            "paasta_tools.utils.get_service_docker_registry", autospec=True,
-        ), mock.patch(
-            "paasta_tools.tron_tools.stringify_spark_env", autospec=True,
-        ), mock.patch(
-            "paasta_tools.tron_tools.load_system_paasta_config", autospec=True
-        ), mock.patch(
-            "paasta_tools.tron_tools.get_aws_credentials",
-            autospec=True,
-            return_value=("access", "secret", "token"),
-        ), mock.patch(
-            "paasta_tools.tron_tools.generate_clusterman_metrics_entries",
-            autospec=True,
-            return_value={
-                "cpus": ("cpus|dimension=2", 1900),
-                "mem": ("mem|dimension=1", "42"),
-            },
-        ):
-            env = action_config.get_env(use_k8s=True)
-            assert not any([env.get("SPARK_OPTS"), env.get("CLUSTERMAN_RESOURCES")])
-            assert env.get("TRON_ENABLE_LOGSPOUT") == "1"
-
     @pytest.mark.parametrize(
         "test_env,expected_env",
         (
@@ -952,6 +927,7 @@ class TestTronTools:
         )
         assert result["docker_image"] == expected_docker
         assert result["env"]["SHELL"] == "/bin/bash"
+        assert result["env"]["TRON_ENABLE_LOGSPOUT"] == "1"
         assert "SOME_SECRET" not in result["env"]
 
     def test_format_tron_action_dict_paasta_no_branch_dict(self):


### PR DESCRIPTION
We don't want to turn this on for existing Mesos tronjobs since the logs
won't be used in that case.

We'll be using logspout to ship tronjob logs to our logging streams and
then displaying those in Tron rather than doing what we did with
Tron-on-Mesos and asking Mesos (or, in this case, K8s) to feed us logs
periodically.