### PR TITLE
Make new paasta status report the instance state as "Stopped" if the …

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1205,7 +1205,10 @@ def get_instance_state(status: InstanceStatusKubernetesV2) -> str:
             return PaastaColors.red("Stopping")
     elif status.desired_state == "start":
         if num_versions == 0:
-            return PaastaColors.yellow("Starting")
+            if status.desired_instances == 0:
+                return PaastaColors.red("Stopped")
+            else:
+                return PaastaColors.yellow("Starting")
         if num_versions == 1:
             if num_ready_replicas < status.desired_instances:
                 return PaastaColors.yellow("Launching replicas")

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1259,6 +1259,12 @@ class TestGetInstanceState:
         mock_kubernetes_status_v2.desired_state = "stop"
         assert "Stop" in get_instance_state(mock_kubernetes_status_v2)
 
+    def test_stop_if_0_desired_instances(self, mock_kubernetes_status_v2):
+        mock_kubernetes_status_v2.desired_state = "start"
+        mock_kubernetes_status_v2.versions = []
+        mock_kubernetes_status_v2.desired_instances = 0
+        assert "Stop" in get_instance_state(mock_kubernetes_status_v2)
+
     def test_running(self, mock_kubernetes_status_v2):
         mock_kubernetes_status_v2.desired_state = "start"
         instance_state = get_instance_state(mock_kubernetes_status_v2)


### PR DESCRIPTION
…desired state is "start" but desired_instance is 0

See PAASTA-17440

---

The old paasta status handles this case explicitly: https://github.com/Yelp/paasta/blob/f6d11632e184a0cd2705da377b51a1d8ef72a1ff/paasta_tools/cli/cmds/status.py#L2149