### PR TITLE
Get docker configuration even if image is not provided

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -768,7 +768,7 @@ def paasta_spark_run(args):
 
     volumes = instance_config.get_volumes(system_paasta_config.get_volumes())
     app_base_name = get_spark_app_name(args.cmd or instance_config.get_cmd())
-    needs_docker_cfg = not args.build and not args.image
+    needs_docker_cfg = not args.build
     user_spark_opts = _parse_user_spark_args(args.spark_args)
     paasta_instance = get_smart_paasta_instance_name(args)
     spark_conf = get_spark_conf(


### PR DESCRIPTION
When `--image` option is provided with spark-run for testing the local changes in the prod environment, it always get stuck in `Initial Job has not accepted any resources'

Failing test case: https://fluffy.yelpcorp.com/i/1VWddpH6C1RhFndkn1F1Wk90x6vLDvTc.html

Passing test case: https://fluffy.yelpcorp.com/i/0K0GzS9X1GqwV3zTLlHLlDQfGxlGN7WD.html

It looks like we need to set the spark.mesos.uris with the docker configuration path over here: https://sourcegraph.yelpcorp.com/Yelp/service_configuration_lib@93583d28aa04153fbe9551bc1980fe5214551ac0/-/blob/service_configuration_lib/spark_config.py#L398:31
even if image is passed as an argument.

Discussion thread: https://yelp.slack.com/archives/CA53J9UJ0/p1625088032466700?thread_ts=1625039677.423700&cid=CA53J9UJ0

Ticket: COREML-2501