### PR TITLE
Add ldap3 to requirements-minimal.txt

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -26,6 +26,7 @@ isodate >= 0.5.0
 jsonschema[format]
 kazoo >= 2.0.0
 kubernetes >= 12.0.0
+ldap3
 manhole
 marathon >= 0.12.0
 mypy-extensions >= 0.3.0


### PR DESCRIPTION
It's used in paasta_tools/utils.py, so we should declare it in the minimal requirements.

ldap3 is probably a transitive dependency of something else right now, since it's in the `requirements.txt` file, but anything that installs Paasta as a package wouldn't know that it needs `ldap3` too.