### PR TITLE
Handle case where container has non-zero restart count but no last_ti…

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1374,6 +1374,7 @@ def recent_container_restart(
     if (
         container.restart_count > 0
         and container.last_state == "terminated"
+        and container.last_timestamp is not None
         and container.last_timestamp > min_timestamp
     ):
         return True

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -52,6 +52,7 @@ from paasta_tools.cli.cmds.status import print_kafka_status
 from paasta_tools.cli.cmds.status import print_kubernetes_status
 from paasta_tools.cli.cmds.status import print_kubernetes_status_v2
 from paasta_tools.cli.cmds.status import print_marathon_status
+from paasta_tools.cli.cmds.status import recent_container_restart
 from paasta_tools.cli.cmds.status import report_invalid_whitelist_values
 from paasta_tools.cli.utils import NoSuchService
 from paasta_tools.cli.utils import PaastaColors
@@ -1295,6 +1296,16 @@ class TestGetInstanceState:
         instance_state = get_instance_state(mock_kubernetes_status_v2)
         instance_state = remove_ansi_escape_sequences(instance_state)
         assert instance_state == "Bouncing to bbb111"
+
+
+def test_recent_container_restart_no_last_timestamp():
+    # we have seen occasional tracebacks where the restart_count and last_state
+    # are set but there is no last timestamp.  This is just a smoke test to
+    # make sure we don't blow up in that case.
+    container = paastamodels.KubernetesContainerV2(
+        last_state="terminated", restart_count=1
+    )
+    recent_container_restart(container)
 
 
 class TestGetVersionsTable:


### PR DESCRIPTION
…mestamp.  This was causing failures in the code that reports recent container restarts

I think this is probalby just a transitory bad state encountered during a deployment

See PAASTA-17442

--- 

I don't think we're doing anything fancy on the API side, so I am inclined to believe this is just a weird state we're encountering.