### PR TITLE
Increase default mark-for-deployment timeout from 1 to 3 hours and de…

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -85,8 +85,8 @@ from paasta_tools.utils import RollbackTypes
 from paasta_tools.utils import TimeoutError
 
 
-DEFAULT_DEPLOYMENT_TIMEOUT = 3600  # seconds
-DEFAULT_WARN_PERCENT = 50
+DEFAULT_DEPLOYMENT_TIMEOUT = 3 * 3600  # seconds
+DEFAULT_WARN_PERCENT = 17  # ~30min for default timeout
 DEFAULT_AUTO_CERTIFY_DELAY = 600  # seconds
 DEFAULT_SLACK_CHANNEL = "#deploy"
 DEFAULT_STUCK_BOUNCE_RUNBOOK = "y/stuckbounce"


### PR DESCRIPTION
…crease default warning percentage so that we warn after about the same amount of time

See PAASTA-17425 for details