### PR TITLE
Make Logspout per-instance logging flag generic

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -726,7 +726,7 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
         # for Tron-on-K8s, we want to ship tronjob output through logspout
         # such that this output eventually makes it into our per-instance
         # log streams automatically
-        result["env"]["TRON_ENABLE_PER_INSTANCE_LOGSPOUT"] = "1"
+        result["env"]["ENABLE_PER_INSTANCE_LOGSPOUT"] = "1"
 
     elif executor in MESOS_EXECUTOR_NAMES:
         result["executor"] = "mesos"

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -927,7 +927,7 @@ class TestTronTools:
         )
         assert result["docker_image"] == expected_docker
         assert result["env"]["SHELL"] == "/bin/bash"
-        assert result["env"]["TRON_ENABLE_PER_INSTANCE_LOGSPOUT"] == "1"
+        assert result["env"]["ENABLE_PER_INSTANCE_LOGSPOUT"] == "1"
         assert "SOME_SECRET" not in result["env"]
 
     def test_format_tron_action_dict_paasta_no_branch_dict(self):


### PR DESCRIPTION
After some discussion on an internal PR, we've decided that we'd rather
have a single toggle for per-instance log routing.