### PR TITLE
Fix cancellation of wait_for_deployment by replacing green_lights wit…

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -28,12 +28,9 @@ import socket
 import sys
 import time
 import traceback
-from collections import defaultdict
-from threading import Event
 from threading import Thread
 from typing import Any
 from typing import Collection
-from typing import DefaultDict
 from typing import Dict
 from typing import Iterator
 from typing import List
@@ -569,11 +566,8 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
         self.diagnosis_interval = diagnosis_interval
         self.time_before_first_diagnosis = time_before_first_diagnosis
 
-        # Separate green_light per commit, so that we can tell wait_for_deployment for one commit to shut down
-        # and quickly launch wait_for_deployment for another commit without causing a race condition.
-        self.wait_for_deployment_green_lights: DefaultDict[str, Event] = defaultdict(
-            Event
-        )
+        # Keep track of each wait_for_deployment task so we can cancel it.
+        self.wait_for_deployment_tasks: Dict[str, asyncio.Task] = {}
 
         self.human_readable_status = "Waiting on mark-for-deployment to initialize..."
         self.progress = Progress()
@@ -986,7 +980,7 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
             self.schedule_paasta_status_reminder()
 
     def on_exit_deploying(self) -> None:
-        self.wait_for_deployment_green_lights[self.commit].clear()
+        self.stop_waiting_for_deployment(self.commit)
         self.cancel_paasta_status_reminder()
 
     def on_enter_start_rollback(self) -> None:
@@ -1024,7 +1018,7 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
             thread.start()
 
     def on_exit_rolling_back(self) -> None:
-        self.wait_for_deployment_green_lights[self.old_git_sha].clear()
+        self.stop_waiting_for_deployment(self.old_git_sha)
 
     def on_enter_deploy_errored(self) -> None:
         report_waiting_aborted(self.service, self.deploy_group)
@@ -1037,33 +1031,43 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
         if self.deploy_group_is_set_to_notify("notify_after_abort"):
             self.ping_authors("Deploy cancelled")
 
-    def do_wait_for_deployment(self, target_commit: str) -> None:
+    def stop_waiting_for_deployment(self, target_commit: str) -> None:
         try:
-            self.wait_for_deployment_green_lights[target_commit].set()
-            wait_for_deployment(
-                service=self.service,
-                deploy_group=self.deploy_group,
-                git_sha=target_commit,
-                soa_dir=self.soa_dir,
-                timeout=self.timeout,
-                green_light=self.wait_for_deployment_green_lights[target_commit],
-                progress=self.progress,
-                polling_interval=self.polling_interval,
-                diagnosis_interval=self.diagnosis_interval,
-                time_before_first_diagnosis=self.time_before_first_diagnosis,
+            self.wait_for_deployment_tasks[target_commit].cancel()
+        except KeyError:
+            pass
+
+    @a_sync.to_blocking
+    async def do_wait_for_deployment(self, target_commit: str) -> None:
+        try:
+            self.stop_waiting_for_deployment(target_commit)
+            wait_for_deployment_task = asyncio.create_task(
+                wait_for_deployment(
+                    service=self.service,
+                    deploy_group=self.deploy_group,
+                    git_sha=target_commit,
+                    soa_dir=self.soa_dir,
+                    timeout=self.timeout,
+                    progress=self.progress,
+                    polling_interval=self.polling_interval,
+                    diagnosis_interval=self.diagnosis_interval,
+                    time_before_first_diagnosis=self.time_before_first_diagnosis,
+                )
             )
+            self.wait_for_deployment_tasks[target_commit] = wait_for_deployment_task
+            await wait_for_deployment_task
             self.update_slack_thread(
                 f"Finished waiting for deployment of {target_commit}"
             )
             self.trigger("deploy_finished")
 
         except (KeyboardInterrupt, TimeoutError):
-            if self.wait_for_deployment_green_lights[target_commit].is_set():
-                # When we manually trigger a rollback, we clear the green_light, which causes wait_for_deployment to
-                # raise KeyboardInterrupt. Don't trigger deploy_cancelled in this case.
-                self.trigger("deploy_cancelled")
+            self.trigger("deploy_cancelled")
         except NoSuchCluster:
             self.trigger("deploy_errored")
+        except asyncio.CancelledError:
+            # Don't trigger deploy_errored when someone calls stop_waiting_for_deployment.
+            raise
         except Exception:
             log.error("Caught exception in wait_for_deployment:")
             log.error(traceback.format_exc())
@@ -1508,14 +1512,12 @@ def get_instance_configs_for_service_in_deploy_group_all_clusters(
     return instance_configs_per_cluster
 
 
-@a_sync.to_blocking
 async def wait_for_deployment(
     service: str,
     deploy_group: str,
     git_sha: str,
     soa_dir: str,
     timeout: float,
-    green_light: Optional[Event] = None,
     progress: Optional[Progress] = None,
     polling_interval: float = None,
     diagnosis_interval: float = None,

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1034,7 +1034,8 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
     def stop_waiting_for_deployment(self, target_commit: str) -> None:
         try:
             self.wait_for_deployment_tasks[target_commit].cancel()
-        except KeyError:
+            del self.wait_for_deployment_tasks[target_commit]
+        except (KeyError, asyncio.InvalidStateError):
             pass
 
     @a_sync.to_blocking

--- a/paasta_tools/cli/cmds/wait_for_deployment.py
+++ b/paasta_tools/cli/cmds/wait_for_deployment.py
@@ -15,6 +15,7 @@
 """Contains methods used by the paasta client to wait for deployment
 of a docker image to a cluster.instance.
 """
+import asyncio
 import logging
 
 from paasta_tools.cli.cmds.mark_for_deployment import NoSuchCluster
@@ -237,15 +238,17 @@ def paasta_wait_for_deployment(args):
         return 1
 
     try:
-        wait_for_deployment(
-            service=service,
-            deploy_group=args.deploy_group,
-            git_sha=args.commit,
-            soa_dir=args.soa_dir,
-            timeout=args.timeout,
-            polling_interval=args.polling_interval,
-            diagnosis_interval=args.diagnosis_interval,
-            time_before_first_diagnosis=args.time_before_first_diagnosis,
+        asyncio.run(
+            wait_for_deployment(
+                service=service,
+                deploy_group=args.deploy_group,
+                git_sha=args.commit,
+                soa_dir=args.soa_dir,
+                timeout=args.timeout,
+                polling_interval=args.polling_interval,
+                diagnosis_interval=args.diagnosis_interval,
+                time_before_first_diagnosis=args.time_before_first_diagnosis,
+            )
         )
         _log(
             service=service,

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
+
 import asynctest
 import mock
 from mock import ANY
@@ -238,22 +240,28 @@ def test_paasta_mark_for_deployment_with_good_rollback(
     assert mock_mark_for_deployment.call_count == 2
 
     mock_do_wait_for_deployment.assert_any_call(
-        mock.ANY, target_commit="d670460b4b4aece5915caf5c68d12f560a9fe3e4"
+        mock.ANY, "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
     )
-    mock_do_wait_for_deployment.assert_any_call(mock.ANY, target_commit="old-sha")
+    mock_do_wait_for_deployment.assert_any_call(mock.ANY, "old-sha")
     assert mock_do_wait_for_deployment.call_count == 2
     # in normal usage, this would also be called once per m-f-d, but we mock that out above
     # so _log_audit is only called as part of handling the rollback
     assert mock__log_audit.call_count == len(mock_list_deploy_groups.return_value)
 
 
+@patch("paasta_tools.cli.cmds.mark_for_deployment._log_audit", autospec=True)
+@patch("paasta_tools.cli.cmds.mark_for_deployment._log", autospec=True)
 @patch("paasta_tools.remote_git.create_remote_refs", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.trigger_deploys", autospec=True)
 @patch(
     "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
 )
 def test_mark_for_deployment_yelpy_repo(
-    mock_load_system_paasta_config, mock_trigger_deploys, mock_create_remote_refs
+    mock_load_system_paasta_config,
+    mock_trigger_deploys,
+    mock_create_remote_refs,
+    mock__log,
+    mock__log_audit,
 ):
     config_mock = mock.Mock()
     config_mock.get_default_push_groups.return_value = None
@@ -267,13 +275,19 @@ def test_mark_for_deployment_yelpy_repo(
     mock_trigger_deploys.assert_called_once_with(service="fake_service")
 
 
+@patch("paasta_tools.cli.cmds.mark_for_deployment._log_audit", autospec=True)
+@patch("paasta_tools.cli.cmds.mark_for_deployment._log", autospec=True)
 @patch("paasta_tools.remote_git.create_remote_refs", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.trigger_deploys", autospec=True)
 @patch(
     "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
 )
 def test_mark_for_deployment_nonyelpy_repo(
-    mock_load_system_paasta_config, mock_trigger_deploys, mock_create_remote_refs
+    mock_load_system_paasta_config,
+    mock_trigger_deploys,
+    mock_create_remote_refs,
+    mock__log,
+    mock__log_audit,
 ):
     config_mock = mock.Mock()
     config_mock.get_default_push_groups.return_value = None
@@ -638,6 +652,9 @@ def test_MarkForDeployProcess_happy_path(
     mock_mark_for_deployment,
     mock_periodically_update_slack,
 ):
+    mock_wait_for_deployment.return_value = asyncio.sleep(
+        0
+    )  # make mock wait_for_deployment awaitable.
     mock_log.return_value = None
     mfdp = WrappedMarkForDeploymentProcess(
         service="service",
@@ -683,6 +700,9 @@ def test_MarkForDeployProcess_happy_path_skips_complete_if_no_auto_rollback(
     mock_mark_for_deployment,
     mock_periodically_update_slack,
 ):
+    mock_wait_for_deployment.return_value = asyncio.sleep(
+        0
+    )  # make mock wait_for_deployment awaitable.
     mock__log1.return_value = None
     mock__log2.return_value = None
     mfdp = WrappedMarkForDeploymentProcess(

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -238,8 +238,10 @@ def test_wait_for_deployment(
         with patch(
             "asyncio.as_completed", side_effect=[asyncio.TimeoutError], autospec=True
         ):
-            mark_for_deployment.wait_for_deployment(
-                "service", "fake_deploy_group", "somesha", "/nail/soa", 1
+            asyncio.run(
+                mark_for_deployment.wait_for_deployment(
+                    "service", "fake_deploy_group", "somesha", "/nail/soa", 1
+                )
             )
 
     mock_get_instance_configs_for_service_in_deploy_group_all_clusters.return_value = {
@@ -254,8 +256,10 @@ def test_wait_for_deployment(
     }
     with patch("sys.stdout", autospec=True, flush=Mock()):
         assert (
-            mark_for_deployment.wait_for_deployment(
-                "service", "fake_deploy_group", "somesha", "/nail/soa", 5
+            asyncio.run(
+                mark_for_deployment.wait_for_deployment(
+                    "service", "fake_deploy_group", "somesha", "/nail/soa", 5
+                )
             )
             == 0
         )
@@ -271,8 +275,10 @@ def test_wait_for_deployment(
         ],
     }
     with raises(TimeoutError):
-        mark_for_deployment.wait_for_deployment(
-            "service", "fake_deploy_group", "somesha", "/nail/soa", 0
+        asyncio.run(
+            mark_for_deployment.wait_for_deployment(
+                "service", "fake_deploy_group", "somesha", "/nail/soa", 0
+            )
         )
 
 
@@ -293,8 +299,10 @@ def test_wait_for_deployment_raise_no_such_cluster(
 
     mock_paasta_service_config_loader.return_value.clusters = ["cluster3"]
     with raises(NoSuchCluster):
-        mark_for_deployment.wait_for_deployment(
-            "service", "deploy_group_3", "somesha", "/nail/soa", 0
+        asyncio.run(
+            mark_for_deployment.wait_for_deployment(
+                "service", "deploy_group_3", "somesha", "/nail/soa", 0
+            )
         )
 
 


### PR DESCRIPTION
…h asyncio task cancellation. PAASTA-17443

In #3149, I refactored wait_for_deployment to run under asyncio rather than as a separate thread. The old thread-based approach used `threading.Event` (essentially a boolean you can wait on) objects that we called "green lights" to know when to die -- every iteration through certain loops, we would check those Events to see if they were still set, and if not, exited. This is how we stopped waiting for deployment of the new version when you click the rollback button, for example.

In my refactor, I didn't add any code that checked those events, so toggling them had no effect.

In this PR, I change all calls to `self.wait_for_deployment_green_lights[some_sha].clear()` to `self.stop_waiting_for_deployment(some_sha)`, which uses `asyncio.cancel` to kill the corresponding task object.

I also fixed some test bugs that only show up when you run `tests/cli/test_cmds_mark_for_deployment.py` by itself -- I think some sort of test pollution from earlier tests was making these pass when you ran the whole test suite.