### PR TITLE
Remove port in service_shard_update and add deploy/smartstack validation

### DIFF
--- a/paasta_tools/cli/schemas/deploy_schema.json
+++ b/paasta_tools/cli/schemas/deploy_schema.json
@@ -1,0 +1,126 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "deploy config schema",
+    "type": "object",
+    "properties": {
+        "allowed_push_groups": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "pipeline": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "step": {
+                        "type": "string"
+                    },
+                    "trigger_next_step_manually": {
+                        "type": "boolean"
+                    },
+                    "confirmation_required": {
+                        "type": "boolean"
+                    },
+                    "disabled": {
+                        "type": "boolean"
+                    },
+                    "wait_for_deployment": {
+                        "type": "boolean"
+                    },
+                    "auto_rollback": {
+                        "type": "boolean"
+                    },
+                    "auto_certify_delay": {
+                        "type": "integer"
+                    },
+                    "auto_abandon_delay": {
+                        "type": "integer"
+                    },
+                    "auto_rollback_delay": {
+                        "type": "integer"
+                    },
+                    "timeout": {
+                        "type": "integer"
+                    },
+                    "command": {
+                        "type": "string"
+                    },
+                    "slack_notify": {
+                        "type": "boolean"
+                    },
+                    "ignore_failure": {
+                        "type": "boolean"
+                    },
+                    "notify_after_mark": {
+                        "type": "boolean"
+                    },
+                    "notify_after_good_deploy": {
+                        "type": "boolean"
+                    },
+                    "notify_after_auto_rollback": {
+                        "type": "boolean"
+                    },
+                    "notify_after_abort": {
+                        "type": "boolean"
+                    },
+                    "deployment_steps": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "deploy_group": {
+                                    "type": "string"
+                                },
+                                "progress": {
+                                    "type": "number"
+                                },
+                                "confirm_before": {
+                                    "type": "boolean"
+                                },
+                                "deploy_below_breakage_pct": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "deploy_group",
+                                "progress"
+                            ]
+                        }
+                    },
+                    "abandon_above_breakage_pct": {
+                        "type": "number"
+                    },
+                    "complete_below_breakage_pct": {
+                        "type": "number"
+                    },
+                    "confirm_complete": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "step"
+                ]
+            }
+        },
+        "production_deploy_group": {
+            "type": "string"
+        },
+        "slack_channels": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "slack_notify": {
+            "type": "boolean"
+        }
+    },
+    "required": [
+        "pipeline"
+    ],
+    "additionalProperties": false
+}

--- a/paasta_tools/cli/schemas/smartstack_schema.json
+++ b/paasta_tools/cli/schemas/smartstack_schema.json
@@ -1,0 +1,232 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "smartstack config schema",
+    "type": "object",
+    "minProperties": 1,
+    "additionalProperties": {
+        "type": "object",
+        "properties": {
+            "proxy_port": {
+                "type": [
+                    "integer",
+                    "null"
+                ],
+                "minimum": 19000,
+                "maximum": 21000
+            },
+            "port": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 65535
+            },
+            "healthcheck_uri": {
+                "type": "string",
+                "pattern": "^/[-_0-9a-zA-Z/\\?&\\.=]*$"
+            },
+            "healthcheck_timeout_s": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 10
+            },
+            "updown_timeout_s": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 86400000
+            },
+            "healthcheck_mode": {
+                "enum": [
+                    "http",
+                    "https",
+                    "tcp"
+                ]
+            },
+            "healthcheck_port": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 65535
+            },
+            "healthcheck_body_expect": {
+                "type": "string"
+            },
+            "retries": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 10
+            },
+            "allredisp": {
+                "type": "boolean"
+            },
+            "timeout_connect_ms": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 60000
+            },
+            "timeout_client_ms": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 86400000
+            },
+            "timeout_server_ms": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 86400000
+            },
+            "idle_timeout": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 86400000
+            },
+            "balance": {
+                "type": "string",
+                "pattern": "^(leastconn|roundrobin)$"
+            },
+            "advertise": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "discover": {
+                "type": "string"
+            },
+            "extra_advertise": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "extra_headers": {
+                "type": "object"
+            },
+            "extra_healthcheck_headers": {
+                "type": "object",
+                "properties": {
+                    "Host": {
+                        "type": "string"
+                    },
+                    "X-ProxiedSSL": {
+                        "type": "string"
+                    },
+                    "X-Source-Id": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": {
+                    "type": "string"
+                }
+            },
+            "mode": {
+                "enum": [
+                    "http",
+                    "https",
+                    "tcp"
+                ]
+            },
+            "chaos": {
+                "type": "object",
+                "additionalProperties": {
+                    "ecosystem": {
+                        "type": "object",
+                        "additionalProperties": true
+                    },
+                    "habitat": {
+                        "type": "object",
+                        "additionalProperties": true
+                    },
+                    "host": {
+                        "type": "object",
+                        "additionalProperties": true
+                    },
+                    "runtimeenv": {
+                        "type": "object",
+                        "additionalProperties": true
+                    }
+                }
+            },
+            "proxied_through": {
+                "type": "string"
+            },
+            "fixed_delay": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                        "duration_ms": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 86400000
+                        },
+                        "percent": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 100
+                        }
+                    },
+                    "required": [
+                        "duration_ms",
+                        "percent"
+                    ]
+                }
+            },
+            "is_proxy": {
+                "type": "boolean"
+            },
+            "plugins": {
+                "type": "object",
+                "properties": {
+                    "source_required": {
+                        "type": "object",
+                        "properties": {
+                            "enabled": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "enabled"
+                        ],
+                        "additionalProperties": false
+                    },
+                    "logging": {
+                        "type": "object",
+                        "properties": {
+                            "enabled": {
+                                "type": "boolean"
+                            },
+                            "sample_rate": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                            }
+                        },
+                        "required": [
+                            "enabled"
+                        ],
+                        "additionalProperties": true
+                    }
+                },
+                "additionalProperties": true
+            },
+            "endpoint_timeouts": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "number",
+                    "minimum": 0
+                }
+            },
+            "allow_websocket_upgrade": {
+                "type": "boolean"
+            },
+            "vip_upgrade": {
+                "type": "string",
+                "description": "The service namespace that this namespace will route to (via Envoy) if a request has the X-Ctx-Vip header."
+            }
+        },
+        "required": [
+            "proxy_port"
+        ],
+        "additionalProperties": false
+    }
+}

--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -12,14 +12,13 @@ import ruamel.yaml as yaml
 from service_configuration_lib import read_extra_service_information
 
 from paasta_tools.cli.cmds.validate import validate_schema
-from paasta_tools.utils import AUTO_SOACONFIG_SUBDIR
 from paasta_tools.utils import DEFAULT_SOA_DIR
 
 
 log = logging.getLogger(__name__)
 
 # Must have a schema defined
-KNOWN_CONFIG_TYPES = ("marathon", "kubernetes")
+KNOWN_CONFIG_TYPES = ("marathon", "kubernetes", "deploy", "smartstack")
 
 
 def write_auto_config_data(
@@ -95,13 +94,12 @@ def _push_to_remote(branch: str) -> None:
             raise
 
 
-def validate_auto_config_file(filepath: str):
+def validate_auto_config_file(filepath: str, schema_subdir: str):
     basename = os.path.basename(filepath)
     for file_type in KNOWN_CONFIG_TYPES:
+        schema_path = f"{schema_subdir}/{file_type}" if schema_subdir else file_type
         if basename.startswith(file_type):
-            return bool(
-                validate_schema(filepath, f"{AUTO_SOACONFIG_SUBDIR}/{file_type}")
-            )
+            return bool(validate_schema(filepath, schema_path))
     else:
         logging.info(f"{filepath} is invalid because it has no validator defined")
         return False
@@ -143,6 +141,7 @@ class AutoConfigUpdater:
         branch: str = "master",
         working_dir: Optional[str] = None,
         do_clone: bool = True,
+        validation_schema_path: str = "",
     ):
         self.config_source = config_source
         self.git_remote = git_remote
@@ -150,6 +149,7 @@ class AutoConfigUpdater:
         self.working_dir = working_dir
         self.do_clone = do_clone
         self.files_changed: Set[str] = set()
+        self.validation_schema_path = validation_schema_path
         self.tmp_dir = None
 
     def __enter__(self):
@@ -197,11 +197,14 @@ class AutoConfigUpdater:
         return_code = True
         for filepath in self.files_changed:
             # We don't short circuit after a failure so the caller gets info on all the failures
-            return_code = validate_auto_config_file(filepath) and return_code
+            return_code = (
+                validate_auto_config_file(filepath, self.validation_schema_path)
+                and return_code
+            )
         return return_code
 
-    def commit_to_remote(self, extra_message: str = "", validate: bool = True):
-        if validate and not self.validate():
+    def commit_to_remote(self, extra_message: str = ""):
+        if not self.validate():
             log.error("Files failed validation, not committing changes")
             raise ValidationError
 

--- a/paasta_tools/contrib/rightsizer_soaconfigs_update.py
+++ b/paasta_tools/contrib/rightsizer_soaconfigs_update.py
@@ -193,6 +193,7 @@ def main(args):
         branch=args.branch,
         working_dir=args.local_dir or "/nail/tmp",
         do_clone=args.local_dir is None,
+        validation_schema_path=AUTO_SOACONFIG_SUBDIR,
     )
     with updater:
         for (service, extra_info), instance_recommendations in results.items():

--- a/paasta_tools/contrib/service_shard_update.py
+++ b/paasta_tools/contrib/service_shard_update.py
@@ -1,7 +1,6 @@
 import argparse
 import logging
 
-from paasta_tools.cli.fsm.autosuggest import suggest_smartstack_proxy_port
 from paasta_tools.cli.utils import trigger_deploys
 from paasta_tools.config_utils import AutoConfigUpdater
 from paasta_tools.utils import DEFAULT_SOA_CONFIGS_GIT_URL
@@ -131,9 +130,8 @@ def main(args):
         # Add the definition with a suggested proxy port
         if args.shard_name not in smartstack_file.keys():
             changes_made = True
-            port = suggest_smartstack_proxy_port(updater.working_dir)
             smartstack_file[args.shard_name] = {
-                "proxy_port": port,
+                "proxy_port": None,
                 "extra_advertise": {"ecosystem:devc": ["ecosystem:devc"]},
             }
             updater.write_configs(args.service, "smartstack", smartstack_file)

--- a/paasta_tools/contrib/service_shard_update.py
+++ b/paasta_tools/contrib/service_shard_update.py
@@ -140,7 +140,7 @@ def main(args):
 
         # Only commit to remote if changes were made
         if changes_made:
-            updater.commit_to_remote(validate=False)
+            updater.commit_to_remote()
             trigger_deploys(args.service)
 
 

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -5,6 +5,7 @@ import pytest
 import yaml
 
 import paasta_tools.config_utils as config_utils
+from paasta_tools.utils import AUTO_SOACONFIG_SUBDIR
 
 
 @pytest.fixture(autouse=True)
@@ -94,13 +95,15 @@ def test_write_auto_config_data_file_exists(tmpdir):
 def test_validate_auto_config_file_config_types(mock_validate, tmpdir):
     for config_type in config_utils.KNOWN_CONFIG_TYPES:
         filepath = f"service/{config_type}-cluster.yaml"
-        config_utils.validate_auto_config_file(filepath)
+        config_utils.validate_auto_config_file(filepath, AUTO_SOACONFIG_SUBDIR)
         mock_validate.assert_called_with(filepath, f"autotuned_defaults/{config_type}")
 
 
 @mock.patch("paasta_tools.config_utils.validate_schema", autospec=True)
 def test_validate_auto_config_file_unknown_type(mock_validate, tmpdir):
-    assert not config_utils.validate_auto_config_file("service/unknown-thing.yaml")
+    assert not config_utils.validate_auto_config_file(
+        "service/unknown-thing.yaml", AUTO_SOACONFIG_SUBDIR
+    )
 
 
 @pytest.mark.parametrize(
@@ -125,7 +128,10 @@ def test_validate_auto_config_file_e2e(data, is_valid, tmpdir):
     filepath = config_utils.write_auto_config_data(
         service=service, extra_info=conf_file, data=data, soa_dir=tmpdir,
     )
-    assert config_utils.validate_auto_config_file(filepath) == is_valid
+    assert (
+        config_utils.validate_auto_config_file(filepath, AUTO_SOACONFIG_SUBDIR)
+        == is_valid
+    )
 
 
 @pytest.mark.parametrize("branch", ["master", "other_test"])


### PR DESCRIPTION
This PR:
- adds smartstack and deploy file validation
- removes the ability to disable validation that I had added a while ago
- removes hardcoded AUTO_SOACONFIG_SUBDIR const when validating
- removes `suggest_smartstack_proxy_port` in favor of `None` in `service_shard_update.py`