### PR TITLE
Allow the `warn` key in deploy.yaml pipeline steps.

### DIFF
--- a/paasta_tools/cli/schemas/deploy_schema.json
+++ b/paasta_tools/cli/schemas/deploy_schema.json
@@ -45,6 +45,9 @@
                     "timeout": {
                         "type": "integer"
                     },
+                    "warn": {
+                        "type": "integer"
+                    },
                     "command": {
                         "type": "string"
                     },


### PR DESCRIPTION
The paasta jenkinsfile parser supports this, but you can't actually commit it because it'll fail validation because it's not in the schema.