### PR TITLE
Remove upper pin on requests-cache

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -46,7 +46,7 @@ python-iptables
 pytimeparse >= 1.1.0
 pytz >= 2014.10
 requests >= 2.18.4
-requests-cache >= 0.4.10,<= 0.5.0
+requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,10 +82,10 @@ pytimeparse==1.1.5
 pytz==2016.10
 pyyaml==5.4.1
 repoze.lru==0.6
-requests==2.21.0
-requests-cache==0.4.10
-requests-oauthlib==0.8.0
-requests-toolbelt==0.4.0
+requests==2.25.0
+requests-cache==0.6.3
+requests-oauthlib==1.2.0
+requests-toolbelt==0.9.1
 retry==0.9.2
 rfc3987==1.3.7
 rsa==4.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ msgpack-python==0.5.6
 multidict==4.7.6
 mypy-extensions==0.4.1
 nulltype==2.3.1
-oauthlib==2.0.7
+oauthlib==3.1.0
 objgraph==3.4.0
 PasteDeploy==1.5.2
 ply==3.4


### PR DESCRIPTION
Allows usage of modern version with security fix:
```
requests-cache@0.4.10: upgrade to 0.6.0.dev1 for Arbitrary Code Execution [high severity][https://snyk.io/vuln/SNYK-PYTHON-REQUESTSCACHE-1089050]
```