### PR TITLE
Add new option to spark-run to choose which cluster manager to use

### DIFF
--- a/.activate.sh
+++ b/.activate.sh
@@ -1,1 +1,1 @@
-.tox/py36-linux/bin/activate
+.tox/py37-linux/bin/activate

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -552,6 +552,7 @@ def configure_and_run_docker_container(
 ) -> int:
 
     # driver specific volumes
+    volumes: List[str] = []
     if cluster_manager == CLUSTER_MANAGER_MESOS:
         volumes = (
             spark_conf.get("spark.mesos.executor.docker.volumes", "").split(",")
@@ -559,7 +560,6 @@ def configure_and_run_docker_container(
             else []
         )
     elif cluster_manager == CLUSTER_MANAGER_K8S:
-        volumes = []
         volume_names = [
             re.match('spark.kubernetes.executor.volumes.hostPath.(\d+).mount.path', key).group(1)
             for key in spark_conf.keys()

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -561,14 +561,28 @@ def configure_and_run_docker_container(
         )
     elif cluster_manager == CLUSTER_MANAGER_K8S:
         volume_names = [
-            re.match('spark.kubernetes.executor.volumes.hostPath.(\d+).mount.path', key).group(1)
+            re.match(
+                r"spark.kubernetes.executor.volumes.hostPath.(\d+).mount.path", key
+            ).group(1)
             for key in spark_conf.keys()
-            if 'spark.kubernetes.executor.volumes.hostPath.' in key and '.mount.path' in key
+            if "spark.kubernetes.executor.volumes.hostPath." in key
+            and ".mount.path" in key
         ]
         for volume_name in volume_names:
-            read_only = 'ro' if spark_conf.get(f'spark.kubernetes.executor.volumes.hostPath.{volume_name}.mount.readOnly') == 'true' else 'rw'
-            container_path = spark_conf.get(f'spark.kubernetes.executor.volumes.hostPath.{volume_name}.mount.path')
-            host_path = spark_conf.get(f'spark.kubernetes.executor.volumes.hostPath.{volume_name}.options.path')
+            read_only = (
+                "ro"
+                if spark_conf.get(
+                    f"spark.kubernetes.executor.volumes.hostPath.{volume_name}.mount.readOnly"
+                )
+                == "true"
+                else "rw"
+            )
+            container_path = spark_conf.get(
+                f"spark.kubernetes.executor.volumes.hostPath.{volume_name}.mount.path"
+            )
+            host_path = spark_conf.get(
+                f"spark.kubernetes.executor.volumes.hostPath.{volume_name}.options.path"
+            )
             volumes.append(f"{host_path}:{container_path}:{read_only}")
 
     volumes.append("%s:rw" % args.work_dir)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -594,6 +594,7 @@ def configure_and_run_docker_container(
             print(
                 f"\nAfter the job is finished, you can find the spark UI from {history_server_url}\n"
             )
+    print(f"Selected cluster manager: {cluster_manager}\n")
 
     if clusterman_metrics and _should_emit_resource_requirements(
         docker_cmd, args.mrjob

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -33,7 +33,6 @@ from service_configuration_lib.spark_config import generate_clusterman_metrics_e
 from service_configuration_lib.spark_config import get_aws_credentials
 from service_configuration_lib.spark_config import get_resources_requested
 from service_configuration_lib.spark_config import get_spark_conf
-from service_configuration_lib.spark_config import K8S_AUTH_FOLDER
 from service_configuration_lib.spark_config import stringify_spark_env
 
 from paasta_tools.mesos_tools import mesos_services_running_here
@@ -48,7 +47,6 @@ from paasta_tools.tron.client import TronClient
 from paasta_tools.tron import tron_command_context
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import DockerParameter
-from paasta_tools.utils import DockerVolume
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import InvalidInstanceConfig
 from paasta_tools.utils import load_system_paasta_config

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -367,23 +367,6 @@ class TronActionConfig(InstanceConfig):
                 }
         return secret_env
 
-    def get_extra_volumes(self):
-        extra_volumes = super().get_extra_volumes()
-        if (
-            self.get_executor() == "spark"
-            and self.get_spark_cluster_manager() == "kubernetes"
-        ):
-            extra_volumes.append(
-                DockerVolume(
-                    {
-                        "hostPath": "/etc/pki/spark",
-                        "containerPath": K8S_AUTH_FOLDER,
-                        "mode": "RO",
-                    }
-                )
-            )
-        return extra_volumes
-
     def get_cpu_burst_add(self) -> float:
         """ For Tron jobs, we don't let them burst by default, because they
         don't represent "real-time" workloads, and should not impact

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
--e ../service_configuration_lib
+-e ../service_configuration_lib  # to be changed to service-configuration-lib==2.5.6
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.5.4
+-e ../service_configuration_lib
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
--e ../service_configuration_lib  # to be changed to service-configuration-lib==2.5.6
+service-configuration-lib==2.5.6
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.5.6
+service-configuration-lib==2.5.7
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -373,16 +373,25 @@ class TestConfigureAndRunDockerContainer:
     @pytest.mark.parametrize(
         ["cluster_manager", "spark_args_volumes", "expected_volumes"],
         [
-            (spark_run.CLUSTER_MANAGER_MESOS, {"spark.mesos.executor.docker.volumes": "/mesos/volume:/mesos/volume:rw"}, ["/mesos/volume:/mesos/volume:rw"]),
-            (spark_run.CLUSTER_MANAGER_K8S, {
-                "spark.kubernetes.executor.volumes.hostPath.0.mount.readOnly": "true",
-                "spark.kubernetes.executor.volumes.hostPath.0.mount.path": "/k8s/volume0",
-                "spark.kubernetes.executor.volumes.hostPath.0.options.path": "/k8s/volume0",
-                "spark.kubernetes.executor.volumes.hostPath.1.mount.readOnly": "false",
-                "spark.kubernetes.executor.volumes.hostPath.1.mount.path": "/k8s/volume1",
-                "spark.kubernetes.executor.volumes.hostPath.1.options.path": "/k8s/volume1",
-            },
-            ["/k8s/volume0:/k8s/volume0:ro", "/k8s/volume1:/k8s/volume1:rw"]),
+            (
+                spark_run.CLUSTER_MANAGER_MESOS,
+                {
+                    "spark.mesos.executor.docker.volumes": "/mesos/volume:/mesos/volume:rw"
+                },
+                ["/mesos/volume:/mesos/volume:rw"],
+            ),
+            (
+                spark_run.CLUSTER_MANAGER_K8S,
+                {
+                    "spark.kubernetes.executor.volumes.hostPath.0.mount.readOnly": "true",
+                    "spark.kubernetes.executor.volumes.hostPath.0.mount.path": "/k8s/volume0",
+                    "spark.kubernetes.executor.volumes.hostPath.0.options.path": "/k8s/volume0",
+                    "spark.kubernetes.executor.volumes.hostPath.1.mount.readOnly": "false",
+                    "spark.kubernetes.executor.volumes.hostPath.1.mount.path": "/k8s/volume1",
+                    "spark.kubernetes.executor.volumes.hostPath.1.options.path": "/k8s/volume1",
+                },
+                ["/k8s/volume0:/k8s/volume0:ro", "/k8s/volume1:/k8s/volume1:rw"],
+            ),
         ],
     )
     def test_configure_and_run_docker_container(
@@ -397,10 +406,14 @@ class TestConfigureAndRunDockerContainer:
         mock_get_username,
         cluster_manager,
         spark_args_volumes,
-        expected_volumes
+        expected_volumes,
     ):
         mock_get_username.return_value = "fake_user"
-        spark_conf = {"spark.app.name": "fake_app", "spark.ui.port": "1234", **spark_args_volumes}
+        spark_conf = {
+            "spark.app.name": "fake_app",
+            "spark.ui.port": "1234",
+            **spark_args_volumes,
+        }
         mock_run_docker_container.return_value = 0
 
         args = mock.MagicMock()
@@ -427,7 +440,10 @@ class TestConfigureAndRunDockerContainer:
         assert retcode == 0
         mock_run_docker_container.assert_called_once_with(
             container_name="fake_app",
-            volumes=expected_volumes + ["/fake_dir:/spark_driver:rw", "/nail/home:/nail/home:rw"],
+            volumes=(
+                expected_volumes
+                + ["/fake_dir:/spark_driver:rw", "/nail/home:/nail/home:rw"]
+            ),
             environment={
                 "env1": "val1",
                 "AWS_ACCESS_KEY_ID": "id",

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -393,6 +393,7 @@ class TestConfigureAndRunDockerContainer:
         args.dry_run = True
         args.mrjob = False
         args.nvidia = False
+        args.cluster_manager = "mesos"
         with mock.patch.object(
             self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
         ):
@@ -403,6 +404,7 @@ class TestConfigureAndRunDockerContainer:
                 system_paasta_config=self.system_paasta_config,
                 aws_creds=("id", "secret", "token"),
                 spark_conf=spark_conf,
+                cluster_manager=args.cluster_manager,
             )
         assert retcode == 0
         mock_run_docker_container.assert_called_once_with(
@@ -454,6 +456,7 @@ class TestConfigureAndRunDockerContainer:
                 system_paasta_config=self.system_paasta_config,
                 aws_creds=("id", "secret", "token"),
                 spark_conf=spark_conf,
+                cluster_manager="mesos",
             )
 
             args, kwargs = mock_run_docker_container.call_args
@@ -489,6 +492,7 @@ class TestConfigureAndRunDockerContainer:
                 system_paasta_config=self.system_paasta_config,
                 aws_creds=("id", "secret", "token"),
                 spark_conf=spark_conf,
+                cluster_manager="mesos",
             )
 
             args, kwargs = mock_run_docker_container.call_args
@@ -528,6 +532,7 @@ class TestConfigureAndRunDockerContainer:
                     system_paasta_config=self.system_paasta_config,
                     aws_creds=("id", "secret", "token"),
                     spark_conf=spark_conf,
+                    cluster_manager="mesos",
                 )
 
             # make sure we don't blow up when this setting is True
@@ -539,6 +544,7 @@ class TestConfigureAndRunDockerContainer:
                 system_paasta_config=self.system_paasta_config,
                 aws_creds=("id", "secret", "token"),
                 spark_conf=spark_conf,
+                cluster_manager="mesos",
             )
 
     def test_dont_emit_metrics_for_inappropriate_commands(
@@ -565,6 +571,7 @@ class TestConfigureAndRunDockerContainer:
                 system_paasta_config=self.system_paasta_config,
                 aws_creds=("id", "secret", "token"),
                 spark_conf={"spark.ui.port": "1234", "spark.app.name": "fake_app"},
+                cluster_manager="mesos",
             )
             assert not mock_send_and_calculate_resources_cost.called
 
@@ -663,6 +670,7 @@ def test_paasta_spark_run(
         aws_credentials_yaml="/path/to/creds",
         aws_profile=None,
         spark_args="spark.cores.max=100 spark.executor.cores=10",
+        cluster_manager="mesos",
     )
     spark_run.paasta_spark_run(args)
     mock_validate_work_dir.assert_called_once_with("/tmp/local")
@@ -706,4 +714,5 @@ def test_paasta_spark_run(
         system_paasta_config=mock_load_system_paasta_config.return_value,
         spark_conf=mock_get_spark_conf.return_value,
         aws_creds=mock_get_aws_credentials.return_value,
+        cluster_manager="mesos",
     )

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -373,14 +373,14 @@ class TestConfigureAndRunDockerContainer:
     @pytest.mark.parametrize(
         ["cluster_manager", "spark_args_volumes", "expected_volumes"],
         [
-            ("mesos", {"spark.mesos.executor.docker.volumes": "/mesos/volume:/mesos/volume:rw"}, ["/mesos/volume:/mesos/volume:rw"]),
-            ("kubernetes", {
+            (spark_run.CLUSTER_MANAGER_MESOS, {"spark.mesos.executor.docker.volumes": "/mesos/volume:/mesos/volume:rw"}, ["/mesos/volume:/mesos/volume:rw"]),
+            (spark_run.CLUSTER_MANAGER_K8S, {
                 "spark.kubernetes.executor.volumes.hostPath.0.mount.readOnly": "true",
                 "spark.kubernetes.executor.volumes.hostPath.0.mount.path": "/k8s/volume0",
-                "spark.kubernetes.executor.volumes.hostPath.0.options.path": "/k8s/volume0", 
+                "spark.kubernetes.executor.volumes.hostPath.0.options.path": "/k8s/volume0",
                 "spark.kubernetes.executor.volumes.hostPath.1.mount.readOnly": "false",
                 "spark.kubernetes.executor.volumes.hostPath.1.mount.path": "/k8s/volume1",
-                "spark.kubernetes.executor.volumes.hostPath.1.options.path": "/k8s/volume1", 
+                "spark.kubernetes.executor.volumes.hostPath.1.options.path": "/k8s/volume1",
             },
             ["/k8s/volume0:/k8s/volume0:ro", "/k8s/volume1:/k8s/volume1:rw"]),
         ],
@@ -474,7 +474,7 @@ class TestConfigureAndRunDockerContainer:
                 system_paasta_config=self.system_paasta_config,
                 aws_creds=("id", "secret", "token"),
                 spark_conf=spark_conf,
-                cluster_manager="mesos",
+                cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
             )
 
             args, kwargs = mock_run_docker_container.call_args
@@ -510,7 +510,7 @@ class TestConfigureAndRunDockerContainer:
                 system_paasta_config=self.system_paasta_config,
                 aws_creds=("id", "secret", "token"),
                 spark_conf=spark_conf,
-                cluster_manager="mesos",
+                cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
             )
 
             args, kwargs = mock_run_docker_container.call_args
@@ -550,7 +550,7 @@ class TestConfigureAndRunDockerContainer:
                     system_paasta_config=self.system_paasta_config,
                     aws_creds=("id", "secret", "token"),
                     spark_conf=spark_conf,
-                    cluster_manager="mesos",
+                    cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
                 )
 
             # make sure we don't blow up when this setting is True
@@ -562,7 +562,7 @@ class TestConfigureAndRunDockerContainer:
                 system_paasta_config=self.system_paasta_config,
                 aws_creds=("id", "secret", "token"),
                 spark_conf=spark_conf,
-                cluster_manager="mesos",
+                cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
             )
 
     def test_dont_emit_metrics_for_inappropriate_commands(
@@ -589,7 +589,7 @@ class TestConfigureAndRunDockerContainer:
                 system_paasta_config=self.system_paasta_config,
                 aws_creds=("id", "secret", "token"),
                 spark_conf={"spark.ui.port": "1234", "spark.app.name": "fake_app"},
-                cluster_manager="mesos",
+                cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
             )
             assert not mock_send_and_calculate_resources_cost.called
 
@@ -688,7 +688,7 @@ def test_paasta_spark_run(
         aws_credentials_yaml="/path/to/creds",
         aws_profile=None,
         spark_args="spark.cores.max=100 spark.executor.cores=10",
-        cluster_manager="mesos",
+        cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
     )
     spark_run.paasta_spark_run(args)
     mock_validate_work_dir.assert_called_once_with("/tmp/local")
@@ -713,7 +713,7 @@ def test_paasta_spark_run(
         "spark.cores.max=100 spark.executor.cores=10"
     )
     mock_get_spark_conf.assert_called_once_with(
-        cluster_manager="mesos",
+        cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
         spark_app_base_name=mock_get_spark_app_name.return_value,
         docker_img=mock_get_docker_image.return_value,
         user_spark_opts=mock_parse_user_spark_args.return_value,
@@ -732,5 +732,5 @@ def test_paasta_spark_run(
         system_paasta_config=mock_load_system_paasta_config.return_value,
         spark_conf=mock_get_spark_conf.return_value,
         aws_creds=mock_get_aws_credentials.return_value,
-        cluster_manager="mesos",
+        cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
     )

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -131,11 +131,6 @@ class TestTronActionConfig:
                 expected_mesos_leader = None
                 expected_extra_volumes = [
                     {
-                        "hostPath": "/etc/pki/spark",
-                        "containerPath": "/etc/spark_k8s_secrets",
-                        "mode": "RO",
-                    },
-                    {
                         "containerPath": "/nail/tmp",
                         "hostPath": "/nail/tmp",
                         "mode": "RW",
@@ -1030,11 +1025,6 @@ class TestTronTools:
                         "container_path": "/nail/tmp",
                         "host_path": "/nail/tmp",
                         "mode": "RW",
-                    },
-                    {
-                        "container_path": "/etc/spark_k8s_secrets",
-                        "host_path": "/etc/pki/spark",
-                        "mode": "RO",
                     },
                 ],
             ),


### PR DESCRIPTION
## What changed
- [x] add option `--cluster-manager mesos|kubernetes` to pick which CM to use
- [x] correctly load ALL containers in the Spark driver to match the behavior with Mesos (https://github.com/Yelp/service_configuration_lib/pull/64)
- [x] update paasta tron to not mount the same volume (`/etc/pki/spark`) twice  

## Testing
Manual
```
./paasta_tools/cli/cli.py spark-run --cluster-manager kubernetes --cluster pnw-devc --cmd ' spark-submit /code/virtualenv_run/bin/spark_etl_runner.py --feature-config /code/batch/xxx/job_configs/xxx.yaml --env-config-path /nail/srv/configs/xxx.yaml --team-name xxx --notify-email y@elp.com --start-date 2021-08-15 --end-date 2021-08-15 --publish-path s3a://yelp-xxx-west-2/x/ -v ' --spark-args ' spark.cores.max=60 spark.executor.memory=13g spark.executor.cores=2 spark.driver.memory=13g spark.driver.cores=2 spark.jars.ivy=/tmp/.ivy spark.executor.instances=30' --service xxx
```
Succeeds: https://fluffy.yelpcorp.com/i/LfQ0XQ47l5s0jCF1pbnBS289ddH855mx.html