### PR TITLE
Stop returning no services if kubelet down

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1823,11 +1823,7 @@ def get_all_kubernetes_services_running_here() -> List[Tuple[str, str, int]]:
 
 def get_kubernetes_services_running_here() -> Sequence[KubernetesServiceRegistration]:
     services = []
-    try:
-        pods = get_k8s_pods()
-    except requests.exceptions.ConnectionError:
-        log.debug("Failed to connect to the kublet when trying to get pods")
-        return []
+    pods = get_k8s_pods()
     for pod in pods["items"]:
         if pod["status"]["phase"] != "Running" or "smartstack_registrations" not in pod[
             "metadata"

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -60,6 +60,7 @@ from kubernetes.client.models.v2beta2_object_metric_source import (
     V2beta2ObjectMetricSource,
 )
 from kubernetes.client.rest import ApiException
+from requests.exceptions import ConnectionError
 
 from paasta_tools import kubernetes_tools
 from paasta_tools.contrib.get_running_task_allocation import (
@@ -2242,6 +2243,11 @@ def test_get_kubernetes_services_running_here():
                 registrations=[],
             )
         ]
+        # if the kubelet is down we don't want to reconfigure nerve until it comes back
+        # and we can be sure what is running or not
+        mock_requests_get.side_effect = ConnectionError
+        with pytest.raises(ConnectionError):
+            get_kubernetes_services_running_here()
 
 
 class MockNerveDict(dict):


### PR DESCRIPTION
PAASTA-17446 for details. If the kubelet is down the services can still
be running so we don't want to tell nerve that there are no services
since that will cause it to deregister the services. I think that is
safe although it is very unsafe if we accidentally stopped all the
kubelets (and we have done that before). We also restart kubelets to
renew certs which triggers this case and deregisters services for a few
minutes before re-registering them when the kubelet starts again.
That creates some unnecessary churn in the mesh.