### PR TITLE
Send node selectors and affinities to tron

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -97,6 +97,90 @@
                 "pool": {
                     "type": "string"
                 },
+                "node_selectors": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+[a-zA-Z0-9-_./]*[a-zA-Z0-9]+$": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "uniqueItems": true
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "anyOf": [
+                                            {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "operator": {
+                                                        "enum": [
+                                                            "In",
+                                                            "NotIn"
+                                                        ]
+                                                    },
+                                                    "values": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "uniqueItems": true
+                                                    }
+                                                },
+                                                "required": [
+                                                    "operator",
+                                                    "values"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "operator": {
+                                                        "enum": [
+                                                            "Exists",
+                                                            "DoesNotExist"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "operator"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "operator": {
+                                                        "enum": [
+                                                            "Gt",
+                                                            "Lt"
+                                                        ]
+                                                    },
+                                                    "value": {
+                                                        "type": "integer"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "operator",
+                                                    "value"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
                 "env": {
                     "type": "object",
                     "patternProperties": {

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -464,7 +464,7 @@ def allowlist_denylist_to_requirements(
 
 
 def raw_selectors_to_requirements(
-    raw_selectors: Mapping[str, any]
+    raw_selectors: Mapping[str, Any]
 ) -> List[Tuple[str, str, List[str]]]:
     """Converts certain node_selectors into requirements, which can be
     converted to node affinities.

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -25,6 +25,7 @@ from string import Formatter
 from typing import List
 from typing import Mapping
 from typing import Tuple
+from typing import Union
 
 import yaml
 from service_configuration_lib import read_extra_service_information
@@ -422,7 +423,7 @@ class TronActionConfig(InstanceConfig):
         node_selectors["yelp.com/pool"] = self.get_pool()
         return node_selectors
 
-    def get_node_affinities(self) -> Optional[List[Any]]:
+    def get_node_affinities(self) -> Optional[List[Dict[str, Union[str, List[str]]]]]:
         """Converts deploy_whitelist and deploy_blacklist in node affinities.
 
         note: At the time of writing, `kubectl describe` does not show affinities,

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -56,7 +56,12 @@ from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import time_cache
 from paasta_tools.utils import filter_templates_from_config
-from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
+from paasta_tools.kubernetes_tools import (
+    allowlist_denylist_to_requirements,
+    raw_selectors_to_requirements,
+    sanitise_kubernetes_name,
+    to_node_label,
+)
 from paasta_tools.secret_tools import is_secret_ref
 from paasta_tools.secret_tools import is_shared_secret
 from paasta_tools.secret_tools import get_secret_name_from_ref
@@ -407,6 +412,36 @@ class TronActionConfig(InstanceConfig):
     def get_use_k8s(self):
         return self.config_dict.get("use_k8s", False)
 
+    def get_node_selectors(self) -> Dict[str, str]:
+        raw_selectors: Dict[str, Any] = self.config_dict.get("node_selectors", {})
+        node_selectors = {
+            to_node_label(label): value
+            for label, value in raw_selectors.items()
+            if isinstance(value, str)
+        }
+        node_selectors["yelp.com/pool"] = self.get_pool()
+        return node_selectors
+
+    def get_node_affinities(self) -> Optional[List[Tuple[str, str, List[str]]]]:
+        """Converts deploy_whitelist and deploy_blacklist in node affinities.
+
+        note: At the time of writing, `kubectl describe` does not show affinities,
+        only selectors. To see affinities, use `kubectl get pod -o json` instead.
+        """
+        requirements = allowlist_denylist_to_requirements(
+            allowlist=self.get_deploy_whitelist(), denylist=self.get_deploy_blacklist(),
+        )
+        requirements.extend(
+            raw_selectors_to_requirements(
+                raw_selectors=self.config_dict.get("node_selectors", {}),
+            )
+        )
+        # package everything into a node affinity - lots of layers :P
+        if len(requirements) == 0:
+            return None
+
+        return requirements
+
     def get_calculated_constraints(self):
         """Combine all configured Mesos constraints."""
         constraints = self.get_constraints()
@@ -708,6 +743,8 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
         # such that this output eventually makes it into our per-instance
         # log streams automatically
         result["env"]["ENABLE_PER_INSTANCE_LOGSPOUT"] = "1"
+        result["node_selectors"] = action_config.get_node_selectors()
+        result["node_affinities"] = action_config.get_node_affinities()
 
         # XXX: once we're off mesos we can make get_cap_* return just the cap names as a list
         result["cap_add"] = [cap["value"] for cap in action_config.get_cap_add()]
@@ -715,8 +752,6 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
     elif executor in MESOS_EXECUTOR_NAMES:
         result["executor"] = "mesos"
         constraint_labels = ["attribute", "operator", "value"]
-        # TODO(TRON-1609): we'll want to either have this spit out a nodeSelector
-        # or add a new field for k8s usage since Mesos-style constraints aren't a thing
         result["constraints"] = [
             dict(zip(constraint_labels, constraint))
             for constraint in action_config.get_calculated_constraints()

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1590,49 +1590,47 @@ class TestKubernetesDeploymentConfig:
             self.deployment.config_dict["node_selectors"] = raw_selectors
         assert self.deployment.get_node_selector() == expected
 
-    @mock.patch(
-        "paasta_tools.kubernetes_tools.allowlist_denylist_to_requirements",
-        mock.Mock(return_value=[("habitat", "In", ["habitat_a"])]),
-        autospec=True,
-    )
-    @mock.patch(
-        "paasta_tools.kubernetes_tools.raw_selectors_to_requirements",
-        mock.Mock(return_value=[("instance_type", "In", ["a1.1xlarge"])]),
-        autospec=True,
-    )
     def test_get_node_affinity_with_reqs(self):
-        assert self.deployment.get_node_affinity() == V1NodeAffinity(
-            required_during_scheduling_ignored_during_execution=V1NodeSelector(
-                node_selector_terms=[
-                    V1NodeSelectorTerm(
-                        match_expressions=[
-                            V1NodeSelectorRequirement(
-                                key="habitat", operator="In", values=["habitat_a"],
-                            ),
-                            V1NodeSelectorRequirement(
-                                key="instance_type",
-                                operator="In",
-                                values=["a1.1xlarge"],
-                            ),
-                            "node_selectors",
-                        ]
-                    )
-                ],
-            ),
-        )
+        with mock.patch(
+            "paasta_tools.kubernetes_tools.allowlist_denylist_to_requirements",
+            return_value=[("habitat", "In", ["habitat_a"])],
+            autospec=True,
+        ), mock.patch(
+            "paasta_tools.kubernetes_tools.raw_selectors_to_requirements",
+            return_value=[("instance_type", "In", ["a1.1xlarge"])],
+            autospec=True,
+        ):
+            assert self.deployment.get_node_affinity() == V1NodeAffinity(
+                required_during_scheduling_ignored_during_execution=V1NodeSelector(
+                    node_selector_terms=[
+                        V1NodeSelectorTerm(
+                            match_expressions=[
+                                V1NodeSelectorRequirement(
+                                    key="habitat", operator="In", values=["habitat_a"],
+                                ),
+                                V1NodeSelectorRequirement(
+                                    key="instance_type",
+                                    operator="In",
+                                    values=["a1.1xlarge"],
+                                ),
+                                "node_selectors",
+                            ]
+                        )
+                    ],
+                ),
+            )
 
-    @mock.patch(
-        "paasta_tools.kubernetes_tools.allowlist_denylist_to_requirements",
-        mock.Mock(return_value=[]),
-        autospec=True,
-    )
-    @mock.patch(
-        "paasta_tools.kubernetes_tools.raw_selectors_to_requirements",
-        mock.Mock(return_value=[]),
-        autospec=True,
-    )
     def test_get_node_affinity_no_reqs(self):
-        assert self.deployment.get_node_affinity() is None
+        with mock.patch(
+            "paasta_tools.kubernetes_tools.allowlist_denylist_to_requirements",
+            return_value=[],
+            autospec=True,
+        ), mock.patch(
+            "paasta_tools.kubernetes_tools.raw_selectors_to_requirements",
+            return_value=[],
+            autospec=True,
+        ):
+            assert self.deployment.get_node_affinity() is None
 
     @pytest.mark.parametrize(
         "anti_affinity,expected",

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1613,7 +1613,6 @@ class TestKubernetesDeploymentConfig:
                                     operator="In",
                                     values=["a1.1xlarge"],
                                 ),
-                                "node_selectors",
                             ]
                         )
                     ],

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -853,6 +853,7 @@ class TestTronTools:
     def test_format_tron_action_dict_paasta_k8s(self):
         action_dict = {
             "command": "echo something",
+            "node_selectors": {"instance_type": ["c5.2xlarge", "c5n.17xlarge",]},
             "requires": ["required_action"],
             "retries": 2,
             "retries_delay": "5m",
@@ -906,6 +907,14 @@ class TestTronTools:
             "disk": 42,
             "cap_add": [],
             "cap_drop": CAPS_DROP,
+            "node_selectors": {"yelp.com/pool": "special_pool"},
+            "node_affinities": [
+                (
+                    "node.kubernetes.io/instance-type",
+                    "In",
+                    ["c5.2xlarge", "c5n.17xlarge"],
+                )
+            ],
             "env": mock.ANY,
             "secret_env": {
                 "SOME_SECRET": {

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -909,11 +909,11 @@ class TestTronTools:
             "cap_drop": CAPS_DROP,
             "node_selectors": {"yelp.com/pool": "special_pool"},
             "node_affinities": [
-                (
-                    "node.kubernetes.io/instance-type",
-                    "In",
-                    ["c5.2xlarge", "c5n.17xlarge"],
-                )
+                {
+                    "key": "node.kubernetes.io/instance-type",
+                    "operator": "In",
+                    "value": ["c5.2xlarge", "c5n.17xlarge"],
+                }
             ],
             "env": mock.ANY,
             "secret_env": {


### PR DESCRIPTION
Just like we do for normal paasta services, we only expose a
`node_selectors` key and then translate that into the correct format
internally. However, unlike paasta services, we don't turn these into
the corresponding k8s representation since this is meant to be POSTed to
the Tron API.

I refactored some of the existing selector/affinity code for k8s
services in order to be able to reuse them as I didn't want to have to
duplicate those functions just so that we could use them for Tron.