### PR TITLE
Update endpoint timeout override docs to include regex-matching

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -955,13 +955,21 @@ Routing and Reliability
  * ``endpoint_timeouts``: Allows you to specify non-default server timeouts for
    specific endpoints. This is useful for when there is a long running endpoint
    that requires a large timeout value but you would like to keep the default
-   timeout at a resonable value. Endpoints are prefix-matched to what is
-   specified here so for example ``/specials/bulk/v1`` will match the
-   endpoints ``/specials/bulk/v1/foo`` and ``/specials/bulk/v1/bar``.
+   timeout at a reasonable value.
+
+   Endpoints use prefix-matching by default; for example ``/specials/bulk/v1``
+   will match both ``/specials/bulk/v1/foo`` and ``/specials/bulk/v1/bar``. 
+
+   Endpoints can also use regex matching, provided that the regex string begins 
+   with a caret ``^`` and backslashes within the string are properly escaped. 
+   For example, ``^/specials/[^/]+/v2/\\d`` will match the endpoints 
+   ``/specials/bulk/v2/1`` and ``^/specials/milk/v2/2``.
+   
    Example::
 
      endpoint_timeouts:
          "/specials/bulk/v1": 15000
+         "^/specials/[^/]+/v2/\\d": 11000
 
 Fault Injection
 ```````````````


### PR DESCRIPTION
Support for regex-matching was recently added in the mesh, so just updating these docs to make sure they reflect reality. 