### PR TITLE
Allow services to register in smartstack/envoy with a null proxy_port…

### DIFF
--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -118,10 +118,7 @@ class ServiceNamespaceConfig(dict):
         return self.get("discover", "region")
 
     def is_in_smartstack(self) -> bool:
-        if self.get("proxy_port") is not None:
-            return True
-        else:
-            return False
+        return "proxy_port" in self
 
 
 class LongRunningServiceConfig(InstanceConfig):


### PR DESCRIPTION
… (so they are only accessible via the envoy shared port.)

This would mean that kubernetes services that have `proxy_port: null` in smartstack.yaml get the `hacheck` container and a routable IP address, etc.

https://jira.yelpcorp.com/browse/PAASTA-17454