### PR TITLE
Fix whitespace in docs

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -958,13 +958,13 @@ Routing and Reliability
    timeout at a reasonable value.
 
    Endpoints use prefix-matching by default; for example ``/specials/bulk/v1``
-   will match both ``/specials/bulk/v1/foo`` and ``/specials/bulk/v1/bar``. 
+   will match both ``/specials/bulk/v1/foo`` and ``/specials/bulk/v1/bar``.
 
-   Endpoints can also use regex matching, provided that the regex string begins 
-   with a caret ``^`` and backslashes within the string are properly escaped. 
-   For example, ``^/specials/[^/]+/v2/\\d`` will match the endpoints 
+   Endpoints can also use regex matching, provided that the regex string begins
+   with a caret ``^`` and backslashes within the string are properly escaped.
+   For example, ``^/specials/[^/]+/v2/\\d`` will match the endpoints
    ``/specials/bulk/v2/1`` and ``^/specials/milk/v2/2``.
-   
+
    Example::
 
      endpoint_timeouts:


### PR DESCRIPTION
I accidentally missed this in #3184; adding this now so that tests will actually pass.