### PR TITLE
Increase default polling interval to 60 seconds

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2584,7 +2584,7 @@ class SystemPaastaConfig:
         return self.config_dict.get("mark_for_deployment_max_polling_threads", 4)
 
     def get_mark_for_deployment_default_polling_interval(self) -> float:
-        return self.config_dict.get("mark_for_deployment_default_polling_interval", 5)
+        return self.config_dict.get("mark_for_deployment_default_polling_interval", 60)
 
     def get_mark_for_deployment_default_diagnosis_interval(self) -> float:
         return self.config_dict.get(


### PR DESCRIPTION
The 5 seconds interval massively increases the load on the etcd nodes. The change introduced here: https://github.com/Yelp/paasta/commit/de82504539b7f45cf2319da92fac400166ef1d70 reduces the interval from 60 to 5 seconds. This PR reverses that change to reduce the load on etcd during y-m and other service bounces.