### PR TITLE
FLINK-3725 Query flink REST API for exceptions 

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1146,8 +1146,9 @@ def print_flink_status(
             # This condition is intended for testing purposes and should be removed later.
             # If the status object contains exceptions, then use it. Otherwise try to get it from calling the API
             exceptions = None
-            if "exceptions" in status and job_id in status["exceptions"]:
-                exceptions = status["exceptions"][job_id]
+            if "exceptions" in status:
+                if job_id in status["exceptions"]:
+                    exceptions = status["exceptions"][job_id]
             else:
                 try:
                     exceptions = get_flink_job_exceptions(cr_name, cluster, job_id)

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1143,17 +1143,24 @@ def print_flink_status(
             break
 
         if verbose > 1:
-            exceptions = get_flink_job_exceptions(cr_name, cluster, job_id)
-            if exceptions is not None:
-                root_exception = exceptions["root-exception"]
-                if root_exception is not None:
-                    output.append(f"        Exception: {root_exception}")
-                    ts = exceptions["timestamp"]
-                    if ts is not None:
-                        exc_ts = datetime.fromtimestamp(int(ts) // 1000)
-                        output.append(
-                            f"            {str(exc_ts)} ({humanize.naturaltime(exc_ts)})"
-                        )
+            try:
+                exceptions = get_flink_job_exceptions(cr_name, cluster, job_id)
+                if exceptions is not None:
+                    root_exception = exceptions["root-exception"]
+                    if root_exception is not None:
+                        output.append(f"        Exception: {root_exception}")
+                        ts = exceptions["timestamp"]
+                        if ts is not None:
+                            exc_ts = datetime.fromtimestamp(int(ts) // 1000)
+                            output.append(
+                                f"            {str(exc_ts)} ({humanize.naturaltime(exc_ts)})"
+                            )
+            except ValueError as e:
+                output.append(
+                    PaastaColors.red(
+                        f"        Failed to fetch exceptions for job {job_id} from jobmanager due to error {str(e)}"
+                    )
+                )
     if verbose and len(status["pod_status"]) > 0:
         append_pod_status(status["pod_status"], output)
     if verbose == 1:

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1144,15 +1144,16 @@ def print_flink_status(
 
         if verbose > 1:
             exceptions = get_flink_job_exceptions(cr_name, cluster, job_id)
-            root_exception = exceptions["root-exception"]
-            if root_exception is not None:
-                output.append(f"        Exception: {root_exception}")
-                ts = exceptions["timestamp"]
-                if ts is not None:
-                    exc_ts = datetime.fromtimestamp(int(ts) // 1000)
-                    output.append(
-                        f"            {str(exc_ts)} ({humanize.naturaltime(exc_ts)})"
-                    )
+            if exceptions is not None:
+                root_exception = exceptions["root-exception"]
+                if root_exception is not None:
+                    output.append(f"        Exception: {root_exception}")
+                    ts = exceptions["timestamp"]
+                    if ts is not None:
+                        exc_ts = datetime.fromtimestamp(int(ts) // 1000)
+                        output.append(
+                            f"            {str(exc_ts)} ({humanize.naturaltime(exc_ts)})"
+                        )
     if verbose and len(status["pod_status"]) > 0:
         append_pod_status(status["pod_status"], output)
     if verbose == 1:

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -179,3 +179,19 @@ def get_flink_jobmanager_overview(cr_name: str, cluster: str) -> Mapping[str, An
         raise ValueError(f"JSON decoding error from Jobmanager dashboard: {e}")
     except ConnectionError as e:
         raise ValueError(f"failed HTTP request to Jobmanager dashboard: {e}")
+
+
+def get_flink_job_exceptions(
+    cr_name: str, cluster: str, job_id: str
+) -> Mapping[str, Any]:
+    try:
+        response = _dashboard_get(cr_name, cluster, f"/jobs/{job_id}/exceptions")
+        return json.loads(response)
+    except requests.RequestException as e:
+        url = e.request.url
+        err = e.response or str(e)
+        raise ValueError(f"failed HTTP request to job exceptions {url}: {err}")
+    except json.JSONDecodeError as e:
+        raise ValueError(f"JSON decoding error from job exceptions: {e}")
+    except ConnectionError as e:
+        raise ValueError(f"failed HTTP request to job exceptions: {e}")

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1042,7 +1042,7 @@ def mock_flink_status() -> Mapping[str, Any]:
                     "jid": "15ee4f8db6e9171489fae6f2178dbd54",
                     "name": "test_flink_job",
                     "state": "RUNNING",
-                    "start-time": 1629821714,
+                    "start-time": 1629900637343,
                 }
             ],
         ),
@@ -1868,10 +1868,7 @@ class TestPrintFlinkStatus:
 
         status = mock_flink_status["status"]
         metadata = mock_flink_status["metadata"]
-        expected_output = [
-            f"    Config SHA: 00000",
-            f"    Flink version: {status['config']['flink-version']}",
-            f"    URL: {metadata['annotations']['flink.yelp.com/dashboard_url']}/",
+        expected_output = _get_base_status_verbose_0(status, metadata) + [
             f"    State: {PaastaColors.green(status['state'].title())}",
             f"    Pods: 3 running, 0 evicted, 0 other",
             f"    Jobs: 1 running, 0 finished, 0 failed, 0 cancelled",
@@ -1880,6 +1877,63 @@ class TestPrintFlinkStatus:
             f"      Job Name       State       Started",
             f"      {status['jobs'][0]['name']} {PaastaColors.green('Running')} {str(datetime.datetime.fromtimestamp(int(status['jobs'][0]['start-time']) // 1000))} ({mock_naturaltime.return_value})",
         ]
+        assert expected_output == output
+
+    @patch("paasta_tools.cli.cmds.status.humanize.naturaltime", autospec=True)
+    def test_output_stopping_jobmanager(
+        self, mock_naturaltime, mock_flink_status,
+    ):
+        mock_naturaltime.return_value = "one day ago"
+        output = []
+        mock_flink_status["status"]["state"] = "Stoppingjobmanager"
+        print_flink_status(
+            cluster="fake_cluster",
+            service="fake_service",
+            instance="fake_instance",
+            output=output,
+            flink=mock_flink_status,
+            verbose=1,
+        )
+        status = mock_flink_status["status"]
+        metadata = mock_flink_status["metadata"]
+        expected_output = _get_base_status_verbose_1(status, metadata) + [
+            f"    State: {PaastaColors.yellow(status['state'].title())}",
+            f"    Pods: 3 running, 0 evicted, 0 other",
+        ]
+        append_pod_status(status["pod_status"], expected_output)
+        expected_output.append(
+            "    No other information available in non-running state"
+        )
+        assert expected_output == output
+
+    @patch("paasta_tools.cli.cmds.status.humanize.naturaltime", autospec=True)
+    def test_output_stopping_taskmanagers(
+        self, mock_naturaltime, mock_flink_status,
+    ):
+        mock_naturaltime.return_value = "one day ago"
+        output = []
+        mock_flink_status["status"]["state"] = "Stoppingtaskmanagers"
+        mock_flink_status["status"]["pod_status"] = mock_flink_status["status"][
+            "pod_status"
+        ][2:]
+        print_flink_status(
+            cluster="fake_cluster",
+            service="fake_service",
+            instance="fake_instance",
+            output=output,
+            flink=mock_flink_status,
+            verbose=1,
+        )
+        status = mock_flink_status["status"]
+        metadata = mock_flink_status["metadata"]
+        expected_output = _get_base_status_verbose_1(status, metadata) + [
+            f"    State: {PaastaColors.yellow(status['state'].title())}",
+            f"    Pods: 1 running, 0 evicted, 0 other",
+        ]
+        append_pod_status(status["pod_status"], expected_output)
+        expected_output.append(
+            "    No other information available in non-running state"
+        )
         assert expected_output == output
 
     @patch("paasta_tools.cli.cmds.status.humanize.naturaltime", autospec=True)
@@ -1899,21 +1953,122 @@ class TestPrintFlinkStatus:
 
         status = mock_flink_status["status"]
         metadata = mock_flink_status["metadata"]
-        expected_output = [
-            f"    Config SHA: 00000",
-            f"    Flink version: {status['config']['flink-version']} {status['config']['flink-revision']}",
-            f"    URL: {metadata['annotations']['flink.yelp.com/dashboard_url']}/",
+        job_start_time = str(
+            datetime.datetime.fromtimestamp(
+                int(status["jobs"][0]["start-time"]) // 1000
+            )
+        )
+        expected_output = _get_base_status_verbose_1(status, metadata) + [
             f"    State: {PaastaColors.green(status['state'].title())}",
             f"    Pods: 3 running, 0 evicted, 0 other",
             f"    Jobs: 1 running, 0 finished, 0 failed, 0 cancelled",
             f"    1 taskmanagers, 3/4 slots available",
             f"    Jobs:",
             f"      Job Name       State       Started",
-            f"      {status['jobs'][0]['name']} {PaastaColors.green('Running')} {str(datetime.datetime.fromtimestamp(int(status['jobs'][0]['start-time']) // 1000))} ({mock_naturaltime.return_value})",
+            f"      {status['jobs'][0]['name']} {PaastaColors.green('Running')} {job_start_time} ({mock_naturaltime.return_value})",
         ]
         append_pod_status(status["pod_status"], expected_output)
         expected_output.append(PaastaColors.yellow(f"    Use -vv to view exceptions"))
         assert expected_output == output
+
+    @patch("paasta_tools.cli.cmds.status.humanize.naturaltime", autospec=True)
+    @patch("paasta_tools.flink_tools._dashboard_get", autospec=True)
+    def test_output_2_verbose_no_exceptions(
+        self, mock__dashboard_get, mock_naturaltime, mock_flink_status,
+    ):
+        mock_naturaltime.return_value = "one day ago"
+        mock__dashboard_get.return_value = '{"root-exception": null}'
+        output = []
+        print_flink_status(
+            cluster="fake_cluster",
+            service="fake_service",
+            instance="fake_instance",
+            output=output,
+            flink=mock_flink_status,
+            verbose=2,
+        )
+
+        status = mock_flink_status["status"]
+        metadata = mock_flink_status["metadata"]
+        dashboard_url = metadata["annotations"]["flink.yelp.com/dashboard_url"]
+        job_start_time = str(
+            datetime.datetime.fromtimestamp(
+                int(status["jobs"][0]["start-time"]) // 1000
+            )
+        )
+        expected_output = _get_base_status_verbose_1(status, metadata) + [
+            f"    State: {PaastaColors.green(status['state'].title())}",
+            f"    Pods: 3 running, 0 evicted, 0 other",
+            f"    Jobs: 1 running, 0 finished, 0 failed, 0 cancelled",
+            f"    1 taskmanagers, 3/4 slots available",
+            f"    Jobs:",
+            f"      Job Name       State       Job ID                           Started",
+            f"""      {status['jobs'][0]['name']} {PaastaColors.green('Running')} {status['jobs'][0]['jid']} {job_start_time} ({mock_naturaltime.return_value})
+        {PaastaColors.grey(f"{dashboard_url}/#/jobs/{status['jobs'][0]['jid']}")}""",
+        ]
+        append_pod_status(status["pod_status"], expected_output)
+        assert expected_output == output
+
+    @patch("paasta_tools.cli.cmds.status.humanize.naturaltime", autospec=True)
+    @patch("paasta_tools.flink_tools._dashboard_get", autospec=True)
+    def test_output_2_verbose_with_exceptions(
+        self, mock__dashboard_get, mock_naturaltime, mock_flink_status,
+    ):
+        mock_naturaltime.return_value = "one day ago"
+        mock__dashboard_get.return_value = '{"root-exception": "org.apache.flink.runtime.fake_exception", "timestamp": 1629900637343, "all-exceptions": [], "truncated": false}'
+        mock_flink_status["status"]["jobs"][0]["state"] = "Restarting"
+        output = []
+        print_flink_status(
+            cluster="fake_cluster",
+            service="fake_service",
+            instance="fake_instance",
+            output=output,
+            flink=mock_flink_status,
+            verbose=2,
+        )
+
+        status = mock_flink_status["status"]
+        metadata = mock_flink_status["metadata"]
+        dashboard_url = metadata["annotations"]["flink.yelp.com/dashboard_url"]
+        job_start_time = str(
+            datetime.datetime.fromtimestamp(
+                int(status["jobs"][0]["start-time"]) // 1000
+            )
+        )
+        expected_output = _get_base_status_verbose_1(status, metadata) + [
+            f"    State: {PaastaColors.green(status['state'].title())}",
+            f"    Pods: 3 running, 0 evicted, 0 other",
+            f"    Jobs: 1 running, 0 finished, 0 failed, 0 cancelled",
+            f"    1 taskmanagers, 3/4 slots available",
+            f"    Jobs:",
+            f"      Job Name       State       Job ID                           Started",
+            f"""      {status['jobs'][0]['name']} {PaastaColors.yellow('Restarting')} {status['jobs'][0]['jid']} {job_start_time} ({mock_naturaltime.return_value})
+        {PaastaColors.grey(f"{dashboard_url}/#/jobs/{status['jobs'][0]['jid']}")}""",
+        ]
+        expected_output.append(
+            "        Exception: org.apache.flink.runtime.fake_exception"
+        )
+        expected_output.append(
+            f"            {job_start_time} ({mock_naturaltime.return_value})"
+        )
+        append_pod_status(status["pod_status"], expected_output)
+        assert expected_output == output
+
+
+def _get_base_status_verbose_0(status, metadata):
+    return [
+        f"    Config SHA: 00000",
+        f"    Flink version: {status['config']['flink-version']}",
+        f"    URL: {metadata['annotations']['flink.yelp.com/dashboard_url']}/",
+    ]
+
+
+def _get_base_status_verbose_1(status, metadata):
+    return [
+        f"    Config SHA: 00000",
+        f"    Flink version: {status['config']['flink-version']} {status['config']['flink-revision']}",
+        f"    URL: {metadata['annotations']['flink.yelp.com/dashboard_url']}/",
+    ]
 
 
 def _formatted_table_to_dict(formatted_table):

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -2053,6 +2053,9 @@ class TestPrintFlinkStatus:
             f"            {job_start_time} ({mock_naturaltime.return_value})"
         )
         append_pod_status(status["pod_status"], expected_output)
+        mock__dashboard_get.assert_called_once_with(
+            "app-9bf849b89", "fake_cluster", f"/jobs/{job_id}/exceptions"
+        )
         assert expected_output == output
 
     @patch("paasta_tools.cli.cmds.status.humanize.naturaltime", autospec=True)

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
+
 import mock
 
 import paasta_tools.flink_tools as flink_tools
@@ -41,3 +43,27 @@ def test_get_flink_jobmanager_overview():
             "flink-version": "1.6.4",
             "flink-commit": "6241481",
         }
+
+
+def test_get_flink_job_exceptions():
+    json_response = """
+    {"root_exception": "java.util.concurrent.TimeoutException",
+     "timestamp": 1629900637343,
+      "all-exceptions": [
+          {"exception": "java.util.concurrent.TimeoutException", "task": "Source", "location": "10.93.111.113:20841", "timestamp": 1629900637342}
+          ],
+       "truncated": false}"""
+    with mock.patch(
+        "paasta_tools.flink_tools._dashboard_get",
+        autospec=True,
+        return_value=json_response,
+    ) as mock_dashboard_get:
+        cluster = "mycluster"
+        cr_name = "kurupt--fm-7c7b459d59"
+        job_id = "b011e2db52306cbf93279c9e4067cd2f"
+        exceptions = flink_tools.get_flink_job_exceptions(cr_name, cluster, job_id)
+        path = f"/jobs/{job_id}/exceptions"
+        mock_dashboard_get.assert_called_once_with(
+            cr_name=cr_name, cluster=cluster, path=path
+        )
+        assert exceptions == json.loads(json_response)


### PR DESCRIPTION
- Get job exceptions from Flink REST API instead of flink object
- Add tests for print flink status for different scenarios

_Not sure if there is a better way rather than calling the job/exceptions endpoint for each job._