### PR TITLE
Send PaaSTA Workload Contract labels to Tron

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -752,6 +752,17 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
         # XXX: once we're off mesos we can make get_cap_* return just the cap names as a list
         result["cap_add"] = [cap["value"] for cap in action_config.get_cap_add()]
         result["cap_drop"] = [cap["value"] for cap in action_config.get_cap_drop()]
+
+        result["labels"] = {
+            "paasta.yelp.com/cluster": action_config.get_cluster(),
+            "paasta.yelp.com/pool": action_config.get_pool(),
+            "paasta.yelp.com/service": action_config.get_service(),
+            "paasta.yelp.com/instance": action_config.get_instance(),
+        }
+
+        if action_config.get_team() is not None:
+            result["labels"]["yelp.com/owner"] = action_config.get_team()
+
     elif executor in MESOS_EXECUTOR_NAMES:
         result["executor"] = "mesos"
         constraint_labels = ["attribute", "operator", "value"]

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -862,6 +862,7 @@ class TestTronTools:
             "executor": "paasta",
             "cpus": 2,
             "mem": 1200,
+            "monitoring": {"team": "some_sensu_team",},
             "disk": 42,
             "pool": "special_pool",
             "env": {"SHELL": "/bin/bash", "SOME_SECRET": "SECRET(secret_name)"},
@@ -907,6 +908,13 @@ class TestTronTools:
             "disk": 42,
             "cap_add": [],
             "cap_drop": CAPS_DROP,
+            "labels": {
+                "paasta.yelp.com/cluster": "test-cluster",
+                "paasta.yelp.com/instance": "my_job.do_something",
+                "paasta.yelp.com/pool": "special_pool",
+                "paasta.yelp.com/service": "my_service",
+                "yelp.com/owner": "some_sensu_team",
+            },
             "node_selectors": {"yelp.com/pool": "special_pool"},
             "node_affinities": [
                 {


### PR DESCRIPTION
As part of the PaaSTA Workload Contract, we should be setting these
labels on Pods that we launch so that our tooling (e.g., OPA) knows what
to do with them.