### PR TITLE
[COREML-2570] fix k8s volumes being mounted twice

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.5.7
+service-configuration-lib==2.5.8
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0


### PR DESCRIPTION
Bump service-configuration-lib==2.5.8.

Merging and running `make release` if all the checks pass successfully.