### PR TITLE
Monk 2524 add kubernetes status for monkrelayclusters

### DIFF
--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -46,6 +46,7 @@ from paasta_tools.kafkacluster_tools import load_kafkacluster_instance_config
 from paasta_tools.kubernetes_tools import load_kubernetes_service_config
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
 from paasta_tools.marathon_tools import load_marathon_service_config
+from paasta_tools.monkrelaycluster_tools import load_monkrelaycluster_instance_config
 from paasta_tools.nrtsearchservice_tools import load_nrtsearchservice_instance_config
 from paasta_tools.tron_tools import load_tron_instance_config
 from paasta_tools.utils import _log
@@ -767,6 +768,9 @@ INSTANCE_TYPE_HANDLERS: Mapping[str, InstanceTypeHandler] = defaultdict(
     nrtsearchservice=InstanceTypeHandler(
         get_service_instance_list, load_nrtsearchservice_instance_config
     ),
+    monkrelaycluster=InstanceTypeHandler(
+        get_service_instance_list, load_monkrelaycluster_instance_config
+    ),
 )
 
 LONG_RUNNING_INSTANCE_TYPE_HANDLERS: Mapping[
@@ -790,6 +794,9 @@ LONG_RUNNING_INSTANCE_TYPE_HANDLERS: Mapping[
     ),
     nrtsearchservice=LongRunningInstanceTypeHandler(
         get_service_instance_list, load_nrtsearchservice_instance_config
+    ),
+    monkrelaycluster=InstanceTypeHandler(
+        get_service_instance_list, load_monkrelaycluster_instance_config
     ),
 )
 

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -795,7 +795,7 @@ LONG_RUNNING_INSTANCE_TYPE_HANDLERS: Mapping[
     nrtsearchservice=LongRunningInstanceTypeHandler(
         get_service_instance_list, load_nrtsearchservice_instance_config
     ),
-    monkrelaycluster=InstanceTypeHandler(
+    monkrelaycluster=LongRunningInstanceTypeHandler(
         get_service_instance_list, load_monkrelaycluster_instance_config
     ),
 )

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -29,6 +29,7 @@ from paasta_tools import flink_tools
 from paasta_tools import kafkacluster_tools
 from paasta_tools import kubernetes_tools
 from paasta_tools import marathon_tools
+from paasta_tools import monkrelaycluster_tools
 from paasta_tools import nrtsearchservice_tools
 from paasta_tools import smartstack_tools
 from paasta_tools.cli.utils import LONG_RUNNING_INSTANCE_TYPE_HANDLERS
@@ -54,6 +55,7 @@ INSTANCE_TYPE_CR_ID = dict(
     cassandracluster=cassandracluster_tools.cr_id,
     kafkacluster=kafkacluster_tools.cr_id,
     nrtsearchservice=nrtsearchservice_tools.cr_id,
+    monkrelaycluster=monkrelaycluster_tools.cr_id,
 )
 
 

--- a/paasta_tools/monkrelaycluster_tools.py
+++ b/paasta_tools/monkrelaycluster_tools.py
@@ -57,7 +57,7 @@ class MonkRelayClusterDeploymentConfig(LongRunningServiceConfig):
     def get_instances(self, with_limit: bool = True) -> int:
         return self.config_dict.get("replicas", 1)
 
-    def validate(self, params: Optional[List[str]] = None,) -> List[str]:
+    def validate(self, params: List[str] = None,) -> List[str]:
         # Use InstanceConfig to validate shared config keys like cpus and mem
         # TODO: add mem back to this list once we fix PAASTA-15582 and
         # move to using the same units as flink/marathon etc.

--- a/paasta_tools/monkrelaycluster_tools.py
+++ b/paasta_tools/monkrelaycluster_tools.py
@@ -57,7 +57,7 @@ class MonkRelayClusterDeploymentConfig(LongRunningServiceConfig):
     def get_instances(self, with_limit: bool = True) -> int:
         return self.config_dict.get("replicas", 1)
 
-    def validate(self, params: List[str],) -> List[str]:
+    def validate(self, params: Optional[List[str]] = None,) -> List[str]:
         # Use InstanceConfig to validate shared config keys like cpus and mem
         # TODO: add mem back to this list once we fix PAASTA-15582 and
         # move to using the same units as flink/marathon etc.
@@ -68,6 +68,7 @@ class MonkRelayClusterDeploymentConfig(LongRunningServiceConfig):
                 "dependencies_reference",
                 "deploy_group",
             ]
+
         error_msgs = super().validate(params=params)
 
         if error_msgs:

--- a/paasta_tools/monkrelaycluster_tools.py
+++ b/paasta_tools/monkrelaycluster_tools.py
@@ -57,18 +57,17 @@ class MonkRelayClusterDeploymentConfig(LongRunningServiceConfig):
     def get_instances(self, with_limit: bool = True) -> int:
         return self.config_dict.get("replicas", 1)
 
-    def validate(
-        self,
-        params: List[str] = [
-            "cpus",
-            "security",
-            "dependencies_reference",
-            "deploy_group",
-        ],
-    ) -> List[str]:
+    def validate(self, params: List[str],) -> List[str]:
         # Use InstanceConfig to validate shared config keys like cpus and mem
         # TODO: add mem back to this list once we fix PAASTA-15582 and
         # move to using the same units as flink/marathon etc.
+        if params is None:
+            params = [
+                "cpus",
+                "security",
+                "dependencies_reference",
+                "deploy_group",
+            ]
         error_msgs = super().validate(params=params)
 
         if error_msgs:

--- a/paasta_tools/monkrelaycluster_tools.py
+++ b/paasta_tools/monkrelaycluster_tools.py
@@ -1,0 +1,149 @@
+# Copyright 2015-2019 Yelp Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from typing import List
+from typing import Mapping
+from typing import Optional
+
+import service_configuration_lib
+
+from paasta_tools.kubernetes_tools import sanitised_cr_name
+from paasta_tools.long_running_service_tools import LongRunningServiceConfig
+from paasta_tools.long_running_service_tools import LongRunningServiceConfigDict
+from paasta_tools.utils import BranchDictV2
+from paasta_tools.utils import deep_merge_dictionaries
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import load_service_instance_config
+from paasta_tools.utils import load_v2_deployments_json
+
+KUBERNETES_NAMESPACE = "paasta-monkrelayclusters"
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class MonkRelayClusterDeploymentConfigDict(LongRunningServiceConfigDict, total=False):
+    replicas: int
+
+
+class MonkRelayClusterDeploymentConfig(LongRunningServiceConfig):
+    config_dict: MonkRelayClusterDeploymentConfigDict
+
+    config_filename_prefix = "monkrelaycluster"
+
+    def __init__(
+        self,
+        service: str,
+        cluster: str,
+        instance: str,
+        config_dict: MonkRelayClusterDeploymentConfigDict,
+        branch_dict: Optional[BranchDictV2],
+        soa_dir: str = DEFAULT_SOA_DIR,
+    ) -> None:
+
+        super().__init__(
+            cluster=cluster,
+            instance=instance,
+            service=service,
+            soa_dir=soa_dir,
+            config_dict=config_dict,
+            branch_dict=branch_dict,
+        )
+
+    def get_instances(self, with_limit: bool = True) -> int:
+        return self.config_dict.get("replicas", 1)
+
+    def validate(
+        self,
+        params: List[str] = [
+            "cpus",
+            "security",
+            "dependencies_reference",
+            "deploy_group",
+        ],
+    ) -> List[str]:
+        # Use InstanceConfig to validate shared config keys like cpus and mem
+        # TODO: add mem back to this list once we fix PAASTA-15582 and
+        # move to using the same units as flink/marathon etc.
+        error_msgs = super().validate(params=params)
+
+        if error_msgs:
+            name = self.get_instance()
+            return [f"{name}: {msg}" for msg in error_msgs]
+        else:
+            return []
+
+
+def load_monkrelaycluster_instance_config(
+    service: str,
+    instance: str,
+    cluster: str,
+    load_deployments: bool = True,
+    soa_dir: str = DEFAULT_SOA_DIR,
+) -> MonkRelayClusterDeploymentConfig:
+    """Read a service instance's configuration for MonkRelayCluster.
+
+    If a branch isn't specified for a config, the 'branch' key defaults to
+    paasta-${cluster}.${instance}.
+
+    :param service: The service name
+    :param instance: The instance of the service to retrieve
+    :param cluster: The cluster to read the configuration for
+    :param load_deployments: A boolean indicating if the corresponding deployments.json for this service
+                             should also be loaded
+    :param soa_dir: The SOA configuration directory to read from
+    :returns: A dictionary of whatever was in the config for the service instance"""
+    general_config = service_configuration_lib.read_service_configuration(
+        service, soa_dir=soa_dir
+    )
+    instance_config = load_service_instance_config(
+        service, instance, "monkrelaycluster", cluster, soa_dir=soa_dir
+    )
+    general_config = deep_merge_dictionaries(
+        overrides=instance_config, defaults=general_config
+    )
+
+    branch_dict: Optional[BranchDictV2] = None
+    if load_deployments:
+        deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
+        temp_instance_config = MonkRelayClusterDeploymentConfig(
+            service=service,
+            cluster=cluster,
+            instance=instance,
+            config_dict=general_config,
+            branch_dict=None,
+            soa_dir=soa_dir,
+        )
+        branch = temp_instance_config.get_branch()
+        deploy_group = temp_instance_config.get_deploy_group()
+        branch_dict = deployments_json.get_branch_dict(service, branch, deploy_group)
+
+    return MonkRelayClusterDeploymentConfig(
+        service=service,
+        cluster=cluster,
+        instance=instance,
+        config_dict=general_config,
+        branch_dict=branch_dict,
+        soa_dir=soa_dir,
+    )
+
+
+# TODO: read this from CRD in service configs
+def cr_id(service: str, instance: str) -> Mapping[str, str]:
+    return dict(
+        group="yelp.com",
+        version="v1alpha1",
+        namespace="paasta-monkrelayclusters",
+        plural="monkrelayclusters",
+        name=sanitised_cr_name(service, instance),
+    )

--- a/paasta_tools/monkrelaycluster_tools.py
+++ b/paasta_tools/monkrelaycluster_tools.py
@@ -10,7 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
 from typing import List
 from typing import Mapping
 from typing import Optional
@@ -25,11 +24,6 @@ from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import load_service_instance_config
 from paasta_tools.utils import load_v2_deployments_json
-
-KUBERNETES_NAMESPACE = "paasta-monkrelayclusters"
-
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
 
 
 class MonkRelayClusterDeploymentConfigDict(LongRunningServiceConfigDict, total=False):

--- a/paasta_tools/monkrelaycluster_tools.py
+++ b/paasta_tools/monkrelaycluster_tools.py
@@ -144,6 +144,6 @@ def cr_id(service: str, instance: str) -> Mapping[str, str]:
         group="yelp.com",
         version="v1alpha1",
         namespace="paasta-monkrelayclusters",
-        plural="monkrelayclusters",
+        plural="monkrelays",
         name=sanitised_cr_name(service, instance),
     )

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -130,6 +130,7 @@ INSTANCE_TYPES = (
     "flink",
     "cassandracluster",
     "kafkacluster",
+    "monkrelaycluster",
     "nrtsearchservice",
 )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2168,6 +2168,7 @@ def test_validate_service_instance_invalid():
     mock_cassandracluster_instances = [("service1", "cassandracluster")]
     mock_kafkacluster_instances = [("service1", "kafkacluster")]
     mock_nrtsearch_instances = [("service1", "nrtsearch")]
+    mock_monkrelaycluster_instances = [("service1", "monkrelaycluster")]
     my_service = "service1"
     my_instance = "main"
     fake_cluster = "fake_cluster"
@@ -2185,6 +2186,7 @@ def test_validate_service_instance_invalid():
             mock_cassandracluster_instances,
             mock_kafkacluster_instances,
             mock_nrtsearch_instances,
+            mock_monkrelaycluster_instances,
         ],
     ):
         with raises(


### PR DESCRIPTION
Adding functionality to paasta to propagate the yelpsoa-configs values to the operator. Currently, this is a basic version that does not hold any information about kubernetes in the way the cassandra operator works