### PR TITLE
Make pre-restart container output available for recent restarts in paasta -vv

### DIFF
--- a/paasta_tools/api/api_docs/oapi.yaml
+++ b/paasta_tools/api/api_docs/oapi.yaml
@@ -640,6 +640,10 @@ components:
           format: float
           type: number
           nullable: true
+        last_tail_lines:
+          $ref: '#/components/schemas/TaskTailLines'
+          description: Previous container's stdout and stderr tail
+          nullable: true
         timestamp:
           description: Unix timestamp at which current state began
           format: float

--- a/paasta_tools/api/api_docs/oapi.yaml
+++ b/paasta_tools/api/api_docs/oapi.yaml
@@ -640,7 +640,7 @@ components:
           format: float
           type: number
           nullable: true
-        last_tail_lines:
+        previous_tail_lines:
           $ref: '#/components/schemas/TaskTailLines'
           description: Previous container's stdout and stderr tail
           nullable: true

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -760,7 +760,7 @@ async def get_pod_containers(
                 if "message" in this_state:
                     message = this_state["message"]
                 if "started_at" in this_state:
-                    start_timestamp = this_state["started_at"]
+                    start_timestamp = this_state["started_at"].timestamp()
 
         last_state_dict = cs.last_state.to_dict()
         last_state = None
@@ -781,14 +781,36 @@ async def get_pod_containers(
                             this_state["finished_at"] - this_state["started_at"]
                         ).total_seconds()
 
-                    last_timestamp = this_state["started_at"]
+                    last_timestamp = this_state["started_at"].timestamp()
 
-        try:
-            tail_lines = await get_tail_lines_for_kubernetes_container(
-                client, pod, cs, num_tail_lines,
-            )
-        except asyncio.TimeoutError:
-            tail_lines = {"error_message": f"Could not fetch logs for {cs.name}"}
+        async def get_tail_lines():
+            try:
+                return await get_tail_lines_for_kubernetes_container(
+                    client, pod, cs, num_tail_lines, previous=False,
+                )
+            except asyncio.TimeoutError:
+                return {"error_message": f"Could not fetch logs for {cs.name}"}
+
+        # get previous log lines as well if this container restarted recently
+        async def get_last_tail_lines():
+            nonlocal last_tail_lines
+            if state == "running" and kubernetes_tools.recent_container_restart(
+                cs.restart_count, last_state, last_timestamp
+            ):
+                try:
+                    return await get_tail_lines_for_kubernetes_container(
+                        client, pod, cs, num_tail_lines, previous=True,
+                    )
+                except asyncio.TimeoutError:
+                    return {
+                        "error_message": f"Could not fetch previous logs for {cs.name}"
+                    }
+            return None
+
+        tail_lines, last_tail_lines = await asyncio.gather(
+            asyncio.ensure_future(get_tail_lines()),
+            asyncio.ensure_future(get_last_tail_lines()),
+        )
 
         containers.append(
             {
@@ -801,10 +823,9 @@ async def get_pod_containers(
                 "last_reason": last_reason,
                 "last_message": last_message,
                 "last_duration": last_duration,
-                "last_timestamp": last_timestamp.timestamp()
-                if last_timestamp
-                else None,
-                "timestamp": start_timestamp.timestamp() if start_timestamp else None,
+                "last_timestamp": last_timestamp,
+                "last_tail_lines": last_tail_lines,
+                "timestamp": start_timestamp,
                 "healthcheck_grace_period": healthcheck_grace_period,
                 "healthcheck_cmd": healthcheck,
                 "tail_lines": tail_lines,

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -792,8 +792,8 @@ async def get_pod_containers(
                 return {"error_message": f"Could not fetch logs for {cs.name}"}
 
         # get previous log lines as well if this container restarted recently
-        async def get_last_tail_lines():
-            nonlocal last_tail_lines
+        async def get_previous_tail_lines():
+            nonlocal previous_tail_lines
             if state == "running" and kubernetes_tools.recent_container_restart(
                 cs.restart_count, last_state, last_timestamp
             ):
@@ -807,9 +807,9 @@ async def get_pod_containers(
                     }
             return None
 
-        tail_lines, last_tail_lines = await asyncio.gather(
+        tail_lines, previous_tail_lines = await asyncio.gather(
             asyncio.ensure_future(get_tail_lines()),
-            asyncio.ensure_future(get_last_tail_lines()),
+            asyncio.ensure_future(get_previous_tail_lines()),
         )
 
         containers.append(
@@ -824,7 +824,7 @@ async def get_pod_containers(
                 "last_message": last_message,
                 "last_duration": last_duration,
                 "last_timestamp": last_timestamp,
-                "last_tail_lines": last_tail_lines,
+                "previous_tail_lines": previous_tail_lines,
                 "timestamp": start_timestamp,
                 "healthcheck_grace_period": healthcheck_grace_period,
                 "healthcheck_cmd": healthcheck,

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2084,14 +2084,14 @@ def format_tail_lines_for_kubernetes_pod(
 ) -> List[str]:
     errors: List[str] = []
     lines: List[str] = []
-    prefixes = (
-        ("", "current"),
-        ("last_", "previous (pre-restart)"),
+    tail_line_prefixes = (
+        ("tail_lines", "current"),
+        ("previous_tail_lines", "previous (pre-restart)"),
     )
 
     for container in pod_containers:
-        for tail_prefix, stream_prefix in prefixes:
-            tail_lines = getattr(container, tail_prefix + "tail_lines", None)
+        for tail_line_key, stream_prefix in tail_line_prefixes:
+            tail_lines = getattr(container, tail_line_key, None)
             if tail_lines is None:
                 break
             if tail_lines.error_message:

--- a/paasta_tools/paastaapi/model/kubernetes_container_v2.py
+++ b/paasta_tools/paastaapi/model/kubernetes_container_v2.py
@@ -93,6 +93,7 @@ class KubernetesContainerV2(ModelNormal):
             'last_message': (str, none_type,),  # noqa: E501
             'last_duration': (float, none_type,),  # noqa: E501
             'last_timestamp': (float, none_type,),  # noqa: E501
+            'last_tail_lines': (TaskTailLines,),  # noqa: E501
             'timestamp': (float, none_type,),  # noqa: E501
             'healthcheck_grace_period': (int,),  # noqa: E501
             'healthcheck_cmd': (KubernetesHealthcheck,),  # noqa: E501
@@ -115,6 +116,7 @@ class KubernetesContainerV2(ModelNormal):
         'last_message': 'last_message',  # noqa: E501
         'last_duration': 'last_duration',  # noqa: E501
         'last_timestamp': 'last_timestamp',  # noqa: E501
+        'last_tail_lines': 'last_tail_lines',  # noqa: E501
         'timestamp': 'timestamp',  # noqa: E501
         'healthcheck_grace_period': 'healthcheck_grace_period',  # noqa: E501
         'healthcheck_cmd': 'healthcheck_cmd',  # noqa: E501
@@ -177,6 +179,7 @@ class KubernetesContainerV2(ModelNormal):
             last_message (str, none_type): Details about state of container. [optional]  # noqa: E501
             last_duration (float, none_type): Duration in seconds of previous state. [optional]  # noqa: E501
             last_timestamp (float, none_type): Unix timestamp at which last state began. [optional]  # noqa: E501
+            last_tail_lines (TaskTailLines): [optional]  # noqa: E501
             timestamp (float, none_type): Unix timestamp at which current state began. [optional]  # noqa: E501
             healthcheck_grace_period (int): Time in seconds for healthcheck grace period, 0 otherwise. [optional]  # noqa: E501
             healthcheck_cmd (KubernetesHealthcheck): [optional]  # noqa: E501

--- a/paasta_tools/paastaapi/model/kubernetes_container_v2.py
+++ b/paasta_tools/paastaapi/model/kubernetes_container_v2.py
@@ -93,7 +93,7 @@ class KubernetesContainerV2(ModelNormal):
             'last_message': (str, none_type,),  # noqa: E501
             'last_duration': (float, none_type,),  # noqa: E501
             'last_timestamp': (float, none_type,),  # noqa: E501
-            'last_tail_lines': (TaskTailLines,),  # noqa: E501
+            'previous_tail_lines': (TaskTailLines,),  # noqa: E501
             'timestamp': (float, none_type,),  # noqa: E501
             'healthcheck_grace_period': (int,),  # noqa: E501
             'healthcheck_cmd': (KubernetesHealthcheck,),  # noqa: E501
@@ -116,7 +116,7 @@ class KubernetesContainerV2(ModelNormal):
         'last_message': 'last_message',  # noqa: E501
         'last_duration': 'last_duration',  # noqa: E501
         'last_timestamp': 'last_timestamp',  # noqa: E501
-        'last_tail_lines': 'last_tail_lines',  # noqa: E501
+        'previous_tail_lines': 'previous_tail_lines',  # noqa: E501
         'timestamp': 'timestamp',  # noqa: E501
         'healthcheck_grace_period': 'healthcheck_grace_period',  # noqa: E501
         'healthcheck_cmd': 'healthcheck_cmd',  # noqa: E501
@@ -179,7 +179,7 @@ class KubernetesContainerV2(ModelNormal):
             last_message (str, none_type): Details about state of container. [optional]  # noqa: E501
             last_duration (float, none_type): Duration in seconds of previous state. [optional]  # noqa: E501
             last_timestamp (float, none_type): Unix timestamp at which last state began. [optional]  # noqa: E501
-            last_tail_lines (TaskTailLines): [optional]  # noqa: E501
+            previous_tail_lines (TaskTailLines): [optional]  # noqa: E501
             timestamp (float, none_type): Unix timestamp at which current state began. [optional]  # noqa: E501
             healthcheck_grace_period (int): Time in seconds for healthcheck grace period, 0 otherwise. [optional]  # noqa: E501
             healthcheck_cmd (KubernetesHealthcheck): [optional]  # noqa: E501

--- a/tests/instance/test_kubernetes.py
+++ b/tests/instance/test_kubernetes.py
@@ -293,7 +293,7 @@ class TestKubernetesStatusV2:
                                     "last_timestamp": datetime.datetime(
                                         2021, 3, 4
                                     ).timestamp(),
-                                    "last_tail_lines": None,
+                                    "previous_tail_lines": None,
                                     "timestamp": datetime.datetime(
                                         2021, 3, 6
                                     ).timestamp(),
@@ -712,7 +712,7 @@ async def test_get_pod_containers(mock_pod):
             last_message="a_last_state_message",
             last_duration=86400.0,
             last_timestamp=datetime.datetime(2021, 3, 4).timestamp(),
-            last_tail_lines=["previous"],
+            previous_tail_lines=["previous"],
             timestamp=datetime.datetime(2021, 3, 6).timestamp(),
             healthcheck_grace_period=1,
             healthcheck_cmd={"http_url": "http://1.2.3.4:8080/healthcheck"},

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2521,6 +2521,7 @@ def test_get_tail_lines_for_kubernetes_container(
             namespace="my_namespace",
             container=container_name,
             tail_lines=10,
+            previous=False,
         ),
     ]
 
@@ -2563,8 +2564,8 @@ def test_format_pod_event_messages():
     pod_name = "test_pod"
     rows = kubernetes_tools.format_pod_event_messages(pod_event_messages, pod_name)
 
-    assert rows[1] == f"   Event at 1: message_1"
-    assert rows[2] == f"   Event at 2: message_2"
+    assert rows[1] == f"    Event at 1: message_1"
+    assert rows[2] == f"    Event at 2: message_2"
 
 
 @given(integers(min_value=0), floats(min_value=0, max_value=1.0))


### PR DESCRIPTION
### Description
This PR will make pre-restart/previous container output show in `paasta status -vv` and above if there has been a recent restart. Previous output does not replace the current container's output.

### Testing
`make test`
local testing against norcal-stagef

### Notes
Will this PR, `paasta status -vv` gets pretty busy, and is even more unusable for larger instances.