### PR TITLE
FLINK-3725: Add concurrency in getting flink job exceptions

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -83,7 +83,7 @@ from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import remove_ansi_escape_sequences
 from paasta_tools.utils import SystemPaastaConfig
 
-
+FLINK_STATUS_MAX_THREAD_POOL_WORKERS = 50
 ALLOWED_INSTANCE_CONFIG: Sequence[Type[InstanceConfig]] = [
     FlinkDeploymentConfig,
     CassandraClusterDeploymentConfig,
@@ -2313,7 +2313,9 @@ def _use_new_paasta_status(args, system_paasta_config) -> bool:
 
 
 def _print_flink_jobs_exceptions_from_api(jobs, cr_name, cluster):
-    with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=FLINK_STATUS_MAX_THREAD_POOL_WORKERS
+    ) as executor:
         job_exceptions = {}
         future_job_mapping = {
             executor.submit(get_flink_job_exceptions, cr_name, cluster, job["jid"]): job

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import concurrent.futures
 import difflib
-import logging
 import shutil
 import sys
 from collections import Counter
@@ -84,7 +83,6 @@ from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import remove_ansi_escape_sequences
 from paasta_tools.utils import SystemPaastaConfig
 
-log = logging.getLogger(__name__)
 
 ALLOWED_INSTANCE_CONFIG: Sequence[Type[InstanceConfig]] = [
     FlinkDeploymentConfig,
@@ -2314,11 +2312,8 @@ def _use_new_paasta_status(args, system_paasta_config) -> bool:
             return True
 
 
-def _print_flink_jobs_exceptions_from_api(unique_jobs, cr_name, cluster):
-    jobs = unique_jobs
-    log.debug("......entered.....")
+def _print_flink_jobs_exceptions_from_api(jobs, cr_name, cluster):
     with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
-        log.debug("entered concurrent....")
         job_exceptions = {}
         future_job_mapping = {
             executor.submit(get_flink_job_exceptions, cr_name, cluster, job["jid"]): job
@@ -2333,7 +2328,6 @@ def _print_flink_jobs_exceptions_from_api(unique_jobs, cr_name, cluster):
                 job_exceptions[job_id]["timestamp"] = exceptions["timestamp"]
             except ValueError as e:
                 job_exceptions[job_id]["error"] = str(e)
-    log.debug(job_exceptions)
     return job_exceptions
 
 

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1977,7 +1977,7 @@ class TestPrintFlinkStatus:
         self, mock__dashboard_get, mock_naturaltime, mock_flink_status,
     ):
         mock_naturaltime.return_value = "one day ago"
-        mock__dashboard_get.return_value = '{"root-exception": null}'
+        mock__dashboard_get.return_value = '{"root-exception":null,"timestamp":null,"all-exceptions":[],"truncated":false}'
         output = []
         print_flink_status(
             cluster="fake_cluster",


### PR DESCRIPTION
- Use ThreadPoolExecutor and futures to parallelize calls to flink rest api
- Modify one test to return the correct response with case of no exceptions