### PR TITLE
Auto generate pod template for pod affinity with weights specified by the user [COREML-2557]

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -847,6 +847,11 @@ def paasta_spark_run(args):
 
     volumes = instance_config.get_volumes(system_paasta_config.get_volumes())
     app_base_name = get_spark_app_name(args.cmd or instance_config.get_cmd(), args.autogen)
+
+    if args.autogen:
+        pod_template_path = "/nail/home/"+get_username()+"/podTemplate.yaml"
+        args.spark_args += f" spark.kubernetes.executor.podTemplateFile=${pod_template_path}"
+
     needs_docker_cfg = not args.build
     user_spark_opts = _parse_user_spark_args(args.spark_args)
     paasta_instance = get_smart_paasta_instance_name(args)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -850,7 +850,10 @@ def paasta_spark_run(args):
 
     if args.autogen:
         pod_template_path = "/nail/home/"+get_username()+"/podTemplate.yaml"
-        args.spark_args += f" spark.kubernetes.executor.podTemplateFile=${pod_template_path}"
+        if args.spark_args:
+            args.spark_args += f" spark.kubernetes.executor.podTemplateFile={pod_template_path}"
+        else:
+            args.spark_args = f"spark.kubernetes.executor.podTemplateFile={pod_template_path}"
 
     needs_docker_cfg = not args.build
     user_spark_opts = _parse_user_spark_args(args.spark_args)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -7,6 +7,7 @@ import shlex
 import socket
 import sys
 import yaml
+
 from typing import Any
 from typing import Dict
 from typing import List
@@ -14,6 +15,7 @@ from typing import Mapping
 from typing import Optional
 from typing import Tuple
 from typing import Union
+
 
 from boto3.exceptions import Boto3Error
 from service_configuration_lib.spark_config import get_aws_credentials
@@ -57,7 +59,9 @@ CLUSTER_MANAGER_K8S = "kubernetes"
 CLUSTER_MANAGERS = {CLUSTER_MANAGER_MESOS, CLUSTER_MANAGER_K8S}
 
 POD_TEMPLATE_PATH = "/nail/tmp/podTemplate.yaml"
-BATCH_SIZE = "2" # Smaller batch size reduces number of nodes initial request is spread across
+BATCH_SIZE = (
+    "2"  # Smaller batch size reduces number of nodes initial request is spread across
+)
 POD_TEMPLATE = """
 apiVersion: v1
 kind: Pod
@@ -488,7 +492,9 @@ def get_spark_env(
     return spark_env
 
 
-def _parse_user_spark_args(spark_args: Optional[str], enable_k8s_autogen: bool) -> Dict[str, str]:
+def _parse_user_spark_args(
+    spark_args: Optional[str], enable_k8s_autogen: bool
+) -> Dict[str, str]:
     if not spark_args:
         return {}
 
@@ -550,7 +556,9 @@ def run_docker_container(
     return 0
 
 
-def get_spark_app_name(original_docker_cmd: Union[Any, str, List[str]], enable_k8s_autogen: bool) -> str:
+def get_spark_app_name(
+    original_docker_cmd: Union[Any, str, List[str]], enable_k8s_autogen: bool
+) -> str:
     """Use submitted batch name as default spark_run job name"""
     docker_cmds = (
         shlex.split(original_docker_cmd)
@@ -853,7 +861,9 @@ def paasta_spark_run(args):
         return 1
 
     volumes = instance_config.get_volumes(system_paasta_config.get_volumes())
-    app_base_name = get_spark_app_name(args.cmd or instance_config.get_cmd(), args.enable_k8s_autogen)
+    app_base_name = get_spark_app_name(
+        args.cmd or instance_config.get_cmd(), args.enable_k8s_autogen
+    )
 
     needs_docker_cfg = not args.build
     user_spark_opts = _parse_user_spark_args(args.spark_args, args.enable_k8s_autogen)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -491,7 +491,7 @@ def get_spark_env(
 
 
 def _parse_user_spark_args(
-    spark_args: Optional[str], enable_k8s_autogen: bool
+    spark_args: Optional[str], enable_k8s_autogen: bool = True
 ) -> Dict[str, str]:
     if not spark_args:
         return {}
@@ -555,7 +555,7 @@ def run_docker_container(
 
 
 def get_spark_app_name(
-    original_docker_cmd: Union[Any, str, List[str]], enable_k8s_autogen: bool
+    original_docker_cmd: Union[Any, str, List[str]], enable_k8s_autogen: bool = True
 ) -> str:
     """Use submitted batch name as default spark_run job name"""
     docker_cmds = (

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -57,9 +57,7 @@ CLUSTER_MANAGER_K8S = "kubernetes"
 CLUSTER_MANAGERS = {CLUSTER_MANAGER_MESOS, CLUSTER_MANAGER_K8S}
 
 POD_TEMPLATE_PATH = "/nail/tmp/podTemplate.yaml"
-BATCH_SIZE = (
-    "2"  # Smaller batch size reduces number of nodes initial request is spread across
-)
+
 POD_TEMPLATE = """
 apiVersion: v1
 kind: Pod
@@ -511,7 +509,6 @@ def _parse_user_spark_args(
 
     if enable_k8s_autogen:
         user_spark_opts["spark.kubernetes.executor.podTemplateFile"] = POD_TEMPLATE_PATH
-        user_spark_opts["spark.kubernetes.allocation.batch.size"] = BATCH_SIZE
 
     return user_spark_opts
 
@@ -583,7 +580,7 @@ def get_spark_app_name(
     if enable_k8s_autogen:
         document = POD_TEMPLATE.format(spark_app_name=spark_app_name)
         parsed_pod_template = yaml.load(document)
-        with open(POD_TEMPLATE_PATH, 'w') as f:
+        with open(POD_TEMPLATE_PATH, "w") as f:
             yaml.dump(parsed_pod_template, f)
 
     return spark_app_name

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -579,13 +579,12 @@ def get_spark_app_name(
     if spark_app_name is None:
         spark_app_name = "paasta_spark_run"
 
-    spark_app_name += "_{}".format(get_username())
+    spark_app_name += f"_{get_username()}"
     if enable_k8s_autogen:
         document = POD_TEMPLATE.format(spark_app_name=spark_app_name)
         parsed_pod_template = yaml.load(document)
-        f = open(POD_TEMPLATE_PATH, "w")
-        f.write(yaml.dump(parsed_pod_template))
-        f.close()
+        with open(POD_TEMPLATE_PATH, 'w') as f:
+            yaml.dump(parsed_pod_template, f)
 
     return spark_app_name
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -6,8 +6,6 @@ import re
 import shlex
 import socket
 import sys
-import yaml
-
 from typing import Any
 from typing import Dict
 from typing import List
@@ -16,7 +14,7 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-
+import yaml
 from boto3.exceptions import Boto3Error
 from service_configuration_lib.spark_config import get_aws_credentials
 from service_configuration_lib.spark_config import get_history_url

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -730,7 +730,7 @@ def test_paasta_spark_run(
     )
     mock_get_spark_app_name.assert_called_once_with("spark-submit test.py", False)
     mock_parse_user_spark_args.assert_called_once_with(
-        "spark.cores.max=100 spark.executor.cores=10"
+        "spark.cores.max=100 spark.executor.cores=10", False
     )
     mock_get_spark_conf.assert_called_once_with(
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -243,6 +243,7 @@ def test_get_spark_env(
         (
             "spark.cores.max=1  spark.executor.memory=24g",
             {"spark.cores.max": "1", "spark.executor.memory": "24g"},
+            {"spark.kubernetes.allocation.batch.size": "2", "spark.kubernetes.executor.podTemplateFile": "/nail/tmp/podTemplate.yaml"},
         ),
         ("spark.cores.max", None),
         (None, {}),
@@ -442,7 +443,7 @@ class TestConfigureAndRunDockerContainer:
             container_name="fake_app",
             volumes=(
                 expected_volumes
-                + ["/fake_dir:/spark_driver:rw", "/nail/home:/nail/home:rw"]
+                + ["/fake_dir:/spark_driver:rw", "/nail/home:/nail/home:rw", "/nail/tmp/podTemplate.yaml:/nail/tmp/podTemplate.yaml:rw"]
             ),
             environment={
                 "env1": "val1",

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -703,7 +703,7 @@ def test_paasta_spark_run(
         no_aws_credentials=False,
         aws_credentials_yaml="/path/to/creds",
         aws_profile=None,
-        enable_k8s_autogen=True,
+        enable_k8s_autogen=False,
         spark_args="spark.cores.max=100 spark.executor.cores=10",
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
     )

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -703,7 +703,7 @@ def test_paasta_spark_run(
         no_aws_credentials=False,
         aws_credentials_yaml="/path/to/creds",
         aws_profile=None,
-        enable_k8s_autogen=True
+        enable_k8s_autogen=True,
         spark_args="spark.cores.max=100 spark.executor.cores=10",
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
     )

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -703,6 +703,7 @@ def test_paasta_spark_run(
         no_aws_credentials=False,
         aws_credentials_yaml="/path/to/creds",
         aws_profile=None,
+        enable_k8s_autogen=True
         spark_args="spark.cores.max=100 spark.executor.cores=10",
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
     )

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -676,7 +676,7 @@ def test_get_docker_cmd(args, instance_config, spark_conf_str, expected):
 @mock.patch.object(spark_run, "get_instance_config", autospec=True)
 @mock.patch.object(spark_run, "get_aws_credentials", autospec=True)
 @mock.patch.object(spark_run, "get_docker_image", autospec=True)
-@mock.patch.object(spark_run, "get_spark_app_name", False, autospec=True)
+@mock.patch.object(spark_run, "get_spark_app_name", autospec=True)
 @mock.patch.object(spark_run, "_parse_user_spark_args", autospec=True)
 @mock.patch.object(spark_run, "get_spark_conf", autospec=True)
 @mock.patch.object(spark_run, "configure_and_run_docker_container", autospec=True)

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -241,9 +241,12 @@ def test_get_spark_env(
     "spark_args,expected",
     [
         (
-            "spark.cores.max=1  spark.executor.memory=24g",
-            {"spark.cores.max": "1", "spark.executor.memory": "24g"},
-            {"spark.kubernetes.allocation.batch.size": "2", "spark.kubernetes.executor.podTemplateFile": "/nail/tmp/podTemplate.yaml"},
+            "spark.cores.max=1  spark.executor.memory=24g  spark.kubernetes.allocation.batch.size=2  spark.kubernetes.executor.podTemplateFile=/nail/tmp/podTemplate.yaml",
+            {"spark.cores.max": "1",
+             "spark.executor.memory": "24g",
+             "spark.kubernetes.allocation.batch.size": "2",
+             "spark.kubernetes.executor.podTemplateFile": "/nail/tmp/podTemplate.yaml"},
+            {},
         ),
         ("spark.cores.max", None),
         (None, {}),

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -635,7 +635,7 @@ class TestConfigureAndRunDockerContainer:
 def test_get_spark_app_name(cmd, expected_name):
     with mock.patch("paasta_tools.cli.cmds.spark_run.get_username", autospec=True) as m:
         m.return_value = "fake_user"
-        assert get_spark_app_name(cmd) == expected_name
+        assert get_spark_app_name(cmd, False) == expected_name
 
 
 @pytest.mark.parametrize(
@@ -673,7 +673,7 @@ def test_get_docker_cmd(args, instance_config, spark_conf_str, expected):
 @mock.patch.object(spark_run, "get_instance_config", autospec=True)
 @mock.patch.object(spark_run, "get_aws_credentials", autospec=True)
 @mock.patch.object(spark_run, "get_docker_image", autospec=True)
-@mock.patch.object(spark_run, "get_spark_app_name", autospec=True)
+@mock.patch.object(spark_run, "get_spark_app_name", False, autospec=True)
 @mock.patch.object(spark_run, "_parse_user_spark_args", autospec=True)
 @mock.patch.object(spark_run, "get_spark_conf", autospec=True)
 @mock.patch.object(spark_run, "configure_and_run_docker_container", autospec=True)
@@ -725,7 +725,7 @@ def test_paasta_spark_run(
     mock_get_docker_image.assert_called_once_with(
         args, mock_get_instance_config.return_value
     )
-    mock_get_spark_app_name.assert_called_once_with("spark-submit test.py")
+    mock_get_spark_app_name.assert_called_once_with("spark-submit test.py", False)
     mock_parse_user_spark_args.assert_called_once_with(
         "spark.cores.max=100 spark.executor.cores=10"
     )

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -241,11 +241,12 @@ def test_get_spark_env(
     "spark_args,expected",
     [
         (
-            "spark.cores.max=1  spark.executor.memory=24g  spark.kubernetes.allocation.batch.size=2  spark.kubernetes.executor.podTemplateFile=/nail/tmp/podTemplate.yaml",
-            {"spark.cores.max": "1",
-             "spark.executor.memory": "24g",
-             "spark.kubernetes.allocation.batch.size": "2",
-             "spark.kubernetes.executor.podTemplateFile": "/nail/tmp/podTemplate.yaml"},
+            "spark.cores.max=1  spark.executor.memory=24g  spark.kubernetes.executor.podTemplateFile=/nail/tmp/podTemplate.yaml",
+            {
+                "spark.cores.max": "1",
+                "spark.executor.memory": "24g",
+                "spark.kubernetes.executor.podTemplateFile": "/nail/tmp/podTemplate.yaml",
+            },
         ),
         ("spark.cores.max", None),
         (None, {}),
@@ -445,7 +446,11 @@ class TestConfigureAndRunDockerContainer:
             container_name="fake_app",
             volumes=(
                 expected_volumes
-                + ["/fake_dir:/spark_driver:rw", "/nail/home:/nail/home:rw", "/nail/tmp/podTemplate.yaml:/nail/tmp/podTemplate.yaml:rw"]
+                + [
+                    "/fake_dir:/spark_driver:rw",
+                    "/nail/home:/nail/home:rw",
+                    "/nail/tmp/podTemplate.yaml:/nail/tmp/podTemplate.yaml:rw",
+                ]
             ),
             environment={
                 "env1": "val1",

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -246,7 +246,6 @@ def test_get_spark_env(
              "spark.executor.memory": "24g",
              "spark.kubernetes.allocation.batch.size": "2",
              "spark.kubernetes.executor.podTemplateFile": "/nail/tmp/podTemplate.yaml"},
-            {},
         ),
         ("spark.cores.max", None),
         (None, {}),


### PR DESCRIPTION
- Auto generate pod affinity with weights specified by the user
- Pod affinity in this case is preferred but not guaranteed, the higher number user specify the tighter bin packing will be
- Pod affinity dependent on spark.kubernetes.allocation.batch.size, the smaller spark.kubernetes.allocation.batch.size is the tighter bin packing will be
testing done with 
```paasta spark-run -a --cluster-manager kubernetes --cluster pnw-devc --pool stable_batch --cmd ' spark-submit /code/virtualenv_run/bin/spark_etl_runner.py --feature-config /code/batch/campaign_info_daily/job_configs/bidding_history_daily.yaml --env-config-path /nail/srv/configs/ad_bidding_transform.yaml --team-name ad_market_dynamics --notify-email gcoll+ad_market_dynamics+batch@yelp.com --start-date 2021-08-08 --end-date 2021-08-08 --publish-path s3a://yelp-sorted-logs-us-west-2/gcoll/ad_bidding_transform/ -v ' --spark-args ' spark.cores.max=60 spark.executor.memory=13g spark.executor.cores=2 spark.driver.memory=13g spark.driver.cores=2 spark.jars.ivy=/tmp/.ivy spark.executor.instances=30' --aws-profile prod --service ad_bidding_transform
```
All available nodes
<img width="944" alt="Screenshot 2021-09-09 at 10 27 45" src="https://user-images.githubusercontent.com/86422363/132687877-dcb7890c-a90f-4838-b0ff-268a0cec9100.png">
Nodes used in the job:
<img width="1792" alt="Screenshot 2021-09-09 at 10 27 34" src="https://user-images.githubusercontent.com/86422363/132687787-2bf736f3-c370-4261-b6dc-94799b0af674.png">
