### PR TITLE
Remove docs on regex-matching endpoint timeouts for now

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -960,16 +960,10 @@ Routing and Reliability
    Endpoints use prefix-matching by default; for example ``/specials/bulk/v1``
    will match both ``/specials/bulk/v1/foo`` and ``/specials/bulk/v1/bar``.
 
-   Endpoints can also use regex matching, provided that the regex string begins
-   with a caret ``^`` and backslashes within the string are properly escaped.
-   For example, ``^/specials/[^/]+/v2/\\d`` will match the endpoints
-   ``/specials/bulk/v2/1`` and ``^/specials/milk/v2/2``.
-
    Example::
 
      endpoint_timeouts:
          "/specials/bulk/v1": 15000
-         "^/specials/[^/]+/v2/\\d": 11000
 
 Fault Injection
 ```````````````


### PR DESCRIPTION
As actually _using_ regex-matching causes many errors, removing this from the docs so that people don't accidentally use it. 