### PR TITLE
[local-run] Conditionally set MESOS env vars + unmangle docker hostname

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -607,16 +607,18 @@ def get_local_run_environment_vars(instance_config, port0, framework):
         # In a local_run environment, the docker_image may not be available
         # so we can fall-back to the injected DOCKER_TAG per the paasta contract
         docker_image = os.environ["DOCKER_TAG"]
-    fake_taskid = uuid.uuid4()
     env = {
         "HOST": hostname,
-        "MESOS_SANDBOX": "/mnt/mesos/sandbox",
-        "MESOS_CONTAINER_NAME": "localrun-%s" % fake_taskid,
-        "MESOS_TASK_ID": str(fake_taskid),
         "PAASTA_DOCKER_IMAGE": docker_image,
         "PAASTA_LAUNCHED_BY": get_possible_launched_by_user_variable_from_env(),
+        "PAASTA_HOST": hostname,
+        "PAASTA_PORT": str(port0),
     }
     if framework == "marathon":
+        fake_taskid = uuid.uuid4()
+        env["MESOS_SANDBOX"] = "/mnt/mesos/sandbox"
+        env["MESOS_CONTAINER_NAME"] = "localrun-%s" % fake_taskid
+        env["MESOS_TASK_ID"] = str(fake_taskid)
         env["MARATHON_PORT"] = str(port0)
         env["MARATHON_PORT0"] = str(port0)
         env["MARATHON_PORTS"] = str(port0)
@@ -629,8 +631,6 @@ def get_local_run_environment_vars(instance_config, port0, framework):
         env["MARATHON_APP_LABELS"] = ""
         env["MARATHON_APP_ID"] = "/simulated_marathon_app_id"
         env["MARATHON_HOST"] = hostname
-        env["PAASTA_HOST"] = hostname
-        env["PAASTA_PORT"] = str(port0)
 
     return env
 

--- a/paasta_tools/docker_wrapper.py
+++ b/paasta_tools/docker_wrapper.py
@@ -340,13 +340,16 @@ def main(argv=None):
     # Marathon sets MESOS_TASK_ID
     mesos_task_id = env_args.get("MESOS_TASK_ID")
 
+    hostname = socket.getfqdn()
     if mesos_task_id and can_add_hostname(argv):
-        hostname = socket.getfqdn()
         argv = add_argument(argv, f"-e=PAASTA_HOST={hostname}")
         hostname_task_id = generate_hostname_task_id(
             hostname.partition(".")[0], mesos_task_id
         )
         argv = add_argument(argv, f"--hostname={hostname_task_id }")
+    elif can_add_hostname(argv):
+        argv = add_argument(argv, f"-e=PAASTA_HOST={hostname}")
+        argv = add_argument(argv, f"--hostname={hostname}")
 
     paasta_firewall = env_args.get("PAASTA_FIREWALL")
     service = env_args.get("PAASTA_SERVICE")

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -320,7 +320,14 @@ class TestMain:
         argv = ["docker", "run", "foobar"]
         docker_wrapper.main(argv)
         assert mock_execlp.mock_calls == [
-            mock.call("docker", "docker", "run", "foobar")
+            mock.call(
+                "docker",
+                "docker",
+                "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
+                "foobar",
+            )
         ]
 
     def test_already_has_hostname(self, mock_execlp):
@@ -353,14 +360,28 @@ class TestMain:
         argv = ["docker", "run", '--env=PIN_TO_NUMA_NODE="true"']
         docker_wrapper.main(argv)
         assert mock_execlp.mock_calls == [
-            mock.call("docker", "docker", "run", '--env=PIN_TO_NUMA_NODE="true"')
+            mock.call(
+                "docker",
+                "docker",
+                "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
+                '--env=PIN_TO_NUMA_NODE="true"',
+            )
         ]
 
     def test_numa_bogus_node(self, mock_execlp):
         argv = ["docker", "run", "--env=PIN_TO_NUMA_NODE=True"]
         docker_wrapper.main(argv)
         assert mock_execlp.mock_calls == [
-            mock.call("docker", "docker", "run", "--env=PIN_TO_NUMA_NODE=True")
+            mock.call(
+                "docker",
+                "docker",
+                "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
+                "--env=PIN_TO_NUMA_NODE=True",
+            )
         ]
 
     def test_numa_unsupported(self, mock_execlp):
@@ -386,6 +407,8 @@ class TestMain:
                 "docker",
                 "docker",
                 "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
                 "--env=PIN_TO_NUMA_NODE=1",
                 "--env=MARATHON_APP_RESOURCE_CPUS=1.5",
             )
@@ -415,6 +438,8 @@ class TestMain:
                 "docker",
                 "docker",
                 "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
                 "--cpuset-mems=1",
                 "--cpuset-cpus=1,3",
                 "--env=PIN_TO_NUMA_NODE=1",
@@ -446,6 +471,8 @@ class TestMain:
                 "docker",
                 "docker",
                 "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
                 "--cpuset-mems=1",
                 "--cpuset-cpus=1,3",
                 "--env=PIN_TO_NUMA_NODE=1",
@@ -478,6 +505,8 @@ class TestMain:
                 "docker",
                 "docker",
                 "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
                 "--cpuset-cpus=0,2",
                 "--env=PIN_TO_NUMA_NODE=1",
                 "--env=MARATHON_APP_RESOURCE_CPUS=1.5",
@@ -509,6 +538,8 @@ class TestMain:
                 "docker",
                 "docker",
                 "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
                 "--cpuset-mems=1",
                 "--cpuset-cpus=1,3",
                 "--env=PIN_TO_NUMA_NODE=1",
@@ -542,6 +573,8 @@ class TestMain:
                 "docker",
                 "docker",
                 "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
                 "--env=PIN_TO_NUMA_NODE=1",
                 "--env=MARATHON_APP_RESOURCE_CPUS=2",
                 "--env=MARATHON_APP_RESOURCE_MEM=40000.0",
@@ -573,6 +606,8 @@ class TestMain:
                 "docker",
                 "docker",
                 "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
                 "--cpuset-mems=1",
                 "--cpuset-cpus=1,3",
                 "--env=PIN_TO_NUMA_NODE=1",
@@ -605,6 +640,8 @@ class TestMain:
                 "docker",
                 "docker",
                 "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
                 "--cpuset-mems=1",
                 "--cpuset-cpus=1,3",
                 "--env=PIN_TO_NUMA_NODE=1",
@@ -636,6 +673,8 @@ class TestMain:
                 "docker",
                 "docker",
                 "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
                 "--env=PIN_TO_NUMA_NODE=1",
                 "--env=MARATHON_APP_RESOURCE_CPUS=3.0",
             )
@@ -660,6 +699,8 @@ class TestMain:
                 "docker",
                 "docker",
                 "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
                 "--cpuset-mems=1",
                 "--cpuset-cpus=1,3",
                 "--env=PIN_TO_NUMA_NODE=1",
@@ -681,7 +722,14 @@ class TestMain:
             docker_wrapper.main(argv)
 
         assert mock_execlp.mock_calls == [
-            mock.call("docker", "docker", "run", "--env=PIN_TO_NUMA_NODE=2")
+            mock.call(
+                "docker",
+                "docker",
+                "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
+                "--env=PIN_TO_NUMA_NODE=2",
+            )
         ]
 
     def test_numa_single_cpu_doesnt_bother_with_cpusets(self, mock_execlp):
@@ -694,7 +742,14 @@ class TestMain:
             docker_wrapper.main(argv)
 
         assert mock_execlp.mock_calls == [
-            mock.call("docker", "docker", "run", "--env=PIN_TO_NUMA_NODE=1")
+            mock.call(
+                "docker",
+                "docker",
+                "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
+                "--env=PIN_TO_NUMA_NODE=1",
+            )
         ]
 
     @contextmanager
@@ -746,6 +801,8 @@ class TestMain:
                 "docker",
                 "run",
                 "--mac-address=00:00:00:00:00:00",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
                 *mock_firewall_env_args,
             )
         ]
@@ -789,6 +846,8 @@ class TestMain:
                 "docker",
                 "docker",
                 "run",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
                 "--mac-address=12:34:56:78:90:ab",
                 *mock_firewall_env_args,
             )
@@ -803,7 +862,14 @@ class TestMain:
             docker_wrapper.main(argv)
 
             assert mock_execlp.mock_calls == [
-                mock.call("docker", "docker", "run", *mock_firewall_env_args)
+                mock.call(
+                    "docker",
+                    "docker",
+                    "run",
+                    f"--hostname={socket.getfqdn()}",
+                    f"-e=PAASTA_HOST={socket.getfqdn()}",
+                    *mock_firewall_env_args,
+                )
             ]
             _, err = capsys.readouterr()
             assert err.startswith(
@@ -835,6 +901,8 @@ class TestMain:
                 "docker",
                 "run",
                 "--mac-address=00:00:00:00:00:00",
+                f"--hostname={socket.getfqdn()}",
+                f"-e=PAASTA_HOST={socket.getfqdn()}",
                 *mock_firewall_env_args,
             )
         ]


### PR DESCRIPTION
In PAASTA-17466, an internal user reported that PAASTA_HOST is not a
resolvable hostname. This is because we're unconditionally mangling that
value and adding a uuid that dates back to when PaaSTA ran on Mesos.

This PR stops unconditionally setting certain Mesos-only environment
variables and additionally stops mangling the hostname we pass to Docker
if Mesos environment variables aren't set