### PR TITLE
Add env and bugsnag paasta secret key to kubernetes configs

### DIFF
--- a/paasta_tools/contrib/service_shard_update.py
+++ b/paasta_tools/contrib/service_shard_update.py
@@ -119,6 +119,9 @@ def main(args):
                         kube_file[args.shard_name] = {
                             "deploy_group": f"{deploy_prefix}.{args.shard_name}",
                             "instances": args.instance_count,
+                            "env": {
+                                "PAASTA_SECRET_BUGSNAG_API_KEY": "SECRET(bugsnag_api_key)",
+                            },
                         }
                         updater.write_configs(args.service, config_path, kube_file)
                         log.info(


### PR DESCRIPTION
## Description

This branch adds an env key and bugsnag paasta secret api key to kubernetes configs. This is so that these keys will not have to be manually added to shards.

## Testing

* `make test` passes.