### PR TITLE
Ensure paasta.yelp.com/instance length is <=63 chars for tron

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -59,6 +59,7 @@ from paasta_tools.utils import time_cache
 from paasta_tools.utils import filter_templates_from_config
 from paasta_tools.kubernetes_tools import (
     allowlist_denylist_to_requirements,
+    limit_size_with_hash,
     raw_selectors_to_requirements,
     sanitise_kubernetes_name,
     to_node_label,
@@ -757,7 +758,9 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
             "paasta.yelp.com/cluster": action_config.get_cluster(),
             "paasta.yelp.com/pool": action_config.get_pool(),
             "paasta.yelp.com/service": action_config.get_service(),
-            "paasta.yelp.com/instance": action_config.get_instance(),
+            "paasta.yelp.com/instance": limit_size_with_hash(
+                action_config.get_instance(), limit=63, suffix=4,
+            ),
         }
 
         if action_config.get_team() is not None:

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -850,7 +850,19 @@ class TestTronTools:
         assert result["env"]["SHELL"] == "/bin/bash"
         assert isinstance(result["docker_parameters"], list)
 
-    def test_format_tron_action_dict_paasta_k8s(self):
+    @pytest.mark.parametrize(
+        "instance_name,expected_instance_label",
+        (
+            ("my_job.do_something", "my_job.do_something"),
+            (
+                f"my_job.{'a'* 100}",
+                "my_job.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-6xhe",
+            ),
+        ),
+    )
+    def test_format_tron_action_dict_paasta_k8s(
+        self, instance_name, expected_instance_label
+    ):
         action_dict = {
             "command": "echo something",
             "node_selectors": {"instance_type": ["c5.2xlarge", "c5n.17xlarge",]},
@@ -881,7 +893,7 @@ class TestTronTools:
         }
         action_config = tron_tools.TronActionConfig(
             service="my_service",
-            instance=tron_tools.compose_instance("my_job", "do_something"),
+            instance=instance_name,
             config_dict=action_dict,
             branch_dict=branch_dict,
             cluster="test-cluster",
@@ -910,7 +922,7 @@ class TestTronTools:
             "cap_drop": CAPS_DROP,
             "labels": {
                 "paasta.yelp.com/cluster": "test-cluster",
-                "paasta.yelp.com/instance": "my_job.do_something",
+                "paasta.yelp.com/instance": expected_instance_label,
                 "paasta.yelp.com/pool": "special_pool",
                 "paasta.yelp.com/service": "my_service",
                 "yelp.com/owner": "some_sensu_team",


### PR DESCRIPTION
This is a hardcoded k8s limit and tron instance names can easily be >63
characters in length since they're {job name}.{action name} and these
are often pretty descriptive names.