### PR TITLE
Revert "Auto generate pod template for pod affinity with weights spec…

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -14,7 +14,6 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-import yaml
 from boto3.exceptions import Boto3Error
 from service_configuration_lib.spark_config import get_aws_credentials
 from service_configuration_lib.spark_config import get_history_url
@@ -56,28 +55,6 @@ CLUSTER_MANAGER_MESOS = "mesos"
 CLUSTER_MANAGER_K8S = "kubernetes"
 CLUSTER_MANAGERS = {CLUSTER_MANAGER_MESOS, CLUSTER_MANAGER_K8S}
 
-POD_TEMPLATE_PATH = "/nail/tmp/podTemplate.yaml"
-
-POD_TEMPLATE = """
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
-    spark: exec-{spark_app_name}
-spec:
-  affinity:
-    podAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 95
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: spark
-              operator: In
-              values:
-              - exec-{spark_app_name}
-          topologyKey: topology.kubernetes.io/hostname
-"""
 
 deprecated_opts = {
     "j": "spark.jars",
@@ -134,13 +111,6 @@ def add_subparser(subparsers):
         help="Use the provided image to start the Spark driver and executors.",
     )
 
-    list_parser.add_argument(
-        "-e",
-        "--enable-k8s-autogen",
-        help="Auto generate pod template with weighted pod affinity used in executors.",
-        action="store_true",
-        default=True,
-    )
     list_parser.add_argument(
         "--docker-registry",
         help="Docker registry to push the Spark image built.",
@@ -488,12 +458,9 @@ def get_spark_env(
     return spark_env
 
 
-def _parse_user_spark_args(
-    spark_args: Optional[str], enable_k8s_autogen: bool = True
-) -> Dict[str, str]:
+def _parse_user_spark_args(spark_args: Optional[str]) -> Dict[str, str]:
     if not spark_args:
         return {}
-
     user_spark_opts = {}
     for spark_arg in spark_args.split():
         fields = spark_arg.split("=", 1)
@@ -506,10 +473,6 @@ def _parse_user_spark_args(
             )
             sys.exit(1)
         user_spark_opts[fields[0]] = fields[1]
-
-    if enable_k8s_autogen:
-        user_spark_opts["spark.kubernetes.executor.podTemplateFile"] = POD_TEMPLATE_PATH
-
     return user_spark_opts
 
 
@@ -551,9 +514,7 @@ def run_docker_container(
     return 0
 
 
-def get_spark_app_name(
-    original_docker_cmd: Union[Any, str, List[str]], enable_k8s_autogen: bool = True
-) -> str:
+def get_spark_app_name(original_docker_cmd: Union[Any, str, List[str]]) -> str:
     """Use submitted batch name as default spark_run job name"""
     docker_cmds = (
         shlex.split(original_docker_cmd)
@@ -577,12 +538,6 @@ def get_spark_app_name(
         spark_app_name = "paasta_spark_run"
 
     spark_app_name += f"_{get_username()}"
-    if enable_k8s_autogen:
-        document = POD_TEMPLATE.format(spark_app_name=spark_app_name)
-        parsed_pod_template = yaml.load(document)
-        with open(POD_TEMPLATE_PATH, "w") as f:
-            yaml.dump(parsed_pod_template, f)
-
     return spark_app_name
 
 
@@ -632,8 +587,6 @@ def configure_and_run_docker_container(
 
     volumes.append("%s:rw" % args.work_dir)
     volumes.append("/nail/home:/nail/home:rw")
-    if args.enable_k8s_autogen:
-        volumes.append(f"{POD_TEMPLATE_PATH}:{POD_TEMPLATE_PATH}:rw")
 
     environment = instance_config.get_env_dictionary()  # type: ignore
     spark_conf_str = create_spark_config_str(spark_conf, is_mrjob=args.mrjob)
@@ -855,12 +808,9 @@ def paasta_spark_run(args):
         return 1
 
     volumes = instance_config.get_volumes(system_paasta_config.get_volumes())
-    app_base_name = get_spark_app_name(
-        args.cmd or instance_config.get_cmd(), args.enable_k8s_autogen
-    )
-
+    app_base_name = get_spark_app_name(args.cmd or instance_config.get_cmd())
     needs_docker_cfg = not args.build
-    user_spark_opts = _parse_user_spark_args(args.spark_args, args.enable_k8s_autogen)
+    user_spark_opts = _parse_user_spark_args(args.spark_args)
     paasta_instance = get_smart_paasta_instance_name(args)
     spark_conf = get_spark_conf(
         cluster_manager=args.cluster_manager,

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -241,12 +241,8 @@ def test_get_spark_env(
     "spark_args,expected",
     [
         (
-            "spark.cores.max=1  spark.executor.memory=24g  spark.kubernetes.executor.podTemplateFile=/nail/tmp/podTemplate.yaml",
-            {
-                "spark.cores.max": "1",
-                "spark.executor.memory": "24g",
-                "spark.kubernetes.executor.podTemplateFile": "/nail/tmp/podTemplate.yaml",
-            },
+            "spark.cores.max=1  spark.executor.memory=24g",
+            {"spark.cores.max": "1", "spark.executor.memory": "24g"},
         ),
         ("spark.cores.max", None),
         (None, {}),
@@ -446,11 +442,7 @@ class TestConfigureAndRunDockerContainer:
             container_name="fake_app",
             volumes=(
                 expected_volumes
-                + [
-                    "/fake_dir:/spark_driver:rw",
-                    "/nail/home:/nail/home:rw",
-                    "/nail/tmp/podTemplate.yaml:/nail/tmp/podTemplate.yaml:rw",
-                ]
+                + ["/fake_dir:/spark_driver:rw", "/nail/home:/nail/home:rw"]
             ),
             environment={
                 "env1": "val1",
@@ -643,7 +635,7 @@ class TestConfigureAndRunDockerContainer:
 def test_get_spark_app_name(cmd, expected_name):
     with mock.patch("paasta_tools.cli.cmds.spark_run.get_username", autospec=True) as m:
         m.return_value = "fake_user"
-        assert get_spark_app_name(cmd, False) == expected_name
+        assert get_spark_app_name(cmd) == expected_name
 
 
 @pytest.mark.parametrize(
@@ -711,7 +703,6 @@ def test_paasta_spark_run(
         no_aws_credentials=False,
         aws_credentials_yaml="/path/to/creds",
         aws_profile=None,
-        enable_k8s_autogen=False,
         spark_args="spark.cores.max=100 spark.executor.cores=10",
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
     )
@@ -733,9 +724,9 @@ def test_paasta_spark_run(
     mock_get_docker_image.assert_called_once_with(
         args, mock_get_instance_config.return_value
     )
-    mock_get_spark_app_name.assert_called_once_with("spark-submit test.py", False)
+    mock_get_spark_app_name.assert_called_once_with("spark-submit test.py")
     mock_parse_user_spark_args.assert_called_once_with(
-        "spark.cores.max=100 spark.executor.cores=10", False
+        "spark.cores.max=100 spark.executor.cores=10"
     )
     mock_get_spark_conf.assert_called_once_with(
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,


### PR DESCRIPTION
…ified by the user [COREML-2557] (#3203)"

This reverts commit 9a81394e3c53b2e0a062be9ca2d2bf01fc692f97.

PR: https://github.com/Yelp/paasta/pull/3203/files pushed caused this error:
* https://yelp.slack.com/archives/CA8BWU65D/p1631916450256800
`PermissionError: [Errno 13] Permission denied: '/nail/tmp/podTemplate.yaml'`

This could cause potentially break all spark-etl batches over the weekend. 