### PR TITLE
don't clear environment when running spark docker container

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -510,7 +510,7 @@ def run_docker_container(
         print(json.dumps(docker_run_cmd))
         return 0
 
-    os.execlpe("paasta_docker_wrapper", *docker_run_cmd)
+    os.execlp("paasta_docker_wrapper", *docker_run_cmd)
     return 0
 
 


### PR DESCRIPTION
This fixes the current issue where the docker client doesn't respect `DOCKER_HOST`, which is used as a alternative to the docker socket. This is required by kubernetes jenkins.