### PR TITLE
Fix paasta status crash on evicted pods bug

### DIFF
--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -686,7 +686,8 @@ async def get_pod_status(
     except asyncio.TimeoutError:
         pod_event_messages = [{"error": "Could not retrieve events. Please try again."}]
 
-    if not scheduled:
+    # if evicted, there is no condition
+    if not scheduled and reason != "Evicted":
         sched_condition = kubernetes_tools.get_pod_condition(pod, "PodScheduled")
         reason = sched_condition.reason
         message = sched_condition.message


### PR DESCRIPTION
### Description
`paasta status` would crash on evicted pods because the API tries to get status conditions for non-scheduled pods, but those don't exist for evicted pods. This PR makes it so that we check for evicted status first before we try to get status conditions.

### Testing
- `make test`
- manual testing by setting up a paasta api on a real cluster, then running paasta status against the local api to test the api fix. instead of crashing, `paasta status` now returns properly, and the pod status is `Evicted` as expected.

### Notes
I couldn't test this by simulating eviction using the eviction api or draining a node, because pods are quickly rescheduled, and don't stay in the `Evicted` state. I essentially had to wait for a real evicted pod in a real cluster. In our busiest cluster though, it does happen regularly so it wasn't too bad. If that didn't work, my next try would've been to manually stress a test cluster to make a pod stay evicted.