### PR TITLE
PAASTA-17456: Update oom_logger to handle new structured oom-kill logs

### DIFF
--- a/tests/test_oom_logger.py
+++ b/tests/test_oom_logger.py
@@ -87,6 +87,23 @@ def sys_stdin_kubernetes_besteffort_qos():
 
 
 @pytest.fixture
+def sys_stdin_kubernetes_structured_burstable_qos():
+    return [
+        "some random line1\n",
+        "1500316299 dev37-devc [30533610.306528] apache2 invoked oom-killer: "
+        "gfp_mask=0x24000c0, order=0, oom_score_adj=0\n",
+        "some random line2\n",
+        "1500316300 dev37-devc [541471.893603] oom-kill:constraint=CONSTRAINT_MEMCG,"
+        "nodemask=(null),cpuset=1b6f55bfbed10cdc2bb6944078eaefd3278f8f9b3a9725c4ddffb722752a2279,"
+        "mems_allowed=0-1,oom_memcg=/kubepods/burstable/podb56c3a7a-a84d-4f84-b97e-446c4e705259/"
+        "0e4a814eda030cdc2bb6944078eaefd3278f8f9b3a9725c4ddffb722752a2279,"
+        "task_memcg=/kubepods/burstable/podb56c3a7a-a84d-4f84-b97e-446c4e705259/"
+        "0e4a814eda030cdc2bb6944078eaefd3278f8f9b3a9725c4ddffb722752a2279,"
+        "task=kafka_exporter,pid=43716,uid=65534\n",
+    ]
+
+
+@pytest.fixture
 def sys_stdin_process_name_with_slashes():
     return [
         "some random line1\n",
@@ -186,6 +203,17 @@ def test_capture_oom_events_from_stdin_kubernetes_qos(
         for a_tuple in capture_oom_events_from_stdin():
             test_output.append(a_tuple)
         assert test_output == [(1500316300, "dev37-devc", "0e4a814eda03", "apache2")]
+
+
+@patch("paasta_tools.oom_logger.sys.stdin", autospec=True)
+def test_capture_oom_events_from_stdin_kubernetes_structured_qos(
+    mock_sys_stdin, sys_stdin_kubernetes_structured_burstable_qos,
+):
+    mock_sys_stdin.readline.side_effect = sys_stdin_kubernetes_structured_burstable_qos
+    test_output = []
+    for a_tuple in capture_oom_events_from_stdin():
+        test_output.append(a_tuple)
+    assert test_output == [(1500316300, "dev37-devc", "0e4a814eda03", "apache2")]
 
 
 @patch("paasta_tools.oom_logger.sys.stdin", autospec=True)


### PR DESCRIPTION
With a recent kernel upgrade, we got these improvements to oom-killer logs, which gave us a structured, key=value formatted summary log line: 
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ef8444ea01d7442652f8e1b8a8b94278cb57eafd
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f0c867d9588d9efc10d6a55009c9560336673369

But this also removed the `Task in /kubepods...` line we had been using to fetch container IDs, so we have been missing OOM events for the hosts on the latest kernels.

This PR fixes oom_logger.py to also match the new one-line summary using essentially the same regex we used for the original `Task in /kubepods...` records. 

Note that I've left fetching the process_name from the `<process_name> invoked oom-killter` line to maintain parity with existing code, though with the new logs we _could_ grab it from the `task=<process_name>` field in the summary line, and we may need to if the initial oom-killer invocation line ever changes.

I tested the regex against the last 7d of `oom-kill:` messages and confirmed they would match container ID successfully.