### PR TITLE
bump service_configuration_lib to 2.6.0

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -50,7 +50,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.5.0
+service-configuration-lib >= 2.6.0
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.5.8
+service-configuration-lib==2.6.0
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0


### PR DESCRIPTION
`make test` passes.

Test was also performed with a successful manual run:
```
TRON_JOB_NAMESPACE=xxx TRON_JOB_NAME=xxx TRON_ACTION=xxx ./paasta_tools/cli/cli.py spark-run --cluster pnw-devc --service ad_bidding_transform --pool stable_batch --cluster-manager kubernetes --cmd 'TRON_JOB_NAMESPACE=xxx TRON_JOB_NAME=xxx TRON_ACTION=xxx spark-submit /code/virtualenv_run/bin/spark_etl_runner.py --feature-config /code/batch/xxx/job_configs/xxx.yaml --env-config-path /nail/srv/configs/xxx.yaml --team-name xxx --no-notification --start-date 2021-09-14 --end-date 2021-09-14 --publish-path s3a://yxxx-us-west-2/gcoll/k8s_darklaunch/ ' --spark-args ' spark.executor.instances=8 spark.executor.memory=16g spark.executor.cores=4 spark.driver.memory=8g '
```
Setting `TRON_ACTION` and `TRON_JOB_NAME` to long values to trigger the 63 chars limit truncation.