### PR TITLE
Fixes `namedtuple` type name

### DIFF
--- a/paasta_tools/iptables.py
+++ b/paasta_tools/iptables.py
@@ -21,7 +21,7 @@ RULE_TARGET_SORT_ORDER = {
 
 
 _RuleBase = collections.namedtuple(
-    "Rule", ("protocol", "src", "dst", "target", "matches", "target_parameters")
+    "_RuleBase", ("protocol", "src", "dst", "target", "matches", "target_parameters")
 )
 
 


### PR DESCRIPTION
The best practice is to match `typename` with variable name.
For example, `mypy` reports any other usages as errors: https://github.com/python/mypy/pull/11206#issuecomment-927985235