### PR TITLE
Add ability to read the default use_k8s value from disk

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -417,9 +417,6 @@ class TronActionConfig(InstanceConfig):
     def get_trigger_timeout(self):
         return self.config_dict.get("trigger_timeout", None)
 
-    def get_use_k8s(self):
-        return self.config_dict.get("use_k8s", _use_k8s_default())
-
     def get_node_selectors(self) -> Dict[str, str]:
         raw_selectors: Dict[str, Any] = self.config_dict.get("node_selectors", {})  # type: ignore
         node_selectors = {

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2603,6 +2603,9 @@ class SystemPaastaConfig:
             "mark_for_deployment_should_ping_for_unhealthy_pods", True
         )
 
+    def get_tron_use_k8s_default(self) -> bool:
+        return self.config_dict.get("tron_use_k8s", False)
+
 
 def _run(
     command: Union[str, List[str]],

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1941,6 +1941,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     vault_environment: str
     volumes: List[DockerVolume]
     zookeeper: str
+    tron_use_k8s: bool
 
 
 def load_system_paasta_config(

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -401,9 +401,14 @@ class TestTronJobConfig:
         job_config = tron_tools.TronJobConfig(
             "my_job", job_dict, cluster, soa_dir=soa_dir
         )
-        result = tron_tools.format_tron_job_dict(
-            job_config=job_config, k8s_enabled=False
-        )
+        with mock.patch(
+            "paasta_tools.tron_tools.load_system_paasta_config",
+            autospec=True,
+            return_value=MOCK_SYSTEM_PAASTA_CONFIG,
+        ):
+            result = tron_tools.format_tron_job_dict(
+                job_config=job_config, k8s_enabled=False
+            )
 
         mock_get_action_config.assert_called_once_with(
             job_config, action_name, action_dict
@@ -450,9 +455,14 @@ class TestTronJobConfig:
         job_config = tron_tools.TronJobConfig(
             "my_job", job_dict, cluster, soa_dir=soa_dir
         )
-        result = tron_tools.format_tron_job_dict(
-            job_config=job_config, k8s_enabled=True
-        )
+        with mock.patch(
+            "paasta_tools.tron_tools.load_system_paasta_config",
+            autospec=True,
+            return_value=MOCK_SYSTEM_PAASTA_CONFIG,
+        ):
+            result = tron_tools.format_tron_job_dict(
+                job_config=job_config, k8s_enabled=True
+            )
 
         mock_get_action_config.assert_called_once_with(
             job_config, action_name, action_dict
@@ -492,7 +502,12 @@ class TestTronJobConfig:
         }
         job_config = tron_tools.TronJobConfig("my_job", job_dict, "paasta-dev")
 
-        result = tron_tools.format_tron_job_dict(job_config, k8s_enabled=False)
+        with mock.patch(
+            "paasta_tools.tron_tools.load_system_paasta_config",
+            autospec=True,
+            return_value=MOCK_SYSTEM_PAASTA_CONFIG,
+        ):
+            result = tron_tools.format_tron_job_dict(job_config, k8s_enabled=False)
 
         assert mock_get_action_config.call_args_list == [
             mock.call(job_config, "normal", job_dict["actions"]["normal"]),


### PR DESCRIPTION
As we progress through our migration, we want to ensure that any new
Tronjobs on clusters that have already been fully migrated run on k8s by
default.

This PR will be accompanied by an internal Puppet PR that will provide
the configuration that this is looking at.