### PR TITLE
Add cprofiling to paasta api

### DIFF
--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -31,6 +31,7 @@ import paasta_tools.api
 from paasta_tools import kubernetes_tools
 from paasta_tools import marathon_tools
 from paasta_tools.api import settings
+from paasta_tools.api.tweens import profiling
 from paasta_tools.api.tweens import request_logger
 from paasta_tools.utils import load_system_paasta_config
 
@@ -98,6 +99,8 @@ def make_app(global_config=None):
 
     config.include("pyramid_swagger")
     config.include(request_logger)
+    config.include(profiling)
+
     config.add_route("resources.utilization", "/v1/resources/utilization")
     config.add_route(
         "service.instance.status", "/v1/services/{service}/{instance}/status"

--- a/paasta_tools/api/tweens/profiling.py
+++ b/paasta_tools/api/tweens/profiling.py
@@ -1,0 +1,111 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Creates a tween that cprofiles requests
+"""
+import functools
+
+import pyramid
+import pytz
+
+from paasta_tools.api import settings as api_settings
+
+try:
+    # hackily patch pytz, since yelp_lib (used by yelp_profiling) type checks
+    # using an older version of pytz where tzinfo didn't exist yet. this needs to
+    # happen before importing `yelp_profiling` since it is used at import time.
+    pytz.BaseTzInfo = pytz.tzinfo.BaseTzInfo  # type: ignore
+    import yelp_profiling
+    from yelp_profiling.cprofile import CProfileConfig
+    from yelp_profiling.cprofile import CProfileScribeContext
+    from yelp_profiling.tweens import YelpSOARequestProcessor
+
+    class PaastaCProfileConfig(CProfileConfig):
+        """Paasta API version of yelp_profiling's CProfileConfig. Instead of reading
+        from srv-configs, this reads configs from /etc/paasta.
+        """
+
+        def __init__(self, pyramid_settings):
+            super().__init__(pyramid_settings)
+            self._cprofile_config = (
+                api_settings.system_paasta_config.get_api_profiling_config()
+            )
+
+        @property
+        def enabled(self):
+            return self._cprofile_config.get("cprofile_sampling_enabled", False)
+
+        @property
+        def output_prefix(self):
+            return self._cprofile_config.get("cprofile_output_prefix", "cprofile")
+
+        @property
+        def scribe_log_name(self):
+            return self._cprofile_config.get(
+                "cprofile_scribe_log", "tmp_paasta_api_cprofiles"
+            )
+
+        @property
+        def default_probability(self):
+            return self._cprofile_config.get("cprofile_sampling_probability", 0)
+
+        @property
+        def path_probabilities(self):
+            probabilities = {"patterns": []}
+            probabilities.update(
+                self._cprofile_config.get("cprofile_path_probabilities", {})
+            )
+            return probabilities
+
+
+except ImportError:
+    yelp_profiling = None
+
+
+def includeme(config):
+    if yelp_profiling is not None:
+        config.add_tween(
+            "paasta_tools.api.tweens.profiling.cprofile_tween_factory",
+            under=pyramid.tweens.INGRESS,
+        )
+
+
+def cprofile_tween_factory(handler, registry):
+    """Tween for profiling API requests and sending them to scribe.
+
+    yelp_profiling does define a tween, but it is designed more for PaaSTA
+    services. So, we need to define our own.
+    """
+
+    def cprofile_tween(request):
+        if yelp_profiling is not None:
+            return handler(request)
+
+        config = PaastaCProfileConfig(registry.settings)
+        processor = YelpSOARequestProcessor(config, registry)
+
+        with CProfileScribeContext(
+            config=config,
+            generate_log_fn=functools.partial(processor.generate_log_fn, request,),
+        ):
+            processor.begin_request(request)
+            status_code = 500
+            try:
+                response = handler(request)
+                status_code = response.status_code
+                return response
+            finally:
+                processor.end_request(request, status_code)
+
+    return cprofile_tween

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1846,6 +1846,7 @@ class KubeStateMetricsCollectorConfigDict(TypedDict, total=False):
 
 class SystemPaastaConfigDict(TypedDict, total=False):
     api_endpoints: Dict[str, str]
+    api_profiling_config: Dict
     auth_certificate_ttl: str
     auto_config_instance_types_enabled: Dict[str, bool]
     auto_hostname_unique_size: int
@@ -2606,6 +2607,11 @@ class SystemPaastaConfig:
 
     def get_tron_use_k8s_default(self) -> bool:
         return self.config_dict.get("tron_use_k8s", False)
+
+    def get_api_profiling_config(self) -> Dict:
+        return self.config_dict.get(
+            "api_profiling_config", {"cprofile_sampling_enabled": False},
+        )
 
 
 def _run(

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ pyrsistent==0.13.0
 pysensu-yelp==0.4.1
 PyStaticConfiguration==0.10.3
 python-crontab==2.1.1
-python-dateutil==2.5.3
+python-dateutil==2.7.2
 python-iptables==0.14.0
 python-utils==2.0.1
 pytimeparse==1.1.5

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -19,3 +19,4 @@ yelp-clog==5.1.0
 yelp-logging==1.0.37
 yelp_meteorite
 yelp_paasta_helpers
+yelp_profiling==9.1.1


### PR DESCRIPTION
### Description
Add `yelp_profiling` so that we can profile paasta api requests. By default, profiling doesn't happen, so to turn it on, we need to add system paasta configs.

### Testing
manual testing on devbox
i didnt write unit tests because nearly 100% of the code i wrote just uses `yelp_profiling` code directly.