### PR TITLE
Make paasta_prune_completed_pods less likely to crash

### DIFF
--- a/paasta_tools/prune_completed_pods.py
+++ b/paasta_tools/prune_completed_pods.py
@@ -126,11 +126,19 @@ def main():
             # (kubectl looks at phase and then container statuses to give something descriptive)
             # but, in the end, we really just care that a Pod is in a Failed phase
             and pod.status.phase == "Failed"
-            # and that said Pod has been around for a while (generally longer than we'd leave
-            # Pods that exited sucessfully)
-            and _scheduled_longer_than_threshold(pod, allowed_error_minutes)
         ):
-            errored_pods.append(pod)
+            try:
+                # and that said Pod has been around for a while (generally longer than we'd leave
+                # Pods that exited sucessfully)
+                # NOTE: we do this in a try-except since we're intermittently seeing pods in an error
+                # state without a PodScheduled condition (even though that should be impossible)
+                # this is not ideal, but its fine to skip these since this isn't a critical process
+                if _scheduled_longer_than_threshold(pod, allowed_error_minutes):
+                    errored_pods.append(pod)
+            except AttributeError:
+                log.exception(
+                    f"Unable to check {pod.metadata.name}'s schedule time. Pod status: {pod.status}.'"
+                )
 
     if not (completed_pods or errored_pods):
         log.debug("No pods to terminate.")
@@ -166,6 +174,10 @@ def main():
                 + "\n ".join(pod_names)
             )
 
+    # we've only really seen this fail recently due to the k8s API being flaky and returning
+    # 404s for Pods that its returning to us when we get all Pods, so we just print the error
+    # here for now and don't exit with a non-zero exit code since, again, this isn't a critical
+    # process
     for typ, pod_names_and_errors in errors.items():
         if pod_names_and_errors:
             log.error(
@@ -174,9 +186,6 @@ def main():
                     f"{pod_name}: {error}" for pod_name, error in pod_names_and_errors
                 )
             )
-
-    if completed_errors or errored_errors:
-        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We've been seeing two weird issues in one of our stage clusters:
1) Pods in an Error state with no PodScheduled condition
2) Pods returned by list_namespaced_pod 404ing when we attempt to delete
   them through delete_namespaced_pod

I was unable to repro 1) even after running this script in dry-run mode
for several days and was similarly unable to repro 2).

Since this is just a cleanup script, I decided to just log that we hit
an exception in these cases and continue on under the assumption that
these will either be cleaned up once the k8s API stops being flaky or
we'll be able to actually get more information on issue 1) with the
added logging and fix the issue at the root.