### PR TITLE
Record prometheus yelpsoaconfig timeouts metrics

### DIFF
--- a/paasta_tools/contrib/timeouts_metrics_prom.py
+++ b/paasta_tools/contrib/timeouts_metrics_prom.py
@@ -1,0 +1,55 @@
+#!/opt/venvs/paasta-tools/bin/python
+"""
+The goal is to walk through all smartstack.yaml in yelpsoa directories
+and convert timeout values to the prometheus format.
+
+For every upstream and path, if endpoint timeout is specified, we record
+per endpoint timeout value. If not and if timeout_server_ms is specified,
+we record timeout_server_ms value in path `default`. Otherwise, we record the default
+timeout_server_ms 1000.
+
+# HELP endpoint timeout value defined in yelpsoa-config.
+# TYPE TYPE yelpsoaconfig_endpoint_timeouts_ms gauge
+yelpsoaconfig_endpoint_timeouts_ms{path="/consumer_app/devices/braze/info",upstream="push_notifications.main.egress_cluster"} 10000.0
+yelpsoaconfig_endpoint_timeouts_ms{path="default",upstream="mysql_read_security.main.egress_cluster"} 100.0
+"""
+import os
+
+import yaml
+from prometheus_client import CollectorRegistry
+from prometheus_client import Gauge
+from prometheus_client import write_to_textfile
+
+SOA_DIR = "/nail/etc/services/"
+PROM_OUTPUT_FILE = "/nail/etc/services/.autotune_timeouts.prom"
+
+
+registry = CollectorRegistry()
+prom_metric = Gauge(
+    "yelpsoaconfig_endpoint_timeouts_ms",
+    "endpoint timeout value defined in yelpsoa-config",
+    ["path", "upstream"],
+    registry=registry,
+)
+for root, dirs, files in os.walk(SOA_DIR):
+    service = root.split("/")[-1]
+    for name in files:
+        if name == "smartstack.yaml":
+            with open(os.path.join(root, name)) as smartstack_file:
+                smartstack_yaml = yaml.safe_load(smartstack_file)
+                for instance_name, info in smartstack_yaml.items():
+                    upstream = service + "." + instance_name + ".egress_cluster"
+                    if "endpoint_timeouts" in info:
+                        for path, endpoint_timeouts in info[
+                            "endpoint_timeouts"
+                        ].items():
+                            prom_metric.labels(path, upstream).set(endpoint_timeouts)
+                    else:
+                        if "timeout_server_ms" in info:
+                            prom_metric.labels("default", upstream).set(
+                                info["timeout_server_ms"]
+                            )
+                        else:
+                            prom_metric.labels("default", upstream).set(1000)
+
+write_to_textfile(PROM_OUTPUT_FILE, registry)

--- a/paasta_tools/contrib/timeouts_metrics_prom.py
+++ b/paasta_tools/contrib/timeouts_metrics_prom.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     for root, dirs, files in os.walk(SOA_DIR):
         service = root.split("/")[-1]
         # Avoid confusion of the smartstacks.yaml under autotuned_defaults/ in the future
-        if "autotuned_defaults" == files:
+        if "autotuned_defaults" == service:
             continue
         for f in files:
             if f == "smartstack.yaml":

--- a/paasta_tools/contrib/timeouts_metrics_prom.py
+++ b/paasta_tools/contrib/timeouts_metrics_prom.py
@@ -29,8 +29,8 @@ def read_and_write_timeouts_metrics(root, service, prom_metric):
         smartstack_yaml = yaml.safe_load(smartstack_file)
     for instance_name, info in smartstack_yaml.items():
         upstream = service + "." + instance_name + ".egress_cluster"
-        if "endpoint_timeout" in info:
-            for path, endpoint_timeout in info["endpoint_timeout"].items():
+        if "endpoint_timeouts" in info:
+            for path, endpoint_timeout in info["endpoint_timeouts"].items():
                 prom_metric.labels(path, upstream).set(endpoint_timeout)
         # always record default timeout
         default_timeout = info.get("timeout_server_ms", 1000)

--- a/paasta_tools/contrib/timeouts_metrics_prom.py
+++ b/paasta_tools/contrib/timeouts_metrics_prom.py
@@ -4,14 +4,14 @@ The goal is to walk through all smartstack.yaml in yelpsoa directories
 and convert timeout values to the prometheus format.
 
 For every upstream and path, if endpoint timeout is specified, we record
-per endpoint timeout value. If not and if timeout_server_ms is specified,
-we record timeout_server_ms value in path `default`. Otherwise, we record the default
+per endpoint timeout value. If timeout_server_ms is specified,
+we record timeout_server_ms value in path `/`. Otherwise, we record the default
 timeout_server_ms 1000.
 
 # HELP endpoint timeout value defined in yelpsoa-config.
 # TYPE TYPE yelpsoaconfig_endpoint_timeouts_ms gauge
 yelpsoaconfig_endpoint_timeouts_ms{path="/consumer_app/devices/braze/info",upstream="push_notifications.main.egress_cluster"} 10000.0
-yelpsoaconfig_endpoint_timeouts_ms{path="default",upstream="mysql_read_security.main.egress_cluster"} 100.0
+yelpsoaconfig_endpoint_timeouts_ms{path="/",upstream="mysql_read_security.main.egress_cluster"} 100.0
 """
 import os
 
@@ -32,10 +32,9 @@ def read_and_write_timeouts_metrics(root, service, prom_metric):
         if "endpoint_timeout" in info:
             for path, endpoint_timeout in info["endpoint_timeout"].items():
                 prom_metric.labels(path, upstream).set(endpoint_timeout)
-        else:
-            if "timeout_server_ms" in info:
-                default_timeout = info.get("timeout_server_ms", 1000)
-                prom_metric.labels("/", upstream).set(default_timeout)
+        # always record default timeout
+        default_timeout = info.get("timeout_server_ms", 1000)
+        prom_metric.labels("/", upstream).set(default_timeout)
 
 
 if __name__ == "__main__":

--- a/paasta_tools/contrib/timeouts_metrics_prom.py
+++ b/paasta_tools/contrib/timeouts_metrics_prom.py
@@ -29,14 +29,13 @@ def read_and_write_timeouts_metrics(root, service, prom_metric):
         smartstack_yaml = yaml.safe_load(smartstack_file)
     for instance_name, info in smartstack_yaml.items():
         upstream = service + "." + instance_name + ".egress_cluster"
-        if "endpoint_timeouts" in info:
-            for path, endpoint_timeouts in info["endpoint_timeouts"].items():
-                prom_metric.labels(path, upstream).set(endpoint_timeouts)
+        if "endpoint_timeout" in info:
+            for path, endpoint_timeout in info["endpoint_timeout"].items():
+                prom_metric.labels(path, upstream).set(endpoint_timeout)
         else:
             if "timeout_server_ms" in info:
-                prom_metric.labels("/", upstream).set(info["timeout_server_ms"])
-            else:
-                prom_metric.labels("/", upstream).set(1000)
+                default_timeout = info.get("timeout_server_ms", 1000)
+                prom_metric.labels("/", upstream).set(default_timeout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The script loops through all yelpsoa folders and parses smartstack.yaml to get either `endpoint_timeouts` or `timeout_server_ms` value. Then we convert timeouts values into prometheus format using `prometheus_client` lib and save into the textfile with name ending with `.prom` which will be scraped by node exporter.

- If `endpoint_timeouts` is defined, we record per endpoint timeouts value. 
- If  `timeout_server_ms` is given, we record `timeout_server_ms` value as default path `/`
- Otherwise, we take default 1000ms  timeout_server_ms 

The metrics format as below:
```
# HELP endpoint timeout value defined in yelpsoa-config.
# TYPE TYPE yelpsoaconfig_endpoint_timeouts_ms gauge
yelpsoaconfig_endpoint_timeouts_ms{path="/consumer_app/devices/braze/info",upstream="push_notifications.main.egress_cluster"} 10000.0
yelpsoaconfig_endpoint_timeouts_ms{path="default",upstream="mysql_read_security.main.egress_cluster"} 100.0
yelpsoaconfig_endpoint_timeouts_ms{path="default",upstream="mysql_snapshot_yelpwifirealtime.main.egress_cluster"} 1000.0

```
Output:
https://fluffy.yelpcorp.com/i/ZXqTVRl84Jvsllmnwv1NsJr8XD9PkhRV.html