### PR TITLE
Send Pod annotations to Tron

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -766,6 +766,12 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
             ),
         }
 
+        # we can hardcode this for now as batches really shouldn't
+        # need routable IPs - we can deal with adding an interface
+        # to actually control annotations once there's a usecase
+        # that requires more dynamicism here
+        result["annotations"] = {"paasta.yelp.com/routable_ip": "false"}
+
         if action_config.get_team() is not None:
             result["labels"]["yelp.com/owner"] = action_config.get_team()
 

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -942,6 +942,7 @@ class TestTronTools:
                 "paasta.yelp.com/service": "my_service",
                 "yelp.com/owner": "some_sensu_team",
             },
+            "annotations": {"paasta.yelp.com/routable_ip": "false",},
             "node_selectors": {"yelp.com/pool": "special_pool"},
             "node_affinities": [
                 {


### PR DESCRIPTION
Currently, we only send a single annotation: the one that toggles
whether or not a Pod gets an internally-routable IP