### PR TITLE
PAASTA-17500: Ensure our async work to fetch events and containers ca…

### DIFF
--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -717,7 +717,6 @@ async def get_pod_status(
     containers_task = asyncio.create_task(
         get_pod_containers(pod, client, num_tail_lines)
     )
-    await asyncio.gather(events_task, containers_task)
 
     reason = pod.status.reason
     message = pod.status.message
@@ -730,6 +729,7 @@ async def get_pod_status(
     )
 
     try:
+        await asyncio.gather(events_task, containers_task)
         # Filter events to only last 15m
         pod_event_messages = events_task.result()
     except asyncio.TimeoutError:


### PR DESCRIPTION
…tches timeouts

In #3218 there was a change to `get_pod_status` where the `await`ed task to fetch events for a pod was moved outside of this try/except block that meant to catch API timeouts, which can occur if the k8s api is generally slow or there are a lot of events for a particular pod/service.

This moves the `asyncio.gather` call to this try/except so we can return data from this endpoint, rather than throw a `500 Internal Server Error` when we hit this problem.