### PR TITLE
PAASTA-17482 Getting per instance streams for clusterman

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -857,7 +857,10 @@ class ScribeLogReader(LogReader):
             if stream_info.per_cluster:
                 stream_name = stream_info.stream_name_fn(service, cluster)
             else:
-                stream_name = stream_info.stream_name_fn(service)
+                if service == "clusterman":
+                    stream_name = stream_info.stream_name_fn(service, instances)
+                else:
+                    stream_name = stream_info.stream_name_fn(service, None)
 
             ctx = self.scribe_get_from_time(
                 scribe_env, stream_name, start_time, end_time

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -605,16 +605,16 @@ class ScribeLogReader(LogReader):
         ),
         "stdout": ScribeComponentStreamInfo(
             per_cluster=False,
-            stream_name_fn=lambda service: get_log_name_for_service(
-                service, prefix="app_output"
+            stream_name_fn=lambda service, instance: get_log_name_for_service(
+                service, prefix="app_output", instance=instance
             ),
             filter_fn=paasta_app_output_passes_filter,
             parse_fn=None,
         ),
         "stderr": ScribeComponentStreamInfo(
             per_cluster=False,
-            stream_name_fn=lambda service: get_log_name_for_service(
-                service, prefix="app_output"
+            stream_name_fn=lambda service, instance: get_log_name_for_service(
+                service, prefix="app_output", instance=instance
             ),
             filter_fn=paasta_app_output_passes_filter,
             parse_fn=None,
@@ -915,7 +915,10 @@ class ScribeLogReader(LogReader):
             if stream_info.per_cluster:
                 stream_name = stream_info.stream_name_fn(service, cluster)
             else:
-                stream_name = stream_info.stream_name_fn(service)
+                if service == "clusterman":
+                    stream_name = stream_info.stream_name_fn(service, instances)
+                else:
+                    stream_name = stream_info.stream_name_fn(service, None)
 
             ctx = self.scribe_get_last_n_lines(scribe_env, stream_name, line_count)
             self.filter_and_aggregate_scribe_logs(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1487,8 +1487,15 @@ def format_audit_log_line(
     return message
 
 
-def get_log_name_for_service(service: str, prefix: str = None) -> str:
+def get_log_name_for_service(
+    service: str, prefix: str = None, instance: str = None
+) -> str:
     if prefix:
+        if instance:
+            if type(instance) == list:
+                return f"stream_paasta_{prefix}_{service}_{instance[0]}"
+            else:
+                return f"stream_paasta_{prefix}_{service}_{instance}"
         return f"stream_paasta_{prefix}_{service}"
     return "stream_paasta_%s" % service
 


### PR DESCRIPTION
## Problem or Feature
Currently, paasta logs are aggregated by service, which makes filtering expensive, especially considering the fact that the most common filtering we do is per-instance.

## Solution
One huge step to improving paasta logs performance is to collect logs per instance into its own streams. This PR will release a prototype of paasta that reads per instance streams for the clusterman service

