### PR TITLE
PAASTA-17500: Handle more timeouts in new kubernetes status

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2349,7 +2349,7 @@ async def controller_revisions_for_service_instance(
     return response.items
 
 
-@async_timeout()
+@async_timeout(15)
 async def pods_for_service_instance(
     service: str, instance: str, kube_client: KubeClient, namespace: str = "paasta"
 ) -> Sequence[V1Pod]:


### PR DESCRIPTION
This change uses asyncio.gather(return_exceptions=True) so we can leave existing try/except logic where they are when handling individual task results, rather than having to add it when we gather the tasks.

In addition, this catches the somewhat new exception where we are running into a timeout when fetching pods.  As the majority of the status won't be useful if we can't fetch pods, this also adds an error message useful for the user when we hit this problem.

In addition, because we use `pods_for_service_instance` only in status and `force_delete_pods`, where we typically _need_ the full results, I've bumped the timeout from the default 10s to 15s to reduce how many people hit this, while we investigate api slowness.

Finally this standardizes how we're patching some of our kubernetes_tools utilities in tests for `paasta_tools.instance.kubernetes`.

Verified this still runs successfully when not hitting timeouts, and validated the error behavior when setting timeout artificially low: https://fluffy.yelpcorp.com/i/TdhrrFbQm6PDT1HXxkfk4bzhdMm18c6W.html