### PR TITLE
[COREML-2694] bump service_configuration_lib to 2.7.0

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -50,7 +50,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.6.0
+service-configuration-lib >= 2.7.0
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.6.0
+service-configuration-lib==2.7.0
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0


### PR DESCRIPTION
Simply make paasta use the new service_configuration_lib change (https://github.com/Yelp/service_configuration_lib/pull/71).