### PR TITLE
Require explicit specification of cluster, service, and instance to r…

### DIFF
--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -318,5 +318,16 @@ def paasta_start(args):
     return paasta_start_or_stop(args, "start")
 
 
+PAASTA_STOP_UNDERSPECIFIED_ARGS_MESSAGE = PaastaColors.red(
+    "paasta stop requires explicit specification of cluster, service, and instance."
+)
+
+
 def paasta_stop(args):
+    if not args.clusters:
+        print(PAASTA_STOP_UNDERSPECIFIED_ARGS_MESSAGE)
+        return 1
+    elif not args.service_instance and not (args.service and args.instances):
+        print(PAASTA_STOP_UNDERSPECIFIED_ARGS_MESSAGE)
+        return 1
     return paasta_start_or_stop(args, "stop")


### PR DESCRIPTION
…un `paasta stop`

This caused an incident when a user did not specify a cluster or instance when paasta stoping a service.

See PAASTA-17411

---

Note that the said to do this for all of start, stop, and restart, but I can find places where people are using things like deploy groups in start/restart commands in tron jobs, so I figured I'd let that be -- seems not especially problematic to start/restart more than you meant to, anyway.  Open to argument there, though.