### PR TITLE
Require that users have push permissions to start/stop/restart instances

### DIFF
--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from humanize import naturaltime
 
-from paasta_tools.cli.cmds.mark_for_deployment import deploy_authz_check
+from paasta_tools.cli.cmds.mark_for_deployment import can_user_deploy_service
 from paasta_tools.cli.cmds.mark_for_deployment import get_deploy_info
 from paasta_tools.cli.cmds.mark_for_deployment import mark_for_deployment
 from paasta_tools.cli.utils import extract_tags
@@ -164,7 +164,8 @@ def paasta_rollback(args):
     service = figure_out_service_name(args, soa_dir)
 
     deploy_info = get_deploy_info(service=service, soa_dir=args.soa_dir)
-    deploy_authz_check(deploy_info, service)
+    if not can_user_deploy_service(deploy_info, service):
+        return 1
 
     git_url = get_git_url(service, soa_dir)
     given_deploy_groups = {

--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -24,6 +24,8 @@ import choice
 from paasta_tools import remote_git
 from paasta_tools import utils
 from paasta_tools.api.client import get_paasta_oapi_client
+from paasta_tools.cli.cmds.mark_for_deployment import can_user_deploy_service
+from paasta_tools.cli.cmds.mark_for_deployment import get_deploy_info
 from paasta_tools.cli.cmds.status import add_instance_filter_arguments
 from paasta_tools.cli.cmds.status import apply_args_filters
 from paasta_tools.cli.utils import get_instance_config
@@ -215,6 +217,15 @@ def paasta_start_or_stop(args, desired_state):
             print()
             print("exiting")
             return 1
+
+    if not all(
+        [
+            can_user_deploy_service(get_deploy_info(service, soa_dir), service)
+            for service in affected_services
+        ]
+    ):
+        print(PaastaColors.red("Exiting due to missing deploy permissions"))
+        return 1
 
     invalid_deploy_groups = []
     marathon_message_printed = False

--- a/tests/cli/test_cmds_rollback.py
+++ b/tests/cli/test_cmds_rollback.py
@@ -31,9 +31,9 @@ from paasta_tools.utils import RollbackTypes
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
-@patch("paasta_tools.cli.cmds.rollback.deploy_authz_check", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.can_user_deploy_service", autospec=True)
 def test_paasta_rollback_mark_for_deployment_simple_invocation(
-    mock_deploy_authz_check,
+    mock_can_user_deploy_service,
     mock_get_git_shas_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,
@@ -91,9 +91,9 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
-@patch("paasta_tools.cli.cmds.rollback.deploy_authz_check", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.can_user_deploy_service", autospec=True)
 def test_paasta_rollback_with_force(
-    mock_deploy_authz_check,
+    mock_can_user_deploy_service,
     mock_get_git_shas_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,
@@ -159,9 +159,9 @@ def test_paasta_rollback_with_force(
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
-@patch("paasta_tools.cli.cmds.rollback.deploy_authz_check", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.can_user_deploy_service", autospec=True)
 def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
-    mock_deploy_authz_check,
+    mock_can_user_deploy_service,
     mock_get_git_shas_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,
@@ -231,9 +231,9 @@ def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
 @patch("paasta_tools.cli.cmds.rollback.figure_out_service_name", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
-@patch("paasta_tools.cli.cmds.rollback.deploy_authz_check", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.can_user_deploy_service", autospec=True)
 def test_paasta_rollback_mark_for_deployment_wrong_deploy_group_args(
-    mock_deploy_authz_check,
+    mock_can_user_deploy_service,
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_figure_out_service_name,
@@ -259,9 +259,9 @@ def test_paasta_rollback_mark_for_deployment_wrong_deploy_group_args(
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
-@patch("paasta_tools.cli.cmds.rollback.deploy_authz_check", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.can_user_deploy_service", autospec=True)
 def test_paasta_rollback_git_sha_was_not_marked_before(
-    mock_deploy_authz_check,
+    mock_can_user_deploy_service,
     mock_get_git_shas_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,
@@ -295,9 +295,9 @@ def test_paasta_rollback_git_sha_was_not_marked_before(
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
-@patch("paasta_tools.cli.cmds.rollback.deploy_authz_check", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.can_user_deploy_service", autospec=True)
 def test_paasta_rollback_mark_for_deployment_multiple_deploy_group_args(
-    mock_deploy_authz_check,
+    mock_can_user_deploy_service,
     mock_get_git_shas_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -129,6 +129,9 @@ def test_log_event():
 
 
 @mock.patch(
+    "paasta_tools.cli.cmds.start_stop_restart.can_user_deploy_service", autospec=True
+)
+@mock.patch(
     "paasta_tools.cli.cmds.start_stop_restart.confirm_to_continue", autospec=True
 )
 @mock.patch(
@@ -160,6 +163,7 @@ def test_paasta_start_or_stop(
     mock_issue_state_change_for_service,
     mock_apply_args_filters,
     mock_confirm_to_continue,
+    mock_can_user_deploy_service,
 ):
     args, _ = parse_args(
         [
@@ -238,6 +242,9 @@ def test_paasta_start_or_stop(
 
 
 @mock.patch(
+    "paasta_tools.cli.cmds.start_stop_restart.can_user_deploy_service", autospec=True
+)
+@mock.patch(
     "paasta_tools.cli.cmds.start_stop_restart.confirm_to_continue", autospec=True
 )
 @mock.patch(
@@ -269,6 +276,7 @@ def test_paasta_start_or_stop_with_deploy_group(
     mock_issue_state_change_for_service,
     mock_apply_args_filters,
     mock_confirm_to_continue,
+    mock_can_user_deploy_service,
 ):
     args, _ = parse_args(
         [
@@ -316,6 +324,9 @@ def test_paasta_start_or_stop_with_deploy_group(
 
 
 @mock.patch(
+    "paasta_tools.cli.cmds.start_stop_restart.can_user_deploy_service", autospec=True
+)
+@mock.patch(
     "paasta_tools.cli.cmds.start_stop_restart.confirm_to_continue", autospec=True
 )
 @mock.patch(
@@ -347,6 +358,7 @@ def test_stop_or_start_figures_out_correct_instances(
     mock_issue_state_change_for_service,
     mock_apply_args_filters,
     mock_confirm_to_continue,
+    mock_can_user_deploy_service,
 ):
     args, _ = parse_args(
         [
@@ -417,6 +429,9 @@ def test_stop_or_start_figures_out_correct_instances(
 
 
 @mock.patch(
+    "paasta_tools.cli.cmds.start_stop_restart.can_user_deploy_service", autospec=True
+)
+@mock.patch(
     "paasta_tools.cli.cmds.start_stop_restart.confirm_to_continue", autospec=True
 )
 @mock.patch(
@@ -435,6 +450,7 @@ def test_stop_or_start_handle_ls_remote_failures(
     mock_get_remote_refs,
     mock_apply_args_filters,
     mock_confirm_to_continue,
+    mock_can_user_deploy_service,
     capfd,
 ):
     args, _ = parse_args(
@@ -455,6 +471,9 @@ def test_stop_or_start_handle_ls_remote_failures(
 
 
 @mock.patch(
+    "paasta_tools.cli.cmds.start_stop_restart.can_user_deploy_service", autospec=True
+)
+@mock.patch(
     "paasta_tools.cli.cmds.start_stop_restart.confirm_to_continue", autospec=True
 )
 @mock.patch(
@@ -471,6 +490,7 @@ def test_start_or_stop_bad_refs(
     mock_get_instance_config,
     mock_apply_args_filters,
     mock_confirm_to_continue,
+    mock_can_user_deploy_service,
     capfd,
 ):
     args, _ = parse_args(
@@ -594,3 +614,29 @@ class TestStopErrorsIfUnderspecified:
         self.run_and_assert_with_args(
             ["stop", "-c", "cluster", "-s", "service"], capfd,
         )
+
+
+@mock.patch(
+    "paasta_tools.cli.cmds.start_stop_restart.apply_args_filters", autospec=True
+)
+@mock.patch(
+    "paasta_tools.cli.cmds.start_stop_restart.issue_state_change_for_service",
+    autospec=True,
+)
+@mock.patch(
+    "paasta_tools.cli.cmds.start_stop_restart.can_user_deploy_service", autospec=True
+)
+def test_error_if_no_deploy_permissions(
+    mock_can_user_deploy_service,
+    mock_issue_state_change_for_service,
+    mock_apply_args_filters,
+):
+    args, _ = parse_args(
+        ["start", "-s", "service", "-c", "cluster", "-i", "instance", "-d", "/soa/dir",]
+    )
+    mock_apply_args_filters.return_value = {"cluster": {"service": {"instance": None}}}
+    mock_can_user_deploy_service.return_value = False
+    ret = args.command(args)
+
+    assert ret == 1
+    assert not mock_issue_state_change_for_service.called


### PR DESCRIPTION
This caused an incident several months ago when a user without permissions or understanding of the process accidentally stopped a bunch of instances

See PAASTA-17412