### PR TITLE
Set driver container memory and cpu limits

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -61,7 +61,6 @@ DEFAULT_DRIVER_CORES_BY_SPARK = 1
 DEFAULT_DRIVER_MEMORY_BY_SPARK = "1g"
 # Extra room for memory overhead and for any other running inside container
 DOCKER_RESOURCE_ADJUSTMENT_FACTOR = 2
-DEFAULT_MAX_DOCKER_MEMORY_LIMIT = "64g"
 
 POD_TEMPLATE_DIR = "/nail/tmp"
 POD_TEMPLATE_PATH = "/nail/tmp/spark-pt-{file_uuid}.yaml"
@@ -675,10 +674,9 @@ def _calculate_docker_memory_limit(
     except Exception as e:
         # For any reason it fails, continue with default value
         print(
-            f"Failed to parse docker memory limit. Error: {e}. Example values: 1g, 200m."
-            " Setting a default value {DEFAULT_MAX_DOCKER_MEMORY_LIMIT}"
+            f"ERROR: Failed to parse docker memory limit. Error: {e}. Example values: 1g, 200m."
         )
-        docker_memory_limit = DEFAULT_MAX_DOCKER_MEMORY_LIMIT
+        raise
 
     return docker_memory_limit
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -58,10 +58,10 @@ CLUSTER_MANAGER_K8S = "kubernetes"
 CLUSTER_MANAGERS = {CLUSTER_MANAGER_MESOS, CLUSTER_MANAGER_K8S}
 # Reference: https://spark.apache.org/docs/latest/configuration.html#application-properties
 DEFAULT_DRIVER_CORES_BY_SPARK = 1
-DEFAULT_DRIVER_MEMORY_BY_SPARK = '1g'
+DEFAULT_DRIVER_MEMORY_BY_SPARK = "1g"
 # Extra room for memory overhead and for any other running inside containe
 DOCKER_RESOURCE_ADJUSTMENT_FACTOR = 2
-DEFAULT_MAX_DOCKER_MEMORY_LIMIT='64g'
+DEFAULT_MAX_DOCKER_MEMORY_LIMIT = "64g"
 
 POD_TEMPLATE_DIR = "/nail/tmp"
 POD_TEMPLATE_PATH = "/nail/tmp/spark-pt-{file_uuid}.yaml"
@@ -382,8 +382,19 @@ def should_enable_compact_bin_packing(enable_compact_bin_packing, cluster_manage
     return True
 
 
-def get_docker_run_cmd(container_name, volumes, env, docker_img, docker_cmd, nvidia, docker_memory_limit, docker_cpu_limit):
-    log.info(f"Setting docker memory limits as {docker_memory_limit} and docker cpus limit as {docker_cpu_limit}")
+def get_docker_run_cmd(
+    container_name,
+    volumes,
+    env,
+    docker_img,
+    docker_cmd,
+    nvidia,
+    docker_memory_limit,
+    docker_cpu_limit,
+):
+    log.info(
+        f"Setting docker memory and cpu limits as {docker_memory_limit}, {docker_cpu_limit} respectively"
+    )
     cmd = ["paasta_docker_wrapper", "run"]
     cmd.append(f"--memory={docker_memory_limit}")
     cmd.append(f"--cpus={docker_cpu_limit}")
@@ -566,7 +577,15 @@ def create_spark_config_str(spark_config_dict, is_mrjob):
 
 
 def run_docker_container(
-    container_name, volumes, environment, docker_img, docker_cmd, dry_run, nvidia, docker_memory_limit, docker_cpu_limit,
+    container_name,
+    volumes,
+    environment,
+    docker_img,
+    docker_cmd,
+    dry_run,
+    nvidia,
+    docker_memory_limit,
+    docker_cpu_limit,
 ) -> int:
 
     docker_run_args = dict(
@@ -617,6 +636,30 @@ def get_spark_app_name(original_docker_cmd: Union[Any, str, List[str]]) -> str:
     return spark_app_name
 
 
+def _calculate_docker_memory_cpu_limit(spark_conf):
+    try:
+
+        docker_memory_limit_str = spark_conf.get(
+            "spark.driver.memory", DEFAULT_DRIVER_MEMORY_BY_SPARK
+        )
+        match = re.match(r"([0-9]+)([a-z]*)", docker_memory_limit_str)
+        memory_val = int(match[1]) * DOCKER_RESOURCE_ADJUSTMENT_FACTOR
+        memory_unit = match[2]
+        docker_memory_limit = f"{memory_val}{memory_unit}"
+    except Exception as e:
+        # For any reason it fails, continue with default value
+        log.error(
+            f"Failed to parse docker memory limit. Error: {e}. Example values: 1g, 200m."
+            " Setting a default value {DEFAULT_MAX_DOCKER_MEMORY_LIMIT}"
+        )
+        docker_memory_limit = DEFAULT_MAX_DOCKER_MEMORY_LIMIT
+
+    docker_cpu_limit = str(
+        int(spark_conf.get("spark.driver.cores", DEFAULT_DRIVER_CORES_BY_SPARK))
+    )
+    return docker_memory_limit, docker_cpu_limit
+
+
 def configure_and_run_docker_container(
     args: argparse.Namespace,
     docker_img: str,
@@ -632,21 +675,24 @@ def configure_and_run_docker_container(
     volumes: List[str] = []
     try:
 
-        docker_memory_limit_str = spark_conf.get("spark.driver.memory", DEFAULT_DRIVER_MEMORY_BY_SPARK)
+        docker_memory_limit_str = spark_conf.get(
+            "spark.driver.memory", DEFAULT_DRIVER_MEMORY_BY_SPARK
+        )
         match = re.match(r"([0-9]+)([a-z]*)", docker_memory_limit_str)
         memory_val = int(match[1]) * DOCKER_RESOURCE_ADJUSTMENT_FACTOR
         memory_unit = match[2]
-        docker_memory_limit =  f"{memory_val}{memory_unit}"
+        docker_memory_limit = f"{memory_val}{memory_unit}"
     except Exception as e:
         # This case shouldn't arise, but if for any reason it fails, we continue with default value
         log.error(
-            f"Failed to parse docker memory limit. Error: {e}. Example values: 1g, 200m." \
+            f"Failed to parse docker memory limit. Error: {e}. Example values: 1g, 200m."
             " Setting a default value {DEFAULT_MAX_DOCKER_MEMORY_LIMIT}"
         )
         docker_memory_limit = DEFAULT_MAX_DOCKER_MEMORY_LIMIT
 
-    docker_cpu_limit = str(int(spark_conf.get("spark.driver.cores", DEFAULT_DRIVER_CORES_BY_SPARK)) * \
-        DOCKER_RESOURCE_ADJUSTMENT_FACTOR
+    docker_cpu_limit = str(
+        int(spark_conf.get("spark.driver.cores", DEFAULT_DRIVER_CORES_BY_SPARK))
+        * DOCKER_RESOURCE_ADJUSTMENT_FACTOR
     )
 
     if cluster_manager == CLUSTER_MANAGER_MESOS:
@@ -928,10 +974,12 @@ def paasta_spark_run(args):
     )
 
     # Get driver-memory and cores
-    sub_cmds = args.cmd.split(' ') # spark.driver.memory=10g
+    sub_cmds = args.cmd.split(" ")  # spark.driver.memory=10g
     for cmd in sub_cmds:
-        if cmd.startswith('spark.driver.memory') or cmd.startswith('spark.driver.cores'):
-            key, value = cmd.split('=')
+        if cmd.startswith("spark.driver.memory") or cmd.startswith(
+            "spark.driver.cores"
+        ):
+            key, value = cmd.split("=")
             user_spark_opts[key] = value
 
     paasta_instance = get_smart_paasta_instance_name(args)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -409,7 +409,7 @@ def get_docker_run_cmd(
     docker_cpu_limit,
 ):
     print(
-        f"Setting docker memory and cpu limits as {docker_memory_limit}, {docker_cpu_limit} cores respectively."
+        f"Setting docker memory and cpu limits as {docker_memory_limit}, {docker_cpu_limit} core(s) respectively."
     )
     cmd = ["paasta_docker_wrapper", "run"]
     cmd.append(f"--memory={docker_memory_limit}")

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -154,12 +154,14 @@ def add_subparser(subparsers):
         help=(
             "Set docker memory limit. Should be greater than driver memory. Defaults to 2x driver memory. Example: 2g, 500m, Max: 64g"
         ),
+        default=False,
     )
     list_parser.add_argument(
         "--docker-cpu-limit",
         help=(
             "Set docker cpus limit. Should be greater than driver cores. Defaults to 1x driver cores."
         ),
+        default=False,
     )
     list_parser.add_argument(
         "--docker-registry",
@@ -651,6 +653,11 @@ def get_spark_app_name(original_docker_cmd: Union[Any, str, List[str]]) -> str:
 def _calculate_docker_memory_limit(
     spark_conf: Mapping[str, str], memory_limit: str
 ) -> str:
+    """ In Order of preference:
+    1. Argument: --docker-memory-limit
+    2. --spark-args or spark-submit: spark.driver.memory
+    3. Default
+    """
     try:
         if memory_limit:
             docker_memory_limit_str = memory_limit
@@ -676,6 +683,11 @@ def _calculate_docker_memory_limit(
 
 
 def _calculate_docker_cpu_limit(spark_conf: Mapping[str, str], cpu_limit: str) -> str:
+    """ In Order of preference:
+    1. Argument: --docker-cpu-limit
+    2. --spark-args or spark-submit: spark.driver.cores
+    3. Default
+    """
     if cpu_limit:
         docker_cpu_limit = cpu_limit
     else:

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -59,7 +59,7 @@ CLUSTER_MANAGERS = {CLUSTER_MANAGER_MESOS, CLUSTER_MANAGER_K8S}
 # Reference: https://spark.apache.org/docs/latest/configuration.html#application-properties
 DEFAULT_DRIVER_CORES_BY_SPARK = 1
 DEFAULT_DRIVER_MEMORY_BY_SPARK = "1g"
-# Extra room for memory overhead and for any other running inside containe
+# Extra room for memory overhead and for any other running inside container
 DOCKER_RESOURCE_ADJUSTMENT_FACTOR = 2
 DEFAULT_MAX_DOCKER_MEMORY_LIMIT = "64g"
 
@@ -691,13 +691,11 @@ def _calculate_docker_cpu_limit(
     2. --spark-args or spark-submit: spark.driver.cores
     3. Default
     """
-    if cpu_limit:
-        docker_cpu_limit = cpu_limit
-    else:
-        docker_cpu_limit = str(
-            int(spark_conf.get("spark.driver.cores", DEFAULT_DRIVER_CORES_BY_SPARK))
-        )
-    return docker_cpu_limit
+    return (
+        cpu_limit
+        if cpu_limit
+        else spark_conf.get("spark.driver.cores", str(DEFAULT_DRIVER_CORES_BY_SPARK))
+    )
 
 
 def configure_and_run_docker_container(

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -155,7 +155,7 @@ def add_subparser(subparsers):
             "Set docker memory limit. Should be greater than driver memory. Defaults to 2x spark.driver.memory. Example: 2g, 500m, Max: 64g"
             "Note: If memory limit provided is greater than associated with the batch instance, it will default to max memory of the box."
         ),
-        default=False,
+        default=None,
     )
     list_parser.add_argument(
         "--docker-cpu-limit",
@@ -163,7 +163,7 @@ def add_subparser(subparsers):
             "Set docker cpus limit. Should be greater than driver cores. Defaults to 1x spark.driver.cores."
             "Note: The job will fail if the limit provided is greater than number of cores present on batch box (8 for production batch boxes)."
         ),
-        default=False,
+        default=None,
     )
     list_parser.add_argument(
         "--docker-registry",
@@ -653,7 +653,7 @@ def get_spark_app_name(original_docker_cmd: Union[Any, str, List[str]]) -> str:
 
 
 def _calculate_docker_memory_limit(
-    spark_conf: Mapping[str, str], memory_limit: str
+    spark_conf: Mapping[str, str], memory_limit: Optional[str]
 ) -> str:
     """ In Order of preference:
     1. Argument: --docker-memory-limit
@@ -683,7 +683,9 @@ def _calculate_docker_memory_limit(
     return docker_memory_limit
 
 
-def _calculate_docker_cpu_limit(spark_conf: Mapping[str, str], cpu_limit: str) -> str:
+def _calculate_docker_cpu_limit(
+    spark_conf: Mapping[str, str], cpu_limit: Optional[str]
+) -> str:
     """ In Order of preference:
     1. Argument: --docker-cpu-limit
     2. --spark-args or spark-submit: spark.driver.cores

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -476,6 +476,8 @@ class TestConfigureAndRunDockerContainer:
         args.nvidia = False
         args.enable_compact_bin_packing = False
         args.cluster_manager = cluster_manager
+        args.docker_cpu_limit = False
+        args.docker_memory_limit = False
         with mock.patch.object(
             self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
         ):
@@ -539,7 +541,7 @@ class TestConfigureAndRunDockerContainer:
             ),
         ],
     )
-    def test_configure_and_run_docker_container_driver_memory(
+    def test_configure_and_run_docker_driver_resource_limits_config(
         self,
         mock_get_history_url,
         mock_et_signalfx_url,
@@ -573,6 +575,107 @@ class TestConfigureAndRunDockerContainer:
         args.nvidia = False
         args.enable_compact_bin_packing = False
         args.cluster_manager = cluster_manager
+        args.docker_cpu_limit = 3
+        args.docker_memory_limit = "4g"
+        with mock.patch.object(
+            self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
+        ):
+            retcode = configure_and_run_docker_container(
+                args=args,
+                docker_img="fake-registry/fake-service",
+                instance_config=self.instance_config,
+                system_paasta_config=self.system_paasta_config,
+                aws_creds=("id", "secret", "token"),
+                spark_conf=spark_conf,
+                cluster_manager=cluster_manager,
+                pod_template_path="unique-run",
+            )
+        assert retcode == 0
+        mock_run_docker_container.assert_called_once_with(
+            container_name="fake_app",
+            volumes=(
+                expected_volumes
+                + ["/fake_dir:/spark_driver:rw", "/nail/home:/nail/home:rw"]
+            ),
+            environment={
+                "env1": "val1",
+                "AWS_ACCESS_KEY_ID": "id",
+                "AWS_SECRET_ACCESS_KEY": "secret",
+                "AWS_SESSION_TOKEN": "token",
+                "AWS_DEFAULT_REGION": "fake_region",
+                "SPARK_OPTS": mock_create_spark_config_str.return_value,
+                "SPARK_USER": "root",
+                "PAASTA_INSTANCE_TYPE": "spark",
+                "PAASTA_LAUNCHED_BY": mock.ANY,
+            },
+            docker_img="fake-registry/fake-service",
+            docker_cmd=mock_get_docker_cmd.return_value,
+            dry_run=True,
+            nvidia=False,
+            docker_memory_limit="4g",
+            docker_cpu_limit=3,
+        )
+
+    @pytest.mark.parametrize(
+        ["cluster_manager", "spark_args_volumes", "expected_volumes"],
+        [
+            (
+                spark_run.CLUSTER_MANAGER_MESOS,
+                {
+                    "spark.mesos.executor.docker.volumes": "/mesos/volume:/mesos/volume:rw"
+                },
+                ["/mesos/volume:/mesos/volume:rw"],
+            ),
+            (
+                spark_run.CLUSTER_MANAGER_K8S,
+                {
+                    "spark.kubernetes.executor.volumes.hostPath.0.mount.readOnly": "true",
+                    "spark.kubernetes.executor.volumes.hostPath.0.mount.path": "/k8s/volume0",
+                    "spark.kubernetes.executor.volumes.hostPath.0.options.path": "/k8s/volume0",
+                    "spark.kubernetes.executor.volumes.hostPath.1.mount.readOnly": "false",
+                    "spark.kubernetes.executor.volumes.hostPath.1.mount.path": "/k8s/volume1",
+                    "spark.kubernetes.executor.volumes.hostPath.1.options.path": "/k8s/volume1",
+                },
+                ["/k8s/volume0:/k8s/volume0:ro", "/k8s/volume1:/k8s/volume1:rw"],
+            ),
+        ],
+    )
+    def test_configure_and_run_docker_driver_resource_limits(
+        self,
+        mock_get_history_url,
+        mock_et_signalfx_url,
+        mock_get_docker_cmd,
+        mock_create_spark_config_str,
+        mock_get_webui_url,
+        mock_send_and_calculate_resources_cost,
+        mock_run_docker_container,
+        mock_get_username,
+        cluster_manager,
+        spark_args_volumes,
+        expected_volumes,
+    ):
+        mock_get_username.return_value = "fake_user"
+        spark_conf = {
+            "spark.app.name": "fake_app",
+            "spark.ui.port": "1234",
+            "spark.driver.memory": "1g",
+            "spark.driver.cores": "2",
+            **spark_args_volumes,
+        }
+        mock_run_docker_container.return_value = 0
+
+        args = mock.MagicMock()
+        args.aws_region = "fake_region"
+        args.cluster = "fake_cluster"
+        args.cmd = "pyspark"
+        args.work_dir = "/fake_dir:/spark_driver"
+        args.dry_run = True
+        args.mrjob = False
+        args.nvidia = False
+        args.enable_compact_bin_packing = False
+        args.cluster_manager = cluster_manager
+        args.docker_cpu_limit = False
+        args.docker_memory_limit = False
         with mock.patch.object(
             self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
         ):

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -21,6 +21,8 @@ from paasta_tools.cli.cmds import spark_run
 from paasta_tools.cli.cmds.spark_run import CLUSTER_MANAGER_K8S
 from paasta_tools.cli.cmds.spark_run import CLUSTER_MANAGER_MESOS
 from paasta_tools.cli.cmds.spark_run import configure_and_run_docker_container
+from paasta_tools.cli.cmds.spark_run import DEFAULT_DRIVER_CORES_BY_SPARK
+from paasta_tools.cli.cmds.spark_run import DEFAULT_DRIVER_MEMORY_BY_SPARK
 from paasta_tools.cli.cmds.spark_run import get_docker_run_cmd
 from paasta_tools.cli.cmds.spark_run import get_smart_paasta_instance_name
 from paasta_tools.cli.cmds.spark_run import get_spark_app_name
@@ -42,12 +44,21 @@ def test_get_docker_run_cmd(mock_getegid, mock_geteuid):
     docker_img = "fake-registry/fake-service"
     docker_cmd = "pyspark"
     nvidia = False
+    docker_memory_limit = "2g"
+    docker_cpu_limit = "2"
 
     actual = get_docker_run_cmd(
-        container_name, volumes, env, docker_img, docker_cmd, nvidia
+        container_name,
+        volumes,
+        env,
+        docker_img,
+        docker_cmd,
+        nvidia,
+        docker_memory_limit,
+        docker_cpu_limit,
     )
 
-    assert actual[5:] == [
+    assert actual[7:] == [
         "--user=1234:100",
         "--name=fake_name",
         "--env",
@@ -349,6 +360,8 @@ def test_run_docker_container(
         docker_cmd=docker_cmd,
         dry_run=dry_run,
         nvidia=nvidia,
+        docker_memory_limit=DEFAULT_DRIVER_MEMORY_BY_SPARK,
+        docker_cpu_limit=DEFAULT_DRIVER_CORES_BY_SPARK,
     )
     mock_get_docker_run_cmd.assert_called_once_with(
         container_name=container_name,
@@ -357,6 +370,8 @@ def test_run_docker_container(
         docker_img=docker_img,
         docker_cmd=docker_cmd,
         nvidia=nvidia,
+        docker_memory_limit=DEFAULT_DRIVER_MEMORY_BY_SPARK,
+        docker_cpu_limit=DEFAULT_DRIVER_CORES_BY_SPARK,
     )
 
     if dry_run:
@@ -496,6 +511,105 @@ class TestConfigureAndRunDockerContainer:
             docker_cmd=mock_get_docker_cmd.return_value,
             dry_run=True,
             nvidia=False,
+            docker_memory_limit="2g",
+            docker_cpu_limit="1",
+        )
+
+    @pytest.mark.parametrize(
+        ["cluster_manager", "spark_args_volumes", "expected_volumes"],
+        [
+            (
+                spark_run.CLUSTER_MANAGER_MESOS,
+                {
+                    "spark.mesos.executor.docker.volumes": "/mesos/volume:/mesos/volume:rw"
+                },
+                ["/mesos/volume:/mesos/volume:rw"],
+            ),
+            (
+                spark_run.CLUSTER_MANAGER_K8S,
+                {
+                    "spark.kubernetes.executor.volumes.hostPath.0.mount.readOnly": "true",
+                    "spark.kubernetes.executor.volumes.hostPath.0.mount.path": "/k8s/volume0",
+                    "spark.kubernetes.executor.volumes.hostPath.0.options.path": "/k8s/volume0",
+                    "spark.kubernetes.executor.volumes.hostPath.1.mount.readOnly": "false",
+                    "spark.kubernetes.executor.volumes.hostPath.1.mount.path": "/k8s/volume1",
+                    "spark.kubernetes.executor.volumes.hostPath.1.options.path": "/k8s/volume1",
+                },
+                ["/k8s/volume0:/k8s/volume0:ro", "/k8s/volume1:/k8s/volume1:rw"],
+            ),
+        ],
+    )
+    def test_configure_and_run_docker_container_driver_memory(
+        self,
+        mock_get_history_url,
+        mock_et_signalfx_url,
+        mock_get_docker_cmd,
+        mock_create_spark_config_str,
+        mock_get_webui_url,
+        mock_send_and_calculate_resources_cost,
+        mock_run_docker_container,
+        mock_get_username,
+        cluster_manager,
+        spark_args_volumes,
+        expected_volumes,
+    ):
+        mock_get_username.return_value = "fake_user"
+        spark_conf = {
+            "spark.app.name": "fake_app",
+            "spark.ui.port": "1234",
+            "spark.driver.memory": "1g",
+            "spark.driver.cores": "2",
+            **spark_args_volumes,
+        }
+        mock_run_docker_container.return_value = 0
+
+        args = mock.MagicMock()
+        args.aws_region = "fake_region"
+        args.cluster = "fake_cluster"
+        args.cmd = "pyspark"
+        args.work_dir = "/fake_dir:/spark_driver"
+        args.dry_run = True
+        args.mrjob = False
+        args.nvidia = False
+        args.enable_compact_bin_packing = False
+        args.cluster_manager = cluster_manager
+        with mock.patch.object(
+            self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
+        ):
+            retcode = configure_and_run_docker_container(
+                args=args,
+                docker_img="fake-registry/fake-service",
+                instance_config=self.instance_config,
+                system_paasta_config=self.system_paasta_config,
+                aws_creds=("id", "secret", "token"),
+                spark_conf=spark_conf,
+                cluster_manager=cluster_manager,
+                pod_template_path="unique-run",
+            )
+        assert retcode == 0
+        mock_run_docker_container.assert_called_once_with(
+            container_name="fake_app",
+            volumes=(
+                expected_volumes
+                + ["/fake_dir:/spark_driver:rw", "/nail/home:/nail/home:rw"]
+            ),
+            environment={
+                "env1": "val1",
+                "AWS_ACCESS_KEY_ID": "id",
+                "AWS_SECRET_ACCESS_KEY": "secret",
+                "AWS_SESSION_TOKEN": "token",
+                "AWS_DEFAULT_REGION": "fake_region",
+                "SPARK_OPTS": mock_create_spark_config_str.return_value,
+                "SPARK_USER": "root",
+                "PAASTA_INSTANCE_TYPE": "spark",
+                "PAASTA_LAUNCHED_BY": mock.ANY,
+            },
+            docker_img="fake-registry/fake-service",
+            docker_cmd=mock_get_docker_cmd.return_value,
+            dry_run=True,
+            nvidia=False,
+            docker_memory_limit="2g",
+            docker_cpu_limit="2",
         )
 
     def test_configure_and_run_docker_container_nvidia(


### PR DESCRIPTION
Setting the docker container memory limit to 2x of the spark driver limit.
Cpu limit I am currently setting the same as the spark.driver.cores.
If needs to be higher kindly let me know.
I have added the manual test results in the ticket COREML-2743
I will test one of the heavy batches in production once the code is reviewed.