### PR TITLE
SEC-14954: Bump hacheck itest container to use recent ubuntu, python,…

### DIFF
--- a/yelp_package/dockerfiles/itest/hacheck/Dockerfile
+++ b/yelp_package/dockerfiles/itest/hacheck/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:xenial
+FROM ${DOCKER_REGISTRY}ubuntu:bionic
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
@@ -23,7 +23,7 @@ RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sou
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
         git \
-        python2.7-dev \
+        python3.7-dev \
         libyaml-dev \
         virtualenv > /dev/null && \
     apt-get clean
@@ -31,7 +31,10 @@ RUN apt-get update > /dev/null && \
 RUN git clone git://github.com/Yelp/hacheck
 WORKDIR /hacheck
 
-RUN virtualenv --python=python2.7 venv && venv/bin/pip install -r requirements.txt && venv/bin/pip install -e .
+RUN virtualenv --python=python3.7 venv && \
+    venv/bin/pip install setuptools==53.0.0 && \
+    venv/bin/pip install -r requirements.txt && \
+    venv/bin/pip install -e .
 
 RUN echo 'allow_remote_spool_changes: yes' > /etc/hacheck.yaml
 


### PR DESCRIPTION
… and setuptools versions

Our hacheck container used for itests was using xenial, python2.7, and an older version of setuptools within virtualenv. 

This bumps up the versions to ensure internal builds continue to work after SEC-14946.

paasta_itests still complete successfully.