### PR TITLE
Add units (minutes) to autoscaler pause output

### DIFF
--- a/paasta_tools/autoscaling/pause_service_autoscaler.py
+++ b/paasta_tools/autoscaling/pause_service_autoscaler.py
@@ -57,7 +57,7 @@ def update_service_autoscale_pause_time(cluster, mins):
         print("Could not connect to zookeeper server")
         return 2
 
-    print(f"Service autoscaler is paused for {mins}")
+    print(f"Service autoscaler is paused for {mins} minutes")
     return 0
 
 


### PR DESCRIPTION
We've run into confusion with this a couple times, first with the region failover exercise on 2021-11-18, and again today. This seems like a simple change to do to make it just a bit clearer.