### PR TITLE
Stop using unauthenticated git protocol for behave

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -131,7 +131,7 @@ whitelist_externals =
 commands =
     mkdir -p /nail/etc
     # TODO: upgrade behave if they ever take this reasonable PR
-    pip install git+git://github.com/Yelp/behave@1.2.5-issue_533-fork
+    pip install git+https://github.com/Yelp/behave@1.2.5-issue_533-fork
     behave {posargs}
 
 [testenv:general_itests]
@@ -145,7 +145,7 @@ deps =
     behave==1.2.5
 commands =
     # TODO: upgrade behave if they ever take this reasonable PR
-    pip install git+git://github.com/Yelp/behave@1.2.5-issue_533-fork
+    pip install git+https://github.com/Yelp/behave@1.2.5-issue_533-fork
     pre-commit install -f --install-hooks
     pre-commit run --all-files
     pylint -E paasta_tools/mesos/ --ignore master.py,task.py

--- a/yelp_package/dockerfiles/itest/hacheck/Dockerfile
+++ b/yelp_package/dockerfiles/itest/hacheck/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update > /dev/null && \
         virtualenv > /dev/null && \
     apt-get clean
 
-RUN git clone git://github.com/Yelp/hacheck
+RUN git clone https://github.com/Yelp/hacheck
 WORKDIR /hacheck
 
 RUN virtualenv --python=python3.7 venv && \


### PR DESCRIPTION
Github is currently browning out access to unauth'd git and will be
fully disabling it in the coming months.