### PR TITLE
Drop xenial GHA builds + use internal source as much as possible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dist: [xenial, bionic]
+        dist: [bionic]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,14 @@
 ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
 	export PIP_INDEX_URL ?= https://pypi.yelpcorp.com/simple
 	export DOCKER_REGISTRY ?= docker-dev.yelpcorp.com/
+	export XENIAL_IMAGE_NAME ?= xenial_pkgbuild
+	export BIONIC_IMAGE_NAME ?= bionic_pkgbuild
 	PAASTA_ENV ?= YELP
 else
 	export PIP_INDEX_URL ?= https://pypi.python.org/simple
 	export DOCKER_REGISTRY ?= ""
+	export XENIAL_IMAGE_NAME ?= ubuntu:xenial
+	export BIONIC_IMAGE_NAME ?= ubuntu:bionic
 	PAASTA_ENV ?= $(shell hostname -f)
 endif
 

--- a/example_cluster/docker-compose.override.yml
+++ b/example_cluster/docker-compose.override.yml
@@ -49,8 +49,8 @@ services:
   marathon2:
     ports:
       - 8080
-  itest_xenial:
-    build: ../yelp_package/dockerfiles/xenial/
+  itest_bionic:
+    build: ../yelp_package/dockerfiles/bionic/
   playground:
     build:
       context: ../
@@ -66,7 +66,7 @@ services:
     command: '/start.sh'
     depends_on:
       - mesosmaster
-      - itest_xenial
+      - itest_bionic
       - registry
       - git
       - mesosslave

--- a/general_itests/fake_simple_service/Dockerfile
+++ b/general_itests/fake_simple_service/Dockerfile
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:xenial
+ARG IMAGE_NAME=bionic_pkgbuild
+FROM ${DOCKER_REGISTRY}${IMAGE_NAME}
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=${PIP_INDEX_URL}

--- a/general_itests/fake_simple_service/Makefile
+++ b/general_itests/fake_simple_service/Makefile
@@ -17,12 +17,18 @@ DOCKER_TAG ?= fake_simple_service-$(USER)-dev
 ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
 	DOCKER_REGISTRY ?= docker-dev.yelpcorp.com/
 	PIP_INDEX_URL ?= https://pypi.yelpcorp.com/simple
+	export XENIAL_IMAGE_NAME ?= xenial_pkgbuild
+	export BIONIC_IMAGE_NAME ?= bionic_pkgbuild
+	PAASTA_ENV ?= YELP
 else
 	DOCKER_REGISTRY ?= ""
 	PIP_INDEX_URL ?= https://pypi.python.org/simple
+	export XENIAL_IMAGE_NAME ?= ubuntu:xenial
+	export BIONIC_IMAGE_NAME ?= ubuntu:bionic
+	PAASTA_ENV ?= $(shell hostname -f)
 endif
 
 .PHONY: cook-image
 
 cook-image:
-	docker build --build-arg PIP_INDEX_URL=$(PIP_INDEX_URL) --build-arg DOCKER_REGISTRY=$(DOCKER_REGISTRY) -t $(DOCKER_TAG) .
+	docker build --build-arg PIP_INDEX_URL=$(PIP_INDEX_URL) --build-arg DOCKER_REGISTRY=$(DOCKER_REGISTRY) --build-arg IMAGE_NAME=${BIONIC_IMAGE_NAME} -t $(DOCKER_TAG) .

--- a/paasta_itests/docker-compose.yml
+++ b/paasta_itests/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - zookeeper
 
   paastatools:
-    build: ../yelp_package/dockerfiles/xenial/
+    build: ../yelp_package/dockerfiles/bionic/
     environment:
       MARATHON_PORT: 'http://marathon:8080'
       MARATHON1_PORT: 'http://marathon1:8080'

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ deps =
     cryptography=={[tox]cryptography_version}
 commands =
     docker-compose down
-    docker-compose --verbose build --build-arg DOCKER_REGISTRY={env:DOCKER_REGISTRY:docker-dev.yelpcorp.com/} --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
+    docker-compose --verbose build --build-arg DOCKER_REGISTRY={env:DOCKER_REGISTRY:docker-dev.yelpcorp.com/} --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple} --build-arg IMAGE_NAME={env:XENIAL_IMAGE_NAME:ubuntu:xenial} --build-arg PAASTA_ENV={env:PAASTA_ENV:external}
     # Fire up the marathon cluster in background
     docker-compose up -d mesosmaster mesosslave marathon marathon1 marathon2 hacheck httpdrain mesosslave2 mesosslave3 mesosslave4 mesosslave5
     docker-compose scale mesosslave=3
@@ -79,10 +79,10 @@ passenv =
 changedir=k8s_itests/
 commands =
     # Build /etc/paasta used by docker-compose
-	{toxinidir}/k8s_itests/scripts/setup.sh
+    {toxinidir}/k8s_itests/scripts/setup.sh
     # Run paasta-tools k8s_itests in docker
     docker-compose down
-    docker-compose --verbose build --build-arg DOCKER_REGISTRY={env:DOCKER_REGISTRY:docker-dev.yelpcorp.com/} --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
+    docker-compose --verbose build --build-arg DOCKER_REGISTRY={env:DOCKER_REGISTRY:docker-dev.yelpcorp.com/} --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple} --build-arg IMAGE_NAME={env:BIONIC_IMAGE_NAME:ubuntu:bionic} --build-arg PAASTA_ENV={env:PAASTA_ENV:external}
     docker-compose up \
         --abort-on-container-exit
 
@@ -94,7 +94,7 @@ deps =
     cryptography=={[tox]cryptography_version}
 commands =
     docker-compose down
-    docker-compose --verbose build --build-arg DOCKER_REGISTRY={env:DOCKER_REGISTRY:docker-dev.yelpcorp.com/} --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
+    docker-compose --verbose build --build-arg DOCKER_REGISTRY={env:DOCKER_REGISTRY:docker-dev.yelpcorp.com/} --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple} --build-arg IMAGE_NAME={env:BIONIC_IMAGE_NAME:ubuntu:bionic}  --build-arg PAASTA_ENV={env:PAASTA_ENV:external}
     # Fire up the marathon cluster in background
     # Run the paastatools container in foreground to catch the output
     # the `docker-compose run` vs `docker-compose up` is important here, as docker-compose run will

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -35,13 +35,12 @@ endif
 build_%_docker:
 	[ -d ../dist ] || mkdir ../dist
 	docker pull "yelp/paastatools_$*_container" || true
-	cd dockerfiles/$*/ && docker build --build-arg DOCKER_REGISTRY=$(DOCKER_REGISTRY) \
-        --build-arg PIP_INDEX_URL=$(PIP_INDEX_URL) -t "yelp/paastatools_$*_container" .
-	if [ "$$TRAVIS_BRANCH" = "master" -a \
-	     "$$TRAVIS_PULL_REQUEST" = "false" -a \
-	     "$$DOCKER_USERNAME" != "" ]; then \
-	  docker push "yelp/paastatools_$*_container"; \
-	fi
+	cd dockerfiles/$*/ && docker build \
+		--build-arg DOCKER_REGISTRY=$(DOCKER_REGISTRY) \
+        --build-arg PIP_INDEX_URL=$(PIP_INDEX_URL) \
+        --build-arg PAASTA_ENV=$(PAASTA_ENV) \
+		--build-arg IMAGE_NAME=$($(shell echo '$*' | tr '[:lower:]' '[:upper:]')_IMAGE_NAME) \
+		-t "yelp/paastatools_$*_container" . \
 
 .SECONDEXPANSION:
 itest_%: package_$$*

--- a/yelp_package/dockerfiles/bionic/Dockerfile
+++ b/yelp_package/dockerfiles/bionic/Dockerfile
@@ -13,21 +13,22 @@
 # limitations under the License.
 
 ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:bionic
+ARG IMAGE_NAME=bionic_pkgbuild
+FROM ${DOCKER_REGISTRY}${IMAGE_NAME}
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
 
-RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
+ARG PAASTA_ENV
+ENV PAASTA_ENV=$PAASTA_ENV
+
 RUN rm /etc/dpkg/dpkg.cfg.d/excludes
 RUN apt-get update && apt-get install -yq gnupg2
-# RUN echo "deb http://repos.mesosphere.com/ubuntu bionic main" > /etc/apt/sources.list.d/mesosphere.list && \
-#     apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
 
 # Need Python 3.7
 RUN apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
+    if [ "$PAASTA_ENV" != "YELP" ]; then add-apt-repository ppa:deadsnakes/ppa; else true; fi # only use deadsnakes externally
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -49,10 +50,12 @@ RUN apt-get update > /dev/null && \
 
 RUN python -m pip install --upgrade pip==20.0.2
 RUN pip install virtualenv==16.0.0
-RUN cd /tmp && \
-    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
-    gdebi -n dh-virtualenv*.deb && \
-    rm dh-virtualenv_*.deb
+RUN if [ "$PAASTA_ENV" != "YELP" ]; then cd /tmp && \
+        wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
+        gdebi -n dh-virtualenv*.deb && \
+        rm dh-virtualenv_*.deb; \
+    else \
+        apt-get install dh-virtualenv=1.0-1; fi
 
 ADD mesos-slave-secret /etc/mesos-slave-secret
 

--- a/yelp_package/dockerfiles/focal/mesos-slave-secret
+++ b/yelp_package/dockerfiles/focal/mesos-slave-secret
@@ -1,4 +1,0 @@
-{
-  "principal": "slave",
-  "secret": "secret1"
-}

--- a/yelp_package/dockerfiles/gitremote/Dockerfile
+++ b/yelp_package/dockerfiles/gitremote/Dockerfile
@@ -1,10 +1,10 @@
 ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:xenial
+ARG IMAGE_NAME=bionic_pkgbuild
+FROM ${DOCKER_REGISTRY}${IMAGE_NAME}
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
 
-RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         git \

--- a/yelp_package/dockerfiles/itest/api/Dockerfile
+++ b/yelp_package/dockerfiles/itest/api/Dockerfile
@@ -13,17 +13,19 @@
 # limitations under the License.
 
 ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:xenial
+ARG IMAGE_NAME=bionic_pkgbuild
+FROM ${DOCKER_REGISTRY}${IMAGE_NAME}
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
 
-RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
+ARG PAASTA_ENV
+ENV PAASTA_ENV=$PAASTA_ENV
 
-# Need Python 3.7
+
 RUN apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
+    if [ "$PAASTA_ENV" != "YELP" ]; then add-apt-repository ppa:deadsnakes/ppa; fi # only use deadsnakes externally
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -45,7 +47,7 @@ ENV PATH=/venv/bin:$PATH
 RUN pip install -r requirements.txt
 
 COPY yelp_package/dockerfiles/xenial/mesos-slave-secret /etc/
-COPY yelp_package/dockerfiles/itest/api/mesos-cli.json yelp_package/dockerfiles/xenial/mesos-slave-secret /nail/etc/
+COPY yelp_package/dockerfiles/itest/api/mesos-cli.json yelp_package/dockerfiles/bionic/mesos-slave-secret /nail/etc/
 COPY yelp_package/dockerfiles/itest/api/*.json /etc/paasta/
 
 ADD . /work/

--- a/yelp_package/dockerfiles/itest/k8s/Dockerfile
+++ b/yelp_package/dockerfiles/itest/k8s/Dockerfile
@@ -13,17 +13,19 @@
 # limitations under the License.
 
 ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:xenial
+ARG IMAGE_NAME=bionic_pkgbuild
+FROM ${DOCKER_REGISTRY}${IMAGE_NAME}
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
 
-RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
+ARG PAASTA_ENV
+ENV PAASTA_ENV=$PAASTA_ENV
 
-# Need Python 3.7
+
 RUN apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends curl software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
+    if [ "$PAASTA_ENV" != "YELP" ]; then add-apt-repository ppa:deadsnakes/ppa; else true; fi # only use deadsnakes externally
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -38,9 +40,13 @@ RUN apt-get update > /dev/null && \
     && apt-get clean > /dev/null
 
 # Install kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
-RUN chmod +x ./kubectl
-RUN mv ./kubectl /usr/local/bin/kubectl
+RUN if [ "$PAASTA_ENV" != "YELP" ]; then \
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \
+        && chmod +x ./kubectl \
+        && mv ./kubectl /usr/local/bin/kubectl; \
+    else \
+        apt-get install kubectl; \
+    fi
 
 WORKDIR /work
 

--- a/yelp_package/dockerfiles/itest/marathon/Dockerfile
+++ b/yelp_package/dockerfiles/itest/marathon/Dockerfile
@@ -18,8 +18,6 @@ FROM ${DOCKER_REGISTRY}ubuntu:xenial
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
 
-RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
-
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -29,9 +29,6 @@ RUN apt-get update > /dev/null && \
     rm -rf /var/lib/apt/lists/*
 
 
-# Need Python 3.7
-RUN add-apt-repository ppa:deadsnakes/ppa
-
 RUN echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
     add-apt-repository ppa:ubuntu-toolchain-r/test && \
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -18,8 +18,6 @@ FROM ${DOCKER_REGISTRY}ubuntu:xenial
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
 
-RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
-
 # Install packages to allow apt to use a repository over HTTPS
 # https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#xenial-1604
 RUN apt-get update > /dev/null && \

--- a/yelp_package/dockerfiles/itest/zookeeper/Dockerfile
+++ b/yelp_package/dockerfiles/itest/zookeeper/Dockerfile
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:xenial
+ARG IMAGE_NAME=bionic_pkgbuild
+FROM ${DOCKER_REGISTRY}${IMAGE_NAME}
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
-
-RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/yelp_package/dockerfiles/xenial/Dockerfile
+++ b/yelp_package/dockerfiles/xenial/Dockerfile
@@ -13,23 +13,19 @@
 # limitations under the License.
 
 ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:xenial
+
+ARG IMAGE_NAME=xenial_pkgbuild
+FROM ${DOCKER_REGISTRY}${IMAGE_NAME}
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
 
-RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
-
-RUN echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-
-# Need Python 3.7
-RUN apt-get update > /dev/null && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
+ARG PAASTA_ENV
+ENV PAASTA_ENV=$PAASTA_ENV
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        software-properties-common \
         build-essential \
         debhelper \
         gdebi-core \
@@ -40,15 +36,19 @@ RUN apt-get update > /dev/null && \
         libyaml-dev \
         python3.7-dev \
         python-pip \
-        python-tox \
         wget \
-        zsh > /dev/null \
-    && rm -rf /var/lib/apt/lists/*
+        zsh > /dev/null
 
-RUN cd /tmp && \
-    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
-    gdebi -n dh-virtualenv*.deb && \
-    rm dh-virtualenv_*.deb
+# our base images already have python-tox
+RUN echo $PAASTA_ENV && if [ "$PAASTA_ENV" != "YELP" ]; then DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python-tox; else true; fi
+RUN rm -rf /var/lib/apt/lists/*
+
+RUN if [ "$PAASTA_ENV" != "YELP" ]; then cd /tmp && \
+        wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
+        gdebi -n dh-virtualenv*.deb && \
+        rm dh-virtualenv_*.deb; \
+    else \
+        apt-get install dh-virtualenv=1.0-1; fi
 
 ADD mesos-slave-secret /etc/mesos-slave-secret
 


### PR DESCRIPTION
I wasn't able to make the Mesos/Marathon Dockerfiles use our internal
bionic images, but these aren't long for this world anyway