### PR TITLE
Drop xenial GHA builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
       matrix:
         toxenv:
           - py37-linux,docs,mypy,tests
-          - general_itests
-          - paasta_itests
-          - example_cluster
     env:
       PIP_INDEX_URL: https://pypi.python.org/simple
       DOCKER_REGISTRY: ""
@@ -49,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dist: [xenial, bionic]
+        dist: [bionic]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,9 +14,6 @@ jobs:
       matrix:
         toxenv:
           - py37-linux,docs,mypy,tests
-          - general_itests
-          - paasta_itests
-          - example_cluster
     env:
       PIP_INDEX_URL: https://pypi.python.org/simple
       DOCKER_REGISTRY: ""

--- a/yelp_package/dockerfiles/itest/api/Dockerfile
+++ b/yelp_package/dockerfiles/itest/api/Dockerfile
@@ -13,20 +13,16 @@
 # limitations under the License.
 
 ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:xenial
+FROM ${DOCKER_REGISTRY}xenial_pkgbuild
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
 
 RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sources.list
 
-# Need Python 3.7
-RUN apt-get update > /dev/null && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
-
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        software-properties-common \
         gcc \
         git \
         curl \

--- a/yelp_package/dockerfiles/itest/api/Dockerfile
+++ b/yelp_package/dockerfiles/itest/api/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}xenial_pkgbuild
+FROM ${DOCKER_REGISTRY}ubuntu:bionic
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL

--- a/yelp_package/dockerfiles/itest/k8s/Dockerfile
+++ b/yelp_package/dockerfiles/itest/k8s/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:xenial
+FROM ${DOCKER_REGISTRY}ubuntu:bionic
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL

--- a/yelp_package/dockerfiles/itest/mesos/Dockerfile
+++ b/yelp_package/dockerfiles/itest/mesos/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:xenial
+FROM ${DOCKER_REGISTRY}xenial_pkgbuild
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
@@ -30,9 +30,6 @@ RUN apt-get update > /dev/null && \
         software-properties-common && \
     rm -rf /var/lib/apt/lists/*
 
-
-# Need Python 3.7
-RUN add-apt-repository ppa:deadsnakes/ppa
 
 RUN echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
     add-apt-repository ppa:ubuntu-toolchain-r/test && \

--- a/yelp_package/dockerfiles/xenial/Dockerfile
+++ b/yelp_package/dockerfiles/xenial/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:xenial
+FROM ${DOCKER_REGISTRY}xenial_pkgbuild
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
@@ -23,32 +23,23 @@ RUN sed -i 's/archive.ubuntu.com/us-east1.gce.archive.ubuntu.com/g' /etc/apt/sou
 RUN echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
 
-# Need Python 3.7
-RUN apt-get update > /dev/null && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
-
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         debhelper \
+        dh-virtualenv \
         gdebi-core \
         git \
         libffi-dev \
         libgpgme11 \
         libssl-dev \
         libyaml-dev \
-        python3.7-dev \
         python-pip \
-        python-tox \
+        python3.7-dev \
+        software-properties-common \
         wget \
         zsh > /dev/null \
     && rm -rf /var/lib/apt/lists/*
-
-RUN cd /tmp && \
-    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
-    gdebi -n dh-virtualenv*.deb && \
-    rm dh-virtualenv_*.deb
 
 ADD mesos-slave-secret /etc/mesos-slave-secret
 


### PR DESCRIPTION
Our itest setup is annoyingly tangled and there's a lot of xenial
dockerfiles, so I'm dropping the itests from GHA until we have more time
to fix things correctly (likely by just removing all the mesos
code/itests)