### PR TITLE
cassandra status: fix error when status.nodes is None

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1778,14 +1778,22 @@ def print_cassandra_status(
     else:
         state = PaastaColors.red(state)
 
+    nodes: List[Dict[str, Any]] = status.get("nodes") or []
     output.append(indent * tab + "State: " + state)
-    output.append(indent * tab + "Nodes: ")
+
+    if not nodes:
+        output.append(
+            indent * tab + "Nodes: " + PaastaColors.red("No node status available")
+        )
+        return 0
+
+    output.append(indent * tab + "Nodes:")
     indent += 1
     now = datetime.now(timezone.utc)
     tableOkNodes = []
     tableErrNodes = []
 
-    for node in status.get("nodes"):
+    for node in nodes:
         ip = node.get("ip")
         err = node.get("error")
         inspectTime = datetime.strptime(

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1915,6 +1915,26 @@ class TestPrintCassandraStatus:
             "    " + PaastaColors.red("Cassandra cluster is not available yet")
         ]
 
+    def test_sucess_no_nodes(self, mock_cassandra_status):
+        mock_cassandra_status["status"]["nodes"] = None
+        output = []
+        return_value = print_cassandra_status(
+            cluster="fake_cluster",
+            service="fake_service",
+            instance="fake_instance",
+            output=output,
+            cassandra_status=mock_cassandra_status,
+            verbose=1,
+        )
+        assert return_value == 0
+
+        expected_output = [
+            f"    Cassandra cluster:",
+            f"        State: {PaastaColors.green('Running')}",
+            f"        Nodes: {PaastaColors.red('No node status available')}",
+        ]
+        assert expected_output == output
+
     def test_successful_return_value(self, mock_cassandra_status):
         return_value = print_cassandra_status(
             cluster="fake_cluster",
@@ -1926,11 +1946,7 @@ class TestPrintCassandraStatus:
         )
         assert return_value == 0
 
-    @patch("paasta_tools.cli.cmds.status.humanize.naturaltime", autospec=True)
-    def test_output(
-        self, mock_naturaltime, mock_cassandra_status,
-    ):
-        mock_naturaltime.return_value = "one day ago"
+    def test_output(self, mock_cassandra_status):
         output = []
         print_cassandra_status(
             cluster="fake_cluster",
@@ -1944,7 +1960,7 @@ class TestPrintCassandraStatus:
         expected_output = [
             f"    Cassandra cluster:",
             f"        State: {PaastaColors.green('Running')}",
-            f"        Nodes: ",
+            f"        Nodes:",
             f"            IP             Available  OperationMode  Joined  Datacenter   Rack          Load       Tokens  InspectedAt",
             f"            10.93.210.204  Yes        NORMAL         Yes     norcal-devc  uswest1cdevc  28.19 MiB  256     6 days ago",
             f"            10.93.200.181  Yes        NORMAL         Yes     norcal-devc  uswest1cdevc  29.68 MiB  256     6 days ago",


### PR DESCRIPTION
The value of status.nodes shouldn't be None normally, however, this PR ensures
that paasta status command will not break even if it is.

Verify it by running:
```
$ paasta status -s service -c cluster -i instance
service: service
cluster: cluster
    instance: instance
    Git sha:    xxxxxxxx (desired)
    Cassandra cluster:
        State: Running
        Nodes: No node status available
```