### PR TITLE
Add schema support for executor: spark

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -239,23 +239,152 @@
                 "trigger_timeout": {
                     "$ref": "#definitions/time_delta"
                 },
-                "spark_paasta_cluster": {
-                    "type": "string"
-                },
-                "spark_paasta_pool": {
+                "aws_credentials": {
+                    "$comment": "we should eventually get rid of this once we move spark to pod identity",
                     "type": "string"
                 },
                 "spark_args": {
-                    "type": "object"
-                },
-                "aws_credentials_yaml": {
-                    "type": "string"
-                },
-                "spark_cluster_manager": {
-                    "enum": [
-                        "mesos",
-                        "kubernetes"
-                    ]
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "spark.cores.max": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "exclusiveMinimum": true
+                        },
+                        "spark.driver.cores": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "exclusiveMinimum": true
+                        },
+                        "spark.kubernetes.driver.request.cores": {
+                            "type": "number",
+                            "minimum": 0,
+                            "exclusiveMinimum": true
+                        },
+                        "spark.executor.instances": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "exclusiveMinimum": true
+                        },
+                        "spark.executor.cores": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "exclusiveMinimum": true
+                        },
+                        "spark.kubernetes.executor.request.cores": {
+                            "type": "number",
+                            "minimum": 0,
+                            "exclusiveMinimum": true
+                        },
+                        "spark.executor.memory": {
+                            "type": "string",
+                            "pattern": "^[1-9]+[0-9]*[kmg]$"
+                        },
+                        "spark.driver.memory": {
+                            "type": "string",
+                            "pattern": "^[1-9]+[0-9]*[kmg]$"
+                        },
+                        "spark.driver.memoryOverhead": {
+                            "$comment": "we still need to validate this in code since there's a spark-enforced minimum of 384mb",
+                            "oneOf": [
+                                {
+                                    "type": "string",
+                                    "pattern": "^[1-9]+[0-9]*[kmg]$"
+                                },
+                                {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "exclusiveMinimum": true
+                                }
+                            ]
+                        },
+                        "spark.executor.memoryOverhead": {
+                            "$comment": "we still need to validate this in code since there's a spark-enforced minimum of 384mb",
+                            "oneOf": [
+                                {
+                                    "type": "string",
+                                    "pattern": "^[1-9]+[0-9]*[kmg]$"
+                                },
+                                {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "exclusiveMinimum": true
+                                }
+                            ]
+                        },
+                        "spark.driver.maxResultSize": {
+                            "type": "string",
+                            "pattern": "^[1-9]+[0-9]*[kmg]$"
+                        },
+                        "spark.scheduler.minRegisteredResourcesRatio": {
+                            "type": "number",
+                            "minimum": 0,
+                            "exclusiveMinimum": true,
+                            "maximum": 1
+                        },
+                        "spark.scheduler.maxRegisteredResourcesWaitingTime": {
+                            "type": "string",
+                            "pattern": "^[1-9]+[0-9]*(s|min)$"
+                        },
+                        "spark.kubernetes.allocation.batch.size": {
+                            "type": "integer"
+                        },
+                        "spark.kubernetes.memoryOverheadFactor": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1,
+                            "exclusiveMinimum": false,
+                            "exclusiveMaximum": false
+                        },
+                        "spark.hadoop.fs.s3a.multiobjectdelete.enable": {
+                            "type": "boolean"
+                        },
+                        "spark.app.name": {
+                            "type": "boolean"
+                        },
+                        "spark.task.maxFailures": {
+                            "type": "integer",
+                            "minimum": 1
+                        },
+                        "spark.stage.maxConsecutiveAttempts": {
+                            "type": "integer"
+                        },
+                        "spark.sql.broadcastTimeout": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "exclusiveMinimum": true
+                        },
+                        "spark.sql.autoBroadcastJoinThreshold": {
+                            "oneOf": [
+                                {
+                                    "$comment": "this is just a silly way to express that we want a non-zero integer or -1",
+                                    "enum": [
+                                        -1
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "exclusiveMinimum": true
+                                }
+                            ]
+                        },
+                        "spark.sql.parquet.enableVectorizedReader": {
+                            "type": "boolean"
+                        },
+                        "spark.sql.shuffle.partitions": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "exclusiveMinimum": true
+                        },
+                        "spark.default.parallelism": {
+                            "type": "integer"
+                        },
+                        "spark.local.dir": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -79,7 +79,7 @@ VALID_MONITORING_KEYS = set(
         pkgutil.get_data("paasta_tools.cli", "schemas/tron_schema.json").decode()
     )["definitions"]["job"]["properties"]["monitoring"]["properties"].keys()
 )
-MESOS_EXECUTOR_NAMES = ("paasta", "spark")
+MESOS_EXECUTOR_NAMES = ("paasta",)
 KUBERNETES_EXECUTOR_NAMES = ("paasta",)
 KUBERNETES_NAMESPACE = "tron"
 DEFAULT_AWS_REGION = "us-west-2"
@@ -243,15 +243,6 @@ class TronActionConfig(InstanceConfig):
             if not self.get_docker_image()
             else super().get_docker_url(system_paasta_config=system_paasta_config)
         )
-
-    def get_spark_paasta_cluster(self):
-        return self.config_dict.get("spark_paasta_cluster", self.get_cluster())
-
-    def get_spark_paasta_pool(self):
-        return self.config_dict.get("spark_paasta_pool", "batch")
-
-    def get_spark_cluster_manager(self):
-        return self.config_dict.get("spark_cluster_manager", "mesos")
 
     def get_secret_env(self) -> Mapping[str, dict]:
         base_env = self.config_dict.get("env", {})


### PR DESCRIPTION
We previously started work on running Spark drivers on Mesos directly
(rather than having them run on physical boxes), but this was never
used. I'm deleting the existing code so that we can start anew.

We're generally going to take the same approach here (i.e., have a
spark_args dictionary in soaconfigs that configures everything so
that users don't need to learn anything new/can use existing spark
knowledge + we don't have to stay on top of what Spark options exist to
add native support for them).

That said, I've added some schema checking for options that I've seen be
used somewhat frequently.

NOTE: this is completely unused at the moment, just splitting this into
its own PR to make future PRs smaller :p