### PR TITLE
Add soa-configs SHA to containers without messing up configs SHA use …

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -745,7 +745,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         :param config: complete_config hash to sanitize
         :returns: sanitized copy of complete_config hash
         """
-        ahash = {
+        ahash: Dict[str, Any] = {
             key: copy.deepcopy(value)
             for key, value in config.items()
             if key not in CONFIG_HASH_BLACKLIST
@@ -755,6 +755,8 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         ] = self.format_docker_parameters(
             with_labels=False, system_paasta_config=system_paasta_config
         )
+        if "PAASTA_SOA_CONFIGS_SHA" in ahash["env"]:
+            del ahash["env"]["PAASTA_SOA_CONFIGS_SHA"]
         secret_hashes = get_secret_hashes(
             environment_variables=config["env"],
             secret_environment=system_paasta_config.get_vault_environment(),

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -76,6 +76,7 @@ from docker.utils import kwargs_from_env
 from kazoo.client import KazooClient
 from mypy_extensions import TypedDict
 from service_configuration_lib import read_service_configuration
+from service_configuration_lib import read_soa_metadata
 
 import paasta_tools.cli.fsm
 
@@ -611,6 +612,9 @@ class InstanceConfig:
             "PAASTA_RESOURCE_CPUS": str(self.get_cpus()),
             "PAASTA_RESOURCE_MEM": str(self.get_mem()),
             "PAASTA_RESOURCE_DISK": str(self.get_disk()),
+            "PAASTA_SOA_CONFIGS_SHA": read_soa_metadata(soa_dir=self.soa_dir).get(
+                "git_sha", ""
+            ),
         }
         if self.get_gpus() is not None:
             env["PAASTA_RESOURCE_GPUS"] = str(self.get_gpus())

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -50,7 +50,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.8.0
+service-configuration-lib >= 2.9.0
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.8.0
+service-configuration-lib==2.9.0
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 
+import mock
 import pytest
 
 from paasta_tools.utils import SystemPaastaConfig
@@ -34,6 +35,21 @@ def system_paasta_config():
         },
         "/fake_dir/",
     )
+
+
+@pytest.fixture(autouse=True)
+def mock_read_soa_metadata():
+    with mock.patch("service_configuration_lib.read_soa_metadata", autospec=True,) as m:
+        m.return_value = {"git_sha": "fake_soa_git_sha"}
+        yield m
+
+
+@pytest.fixture(autouse=True)
+def mock_utils_read_soa_metadata(mock_read_soa_metadata):
+    with mock.patch(
+        "paasta_tools.utils.read_soa_metadata", mock_read_soa_metadata, autospec=None,
+    ):
+        yield mock_read_soa_metadata
 
 
 class Struct:

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -995,6 +995,7 @@ class TestMarathonTools:
             "PAASTA_RESOURCE_MEM": str(fake_mem),
             "PAASTA_PORT": "8888",
             "PAASTA_GIT_SHA": "dockerva",
+            "PAASTA_SOA_CONFIGS_SHA": "fake_soa_git_sha",
         }
         fake_args = ["arg1", "arg2"]
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1656,7 +1656,8 @@ class TestInstanceConfig:
         )
         assert fake_conf.get_cmd() == "FAKECMD"
 
-    def test_get_env_default(self):
+    def test_get_env_default(self, mock_utils_read_soa_metadata):
+        mock_utils_read_soa_metadata.return_value = {}
         fake_conf = utils.InstanceConfig(
             service="fake_service",
             cluster="fake_cluster",
@@ -1673,6 +1674,7 @@ class TestInstanceConfig:
             "PAASTA_RESOURCE_CPUS": "1",
             "PAASTA_RESOURCE_DISK": "1024",
             "PAASTA_RESOURCE_MEM": "4096",
+            "PAASTA_SOA_CONFIGS_SHA": "",
         }
 
     def test_get_env_handles_non_strings_and_returns_strings(self):
@@ -1692,6 +1694,7 @@ class TestInstanceConfig:
             "PAASTA_RESOURCE_CPUS": "1",
             "PAASTA_RESOURCE_DISK": "1024",
             "PAASTA_RESOURCE_MEM": "4096",
+            "PAASTA_SOA_CONFIGS_SHA": "fake_soa_git_sha",
         }
 
     def test_get_env_with_config(self):
@@ -1728,6 +1731,7 @@ class TestInstanceConfig:
                 "PAASTA_RESOURCE_DISK": "1024",
                 "PAASTA_RESOURCE_MEM": "4096",
                 "PAASTA_GIT_SHA": "somethin",
+                "PAASTA_SOA_CONFIGS_SHA": "fake_soa_git_sha",
             }
 
     def test_get_args_default_no_cmd(self):


### PR DESCRIPTION
…to diff for deployment updates

### Description
This PR makes instance configs pull in a soa-configs SHA from the new soa-configs metadata file, if there is one, and sets it as an env var in containers. This env var is explicitly removed so that it is not factored into hashing for the configs SHA to prevent services from re-deploying every time the soa-configs SHA changes (which is pretty often). 

### Testing
`make test`
local testing 

### Notes
This will need to be released in dev or stage first for safety to make sure we aren't redeploying service instances every time a soa-configs change is made.