### PR TITLE
Update utils.py to support parallel steps in deploy.yaml

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -3013,7 +3013,15 @@ def get_pipeline_config(service: str, soa_dir: str = DEFAULT_SOA_DIR) -> List[Di
 def get_pipeline_deploy_groups(
     service: str, soa_dir: str = DEFAULT_SOA_DIR
 ) -> List[str]:
-    pipeline_steps = [step["step"] for step in get_pipeline_config(service, soa_dir)]
+    pipeline_steps = []
+    for step in get_pipeline_config(service, soa_dir):
+        if(step.get("parallel", False)):
+            for parallel_step in step.get("parallel"):
+                if(parallel_step.get("step", False)):
+                    pipeline_steps.append(parallel_step["step"])
+        else:
+            pipeline_steps.append(step["step"])
+            
     return [step for step in pipeline_steps if is_deploy_step(step)]
 
 


### PR DESCRIPTION
This change proposes to allow deploy.yaml parsing of steps which are in a parallel block. Currently deploy.yamls which have parallel steps throw the following error:

```
File "/opt/venvs/paasta-tools/lib/python3.7/site-packages/paasta_tools/utils.py", line 3012, in 
    pipeline_steps = [step["step"] for step in get_pipeline_config(service, soa_dir)]
KeyError: 'step'
```

The current code change supports formats such as
-pipeline:
  -parallel:
    -step: stepname1
    -step: stepname2
  -step: stepname3
  
 It keeps backward compatibility for non parallelized steps. 
 Test non parallel steps output: https://pastebin.com/FKeKDir5
 Test parallel steps output: https://pastebin.com/hjqU10Fc
