### PR TITLE
Limit pod name to 63 chars for spark runs

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -23,13 +23,13 @@ from service_configuration_lib.spark_config import get_signalfx_url
 from service_configuration_lib.spark_config import get_spark_conf
 from service_configuration_lib.spark_config import send_and_calculate_resources_cost
 
-from paasta_tools import kubernetes_tools
 from paasta_tools.cli.cmds.check import makefile_responds_to
 from paasta_tools.cli.cmds.cook_image import paasta_cook_image
 from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
 from paasta_tools.clusterman import get_clusterman_metrics
+from paasta_tools.kubernetes_tools import limit_size_with_hash
 from paasta_tools.spark_tools import DEFAULT_SPARK_SERVICE
 from paasta_tools.spark_tools import get_webui_url
 from paasta_tools.spark_tools import inject_spark_conf_str
@@ -985,9 +985,7 @@ def paasta_spark_run(args):
 
     if args.enable_compact_bin_packing:
         document = POD_TEMPLATE.format(
-            spark_pod_label=kubernetes_tools.limit_size_with_hash(
-                f"exec-{app_base_name}"
-            ),
+            spark_pod_label=limit_size_with_hash(f"exec-{app_base_name}"),
         )
         parsed_pod_template = yaml.load(document)
         with open(pod_template_path, "w") as f:


### PR DESCRIPTION
Fix this issue where pod name based on the filename of the batch is too long >63 chars:
```
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://k8s.pnw-prod.paasta:6443/api/v1/namespaces/paasta-spark/pods. Message: Pod "generate-xxxxxxxxxxxxxxxxx-event-log-spark-app-f63a027ed986911e-exec-1" is invalid: metadata.labels: Invalid value: "exec-paasta_spark_generate_xxxxxxxxxxxxxxxxx_event_log_batch": must be no more than 63 characters. Received status: Status(apiVersion=v1, code=422, details=StatusDetails(causes=[StatusCause(field=metadata.labels, message=Invalid value: "exec-paasta_spark_generate_xxxxxxxxxxxxxxxxxx_event_log_batch": must be no more than 63 characters, reason=FieldValueInvalid, additionalProperties={})], group=null, kind=Pod, name=generate-syndication-ad-billable-event-log-spark-app-f63a027ed986911e-exec-1, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=Pod "generate-syndication-ad-billable-event-log-spark-app-f63a027ed986911e-exec-1" is invalid: metadata.labels: Invalid value: "exec-paasta_spark_generate_syndication_ad_billable_event_log_batch": must be no more than 63 characters, metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Invalid, status=Failure, additionalProperties={}).
```