### PR TITLE
Only expose PAASTA_SOA_CONFIGS_SHA to k8s long-running service containers

### DIFF
--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -745,7 +745,7 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         :param config: complete_config hash to sanitize
         :returns: sanitized copy of complete_config hash
         """
-        ahash: Dict[str, Any] = {
+        ahash = {
             key: copy.deepcopy(value)
             for key, value in config.items()
             if key not in CONFIG_HASH_BLACKLIST
@@ -755,8 +755,6 @@ class MarathonServiceConfig(LongRunningServiceConfig):
         ] = self.format_docker_parameters(
             with_labels=False, system_paasta_config=system_paasta_config
         )
-        if "PAASTA_SOA_CONFIGS_SHA" in ahash["env"]:
-            del ahash["env"]["PAASTA_SOA_CONFIGS_SHA"]
         secret_hashes = get_secret_hashes(
             environment_variables=config["env"],
             secret_environment=system_paasta_config.get_vault_environment(),

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -76,7 +76,6 @@ from docker.utils import kwargs_from_env
 from kazoo.client import KazooClient
 from mypy_extensions import TypedDict
 from service_configuration_lib import read_service_configuration
-from service_configuration_lib import read_soa_metadata
 
 import paasta_tools.cli.fsm
 
@@ -612,9 +611,6 @@ class InstanceConfig:
             "PAASTA_RESOURCE_CPUS": str(self.get_cpus()),
             "PAASTA_RESOURCE_MEM": str(self.get_mem()),
             "PAASTA_RESOURCE_DISK": str(self.get_disk()),
-            "PAASTA_SOA_CONFIGS_SHA": read_soa_metadata(soa_dir=self.soa_dir).get(
-                "git_sha", ""
-            ),
         }
         if self.get_gpus() is not None:
             env["PAASTA_RESOURCE_GPUS"] = str(self.get_gpus())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,9 +45,11 @@ def mock_read_soa_metadata():
 
 
 @pytest.fixture(autouse=True)
-def mock_utils_read_soa_metadata(mock_read_soa_metadata):
+def mock_ktools_read_soa_metadata(mock_read_soa_metadata):
     with mock.patch(
-        "paasta_tools.utils.read_soa_metadata", mock_read_soa_metadata, autospec=None,
+        "paasta_tools.kubernetes_tools.read_soa_metadata",
+        mock_read_soa_metadata,
+        autospec=None,
     ):
         yield mock_read_soa_metadata
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -808,6 +808,17 @@ class TestKubernetesDeploymentConfig:
                 is True
             )
 
+    def test_get_env(self):
+        with mock.patch(
+            "paasta_tools.kubernetes_tools.LongRunningServiceConfig.get_env",
+            autospec=True,
+            return_value={"hello": "world"},
+        ):
+            assert self.deployment.get_env() == {
+                "hello": "world",
+                "PAASTA_SOA_CONFIGS_SHA": "fake_soa_git_sha",
+            }
+
     def test_get_container_env(self):
         with mock.patch(
             "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_env",

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -995,7 +995,6 @@ class TestMarathonTools:
             "PAASTA_RESOURCE_MEM": str(fake_mem),
             "PAASTA_PORT": "8888",
             "PAASTA_GIT_SHA": "dockerva",
-            "PAASTA_SOA_CONFIGS_SHA": "fake_soa_git_sha",
         }
         fake_args = ["arg1", "arg2"]
         fake_service_namespace_config = long_running_service_tools.ServiceNamespaceConfig(

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -156,7 +156,9 @@ class TestTronActionConfig:
             )
 
     @pytest.mark.parametrize("executor", MESOS_EXECUTOR_NAMES)
-    def test_get_env(self, action_config, executor, monkeypatch):
+    def test_get_env(
+        self, mock_read_soa_metadata, action_config, executor, monkeypatch
+    ):
         monkeypatch.setattr(tron_tools, "clusterman_metrics", mock.Mock())
         action_config.config_dict["executor"] = executor
         with mock.patch(
@@ -186,6 +188,8 @@ class TestTronActionConfig:
                 assert env["SPARK_MESOS_SECRET"] == "SHARED_SECRET(SPARK_MESOS_SECRET)"
             else:
                 assert not any([env.get("SPARK_OPTS"), env.get("CLUSTERMAN_RESOURCES")])
+
+        assert "PAASTA_SOA_CONFIGS_SHA" not in env
 
     @pytest.mark.parametrize(
         "test_env,expected_env",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1656,8 +1656,7 @@ class TestInstanceConfig:
         )
         assert fake_conf.get_cmd() == "FAKECMD"
 
-    def test_get_env_default(self, mock_utils_read_soa_metadata):
-        mock_utils_read_soa_metadata.return_value = {}
+    def test_get_env_default(self):
         fake_conf = utils.InstanceConfig(
             service="fake_service",
             cluster="fake_cluster",
@@ -1674,7 +1673,6 @@ class TestInstanceConfig:
             "PAASTA_RESOURCE_CPUS": "1",
             "PAASTA_RESOURCE_DISK": "1024",
             "PAASTA_RESOURCE_MEM": "4096",
-            "PAASTA_SOA_CONFIGS_SHA": "",
         }
 
     def test_get_env_handles_non_strings_and_returns_strings(self):
@@ -1694,7 +1692,6 @@ class TestInstanceConfig:
             "PAASTA_RESOURCE_CPUS": "1",
             "PAASTA_RESOURCE_DISK": "1024",
             "PAASTA_RESOURCE_MEM": "4096",
-            "PAASTA_SOA_CONFIGS_SHA": "fake_soa_git_sha",
         }
 
     def test_get_env_with_config(self):
@@ -1731,7 +1728,6 @@ class TestInstanceConfig:
                 "PAASTA_RESOURCE_DISK": "1024",
                 "PAASTA_RESOURCE_MEM": "4096",
                 "PAASTA_GIT_SHA": "somethin",
-                "PAASTA_SOA_CONFIGS_SHA": "fake_soa_git_sha",
             }
 
     def test_get_args_default_no_cmd(self):


### PR DESCRIPTION
### Description
I previously made the `PAASTA_SOA_CONFIGS_SHA` env var available to what I thought was only long-running service containers, but because I made the change in `utils.py`, all containers configured through `paasta-tools` got it to. Because I only made sure the new env var doesn't affect config hashing for long-running services, Tron jobs were continuously reconfigured, causing an incident. 

To fix the issue, I've moved the env var setting to happen only for k8s long-running containers, and reverted changes to Marathon (which we no longer use) and `utils.py`.

### Testing
`make test`