### PR TITLE
DREIMP-7929: add pod start time to Cassandra status writer

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1843,6 +1843,9 @@ def print_cassandra_status(
                 row["Initialized"] = "Yes" if details.get("initialized") else "No"
                 row["Drained"] = "Yes" if details.get("drained") else "No"
                 row["Draining"] = "Yes" if details.get("draining") else "No"
+                # Show absolute dates:
+                row["StartTime"] = node.get("startTime", "None")
+                row["InspectedAt"] = node.get("inspectTime", "None")
             if verbose > 1:
                 row["LocalHostID"] = details.get("localHostId")
                 row["Schema"] = details.get("schemaVersion")

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1790,31 +1790,31 @@ def print_cassandra_status(
     output.append(indent * tab + "Nodes:")
     indent += 1
     now = datetime.now(timezone.utc)
-    tableOkNodes = []
-    tableErrNodes = []
+    table_ok_nodes = []
+    table_err_nodes = []
 
     for node in nodes:
         ip = node.get("ip")
         err = node.get("error")
-        startAge = "None"
+        start_age = "None"
         if node.get("startTime"):
-            startTime = datetime.strptime(
+            start_time = datetime.strptime(
                 node.get("startTime"), "%Y-%m-%dT%H:%M:%SZ"
             ).replace(tzinfo=timezone.utc)
-            startAge = (
+            start_age = (
                 humanize.naturaldelta(
-                    timedelta(seconds=(now - startTime).total_seconds())
+                    timedelta(seconds=(now - start_time).total_seconds())
                 )
                 + " ago"
             )
-        inspectTime = datetime.strptime(
+        inspect_time = datetime.strptime(
             node.get("inspectTime"), "%Y-%m-%dT%H:%M:%SZ"
         ).replace(tzinfo=timezone.utc)
         details = node.get("details")
 
-        inspectAge = (
+        inspect_age = (
             humanize.naturaldelta(
-                timedelta(seconds=(now - inspectTime).total_seconds())
+                timedelta(seconds=(now - inspect_time).total_seconds())
             )
             + " ago"
         )
@@ -1822,10 +1822,10 @@ def print_cassandra_status(
         if details is None or err is not None:
             row = {}
             row["IP"] = ip
-            row["StartTime"] = startAge
-            row["InspectedAt"] = inspectAge
+            row["StartTime"] = start_age
+            row["InspectedAt"] = inspect_age
             row["Error"] = PaastaColors.red(err)
-            tableErrNodes.append(row)
+            table_err_nodes.append(row)
         else:
             row = {}
             row["IP"] = ip
@@ -1836,8 +1836,8 @@ def print_cassandra_status(
             row["Rack"] = details.get("rack")
             row["Load"] = details.get("loadString")
             row["Tokens"] = str(details.get("tokenRangesCount"))
-            row["StartTime"] = startAge
-            row["InspectedAt"] = inspectAge
+            row["StartTime"] = start_age
+            row["InspectedAt"] = inspect_age
             if verbose > 0:
                 row["Starting"] = "Yes" if details.get("starting") else "No"
                 row["Initialized"] = "Yes" if details.get("initialized") else "No"
@@ -1868,11 +1868,11 @@ def print_cassandra_status(
                     "Yes" if details.get("hintedHandoffEnabled") else "No"
                 )
                 row["LoggingLevels"] = str(details.get("loggingLevels"))
-            tableOkNodes.append(row)
+            table_ok_nodes.append(row)
 
     header: List[str] = []
     lines: List[List[str]] = []
-    for row in tableOkNodes:
+    for row in table_ok_nodes:
         if len(header) == 0:
             header = list(row.keys())
             lines.append(list(header))
@@ -1881,7 +1881,7 @@ def print_cassandra_status(
         ftable = format_table(lines)
         output.extend([indent * tab + line for line in ftable])
     else:
-        for node in tableOkNodes:
+        for node in table_ok_nodes:
             output.append(indent * tab + "Node: ")
             indent += 1
             for key in node.keys():
@@ -1891,14 +1891,14 @@ def print_cassandra_status(
             indent -= 1
     indent -= 1
 
-    if len(tableErrNodes) == 0:
+    if len(table_err_nodes) == 0:
         return 0
 
     output.append(indent * tab + "Nodes with errors:")
     header = []
     lines = []
     indent += 1
-    for row in tableErrNodes:
+    for row in table_err_nodes:
         if len(header) == 0:
             header = list(row.keys())
             lines.append(list(header))


### PR DESCRIPTION
Display node's StartTime, when this value is available. We want to make sure nothing breaks even when StartTime is not available. We have added a test for this scenario as well.

Context: DREIMP-7929