### PR TITLE
[COREML-2697] spark-run defaults to kubernetes

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -145,7 +145,19 @@ def add_subparser(subparsers):
     list_parser.add_argument(
         "-e",
         "--enable-compact-bin-packing",
-        help="Enabling compact bin packing will try to ensure executors are scheduled on the same nodes. Requires --cluster-manager to be kubernetes.",
+        help=(
+            "Enabling compact bin packing will try to ensure executors are scheduled on the same nodes. Requires --cluster-manager to be kubernetes."
+            " Always true by default, keep around for backward compability."
+        ),
+        action="store_true",
+        default=True,
+    )
+    list_parser.add_argument(
+        "--disable-compact-bin-packing",
+        help=(
+            "Disable compact bin packing. Requires --cluster-manager to be kubernetes. Note: this option is only for advanced Spark configurations,"
+            " don't use it unless you've been instructed to do so."
+        ),
         action="store_true",
         default=False,
     )
@@ -379,8 +391,8 @@ def generate_pod_template_path():
     return POD_TEMPLATE_PATH.format(file_uuid=uuid.uuid4().hex)
 
 
-def should_enable_compact_bin_packing(enable_compact_bin_packing, cluster_manager):
-    if not enable_compact_bin_packing:
+def should_enable_compact_bin_packing(disable_compact_bin_packing, cluster_manager):
+    if disable_compact_bin_packing:
         return False
 
     if cluster_manager != CLUSTER_MANAGER_K8S:
@@ -977,7 +989,7 @@ def paasta_spark_run(args):
 
     pod_template_path = generate_pod_template_path()
     args.enable_compact_bin_packing = should_enable_compact_bin_packing(
-        args.enable_compact_bin_packing, args.cluster_manager
+        args.disable_compact_bin_packing, args.cluster_manager
     )
 
     volumes = instance_config.get_volumes(system_paasta_config.get_volumes())

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.9.0
+service-configuration-lib==2.10.0
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -89,22 +89,22 @@ def test_sanitize_container_name(container_name, expected):
 
 
 @pytest.mark.parametrize(
-    "enable_compact_bin_packing,cluster_manager,dir_access,expected",
+    "disable_compact_bin_packing,cluster_manager,dir_access,expected",
     [
         (False, CLUSTER_MANAGER_MESOS, True, False),
-        (False, CLUSTER_MANAGER_K8S, True, False),
+        (False, CLUSTER_MANAGER_K8S, True, True),
         (True, CLUSTER_MANAGER_MESOS, True, False),
-        (True, CLUSTER_MANAGER_K8S, True, True),
+        (True, CLUSTER_MANAGER_K8S, True, False),
         (True, CLUSTER_MANAGER_K8S, False, False),
     ],
 )
 def test_should_enable_compact_bin_packing(
-    enable_compact_bin_packing, cluster_manager, dir_access, expected
+    disable_compact_bin_packing, cluster_manager, dir_access, expected
 ):
     with mock.patch("os.access", autospec=True, return_value=dir_access):
         assert (
             should_enable_compact_bin_packing(
-                enable_compact_bin_packing, cluster_manager
+                disable_compact_bin_packing, cluster_manager
             )
             == expected
         )
@@ -956,6 +956,7 @@ def test_paasta_spark_run(
         build=True,
         image=None,
         enable_compact_bin_packing=False,
+        disable_compact_bin_packing=False,
         service="test-service",
         instance="test-instance",
         cluster="test-cluster",


### PR DESCRIPTION
## Changes

* make `kubernetes` the default option for `--cluster-manager`
* introduce `--disable-compact-bin-packing` which defaults to False
* make `--enable-compact-bin-packing` an always-True option which is basically a dummy option.
* update tests