### PR TITLE
Emit events to metrics provider on rollbacks

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -87,7 +87,6 @@ from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import RollbackTypes
 from paasta_tools.utils import TimeoutError
 
-
 DEFAULT_DEPLOYMENT_TIMEOUT = 3 * 3600  # seconds
 DEFAULT_WARN_PERCENT = 17  # ~30min for default timeout
 DEFAULT_AUTO_CERTIFY_DELAY = 600  # seconds
@@ -517,6 +516,7 @@ def paasta_mark_for_deployment(args: argparse.Namespace) -> int:
             polling_interval=args.polling_interval,
             diagnosis_interval=args.diagnosis_interval,
             time_before_first_diagnosis=args.time_before_first_diagnosis,
+            metrics_interface=metrics,
         )
         ret = deploy_process.run()
         return ret
@@ -584,6 +584,7 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
         polling_interval: float = None,
         diagnosis_interval: float = None,
         time_before_first_diagnosis: float = None,
+        metrics_interface: Optional[metrics_lib.BaseMetrics] = None,
     ) -> None:
         self.service = service
         self.deploy_info = deploy_info
@@ -607,6 +608,7 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
         self.polling_interval = polling_interval
         self.diagnosis_interval = diagnosis_interval
         self.time_before_first_diagnosis = time_before_first_diagnosis
+        self.metrics_interface = metrics_interface
 
         # Keep track of each wait_for_deployment task so we can cancel it.
         self.wait_for_deployment_tasks: Dict[str, asyncio.Task] = {}
@@ -1222,21 +1224,33 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
         }
 
     def log_slo_rollback(self) -> None:
+        rollback_details = self.__build_rollback_audit_details(
+            RollbackTypes.AUTOMATIC_SLO_ROLLBACK
+        )
+
+        if self.metrics_interface:
+            dimensions = rollback_details
+            dimensions["paasta_service"] = self.service
+            self.metrics_interface.emit_event(
+                name="rollback", dimensions=dimensions,
+            )
         _log_audit(
-            action="rollback",
-            action_details=self.__build_rollback_audit_details(
-                RollbackTypes.AUTOMATIC_SLO_ROLLBACK
-            ),
-            service=self.service,
+            action="rollback", action_details=rollback_details, service=self.service,
         )
 
     def log_user_rollback(self) -> None:
+        rollback_details = self.__build_rollback_audit_details(
+            RollbackTypes.USER_INITIATED_ROLLBACK
+        )
+
+        if self.metrics_interface:
+            dimensions = rollback_details
+            dimensions["paasta_service"] = self.service
+            self.metrics_interface.emit_event(
+                name="rollback", dimensions=dimensions,
+            )
         _log_audit(
-            action="rollback",
-            action_details=self.__build_rollback_audit_details(
-                RollbackTypes.USER_INITIATED_ROLLBACK
-            ),
-            service=self.service,
+            action="rollback", action_details=rollback_details, service=self.service,
         )
 
 

--- a/paasta_tools/metrics/metrics_lib.py
+++ b/paasta_tools/metrics/metrics_lib.py
@@ -72,6 +72,10 @@ class BaseMetrics(ABC):
     def create_counter(self, name: str, **kwargs: Any) -> CounterProtocol:
         raise NotImplementedError()
 
+    @abstractmethod
+    def emit_event(self, name: str, **kwargs: Any) -> bool:
+        raise NotImplementedError()
+
 
 def get_metrics_interface(base_name: str) -> BaseMetrics:
     metrics_provider = load_system_paasta_config().get_metrics_provider()
@@ -105,6 +109,9 @@ class MeteoriteMetrics(BaseMetrics):
 
     def create_counter(self, name: str, **kwargs: Any) -> CounterProtocol:
         return yelp_meteorite.create_counter(self.base_name + "." + name, **kwargs)
+
+    def emit_event(self, name: str, **kwargs: Any) -> bool:
+        return yelp_meteorite.emit_event(self.base_name + "." + name, **kwargs)
 
 
 class Timer(TimerProtocol):
@@ -165,3 +172,7 @@ class NoMetrics(BaseMetrics):
 
     def create_counter(self, name: str, **kwargs: Any) -> Counter:
         return Counter(self.base_name + "." + name)
+
+    def emit_event(self, name: str, **kwargs: Any) -> bool:
+        log.debug(f"event {name} occurred with properties: {kwargs}")
+        return True

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -265,6 +265,17 @@ def test_paasta_mark_for_deployment_with_good_rollback(
     mock_timer = mock_get_metrics.return_value.create_timer.return_value
     mock_timer.start.assert_called_once_with()
     mock_timer.stop.assert_called_once_with(tmp_dimensions=dict(exit_status=1))
+    mock_emit_event = mock_get_metrics.return_value.emit_event
+    mock_emit_event.assert_called_once_with(
+        name="rollback",
+        dimensions=dict(
+            paasta_service="test_service",
+            deploy_group="test_deploy_group",
+            rolled_back_from="d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+            rolled_back_to="old-sha",
+            rollback_type="user_initiated_rollback",
+        ),
+    )
 
 
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log_audit", autospec=True)

--- a/tests/metrics/test_metrics_lib.py
+++ b/tests/metrics/test_metrics_lib.py
@@ -23,6 +23,9 @@ class TestNoMetrics(unittest.TestCase):
         counter = self.metrics.create_counter("name", dimension="thing")
         counter.count()
 
+    def test_event(self):
+        self.metrics.emit_event("name", dimension="thing")
+
 
 class TestMeteoriteMetrics(unittest.TestCase):
     def setUp(self):
@@ -53,6 +56,12 @@ class TestMeteoriteMetrics(unittest.TestCase):
     def test_create_counter(self):
         self.metrics.create_counter("name", dimension="thing")
         self.mock_meteorite.create_counter.assert_called_with(
+            "paasta.deployd.name", dimension="thing"
+        )
+
+    def test_emit_event(self):
+        self.metrics.emit_event("name", dimension="thing")
+        self.mock_meteorite.emit_event.assert_called_with(
             "paasta.deployd.name", dimension="thing"
         )
 


### PR DESCRIPTION
This change builds upon the metrics support added to mark-for-deployment in #3245 and adds support for emitting simple events via our metrics_lib interfaces (as already supported by yelp_meteorite), and then using this functionality to emit events when a rollback occurs.

Tests are running cleanly and I've verified running a manual m-f-d with manual user rollback generates the expected event in SignalFX: https://fluffy.yelpcorp.com/i/r7lth1Z4zQWHTd7B74fLGcKV1Jh4SxXB.png

As metrics collection is already turned on everywhere, this will begin to emit rollback events as soon as the new version is deployed. This seems safe to do as we've seen the metrics interface is functioning without issue currently, and this adds code only when we are logging a rollback which has already been initiated in a separate thread.
