### PR TITLE
Remove boto-key secret signature if some files are missing

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2997,6 +2997,19 @@ def create_kubernetes_secret_signature(
     )
 
 
+def remove_kubernetes_secret_signature(
+    kube_client: KubeClient, secret: str, service: str, namespace: str = "paasta",
+) -> None:
+    service = sanitise_kubernetes_name(service)
+    secret = sanitise_kubernetes_name(secret)
+    body = V1DeleteOptions()
+    kube_client.core.delete_namespaced_config_map(
+        name=f"{namespace}-secret-{service}-{secret}-signature",
+        namespace=namespace,
+        body=body,
+    )
+
+
 def sanitise_kubernetes_name(service: str,) -> str:
     name = service.replace("_", "--")
     if name.startswith("--"):


### PR DESCRIPTION
For context on the original feature, see https://github.com/Yelp/paasta/pull/3130.

The current code has a somewhat undesirable behavior. If you provide a boto_key that doesn't exist or can't be read for whatever reason, it will emit a warning and then move on. The code that actually launches containers will attempt to mount the secret if the secret signature exists. 

In the case of a new but invalid boto_keys value, there won't be any signature, and the container will not be changed.

However, in the case of changing from a valid boto_key to an invalid one, the previous signature will remain unchanged. The code that launches the containers will attempt to extract items from the secret based on the new boto_keys values, but will fail. This causes new pods to fail to launch with
```
  Warning  FailedMount  4m26s               kubelet            Unable to attach or mount volumes: unmounted volumes=[secret-boto-key-  .....
```

This would fix the issue by forcing a deletion on the signature if there are any issues reading the key values. This will prevent the new pods from getting stuck, and instead they'll just emit another warning and launch without the special boto_cfg secret mount.

There's alternative solutions. For one, we could repurpose the configmaps (used for secret signatures) to actually store which keys were found and valid. That would allow, for example, 2 of 3 keys to appear fine even if there was a typo with the 3rd.  Perhaps the kubernetes_tools code could actually build a volume mount based on which keys exist in the secret and not what yelpsoa-configs says, but I don't know how easy that would be to implement. 

I'll be doing some testing on this code shortly and will update this when I have results. 