### PR TITLE
PAASTA-17560: Update brutal deployment handling to background delete …

### DIFF
--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -244,10 +244,10 @@ class DeploymentWrapper(Application):
                 )
             except ApiException as e:
                 if e.status == 404:
-                    # Deployment does not exist, nothing to delete but
-                    # we can consider this a success.
+                    # Pod(s) may have been deleted by GC before we got to it
+                    # We can consider this a success
                     self.logging.debug(
-                        "not deleting nonexistent deploy/{} from namespace/{}".format(
+                        "pods already deleted for {} from namespace/{}. Continuing.".format(
                             self.kube_deployment.service, self.item.metadata.namespace
                         )
                     )

--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -2,7 +2,6 @@ import logging
 import threading
 from abc import ABC
 from abc import abstractmethod
-from time import sleep
 from typing import Optional
 from typing import Union
 
@@ -173,12 +172,14 @@ class Application(ABC):
 
 
 class DeploymentWrapper(Application):
-    def deep_delete(self, kube_client: KubeClient) -> None:
+    def deep_delete(
+        self, kube_client: KubeClient, propagation_policy="Foreground"
+    ) -> None:
         """
         Remove all controllers, pods, and pod disruption budgets related to this application
         :param kube_client:
         """
-        delete_options = V1DeleteOptions(propagation_policy="Foreground")
+        delete_options = V1DeleteOptions(propagation_policy=propagation_policy)
         try:
             kube_client.deployments.delete_namespaced_deployment(
                 self.item.metadata.name,
@@ -216,37 +217,31 @@ class DeploymentWrapper(Application):
         self.sync_horizontal_pod_autoscaler(kube_client)
 
     def deep_delete_and_create(self, kube_client: KubeClient) -> None:
-        self.deep_delete(kube_client)
-        timer = 0
-        while (
-            self.kube_deployment in set(list_all_deployments(kube_client))
-            and timer < 60
-        ):
-            sleep(1)
-            timer += 1
-
-        if timer >= 60 and self.kube_deployment in set(
-            list_all_deployments(kube_client)
-        ):
-            try:
-                force_delete_pods(
-                    self.item.metadata.name,
-                    self.kube_deployment.service,
-                    self.kube_deployment.instance,
-                    self.item.metadata.namespace,
-                    kube_client,
-                )
-            except ApiException as e:
-                if e.status == 404:
-                    # Deployment does not exist, nothing to delete but
-                    # we can consider this a success.
-                    self.logging.debug(
-                        "not deleting nonexistent deploy/{} from namespace/{}".format(
-                            self.kube_deployment.service, self.item.metadata.namespace
-                        )
+        # When deleting then immediately creating, we need to use Background deletion to ensure we can create the deployment immediately
+        self.deep_delete(kube_client, propagation_policy="Background")
+        # Also forcibly delete remaining pods
+        try:
+            force_delete_pods(
+                self.item.metadata.name,
+                self.kube_deployment.service,
+                self.kube_deployment.instance,
+                self.item.metadata.namespace,
+                kube_client,
+            )
+        except ApiException as e:
+            if e.status == 404:
+                # Deployment does not exist, nothing to delete but
+                # we can consider this a success.
+                self.logging.debug(
+                    "not deleting nonexistent deploy/{} from namespace/{}".format(
+                        self.kube_deployment.service, self.item.metadata.namespace
                     )
-                else:
-                    raise
+                )
+            else:
+                raise
+        if self.kube_deployment in set(list_all_deployments(kube_client)):
+            # deployment deletion failed, we cannot continue
+            raise Exception(f"Could not delete deployment {self.item.metadata.name}")
         else:
             self.logging.info(
                 "deleted deploy/{} from namespace/{}".format(

--- a/tests/kubernetes/application/test_controller_wrapper.py
+++ b/tests/kubernetes/application/test_controller_wrapper.py
@@ -1,5 +1,7 @@
+import kubernetes.client
 import mock
 import pytest
+from kubernetes.client import V1DeleteOptions
 from kubernetes.client.rest import ApiException
 
 from paasta_tools.kubernetes.application.controller_wrappers import Application
@@ -59,6 +61,39 @@ def test_brutal_bounce(mock_load_system_paasta_config):
             mock_deep_delete_and_create.assert_called_once_with(
                 target=app.deep_delete_and_create, args=[mock_cloned_client]
             )
+
+
+def test_deep_delete_and_create(mock_load_system_paasta_config):
+    with mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.sleep", autospec=True
+    ), mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.list_all_deployments",
+        autospec=True,
+    ) as mock_list_deployments, mock.patch(
+        "paasta_tools.kubernetes.application.controller_wrappers.force_delete_pods",
+        autospec=True,
+    ) as mock_force_delete_pods:
+        mock_kube_client = mock.MagicMock()
+        mock_kube_client.deployments = mock.Mock(spec=kubernetes.client.AppsV1Api)
+        config_dict = {"instances": 1, "bounce_method": "brutal"}
+        app = setup_app(config_dict, True)
+        # This mocks being unable to delete the deployment
+        mock_list_deployments.return_value = [app.kube_deployment]
+        delete_options = V1DeleteOptions(propagation_policy="Background")
+
+        with pytest.raises(Exception):
+            # test deep_delete_and_create makes kubeclient calls correctly
+            app.deep_delete_and_create(mock_kube_client)
+        mock_force_delete_pods.assert_called_with(
+            app.item.metadata.name,
+            app.kube_deployment.service,
+            app.kube_deployment.instance,
+            app.item.metadata.namespace,
+            mock_kube_client,
+        )
+        mock_kube_client.deployments.delete_namespaced_deployment.assert_called_with(
+            app.item.metadata.name, app.item.metadata.namespace, body=delete_options
+        )
 
 
 @pytest.mark.parametrize("bounce_margin_factor_set", [True, False])


### PR DESCRIPTION
…deployments and always force delete pods

With 'brutal' paasta deployments, we attempt to fully delete the k8s deployment and related pods, then recreate.

We used to delete the deployment w/ foreground deletion of dependent objects, wait 60s, and if the deployment still existed, we assumed this was due to pods still needing to be deleted.  After force-deleting pods, we assumed we were successful and continued with creation.  However, this is dependent on the garbage collector actually kicking in to clean up, which can lead to problems when GC doesn't occur fast enough.

This changes the behavior to delete the deployment w/ background cascading deletion which has the same effect (allowing garbage collection to delete dependent objects) but causes the deployment resource to be deleted immediately (https://v1-19.docs.kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#background-cascading-deletion), then forcibly delete pods ourselves.  This also adds a check to confirm the deployment is deleted prior to attempting to recreate it, to minimize the number of failed creations.

I'm not entirely sure how dangerous this change could be. the 1.19 changelog doesn't indicate any major changes in garbage collection or deletion propagation policies, so this change should work on both versions, and our version of the clientlib does support the `Background` propagation policy: https://github.com/kubernetes-client/python/blob/v18.20.0/kubernetes/docs/V1DeleteOptions.md 