### PR TITLE
Run pre-commit as part of make test + readd general_itests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         toxenv:
           - py37-linux,docs,mypy,tests
+          - general_itests
     env:
       PIP_INDEX_URL: https://pypi.python.org/simple
       DOCKER_REGISTRY: ""

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         toxenv:
           - py37-linux,docs,mypy,tests
+          - general_itests
     env:
       PIP_INDEX_URL: https://pypi.python.org/simple
       DOCKER_REGISTRY: ""

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,8 @@ commands =
 envdir = .tox/py37-linux/
 commands =
     check-requirements -vv
+    pre-commit install -f --install-hooks
+    pre-commit run --all-files
     py.test {posargs:tests}
 
 [testenv:tests-yelpy]
@@ -51,6 +53,8 @@ deps =
     --editable={toxinidir}
 commands =
     check-requirements -vv
+    pre-commit install -f --install-hooks
+    pre-commit run --all-files
     py.test {posargs:tests}
 
 [testenv:docs]
@@ -169,8 +173,6 @@ deps =
 commands =
     # TODO: upgrade behave if they ever take this reasonable PR
     pip install git+https://github.com/Yelp/behave@1.2.5-issue_533-fork
-    pre-commit install -f --install-hooks
-    pre-commit run --all-files
     pylint -E paasta_tools/mesos/ --ignore master.py,task.py
     behave {posargs}
 


### PR DESCRIPTION
We've had a couple pre-commit failures sneak in since `make test`
doesn't install/run hooks (and none of the toxenvs run in GHA do so
either)