### PR TITLE
Add paasta_cluster to rollback events emitted to sfx

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -611,6 +611,11 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
         self.diagnosis_interval = diagnosis_interval
         self.time_before_first_diagnosis = time_before_first_diagnosis
         self.metrics_interface = metrics_interface
+        self.instance_configs_per_cluster: Dict[
+            str, List[LongRunningServiceConfig]
+        ] = get_instance_configs_for_service_in_deploy_group_all_clusters(
+            service, deploy_group, commit, soa_dir
+        )
 
         # Keep track of each wait_for_deployment task so we can cancel it.
         self.wait_for_deployment_tasks: Dict[str, asyncio.Task] = {}
@@ -1091,6 +1096,7 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
                 wait_for_deployment(
                     service=self.service,
                     deploy_group=self.deploy_group,
+                    instance_configs_per_cluster=self.instance_configs_per_cluster,
                     git_sha=target_commit,
                     soa_dir=self.soa_dir,
                     timeout=self.timeout,
@@ -1229,26 +1235,24 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
         rollback_details = self.__build_rollback_audit_details(
             RollbackTypes.AUTOMATIC_SLO_ROLLBACK
         )
-
-        dimensions = dict(rollback_details)
-        dimensions["paasta_service"] = self.service
-        self.metrics_interface.emit_event(
-            name="rollback", dimensions=dimensions,
-        )
-        _log_audit(
-            action="rollback", action_details=rollback_details, service=self.service,
-        )
+        self._log_rollback(rollback_details)
 
     def log_user_rollback(self) -> None:
         rollback_details = self.__build_rollback_audit_details(
             RollbackTypes.USER_INITIATED_ROLLBACK
         )
+        self._log_rollback(rollback_details)
 
-        dimensions = dict(rollback_details)
-        dimensions["paasta_service"] = self.service
-        self.metrics_interface.emit_event(
-            name="rollback", dimensions=dimensions,
-        )
+    def _log_rollback(self, rollback_details: Dict[str, str]) -> None:
+        base_dimensions = dict(rollback_details)
+        base_dimensions["paasta_service"] = self.service
+        # Emit one event per cluster to sfx
+        for cluster in self.instance_configs_per_cluster.keys():
+            dimensions = dict(base_dimensions)
+            dimensions["paasta_cluster"] = cluster
+            self.metrics_interface.emit_event(
+                name="rollback", dimensions=dimensions,
+            )
         _log_audit(
             action="rollback", action_details=rollback_details, service=self.service,
         )
@@ -1623,6 +1627,7 @@ def get_instance_configs_for_service_in_deploy_group_all_clusters(
 async def wait_for_deployment(
     service: str,
     deploy_group: str,
+    instance_configs_per_cluster: Dict[str, List[LongRunningServiceConfig]],
     git_sha: str,
     soa_dir: str,
     timeout: float,
@@ -1632,11 +1637,6 @@ async def wait_for_deployment(
     time_before_first_diagnosis: float = None,
     notify_fn: Optional[Callable[[str], None]] = None,
 ) -> Optional[int]:
-    instance_configs_per_cluster: Dict[
-        str, List[LongRunningServiceConfig]
-    ] = get_instance_configs_for_service_in_deploy_group_all_clusters(
-        service, deploy_group, git_sha, soa_dir
-    )
     total_instances = sum(len(ics) for ics in instance_configs_per_cluster.values())
 
     if not instance_configs_per_cluster:

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -16,6 +16,7 @@ import asyncio
 import asynctest
 import mock
 from mock import ANY
+from mock import call
 from mock import MagicMock
 from mock import patch
 from pytest import fixture
@@ -164,6 +165,10 @@ def test_paasta_mark_for_deployment_when_verify_image_succeeds(
     new=1.0,
     autospec=False,
 )
+@patch(
+    "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+    autospec=True,
+)
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log_audit", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.get_slack_client", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.validate_service_name", autospec=True)
@@ -191,6 +196,7 @@ def test_paasta_mark_for_deployment_with_good_rollback(
     mock_validate_service_name,
     mock_get_slack_client,
     mock__log_audit,
+    mock_get_instance_configs,
     mock_periodically_update_slack,
 ):
     class FakeArgsRollback(FakeArgs):
@@ -206,6 +212,7 @@ def test_paasta_mark_for_deployment_with_good_rollback(
     config_mock = mock.Mock()
     config_mock.get_default_push_groups.return_value = None
     mock_load_system_paasta_config.return_value = config_mock
+    mock_get_instance_configs.return_value = {"fake_cluster": [], "fake_cluster2": []}
     mock_mark_for_deployment.return_value = 0
 
     def do_wait_for_deployment_side_effect(self, target_commit):
@@ -276,16 +283,20 @@ def test_paasta_mark_for_deployment_with_good_rollback(
     mock_timer.start.assert_called_once_with()
     mock_timer.stop.assert_called_once_with(tmp_dimensions=dict(exit_status=1))
     mock_emit_event = mock_get_metrics.return_value.emit_event
-    mock_emit_event.assert_called_once_with(
-        name="rollback",
-        dimensions=dict(
-            paasta_service="test_service",
-            deploy_group="test_deploy_group",
-            rolled_back_from="d670460b4b4aece5915caf5c68d12f560a9fe3e4",
-            rolled_back_to="old-sha",
-            rollback_type="user_initiated_rollback",
-        ),
+    event_dimensions = dict(
+        paasta_service="test_service",
+        deploy_group="test_deploy_group",
+        rolled_back_from="d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+        rolled_back_to="old-sha",
+        rollback_type="user_initiated_rollback",
     )
+    expected_calls = []
+    for cluster in mock_get_instance_configs.return_value.keys():
+        dims = dict(event_dimensions)
+        dims["paasta_cluster"] = cluster
+        exp_call = call(name="rollback", dimensions=dims)
+        expected_calls.append(exp_call)
+    mock_emit_event.assert_has_calls(expected_calls, any_order=True)
 
 
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log_audit", autospec=True)
@@ -331,6 +342,7 @@ def test_mark_for_deployment_nonyelpy_repo(
     config_mock = mock.Mock()
     config_mock.get_default_push_groups.return_value = None
     mock_load_system_paasta_config.return_value = config_mock
+
     mark_for_deployment.mark_for_deployment(
         git_url="git://false.repo/services/test_services",
         deploy_group="fake_deploy_group",
@@ -340,6 +352,10 @@ def test_mark_for_deployment_nonyelpy_repo(
     assert not mock_trigger_deploys.called
 
 
+@patch(
+    "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+    autospec=True,
+)
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log_audit", autospec=True)
 @patch("paasta_tools.remote_git.get_authors", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.get_slack_client", autospec=True)
@@ -357,6 +373,7 @@ def test_MarkForDeployProcess_handles_wait_for_deployment_failure(
     mock_get_slack_client,
     mock_get_authors,
     mock__log_audit,
+    mock_get_instance_configs,
 ):
     mock_get_authors.return_value = 0, "fakeuser1 fakeuser2"
     mfdp = mark_for_deployment.MarkForDeploymentProcess(
@@ -391,6 +408,10 @@ def test_MarkForDeployProcess_handles_wait_for_deployment_failure(
     assert not mock__log_audit.called
 
 
+@patch(
+    "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+    autospec=True,
+)
 @patch("paasta_tools.remote_git.get_authors", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.get_slack_client", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.mark_for_deployment", autospec=True)
@@ -406,6 +427,7 @@ def test_MarkForDeployProcess_handles_first_time_deploys(
     mock_mark_for_deployment,
     mock_get_slack_client,
     mock_get_authors,
+    mock_get_instance_configs,
     mock_periodically_update_slack,
 ):
     mock_get_authors.return_value = 0, "fakeuser1 fakeuser2"
@@ -437,6 +459,11 @@ def test_MarkForDeployProcess_handles_first_time_deploys(
     assert retval == 2
 
 
+@patch.object(
+    mark_for_deployment,
+    "get_instance_configs_for_service_in_deploy_group_all_clusters",
+    autospec=True,
+)
 @patch.object(mark_for_deployment, "get_authors_to_be_notified", autospec=True)
 @patch.object(mark_for_deployment, "get_currently_deployed_sha", autospec=True)
 @patch.object(mark_for_deployment, "get_slack_client", autospec=True)
@@ -448,6 +475,7 @@ def test_MarkForDeployProcess_get_authors_diffs_against_prod_deploy_group(
     mock_get_slack_client,
     mock_get_currently_deployed_sha,
     mock_get_authors_to_be_notified,
+    mock_get_instance_configs,
 ):
     # get_authors should calculate authors since the production_deploy_group's
     # current SHA, when available.
@@ -478,6 +506,11 @@ def test_MarkForDeployProcess_get_authors_diffs_against_prod_deploy_group(
     )
 
 
+@patch.object(
+    mark_for_deployment,
+    "get_instance_configs_for_service_in_deploy_group_all_clusters",
+    autospec=True,
+)
 @patch.object(mark_for_deployment, "get_authors_to_be_notified", autospec=True)
 @patch.object(mark_for_deployment, "get_currently_deployed_sha", autospec=True)
 @patch.object(mark_for_deployment, "get_slack_client", autospec=True)
@@ -489,6 +522,7 @@ def test_MarkForDeployProcess_get_authors_falls_back_to_current_deploy_group(
     mock_get_slack_client,
     mock_get_currently_deployed_sha,
     mock_get_authors_to_be_notified,
+    mock_get_instance_configs,
 ):
     # When there's no production_deploy_group configured, get_authors should
     # fall back to calculating authors using the previous SHA for this deploy
@@ -520,6 +554,10 @@ def test_MarkForDeployProcess_get_authors_falls_back_to_current_deploy_group(
     )
 
 
+@patch(
+    "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+    autospec=True,
+)
 @patch("paasta_tools.remote_git.get_authors", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.get_slack_client", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.mark_for_deployment", autospec=True)
@@ -535,6 +573,7 @@ def test_MarkForDeployProcess_handles_wait_for_deployment_cancelled(
     mock_mark_for_deployment,
     mock_get_slack_client,
     mock_get_authors,
+    mock_get_instance_configs,
     mock_periodically_update_slack,
 ):
     mock_get_authors.return_value = 0, "fakeuser1 fakeuser2"
@@ -567,6 +606,10 @@ def test_MarkForDeployProcess_handles_wait_for_deployment_cancelled(
     assert mfdp.state == "deploy_cancelled"
 
 
+@patch(
+    "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+    autospec=True,
+)
 @patch("paasta_tools.remote_git.get_authors", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.Thread", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.get_slack_client", autospec=True)
@@ -586,6 +629,7 @@ def test_MarkForDeployProcess_skips_wait_for_deployment_when_block_is_False(
     mock_get_slack_client,
     mock_Thread,
     mock_get_authors,
+    mock_get_instance_configs,
 ):
     mock_get_authors.return_value = 0, "fakeuser1 fakeuser2"
     mfdp = mark_for_deployment.MarkForDeploymentProcess(
@@ -616,6 +660,10 @@ def test_MarkForDeployProcess_skips_wait_for_deployment_when_block_is_False(
     assert mfdp.state == "deploying"
 
 
+@patch(
+    "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+    autospec=True,
+)
 @patch("paasta_tools.remote_git.get_authors", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.get_slack_client", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.mark_for_deployment", autospec=True)
@@ -631,6 +679,7 @@ def test_MarkForDeployProcess_goes_to_mfd_failed_when_mark_for_deployment_fails(
     mock_mark_for_deployment,
     mock_get_slack_client,
     mock_get_authors,
+    mock_get_instance_configs,
     mock_periodically_update_slack,
 ):
     mock_get_authors.return_value = 0, "fakeuser1 fakeuser2"


### PR DESCRIPTION
When emitting events, we currently only indicate the deploy_group and service.  

However, SLOs are reported based on service and paasta_cluster, rather than deploy_group, so if we mapped the current events to the existing SLO charts, we'll include these events for some clusters where rollbacks did not actually occur. 

We already have the function `get_instance_configs_for_service_in_deploy_group_all_clusters` which will give us the specific instances by cluster in the requested deploy_group, used in wait_for_deployment when actually monitoring the affected instances.  This moves this function to be called when we initialize a MarkForDeploymentProcess and then uses this information when emitting events.