### PR TITLE
Skip clusterman metrics for spark-on-k8s

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -833,9 +833,9 @@ def configure_and_run_docker_container(
 def _should_emit_resource_requirements(
     docker_cmd: str, is_mrjob: bool, cluster_manager: str
 ) -> bool:
-    return is_mrjob or (
-        cluster_manager == CLUSTER_MANAGER_MESOS
-        and any(c in docker_cmd for c in ["pyspark", "spark-shell", "spark-submit"])
+    return cluster_manager == CLUSTER_MANAGER_MESOS and (
+        is_mrjob
+        or any(c in docker_cmd for c in ["pyspark", "spark-shell", "spark-submit"])
     )
 
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -789,7 +789,7 @@ def configure_and_run_docker_container(
     print(f"Selected cluster manager: {cluster_manager}\n")
 
     if clusterman_metrics and _should_emit_resource_requirements(
-        docker_cmd, args.mrjob
+        docker_cmd, args.mrjob, cluster_manager
     ):
         try:
             print("Sending resource request metrics to Clusterman")
@@ -830,9 +830,12 @@ def configure_and_run_docker_container(
     )
 
 
-def _should_emit_resource_requirements(docker_cmd, is_mrjob):
-    return is_mrjob or any(
-        c in docker_cmd for c in ["pyspark", "spark-shell", "spark-submit"]
+def _should_emit_resource_requirements(
+    docker_cmd: str, is_mrjob: bool, cluster_manager: str
+) -> bool:
+    return is_mrjob or (
+        cluster_manager == CLUSTER_MANAGER_MESOS
+        and any(c in docker_cmd for c in ["pyspark", "spark-shell", "spark-submit"])
     )
 
 

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -18,6 +18,7 @@ import pytest
 from boto3.exceptions import Boto3Error
 
 from paasta_tools.cli.cmds import spark_run
+from paasta_tools.cli.cmds.spark_run import _should_emit_resource_requirements
 from paasta_tools.cli.cmds.spark_run import CLUSTER_MANAGER_K8S
 from paasta_tools.cli.cmds.spark_run import CLUSTER_MANAGER_MESOS
 from paasta_tools.cli.cmds.spark_run import configure_and_run_docker_container
@@ -1014,3 +1015,32 @@ def test_paasta_spark_run(
         pod_template_path="unique-run",
     )
     mock_generate_pod_template_path.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "docker_cmd, is_mrjob, cluster_manager, expected",
+    (
+        # normal mesos cases
+        ("spark-submit FOO", False, "mesos", True),
+        ("spark-shell FOO", False, "mesos", True),
+        ("pyspark FOO", False, "mesos", True),
+        # mesos, but wrong command
+        ("spark-nope FOO", False, "mesos", False),
+        # mrjob
+        ("FOO", True, "mesos", True),
+        ("FOO", True, "kubernetes", False),
+        # normal k8s cases
+        ("spark-submit FOO", False, "kubernetes", False),
+        ("spark-shell FOO", False, "kubernetes", False),
+        ("pyspark FOO", False, "kubernetes", False),
+        # k8s, but wrong command
+        ("spark-nope FOO", False, "kubernetes", False),
+    ),
+)
+def test__should_emit_resource_requirements(
+    docker_cmd, is_mrjob, cluster_manager, expected
+):
+    assert (
+        _should_emit_resource_requirements(docker_cmd, is_mrjob, cluster_manager)
+        is expected
+    )


### PR DESCRIPTION
This is causing us to scale up our legacy mesos pools when k8s jobs
launch.

This does also mean that we won't print any cost warnings, but we should
probably get Core ML to refactor this further once we've stopped the
bleeding with this PR to get that feature back.