### PR TITLE
Teach paasta cook-image --commit

### DIFF
--- a/paasta_tools/cli/cmds/cook_image.py
+++ b/paasta_tools/cli/cmds/cook_image.py
@@ -21,6 +21,7 @@ from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.utils import _log
 from paasta_tools.utils import _log_audit
 from paasta_tools.utils import _run
+from paasta_tools.utils import build_docker_tag
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_username
 
@@ -54,6 +55,9 @@ def add_subparser(subparsers):
         help="A directory from which yelpsoa-configs should be read from",
         default=DEFAULT_SOA_DIR,
     )
+    list_parser.add_argument(
+        "-c", "--commit", help="Git sha used to construct tag for built image",
+    )
     list_parser.set_defaults(command=paasta_cook_image)
 
 
@@ -68,8 +72,14 @@ def paasta_cook_image(args, service=None, soa_dir=None):
     validate_service_name(service, soa_dir)
 
     run_env = os.environ.copy()
-    default_tag = "paasta-cook-image-{}-{}".format(service, get_username())
-    tag = run_env.get("DOCKER_TAG", default_tag)
+    if args.commit is not None:
+        # if we're given a commit, we're likely being called by Jenkins or someone
+        # trying to push the cooked image to our registry - as such, we should tag
+        # the cooked image as `paasta itest` would.
+        tag = build_docker_tag(service, args.commit)
+    else:
+        default_tag = "paasta-cook-image-{}-{}".format(service, get_username())
+        tag = run_env.get("DOCKER_TAG", default_tag)
     run_env["DOCKER_TAG"] = tag
 
     if not makefile_responds_to("cook-image"):

--- a/tests/cli/test_cmds_cook_image.py
+++ b/tests/cli/test_cmds_cook_image.py
@@ -29,6 +29,7 @@ def test_run_success(
     mock_validate_service_name.return_value = True
 
     args = mock.MagicMock()
+    args.commit = None
     args.service = "fake_service"
     assert paasta_cook_image(args) == 0
 
@@ -36,6 +37,31 @@ def test_run_success(
         action="cook-image",
         action_details={
             "tag": "paasta-cook-image-fake_service-{}".format(get_username())
+        },
+        service="fake_service",
+    )
+
+
+@mock.patch("paasta_tools.cli.cmds.cook_image.validate_service_name", autospec=True)
+@mock.patch("paasta_tools.cli.cmds.cook_image.makefile_responds_to", autospec=True)
+@mock.patch("paasta_tools.cli.cmds.cook_image._run", autospec=True)
+@mock.patch("paasta_tools.cli.cmds.cook_image._log_audit", autospec=True)
+def test_run_success_with_commit(
+    mock_log_audit, mock_run, mock_makefile_responds_to, mock_validate_service_name
+):
+    mock_run.return_value = (0, "Output")
+    mock_makefile_responds_to.return_value = True
+    mock_validate_service_name.return_value = True
+
+    args = mock.MagicMock()
+    args.commit = "0" * 40
+    args.service = "fake_service"
+    assert paasta_cook_image(args) == 0
+
+    mock_log_audit.assert_called_once_with(
+        action="cook-image",
+        action_details={
+            "tag": f"docker-paasta.yelpcorp.com:443/services-fake_service:paasta-{args.commit}"
         },
         service="fake_service",
     )

--- a/tests/cli/test_cmds_cook_image.py
+++ b/tests/cli/test_cmds_cook_image.py
@@ -56,12 +56,18 @@ def test_run_success_with_commit(
     args = mock.MagicMock()
     args.commit = "0" * 40
     args.service = "fake_service"
-    assert paasta_cook_image(args) == 0
+
+    with mock.patch(
+        "paasta_tools.utils.get_service_docker_registry",
+        autospec=True,
+        return_value="fake_registry",
+    ):
+        assert paasta_cook_image(args) == 0
 
     mock_log_audit.assert_called_once_with(
         action="cook-image",
         action_details={
-            "tag": f"docker-paasta.yelpcorp.com:443/services-fake_service:paasta-{args.commit}"
+            "tag": f"fake_registry/services-fake_service:paasta-{args.commit}"
         },
         service="fake_service",
     )
@@ -80,6 +86,7 @@ def test_run_makefile_fail(
 
     args = mock.MagicMock()
     args.service = "fake_service"
+    args.commit = None
 
     assert paasta_cook_image(args) == 1
     assert not mock_log_audit.called
@@ -103,6 +110,7 @@ def test_run_keyboard_interrupt(
 
     args = mock.MagicMock()
     args.service = "fake_service"
+    args.commit = None
 
     assert paasta_cook_image(args) == 2
     assert not mock_log_audit.called


### PR DESCRIPTION
CID would like this so that Jenkins can skip itesting and just cook an
image if tests have already passed pre-merge.

Unless --commit is passed, paasta cook-image will behave as it always
has.