### PR TITLE
Add hash limit function to boto_keys secret names

### DIFF
--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -36,6 +36,7 @@ from paasta_tools.kubernetes_tools import get_kubernetes_app_name
 from paasta_tools.kubernetes_tools import get_kubernetes_secret_signature
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
+from paasta_tools.kubernetes_tools import limit_size_with_hash
 from paasta_tools.kubernetes_tools import update_kubernetes_secret_signature
 from paasta_tools.kubernetes_tools import update_plaintext_dict_secret
 from paasta_tools.kubernetes_tools import update_secret
@@ -314,7 +315,7 @@ def sync_boto_secrets(
         # In order to prevent slamming the k8s API, add some artificial delay here
         time.sleep(0.3)
         app_name = get_kubernetes_app_name(service, instance)
-        secret = f"paasta-boto-key-{app_name}"
+        secret = limit_size_with_hash(f"paasta-boto-key-{app_name}")
         hashable_data = "".join([secret_data[key] for key in secret_data])
         signature = hashlib.sha1(hashable_data.encode("utf-8")).hexdigest()
         kubernetes_signature = get_kubernetes_secret_signature(

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1324,7 +1324,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             return None
         secret_name = limit_size_with_hash(f"paasta-boto-key-{service_name}")
         volume = V1Volume(
-            name=limit_size_with_hash(f"secret-boto-key-{service_name}"),
+            name=self.get_sanitised_volume_name(
+                f"secret-boto-key-{service_name}", length_limit=253
+            ),
             secret=V1SecretVolumeSource(
                 secret_name=secret_name, default_mode=mode_to_int("0444"), items=items,
             ),
@@ -1378,7 +1380,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             if secret_hash:
                 mount = V1VolumeMount(
                     mount_path="/etc/boto_cfg",
-                    name=limit_size_with_hash(f"secret-boto-key-{service_name}"),
+                    name=self.get_sanitised_volume_name(
+                        f"secret-boto-key-{service_name}", length_limit=253
+                    ),
                     read_only=True,
                 )
                 for existing_mount in volume_mounts:

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1322,9 +1322,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         if not secret_hash:
             log.warning(f"Expected to find k8s secret {secret_name} for boto_cfg")
             return None
-        secret_name = f"paasta-boto-key-{service_name}"
+        secret_name = limit_size_with_hash(f"paasta-boto-key-{service_name}")
         volume = V1Volume(
-            name=f"secret-boto-key-{service_name}",
+            name=limit_size_with_hash(f"secret-boto-key-{service_name}"),
             secret=V1SecretVolumeSource(
                 secret_name=secret_name, default_mode=mode_to_int("0444"), items=items,
             ),
@@ -1378,7 +1378,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             if secret_hash:
                 mount = V1VolumeMount(
                     mount_path="/etc/boto_cfg",
-                    name=f"secret-boto-key-{service_name}",
+                    name=limit_size_with_hash(f"secret-boto-key-{service_name}"),
                     read_only=True,
                 )
                 for existing_mount in volume_mounts:
@@ -1391,7 +1391,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
     def get_boto_secret_hash(self) -> str:
         kube_client = KubeClient()
         service_name = self.get_sanitised_deployment_name()
-        secret_name = f"paasta-boto-key-{service_name}"
+        secret_name = limit_size_with_hash(f"paasta-boto-key-{service_name}")
         return get_kubernetes_secret_signature(
             kube_client=kube_client, secret=secret_name, service=service_name
         )


### PR DESCRIPTION
when the service and instance name are long enough, this can make the secret name hit k8s' 63 character limit, resulting in an error:
```
"reason":"FieldValueInvalid","message":"Invalid value: \"secret-boto-key-service-name-instance-name-blah-blah\": must be no more than 63 characters"
```

This should fix the issue by using the limit_size_with_hash function provided for exactly this purpose. I'm applying it to both the secret name and the volume name.

Tests pass, though I haven't done any additional testing. 