### PR TITLE
Add/Use cluster aliases for paasta spark-run

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -953,7 +953,9 @@ def paasta_spark_run(args):
         instance_config = get_instance_config(
             service=args.service,
             instance=args.instance,
-            cluster=args.cluster,
+            cluster=system_paasta_config.get_cluster_aliases().get(
+                args.cluster, args.cluster
+            ),
             load_deployments=args.build is False and args.image is None,
             soa_dir=args.yelpsoa_config_root,
         )

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1964,6 +1964,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     zookeeper: str
     tron_use_k8s: bool
     skip_cpu_override_validation: List[str]
+    cluster_aliases: Dict[str, str]
 
 
 def load_system_paasta_config(
@@ -2639,6 +2640,9 @@ class SystemPaastaConfig:
 
     def get_skip_cpu_override_validation_services(self) -> List[str]:
         return self.config_dict.get("skip_cpu_override_validation", [])
+
+    def get_cluster_aliases(self) -> Dict[str, str]:
+        return self.config_dict.get("cluster_aliases", {})
 
 
 def _run(

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -969,6 +969,7 @@ def test_paasta_spark_run(
         spark_args="spark.cores.max=100 spark.executor.cores=10",
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
     )
+    mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     spark_run.paasta_spark_run(args)
     mock_validate_work_dir.assert_called_once_with("/tmp/local")
     mock_get_instance_config.assert_called_once_with(


### PR DESCRIPTION
We're in a bit of a weird situation with spark where we want to run
stuff in a separate sparl-specific cluster, but there's a lot of
assumptions in the paasta codebase where the cluster you're running
stuff on will be populated by {workload}-{cluster}.yaml files - and we
don't really want to embark on migrating all the existing configuration
(since that requires that we migrate/work on a bunch of other stuff like
Tron to "natively" support this as a separate cluster in the same way as
every other cluster works)