### PR TITLE
Remove paastaca

### DIFF
--- a/paasta_tools/api/client.py
+++ b/paasta_tools/api/client.py
@@ -26,33 +26,11 @@ from urllib.parse import urlparse
 
 import paasta_tools.paastaapi.apis as paastaapis
 from paasta_tools import paastaapi
-from paasta_tools.secret_tools import get_secret_provider
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import SystemPaastaConfig
 
 
 log = logging.getLogger(__name__)
-
-
-def get_paasta_ssl_opts(
-    cluster: str, system_paasta_config: SystemPaastaConfig
-) -> Mapping:
-    if system_paasta_config.get_enable_client_cert_auth():
-        ecosystem = system_paasta_config.get_vault_cluster_config()[cluster]
-        paasta_dir = os.path.expanduser("~/.paasta/pki")
-        if (
-            not os.path.isfile(f"{paasta_dir}/{ecosystem}.crt")
-            or not os.path.isfile(f"{paasta_dir}/{ecosystem}.key")
-            or not os.path.isfile(f"{paasta_dir}/{ecosystem}_ca.crt")
-        ):
-            renew_issue_cert(system_paasta_config=system_paasta_config, cluster=cluster)
-        return dict(
-            key=f"{paasta_dir}/{ecosystem}.crt",
-            cert=f"{paasta_dir}/{ecosystem}.key",
-            ca=f"{paasta_dir}/{ecosystem}_ca.crt",
-        )
-    else:
-        return {}
 
 
 @dataclass
@@ -114,28 +92,6 @@ def get_paasta_oapi_client(
 
     parsed = urlparse(api_endpoints[cluster])
     cert_file = key_file = ssl_ca_cert = None
-    if parsed.scheme == "https":
-        opts = get_paasta_ssl_opts(cluster, system_paasta_config)
-        if opts:
-            cert_file = opts["cert"]
-            key_file = opts["key"]
-            ssl_ca_cert = opts["ca"]
 
     return get_paasta_oapi_client_by_url(parsed, cert_file, key_file, ssl_ca_cert)
 
-
-def renew_issue_cert(system_paasta_config: SystemPaastaConfig, cluster: str) -> None:
-    secret_provider_kwargs = {
-        "vault_cluster_config": system_paasta_config.get_vault_cluster_config()
-    }
-    sp = get_secret_provider(
-        secret_provider_name=system_paasta_config.get_secret_provider_name(),
-        cluster_names=[cluster],
-        secret_provider_kwargs=secret_provider_kwargs,
-        soa_dir=None,
-        service_name=None,
-    )
-    sp.renew_issue_cert(
-        pki_backend=system_paasta_config.get_pki_backend(),
-        ttl=system_paasta_config.get_auth_certificate_ttl(),
-    )

--- a/paasta_tools/secret_providers/__init__.py
+++ b/paasta_tools/secret_providers/__init__.py
@@ -47,9 +47,6 @@ class BaseSecretProvider:
     def get_secret_signature_from_data(self, data: Mapping[str, Any]) -> Optional[str]:
         raise NotImplementedError
 
-    def renew_issue_cert(self, pki_backend: str, ttl: str) -> None:
-        raise NotImplementedError
-
 
 class SecretProvider(BaseSecretProvider):
     pass

--- a/paasta_tools/secret_providers/vault.py
+++ b/paasta_tools/secret_providers/vault.py
@@ -11,7 +11,6 @@ try:
     from vault_tools.paasta_secret import get_vault_client
     from vault_tools.gpg import TempGpgKeyring
     from vault_tools.paasta_secret import encrypt_secret
-    from vault_tools.cert_tools import do_cert_renew
     import hvac
 except ImportError:
 
@@ -24,9 +23,6 @@ except ImportError:
     TempGpgKeyring = None
 
     def encrypt_secret(*args: Any, **kwargs: Any) -> None:
-        return None
-
-    def do_cert_renew(*args: Any, **kwargs: Any) -> None:
         return None
 
 
@@ -164,20 +160,3 @@ class SecretProvider(BaseSecretProvider):
         else:
             return None
 
-    def renew_issue_cert(self, pki_backend: str, ttl: str) -> None:
-        client = self.clients[self.ecosystems[0]]
-        user = getpass.getuser()
-        pki_dir = os.path.expanduser("~/.paasta/pki")
-        do_cert_renew(
-            client=client,
-            pki_backend=pki_backend,
-            role=user,
-            cn=f"{user}.{self.ecosystems[0]}.paasta.yelp",
-            cert_path=f"{pki_dir}/{self.ecosystems[0]}.crt",
-            key_path=f"{pki_dir}/{self.ecosystems[0]}.key",
-            ca_path=f"{pki_dir}/{self.ecosystems[0]}_ca.crt",
-            cert_owner=user,
-            cert_group="users",
-            cert_mode="0600",
-            ttl=ttl,
-        )

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2183,12 +2183,6 @@ class SystemPaastaConfig:
         """
         return self.config_dict.get("auth_certificate_ttl", "11h")
 
-    def get_pki_backend(self) -> str:
-        """
-        The Vault pki backend to use for issueing certificates
-        """
-        return self.config_dict.get("pki_backend", "paastaca")
-
     def get_fsm_template(self) -> str:
         fsm_path = os.path.dirname(paasta_tools.cli.fsm.__file__)
         template_path = os.path.join(fsm_path, "template")

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -14,7 +14,6 @@
 import mock
 
 from paasta_tools.api.client import get_paasta_oapi_client
-from paasta_tools.api.client import renew_issue_cert
 
 
 def test_get_paasta_oapi_client(system_paasta_config):
@@ -27,13 +26,3 @@ def test_get_paasta_oapi_client(system_paasta_config):
         assert client
 
 
-def test_renew_issue_cert():
-    with mock.patch(
-        "paasta_tools.api.client.get_secret_provider", autospec=True
-    ) as mock_get_secret_provider:
-        mock_config = mock.Mock()
-        renew_issue_cert(mock_config, "westeros-prod")
-        mock_get_secret_provider.return_value.renew_issue_cert.assert_called_with(
-            pki_backend=mock_config.get_pki_backend(),
-            ttl=mock_config.get_auth_certificate_ttl(),
-        )

--- a/tests/secret_providers/test_vault.py
+++ b/tests/secret_providers/test_vault.py
@@ -174,9 +174,3 @@ def test_get_secret_signature_from_data_missing(mock_secret_provider):
         )
 
 
-def test_renew_issue_cert(mock_secret_provider):
-    with mock.patch(
-        "paasta_tools.secret_providers.vault.do_cert_renew", autospec=True
-    ) as mock_do_cert_renew:
-        mock_secret_provider.renew_issue_cert("paasta", "30m")
-        assert mock_do_cert_renew.called


### PR DESCRIPTION
I don't think the paasta CA is used/actually works - all the config we have internally points the API to HTTP, and the CA config is only present in a subset of dev regions.

Lets remove to to simplify Vault config and avoid confusion unless we plan to work on this soon.