### PR TITLE
Fix additional pre-commit failures + fix oapi hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,4 +68,5 @@ repos:
         entry: paasta_tools/contrib/check_manual_oapi_changes.sh
         language: script
         exclude: ^$
-        files: ^.*paasta_tools/api/api_docs/oapi.yaml|^.*paasta_tools/paastaapi.*
+        # we just want to run this hook once, so only include a single file
+        files: ^paasta_tools/api/api_docs/oapi.yaml

--- a/paasta_tools/api/client.py
+++ b/paasta_tools/api/client.py
@@ -92,4 +92,3 @@ def get_paasta_oapi_client(
     cert_file = key_file = ssl_ca_cert = None
 
     return get_paasta_oapi_client_by_url(parsed, cert_file, key_file, ssl_ca_cert)
-

--- a/paasta_tools/contrib/check_manual_oapi_changes.sh
+++ b/paasta_tools/contrib/check_manual_oapi_changes.sh
@@ -5,6 +5,9 @@ diff_names=$(git diff origin/master --name-only)
 schema_touched=$(echo "$diff_names" | grep 'paasta_tools/api/api_docs/oapi.yaml')
 api_touched=$(echo "$diff_names" | grep 'paasta_tools/paastaapi')
 
+# this case will only be hit as part of `make test` or someone running pre-commit on
+# all files manually since we've chosen to only run this hook on changes to the schema
+# file
 if [ ! -z "$api_touched" -a -z "$schema_touched" ]; then
     echo "paasta_tools/paastaapi must not be modified manually" >&2
     echo "Please revert your changes:" >&2

--- a/paasta_tools/contrib/check_manual_oapi_changes.sh
+++ b/paasta_tools/contrib/check_manual_oapi_changes.sh
@@ -1,18 +1,15 @@
 #!/bin/bash
 set -uo pipefail
 
-if ! [[ "${PAASTA_SYSTEM_CONFIG_DIR:-}" =~ ^.*/general_itests/fake_etc_paasta ]] ; then
-    # Do not run during general_itests
-    diff_names=$(git diff origin/master --name-only)
-    schema_touched=$(echo "$diff_names" | grep 'paasta_tools/api/api_docs/oapi.yaml')
-    api_touched=$(echo "$diff_names" | grep 'paasta_tools/paastaapi')
+diff_names=$(git diff origin/master --name-only)
+schema_touched=$(echo "$diff_names" | grep 'paasta_tools/api/api_docs/oapi.yaml')
+api_touched=$(echo "$diff_names" | grep 'paasta_tools/paastaapi')
 
-    if [ ! -z "$api_touched" -a -z "$schema_touched" ]; then
-        echo "paasta_tools/paastaapi must not be modified manually" >&2
-        echo "Please revert your changes:" >&2
-        echo -e "$api_touched" >&2
-        exit 1
-    fi
+if [ ! -z "$api_touched" -a -z "$schema_touched" ]; then
+    echo "paasta_tools/paastaapi must not be modified manually" >&2
+    echo "Please revert your changes:" >&2
+    echo -e "$api_touched" >&2
+    exit 1
 fi
 
 make openapi-codegen &>/dev/null

--- a/paasta_tools/secret_providers/vault.py
+++ b/paasta_tools/secret_providers/vault.py
@@ -159,4 +159,3 @@ class SecretProvider(BaseSecretProvider):
             return data["environments"][ecosystem]["signature"]
         else:
             return None
-

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -24,5 +24,3 @@ def test_get_paasta_oapi_client(system_paasta_config):
 
         client = get_paasta_oapi_client()
         assert client
-
-

--- a/tests/secret_providers/test_vault.py
+++ b/tests/secret_providers/test_vault.py
@@ -172,5 +172,3 @@ def test_get_secret_signature_from_data_missing(mock_secret_provider):
         assert not mock_secret_provider.get_secret_signature_from_data(
             {"environments": {"westeros": {}}}
         )
-
-


### PR DESCRIPTION
There were some other PRs merged in between the last pre-commit fix and
getting pre-commit running in GHA again


We were also running check_manual_oapi_changes once for every file whenever
we ran `pre-commit run --all-files`, which was making things unhappy when
the hook was run in parallel (since `make openapi-codegen` mucks with files)