### PR TITLE
Add deploy events to setup_kubernetes_job

### DIFF
--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -93,7 +93,7 @@ def main() -> None:
         logging.getLogger("kazoo").setLevel(logging.WARN)
         logging.basicConfig(level=logging.INFO)
 
-    deploy_metrics = metrics_lib.get_metrics_interface("paasta.deploy")
+    deploy_metrics = metrics_lib.get_metrics_interface("paasta")
 
     # system_paasta_config = load_system_paasta_config()
     kube_client = KubeClient()
@@ -127,7 +127,7 @@ def setup_kube_deployments(
     cluster: str,
     rate_limit: int = 0,
     soa_dir: str = DEFAULT_SOA_DIR,
-    metrics_interface: metrics_lib.BaseMetrics = metrics_lib.NoMetrics("paasta.deploy"),
+    metrics_interface: metrics_lib.BaseMetrics = metrics_lib.NoMetrics("paasta"),
 ) -> bool:
     if service_instances:
         existing_kube_deployments = set(list_all_deployments(kube_client))


### PR DESCRIPTION
In setup_marathon_job, when we updated a deployment and caused a bounce, we emitted a `deploy.paasta` event to our metrics provider.

We lost that during the migration to kubernetes, which meant these events no longer showed up in the dashboards we present to service owners.

This change re-adds events, although now under `paasta.deploy` events rather than `deploy.paasta` events, with additional information whether the deploy was `created` or `updated`.  I swapped to be `paasta`-prefixed since that follows the other paasta-generated events we've been adding in e.g. mark-for-deployment.

Let me know if you think these should be logged with a different name/prefix. 

Manually running setup_kubernetes_job for compute-infra-test-service.status_test in infrastage generated the events in SFX as expected:
 https://fluffy.yelpcorp.com/i/j7f1gmKlNKHx9Gj5ZxgQxsD2vpLwLZxh.png