### PR TITLE
Allow issuetype key in tron monitoring configs

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -431,6 +431,9 @@
                 "monitoring": {
                     "type": "object",
                     "properties": {
+                        "issuetype": {
+                            "type": "string"
+                        },
                         "team": {
                             "type": "string"
                         },


### PR DESCRIPTION
We're deploying a version of tron that includes a pysensu-yelp version
that allows users to set the issuetype for any jira tickets that are
created - but the tron schema is strict and won't allow this to be set
without having a schema entry for the config key