### PR TITLE
Add fake api_endpoints.json for general_itests

### DIFF
--- a/general_itests/fake_etc_paasta/api_endpoints.json
+++ b/general_itests/fake_etc_paasta/api_endpoints.json
@@ -1,0 +1,5 @@
+{
+    "api_endpoints": {
+        "test-cluster": "http://test.paasta.api"
+    }
+}


### PR DESCRIPTION
In https://github.com/Yelp/paasta/pull/3293 I added a dependence on api_endpoints (just to get valid cluster names) for `mark-for-deployment`, which broke `general_itests`.

This adds a dummy api_endpoints so mark-for-deployment works as expected.