### PR TITLE
Limit size of service name labels for signatures and volume mount names

### DIFF
--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -321,7 +321,7 @@ def sync_boto_secrets(
         kubernetes_signature = get_kubernetes_secret_signature(
             kube_client=kube_client,
             secret=secret,
-            service=app_name,
+            service=service,
             namespace=namespace,
         )
         if not kubernetes_signature:
@@ -344,7 +344,7 @@ def sync_boto_secrets(
             create_kubernetes_secret_signature(
                 kube_client=kube_client,
                 secret=secret,
-                service=app_name,
+                service=service,
                 secret_signature=signature,
                 namespace=namespace,
             )
@@ -362,7 +362,7 @@ def sync_boto_secrets(
             update_kubernetes_secret_signature(
                 kube_client=kube_client,
                 secret=secret,
-                service=app_name,
+                service=service,
                 secret_signature=signature,
                 namespace=namespace,
             )

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2960,6 +2960,7 @@ def update_kubernetes_secret_signature(
     namespace: str = "paasta",
 ) -> None:
     service = sanitise_kubernetes_name(service)
+    limited_service = limit_size_with_hash(service)
     secret = sanitise_kubernetes_name(secret)
     kube_client.core.replace_namespaced_config_map(
         name=f"{namespace}-secret-{service}-{secret}-signature",
@@ -2968,8 +2969,8 @@ def update_kubernetes_secret_signature(
             metadata=V1ObjectMeta(
                 name=f"{namespace}-secret-{service}-{secret}-signature",
                 labels={
-                    "yelp.com/paasta_service": service,
-                    "paasta.yelp.com/service": service,
+                    "yelp.com/paasta_service": limited_service,
+                    "paasta.yelp.com/service": limited_service,
                 },
             ),
             data={"signature": secret_signature},
@@ -2985,6 +2986,7 @@ def create_kubernetes_secret_signature(
     namespace: str = "paasta",
 ) -> None:
     service = sanitise_kubernetes_name(service)
+    limited_service = limit_size_with_hash(service)
     secret = sanitise_kubernetes_name(secret)
     kube_client.core.create_namespaced_config_map(
         namespace=namespace,
@@ -2992,8 +2994,8 @@ def create_kubernetes_secret_signature(
             metadata=V1ObjectMeta(
                 name=f"{namespace}-secret-{service}-{secret}-signature",
                 labels={
-                    "yelp.com/paasta_service": service,
-                    "paasta.yelp.com/service": service,
+                    "yelp.com/paasta_service": limited_service,
+                    "paasta.yelp.com/service": limited_service,
                 },
             ),
             data={"signature": secret_signature},

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2961,7 +2961,6 @@ def update_kubernetes_secret_signature(
     namespace: str = "paasta",
 ) -> None:
     service = sanitise_kubernetes_name(service)
-    limited_service = limit_size_with_hash(service)
     secret = sanitise_kubernetes_name(secret)
     kube_client.core.replace_namespaced_config_map(
         name=f"{namespace}-secret-{service}-{secret}-signature",
@@ -2970,8 +2969,8 @@ def update_kubernetes_secret_signature(
             metadata=V1ObjectMeta(
                 name=f"{namespace}-secret-{service}-{secret}-signature",
                 labels={
-                    "yelp.com/paasta_service": limited_service,
-                    "paasta.yelp.com/service": limited_service,
+                    "yelp.com/paasta_service": service,
+                    "paasta.yelp.com/service": service,
                 },
             ),
             data={"signature": secret_signature},
@@ -2987,7 +2986,6 @@ def create_kubernetes_secret_signature(
     namespace: str = "paasta",
 ) -> None:
     service = sanitise_kubernetes_name(service)
-    limited_service = limit_size_with_hash(service)
     secret = sanitise_kubernetes_name(secret)
     kube_client.core.create_namespaced_config_map(
         namespace=namespace,
@@ -2995,8 +2993,8 @@ def create_kubernetes_secret_signature(
             metadata=V1ObjectMeta(
                 name=f"{namespace}-secret-{service}-{secret}-signature",
                 labels={
-                    "yelp.com/paasta_service": limited_service,
-                    "paasta.yelp.com/service": limited_service,
+                    "yelp.com/paasta_service": service,
+                    "paasta.yelp.com/service": service,
                 },
             ),
             data={"signature": secret_signature},

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1325,7 +1325,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         secret_name = limit_size_with_hash(f"paasta-boto-key-{service_name}")
         volume = V1Volume(
             name=self.get_sanitised_volume_name(
-                f"secret-boto-key-{service_name}", length_limit=253
+                f"secret-boto-key-{service_name}", length_limit=63
             ),
             secret=V1SecretVolumeSource(
                 secret_name=secret_name, default_mode=mode_to_int("0444"), items=items,
@@ -1381,7 +1381,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 mount = V1VolumeMount(
                     mount_path="/etc/boto_cfg",
                     name=self.get_sanitised_volume_name(
-                        f"secret-boto-key-{service_name}", length_limit=253
+                        f"secret-boto-key-{service_name}", length_limit=63
                     ),
                     read_only=True,
                 )
@@ -1394,8 +1394,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
     def get_boto_secret_hash(self) -> str:
         kube_client = KubeClient()
-        service_name = self.get_sanitised_deployment_name()
-        secret_name = limit_size_with_hash(f"paasta-boto-key-{service_name}")
+        deployment_name = self.get_sanitised_deployment_name()
+        service_name = self.get_sanitised_service_name()
+        secret_name = limit_size_with_hash(f"paasta-boto-key-{deployment_name}")
         return get_kubernetes_secret_signature(
             kube_client=kube_client, secret=secret_name, service=service_name
         )


### PR DESCRIPTION
First fix attempt: https://github.com/Yelp/paasta/pull/3299/files

This change wasn't sufficient. We encountered an error when setting `boto_keys` for some services saying that the label attached to the ConfigMap object used to store secret signatures is too long:

(Service name changed slightly for the paste)
```
...HTTP response body: {\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"ConfigMap \\\"paasta-secret-servicename-this--one--just--has--a--really--long--instance--name-paasta-boto-key-servicename-this--one--just-yvib-signature\\\" is invalid: metadata.labels: Invalid value: \\\"servicename-this--one--just--has--a--really--long--instance--name\\\": must be no more than 63 characters\",\"reason\":\"Invalid\",\"details\":{\"name\":\"paasta-secret-servicename-this--one--just--has--a--really--long--instance--name-paasta-boto-key-servicename-this--one--just-yvib-signature\",\"kind\":\"ConfigMap\",\"causes\":[{\"reason\":\"FieldValueInvalid\",\"message\":\"Invalid value: \\\"servicename-this--one--just--has--a--really--long--instance--name\\\": must be no more than 63 characters\",\"field\":\"metadata.labels\"},{\"reason\":\"FieldValueInvalid\",\"message\":\"Invalid value: \\\"servicename-thi", ...
```

This happens because we were passing the full deployment name into `service` parameter of *_kubernetes_secret_hash instead of just the service name. 

After I made that change, I encountered another error that the volume name was also too long. I picked 253 previously because that's the limit on other K8s resource names. In this case, Volume names, it can only be 63.