### PR TITLE
COMPINFRA-989: fix healthcheck_grace_period_seconds not being set for hacheck

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1967,6 +1967,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     spark_k8s_role: str
     tron_use_suffixed_log_streams: bool
     cluster_aliases: Dict[str, str]
+    hacheck_match_initial_delay: bool
 
 
 def load_system_paasta_config(
@@ -2645,6 +2646,9 @@ class SystemPaastaConfig:
 
     def get_cluster_aliases(self) -> Dict[str, str]:
         return self.config_dict.get("cluster_aliases", {})
+
+    def get_hacheck_match_initial_delay(self) -> bool:
+        return self.config_dict.get("hacheck_match_initial_delay", True)
 
 
 def _run(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2648,7 +2648,7 @@ class SystemPaastaConfig:
         return self.config_dict.get("cluster_aliases", {})
 
     def get_hacheck_match_initial_delay(self) -> bool:
-        return self.config_dict.get("hacheck_match_initial_delay", True)
+        return self.config_dict.get("hacheck_match_initial_delay", False)
 
 
 def _run(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -570,6 +570,7 @@ class TestKubernetesDeploymentConfig:
                 get_hacheck_sidecar_image_url=mock.Mock(
                     return_value="some-docker-image"
                 ),
+                get_hacheck_match_initial_delay=mock.Mock(return_value=False),
             )
             ret = self.deployment.get_sidecar_containers(
                 mock_system_config, mock_service_namespace, hacheck_sidecar_volumes
@@ -608,7 +609,7 @@ class TestKubernetesDeploymentConfig:
                         _exec=V1ExecAction(
                             command=["/nail/blah.sh", "8888", "universal.credit"]
                         ),
-                        initial_delay_seconds=self.deployment.get_healthcheck_grace_period_seconds(),
+                        initial_delay_seconds=10,
                         period_seconds=10,
                     ),
                 )

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -608,7 +608,7 @@ class TestKubernetesDeploymentConfig:
                         _exec=V1ExecAction(
                             command=["/nail/blah.sh", "8888", "universal.credit"]
                         ),
-                        initial_delay_seconds=10,
+                        initial_delay_seconds=self.deployment.get_healthcheck_grace_period_seconds(),
                         period_seconds=10,
                     ),
                 )


### PR DESCRIPTION
By default it'll continue to use 10s as delay for hacheck, but we can switch it (per cluster) with puppet like

```
  paasta_tools::config_file {'hacheck':
    config => {
      'hacheck_match_initial_delay' => true,
    }
  }
```

(probably in conjunction with a bunch of manual prep work)