### PR TITLE
Update boto_keys secret if it already exists

### DIFF
--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -337,7 +337,14 @@ def sync_boto_secrets(
             except ApiException as e:
                 if e.status == 409:
                     log.warning(
-                        f"Secret {secret} for {service}in {namespace} already exists"
+                        f"Secret {secret} for {service} already exists in {namespace} but no signature found. Updating secret and signature."
+                    )
+                    update_plaintext_dict_secret(
+                        kube_client=kube_client,
+                        secret_name=secret,
+                        secret_data=secret_data,
+                        service=service,
+                        namespace=namespace,
                     )
                 else:
                     raise

--- a/tests/kubernetes/bin/test_paasta_secrets_sync.py
+++ b/tests/kubernetes/bin/test_paasta_secrets_sync.py
@@ -357,3 +357,25 @@ def test_sync_boto_secrets():
         )
         assert not mock_update_secret.called
         assert not mock_create_secret.called
+
+        # No signature, but secret exists
+        mock_update_secret.reset_mock()
+        mock_create_secret.reset_mock()
+        mock_handle.read.side_effect = ["file1", "file2", "file3", "file4"]
+        mock_get_kubernetes_secret_signature.return_value = None
+        mock_create_secret.side_effect = ApiException(409)
+        mock_update_kubernetes_secret_signature.reset_mock()
+        assert sync_boto_secrets(
+            kube_client=mock_client,
+            cluster="westeros-prod",
+            service="universe",
+            secret_provider_name="vaulty",
+            vault_cluster_config={},
+            soa_dir="/nail/blah",
+            namespace="paasta",
+        )
+        assert mock_get_kubernetes_secret_signature.called
+        assert mock_create_secret.called
+        assert mock_update_secret.called
+        assert mock_create_kubernetes_secret_signature.called
+        assert not mock_update_kubernetes_secret_signature.called


### PR DESCRIPTION
This fixes an edge case that can happen if the ConfigMap containing the signature is deleted but the secret exists, and may be out of date.

In that scenario:
- It doesn't find the signature, so it tries to create a new secret
- That fails with a 409
- The signature hash is set to the correct value
- On next run, the signature will look correct and it will do nothing
- The actual secret would only get updated once the actual value changes

Now, it will update the secret value anyway to the correct value.

We encountered this scenario when upgrading paasta to 0.123, because the name of the ConfigMap object changed. This left some services with an outdated secret value.