### PR TITLE
Update scribereader to 0.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ pyrsistent==0.13.0
 pysensu-yelp==0.4.1
 PyStaticConfiguration==0.10.3
 python-crontab==2.1.1
-python-dateutil==2.7.2
+python-dateutil==2.8.1
 python-iptables==0.14.0
 python-utils==2.0.1
 pytimeparse==1.1.5

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -24,7 +24,7 @@ pyopenssl==19.0.0
 PySubnetTree==0.34
 python-jsonschema-objects==0.3.1
 retrying==1.3.3
-scribereader==0.10.0
+scribereader==0.15.0
 signalform-tools==0.0.16
 slo-transcoder==3.3.0
 smmap2==2.0.3


### PR DESCRIPTION
Update scribereader to 0.15 to get paasta logs working in uswest2-corpprod