### PR TITLE
Allow for dry-running paasta_setup_tron_namespace

### DIFF
--- a/paasta_tools/setup_tron_namespace.py
+++ b/paasta_tools/setup_tron_namespace.py
@@ -122,6 +122,7 @@ def main():
                 service=service,
                 soa_dir=args.soa_dir,
                 k8s_enabled=k8s_enabled_for_cluster,
+                dry_run=args.dry_run,
             )
             if args.dry_run:
                 log.info(f"Would update {service} to:")

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -694,6 +694,7 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
                 iam_role=action_config.get_iam_role(),
                 namespace=EXECUTOR_TYPE_TO_NAMESPACE[executor],
                 k8s_role=None,
+                dry_run=action_config.for_validation,
             )
 
         if executor == "spark":
@@ -705,6 +706,7 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
                 iam_role=action_config.get_iam_role(),
                 namespace=EXECUTOR_TYPE_TO_NAMESPACE[executor],
                 k8s_role=_spark_k8s_role(),
+                dry_run=action_config.for_validation,
             )
 
     elif executor in MESOS_EXECUTOR_NAMES:
@@ -860,10 +862,15 @@ def create_complete_config(
     cluster: str,
     soa_dir: str = DEFAULT_SOA_DIR,
     k8s_enabled: bool = False,
+    dry_run: bool = False,
 ):
     """Generate a namespace configuration file for Tron, for a service."""
     job_configs = load_tron_service_config(
-        service=service, cluster=cluster, load_deployments=True, soa_dir=soa_dir,
+        service=service,
+        cluster=cluster,
+        load_deployments=True,
+        soa_dir=soa_dir,
+        for_validation=dry_run,
     )
     preproccessed_config = {}
     preproccessed_config["jobs"] = {

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1101,7 +1101,11 @@ class TestTronTools:
             == mock_yaml_dump.return_value
         )
         mock_tron_service_config.assert_called_once_with(
-            service=service, cluster=cluster, load_deployments=True, soa_dir=soa_dir
+            service=service,
+            cluster=cluster,
+            for_validation=False,
+            load_deployments=True,
+            soa_dir=soa_dir,
         )
         mock_format_job.assert_called_once_with(
             job_config=job_config, k8s_enabled=k8s_enabled


### PR DESCRIPTION
It's a little annoying to be developing on this on a box with no creds,
so let's take advantage of the for_validation flag on all our config
options to allow us to skip any actual k8s operations as we would when
validating configs whenever we want to dry-run