### PR TITLE
Add skeleton for generating spark driver env/cmd

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -240,8 +240,9 @@
                     "$ref": "#definitions/time_delta"
                 },
                 "aws_credentials": {
-                    "$comment": "we should eventually get rid of this once we move spark to pod identity",
-                    "type": "string"
+                    "$comment": "we should eventually get rid of this once we move spark to pod identity - that said, this should be just the filename sans extension",
+                    "type": "string",
+                    "pattern": "[-a-zA-z0-9_]"
                 },
                 "spark_args": {
                     "type": "object",


### PR DESCRIPTION
This just sets up some scaffolding for what we need to actually start a
driver - a follow-up PR will actually do all the spark_args dict parsing
and use the code from this PR to turn that into a command line