### PR TITLE
Add prompt_after_abandon option to allow continuation of pipelines af…

### DIFF
--- a/paasta_tools/cli/schemas/deploy_schema.json
+++ b/paasta_tools/cli/schemas/deploy_schema.json
@@ -92,6 +92,9 @@
                 "complete_below_breakage_pct": {
                     "type": "number"
                 },
+                "prompt_after_abandon": {
+                    "type": "boolean"
+                },
                 "confirm_complete": {
                     "type": "boolean"
                 }


### PR DESCRIPTION
…ter rollback/abandonment

Some service owners would like to be able to continue with a deployment even if it has been automatically rolled back due to SLO failures in one deploy group (e.g. to allow continuation while they investigate the SLO problems/determine if they are a false positive).

Currently our mark-for-deployment does not distinguish between a step that has been rolled back (automatic or otherwise) versus a step that has been otherwise manually abandoned, hence this option references the overarching 'abandoned' state.

This change just adds our new option to the deploy.yaml schema.