### PR TITLE
Handle potentially empty but present started_at property of pod state

### DIFF
--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -826,7 +826,7 @@ async def get_pod_containers(
                     reason = this_state["reason"]
                 if "message" in this_state:
                     message = this_state["message"]
-                if "started_at" in this_state:
+                if this_state.get("started_at"):
                     start_timestamp = this_state["started_at"].timestamp()
 
         last_state_dict = cs.last_state.to_dict()

--- a/tests/instance/test_kubernetes.py
+++ b/tests/instance/test_kubernetes.py
@@ -817,7 +817,7 @@ async def test_get_pod_containers(mock_pod):
 
     with asynctest.patch(
         "paasta_tools.instance.kubernetes.get_tail_lines_for_kubernetes_container",
-        side_effect=[["current"], ["previous"]],
+        side_effect=[["current"], ["previous"], ["current"], ["previous"]],
         autospec=None,
     ), mock.patch(
         "paasta_tools.kubernetes_tools.recent_container_restart",
@@ -825,6 +825,8 @@ async def test_get_pod_containers(mock_pod):
         autospec=None,
     ):
         containers = await pik.get_pod_containers(mock_pod, mock_client, 10)
+        mock_pod.status.container_statuses[0].state.running["started_at"] = None
+        no_start_containers = await pik.get_pod_containers(mock_pod, mock_client, 10)
 
     assert containers == [
         dict(
@@ -845,3 +847,5 @@ async def test_get_pod_containers(mock_pod):
             tail_lines=["current"],
         ),
     ]
+
+    assert no_start_containers[0]["timestamp"] is None

--- a/tests/instance/test_kubernetes.py
+++ b/tests/instance/test_kubernetes.py
@@ -56,7 +56,7 @@ def mock_pod():
                     name="main_container",
                     restart_count=0,
                     state=Struct(
-                        running=Struct(
+                        running=dict(
                             reason="a_state_reason",
                             message="a_state_message",
                             started_at=datetime.datetime(2021, 3, 6),


### PR DESCRIPTION
This should fix the occasional 500s we get when a pod has recently started and has a container state with an empty `started_at` property.  
```
2022-03-25 12:26:53 | ERROR:paasta_tools.api.views.exception:Traceback (most recent call last):
2022-03-25 12:26:53 | AttributeError: 'NoneType' object has no attribute 'timestamp'
2022-03-25 12:26:53 | start_timestamp = this_state["started_at"].timestamp()
2022-03-25 12:26:53 | File "/opt/venvs/paasta-tools/lib/python3.7/site-packages/paasta_tools/instance/kubernetes.py", line 830, in get_pod_containers
2022-03-25 12:26:53 | "containers": containers_task.result(),
2022-03-25 12:26:53 | File "/opt/venvs/paasta-tools/lib/python3.7/site-packages/paasta_tools/instance/kubernetes.py", line 776, in get_pod_status
2022-03-25 12:26:53 | "pods": await asyncio.gather(*pod_status_tasks) if pod_status_tasks else [],
2022-03-25 12:26:53

<br class="Apple-interchange-newline">
```

We had correctly handled this when looking at `last_state` for the container, but not the current one. 

This also adds another test for `get_pod_containers` to check this exact issue sets `timestamp` correctly w/o throwing errors (None)