### PR TITLE
Return a traceback when we hit an error in bounce_status

### DIFF
--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -849,8 +849,9 @@ def bounce_status(request):
 
     try:
         return pik.bounce_status(service, instance, settings)
-    except Exception as e:
-        raise ApiFailure(e, 500)
+    except Exception:
+        error_message = traceback.format_exc()
+        raise ApiFailure(error_message, 500)
 
 
 def add_executor_info(task):


### PR DESCRIPTION
Currently we're seeing quite a few 500s during deployments when wait-for-deployment is hitting the `bounce_status` endpoint, but the logs are blank.
The full body of the response is simply `ERROR:  `, due to https://github.com/Yelp/paasta/blob/master/paasta_tools/api/views/exception.py#L43-L44 , and the logged error only includes the apparently-blank message:     `log.error(exc.msg)`

I'm suspecting that this is running into a problem during `paasta_tools.instance.kubernetes.bounce_status`, so this change should now include the traceback in the response if we run into a problem here, rather than just the error itself.

This mirrors our error handling above on lines 838-840 if we do not have a valid instance, for example.