### PR TITLE
Catch timeout issues in bounce_status and present less-drastic error message

### DIFF
--- a/paasta_tools/api/api_docs/oapi.yaml
+++ b/paasta_tools/api/api_docs/oapi.yaml
@@ -1477,6 +1477,8 @@ paths:
           description: Deployment key not found
         "500":
           description: Instance failure
+        "599":
+          description: Temporary issue fetching instance status
       summary: Get bounce status of service_name.instance_name
       tags:
       - service

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -862,7 +862,7 @@ def bounce_status(request):
         return pik.bounce_status(service, instance, settings)
     except asyncio.TimeoutError:
         raise ApiFailure(
-            "Temporary issue fetching bounce status. Please try again.", 500
+            "Temporary issue fetching bounce status. Please try again.", 599
         )
     except Exception:
         error_message = traceback.format_exc()

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -860,6 +860,10 @@ def bounce_status(request):
 
     try:
         return pik.bounce_status(service, instance, settings)
+    except asyncio.TimeoutError:
+        raise ApiFailure(
+            "Temporary issue fetching bounce status. Please try again.", 500
+        )
     except Exception:
         error_message = traceback.format_exc()
         raise ApiFailure(error_message, 500)

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1503,9 +1503,9 @@ def check_if_instance_is_done(
                     instance, service, cluster
                 )
             )
-        elif e.body and "Temporary" in e.body:
+        elif e.status == 599:  # Temporary issue
             log.warning(
-                f"Timed out fetching service status from PaaSTA API for {cluster}. Will retry on next poll interval."
+                f"Temporary issue fetching service status from PaaSTA API for {cluster}. Will retry on next poll interval."
             )
         else:  # 500 - error talking to api
             log.warning(

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1503,6 +1503,10 @@ def check_if_instance_is_done(
                     instance, service, cluster
                 )
             )
+        elif e.body and "Temporary" in e.body:
+            log.warning(
+                f"Timed out fetching service status from PaaSTA API for {cluster}. Will retry on next poll interval."
+            )
         else:  # 500 - error talking to api
             log.warning(
                 "Error getting service status from PaaSTA API for "

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -1316,7 +1316,7 @@ class TestBounceStatus:
         mock_validate_service_instance.return_value = "kubernetes"
         with pytest.raises(ApiFailure) as excinfo:
             instance.bounce_status(mock_request)
-        assert excinfo.value.err == 500
+        assert excinfo.value.err == 599
         assert (
             excinfo.value.msg
             == "Temporary issue fetching bounce status. Please try again."

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import datetime
 
 import asynctest
@@ -1303,3 +1304,20 @@ class TestBounceStatus:
         mock_validate_service_instance.return_value = "not_kubernetes"
         response = instance.bounce_status(mock_request)
         assert response.status_code == 204
+
+    def test_timeout(
+        self,
+        mock_pik_bounce_status,
+        mock_validate_service_instance,
+        mock_request,
+        mock_settings,
+    ):
+        mock_pik_bounce_status.side_effect = [asyncio.TimeoutError]
+        mock_validate_service_instance.return_value = "kubernetes"
+        with pytest.raises(ApiFailure) as excinfo:
+            instance.bounce_status(mock_request)
+        assert excinfo.value.err == 500
+        assert (
+            excinfo.value.msg
+            == "Temporary issue fetching bounce status. Please try again."
+        )

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -61,6 +61,7 @@ def fake_bounce_status_resp(**kwargs):
     "side_effect,expected",
     [
         (ApiException(status=500, reason=""), False),  # api bad
+        (ApiException(status=599, reason=""), False),  # temporary api issue
         (ApiException(status=404, reason=""), False),  # instance dne
         ([""], True),  # status=204 produces empty response
         (  # instance stopped

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ commands =
 
 [testenv:dev-api]
 envdir = .tox/py37-linux/
+passenv = PAASTA_TEST_CLUSTER KUBECONFIG PAASTA_SYSTEM_CONFIG_DIR
 deps =
     --requirement={toxinidir}/requirements.txt
     --requirement={toxinidir}/requirements-dev.txt


### PR DESCRIPTION
We are occasionally seeing slowness grabbing responses from the k8s api, but eventually things do return.

This forces paasta_tools.api.views.instance to slightly modify the response body if we hit this particular issue such that mark-for-deployment/wait-for-deployment can identify this specific response & print a more friendly error to users.

I also considered throwing a 599 rather than a 500 for this issue to make things even more easily identifiable, however 599 is not exactly an HTTP standard, and this does still represent an error on the backend where we cannot return a valid repsonse to the user.  Let me know if it makes sense to go w/ an alternate return code here.

Previously during deploys where we wait-for-deployment, we would see only
`WARNING:paasta_tools.cli.cmds.mark_for_deployment:Error getting service status from PaaSTA API for kubestage: 500 Internal Server Error`.  This would lead to many people thinking something was wrong with their services/instances/the deploy, though it was a transient issue on the API side.

This will now print out 
`WARNING:paasta_tools.cli.cmds.mark_for_deployment:Timed out fetching service status from PaaSTA API for kubestage. Will retry on next poll interval.`
