### PR TITLE
set progress_deadline_seconds if min_ready_seconds is more than 600

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -178,6 +178,8 @@ DISCOVERY_ATTRIBUTES = {
 GPU_RESOURCE_NAME = "nvidia.com/gpu"
 DEFAULT_STORAGE_CLASS_NAME = "ebs"
 DEFAULT_PRESTOP_SLEEP_SECONDS = 30
+DEFAULT_PROGRESS_DEADLINE_SECONDS = 600
+DEFAULT_PROGRESS_DEADLINE_SECONDS_OFFSET = 60
 DEFAULT_HADOWN_PRESTOP_SLEEP_SECONDS = DEFAULT_PRESTOP_SLEEP_SECONDS + 1
 
 
@@ -1620,9 +1622,11 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 # Default to none for progress_deadline_seconds to not change
                 # existing deployments
                 progress_deadline_seconds = None
-                if self.get_min_task_uptime() >= 600:
-                    # 600s is kubernetes default
-                    progress_deadline_seconds = self.get_min_task_uptime()
+                if self.get_min_task_uptime() >= DEFAULT_PROGRESS_DEADLINE_SECONDS:
+                    progress_deadline_seconds = (
+                        self.get_min_task_uptime()
+                        + DEFAULT_PROGRESS_DEADLINE_SECONDS_OFFSET
+                    )
                 complete_config = V1Deployment(
                     api_version="apps/v1",
                     kind="Deployment",

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1617,6 +1617,12 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     ),
                 )
             else:
+                # Default to none for progress_deadline_seconds to not change
+                # existing deployments
+                progress_deadline_seconds = None
+                if self.get_min_task_uptime() >= 600:
+                    # 600s is kubernetes default
+                    progress_deadline_seconds = self.get_min_task_uptime()
                 complete_config = V1Deployment(
                     api_version="apps/v1",
                     kind="Deployment",
@@ -1624,6 +1630,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     spec=V1DeploymentSpec(
                         replicas=self.get_desired_instances(),
                         min_ready_seconds=self.get_min_task_uptime(),
+                        progress_deadline_seconds=progress_deadline_seconds,
                         selector=V1LabelSelector(
                             match_labels={
                                 "paasta.yelp.com/service": self.get_service(),


### PR DESCRIPTION
While testing some stuff for COMPINFRA-989 we set the min_ready_seconds to 600 to test. Turns out that breaks paasta because we don't set progress_deadline_seconds (which needs to be more than min_ready_seconds), and progress_deadline_seconds defaults to 600s in kubernetes