### PR TITLE
Forward Spark ports to Tron/task_proc

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -876,9 +876,11 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
             # spark, unlike normal batches, needs to expose  several ports for things like the spark
             # ui and for executor->driver communication
             result["ports"] = list(
-                _get_spark_ports(
-                    system_paasta_config=load_system_paasta_config()
-                ).values()
+                set(
+                    _get_spark_ports(
+                        system_paasta_config=load_system_paasta_config()
+                    ).values()
+                )
             )
 
     elif executor in MESOS_EXECUTOR_NAMES:

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -27,6 +27,7 @@ from typing import Tuple
 from typing import Union
 
 import yaml
+from mypy_extensions import TypedDict
 from service_configuration_lib import read_extra_service_information
 from service_configuration_lib import read_yaml_file
 from service_configuration_lib.spark_config import _filter_user_spark_opts
@@ -99,6 +100,10 @@ EXECUTOR_TYPE_TO_NAMESPACE = {
     "spark": "paasta-spark",
 }
 clusterman_metrics, _ = get_clusterman_metrics()
+
+
+class FieldSelectorConfig(TypedDict):
+    field_path: str
 
 
 class TronNotConfigured(Exception):
@@ -217,6 +222,15 @@ def _use_suffixed_log_streams_k8s() -> bool:
     return load_system_paasta_config().get_tron_k8s_use_suffixed_log_streams_k8s()
 
 
+def _get_spark_ports(system_paasta_config: SystemPaastaConfig) -> Dict[str, int]:
+    return {
+        "spark.ui.port": system_paasta_config.get_spark_ui_port(),
+        "spark.driver.port": system_paasta_config.get_spark_driver_port(),
+        "spark.blockManager.port": system_paasta_config.get_spark_blockmanager_port(),
+        "spark.driver.blockManager.port": system_paasta_config.get_spark_blockmanager_port(),
+    }
+
+
 class TronActionConfig(InstanceConfig):
     config_filename_prefix = "tron"
 
@@ -266,7 +280,6 @@ class TronActionConfig(InstanceConfig):
                 "spark.app.name",
                 f"tron_spark_{self.get_service()}_{self.get_instance()}",
             ),
-            "spark.ui.port": system_paasta_config.get_spark_ui_port(),
             # TODO: figure out how to handle dedicated spark cluster here
             "spark.master": f"k8s://https://k8s.{self.get_cluster()}.paasta:6443",
             # TODO: add PAASTA_RESOURCE_* environment variables here
@@ -291,6 +304,10 @@ class TronActionConfig(InstanceConfig):
             "spark.kubernetes.executor.label.paasta.yelp.com/cluster": self.get_cluster(),
             "spark.kubernetes.node.selector.yelp.com/pool": self.get_pool(),
             "spark.kubernetes.executor.label.yelp.com/pool": self.get_pool(),
+            # this relies on the PaaSTA workload contract being followed - $PAASTA_POD_IP
+            # will be, drumroll please, the routable IP for the Pod - this allows us to
+            # not need to worry about DNS
+            "spark.driver.host": "$PAASTA_POD_IP",
         }
 
         # most of the service_configuration_lib function expected string values only
@@ -305,6 +322,8 @@ class TronActionConfig(InstanceConfig):
 
         if self.get_team() is not None:
             conf["spark.kubernetes.executor.label.yelp.com/owner"] = self.get_team()
+
+        conf.update(_get_spark_ports(system_paasta_config=system_paasta_config))
 
         # Spark defaults to using the Service Account that the driver uses for executors,
         # but that has more permissions than what we'd like to give the executors, so use
@@ -415,6 +434,15 @@ class TronActionConfig(InstanceConfig):
                     "key": secret,
                 }
         return secret_env
+
+    def get_field_selector_env(self) -> Dict[str, FieldSelectorConfig]:
+        # we're not expecting users to need to add any of these themselves, so for now
+        # we'll just hardcode the env vars we want to add by default
+        return {
+            "PAASTA_POD_IP": {
+                "field_path": "status.podIP",
+            }
+        }
 
     def get_cpu_burst_add(self) -> float:
         """For Tron jobs, we don't let them burst by default, because they
@@ -773,9 +801,15 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
         )
 
         result["secret_env"] = action_config.get_secret_env()
+        result["field_selector_env"] = action_config.get_field_selector_env()
         all_env = action_config.get_env()
         # For k8s, we do not want secret envvars to be duplicated in both `env` and `secret_env`
-        result["env"] = {k: v for k, v in all_env.items() if not is_secret_ref(v)}
+        # or for field selector env vars to be overwritten
+        result["env"] = {
+            k: v
+            for k, v in all_env.items()
+            if not is_secret_ref(v) and k not in result["field_selector_env"]
+        }
         # for Tron-on-K8s, we want to ship tronjob output through logspout
         # such that this output eventually makes it into our per-instance
         # log streams automatically
@@ -838,6 +872,13 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
                 namespace=EXECUTOR_TYPE_TO_NAMESPACE[executor],
                 k8s_role=_spark_k8s_role(),
                 dry_run=action_config.for_validation,
+            )
+            # spark, unlike normal batches, needs to expose  several ports for things like the spark
+            # ui and for executor->driver communication
+            result["ports"] = list(
+                _get_spark_ports(
+                    system_paasta_config=load_system_paasta_config()
+                ).values()
             )
 
     elif executor in MESOS_EXECUTOR_NAMES:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1975,6 +1975,8 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     cluster_aliases: Dict[str, str]
     hacheck_match_initial_delay: bool
     spark_ui_port: int
+    spark_driver_port: int
+    spark_blockmanager_port: int
 
 
 def load_system_paasta_config(
@@ -2647,6 +2649,14 @@ class SystemPaastaConfig:
         # 33000 was picked arbitrarily (it was the base port when we used to
         # randomly reserve port numbers)
         return self.config_dict.get("spark_ui_port", 33000)
+
+    def get_spark_driver_port(self) -> int:
+        # default value is an arbitrary value
+        return self.config_dict.get("spark_driver_port", 33001)
+
+    def get_spark_blockmanager_port(self) -> int:
+        # default value is an arbitrary value
+        return self.config_dict.get("spark_blockmanager_port", 33002)
 
     def get_api_profiling_config(self) -> Dict:
         return self.config_dict.get(

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -848,7 +848,6 @@ class TestTronTools:
         assert result == {
             "command": "spark-submit "
             "--conf spark.app.name=tron_spark_my_service_my_job.do_something "
-            "--conf spark.ui.port=33000 "
             "--conf spark.master=k8s://https://k8s.test-cluster.paasta:6443 "
             "--conf spark.executorEnv.PAASTA_SERVICE=my_service "
             "--conf spark.executorEnv.PAASTA_INSTANCE=my_job.do_something "
@@ -867,11 +866,16 @@ class TestTronTools:
             "--conf spark.kubernetes.executor.label.paasta.yelp.com/cluster=test-cluster "
             "--conf spark.kubernetes.node.selector.yelp.com/pool=special_pool "
             "--conf spark.kubernetes.executor.label.yelp.com/pool=special_pool "
+            "--conf spark.driver.host=$PAASTA_POD_IP "
             # user args
             "--conf spark.cores.max=4 "
             "--conf spark.driver.memory=1g "
             "--conf spark.executor.memory=1g "
             "--conf spark.executor.cores=2 "
+            "--conf spark.ui.port=33000 "
+            "--conf spark.driver.port=33001 "
+            "--conf spark.blockManager.port=33002 "
+            "--conf spark.driver.blockManager.port=33002 "
             "--conf spark.kubernetes.authenticate.executor.serviceAccountName=paasta--arn-aws-iam-000000000000-role-some-role "
             # extra_volumes from config
             "--conf spark.kubernetes.executor.volumes.hostPath.0.mount.path=/nail/tmp "
@@ -910,8 +914,10 @@ class TestTronTools:
             "triggered_by": ["foo.bar.{shortdate}"],
             "trigger_timeout": "5m",
             "secret_env": {},
+            "field_selector_env": {"PAASTA_POD_IP": {"field_path": "status.podIP"}},
             "service_account_name": "paasta--arn-aws-iam-000000000000-role-some-role--spark",
             "node_selectors": {"yelp.com/pool": "special_pool"},
+            "ports": [33000, 33001, 33002],
             "labels": {
                 "paasta.yelp.com/cluster": "test-cluster",
                 "paasta.yelp.com/instance": "my_job.do_something",
@@ -1041,6 +1047,7 @@ class TestTronTools:
                     "key": "secret_name",
                 }
             },
+            "field_selector_env": {"PAASTA_POD_IP": {"field_path": "status.podIP"}},
             "extra_volumes": [
                 {"container_path": "/nail/tmp", "host_path": "/nail/tmp", "mode": "RW"}
             ],


### PR DESCRIPTION
Right now, drivers will start and spin up executors - but these
executors will instantly crash since they can't communicate with the
driver.

This change sets things up so that drivers can be started in a way that
makes them reachable by the executors they start