### PR TITLE
Set KubeDeployment replicas to None for autoscaled deployments

### DIFF
--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -47,7 +47,13 @@ class Application(ABC):
             attr: item.metadata.labels[paasta_prefixed(attr)]
             for attr in ["service", "instance", "git_sha", "config_sha"]
         }
-        self.kube_deployment = KubeDeployment(replicas=item.spec.replicas, **attrs)
+
+        replicas = (
+            item.spec.replicas
+            if item.spec.template.metadata.annotations.get("autoscaling") is None
+            else None
+        )
+        self.kube_deployment = KubeDeployment(replicas=replicas, **attrs)
         self.item = item
         self.soa_config = None  # type: KubernetesDeploymentConfig
         self.logging = logging

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -215,7 +215,7 @@ class KubeDeployment(NamedTuple):
     instance: str
     git_sha: str
     config_sha: str
-    replicas: int
+    replicas: Optional[int]
 
 
 class KubeCustomResource(NamedTuple):
@@ -2149,7 +2149,9 @@ def list_deployments(
             instance=item.metadata.labels["paasta.yelp.com/instance"],
             git_sha=item.metadata.labels.get("paasta.yelp.com/git_sha", ""),
             config_sha=item.metadata.labels["paasta.yelp.com/config_sha"],
-            replicas=item.spec.replicas,
+            replicas=item.spec.replicas
+            if item.spec.template.metadata.annotations.get("autoscaling") is None
+            else None,
         )
         for item in deployments.items + stateful_sets.items
     ]

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2557,7 +2557,14 @@ def test_ensure_namespace():
     assert mock_client.core.create_namespace.called
 
 
-def test_list_all_deployments():
+@pytest.mark.parametrize(
+    "annotations,replicas",
+    (
+        ({}, 3),
+        ({"autoscaling": "something"}, None),
+    ),
+)
+def test_list_all_deployments(annotations, replicas):
     mock_deployments = mock.Mock(items=[])
     mock_stateful_sets = mock.Mock(items=[])
     mock_client = mock.Mock(
@@ -2598,8 +2605,12 @@ def test_list_all_deployments():
             )
         ),
     ]
-    type(mock_items[0]).spec = mock.Mock(replicas=3)
-    type(mock_items[1]).spec = mock.Mock(replicas=3)
+    type(mock_items[0]).spec = mock.Mock(
+        **{"replicas": 3, "template.metadata.annotations": annotations}
+    )
+    type(mock_items[1]).spec = mock.Mock(
+        **{"replicas": 3, "template.metadata.annotations": annotations}
+    )
     mock_deployments = mock.Mock(items=[mock_items[0]])
     mock_stateful_sets = mock.Mock(items=[mock_items[1]])
     mock_client = mock.Mock(
@@ -2614,14 +2625,14 @@ def test_list_all_deployments():
             instance="fm",
             git_sha="a12345",
             config_sha="b12345",
-            replicas=3,
+            replicas=replicas,
         ),
         KubeDeployment(
             service="kurupt",
             instance="am",
             git_sha="a12345",
             config_sha="b12345",
-            replicas=3,
+            replicas=replicas,
         ),
     ]
 


### PR DESCRIPTION
We need a way to compare two KubeDeployment's that is not sensitive to
an autoscaler changing the amount of replicas present - otherwise, when
we go to compare the current and target deployment, we could oscillate
between what the autoscaler (HPA, in this case) has set a Deployments
replicas to and what setup_kubernetes_job saw prior to an HPA
scale-{up,down}

To accommplish this, we use the fact that we attach an annotation with
the autoscaling policy name to every autoscaled deployment and set the
replicas field of our internal KubeDeployment object to None for
anything that is autoscaled - which should be the same as leaving that
value unspecified (which will then let the HPA be the only thing
managing the replicas for a Deployment)