### PR TITLE
Add verbose flag to paasta validate that displays next 5 cron runs sc…

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -634,7 +634,9 @@ def validate_secrets(service_path):
     return return_value
 
 
-def paasta_validate_soa_configs(service, service_path, verbose=False):
+def paasta_validate_soa_configs(
+    service: str, service_path: str, verbose: bool = False
+) -> bool:
     """Analyze the service in service_path to determine if the conf files are valid
 
     :param service_path: Path to directory containing soa conf yaml files for service

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -347,7 +347,7 @@ def validate_tron(service_path: str, verbose: bool = False) -> bool:
                     config_tz_str = config.get_time_zone() or "US/Pacific"
                     tz = pytz.timezone(config_tz_str)
 
-                    print(info_message(f"Upcoming runs for {config.get_name()}"))
+                    print(info_message(f"Upcoming runs for {config.get_name()}:"))
                     next_cron_runs = list_upcoming_runs(
                         # most cron parsers won't understand our schedule tag, so we need to strip
                         # that off before passing it to anything else

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -47,6 +47,7 @@ from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
 from paasta_tools.secret_tools import get_secret_name_from_ref
 from paasta_tools.secret_tools import is_secret_ref
 from paasta_tools.secret_tools import is_shared_secret
+from paasta_tools.tron_tools import DEFAULT_TZ
 from paasta_tools.tron_tools import list_tron_clusters
 from paasta_tools.tron_tools import load_tron_service_config
 from paasta_tools.tron_tools import TronJobConfig
@@ -352,12 +353,10 @@ def validate_tron(service_path: str, verbose: bool = False) -> bool:
 def print_upcoming_runs(config: TronJobConfig, cron_expression: str) -> None:
     print(info_message(f"Upcoming runs for {config.get_name()}:"))
 
-    config_tz = config.get_time_zone() or "US/Pacific"
+    config_tz = config.get_time_zone() or DEFAULT_TZ
 
     next_cron_runs = list_upcoming_runs(
-        # most cron parsers won't understand our schedule tag, so we need to strip
-        # that off before passing it to anything else
-        cron_schedule=cron_expression.replace("cron", ""),
+        cron_schedule=cron_expression,
         starting_from=pytz.timezone(config_tz).localize(datetime.today()),
     )
 

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -106,6 +106,13 @@ def x_mark():
     return PaastaColors.red("\u2717")
 
 
+def info_mark():
+    """
+    :return: string that can print an info symbol
+    """
+    return PaastaColors.blue("\u2139")
+
+
 def success(msg):
     """Format a paasta check success message.
 
@@ -122,6 +129,15 @@ def failure(msg, link):
     :return: a beautiful string
     """
     return "{} {} {}".format(x_mark(), msg, PaastaColors.blue(link))
+
+
+def info_message(msg):
+    """Format a paasta info message.
+
+    :param msg: a string
+    :return: a beautiful string
+    """
+    return "{} {}".format(info_mark(), msg)
 
 
 class PaastaCheckMessages:

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -106,7 +106,7 @@ def x_mark():
     return PaastaColors.red("\u2717")
 
 
-def info_mark():
+def info_mark() -> str:
     """
     :return: string that can print an info symbol
     """
@@ -131,13 +131,13 @@ def failure(msg, link):
     return "{} {} {}".format(x_mark(), msg, PaastaColors.blue(link))
 
 
-def info_message(msg):
+def info_message(msg: str) -> str:
     """Format a paasta info message.
 
     :param msg: a string
     :return: a beautiful string
     """
-    return "{} {}".format(info_mark(), msg)
+    return f"{info_mark()} {msg}"
 
 
 class PaastaCheckMessages:

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -132,11 +132,6 @@ def failure(msg, link):
 
 
 def info_message(msg: str) -> str:
-    """Format a paasta info message.
-
-    :param msg: a string
-    :return: a beautiful string
-    """
     return f"{info_mark()} {msg}"
 
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -98,6 +98,7 @@ EXECUTOR_TYPE_TO_NAMESPACE = {
     "paasta": "tron",
     "spark": "paasta-spark",
 }
+DEFAULT_TZ = "US/Pacific"
 clusterman_metrics, _ = get_clusterman_metrics()
 
 
@@ -561,14 +562,17 @@ class TronJobConfig:
 
     def get_cron_expression(self) -> Optional[str]:
         schedule = self.config_dict.get("schedule")
+        # TODO(TRON-1746): once we simplify this format, we can clean this code up
         if (
-            isinstance(schedule, Dict)
+            isinstance(schedule, dict)
             and "type" in schedule
             and schedule["type"] == "cron"
         ):
             return schedule["value"]
         elif isinstance(schedule, str) and schedule.startswith("cron"):
-            return schedule
+            # most cron parsers won't understand our schedule tag, so we need to strip
+            # that off before passing it to anything else
+            return schedule.replace("cron", "")
 
         return None
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -559,6 +559,19 @@ class TronJobConfig:
     def get_schedule(self):
         return self.config_dict.get("schedule")
 
+    def get_cron_expression(self) -> Optional[str]:
+        schedule = self.config_dict.get("schedule")
+        if (
+            isinstance(schedule, Dict)
+            and "type" in schedule
+            and schedule["type"] == "cron"
+        ):
+            return schedule["value"]
+        elif isinstance(schedule, str) and schedule.startswith("cron"):
+            return schedule
+
+        return None
+
     def get_monitoring(self):
         srv_monitoring = dict(
             monitoring_tools.read_monitoring_config(self.service, soa_dir=self.soa_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ chardet==3.0.4
 choice==0.1
 click==6.6
 cookiecutter==1.4.0
-croniter==0.3.20
+croniter==1.3.4
 decorator==4.1.2
 docker-py==1.2.3
 docutils==0.12

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -20,9 +20,9 @@ from mock import patch
 
 from paasta_tools.cli.cmds.validate import check_secrets_for_instance
 from paasta_tools.cli.cmds.validate import check_service_path
-from paasta_tools.cli.cmds.validate import get_next_x_cron_runs
 from paasta_tools.cli.cmds.validate import get_schema
 from paasta_tools.cli.cmds.validate import get_service_path
+from paasta_tools.cli.cmds.validate import list_upcoming_runs
 from paasta_tools.cli.cmds.validate import paasta_validate
 from paasta_tools.cli.cmds.validate import paasta_validate_soa_configs
 from paasta_tools.cli.cmds.validate import SCHEMA_INVALID
@@ -858,12 +858,12 @@ def test_validate_autoscaling_configs_no_offset_specified(
 
 
 @pytest.mark.parametrize(
-    "num_runs, cron_schedule, start_date, expected",
+    "schedule, starting_from, num_runs, expected",
     [
         (
-            5,
             "0 22 * * 1-5",
             datetime.datetime(2022, 4, 12, 0, 0),
+            5,
             [
                 datetime.datetime(2022, 4, 12, 22, 0),
                 datetime.datetime(2022, 4, 13, 22, 0),
@@ -873,9 +873,9 @@ def test_validate_autoscaling_configs_no_offset_specified(
             ],
         ),
         (
-            2,
             "5 4 * * *",
             datetime.datetime(2020, 12, 4, 18, 0),
+            2,
             [
                 datetime.datetime(2020, 12, 5, 4, 5),
                 datetime.datetime(2020, 12, 6, 4, 5),
@@ -883,5 +883,5 @@ def test_validate_autoscaling_configs_no_offset_specified(
         ),
     ],
 )
-def test_get_next_x_cron_runs(num_runs, cron_schedule, start_date, expected):
-    assert get_next_x_cron_runs(num_runs, cron_schedule, start_date) == expected
+def test_list_upcoming_runs(schedule, starting_from, num_runs, expected):
+    assert list_upcoming_runs(schedule, starting_from, num_runs) == expected

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -881,6 +881,16 @@ def test_validate_autoscaling_configs_no_offset_specified(
                 datetime.datetime(2020, 12, 6, 4, 5),
             ],
         ),
+        (
+            "0 17 29 2 *",
+            datetime.datetime(2022, 4, 12, 0, 0),
+            3,
+            [
+                datetime.datetime(2024, 2, 29, 17, 0),
+                datetime.datetime(2028, 2, 29, 17, 0),
+                datetime.datetime(2032, 2, 29, 17, 0),
+            ],
+        ),
     ],
 )
 def test_list_upcoming_runs(schedule, starting_from, num_runs, expected):

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
 import os
 
 import mock
@@ -19,6 +20,7 @@ from mock import patch
 
 from paasta_tools.cli.cmds.validate import check_secrets_for_instance
 from paasta_tools.cli.cmds.validate import check_service_path
+from paasta_tools.cli.cmds.validate import get_next_x_cron_runs
 from paasta_tools.cli.cmds.validate import get_schema
 from paasta_tools.cli.cmds.validate import get_service_path
 from paasta_tools.cli.cmds.validate import paasta_validate
@@ -853,3 +855,33 @@ def test_validate_autoscaling_configs_no_offset_specified(
         ),
     ):
         assert validate_autoscaling_configs("fake-service-path") is True
+
+
+@pytest.mark.parametrize(
+    "num_runs, cron_schedule, start_date, expected",
+    [
+        (
+            5,
+            "0 22 * * 1-5",
+            datetime.datetime(2022, 4, 12, 0, 0),
+            [
+                datetime.datetime(2022, 4, 12, 22, 0),
+                datetime.datetime(2022, 4, 13, 22, 0),
+                datetime.datetime(2022, 4, 14, 22, 0),
+                datetime.datetime(2022, 4, 15, 22, 0),
+                datetime.datetime(2022, 4, 18, 22, 0),
+            ],
+        ),
+        (
+            2,
+            "5 4 * * *",
+            datetime.datetime(2020, 12, 4, 18, 0),
+            [
+                datetime.datetime(2020, 12, 5, 4, 5),
+                datetime.datetime(2020, 12, 6, 4, 5),
+            ],
+        ),
+    ],
+)
+def test_get_next_x_cron_runs(num_runs, cron_schedule, start_date, expected):
+    assert get_next_x_cron_runs(num_runs, cron_schedule, start_date) == expected


### PR DESCRIPTION
Right now there isn't any real insight into the cron schedules when running paasta validate. This change introduces a verbose flag that will dump the next 5 runs for any valid cron schedule.

[Fluffy of the verbose output](https://fluffy.yelpcorp.com/i/2Kb3NkXTT9bfMrPlhQK80zjkp3HrmM56.html)