### PR TITLE
Add some missing workload labels + add autoscaled label

### DIFF
--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -50,7 +50,8 @@ class Application(ABC):
 
         replicas = (
             item.spec.replicas
-            if item.spec.template.metadata.annotations.get("autoscaling") is None
+            if item.metadata.labels.get(paasta_prefixed("autoscaled"), "false")
+            == "false"
             else None
         )
         self.kube_deployment = KubeDeployment(replicas=replicas, **attrs)

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1793,6 +1793,8 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "paasta.yelp.com/instance": self.get_instance(),
             "paasta.yelp.com/git_sha": git_sha,
             "paasta.yelp.com/autoscaled": str(self.is_autoscaling_enabled()).lower(),
+            "paasta.yelp.com/cluster": self.get_cluster(),
+            "paasta.yelp.com/pool": self.get_pool(),
         }
 
         # Allow the Prometheus Operator's Pod Service Monitor for specified

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1605,6 +1605,8 @@ class TestKubernetesDeploymentConfig:
                     "paasta.yelp.com/instance": mock_get_instance.return_value,
                     "paasta.yelp.com/service": mock_get_service.return_value,
                     "paasta.yelp.com/autoscaled": "false",
+                    "paasta.yelp.com/pool": "default",
+                    "paasta.yelp.com/cluster": "brentford",
                     "registrations.paasta.yelp.com/kurupt.fm": "true",
                 },
                 annotations={
@@ -3585,7 +3587,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config2c8004b5"
+            == "config5e31645f"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 


### PR DESCRIPTION
this will cause a big bounce!

the annotation i'm using for https://github.com/Yelp/paasta/pull/3335 is only available for uwsgi-autoscaled instances, so this switches us to something more generic. and, while we're incurring a big bounce, we might as well also add in some missing paasta contract labels that we're missing

todo:
- still need to add owner, but i wanna talk to cic about what they'd like
there
- need to see what other objects they'd like these labels on (since some of the labels don't make sense for certain objects)