### PR TITLE
Add autoscaled label

### DIFF
--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -50,7 +50,8 @@ class Application(ABC):
 
         replicas = (
             item.spec.replicas
-            if item.spec.template.metadata.annotations.get("autoscaling") is None
+            if item.metadata.labels.get(paasta_prefixed("autoscaled"), "false")
+            == "false"
             else None
         )
         self.kube_deployment = KubeDeployment(replicas=replicas, **attrs)

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -303,6 +303,8 @@ KubePodAnnotations = TypedDict(
 KubePodLabels = TypedDict(
     "KubePodLabels",
     {
+        # NOTE: we can't use the paasta_prefixed() helper here
+        # since mypy expects TypedDict keys to be string literals
         "paasta.yelp.com/deploy_group": str,
         "paasta.yelp.com/git_sha": str,
         "paasta.yelp.com/instance": str,
@@ -310,6 +312,7 @@ KubePodLabels = TypedDict(
         "paasta.yelp.com/scrape_uwsgi_prometheus": str,
         "paasta.yelp.com/scrape_piscina_prometheus": str,
         "paasta.yelp.com/service": str,
+        "paasta.yelp.com/autoscaled": str,
         "yelp.com/paasta_git_sha": str,
         "yelp.com/paasta_instance": str,
         "yelp.com/paasta_service": str,
@@ -1789,10 +1792,12 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "yelp.com/paasta_service": self.get_service(),
             "yelp.com/paasta_instance": self.get_instance(),
             "yelp.com/paasta_git_sha": git_sha,
+            # NOTE: we can't use the paasta_prefixed() helper here
+            # since mypy expects TypedDict keys to be string literals
             "paasta.yelp.com/service": self.get_service(),
             "paasta.yelp.com/instance": self.get_instance(),
             "paasta.yelp.com/git_sha": git_sha,
-            paasta_prefixed("autoscaled"): str(self.is_autoscaling_enabled()).lower(),
+            "paasta.yelp.com/autoscaled": str(self.is_autoscaling_enabled()).lower(),
         }
 
         # Allow the Prometheus Operator's Pod Service Monitor for specified

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1556,7 +1556,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 "paasta.yelp.com/service": self.get_service(),
                 "paasta.yelp.com/instance": self.get_instance(),
                 "paasta.yelp.com/git_sha": git_sha,
-                paasta_prefixed("autoscaled"): str(self.is_autoscaling_enabled()).lower(),
+                paasta_prefixed("autoscaled"): str(
+                    self.is_autoscaling_enabled()
+                ).lower(),
             },
         )
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1556,6 +1556,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 "paasta.yelp.com/service": self.get_service(),
                 "paasta.yelp.com/instance": self.get_instance(),
                 "paasta.yelp.com/git_sha": git_sha,
+                paasta_prefixed("autoscaled"): str(self.is_autoscaling_enabled()).lower(),
             },
         )
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1792,7 +1792,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "paasta.yelp.com/service": self.get_service(),
             "paasta.yelp.com/instance": self.get_instance(),
             "paasta.yelp.com/git_sha": git_sha,
-            "paasta.yelp.com/autoscaled": str(self.is_autoscaling_enabled()).lower(),
+            paasta_prefixed("autoscaled"): str(self.is_autoscaling_enabled()).lower(),
         }
 
         # Allow the Prometheus Operator's Pod Service Monitor for specified

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1853,7 +1853,14 @@ class TestKubernetesDeploymentConfig:
         with pytest.raises(ValueError):
             raw_selectors_to_requirements(node_selectors)
 
-    def test_get_kubernetes_metadata(self):
+    @pytest.mark.parametrize(
+        "is_autoscaled, autoscaled_label",
+        (
+            (True, "true"),
+            (False, "false"),
+        ),
+    )
+    def test_get_kubernetes_metadata(self, is_autoscaled, autoscaled_label):
         with mock.patch(
             "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_service",
             autospec=True,
@@ -1862,7 +1869,11 @@ class TestKubernetesDeploymentConfig:
             "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_instance",
             autospec=True,
             return_value="fm",
-        ) as mock_get_instance:
+        ) as mock_get_instance, mock.patch(
+            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.is_autoscaling_enabled",
+            autospec=True,
+            return_value=is_autoscaled,
+        ):
 
             ret = self.deployment.get_kubernetes_metadata("aaa123")
             assert ret == V1ObjectMeta(
@@ -1873,6 +1884,7 @@ class TestKubernetesDeploymentConfig:
                     "paasta.yelp.com/git_sha": "aaa123",
                     "paasta.yelp.com/instance": mock_get_instance.return_value,
                     "paasta.yelp.com/service": mock_get_service.return_value,
+                    "paasta.yelp.com/autoscaled": autoscaled_label,
                 },
                 name="kurupt-fm",
             )
@@ -3585,7 +3597,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config2c8004b5"
+            == "confige0334534"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 


### PR DESCRIPTION
The original approach here used an annotation that was only present for uwsgi-scaled services. To fix this, we'll add another label and use that instead in order to prevent any issues from our existing metrics collectors potentially getting confused by a new value for the existing annotation