### PR TITLE
Update to check all status versions before setting state to stopped

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1211,7 +1211,7 @@ def get_instance_state(status: InstanceStatusKubernetesV2) -> str:
     num_versions = len(status.versions)
     num_ready_replicas = sum(r.ready_replicas for r in status.versions)
     if status.desired_state == "stop":
-        if num_versions == 1 and status.versions[0].replicas == 0:
+        if all(replica == 0 for replica in status.versions):
             return PaastaColors.red("Stopped")
         else:
             return PaastaColors.red("Stopping")

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1211,7 +1211,6 @@ def get_instance_state(status: InstanceStatusKubernetesV2) -> str:
     num_versions = len(status.versions)
     num_ready_replicas = sum(r.ready_replicas for r in status.versions)
     if status.desired_state == "stop":
-        # num_versions == 1 and status.versions[0].replicas == 0:
         if all(version.replicas == 0 for version in status.versions):
             return PaastaColors.red("Stopped")
         else:

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1211,7 +1211,8 @@ def get_instance_state(status: InstanceStatusKubernetesV2) -> str:
     num_versions = len(status.versions)
     num_ready_replicas = sum(r.ready_replicas for r in status.versions)
     if status.desired_state == "stop":
-        if all(replica == 0 for replica in status.versions):
+        # num_versions == 1 and status.versions[0].replicas == 0:
+        if all(version.replicas == 0 for version in status.versions):
             return PaastaColors.red("Stopped")
         else:
             return PaastaColors.red("Stopping")


### PR DESCRIPTION
Currently if an instance has been manually stopped with paasta stop, paasta status will show State: Stopping when instance count is 0. The state should show Stopped when the process is complete.

[Before](https://fluffy.yelpcorp.com/i/MD36h6KW5gqMbVDWPgzj6sl0341xgdJC.html)
[After](https://fluffy.yelpcorp.com/i/3TztB9xmgdCQQnw1MnfC19KPB94TrJtl.html)