### PR TITLE
Update get_actual_deployments to use deployments.json v2

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -46,6 +46,7 @@ from paasta_tools.adhoc_tools import AdhocJobConfig
 from paasta_tools.api.client import get_paasta_oapi_client
 from paasta_tools.cassandracluster_tools import CassandraClusterDeploymentConfig
 from paasta_tools.cli.utils import figure_out_service_name
+from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.cli.utils import get_instance_configs_for_service
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
@@ -77,10 +78,11 @@ from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import is_under_replicated
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
-from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import remove_ansi_escape_sequences
+from paasta_tools.utils import SPACER
 from paasta_tools.utils import SystemPaastaConfig
 
 FLINK_STATUS_MAX_THREAD_POOL_WORKERS = 50
@@ -239,7 +241,8 @@ def list_deployed_clusters(
 
 
 def get_actual_deployments(service: str, soa_dir: str) -> Mapping[str, str]:
-    deployments_json = load_deployments_json(service, soa_dir)
+    """Returns a dict of branch names (typically cluster.instance) to git sha"""
+    deployments_json = load_v2_deployments_json(service, soa_dir)
     if not deployments_json:
         print(
             "Warning: it looks like %s has not been deployed anywhere yet!" % service,
@@ -247,12 +250,19 @@ def get_actual_deployments(service: str, soa_dir: str) -> Mapping[str, str]:
         )
     # Create a dictionary of actual $service Jenkins deployments
     actual_deployments = {}
-    for key, branch_dict in deployments_json.config_dict.items():
+    for key, branch_dict in deployments_json.config_dict.get("controls", {}).items():
         service, namespace = key.split(":")
         if service == service:
-            value = branch_dict["docker_image"]
-            sha = value[value.rfind("-") + 1 :]
-            actual_deployments[namespace.replace("paasta-", "", 1)] = sha
+            # extract cluster and instance from branch name
+            cluster, instance = namespace.split(SPACER, 1)
+            instance_config = get_instance_config(
+                service=service, instance=instance, cluster=cluster, soa_dir=soa_dir
+            )
+            actual_deployments[
+                namespace
+            ] = deployments_json.get_git_sha_for_deploy_group(
+                deploy_group=instance_config.get_deploy_group()
+            )
     return actual_deployments
 
 

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -216,23 +216,37 @@ def test_status_pending_pipeline_build_message(
     assert expected_output in output
 
 
-@patch("paasta_tools.cli.cmds.status.load_deployments_json", autospec=True)
+@patch("paasta_tools.cli.cmds.status.get_instance_config", autospec=True)
+@patch("paasta_tools.cli.cmds.status.load_v2_deployments_json", autospec=True)
 def test_get_actual_deployments(
     mock_get_deployments,
+    mock_get_instance_config,
 ):
-    mock_get_deployments.return_value = utils.DeploymentsJsonV1(
-        {
-            "fake_service:paasta-b_cluster.b_instance": {
-                "docker_image": "this_is_a_sha"
+    mock_get_deployments.return_value = utils.DeploymentsJsonV2(
+        service="fake_service",
+        config_dict={
+            "deployments": {
+                "deploy_group_a": {"git_sha": "this_is_a_sha"},
+                "deploy_group_b": {"git_sha": "this_is_b_sha"},
             },
-            "fake_service:paasta-a_cluster.a_instance": {
-                "docker_image": "this_is_a_sha"
+            "controls": {
+                "fake_service:a_cluster.a_instance": {
+                    "state": "start",
+                },
+                "fake_service:b_cluster.b_instance": {
+                    "state": "start",
+                },
             },
-        }
+        },
     )
+
+    mock_get_deploy_group = mock.Mock()
+    mock_get_deploy_group.side_effect = ["deploy_group_a", "deploy_group_b"]
+    mock_get_instance_config.return_value.get_deploy_group = mock_get_deploy_group
+
     expected = {
         "a_cluster.a_instance": "this_is_a_sha",
-        "b_cluster.b_instance": "this_is_a_sha",
+        "b_cluster.b_instance": "this_is_b_sha",
     }
 
     actual = status.get_actual_deployments("fake_service", "/fake/soa/dir")


### PR DESCRIPTION
`paasta_tools.cli.cmds.status.get_actual_deployments` was the last remaining non-test usecase depending on the v1 version of deployments.json, and in particular depending on the current format of our docker images as `service-<servicename>:paasta-<gitsha>`.  

As docker_image format will be changing with our no-commit redeploy project this quarter, this PR updates `get_actual_deployments` to use the information from the v2 deployment information, which stores gitsha directly, rather than needing to parse it from the docker image.  This required using `get_instance_config` to be able to match an instance to a deploy group in order to grab the git sha and maintain `get_actual_deployments`'s original return value.

`get_actual_deployments` was used in:
* paasta_tools/cli/cmds/status.py
* paasta_tools/cli/cmds/info.py
* paasta_tools/api/views/instance.py

Manual tests of `paasta status`, `paasta info`, and curl'ing a local paasta API for instance status all returned the same data as the current paasta version.
