### PR TITLE
Use workload owners for workload contract labels

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1975,6 +1975,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     cluster_aliases: Dict[str, str]
     hacheck_match_initial_delay: bool
     spark_ui_port: int
+    workload_owners: Dict[str, str]
 
 
 def load_system_paasta_config(
@@ -2662,6 +2663,12 @@ class SystemPaastaConfig:
 
     def get_hacheck_match_initial_delay(self) -> bool:
         return self.config_dict.get("hacheck_match_initial_delay", False)
+
+    def get_workload_owner(self, workload: str) -> str:
+        # TODO: we probably wanna set up a scanner or something such that we can quickly
+        # detect when someone has added a new PaaSTA-powered workload not not updated
+        # the workload owner configuration
+        return self.config_dict.get("workload_owners", {}).get(workload, "Unknown")
 
 
 def _run(


### PR DESCRIPTION
the workload contract was previously under-specified and did not mention
what the value for the "yelp.com/owner" label should be (i.e., should it
be the owner of the code that the labeled objects support or should it
be the owners of the infra itself)

We've gone ahead and decided that this should point to the infra (i.e.,
workload) owners.

Tron was the only thing in this repo currently setting this label
(adding these labels to PaaSTA itself is happening in another PR)