### PR TITLE
Support additional version information in push-to-registry

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -81,3 +81,6 @@ ignore_errors = True
 
 [mypy-paasta_tools.cli.cmds.mark_for_deployment]
 disallow_untyped_defs = True
+
+[mypy-paasta_tools.cli.cmds.push_to_registry]
+disallow_untyped_defs = True

--- a/paasta_tools/cli/cmds/push_to_registry.py
+++ b/paasta_tools/cli/cmds/push_to_registry.py
@@ -67,7 +67,6 @@ def add_subparser(subparsers):
         type=validate_full_git_sha,
     )
     list_parser.add_argument(
-        "-v",
         "--version-metadata",
         type=str,
         required=False,

--- a/paasta_tools/cli/cmds/push_to_registry.py
+++ b/paasta_tools/cli/cmds/push_to_registry.py
@@ -15,10 +15,13 @@
 """Contains methods used by the paasta client to upload a docker
 image to a registry.
 """
+import argparse
 import base64
 import binascii
 import json
 import os
+from typing import Optional
+from typing import Tuple
 
 import requests
 from requests.exceptions import RequestException
@@ -32,11 +35,12 @@ from paasta_tools.utils import _log
 from paasta_tools.utils import _log_audit
 from paasta_tools.utils import _run
 from paasta_tools.utils import build_docker_tag
+from paasta_tools.utils import build_image_identifier
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_service_docker_registry
 
 
-def add_subparser(subparsers):
+def add_subparser(subparsers: argparse._SubParsersAction) -> None:
     list_parser = subparsers.add_parser(
         "push-to-registry",
         help="Uploads a docker image to a registry",
@@ -67,7 +71,7 @@ def add_subparser(subparsers):
         type=validate_full_git_sha,
     )
     list_parser.add_argument(
-        "--version-metadata",
+        "--image-version",
         type=str,
         required=False,
         default=None,
@@ -93,26 +97,31 @@ def add_subparser(subparsers):
     list_parser.set_defaults(command=paasta_push_to_registry)
 
 
-def build_command(upstream_job_name, upstream_git_commit, version_metadata=None):
+def build_command(
+    upstream_job_name: str,
+    upstream_git_commit: str,
+    image_version: Optional[str] = None,
+) -> str:
     # This is kinda dumb since we just cleaned the 'services-' off of the
     # service so we could validate it, but the Docker image will have the full
     # name with 'services-' so add it back.
-    tag = build_docker_tag(upstream_job_name, upstream_git_commit, version_metadata)
+    tag = build_docker_tag(upstream_job_name, upstream_git_commit, image_version)
     cmd = f"docker push {tag}"
     return cmd
 
 
-def paasta_push_to_registry(args):
+def paasta_push_to_registry(args: argparse.Namespace) -> int:
     """Upload a docker image to a registry"""
     service = args.service
     if service and service.startswith("services-"):
         service = service.split("services-", 1)[1]
     validate_service_name(service, args.soa_dir)
+    image_identifier = build_image_identifier(args.commit, None, args.image_version)
 
     if not args.force:
         try:
             if is_docker_image_already_in_registry(
-                service, args.soa_dir, args.commit, args.version_metadata
+                service, args.soa_dir, args.commit, args.image_version
             ):
                 print(
                     "The docker image is already in the PaaSTA docker registry. "
@@ -128,7 +137,7 @@ def paasta_push_to_registry(args):
             )
             return 1
 
-    cmd = build_command(service, args.commit, args.version_metadata)
+    cmd = build_command(service, args.commit, args.image_version)
     loglines = []
     returncode, output = _run(
         cmd,
@@ -139,12 +148,14 @@ def paasta_push_to_registry(args):
         loglevel="debug",
     )
     if returncode != 0:
-        loglines.append("ERROR: Failed to promote image for %s." % args.commit)
+        loglines.append("ERROR: Failed to promote image for %s." % image_identifier)
         output = get_jenkins_build_output_url()
         if output:
             loglines.append("See output: %s" % output)
     else:
-        loglines.append("Successfully pushed image for %s to registry" % args.commit)
+        loglines.append(
+            "Successfully pushed image for %s to registry" % image_identifier
+        )
         _log_audit(
             action="push-to-registry",
             action_details={"commit": args.commit},
@@ -155,7 +166,9 @@ def paasta_push_to_registry(args):
     return returncode
 
 
-def read_docker_registry_creds(registry_uri):
+def read_docker_registry_creds(
+    registry_uri: str,
+) -> Tuple[Optional[str], Optional[str]]:
     dockercfg_path = os.path.expanduser("~/.dockercfg")
     try:
         with open(dockercfg_path) as f:
@@ -166,14 +179,14 @@ def read_docker_registry_creds(registry_uri):
                 return (auth[:first_colon], auth[first_colon + 1 : -2])
     except IOError:  # Can't open ~/.dockercfg
         pass
-    except json.scanner.JSONDecodeError:  # JSON decoder error
+    except json.JSONDecodeError:  # JSON decoder error
         pass
     except binascii.Error:  # base64 decode error
         pass
     return (None, None)
 
 
-def is_docker_image_already_in_registry(service, soa_dir, sha, version_metadata=None):
+def is_docker_image_already_in_registry(service: str, soa_dir: str, sha: str, image_version: Optional[str] = None) -> bool:  # type: ignore
     """Verifies that docker image exists in the paasta registry.
 
     :param service: name of the service
@@ -181,9 +194,7 @@ def is_docker_image_already_in_registry(service, soa_dir, sha, version_metadata=
     :returns: True, False or raises requests.exceptions.RequestException
     """
     registry_uri = get_service_docker_registry(service, soa_dir)
-    repository, tag = build_docker_image_name(service, sha, version_metadata).split(
-        ":", 1
-    )
+    repository, tag = build_docker_image_name(service, sha, image_version).split(":", 1)
 
     creds = read_docker_registry_creds(registry_uri)
     uri = f"{registry_uri}/v2/{repository}/manifests/{tag}"

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -202,12 +202,10 @@ def get_deploy_group_mappings(
     return mappings, v2_mappings
 
 
-def build_docker_image_name(
-    service: str, sha: str, version_metadata: str = None
-) -> str:
+def build_docker_image_name(service: str, sha: str, image_version: str = None) -> str:
     image_name = f"services-{service}:paasta-{sha}"
-    if version_metadata is not None:
-        image_name += f"-{version_metadata}"
+    if image_version is not None:
+        image_name += f"-{image_version}"
 
     return image_name
 

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -46,6 +46,7 @@ import re
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 from mypy_extensions import TypedDict
@@ -202,7 +203,9 @@ def get_deploy_group_mappings(
     return mappings, v2_mappings
 
 
-def build_docker_image_name(service: str, sha: str, image_version: str = None) -> str:
+def build_docker_image_name(
+    service: str, sha: str, image_version: Optional[str] = None
+) -> str:
     image_name = f"services-{service}:paasta-{sha}"
     if image_version is not None:
         image_name += f"-{image_version}"

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -202,8 +202,14 @@ def get_deploy_group_mappings(
     return mappings, v2_mappings
 
 
-def build_docker_image_name(service: str, sha: str) -> str:
-    return f"services-{service}:paasta-{sha}"
+def build_docker_image_name(
+    service: str, sha: str, version_metadata: str = None
+) -> str:
+    image_name = f"services-{service}:paasta-{sha}"
+    if version_metadata is not None:
+        image_name += f"-{version_metadata}"
+
+    return image_name
 
 
 def get_service_from_docker_image(image_name: str) -> str:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2865,13 +2865,17 @@ def build_docker_image_name(service: str) -> str:
     return name
 
 
-def build_docker_tag(service: str, upstream_git_commit: str) -> str:
+def build_docker_tag(
+    service: str, upstream_git_commit: str, version_metadata: str = None
+) -> str:
     """Builds the DOCKER_TAG string
 
     upstream_git_commit is the SHA that we're building. Usually this is the
     tip of origin/master.
     """
     tag = "{}:paasta-{}".format(build_docker_image_name(service), upstream_git_commit)
+    if version_metadata is not None:
+        tag += f"-{version_metadata}"
     return tag
 
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2866,7 +2866,7 @@ def build_docker_image_name(service: str) -> str:
 
 
 def build_docker_tag(
-    service: str, upstream_git_commit: str, image_version: str = None
+    service: str, upstream_git_commit: str, image_version: Optional[str] = None
 ) -> str:
     """Builds the DOCKER_TAG string
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2866,7 +2866,7 @@ def build_docker_image_name(service: str) -> str:
 
 
 def build_docker_tag(
-    service: str, upstream_git_commit: str, version_metadata: str = None
+    service: str, upstream_git_commit: str, image_version: str = None
 ) -> str:
     """Builds the DOCKER_TAG string
 
@@ -2874,8 +2874,8 @@ def build_docker_tag(
     tip of origin/master.
     """
     tag = "{}:paasta-{}".format(build_docker_image_name(service), upstream_git_commit)
-    if version_metadata is not None:
-        tag += f"-{version_metadata}"
+    if image_version is not None:
+        tag += f"-{image_version}"
     return tag
 
 
@@ -3417,6 +3417,18 @@ def get_paasta_tag(cluster: str, instance: str, desired_state: str) -> str:
 
 def format_tag(tag: str) -> str:
     return "refs/tags/%s" % tag
+
+
+def build_image_identifier(
+    git_sha: str, sha_len: Optional[int] = None, image_version: Optional[str] = None
+) -> str:
+    image = git_sha
+    if sha_len is not None:
+        image = image[:sha_len]
+    if image_version is not None:
+        image += f"-{image_version}"
+
+    return image
 
 
 class NoDockerImageError(Exception):

--- a/tests/cli/test_cmds_push_to_registry.py
+++ b/tests/cli/test_cmds_push_to_registry.py
@@ -204,7 +204,7 @@ def test_push_to_registry_works_when_service_name_starts_with_services_dash(
     mock_run.return_value = (0, "Success")
     mock_is_docker_image_already_in_registry.return_value = False
     assert paasta_push_to_registry(args) == 0
-    mock_build_command.assert_called_once_with("foo", "abcd" * 10)
+    mock_build_command.assert_called_once_with("foo", "abcd" * 10, None)
     mock_log_audit.assert_called_once_with(
         action="push-to-registry", action_details={"commit": "abcd" * 10}, service="foo"
     )
@@ -347,5 +347,56 @@ def test_is_docker_image_already_in_registry_http_when_image_does_not_exist(
     mock_request_head.assert_called_with(
         ANY,
         "http://registry/v2/services-fake_service/manifests/paasta-fake_sha",
+        timeout=30,
+    )
+
+
+@patch(
+    "paasta_tools.cli.cmds.push_to_registry.is_docker_image_already_in_registry",
+    autospec=True,
+)
+@patch("paasta_tools.cli.cmds.push_to_registry.build_command", autospec=True)
+@patch("paasta_tools.cli.cmds.push_to_registry.validate_service_name", autospec=True)
+@patch("paasta_tools.cli.cmds.push_to_registry._run", autospec=True)
+@patch("paasta_tools.cli.cmds.push_to_registry._log", autospec=True)
+@patch("paasta_tools.cli.cmds.push_to_registry._log_audit", autospec=True)
+def test_push_to_registry_with_version_metadata(
+    mock_log_audit,
+    mock_log,
+    mock_run,
+    mock_validate_service_name,
+    mock_build_command,
+    mock_is_docker_image_already_in_registry,
+):
+    args, _ = parse_args(
+        ["push-to-registry", "-s", "foo", "-c", "abcd" * 10, "-v", "extrastuff:this"]
+    )
+
+    mock_run.return_value = (0, "Success")
+    mock_is_docker_image_already_in_registry.return_value = False
+    assert paasta_push_to_registry(args) == 0
+    mock_build_command.assert_called_once_with("foo", "abcd" * 10, "extrastuff:this")
+    assert mock_run.called
+
+
+@patch(
+    "paasta_tools.cli.cmds.push_to_registry.get_service_docker_registry", autospec=True
+)
+@patch("paasta_tools.cli.cmds.push_to_registry.requests.Session.head", autospec=True)
+@patch(
+    "paasta_tools.cli.cmds.push_to_registry.read_docker_registry_creds", autospec=True
+)
+def test_is_docker_image_already_with_version_metadata(
+    mock_read_docker_registry_creds, mock_request_head, mock_get_service_docker_registry
+):
+    mock_read_docker_registry_creds.return_value = (None, None)
+    mock_get_service_docker_registry.return_value = "registry"
+    mock_request_head.return_value = MagicMock(status_code=404)
+    assert not is_docker_image_already_in_registry(
+        "fake_service", "fake_soa_dir", "fake_sha", "extrastuff"
+    )
+    mock_request_head.assert_called_with(
+        ANY,
+        "https://registry/v2/services-fake_service/manifests/paasta-fake_sha-extrastuff",
         timeout=30,
     )

--- a/tests/cli/test_cmds_push_to_registry.py
+++ b/tests/cli/test_cmds_push_to_registry.py
@@ -360,7 +360,7 @@ def test_is_docker_image_already_in_registry_http_when_image_does_not_exist(
 @patch("paasta_tools.cli.cmds.push_to_registry._run", autospec=True)
 @patch("paasta_tools.cli.cmds.push_to_registry._log", autospec=True)
 @patch("paasta_tools.cli.cmds.push_to_registry._log_audit", autospec=True)
-def test_push_to_registry_with_version_metadata(
+def test_push_to_registry_with_image_version(
     mock_log_audit,
     mock_log,
     mock_run,
@@ -375,7 +375,7 @@ def test_push_to_registry_with_version_metadata(
             "foo",
             "-c",
             "abcd" * 10,
-            "--version-metadata",
+            "--image-version",
             "extrastuff:this",
         ]
     )
@@ -394,7 +394,7 @@ def test_push_to_registry_with_version_metadata(
 @patch(
     "paasta_tools.cli.cmds.push_to_registry.read_docker_registry_creds", autospec=True
 )
-def test_is_docker_image_already_with_version_metadata(
+def test_is_docker_image_already_with_image_version(
     mock_read_docker_registry_creds, mock_request_head, mock_get_service_docker_registry
 ):
     mock_read_docker_registry_creds.return_value = (None, None)

--- a/tests/cli/test_cmds_push_to_registry.py
+++ b/tests/cli/test_cmds_push_to_registry.py
@@ -369,7 +369,15 @@ def test_push_to_registry_with_version_metadata(
     mock_is_docker_image_already_in_registry,
 ):
     args, _ = parse_args(
-        ["push-to-registry", "-s", "foo", "-c", "abcd" * 10, "-v", "extrastuff:this"]
+        [
+            "push-to-registry",
+            "-s",
+            "foo",
+            "-c",
+            "abcd" * 10,
+            "--version-metadata",
+            "extrastuff:this",
+        ]
     )
 
     mock_run.return_value = (0, "Success")


### PR DESCRIPTION
We want push-to-registry to support the new docker image name:
`services-{service}:paasta-{git_sha}-{extrastuff}`

The relevant ticket for this is:
https://jira.yelpcorp.com/browse/COMPINFRA-1039
