### PR TITLE
Add a toggle to exclude terminating pods when reporting local pods to nerve

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2062,7 +2062,7 @@ def get_kubernetes_services_running_here(
 
 
 def get_kubernetes_services_running_here_for_nerve(
-    cluster: Optional[str], soa_dir: str, exclude_terminating_pods: bool = False
+    cluster: Optional[str], soa_dir: str
 ) -> Sequence[Tuple[str, ServiceNamespaceConfig]]:
     try:
         system_paasta_config = load_system_paasta_config()

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1939,6 +1939,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     metrics_provider: str
     monitoring_config: Dict
     nerve_readiness_check_script: List[str]
+    nerve_register_k8s_terminating: bool
     paasta_native: PaastaNativeConfig
     paasta_status_version: str
     pdb_max_unavailable: Union[str, int]

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2175,6 +2175,9 @@ class SystemPaastaConfig:
             ["/check_proxy_up.sh", "--enable-smartstack", "--enable-envoy"],
         )
 
+    def get_nerve_register_k8s_terminating(self) -> bool:
+        return self.config_dict.get("nerve_register_k8s_terminating", True)
+
     def get_enforce_disk_quota(self) -> bool:
         """
         If enabled, add `--storage-opt size=SIZE` arg to `docker run` calls,

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2351,7 +2351,7 @@ def test_get_kubernetes_services_running_here():
             ]
         }
 
-        mock_pod_results = {
+        mock_pod_results: dict = {
             "items": [
                 # valid pod
                 {


### PR DESCRIPTION
Currently configure_nerve uses [get_kubernetes_services_running_here_for_nerve](https://github.com/Yelp/nerve-tools/blob/master/src/nerve_tools/configure_nerve.py#L365-L368) to determine whether to report a local pod.

This caused an issue recently when a pod was stuck in `Terminating` for a long time, but its IP had already been reassigned to a different pod on the same host.  `get_kubernetes_running_services_for_nerve` reported the terminating pod, which then kept it in nerve configuration.  Because the new pod used the same healthcheck uri and returned a healthy result, the registration for the old pod continued to exist.

Currently our smartstack-registered pods' hacheck containers have a preStop that immediately marks the instance as down in the service mesh.  It seems correct to also stop reporting this instance to nerve at this time.

This PR adds a new paasta system toggle to exclude these terminating pods from being reported to nerve, but maintains the default of current behavior.

Note that there is no `Terminating` phase or state to check directly.  Pods will be in phase `Running` but include a `deletionTimestamp`. See [related docs](https://kubernetes.io/blog/2021/05/14/using-finalizers-to-control-deletion/)

This PR also changes the existing tests for `get_kubernetes_services_running_here` to make it clearer what we are testing, and which test pod is 'valid'. 