### PR TITLE
Status: print all available status objects

### DIFF
--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -46,8 +46,6 @@ from paasta_tools.utils import calculate_tail_lines
 
 
 INSTANCE_TYPES_CR = {"flink", "cassandracluster", "kafkacluster"}
-# TODO: remove "cassandracluster" from INSTANCE_TYPES_K8S after
-# print_cassandra_status proves to be stable.
 INSTANCE_TYPES_K8S = {"kubernetes", "cassandracluster"}
 INSTANCE_TYPES = INSTANCE_TYPES_K8S.union(INSTANCE_TYPES_CR)
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1931,7 +1931,6 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     kubernetes_add_registration_labels: bool
     kubernetes_custom_resources: List[KubeCustomResourceDict]
     kubernetes_use_hacheck_sidecar: bool
-    enable_custom_cassandra_status_writer: bool
     ldap_host: str
     ldap_reader_password: str
     ldap_reader_username: str
@@ -2507,9 +2506,6 @@ class SystemPaastaConfig:
 
     def get_kubernetes_use_hacheck_sidecar(self) -> bool:
         return self.config_dict.get("kubernetes_use_hacheck_sidecar", True)
-
-    def get_enable_custom_cassandra_status_writer(self) -> bool:
-        return self.config_dict.get("enable_custom_cassandra_status_writer", False)
 
     def get_register_marathon_services(self) -> bool:
         """Enable registration of marathon services in nerve"""


### PR DESCRIPTION
The Cassandra status object contains data for both kubernetes and
cassandracluster. This change will make paasta status print all available
status objects. So, for Cassandra clusters, it will use the custom status
writer as well as the Kubernetes status writer, and for other objects the
output will not change.

The motivation for this change is that the Kubernetes writer provides
information that are not available in the custom Cassandra status writer.
So, we would ideally want to switch between them when necessary.

Context: [PAASTA-17617](https://jira.yelpcorp.com/browse/PAASTA-17617)