### PR TITLE
Update git-tag format in generate-deployments-for-service

### DIFF
--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -121,7 +121,7 @@ def get_latest_deployment_tag(
     most_recent_sha = None
     most_recent_image_version = None
     pattern = re.compile(
-        r"^refs/tags/paasta-%s(?::(?P<image_version>.*)){0,1}-(?P<dtime>\d{8}T\d{6})-deploy$"
+        r"^refs/tags/paasta-%s(?:\+(?P<image_version>.*)){0,1}-(?P<dtime>\d{8}T\d{6})-deploy$"
         % deploy_group
     )
 

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -121,7 +121,7 @@ def get_latest_deployment_tag(
     most_recent_sha = None
     most_recent_image_version = None
     pattern = re.compile(
-        r"^refs/tags/paasta-%s(?:-(?P<image_version>.*)){0,1}-(?P<dtime>\d{8}T\d{6})-deploy$"
+        r"^refs/tags/paasta-%s(?::(?P<image_version>.*)){0,1}-(?P<dtime>\d{8}T\d{6})-deploy$"
         % deploy_group
     )
 

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -51,7 +51,7 @@ def test_get_deploy_group_mappings():
         "refs/tags/paasta-okay-20160308T053933-deploy": "ijowarg",
         "refs/tags/paasta-no_thanks-20160308T053933-deploy": "789009",
         "refs/tags/paasta-nah-20160308T053933-deploy": "j8yiomwer",
-        "refs/tags/paasta-but-why:extrastuff-20220308T053933-deploy": "123456",
+        "refs/tags/paasta-but-why+extrastuff-20220308T053933-deploy": "123456",
     }
 
     expected = {

--- a/tests/test_generate_deployments_for_service.py
+++ b/tests/test_generate_deployments_for_service.py
@@ -41,7 +41,7 @@ def test_get_deploy_group_mappings():
             cluster="clusterC",
             instance="main",
             branch_dict=None,
-            config_dict={"deploy_group": "but_why"},
+            config_dict={"deploy_group": "but-why"},
         ),
     ]
 
@@ -51,7 +51,7 @@ def test_get_deploy_group_mappings():
         "refs/tags/paasta-okay-20160308T053933-deploy": "ijowarg",
         "refs/tags/paasta-no_thanks-20160308T053933-deploy": "789009",
         "refs/tags/paasta-nah-20160308T053933-deploy": "j8yiomwer",
-        "refs/tags/paasta-but_why-extrastuff-20220308T053933-deploy": "123456",
+        "refs/tags/paasta-but-why:extrastuff-20220308T053933-deploy": "123456",
     }
 
     expected = {
@@ -83,7 +83,7 @@ def test_get_deploy_group_mappings():
                 "git_sha": "789009",
                 "image_version": None,
             },
-            "but_why": {
+            "but-why": {
                 "docker_image": "services-fake_service:paasta-123456-extrastuff",
                 "git_sha": "123456",
                 "image_version": "extrastuff",


### PR DESCRIPTION
Initially we wanted the git-tag format to be:
`paasta-{deploy_group}-{image_version}-{timestamp}-deploy`

However, this made it hard to parse when the deploy group included a `"-"`. As a result, we're instead opting for:
`paasta-{deploy_group}:{image_version}-{timestamp}-deploy`

This changes the format in the most recent changes. We'll use this format going forward in the upcoming changes.