### PR TITLE
Show image-version in new paasta status

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1302,11 +1302,11 @@ def get_version_table_entry(
     version_name = version.git_sha[:8]
     if show_config_sha or verbose > 1:
         version_name += f", {version.config_sha}"
+    if version.image_version is not None:
+        version_name += PaastaColors.blue(f" (image version: {version.image_version})")
     if version_name_suffix is not None:
         version_name += f" ({version_name_suffix})"
     version_name = PaastaColors.blue(version_name)
-    if version.image_version is not None:
-        version_name += PaastaColors.blue(f" (image version: {version.image_version})")
 
     start_datetime = datetime.fromtimestamp(version.create_timestamp)
     humanized_start_time = humanize.naturaltime(start_datetime)

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1300,6 +1300,9 @@ def get_version_table_entry(
     verbose: int = 0,
 ) -> List[str]:
     version_name = version.git_sha[:8]
+    image_version = (
+        version.image_version if version.image_version is not None else "none"
+    )
     if show_config_sha or verbose > 1:
         version_name += f", {version.config_sha}"
     if version_name_suffix is not None:
@@ -1308,7 +1311,9 @@ def get_version_table_entry(
 
     start_datetime = datetime.fromtimestamp(version.create_timestamp)
     humanized_start_time = humanize.naturaltime(start_datetime)
-    entry = [f"{version_name} - Started {start_datetime} ({humanized_start_time})"]
+    entry = [
+        f"{version_name} (image_version: {image_version}) - Started {start_datetime} ({humanized_start_time})"
+    ]
     replica_states = get_replica_states(version.pods)
     replica_states = sorted(replica_states, key=lambda s: s[1].create_timestamp)
     if len(replica_states) == 0:

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1300,20 +1300,17 @@ def get_version_table_entry(
     verbose: int = 0,
 ) -> List[str]:
     version_name = version.git_sha[:8]
-    image_version = (
-        version.image_version if version.image_version is not None else "none"
-    )
     if show_config_sha or verbose > 1:
         version_name += f", {version.config_sha}"
     if version_name_suffix is not None:
         version_name += f" ({version_name_suffix})"
     version_name = PaastaColors.blue(version_name)
+    if version.image_version is not None:
+        version_name += PaastaColors.blue(f" (image version: {version.image_version})")
 
     start_datetime = datetime.fromtimestamp(version.create_timestamp)
     humanized_start_time = humanize.naturaltime(start_datetime)
-    entry = [
-        f"{version_name} (image_version: {image_version}) - Started {start_datetime} ({humanized_start_time})"
-    ]
+    entry = [f"{version_name} - Started {start_datetime} ({humanized_start_time})"]
     replica_states = get_replica_states(version.pods)
     replica_states = sorted(replica_states, key=lambda s: s[1].create_timestamp)
     if len(replica_states) == 0:

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1303,7 +1303,7 @@ def get_version_table_entry(
     if show_config_sha or verbose > 1:
         version_name += f", {version.config_sha}"
     if version.image_version is not None:
-        version_name += f" (image version: {version.image_version})"
+        version_name += f" (image_version: {version.image_version})"
     if version_name_suffix is not None:
         version_name += f" ({version_name_suffix})"
     version_name = PaastaColors.blue(version_name)

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1303,7 +1303,7 @@ def get_version_table_entry(
     if show_config_sha or verbose > 1:
         version_name += f", {version.config_sha}"
     if version.image_version is not None:
-        version_name += PaastaColors.blue(f" (image version: {version.image_version})")
+        version_name += f" (image version: {version.image_version})"
     if version_name_suffix is not None:
         version_name += f" ({version_name_suffix})"
     version_name = PaastaColors.blue(version_name)


### PR DESCRIPTION
This is for:
[COMPINFRA-1043](https://jira.yelpcorp.com/browse/COMPINFRA-1043)

The output should look like:
```
service: pii_logging_detection
cluster: pnw-prod
    instance: main
    Git sha:    409f8265 (desired)
    State: Running
    Running versions:
      Rerun with -v to see all replicas
      409f8265 (image_version: none) - Started 2022-05-17 12:33:09 (20 hours ago)
        Replica States: 1 Healthy
    instance: pii_logging_detection_kafka_sampling.run
    Tron job: pii_logging_detection_kafka_sampling
      Dashboard: http://y/tron-pnw-prod#job/pii_logging_detection.pii_logging_detection_kafka_sampling
```

We could also make it so that it stays the same if image_version is unset to keep the status-quo? Happy to do it either way.