### PR TITLE
Update deploy_schema.json to restrict deploy group names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
+      - run: sudo apt-get update
       - run: sudo apt-get install -yq devscripts
       - run: make itest_${{ matrix.dist }}

--- a/paasta_tools/cli/schemas/deploy_schema.json
+++ b/paasta_tools/cli/schemas/deploy_schema.json
@@ -8,7 +8,8 @@
             "properties": {
                 "parallel": {},
                 "step": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^[a-zA-Z0-9_.-]+$"
                 },
                 "trigger_next_step_manually": {
                     "type": "boolean"


### PR DESCRIPTION
Bumping paasta's deploy.yaml schema to match our internal py-gitolite version.

See https://github.yelpcorp.com/packages/py-gitolite/pull/58 for more information.

This change does not add schema validation to `paasta validate`, just ensures the schema is in sync w/ our validation script's copy.