### PR TITLE
COMPINFRA-1080: Update rollback to support new extra image metadata

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -87,3 +87,6 @@ disallow_untyped_defs = True
 
 [mypy-paasta_tools.cli.cmds.push_to_registry]
 disallow_untyped_defs = True
+
+[mypy-paasta_tools.cli.cmds.rollback]
+disallow_untyped_defs = True

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -265,9 +265,14 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
 
 
 def mark_for_deployment(
-    git_url: str, deploy_group: str, service: str, commit: str
+    git_url: str,
+    deploy_group: str,
+    service: str,
+    commit: str,
+    image_version: Optional[str] = None,
 ) -> int:
     """Mark a docker image for deployment"""
+    # TODO: Handle image_version, currently does nothing
     tag = get_paasta_tag_from_deploy_group(
         identifier=deploy_group, desired_state="deploy"
     )

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -274,6 +274,8 @@ def paasta_rollback(args: argparse.Namespace) -> int:
         )
         return 1
 
+    # TODO: Add similar check for when image_version is empty and no-commit redeploys is enforced for requested deploy_group
+
     returncode = 0
 
     for deploy_group in deploy_groups:
@@ -289,7 +291,6 @@ def paasta_rollback(args: argparse.Namespace) -> int:
         # we could also gate this by the return code from m-f-d, but we probably care more about someone wanting to
         # rollback than we care about if the underlying machinery was successfully able to complete the request
 
-        # TODO: Eventually we should include full version in rollback event, but currently leave things as status-quo
         if rolled_back_from != new_version:
             audit_action_details = {
                 "rolled_back_from": str(rolled_back_from),

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -843,9 +843,9 @@ def get_instance_config(
     )
 
 
-def extract_tags(paasta_tag):
+def extract_tags(paasta_tag: str) -> Mapping[str, str]:
     """Returns a dictionary containing information from a git tag"""
-    regex = r"^refs/tags/(?:paasta-){1,2}(?P<deploy_group>.*?)-(?P<tstamp>\d{8}T\d{6})-(?P<tag>.*?)$"
+    regex = r"^refs/tags/(?:paasta-){1,2}(?P<deploy_group>[a-zA-Z0-9._-]+)(?:\+(?P<image_version>.*)){0,1}-(?P<tstamp>\d{8}T\d{6})-(?P<tag>.*?)$"
     regex_match = re.match(regex, paasta_tag)
     return regex_match.groupdict() if regex_match else {}
 

--- a/paasta_tools/deployment_utils.py
+++ b/paasta_tools/deployment_utils.py
@@ -12,7 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
+
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import DeploymentVersion
 from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import NoDeploymentsAvailable
 
@@ -23,5 +26,19 @@ def get_currently_deployed_sha(service, deploy_group, soa_dir=DEFAULT_SOA_DIR):
     try:
         deployments = load_v2_deployments_json(service=service, soa_dir=soa_dir)
         return deployments.get_git_sha_for_deploy_group(deploy_group=deploy_group)
+    except NoDeploymentsAvailable:
+        return None
+
+
+def get_currently_deployed_version(
+    service, deploy_group, soa_dir=DEFAULT_SOA_DIR
+) -> Optional[DeploymentVersion]:
+    """Tries to determine the currently deployed version for a service and deploy_group,
+    returns None if there isn't one ready yet"""
+    try:
+        deployments = load_v2_deployments_json(service=service, soa_dir=soa_dir)
+        return deployments.get_deployment_version_for_deploy_group(
+            deploy_group=deploy_group
+        )
     except NoDeploymentsAvailable:
         return None

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -58,6 +58,7 @@ from typing import Iterable
 from typing import Iterator
 from typing import List
 from typing import Mapping
+from typing import NamedTuple
 from typing import Optional
 from typing import Sequence
 from typing import Set
@@ -3282,6 +3283,18 @@ class NoDeploymentsAvailable(Exception):
     pass
 
 
+class DeploymentVersion(NamedTuple):
+    sha: str
+    image_version: Optional[str]
+
+    def __repr__(self) -> str:
+        return (
+            f"DeploymentVersion(sha={self.sha}, image_version={self.image_version})"
+            if self.image_version
+            else self.sha
+        )
+
+
 DeploymentsJsonV1Dict = Dict[str, BranchDictV1]
 
 DeployGroup = str
@@ -3383,6 +3396,14 @@ class DeploymentsJsonV2:
         except KeyError:
             e = f"The configuration for service {self.service} in deploy group {deploy_group} does not contain 'image_version' metadata."
             raise KeyError(e)
+
+    def get_deployment_version_for_deploy_group(
+        self, deploy_group: str
+    ) -> DeploymentVersion:
+        return DeploymentVersion(
+            sha=self.get_git_sha_for_deploy_group(deploy_group),
+            image_version=self.get_image_version_for_deploy_group(deploy_group),
+        )
 
     def get_desired_state_for_branch(self, control_branch: str) -> str:
         try:

--- a/tests/cli/test_cmds_rollback.py
+++ b/tests/cli/test_cmds_rollback.py
@@ -17,45 +17,55 @@ from mock import Mock
 from mock import patch
 
 from paasta_tools.cli.cli import parse_args
-from paasta_tools.cli.cmds.rollback import get_git_shas_for_service
+from paasta_tools.cli.cmds.rollback import get_versions_for_service
+from paasta_tools.cli.cmds.rollback import list_previously_deployed_image_versions
 from paasta_tools.cli.cmds.rollback import list_previously_deployed_shas
 from paasta_tools.cli.cmds.rollback import paasta_rollback
 from paasta_tools.cli.cmds.rollback import validate_given_deploy_groups
+from paasta_tools.utils import DeploymentVersion
 from paasta_tools.utils import RollbackTypes
 
 
-@patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_sha", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.list_deploy_groups", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.figure_out_service_name", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
-@patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.get_versions_for_service", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.can_user_deploy_service", autospec=True)
 def test_paasta_rollback_mark_for_deployment_simple_invocation(
     mock_can_user_deploy_service,
-    mock_get_git_shas_for_service,
+    mock_get_versions_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_figure_out_service_name,
     mock_list_deploy_groups,
     mock_log_audit,
-    mock_get_currently_deployed_sha,
+    mock_get_currently_deployed_version,
 ):
     fake_args, _ = parse_args(
         ["rollback", "-s", "fakeservice", "-k", "abcd" * 10, "-l", "fake_deploy_group1"]
     )
 
-    mock_get_git_shas_for_service.return_value = {
-        fake_args.commit: ("20170403T025512", fake_args.deploy_groups),
-        "dcba" * 10: ("20161006T025416", "fake_deploy_group2"),
+    mock_get_versions_for_service.return_value = {
+        DeploymentVersion(sha=fake_args.commit, image_version=None): (
+            "20170403T025512",
+            fake_args.deploy_groups,
+        ),
+        DeploymentVersion(sha="dcba" * 10, image_version=None): (
+            "20161006T025416",
+            "fake_deploy_group2",
+        ),
     }
 
     mock_get_git_url.return_value = "git://git.repo"
     mock_figure_out_service_name.return_value = fake_args.service
     mock_list_deploy_groups.return_value = [fake_args.deploy_groups]
     mock_mark_for_deployment.return_value = 0
-    mock_get_currently_deployed_sha.return_value = "1234" * 10
+    mock_get_currently_deployed_version.return_value = DeploymentVersion(
+        sha="1234" * 10, image_version=None
+    )
 
     assert paasta_rollback(fake_args) == 0
 
@@ -64,6 +74,7 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
         deploy_group=fake_args.deploy_groups,
         service=mock_figure_out_service_name.return_value,
         commit=fake_args.commit,
+        image_version=None,
     )
 
     # ensure that we logged each deploy group that was rolled back AND that we logged things correctly
@@ -71,9 +82,8 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
     for call_args in mock_log_audit.call_args_list:
         _, call_kwargs = call_args
         assert call_kwargs["action"] == "rollback"
-        assert (
-            call_kwargs["action_details"]["rolled_back_from"]
-            == mock_get_currently_deployed_sha.return_value
+        assert call_kwargs["action_details"]["rolled_back_from"] == str(
+            mock_get_currently_deployed_version.return_value
         )
         assert call_kwargs["action_details"]["rolled_back_to"] == fake_args.commit
         assert (
@@ -84,23 +94,107 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
         assert call_kwargs["service"] == fake_args.service
 
 
-@patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_sha", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.list_deploy_groups", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.figure_out_service_name", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
-@patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.get_versions_for_service", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.can_user_deploy_service", autospec=True)
-def test_paasta_rollback_with_force(
+def test_paasta_rollback_mark_for_deployment_with_image(
     mock_can_user_deploy_service,
-    mock_get_git_shas_for_service,
+    mock_get_versions_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_figure_out_service_name,
     mock_list_deploy_groups,
     mock_log_audit,
-    mock_get_currently_deployed_sha,
+    mock_get_currently_deployed_version,
+):
+    fake_args, _ = parse_args(
+        [
+            "rollback",
+            "-s",
+            "fakeservice",
+            "-k",
+            "abcd" * 10,
+            "-l",
+            "fake_deploy_group1",
+            "-i",
+            "extra_image_info",
+        ]
+    )
+
+    mock_get_versions_for_service.return_value = {
+        DeploymentVersion(
+            sha=fake_args.commit, image_version=fake_args.image_version
+        ): (
+            "20170403T025512",
+            fake_args.deploy_groups,
+        ),
+        DeploymentVersion(sha="dcba" * 10, image_version=None): (
+            "20161006T025416",
+            "fake_deploy_group2",
+        ),
+    }
+
+    mock_get_git_url.return_value = "git://git.repo"
+    mock_figure_out_service_name.return_value = fake_args.service
+    mock_list_deploy_groups.return_value = [fake_args.deploy_groups]
+    mock_mark_for_deployment.return_value = 0
+    mock_get_currently_deployed_version.return_value = DeploymentVersion(
+        sha="1234" * 10, image_version=None
+    )
+
+    rollback_version = DeploymentVersion(
+        sha=fake_args.commit, image_version=fake_args.image_version
+    )
+
+    assert paasta_rollback(fake_args) == 0
+
+    mock_mark_for_deployment.assert_called_once_with(
+        git_url=mock_get_git_url.return_value,
+        deploy_group=fake_args.deploy_groups,
+        service=mock_figure_out_service_name.return_value,
+        commit=fake_args.commit,
+        image_version=fake_args.image_version,
+    )
+
+    # ensure that we logged each deploy group that was rolled back AND that we logged things correctly
+    mock_log_audit.call_count == len(fake_args.deploy_groups)
+    for call_args in mock_log_audit.call_args_list:
+        _, call_kwargs = call_args
+        assert call_kwargs["action"] == "rollback"
+        assert call_kwargs["action_details"]["rolled_back_from"] == str(
+            mock_get_currently_deployed_version.return_value
+        )
+        assert call_kwargs["action_details"]["rolled_back_to"] == str(rollback_version)
+        assert (
+            call_kwargs["action_details"]["rollback_type"]
+            == RollbackTypes.USER_INITIATED_ROLLBACK.value
+        )
+        assert call_kwargs["action_details"]["deploy_group"] in fake_args.deploy_groups
+        assert call_kwargs["service"] == fake_args.service
+
+
+@patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.list_deploy_groups", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.figure_out_service_name", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.get_versions_for_service", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.can_user_deploy_service", autospec=True)
+def test_paasta_rollback_with_force(
+    mock_can_user_deploy_service,
+    mock_get_versions_for_service,
+    mock_mark_for_deployment,
+    mock_get_git_url,
+    mock_figure_out_service_name,
+    mock_list_deploy_groups,
+    mock_log_audit,
+    mock_get_currently_deployed_version,
 ):
     fake_args, _ = parse_args(
         [
@@ -115,16 +209,24 @@ def test_paasta_rollback_with_force(
         ]
     )
 
-    mock_get_git_shas_for_service.return_value = {
-        "fake_sha1": ("20170403T025512", "fake_deploy_group1"),
-        "fake_sha2": ("20161006T025416", "fake_deploy_group2"),
+    mock_get_versions_for_service.return_value = {
+        DeploymentVersion(sha="fake_sha1", image_version=None): (
+            "20170403T025512",
+            "fake_deploy_group1",
+        ),
+        DeploymentVersion(sha="fake_sha2", image_version=None): (
+            "20161006T025416",
+            "fake_deploy_group2",
+        ),
     }
 
     mock_get_git_url.return_value = "git://git.repo"
     mock_figure_out_service_name.return_value = fake_args.service
     mock_list_deploy_groups.return_value = [fake_args.deploy_groups]
     mock_mark_for_deployment.return_value = 0
-    mock_get_currently_deployed_sha.return_value = "1234" * 10
+    mock_get_currently_deployed_version.return_value = DeploymentVersion(
+        sha="1234" * 10, image_version=None
+    )
 
     assert paasta_rollback(fake_args) == 0
 
@@ -133,15 +235,15 @@ def test_paasta_rollback_with_force(
         deploy_group=fake_args.deploy_groups,
         service=mock_figure_out_service_name.return_value,
         commit=fake_args.commit,
+        image_version=None,
     )
     # ensure that we logged each deploy group that was rolled back AND that we logged things correctly
     mock_log_audit.call_count == len(fake_args.deploy_groups)
     for call_args in mock_log_audit.call_args_list:
         _, call_kwargs = call_args
         assert call_kwargs["action"] == "rollback"
-        assert (
-            call_kwargs["action_details"]["rolled_back_from"]
-            == mock_get_currently_deployed_sha.return_value
+        assert call_kwargs["action_details"]["rolled_back_from"] == str(
+            mock_get_currently_deployed_version.return_value
         )
         assert call_kwargs["action_details"]["rolled_back_to"] == fake_args.commit
         assert (
@@ -152,29 +254,35 @@ def test_paasta_rollback_with_force(
         assert call_kwargs["service"] == fake_args.service
 
 
-@patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_sha", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.list_deploy_groups", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.figure_out_service_name", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
-@patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.get_versions_for_service", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.can_user_deploy_service", autospec=True)
 def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
     mock_can_user_deploy_service,
-    mock_get_git_shas_for_service,
+    mock_get_versions_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_figure_out_service_name,
     mock_list_deploy_groups,
     mock_log_audit,
-    mock_get_currently_deployed_sha,
+    mock_get_currently_deployed_version,
 ):
     fake_args, _ = parse_args(["rollback", "-s", "fakeservice", "-k", "abcd" * 10])
 
-    mock_get_git_shas_for_service.return_value = {
-        "fake_sha1": ("20170403T025512", "fake_deploy_group1"),
-        fake_args.commit: ("20161006T025416", "fake_deploy_group2"),
+    mock_get_versions_for_service.return_value = {
+        DeploymentVersion(sha="fake_sha1", image_version=None): (
+            "20170403T025512",
+            "fake_deploy_group1",
+        ),
+        DeploymentVersion(sha=fake_args.commit, image_version=None): (
+            "20161006T025416",
+            "fake_deploy_group2",
+        ),
     }
 
     mock_get_git_url.return_value = "git://git.repo"
@@ -184,7 +292,9 @@ def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
         "fake_cluster.fake_instance",
     ]
     mock_mark_for_deployment.return_value = 0
-    mock_get_currently_deployed_sha.return_value = "1234" * 10
+    mock_get_currently_deployed_version.return_value = DeploymentVersion(
+        sha="1234" * 10, image_version=None
+    )
 
     assert paasta_rollback(fake_args) == 0
 
@@ -194,12 +304,14 @@ def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
             service=mock_figure_out_service_name.return_value,
             commit=fake_args.commit,
             deploy_group="fake_cluster.fake_instance",
+            image_version=None,
         ),
         call(
             git_url=mock_get_git_url.return_value,
             service=mock_figure_out_service_name.return_value,
             commit=fake_args.commit,
             deploy_group="fake_deploy_group",
+            image_version=None,
         ),
     ]
 
@@ -210,9 +322,8 @@ def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
     for call_args in mock_log_audit.call_args_list:
         _, call_kwargs = call_args
         assert call_kwargs["action"] == "rollback"
-        assert (
-            call_kwargs["action_details"]["rolled_back_from"]
-            == mock_get_currently_deployed_sha.return_value
+        assert call_kwargs["action_details"]["rolled_back_from"] == str(
+            mock_get_currently_deployed_version.return_value
         )
         assert call_kwargs["action_details"]["rolled_back_to"] == fake_args.commit
         assert (
@@ -258,11 +369,11 @@ def test_paasta_rollback_mark_for_deployment_wrong_deploy_group_args(
 @patch("paasta_tools.cli.cmds.rollback.figure_out_service_name", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
-@patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.get_versions_for_service", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.can_user_deploy_service", autospec=True)
 def test_paasta_rollback_git_sha_was_not_marked_before(
     mock_can_user_deploy_service,
-    mock_get_git_shas_for_service,
+    mock_get_versions_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_figure_out_service_name,
@@ -273,9 +384,19 @@ def test_paasta_rollback_git_sha_was_not_marked_before(
         ["rollback", "-s", "fakeservice", "-k", "abcd" * 10, "-l", "fake_deploy_group1"]
     )
 
-    mock_get_git_shas_for_service.return_value = {
-        "fake_sha1": ("20170403T025512", "fake_deploy_group1"),
-        "fake_sha2": ("20161006T025416", "fake_deploy_group2"),
+    mock_get_versions_for_service.return_value = {
+        DeploymentVersion(sha="fake_sha1", image_version="fake_image"): (
+            "20170403T025512",
+            "fake_deploy_group1",
+        ),
+        DeploymentVersion(sha="fake_sha2", image_version="fake_image"): (
+            "20161006T025416",
+            "fake_deploy_group2",
+        ),
+        DeploymentVersion(sha=fake_args.commit, image_version="fake_image"): (
+            "20161006T025416",
+            "fake_deploy_group2",
+        ),
     }
 
     mock_get_git_url.return_value = "git://git.repo"
@@ -288,23 +409,23 @@ def test_paasta_rollback_git_sha_was_not_marked_before(
     assert not mock_log_audit.called
 
 
-@patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_sha", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.list_deploy_groups", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.figure_out_service_name", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_git_url", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.mark_for_deployment", autospec=True)
-@patch("paasta_tools.cli.cmds.rollback.get_git_shas_for_service", autospec=True)
+@patch("paasta_tools.cli.cmds.rollback.get_versions_for_service", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.can_user_deploy_service", autospec=True)
 def test_paasta_rollback_mark_for_deployment_multiple_deploy_group_args(
     mock_can_user_deploy_service,
-    mock_get_git_shas_for_service,
+    mock_get_versions_for_service,
     mock_mark_for_deployment,
     mock_get_git_url,
     mock_figure_out_service_name,
     mock_list_deploy_groups,
     mock_log_audit,
-    mock_get_currently_deployed_sha,
+    mock_get_currently_deployed_version,
 ):
     fake_args, _ = parse_args(
         [
@@ -320,16 +441,24 @@ def test_paasta_rollback_mark_for_deployment_multiple_deploy_group_args(
 
     fake_deploy_groups = fake_args.deploy_groups.split(",")
 
-    mock_get_git_shas_for_service.return_value = {
-        "fake_sha1": ("20170403T025512", "fake_deploy_group1"),
-        fake_args.commit: ("20161006T025416", "fake_deploy_group2"),
+    mock_get_versions_for_service.return_value = {
+        DeploymentVersion(sha="fake_sha1", image_version=None): (
+            "20170403T025512",
+            "fake_deploy_group1",
+        ),
+        DeploymentVersion(sha=fake_args.commit, image_version=None): (
+            "20161006T025416",
+            "fake_deploy_group2",
+        ),
     }
 
     mock_get_git_url.return_value = "git://git.repo"
     mock_figure_out_service_name.return_value = fake_args.service
     mock_list_deploy_groups.return_value = fake_deploy_groups
     mock_mark_for_deployment.return_value = 0
-    mock_get_currently_deployed_sha.return_value = "1234" * 10
+    mock_get_currently_deployed_version.return_value = DeploymentVersion(
+        sha="1234" * 10, image_version=None
+    )
 
     assert paasta_rollback(fake_args) == 0
 
@@ -339,6 +468,7 @@ def test_paasta_rollback_mark_for_deployment_multiple_deploy_group_args(
             service=mock_figure_out_service_name.return_value,
             commit=fake_args.commit,
             deploy_group=deploy_group,
+            image_version=None,
         )
         for deploy_group in fake_deploy_groups
     ]
@@ -350,9 +480,8 @@ def test_paasta_rollback_mark_for_deployment_multiple_deploy_group_args(
     for call_args in mock_log_audit.call_args_list:
         _, call_kwargs = call_args
         assert call_kwargs["action"] == "rollback"
-        assert (
-            call_kwargs["action_details"]["rolled_back_from"]
-            == mock_get_currently_deployed_sha.return_value
+        assert call_kwargs["action_details"]["rolled_back_from"] == str(
+            mock_get_currently_deployed_version.return_value
         )
         assert call_kwargs["action_details"]["rolled_back_to"] == fake_args.commit
         assert (
@@ -445,6 +574,7 @@ def test_list_previously_deployed_shas():
     fake_refs = {
         "refs/tags/paasta-test.deploy.group-00000000T000000-deploy": "SHA_IN_OUTPUT",
         "refs/tags/paasta-other.deploy.group-00000000T000000-deploy": "NOT_IN_OUTPUT",
+        "refs/tags/paasta-other.deploy.group+extra_image_info-00000000T000000-deploy": "NOT_IN_OUTPUT",
     }
     fake_deploy_groups = ["test.deploy.group"]
 
@@ -464,6 +594,34 @@ def test_list_previously_deployed_shas():
             force=None,
         )
         assert set(list_previously_deployed_shas(fake_args)) == {"SHA_IN_OUTPUT"}
+
+
+def test_list_previously_deployed_image_versions():
+    fake_refs = {
+        "refs/tags/paasta-test.deploy.group+extra_image_info-00000000T000000-deploy": "SHA_IN_OUTPUT",
+        "refs/tags/paasta-other.deploy.group-00000000T000000-deploy": "NOT_IN_OUTPUT",
+        "refs/tags/paasta-other.deploy.group+extra_image_info-00000000T000000-deploy": "NOT_IN_OUTPUT",
+    }
+    fake_deploy_groups = ["test.deploy.group"]
+
+    with patch(
+        "paasta_tools.cli.cmds.rollback.list_remote_refs",
+        autospec=True,
+        return_value=fake_refs,
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.list_deploy_groups",
+        autospec=True,
+        return_value=fake_deploy_groups,
+    ):
+        fake_args = Mock(
+            service="fake_service",
+            deploy_groups="test.deploy.group,nonexistant.deploy.group",
+            soa_dir="/fake/soa/dir",
+            force=None,
+        )
+        assert set(list_previously_deployed_image_versions(fake_args)) == {
+            "extra_image_info"
+        }
 
 
 def test_list_previously_deployed_shas_no_deploy_groups():
@@ -495,5 +653,5 @@ def test_list_previously_deployed_shas_no_deploy_groups():
         }
 
 
-def test_get_git_shas_for_service_no_service_name():
-    assert get_git_shas_for_service(None, None, "/fake/soa/dir") == []
+def test_get_versions_for_service_no_service_name():
+    assert get_versions_for_service(None, None, "/fake/soa/dir") == {}

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -23,6 +23,7 @@ from pytest import mark
 from pytest import raises
 
 from paasta_tools.cli import utils
+from paasta_tools.cli.utils import extract_tags
 from paasta_tools.cli.utils import verify_instances
 from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.utils import SystemPaastaConfig
@@ -498,3 +499,48 @@ def test_verify_instances_with_suffixes(mock_list_all_instances_for_service):
         verify_instances("fake_instance2.jobname", "fake_service", ["fake_cluster"])
         == []
     )
+
+
+@mark.parametrize(
+    "tag,expected_result",
+    [
+        (
+            "refs/tags/paasta-paasta-deploy.group-00000000T000000-deploy",
+            {
+                "deploy_group": "deploy.group",
+                "image_version": None,
+                "tstamp": "00000000T000000",
+                "tag": "deploy",
+            },
+        ),
+        (
+            "refs/tags/paasta-paasta-test-cluster.main-00000000T000000-start",
+            {
+                "deploy_group": "test-cluster.main",
+                "image_version": None,
+                "tstamp": "00000000T000000",
+                "tag": "start",
+            },
+        ),  # technically not a deploy tag, but we use this on all tags
+        (
+            "refs/tags/paasta-deploy.group-00000000T000000-deploy",
+            {
+                "deploy_group": "deploy.group",
+                "image_version": None,
+                "tstamp": "00000000T000000",
+                "tag": "deploy",
+            },
+        ),
+        (
+            "refs/tags/paasta-no-commit-deploy.group+11111111T111111-00000000T000000-deploy",
+            {
+                "deploy_group": "no-commit-deploy.group",
+                "image_version": "11111111T111111",
+                "tstamp": "00000000T000000",
+                "tag": "deploy",
+            },
+        ),
+    ],
+)
+def test_extract_tags(tag, expected_result):
+    assert extract_tags(tag) == expected_result

--- a/tests/test_deployment_utils.py
+++ b/tests/test_deployment_utils.py
@@ -15,6 +15,7 @@ import mock
 
 from paasta_tools import deployment_utils
 from paasta_tools.utils import DeploymentsJsonV2
+from paasta_tools.utils import DeploymentVersion
 
 
 @mock.patch("paasta_tools.deployment_utils.load_v2_deployments_json", autospec=True)
@@ -32,3 +33,43 @@ def test_get_currently_deployed_sha(
         service="service", deploy_group="everything"
     )
     assert actual == "abc"
+
+
+@mock.patch("paasta_tools.deployment_utils.load_v2_deployments_json", autospec=True)
+def test_get_currently_deployed_version_no_image(
+    mock_load_v2_deployments_json,
+):
+    mock_load_v2_deployments_json.return_value = DeploymentsJsonV2(
+        service="fake-service",
+        config_dict={
+            "controls": {},
+            "deployments": {"everything": {"git_sha": "abc", "docker_image": "foo"}},
+        },
+    )
+    actual = deployment_utils.get_currently_deployed_version(
+        service="service", deploy_group="everything"
+    )
+    assert actual == DeploymentVersion(sha="abc", image_version=None)
+
+
+@mock.patch("paasta_tools.deployment_utils.load_v2_deployments_json", autospec=True)
+def test_get_currently_deployed_version(
+    mock_load_v2_deployments_json,
+):
+    mock_load_v2_deployments_json.return_value = DeploymentsJsonV2(
+        service="fake-service",
+        config_dict={
+            "controls": {},
+            "deployments": {
+                "everything": {
+                    "git_sha": "abc",
+                    "docker_image": "foo",
+                    "image_version": "extrastuff",
+                }
+            },
+        },
+    )
+    actual = deployment_utils.get_currently_deployed_version(
+        service="service", deploy_group="everything"
+    )
+    assert actual == DeploymentVersion(sha="abc", image_version="extrastuff")


### PR DESCRIPTION
This adds a new DeploymentVersion type that contains just `sha` and `image_version`.  When converting this type to a string, it should only return the sha if image_version is None, but print the full version otherwise -- this should help keep user-presented output consistent w/ status quo until things actually start getting `image_version`.

Where rollback previously dealt with just listing past shas for deployment info, I've converted it to use this new class.

This required adding the `image_version` keyword to `paasta_tools.cli.cmds.mark_for_deployment.mark_for_deployment` but this leaves the actual mark-for-deployment changes to a separate task.

I confirmed that the command still works as expected w/o an `--image-version`, and the output is nearly identical with status quo:
old: https://fluffy.yelpcorp.com/i/8smJkb3vw0fH4FgJhFJXLBPs091zRzhC.html
new: https://fluffy.yelpcorp.com/i/f12z9GlRv9sRrJ0L37jl5lDgNPdn3NQr.html