### PR TITLE
Change active_shas to active_versions

### DIFF
--- a/paasta_tools/api/api_docs/oapi.yaml
+++ b/paasta_tools/api/api_docs/oapi.yaml
@@ -171,9 +171,9 @@ components:
       type: object
     InstanceBounceStatus:
       properties:
-        active_shas:
+        active_versions:
           type: array
-          description: List of git/config SHAs running.
+          description: List of git SHA/image_version/config SHAs running.
           items:
             type: array
             items:
@@ -308,9 +308,9 @@ components:
       type: object
     InstanceStatusKubernetes:
       properties:
-        active_shas:
+        active_versions:
           type: array
-          description: List of git/config SHAs running.
+          description: List of git SHA/image_version/config SHAs running.
           items:
             type: array
             items:
@@ -469,9 +469,9 @@ components:
           description: Status of the service in Envoy
     InstanceStatusMarathon:
       properties:
-        active_shas:
+        active_versions:
           type: array
-          description: List of git/config SHAs running.
+          description: List of git SHA/image_version/config SHAs running.
           items:
             type: array
             items:

--- a/paasta_tools/api/api_docs/oapi.yaml
+++ b/paasta_tools/api/api_docs/oapi.yaml
@@ -171,6 +171,14 @@ components:
       type: object
     InstanceBounceStatus:
       properties:
+        active_shas:
+          type: array
+          description: List of git/config SHAs running.
+          items:
+            type: array
+            items:
+              type: string
+              nullable: true
         active_versions:
           type: array
           description: List of git SHA/image_version/config SHAs running.
@@ -308,6 +316,16 @@ components:
       type: object
     InstanceStatusKubernetes:
       properties:
+        active_shas:
+          type: array
+          description: List of git/config SHAs running.
+          items:
+            type: array
+            items:
+              type: string
+              nullable: true
+            minItems: 2
+            maxItems: 2
         active_versions:
           type: array
           description: List of git SHA/image_version/config SHAs running.
@@ -316,8 +334,8 @@ components:
             items:
               type: string
               nullable: true
-            minItems: 2
-            maxItems: 2
+            minItems: 3
+            maxItems: 3
         app_count:
           description: The number of different running versions of the same service
             (0 for stopped, 1 for running and 1+ for bouncing)
@@ -469,6 +487,16 @@ components:
           description: Status of the service in Envoy
     InstanceStatusMarathon:
       properties:
+        active_shas:
+          type: array
+          description: List of git/config SHAs running.
+          items:
+            type: array
+            items:
+              type: string
+              nullable: true
+            minItems: 2
+            maxItems: 2
         active_versions:
           type: array
           description: List of git SHA/image_version/config SHAs running.
@@ -477,8 +505,8 @@ components:
             items:
               type: string
               nullable: true
-            minItems: 2
-            maxItems: 2
+            minItems: 3
+            maxItems: 3
         app_count:
           description: The number of different running versions of the same service
             (0 for stopped, 1 for running and 1+ for bouncing)

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -908,17 +908,17 @@
                     "type": "string",
                     "description": "Error message when a marathon job ID cannot be found"
                 },
-                "active_shas": {
+                "active_versions": {
                     "type": "array",
-                    "description": "List of git/config SHAs running.",
+                    "description": "List of git SHA/image_version/config SHAs running.",
                     "items": {
                         "type": "array",
                         "items": {
                             "type": "string",
                             "x-nullable": true
                         },
-                        "minItems": 2,
-                        "maxItems": 2
+                        "minItems": 3,
+                        "maxItems": 3
                     }
                 }
             },
@@ -1356,9 +1356,9 @@
                     "format": "int32",
                     "description": "The number of desired instances of the service"
                 },
-                "active_shas": {
+                "active_versions": {
                     "type": "array",
-                    "description": "List of git/config SHAs running.",
+                    "description": "List of git SHA/image_version/config SHAs running.",
                     "items": {
                         "type": "array",
                         "items": {
@@ -1494,17 +1494,17 @@
                     "type": "string",
                     "description": "Error message when a kubernetes object (Deployment/Statefulset) cannot be found"
                 },
-                "active_shas": {
+                "active_versions": {
                     "type": "array",
-                    "description": "List of git/config SHAs running.",
+                    "description": "List of git SHA/image_version/config SHAs running.",
                     "items": {
                         "type": "array",
                         "items": {
                             "type": "string",
                             "x-nullable": true
                         },
-                        "minItems": 2,
-                        "maxItems": 2
+                        "minItems": 3,
+                        "maxItems": 3
                     }
                 }
             },

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -908,6 +908,19 @@
                     "type": "string",
                     "description": "Error message when a marathon job ID cannot be found"
                 },
+                "active_shas": {
+                    "type": "array",
+                    "description": "List of git/config SHAs running.",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "x-nullable": true
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                    }
+                },
                 "active_versions": {
                     "type": "array",
                     "description": "List of git SHA/image_version/config SHAs running.",
@@ -1356,6 +1369,17 @@
                     "format": "int32",
                     "description": "The number of desired instances of the service"
                 },
+                "active_shas": {
+                    "type": "array",
+                    "description": "List of git/config SHAs running.",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "x-nullable": true
+                        }
+                    }
+                },
                 "active_versions": {
                     "type": "array",
                     "description": "List of git SHA/image_version/config SHAs running.",
@@ -1493,6 +1517,19 @@
                 "error_message": {
                     "type": "string",
                     "description": "Error message when a kubernetes object (Deployment/Statefulset) cannot be found"
+                },
+                "active_shas": {
+                    "type": "array",
+                    "description": "List of git/config SHAs running.",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "x-nullable": true
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                    }
                 },
                 "active_versions": {
                     "type": "array",

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -241,6 +241,10 @@ def marathon_job_status(
         "desired_state": job_config.get_desired_state(),
         "bounce_method": job_config.get_bounce_method(),
         "expected_instance_count": job_config.get_instances(),
+        "active_shas": [
+            (deployment_version.sha, config_sha)
+            for deployment_version, config_sha in active_versions
+        ],
         "active_versions": [
             (deployment_version.sha, deployment_version.image_version, config_sha)
             for deployment_version, config_sha in active_versions

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -218,11 +218,12 @@ def get_active_versions_for_marathon_apps(
     for (app, client) in marathon_apps_with_clients:
         git_sha = get_git_sha_from_dockerurl(app.container.docker.image, long=True)
         image_version = get_image_version_from_dockerurl(app.container.docker.image)
-        deployment_version = DeploymentVersion(sha=git_sha, image_version=image_version)
         _, _, _, config_sha = marathon_tools.deformat_job_id(app.id)
         if config_sha.startswith("config"):
             config_sha = config_sha[len("config") :]
-        ret.add((deployment_version, config_sha))
+        ret.add(
+            (DeploymentVersion(sha=git_sha, image_version=image_version), config_sha)
+        )
     return ret
 
 

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -70,7 +70,9 @@ from paasta_tools.mesos_tools import select_tasks_by_id
 from paasta_tools.mesos_tools import TaskNotFound
 from paasta_tools.utils import calculate_tail_lines
 from paasta_tools.utils import compose_job_id
+from paasta_tools.utils import DeploymentVersion
 from paasta_tools.utils import get_git_sha_from_dockerurl
+from paasta_tools.utils import get_image_version_from_dockerurl
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import TimeoutError
@@ -209,16 +211,18 @@ def marathon_instance_status(
     return mstatus
 
 
-def get_active_shas_for_marathon_apps(
+def get_active_versions_for_marathon_apps(
     marathon_apps_with_clients: List[Tuple[MarathonApp, MarathonClient]],
-) -> Set[Tuple[str, str]]:
+) -> Set[Tuple[DeploymentVersion, str]]:
     ret = set()
     for (app, client) in marathon_apps_with_clients:
         git_sha = get_git_sha_from_dockerurl(app.container.docker.image, long=True)
+        image_version = get_image_version_from_dockerurl(app.container.docker.image)
+        deployment_version = DeploymentVersion(sha=git_sha, image_version=image_version)
         _, _, _, config_sha = marathon_tools.deformat_job_id(app.id)
         if config_sha.startswith("config"):
             config_sha = config_sha[len("config") :]
-        ret.add((git_sha, config_sha))
+        ret.add((deployment_version, config_sha))
     return ret
 
 
@@ -229,15 +233,17 @@ def marathon_job_status(
     marathon_apps_with_clients: List[Tuple[MarathonApp, MarathonClient]],
     verbose: int,
 ) -> MutableMapping[str, Any]:
+    active_versions = get_active_versions_for_marathon_apps(marathon_apps_with_clients)
     job_status_fields: MutableMapping[str, Any] = {
         "app_statuses": [],
         "app_count": len(marathon_apps_with_clients),
         "desired_state": job_config.get_desired_state(),
         "bounce_method": job_config.get_bounce_method(),
         "expected_instance_count": job_config.get_instances(),
-        "active_shas": list(
-            get_active_shas_for_marathon_apps(marathon_apps_with_clients)
-        ),
+        "active_versions": [
+            (deployment_version.sha, deployment_version.image_version, config_sha)
+            for deployment_version, config_sha in active_versions
+        ],
     }
 
     try:

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1537,7 +1537,7 @@ def check_if_instance_is_done(
         return True
 
     short_git_sha = git_sha[:8]
-    active_shas = {g[:8] for g, _, _ in status.active_versions}
+    active_shas = {g[:8] for g, c in status.active_shas}
     if short_git_sha in active_shas:
         non_desired_shas = active_shas.difference({short_git_sha})
         # Case: bounce in-progress
@@ -1588,7 +1588,7 @@ def check_if_instance_is_done(
     # Case: completed
     print(
         f"Complete: {service}.{instance} on {cluster} is 100% deployed at "
-        f"{status.running_instance_count} replicas on {status.active_versions[0][0]}"
+        f"{status.running_instance_count} replicas on {status.active_shas[0][0]}"
     )
     return True
 

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1537,7 +1537,7 @@ def check_if_instance_is_done(
         return True
 
     short_git_sha = git_sha[:8]
-    active_shas = {g[:8] for g, c in status.active_shas}
+    active_shas = {g[:8] for g, _, _ in status.active_versions}
     if short_git_sha in active_shas:
         non_desired_shas = active_shas.difference({short_git_sha})
         # Case: bounce in-progress
@@ -1588,7 +1588,7 @@ def check_if_instance_is_done(
     # Case: completed
     print(
         f"Complete: {service}.{instance} on {cluster} is 100% deployed at "
-        f"{status.running_instance_count} replicas on {status.active_shas[0][0]}"
+        f"{status.running_instance_count} replicas on {status.active_versions[0][0]}"
     )
     return True
 

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -518,6 +518,10 @@ def bounce_status(
     active_versions = kubernetes_tools.get_active_versions_for_service(
         [app, *version_objects],
     )
+    status["active_shas"] = [
+        (deployment_version.sha, config_sha)
+        for deployment_version, config_sha in active_versions
+    ]
     status["active_versions"] = [
         (deployment_version.sha, deployment_version.image_version, config_sha)
         for deployment_version, config_sha in active_versions
@@ -1083,6 +1087,10 @@ async def kubernetes_status(
     kstatus["app_count"] = len(active_versions)
     kstatus["desired_state"] = job_config.get_desired_state()
     kstatus["bounce_method"] = job_config.get_bounce_method()
+    kstatus["active_shas"] = [
+        (deployment_version.sha, config_sha)
+        for deployment_version, config_sha in active_versions
+    ]
     kstatus["active_versions"] = [
         (deployment_version.sha, deployment_version.image_version, config_sha)
         for deployment_version, config_sha in active_versions

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -520,7 +520,7 @@ def bounce_status(
     )
     status["active_versions"] = [
         (deployment_version.sha, deployment_version.image_version, config_sha)
-        for (deployment_version, config_sha) in active_versions
+        for deployment_version, config_sha in active_versions
     ]
     status["app_count"] = len(active_versions)
     return status

--- a/paasta_tools/paastaapi/model/instance_bounce_status.py
+++ b/paasta_tools/paastaapi/model/instance_bounce_status.py
@@ -88,7 +88,7 @@ class InstanceBounceStatus(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'active_shas': ([[str, none_type]],),  # noqa: E501
+            'active_versions': ([[str, none_type]],),  # noqa: E501
             'app_count': (int,),  # noqa: E501
             'deploy_status': (str,),  # noqa: E501
             'desired_state': (str,),  # noqa: E501
@@ -102,7 +102,7 @@ class InstanceBounceStatus(ModelNormal):
 
 
     attribute_map = {
-        'active_shas': 'active_shas',  # noqa: E501
+        'active_versions': 'active_versions',  # noqa: E501
         'app_count': 'app_count',  # noqa: E501
         'deploy_status': 'deploy_status',  # noqa: E501
         'desired_state': 'desired_state',  # noqa: E501
@@ -156,7 +156,7 @@ class InstanceBounceStatus(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            active_shas ([[str, none_type]]): List of git/config SHAs running.. [optional]  # noqa: E501
+            active_versions ([[str, none_type]]): List of git SHA/image_version/config SHAs running.. [optional]  # noqa: E501
             app_count (int): The number of different running versions of the same service (0 for stopped, 1 for running and 1+ for bouncing). [optional]  # noqa: E501
             deploy_status (str): Deploy status of a Kubernetes service. [optional]  # noqa: E501
             desired_state (str): Desired state of a service, for Kubernetes. [optional]  # noqa: E501

--- a/paasta_tools/paastaapi/model/instance_bounce_status.py
+++ b/paasta_tools/paastaapi/model/instance_bounce_status.py
@@ -88,6 +88,7 @@ class InstanceBounceStatus(ModelNormal):
                 and the value is attribute type.
         """
         return {
+            'active_shas': ([[str, none_type]],),  # noqa: E501
             'active_versions': ([[str, none_type]],),  # noqa: E501
             'app_count': (int,),  # noqa: E501
             'deploy_status': (str,),  # noqa: E501
@@ -102,6 +103,7 @@ class InstanceBounceStatus(ModelNormal):
 
 
     attribute_map = {
+        'active_shas': 'active_shas',  # noqa: E501
         'active_versions': 'active_versions',  # noqa: E501
         'app_count': 'app_count',  # noqa: E501
         'deploy_status': 'deploy_status',  # noqa: E501
@@ -156,6 +158,7 @@ class InstanceBounceStatus(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            active_shas ([[str, none_type]]): List of git/config SHAs running.. [optional]  # noqa: E501
             active_versions ([[str, none_type]]): List of git SHA/image_version/config SHAs running.. [optional]  # noqa: E501
             app_count (int): The number of different running versions of the same service (0 for stopped, 1 for running and 1+ for bouncing). [optional]  # noqa: E501
             deploy_status (str): Deploy status of a Kubernetes service. [optional]  # noqa: E501

--- a/paasta_tools/paastaapi/model/instance_status_kubernetes.py
+++ b/paasta_tools/paastaapi/model/instance_status_kubernetes.py
@@ -110,6 +110,7 @@ class InstanceStatusKubernetes(ModelNormal):
             'app_count': (int,),  # noqa: E501
             'bounce_method': (str,),  # noqa: E501
             'desired_state': (str,),  # noqa: E501
+            'active_shas': ([[str, none_type]],),  # noqa: E501
             'active_versions': ([[str, none_type]],),  # noqa: E501
             'app_id': (str,),  # noqa: E501
             'autoscaling_status': (InstanceStatusKubernetesAutoscalingStatus,),  # noqa: E501
@@ -137,6 +138,7 @@ class InstanceStatusKubernetes(ModelNormal):
         'app_count': 'app_count',  # noqa: E501
         'bounce_method': 'bounce_method',  # noqa: E501
         'desired_state': 'desired_state',  # noqa: E501
+        'active_shas': 'active_shas',  # noqa: E501
         'active_versions': 'active_versions',  # noqa: E501
         'app_id': 'app_id',  # noqa: E501
         'autoscaling_status': 'autoscaling_status',  # noqa: E501
@@ -206,6 +208,7 @@ class InstanceStatusKubernetes(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            active_shas ([[str, none_type]]): List of git/config SHAs running.. [optional]  # noqa: E501
             active_versions ([[str, none_type]]): List of git SHA/image_version/config SHAs running.. [optional]  # noqa: E501
             app_id (str): ID of the desired version of a service instance. [optional]  # noqa: E501
             autoscaling_status (InstanceStatusKubernetesAutoscalingStatus): [optional]  # noqa: E501

--- a/paasta_tools/paastaapi/model/instance_status_kubernetes.py
+++ b/paasta_tools/paastaapi/model/instance_status_kubernetes.py
@@ -110,7 +110,7 @@ class InstanceStatusKubernetes(ModelNormal):
             'app_count': (int,),  # noqa: E501
             'bounce_method': (str,),  # noqa: E501
             'desired_state': (str,),  # noqa: E501
-            'active_shas': ([[str, none_type]],),  # noqa: E501
+            'active_versions': ([[str, none_type]],),  # noqa: E501
             'app_id': (str,),  # noqa: E501
             'autoscaling_status': (InstanceStatusKubernetesAutoscalingStatus,),  # noqa: E501
             'backoff_seconds': (int,),  # noqa: E501
@@ -137,7 +137,7 @@ class InstanceStatusKubernetes(ModelNormal):
         'app_count': 'app_count',  # noqa: E501
         'bounce_method': 'bounce_method',  # noqa: E501
         'desired_state': 'desired_state',  # noqa: E501
-        'active_shas': 'active_shas',  # noqa: E501
+        'active_versions': 'active_versions',  # noqa: E501
         'app_id': 'app_id',  # noqa: E501
         'autoscaling_status': 'autoscaling_status',  # noqa: E501
         'backoff_seconds': 'backoff_seconds',  # noqa: E501
@@ -206,7 +206,7 @@ class InstanceStatusKubernetes(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            active_shas ([[str, none_type]]): List of git/config SHAs running.. [optional]  # noqa: E501
+            active_versions ([[str, none_type]]): List of git SHA/image_version/config SHAs running.. [optional]  # noqa: E501
             app_id (str): ID of the desired version of a service instance. [optional]  # noqa: E501
             autoscaling_status (InstanceStatusKubernetesAutoscalingStatus): [optional]  # noqa: E501
             backoff_seconds (int): backoff in seconds before launching the next task. [optional]  # noqa: E501

--- a/paasta_tools/paastaapi/model/instance_status_marathon.py
+++ b/paasta_tools/paastaapi/model/instance_status_marathon.py
@@ -111,7 +111,7 @@ class InstanceStatusMarathon(ModelNormal):
             'app_count': (int,),  # noqa: E501
             'bounce_method': (str,),  # noqa: E501
             'desired_state': (str,),  # noqa: E501
-            'active_shas': ([[str, none_type]],),  # noqa: E501
+            'active_versions': ([[str, none_type]],),  # noqa: E501
             'app_statuses': ([MarathonAppStatus],),  # noqa: E501
             'autoscaling_info': (MarathonAutoscalingInfo,),  # noqa: E501
             'backoff_seconds': (int,),  # noqa: E501
@@ -135,7 +135,7 @@ class InstanceStatusMarathon(ModelNormal):
         'app_count': 'app_count',  # noqa: E501
         'bounce_method': 'bounce_method',  # noqa: E501
         'desired_state': 'desired_state',  # noqa: E501
-        'active_shas': 'active_shas',  # noqa: E501
+        'active_versions': 'active_versions',  # noqa: E501
         'app_statuses': 'app_statuses',  # noqa: E501
         'autoscaling_info': 'autoscaling_info',  # noqa: E501
         'backoff_seconds': 'backoff_seconds',  # noqa: E501
@@ -201,7 +201,7 @@ class InstanceStatusMarathon(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            active_shas ([[str, none_type]]): List of git/config SHAs running.. [optional]  # noqa: E501
+            active_versions ([[str, none_type]]): List of git SHA/image_version/config SHAs running.. [optional]  # noqa: E501
             app_statuses ([MarathonAppStatus]): Statuses of each app of the service. [optional]  # noqa: E501
             autoscaling_info (MarathonAutoscalingInfo): [optional]  # noqa: E501
             backoff_seconds (int): backoff in seconds before launching the next task. [optional]  # noqa: E501

--- a/paasta_tools/paastaapi/model/instance_status_marathon.py
+++ b/paasta_tools/paastaapi/model/instance_status_marathon.py
@@ -111,6 +111,7 @@ class InstanceStatusMarathon(ModelNormal):
             'app_count': (int,),  # noqa: E501
             'bounce_method': (str,),  # noqa: E501
             'desired_state': (str,),  # noqa: E501
+            'active_shas': ([[str, none_type]],),  # noqa: E501
             'active_versions': ([[str, none_type]],),  # noqa: E501
             'app_statuses': ([MarathonAppStatus],),  # noqa: E501
             'autoscaling_info': (MarathonAutoscalingInfo,),  # noqa: E501
@@ -135,6 +136,7 @@ class InstanceStatusMarathon(ModelNormal):
         'app_count': 'app_count',  # noqa: E501
         'bounce_method': 'bounce_method',  # noqa: E501
         'desired_state': 'desired_state',  # noqa: E501
+        'active_shas': 'active_shas',  # noqa: E501
         'active_versions': 'active_versions',  # noqa: E501
         'app_statuses': 'app_statuses',  # noqa: E501
         'autoscaling_info': 'autoscaling_info',  # noqa: E501
@@ -201,6 +203,7 @@ class InstanceStatusMarathon(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            active_shas ([[str, none_type]]): List of git/config SHAs running.. [optional]  # noqa: E501
             active_versions ([[str, none_type]]): List of git SHA/image_version/config SHAs running.. [optional]  # noqa: E501
             app_statuses ([MarathonAppStatus]): Statuses of each app of the service. [optional]  # noqa: E501
             autoscaling_info (MarathonAutoscalingInfo): [optional]  # noqa: E501

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -3549,6 +3549,17 @@ def get_git_sha_from_dockerurl(docker_url: str, long: bool = False) -> str:
     return git_sha if long else git_sha[:8]
 
 
+def get_image_version_from_dockerurl(docker_url: str) -> Optional[str]:
+    """We can optionally encode additional metadata about the docker image *in*
+    the docker url. This function takes that url as input and outputs the sha.
+    """
+    regex_match = re.match(
+        r".*:paasta-(?P<git_sha>[A-Za-z0-9]+)-(?P<image_version>.+)", docker_url
+    )
+
+    return regex_match.group("image_version") if regex_match is not None else None
+
+
 def get_code_sha_from_dockerurl(docker_url: str) -> str:
     """code_sha is hash extracted from docker url prefixed with "git", short
     hash is used because it's embedded in marathon app names and there's length

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -245,7 +245,7 @@ def test_marathon_job_status(
         "deploy_status": "Running",
         "running_instance_count": 2,
         "autoscaling_info": expected_autoscaling_info,
-        "active_shas": [("abc", "123")],
+        "active_versions": [("abc", None, "123")],
     }
 
     assert mock_marathon_app_status.call_count == 1
@@ -1068,7 +1068,7 @@ def test_kubernetes_instance_status_bounce_method():
         "paasta_tools.instance.kubernetes.job_status",
         autospec=True,
     ), asynctest.patch(
-        "paasta_tools.kubernetes_tools.get_active_shas_for_service",
+        "paasta_tools.kubernetes_tools.get_active_versions_for_service",
         autospec=True,
     ), asynctest.patch(
         "paasta_tools.kubernetes_tools.replicasets_for_service_instance",
@@ -1107,7 +1107,7 @@ def test_kubernetes_instance_status_evicted_nodes():
         "paasta_tools.instance.kubernetes.job_status",
         autospec=True,
     ), asynctest.patch(
-        "paasta_tools.kubernetes_tools.get_active_shas_for_service",
+        "paasta_tools.kubernetes_tools.get_active_versions_for_service",
         autospec=True,
     ), asynctest.patch(
         "paasta_tools.kubernetes_tools.replicasets_for_service_instance",

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -245,6 +245,7 @@ def test_marathon_job_status(
         "deploy_status": "Running",
         "running_instance_count": 2,
         "autoscaling_info": expected_autoscaling_info,
+        "active_shas": [("abc", "123")],
         "active_versions": [("abc", None, "123")],
     }
 

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -49,7 +49,7 @@ def fake_bounce_status_resp(**kwargs):
         running_instance_count=1,
         desired_state="start",
         app_count=1,
-        active_shas=[["abc123", "cfg"]],
+        active_versions=[["abc123", None, "cfg"]],
         deploy_status="Running",
     )
     for k, v in kwargs.items():
@@ -72,7 +72,7 @@ def fake_bounce_status_resp(**kwargs):
         (  # bounce in-progress
             [
                 fake_bounce_status_resp(
-                    active_shas=[["wrong1", "cfg"], ["abc123", "cfg"]]
+                    active_versions=[["wrong1", None, "cfg"], ["abc123", None, "cfg"]]
                 )
             ],
             False,
@@ -80,17 +80,17 @@ def fake_bounce_status_resp(**kwargs):
         (  # previous bounces not yet finished
             [
                 fake_bounce_status_resp(
-                    active_shas=[
-                        ["wrong1", "cfg"],
-                        ["wrong2", "cfg"],
-                        ["abc123", "cfg"],
+                    active_versions=[
+                        ["wrong1", None, "cfg"],
+                        ["wrong2", None, "cfg"],
+                        ["abc123", None, "cfg"],
                     ]
                 )
             ],
             False,
         ),
         (  # bounce not started
-            [fake_bounce_status_resp(active_shas=[["wrong1", "cfg"]])],
+            [fake_bounce_status_resp(active_versions=[["wrong1", None, "cfg"]])],
             False,
         ),
         (  # instance not running

--- a/tests/cli/test_cmds_wait_for_deployment.py
+++ b/tests/cli/test_cmds_wait_for_deployment.py
@@ -49,6 +49,7 @@ def fake_bounce_status_resp(**kwargs):
         running_instance_count=1,
         desired_state="start",
         app_count=1,
+        active_shas=[["abc123", "cfg"]],
         active_versions=[["abc123", None, "cfg"]],
         deploy_status="Running",
     )
@@ -72,7 +73,8 @@ def fake_bounce_status_resp(**kwargs):
         (  # bounce in-progress
             [
                 fake_bounce_status_resp(
-                    active_versions=[["wrong1", None, "cfg"], ["abc123", None, "cfg"]]
+                    active_shas=[["wrong1", "cfg"], ["abc123", "cfg"]],
+                    active_versions=[["wrong1", None, "cfg"], ["abc123", None, "cfg"]],
                 )
             ],
             False,
@@ -80,17 +82,27 @@ def fake_bounce_status_resp(**kwargs):
         (  # previous bounces not yet finished
             [
                 fake_bounce_status_resp(
+                    active_shas=[
+                        ["wrong1", "cfg"],
+                        ["wrong2", "cfg"],
+                        ["abc123", "cfg"],
+                    ],
                     active_versions=[
                         ["wrong1", None, "cfg"],
                         ["wrong2", None, "cfg"],
                         ["abc123", None, "cfg"],
-                    ]
+                    ],
                 )
             ],
             False,
         ),
         (  # bounce not started
-            [fake_bounce_status_resp(active_versions=[["wrong1", None, "cfg"]])],
+            [
+                fake_bounce_status_resp(
+                    active_shas=[["wrong1", "cfg"]],
+                    active_versions=[["wrong1", None, "cfg"]],
+                )
+            ],
             False,
         ),
         (  # instance not running

--- a/tests/instance/test_kubernetes.py
+++ b/tests/instance/test_kubernetes.py
@@ -886,6 +886,7 @@ def test_bounce_status():
         mock_kubernetes_tools.get_active_versions_for_service.return_value = [
             (DeploymentVersion("aaa", None), "config_aaa"),
             (DeploymentVersion("bbb", None), "config_bbb"),
+            (DeploymentVersion("ccc", "extrastuff"), "config_ccc"),
         ]
 
         mock_settings = mock.Mock()
@@ -898,8 +899,9 @@ def test_bounce_status():
             "active_versions": [
                 ("aaa", None, "config_aaa"),
                 ("bbb", None, "config_bbb"),
+                ("ccc", "extrastuff", "config_ccc"),
             ],
-            "app_count": 2,
+            "app_count": 3,
         }
 
 

--- a/tests/instance/test_kubernetes.py
+++ b/tests/instance/test_kubernetes.py
@@ -896,6 +896,11 @@ def test_bounce_status():
             "desired_state": mock_config.get_desired_state.return_value,
             "running_instance_count": mock_kubernetes_tools.get_kubernetes_app_by_name.return_value.status.ready_replicas,
             "deploy_status": mock_kubernetes_tools.KubernetesDeployStatus.tostring.return_value,
+            "active_shas": [
+                ("aaa", "config_aaa"),
+                ("bbb", "config_bbb"),
+                ("ccc", "config_ccc"),
+            ],
             "active_versions": [
                 ("aaa", None, "config_aaa"),
                 ("bbb", None, "config_bbb"),

--- a/tests/instance/test_kubernetes.py
+++ b/tests/instance/test_kubernetes.py
@@ -21,6 +21,7 @@ import pytest
 
 import paasta_tools.instance.kubernetes as pik
 from paasta_tools import utils
+from paasta_tools.utils import DeploymentVersion
 from tests.conftest import Struct
 from tests.conftest import wrap_value_in_task
 
@@ -882,9 +883,9 @@ def test_bounce_status():
             "deploy_status",
             "message",
         )
-        mock_kubernetes_tools.get_active_shas_for_service.return_value = [
-            ("aaa", "config_aaa"),
-            ("bbb", "config_bbb"),
+        mock_kubernetes_tools.get_active_versions_for_service.return_value = [
+            (DeploymentVersion("aaa", None), "config_aaa"),
+            (DeploymentVersion("bbb", None), "config_bbb"),
         ]
 
         mock_settings = mock.Mock()
@@ -894,9 +895,9 @@ def test_bounce_status():
             "desired_state": mock_config.get_desired_state.return_value,
             "running_instance_count": mock_kubernetes_tools.get_kubernetes_app_by_name.return_value.status.ready_replicas,
             "deploy_status": mock_kubernetes_tools.KubernetesDeployStatus.tostring.return_value,
-            "active_shas": [
-                ("aaa", "config_aaa"),
-                ("bbb", "config_bbb"),
+            "active_versions": [
+                ("aaa", None, "config_aaa"),
+                ("bbb", None, "config_bbb"),
             ],
             "app_count": 2,
         }

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -88,7 +88,7 @@ from paasta_tools.kubernetes_tools import ensure_namespace
 from paasta_tools.kubernetes_tools import filter_nodes_by_blacklist
 from paasta_tools.kubernetes_tools import filter_pods_by_service_instance
 from paasta_tools.kubernetes_tools import force_delete_pods
-from paasta_tools.kubernetes_tools import get_active_shas_for_service
+from paasta_tools.kubernetes_tools import get_active_versions_for_service
 from paasta_tools.kubernetes_tools import get_all_nodes
 from paasta_tools.kubernetes_tools import get_all_pods
 from paasta_tools.kubernetes_tools import get_annotations_for_kubernetes_service
@@ -131,6 +131,7 @@ from paasta_tools.kubernetes_tools import update_stateful_set
 from paasta_tools.secret_tools import SHARED_SECRET_SERVICE
 from paasta_tools.utils import AwsEbsVolume
 from paasta_tools.utils import CAPS_DROP
+from paasta_tools.utils import DeploymentVersion
 from paasta_tools.utils import DockerVolume
 from paasta_tools.utils import PersistentVolume
 from paasta_tools.utils import SecretVolume
@@ -3124,7 +3125,7 @@ async def test_pods_for_service_instance():
     )
 
 
-def test_get_active_shas_for_service():
+def test_get_active_versions_for_service():
     mock_pod_list = [
         mock.Mock(
             metadata=mock.Mock(
@@ -3157,9 +3158,9 @@ def test_get_active_shas_for_service():
             )
         ),
     ]
-    assert get_active_shas_for_service(mock_pod_list) == {
-        ("b456!!!", "a123!!!"),
-        ("b456", "a123"),
+    assert get_active_versions_for_service(mock_pod_list) == {
+        (DeploymentVersion("b456!!!", None), "a123!!!"),
+        (DeploymentVersion("b456", None), "a123"),
     }
 
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -3157,10 +3157,22 @@ def test_get_active_versions_for_service():
                 }
             )
         ),
+        mock.Mock(
+            metadata=mock.Mock(
+                labels={
+                    "yelp.com/paasta_config_sha": "c123",
+                    "yelp.com/paasta_git_sha": "d456",
+                    "paasta.yelp.com/config_sha": "c123",
+                    "paasta.yelp.com/git_sha": "d456",
+                    "paasta.yelp.com/image_version": "extrastuff",
+                }
+            )
+        ),
     ]
     assert get_active_versions_for_service(mock_pod_list) == {
         (DeploymentVersion("b456!!!", None), "a123!!!"),
         (DeploymentVersion("b456", None), "a123"),
+        (DeploymentVersion("d456", "extrastuff"), "c123"),
     }
 
 


### PR DESCRIPTION
Instead of caring about `active_shas`, we want to look at `active_versions` which include the new `image_version` information. This adds another element to the tuple that used to represent `versions`; I wonder if we should just add something like `DeploymentVersion` to the API and just use that instead, happy to go with either!