### PR TITLE
Add check for valid pools and get spark cost for emitted for jobs on k8s

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -64,7 +64,6 @@ DEFAULT_DRIVER_CORES_BY_SPARK = 1
 DEFAULT_DRIVER_MEMORY_BY_SPARK = "1g"
 # Extra room for memory overhead and for any other running inside container
 DOCKER_RESOURCE_ADJUSTMENT_FACTOR = 2
-SPARK_POOLS = ["stable_batch", "batch"]
 
 POD_TEMPLATE_DIR = "/nail/tmp"
 POD_TEMPLATE_PATH = "/nail/tmp/spark-pt-{file_uuid}.yaml"
@@ -222,7 +221,6 @@ def add_subparser(subparsers):
     list_parser.add_argument(
         "-p",
         "--pool",
-        choices=SPARK_POOLS,
         help="Name of the resource pool to run the Spark job.",
         default=default_spark_pool,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.10.2
+service-configuration-lib==2.10.3
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -18,7 +18,7 @@ import pytest
 from boto3.exceptions import Boto3Error
 
 from paasta_tools.cli.cmds import spark_run
-from paasta_tools.cli.cmds.spark_run import _should_emit_resource_requirements
+from paasta_tools.cli.cmds.spark_run import _should_get_resource_requirements
 from paasta_tools.cli.cmds.spark_run import CLUSTER_MANAGER_K8S
 from paasta_tools.cli.cmds.spark_run import CLUSTER_MANAGER_MESOS
 from paasta_tools.cli.cmds.spark_run import configure_and_run_docker_container
@@ -1026,29 +1026,17 @@ def test_paasta_spark_run(
 
 
 @pytest.mark.parametrize(
-    "docker_cmd, is_mrjob, cluster_manager, expected",
+    "docker_cmd, is_mrjob, expected",
     (
         # normal mesos cases
-        ("spark-submit FOO", False, "mesos", True),
-        ("spark-shell FOO", False, "mesos", True),
-        ("pyspark FOO", False, "mesos", True),
+        ("spark-submit FOO", False, True),
+        ("spark-shell FOO", False, True),
+        ("pyspark FOO", False, True),
         # mesos, but wrong command
-        ("spark-nope FOO", False, "mesos", False),
+        ("spark-nope FOO", False, False),
         # mrjob
-        ("FOO", True, "mesos", True),
-        ("FOO", True, "kubernetes", False),
-        # normal k8s cases
-        ("spark-submit FOO", False, "kubernetes", False),
-        ("spark-shell FOO", False, "kubernetes", False),
-        ("pyspark FOO", False, "kubernetes", False),
-        # k8s, but wrong command
-        ("spark-nope FOO", False, "kubernetes", False),
+        ("FOO", True, True),
     ),
 )
-def test__should_emit_resource_requirements(
-    docker_cmd, is_mrjob, cluster_manager, expected
-):
-    assert (
-        _should_emit_resource_requirements(docker_cmd, is_mrjob, cluster_manager)
-        is expected
-    )
+def test__should_get_resource_requirements(docker_cmd, is_mrjob, expected):
+    assert _should_get_resource_requirements(docker_cmd, is_mrjob) is expected


### PR DESCRIPTION
Issue: Spark users on kubernetes no longer able to see expected cost of the job on their driver logs as it used to be on mesos.

Ticker: COREML-3192
Changes:
1. Spark users can see the cost of their job on driver logs

2. Make sure spark users don't give invalid pool. 
To avoid this issue: https://yelp.slack.com/archives/C027FRM6285/p1652552586482009

Test:
1. make test
2. Manual test(s)

```
Selected cluster manager: mesos

Sending resource request metrics to Clusterman
Resource request (4 cpus and 9010 MB memory total) is estimated to cost $0.064 per hour
Setting docker memory and cpu limits as 2g, 1 core(s) respectively.
```

```
Selected cluster manager: kubernetes

Resource request (4 cpus and 9010 MB memory total) is estimated to cost $0.064 per hour
Setting docker memory and cpu limits as 2g, 1 core(s) respectively.
```

`Invalid Pool Test`:
```
paasta spark-run -s spark --aws-credentials-yaml /etc/boto_cfg/mrjob.yaml --cluster-manager mesos --cmd 'spark-submit /work/integration_tests/s3.py' --pool wrong_pool
Argument parse error: argument -p/--pool: invalid choice: 'wrong_pool' (choose from 'stable_batch', 'batch')
```