### PR TITLE
Don't show progress in slack when not waiting for deployment. PAASTA-17585

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -631,6 +631,8 @@ class MarkForDeploymentProcess(SLOSlackDeploymentProcess):
         self.print_who_is_running_this()
 
     def get_progress(self, summary: bool = False) -> str:
+        if not self.block:
+            return "Deploying in background, progress not tracked."
         return self.progress.human_readable(summary)
 
     def print_who_is_running_this(self) -> None:


### PR DESCRIPTION

<img width="578" alt="image" src="https://user-images.githubusercontent.com/233961/171313676-17c2dbaa-74f1-47bc-bb7f-3b7f2d275478.png">

Example output when not passing --wait-for-deployment: https://yelp.slack.com/archives/CA7BTF81J/p1654049006105819 (same as screenshot)

Example output when passing --wait-for-deployment (same as status quo): https://yelp.slack.com/archives/CA7BTF81J/p1654049042095339
