### PR TITLE
Add --disable-aws-credential-env-variables to spark run cli

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -49,7 +49,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.9.0
+service-configuration-lib >= 2.10.4
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0


### PR DESCRIPTION
This is needed for the Spark v3.2 stuff to prevent the weird race conditions with the temporary credentials provider.  I've already made changes to the other systems like service_configuration_lib to set creds in the spark configuration instead.

Is backwards compatible behavior by default so shouldn't impact any productions systems.