### PR TITLE
Update get_config_hash function to include boto_keys sig

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1966,6 +1966,13 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             service=self.get_service(), environment_variables=self.get_env()
         )
 
+        # Only record whether a boto_keys hash exists
+        # This allows the service to restart once when boto_keys secret is
+        # first added, not when the values change
+        if ahash.get("boto_keys"):
+            boto_secret_hash = self.get_boto_secret_hash()
+            ahash["boto_keys_sig"] = "present" if boto_secret_hash else ""
+
         # remove data we dont want used to hash configs
         # replica count
         if ahash["spec"] is not None:


### PR DESCRIPTION
I think that this should fix a race condition that happens in the follow case:

- Add boto_keys to a service config for the first time
- Paasta computes config hash and deploys
   - boto_keys secret is not yet synced and is not mounted
- paasta_secret_sync adds boto_keys secret and secret signature
- config hash remains unchanged and nothing happens

We'd like paasta to redeploy the service once the boto_keys secret is added. We don't want it to redeploy based no the value of the secret. Therefore I added a flag in the config hash to represent that the signature has some value, which should cause a redeployment at most once.

