### PR TITLE
Add --auto-set-temporary-credentials-provider to spark cli.

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -362,6 +362,14 @@ def add_subparser(subparsers):
     )
 
     aws_group.add_argument(
+        "--auto-set-temporary-credentials-provider",
+        help="Automatically set the TemporaryCredentialsProvider if a session token "
+        "is found in the AWS credentials.  In Spark v3.2 you want to set this argument "
+        "to false.",
+        default=True,
+    )
+
+    aws_group.add_argument(
         "--aws-region",
         help=f"Specify an aws region. If the region is not specified, we will"
         f"default to using {DEFAULT_AWS_REGION}.",
@@ -1055,6 +1063,7 @@ def paasta_spark_run(args):
         extra_volumes=volumes,
         aws_creds=aws_creds,
         needs_docker_cfg=needs_docker_cfg,
+        auto_set_temporary_credentials_provider=args.auto_set_temporary_credentials_provider,
     )
     return configure_and_run_docker_container(
         args,

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -49,7 +49,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.10.4
+service-configuration-lib >= 2.10.6
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.10.5
+service-configuration-lib==2.10.6
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -1007,6 +1007,7 @@ def test_paasta_spark_run(
         aws_profile=None,
         spark_args="spark.cores.max=100 spark.executor.cores=10",
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
+        auto_set_temporary_credentials_provider=mock.sentinel.temp_provider,
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     spark_run.paasta_spark_run(args)
@@ -1043,6 +1044,7 @@ def test_paasta_spark_run(
         extra_volumes=mock_get_instance_config.return_value.get_volumes.return_value,
         aws_creds=mock_get_aws_credentials.return_value,
         needs_docker_cfg=False,
+        auto_set_temporary_credentials_provider=mock.sentinel.temp_provider,
     )
     mock_configure_and_run_docker_container.assert_called_once_with(
         args,


### PR DESCRIPTION
Exposing this param to paasta.  Should be backwards compatible.