### PR TITLE
Fix argparse for disabling temporary credential provider in spark cli

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -362,11 +362,11 @@ def add_subparser(subparsers):
     )
 
     aws_group.add_argument(
-        "--auto-set-temporary-credentials-provider",
-        help="Automatically set the TemporaryCredentialsProvider if a session token "
-        "is found in the AWS credentials.  In Spark v3.2 you want to set this argument "
-        "to false.",
-        default=True,
+        "--disable-temporary-credentials-provider",
+        help="Disable explicit setting of TemporaryCredentialsProvider if a session token "
+        "is found in the AWS credentials.  In Spark v3.2 you want to set this argument ",
+        action="store_true",
+        default=False,
     )
 
     aws_group.add_argument(
@@ -1051,6 +1051,9 @@ def paasta_spark_run(args):
             user_spark_opts[key] = value
 
     paasta_instance = get_smart_paasta_instance_name(args)
+    auto_set_temporary_credentials_provider = (
+        args.disable_temporary_credentials_provider is False
+    )
     spark_conf = get_spark_conf(
         cluster_manager=args.cluster_manager,
         spark_app_base_name=app_base_name,
@@ -1063,7 +1066,7 @@ def paasta_spark_run(args):
         extra_volumes=volumes,
         aws_creds=aws_creds,
         needs_docker_cfg=needs_docker_cfg,
-        auto_set_temporary_credentials_provider=args.auto_set_temporary_credentials_provider,
+        auto_set_temporary_credentials_provider=auto_set_temporary_credentials_provider,
     )
     return configure_and_run_docker_container(
         args,

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -1007,7 +1007,7 @@ def test_paasta_spark_run(
         aws_profile=None,
         spark_args="spark.cores.max=100 spark.executor.cores=10",
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
-        auto_set_temporary_credentials_provider=mock.sentinel.temp_provider,
+        disable_temporary_credentials_provider=True,
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     spark_run.paasta_spark_run(args)
@@ -1044,7 +1044,7 @@ def test_paasta_spark_run(
         extra_volumes=mock_get_instance_config.return_value.get_volumes.return_value,
         aws_creds=mock_get_aws_credentials.return_value,
         needs_docker_cfg=False,
-        auto_set_temporary_credentials_provider=mock.sentinel.temp_provider,
+        auto_set_temporary_credentials_provider=False,
     )
     mock_configure_and_run_docker_container.assert_called_once_with(
         args,


### PR DESCRIPTION
argparse struggles to parse into bool types.  `--auto-set-temporary-credentials-provider=False` resulted in `auto_set_temporary_credentials_provider="False"`, which of course equals True and meant that service_configuration_lib wouldn't disable the temporary credentials provider...

So making this be more standard "store_true" flow even if it is somewhat annoying due to the double negatives