### PR TITLE
MLCOMPUTE-23 | Enable DRA in paasta spark-run through a flag

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1077,7 +1077,10 @@ def paasta_spark_run(args):
 
     needs_docker_cfg = not args.build
     user_spark_opts = _parse_user_spark_args(
-        args.spark_args, pod_template_path, args.enable_compact_bin_packing, args.enable_dra
+        args.spark_args,
+        pod_template_path,
+        args.enable_compact_bin_packing,
+        args.enable_dra,
     )
 
     args.cmd = _auto_add_timeout_for_job(args.cmd, args.timeout_job_runtime)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -295,8 +295,9 @@ def add_subparser(subparsers):
     list_parser.add_argument(
         "--enable-dra",
         help=(
-            "Enable Dynamic Resource Allocation (DRA) for the Spark job as documented in https://yelpwiki.yelpcorp.com/display/AML/Spark+Dynamic+Resource+Allocation+%28DRA%29+Runbook. "
-            " Disabled by default. Does not override Spark DRA configs explicitly specified by the user."
+            "Enable Dynamic Resource Allocation (DRA) for the Spark job as documented in y/spark-dra. DRA aims "
+            "to utilize cluster resources in a more efficient way and save costs by requesting and releasing "
+            "resources dynamically. Disabled by default. Does not override Spark DRA configs specified by the user."
         ),
         action="store_true",
         default=False,

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -292,6 +292,16 @@ def add_subparser(subparsers):
         default=CLUSTER_MANAGER_K8S,
     )
 
+    list_parser.add_argument(
+        "--enable-dra",
+        help=(
+            "Enable Dynamic Resource Allocation (DRA) for the Spark job as documented in https://yelpwiki.yelpcorp.com/display/AML/Spark+Dynamic+Resource+Allocation+%28DRA%29+Runbook. "
+            " Disabled by default. Does not override Spark DRA configs explicitly specified by the user."
+        ),
+        action="store_true",
+        default=False,
+    )
+
     if clusterman_metrics:
         list_parser.add_argument(
             "--suppress-clusterman-metrics-errors",
@@ -594,6 +604,7 @@ def _parse_user_spark_args(
     spark_args: Optional[str],
     pod_template_path: str,
     enable_compact_bin_packing: bool = False,
+    enable_spark_dra: bool = False,
 ) -> Dict[str, str]:
     if not spark_args:
         return {}
@@ -613,6 +624,9 @@ def _parse_user_spark_args(
 
     if enable_compact_bin_packing:
         user_spark_opts["spark.kubernetes.executor.podTemplateFile"] = pod_template_path
+
+    if enable_spark_dra:
+        user_spark_opts["spark.dynamicAllocation.enabled"] = "true"
 
     return user_spark_opts
 
@@ -1062,7 +1076,7 @@ def paasta_spark_run(args):
 
     needs_docker_cfg = not args.build
     user_spark_opts = _parse_user_spark_args(
-        args.spark_args, pod_template_path, args.enable_compact_bin_packing
+        args.spark_args, pod_template_path, args.enable_compact_bin_packing, args.enable_dra
     )
 
     args.cmd = _auto_add_timeout_for_job(args.cmd, args.timeout_job_runtime)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -295,9 +295,9 @@ def add_subparser(subparsers):
     list_parser.add_argument(
         "--enable-dra",
         help=(
-            "Enable Dynamic Resource Allocation (DRA) for the Spark job as documented in y/spark-dra. DRA aims "
-            "to utilize cluster resources in a more efficient way and save costs by requesting and releasing "
-            "resources dynamically. Disabled by default. Does not override Spark DRA configs specified by the user."
+            "Enable Dynamic Resource Allocation (DRA) for the Spark job as documented in (y/spark-dra). DRA "
+            "dynamically scales up and down the executor instance count based on the number of pending tasks "
+            "and requirements. Disabled by default. Does not override Spark DRA configs if specified by the user."
         ),
         action="store_true",
         default=False,
@@ -627,6 +627,20 @@ def _parse_user_spark_args(
         user_spark_opts["spark.kubernetes.executor.podTemplateFile"] = pod_template_path
 
     if enable_spark_dra:
+        if (
+            "spark.dynamicAllocation.enabled" in user_spark_opts
+            and user_spark_opts["spark.dynamicAllocation.enabled"] == "false"
+        ):
+            print(
+                PaastaColors.red(
+                    "Error: --enable-dra flag is provided while spark.dynamicAllocation.enabled "
+                    "is explicitly set to false in --spark-args. If you want to enable DRA, please remove the "
+                    "spark.dynamicAllocation.enabled=false config from spark-args. If you don't want to "
+                    "enable DRA, please remove the --enable-dra flag."
+                ),
+                file=sys.stderr,
+            )
+            sys.exit(1)
         user_spark_opts["spark.dynamicAllocation.enabled"] = "true"
 
     return user_spark_opts

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.10.6
+service-configuration-lib==2.10.7
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -1023,6 +1023,7 @@ def test_paasta_spark_run_bash(
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
         timeout_job_runtime="1m",
         disable_temporary_credentials_provider=True,
+        enable_dra=False,
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     spark_run.paasta_spark_run(args)
@@ -1046,7 +1047,7 @@ def test_paasta_spark_run_bash(
     )
     mock_get_spark_app_name.assert_called_once_with("/bin/bash")
     mock_parse_user_spark_args.assert_called_once_with(
-        "spark.cores.max=100 spark.executor.cores=10", "unique-run", False
+        "spark.cores.max=100 spark.executor.cores=10", "unique-run", False, False
     )
     mock_get_spark_conf.assert_called_once_with(
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
@@ -1214,6 +1215,7 @@ def test_paasta_spark_run_pyspark(
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
         timeout_job_runtime="1m",
         disable_temporary_credentials_provider=True,
+        enable_dra=False,
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     spark_run.paasta_spark_run(args)
@@ -1237,7 +1239,7 @@ def test_paasta_spark_run_pyspark(
     )
     mock_get_spark_app_name.assert_called_once_with("pyspark")
     mock_parse_user_spark_args.assert_called_once_with(
-        "spark.cores.max=100 spark.executor.cores=10", "unique-run", False
+        "spark.cores.max=100 spark.executor.cores=10", "unique-run", False, False
     )
     mock_get_spark_conf.assert_called_once_with(
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,


### PR DESCRIPTION
This adds an option to enable Dynamic Resource Allocation (DRA) for spark jobs through a flag --enable-dra in paasta spark-run sub-command. This translates to spark.dynamicAllocation.enabled=true in spark args.
The logic for setting the desired spark configs for dra is handled in service_configuration_lib: https://github.com/Yelp/service_configuration_lib/pull/81

Testing:
Unit tests
Tested this with service_configuration_lib changes using: https://yelpwiki.yelpcorp.com/pages/viewpage.action?pageId=208483399#Sparkdevelopmentrunbook-Method1: