### PR TITLE
Add fix for auto timeout add for non spark-submit commands

### DIFF
--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -977,6 +977,100 @@ def test_get_docker_cmd(args, instance_config, spark_conf_str, expected):
 @mock.patch.object(spark_run, "get_spark_conf", autospec=True)
 @mock.patch.object(spark_run, "configure_and_run_docker_container", autospec=True)
 @mock.patch.object(spark_run, "get_smart_paasta_instance_name", autospec=True)
+def test_paasta_spark_run_bash(
+    mock_get_smart_paasta_instance_name,
+    mock_configure_and_run_docker_container,
+    mock_get_spark_conf,
+    mock_parse_user_spark_args,
+    mock_get_spark_app_name,
+    mock_get_docker_image,
+    mock_get_aws_credentials,
+    mock_get_instance_config,
+    mock_load_system_paasta_config,
+    mock_validate_work_dir,
+    mock_generate_pod_template_path,
+):
+    args = argparse.Namespace(
+        work_dir="/tmp/local",
+        cmd="/bin/bash",
+        build=True,
+        image=None,
+        enable_compact_bin_packing=False,
+        disable_compact_bin_packing=False,
+        service="test-service",
+        instance="test-instance",
+        cluster="test-cluster",
+        pool="test-pool",
+        yelpsoa_config_root="/path/to/soa",
+        no_aws_credentials=False,
+        aws_credentials_yaml="/path/to/creds",
+        aws_profile=None,
+        spark_args="spark.cores.max=100 spark.executor.cores=10",
+        cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
+        timeout_job_runtime="1m",
+        disable_temporary_credentials_provider=True,
+    )
+    mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
+    spark_run.paasta_spark_run(args)
+    mock_validate_work_dir.assert_called_once_with("/tmp/local")
+    assert args.cmd == "/bin/bash"
+    mock_get_instance_config.assert_called_once_with(
+        service="test-service",
+        instance="test-instance",
+        cluster="test-cluster",
+        load_deployments=False,
+        soa_dir="/path/to/soa",
+    )
+    mock_get_aws_credentials.assert_called_once_with(
+        service="test-service",
+        no_aws_credentials=False,
+        aws_credentials_yaml="/path/to/creds",
+        profile_name=None,
+    )
+    mock_get_docker_image.assert_called_once_with(
+        args, mock_get_instance_config.return_value
+    )
+    mock_get_spark_app_name.assert_called_once_with("/bin/bash")
+    mock_parse_user_spark_args.assert_called_once_with(
+        "spark.cores.max=100 spark.executor.cores=10", "unique-run", False
+    )
+    mock_get_spark_conf.assert_called_once_with(
+        cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
+        spark_app_base_name=mock_get_spark_app_name.return_value,
+        docker_img=mock_get_docker_image.return_value,
+        user_spark_opts=mock_parse_user_spark_args.return_value,
+        paasta_cluster="test-cluster",
+        paasta_pool="test-pool",
+        paasta_service="test-service",
+        paasta_instance=mock_get_smart_paasta_instance_name.return_value,
+        extra_volumes=mock_get_instance_config.return_value.get_volumes.return_value,
+        aws_creds=mock_get_aws_credentials.return_value,
+        needs_docker_cfg=False,
+        auto_set_temporary_credentials_provider=False,
+    )
+    mock_configure_and_run_docker_container.assert_called_once_with(
+        args,
+        docker_img=mock_get_docker_image.return_value,
+        instance_config=mock_get_instance_config.return_value,
+        system_paasta_config=mock_load_system_paasta_config.return_value,
+        spark_conf=mock_get_spark_conf.return_value,
+        aws_creds=mock_get_aws_credentials.return_value,
+        cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
+        pod_template_path="unique-run",
+    )
+    mock_generate_pod_template_path.assert_called_once()
+
+
+@mock.patch.object(spark_run, "validate_work_dir", autospec=True)
+@mock.patch.object(spark_run, "load_system_paasta_config", autospec=True)
+@mock.patch.object(spark_run, "get_instance_config", autospec=True)
+@mock.patch.object(spark_run, "get_aws_credentials", autospec=True)
+@mock.patch.object(spark_run, "get_docker_image", autospec=True)
+@mock.patch.object(spark_run, "get_spark_app_name", autospec=True)
+@mock.patch.object(spark_run, "_parse_user_spark_args", autospec=True)
+@mock.patch.object(spark_run, "get_spark_conf", autospec=True)
+@mock.patch.object(spark_run, "configure_and_run_docker_container", autospec=True)
+@mock.patch.object(spark_run, "get_smart_paasta_instance_name", autospec=True)
 def test_paasta_spark_run(
     mock_get_smart_paasta_instance_name,
     mock_configure_and_run_docker_container,


### PR DESCRIPTION
The rollout of https://github.com/Yelp/paasta/pull/3382, broke use-cases for batch runs without spark-submit commands.
I noticed there weren't any unit test cases for when the command is not `spark-submit`

Description: 
1. Add fix for non spark-submit commands
2. Add more unit-test cases for non spark-submit commands (pyspark and bin/bash)
3. Continue even if the timeout couldn't be added with `warning`
4. Add more manual test cases and reproduction of error

Test cases: 
* make test
* Reproduction of error: https://fluffy.yelpcorp.com/i/VXcrTsXlldv20BRmSHb1Jn32rmBP1jKl.html (Without the fix)
* With `pyspark`: https://fluffy.yelpcorp.com/i/dfTF6VWl8SHl7djr4VZpqN9T31Sn7KzQ.html#L1 (With fix)
* With `spark-submit` with `timeout` added: https://fluffy.yelpcorp.com/i/0CFl1chcd3qKsp2fx3pxFNtMkmcT7RGL.html#L1
* With `spark-sumbit` with `timeout` command: https://fluffy.yelpcorp.com/i/80JhzBVtgznRph7k5Mjt8pgcJ2BXv5NN.html#L1,L9
* With `spark-submit' default `timeout`: https://fluffy.yelpcorp.com/i/7Qgxm84KB1wp729GN7PcCbLdTFBzhxPx.html#L1,L9
* Verifying timed out job: https://fluffy.yelpcorp.com/i/0PwJ1mrsQLrrz17bBfcW42MQ2KrMcqs3.html#L1,L276-277
(124 exit status)

