### PR TITLE
Use make --question to check if a Makefile has a given target

### DIFF
--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -97,13 +97,12 @@ def docker_check():
 
 
 def makefile_responds_to(target):
-    """Runs `make --dry-run <target>` to detect if a makefile responds to the
+    """Runs `make --question <target>` to detect if a makefile responds to the
     specified target."""
-    cmd = "make --dry-run %s" % target
     # According to http://www.gnu.org/software/make/manual/make.html#index-exit-status-of-make,
-    # 0 means OK, and 2 means error
-    returncode, _ = _run(cmd, timeout=5)
-    return returncode == 0
+    # 0 means OK, 1 means the target is not up to date, and 2 means error
+    returncode, _ = _run(["make", "--question", target], timeout=5)
+    return returncode != 2
 
 
 def makefile_has_a_tab(makefile_path):

--- a/paasta_tools/cli/cmds/cook_image.py
+++ b/paasta_tools/cli/cmds/cook_image.py
@@ -112,8 +112,8 @@ def paasta_cook_image(
 
     if not makefile_responds_to("cook-image"):
         print(
-            "ERROR: local-run now requires a cook-image target to be present in the Makefile. See"
-            "http://paasta.readthedocs.io/en/latest/about/contract.html",
+            "ERROR: local-run now requires a cook-image target to be present in the Makefile. See "
+            "http://paasta.readthedocs.io/en/latest/about/contract.html.",
             file=sys.stderr,
         )
         return 1


### PR DESCRIPTION
--dry-run can, in certain cases, actually result in Make doing real
work. To ensure that we don't inadvertantly run anything while figuring
out if a Makefile does respond to a target, we'll switch to using
--question which won't execute anything.