### PR TITLE
Add soa_dir arg to verbose logging

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -401,8 +401,10 @@ def validate_tron(service_path: str, verbose: bool = False) -> bool:
         if not validate_tron_namespace(service, cluster, soa_dir):
             returncode = False
         elif verbose:
-            # service config has been validated and cron schedules are safe to parse
-            service_config = load_tron_service_config(service, cluster)
+            # service config has been validated and cron schedules should be safe to parse TODO: TRON-1761
+            service_config = load_tron_service_config(
+                service=service, cluster=cluster, soa_dir=soa_dir
+            )
             for config in service_config:
                 cron_expression = config.get_cron_expression()
                 if cron_expression:

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -401,7 +401,9 @@ def validate_tron(service_path: str, verbose: bool = False) -> bool:
         if not validate_tron_namespace(service, cluster, soa_dir):
             returncode = False
         elif verbose:
-            # service config has been validated and cron schedules should be safe to parse TODO: TRON-1761
+            # service config has been validated and cron schedules should be safe to parse
+
+            # TODO(TRON-1761): unify tron/paasta validate cron syntax validation
             service_config = load_tron_service_config(
                 service=service, cluster=cluster, soa_dir=soa_dir
             )


### PR DESCRIPTION
The `paasta validate -v` command is supposed to print the date and time of the next 5 cron runs for valid schedules. This wasn't making use of the soa_dir argument in `load_tron_service_config()` which means it was always using the default value and local changes to yelpsoa had no impact.

Added a new job and updated the schedule for it:

- [Initial add of kevins_cool_job](https://fluffy.yelpcorp.com/i/MLRLFNG174qsNLVpkQpxs3B5zx0k9CdH.html)
- [Updating kevins_cool_job](https://fluffy.yelpcorp.com/i/Sw0pd5Q7VcJhKqBvpFH0MbC2rghw9G6m.html)

Also added a todo for TRON-1761 to address the issues I found with cron validation in Tron.