### PR TITLE
Enable spark.sql.adaptive.enabled to true for all spark jobs

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -863,7 +863,7 @@ def configure_and_run_docker_container(
             else:
                 raise
 
-    final_spark_submit_cmd_msg = f"Executing spark-submit command: {docker_cmd}"
+    final_spark_submit_cmd_msg = f"Final command: {docker_cmd}"
     print(PaastaColors.grey(final_spark_submit_cmd_msg))
     log.info(final_spark_submit_cmd_msg)
     return run_docker_container(

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -805,19 +805,26 @@ def configure_and_run_docker_container(
     )  # type:ignore
 
     webui_url = get_webui_url(spark_conf["spark.ui.port"])
+    webui_url_msg = f"\nSpark monitoring URL {webui_url}\n"
 
     docker_cmd = get_docker_cmd(args, instance_config, spark_conf_str)
     if "history-server" in docker_cmd:
         print(f"\nSpark history server URL {webui_url}\n")
     elif any(c in docker_cmd for c in ["pyspark", "spark-shell", "spark-submit"]):
         signalfx_url = get_signalfx_url(spark_conf)
-        print(f"\nSpark monitoring URL {webui_url}\n")
-        print(f"\nSignalfx dashboard: {signalfx_url}\n")
+        signalfx_url_msg = f"\nSignalfx dashboard: {signalfx_url}\n"
+        print(webui_url_msg)
+        print(signalfx_url_msg)
+        log.info(webui_url_msg)
+        log.info(signalfx_url_msg)
         history_server_url = get_history_url(spark_conf)
         if history_server_url:
-            print(
+            history_server_url_msg = (
                 f"\nAfter the job is finished, you can find the spark UI from {history_server_url}\n"
+                "Check y/spark-recent-history for faster access to prod logs\n"
             )
+            print(history_server_url_msg)
+            log.info(history_server_url_msg)
     print(f"Selected cluster manager: {cluster_manager}\n")
 
     if clusterman_metrics and _should_get_resource_requirements(docker_cmd, args.mrjob):
@@ -856,6 +863,9 @@ def configure_and_run_docker_container(
             else:
                 raise
 
+    final_spark_submit_cmd_msg = f"Executing spark-submit command: {docker_cmd}"
+    print(PaastaColors.grey(final_spark_submit_cmd_msg))
+    log.info(final_spark_submit_cmd_msg)
     return run_docker_container(
         container_name=spark_conf["spark.app.name"],
         volumes=volumes,
@@ -1108,6 +1118,13 @@ def paasta_spark_run(args):
         needs_docker_cfg=needs_docker_cfg,
         auto_set_temporary_credentials_provider=auto_set_temporary_credentials_provider,
     )
+    # Experimental: TODO: Move to service_configuration_lib once confirmed that there are no issues
+    # Enable AQE: Adaptive Query Execution
+    if "spark.sql.adaptive.enabled" not in spark_conf:
+        spark_conf["spark.sql.adaptive.enabled"] = "true"
+        aqe_msg = "Spark performance improving feature Adaptive Query Execution (AQE) is enabled. Set spark.sql.adaptive.enabled as false to disable."
+        log.info(aqe_msg)
+        print(PaastaColors.blue(aqe_msg))
     return configure_and_run_docker_container(
         args,
         docker_img=docker_image,

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -1048,12 +1048,14 @@ def test_paasta_spark_run_bash(
         needs_docker_cfg=False,
         auto_set_temporary_credentials_provider=False,
     )
+    mock_spark_conf = mock_get_spark_conf.return_value
+    mock_spark_conf["spark.sql.adaptive.enabled"] = "true"
     mock_configure_and_run_docker_container.assert_called_once_with(
         args,
         docker_img=mock_get_docker_image.return_value,
         instance_config=mock_get_instance_config.return_value,
         system_paasta_config=mock_load_system_paasta_config.return_value,
-        spark_conf=mock_get_spark_conf.return_value,
+        spark_conf=mock_spark_conf,
         aws_creds=mock_get_aws_credentials.return_value,
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
         pod_template_path="unique-run",


### PR DESCRIPTION
1. Enabled AQE: adaptive query execution by default.
2. Log Signalfx url and final command. There were not originally logged in tron web ui. 
Useful for debugging.

Test result added as a comment in ticket: [MLCOMPUTE-17](https://jira.yelpcorp.com/browse/MLCOMPUTE-17)

Rollout plan:
1. Live Experiment Stage: Roll this pr out
2. Monitoring: 1 week: Observe on internal channel for any unexpected behavior, impacted runtimes of spark batches
- Rollback, debug and fix any unprecedented issues
4. GA: Roll the change out on service_configuration_lib and rollback this change
