### PR TITLE
COMPINFRA-1248: update get-latest-deployment for full DeploymentVersion & add json option

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -3323,6 +3323,9 @@ class DeploymentVersion(NamedTuple):
             else short_sha
         )
 
+    def json(self) -> str:
+        return json.dumps(self._asdict())
+
 
 DeploymentsJsonV1Dict = Dict[str, BranchDictV1]
 


### PR DESCRIPTION
This updates `paasta get-latest-deployment` to support full DeploymentVersions with the following behavior:
* (status quo) if the deploy group specified does not have an image_version, it will print the plain sha due to the default conversion of DeploymentVersion to string
* if the deploy group specified does have an image_version, it will default to the default conversion of DeploymentVersion to string, i.e. `DeploymentVersion(sha=...,image_version=...)`
* new arg: `--sha-only`: if the caller wants *only* the sha, regardless if there is an image_version specified for this deploy group, they can do this with the `--sha-only` flag, which will behave exactly like status quo for any invocations (possibly useful for those using `get-latest-deployment` to strictly get the latest sha deployed
* new arg: `--json`: if the caller wants to use the output of `get-latest-deployment` in some programmatic way, they'll probably want it in an easy to parse format such as json. 

I've validated this works as intended with manual tests (note for the examples with `-d` i have a modified version of yelpsoa-configs where the mesosstage.k8s deploy group of compute-infra-test-service has an image version specified) :
```
 $ python -m paasta_tools.cli.cli get-latest-deployment -j -s compute-infra-test-service -i mesosstage.k8s -d /nail/home/jfong/work/yelpsoa-configs
{"sha": "833c8de1d7a4879aa2b5544c4f9bcd6fe035ffe2", "image_version": "thisistheimageformesosstage"}
 $ python -m paasta_tools.cli.cli get-latest-deployment -s compute-infra-test-service -i mesosstage.k8s -d /nail/home/jfong/work/yelpsoa-configs
DeploymentVersion(sha=833c8de1d7a4879aa2b5544c4f9bcd6fe035ffe2, image_version=thisistheimageformesosstage)
 $ python -m paasta_tools.cli.cli get-latest-deployment -s compute-infra-test-service -i mesosstage.k8s
833c8de1d7a4879aa2b5544c4f9bcd6fe035ffe2
 $ python -m paasta_tools.cli.cli get-latest-deployment --sha-only -s compute-infra-test-service -i mesosstage.k8s -d /nail/home/jfong/work/yelpsoa-configs
833c8de1d7a4879aa2b5544c4f9bcd6fe035ffe2
```

The tl;dr is that this shouldn't affect any usages today, and when we do get around to supporting image_version fully, we'll be able to just modify the current uses of `get-latest-deployment` with the right flags. 