### PR TITLE
Wrap readiness check script with a timeout

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -937,19 +937,19 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             if not system_paasta_config.get_hacheck_match_initial_delay():
                 initial_delay = 10
 
-            # we probably don't need to make this configurable - hopefully we never need to run a readiness probe
-            # that takes over 1s...
-            timeout_s = 1  # this is the default, but we need to refer to this value for actually killing the command
+            period_s = 10  # we probably don't need to make this configurable...
+            timeout_s = (
+                period_s - 1
+            )  # same here, one second less than the period is probably ok
             readiness_probe = V1Probe(
                 _exec=V1ExecAction(
-                    #
                     command=["timeout", "--signal=KILL", f"{timeout_s}s"]
                     + self.get_readiness_check_script(system_paasta_config)
                     + [str(self.get_container_port())]
                     + self.get_registrations()
                 ),
                 initial_delay_seconds=initial_delay,
-                period_seconds=10,
+                period_seconds=period_s,
                 timeout_seconds=timeout_s,
             )
         else:

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -618,7 +618,7 @@ class TestKubernetesDeploymentConfig:
                             command=[
                                 "timeout",
                                 "--signal=KILL",
-                                "1s",
+                                "9s",
                                 "/nail/blah.sh",
                                 "8888",
                                 "universal.credit",
@@ -626,7 +626,7 @@ class TestKubernetesDeploymentConfig:
                         ),
                         initial_delay_seconds=10,
                         period_seconds=10,
-                        timeout_seconds=1,
+                        timeout_seconds=9,
                     ),
                 )
             ]

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -615,10 +615,18 @@ class TestKubernetesDeploymentConfig:
                     volume_mounts=expected_volumes,
                     readiness_probe=V1Probe(
                         _exec=V1ExecAction(
-                            command=["/nail/blah.sh", "8888", "universal.credit"]
+                            command=[
+                                "timeout",
+                                "--signal=KILL",
+                                "1s",
+                                "/nail/blah.sh",
+                                "8888",
+                                "universal.credit",
+                            ]
                         ),
                         initial_delay_seconds=10,
                         period_seconds=10,
+                        timeout_seconds=1,
                     ),
                 )
             ]


### PR DESCRIPTION
In PAASTA-17673 we noticed that even though there's a 1s timeout set on
this V1Probe, that timeout doesn't actually kill the script that the
probe runs - which can lead to these checks stacking up in our hacheck
sidecar and overwhelming the CPU request+limit of that sidecar and
leads to the hacheck sidecar getting heavily throttled (which doesn't
help :p)

**NOTE**: this *will* cause a big bounce