### PR TITLE
Randomize host selected in mesh_status

### DIFF
--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -325,7 +325,7 @@ async def mesh_status(
 
     pods = await pods_task
     for location, hosts in node_hostname_by_location.items():
-        host = replication_checker.get_first_host_in_pool(hosts, instance_pool)
+        host = replication_checker.get_hostname_in_pool(hosts, instance_pool)
         if service_mesh == ServiceMesh.SMARTSTACK:
             mesh_status["locations"].append(
                 _build_smartstack_location_dict(

--- a/paasta_tools/smartstack_tools.py
+++ b/paasta_tools/smartstack_tools.py
@@ -15,6 +15,7 @@ import abc
 import collections
 import csv
 import logging
+import random
 import socket
 from typing import Any
 from typing import cast
@@ -612,6 +613,9 @@ class BaseReplicationChecker(ReplicationChecker):
             if host.pool == pool:
                 return host.hostname
         return hosts[0].hostname
+
+    def get_hostname_in_pool(self, hosts: Sequence[DiscoveredHost], pool: str) -> str:
+        return random.choice(self.get_hostnames_in_pool(hosts, pool))
 
     def get_hostnames_in_pool(
         self, hosts: Sequence[DiscoveredHost], pool: str


### PR DESCRIPTION
We sometimes see single hosts have envoy issues, and having these
cascade into paasta status breaking for the pool these hosts are in is
not a great experience.

To minimize the impact here, grab a random host from the target pool
rather than the "first".