### PR TITLE
Add enable_automated_deploys param to deploy_schema.json for no-commit (automated) deploys

### DIFF
--- a/paasta_tools/cli/schemas/deploy_schema.json
+++ b/paasta_tools/cli/schemas/deploy_schema.json
@@ -101,6 +101,9 @@
                 },
                 "confirm_complete": {
                     "type": "boolean"
+                },
+                "enable_automated_deploys": {
+                    "type": "boolean"
                 }
             },
             "required": [


### PR DESCRIPTION
This just adds a new option to deploy.yaml steps to enable our enable_automated_deploys param.
This just keeps the schema in sync w/ our internal copy used for yelpsoa-configs-checker. 
