### PR TITLE
Rename new automated redeploy option

### DIFF
--- a/paasta_tools/cli/schemas/deploy_schema.json
+++ b/paasta_tools/cli/schemas/deploy_schema.json
@@ -102,7 +102,7 @@
                 "confirm_complete": {
                     "type": "boolean"
                 },
-                "enable_automated_deploys": {
+                "enable_automated_redeploys": {
                     "type": "boolean"
                 }
             },


### PR DESCRIPTION
@krall pointed out that the `enable_automated_deploys` flag is really only controlling *redeploys* of the same service sha, so we're renaming it appropriately.