### PR TITLE
Support additional version information in "paasta itest"

### DIFF
--- a/paasta_tools/cli/cmds/itest.py
+++ b/paasta_tools/cli/cmds/itest.py
@@ -50,6 +50,13 @@ def add_subparser(subparsers):
         required=True,
     )
     list_parser.add_argument(
+        "--image-version",
+        type=str,
+        required=False,
+        default=None,
+        help="Extra version metadata used to construct tag for built image",
+    )
+    list_parser.add_argument(
         "-d",
         "--soa-dir",
         dest="soa_dir",
@@ -74,7 +81,7 @@ def paasta_itest(args):
         service = service.split("services-", 1)[1]
     validate_service_name(service, soa_dir=soa_dir)
 
-    tag = build_docker_tag(service, args.commit)
+    tag = build_docker_tag(service, args.commit, args.image_version)
     run_env = os.environ.copy()
     run_env["DOCKER_TAG"] = tag
     cmd = "make itest"
@@ -102,7 +109,7 @@ def paasta_itest(args):
             loglines.append("See output: %s" % output)
     else:
         loglines.append("itest passed for %s." % args.commit)
-        if not check_docker_image(service, args.commit):
+        if not check_docker_image(service, args.commit, args.image_version):
             loglines.append("ERROR: itest has not created %s" % tag)
             returncode = 1
     for logline in loglines:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2902,7 +2902,11 @@ def build_docker_tag(
     return tag
 
 
-def check_docker_image(service: str, tag: str) -> bool:
+def check_docker_image(
+    service: str,
+    commit: str,
+    image_version: Optional[str] = None,
+) -> bool:
     """Checks whether the given image for :service: with :tag: exists.
 
     :raises: ValueError if more than one docker image with :tag: found.
@@ -2910,7 +2914,7 @@ def check_docker_image(service: str, tag: str) -> bool:
     """
     docker_client = get_docker_client()
     image_name = build_docker_image_name(service)
-    docker_tag = build_docker_tag(service, tag)
+    docker_tag = build_docker_tag(service, commit, image_version)
     images = docker_client.images(name=image_name)
     # image['RepoTags'] may be None
     # Fixed upstream but only in docker-py 2.

--- a/tests/cli/test_cmds_itest.py
+++ b/tests/cli/test_cmds_itest.py
@@ -32,8 +32,14 @@ def test_itest_run_fail(
     mock_build_docker_tag.return_value = "fake-registry/services-foo:paasta-bar"
     mock_docker_image.return_value = True
     mock_run.return_value = (1, "fake_output")
-    args = MagicMock()
+    args = MagicMock(
+        service="services-fake_service", commit="unused", image_version="extrastuff"
+    )
     assert paasta_itest(args) == 1
+    mock_build_docker_tag.assert_called_once_with(
+        "fake_service", "unused", "extrastuff"
+    )
+    assert not mock_docker_image.called
 
 
 @patch("paasta_tools.cli.cmds.itest.validate_service_name", autospec=True)
@@ -51,8 +57,14 @@ def test_itest_success(
     mock_build_docker_tag.return_value = "fake-registry/services-foo:paasta-bar"
     mock_docker_image.return_value = True
     mock_run.return_value = (0, "Yeeehaaa")
-    args = MagicMock()
+    args = MagicMock(
+        service="services-fake_service", commit="unused", image_version="extrastuff"
+    )
     assert paasta_itest(args) == 0
+    mock_build_docker_tag.assert_called_once_with(
+        "fake_service", "unused", "extrastuff"
+    )
+    mock_docker_image.assert_called_once_with("fake_service", "unused", "extrastuff")
 
 
 @patch("paasta_tools.cli.cmds.itest.validate_service_name", autospec=True)
@@ -70,8 +82,11 @@ def test_itest_works_when_service_name_starts_with_services_dash(
     mock_docker_image.return_value = True
     mock_build_docker_tag.return_value = "unused_docker_tag"
     mock_run.return_value = (0, "Yeeehaaa")
-    args = MagicMock()
-    args.service = "services-fake_service"
-    args.commit = "unused"
+    args = MagicMock(
+        service="services-fake_service", commit="unused", image_version="extrastuff"
+    )
     assert paasta_itest(args) == 0
-    mock_build_docker_tag.assert_called_once_with("fake_service", "unused")
+    mock_build_docker_tag.assert_called_once_with(
+        "fake_service", "unused", "extrastuff"
+    )
+    mock_docker_image.assert_called_once_with("fake_service", "unused", "extrastuff")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -767,12 +767,13 @@ def test_check_docker_image_false(mock_build_docker_image_name):
         assert utils.check_docker_image("test_service", "tag2") is False
 
 
+@pytest.mark.parametrize(("fake_image_version",), ((None,), ("extrastuff",)))
 @mock.patch("paasta_tools.utils.build_docker_image_name", autospec=True)
-def test_check_docker_image_true(mock_build_docker_image_name):
+def test_check_docker_image_true(mock_build_docker_image_name, fake_image_version):
     fake_app = "fake_app"
     fake_commit = "fake_commit"
     mock_build_docker_image_name.return_value = "fake-registry/services-foo"
-    docker_tag = utils.build_docker_tag(fake_app, fake_commit)
+    docker_tag = utils.build_docker_tag(fake_app, fake_commit, fake_image_version)
     with mock.patch(
         "paasta_tools.utils.get_docker_client", autospec=True
     ) as mock_docker:
@@ -787,7 +788,9 @@ def test_check_docker_image_true(mock_build_docker_image_name):
                 "Size": 0,
             }
         ]
-        assert utils.check_docker_image(fake_app, fake_commit) is True
+        assert (
+            utils.check_docker_image(fake_app, fake_commit, fake_image_version) is True
+        )
 
 
 def test_remove_ansi_escape_sequences():


### PR DESCRIPTION
Given that for the purposes of the deployment pipeline `paasta itest` serves pretty much the same purpose of `paasta cook-image`, i.e. building the docker image but with the addition of running the service's integration tests afterwards, I replicated what was done in https://github.com/Yelp/paasta/pull/3348.