### PR TITLE
Bump timeout for readiness probe

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -937,10 +937,10 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             if not system_paasta_config.get_hacheck_match_initial_delay():
                 initial_delay = 10
 
-            period_s = 10  # we probably don't need to make this configurable...
+            period_s = 60  # we probably don't need to make this configurable...
             timeout_s = (
-                period_s - 1
-            )  # same here, one second less than the period is probably ok
+                period_s - 5
+            )  # same here, five seconds less than the period is probably ok
             readiness_probe = V1Probe(
                 _exec=V1ExecAction(
                     command=["timeout", "--signal=KILL", f"{timeout_s}s"]

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -618,7 +618,7 @@ class TestKubernetesDeploymentConfig:
                             command=[
                                 "timeout",
                                 "--signal=KILL",
-                                "9s",
+                                "55s",
                                 "/nail/blah.sh",
                                 "8888",
                                 "universal.credit",


### PR DESCRIPTION
This caused issues with the readiness probe where the timeout would kill the check too early