### PR TITLE
Fix regex to also assert timeout values of type float

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1003,7 +1003,7 @@ def _auto_add_timeout_for_job(cmd, timeout_job_runtime):
         return cmd
     try:
         timeout_present = re.match(
-            r"^.*timeout[\s]+[\d]*[m|h][\s]+spark-submit .*$", cmd
+            r"^.*timeout[\s]+[\d]+[\.]?[\d]*[m|h][\s]+spark-submit .*$", cmd
         )
         if not timeout_present:
             split_cmd = cmd.split("spark-submit")


### PR DESCRIPTION
This is to fix the issue that if the users provide timeout as floating hours (instead of integer ones) example: 1.0h, it would still use the default timeout value as 12h.

Few more manual test runs: https://fluffy.yelpcorp.com/i/wFH1MlCVtZR5W82DWxMm5VBw9bHGgDJp.html
