### PR TITLE
CID-2427: Replacing raw 'node' with 'ynode'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ commit = ''
 
 ircMsgResult(CHANNELS) {
     ystage('Test') {
-        ynode.forConfiguredHostType(ownerName: 'Yelp', repoName: 'paasta') {
+        ynode {
             ensureCleanWorkspace {
                 commit = clone(
                     PACKAGE_NAME,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ ircMsgResult(CHANNELS) {
     )
 
     ystage('Upload to PyPi') {
-        ynode.forConfiguredHostType(ownerName: 'Yelp', repoName: 'paasta') {
+        ynode {
             promoteToPypi(
                 "git@git.yelpcorp.com:mirrors/Yelp/paasta.git",
                 commit,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ commit = ''
 
 ircMsgResult(CHANNELS) {
     ystage('Test') {
-        node {
+        ynode.forConfiguredHostType(ownerName: 'Yelp', repoName: 'paasta') {
             ensureCleanWorkspace {
                 commit = clone(
                     PACKAGE_NAME,
@@ -32,7 +32,7 @@ ircMsgResult(CHANNELS) {
     )
 
     ystage('Upload to PyPi') {
-        node {
+        ynode.forConfiguredHostType(ownerName: 'Yelp', repoName: 'paasta') {
             promoteToPypi(
                 "git@git.yelpcorp.com:mirrors/Yelp/paasta.git",
                 commit,


### PR DESCRIPTION
As part of K8s migration, we want to replace raw 'node' usage with 'ynode' so we can better control what node executors we use. 