### PR TITLE
PAASTA-17666: Fixes paasta validate to allow preceding comments

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -507,16 +507,24 @@ def _get_comments_for_key(data: CommentedMap, key: Any) -> Optional[str]:
     # this is a little weird, but ruamel is returning a list that looks like:
     # [None, None, CommentToken(...), None] for some reason instead of just a
     # single string
-    raw_comments = [
-        comment.value for comment in data.ca.items.get(key, []) if comment is not None
-    ]
+    # Sometimes ruamel returns a recursive list of as well that looks like
+    # [None, None, [CommentToken(...),CommentToken(...),None], CommentToken(...), None]
+    def _flatten_comments(comments):
+        for comment in comments:
+            if comment is None:
+                continue
+            if isinstance(comment, list):
+                yield from _flatten_comments(comment)
+            else:
+                yield comment.value
+
+    raw_comments = [*_flatten_comments(data.ca.items.get(key, []))]
     if not raw_comments:
         # return None so that we don't return an empty string below if there really aren't
         # any comments
         return None
-    # there should really just be a single item in the list, but just in case...
+    # joining all comments together before returning them
     comment = "".join(raw_comments)
-
     return comment
 
 

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -608,6 +608,7 @@ def validate_autoscaling_configs(service_path):
                         )
                         is None
                     ):
+                        returncode = False
                         print(
                             failure(
                                 msg=f"CPU override detected for a CPU-autoscaled instance in {cluster}: {service}.{instance}. Please read "

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -100,7 +100,7 @@ SCHEMA_TYPES = {
 # we expect a comment that looks like # override-cpu-setting PROJ-1234
 # but we don't have a $ anchor in case users want to add an additional
 # comment
-OVERRIDE_CPU_AUTOTUNE_ACK_PATTERN = r"^#\s*override-cpu-setting\s+\([A-Z]+-[0-9]+\)"
+OVERRIDE_CPU_AUTOTUNE_ACK_PATTERN = r"#\s*override-cpu-setting\s+\([A-Z]+-[0-9]+\)"
 
 
 class ConditionConfig(TypedDict, total=False):
@@ -507,7 +507,7 @@ def _get_comments_for_key(data: CommentedMap, key: Any) -> Optional[str]:
     # this is a little weird, but ruamel is returning a list that looks like:
     # [None, None, CommentToken(...), None] for some reason instead of just a
     # single string
-    # Sometimes ruamel returns a recursive list of as well that looks like
+    # Sometimes ruamel returns a recursive list of CommentTokens as well that looks like
     # [None, None, [CommentToken(...),CommentToken(...),None], CommentToken(...), None]
     def _flatten_comments(comments):
         for comment in comments:
@@ -602,7 +602,7 @@ def validate_autoscaling_configs(service_path):
                     # a DAR if people aren't being careful.
                     if (
                         cpu_comment is None
-                        or re.match(
+                        or re.search(
                             pattern=OVERRIDE_CPU_AUTOTUNE_ACK_PATTERN,
                             string=cpu_comment,
                         )

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -100,7 +100,7 @@ SCHEMA_TYPES = {
 # we expect a comment that looks like # override-cpu-setting PROJ-1234
 # but we don't have a $ anchor in case users want to add an additional
 # comment
-OVERRIDE_CPU_AUTOTUNE_ACK_PATTERN = r"#\s*override-cpu-setting\s+\([A-Z]+-[0-9]+\)"
+OVERRIDE_CPU_AUTOTUNE_ACK_PATTERN = r"#\s*override-cpu-setting\s+\(.+[A-Z]+-[0-9]+.+\)"
 
 
 class ConditionConfig(TypedDict, total=False):

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -1001,6 +1001,60 @@ def test_validate_autoscaling_configs_no_offset_specified(
 
 
 @pytest.mark.parametrize(
+    "filecontents,expected",
+    [
+        ("# overridexxx-cpu-setting", False),
+        ("# override-cpu-setting", False),
+        ("", False),
+        ("# override-cpu-setting (PAASTA-17522)", True),
+    ],
+)
+@patch("paasta_tools.cli.cmds.validate.get_file_contents", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.get_instance_config", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.list_all_instances_for_service", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
+def test_validate_cpu_autotune_override_no_comments(
+    mock_path_to_soa_dir_service,
+    mock_list_clusters,
+    mock_list_all_instances_for_service,
+    mock_get_instance_config,
+    mock_get_file_contents,
+    filecontents,
+    expected,
+):
+    mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
+    mock_list_clusters.return_value = ["fake_cluster"]
+    mock_list_all_instances_for_service.return_value = {"fake_instance1"}
+    mock_get_instance_config.return_value = mock.Mock(
+        get_instance=mock.Mock(return_value="fake_instance1"),
+        get_instance_type=mock.Mock(return_value="kubernetes"),
+        is_autoscaling_enabled=mock.Mock(return_value=True),
+        get_autoscaling_params=mock.Mock(
+            return_value={
+                "metrics_provider": "cpu",
+                "setpoint": 0.8,
+            }
+        ),
+    )
+    mock_get_file_contents.return_value = f"""
+---
+fake_instance1:
+  cpus: 1 {filecontents}
+"""
+
+    with mock.patch(
+        "paasta_tools.cli.cmds.validate.load_system_paasta_config",
+        autospec=True,
+        return_value=SystemPaastaConfig(
+            config={"skip_cpu_override_validation": ["not-a-real-service"]},
+            directory="/some/test/dir",
+        ),
+    ):
+        assert validate_autoscaling_configs("fake-service-path") is expected
+
+
+@pytest.mark.parametrize(
     "schedule, starting_from, num_runs, expected",
     [
         (

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -1014,7 +1014,7 @@ def test_validate_autoscaling_configs_no_offset_specified(
 @patch("paasta_tools.cli.cmds.validate.list_all_instances_for_service", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
-def test_validate_cpu_autotune_override_no_comments(
+def test_validate_cpu_autotune_override(
     mock_path_to_soa_dir_service,
     mock_list_clusters,
     mock_list_all_instances_for_service,


### PR DESCRIPTION
## Problem or Feature
Currently, paasta validate fails when entering any preceding comments in yelpsoa-configs.

## Solution
This PR will fix the failure and join together multiline comments.
