### PR TITLE
Use execlp instead of execlpe

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -694,7 +694,7 @@ def run_docker_container(
         print(json.dumps(docker_run_cmd))
         return 0
 
-    os.execlpe("paasta_docker_wrapper", *docker_run_cmd)
+    os.execlp("paasta_docker_wrapper", *docker_run_cmd)
     return 0
 
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 import shlex
-import shutil
 import socket
 import sys
 import uuid
@@ -473,8 +472,6 @@ def get_docker_run_cmd(
     cmd.append("--rm")
     cmd.append("--net=host")
 
-    sensitive_env = {}
-
     non_interactive_cmd = ["spark-submit", "history-server"]
     if not any(c in docker_cmd for c in non_interactive_cmd):
         cmd.append("--interactive=true")
@@ -486,7 +483,6 @@ def get_docker_run_cmd(
     for k, v in env.items():
         cmd.append("--env")
         if k in SENSITIVE_ENV:
-            sensitive_env[k] = v
             cmd.append(k)
         else:
             cmd.append(f"{k}={v}")
@@ -498,7 +494,6 @@ def get_docker_run_cmd(
         cmd.append("--volume=%s" % volume)
     cmd.append("%s" % docker_img)
     cmd.extend(("sh", "-c", docker_cmd))
-    cmd.append(sensitive_env)
 
     return cmd
 
@@ -695,11 +690,9 @@ def run_docker_container(
         return 0
 
     merged_env = {**os.environ, **environment}
-    wrapper_path = shutil.which("paasta_docker_wrapper")
 
     # Remove the environment variables provided as the last argument
-    docker_run_cmd = docker_run_cmd[:-1]
-    os.execlpe(wrapper_path, *docker_run_cmd, merged_env)
+    os.execlpe("paasta_docker_wrapper", *docker_run_cmd, merged_env)
     return 0
 
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -690,8 +690,6 @@ def run_docker_container(
         return 0
 
     merged_env = {**os.environ, **environment}
-
-    # Remove the environment variables provided as the last argument
     os.execlpe("paasta_docker_wrapper", *docker_run_cmd, merged_env)
     return 0
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import shlex
+import shutil
 import socket
 import sys
 import uuid
@@ -689,12 +690,16 @@ def run_docker_container(
         docker_cpu_limit=docker_cpu_limit,
     )
     docker_run_cmd = get_docker_run_cmd(**docker_run_args)
-
     if dry_run:
         print(json.dumps(docker_run_cmd))
         return 0
 
-    os.execlp("paasta_docker_wrapper", *docker_run_cmd)
+    merged_env = {**os.environ, **environment}
+    wrapper_path = shutil.which("paasta_docker_wrapper")
+
+    # Remove the environment variables provided as the last argument
+    docker_run_cmd = docker_run_cmd[:-1]
+    os.execlpe(wrapper_path, *docker_run_cmd, merged_env)
     return 0
 
 


### PR DESCRIPTION
[MLCOMPUTE-436](https://jira.yelpcorp.com/browse/MLCOMPUTE-436)

Based on PR: https://github.com/Yelp/paasta/pull/3211 originally written by @benbariteau.
This should likely fix the docker daemon not found issue.

Definition: https://docs.python.org/3/library/os.html
```...For [execle()](https://docs.python.org/3/library/os.html#os.execle), [execlpe()](https://docs.python.org/3/library/os.html#os.execlpe), [execve()](https://docs.python.org/3/library/os.html#os.execve), and [execvpe()](https://docs.python.org/3/library/os.html#os.execvpe) (note that these all end in “e”), the env parameter must be a mapping which is used to define the environment variables for the new process (these are used instead of the current process’ environment); the functions [execl()](https://docs.python.org/3/library/os.html#os.execl), [execlp()](https://docs.python.org/3/library/os.html#os.execlp), [execv()](https://docs.python.org/3/library/os.html#os.execv), and [execvp()](https://docs.python.org/3/library/os.html#os.execvp) all cause the new process to inherit the environment of the current process....```

The reason I think this should work, AIU, is `execlpe` uses new given environment variable (currently None, I think).
`execlp` uses the previous process's env variables, which I think has DOCKER_HOST env variable.

Using the same logic as `local-run` to pass all the parent process and spark specific environment.

`Testing:`
a) Manual test accessing S3
b) Unit test


