### PR TITLE
Revert "[FLINK-4124] Small fix to display status info"

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1088,7 +1088,6 @@ def _print_flink_status_from_custom_resource(
         output.append(f"    No other information available in non-running state")
         return 0
 
-    if status["state"] == "running":
         output.append(
             "    Jobs:"
             f" {status['overview']['jobs-running']} running,"


### PR DESCRIPTION
Reverts Yelp/paasta#3425

This seems to be affecting the `check_job_status.py` check for cicd staleness. @jfongatyelp and @nemacysts suggested reverting these changes.