### PR TITLE
Add validation to discourage large cpu_burst_add

### DIFF
--- a/general_itests/validate.feature
+++ b/general_itests/validate.feature
@@ -11,4 +11,4 @@ Feature: paasta validate can be used
     When we run paasta validate
     Then it should have a return code of "1"
      And it should report an error in the output
-     And the output should contain "There were failures validating fake_invalid_service"
+     And the output should contain "Failed to"

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -633,6 +633,12 @@ def validate_autoscaling_configs(service_path):
     return returncode
 
 
+def __is_templated(service: str, soa_dir: str, cluster: str, workload: str) -> bool:
+    return os.path.exists(
+        os.path.join(os.path.abspath(soa_dir), service, f"{workload}-{cluster}.in")
+    )
+
+
 def validate_min_max_instances(service_path):
     soa_dir, service = path_to_soa_dir_service(service_path)
     returncode = True
@@ -736,6 +742,10 @@ def validate_cpu_burst(service_path: str) -> bool:
 
     returncode = True
     for cluster in list_clusters(service, soa_dir):
+        if __is_templated(service, soa_dir, cluster, workload="kubernetes"):
+            # we should eventually make the python templates add the override comment
+            # to the correspoding YAML line, but until then we just opt these out of that validation
+            continue
         for instance in list_all_instances_for_service(
             service=service, clusters=[cluster], soa_dir=soa_dir
         ):

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -22,6 +22,7 @@ from functools import lru_cache
 from functools import partial
 from glob import glob
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -802,7 +803,7 @@ def paasta_validate_soa_configs(
     if not validate_service_name(service):
         return False
 
-    checks = [
+    checks: List[Callable[[str], bool]] = [
         validate_all_schemas,
         partial(validate_tron, verbose=verbose),
         validate_paasta_objects,

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -18,6 +18,8 @@ import pkgutil
 import re
 from collections import Counter
 from datetime import datetime
+from functools import lru_cache
+from functools import partial
 from glob import glob
 from typing import Any
 from typing import Dict
@@ -101,6 +103,15 @@ SCHEMA_TYPES = {
 # but we don't have a $ anchor in case users want to add an additional
 # comment
 OVERRIDE_CPU_AUTOTUNE_ACK_PATTERN = r"#\s*override-cpu-setting\s+\(.+[A-Z]+-[0-9]+.+\)"
+
+# we expect a comment that looks like # override-cpu-burst PROJ-1234
+# but we don't have a $ anchor in case users want to add an additional
+# comment
+OVERRIDE_CPU_BURST_ACK_PATTERN = r"#\s*override-cpu-burst\s+\(.+[A-Z]+-[0-9]+.+\)"
+# for now, double the autotune cap to give people the benefit of the doubt
+# if we see that people are still misusing this configuration, we can lower
+# this to the autotune cap (i.e., 1)
+CPU_BURST_THRESHOLD = 2
 
 
 class ConditionConfig(TypedDict, total=False):
@@ -218,6 +229,7 @@ def validate_service_name(service):
     return True
 
 
+@lru_cache()
 def get_config_file_dict(file_path: str, use_ruamel: bool = False) -> Dict[Any, Any]:
     basename = os.path.basename(file_path)
     extension = os.path.splitext(basename)[1]
@@ -715,6 +727,68 @@ def validate_secrets(service_path):
     return return_value
 
 
+def validate_cpu_burst(service_path: str) -> bool:
+    soa_dir, service = path_to_soa_dir_service(service_path)
+    skip_cpu_burst_validation_list = (
+        load_system_paasta_config().get_skip_cpu_burst_validation_services()
+    )
+
+    returncode = True
+    for cluster in list_clusters(service, soa_dir):
+        for instance in list_all_instances_for_service(
+            service=service, clusters=[cluster], soa_dir=soa_dir
+        ):
+            instance_config = get_instance_config(
+                service=service,
+                instance=instance,
+                cluster=cluster,
+                load_deployments=False,
+                soa_dir=soa_dir,
+            )
+            is_k8s_service = instance_config.get_instance_type() == "kubernetes"
+            should_skip_cpu_burst_validation = service in skip_cpu_burst_validation_list
+            if is_k8s_service and not should_skip_cpu_burst_validation:
+                # we need access to the comments, so we need to read the config with ruamel to be able
+                # to actually get them in a "nice" automated fashion
+                config = get_config_file_dict(
+                    os.path.join(soa_dir, service, f"kubernetes-{cluster}.yaml"),
+                    use_ruamel=True,
+                )
+
+                if config[instance].get("cpu_burst_add") is None:
+                    # using autotuned values - can skip
+                    continue
+                if config[instance]["cpu_burst_add"] <= CPU_BURST_THRESHOLD:
+                    # under the threshold - can also skip
+                    continue
+
+                burst_comment = _get_comments_for_key(
+                    data=config[instance], key="cpu_burst_add"
+                )
+                # we could probably have a separate error message if there's a comment that doesn't match
+                # the ack pattern, but that seems like overkill - especially for something that could cause
+                # a DAR if people aren't being careful.
+                if (
+                    burst_comment is None
+                    or re.search(
+                        pattern=OVERRIDE_CPU_BURST_ACK_PATTERN,
+                        string=burst_comment,
+                    )
+                    is None
+                ):
+                    returncode = False
+                    print(
+                        failure(
+                            msg=f"Potentially excessive CPU burst (cpu_burst_add: {config[instance]['cpu_burst_add']} "
+                            f"higher than current threshold of {CPU_BURST_THRESHOLD} cores) detected in {cluster}: {service}.{instance}."
+                            " Please read the following link for next steps:",
+                            link="y/high-cpu-burst",
+                        )
+                    )
+
+    return returncode
+
+
 def paasta_validate_soa_configs(
     service: str, service_path: str, verbose: bool = False
 ) -> bool:
@@ -728,30 +802,18 @@ def paasta_validate_soa_configs(
     if not validate_service_name(service):
         return False
 
-    returncode = True
+    checks = [
+        validate_all_schemas,
+        partial(validate_tron, verbose=verbose),
+        validate_paasta_objects,
+        validate_unique_instance_names,
+        validate_autoscaling_configs,
+        validate_secrets,
+        validate_min_max_instances,
+        validate_cpu_burst,
+    ]
 
-    if not validate_all_schemas(service_path):
-        returncode = False
-
-    if not validate_tron(service_path, verbose):
-        returncode = False
-
-    if not validate_paasta_objects(service_path):
-        returncode = False
-
-    if not validate_unique_instance_names(service_path):
-        returncode = False
-
-    if not validate_autoscaling_configs(service_path):
-        returncode = False
-
-    if not validate_secrets(service_path):
-        returncode = False
-
-    if not validate_min_max_instances(service_path):
-        returncode = False
-
-    return returncode
+    return all(check(service_path) for check in checks)
 
 
 def paasta_validate(args):

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -828,7 +828,10 @@ def paasta_validate_soa_configs(
         validate_cpu_burst,
     ]
 
-    return all(check(service_path) for check in checks)
+    # NOTE: we're explicitly passing a list comprehension to all()
+    # instead of a generator expression so that we run all checks
+    # no matter what
+    return all([check(service_path) for check in checks])
 
 
 def paasta_validate(args):

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1991,6 +1991,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     spark_ui_port: int
     spark_driver_port: int
     spark_blockmanager_port: int
+    skip_cpu_burst_validation: List[str]
 
 
 def load_system_paasta_config(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2681,6 +2681,9 @@ class SystemPaastaConfig:
     def get_skip_cpu_override_validation_services(self) -> List[str]:
         return self.config_dict.get("skip_cpu_override_validation", [])
 
+    def get_skip_cpu_burst_validation_services(self) -> List[str]:
+        return self.config_dict.get("skip_cpu_burst_validation", [])
+
     def get_cluster_aliases(self) -> Dict[str, str]:
         return self.config_dict.get("cluster_aliases", {})
 

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -20,6 +20,7 @@ from mock import patch
 
 from paasta_tools.cli.cmds.validate import check_secrets_for_instance
 from paasta_tools.cli.cmds.validate import check_service_path
+from paasta_tools.cli.cmds.validate import get_config_file_dict
 from paasta_tools.cli.cmds.validate import get_schema
 from paasta_tools.cli.cmds.validate import get_service_path
 from paasta_tools.cli.cmds.validate import list_upcoming_runs
@@ -29,6 +30,7 @@ from paasta_tools.cli.cmds.validate import SCHEMA_INVALID
 from paasta_tools.cli.cmds.validate import SCHEMA_VALID
 from paasta_tools.cli.cmds.validate import UNKNOWN_SERVICE
 from paasta_tools.cli.cmds.validate import validate_autoscaling_configs
+from paasta_tools.cli.cmds.validate import validate_cpu_burst
 from paasta_tools.cli.cmds.validate import validate_instance_names
 from paasta_tools.cli.cmds.validate import validate_min_max_instances
 from paasta_tools.cli.cmds.validate import validate_paasta_objects
@@ -40,6 +42,15 @@ from paasta_tools.cli.cmds.validate import validate_unique_instance_names
 from paasta_tools.utils import SystemPaastaConfig
 
 
+@pytest.fixture(autouse=True)
+def clear_get_config_file_dict_cache():
+    # this will clear the cache in-between tests, but you'll need to clear in tests
+    # if you're calling validate_* functions multiple times and changing the underlying
+    # files
+    get_config_file_dict.cache_clear()
+
+
+@patch("paasta_tools.cli.cmds.validate.validate_cpu_burst", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_autoscaling_configs", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_unique_instance_names", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_min_max_instances", autospec=True)
@@ -50,6 +61,7 @@ from paasta_tools.utils import SystemPaastaConfig
 @patch("paasta_tools.cli.cmds.validate.check_service_path", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_secrets", autospec=True)
 def test_paasta_validate_calls_everything(
+    mock_validate_cpu_burst,
     mock_validate_autoscaling_configs,
     mock_validate_secrets,
     mock_check_service_path,
@@ -61,6 +73,7 @@ def test_paasta_validate_calls_everything(
     mock_validate_min_max_instances,
 ):
     # Ensure each check in 'paasta_validate' is called
+    mock_validate_cpu_burst.return_value = True
     mock_validate_autoscaling_configs.return_value = True
     mock_validate_secrets.return_value = True
     mock_check_service_path.return_value = True
@@ -83,6 +96,7 @@ def test_paasta_validate_calls_everything(
     assert mock_validate_paasta_objects.called
     assert mock_validate_secrets.called
     assert mock_validate_autoscaling_configs.called
+    assert mock_validate_cpu_burst.called
 
 
 @patch("paasta_tools.cli.cmds.validate.get_instance_config", autospec=True)
@@ -390,6 +404,7 @@ dashes-are-okay-too:
     mock_get_file_contents.return_value = marathon_content
     for schema_type in ["marathon", "kubernetes"]:
         assert validate_schema("unused_service_path.yaml", schema_type)
+        get_config_file_dict.cache_clear()  # HACK: ensure cache is cleared for future calls
         output, _ = capsys.readouterr()
         assert SCHEMA_VALID in output
 
@@ -405,6 +420,7 @@ main_worker_CAPITALS_INVALID:
     mock_get_file_contents.return_value = marathon_content
     for schema_type in ["marathon", "kubernetes"]:
         assert not validate_schema("unused_service_path.yaml", schema_type)
+        get_config_file_dict.cache_clear()  # HACK: ensure cache is cleared for future calls
         output, _ = capsys.readouterr()
         assert SCHEMA_INVALID in output
 
@@ -441,6 +457,7 @@ main_worker:
     mock_get_file_contents.return_value = marathon_content
     for schema_type in ["marathon", "kubernetes"]:
         assert not validate_schema("unused_service_path.yaml", schema_type)
+        get_config_file_dict.cache_clear()  # HACK: ensure cache is cleared for future calls
         output, _ = capsys.readouterr()
         assert SCHEMA_INVALID in output
         marathon_content = """
@@ -457,6 +474,7 @@ main_worker:
     mock_get_file_contents.return_value = marathon_content
     for schema_type in ["marathon", "kubernetes"]:
         assert validate_schema("unused_service_path.yaml", schema_type)
+        get_config_file_dict.cache_clear()  # HACK: ensure cache is cleared for future calls
         output, _ = capsys.readouterr()
         assert SCHEMA_VALID in output
 
@@ -475,6 +493,7 @@ def test_marathon_validate_schema_keys_outside_instance_blocks_bad(
 """
     for schema_type in ["marathon", "kubernetes"]:
         assert not validate_schema("unused_service_path.json", schema_type)
+        get_config_file_dict.cache_clear()  # HACK: ensure cache is cleared for future calls
 
         output, _ = capsys.readouterr()
         assert SCHEMA_INVALID in output
@@ -1092,3 +1111,60 @@ fake_instance1:
 )
 def test_list_upcoming_runs(schedule, starting_from, num_runs, expected):
     assert list_upcoming_runs(schedule, starting_from, num_runs) == expected
+
+
+@pytest.mark.parametrize(
+    "burst, comment, expected",
+    [
+        (3, "# overridexxx-cpu-burst", False),
+        (4, "# override-cpu-burst", False),
+        (5, "", False),
+        (6, "# override-cpu-burst (MAGIC-42)", True),
+        (7, "# override-cpu-burst (SECURE-1234#some comment)", True),
+        (1, "# override-cpu-burst (HWAT-789)", True),
+        (1, "# override-cpu-burst", True),
+    ],
+)
+def test_validate_cpu_burst_override(
+    burst,
+    comment,
+    expected,
+):
+    instance_config = f"""
+---
+fake_instance1:
+  cpu_burst_add: {burst} {comment}
+"""
+
+    with mock.patch(
+        "paasta_tools.cli.cmds.validate.load_system_paasta_config",
+        autospec=True,
+        return_value=SystemPaastaConfig(
+            config={"skip_cpu_burst_validation": ["not-a-real-service"]},
+            directory="/some/test/dir",
+        ),
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.get_file_contents",
+        autospec=True,
+        return_value=instance_config,
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.get_instance_config",
+        autospec=True,
+        return_value=mock.Mock(
+            get_instance=mock.Mock(return_value="fake_instance1"),
+            get_instance_type=mock.Mock(return_value="kubernetes"),
+        ),
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.list_all_instances_for_service",
+        autospec=True,
+        return_value={"fake_instance1"},
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.list_clusters",
+        autospec=True,
+        return_value=["fake_cluster"],
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.path_to_soa_dir_service",
+        autospec=True,
+        return_value=("fake_soa_dir", "fake_service"),
+    ):
+        assert validate_cpu_burst("fake-service-path") is expected


### PR DESCRIPTION
cpu_burst_add is added on to the `cpus` value (which we use for k8s
cpu requests to get a k8s cpu limit - and we've seen internal users
set excessively high values here (which can impact other services
running on the same node).

To discourage this without blocking legitimate usecases (/providing a
smooth transition to outright blocking this if possible in the future),
we allow users to bypass this validation by adding a special comment
(just like we do with the cpu-autoscaled-but-not-autotuned validation)