### PR TITLE
Stop calling paasta_itests toxenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ dev-api: .tox/py37-linux
 
 itest: test .paasta/bin/activate
 	.paasta/bin/tox -i $(PIP_INDEX_URL) -e general_itests
-	.paasta/bin/tox -i $(PIP_INDEX_URL) -e paasta_itests
 
 itest_%:
 	# See the makefile in yelp_package/Makefile for packaging stuff


### PR DESCRIPTION
This doesn't exist anymore - not sure how jenkins internally is fine
with this...