### PR TITLE
Move the service.instance header so that it prints at the same time a…

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -266,7 +266,7 @@ def paasta_status_on_api_endpoint(
     verbose: int,
     new: bool = False,
 ) -> int:
-    output = [""]
+    output = ["", f"\n{service}.{PaastaColors.cyan(instance)} in {cluster}"]
     client = get_paasta_oapi_client(cluster, system_paasta_config)
     if not client:
         print("Cannot get a paasta-api client")
@@ -2160,9 +2160,6 @@ def report_status_for_cluster(
     return_code = 0
     return_codes = []
     for deployed_instance in instances:
-        print(
-            f"\n{service}.{PaastaColors.cyan(deployed_instance)} in {cluster}", end=""
-        )
         return_codes.append(
             paasta_status_on_api_endpoint(
                 cluster=cluster,


### PR DESCRIPTION
…s the output for that service.instance. PAASTA-17657

Otherwise, the different threads might get interleaved in a way that makes it look like some output belongs to an instance in a different cluster.