### PR TITLE
COMPINFRA-1244: Add get-image-version cli tool to generate extra image version

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -93,3 +93,6 @@ disallow_untyped_defs = True
 
 [mypy-paasta_tools.cli.cmds.rollback]
 disallow_untyped_defs = True
+
+[mypy-paasta_tools.cli.cmds.get_image_version]
+disallow_untyped_defs = True

--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -105,6 +105,7 @@ PAASTA_SUBCOMMANDS = {
     "check": "check",
     "cook-image": "cook_image",
     "get-docker-image": "get_docker_image",
+    "get-image-version": "get_image_version",
     "get-latest-deployment": "get_latest_deployment",
     "info": "info",
     "itest": "itest",

--- a/paasta_tools/cli/cmds/get_image_version.py
+++ b/paasta_tools/cli/cmds/get_image_version.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import datetime
+import re
+import sys
+from typing import Optional
+
+from paasta_tools.cli.utils import lazy_choices_completer
+from paasta_tools.cli.utils import PaastaColors
+from paasta_tools.cli.utils import validate_service_name
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import DeploymentsJsonV2Dict
+from paasta_tools.utils import format_timestamp
+from paasta_tools.utils import get_pipeline_deploy_group_configs
+from paasta_tools.utils import list_services
+from paasta_tools.utils import load_v2_deployments_json
+from paasta_tools.utils import parse_timestamp
+
+
+def add_subparser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "get-image-version",
+        help="Returns the value to be used for an image version, which will be used in automated redeploys of the same service SHA. If no deploy groups are configured for automated redeploys, will return no output.",
+    )
+    parser.add_argument(
+        "-f",
+        "--force",
+        help="Force a brand new image_version, regardless if the latest build was recent",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--max-age",
+        help="max age in seconds",
+        type=int,
+        default=3600,  # TODO: Get from paasta system config
+    )
+    arg_service = parser.add_argument(
+        "-s",
+        "--service",
+        help="Name of the service which you want to get the image version for.",
+        required=True,
+    )
+    arg_service.completer = lazy_choices_completer(list_services)  # type: ignore
+    parser.add_argument(
+        "-y",
+        "--soa-dir",
+        help="A directory from which soa-configs should be read from",
+        default=DEFAULT_SOA_DIR,
+    )
+    parser.set_defaults(command=paasta_get_image_version)
+
+
+def check_enable_automated_redeploys(service: str, soa_dir: str) -> bool:
+    # TODO: Handle global flag
+    deploy_steps = get_pipeline_deploy_group_configs(service, soa_dir)
+    return any([step.get("enable_automated_redeploys", False) for step in deploy_steps])
+
+
+def extract_timestamp(image_version: str) -> Optional[datetime.datetime]:
+    ts_str = re.match(r"^(?P<ts_str>[0-9]{8}T[0-9]{6})", image_version).group()
+    return parse_timestamp(ts_str)
+
+
+def should_generate_new_image_version(old: str, new: str, max_age: int) -> bool:
+    # TODO: Handle additional criteria
+    # Extract dates & compare
+    try:
+        age_diff = (extract_timestamp(new) - extract_timestamp(old)).total_seconds()
+
+        if age_diff < max_age:
+            return False
+        print(
+            PaastaColors.yellow(
+                f"Old image version was {age_diff}s old, generating new one"
+            ),
+            file=sys.stderr,
+        )
+    except Exception as e:
+        print(
+            PaastaColors.red(
+                f"Error: hit an exception {e} checking image version, will create new version {new}"
+            ),
+            file=sys.stderr,
+        )
+    return True
+
+
+def get_latest_image_version(deployments: DeploymentsJsonV2Dict) -> str:
+    image_version = None
+    # Image versions start with sortable timestamp
+    sorted_image_versions = sorted(
+        [
+            deployment.get("image_version")
+            for deployment in deployments["deployments"].values()
+            if deployment.get("image_version")
+        ],
+        reverse=True,
+    )
+    if sorted_image_versions:
+        image_version = sorted_image_versions[0]
+    return image_version
+
+
+def paasta_get_image_version(args: argparse.Namespace) -> int:
+    service = args.service
+    soa_dir = args.soa_dir
+
+    validate_service_name(service, soa_dir)
+
+    # Check if any deploy groups have set enable_automated_redeploys
+    if not check_enable_automated_redeploys(service, soa_dir):
+        print(
+            PaastaColors.red(
+                f"Automated redeploys not enabled for {service}, returning no image_version"
+            ),
+            file=sys.stderr,
+        )
+        return 0
+
+    current_timestamp = datetime.datetime.now()
+
+    # TODO: Handle additional identifiers, flavor, etc
+    new_image_version = format_timestamp(current_timestamp)
+
+    if args.force:
+        # Force a new version immediately
+        print(new_image_version)
+        return 0
+
+    # get latest image_version of any deploy group from deployments.json
+    deployments = load_v2_deployments_json(service, soa_dir)
+    latest_image_version = get_latest_image_version(deployments.config_dict)
+
+    if should_generate_new_image_version(
+        old=latest_image_version, new=new_image_version, max_age=args.max_age
+    ):
+        print(new_image_version)
+    else:
+        print(latest_image_version)
+
+    return 0

--- a/paasta_tools/cli/cmds/get_image_version.py
+++ b/paasta_tools/cli/cmds/get_image_version.py
@@ -58,7 +58,7 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
     parser.add_argument(
         "-y",
         "--soa-dir",
-        help="A directory from which soa-configs should be read from",
+        help="A directory from which soa-configs should be read",
         default=DEFAULT_SOA_DIR,
     )
     parser.set_defaults(command=paasta_get_image_version)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -3086,9 +3086,9 @@ def get_pipeline_config(service: str, soa_dir: str = DEFAULT_SOA_DIR) -> List[Di
     return service_configuration.get("deploy", {}).get("pipeline", [])
 
 
-def get_pipeline_deploy_groups(
+def get_pipeline_deploy_group_configs(
     service: str, soa_dir: str = DEFAULT_SOA_DIR
-) -> List[str]:
+) -> List[Dict]:
     pipeline_steps = []
     for step in get_pipeline_config(service, soa_dir):
         # added support for parallel steps in a deploy.yaml
@@ -3097,11 +3097,17 @@ def get_pipeline_deploy_groups(
         if step.get("parallel"):
             for parallel_step in step.get("parallel"):
                 if parallel_step.get("step"):
-                    pipeline_steps.append(parallel_step["step"])
+                    pipeline_steps.append(parallel_step)
         else:
-            pipeline_steps.append(step["step"])
+            pipeline_steps.append(step)
+    return [step for step in pipeline_steps if is_deploy_step(step["step"])]
 
-    return [step for step in pipeline_steps if is_deploy_step(step)]
+
+def get_pipeline_deploy_groups(
+    service: str, soa_dir: str = DEFAULT_SOA_DIR
+) -> List[str]:
+    deploy_group_configs = get_pipeline_deploy_group_configs(service, soa_dir)
+    return [step["step"] for step in deploy_group_configs]
 
 
 def get_service_instance_list_no_cache(

--- a/tests/cli/test_cmds_get_image_version.py
+++ b/tests/cli/test_cmds_get_image_version.py
@@ -1,0 +1,78 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import datetime
+
+import pytest
+from mock import MagicMock
+from mock import patch
+
+from paasta_tools.cli.cmds.get_image_version import paasta_get_image_version
+
+
+@pytest.mark.parametrize(
+    "nocommits_enabled, force, mock_latest_version, expected_out, expected_err_match",
+    (
+        (False, False, None, "", "Automated redeploys not enabled for test_service"),
+        (
+            False,
+            False,
+            "00000000T000000",
+            "",
+            "Automated redeploys not enabled for test_service",
+        ),  # disabling nocommits after having been enabled
+        (True, False, None, "20220101T000000", ""),
+        (True, False, "20210101T000000", "20220101T000000", ""),
+        (True, False, "20211231T233000", "20211231T233000", ""),
+        (True, True, "20211231T233000", "20220101T000000", ""),
+    ),
+)
+def test_get_image_version(
+    capfd,
+    nocommits_enabled,
+    force,
+    mock_latest_version,
+    expected_out,
+    expected_err_match,
+):
+    mock_args = MagicMock(
+        service="test_service",
+        soa_dir="",
+        max_age=3600,
+        force=force,
+    )
+    with patch(
+        "paasta_tools.cli.cmds.get_image_version.check_enable_automated_redeploys",
+        return_value=nocommits_enabled,
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.get_image_version.get_latest_image_version",
+        return_value=mock_latest_version,
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.get_image_version.validate_service_name",
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.get_image_version.load_v2_deployments_json",
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.get_image_version.datetime",
+        autospec=True,
+    ) as mock_datetime:
+        mock_datetime.datetime.now.return_value = datetime.datetime(
+            year=2022, month=1, day=1
+        )
+        paasta_get_image_version(mock_args)
+        out, err = capfd.readouterr()
+        assert expected_out == out.strip()
+        assert expected_err_match in err


### PR DESCRIPTION
This adds a new (currently trivial) cli tool that will 'generate' a new image_version value to be used during paasta deploys.

As of right now we do only the following:
* check if automated redeploys is enabled for any deploy groups
* compare the current timestamp with the latest image_version tags found in current deployments
  * If current image_versions do not start with a timestamp and cannot properly be converted to a datetime, this will essentially force a new version
* print the new image version as appropriate

This required modifying the `get_pipeline_deploy_groups` helper as that originally just gave deploy step _names_, whereas we needed the full step contents to be able to identify if any had enabled automated redeploys.