### PR TITLE
[FLINK-4152] Use V1 apiextensions

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -480,7 +480,7 @@ class KubeClient:
         self.deployments = kube_client.AppsV1Api(self.api_client)
         self.core = kube_client.CoreV1Api(self.api_client)
         self.policy = kube_client.PolicyV1beta1Api(self.api_client)
-        self.apiextensions = kube_client.ApiextensionsV1beta1Api(self.api_client)
+        self.apiextensions = kube_client.ApiextensionsV1Api(self.api_client)
         self.custom = kube_client.CustomObjectsApi(self.api_client)
         self.autoscaling = kube_client.AutoscalingV2beta2Api(self.api_client)
         self.rbac = kube_client.RbacAuthorizationV1Api(self.api_client)

--- a/paasta_tools/setup_kubernetes_internal_crd.py
+++ b/paasta_tools/setup_kubernetes_internal_crd.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 
 INTERNAL_CRDS = [
     V1beta1CustomResourceDefinition(
-        api_version="apiextensions.k8s.io/v1beta1",
+        api_version="apiextensions.k8s.io/v1",
         kind="CustomResourceDefinition",
         metadata={
             "name": "deploygroups.paasta.yelp.com",
@@ -44,7 +44,24 @@ INTERNAL_CRDS = [
         },
         spec={
             "group": "paasta.yelp.com",
-            "versions": [{"name": "v1beta1", "served": True, "storage": True}],
+            "versions": [
+                {
+                    "name": "v1beta1",
+                    "schema": {
+                        "openAPIV3Schema": {
+                            "type": "object",
+                            "properties": {
+                                "service": {"type": "string"},
+                                "deploy_group": {"type": "string"},
+                                "git_sha": {"type": "string"},
+                                "image_version": {"type": "string"},
+                            },
+                        },
+                    },
+                    "served": True,
+                    "storage": True,
+                },
+            ],
             "scope": "Namespaced",
             "names": {
                 "plural": "deploygroups",
@@ -52,21 +69,10 @@ INTERNAL_CRDS = [
                 "kind": "DeployGroup",
                 "shortNames": ["dg"],
             },
-            "validation": {
-                "openAPIV3Schema": {
-                    "type": "object",
-                    "properties": {
-                        "service": {"type": "string"},
-                        "deploy_group": {"type": "string"},
-                        "git_sha": {"type": "string"},
-                        "image_version": {"type": "string"},
-                    },
-                }
-            },
         },
     ),
     V1beta1CustomResourceDefinition(
-        api_version="apiextensions.k8s.io/v1beta1",
+        api_version="apiextensions.k8s.io/v1",
         kind="CustomResourceDefinition",
         metadata={
             "name": "startstopcontrols.paasta.yelp.com",
@@ -76,23 +82,29 @@ INTERNAL_CRDS = [
         },
         spec={
             "group": "paasta.yelp.com",
-            "versions": [{"name": "v1beta1", "served": True, "storage": True}],
+            "versions": [
+                {
+                    "name": "v1beta1",
+                    "schema": {
+                        "openAPIV3Schema": {
+                            "type": "object",
+                            "properties": {
+                                "service": {"type": "string"},
+                                "instance": {"type": "string"},
+                                "desired_state": {"type": "string"},
+                                "force_bounce": {"type": "string"},
+                            },
+                        },
+                    },
+                    "served": True,
+                    "storage": True,
+                },
+            ],
             "scope": "Namespaced",
             "names": {
                 "plural": "startstopcontrols",
                 "singular": "startstopcontrol",
                 "kind": "StartStopControl",
-            },
-            "validation": {
-                "openAPIV3Schema": {
-                    "type": "object",
-                    "properties": {
-                        "service": {"type": "string"},
-                        "instance": {"type": "string"},
-                        "desired_state": {"type": "string"},
-                        "force_bounce": {"type": "string"},
-                    },
-                }
             },
         },
     ),


### PR DESCRIPTION
Simple upgrade to apiextensions to v1.
This fixes our local testing environment for the flink operator: we were getting 400s (malformed request) while registering the CRD with local kind cluster.
~~I'm going to leave it as a draft until I have more clarity on the implications for other k8s services.~~