### PR TITLE
Evicted pods should cause replica state to be 'Not Running'

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1673,6 +1673,7 @@ def get_main_container(pod: KubernetesPodV2) -> Optional[KubernetesContainerV2]:
 def get_replica_state(pod: KubernetesPodV2) -> ReplicaState:
     phase = pod.phase
     state = ReplicaState.UNKNOWN
+    reason = pod.reason
     if phase is None or not pod.scheduled:
         state = ReplicaState.UNSCHEDULED
     elif pod.delete_timestamp:
@@ -1715,7 +1716,7 @@ def get_replica_state(pod: KubernetesPodV2) -> ReplicaState:
             state = ReplicaState.UNKNOWN
 
         # Catch
-    elif phase == "Failed":
+    elif phase == "Failed" or reason == "Evicted":
         # e.g. pod.reason == evicted
         state = ReplicaState.NOT_RUNNING
     return state

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1674,7 +1674,9 @@ def get_replica_state(pod: KubernetesPodV2) -> ReplicaState:
     phase = pod.phase
     state = ReplicaState.UNKNOWN
     reason = pod.reason
-    if phase is None or not pod.scheduled:
+    if phase == "Failed" or reason == "Evicted":
+        state = ReplicaState.NOT_RUNNING
+    elif phase is None or not pod.scheduled:
         state = ReplicaState.UNSCHEDULED
     elif pod.delete_timestamp:
         state = ReplicaState.TERMINATING
@@ -1715,10 +1717,6 @@ def get_replica_state(pod: KubernetesPodV2) -> ReplicaState:
         else:
             state = ReplicaState.UNKNOWN
 
-        # Catch
-    elif phase == "Failed" or reason == "Evicted":
-        # e.g. pod.reason == evicted
-        state = ReplicaState.NOT_RUNNING
     return state
 
 

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -2389,6 +2389,9 @@ class TestGetVersionsTable:
             assert any(["Healthchecks are failing" in row for row in versions_table])
 
     def test_evicted_pods_unhealthy(self, mock_replicasets):
+        mock_replicasets[1].pods[1].phase = ""
+        mock_replicasets[1].pods[1].scheduled = False
+        mock_replicasets[1].pods[1].host = ""
         versions_table = get_versions_table(
             mock_replicasets, "service", "instance", "cluster", verbose=1
         )

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -2388,6 +2388,12 @@ class TestGetVersionsTable:
             assert any(["1 Warning" in row for row in versions_table])
             assert any(["Healthchecks are failing" in row for row in versions_table])
 
+    def test_evicted_pods_unhealthy(self, mock_replicasets):
+        versions_table = get_versions_table(
+            mock_replicasets, "service", "instance", "cluster", verbose=1
+        )
+        assert any(["1 Not Running" in row for row in versions_table])
+
 
 class TestPrintKubernetesStatus:
     def test_error(self, mock_kubernetes_status):


### PR DESCRIPTION
Added a condition to set Evicted pod's replica state to be Not running.
All tests are passing. 