### PR TITLE
Adds specifying vault token path PAASTA-17437

### DIFF
--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -43,6 +43,7 @@ from paasta_tools.kubernetes_tools import update_secret
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.secret_tools import get_secret_provider
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import DEFAULT_VAULT_TOKEN_FILE
 from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import INSTANCE_TYPE_TO_K8S_NAMESPACE
 from paasta_tools.utils import INSTANCE_TYPES
@@ -82,6 +83,13 @@ def parse_args() -> argparse.Namespace:
         help="Overwrite destination namespace for secrets",
     )
     parser.add_argument(
+        "-vtf",
+        "--vault-token-file",
+        dest="vault_token_file",
+        default=DEFAULT_VAULT_TOKEN_FILE,
+        help="Define a different vault token file location",
+    )
+    parser.add_argument(
         "-v", "--verbose", action="store_true", dest="verbose", default=False
     )
     args = parser.parse_args()
@@ -116,6 +124,7 @@ def main() -> None:
         secret_provider_name=secret_provider_name,
         vault_cluster_config=vault_cluster_config,
         soa_dir=args.soa_dir,
+        vault_token_file=args.vault_token_file,
         overwrite_namespace=args.namespace,
     ) else sys.exit(1)
 
@@ -156,6 +165,7 @@ def sync_all_secrets(
     secret_provider_name: str,
     vault_cluster_config: Mapping[str, str],
     soa_dir: str,
+    vault_token_file: str,
     overwrite_namespace: Optional[str] = None,
 ) -> bool:
     results = []
@@ -172,6 +182,7 @@ def sync_all_secrets(
                     vault_cluster_config=vault_cluster_config,
                     soa_dir=soa_dir,
                     namespace=namespace,
+                    vault_token_file=vault_token_file,
                 )
             )
             results.append(
@@ -196,6 +207,7 @@ def sync_secrets(
     vault_cluster_config: Mapping[str, str],
     soa_dir: str,
     namespace: str,
+    vault_token_file: str,
 ) -> bool:
     secret_dir = os.path.join(soa_dir, service, "secrets")
     secret_provider_kwargs = {
@@ -203,7 +215,7 @@ def sync_secrets(
         # TODO: make vault-tools support k8s auth method so we don't have to
         # mount a token in.
         "vault_auth_method": "token",
-        "vault_token_file": "/root/.vault_token",
+        "vault_token_file": vault_token_file,
     }
     secret_provider = get_secret_provider(
         secret_provider_name=secret_provider_name,

--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -83,7 +83,7 @@ def parse_args() -> argparse.Namespace:
         help="Overwrite destination namespace for secrets",
     )
     parser.add_argument(
-        "-vtf",
+        "-t",
         "--vault-token-file",
         dest="vault_token_file",
         default=DEFAULT_VAULT_TOKEN_FILE,
@@ -165,7 +165,7 @@ def sync_all_secrets(
     secret_provider_name: str,
     vault_cluster_config: Mapping[str, str],
     soa_dir: str,
-    vault_token_file: str,
+    vault_token_file: str = DEFAULT_VAULT_TOKEN_FILE,
     overwrite_namespace: Optional[str] = None,
 ) -> bool:
     results = []
@@ -207,7 +207,7 @@ def sync_secrets(
     vault_cluster_config: Mapping[str, str],
     soa_dir: str,
     namespace: str,
-    vault_token_file: str,
+    vault_token_file: str = DEFAULT_VAULT_TOKEN_FILE,
 ) -> bool:
     secret_dir = os.path.join(soa_dir, service, "secrets")
     secret_provider_kwargs = {

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -90,6 +90,7 @@ PATH_TO_SYSTEM_PAASTA_CONFIG_DIR = os.environ.get(
     "PAASTA_SYSTEM_CONFIG_DIR", "/etc/paasta/"
 )
 DEFAULT_SOA_DIR = service_configuration_lib.DEFAULT_SOA_DIR
+DEFAULT_VAULT_TOKEN_FILE = "/root/.vault_token"
 AUTO_SOACONFIG_SUBDIR = "autotuned_defaults"
 DEFAULT_DOCKERCFG_LOCATION = "file:///root/.dockercfg"
 DEPLOY_PIPELINE_NON_DEPLOY_STEPS = (

--- a/tests/kubernetes/bin/test_paasta_secrets_sync.py
+++ b/tests/kubernetes/bin/test_paasta_secrets_sync.py
@@ -65,7 +65,6 @@ def test_sync_all_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
-            vault_token_file="/root/.vault_token",
         )
 
         mock_sync_secrets.side_effect = [True, False]
@@ -76,7 +75,6 @@ def test_sync_all_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
-            vault_token_file="/root/.vault_token",
         )
 
         mock_sync_secrets.side_effect = None
@@ -87,7 +85,6 @@ def test_sync_all_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
-            vault_token_file="/root/.vault_token",
         )
 
 
@@ -146,7 +143,6 @@ def test_sync_secrets(namespace):
             vault_cluster_config={},
             soa_dir="/nail/blah",
             namespace=namespace,
-            vault_token_file="/root/.vault_token",
         )
 
         mock_scandir.return_value.__enter__.return_value = [mock.Mock(path="some_file")]
@@ -159,7 +155,6 @@ def test_sync_secrets(namespace):
             vault_cluster_config={},
             soa_dir="/nail/blah",
             namespace=namespace,
-            vault_token_file="/root/.vault_token",
         )
 
         mock_get_secret_provider.return_value = mock.Mock(
@@ -178,7 +173,6 @@ def test_sync_secrets(namespace):
             vault_cluster_config={},
             soa_dir="/nail/blah",
             namespace=namespace,
-            vault_token_file="/root/.vault_token",
         )
         assert mock_get_kubernetes_secret_signature.called
         _, kwargs = mock_get_kubernetes_secret_signature.call_args_list[-1]
@@ -197,7 +191,6 @@ def test_sync_secrets(namespace):
             vault_cluster_config={},
             soa_dir="/nail/blah",
             namespace=namespace,
-            vault_token_file="/root/.vault_token",
         )
         assert mock_get_kubernetes_secret_signature.called
         assert not mock_create_secret.called
@@ -220,7 +213,6 @@ def test_sync_secrets(namespace):
             vault_cluster_config={},
             soa_dir="/nail/blah",
             namespace=namespace,
-            vault_token_file="/root/.vault_token",
         )
         assert mock_get_kubernetes_secret_signature.called
         assert mock_create_secret.called
@@ -243,7 +235,6 @@ def test_sync_secrets(namespace):
             vault_cluster_config={},
             soa_dir="/nail/blah",
             namespace=namespace,
-            vault_token_file="/root/.vault_token",
         )
         assert mock_get_kubernetes_secret_signature.called
         assert mock_create_secret.called
@@ -261,7 +252,6 @@ def test_sync_secrets(namespace):
                 vault_cluster_config={},
                 soa_dir="/nail/blah",
                 namespace=namespace,
-                vault_token_file="/root/.vault_token",
             )
 
 

--- a/tests/kubernetes/bin/test_paasta_secrets_sync.py
+++ b/tests/kubernetes/bin/test_paasta_secrets_sync.py
@@ -65,6 +65,7 @@ def test_sync_all_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
+            vault_token_file="/root/.vault_token",
         )
 
         mock_sync_secrets.side_effect = [True, False]
@@ -75,6 +76,7 @@ def test_sync_all_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
+            vault_token_file="/root/.vault_token",
         )
 
         mock_sync_secrets.side_effect = None
@@ -85,6 +87,7 @@ def test_sync_all_secrets():
             secret_provider_name="vaulty",
             vault_cluster_config={},
             soa_dir="/nail/blah",
+            vault_token_file="/root/.vault_token",
         )
 
 
@@ -143,6 +146,7 @@ def test_sync_secrets(namespace):
             vault_cluster_config={},
             soa_dir="/nail/blah",
             namespace=namespace,
+            vault_token_file="/root/.vault_token",
         )
 
         mock_scandir.return_value.__enter__.return_value = [mock.Mock(path="some_file")]
@@ -155,6 +159,7 @@ def test_sync_secrets(namespace):
             vault_cluster_config={},
             soa_dir="/nail/blah",
             namespace=namespace,
+            vault_token_file="/root/.vault_token",
         )
 
         mock_get_secret_provider.return_value = mock.Mock(
@@ -173,6 +178,7 @@ def test_sync_secrets(namespace):
             vault_cluster_config={},
             soa_dir="/nail/blah",
             namespace=namespace,
+            vault_token_file="/root/.vault_token",
         )
         assert mock_get_kubernetes_secret_signature.called
         _, kwargs = mock_get_kubernetes_secret_signature.call_args_list[-1]
@@ -191,6 +197,7 @@ def test_sync_secrets(namespace):
             vault_cluster_config={},
             soa_dir="/nail/blah",
             namespace=namespace,
+            vault_token_file="/root/.vault_token",
         )
         assert mock_get_kubernetes_secret_signature.called
         assert not mock_create_secret.called
@@ -213,6 +220,7 @@ def test_sync_secrets(namespace):
             vault_cluster_config={},
             soa_dir="/nail/blah",
             namespace=namespace,
+            vault_token_file="/root/.vault_token",
         )
         assert mock_get_kubernetes_secret_signature.called
         assert mock_create_secret.called
@@ -235,6 +243,7 @@ def test_sync_secrets(namespace):
             vault_cluster_config={},
             soa_dir="/nail/blah",
             namespace=namespace,
+            vault_token_file="/root/.vault_token",
         )
         assert mock_get_kubernetes_secret_signature.called
         assert mock_create_secret.called
@@ -252,6 +261,7 @@ def test_sync_secrets(namespace):
                 vault_cluster_config={},
                 soa_dir="/nail/blah",
                 namespace=namespace,
+                vault_token_file="/root/.vault_token",
             )
 
 


### PR DESCRIPTION
This PR will allow vault token path to be passed as a parameter in sync_secrets and default to /root/.vault_token if not defined to prevent any previous functions from breaking