### PR TITLE
Added a warning message to paasta rollback - PAASTA-17749

### DIFF
--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -306,7 +306,6 @@ def paasta_rollback(args: argparse.Namespace) -> int:
 
         # we could also gate this by the return code from m-f-d, but we probably care more about someone wanting to
         # rollback than we care about if the underlying machinery was successfully able to complete the request
-
         if rolled_back_from != new_version:
             audit_action_details = {
                 "rolled_back_from": str(rolled_back_from),
@@ -317,5 +316,12 @@ def paasta_rollback(args: argparse.Namespace) -> int:
             _log_audit(
                 action="rollback", action_details=audit_action_details, service=service
             )
+
+    if returncode == 0:
+        print(
+            PaastaColors.cyan(
+                f"Warning: Don't forget to revert in git as well. Use 'git revert {rolled_back_from.sha}', and go through the normal push process. "
+            )
+        )
 
     return returncode


### PR DESCRIPTION
### Purpose of this PR
Added a warning message about needing to revert in git in paasta rollback.

### Testing
Testing in two ways:

1) Tested the change by running the unit tests in ``test_cmds_rollback.py`` ensuring I see the warning message shown when assert results in 0. 

```
(py37-linux) emanelsabban@dev55-uswest1adevc:~/pg/paasta$ py.test -s ./tests/cli/test_cmds_rollback.py
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.7.5, pytest-3.3.1, py-1.5.2, pluggy-0.6.0
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/nail/home/emanelsabban/pg/paasta/.hypothesis/examples')
rootdir: /nail/home/emanelsabban/pg/paasta, inifile:
plugins: asyncio-0.8.0, pyfakefs-4.1.0, hypothesis-3.71.10
collected 17 items                                                                                                                                                                                        

tests/cli/test_cmds_rollback.py Warning: Don't forget to revert in git as well
.Warning: Don't forget to revert in git as well
.Warning: Don't forget to revert in git as well
.ERROR: No valid deploy groups specified for fakeservice.
 Use the flag -a to rollback all valid deploy groups for this service
.Warning: Don't forget to revert in git as well
.These deploy groups are not valid and will be skipped: wrong_deploy_group.

ERROR: No valid deploy groups specified for fakeservice.
 Use the flag -a to rollback all valid deploy groups for this service
.This version abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd has never been deployed before.
Please double check it or use --force to skip this verification.

Below is a list of recent commits:
Timestamp -- UTC  Human time   deploy_group        Version
20170403T025512   5 years ago  fake_deploy_group1  DeploymentVersion(sha=fake_sha1, image_version=fake_image)
20161006T025416   5 years ago  fake_deploy_group2  DeploymentVersion(sha=fake_sha2, image_version=fake_image)
20161006T025416   5 years ago  fake_deploy_group2  DeploymentVersion(sha=abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd, image_version=fake_image)

For example, to use the second to last version from 5 years ago used on fake_deploy_group2, run:
    paasta rollback -s fakeservice -l fake_deploy_group1 -k fake_sha2 --image-version fake_image
.Warning: Don't forget to revert in git as well
..........                                                                                                                                                   [100%]

======================================================================================== 17 passed in 0.86 seconds ========================================================================================
(py37-linux) emanelsabban@dev55-uswest1adevc:~/pg/paasta$ 
```

2) Testing by running `` paasta rollback`` locally with a test service ``katamari_test_service`` and making sure I see the warning message outputted when rolling back.

```
(py37-linux) emanelsabban@dev55-uswest1adevc:~/pg/paasta$  cd /nail/home/emanelsabban/pg/paasta ; /usr/bin/env /nail/home/emanelsabban/pg/paasta/.tox/py37-linux/bin/python /nail/home/emanelsabban/.vscode-server/extensions/ms-python.python-2022.12.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher 33309 -- -m paasta_tools.cli.cli rollback --service katamari_test_service --deploy-group dev.canary --commit 224173aca322207994e655c4316ddb16f00eaab7 
[service katamari_test_service] Notifying soa-configs primary to generate a deployment for katamari_test_service
[service katamari_test_service] Marked 224173aca322207994e655c4316ddb16f00eaab7 for deployment in deploy group dev.canary
Warning: Don't forget to revert in git as well
```
Then checking using ``paasta status`` command.

```
py37-linux) emanelsabban@dev55-uswest1adevc:~/pg/paasta$ paasta status --service katamari_test_service


katamari_test_service.main in norcal-devc
    Git sha:    e58c66df (desired)
    State: Running
    Running versions:
      Rerun with -v to see all replicas
      e58c66df - Started 2022-08-05 19:00:01 (20 days ago)
        Replica States: 9 Healthy


katamari_test_service.canary in norcal-devc
    Git sha:    224173ac (desired)
    State: Running
    Running versions:
      Rerun with -v to see all replicas
      614c0abd - Started 2022-08-26 04:32:59 (2 hours ago)
        Replica States: 1 Healthy
```