### PR TITLE
maintain yaml comments when autoupdating configs

### DIFF
--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -216,6 +216,38 @@ def test_auto_config_updater_read_write(updater):
     assert len(updater.files_changed) == 1
 
 
+def test_auto_config_updater_read_write_with_comments(updater):
+    service = "foo"
+    conf_file = "something"
+    data = {"key": "g_minor", "bar": "foo"}
+
+    with open(f"{updater.working_dir}/{service}/{conf_file}.yaml", "x") as f:
+        f.write(
+            """# top comment
+key: c_minor # inline comment
+"""
+        )
+
+    existing_data = updater.get_existing_configs(service, conf_file)
+    assert existing_data == {"key": "c_minor"}
+
+    # Update existing config and add another key
+    existing_data["key"] = "g_minor"
+    existing_data["bar"] = "foo"
+
+    updater.write_configs(service, conf_file, existing_data)
+    assert updater.get_existing_configs(service, conf_file) == data
+    assert len(updater.files_changed) == 1
+    with open(f"{updater.working_dir}/{service}/{conf_file}.yaml", "r") as f:
+        assert (
+            f.read()
+            == """# top comment
+key: g_minor # inline comment
+bar: foo
+"""
+        )
+
+
 @mock.patch("paasta_tools.config_utils._push_to_remote", autospec=True)
 @mock.patch("paasta_tools.config_utils._commit_files", autospec=True)
 def test_auto_config_updater_commit_validate_fails(mock_push, mock_commit, updater):


### PR DESCRIPTION
Currently, comments are thrown away due to two different issues:
1. `get_existing_configs` throws away comments
2. Writing configs throws away comments **if** the comment occurs in the yaml data itself (ie. a comment at the start of a yaml file is OK)

Resolve the first issue by using ruamel to read yaml, and resolve the second by messing with the internal structure of the read yaml file. In the future, we can combine this if/else block to more cleanly insert a header comment (as used by other contrib scripts), but this should do for now