### PR TITLE
Allow setting load balancer weight per instance in yelpsoa-configs

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -447,6 +447,14 @@ instance MAY have:
     accessed externally. This option is implied when registered to smartstack or
     when specifying a ``prometheus_port``. Defaults to ``false``
 
+  * ``weight``: Load balancer/service mesh weight to assign to pods belonging to this instance.
+    Pods should receive traffic proportional to their weight, i.e. a pod with
+    weight 20 should receive 2x as much traffic as a pod with weight 10.
+    Defaults to 10.
+    Must be an integer.
+    This only makes a difference when some pods in the same load balancer have different weights than others, such as when you have two or more instances with the same ``registration`` but different ``weight``.
+
+
 **Note**: Although many of these settings are inherited from ``smartstack.yaml``,
 their thresholds are not the same. The reason for this has to do with control
 loops and infrastructure stability. The load balancer tier can be pickier

--- a/mypy.ini
+++ b/mypy.ini
@@ -96,3 +96,6 @@ disallow_untyped_defs = True
 
 [mypy-paasta_tools.cli.cmds.get_image_version]
 disallow_untyped_defs = True
+
+[mypy-paasta_tools.dump_locally_running_services]
+disallow_untyped_defs = True

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -780,6 +780,10 @@
                 },
                 "is_istio_sidecar_injection_enabled": {
                     "type": "boolean"
+                },
+                "weight": {
+                    "type": "integer",
+                    "minimum": 1
                 }
             }
         }

--- a/paasta_tools/dump_locally_running_services.py
+++ b/paasta_tools/dump_locally_running_services.py
@@ -25,14 +25,16 @@ Command line options:
 import argparse
 import json
 import sys
+from typing import List
+from typing import Tuple
 
 from paasta_tools.kubernetes_tools import get_kubernetes_services_running_here_for_nerve
-from paasta_tools.marathon_tools import get_marathon_services_running_here_for_nerve
+from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
 from paasta_tools.marathon_tools import get_puppet_services_running_here_for_nerve
 from paasta_tools.utils import DEFAULT_SOA_DIR
 
 
-def parse_args(argv):
+def parse_args(argv) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Dumps information about locally running services."
     )
@@ -47,14 +49,16 @@ def parse_args(argv):
     return parser.parse_args(argv)
 
 
-def main(argv=None):
+def main(argv=None) -> None:
     args = parse_args(argv)
     soa_dir = args.soa_dir
 
-    service_dump = (
-        get_marathon_services_running_here_for_nerve(cluster=None, soa_dir=soa_dir)
-        + get_puppet_services_running_here_for_nerve(soa_dir=soa_dir)
-        + get_kubernetes_services_running_here_for_nerve(cluster=None, soa_dir=soa_dir)
+    service_dump: List[
+        Tuple[str, ServiceNamespaceConfig]
+    ] = get_puppet_services_running_here_for_nerve(
+        soa_dir=soa_dir
+    ) + get_kubernetes_services_running_here_for_nerve(
+        cluster=None, soa_dir=soa_dir
     )
 
     print(json.dumps(service_dump))

--- a/paasta_tools/dump_locally_running_services.py
+++ b/paasta_tools/dump_locally_running_services.py
@@ -26,6 +26,8 @@ import argparse
 import json
 import sys
 from typing import List
+from typing import Optional
+from typing import Sequence
 from typing import Tuple
 
 from paasta_tools.kubernetes_tools import get_kubernetes_services_running_here_for_nerve
@@ -34,7 +36,7 @@ from paasta_tools.marathon_tools import get_puppet_services_running_here_for_ner
 from paasta_tools.utils import DEFAULT_SOA_DIR
 
 
-def parse_args(argv) -> argparse.Namespace:
+def parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Dumps information about locally running services."
     )
@@ -49,7 +51,7 @@ def parse_args(argv) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv=None) -> None:
+def main(argv: Optional[Sequence[str]] = None) -> None:
     args = parse_args(argv)
     soa_dir = args.soa_dir
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -325,6 +325,7 @@ KubePodLabels = TypedDict(
         "yelp.com/paasta_service": str,
         "sidecar.istio.io/inject": str,
         "paasta.yelp.com/pool": str,
+        "paasta.yelp.com/weight": str,
     },
     total=False,
 )
@@ -1843,6 +1844,8 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "paasta.yelp.com/autoscaled": str(self.is_autoscaling_enabled()).lower(),
             "paasta.yelp.com/pool": self.get_pool(),
         }
+        if service_namespace_config.is_in_smartstack():
+            labels["paasta.yelp.com/weight"] = str(self.get_weight())
 
         # Allow the Prometheus Operator's Pod Service Monitor for specified
         # shard to find this pod

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2107,7 +2107,7 @@ def get_kubernetes_services_running_here(
 
 def get_kubernetes_services_running_here_for_nerve(
     cluster: Optional[str], soa_dir: str
-) -> Sequence[Tuple[str, ServiceNamespaceConfig]]:
+) -> List[Tuple[str, ServiceNamespaceConfig]]:
     try:
         system_paasta_config = load_system_paasta_config()
         if not cluster:

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -75,6 +75,7 @@ class LongRunningServiceConfigDict(InstanceConfigDict, total=False):
     bounce_start_deadline: float
     bounce_margin_factor: float
     should_ping_for_unhealthy_pods: bool
+    weight: int
 
 
 # Defined here to avoid import cycles -- this gets used in bounce_lib and subclassed in marathon_tools.
@@ -369,6 +370,9 @@ class LongRunningServiceConfig(InstanceConfig):
 
     def get_should_ping_for_unhealthy_pods(self, default: bool) -> bool:
         return self.config_dict.get("should_ping_for_unhealthy_pods", default)
+
+    def get_weight(self) -> int:
+        return self.config_dict.get("weight", 10)
 
 
 class InvalidHealthcheckMode(Exception):

--- a/paasta_tools/marathon_tools.py
+++ b/paasta_tools/marathon_tools.py
@@ -1175,7 +1175,7 @@ def get_puppet_services_that_run_here() -> Dict[str, List[str]]:
 
 def get_puppet_services_running_here_for_nerve(
     soa_dir: str,
-) -> Sequence[Tuple[str, ServiceNamespaceConfig]]:
+) -> List[Tuple[str, ServiceNamespaceConfig]]:
     puppet_services = []
     for service, namespaces in sorted(get_puppet_services_that_run_here().items()):
         for namespace in namespaces:

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2441,6 +2441,7 @@ def test_get_kubernetes_services_running_here():
                 port=8888,
                 pod_ip="10.1.1.3",
                 registrations=[],
+                weight=10,
             )
         ]
 
@@ -2481,6 +2482,7 @@ def test_get_kubernetes_services_running_here_for_nerve():
                 port=8888,
                 pod_ip="10.1.1.1",
                 registrations=["kurupt.fm"],
+                weight=10,
             ),
             KubernetesServiceRegistration(
                 name="unkurupt",
@@ -2488,6 +2490,7 @@ def test_get_kubernetes_services_running_here_for_nerve():
                 port=8888,
                 pod_ip="10.1.1.1",
                 registrations=["unkurupt.garage"],
+                weight=10,
             ),
             KubernetesServiceRegistration(
                 name="kurupt",
@@ -2495,6 +2498,7 @@ def test_get_kubernetes_services_running_here_for_nerve():
                 port=8888,
                 pod_ip="10.1.1.1",
                 registrations=[],
+                weight=10,
             ),
         ]
 
@@ -2519,6 +2523,7 @@ def test_get_kubernetes_services_running_here_for_nerve():
                     "hacheck_ip": "10.1.1.1",
                     "service_ip": "10.1.1.1",
                     "port": 8888,
+                    "weight": 10,
                 },
             )
         ]
@@ -2537,6 +2542,7 @@ def test_get_kubernetes_services_running_here_for_nerve():
                     "service_ip": "10.1.1.1",
                     "port": 8888,
                     "extra_healthcheck_headers": {"X-Nerve-Check-IP": "10.1.1.1"},
+                    "weight": 10,
                 },
             )
         ]

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1602,19 +1602,24 @@ class TestKubernetesDeploymentConfig:
             termination_grace_period_seconds=termination_grace_period,
         )
         pod_spec_kwargs.update(spec_affinity)
+
+        expected_labels = {
+            "paasta.yelp.com/pool": "default",
+            "yelp.com/paasta_git_sha": "aaaa123",
+            "yelp.com/paasta_instance": mock_get_instance.return_value,
+            "yelp.com/paasta_service": mock_get_service.return_value,
+            "paasta.yelp.com/git_sha": "aaaa123",
+            "paasta.yelp.com/instance": mock_get_instance.return_value,
+            "paasta.yelp.com/service": mock_get_service.return_value,
+            "paasta.yelp.com/autoscaled": "false",
+            "registrations.paasta.yelp.com/kurupt.fm": "true",
+        }
+        if in_smtstk:
+            expected_labels["paasta.yelp.com/weight"] = "10"
+
         assert ret == V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                labels={
-                    "paasta.yelp.com/pool": "default",
-                    "yelp.com/paasta_git_sha": "aaaa123",
-                    "yelp.com/paasta_instance": mock_get_instance.return_value,
-                    "yelp.com/paasta_service": mock_get_service.return_value,
-                    "paasta.yelp.com/git_sha": "aaaa123",
-                    "paasta.yelp.com/instance": mock_get_instance.return_value,
-                    "paasta.yelp.com/service": mock_get_service.return_value,
-                    "paasta.yelp.com/autoscaled": "false",
-                    "registrations.paasta.yelp.com/kurupt.fm": "true",
-                },
+                labels=expected_labels,
                 annotations={
                     "smartstack_registrations": '["kurupt.fm"]',
                     "paasta.yelp.com/routable_ip": routable_ip,
@@ -3688,7 +3693,7 @@ def test_warning_big_bounce_routable_pod():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "configf46d563a"
+            == "config1404b38f"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every smartstack-registered service to bounce!"
 
 

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -920,11 +920,15 @@ class TestMarathonTools:
             "paasta_tools.marathon_tools.load_service_namespace_config",
             autospec=True,
             return_value={"ten": 10},
+        ), mock.patch(
+            "multiprocessing.cpu_count",
+            return_value=13,
+            autospec=True,
         ):
             info = marathon_tools.get_classic_service_information_for_nerve(
                 "no_water", "we_are_the_one"
             )
-            assert info == ("no_water.main", {"ten": 10, "port": 101})
+            assert info == ("no_water.main", {"ten": 10, "port": 101, "weight": 13})
 
     def test_get_puppet_services_that_run_here(self):
         with mock.patch(


### PR DESCRIPTION
For PEREL-3176, this should let me run two sets of pods simultaneously in the same nerve namespace, with different sizes (cpus, number of workers) but also different weights.

This should let us do side-by-side comparisons of different sizes of containers, while keeping their relative traffic levels the same. (e.g. bigger pods would get more traffic, so that percent utilization is the same for both sizes.)

Corresponding configure_nerve PR: https://github.com/Yelp/nerve-tools/pull/96