### PR TITLE
Added VS code debug settings for paasta - CIPXIDEAS-209

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,3 +120,7 @@ swagger-validate:
 		yelp/openapi-generator-cli:20201026 \
 		validate \
 		-i paasta_tools/api/api_docs/swagger.json
+
+.PHONY: my_life_easier
+my_life_easier:
+	.paasta/bin/python paasta_tools/contrib/ide_helper.py

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,6 @@ swagger-validate:
 		validate \
 		-i paasta_tools/api/api_docs/swagger.json
 
-.PHONY: my_life_easier
-my_life_easier:
+.PHONY: vscode_settings
+vscode_settings:
 	.paasta/bin/python paasta_tools/contrib/ide_helper.py

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ to build a cohesive PaaS. It is not a turn-key PaaS solution.
 See the [getting started](http://paasta.readthedocs.io/en/latest/installation/getting_started.html)
 documentation for how to deploy PaaSTA.
 
+## Debugging PaaSTA (in VS Code)
+
+To debug PaaSTA in VS Code, please refer to the internal PaaSTA wiki page "[Debugging PaaSTA (in VS Code)](https://y.yelpcorp.com/paasta-vscode)".
+
 ## Documentation
 
 Read the documentation at [Read the Docs](http://paasta.readthedocs.io/en/latest/).

--- a/paasta_tools/contrib/ide_helper.py
+++ b/paasta_tools/contrib/ide_helper.py
@@ -1,0 +1,163 @@
+import json
+import os
+from typing import Any
+from typing import Dict
+
+
+def merge_vscode_settings(file: str, setting_dict: Dict[str, Any]) -> None:
+    os.makedirs("./.vscode", exist_ok=True)
+
+    json_path = os.path.join("./.vscode", file)
+    # first checks if the file exists
+    # if it does then load the file content as json into settings
+    # if it doesn't exist then set settings to empty
+    if os.path.exists(json_path):
+        with open(json_path, mode="r") as settings_file:
+            settings = json.load(settings_file)
+    else:
+        settings = {}
+
+    # update settings with the default configurations we want each file to have
+    settings.update(setting_dict)
+
+    with open(json_path, mode="w") as settings_file:
+        json.dump(settings, settings_file, indent=2)
+
+
+def install_vscode_support() -> None:
+    paasta_schema_settings = {
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "tox test",
+                "type": "python",
+                "request": "launch",
+                "cwd": "${workspaceFolder}",
+                "console": "integratedTerminal",
+                "python": "${workspaceFolder}/.paasta/bin/python",
+                "program": "${workspaceFolder}/.paasta/bin/tox",
+                "subProcess": True,
+                "args": ["-e", "py37-linux,docs,mypy,tests"],
+            },
+            {
+                "name": "paasta cli",
+                "cwd": "${workspaceFolder}",
+                "python": "${workspaceFolder}/.tox/py37-linux/bin/python",
+                "type": "python",
+                "request": "launch",
+                "module": "paasta_tools.cli.cli",
+            },
+            {
+                "name": "paasta rollback",
+                "cwd": "${workspaceFolder}",
+                "python": "${workspaceFolder}/.tox/py37-linux/bin/python",
+                "type": "python",
+                "request": "launch",
+                "module": "paasta_tools.cli.cli",
+                "args": [
+                    "rollback",
+                    "--service",
+                    "katamari_test_service",
+                    "--deploy-group",
+                    "dev.canary",
+                    "--commit",
+                    "fa7f2023c84736bd05201ef96ebd3c3fed6ab903",  # pragma: whitelist secret
+                ],
+            },
+            {
+                "name": "paasta mark-for-deployment",
+                "cwd": "${workspaceFolder}",
+                "python": "${workspaceFolder}/.tox/py37-linux/bin/python",
+                "type": "python",
+                "request": "launch",
+                "module": "paasta_tools.cli.cli",
+                "args": [
+                    "mark-for-deployment",
+                    "--service",
+                    "katamari_test_service",
+                    "--deploy-group",
+                    "dev.canary",
+                    "--commit",
+                    "224173aca322207994e655c4316ddb16f00eaab7",  # pragma: whitelist secret
+                    "--wait-for-deployment",
+                ],
+            },
+            {
+                "name": "paasta status",
+                "cwd": "${workspaceFolder}",
+                "python": "${workspaceFolder}/.tox/py37-linux/bin/python",
+                "type": "python",
+                "request": "launch",
+                "module": "paasta_tools.cli.cli",
+                "args": [
+                    "status",
+                    "--service",
+                    "katamari_test_service",
+                    "--clusters",
+                    "norcal-devc",
+                    "--instance",
+                    "canary",
+                ],
+            },
+            {
+                "name": "paasta logs",
+                "cwd": "${workspaceFolder}",
+                "python": "${workspaceFolder}/.tox/py37-linux/bin/python",
+                "type": "python",
+                "request": "launch",
+                "module": "paasta_tools.cli.cli",
+                "args": [
+                    "logs",
+                    "--service",
+                    "katamari_test_service",
+                    "--cluster",
+                    "norcal-devc",
+                    "--instance",
+                    "canary",
+                ],
+            },
+            {
+                "name": "paasta validate",
+                # This command has to be ran from inside the service repo in yelpsoa-configs
+                "cwd": "${userHome}/pg/yelpsoa-configs/",
+                "python": "${workspaceFolder}/.tox/py37-linux/bin/python",
+                "type": "python",
+                "request": "launch",
+                "module": "paasta_tools.cli.cli",
+                "args": ["validate", "--service", "katamari_test_service"],
+            },
+            {
+                # 1) Follow step 1 in "Running the PaaSTA HTTP API Locally" wiki
+                # 2) Run this "paasta API" test to debug paasta API
+                # 3) Run client command, e.g. PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_for_development/  .tox/py37-linux/bin/python paasta_tools/cli/cli.py status --clusters norcal-devc --service katamari_test_service
+                "name": "paasta API",
+                "cwd": "${workspaceFolder}",
+                "python": "${workspaceFolder}/.tox/py37-linux/bin/python",
+                "type": "python",
+                "request": "launch",
+                "module": "paasta_tools.run-paasta-api-in-dev-mode",
+                "env": {
+                    "KUBECONFIG": "./etc_paasta_for_development/admin.conf",
+                    "PAASTA_SYSTEM_CONFIG_DIR": "./etc_paasta_for_development/",
+                    "PAASTA_TEST_CLUSTER": "norcal-devc",
+                    "PYDEVD_USE_CYTHON": "NO",
+                    "PYTHONUNBUFFERED": "1",
+                },
+            },
+        ],
+    }
+    merge_vscode_settings("launch.json", paasta_schema_settings)
+    recommended_extensions = {
+        "recommendations": [
+            "redhat.vscode-yaml",
+            "ms-python.python",
+            "ms-python.vscode-pylance",
+            "ms-vscode.makefile-tools",
+        ]
+    }
+    merge_vscode_settings("extensions.json", recommended_extensions)
+    print("VS Code IDE Helpers installed")
+
+
+if __name__ == "__main__":
+    install_vscode_support()


### PR DESCRIPTION
### Purpose of PR
Added debugging settings in VS Code for some PaaSTA CLI commands and the PaaSTA API via a make target.

More specifically I added debugging settings for running tests, the paasta API and the following paasta CLI commands:

- logs
- status
- validate
- rollback
- mfd

The make target is called ``vscode_settings`` which set launch.json with default debugging configurations for the PaaSTA codebase and adds a list of recommended extensions to the extensions.json file.

I also added **Debugging** section in PaaSTA README.

### Testing

I tested each CLI command by running it with a test service ``katamari_test_service``. I tested paasta api by following the steps below:

1. Ran ``make vscode_settings`` to add the launch.json and extension.json files.
2. Running the paasta api test in debugger to create the etc_paasta_for_development directory.
3. Copied the script in "Running the PaaSTA HTTP API Locally" wiki in etc_paasta_for_development directory.
4. Ran the script with ``norcal-devc`` cluster
5. Ran the paasta api test again in debugger
6. Ran a paasta CLI command to test it with the api server:
```
(py37-linux) emanelsabban@dev55-uswest1adevc:~/pg/paasta$ PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_for_development/  .tox/py37-linux/bin/python paasta_tools/cli/cli.py status --clusters norcal-devc --service katamari_test_service


katamari_test_service.main in norcal-devc
    Git sha:    e58c66df (desired)
    State: Running
    Running versions:
      Rerun with -v to see all replicas
      e58c66df - Started 2022-08-05 19:00:01 (26 days ago)
        Replica States: 9 Healthy


katamari_test_service.canary in norcal-devc
    Git sha:    614c0abd (desired)
    State: Running
    Running versions:
      Rerun with -v to see all replicas
      614c0abd - Started 2022-08-31 14:07:54 (21 hours ago)
        Replica States: 1 Healthy


katamari_test_service.load_generator in norcal-devc
    Git sha:    e58c66df (desired)
    State: Running
    Running versions:
      Rerun with -v to see all replicas
      e58c66df - Started 2022-07-28 06:10:07 (a month ago)
        Replica States: 3 Healthy
```
