### PR TITLE
Run ci github actions workflow on v*.* tags as well as master.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*.*
   pull_request:
   release:
 


### PR DESCRIPTION
Without this, it seems like even though there was a tag pointing at master for [this actions run](https://github.com/Yelp/paasta/actions/runs/2981987092), the conditional failed because github.ref was `refs/heads/master` instead of the tag.