### PR TITLE
Update last few references to sha-only versions in mark-for-deployment

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1207,16 +1207,16 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
 
     def send_manual_rollback_instructions(self) -> None:
         if self.deployment_version != self.old_deployment_version:
+            extra_rollback_args = ""
+            if self.old_deployment_version.image_version:
+                extra_rollback_args = (
+                    f" --image-version {self.old_deployment_version.image_version}"
+                )
             message = (
                 "If you need to roll back manually, run: "
                 f"`paasta rollback --service {self.service} --deploy-group {self.deploy_group} "
-                f"--commit {self.old_git_sha}`"
+                f"--commit {self.old_git_sha}{extra_rollback_args}`"
             )
-            if self.old_deployment_version.image_version:
-                message += (
-                    f" --image-version {self.old_deployment_version.image_version}"
-                )
-
             self.update_slack_thread(message)
             print(message)
 


### PR DESCRIPTION
We had a few UI components that still only reported git sha during a bounce, even if we were bouncing to/from a version w/ no-commits/automated redeploys enabled.

This updates the last few components, including slack button text, which must remain <76 characters long and even then, may truncate at 30 characters ([docs](https://api.slack.com/reference/block-kit/block-elements#button__fields)).  In these situations, given we have potential plans to make `image_version` potentially even longer, it seemed prudent to just set these to `old version`/`new version` strings and allow the full versions be included in other slack messages, given we are only updating to one version during these interactive deploys.

Resulting slack thread looks something like https://fluffy.yelpcorp.com/i/mvMlDV8ZD3rv3ktbZhBVTjWbcPQ7CHRD.html

Note that until no-commits are enabled for a deploy group, these buttons should all still show the short git sha, since that is only 8 chars and will always fit.

This change also fixes a minor issue when displaying the `paasta rollback` command in slack: 
Old: https://fluffy.yelpcorp.com/i/XfJ02zZ8jSbTmKlPtRpJVSPdbxGmHBZG.png
New: https://fluffy.yelpcorp.com/i/rPS5fp32FVXbHwt9kQCr5w1JVSNr5l9K.png