### PR TITLE
Take in commit for get-image-version

### DIFF
--- a/paasta_tools/cli/cmds/get_image_version.py
+++ b/paasta_tools/cli/cmds/get_image_version.py
@@ -56,6 +56,12 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
     arg_service.completer = lazy_choices_completer(list_services)  # type: ignore
     parser.add_argument(
+        "-c",
+        "--commit",
+        help="Commit to be used with generated image version",
+        required=True,
+    )
+    parser.add_argument(
         "-y",
         "--soa-dir",
         help="A directory from which soa-configs should be read",
@@ -99,14 +105,15 @@ def should_generate_new_image_version(old: str, new: str, max_age: int) -> bool:
     return True
 
 
-def get_latest_image_version(deployments: DeploymentsJsonV2Dict) -> str:
+def get_latest_image_version(deployments: DeploymentsJsonV2Dict, commit: str) -> str:
     image_version = None
     # Image versions start with sortable timestamp
+    # We only care about deployments for this sha; otherwise we will generate a new image_version
     sorted_image_versions = sorted(
         [
             deployment.get("image_version")
             for deployment in deployments["deployments"].values()
-            if deployment.get("image_version")
+            if deployment.get("image_version") and deployment.get("git_sha") == commit
         ],
         reverse=True,
     )
@@ -143,7 +150,9 @@ def paasta_get_image_version(args: argparse.Namespace) -> int:
 
     # get latest image_version of any deploy group from deployments.json
     deployments = load_v2_deployments_json(service, soa_dir)
-    latest_image_version = get_latest_image_version(deployments.config_dict)
+    latest_image_version = get_latest_image_version(
+        deployments.config_dict, commit=args.commit
+    )
 
     if should_generate_new_image_version(
         old=latest_image_version, new=new_image_version, max_age=args.max_age


### PR DESCRIPTION
Currently we are using `paasta get-image-version` to determine what image_version to use for a particular deploy.

Right now, we would re-use the latest image_version from the latest deploy_group with no-commits enabled, but if we are performing a new deploy due to a code change, we will want to generate a new image_version each time.

This updates get-image-version to only get the 'latest' image_version if the passed commit is the same as the deployment's git_sha.

Manually running this shows the tool behaves as expected:
```
$ paasta get-image-version -s compute-infra-test-service -c c4ac93a98809383a275df749318c5e04524fc3ab # a sha already used in a deploy, with image_version 20220906T174732
20220906T174732
$ paasta get-image-version -s compute-infra-test-service -c abcabc # passed sha does not match, generate a new one
Error: hit an exception expected string or bytes-like object checking image version, will create new version # this goes to stderr, due to being unable to find a 'latest' image_version with this sha
20220906T181830 
$ paasta get-image-version -s paasta-contract-monitor -c abcabc
Automated redeploys not enabled for paasta-contract-monitor, returning no image_version
```