### PR TITLE
generate release notes now that we create releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/v')
         with:
+          generate_release_notes: true
           files: |
             dist/paasta-tools_*.deb
           fail_on_unmatched_files: true


### PR DESCRIPTION
Very minor change, but we might as well use the github generated changelogs in releases (feel free to merge this PR)