### PR TITLE
Build and publish xenial debs for github actions, so itest_xenial in …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dist: [bionic, jammy]
+        dist: [xenial, bionic, jammy]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
…nerve-tools can pass.


https://yelp.slack.com/archives/CCYF30A1K/p1662684940767559