### PR TITLE
Delete support for using host network in k8s

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -573,9 +573,6 @@
                     "maximum": 1000000,
                     "exclusiveMinimum": false
                 },
-                "net": {
-                    "type": "string"
-                },
                 "container_port": {
                     "type": "number"
                 },


### PR DESCRIPTION
This was never plumbed through for k8s and we don't seem to actually need it, so let's prevent folks from adding a misleading config option that will actually noop

NB: we could support this, but it's pretty insecure so until someone has a good reason to need this - we can punt on that.