### PR TITLE
COMPINFRA-1495, add yelp.com/owner label to pods

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1844,7 +1844,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "paasta.yelp.com/git_sha": git_sha,
             "paasta.yelp.com/autoscaled": str(self.is_autoscaling_enabled()).lower(),
             "paasta.yelp.com/pool": self.get_pool(),
-            "yelp.com/owner": self.get_team(),
+            "yelp.com/owner": "compute_infra",
         }
         if service_namespace_config.is_in_smartstack():
             labels["paasta.yelp.com/weight"] = str(self.get_weight())

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -326,6 +326,7 @@ KubePodLabels = TypedDict(
         "sidecar.istio.io/inject": str,
         "paasta.yelp.com/pool": str,
         "paasta.yelp.com/weight": str,
+        "yelp.com/owner": str,
     },
     total=False,
 )
@@ -1843,6 +1844,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "paasta.yelp.com/git_sha": git_sha,
             "paasta.yelp.com/autoscaled": str(self.is_autoscaling_enabled()).lower(),
             "paasta.yelp.com/pool": self.get_pool(),
+            "yelp.com/owner": self.get_team(),
         }
         if service_namespace_config.is_in_smartstack():
             labels["paasta.yelp.com/weight"] = str(self.get_weight())

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1844,7 +1844,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "paasta.yelp.com/git_sha": git_sha,
             "paasta.yelp.com/autoscaled": str(self.is_autoscaling_enabled()).lower(),
             "paasta.yelp.com/pool": self.get_pool(),
-            "yelp.com/owner": "compute_infra",
+            "yelp.com/owner": "compute_infrastructure_platform_experience",
         }
         if service_namespace_config.is_in_smartstack():
             labels["paasta.yelp.com/weight"] = str(self.get_weight())

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1844,7 +1844,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "paasta.yelp.com/git_sha": git_sha,
             "paasta.yelp.com/autoscaled": str(self.is_autoscaling_enabled()).lower(),
             "paasta.yelp.com/pool": self.get_pool(),
-            "yelp.com/owner": "compute_infrastructure_platform_experience",
+            "yelp.com/owner": "compute_infra_platform_experience",
         }
         if service_namespace_config.is_in_smartstack():
             labels["paasta.yelp.com/weight"] = str(self.get_weight())

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1613,7 +1613,7 @@ class TestKubernetesDeploymentConfig:
             "paasta.yelp.com/service": mock_get_service.return_value,
             "paasta.yelp.com/autoscaled": "false",
             "registrations.paasta.yelp.com/kurupt.fm": "true",
-            "yelp.com/owner": "compute_infra",
+            "yelp.com/owner": "compute_infrastructure_platform_experience",
         }
         if in_smtstk:
             expected_labels["paasta.yelp.com/weight"] = "10"

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -3648,7 +3648,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config2cded293"
+            == "configd0fb245f"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 
@@ -3694,7 +3694,7 @@ def test_warning_big_bounce_routable_pod():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "configb118556c"
+            == "configce04911e"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every smartstack-registered service to bounce!"
 
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1613,6 +1613,7 @@ class TestKubernetesDeploymentConfig:
             "paasta.yelp.com/service": mock_get_service.return_value,
             "paasta.yelp.com/autoscaled": "false",
             "registrations.paasta.yelp.com/kurupt.fm": "true",
+            "yelp.com/owner": "compute_infra",
         }
         if in_smtstk:
             expected_labels["paasta.yelp.com/weight"] = "10"

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -3647,7 +3647,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config2c177d7a"
+            == "config2cded293"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 
@@ -3693,7 +3693,7 @@ def test_warning_big_bounce_routable_pod():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config1404b38f"
+            == "configb118556c"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every smartstack-registered service to bounce!"
 
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -3648,7 +3648,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config37a04aac"
+            == "config80007736"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 
@@ -3694,7 +3694,7 @@ def test_warning_big_bounce_routable_pod():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config07f16e13"
+            == "config81e5b468"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every smartstack-registered service to bounce!"
 
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1613,7 +1613,7 @@ class TestKubernetesDeploymentConfig:
             "paasta.yelp.com/service": mock_get_service.return_value,
             "paasta.yelp.com/autoscaled": "false",
             "registrations.paasta.yelp.com/kurupt.fm": "true",
-            "yelp.com/owner": "compute_infrastructure_platform_experience",
+            "yelp.com/owner": "compute_infra_platform_experience",
         }
         if in_smtstk:
             expected_labels["paasta.yelp.com/weight"] = "10"

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -3648,7 +3648,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "configd0fb245f"
+            == "config37a04aac"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 
@@ -3694,7 +3694,7 @@ def test_warning_big_bounce_routable_pod():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "configce04911e"
+            == "config07f16e13"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every smartstack-registered service to bounce!"
 
 


### PR DESCRIPTION
## Description 
Pods in paasta namespace do not have the yelp.com/owner label, this PR adds those

To fulfil  the project - https://yelpwiki.yelpcorp.com/display/COMPUTE/Enforce+PaaSTA+workload+contract we need the labels on pods

This PR adds `compute_infrastructure_platform_experience ` as the value of the label `yelp.com/owner` for pods, the pods already have the name of the service running as the value of the label - `paasta.yelp.com/service`

## Investigation

```sh
akshaysha@dev56-uswest1adevc:~$ kubectl-pnw-prod get pods --all-namespaces -L yelp.com/owner
INFO: You are using an Okta authenticated kubectl wrapper
NAMESPACE                  NAME                                                                                                                                                     READY   STATUS                       RESTARTS   AGE     OWNER


paasta                     abu-main-568b9745b-sx89n                                                                                                                                 1/1     Running                      0          8d      
paasta                     access--hub-canary-6cb7c4fb79-mdb7m                                                                                                                      2/2     Running                      0          16h     
paasta                     access--hub-main-777458c679-vdkmd                                                                                                                        3/3     Running                      0          34h     
paasta                     actionable--alerting--service-main-756cc85b5-42hgm                                                                                                       1/1     Running                      0          120m    
paasta                     ad--admin-canary-7b69f498f-24csb                                                                                                                         2/2     Running                      1          2d2h    
paasta                     ad--admin-main-77d785bf79-gwvtw                                                                                                                          2/2     Running                      0          3h21m   
paasta                     ad--admin-main-77d785bf79-nv86w                                                                                                                          2/2     Running                      0          2d5h    
paasta                     ad--campaign--batch-bulk--csv--create--custom--syndicationfdkzs                                                                                          1/1     Running                      0          3h22m   
paasta                     ad--campaign--batch-bulk--csv--create--custom--syndicationfnb47                                                                                          1/1     Running                      0          85m     
paasta                     ad--campaign--batch-call--tracking--sync--ad--driven--task9xd75                                                                                          1/1     Running                      0          3h22m   
paasta                     ad--campaign--batch-call--tracking--sync--ad--driven--taskclk5l                                                                                          1/1     Running                      0          3h31m   
paasta                     ad--campaign--batch-call--tracking--sync--ad--driven--taskg54jd                                                                                          1/1     Running                      0          4h27m   
paasta                     ad--campaign--batch-call--tracking--sync--ad--driven--taskgmfzn                                                                                          1/1     Running                      0          81m     
paasta                     ad--campaign--batch-call--tracking--sync--ad--driven--taskhqjvr                                                                                          1/1     Running                      0          3h10m   
paasta                     ad--campaign--batch-call--tracking--sync--ad--driven--tasknlppb                                                                                          1/1     Running                      0          3h14m   
paasta                     ad--campaign--batch-call--tracking--sync--ad--driven--taskp9szx                                                                                          1/1     Running                      0          111m    
paasta                     ad--campaign--batch-call--tracking--sync--ad--driven--taskpfhxk                                                                                          1/1     Running                      0          3h5m    
paasta                     ad--campaign--batch-call--tracking--sync--ad--driven--taskq5mfl                                                                                          1/1     Running                      0          4h25m   
paasta                     ad--campaign--batch-call--tracking--sync--ad--driven--taskw55hj                                                                                          1/1     Running                      0          3h21m   
paasta                     ad--campaign--batch-custom--ads--sync--blacklisted--search5vm9b                                                                                          1/1     Running                      0          4h27m   
paasta                     ad--campaign--batch-custom--ads--sync--blacklisted--searchdb85b                                                                                          1/1     Running                      0          3h14m   
paasta                     ad--campaign--batch-custom--ads--sync--blacklisted--searchdqstk                                                                                          1/1     Running                      0          81m     
paasta                     ad--campaign--batch-custom--ads--sync--blacklisted--searchg5d9f                                                                                          1/1     Running                      0          4h27m   
paasta                     ad--campaign--batch-custom--ads--sync--blacklisted--searchgdlgk                                                                                          1/1     Running                      0          3h5m    
paasta                     ad--campaign--batch-custom--ads--sync--blacklisted--searchprjjl                                                                                          1/1     Running                      0          3h21m   
paasta                     ad--campaign--batch-custom--ads--sync--blacklisted--searchqkscj                                                                                          1/1     Running                      0          111m    
paasta                     ad--campaign--batch-custom--ads--sync--blacklisted--searchql9l2                                                                                          1/1     Running                      0          138m    
paasta                     ad--campaign--batch-custom--ads--sync--blacklisted--searchs79z5                                                                                          1/1     Running                      0          3h31m   
paasta                     ad--campaign--batch-custom--ads--sync--blacklisted--searchtvpk9                                                                                          1/1     Running                      0          3h22m   
paasta                     ad--campaign--batch-custom--ads--sync--boosted--keywords--2xl8d                                                                                          1/1     Running                      0          3h5m    
paasta                     ad--campaign--batch-custom--ads--sync--boosted--keywords--46ljn                                                                                          1/1     Running                      0          3h22m   
paasta                     ad--campaign--batch-custom--ads--sync--boosted--keywords--5dnh7                                                                                          1/1     Running                      0          3h31m   
paasta                     ad--campaign--batch-custom--ads--sync--boosted--keywords--94nrw                                                                                          1/1     Running                      0          4h27m   
paasta                     ad--campaign--batch-custom--ads--sync--boosted--keywords--bqblz                                                                                          1/1     Running                      0          138m    
paasta                     ad--campaign--batch-custom--ads--sync--boosted--keywords--drl98                                                                                          1/1     Running                      0          85m     
paasta                     ad--campaign--batch-custom--ads--sync--boosted--keywords--hnfx9                                                                                          1/1     Running                      0          4h25m   
paasta                     ad--campaign--batch-custom--ads--sync--boosted--keywords--lsk6v                                                                                          1/1     Running                      0          81m     
paasta                     ad--campaign--batch-custom--ads--sync--boosted--keywords--qtv7q                                                                                          1/1     Running                      0          3h10m   
paasta                     ad--campaign--batch-custom--ads--sync--boosted--keywords--zftxb                                                                                          1/1     Running                      0          3h21m   
paasta                     ad--campaign--batch-custom--ads--sync--location--targeting4kfc9                                                                                          1/1     Running                      0          3h31m   
```

## Test Passing
```sh
(py37-linux) akshaysha@dev56-uswest1adevc:~/playground/paasta$ make test
if [ "YELP" != "YELP" ]; then \
	.paasta/bin/tox -i https://pypi.yelpcorp.com/simple -e tests; \
else \
	.paasta/bin/tox -i https://pypi.yelpcorp.com/simple -e tests-yelpy; \
fi

================================================================================================================== 4 passed in 0.94 seconds ==================================================================================================================
tests-yelpy runtests: commands[1] | pre-commit install -f --install-hooks
pre-commit installed at .git/hooks/pre-commit
tests-yelpy runtests: commands[2] | pre-commit run --all-files
Trim Trailing Whitespace...................................................Passed
Fix End of Files...........................................................Passed
Check docstring is first...................................................Passed
Check JSON.................................................................Passed
Check Yaml.................................................................Passed
Debug Statements (Python)..................................................Passed
Tests should end in _test.py...............................................Passed
Fix requirements.txt.......................................................Passed
Fix python encoding pragma.................................................Passed
Pretty format JSON.........................................................Passed
Reorder python imports.....................................................Passed
pyupgrade..................................................................Passed
black......................................................................Passed
flake8.....................................................................Passed
Detect secrets.............................................................Passed
mock.patch enforce autospec................................................Passed
check that oapi.yaml is updated if paastaapi changes.......................Passed
tests-yelpy runtests: commands[3] | py.test tests
==================================================================================================================== test session starts =====================================================================================================================
platform linux -- Python 3.7.5, pytest-3.3.1, py-1.5.2, pluggy-0.6.0
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/nail/home/akshaysha/playground/paasta/.hypothesis/examples')
rootdir: /nail/home/akshaysha/playground/paasta, inifile:
plugins: asyncio-0.8.0, pyfakefs-4.1.0, hypothesis-3.71.10
collected 2153 items                                                                                                                                                                                                                                         

tests/test_adhoc_tools.py ..                                                                                                                                                                                                                           [  0%]
tests/test_apply_external_resources.py ....                                                                                                                                                                                                            [  0%]
tests/test_async_utils.py .......                                                                                                                                                                                                                      [  0%]
tests/test_autoscale_all_services.py .                                                                                                                                                                                                                 [  0%]
tests/test_bounce_lib.py ...................................................                                                                                                                                                                           [  3%]
tests/test_check_flink_services_health.py ......                                                                                                                                                                                                       [  3%]
tests/test_check_kubernetes_services_replication.py ....                                                                                                                                                                                               [  3%]
tests/test_check_marathon_services_replication.py .......                                                                                                                                                                                              [  3%]
tests/test_check_oom_events.py ........                                                                                                                                                                                                                [  4%]
tests/test_check_service_replication_tools.py ...                                                                                                                                                                                                      [  4%]
tests/test_check_spark_jobs.py ..........                                                                                                                                                                                                              [  4%]
tests/test_cleanup_kubernetes_jobs.py .......                                                                                                                                                                                                          [  5%]
tests/test_config_utils.py .........................                                                                                                                                                                                                   [  6%]
tests/test_delete_kubernetes_deployments.py ..                                                                                                                                                                                                         [  6%]
tests/test_deployment_utils.py ...                                                                                                                                                                                                                     [  6%]
tests/test_docker_wrapper.py ...................................................................................                                                                                                                                       [ 10%]
tests/test_drain_lib.py ...........                                                                                                                                                                                                                    [ 10%]
tests/test_envoy_tools.py ...........                                                                                                                                                                                                                  [ 11%]
tests/test_firewall.py .....................                                                                                                                                                                                                           [ 12%]
tests/test_firewall_logging.py ............                                                                                                                                                                                                            [ 12%]
tests/test_firewall_update.py ..........                                                                                                                                                                                                               [ 13%]
tests/test_flink_tools.py .......                                                                                                                                                                                                                      [ 13%]
tests/test_generate_deployments_for_service.py ....                                                                                                                                                                                                    [ 13%]
tests/test_generate_services_file.py ...                                                                                                                                                                                                               [ 14%]
tests/test_generate_services_yaml.py .                                                                                                                                                                                                                 [ 14%]
tests/test_hacheck.py ..                                                                                                                                                                                                                               [ 14%]
tests/test_iptables.py .........................                                                                                                                                                                                                       [ 15%]
tests/test_kubernetes_tools.py ..................................................................................................................................................................................                                      [ 23%]
tests/test_list_kubernetes_service_instances.py ...                                                                                                                                                                                                    [ 23%]
tests/test_list_marathon_service_instances.py ........                                                                                                                                                                                                 [ 24%]
tests/test_long_running_service_tools.py ......................                                                                                                                                                                                        [ 25%]
tests/test_mac_address.py ....                                                                                                                                                                                                                         [ 25%]
tests/test_marathon_dashboard.py ..                                                                                                                                                                                                                    [ 25%]
tests/test_marathon_tools.py ...........................................................................................................                                                                                                               [ 30%]
tests/test_mesos_maintenance.py .........................................................                                                                                                                                                              [ 33%]
tests/test_mesos_tools.py ..............................................                                                                                                                                                                               [ 35%]
tests/test_monitoring_tools.py .......................................                                                                                                                                                                                 [ 36%]
tests/test_native_mesos_scheduler.py ........                                                                                                                                                                                                          [ 37%]
tests/test_oom_logger.py .........                                                                                                                                                                                                                     [ 37%]
tests/test_paasta_cluster_boost.py ..                                                                                                                                                                                                                  [ 37%]
tests/test_paasta_execute_docker_command.py ........                                                                                                                                                                                                   [ 38%]
tests/test_paasta_maintenance.py ...........                                                                                                                                                                                                           [ 38%]
tests/test_paasta_metastatus.py ....                                                                                                                                                                                                                   [ 38%]
tests/test_paasta_service_config_loader.py .....                                                                                                                                                                                                       [ 39%]
tests/test_remote_git.py ........                                                                                                                                                                                                                      [ 39%]
tests/test_secret_tools.py ..........                                                                                                                                                                                                                  [ 39%]
tests/test_setup_istio_mesh.py .....                                                                                                                                                                                                                   [ 40%]
tests/test_setup_kubernetes_cr.py .......                                                                                                                                                                                                              [ 40%]
tests/test_setup_kubernetes_job.py .......                                                                                                                                                                                                             [ 40%]
tests/test_setup_prometheus_adapter_config.py ........................                                                                                                                                                                                 [ 41%]
tests/test_slack.py ..                                                                                                                                                                                                                                 [ 42%]
tests/test_smartstack_tools.py ..................                                                                                                                                                                                                      [ 42%]
tests/test_spark_tools.py .....                                                                                                                                                                                                                        [ 43%]
tests/test_task_processing.py .                                                                                                                                                                                                                        [ 43%]
tests/test_tron_tools.py .......................................................                                                                                                                                                                       [ 45%]
tests/test_utils.py ...........................................................................................................................................................................................                                        [ 54%]
tests/api/test_autoscaler.py ....                                                                                                                                                                                                                      [ 54%]
tests/api/test_client.py .                                                                                                                                                                                                                             [ 54%]
tests/api/test_flink.py ........                                                                                                                                                                                                                       [ 55%]
tests/api/test_instance.py ..............................................                                                                                                                                                                              [ 57%]
tests/api/test_marathon_dashboard_api.py .                                                                                                                                                                                                             [ 57%]
tests/api/test_pause_autoscaler.py ...                                                                                                                                                                                                                 [ 57%]
tests/api/test_resources.py .....                                                                                                                                                                                                                      [ 57%]
tests/api/test_service.py ..                                                                                                                                                                                                                           [ 57%]
tests/api/tweens/test_request_logger.py ......                                                                                                                                                                                                         [ 57%]
tests/autoscaling/test_autoscaling_service_lib.py .............................................                                                                                                                                                        [ 60%]
tests/autoscaling/test_ec2_fitness.py ......                                                                                                                                                                                                           [ 60%]
tests/autoscaling/test_forecasting.py ..                                                                                                                                                                                                               [ 60%]
tests/autoscaling/test_load_boost.py ...                                                                                                                                                                                                               [ 60%]
tests/autoscaling/test_pause_service_autoscaler.py .....                                                                                                                                                                                               [ 60%]
tests/cli/test_cmds_autoscale.py .                                                                                                                                                                                                                     [ 60%]
tests/cli/test_cmds_check.py .............................                                                                                                                                                                                             [ 62%]
tests/cli/test_cmds_cook_image.py .....                                                                                                                                                                                                                [ 62%]
tests/cli/test_cmds_get_image_version.py .......                                                                                                                                                                                                       [ 62%]
tests/cli/test_cmds_get_latest_deployment.py .....                                                                                                                                                                                                     [ 62%]
tests/cli/test_cmds_help.py ......................................                                                                                                                                                                                     [ 64%]
tests/cli/test_cmds_info.py ........                                                                                                                                                                                                                   [ 65%]
tests/cli/test_cmds_itest.py ...                                                                                                                                                                                                                       [ 65%]
tests/cli/test_cmds_list.py ..                                                                                                                                                                                                                         [ 65%]
tests/cli/test_cmds_list_deploy_queue.py ...                                                                                                                                                                                                           [ 65%]
tests/cli/test_cmds_local_run.py .................................................Unhandled exception in thread started by <bound method Thread._bootstrap of <Thread(Thread-11, started daemon 140416371390208)>>
........                                                                                                                                                             [ 68%]
tests/cli/test_cmds_logs.py ......................................................                                                                                                                                                                     [ 70%]
tests/cli/test_cmds_mark_for_deployment.py ................                                                                                                                                                                                            [ 71%]
tests/cli/test_cmds_mesh_status.py ..                                                                                                                                                                                                                  [ 71%]
tests/cli/test_cmds_metastatus.py ........                                                                                                                                                                                                             [ 71%]
tests/cli/test_cmds_pause_service_autoscaler.py .....                                                                                                                                                                                                  [ 72%]
tests/cli/test_cmds_performance_check.py ..                                                                                                                                                                                                            [ 72%]
tests/cli/test_cmds_push_to_registry.py ................                                                                                                                                                                                               [ 72%]
tests/cli/test_cmds_rollback.py .................                                                                                                                                                                                                      [ 73%]
tests/cli/test_cmds_secret.py .........                                                                                                                                                                                                                [ 74%]
tests/cli/test_cmds_spark_run.py ..........................................................                                                                                                                                                            [ 76%]
tests/cli/test_cmds_start_stop_restart.py ..................                                                                                                                                                                                           [ 77%]
tests/cli/test_cmds_status.py ..........................................................................................................................                                                                                               [ 83%]
tests/cli/test_cmds_sysdig.py .....                                                                                                                                                                                                                    [ 83%]
tests/cli/test_cmds_validate.py ............................................................................                                                                                                                                           [ 87%]
tests/cli/test_cmds_version.py .                                                                                                                                                                                                                       [ 87%]
tests/cli/test_cmds_wait_for_deployment.py ......................                                                                                                                                                                                      [ 88%]
tests/cli/test_utils.py ....................................                                                                                                                                                                                           [ 89%]
tests/cli/fsm/test_autosuggest.py ....                                                                                                                                                                                                                 [ 90%]
tests/contrib/test_get_running_task_allocation.py .                                                                                                                                                                                                    [ 90%]
tests/frameworks/test_adhoc_scheduler.py ...                                                                                                                                                                                                           [ 90%]
tests/frameworks/test_constraints.py ...                                                                                                                                                                                                               [ 90%]
tests/frameworks/test_native_scheduler.py ......                                                                                                                                                                                                       [ 90%]
tests/frameworks/test_task_store.py ....                                                                                                                                                                                                               [ 90%]
tests/instance/test_hpa_metrics_parser.py ...........                                                                                                                                                                                                  [ 91%]
tests/instance/test_kubernetes.py .............................                                                                                                                                                                                        [ 92%]
tests/kubernetes/application/test_controller_wrapper.py .............                                                                                                                                                                                  [ 93%]
tests/kubernetes/bin/test_kubernetes_remove_evicted_pods.py ........                                                                                                                                                                                   [ 93%]
tests/kubernetes/bin/test_paasta_cleanup_stale_nodes.py .....                                                                                                                                                                                          [ 93%]
tests/kubernetes/bin/test_paasta_secrets_sync.py .......                                                                                                                                                                                               [ 94%]
tests/mesos/test_cluster.py ...                                                                                                                                                                                                                        [ 94%]
tests/mesos/test_master.py .......                                                                                                                                                                                                                     [ 94%]
tests/metrics/test_metastatus_lib.py .................................................................                                                                                                                                                 [ 97%]
tests/metrics/test_metrics_lib.py ..........                                                                                                                                                                                                           [ 98%]
tests/monitoring/test_check_capacity.py ........                                                                                                                                                                                                       [ 98%]
tests/monitoring/test_check_marathon_has_apps.py ...                                                                                                                                                                                                   [ 98%]
tests/monitoring/test_check_mesos_active_frameworks.py ..                                                                                                                                                                                              [ 98%]
tests/monitoring/test_check_mesos_duplicate_frameworks.py ..                                                                                                                                                                                           [ 98%]
tests/monitoring/test_check_mesos_outdated_tasks.py .                                                                                                                                                                                                  [ 98%]
tests/monitoring/test_check_mesos_quorum.py ..                                                                                                                                                                                                         [ 98%]
tests/secret_providers/test_secret_providers.py ....                                                                                                                                                                                                   [ 99%]
tests/secret_providers/test_vault.py ........                                                                                                                                                                                                          [ 99%]
tests/tron/test_tron_client.py ..........                                                                                                                                                                                                              [100%]

================================================================================================================ 2153 passed in 22.34 seconds ================================================================================================================
__________________________________________________________________________________________________________________________ summary ___________________________________________________________________________________________________________________________
  tests-yelpy: commands succeeded
  congratulations :)
(py37-linux) akshaysha@dev56-uswest1adevc:~/playground/paasta$ 
```

