### PR TITLE
Adhoc spark runs use environment credentials provider.

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -847,9 +847,6 @@ def configure_and_run_docker_container(
             else:
                 raise
 
-    final_spark_submit_cmd_msg = f"Final command: {docker_cmd}"
-    print(PaastaColors.grey(final_spark_submit_cmd_msg))
-    log.info(final_spark_submit_cmd_msg)
     return run_docker_container(
         container_name=spark_conf["spark.app.name"],
         volumes=volumes,

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -49,7 +49,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.11.2
+service-configuration-lib >= 2.12.0
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.11.2
+service-configuration-lib==2.12.0
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -215,7 +215,6 @@ def mock_get_possible_launced_by_user_variable_from_env():
                 cmd="jupyter-lab",
                 aws_region="test-region",
                 mrjob=False,
-                disable_aws_credential_env_variables=False,
             ),
             {
                 "JUPYTER_RUNTIME_DIR": "/source/.jupyter",
@@ -230,7 +229,6 @@ def mock_get_possible_launced_by_user_variable_from_env():
                 mrjob=False,
                 spark_args="spark.history.fs.logDirectory=s3a://bucket",
                 work_dir="/first:/second",
-                disable_aws_credential_env_variables=False,
             ),
             {
                 "SPARK_LOG_DIR": "/second",
@@ -244,7 +242,6 @@ def mock_get_possible_launced_by_user_variable_from_env():
                 cmd="spark-submit job.py",
                 aws_region="test-region",
                 mrjob=True,
-                disable_aws_credential_env_variables=False,
             ),
             {},
         ),
@@ -282,28 +279,6 @@ def test_get_spark_env(
         **expected_aws,
     }
     assert spark_run.get_spark_env(args, spark_conf_str, aws, "1234") == expected_output
-
-
-def test_disable_aws_credential_env_variables(
-    mock_get_possible_launced_by_user_variable_from_env,
-):
-    args = argparse.Namespace(
-        cmd="spark-submit job.py",
-        aws_region="test-region",
-        disable_aws_credential_env_variables=True,
-    )
-    aws = ("access-key", "secret-key", "token")
-    expected_output = {
-        "PAASTA_LAUNCHED_BY": mock_get_possible_launced_by_user_variable_from_env.return_value,
-        "PAASTA_INSTANCE_TYPE": "spark",
-        "SPARK_USER": "root",
-        "SPARK_OPTS": mock.sentinel.spark_opts,
-        "AWS_DEFAULT_REGION": "test-region",
-    }
-    assert (
-        spark_run.get_spark_env(args, mock.sentinel.spark_opts, aws, "1234")
-        == expected_output
-    )
 
 
 @pytest.mark.parametrize(
@@ -542,7 +517,6 @@ class TestConfigureAndRunDockerContainer:
         args.nvidia = False
         args.enable_compact_bin_packing = False
         args.cluster_manager = cluster_manager
-        args.disable_aws_credential_env_variables = False
         args.docker_cpu_limit = False
         args.docker_memory_limit = False
         with mock.patch.object(
@@ -653,7 +627,6 @@ class TestConfigureAndRunDockerContainer:
         args.mrjob = False
         args.nvidia = False
         args.enable_compact_bin_packing = False
-        args.disable_aws_credential_env_variables = False
         args.cluster_manager = cluster_manager
         args.docker_cpu_limit = 3
         args.docker_memory_limit = "4g"
@@ -766,7 +739,6 @@ class TestConfigureAndRunDockerContainer:
         args.nvidia = False
         args.enable_compact_bin_packing = False
         args.cluster_manager = cluster_manager
-        args.disable_aws_credential_env_variables = False
         args.docker_cpu_limit = False
         args.docker_memory_limit = False
         with mock.patch.object(
@@ -1064,8 +1036,8 @@ def test_paasta_spark_run_bash(
         spark_args="spark.cores.max=100 spark.executor.cores=10",
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
         timeout_job_runtime="1m",
-        disable_temporary_credentials_provider=True,
         enable_dra=False,
+        aws_region="test-region",
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     spark_run.paasta_spark_run(args)
@@ -1103,7 +1075,7 @@ def test_paasta_spark_run_bash(
         extra_volumes=mock_get_instance_config.return_value.get_volumes.return_value,
         aws_creds=mock_get_aws_credentials.return_value,
         needs_docker_cfg=False,
-        auto_set_temporary_credentials_provider=False,
+        aws_region="test-region",
     )
     mock_spark_conf = mock_get_spark_conf.return_value
     mock_spark_conf["spark.sql.adaptive.enabled"] = "true"
@@ -1161,8 +1133,8 @@ def test_paasta_spark_run(
         spark_args="spark.cores.max=100 spark.executor.cores=10",
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
         timeout_job_runtime="1m",
-        disable_temporary_credentials_provider=True,
         enable_dra=True,
+        aws_region="test-region",
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     spark_run.paasta_spark_run(args)
@@ -1200,7 +1172,7 @@ def test_paasta_spark_run(
         extra_volumes=mock_get_instance_config.return_value.get_volumes.return_value,
         aws_creds=mock_get_aws_credentials.return_value,
         needs_docker_cfg=False,
-        auto_set_temporary_credentials_provider=False,
+        aws_region="test-region",
     )
     mock_configure_and_run_docker_container.assert_called_once_with(
         args,
@@ -1256,8 +1228,8 @@ def test_paasta_spark_run_pyspark(
         spark_args="spark.cores.max=100 spark.executor.cores=10",
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
         timeout_job_runtime="1m",
-        disable_temporary_credentials_provider=True,
         enable_dra=False,
+        aws_region="test-region",
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     spark_run.paasta_spark_run(args)
@@ -1295,7 +1267,7 @@ def test_paasta_spark_run_pyspark(
         extra_volumes=mock_get_instance_config.return_value.get_volumes.return_value,
         aws_creds=mock_get_aws_credentials.return_value,
         needs_docker_cfg=False,
-        auto_set_temporary_credentials_provider=False,
+        aws_region="test-region",
     )
     mock_configure_and_run_docker_container.assert_called_once_with(
         args,


### PR DESCRIPTION
Swap over to environment credentials provider from the temporary credentials provider.

This also allows us to drop several of the other options I had added which are no longer needed.