### PR TITLE
COMPINFRA-1050, COMPINFRA-1043: fix paasta status output to show full version if provided

### DIFF
--- a/paasta_tools/api/api_docs/oapi.yaml
+++ b/paasta_tools/api/api_docs/oapi.yaml
@@ -355,6 +355,9 @@ components:
         git_sha:
           description: Git sha of a service
           type: string
+        version:
+          description: Deployment Version of a service
+          type: string
         instance:
           description: Instance name
           type: string

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -684,10 +684,13 @@ def instance_status(request):
             )
             raise ApiFailure(error_message, 404)
 
-        instance_status["git_sha"] = version
+        instance_status["version"] = version.short_sha_repr()
+        # Kept for backwards compatibility
+        # TODO: Remove once all clients+clusters updated to use deploymentversion
+        instance_status["git_sha"] = version.sha[:8]
     else:
+        instance_status["version"] = ""
         instance_status["git_sha"] = ""
-
     try:
         if instance_type == "marathon":
             instance_status["marathon"] = marathon_instance_status(
@@ -909,9 +912,9 @@ def get_marathon_dashboard_links(marathon_clients, system_paasta_config):
 
 def get_deployment_version(
     actual_deployments: Mapping[str, str], cluster: str, instance: str
-) -> Optional[str]:
+) -> Optional[DeploymentVersion]:
     key = ".".join((cluster, instance))
-    return actual_deployments[key][:8] if key in actual_deployments else None
+    return actual_deployments[key] if key in actual_deployments else None
 
 
 @view_config(

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -911,7 +911,7 @@ def get_marathon_dashboard_links(marathon_clients, system_paasta_config):
 
 
 def get_deployment_version(
-    actual_deployments: Mapping[str, str], cluster: str, instance: str
+    actual_deployments: Mapping[str, DeploymentVersion], cluster: str, instance: str
 ) -> Optional[DeploymentVersion]:
     key = ".".join((cluster, instance))
     return actual_deployments[key] if key in actual_deployments else None

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -306,10 +306,10 @@ def paasta_status_on_api_endpoint(
         return 1
 
     if status.version and status.version != "":
-        output.append("    Version:    %s (desired)" % status.version)
+        output.append(f"    Version:    {status.version} (desired)")
     # TODO: Remove this when all clusters are returning status.version
     elif status.git_sha != "":
-        output.append("    Git sha:    %s (desired)" % status.git_sha)
+        output.append(f"    Git sha:    {status.git_sha} (desired)")
     instance_types = find_instance_types(status)
     if not instance_types:
         output.append(

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -72,6 +72,7 @@ from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.mesos_tools import format_tail_lines_for_mesos_task
 from paasta_tools.monitoring_tools import get_team
 from paasta_tools.monitoring_tools import list_teams
+from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.paastaapi.model.flink_job_details import FlinkJobDetails
 from paasta_tools.paastaapi.model.flink_jobs import FlinkJobs
 from paasta_tools.paastaapi.models import InstanceStatusKubernetesV2
@@ -81,13 +82,14 @@ from paasta_tools.paastaapi.models import KubernetesVersion
 from paasta_tools.tron_tools import TronActionConfig
 from paasta_tools.utils import compose_job_id
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import DeploymentVersion
 from paasta_tools.utils import format_table
+from paasta_tools.utils import get_deployment_version_from_dockerurl
 from paasta_tools.utils import get_soa_cluster_deploy_files
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import is_under_replicated
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
-from paasta_tools.utils import load_deployments_json
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import remove_ansi_escape_sequences
@@ -102,6 +104,16 @@ ALLOWED_INSTANCE_CONFIG: Sequence[Type[InstanceConfig]] = [
     AdhocJobConfig,
     MarathonServiceConfig,
     TronActionConfig,
+]
+
+# Tron instances are not included in deployments, so skip these InstanceConfigs
+DEPLOYMENT_INSTANCE_CONFIG: Sequence[Type[InstanceConfig]] = [
+    FlinkDeploymentConfig,
+    CassandraClusterDeploymentConfig,
+    KafkaClusterDeploymentConfig,
+    KubernetesDeploymentConfig,
+    AdhocJobConfig,
+    MarathonServiceConfig,
 ]
 
 InstanceStatusWriter = Callable[
@@ -234,35 +246,27 @@ def get_planned_deployments(service: str, soa_dir: str) -> Iterable[str]:
             yield f"{cluster}.{instance}"
 
 
-def list_deployed_clusters(
-    pipeline: Sequence[str], actual_deployments: Sequence[str]
-) -> Sequence[str]:
-    """Returns a list of clusters that a service is deployed to given
-    an input deploy pipeline and the actual deployments"""
-    deployed_clusters: List[str] = []
-    for namespace in pipeline:
-        cluster, instance = namespace.split(".")
-        if namespace in actual_deployments:
-            if cluster not in deployed_clusters:
-                deployed_clusters.append(cluster)
-    return deployed_clusters
-
-
-def get_actual_deployments(service: str, soa_dir: str) -> Mapping[str, str]:
-    deployments_json = load_deployments_json(service, soa_dir)
-    if not deployments_json:
+def get_actual_deployments(
+    service: str, soa_dir: str
+) -> Mapping[str, DeploymentVersion]:
+    """Given a service, return a dict of instances->DeploymentVersions"""
+    config_loader = PaastaServiceConfigLoader(service=service, soa_dir=soa_dir)
+    clusters = list_clusters(service=service, soa_dir=soa_dir)
+    actual_deployments = {}
+    for cluster in clusters:
+        for instance_type in DEPLOYMENT_INSTANCE_CONFIG:
+            for instance_config in config_loader.instance_configs(
+                cluster=cluster, instance_type_class=instance_type
+            ):
+                namespace = f"{cluster}.{instance_config.instance}"
+                actual_deployments[namespace] = get_deployment_version_from_dockerurl(
+                    instance_config.get_docker_image()
+                )
+    if not actual_deployments:
         print(
-            "Warning: it looks like %s has not been deployed anywhere yet!" % service,
+            f"Warning: it looks like {service} has not been deployed anywhere yet!",
             file=sys.stderr,
         )
-    # Create a dictionary of actual $service Jenkins deployments
-    actual_deployments = {}
-    for key, branch_dict in deployments_json.config_dict.items():
-        service, namespace = key.split(":")
-        if service == service:
-            value = branch_dict["docker_image"]
-            sha = value[value.rfind("-") + 1 :]
-            actual_deployments[namespace.replace("paasta-", "", 1)] = sha
     return actual_deployments
 
 
@@ -301,9 +305,11 @@ def paasta_status_on_api_endpoint(
         output.append(str(e))
         return 1
 
-    if status.git_sha != "":
+    if status.version and status.version != "":
+        output.append("    Version:    %s (desired)" % status.version)
+    # TODO: Remove this when all clusters are returning status.version
+    elif status.git_sha != "":
         output.append("    Git sha:    %s (desired)" % status.git_sha)
-
     instance_types = find_instance_types(status)
     if not instance_types:
         output.append(
@@ -2279,7 +2285,7 @@ def report_status_for_cluster(
     service: str,
     cluster: str,
     deploy_pipeline: Sequence[str],
-    actual_deployments: Mapping[str, str],
+    actual_deployments: Mapping[str, DeploymentVersion],
     instance_whitelist: Mapping[str, Type[InstanceConfig]],
     system_paasta_config: SystemPaastaConfig,
     lock: Lock,
@@ -2535,7 +2541,7 @@ def paasta_status(args) -> int:
     for cluster, service_instances in clusters_services_instances.items():
         for service, instances in service_instances.items():
             all_flink = all(i == FlinkDeploymentConfig for i in instances.values())
-            actual_deployments: Mapping[str, str]
+            actual_deployments: Mapping[str, DeploymentVersion]
             if all_flink:
                 actual_deployments = {}
             else:

--- a/paasta_tools/paasta_service_config_loader.py
+++ b/paasta_tools/paasta_service_config_loader.py
@@ -45,13 +45,13 @@ class PaastaServiceConfigLoader:
     >>>
     >>> sc = PaastaServiceConfigLoader(service='fake_service', soa_dir=DEFAULT_SOA_DIR)
     >>>
-    >>> for instance in sc.instances(cluster='fake_cluster', instance_type='marathon'):
+    >>> for instance in sc.instances(cluster='fake_cluster', instance_type_class=MarathonServiceConfig):
     ...     print(instance)
     ...
     main
     canary
     >>>
-    >>> for instance_config in sc.instance_configs(cluster='fake_cluster', instance_type='marathon'):
+    >>> for instance_config in sc.instance_configs(cluster='fake_cluster', instance_type_class=MarathonServiceConfig):
     ...     print(instance_config.get_instance())
     ...
     main
@@ -94,7 +94,7 @@ class PaastaServiceConfigLoader:
         """Returns an iterator that yields instance names as strings.
 
         :param cluster: The cluster name
-        :param instance_type: One of paasta_tools.utils.INSTANCE_TYPES
+        :param instance_type_class: a subclass of InstanceConfig
         :returns: an iterator that yields instance names
         """
         if (cluster, instance_type_class) not in self._framework_configs:
@@ -108,9 +108,9 @@ class PaastaServiceConfigLoader:
         """Returns an iterator that yields InstanceConfig objects.
 
         :param cluster: The cluster name
-        :param instance_type: One of paasta_tools.utils.INSTANCE_TYPES
+        :param instance_type_class: a subclass of InstanceConfig
         :returns: an iterator that yields instances of MarathonServiceConfig, etc.
-        :raises NotImplementedError: when it doesn't know how to create a config for instance_type
+        :raises NotImplementedError: when it doesn't know how to create a config for instance_type_class
         """
         if (cluster, instance_type_class) not in self._framework_configs:
             self._refresh_framework_config(cluster, instance_type_class)

--- a/paasta_tools/paastaapi/model/instance_status.py
+++ b/paasta_tools/paastaapi/model/instance_status.py
@@ -98,6 +98,7 @@ class InstanceStatus(ModelNormal):
             'adhoc': (InstanceStatusAdhoc,),  # noqa: E501
             'flink': (InstanceStatusFlink,),  # noqa: E501
             'git_sha': (str,),  # noqa: E501
+            'version': (str,),  # noqa: E501
             'instance': (str,),  # noqa: E501
             'cassandracluster': (InstanceStatusCassandracluster,),  # noqa: E501
             'kafkacluster': (InstanceStatusKafkacluster,),  # noqa: E501
@@ -117,6 +118,7 @@ class InstanceStatus(ModelNormal):
         'adhoc': 'adhoc',  # noqa: E501
         'flink': 'flink',  # noqa: E501
         'git_sha': 'git_sha',  # noqa: E501
+        'version': 'version',  # noqa: E501
         'instance': 'instance',  # noqa: E501
         'cassandracluster': 'cassandracluster',  # noqa: E501
         'kafkacluster': 'kafkacluster',  # noqa: E501
@@ -176,6 +178,7 @@ class InstanceStatus(ModelNormal):
             adhoc (InstanceStatusAdhoc): [optional]  # noqa: E501
             flink (InstanceStatusFlink): [optional]  # noqa: E501
             git_sha (str): Git sha of a service. [optional]  # noqa: E501
+            version (str): Deployment Version of a service. [optional]  # noqa: E501
             instance (str): Instance name. [optional]  # noqa: E501
             cassandracluster (InstanceStatusCassandracluster): [optional]  # noqa: E501
             kafkacluster (InstanceStatusKafkacluster): [optional]  # noqa: E501

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -38,6 +38,7 @@ from paasta_tools.mesos.slave import MesosSlave
 from paasta_tools.mesos.task import Task
 from paasta_tools.smartstack_tools import DiscoveredHost
 from paasta_tools.smartstack_tools import HaproxyBackend
+from paasta_tools.utils import DeploymentVersion
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDockerImageError
 from paasta_tools.utils import SystemPaastaConfig
@@ -87,11 +88,12 @@ def test_instance_status_marathon(
 ):
     settings.cluster = "fake_cluster"
 
+    mock_deployment_version = DeploymentVersion("GIT_SHA", None)
     mock_get_actual_deployments.return_value = {
-        "fake_cluster.fake_instance": "GIT_SHA",
-        "fake_cluster.fake_instance2": "GIT_SHA",
-        "fake_cluster2.fake_instance": "GIT_SHA",
-        "fake_cluster2.fake_instance2": "GIT_SHA",
+        "fake_cluster.fake_instance": mock_deployment_version,
+        "fake_cluster.fake_instance2": mock_deployment_version,
+        "fake_cluster2.fake_instance": mock_deployment_version,
+        "fake_cluster2.fake_instance2": mock_deployment_version,
     }
     mock_validate_service_instance.return_value = "marathon"
 
@@ -853,11 +855,12 @@ def test_instances_status_adhoc(
     mock_adhoc_instance_status,
 ):
     settings.cluster = "fake_cluster"
+    mock_deployment_version = DeploymentVersion("GIT_SHA", "20220101T000000")
     mock_get_actual_deployments.return_value = {
-        "fake_cluster.fake_instance": "GIT_SHA",
-        "fake_cluster.fake_instance2": "GIT_SHA",
-        "fake_cluster2.fake_instance": "GIT_SHA",
-        "fake_cluster2.fake_instance2": "GIT_SHA",
+        "fake_cluster.fake_instance": mock_deployment_version,
+        "fake_cluster.fake_instance2": mock_deployment_version,
+        "fake_cluster2.fake_instance": mock_deployment_version,
+        "fake_cluster2.fake_instance2": mock_deployment_version,
     }
     mock_validate_service_instance.return_value = "adhoc"
     mock_adhoc_instance_status.return_value = {}
@@ -871,6 +874,7 @@ def test_instances_status_adhoc(
         "service": "fake_service",
         "instance": "fake_instance",
         "git_sha": "GIT_SHA",
+        "version": mock_deployment_version.short_sha_repr(),
         "adhoc": {},
     }
 


### PR DESCRIPTION
Two issues fixed:
1. Stops using DeploymentsJsonV1 in `get_actual_deployments`. This was attempted once before but caused severe performance issues during bounces.  Because this now uses `PaastaServiceConfigLoader` those same performance issues have been mitigated, as we'll be loading the deployments.json only once per service, rather than clusters*instances times
In making this change, I found that the PaastaServiceConfigLoader comments were slightly incorrect about usage (`instance_type` vs `instance_type_class`), so fixed them
2. We had one reference to a top-level `git_sha` in our `InstanceStatus` type, so this adds an equivalent `version` field and sets it appropriately to the short representation of the DeploymentVersion.
Because this depends on a change to the API, the client side has a fallback to maintain status quo & use `git_sha` if `version` is not found yet.

### Verification
Tests all pass
1. Ran this version of the API against the same instances that were having problems bouncing with the last change, and confirmed API response for e.g. `v1/services/<service>/<instance>/status` returned in <30s, with similar results from calling the real API, which was not the case after https://github.com/Yelp/paasta/pull/3342.
2.  Testing with a modified API instance shows the correct output for both a non-no-commit instance and a no-commit instance: 
```
compute-infra-test-service.slow_termination in kubestage
    Version:    0ae13cf2 (desired)
    State: Running
    Running versions:
      Rerun with -v to see all replicas
      0ae13cf2 - Started 2022-09-23 04:56:03 (7 days ago)
        Replica States: 1 Healthy

compute-infra-test-service.no_commits in kubestage
    Version:    DeploymentVersion(sha=0ae13cf2, image_version=20220929T181107) (desired)
    State: Running
    Running versions:
      Rerun with -v to see all replicas
      0ae13cf2 (image_version: 20220929T181107) - Started 2022-09-29 18:18:03 (23 hours ago)
        Replica States: 1 Healthy 
```

And against current API w/o the `version` field in the response, still has slightly cosmetic problem of showing the wrong `Git sha` but includes the correct information under `Running versions`, and otherwise does not otherwise break the output:
```
compute-infra-test-service.slow_termination in kubestage
    Git sha:    0ae13cf2 (desired)
    State: Running
    Running versions:
      Rerun with -v to see all replicas
      0ae13cf2 - Started 2022-09-23 04:56:03 (7 days ago)
        Replica States: 1 Healthy


compute-infra-test-service.no_commits in kubestage
    Git sha:    20220929 (desired)
    State: Running
    Running versions:
      Rerun with -v to see all replicas
      0ae13cf2 (image_version: 20220929T181107) - Started 2022-09-29 18:18:03 (23 hours ago)
        Replica States: 1 Healthy
```