### PR TITLE
CLUSTERMAN-710, bump version for service_configuration_lib to 2.12.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.12.0
+service-configuration-lib==2.12.2
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0


### PR DESCRIPTION
We have bumped the version for service_configuration_lib here - https://github.com/Yelp/service_configuration_lib/pull/90, doing the same in Paasta