### PR TITLE
Secrets for teams feature in paasta secret cli

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -238,10 +238,7 @@ def paasta_secret(args):
             )
             sys.exit(1)
 
-        try:
-            print(get_kubernetes_secret(args.secret_name, service, clusters[0]))
-        except Exception as e:
-            print(e)
+        print(get_kubernetes_secret(args.secret_name, service, clusters[0]))
         return
 
     secret_provider = _get_secret_provider_for_service(

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -238,7 +238,10 @@ def paasta_secret(args):
             )
             sys.exit(1)
 
-        print(get_kubernetes_secret(args.secret_name, service, clusters[0]))
+        try:
+            print(get_kubernetes_secret(args.secret_name, service, clusters[0]))
+        except Exception as e:
+            print(e)
         return
 
     secret_provider = _get_secret_provider_for_service(

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -17,14 +17,17 @@ import os
 import re
 import sys
 
+from service_configuration_lib import DEFAULT_SOA_DIR
+
 from paasta_tools.cli.utils import lazy_choices_completer
+from paasta_tools.kubernetes_tools import get_kubernetes_secret
 from paasta_tools.secret_tools import get_secret_provider
 from paasta_tools.secret_tools import SHARED_SECRET_SERVICE
 from paasta_tools.utils import _log_audit
+from paasta_tools.utils import is_secrets_for_teams_enabled
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
-
 
 SECRET_NAME_REGEX = r"([A-Za-z0-9_-]*)"
 
@@ -67,6 +70,13 @@ def add_subparser(subparsers):
         "services yaml files and should "
         "be unique per service.",
     )
+    secret_parser.add_argument(
+        "-y",
+        "--yelpsoa-config-root",
+        dest="yelpsoa_config_root",
+        help="A directory from which yelpsoa-configs should be read from",
+        default=DEFAULT_SOA_DIR,
+    )
 
     # Must choose valid service or act on a shared secret
     service_group = secret_parser.add_mutually_exclusive_group(required=True)
@@ -78,7 +88,6 @@ def add_subparser(subparsers):
         help="Act on a secret that can be shared by all services",
         action="store_true",
     )
-
     secret_parser.add_argument(
         "-c",
         "--clusters",
@@ -211,9 +220,36 @@ def paasta_secret(args):
             sys.exit(1)
     else:
         service = args.service
+
+    # Check if "decrypt" and "secrets_for_teams" first to avoid vault auth
+    if args.action == "decrypt":
+        secrets_for_teams_only = is_secrets_for_teams_enabled(
+            service, args.yelpsoa_config_root
+        )
+        if secrets_for_teams_only:
+            clusters = (
+                args.clusters.split(",")
+                if args.clusters
+                else list_clusters(service=service, soa_dir=os.getcwd())
+            )
+
+            if len(clusters) > 1 or not clusters:
+                print(
+                    "Can only decrypt for one specified cluster at a time!\nFor example,"
+                    " try '-c norcal-devc' to decrypt the secret for this service in norcal-devc."
+                )
+                sys.exit(1)
+
+            print(
+                get_kubernetes_secret(args.secret_name, service, clusters),
+                end="",
+            )
+            return
+
     secret_provider = _get_secret_provider_for_service(
         service, cluster_names=args.clusters
     )
+
     if args.action in ["add", "update"]:
         plaintext = get_plaintext_input(args)
         if not plaintext:
@@ -253,4 +289,5 @@ def decrypt_secret(secret_provider, secret_name):
             " to decrypt the secret for this service in norcal-devc."
         )
         sys.exit(1)
+
     return secret_provider.decrypt_secret(secret_name)

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -3444,6 +3444,12 @@ def get_kubernetes_secret_name(service_name, secret_name, namespace="paasta"):
 
 
 def get_kubernetes_secret(secret_name, service_name, cluster):
+    # sanitise input before cmd run
+    sanitise_exp = r"[^a-zA-Z0-9-_]"
+    secret_name = re.sub(sanitise_exp, "", secret_name)
+    service_name = re.sub(sanitise_exp, "", service_name)
+    cluster = re.sub(sanitise_exp, "", cluster)
+
     k8s_secret_name = get_kubernetes_secret_name(service_name, secret_name)
     template_name = f"{{.data.{secret_name}}}"
 
@@ -3468,9 +3474,7 @@ def get_kubernetes_secret(secret_name, service_name, cluster):
     # Error running kubectl
     if proc.returncode != 0:
         process_errors = proc.stderr.decode("utf-8").strip()
-        if process_errors:
-            print(process_errors)
-        return "Could not get secret.\n"
+        raise Exception(f"Error getting secret: {process_errors}")
 
     secret = base64.b64decode(proc.stdout).decode("utf-8")
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -3436,20 +3436,16 @@ def update_crds(
     return success
 
 
-def get_kubernetes_secret_name(service_name, secret_name, namespace="paasta"):
+def get_kubernetes_secret_name(
+    service_name: str, secret_name: str, namespace: str = "paasta"
+) -> str:
     service = sanitise_kubernetes_name(service_name)
     sanitised_secret = sanitise_kubernetes_name(secret_name)
     name = f"{namespace}-secret-{service}-{sanitised_secret}"
     return name
 
 
-def get_kubernetes_secret(secret_name, service_name, cluster):
-    # sanitise input before cmd run
-    sanitise_exp = r"[^a-zA-Z0-9-_]"
-    secret_name = re.sub(sanitise_exp, "", secret_name)
-    service_name = re.sub(sanitise_exp, "", service_name)
-    cluster = re.sub(sanitise_exp, "", cluster)
-
+def get_kubernetes_secret(secret_name: str, service_name: str, cluster: str) -> str:
     k8s_secret_name = get_kubernetes_secret_name(service_name, secret_name)
     template_name = f"{{.data.{secret_name}}}"
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -3455,7 +3455,7 @@ def get_kubernetes_secret(secret_name, service_name, cluster):
             "kubectl",
             "get",
             "secrets",
-            f"--cluster={cluster[0]}",
+            f"--cluster={cluster}",
             f"-n=paasta",
             f"{k8s_secret_name}",
             f"--template={{{template_name}}}",

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -158,7 +158,7 @@ from paasta_tools.utils import VolumeWithMode
 log = logging.getLogger(__name__)
 
 KUBE_CONFIG_PATH = "/etc/kubernetes/admin.conf"
-DEFAULT_KUBECTL_CONFIG_PATH = "/etc/kubernetes/paasta.conf"
+KUBE_CONFIG_USER_PATH = "/etc/kubernetes/paasta.conf"
 YELP_ATTRIBUTE_PREFIX = "yelp.com/"
 PAASTA_ATTRIBUTE_PREFIX = "paasta.yelp.com/"
 KUBE_DEPLOY_STATEGY_MAP = {
@@ -3457,7 +3457,7 @@ def get_kubernetes_secret_name(
 def get_kubernetes_secret(secret_name: str, service_name: str, cluster: str) -> str:
     k8s_secret_name = get_kubernetes_secret_name(service_name, secret_name)
 
-    kube_client = KubeClient(config_file=DEFAULT_KUBECTL_CONFIG_PATH, context=cluster)
+    kube_client = KubeClient(config_file=KUBE_CONFIG_USER_PATH, context=cluster)
     secret_data = kube_client.core.read_namespaced_secret(
         name=k8s_secret_name, namespace="paasta"
     ).data[secret_name]

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -76,6 +76,7 @@ from docker import Client
 from docker.utils import kwargs_from_env
 from kazoo.client import KazooClient
 from mypy_extensions import TypedDict
+from service_configuration_lib import read_extra_service_information
 from service_configuration_lib import read_service_configuration
 
 import paasta_tools.cli.fsm
@@ -3089,6 +3090,13 @@ def get_production_deploy_group(service: str, soa_dir: str = DEFAULT_SOA_DIR) ->
 def get_pipeline_config(service: str, soa_dir: str = DEFAULT_SOA_DIR) -> List[Dict]:
     service_configuration = read_service_configuration(service, soa_dir)
     return service_configuration.get("deploy", {}).get("pipeline", [])
+
+
+def is_secrets_for_teams_enabled(service: str, soa_dir: str = DEFAULT_SOA_DIR) -> bool:
+    service_yaml_contents = read_extra_service_information(service, "service", soa_dir)
+    if "secrets_for_owner_team" in service_yaml_contents:
+        return service_yaml_contents["secrets_for_owner_team"]
+    return False
 
 
 def get_pipeline_deploy_group_configs(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -3094,9 +3094,7 @@ def get_pipeline_config(service: str, soa_dir: str = DEFAULT_SOA_DIR) -> List[Di
 
 def is_secrets_for_teams_enabled(service: str, soa_dir: str = DEFAULT_SOA_DIR) -> bool:
     service_yaml_contents = read_extra_service_information(service, "service", soa_dir)
-    if "secrets_for_owner_team" in service_yaml_contents:
-        return service_yaml_contents["secrets_for_owner_team"]
-    return False
+    return service_yaml_contents.get("secrets_for_owner_team", False)
 
 
 def get_pipeline_deploy_group_configs(

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -227,7 +227,7 @@ def test_paasta_secret():
         secret.paasta_secret(mock_args)
         mock_is_secrets_for_teams_enabled.assert_called_with("middleearth", "something")
         mock_get_kubernetes_secret.assert_called_with(
-            "theonering", "middleearth", ["mesosstage"]
+            "theonering", "middleearth", "mesosstage"
         )
 
         mock_args = mock.Mock(

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -143,7 +143,11 @@ def test_paasta_secret():
         "paasta_tools.cli.cmds.secret.get_plaintext_input", autospec=True
     ) as mock_get_plaintext_input, mock.patch(
         "paasta_tools.cli.cmds.secret._log_audit", autospec=True
-    ) as mock_log_audit:
+    ) as mock_log_audit, mock.patch(
+        "paasta_tools.cli.cmds.secret.is_secrets_for_teams_enabled", autospec=True
+    ) as mock_is_secrets_for_teams_enabled, mock.patch(
+        "paasta_tools.cli.cmds.secret.get_kubernetes_secret", autospec=True
+    ) as mock_get_kubernetes_secret:
         mock_secret_provider = mock.Mock(secret_dir="/nail/blah")
         mock_get_secret_provider_for_service.return_value = mock_secret_provider
         mock_args = mock.Mock(
@@ -201,12 +205,29 @@ def test_paasta_secret():
             clusters="mesosstage",
             shared=False,
         )
+        mock_is_secrets_for_teams_enabled.return_value = False
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(
             "middleearth", cluster_names="mesosstage"
         )
         mock_decrypt_secret.assert_called_with(
             secret_provider=mock_secret_provider, secret_name="theonering"
+        )
+
+        # decrypt with secrets_for_teams enabled
+        mock_args = mock.Mock(
+            action="decrypt",
+            secret_name="theonering",
+            service="middleearth",
+            clusters="mesosstage",
+            yelpsoa_config_root="something",
+            shared=False,
+        )
+        mock_is_secrets_for_teams_enabled.return_value = True
+        secret.paasta_secret(mock_args)
+        mock_is_secrets_for_teams_enabled.assert_called_with("middleearth", "something")
+        mock_get_kubernetes_secret.assert_called_with(
+            "theonering", "middleearth", ["mesosstage"]
         )
 
         mock_args = mock.Mock(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -4041,7 +4041,7 @@ def test_get_kubernetes_secret():
 
         service_name = "example_service"
         secret_name = "example_secret"
-        cluster = ["messosstage"]
+        cluster = "messosstage"
         mock_env.return_value = {}
         proc_args = [
             "kubectl",
@@ -4084,11 +4084,17 @@ def test_get_kubernetes_secret():
         )
         mock_subprocess.return_value = mock_out
 
-        ret = get_kubernetes_secret(secret_name, service_name, cluster)
+        with pytest.raises(Exception) as e_info:
+            ret = get_kubernetes_secret(secret_name, service_name, cluster)
+
+        assert (
+            str(e_info.value)
+            == f'Error getting secret: error: cluster `"wrong place" does not exist'
+        )
+
         mock_subprocess.assert_called_with(
             proc_args,
             env=env,
             stderr=-1,
             stdout=-1,
         )
-        assert ret == "Could not get secret.\n"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2664,3 +2664,28 @@ def test_filter_templates_from_config():
         "instance0": "bar",
         "instance1": "baz",
     }
+
+
+def test_is_secrets_for_teams_enabled():
+    with mock.patch(
+        "paasta_tools.utils.read_extra_service_information", autospec=True
+    ) as mock_read_extra_service_information:
+        service = "example_secrets_for_teams"
+
+        # if enabled
+        mock_read_extra_service_information.return_value = {
+            "description": "something",
+            "secrets_for_owner_team": True,
+        }
+        assert utils.is_secrets_for_teams_enabled(service)
+
+        # if specifically not enabled
+        mock_read_extra_service_information.return_value = {
+            "description": "something",
+            "secrets_for_owner_team": False,
+        }
+        assert not utils.is_secrets_for_teams_enabled(service)
+
+        # if not present
+        mock_read_extra_service_information.return_value = {"description": "something"}
+        assert not utils.is_secrets_for_teams_enabled(service)


### PR DESCRIPTION
Checks wether a service has opted-in for team level access patterns to secrets in service configs.
If so, paasta secret decrypt cli changes logic to retrieve the secrets from k8s (using kubectl), instead of the default secret provider decryption. Otherwise, the logic remains unchanged.