### PR TITLE
FLINK-4163: Add more generic config loading for setup cr

### DIFF
--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -47,8 +47,8 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_git_sha_from_dockerurl
 from paasta_tools.utils import load_all_configs
-from paasta_tools.utils import load_all_flink_configs
 from paasta_tools.utils import load_system_paasta_config
+
 
 log = logging.getLogger(__name__)
 
@@ -168,20 +168,16 @@ def setup_all_custom_resources(
             continue
 
         # by convention, entries where key begins with _ are used as templates
-        raw_config_dicts = {}
-        if crd.kube_kind.singular == "flink":
-            raw_config_dicts = load_all_flink_configs(cluster=cluster, soa_dir=soa_dir)
-        else:
-            raw_config_dicts = load_all_configs(
-                cluster=cluster, file_prefix=crd.file_prefix, soa_dir=soa_dir
-            )
-        config_dicts = {}
-        for svc, raw_sdict in raw_config_dicts.items():
-            sdict = {inst: idict for inst, idict in raw_sdict.items() if inst[0] != "_"}
-            if sdict:
-                config_dicts[svc] = sdict
-        if not config_dicts:
-            continue
+        config_dicts = load_all_configs(
+            cluster=cluster, file_prefix=crd.file_prefix, soa_dir=soa_dir
+        )
+        # config_dicts = {}
+        # for svc, raw_sdict in raw_config_dicts.items():
+        #     sdict = {inst: idict for inst, idict in raw_sdict.items() if inst[0] != "_"}
+        #     if sdict:
+        #         config_dicts[svc] = sdict
+        # if not config_dicts:
+        #     continue
 
         ensure_namespace(
             kube_client=kube_client, namespace=f"paasta-{crd.kube_kind.plural}"

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -168,16 +168,10 @@ def setup_all_custom_resources(
             continue
 
         # by convention, entries where key begins with _ are used as templates
+        # and will be filter out here
         config_dicts = load_all_configs(
             cluster=cluster, file_prefix=crd.file_prefix, soa_dir=soa_dir
         )
-        # config_dicts = {}
-        # for svc, raw_sdict in raw_config_dicts.items():
-        #     sdict = {inst: idict for inst, idict in raw_sdict.items() if inst[0] != "_"}
-        #     if sdict:
-        #         config_dicts[svc] = sdict
-        # if not config_dicts:
-        #     continue
 
         ensure_namespace(
             kube_client=kube_client, namespace=f"paasta-{crd.kube_kind.plural}"

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -47,6 +47,7 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_git_sha_from_dockerurl
 from paasta_tools.utils import load_all_configs
+from paasta_tools.utils import load_all_flink_configs
 from paasta_tools.utils import load_system_paasta_config
 
 log = logging.getLogger(__name__)
@@ -167,9 +168,13 @@ def setup_all_custom_resources(
             continue
 
         # by convention, entries where key begins with _ are used as templates
-        raw_config_dicts = load_all_configs(
-            cluster=cluster, file_prefix=crd.file_prefix, soa_dir=soa_dir
-        )
+        raw_config_dicts = {}
+        if crd.kube_kind.singular == "flink":
+            raw_config_dicts = load_all_flink_configs(cluster=cluster, soa_dir=soa_dir)
+        else:
+            raw_config_dicts = load_all_configs(
+                cluster=cluster, file_prefix=crd.file_prefix, soa_dir=soa_dir
+            )
         config_dicts = {}
         for svc, raw_sdict in raw_config_dicts.items():
             sdict = {inst: idict for inst, idict in raw_sdict.items() if inst[0] != "_"}

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -4047,6 +4047,31 @@ def load_all_configs(
     return config_dicts
 
 
+def load_all_flink_configs(
+    cluster: str, soa_dir: str
+) -> Mapping[str, Mapping[str, Any]]:
+    config_dicts = {}
+    for service in os.listdir(soa_dir):
+        user_config = service_configuration_lib.read_extra_service_information(
+            service,
+            f"flink-{cluster}",
+            soa_dir=soa_dir,
+            deepcopy=False,
+        )
+        auto_config = service_configuration_lib.read_extra_service_information(
+            service,
+            f"{AUTO_SOACONFIG_SUBDIR}/flink-{cluster}",
+            soa_dir=soa_dir,
+            deepcopy=False,
+        )
+        config_dicts[service] = deep_merge_dictionaries(
+            overrides=user_config,
+            defaults=auto_config,
+        )
+
+    return config_dicts
+
+
 def ldap_user_search(
     cn: str,
     search_base: str,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -4039,10 +4039,8 @@ def load_all_configs(
 ) -> Mapping[str, Mapping[str, Any]]:
     config_dicts = {}
     for service in os.listdir(soa_dir):
-        config_dicts[
-            service
-        ] = service_configuration_lib.read_extra_service_information(
-            service, f"{file_prefix}-{cluster}", soa_dir=soa_dir
+        config_dicts[service] = load_service_instance_configs(
+            service, file_prefix, cluster, soa_dir
         )
     return config_dicts
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -4045,31 +4045,6 @@ def load_all_configs(
     return config_dicts
 
 
-def load_all_flink_configs(
-    cluster: str, soa_dir: str
-) -> Mapping[str, Mapping[str, Any]]:
-    config_dicts = {}
-    for service in os.listdir(soa_dir):
-        user_config = service_configuration_lib.read_extra_service_information(
-            service,
-            f"flink-{cluster}",
-            soa_dir=soa_dir,
-            deepcopy=False,
-        )
-        auto_config = service_configuration_lib.read_extra_service_information(
-            service,
-            f"{AUTO_SOACONFIG_SUBDIR}/flink-{cluster}",
-            soa_dir=soa_dir,
-            deepcopy=False,
-        )
-        config_dicts[service] = deep_merge_dictionaries(
-            overrides=user_config,
-            defaults=auto_config,
-        )
-
-    return config_dicts
-
-
 def ldap_user_search(
     cn: str,
     search_base: str,

--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -119,6 +119,49 @@ def test_setup_all_custom_resources():
         )
 
 
+def test_setup_all_custom_resources_flink():
+    with mock.patch(
+        "paasta_tools.setup_kubernetes_cr.ensure_namespace", autospec=True
+    ), mock.patch(
+        "paasta_tools.setup_kubernetes_cr.load_all_configs", autospec=True
+    ) as mock_load_all, mock.patch(
+        "paasta_tools.setup_kubernetes_cr.load_all_flink_configs", autospec=True
+    ) as mock_load_all_flink, mock.patch(
+        "paasta_tools.setup_kubernetes_cr.setup_custom_resources", autospec=True
+    ) as mock_setup:
+        mock_system_config = mock.Mock(
+            get_cluster=mock.Mock(return_value="westeros-prod")
+        )
+        # if some CRs setup okay should return True
+        mock_setup.side_effect = [True, False]
+
+        mock_client = mock.Mock()
+        flink_crd = mock.Mock()
+        flink_crd.spec.names = mock.Mock(
+            singular="flink", plural="flinks", kind="flink"
+        )
+
+        mock_client.apiextensions.list_custom_resource_definition.return_value = (
+            mock.Mock(items=[flink_crd])
+        )
+
+        custom_resource_definitions = [
+            mock.Mock(
+                kube_kind=mock.Mock(plural="flinks", singular="flink", kind="Flink")
+            ),
+        ]
+
+        setup_kubernetes_cr.setup_all_custom_resources(
+            mock_client,
+            "/nail/soa",
+            mock_system_config,
+            custom_resource_definitions=custom_resource_definitions,
+        )
+
+        assert not mock_load_all.called
+        assert mock_load_all_flink.called
+
+
 def test_load_all_configs():
     with mock.patch(
         "paasta_tools.kubernetes_tools.service_configuration_lib.read_extra_service_information",
@@ -132,6 +175,43 @@ def test_load_all_configs():
             [
                 mock.call("mc", "thing-westeros-prod", soa_dir="/nail/soa"),
                 mock.call("kurupt", "thing-westeros-prod", soa_dir="/nail/soa"),
+            ],
+            any_order=True,
+        )
+        assert "kurupt" in ret.keys()
+        assert "mc" in ret.keys()
+
+
+def test_load_all_flink_configs():
+    with mock.patch(
+        "paasta_tools.kubernetes_tools.service_configuration_lib.read_extra_service_information",
+        autospec=True,
+    ) as mock_read_info, mock.patch("os.listdir", autospec=True) as mock_oslist:
+        mock_oslist.return_value = ["kurupt", "mc"]
+        ret = setup_kubernetes_cr.load_all_flink_configs(
+            cluster="westeros-prod", soa_dir="/nail/soa"
+        )
+
+        mock_read_info.assert_has_calls(
+            [
+                mock.call(
+                    "mc", "flink-westeros-prod", soa_dir="/nail/soa", deepcopy=False
+                ),
+                mock.call(
+                    "kurupt", "flink-westeros-prod", soa_dir="/nail/soa", deepcopy=False
+                ),
+                mock.call(
+                    "mc",
+                    "autotuned_defaults/flink-westeros-prod",
+                    soa_dir="/nail/soa",
+                    deepcopy=False,
+                ),
+                mock.call(
+                    "kurupt",
+                    "autotuned_defaults/flink-westeros-prod",
+                    soa_dir="/nail/soa",
+                    deepcopy=False,
+                ),
             ],
             any_order=True,
         )


### PR DESCRIPTION
The changes attempt to customly load flink configurations when updating crs of kind Flink. 
Context: 
- Yelp internal flink operator looks for changes in CRs specs and apply the changes by reconciling the flink clusters. 
- In scope of https://jira.yelpcorp.com/browse/FLINK-4103 project, this is needed to load extra configuration for auto config files on updating Flink k8s CRs (if exists)
- This is similar to the approach taken when reading instances configs for paasta services with autotune (y/autotune)

Open questions: 
- Is this the right way to modify? Any feedback would be appreciated given the basic knowledge of paasta I have. 
- How to test this is completely working without rolling it out? 
- Why the [step](https://github.com/Yelp/paasta/actions/runs/3242377865/jobs/5315550295) is failing? 