### PR TITLE
MLCOMPUTE-216 | increase dra mass rollout executor range to 16

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -71,7 +71,7 @@ DEFAULT_DRIVER_MEMORY_BY_SPARK = "1g"
 DOCKER_RESOURCE_ADJUSTMENT_FACTOR = 2
 
 # Mass enable DRA configs
-EXECUTOR_RANGES = {(0, 8)}
+EXECUTOR_RANGES = {(0, 16)}
 
 POD_TEMPLATE_DIR = "/nail/tmp"
 POD_TEMPLATE_PATH = "/nail/tmp/spark-pt-{file_uuid}.yaml"


### PR DESCRIPTION
- Increase executor range for mass rollout of Spark DRA to 16.