### PR TITLE
SLO Watcher Threads take precendence over Metric Watcher Threads

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -80,6 +80,7 @@ from paasta_tools.utils import _log_audit
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import DeploymentVersion
 from paasta_tools.utils import format_tag
+from paasta_tools.utils import get_files_of_type_in_dir
 from paasta_tools.utils import get_git_url
 from paasta_tools.utils import get_paasta_tag_from_deploy_group
 from paasta_tools.utils import get_username
@@ -361,6 +362,24 @@ def can_user_deploy_service(deploy_info: Dict[str, Any], service: str) -> bool:
             print(logline, file=sys.stderr)
             return False
     return True
+
+
+def can_run_metric_watcher_threads(
+    service: str,
+    soa_dir: str,
+) -> bool:
+    """
+    Cannot run slo and metric watcher threads together for now.
+    SLO Watcher Threads take precedence over metric watcher threads.
+    Metric Watcher Threads can run if there are no SLOs available.
+    """
+    slo_files = get_files_of_type_in_dir(
+        file_type="slo", service=service, soa_dir=soa_dir
+    )
+    rollback_files = get_files_of_type_in_dir(
+        file_type="rollback", service=service, soa_dir=soa_dir
+    )
+    return bool(not slo_files and rollback_files)
 
 
 def report_waiting_aborted(service: str, deploy_group: str) -> None:
@@ -647,8 +666,9 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
 
         self.start_slo_watcher_threads(self.service, self.soa_dir)
 
-        # TODO: Enable once Rollback Conditions are available
-        # self.start_metric_watcher_threads(self.service, self.soa_dir)
+        # TODO: Allow both metric and slo watcher threads to run together in the future
+        if can_run_metric_watcher_threads(service=self.service, soa_dir=self.soa_dir):
+            self.start_metric_watcher_threads(self.service, self.soa_dir)
 
         # Initialize Slack threads and send the first message
         super().__init__()

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -168,6 +168,7 @@ CAPS_DROP = [
 
 class RollbackTypes(Enum):
     AUTOMATIC_SLO_ROLLBACK = "automatic_slo_rollback"
+    AUTOMATIC_METRIC_ROLLBACK = "automatic_metric_rollback"
     USER_INITIATED_ROLLBACK = "user_initiated_rollback"
 
 
@@ -2993,6 +2994,31 @@ def get_hostname() -> str:
     running on.
     """
     return socket.getfqdn()
+
+
+def get_files_of_type_in_dir(
+    file_type: str,
+    service: str = None,
+    soa_dir: str = DEFAULT_SOA_DIR,
+) -> List[str]:
+    """Recursively search path if type of file exists.
+
+    :param file_type: a string of a type of a file (kubernetes, slo, etc.)
+    :param service: a string of a service
+    :param soa_dir: a string of a path to a soa_configs directory
+    :return: a list
+    """
+    # TODO: Only use INSTANCE_TYPES as input by making file_type Literal
+    service = "**" if service is None else service
+    soa_dir = DEFAULT_SOA_DIR if soa_dir is None else soa_dir
+    file_type += "-*.yaml"
+    return [
+        file_path
+        for file_path in glob.glob(
+            os.path.join(soa_dir, service, file_type),
+            recursive=True,
+        )
+    ]
 
 
 def get_soa_cluster_deploy_files(


### PR DESCRIPTION
For the time being, we're not able to run SLO Watcher Threads and Metric Watcher Threads at the same time. 

If there are no SLOs present, Metric Watcher Threads may run.