### PR TITLE
 Sync paasta spark secrets for paasta-spark namespace

### DIFF
--- a/paasta_tools/list_tron_namespaces.py
+++ b/paasta_tools/list_tron_namespaces.py
@@ -16,6 +16,9 @@ import argparse
 from paasta_tools import tron_tools
 
 
+EXECUTOR_TYPES = ["paasta", "spark", "ssh_not_spark"]
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Lists Tron namespaces for a cluster, excluding MASTER"
@@ -34,6 +37,14 @@ def parse_args():
         default=tron_tools.DEFAULT_SOA_DIR,
         help="Use a different soa config directory",
     )
+    parser.add_argument(
+        "-e",
+        "--executors",
+        default=EXECUTOR_TYPES,
+        nargs="+",
+        help="tron executor types to list namespaces for",
+        choices=EXECUTOR_TYPES,
+    )
     args = parser.parse_args()
     return args
 
@@ -41,7 +52,9 @@ def parse_args():
 def main():
     args = parse_args()
     namespaces = tron_tools.get_tron_namespaces(
-        cluster=args.cluster, soa_dir=args.soa_dir
+        cluster=args.cluster,
+        soa_dir=args.soa_dir,
+        tron_executors=args.executors,
     )
     print("\n".join(namespaces))
 

--- a/paasta_tools/list_tron_namespaces.py
+++ b/paasta_tools/list_tron_namespaces.py
@@ -16,9 +16,6 @@ import argparse
 from paasta_tools import tron_tools
 
 
-EXECUTOR_TYPES = ["paasta", "spark", "ssh_not_spark"]
-
-
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Lists Tron namespaces for a cluster, excluding MASTER"
@@ -40,10 +37,10 @@ def parse_args():
     parser.add_argument(
         "-e",
         "--executors",
-        default=EXECUTOR_TYPES,
+        default=tron_tools.EXECUTOR_TYPES,
         nargs="+",
         help="tron executor types to list namespaces for",
-        choices=EXECUTOR_TYPES,
+        choices=tron_tools.EXECUTOR_TYPES,
     )
     args = parser.parse_args()
     return args

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -100,7 +100,7 @@ EXECUTOR_TYPE_TO_NAMESPACE = {
 }
 DEFAULT_TZ = "US/Pacific"
 clusterman_metrics, _ = get_clusterman_metrics()
-EXECUTOR_TYPES = ["paasta", "spark"]
+EXECUTOR_TYPES = ["paasta", "ssh"]
 
 
 class FieldSelectorConfig(TypedDict):
@@ -1190,16 +1190,7 @@ def validate_complete_config(
 
 def _is_valid_namespace(job: Any, tron_executors: List[str]) -> bool:
     for action_info in job.get("actions", {}).values():
-        if "paasta" in tron_executors and action_info.get("executor", "") in [
-            "paasta",
-            "",
-        ]:
-            return True
-        elif (
-            "spark" in tron_executors
-            and action_info.get("executor", "") == "ssh"
-            and "spark-run" in action_info.get("command", "")
-        ):
+        if action_info.get("executor", "paasta") in tron_executors:
             return True
     return False
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -324,9 +324,6 @@ class InstanceConfigDict(TypedDict, total=False):
     branch: str
     iam_role: str
     iam_role_provider: str
-    # the values for this dict can be anything since it's whatever
-    # spark accepts
-    spark_args: Dict[str, Any]
 
 
 class BranchDictV1(TypedDict, total=False):

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1479,7 +1479,7 @@ fake_job:
 
     @mock.patch("os.walk", autospec=True)
     @mock.patch("os.listdir", autospec=True)
-    def test_get_tron_namespaces(self, mock_ls, mock_walk):
+    def test_get_tron_namespaces_paasta(self, mock_ls, mock_walk):
         cluster_name = "stage"
         expected_namespaces = ["app", "foo"]
         mock_walk.return_value = [
@@ -1506,6 +1506,22 @@ fake_job:
                 tron_executors=["paasta"],
             )
             assert sorted(expected_namespaces) == sorted(namespaces)
+
+    @mock.patch("os.walk", autospec=True)
+    @mock.patch("os.listdir", autospec=True)
+    def test_get_tron_namespaces_spark(self, mock_ls, mock_walk):
+        cluster_name = "stage"
+        expected_namespaces = ["app", "foo"]
+        mock_walk.return_value = [
+            ("/my_soa_dir/foo", [], ["tron-stage.yaml"]),
+            ("/my_soa_dir/app", [], ["tron-stage.yaml"]),
+            ("my_soa_dir/woo", [], ["something-else.yaml"]),
+        ]
+        soa_dir = "/my_soa_dir"
+
+        with mock.patch(
+            "paasta_tools.tron_tools.filter_templates_from_config", autospec=True
+        ) as mock_filter_templates_from_config:
 
             mock_filter_templates_from_config.return_value = {
                 "test-spark-job": {

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1494,11 +1494,7 @@ fake_job:
         ) as mock_filter_templates_from_config:
             mock_filter_templates_from_config.return_value = {
                 "test-tron-job": {"actions": {"run": {"executor": "paasta"}}},
-                "test-spark-job": {
-                    "actions": {
-                        "run": {"executor": "ssh", "command": 'spark-run test.py"'}
-                    }
-                },
+                "test-spark-job": {"actions": {"run": {"executor": "ssh"}}},
             }
             namespaces = tron_tools.get_tron_namespaces(
                 cluster=cluster_name,
@@ -1524,11 +1520,7 @@ fake_job:
         ) as mock_filter_templates_from_config:
 
             mock_filter_templates_from_config.return_value = {
-                "test-spark-job": {
-                    "actions": {
-                        "run": {"executor": "ssh", "command": 'spark-run test.py"'}
-                    }
-                },
+                "test-spark-job": {"actions": {"run": {"executor": "ssh"}}},
             }
             namespaces = tron_tools.get_tron_namespaces(
                 cluster=cluster_name,
@@ -1539,7 +1531,7 @@ fake_job:
             namespaces = tron_tools.get_tron_namespaces(
                 cluster=cluster_name,
                 soa_dir=soa_dir,
-                tron_executors=["spark"],
+                tron_executors=["ssh"],
             )
             assert sorted(expected_namespaces) == sorted(namespaces)
 


### PR DESCRIPTION
[MLCOMPUTE-516](https://jira.yelpcorp.com/browse/MLCOMPUTE-516)
Add support for syncing paasta secrets onto k8s clusters for `paasta-spark` namespace 

The issue was `tron` instance_type is mapped with `tron` namespace, which is mapped with `tron*` .yaml files.

Added description:
These changes also take care of many edge cases with existing way of choosing and restructuring the tricky and confusing  tron namespaces. 

Trick used is, `spark` instance_type maps to `tron*` .yaml files and `paasta-spark` namespace.

Testing: 
* Unit tests
* Manual tests: 
-- I have manually tested if I am able get get correct instance list for instance_type , `spark`
Result in the ticket. 

I can try to run this sync script manually if:
-- I can get permission from CI to run it and
-- I have authorization to run the same

Next step is to integrate this in `puppet`. 
Note:  For some reason the tests were not failing locally but fail here. 
Hopefully now they are fixed. 