### PR TITLE
Added support for namespace parameter in soaconfigs - PAASTA-17791

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -745,6 +745,9 @@
                 "routable_ip": {
                     "type": "boolean"
                 },
+                "namespace": {
+                    "type": "string"
+                },
                 "lifecycle": {
                     "type": "object",
                     "properties": {

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -745,9 +745,6 @@
                 "routable_ip": {
                     "type": "boolean"
                 },
-                "namespace": {
-                    "type": "string"
-                },
                 "lifecycle": {
                     "type": "object",
                     "properties": {

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2235,13 +2235,8 @@ def ensure_namespace(kube_client: KubeClient, namespace: str) -> None:
 def list_deployments(
     kube_client: KubeClient,
     label_selector: str = "",
-    service_config: KubernetesDeploymentConfig = None,
+    namespace: str = "paasta",
 ) -> Sequence[KubeDeployment]:
-
-    if service_config:
-        namespace = service_config.get_namespace()
-    else:
-        namespace = "paasta"
 
     deployments = kube_client.deployments.list_namespaced_deployment(
         namespace=namespace, label_selector=label_selector
@@ -2512,12 +2507,8 @@ def pod_disruption_budget_for_service_instance(
     service: str,
     instance: str,
     max_unavailable: Union[str, int],
-    service_config: KubernetesDeploymentConfig = None,
+    namespace: str = "paasta",
 ) -> V1beta1PodDisruptionBudget:
-    if service_config:
-        namespace = service_config.get_namespace()
-    else:
-        namespace = "paasta"
     return V1beta1PodDisruptionBudget(
         metadata=V1ObjectMeta(
             name=get_kubernetes_app_name(service, instance),
@@ -2538,12 +2529,8 @@ def pod_disruption_budget_for_service_instance(
 def create_pod_disruption_budget(
     kube_client: KubeClient,
     pod_disruption_budget: V1beta1PodDisruptionBudget,
-    service_config: KubernetesDeploymentConfig = None,
+    namespace: str = "paasta",
 ) -> None:
-    if service_config:
-        namespace = service_config.get_namespace()
-    else:
-        namespace = "paasta"
     return kube_client.policy.create_namespaced_pod_disruption_budget(
         namespace=namespace, body=pod_disruption_budget
     )
@@ -2609,17 +2596,21 @@ def write_annotation_for_kubernetes_service(
 
 
 def list_all_deployments(
-    kube_client: KubeClient, service_config: KubernetesDeploymentConfig = None
+    kube_client: KubeClient, namespace: str = "paasta"
 ) -> Sequence[KubeDeployment]:
-    return list_deployments(kube_client=kube_client, service_config=service_config)
+    return list_deployments(kube_client=kube_client, namespace=namespace)
 
 
 def list_matching_deployments(
-    service: str, instance: str, kube_client: KubeClient
+    service: str,
+    instance: str,
+    kube_client: KubeClient,
+    namespace: str = "paasta",
 ) -> Sequence[KubeDeployment]:
     return list_deployments(
         kube_client,
         f"paasta.yelp.com/service={service},paasta.yelp.com/instance={instance}",
+        namespace=namespace,
     )
 
 
@@ -2888,12 +2879,8 @@ def get_kubernetes_app_by_name(
 def create_deployment(
     kube_client: KubeClient,
     formatted_deployment: V1Deployment,
-    service_config: KubernetesDeploymentConfig = None,
+    namespace: str = "paasta",
 ) -> None:
-    if service_config:
-        namespace = service_config.get_namespace()
-    else:
-        namespace = "paasta"
     return kube_client.deployments.create_namespaced_deployment(
         namespace=namespace, body=formatted_deployment
     )
@@ -2902,12 +2889,8 @@ def create_deployment(
 def update_deployment(
     kube_client: KubeClient,
     formatted_deployment: V1Deployment,
-    service_config: KubernetesDeploymentConfig = None,
+    namespace: str = "paasta",
 ) -> None:
-    if service_config:
-        namespace = service_config.get_namespace()
-    else:
-        namespace = "paasta"
     return kube_client.deployments.replace_namespaced_deployment(
         name=formatted_deployment.metadata.name,
         namespace=namespace,
@@ -2916,13 +2899,13 @@ def update_deployment(
 
 
 def patch_deployment(
-    service_config: KubernetesDeploymentConfig,
     kube_client: KubeClient,
     formatted_deployment: V1Deployment,
+    namespace: str = "paasta",
 ) -> None:
     return kube_client.deployments.patch_namespaced_deployment(
         name=formatted_deployment.metadata.name,
-        namespace=service_config.get_namespace(),
+        namespace=namespace,
         body=formatted_deployment,
     )
 
@@ -2930,13 +2913,8 @@ def patch_deployment(
 def delete_deployment(
     kube_client: KubeClient,
     deployment_name: str,
-    service_config: KubernetesDeploymentConfig = None,
+    namespace: str = "paasta",
 ) -> None:
-    if service_config:
-        namespace = service_config.get_namespace()
-    else:
-        namespace = "paasta"
-
     return kube_client.deployments.delete_namespaced_deployment(
         name=deployment_name,
         namespace=namespace,
@@ -2946,21 +2924,21 @@ def delete_deployment(
 def create_stateful_set(
     kube_client: KubeClient,
     formatted_stateful_set: V1StatefulSet,
-    service_config: KubernetesDeploymentConfig = None,
+    namespace: str = "paasta",
 ) -> None:
     return kube_client.deployments.create_namespaced_stateful_set(
-        namespace=service_config.get_namespace(), body=formatted_stateful_set
+        namespace=namespace, body=formatted_stateful_set
     )
 
 
 def update_stateful_set(
     kube_client: KubeClient,
     formatted_stateful_set: V1StatefulSet,
-    service_config: KubernetesDeploymentConfig = None,
+    namespace: str = "paasta",
 ) -> None:
     return kube_client.deployments.replace_namespaced_stateful_set(
         name=formatted_stateful_set.metadata.name,
-        namespace=service_config.get_namespace(),
+        namespace=namespace,
         body=formatted_stateful_set,
     )
 
@@ -3523,13 +3501,9 @@ def get_kubernetes_secret(
     kube_client: KubeClient,
     secret_name: str,
     service_name: str,
-    service_config: KubernetesDeploymentConfig = None,
+    namespace: str = "paasta",
 ) -> str:
 
-    if service_config:
-        namespace = service_config.get_namespace()
-    else:
-        namespace = "paasta"
     k8s_secret_name = get_kubernetes_secret_name(service_name, secret_name)
 
     secret_data = kube_client.core.read_namespaced_secret(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2816,18 +2816,12 @@ def test_max_unavailable(instances, bmf):
 
 
 def test_pod_disruption_budget_for_service_instance():
-    mock_kube_deploy_config = KubernetesDeploymentConfig(
-        service="my-service",
-        instance="my-instance",
-        cluster="cluster",
-        config_dict={},
-        branch_dict=None,
-    )
+    mock_namespace = "paasta"
     x = pod_disruption_budget_for_service_instance(
         service="foo_1",
         instance="bar_1",
         max_unavailable="10%",
-        service_config=mock_kube_deploy_config,
+        namespace=mock_namespace,
     )
 
     assert x.metadata.name == "foo--1-bar--1"
@@ -2842,14 +2836,8 @@ def test_pod_disruption_budget_for_service_instance():
 def test_create_pod_disruption_budget():
     mock_client = mock.Mock()
     mock_pdr = V1beta1PodDisruptionBudget()
-    mock_kube_deploy_config = KubernetesDeploymentConfig(
-        service="my-service",
-        instance="my-instance",
-        cluster="cluster",
-        config_dict={},
-        branch_dict=None,
-    )
-    create_pod_disruption_budget(mock_client, mock_pdr, mock_kube_deploy_config)
+    mock_namespace = "paasta"
+    create_pod_disruption_budget(mock_client, mock_pdr, mock_namespace)
     mock_client.policy.create_namespaced_pod_disruption_budget.assert_called_with(
         namespace="paasta", body=mock_pdr
     )
@@ -2857,16 +2845,8 @@ def test_create_pod_disruption_budget():
 
 def test_create_deployment():
     mock_client = mock.Mock()
-    mock_kube_deploy_config = KubernetesDeploymentConfig(
-        service="my-service",
-        instance="my-instance",
-        cluster="cluster",
-        config_dict={},
-        branch_dict=None,
-    )
-    create_deployment(
-        mock_client, V1Deployment(api_version="some"), mock_kube_deploy_config
-    )
+    mock_namespace = "paasta"
+    create_deployment(mock_client, V1Deployment(api_version="some"), mock_namespace)
     mock_client.deployments.create_namespaced_deployment.assert_called_with(
         namespace="paasta", body=V1Deployment(api_version="some")
     )
@@ -2874,17 +2854,11 @@ def test_create_deployment():
 
 def test_update_deployment():
     mock_client = mock.Mock()
-    mock_kube_deploy_config = KubernetesDeploymentConfig(
-        service="my-service",
-        instance="my-instance",
-        cluster="cluster",
-        config_dict={},
-        branch_dict=None,
-    )
+    mock_namespace = "paasta"
     update_deployment(
         mock_client,
         V1Deployment(metadata=V1ObjectMeta(name="kurupt")),
-        mock_kube_deploy_config,
+        mock_namespace,
     )
     mock_client.deployments.replace_namespaced_deployment.assert_called_with(
         namespace="paasta",
@@ -2893,9 +2867,7 @@ def test_update_deployment():
     )
 
     mock_client = mock.Mock()
-    create_deployment(
-        mock_client, V1Deployment(api_version="some"), mock_kube_deploy_config
-    )
+    create_deployment(mock_client, V1Deployment(api_version="some"), mock_namespace)
     mock_client.deployments.create_namespaced_deployment.assert_called_with(
         namespace="paasta", body=V1Deployment(api_version="some")
     )
@@ -3057,16 +3029,8 @@ def test_list_custom_resources():
 
 def test_create_stateful_set():
     mock_client = mock.Mock()
-    mock_kube_deploy_config = KubernetesDeploymentConfig(
-        service="my-service",
-        instance="my-instance",
-        cluster="cluster",
-        config_dict={},
-        branch_dict=None,
-    )
-    create_stateful_set(
-        mock_client, V1StatefulSet(api_version="some"), mock_kube_deploy_config
-    )
+    mock_namespace = "paasta"
+    create_stateful_set(mock_client, V1StatefulSet(api_version="some"), mock_namespace)
     mock_client.deployments.create_namespaced_stateful_set.assert_called_with(
         namespace="paasta", body=V1StatefulSet(api_version="some")
     )
@@ -3074,17 +3038,11 @@ def test_create_stateful_set():
 
 def test_update_stateful_set():
     mock_client = mock.Mock()
-    mock_kube_deploy_config = KubernetesDeploymentConfig(
-        service="my-service",
-        instance="my-instance",
-        cluster="cluster",
-        config_dict={},
-        branch_dict=None,
-    )
+    mock_namespace = "paasta"
     update_stateful_set(
         mock_client,
         V1StatefulSet(metadata=V1ObjectMeta(name="kurupt")),
-        mock_kube_deploy_config,
+        mock_namespace,
     )
     mock_client.deployments.replace_namespaced_stateful_set.assert_called_with(
         namespace="paasta",
@@ -3093,9 +3051,7 @@ def test_update_stateful_set():
     )
 
     mock_client = mock.Mock()
-    create_stateful_set(
-        mock_client, V1StatefulSet(api_version="some"), mock_kube_deploy_config
-    )
+    create_stateful_set(mock_client, V1StatefulSet(api_version="some"), mock_namespace)
     mock_client.deployments.create_namespaced_stateful_set.assert_called_with(
         namespace="paasta", body=V1StatefulSet(api_version="some")
     )
@@ -4098,14 +4054,7 @@ def test_get_kubernetes_secret():
     ) as mock_env, mock.patch(
         "paasta_tools.kubernetes_tools.KubeClient", autospec=True
     ) as mock_kube_client:
-
-        mock_kube_deploy_config = KubernetesDeploymentConfig(
-            service="my-service",
-            instance="my-instance",
-            cluster="cluster",
-            config_dict={},
-            branch_dict=None,
-        )
+        mock_namespace = "paasta"
         service_name = "example_service"
         secret_name = "example_secret"
         mock_env.return_value = {}
@@ -4121,7 +4070,7 @@ def test_get_kubernetes_secret():
         mock_kube_client.return_value = mock_client
 
         ret = get_kubernetes_secret(
-            mock_client, secret_name, service_name, mock_kube_deploy_config
+            mock_client, secret_name, service_name, mock_namespace
         )
         mock_client.core.read_namespaced_secret.assert_called_with(
             name="paasta-secret-example--service-example--secret", namespace="paasta"

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2619,7 +2619,7 @@ def test_list_all_deployments(addl_labels, replicas):
             list_namespaced_stateful_set=mock.Mock(return_value=mock_stateful_sets),
         )
     )
-    assert list_all_deployments(mock_client) == []
+    assert list_all_deployments(kube_client=mock_client) == []
 
     mock_items = [
         mock.Mock(
@@ -2816,8 +2816,18 @@ def test_max_unavailable(instances, bmf):
 
 
 def test_pod_disruption_budget_for_service_instance():
+    mock_kube_deploy_config = KubernetesDeploymentConfig(
+        service="my-service",
+        instance="my-instance",
+        cluster="cluster",
+        config_dict={},
+        branch_dict=None,
+    )
     x = pod_disruption_budget_for_service_instance(
-        service="foo_1", instance="bar_1", max_unavailable="10%"
+        service="foo_1",
+        instance="bar_1",
+        max_unavailable="10%",
+        service_config=mock_kube_deploy_config,
     )
 
     assert x.metadata.name == "foo--1-bar--1"
@@ -2832,7 +2842,14 @@ def test_pod_disruption_budget_for_service_instance():
 def test_create_pod_disruption_budget():
     mock_client = mock.Mock()
     mock_pdr = V1beta1PodDisruptionBudget()
-    create_pod_disruption_budget(mock_client, mock_pdr)
+    mock_kube_deploy_config = KubernetesDeploymentConfig(
+        service="my-service",
+        instance="my-instance",
+        cluster="cluster",
+        config_dict={},
+        branch_dict=None,
+    )
+    create_pod_disruption_budget(mock_client, mock_pdr, mock_kube_deploy_config)
     mock_client.policy.create_namespaced_pod_disruption_budget.assert_called_with(
         namespace="paasta", body=mock_pdr
     )
@@ -2840,7 +2857,16 @@ def test_create_pod_disruption_budget():
 
 def test_create_deployment():
     mock_client = mock.Mock()
-    create_deployment(mock_client, V1Deployment(api_version="some"))
+    mock_kube_deploy_config = KubernetesDeploymentConfig(
+        service="my-service",
+        instance="my-instance",
+        cluster="cluster",
+        config_dict={},
+        branch_dict=None,
+    )
+    create_deployment(
+        mock_client, V1Deployment(api_version="some"), mock_kube_deploy_config
+    )
     mock_client.deployments.create_namespaced_deployment.assert_called_with(
         namespace="paasta", body=V1Deployment(api_version="some")
     )
@@ -2848,7 +2874,18 @@ def test_create_deployment():
 
 def test_update_deployment():
     mock_client = mock.Mock()
-    update_deployment(mock_client, V1Deployment(metadata=V1ObjectMeta(name="kurupt")))
+    mock_kube_deploy_config = KubernetesDeploymentConfig(
+        service="my-service",
+        instance="my-instance",
+        cluster="cluster",
+        config_dict={},
+        branch_dict=None,
+    )
+    update_deployment(
+        mock_client,
+        V1Deployment(metadata=V1ObjectMeta(name="kurupt")),
+        mock_kube_deploy_config,
+    )
     mock_client.deployments.replace_namespaced_deployment.assert_called_with(
         namespace="paasta",
         name="kurupt",
@@ -2856,7 +2893,9 @@ def test_update_deployment():
     )
 
     mock_client = mock.Mock()
-    create_deployment(mock_client, V1Deployment(api_version="some"))
+    create_deployment(
+        mock_client, V1Deployment(api_version="some"), mock_kube_deploy_config
+    )
     mock_client.deployments.create_namespaced_deployment.assert_called_with(
         namespace="paasta", body=V1Deployment(api_version="some")
     )
@@ -3018,7 +3057,16 @@ def test_list_custom_resources():
 
 def test_create_stateful_set():
     mock_client = mock.Mock()
-    create_stateful_set(mock_client, V1StatefulSet(api_version="some"))
+    mock_kube_deploy_config = KubernetesDeploymentConfig(
+        service="my-service",
+        instance="my-instance",
+        cluster="cluster",
+        config_dict={},
+        branch_dict=None,
+    )
+    create_stateful_set(
+        mock_client, V1StatefulSet(api_version="some"), mock_kube_deploy_config
+    )
     mock_client.deployments.create_namespaced_stateful_set.assert_called_with(
         namespace="paasta", body=V1StatefulSet(api_version="some")
     )
@@ -3026,8 +3074,17 @@ def test_create_stateful_set():
 
 def test_update_stateful_set():
     mock_client = mock.Mock()
+    mock_kube_deploy_config = KubernetesDeploymentConfig(
+        service="my-service",
+        instance="my-instance",
+        cluster="cluster",
+        config_dict={},
+        branch_dict=None,
+    )
     update_stateful_set(
-        mock_client, V1StatefulSet(metadata=V1ObjectMeta(name="kurupt"))
+        mock_client,
+        V1StatefulSet(metadata=V1ObjectMeta(name="kurupt")),
+        mock_kube_deploy_config,
     )
     mock_client.deployments.replace_namespaced_stateful_set.assert_called_with(
         namespace="paasta",
@@ -3036,7 +3093,9 @@ def test_update_stateful_set():
     )
 
     mock_client = mock.Mock()
-    create_stateful_set(mock_client, V1StatefulSet(api_version="some"))
+    create_stateful_set(
+        mock_client, V1StatefulSet(api_version="some"), mock_kube_deploy_config
+    )
     mock_client.deployments.create_namespaced_stateful_set.assert_called_with(
         namespace="paasta", body=V1StatefulSet(api_version="some")
     )
@@ -4040,6 +4099,13 @@ def test_get_kubernetes_secret():
         "paasta_tools.kubernetes_tools.KubeClient", autospec=True
     ) as mock_kube_client:
 
+        mock_kube_deploy_config = KubernetesDeploymentConfig(
+            service="my-service",
+            instance="my-instance",
+            cluster="cluster",
+            config_dict={},
+            branch_dict=None,
+        )
         service_name = "example_service"
         secret_name = "example_secret"
         mock_env.return_value = {}
@@ -4054,7 +4120,9 @@ def test_get_kubernetes_secret():
         )
         mock_kube_client.return_value = mock_client
 
-        ret = get_kubernetes_secret(mock_client, secret_name, service_name)
+        ret = get_kubernetes_secret(
+            mock_client, secret_name, service_name, mock_kube_deploy_config
+        )
         mock_client.core.read_namespaced_secret.assert_called_with(
             name="paasta-secret-example--service-example--secret", namespace="paasta"
         )
@@ -4078,6 +4146,7 @@ def test_get_kubernetes_secret_env_variables():
             "SECRET_NAME1": "SECRET(SECRET_NAME1)",
             "SECRET_NAME2": "SECRET(SECRET_NAME2)",
         }
+
         mock_is_secret_ref.side_effect = lambda val: "SECRET" in val
         mock_get_ref.side_effect = ["SECRET_NAME1", "SECRET_NAME2"]
         mock_get_kubernetes_secret.side_effect = ["123", "abc"]


### PR DESCRIPTION
### Purpose of this PR

Added a parameter ``namespace`` in ``KubernetesDeploymentConfigDict`` and replaced hardcoded ``paasta`` namespace in ``kubernetes_tools.py`` file with the new namespace parameter.

### Testing

Tested manually and using unit tests