### PR TITLE
Add instance_type flag to list_kubernetes_service_instances

### DIFF
--- a/paasta_tools/list_kubernetes_service_instances.py
+++ b/paasta_tools/list_kubernetes_service_instances.py
@@ -60,8 +60,15 @@ def parse_args():
         action="store_true",
         help=(
             "Whether or not to sanitise service instance names before displaying "
-            "them. Kubernets apps created by PaaSTA use sanitised names."
+            "them. Kubernetes apps created by PaaSTA use sanitised names."
         ),
+    )
+    parser.add_argument(
+        "-t",
+        "--instance-type",
+        dest="instance_type",
+        default="kubernetes",
+        help="Instance type to list, default %(default)s",
     )
     args = parser.parse_args()
     return args
@@ -72,7 +79,7 @@ def main():
     soa_dir = args.soa_dir
     cluster = args.cluster
     instances = get_services_for_cluster(
-        cluster=cluster, instance_type="kubernetes", soa_dir=soa_dir
+        cluster=cluster, instance_type=args.instance_type, soa_dir=soa_dir
     )
     service_instances = []
     for name, instance in instances:


### PR DESCRIPTION
This allows us to pass an explicit instance type to `paasta_list_kubernetes_service_instances` instead of just `kubernetes`.

I think an improvement may be to accept only actual kubernetes instance types, but for now will accept any string.

This should help us pass in the right set of services to `paasta_secret_sync` for operator workloads.

Manually tested for flink jobs in infrastage, and appears to work as expected:
```
$ python -m paasta_tools.list_kubernetes_service_instances -t flink -c infrastage
flink_audit_example.main
pipeline_builder.joinery_main_k8s_copy
flink-operator-test.main
acorn.main_k8s_copy
beam_happyhour.main
```
