### PR TITLE
Teach get_running_task_allocation about non-prefixed namespaces

### DIFF
--- a/tests/contrib/test_get_running_task_allocation.py
+++ b/tests/contrib/test_get_running_task_allocation.py
@@ -1,8 +1,10 @@
+import pytest
 from kubernetes.client import V1ResourceRequirements
 
 from paasta_tools.contrib.get_running_task_allocation import (
     get_kubernetes_resource_request_limit,
 )
+from paasta_tools.contrib.get_running_task_allocation import get_matching_namespaces
 
 
 def test_get_kubernetes_resource_request_limit():
@@ -21,3 +23,28 @@ def test_get_kubernetes_resource_request_limit():
         "disk": 4096.0,
         "mem": 2048.0,
     }
+
+
+@pytest.mark.parametrize(
+    "namespaces, namespace_prefix, additional_namespaces, expected",
+    (
+        (
+            ["paasta", "paasta-flink", "paasta-spark", "luisp-was-here", "tron"],
+            "paasta",
+            ["tron"],
+            ["paasta", "paasta-flink", "paasta-spark", "tron"],
+        ),
+        (
+            ["paasta", "paasta-flink", "paasta-spark", "luisp-was-here", "tron"],
+            "paasta",
+            [""],
+            ["paasta", "paasta-flink", "paasta-spark"],
+        ),
+    ),
+)
+def test_get_matching_namespaces(
+    namespaces, namespace_prefix, additional_namespaces, expected
+):
+    assert sorted(
+        get_matching_namespaces(namespaces, namespace_prefix, additional_namespaces)
+    ) == sorted(expected)


### PR DESCRIPTION
Most of the namespaces that "belong" to PaaSTA are prefixed with paasta, with the exception of tron.

This teaches this script how to include additional namespaces in its output and sets the default to ["tron"] to avoid having to roll anything out :p