### PR TITLE
TRON-1818: Updates paasta tools to allow tron pool override

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         language_version: python3.7
         args: ['--target-version', 'py37']
         exclude: ^paasta_tools/paastaapi
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/PyCQA/flake8
     rev: 3.7.7
     hooks:
     -   id: flake8

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -586,6 +586,18 @@ class TronActionConfig(InstanceConfig):
             )
         return error_msgs
 
+    def get_pool(self) -> str:
+        """
+        Returns the default pool override if pool is not defined in the action configuration.
+
+        This is useful for environments like spam to allow us to default the pool to spam but allow users to
+        override this value. To control this, we have an optional config item that we'll puppet onto Tron masters
+        which this function will read.
+        """
+        return self.config_dict.get(
+            "pool", load_system_paasta_config().get_tron_default_pool_override()
+        )
+
 
 class TronJobConfig:
     """Represents a job in Tron, consisting of action(s) and job-level configuration values."""

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -987,7 +987,6 @@ def format_tron_job_dict(job_config: TronJobConfig, k8s_enabled: bool = False):
 
     :param job_config: TronJobConfig
     """
-
     # TODO: this use_k8s flag should be removed once we've fully migrated off of mesos
     use_k8s = job_config.get_use_k8s() and k8s_enabled
     action_dict = {

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -19,7 +19,6 @@ import os
 import pkgutil
 import re
 import subprocess
-from functools import lru_cache
 from string import Formatter
 from typing import List
 from typing import Mapping
@@ -208,12 +207,10 @@ def parse_time_variables(command: str, parse_time: datetime.datetime = None) -> 
     return StringFormatter(job_context).format(command)
 
 
-@lru_cache(maxsize=1)
 def _use_k8s_default() -> bool:
     return load_system_paasta_config().get_tron_use_k8s_default()
 
 
-@lru_cache(maxsize=1)
 def _get_tron_k8s_cluster_override(cluster: str) -> Optional[str]:
     """
     Return the name of a compute cluster if there's a different compute cluster that should be used to run a Tronjob.
@@ -240,7 +237,6 @@ def _spark_k8s_role() -> str:
     return load_system_paasta_config().get_spark_k8s_role()
 
 
-@lru_cache(maxsize=1)
 def _use_suffixed_log_streams_k8s() -> bool:
     return load_system_paasta_config().get_tron_k8s_use_suffixed_log_streams_k8s()
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1994,6 +1994,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     spark_driver_port: int
     spark_blockmanager_port: int
     skip_cpu_burst_validation: List[str]
+    tron_default_pool_override: str
 
 
 def load_system_paasta_config(
@@ -2069,6 +2070,13 @@ class SystemPaastaConfig:
 
     def __repr__(self) -> str:
         return f"SystemPaastaConfig({self.config_dict!r}, {self.directory!r})"
+
+    def get_tron_default_pool_override(self) -> str:
+        """Get the default pool override variable defined in this host's cluster config file.
+
+        :returns: The default_pool_override specified in the paasta configuration
+        """
+        return self.config_dict.get("tron_default_pool_override", "default")
 
     def get_zk_hosts(self) -> str:
         """Get the zk_hosts defined in this hosts's cluster config file.

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -28,9 +28,11 @@ MOCK_SYSTEM_PAASTA_CONFIG_OVERRIDES = utils.SystemPaastaConfig(
         "docker_registry": "mock_registry",
         "volumes": [],
         "dockercfg_location": "/mock/dockercfg",
-        "spark_k8s_role": "spark",
         "tron_default_pool_override": "big_pool",
         "tron_use_k8s": True,
+        "tron_k8s_cluster_overrides": {
+            "paasta-dev-test": "paasta-dev",
+        },
     },
     "/mock/system/configs",
 )
@@ -287,11 +289,8 @@ class TestTronJobConfig:
             cluster=expected_cluster,
         )
 
-    @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)
     @mock.patch("paasta_tools.tron_tools.load_v2_deployments_json", autospec=True)
-    def test_get_action_config_load_deployments_false(
-        self, mock_load_deployments, mock_load_system_paasta_config
-    ):
+    def test_get_action_config_load_deployments_false(self, mock_load_deployments):
         action_dict = {"command": "echo first"}
         job_dict = {
             "node": "batch_server",

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -742,7 +742,12 @@ class TestTronTools:
         )
         with mock.patch.object(
             action_config, "get_docker_registry", return_value="docker-registry.com:400"
-        ), mock.patch("paasta_tools.utils.load_system_paasta_config", autospec=True):
+        ), mock.patch(
+            "paasta_tools.utils.load_system_paasta_config", autospec=True
+        ), mock.patch(
+            "paasta_tools.tron_tools.load_system_paasta_config",
+            autospec=True,
+        ):
             result = tron_tools.format_tron_action_dict(action_config)
         assert result["executor"] == "mesos"
 
@@ -791,6 +796,9 @@ class TestTronTools:
             "paasta_tools.tron_tools._use_suffixed_log_streams_k8s",
             autospec=True,
             return_value=True,
+        ), mock.patch(
+            "paasta_tools.tron_tools.load_system_paasta_config",
+            autospec=True,
         ):
             result = tron_tools.format_tron_action_dict(action_config)
 
@@ -1070,6 +1078,9 @@ class TestTronTools:
             "paasta_tools.tron_tools._use_suffixed_log_streams_k8s",
             autospec=True,
             return_value=False,
+        ), mock.patch(
+            "paasta_tools.tron_tools.load_system_paasta_config",
+            autospec=True,
         ):
             result = tron_tools.format_tron_action_dict(action_config, use_k8s=True)
 
@@ -1160,6 +1171,9 @@ class TestTronTools:
             "paasta_tools.tron_tools._use_suffixed_log_streams_k8s",
             autospec=True,
             return_value=False,
+        ), mock.patch(
+            "paasta_tools.tron_tools.load_system_paasta_config",
+            autospec=True,
         ):
             result = tron_tools.format_tron_action_dict(action_config)
 
@@ -1360,7 +1374,7 @@ fake_job:
                 soa_dir=str(soa_dir),
                 k8s_enabled=True,
             )
-
+        print(yaml.safe_load(tronfig)["jobs"]["fake_job"]["actions"]["run"])
         assert (
             yaml.safe_load(tronfig)["jobs"]["fake_job"]["actions"]["run"][
                 "node_selectors"

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -310,6 +310,9 @@ class TestTronJobConfig:
             "my_job", job_dict, cluster, load_deployments=False, soa_dir=soa_dir
         )
         mock_load_deployments.side_effect = NoDeploymentsAvailable
+        mock_load_system_paasta_config.return_value.get_tron_k8s_cluster_overrides.return_value = (
+            {}
+        )
 
         action_config = job_config._get_action_config("normal", action_dict)
 

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -289,8 +289,11 @@ class TestTronJobConfig:
             cluster=expected_cluster,
         )
 
+    @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)
     @mock.patch("paasta_tools.tron_tools.load_v2_deployments_json", autospec=True)
-    def test_get_action_config_load_deployments_false(self, mock_load_deployments):
+    def test_get_action_config_load_deployments_false(
+        self, mock_load_deployments, mock_load_system_paasta_config
+    ):
         action_dict = {"command": "echo first"}
         job_dict = {
             "node": "batch_server",
@@ -498,7 +501,10 @@ class TestTronJobConfig:
         assert len(errors) == 3
 
     @mock.patch("paasta_tools.utils.get_pipeline_deploy_groups", autospec=True)
-    def test_validate_invalid_deploy_group(self, mock_get_pipeline_deploy_groups):
+    @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)
+    def test_validate_invalid_deploy_group(
+        self, mock_load_system_paasta_config, mock_get_pipeline_deploy_groups
+    ):
         job_dict = {
             "node": "batch_server",
             "schedule": "daily 12:10:00",
@@ -515,7 +521,10 @@ class TestTronJobConfig:
         assert len(errors) == 1
 
     @mock.patch("paasta_tools.utils.get_pipeline_deploy_groups", autospec=True)
-    def test_validate_valid_deploy_group(self, mock_get_pipeline_deploy_groups):
+    @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)
+    def test_validate_valid_deploy_group(
+        self, mock_load_system_paasta_config, mock_get_pipeline_deploy_groups
+    ):
         job_dict = {
             "node": "batch_server",
             "schedule": "daily 12:10:00",
@@ -532,8 +541,9 @@ class TestTronJobConfig:
         assert len(errors) == 0
 
     @mock.patch("paasta_tools.utils.get_pipeline_deploy_groups", autospec=True)
+    @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)
     def test_validate_invalid_action_deploy_group(
-        self, mock_get_pipeline_deploy_groups
+        self, mock_load_system_paasta_config, mock_get_pipeline_deploy_groups
     ):
         job_dict = {
             "node": "batch_server",
@@ -555,7 +565,10 @@ class TestTronJobConfig:
         assert len(errors) == 1
 
     @mock.patch("paasta_tools.utils.get_pipeline_deploy_groups", autospec=True)
-    def test_validate_action_valid_deploy_group(self, mock_get_pipeline_deploy_groups):
+    @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)
+    def test_validate_action_valid_deploy_group(
+        self, mock_load_system_paasta_config, mock_get_pipeline_deploy_groups
+    ):
         job_dict = {
             "node": "batch_server",
             "schedule": "daily 12:10:00",
@@ -574,7 +587,10 @@ class TestTronJobConfig:
         assert len(errors) == 0
 
     @mock.patch("paasta_tools.utils.get_pipeline_deploy_groups", autospec=True)
-    def test_validate_monitoring(self, mock_get_pipeline_deploy_groups):
+    @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)
+    def test_validate_monitoring(
+        self, mock_load_system_paasta_config, mock_get_pipeline_deploy_groups
+    ):
         job_dict = {
             "node": "batch_server",
             "schedule": "daily 12:10:00",
@@ -588,7 +604,10 @@ class TestTronJobConfig:
         assert len(errors) == 0
 
     @mock.patch("paasta_tools.utils.get_pipeline_deploy_groups", autospec=True)
-    def test_validate_monitoring_without_team(self, mock_get_pipeline_deploy_groups):
+    @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)
+    def test_validate_monitoring_without_team(
+        self, mock_load_system_paasta_config, mock_get_pipeline_deploy_groups
+    ):
         job_dict = {
             "node": "batch_server",
             "schedule": "daily 12:10:00",
@@ -603,8 +622,9 @@ class TestTronJobConfig:
         assert job_config.get_monitoring()["team"] == "default_team"
 
     @mock.patch("paasta_tools.utils.get_pipeline_deploy_groups", autospec=True)
+    @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)
     def test_validate_monitoring_with_invalid_team(
-        self, mock_get_pipeline_deploy_groups
+        self, mock_load_system_paasta_config, mock_get_pipeline_deploy_groups
     ):
         job_dict = {
             "node": "batch_server",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -419,6 +419,16 @@ def test_SystemPaastaConfig_get_volumes():
     assert actual == expected
 
 
+def test_SystemPaastaConfig_get_tron_default_pool_override():
+    fake_config = utils.SystemPaastaConfig(
+        {"tron_default_pool_override": "spam"},
+        "/some/fake/dir",
+    )
+    actual = fake_config.get_tron_default_pool_override()
+    expected = "spam"
+    assert actual == expected
+
+
 def test_SystemPaastaConfig_get_hacheck_sidecar_volumes():
     fake_config = utils.SystemPaastaConfig(
         {


### PR DESCRIPTION
Currently there is no way to override the default pool for tronjobs. We want to be able to enable the default pool as spam for the tron-spam-pnw-prod environment to remove unnecessary configuration needed in yelpsoaconfigs after finishing the migration to k8s for spam-pnw-prod.

This allows us to override the default pool via puppet for tron.