### PR TITLE
Allow us to check service mesh orphans separately from collisions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         language_version: python3.7
         args: ['--target-version', 'py37']
         exclude: ^paasta_tools/paastaapi
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/PyCQA/flake8
     rev: 3.7.7
     hooks:
     -   id: flake8


### PR DESCRIPTION
Because we now remove terminating pods from nerve config immediately, it seems like we're running into a race condition where this check can catch us between configure-nerve updating the config and nerve removing the affected registrations from zookeeper. This normally happens very quickly (within a second or two) in dev, but I suspect might take a little longer in prod due to the # of registrations per host (unconfirmed, but the alert behavior seems to support this).

This change to the script allows us to at least configure the 2 checks separately so we can continue to alert immediately if we see collisions, but alert only if orphans stick around after some configurable period of time (i.e. alert_after). 

Currently from searching splunk, the identified orphans come up only once in the check results and then go away, so this should help the volume of alerts right now. 