### PR TITLE
TRON-1824: change default owner of Tron generated resources to CIPX

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -915,8 +915,7 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
             "paasta.yelp.com/routable_ip": "true" if executor == "spark" else "false",
         }
 
-        if action_config.get_team() is not None:
-            result["labels"]["yelp.com/owner"] = action_config.get_team()
+        result["labels"]["yelp.com/owner"] = "compute_infra_platform_experience"
 
         # create_or_find_service_account_name requires k8s credentials, and we don't
         # have those available for CI to use (nor do we check these for normal PaaSTA

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1016,6 +1016,7 @@ class TestTronTools:
                 "paasta.yelp.com/instance": "my_job.do_something",
                 "paasta.yelp.com/pool": "special_pool",
                 "paasta.yelp.com/service": "my_service",
+                "yelp.com/owner": "compute_infra_platform_experience",
             },
             "annotations": {"paasta.yelp.com/routable_ip": "true"},
             "cap_drop": CAPS_DROP,

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1123,7 +1123,7 @@ class TestTronTools:
                 "paasta.yelp.com/instance": expected_instance_label,
                 "paasta.yelp.com/pool": "special_pool",
                 "paasta.yelp.com/service": "my_service",
-                "yelp.com/owner": "some_sensu_team",
+                "yelp.com/owner": "compute_infra_platform_experience",
             },
             "annotations": {
                 "paasta.yelp.com/routable_ip": "false",


### PR DESCRIPTION
For PaaSTA generated Kubernetes resources, we set the `yelp.com/owner` label to CIPX by default.
We should do the same for TRON generated Kubernetes resources.

Signed-off-by: Max Falk <gfalk@yelp.com>
