### PR TITLE
Bump service-configuration-lib to 2.13.5 to cap spark executor resources

### DIFF
--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -13,7 +13,7 @@ from typing import Set
 import yaml
 from mypy_extensions import TypedDict
 from service_configuration_lib.spark_config import _adjust_spark_requested_resources
-from service_configuration_lib.spark_config import _append_sql_shuffle_partitions_conf
+from service_configuration_lib.spark_config import _append_sql_partitions_conf
 from service_configuration_lib.spark_config import DEFAULT_SPARK_RUN_CONFIG
 
 from paasta_tools.utils import DockerVolume
@@ -148,13 +148,13 @@ def adjust_spark_resources(
 
 def setup_shuffle_partitions(spark_args: Dict[str, str]) -> Dict[str, str]:
     """
-    Wrapper around _append_sql_shuffle_partitions_conf from service_configuration_lib.
+    Wrapper around _append_sql_partitions_conf from service_configuration_lib.
 
     For now, this really just sets a default number of partitions based on # of cores.
     """
     # as above, this function also returns everything + mutates the passed in dictionary
     # which is not ideal
-    return _append_sql_shuffle_partitions_conf(
+    return _append_sql_partitions_conf(
         spark_opts=copy.copy(spark_args),
     )
 

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -49,7 +49,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.12.0
+service-configuration-lib >= 2.13.5
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.12.3
+service-configuration-lib==2.13.5
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -986,7 +986,9 @@ class TestTronTools:
             "--conf spark.kubernetes.allocation.batch.size=512 "
             "--conf spark.kubernetes.executor.limit.cores=2 "
             "--conf spark.scheduler.maxRegisteredResourcesWaitingTime=15min "
-            "--conf spark.sql.shuffle.partitions=8 "
+            "--conf spark.sql.shuffle.partitions=12 "
+            "--conf spark.sql.files.minPartitionNum=12 "
+            "--conf spark.default.parallelism=12 "
             "--conf spark.eventLog.enabled=true "
             "--conf spark.eventLog.dir=s3a://test "
             # actual script to run


### PR DESCRIPTION
1. Follow-up PR for: https://github.com/Yelp/service_configuration_lib/pull/95
2. Update function name and test case for https://github.com/Yelp/service_configuration_lib/pull/94 which is included in this version update

