### PR TITLE
Adding Yelp docker registry credentials to kind cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ k8s_itests: .paasta/bin/activate
 	make -C k8s_itests all
 
 .PHONY: k8s_fake_cluster
-k8s_fake_cluster: .paasta/bin/activate
+k8s_fake_cluster: .tox/py37-linux
 	make -C k8s_itests fake_cluster
 
 .PHONY: k8s_clean

--- a/k8s_itests/Makefile
+++ b/k8s_itests/Makefile
@@ -11,8 +11,10 @@ export KUBECONFIG=$(CWD)/kubeconfig
 
 ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
 	export KIND_CONFIG=deployments/kind/cluster-devbox.yaml
+	PAASTA_K8S_ENV ?= YELP
 else
 	export KIND_CONFIG=deployments/kind/cluster.yaml
+	PAASTA_K8S_ENV ?= $(shell hostname --fqdn)
 endif
 
 .PHONY: all itest fake_cluster kind create_cluster clean
@@ -20,6 +22,9 @@ endif
 all: clean itest
 
 fake_cluster: clean create_cluster
+	if [ "$(PAASTA_K8S_ENV)" = "YELP" ]; then \
+		./scripts/set-paasta-registry-credentials.sh $(CLUSTER); \
+	fi
 
 kind:
 	./scripts/install-kind.sh

--- a/k8s_itests/deployments/kind/cluster-devbox.yaml
+++ b/k8s_itests/deployments/kind/cluster-devbox.yaml
@@ -5,4 +5,8 @@ network: k8s_kindest
 nodes:
   - role: control-plane
   - role: worker
+    labels:
+      yelp.com/pool: default
   - role: worker
+    labels:
+      yelp.com/pool: default

--- a/k8s_itests/deployments/kind/cluster.yaml
+++ b/k8s_itests/deployments/kind/cluster.yaml
@@ -4,4 +4,8 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
   - role: worker
+    labels:
+      yelp.com/pool: default
   - role: worker
+    labels:
+      yelp.com/pool: default

--- a/k8s_itests/scripts/containerd_registry_setup.py
+++ b/k8s_itests/scripts/containerd_registry_setup.py
@@ -1,0 +1,20 @@
+import json
+import sys
+
+import toml
+
+containerdcfg_file_path = sys.argv[1]
+containerdcfg = toml.load(containerdcfg_file_path)
+dockercfg = json.load(open("/nail/etc/docker-registry-ro"))
+registry = list(dockercfg.keys())[0]
+
+containerdcfg["plugins"]["io.containerd.grpc.v1.cri"]["registry"]["configs"] = {
+    registry: {"auth": {"auth": dockercfg[registry]["auth"]}}
+}
+
+containerdcfg["plugins"]["io.containerd.grpc.v1.cri"]["registry"]["mirrors"][
+    registry
+] = {"endpoint": [f"https://{registry}"]}
+
+with open(containerdcfg_file_path, "w") as containerdcfg_file:
+    containerdcfg_file.write(toml.dumps(containerdcfg))

--- a/k8s_itests/scripts/set-paasta-registry-credentials.sh
+++ b/k8s_itests/scripts/set-paasta-registry-credentials.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+CLUSTER=$1
+
+for node in $(./kind get nodes --name "${CLUSTER}"); do
+  echo "Moving credentials to kind node: $node ..."
+  docker cp "${node}:/etc/containerd/config.toml" "./.tmp/${node}-containerd.toml"
+  ../.tox/py37-linux/bin/python ./scripts/containerd_registry_setup.py "./.tmp/${node}-containerd.toml"
+  docker cp "./.tmp/${node}-containerd.toml" "${node}:/etc/containerd/config.toml"
+  rm ./.tmp/${node}-containerd.toml
+#   restart kubelet and containerd to pick up the updated config
+  docker exec "${node}" systemctl restart containerd.service
+  docker exec "${node}" systemctl restart kubelet.service
+done


### PR DESCRIPTION
This PR adds the default pool tag and the Yelp docker registry credentials to the local kind nodes