### PR TITLE
PAASTA-17808: Add code coverage to paasta unit test targets

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,23 @@
+[run]
+source =
+    .
+omit =
+    .tox/*
+    .paasta/*
+    tests/*
+    setup.py
+
+[report]
+
+exclude_lines =
+    # Have to re-enable the standard pragma
+    \#\s*pragma: no cover
+
+    # Don't complain if tests don't hit defensive assertion code:
+    ^\s*raise AssertionError\b
+    ^\s*raise NotImplementedError\b
+    ^\s*return NotImplemented\b
+    ^\s*raise$
+
+    # Don't complain if non-runnable code isn't run:
+    ^if __name__ == ['"]__main__['"]:$

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ example_cluster/paasta/docker_registry.json
 general_itests/fake_etc_paasta/clusters.json
 pip-wheel-metadata
 debian/debhelper-build-stamp
+
+# Coverage artifacts
+.coverage

--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -1,5 +1,6 @@
 astroid
 asynctest
+coverage
 docutils
 flake8
 freezegun

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ astroid==2.4.2
 asynctest==0.12.0
 Babel==2.9.1
 cfgv==2.0.1
+coverage==6.5.0
 distlib==0.3.4
 filelock==3.0.12
 flake8==3.5.0

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1668,7 +1668,7 @@ class TestMarathonTools:
             )
             args, kwargs = client_patch.call_args
             assert "User-Agent" in kwargs["session"].headers
-            assert "py.test" in kwargs["session"].headers["User-Agent"]
+            assert "test" in kwargs["session"].headers["User-Agent"]
 
     def test_list_all_marathon_app_ids(self):
         fakeapp1 = mock.Mock(id="/fake_app1")

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,9 @@ commands =
     check-requirements -vv
     pre-commit install -f --install-hooks
     pre-commit run --all-files
-    py.test {posargs:tests}
+    coverage erase
+    coverage run -m py.test {posargs:tests}
+    coverage report -m
 
 [testenv:tests-yelpy]
 envdir = .tox/py37-linux/
@@ -72,7 +74,9 @@ commands =
     check-requirements -vv
     pre-commit install -f --install-hooks
     pre-commit run --all-files
-    py.test {posargs:tests}
+    coverage erase
+    coverage run -m py.test {posargs:tests}
+    coverage report -m
 
 [testenv:docs]
 commands =


### PR DESCRIPTION
## Problem or feature
The repo doesn't have code coverage set up, making it difficult to know which code paths are covered by unit tests

## Solution
Add coverage dependencies and call pytest with coverage for `test` and `test-yelpy` Makefile targets

## Testing done
Ran unit tests


Note: the one test change is because of this change that happens when running with coverage vs not:

```
___________________________________ TestMarathonTools.test_get_marathon_client ____________________________________

self = <tests.test_marathon_tools.TestMarathonTools object at 0x7fb7f53040d0>

    def test_get_marathon_client(self):
        fake_url = ["nothing_for_me_to_do_but_dance"]
        fake_user = "the_boogie"
        fake_passwd = "is_for_real"
        with mock.patch(
            "paasta_tools.marathon_tools.MarathonClient", autospec=True
        ) as client_patch:
            marathon_tools.get_marathon_client(fake_url, fake_user, fake_passwd)
            client_patch.assert_called_once_with(
                fake_url, fake_user, fake_passwd, timeout=30, session=mock.ANY
            )
            args, kwargs = client_patch.call_args
            assert "User-Agent" in kwargs["session"].headers
>           assert "py.test" in kwargs["session"].headers["User-Agent"]
E           AssertionError: assert 'py.test' in 'test.py 0.152.2'

tests/test_marathon_tools.py:1671: AssertionError
```