### PR TITLE
Ensure paasta status supports arbitrary namespaces - PAASTA-17825

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -610,7 +610,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         )
 
     def get_kubernetes_namespace(self) -> str:
-        return KUBERNETES_NAMESPACE
+        return self.get_namespace()
 
     def get_cmd(self) -> Optional[List[str]]:
         cmd = super(LongRunningServiceConfig, self).get_cmd()


### PR DESCRIPTION
### Problem

paasta status doesn't show the status of services not in "paasta" namespace.

### solution

Check what namespace is specified in soaconfigs and get status of instance in that namespace

### Testing

- Unit tests pass
- Manual testing:
Tested on infrastage by running the paasta API and then point it to my version of soaconfigs and then running paasta status and point it to my version of soaconfigs. Output matches what is deployed on infrastage for service ``compute-infra-test-service`` :  https://fluffy.yelpcorp.com/i/XtHBSwDf0sPtfgsjFHL7mX7bNRKG61sP.html


