### PR TITLE
Fix mock usage

### DIFF
--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -1357,13 +1357,15 @@ def test_get_new_instance_count():
             num_healthy_instances=4,
             persist_data=False,
         )
-        assert mock_decision_policy.called_with(
+        mock_decision_policy.assert_called_with(
             error=0.1,
-            min_instances=mock_marathon_service_config.get_min_instances(),
-            max_instances=mock_marathon_service_config.get_max_instances(),
             current_instances=4,
             zookeeper_path=mock_compose_autoscaling_zookeeper_root.return_value,
+            decision_policy="mock_dp",
+            utilization=0.7,
             mock_param=2,
+            num_healthy_instances=4,
+            persist_data=False,
         )
         mock_marathon_service_config.limit_instance_count.assert_called_with(5)
         assert ret == mock_marathon_service_config.limit_instance_count.return_value

--- a/tests/test_marathon_tools.py
+++ b/tests/test_marathon_tools.py
@@ -1748,7 +1748,7 @@ class TestMarathonTools:
     def test_add_leading_slash(self):
         fake_client = mock.Mock(list_tasks=mock.Mock(return_value=[{}, {}, {}, {}]))
         marathon_tools.app_has_tasks(fake_client, "fake_app", 4)
-        assert fake_client.list_tasks.called_with("/fake_app")
+        fake_client.list_tasks.assert_called_with(app_id="/fake_app")
 
     def test_get_config_hash(self):
         test_input = {"foo": "bar"}


### PR DESCRIPTION
Some tests used `assert mock_object.called_once_with()`. The return value of `called_once_with()` is a mock object which always evaluates to true which means it always passes the assertion.