### PR TITLE
passing soadir specified with -d flag when listing all instances of a service 

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -1381,7 +1381,7 @@ def paasta_logs(args: argparse.Namespace) -> int:
         )
         return 1
 
-    if verify_instances(args.instance, service, cluster):
+    if verify_instances(args.instance, service, cluster, soa_dir):
         return 1
 
     instance = args.instance

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -1065,7 +1065,10 @@ def trigger_deploys(
 
 
 def verify_instances(
-    args_instances: str, service: str, clusters: Sequence[str]
+    args_instances: str,
+    service: str,
+    clusters: Sequence[str],
+    soa_dir: str = DEFAULT_SOA_DIR,
 ) -> Sequence[str]:
     """Verify that a list of instances specified by user is correct for this service.
 
@@ -1076,7 +1079,7 @@ def verify_instances(
     """
     unverified_instances = args_instances.split(",")
     service_instances: Set[str] = list_all_instances_for_service(
-        service, clusters=clusters
+        service, clusters=clusters, soa_dir=soa_dir
     )
 
     misspelled_instances: Sequence[str] = [


### PR DESCRIPTION
When I was testing paasta logs with my own soaconfigs I wasn't getting logs for any instance I added. This is because even though I specified my soaconfig with -d flag, it wasn't being passed to ``list_all_instances_for_service`` function and thus it always was set to the default soaconfig