### PR TITLE
Adding group_lines.py functionality to paasta

### DIFF
--- a/paasta_tools/list_kubernetes_service_instances.py
+++ b/paasta_tools/list_kubernetes_service_instances.py
@@ -29,7 +29,7 @@ Command line options:
 import argparse
 import random
 import sys
-from typing import Sequence
+from typing import List
 
 from paasta_tools import kubernetes_tools
 from paasta_tools.utils import compose_job_id
@@ -113,8 +113,8 @@ def main():
     sys.exit(0)
 
 
-def group_lines(service_instances: Sequence[str], num_lines: int) -> None:
-    output = [[] for _ in range(num_lines)]
+def group_lines(service_instances: List[str], num_lines: int) -> None:
+    output: List[List[str]] = [[] for _ in range(num_lines)]
     curr_index = 0
     for instance in service_instances:
         output[curr_index].append(instance)

--- a/paasta_tools/list_kubernetes_service_instances.py
+++ b/paasta_tools/list_kubernetes_service_instances.py
@@ -74,14 +74,14 @@ def parse_args():
     parser.add_argument(
         "--shuffle",
         action="store_true",
-        help=("Random shuffle the instances output."),
+        help=("Shuffle the instances output."),
     )
     parser.add_argument(
         "--group-lines",
         type=int,
         dest="group_lines",
         help=(
-            "Groups output into a desired number of lines with each instance element separated by spaces"
+            "Groups instances output into a desired number of lines with each instance separated by spaces"
         ),
     )
     args = parser.parse_args()

--- a/paasta_tools/list_kubernetes_service_instances.py
+++ b/paasta_tools/list_kubernetes_service_instances.py
@@ -29,6 +29,7 @@ Command line options:
 import argparse
 import random
 import sys
+from typing import Sequence
 
 from paasta_tools import kubernetes_tools
 from paasta_tools.utils import compose_job_id
@@ -104,7 +105,7 @@ def main():
         service_instances.append(app_name)
     if args.shuffle:
         random.shuffle(service_instances)
-        
+
     if args.group_lines:
         group_lines(service_instances, args.group_lines)
     else:

--- a/tests/test_list_kubernetes_service_instances.py
+++ b/tests/test_list_kubernetes_service_instances.py
@@ -21,18 +21,28 @@ def test_parse_args():
 )
 @mock.patch("builtins.print", autospec=True)
 @pytest.mark.parametrize(
-    "instance_type,sanitise,expected",
+    "instance_type,sanitise,expected,shuffle,group_lines",
     [
-        ("kubernetes", False, "service_1.instance1\nservice_2.instance1"),
-        ("kubernetes", True, "service--1-instance1\nservice--2-instance1"),
-        ("flink", True, "service--1-instance1\nservice--2-instance1"),
+        ("kubernetes", False, "service_1.instance1\nservice_2.instance1", False, None),
+        ("kubernetes", True, "service--1-instance1\nservice--2-instance1", False, None),
+        ("flink", True, "service--1-instance1\nservice--2-instance1", False, None),
     ],
 )
 def test_main(
-    mock_print, mock_get_services, mock_parse_args, instance_type, sanitise, expected
+    mock_print,
+    mock_get_services,
+    mock_parse_args,
+    instance_type,
+    sanitise,
+    expected,
+    shuffle,
+    group_lines,
 ):
     mock_parse_args.return_value = mock.Mock(
-        instance_type=instance_type, sanitise=sanitise
+        instance_type=instance_type,
+        sanitise=sanitise,
+        shuffle=shuffle,
+        group_lines=group_lines,
     )
 
     with pytest.raises(SystemExit) as e:


### PR DESCRIPTION
This PR adds `group_lines.py`(file from puppet) functionality into `paasta_list_kubernetes_service_instances`