### PR TITLE
Call create_application_object only when a service instance exist

### DIFF
--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -215,13 +215,14 @@ def setup_kube_deployments(
 
     applications = [
         create_application_object(
-            cluster=service_instance.get_cluster(),
+            cluster=cluster,
             soa_dir=soa_dir,
             service_instance_config=service_instance,
         )
+        if service_instance
+        else (_, None)
         for _, service_instance in service_instance_configs_list
     ]
-
     api_updates = 0
     for _, app in applications:
         if app:


### PR DESCRIPTION
### Problem

Before, we called create_application_object passing ``cluster=service_instance.get_cluster()`` and when the service_instance is none then it would crash. Also, later on in the function it might crash when doing ``service_instance_config.format_kubernetes_app()`` in ``create_application_object``.

### Solution
Don't call `` create_application_object`` when ``service_instance`` is None but ensure we add the tuple whether it's (False, None) or (True, None) to applications list. This way later if we have (False, None) in the list it would return 1 :
`` return (False, None) not in applications``  as this is what we return end of ``setup_kube_deployments`` function