### PR TITLE
Enable explicitly setting service_account_name in tron actions

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -97,6 +97,9 @@
                 "pool": {
                     "type": "string"
                 },
+                "service_account_name": {
+                    "type": "string"
+                },
                 "iam_role": {
                     "type": "string"
                 },

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -856,6 +856,14 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
         "triggered_by": action_config.get_triggered_by(),
         "on_upstream_rerun": action_config.get_on_upstream_rerun(),
         "trigger_timeout": action_config.get_trigger_timeout(),
+        # outside of Spark usescases, we also allow users to specify an expected-to-exist Service Account name
+        # in the Tron namespace in case an action needs specific k8s permissions (e.g., a Jolt batch may need
+        # k8s permissions to list Jolt pods in the jolt namespace to do science™ to them).
+        # if the provided Service Account does not exist, Tron should simply fail to create the Podspec and report
+        # a failure
+        # TODO: verify the above sentence
+        # NOTE: this will get overridden if an action specifies Pod Identity configs
+        "service_account_name": action_config.get_service_account_name(),
     }
 
     # while we're tranisitioning, we want to be able to cleanly fallback to Mesos

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -865,7 +865,6 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
         # k8s permissions to list Jolt pods in the jolt namespace to do science™ to them).
         # if the provided Service Account does not exist, Tron should simply fail to create the Podspec and report
         # a failure
-        # TODO: verify the above sentence
         # NOTE: this will get overridden if an action specifies Pod Identity configs
         "service_account_name": action_config.get_service_account_name(),
     }

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -259,6 +259,7 @@ class TronActionConfigDict(InstanceConfigDict, total=False):
     # the values for this dict can be anything since it's whatever
     # spark accepts
     spark_args: Dict[str, Any]
+    service_account_name: str
 
 
 class TronActionConfig(InstanceConfig):
@@ -594,6 +595,9 @@ class TronActionConfig(InstanceConfig):
         return self.config_dict.get(
             "pool", load_system_paasta_config().get_tron_default_pool_override()
         )
+
+    def get_service_account_name(self) -> Optional[str]:
+        return self.config_dict.get("service_account_name")
 
 
 class TronJobConfig:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1003,6 +1003,9 @@ class InstanceConfig:
             return None
         return security.get("outbound_firewall")
 
+    def get_service_account_name(self) -> Optional[str]:
+        return self.config_dict.get("service_account_name")
+
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, type(self)):
             return (

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1003,9 +1003,6 @@ class InstanceConfig:
             return None
         return security.get("outbound_firewall")
 
-    def get_service_account_name(self) -> Optional[str]:
-        return self.config_dict.get("service_account_name")
-
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, type(self)):
             return (


### PR DESCRIPTION
There's internal users that would like to configure a Service Account
with specific permissions for use in their batches.

Right now, we can only dynamically create Service Accounts - and these
are generally only used for Pod Identity (or, they're mapped 1:1 with an
existing Role).

This PR enables users to explicitly set service_account_name in their
action configs and have that be plumbed all the way through to Tron
