### PR TITLE
Add documentation note about using non-standard uwsgi_stats_port

### DIFF
--- a/docs/source/autoscaling.rst
+++ b/docs/source/autoscaling.rst
@@ -69,6 +69,7 @@ The currently available metrics providers are:
   This sidecar will listen on port 9117, and will request metrics from your uWSGI master via its `stats server <http://uwsgi-docs.readthedocs.io/en/latest/StatsServer.html>`_.
   The uwsgi_exporter container needs to know what port your uWSGI master's stats server is on - you can configure this with the ``uwsgi_stats_port`` key in the ``autoscaling`` dictionary.
   ``uwsgi_exporter`` will translate the uWSGI stats into Prometheus format, which Prometheus will scrape.
+  If you have configured your service to use a non-default stats port (8889), you need to explicity set ``uwsgi_stats_port`` in your autoscaling config with the same value to ensure that metrics are being exported.
 
   Extra parameters:
 

--- a/docs/source/autoscaling.rst
+++ b/docs/source/autoscaling.rst
@@ -69,7 +69,10 @@ The currently available metrics providers are:
   This sidecar will listen on port 9117, and will request metrics from your uWSGI master via its `stats server <http://uwsgi-docs.readthedocs.io/en/latest/StatsServer.html>`_.
   The uwsgi_exporter container needs to know what port your uWSGI master's stats server is on - you can configure this with the ``uwsgi_stats_port`` key in the ``autoscaling`` dictionary.
   ``uwsgi_exporter`` will translate the uWSGI stats into Prometheus format, which Prometheus will scrape.
-  If you have configured your service to use a non-default stats port (8889), you need to explicity set ``uwsgi_stats_port`` in your autoscaling config with the same value to ensure that metrics are being exported.
+
+  .. note::
+
+    If you have configured your service to use a non-default stats port (8889), you need to explicity set ``uwsgi_stats_port`` in your autoscaling config with the same value to ensure that metrics are being exported.
 
   Extra parameters:
 


### PR DESCRIPTION
This is a follow up from #dar-1587.
In addition to this PR I have also updated our internal [confluence guide](https://yelpwiki.yelpcorp.com/display/PAASTA/HOWTO%3A+Autoscale+Your+PaaSTA+Service) to mention this.
