### PR TITLE
Enable setting a multiplier to uwsgi offset config

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1995,6 +1995,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     spark_blockmanager_port: int
     skip_cpu_burst_validation: List[str]
     tron_default_pool_override: str
+    uwsgi_offset_multiplier: float
 
 
 def load_system_paasta_config(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2734,6 +2734,15 @@ class SystemPaastaConfig:
         """
         return self.config_dict.get("tron_k8s_cluster_overrides", {})
 
+    def get_uwsgi_offset_multiplier(self) -> float:
+        """
+        Temporary configuration to allow us to slowly deprecate the usage of `offset` in uwsgi-based autoscaling
+        configurations without making a single massive change to how usage is calculated.
+
+        To be removed once PAASTA-17840 is done.
+        """
+        return self.config_dict.get("uwsgi_offset_multiplier", 1.0)
+
 
 def _run(
     command: Union[str, List[str]],


### PR DESCRIPTION
This will allow us to slowly lower the impact of the offset parameter by decreasing this value from 1.0 -> 0 rather than completely removing it all at once (and potentially exposing problems hidden by our overscaling)