### PR TITLE
removing hardcoded paasta ns in setup_prometheus_adapter_config file - PAASTA-17777

### DIFF
--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -173,6 +173,7 @@ def test_create_instance_cpu_scaling_rule() -> None:
     service_name = "test_service"
     instance_name = "test_instance"
     paasta_cluster = "test_cluster"
+    namespace = "test_namespace"
     autoscaling_config: AutoscalingParamsDict = {
         "metrics_provider": "cpu",
         "setpoint": 0.1234567890,
@@ -185,6 +186,7 @@ def test_create_instance_cpu_scaling_rule() -> None:
         instance=instance_name,
         paasta_cluster=paasta_cluster,
         autoscaling_config=autoscaling_config,
+        namespace=namespace,
     )
 
     # our query doesn't include the setpoint as we'll just give the HPA the current CPU usage and
@@ -251,6 +253,7 @@ def test_get_rules_for_service_instance(
                     instance_name="instance",
                     autoscaling_config=autoscaling_config,
                     paasta_cluster="cluster",
+                    namespace="test_namespace",
                 )
             )
             == expected_rules
@@ -280,6 +283,7 @@ def test_create_instance_arbitrary_promql_scaling_rule_no_seriesQuery():
         instance="instance",
         autoscaling_config={"prometheus_adapter_config": {"metricsQuery": "foo"}},
         paasta_cluster="cluster",
+        namespace="paasta",
     )
 
     assert rule == {
@@ -303,6 +307,7 @@ def test_create_instance_arbitrary_promql_scaling_rule_with_seriesQuery():
             "prometheus_adapter_config": {"metricsQuery": "foo", "seriesQuery": "bar"}
         },
         paasta_cluster="cluster",
+        namespace="test_namespace",
     )
 
     assert rule == {


### PR DESCRIPTION
### Feature

In this PR we remove hardcoded "paasta" namespace in ``setup_prometheus_adapter_config`` file and replace it with the namespace from soaconfigs. We also ensure that we call ``ensure_namespace`` for all namespaces not just "paasta"

### Testing

- Unit tests pass
- manually tested it on paasta playground and I see the adapter-config map created:
```
(py37-linux) emanelsabban@dev55-uswest1adevc:~/pg/paasta$ KUBECONFIG="./k8s_itests/kubeconfig" kubectl get configmap -n custom-metrics
NAME               DATA   AGE
adapter-config     1      22s
```
Describing configmap: https://fluffy.yelpcorp.com/i/hLq5wHQ8rXS4G0PM0mKzh0trzNr9Mh6k.html