### PR TITLE
Add support for aws assume role in local-run

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -774,7 +774,7 @@ def assume_aws_role(
         # The contents of "Credentials" key from assume_role is the same as from aws-okta
         cmd_output = assumed_role["Credentials"]
 
-    creds_dict = {
+    creds_dict: AWSSessionCreds = {
         "AWS_ACCESS_KEY_ID": cmd_output["AccessKeyId"],
         "AWS_SECRET_ACCESS_KEY": cmd_output["SecretAccessKey"],
         "AWS_SESSION_TOKEN": cmd_output["SessionToken"],

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -707,13 +707,20 @@ def assume_aws_role(
             file=sys.stderr,
         )
         sys.exit(1)
-    with open("/nail/etc/runtimeenv") as runtimeenv_file:
-        aws_account = runtimeenv_file.read()
-        # Map runtimeenv in special cases to proper aws account name
-        if aws_account == "stage":
-            aws_account = "dev"
-        elif aws_account == "corp":
-            aws_account = "corpprod"
+    try:
+        with open("/nail/etc/runtimeenv") as runtimeenv_file:
+            aws_account = runtimeenv_file.read()
+            # Map runtimeenv in special cases to proper aws account name
+            if aws_account == "stage":
+                aws_account = "dev"
+            elif aws_account == "corp":
+                aws_account = "corpprod"
+    except FileNotFoundError:
+        print(
+            "Unable to determine environment for AWS account name. Using 'dev'",
+            file=sys.stderr,
+        )
+        aws_account = "dev"
     if pod_identity and (assume_pod_identity or assume_role_arn):
         print(
             "Calling aws-okta to assume role {} using account {}".format(

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -720,7 +720,7 @@ def assume_aws_role(
         cmd = subprocess.run(assume_role_cmd, shell=True, stdout=subprocess.PIPE)
         if cmd.returncode != 0:
             print(
-                "Error assuming pod identity role. Use --skip-pod-identity to run without pod identity role",
+                "Error assuming pod identity role. Remove --assume-pod-identity to run without pod identity role, or specify another role via --assume-role",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -781,7 +781,7 @@ def assume_aws_role(
         cred_process = get_cred_process_cmd.stdout.decode("utf-8").split(" ")
         if os.getuid() == 0:
             cred_process = [
-                "sudio",
+                "sudo",
                 "-u",
                 get_username(),
                 f"HOME=/nail/home/{get_username()}",

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -388,7 +388,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
     args.vault_token_file = "/blah/token"
     args.skip_secrets = False
     args.volumes = []
-    args.assume_role = ""
+    args.assume_role_arn = ""
     args.assume_pod_identity = False
     args.use_okta_role = False
 
@@ -428,7 +428,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
         json_dict=False,
         secret_provider_kwargs=mock_secret_provider_kwargs,
         skip_secrets=False,
-        assume_role="",
+        assume_role_arn="",
         assume_pod_identity=False,
         use_okta_role=False,
     )
@@ -462,7 +462,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
     args.vault_token_file = "/blah/token"
     args.skip_secrets = False
     args.volumes = []
-    args.assume_role = ""
+    args.assume_role_arn = ""
     args.assume_pod_identity = False
     args.use_okta_role = False
 
@@ -501,7 +501,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
         json_dict=False,
         secret_provider_kwargs=mock_secret_provider_kwargs,
         skip_secrets=False,
-        assume_role="",
+        assume_role_arn="",
         assume_pod_identity=False,
         use_okta_role=False,
     )
@@ -541,7 +541,7 @@ def test_configure_and_run_pulls_image_when_asked(
     args.vault_token_file = "/blah/token"
     args.skip_secrets = False
     args.volumes = []
-    args.assume_role = ""
+    args.assume_role_arn = ""
     args.assume_pod_identity = False
     args.use_okta_role = False
 
@@ -582,7 +582,7 @@ def test_configure_and_run_pulls_image_when_asked(
         json_dict=False,
         secret_provider_kwargs=mock_secret_provider_kwargs,
         skip_secrets=False,
-        assume_role="",
+        assume_role_arn="",
         assume_pod_identity=False,
         use_okta_role=False,
     )
@@ -618,7 +618,7 @@ def test_configure_and_run_docker_container_defaults_to_interactive_instance(
         args.vault_token_file = "/blah/token"
         args.skip_secrets = False
         args.volumes = []
-        args.assume_role = ""
+        args.assume_role_arn = ""
         args.assume_pod_identity = False
         args.use_okta_role = False
 
@@ -659,7 +659,7 @@ def test_configure_and_run_docker_container_defaults_to_interactive_instance(
             json_dict=False,
             secret_provider_kwargs=mock_secret_provider_kwargs,
             skip_secrets=False,
-            assume_role="",
+            assume_role_arn="",
             assume_pod_identity=False,
             use_okta_role=False,
         )


### PR DESCRIPTION
Seeking feedback on this proposed change to add more AWS functionality to local-run. The goal of this is to allow local-run to run within an AWS role context, to emulate what happens in a normal paasta context when pod identity (or kiam) is set.

This supports several scenarios:
- The service has an iam role configured, and you want to assume that role
- You want to specify a different role to assume
- You want to use whatever role aws-okta provides

Unless one of these new arguments is specified, behavior will be identical to before. 

If `--assume-pod-identity` is provided, it will check the relevant instance config for `iam-role`, and attempt to assume that role by using the aws-okta for an account matching the current runtimeenv. 

if `--use-okta-role` is provided, it will attempt to get a session from aws-okta and use those credentials.

if `--aws-role` is provided, it will attempt to assume into that role rather than one from the instance config.

Looking to get some feedback on this before I finish writing tests. 

Manual test / example behavior:
Attempt to use actual iam role (I don't have permissions) https://fluffy.yelpcorp.com/i/R6SrxqhtrXf8WXB8p5hZhLCv9kZMB0hK.html
Attempt to use my current role
https://fluffy.yelpcorp.com/i/sqZxqfhW4WpRJSj1vzCLwZFppN8wGhD4.html

