### PR TITLE
Adding support to any ns that runs a paasta service in check_kubernetes_services_replication - PAASTA-17846

### DIFF
--- a/paasta_tools/check_kubernetes_services_replication.py
+++ b/paasta_tools/check_kubernetes_services_replication.py
@@ -132,5 +132,4 @@ if __name__ == "__main__":
     main(
         instance_type_class=kubernetes_tools.KubernetesDeploymentConfig,
         check_service_replication=check_kubernetes_pod_replication,
-        kubernetes_services=True,
     )

--- a/paasta_tools/check_kubernetes_services_replication.py
+++ b/paasta_tools/check_kubernetes_services_replication.py
@@ -130,7 +130,7 @@ def check_kubernetes_pod_replication(
 
 if __name__ == "__main__":
     main(
-        kubernetes_tools.KubernetesDeploymentConfig,
-        check_kubernetes_pod_replication,
-        namespace="paasta",
+        instance_type_class=kubernetes_tools.KubernetesDeploymentConfig,
+        check_service_replication=check_kubernetes_pod_replication,
+        kubernetes_services=True,
     )

--- a/paasta_tools/check_marathon_services_replication.py
+++ b/paasta_tools/check_marathon_services_replication.py
@@ -130,5 +130,4 @@ if __name__ == "__main__":
         instance_type_class=marathon_tools.MarathonServiceConfig,
         check_service_replication=check_service_replication,
         namespace=None,  # not relevant for mesos
-        mesos=True,
     )

--- a/paasta_tools/check_services_replication_tools.py
+++ b/paasta_tools/check_services_replication_tools.py
@@ -29,8 +29,10 @@ from marathon.models.task import MarathonTask
 from mypy_extensions import Arg
 from mypy_extensions import NamedArg
 
+from paasta_tools.kubernetes_tools import get_all_namespaces
 from paasta_tools.kubernetes_tools import get_all_nodes
 from paasta_tools.kubernetes_tools import get_all_pods
+from paasta_tools.kubernetes_tools import get_matching_namespaces
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import V1Node
 from paasta_tools.kubernetes_tools import V1Pod
@@ -40,7 +42,6 @@ from paasta_tools.mesos_tools import get_slaves
 from paasta_tools.monitoring_tools import ReplicationChecker
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.smartstack_tools import KubeSmartstackEnvoyReplicationChecker
-from paasta_tools.smartstack_tools import MesosSmartstackEnvoyReplicationChecker
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import InstanceConfig_T
 from paasta_tools.utils import list_services
@@ -107,6 +108,23 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         dest="dry_run",
         help="Print Sensu alert events and metrics instead of sending them",
+    )
+    parser.add_argument(
+        "--namespace-prefix",
+        help="prefix of the namespace to check services replication for"
+        "Used only when service is kubernetes",
+        dest="namespace_prefix",
+        default="paastasvc",
+    )
+    parser.add_argument(
+        "--additional-namespaces",
+        help="full names of namespaces to check services replication for that don't match --namespace-prefix"
+        "Used only when service is kubernetes",
+        dest="additional_namespaces",
+        nargs="+",
+        # we default this to paasta since we always want to run this check on paasta namespace
+        # to avoid having two cron jobs running with two different namespace-prefix
+        default=["paasta"],
     )
     options = parser.parse_args()
 
@@ -177,8 +195,8 @@ def emit_cluster_replication_metrics(
 def main(
     instance_type_class: Type[InstanceConfig_T],
     check_service_replication: CheckServiceReplication,
-    namespace: str,
-    mesos: bool = False,
+    namespace: str = None,
+    kubernetes_services: bool = False,
 ) -> None:
     args = parse_args()
     if args.verbose:
@@ -190,14 +208,24 @@ def main(
     cluster = system_paasta_config.get_cluster()
     replication_checker: ReplicationChecker
 
-    if mesos:
-        tasks_or_pods, slaves = get_mesos_tasks_and_slaves(system_paasta_config)
-        replication_checker = MesosSmartstackEnvoyReplicationChecker(
-            mesos_slaves=slaves,
+    # throw an exception if kubernetes_services flag is false and namespace is not set
+    if kubernetes_services is False and namespace is None:
+        raise Exception("Please set namespace when calling the main function")
+
+    if kubernetes_services:
+        tasks_or_pods, nodes = get_kubernetes_pods_and_nodes(
+            namespace_prefix=args.namespace_prefix,
+            additional_namespaces=args.additional_namespaces,
+        )
+        replication_checker = KubeSmartstackEnvoyReplicationChecker(
+            nodes=nodes,
             system_paasta_config=system_paasta_config,
         )
     else:
-        tasks_or_pods, nodes = get_kubernetes_pods_and_nodes(namespace)
+        # Note: we will have by default namespace_prefix always set to paastasvc
+        # which means we could have namespace and namespace_prefix set at the same time
+        # what differentiate between which one we will use, will be the kubernetes_services flag
+        tasks_or_pods, nodes = get_kubernetes_pods_and_nodes(namespace=namespace)
         replication_checker = KubeSmartstackEnvoyReplicationChecker(
             nodes=nodes,
             system_paasta_config=system_paasta_config,
@@ -218,7 +246,7 @@ def main(
         emit_cluster_replication_metrics(
             pct_under_replicated,
             cluster,
-            scheduler="mesos" if mesos else "kubernetes",
+            scheduler="kubernetes",
             dry_run=args.dry_run,
         )
 
@@ -249,10 +277,24 @@ def get_mesos_tasks_and_slaves(
 
 
 def get_kubernetes_pods_and_nodes(
-    namespace: str,
+    namespace_prefix: str = None,
+    namespace: str = None,
+    additional_namespaces: List[str] = None,
 ) -> Tuple[Sequence[V1Pod], Sequence[V1Node]]:
     kube_client = KubeClient()
-    all_pods = get_all_pods(kube_client=kube_client, namespace=namespace)
+
+    all_pods: Sequence[V1Pod] = []
+    if namespace:
+        all_pods = get_all_pods(kube_client=kube_client, namespace=namespace)
+    else:
+        all_namespaces = get_all_namespaces(kube_client)
+        for matching_namespace in get_matching_namespaces(
+            all_namespaces, namespace_prefix, additional_namespaces
+        ):
+            all_pods += get_all_pods(
+                kube_client=kube_client, namespace=matching_namespace
+            )
+
     all_nodes = get_all_nodes(kube_client)
 
     return all_pods, all_nodes

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2227,6 +2227,16 @@ def get_all_namespaces(kube_client: KubeClient) -> List[str]:
     return [item.metadata.name for item in namespaces.items]
 
 
+def get_matching_namespaces(
+    all_namespaces: List[str], namespace_prefix: str, additional_namespaces: List[str]
+) -> List[str]:
+    return [
+        n
+        for n in all_namespaces
+        if n.startswith(namespace_prefix) or n in additional_namespaces
+    ]
+
+
 def ensure_namespace(kube_client: KubeClient, namespace: str) -> None:
     paasta_namespace = V1Namespace(
         metadata=V1ObjectMeta(name=namespace, labels={"name": namespace})
@@ -2705,6 +2715,12 @@ def get_pods_by_node(kube_client: KubeClient, node: V1Node) -> Sequence[V1Pod]:
 
 def get_all_pods(kube_client: KubeClient, namespace: str = "paasta") -> Sequence[V1Pod]:
     return kube_client.core.list_namespaced_pod(namespace=namespace).items
+
+
+def get_pods_in_all_namespaces(
+    kube_client: KubeClient, label_selector: str = "paasta.yelp.com/service"
+) -> Sequence[V1Pod]:
+    return kube_client.core.list_pod_for_all_namespaces(label_selector=label_selector)
 
 
 @time_cache(ttl=300)

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -24,7 +24,9 @@ from inspect import currentframe
 from pathlib import Path
 from typing import Any
 from typing import Collection
+from typing import Container
 from typing import Dict
+from typing import Iterable
 from typing import List
 from typing import Mapping
 from typing import MutableMapping
@@ -2228,12 +2230,15 @@ def get_all_namespaces(kube_client: KubeClient) -> List[str]:
 
 
 def get_matching_namespaces(
-    all_namespaces: List[str], namespace_prefix: str, additional_namespaces: List[str]
+    all_namespaces: Iterable[str],
+    namespace_prefix: Optional[str],
+    additional_namespaces: Container[str],
 ) -> List[str]:
     return [
         n
         for n in all_namespaces
-        if n.startswith(namespace_prefix) or n in additional_namespaces
+        if (namespace_prefix is not None and n.startswith(namespace_prefix))
+        or n in additional_namespaces
     ]
 
 
@@ -2713,14 +2718,8 @@ def get_pods_by_node(kube_client: KubeClient, node: V1Node) -> Sequence[V1Pod]:
     ).items
 
 
-def get_all_pods(kube_client: KubeClient, namespace: str = "paasta") -> Sequence[V1Pod]:
+def get_all_pods(kube_client: KubeClient, namespace: str = "paasta") -> List[V1Pod]:
     return kube_client.core.list_namespaced_pod(namespace=namespace).items
-
-
-def get_pods_in_all_namespaces(
-    kube_client: KubeClient, label_selector: str = "paasta.yelp.com/service"
-) -> Sequence[V1Pod]:
-    return kube_client.core.list_pod_for_all_namespaces(label_selector=label_selector)
 
 
 @time_cache(ttl=300)
@@ -2849,7 +2848,7 @@ def get_active_versions_for_service(
 
 def get_all_nodes(
     kube_client: KubeClient,
-) -> Sequence[V1Node]:
+) -> List[V1Node]:
     return kube_client.core.list_node().items
 
 

--- a/tests/test_check_service_replication_tools.py
+++ b/tests/test_check_service_replication_tools.py
@@ -29,9 +29,7 @@ def test_main_kubernetes():
         mock_check_services_replication.return_value = (6, 100)
 
         check_services_replication_tools.main(
-            instance_type_class=None,
-            check_service_replication=None,
-            namespace="baz",
+            instance_type_class=None, check_service_replication=None, namespace="test"
         )
         assert mock_check_services_replication.called
 
@@ -40,52 +38,6 @@ def test_main_kubernetes():
             {
                 "paasta_cluster": mock_load_system_paasta_config.return_value.get_cluster.return_value,
                 "scheduler": "kubernetes",
-            },
-        )
-        mock_gauge = mock_yelp_meteorite.create_gauge.return_value
-        mock_gauge.set.assert_called_once_with(6)
-
-        mock_sys_exit.assert_called_once_with(2)
-
-
-def test_main_mesos():
-    with mock.patch(
-        "paasta_tools.check_services_replication_tools.check_services_replication",
-        autospec=True,
-    ) as mock_check_services_replication, mock.patch(
-        "paasta_tools.check_services_replication_tools.parse_args", autospec=True
-    ) as mock_parse_args, mock.patch(
-        "paasta_tools.check_services_replication_tools.get_mesos_tasks_and_slaves",
-        autospec=True,
-        return_value=([mock.Mock()], [mock.Mock()]),
-    ), mock.patch(
-        "paasta_tools.check_services_replication_tools.load_system_paasta_config",
-        autospec=True,
-    ) as mock_load_system_paasta_config, mock.patch(
-        "paasta_tools.check_services_replication_tools.yelp_meteorite",
-        autospec=True,
-    ) as mock_yelp_meteorite, mock.patch(
-        "paasta_tools.check_services_replication_tools.sys.exit",
-        autospec=True,
-    ) as mock_sys_exit:
-        mock_parse_args.return_value.under_replicated_crit_pct = 5
-        mock_parse_args.return_value.min_count_critical = 1
-        mock_parse_args.return_value.dry_run = False
-        mock_check_services_replication.return_value = (6, 100)
-
-        check_services_replication_tools.main(
-            instance_type_class=None,
-            check_service_replication=None,
-            namespace=None,
-            mesos=True,
-        )
-        assert mock_check_services_replication.called
-
-        mock_yelp_meteorite.create_gauge.assert_called_once_with(
-            "paasta.pct_services_under_replicated",
-            {
-                "paasta_cluster": mock_load_system_paasta_config.return_value.get_cluster.return_value,
-                "scheduler": "mesos",
             },
         )
         mock_gauge = mock_yelp_meteorite.create_gauge.return_value


### PR DESCRIPTION
### Feature

This PR adds support to arbitrary namespaces for paasta services.

### Testing 

Unit tests pass


**Note:** Added the elif  block because I realized that we call main() passing namespaces for ``check_cassandracluster_services_replication`` and ``check_flink_services_health``