### PR TITLE
fixes iptables tests on jammy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ pysensu-yelp==0.4.1
 PyStaticConfiguration==0.10.3
 python-crontab==2.1.1
 python-dateutil==2.8.1
-python-iptables==0.14.0
+python-iptables==1.0.1
 python-utils==2.0.1
 pytimeparse==1.1.5
 pytz==2016.10

--- a/tests/test_iptables.py
+++ b/tests/test_iptables.py
@@ -44,9 +44,12 @@ def test_rule_from_iptc_mac_match():
     rule = iptc.Rule()
     rule.create_target("DROP")
     rule.create_match("mac")
-    rule.matches[0].mac_source = "20:C9:D0:2B:6F:F3"
+    rule.matches[0].mac_source = "20:c9:d0:2b:6f:f3"
 
-    assert iptables.Rule.from_iptc(rule) == EMPTY_RULE._replace(
+    iptables_rule = iptables.Rule.from_iptc(rule)
+    assert iptables_rule == EMPTY_RULE._replace(
+        target="DROP", matches=(("mac", (("mac-source", ("20:c9:d0:2b:6f:f3",)),)),)
+    ) or iptables_rule == EMPTY_RULE._replace(
         target="DROP", matches=(("mac", (("mac-source", ("20:C9:D0:2B:6F:F3",)),)),)
     )
 
@@ -80,7 +83,7 @@ def test_mac_src_to_iptc():
     assert rule.target.name == "ACCEPT"
     assert len(rule.matches) == 1
     assert rule.matches[0].name == "mac"
-    assert rule.matches[0].parameters["mac_source"] == "20:C9:D0:2B:6F:F3"
+    assert rule.matches[0].parameters["mac_source"].upper() == "20:C9:D0:2B:6F:F3"
 
 
 def test_iptables_txn_normal():


### PR DESCRIPTION
https://github.com/ldx/python-iptables/compare/v0.14.0...v1.0.1

specifically it needed https://github.com/ldx/python-iptables/commit/8e68d16969632d629fa42a1fafc0bf2edc84e678 in order for `make test` to pass on jammy

Internal discussion: https://yelp.slack.com/archives/C029N4YSWEP/p1674088275418569

Capitalization in the rules apparently differs between libxtables versions on bionic vs jammy so I had to edit the tests to accept either (I'm assuming this isn't semantically meaningful)


testing: `make test` passes locally on bionic and jammy
