### PR TITLE
adds "paasta secret run" subcommand

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -203,7 +203,7 @@ def _add_and_update_args(parser: argparse.ArgumentParser):
         "be unique per service.",
     )
 
-    parser.add_argument(
+    parser.add_argument(  # type: ignore
         "-c",
         "--clusters",
         help="A comma-separated list of clusters to create secrets for. "
@@ -229,9 +229,9 @@ def _add_common_args(parser: argparse.ArgumentParser, allow_shared: bool = True)
     if allow_shared:
         service_group = parser.add_mutually_exclusive_group(required=True)
     else:
-        service_group = parser
+        service_group = parser  # type: ignore
 
-    service_group.add_argument(
+    service_group.add_argument(  # type: ignore
         "-s",
         "--service",
         required=not allow_shared,

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -93,7 +93,7 @@ def add_decrypt_subparser(subparsers):
     ).completer = lazy_choices_completer(list_clusters)
 
 
-def _validate_single_cluster(arg):
+def _validate_single_cluster(arg: str) -> str:
     if len(arg.split(",")) > 1:
         raise argparse.ArgumentTypeError("can only decrypt from one cluster at a time")
     return arg
@@ -146,7 +146,6 @@ def add_run_subparser(subparsers):
         ),
     )
 
-    # see local_run.py
     secret_parser_run.add_argument(
         "--vault-auth-method",
         help="Override how we auth with vault, defaults to token if not present",
@@ -166,7 +165,7 @@ def add_run_subparser(subparsers):
     )
 
 
-def _add_and_update_args(parser):
+def _add_and_update_args(parser: argparse.ArgumentParser):
     """common args for `add` and `update`."""
     parser.add_argument(
         "-p",
@@ -217,7 +216,7 @@ def _add_and_update_args(parser):
     ).completer = lazy_choices_completer(list_clusters)
 
 
-def _add_common_args(parser, allow_shared=True):
+def _add_common_args(parser: argparse.ArgumentParser, allow_shared: bool = True):
     # available from any subcommand
     parser.add_argument(
         "-y",

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -15,14 +15,18 @@
 import argparse
 import os
 import re
+import subprocess
 import sys
 
 from service_configuration_lib import DEFAULT_SOA_DIR
 
+from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.cli.utils import lazy_choices_completer
+from paasta_tools.cli.utils import list_instances
 from paasta_tools.kubernetes_tools import get_kubernetes_secret
 from paasta_tools.kubernetes_tools import KUBE_CONFIG_USER_PATH
 from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.secret_tools import decrypt_secret_environment_variables
 from paasta_tools.secret_tools import get_secret_provider
 from paasta_tools.secret_tools import SHARED_SECRET_SERVICE
 from paasta_tools.utils import _log_audit
@@ -48,21 +52,148 @@ def check_secret_name(secret_name_arg: str):
     )
 
 
-def add_subparser(subparsers):
-    secret_parser = subparsers.add_parser(
-        "secret",
-        help="Add/update PaaSTA service secrets",
+def add_add_subparser(subparsers):
+    secret_parser_add = subparsers.add_parser("add", help="adds a paasta secret")
+    _add_common_args(secret_parser_add)
+    _add_and_update_args(secret_parser_add)
+
+
+def add_update_subparser(subparsers):
+    secret_parser_update = subparsers.add_parser(
+        "update", help="updates a paasta secret"
+    )
+    _add_common_args(secret_parser_update)
+    _add_and_update_args(secret_parser_update)
+
+
+def add_decrypt_subparser(subparsers):
+    secret_parser_decrypt = subparsers.add_parser(
+        "decrypt", help="decrypts a single paasta secret"
+    )
+    _add_common_args(secret_parser_decrypt)
+
+    secret_parser_decrypt.add_argument(
+        "-n",
+        "--secret-name",
+        type=check_secret_name,
+        required=True,
+        help="The name of the secret to decrypt, this is the secret filename without the extension.",
+    )
+
+    secret_parser_decrypt.add_argument(
+        "-c",
+        "--clusters",
+        required=False,
+        type=_validate_single_cluster,
+        help=(
+            "The cluster to decrypt for, e.g. pnw-prod. "
+            "Note: for decrypt only one cluster is allowed. "
+            "This argument is required unless the secret is only defined in one cluster."
+        ),
+    ).completer = lazy_choices_completer(list_clusters)
+
+
+def _validate_single_cluster(arg):
+    if len(arg.split(",")) > 1:
+        raise argparse.ArgumentTypeError("can only decrypt from one cluster at a time")
+    return arg
+
+
+def add_run_subparser(subparsers):
+    secret_parser_run = subparsers.add_parser(
+        "run",
+        help="runs a command with paasta secrets",
         description=(
-            "This script allows you to add secrets to your services "
-            "as environment variables. This script modifies your local "
-            "checkout of yelpsoa-configs and you must then commit and "
-            "push the changes back to git."
+            "Runs a command with the secret environment variables from "
+            "a given service instance. The command is run directly, not "
+            "in a Docker container. "
+            "Only the environment variables containing secrets are included. "
+            "No attempt at redacting secrets appearing in the output is made."
+        ),
+        conflict_handler="resolve",
+    )
+    _add_common_args(secret_parser_run, allow_shared=False)
+
+    secret_parser_run.add_argument(
+        "-i",
+        "--instance",
+        help=(
+            "Instance of the service to retrieve secret environment variables "
+            "for, such as 'main' or 'canary'. Secrets will be selected and "
+            "mapped to environment variables based on the configs for the instance."
+        ),
+        required=True,
+    ).completer = lazy_choices_completer(list_instances)
+
+    secret_parser_run.add_argument(
+        "-c",
+        "--clusters",
+        required=True,
+        type=_validate_single_cluster,
+        help=(
+            "The cluster to retrieve secrets for, e.g. norcal-devc. "
+            "A list of clusters is not supported for this command."
+        ),
+    ).completer = lazy_choices_completer(list_clusters)
+
+    secret_parser_run.add_argument(
+        "cmd",
+        nargs="*",
+        default=["bash"],
+        help=(
+            "The command to run with the specified PaaSTA secrets. "
+            "If not given, starts an interactive bash shell."
         ),
     )
-    secret_parser.add_argument(
-        "action", help="should be add/update", choices=["add", "update", "decrypt"]
+
+    # see local_run.py
+    secret_parser_run.add_argument(
+        "--vault-auth-method",
+        help="Override how we auth with vault, defaults to token if not present",
+        type=str,
+        dest="vault_auth_method",
+        required=False,
+        default="token",  # token falls back to ldap if token file is unreadable
+        choices=["token", "ldap"],
     )
-    secret_parser.add_argument(
+    secret_parser_run.add_argument(
+        "--vault-token-file",
+        help="Override vault token file, defaults to %(default)s",
+        type=str,
+        dest="vault_token_file",
+        required=False,
+        default="/var/spool/.paasta_vault_token",
+    )
+
+
+def _add_and_update_args(parser):
+    """common args for `add` and `update`."""
+    parser.add_argument(
+        "-p",
+        "--plain-text",
+        required=False,
+        type=str,
+        help="Optionally specify the secret as a command line argument",
+    )
+    parser.add_argument(
+        "-i",
+        "--stdin",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Optionally pass the plaintext from stdin",
+    )
+    parser.add_argument(
+        "--cross-env-motivation",
+        required=False,
+        type=str,
+        help=(
+            "Provide motivation in case the same value is being duplicated "
+            "across multiple runtime environments when adding or updating a secret"
+        ),
+        metavar="MOTIVATION",
+    )
+    parser.add_argument(
         "-n",
         "--secret-name",
         type=check_secret_name,
@@ -72,25 +203,8 @@ def add_subparser(subparsers):
         "services yaml files and should "
         "be unique per service.",
     )
-    secret_parser.add_argument(
-        "-y",
-        "--yelpsoa-config-root",
-        dest="yelpsoa_config_root",
-        help="A directory from which yelpsoa-configs should be read from",
-        default=DEFAULT_SOA_DIR,
-    )
 
-    # Must choose valid service or act on a shared secret
-    service_group = secret_parser.add_mutually_exclusive_group(required=True)
-    service_group.add_argument(
-        "-s", "--service", help="The name of the service on which you wish to act"
-    ).completer = lazy_choices_completer(list_services)
-    service_group.add_argument(
-        "--shared",
-        help="Act on a secret that can be shared by all services",
-        action="store_true",
-    )
-    secret_parser.add_argument(
+    parser.add_argument(
         "-c",
         "--clusters",
         help="A comma-separated list of clusters to create secrets for. "
@@ -101,32 +215,70 @@ def add_subparser(subparsers):
         "Defaults to all clusters in which the service runs. "
         "For example: --clusters pnw-prod,nova-prod ",
     ).completer = lazy_choices_completer(list_clusters)
-    secret_parser.add_argument(
-        "-p",
-        "--plain-text",
-        required=False,
-        type=str,
-        help="Optionally specify the secret as a command line argument",
+
+
+def _add_common_args(parser, allow_shared=True):
+    # available from any subcommand
+    parser.add_argument(
+        "-y",
+        "--yelpsoa-config-root",
+        dest="yelpsoa_config_root",
+        help="A directory from which yelpsoa-configs should be read from",
+        default=DEFAULT_SOA_DIR,
     )
-    secret_parser.add_argument(
-        "-i",
-        "--stdin",
-        required=False,
-        action="store_true",
-        default=False,
-        help="Optionally pass the plaintext from stdin",
-    )
-    secret_parser.add_argument(
-        "--cross-env-motivation",
-        required=False,
-        type=str,
-        help=(
-            "Provide motivation in case the same value is being duplicated "
-            "across multiple runtime environments when adding or updating a secret"
+
+    if allow_shared:
+        service_group = parser.add_mutually_exclusive_group(required=True)
+    else:
+        service_group = parser
+
+    service_group.add_argument(
+        "-s",
+        "--service",
+        required=not allow_shared,
+        help="The name of the service on which you wish to act",
+    ).completer = lazy_choices_completer(list_services)
+
+    if allow_shared:
+        service_group.add_argument(
+            "--shared",
+            help="Act on a secret that can be shared by all services",
+            action="store_true",
+        )
+    else:
+        service_group.add_argument(
+            "--shared",
+            action="store_false",
+            help=argparse.SUPPRESS,
+        )
+
+
+def add_subparser(subparsers):
+    secret_parser = subparsers.add_parser(
+        "secret",
+        help="Add/update/read PaaSTA service secrets",
+        description=(
+            "This set of commands allows you to add, update, or read secrets for your services, "
+            "configured as environment variables. If adding or updating, it modifies your local "
+            "checkout of yelpsoa-configs and you must then commit and "
+            "push the changes back to git."
         ),
-        metavar="MOTIVATION",
     )
     secret_parser.set_defaults(command=paasta_secret)
+
+    secret_subparsers = secret_parser.add_subparsers(
+        dest="action",
+        title="paasta secret subcommands",
+        help=(
+            "Run paasta secret <SUBCOMMAND> --help for information on per-subcommand arguments. "
+            "Not all arguments are available on all subcommands."
+        ),
+    )
+
+    add_add_subparser(secret_subparsers)
+    add_decrypt_subparser(secret_subparsers)
+    add_update_subparser(secret_subparsers)
+    add_run_subparser(secret_subparsers)
 
 
 def secret_name_for_env(secret_name):
@@ -177,8 +329,8 @@ def get_plaintext_input(args):
                 break
             lines.append(line)
         plaintext = "\n".join(lines).encode("utf-8")
-        print("The secret as a Python string is:", repr(plaintext))
-        print("Please make sure this is correct.")
+        print("The secret as Python bytes is:", repr(plaintext))
+        print("Please make sure the value inside the quotes is correct.")
     return plaintext
 
 
@@ -186,8 +338,10 @@ def is_service_folder(soa_dir, service_name):
     return os.path.isfile(os.path.join(soa_dir, service_name, "service.yaml"))
 
 
-def _get_secret_provider_for_service(service_name, cluster_names=None):
-    if not is_service_folder(os.getcwd(), service_name):
+def _get_secret_provider_for_service(service_name, cluster_names=None, soa_dir=None):
+    soa_dir = soa_dir or os.getcwd()
+
+    if not is_service_folder(soa_dir, service_name):
         print(
             "{} not found.\n"
             "You must run this tool from the root of your local yelpsoa checkout\n"
@@ -202,12 +356,12 @@ def _get_secret_provider_for_service(service_name, cluster_names=None):
     clusters = (
         cluster_names.split(",")
         if cluster_names
-        else list_clusters(service=service_name, soa_dir=os.getcwd())
+        else list_clusters(service=service_name, soa_dir=soa_dir)
     )
 
     return get_secret_provider(
         secret_provider_name=system_paasta_config.get_secret_provider_name(),
-        soa_dir=os.getcwd(),
+        soa_dir=soa_dir,
         service_name=service_name,
         cluster_names=clusters,
         secret_provider_kwargs=secret_provider_kwargs,
@@ -244,14 +398,14 @@ def paasta_secret(args):
         print(get_kubernetes_secret(kube_client, service, args.secret_name))
         return
 
-    secret_provider = _get_secret_provider_for_service(
-        service, cluster_names=args.clusters
-    )
-
     if args.action in ["add", "update"]:
         plaintext = get_plaintext_input(args)
         if not plaintext:
             print("Warning: Given plaintext is an empty string.")
+        secret_provider = _get_secret_provider_for_service(
+            service,
+            cluster_names=args.clusters,
+        )
         secret_provider.write_secret(
             action=args.action,
             secret_name=args.secret_name,
@@ -269,12 +423,60 @@ def paasta_secret(args):
 
         print_paasta_helper(secret_path, args.secret_name, args.shared)
     elif args.action == "decrypt":
+        secret_provider = _get_secret_provider_for_service(
+            service,
+            cluster_names=args.clusters,
+            # `decrypt` does not require the current working directory
+            # to be a writeable git checkout of yelpsoa-configs
+            soa_dir=args.yelpsoa_config_root,
+        )
         print(
             decrypt_secret(
                 secret_provider=secret_provider, secret_name=args.secret_name
             ),
             end="",
         )
+    elif args.action == "run":
+        new_environ = os.environ.copy()
+
+        system_paasta_config = load_system_paasta_config()
+        secret_provider_kwargs = {
+            "vault_cluster_config": system_paasta_config.get_vault_cluster_config(),
+            "vault_auth_method": args.vault_auth_method,
+            "vault_token_file": args.vault_token_file,
+        }
+
+        # This includes only the environment variables mapped to secrets,
+        # other environment variables are not included.
+        # All environment variables set in the current shell will also
+        # be passed through.
+        new_secret_vars = decrypt_secret_environment_variables(
+            secret_provider_name=system_paasta_config.get_secret_provider_name(),
+            environment=get_instance_config(
+                service=args.service,
+                instance=args.instance,
+                cluster=args.clusters,
+            ).get_env(),
+            soa_dir=args.yelpsoa_config_root,
+            service_name=args.service,
+            cluster_name=args.clusters,
+            secret_provider_kwargs=secret_provider_kwargs,
+        )
+
+        for var_name, var_value in new_secret_vars.items():
+            new_environ[var_name] = var_value
+
+        if args.cmd == ["bash"]:
+            # make it clear that we're running in a sub-shell
+            new_environ["PS1"] = r"(paasta secret run) \$ "
+
+        command_to_run = subprocess.run(
+            args.cmd,
+            shell=False,
+            check=False,
+            env=new_environ,
+        )
+        sys.exit(command_to_run.returncode)
     else:
         print("Unknown action")
         sys.exit(1)


### PR DESCRIPTION
This allows you to run tests and other non-paasta tasks (`make test`, integration/acceptance tests, service start-dev, etc) , with environment variables sourced directly from paasta secrets.

Along the way I refactored the argument parsing here, I tried to keep it as close as possible to previous behavior but it might be a bit stricter (in particular you can't put arguments between `paasta secret` and `add/update/decrypt` anymore)



```
$ .tox/py37-linux/bin/paasta secret run --help
usage: secret run [-h] [-y YELPSOA_CONFIG_ROOT] -s SERVICE -i INSTANCE -c
                  CLUSTERS [--vault-auth-method {token,ldap}]
                  [--vault-token-file VAULT_TOKEN_FILE]
                  [cmd [cmd ...]]

Runs a command with the secret environment variables from a given service
instance. The command is run directly, not in a Docker container. Only the
environment variables containing secrets are included. No attempt at redacting
secrets appearing in the output is made.

positional arguments:
  cmd                   The command to run with the specified PaaSTA secrets.
                        If not given, starts an interactive bash shell.

optional arguments:
  -h, --help            show this help message and exit
  -y YELPSOA_CONFIG_ROOT, --yelpsoa-config-root YELPSOA_CONFIG_ROOT
                        A directory from which yelpsoa-configs should be read
                        from
  -s SERVICE, --service SERVICE
                        The name of the service on which you wish to act
  -i INSTANCE, --instance INSTANCE
                        Instance of the service to retrieve secret environment
                        variables for, such as 'main' or 'canary'. Secrets
                        will be selected and mapped to environment variables
                        based on the configs for the instance.
  -c CLUSTERS, --clusters CLUSTERS
                        The cluster to retrieve secrets for, e.g. norcal-devc.
                        A list of clusters is not supported for this command.
  --vault-auth-method {token,ldap}
                        Override how we auth with vault, defaults to token if
                        not present
  --vault-token-file VAULT_TOKEN_FILE
                        Override vault token file, defaults to
                        /var/spool/.paasta_vault_token
```

testing: I've been using this locally