### PR TITLE
Clearing paasta status threads after catching KeyboardInterrupt

### DIFF
--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -255,7 +255,7 @@ def main(argv=None):
         else:
             return_code = args.command(args)
     except KeyboardInterrupt:
-        return_code = 1
+        return_code = 130
     sys.exit(return_code)
 
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -2414,6 +2414,7 @@ def paasta_status(args) -> int:
         except KeyboardInterrupt:
             executor._threads.clear()  # type: ignore
             concurrent.futures.thread._threads_queues.clear()  # type: ignore
+            raise KeyboardInterrupt
 
     return max(return_codes)
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -2412,6 +2412,9 @@ def paasta_status(args) -> int:
                 return_code, output = future.result()
                 return_codes.append(return_code)
         except KeyboardInterrupt:
+            # ideally we wouldn't need to reach into `ThreadPoolExecutor`
+            # internals, but so far this is the best way to stop all these
+            # threads until a public interface is added
             executor._threads.clear()  # type: ignore
             concurrent.futures.thread._threads_queues.clear()  # type: ignore
             raise KeyboardInterrupt

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -2412,8 +2412,8 @@ def paasta_status(args) -> int:
                 return_code, output = future.result()
                 return_codes.append(return_code)
         except KeyboardInterrupt:
-            executor._threads.clear()
-            concurrent.futures.thread._threads_queues.clear()
+            executor._threads.clear()  # type: ignore
+            concurrent.futures.thread._threads_queues.clear()  # type: ignore
 
     return max(return_codes)
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -2407,9 +2407,13 @@ def paasta_status(args) -> int:
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
         tasks = [executor.submit(t[0], **t[1]) for t in tasks]  # type: ignore
-        for future in concurrent.futures.as_completed(tasks):  # type: ignore
-            return_code, output = future.result()
-            return_codes.append(return_code)
+        try:
+            for future in concurrent.futures.as_completed(tasks):  # type: ignore
+                return_code, output = future.result()
+                return_codes.append(return_code)
+        except KeyboardInterrupt:
+            executor._threads.clear()
+            concurrent.futures.thread._threads_queues.clear()
 
     return max(return_codes)
 


### PR DESCRIPTION
This PR will clear threads after catching a `KeyboardInterrupt` to make sure that `paasta status` don't spookily 👻👻 take over people’s terminals 