### PR TITLE
Add force-spark-resource-configs option

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -185,6 +185,15 @@ def add_subparser(subparsers):
         default=None,
     )
     list_parser.add_argument(
+        "--force-spark-resource-configs",
+        help=(
+            "Skip the resource/instances recalculation. "
+            "This is strongly not recommended."
+        ),
+        action="store_true",
+        default=False,
+    )
+    list_parser.add_argument(
         "--docker-registry",
         help="Docker registry to push the Spark image built.",
         default=DEFAULT_SPARK_DOCKER_REGISTRY,
@@ -1149,6 +1158,7 @@ def paasta_spark_run(args):
         aws_creds=aws_creds,
         needs_docker_cfg=needs_docker_cfg,
         aws_region=args.aws_region,
+        force_spark_resource_configs=args.force_spark_resource_configs,
     )
 
     # Experimental: TODO: Move to service_configuration_lib once confirmed that there are no issues

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -49,7 +49,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.13.5
+service-configuration-lib >= 2.14.0
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.13.5
+service-configuration-lib==2.14.0
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -1083,6 +1083,7 @@ def test_paasta_spark_run_bash(
         timeout_job_runtime="1m",
         enable_dra=False,
         aws_region="test-region",
+        force_spark_resource_configs=False,
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     mock_load_system_paasta_config.return_value.get_cluster_pools.return_value = {
@@ -1124,6 +1125,7 @@ def test_paasta_spark_run_bash(
         aws_creds=mock_get_aws_credentials.return_value,
         needs_docker_cfg=False,
         aws_region="test-region",
+        force_spark_resource_configs=False,
     )
     mock_spark_conf = mock_get_spark_conf.return_value
     mock_spark_conf["spark.sql.adaptive.enabled"] = "true"
@@ -1183,6 +1185,7 @@ def test_paasta_spark_run(
         timeout_job_runtime="1m",
         enable_dra=True,
         aws_region="test-region",
+        force_spark_resource_configs=False,
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     mock_load_system_paasta_config.return_value.get_cluster_pools.return_value = {
@@ -1224,6 +1227,7 @@ def test_paasta_spark_run(
         aws_creds=mock_get_aws_credentials.return_value,
         needs_docker_cfg=False,
         aws_region="test-region",
+        force_spark_resource_configs=False,
     )
     mock_configure_and_run_docker_container.assert_called_once_with(
         args,
@@ -1283,6 +1287,7 @@ def test_paasta_spark_run_pyspark(
         timeout_job_runtime="1m",
         enable_dra=False,
         aws_region="test-region",
+        force_spark_resource_configs=False,
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     mock_load_system_paasta_config.return_value.get_cluster_pools.return_value = {
@@ -1332,6 +1337,7 @@ def test_paasta_spark_run_pyspark(
         aws_creds=mock_get_aws_credentials.return_value,
         needs_docker_cfg=False,
         aws_region="test-region",
+        force_spark_resource_configs=False,
     )
     mock_configure_and_run_docker_container.assert_called_once_with(
         args,

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -982,10 +982,11 @@ class TestTronTools:
             "--conf spark.kubernetes.executor.volumes.hostPath.2.options.path=/etc/group "
             "--conf spark.kubernetes.executor.volumes.hostPath.2.mount.readOnly=true "
             # coreml adjustments
-            "--conf spark.executor.instances=2 "
+            "--conf spark.executor.instances=1 "
             "--conf spark.kubernetes.allocation.batch.size=512 "
             "--conf spark.kubernetes.executor.limit.cores=2 "
             "--conf spark.scheduler.maxRegisteredResourcesWaitingTime=15min "
+            "--conf spark.task.cpus=1 "
             "--conf spark.sql.shuffle.partitions=12 "
             "--conf spark.sql.files.minPartitionNum=12 "
             "--conf spark.default.parallelism=12 "


### PR DESCRIPTION
This PR adds an option `--force-spark-resource-configs` for `paasta spark-run` for users to skip the changes made by:  
https://github.com/Yelp/service_configuration_lib/pull/97
