### PR TITLE
Ensure we pass ns to functions in kubernetes_tools.py - PAASTA-17857

### DIFF
--- a/paasta_tools/cassandracluster_tools.py
+++ b/paasta_tools/cassandracluster_tools.py
@@ -100,6 +100,10 @@ class CassandraClusterDeploymentConfig(LongRunningServiceConfig):
     def get_kubernetes_namespace(self) -> str:
         return KUBERNETES_NAMESPACE
 
+    def get_namespace(self) -> str:
+        """Get namespace from config, default to 'paasta'"""
+        return self.config_dict.get("namespace", KUBERNETES_NAMESPACE)
+
     def get_instances(self, with_limit: bool = True) -> int:
         return self.config_dict.get("replicas", 1)
 

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -42,6 +42,7 @@ from paasta_tools.kubernetes_tools import get_kubernetes_secret_env_variables
 from paasta_tools.kubernetes_tools import get_kubernetes_secret_volumes
 from paasta_tools.kubernetes_tools import KUBE_CONFIG_USER_PATH
 from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.kubernetes_tools import load_kubernetes_service_config_no_cache
 from paasta_tools.long_running_service_tools import get_healthcheck_for_instance
 from paasta_tools.paasta_execute_docker_command import execute_in_container
 from paasta_tools.secret_tools import decrypt_secret_environment_variables
@@ -695,6 +696,9 @@ def run_docker_container(
     else:
         chosen_port = pick_random_port(service)
     environment = instance_config.get_env_dictionary()
+    service_config = load_kubernetes_service_config_no_cache(
+        service=service, instance=instance, cluster=instance_config.get_cluster()
+    )
     secret_volumes = {}
     if not skip_secrets:
         # if secrets_for_owner_team enabled in yelpsoa for service
@@ -704,10 +708,13 @@ def run_docker_container(
                     config_file=KUBE_CONFIG_USER_PATH, context=instance_config.cluster
                 )
                 secret_environment = get_kubernetes_secret_env_variables(
-                    kube_client, environment, service
+                    kube_client, environment, service, service_config.get_namespace()
                 )
                 secret_volumes = get_kubernetes_secret_volumes(
-                    kube_client, instance_config.get_secret_volumes(), service
+                    kube_client,
+                    instance_config.get_secret_volumes(),
+                    service,
+                    service_config.get_namespace(),
                 )
             except Exception as e:
                 print(

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -42,7 +42,6 @@ from paasta_tools.kubernetes_tools import get_kubernetes_secret_env_variables
 from paasta_tools.kubernetes_tools import get_kubernetes_secret_volumes
 from paasta_tools.kubernetes_tools import KUBE_CONFIG_USER_PATH
 from paasta_tools.kubernetes_tools import KubeClient
-from paasta_tools.kubernetes_tools import load_kubernetes_service_config_no_cache
 from paasta_tools.long_running_service_tools import get_healthcheck_for_instance
 from paasta_tools.paasta_execute_docker_command import execute_in_container
 from paasta_tools.secret_tools import decrypt_secret_environment_variables
@@ -696,9 +695,6 @@ def run_docker_container(
     else:
         chosen_port = pick_random_port(service)
     environment = instance_config.get_env_dictionary()
-    service_config = load_kubernetes_service_config_no_cache(
-        service=service, instance=instance, cluster=instance_config.get_cluster()
-    )
     secret_volumes = {}
     if not skip_secrets:
         # if secrets_for_owner_team enabled in yelpsoa for service
@@ -708,13 +704,13 @@ def run_docker_container(
                     config_file=KUBE_CONFIG_USER_PATH, context=instance_config.cluster
                 )
                 secret_environment = get_kubernetes_secret_env_variables(
-                    kube_client, environment, service, service_config.get_namespace()
+                    kube_client, environment, service, instance_config.get_namespace()
                 )
                 secret_volumes = get_kubernetes_secret_volumes(
                     kube_client,
                     instance_config.get_secret_volumes(),
                     service,
-                    service_config.get_namespace(),
+                    instance_config.get_namespace(),
                 )
             except Exception as e:
                 print(

--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -243,14 +243,15 @@ class DeploymentWrapper(Application):
         self.deep_delete(kube_client)
         timer = 0
         while (
-            self.kube_deployment in set(list_all_deployments(kube_client))
+            self.kube_deployment
+            in set(list_all_deployments(kube_client, self.soa_config.get_namespace()))
             and timer < 60
         ):
             sleep(1)
             timer += 1
 
         if timer >= 60 and self.kube_deployment in set(
-            list_all_deployments(kube_client)
+            list_all_deployments(kube_client, self.soa_config.get_namespace())
         ):
             # When deleting then immediately creating, we need to use Background
             # deletion to ensure we can create the deployment immediately
@@ -276,7 +277,9 @@ class DeploymentWrapper(Application):
                 else:
                     raise
 
-        if self.kube_deployment in set(list_all_deployments(kube_client)):
+        if self.kube_deployment in set(
+            list_all_deployments(kube_client, self.soa_config.get_namespace())
+        ):
             # deployment deletion failed, we cannot continue
             raise Exception(f"Could not delete deployment {self.item.metadata.name}")
         else:

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -346,7 +346,6 @@ class KubernetesDeploymentConfigDict(LongRunningServiceConfigDict, total=False):
     prometheus_path: str
     prometheus_port: int
     routable_ip: bool
-    namespace: str
     pod_management_policy: str
     is_istio_sidecar_injection_enabled: bool
     boto_keys: List[str]
@@ -1496,7 +1495,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             kube_client=kube_client,
             secret=secret_name,
             service=service_name,
-            namespace=self.config_dict.get_namespace(),
+            namespace=self.get_namespace(),
         )
 
     def get_sanitised_service_name(self) -> str:

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -146,6 +146,10 @@ class LongRunningServiceConfig(InstanceConfig):
     def get_bounce_method(self) -> str:
         raise NotImplementedError
 
+    def get_namespace(self) -> str:
+        """Get namespace from config"""
+        raise NotImplementedError
+
     def get_kubernetes_namespace(self) -> str:
         """
         Only needed on kubernetes LongRunningServiceConfig

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -32,6 +32,7 @@ from paasta_tools import __version__
 from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.kubernetes_tools import is_kubernetes_available
 from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.kubernetes_tools import load_kubernetes_service_config_no_cache
 from paasta_tools.marathon_tools import get_marathon_clients
 from paasta_tools.marathon_tools import get_marathon_servers
 from paasta_tools.marathon_tools import MarathonClient
@@ -95,6 +96,7 @@ def parse_args(argv):
     parser.add_argument(
         "-s",
         "--service",
+        dest="service_name",
         help=(
             "Show how many of a given service instance can be run on a cluster slave."
             "Note: This is only effective with -vvv and --instance must also be specified"
@@ -103,6 +105,7 @@ def parse_args(argv):
     parser.add_argument(
         "-i",
         "--instance",
+        dest="instance_name",
         help=(
             "Show how many of a given service instance can be run on a cluster slave."
             "Note: This is only effective with -vvv and --service must also be specified"
@@ -228,12 +231,15 @@ def utilization_table_by_grouping_from_kube(
     threshold: float,
     kube_client: KubeClient,
     service_instance_stats: Optional[ServiceInstanceStats] = None,
+    namespace: str = "paasta",
 ) -> Tuple[Sequence[MutableSequence[str]], bool]:
     grouping_function = metastatus_lib.key_func_for_attribute_multi_kube(groupings)
 
     resource_info_dict_grouped = (
         metastatus_lib.get_resource_utilization_by_grouping_kube(
-            grouping_function, kube_client
+            grouping_func=grouping_function,
+            kube_client=kube_client,
+            namespace=namespace,
         )
     )
 
@@ -311,9 +317,9 @@ def get_service_instance_stats(
 
 
 def _run_kube_checks(
-    kube_client: KubeClient,
+    kube_client: KubeClient, namespace: str = "paasta"
 ) -> Sequence[HealthCheckResult]:
-    kube_status = metastatus_lib.get_kube_status(kube_client)
+    kube_status = metastatus_lib.get_kube_status(kube_client, namespace)
     kube_metrics_status = metastatus_lib.get_kube_resource_utilization_health(
         kube_client=kube_client
     )
@@ -327,7 +333,11 @@ def print_output(argv: Optional[Sequence[str]] = None) -> None:
     args = parse_args(argv)
 
     system_paasta_config = load_system_paasta_config()
-
+    service_config_dict = load_kubernetes_service_config_no_cache(
+        service=args.service_name,
+        instance=args.instance_name,
+        cluster=system_paasta_config.get_cluster(),
+    )
     if mesos_available:
         master_kwargs = {}
         # we don't want to be passing False to not override a possible True
@@ -369,7 +379,9 @@ def print_output(argv: Optional[Sequence[str]] = None) -> None:
 
     if kube_available:
         kube_client = KubeClient()
-        kube_results = _run_kube_checks(kube_client)
+        kube_results = _run_kube_checks(
+            kube_client, service_config_dict.get_namespace()
+        )
     else:
         kube_results = [
             metastatus_lib.HealthCheckResult(
@@ -437,7 +449,10 @@ def print_output(argv: Optional[Sequence[str]] = None) -> None:
     if args.verbose > 1 and kube_available:
         print_with_indent("Resources Grouped by %s" % ", ".join(args.groupings), 2)
         all_rows, healthy_exit = utilization_table_by_grouping_from_kube(
-            groupings=args.groupings, threshold=args.threshold, kube_client=kube_client
+            groupings=args.groupings,
+            threshold=args.threshold,
+            kube_client=kube_client,
+            namespace=service_config_dict.get_namespace(),
         )
         for line in format_table(all_rows):
             print_with_indent(line, 4)
@@ -460,6 +475,7 @@ def print_output(argv: Optional[Sequence[str]] = None) -> None:
                 threshold=args.threshold,
                 kube_client=kube_client,
                 service_instance_stats=service_instance_stats,
+                namespace=service_config_dict.get_namespace(),
             )
             # The last column from utilization_table_by_grouping_from_kube is "Agent count", which will always be
             # 1 for per-node resources, so delete it.

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -32,7 +32,7 @@ from paasta_tools import __version__
 from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.kubernetes_tools import is_kubernetes_available
 from paasta_tools.kubernetes_tools import KubeClient
-from paasta_tools.kubernetes_tools import load_kubernetes_service_config_no_cache
+from paasta_tools.kubernetes_tools import load_kubernetes_service_config
 from paasta_tools.marathon_tools import get_marathon_clients
 from paasta_tools.marathon_tools import get_marathon_servers
 from paasta_tools.marathon_tools import MarathonClient
@@ -333,7 +333,7 @@ def print_output(argv: Optional[Sequence[str]] = None) -> None:
     args = parse_args(argv)
 
     system_paasta_config = load_system_paasta_config()
-    service_config_dict = load_kubernetes_service_config_no_cache(
+    service_config_dict = load_kubernetes_service_config(
         service=args.service_name,
         instance=args.instance_name,
         cluster=system_paasta_config.get_cluster(),

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -413,6 +413,10 @@ class TronActionConfig(InstanceConfig):
     def get_action_name(self):
         return self.action
 
+    def get_namespace(self) -> str:
+        """Get namespace from config, default to 'paasta'"""
+        return self.config_dict.get("namespace", KUBERNETES_NAMESPACE)
+
     def get_deploy_group(self) -> Optional[str]:
         return self.config_dict.get("deploy_group", None)
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -299,6 +299,7 @@ class InstanceConfigDict(TypedDict, total=False):
     cpus: float
     disk: float
     cmd: str
+    namespace: str
     args: List[str]
     cfs_period_us: float
     cpu_burst_add: float
@@ -411,6 +412,10 @@ class InstanceConfig:
 
     def get_cluster(self) -> str:
         return self.cluster
+
+    def get_namespace(self) -> str:
+        """Get namespace from config, default to 'paasta'"""
+        return self.config_dict.get("namespace", "paasta")
 
     def get_instance(self) -> str:
         return self.instance

--- a/paasta_tools/vitess_tools.py
+++ b/paasta_tools/vitess_tools.py
@@ -85,6 +85,10 @@ class VitessDeploymentConfig(LongRunningServiceConfig):
     def get_kubernetes_namespace(self) -> str:
         return KUBERNETES_NAMESPACE
 
+    def get_namespace(self) -> str:
+        """Get namespace from config, default to 'paasta'"""
+        return self.config_dict.get("namespace", KUBERNETES_NAMESPACE)
+
     def get_instances(self, with_limit: bool = True) -> int:
         return self.config_dict.get("replicas", 1)
 

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -48,7 +48,12 @@ from paasta_tools.utils import TimeoutError
 @mock.patch("paasta_tools.cli.cmds.local_run.paasta_cook_image", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.local_run.validate_service_instance", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.local_run.get_instance_config", autospec=True)
+@mock.patch(
+    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
+    autospec=True,
+)
 def test_dry_run(
+    mock_load_kubernetes_service_config,
     mock_get_instance_config,
     mock_validate_service_instance,
     mock_paasta_cook_image,
@@ -89,7 +94,12 @@ def test_dry_run(
 @mock.patch("paasta_tools.cli.cmds.local_run.paasta_cook_image", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.local_run.validate_service_instance", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.local_run.get_instance_config", autospec=True)
+@mock.patch(
+    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
+    autospec=True,
+)
 def test_dry_run_json_dict(
+    mock_load_kubernetes_service_config,
     mock_get_instance_config,
     mock_validate_service_instance,
     mock_paasta_cook_image,
@@ -1069,7 +1079,12 @@ def test_get_container_id_name_not_found():
     autospec=True,
     return_value=("fake_healthcheck_mode", "fake_healthcheck_uri"),
 )
+@mock.patch(
+    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
+    autospec=True,
+)
 def test_run_docker_container_non_interactive_no_healthcheck(
+    mock_load_kubernetes_service_config,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
     mock_run,
@@ -1124,7 +1139,12 @@ def test_run_docker_container_non_interactive_no_healthcheck(
     autospec=True,
     return_value=("fake_healthcheck_mode", "fake_healthcheck_uri"),
 )
+@mock.patch(
+    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
+    autospec=True,
+)
 def test_run_docker_container_interactive(
+    mock_load_kubernetes_service_config,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
     mock_run,
@@ -1185,7 +1205,12 @@ def test_run_docker_container_interactive(
 @mock.patch(
     "paasta_tools.cli.cmds.local_run.run_healthcheck_on_container", autospec=True
 )
+@mock.patch(
+    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
+    autospec=True,
+)
 def test_run_docker_container_non_interactive_keyboard_interrupt_with_healthcheck(
+    mock_load_kubernetes_service_config,
     mock_run_healthcheck_on_container,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
@@ -1242,7 +1267,12 @@ def test_run_docker_container_non_interactive_keyboard_interrupt_with_healthchec
     autospec=True,
     return_value=("fake_healthcheck_mode", "fake_healthcheck_uri"),
 )
+@mock.patch(
+    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
+    autospec=True,
+)
 def test_run_docker_container_non_interactive_run_returns_nonzero(
+    mock_load_kubernetes_service_config,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
     mock_run,
@@ -1302,7 +1332,12 @@ def test_run_docker_container_non_interactive_run_returns_nonzero(
     autospec=True,
     return_value=("fake_healthcheck_mode", "fake_healthcheck_uri"),
 )
+@mock.patch(
+    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
+    autospec=True,
+)
 def test_run_docker_container_with_custom_soadir_uses_healthcheck(
+    mock_load_kubernetes_service_config,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
     mock_run,
@@ -1367,7 +1402,12 @@ def test_run_docker_container_with_custom_soadir_uses_healthcheck(
     autospec=True,
     return_value=("cmd", "fake_healthcheck_uri"),
 )
+@mock.patch(
+    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
+    autospec=True,
+)
 def test_run_docker_container_terminates_with_healthcheck_only_success(
+    mock_load_kubernetes_service_config,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
     mock_run,
@@ -1425,7 +1465,12 @@ def test_run_docker_container_terminates_with_healthcheck_only_success(
     autospec=True,
     return_value=("cmd", "fake_healthcheck_uri"),
 )
+@mock.patch(
+    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
+    autospec=True,
+)
 def test_run_docker_container_terminates_with_healthcheck_only_fail(
+    mock_load_kubernetes_service_config,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
     mock_run,
@@ -1488,7 +1533,12 @@ def test_run_docker_container_terminates_with_healthcheck_only_fail(
     autospec=True,
     return_value=("fake_healthcheck_mode", "fake_healthcheck_uri"),
 )
+@mock.patch(
+    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
+    autospec=True,
+)
 def test_run_docker_container_with_user_specified_port(
+    mock_load_kubernetes_service_config,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
     mock_check_if_port_free,
@@ -1995,7 +2045,12 @@ def test_missing_volumes_skipped(mock_exists):
     autospec=None,
 )
 @mock.patch("os.makedirs", autospec=True)
+@mock.patch(
+    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
+    autospec=True,
+)
 def test_run_docker_container_secret_volumes(
+    mock_load_kubernetes_service_config,
     mock_os_makedirs,
     mock_open,
     mock_decrypt_secret_volumes,
@@ -2095,7 +2150,12 @@ def test_run_docker_container_secret_volumes(
 )
 @mock.patch("paasta_tools.cli.cmds.local_run.KubeClient", autospec=True)
 @mock.patch("os.makedirs", autospec=True)
+@mock.patch(
+    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
+    autospec=True,
+)
 def test_run_docker_container_secret_volumes_for_teams(
+    mock_load_kubernetes_service_config,
     mock_os_makedirs,
     mock_kube_client,
     mock_is_secrets_for_teams_enabled,
@@ -2190,7 +2250,12 @@ def test_run_docker_container_secret_volumes_for_teams(
     new_callable=mock.mock_open(),
     autospec=None,
 )
+@mock.patch(
+    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
+    autospec=True,
+)
 def test_run_docker_container_secret_volumes_raises(
+    mock_load_kubernetes_service_config,
     mock_open,
     mock_decrypt_secret_volumes,
     mock_get_healthcheck_for_instance,
@@ -2266,7 +2331,12 @@ def test_run_docker_container_secret_volumes_raises(
     "paasta_tools.cli.cmds.local_run.is_secrets_for_teams_enabled", autospec=True
 )
 @mock.patch("paasta_tools.cli.cmds.local_run.KubeClient", autospec=True)
+@mock.patch(
+    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
+    autospec=True,
+)
 def test_run_docker_container_secret_volumes_for_teams_raises(
+    mock_load_kubernetes_service_config,
     mock_kube_client,
     mock_is_secrets_for_teams_enabled,
     mock_open,

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -48,12 +48,7 @@ from paasta_tools.utils import TimeoutError
 @mock.patch("paasta_tools.cli.cmds.local_run.paasta_cook_image", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.local_run.validate_service_instance", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.local_run.get_instance_config", autospec=True)
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
-    autospec=True,
-)
 def test_dry_run(
-    mock_load_kubernetes_service_config,
     mock_get_instance_config,
     mock_validate_service_instance,
     mock_paasta_cook_image,
@@ -94,12 +89,7 @@ def test_dry_run(
 @mock.patch("paasta_tools.cli.cmds.local_run.paasta_cook_image", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.local_run.validate_service_instance", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.local_run.get_instance_config", autospec=True)
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
-    autospec=True,
-)
 def test_dry_run_json_dict(
-    mock_load_kubernetes_service_config,
     mock_get_instance_config,
     mock_validate_service_instance,
     mock_paasta_cook_image,
@@ -1079,12 +1069,7 @@ def test_get_container_id_name_not_found():
     autospec=True,
     return_value=("fake_healthcheck_mode", "fake_healthcheck_uri"),
 )
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
-    autospec=True,
-)
 def test_run_docker_container_non_interactive_no_healthcheck(
-    mock_load_kubernetes_service_config,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
     mock_run,
@@ -1139,12 +1124,7 @@ def test_run_docker_container_non_interactive_no_healthcheck(
     autospec=True,
     return_value=("fake_healthcheck_mode", "fake_healthcheck_uri"),
 )
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
-    autospec=True,
-)
 def test_run_docker_container_interactive(
-    mock_load_kubernetes_service_config,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
     mock_run,
@@ -1205,12 +1185,7 @@ def test_run_docker_container_interactive(
 @mock.patch(
     "paasta_tools.cli.cmds.local_run.run_healthcheck_on_container", autospec=True
 )
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
-    autospec=True,
-)
 def test_run_docker_container_non_interactive_keyboard_interrupt_with_healthcheck(
-    mock_load_kubernetes_service_config,
     mock_run_healthcheck_on_container,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
@@ -1267,12 +1242,7 @@ def test_run_docker_container_non_interactive_keyboard_interrupt_with_healthchec
     autospec=True,
     return_value=("fake_healthcheck_mode", "fake_healthcheck_uri"),
 )
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
-    autospec=True,
-)
 def test_run_docker_container_non_interactive_run_returns_nonzero(
-    mock_load_kubernetes_service_config,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
     mock_run,
@@ -1332,12 +1302,7 @@ def test_run_docker_container_non_interactive_run_returns_nonzero(
     autospec=True,
     return_value=("fake_healthcheck_mode", "fake_healthcheck_uri"),
 )
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
-    autospec=True,
-)
 def test_run_docker_container_with_custom_soadir_uses_healthcheck(
-    mock_load_kubernetes_service_config,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
     mock_run,
@@ -1402,12 +1367,7 @@ def test_run_docker_container_with_custom_soadir_uses_healthcheck(
     autospec=True,
     return_value=("cmd", "fake_healthcheck_uri"),
 )
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
-    autospec=True,
-)
 def test_run_docker_container_terminates_with_healthcheck_only_success(
-    mock_load_kubernetes_service_config,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
     mock_run,
@@ -1465,12 +1425,7 @@ def test_run_docker_container_terminates_with_healthcheck_only_success(
     autospec=True,
     return_value=("cmd", "fake_healthcheck_uri"),
 )
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
-    autospec=True,
-)
 def test_run_docker_container_terminates_with_healthcheck_only_fail(
-    mock_load_kubernetes_service_config,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
     mock_run,
@@ -1533,12 +1488,7 @@ def test_run_docker_container_terminates_with_healthcheck_only_fail(
     autospec=True,
     return_value=("fake_healthcheck_mode", "fake_healthcheck_uri"),
 )
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
-    autospec=True,
-)
 def test_run_docker_container_with_user_specified_port(
-    mock_load_kubernetes_service_config,
     mock_get_healthcheck_for_instance,
     mock_get_container_id,
     mock_check_if_port_free,
@@ -2045,12 +1995,7 @@ def test_missing_volumes_skipped(mock_exists):
     autospec=None,
 )
 @mock.patch("os.makedirs", autospec=True)
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
-    autospec=True,
-)
 def test_run_docker_container_secret_volumes(
-    mock_load_kubernetes_service_config,
     mock_os_makedirs,
     mock_open,
     mock_decrypt_secret_volumes,
@@ -2150,12 +2095,7 @@ def test_run_docker_container_secret_volumes(
 )
 @mock.patch("paasta_tools.cli.cmds.local_run.KubeClient", autospec=True)
 @mock.patch("os.makedirs", autospec=True)
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
-    autospec=True,
-)
 def test_run_docker_container_secret_volumes_for_teams(
-    mock_load_kubernetes_service_config,
     mock_os_makedirs,
     mock_kube_client,
     mock_is_secrets_for_teams_enabled,
@@ -2250,12 +2190,7 @@ def test_run_docker_container_secret_volumes_for_teams(
     new_callable=mock.mock_open(),
     autospec=None,
 )
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
-    autospec=True,
-)
 def test_run_docker_container_secret_volumes_raises(
-    mock_load_kubernetes_service_config,
     mock_open,
     mock_decrypt_secret_volumes,
     mock_get_healthcheck_for_instance,
@@ -2331,12 +2266,7 @@ def test_run_docker_container_secret_volumes_raises(
     "paasta_tools.cli.cmds.local_run.is_secrets_for_teams_enabled", autospec=True
 )
 @mock.patch("paasta_tools.cli.cmds.local_run.KubeClient", autospec=True)
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.load_kubernetes_service_config_no_cache",
-    autospec=True,
-)
 def test_run_docker_container_secret_volumes_for_teams_raises(
-    mock_load_kubernetes_service_config,
     mock_kube_client,
     mock_is_secrets_for_teams_enabled,
     mock_open,

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -3685,6 +3685,7 @@ def test_get_kubernetes_secret_hashes():
                 "SOME": "SHAREDSECRET(ref1)",
             },
             service="universe",
+            namespace="paasta",
         )
         mock_get_kubernetes_secret_signature.assert_has_calls(
             [
@@ -3692,11 +3693,13 @@ def test_get_kubernetes_secret_hashes():
                     kube_client=mock_client.return_value,
                     secret="ref",
                     service="universe",
+                    namespace="paasta",
                 ),
                 mock.call(
                     kube_client=mock_client.return_value,
                     secret="ref1",
                     service=SHARED_SECRET_SERVICE,
+                    namespace="paasta",
                 ),
             ]
         )
@@ -4218,16 +4221,10 @@ def test_get_kubernetes_secret_env_variables():
 
         assert mock_get_kubernetes_secret.call_args_list == [
             mock.call(
-                mock_client,
-                "universe",
-                "SECRET_NAME1",
-                decode=True,
+                mock_client, "universe", "SECRET_NAME1", decode=True, namespace="paasta"
             ),
             mock.call(
-                mock_client,
-                "universe",
-                "SECRET_NAME2",
-                decode=True,
+                mock_client, "universe", "SECRET_NAME2", decode=True, namespace="paasta"
             ),
         ]
 

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -54,7 +54,7 @@ def test_main_no_marathon_servers():
         autospec=True,
         return_value=False,
     ), patch(
-        "paasta_tools.paasta_metastatus.load_kubernetes_service_config_no_cache",
+        "paasta_tools.paasta_metastatus.load_kubernetes_service_config",
         autospec=True,
     ):
         fake_master = Mock(autospace=True)
@@ -90,7 +90,7 @@ def test_main_marathon_jsondecode_error():
     ) as get_mesos_resource_utilization_health_patch, patch(
         "paasta_tools.metrics.metastatus_lib.get_marathon_status", autospec=True
     ) as get_marathon_status_patch, patch(
-        "paasta_tools.paasta_metastatus.load_kubernetes_service_config_no_cache",
+        "paasta_tools.paasta_metastatus.load_kubernetes_service_config",
         autospec=True,
     ):
         fake_master = Mock(autospace=True)

--- a/tests/test_paasta_metastatus.py
+++ b/tests/test_paasta_metastatus.py
@@ -53,6 +53,9 @@ def test_main_no_marathon_servers():
         "paasta_tools.paasta_metastatus.is_kubernetes_available",
         autospec=True,
         return_value=False,
+    ), patch(
+        "paasta_tools.paasta_metastatus.load_kubernetes_service_config_no_cache",
+        autospec=True,
     ):
         fake_master = Mock(autospace=True)
         fake_master.state.return_value = {}
@@ -86,7 +89,10 @@ def test_main_marathon_jsondecode_error():
         autospec=True,
     ) as get_mesos_resource_utilization_health_patch, patch(
         "paasta_tools.metrics.metastatus_lib.get_marathon_status", autospec=True
-    ) as get_marathon_status_patch:
+    ) as get_marathon_status_patch, patch(
+        "paasta_tools.paasta_metastatus.load_kubernetes_service_config_no_cache",
+        autospec=True,
+    ):
         fake_master = Mock(autospace=True)
         fake_master.state.return_value = {}
         get_mesos_master.return_value = fake_master


### PR DESCRIPTION
### Purpose
In this PR, we pass namespace to all the functions that requires it, otherwise it will be hardcode to "paasta" namespace.
These changes provide support for arbitrary namespaces in **paasta local-run** and **paasta_metastatus**.

### Testing
passes unit tests


Note: The functions below also must be changed by passing namespace  but I didn't change them since they fall under ``paasta_secrets_sync.py`` work:

- ``create_secret``
- ``create_plaintext_dict_secret``
- ``update_secret``
- ``update_plaintext_dict_secret``
- ``update_kubernetes_secret_signature``
- ``create_kubernetes_secret_signature``
- ``get_kubernetes_secret_signature``

[WIP functions] Still looking into these functions:

- ``list_all_deployments`` -- > in metastatus_lib.py (Done- addressed in second commit)
- ``get_all_pods_cached`` -- > in  metastatus_lib.py (Done- addressed in second commit)

[Ignored function] ``delete_deployment`` : it's being called in ``delete_kubernetes_deployments.py`` and we don't call this file anywhere. We should probably delete this file.