### PR TITLE
Add toggle to disable default preStop hook

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1326,7 +1326,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
     def get_kubernetes_container_termination_action(
         self,
         mesh_registered: bool,
-    ) -> V1Handler:
+    ) -> Optional[V1Handler]:
         command = self.config_dict.get("lifecycle", KubeLifecycleDict({})).get(
             "pre_stop_command", []
         )

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1292,7 +1292,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             env=self.get_container_env(),
             resources=self.get_resource_requirements(),
             lifecycle=V1Lifecycle(
-                pre_stop=self.get_kubernetes_container_termination_action()
+                pre_stop=self.get_kubernetes_container_termination_action(
+                    system_paasta_config
+                )
             ),
             name=self.get_sanitised_instance_name(),
             liveness_probe=self.get_liveness_probe(service_namespace_config),
@@ -1321,17 +1323,24 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         else:
             return self.get_liveness_probe(service_namespace_config)
 
-    def get_kubernetes_container_termination_action(self) -> V1Handler:
+    def get_kubernetes_container_termination_action(
+        self, system_paasta_config: SystemPaastaConfig
+    ) -> V1Handler:
         command = self.config_dict.get("lifecycle", KubeLifecycleDict({})).get(
             "pre_stop_command", []
         )
-        # default pre stop hook for the container
-        if not command:
-            return V1Handler(
-                _exec=V1ExecAction(
-                    command=["/bin/sh", "-c", f"sleep {DEFAULT_PRESTOP_SLEEP_SECONDS}"]
+        if system_paasta_config.should_add_default_prestop_hook():
+            # default pre stop hook for the container
+            if not command:
+                return V1Handler(
+                    _exec=V1ExecAction(
+                        command=[
+                            "/bin/sh",
+                            "-c",
+                            f"sleep {DEFAULT_PRESTOP_SLEEP_SECONDS}",
+                        ]
+                    )
                 )
-            )
         if isinstance(command, str):
             command = [command]
         return V1Handler(_exec=V1ExecAction(command=command))

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1348,7 +1348,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         if isinstance(command, str):
             command = [command]
 
-        return V1Handler(_exec=V1ExecAction(command=command))
+        return V1Handler(_exec=V1ExecAction(command=command)) if command else None
 
     def get_pod_volumes(
         self,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1996,6 +1996,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     skip_cpu_burst_validation: List[str]
     tron_default_pool_override: str
     uwsgi_offset_multiplier: float
+    add_default_prestop_hook: bool
 
 
 def load_system_paasta_config(
@@ -2071,6 +2072,9 @@ class SystemPaastaConfig:
 
     def __repr__(self) -> str:
         return f"SystemPaastaConfig({self.config_dict!r}, {self.directory!r})"
+
+    def should_add_default_prestop_hook(self) -> str:
+        return self.config_dict.get("add_default_prestop_hook", True)
 
     def get_tron_default_pool_override(self) -> str:
         """Get the default pool override variable defined in this host's cluster config file.

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1996,7 +1996,6 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     skip_cpu_burst_validation: List[str]
     tron_default_pool_override: str
     uwsgi_offset_multiplier: float
-    add_default_prestop_hook: bool
 
 
 def load_system_paasta_config(
@@ -2072,9 +2071,6 @@ class SystemPaastaConfig:
 
     def __repr__(self) -> str:
         return f"SystemPaastaConfig({self.config_dict!r}, {self.directory!r})"
-
-    def should_add_default_prestop_hook(self) -> str:
-        return self.config_dict.get("add_default_prestop_hook", True)
 
     def get_tron_default_pool_override(self) -> str:
         """Get the default pool override variable defined in this host's cluster config file.

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -3800,7 +3800,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config52071d00"
+            == "config97b33cdf"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 


### PR DESCRIPTION
Having a default preStop hook will interfere with upcoming plans to make some of our non-mesh workers gracefully shutdown - this should let us disable this hook per-cluster until we're done (after which, we'll just delete this code entirely) and give us an easy way to rollback without needing to pin paasta-tools back.