### PR TITLE
paasta secret run: subprocess.run -> os.execvpe

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -15,7 +15,6 @@
 import argparse
 import os
 import re
-import subprocess
 import sys
 
 from service_configuration_lib import DEFAULT_SOA_DIR
@@ -482,13 +481,8 @@ def paasta_secret(args):
             # make it clear that we're running in a sub-shell
             new_environ["PS1"] = r"(paasta secret run) \$ "
 
-        command_to_run = subprocess.run(
-            args.cmd,
-            shell=False,
-            check=False,
-            env=new_environ,
-        )
-        sys.exit(command_to_run.returncode)
+        # Note: this never returns, it replaces the current process
+        os.execvpe(args.cmd[0], args.cmd, new_environ)
     else:
         print("Unknown action")
         sys.exit(1)

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -481,7 +481,9 @@ def paasta_secret(args):
             # make it clear that we're running in a sub-shell
             new_environ["PS1"] = r"(paasta secret run) \$ "
 
-        # Note: this never returns, it replaces the current process
+        # This is like subprocess.run but never returns (it replaces the current process),
+        # we do this to play nicely with pgctl:
+        # https://pgctl.readthedocs.io/en/latest/user/quickstart.html#writing-playground-services
         os.execvpe(args.cmd[0], args.cmd, new_environ)
     else:
         print("Unknown action")

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -296,9 +296,9 @@ def test_paasta_secret_run():
     ), mock.patch(
         "paasta_tools.cli.cmds.secret.load_system_paasta_config", autospec=True
     ), mock.patch(
-        "subprocess.run",
+        "os.execvpe",
         autospec=True,
-    ) as mock_subprocess:
+    ) as mock_exec:
         mock_decrypt_secret_environment_variables.return_value = {
             "PAASTA_SECRET_TEST": "test secret value",
         }
@@ -309,16 +309,14 @@ def test_paasta_secret_run():
             instance="main",
             cmd=["foo"],
         )
-        with raises(SystemExit):
-            secret.paasta_secret(mock_args)
 
-        mock_subprocess.assert_called_once_with(
+        secret.paasta_secret(mock_args)
+
+        mock_exec.assert_called_once_with(
+            "foo",
             ["foo"],
-            shell=False,
-            check=False,
-            env=mock.ANY,
+            mock.ANY,
         )
         assert (
-            mock_subprocess.call_args[1]["env"].get("PAASTA_SECRET_TEST")
-            == "test secret value"
+            mock_exec.call_args[0][2].get("PAASTA_SECRET_TEST") == "test secret value"
         )


### PR DESCRIPTION
This change is to play nicely with [`pgctl`](https://github.com/Yelp/pgctl), which wants a single process (for ease of signal handling): https://pgctl.readthedocs.io/en/latest/user/quickstart.html#writing-playground-services

(`pgctl-poll-ready` also does some file descriptor juggling which doesn't work with `subprocess`)

There's no cleanup in `paasta_tools.cli.cli.main` beyond catching `KeyboardInterrupt` so this change should be transparent (we aren't cutting off any cleanup actions): https://github.com/Yelp/paasta/blob/d336d2a58089eab453f2ffc870ad399653494b47/paasta_tools/cli/cli.py#L257

and I've also been using this locally.