### PR TITLE
Add --assume-pod-identity option to spark-run

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -395,6 +395,14 @@ def add_subparser(subparsers):
         default=DEFAULT_AWS_REGION,
     )
 
+    aws_group.add_argument(
+        "--assume-pod-identity",
+        help="If running running in the context of a Kubernetes pod with pod identity set, "
+        "assume the role and pass the session credentials to the spark job.",
+        action="store_true",
+        default=False,
+    )
+
     jupyter_group = list_parser.add_argument_group(
         title="Jupyter kernel culling options",
         description="Idle kernels will be culled by default. Idle "
@@ -1099,6 +1107,7 @@ def paasta_spark_run(args):
         no_aws_credentials=args.no_aws_credentials,
         aws_credentials_yaml=args.aws_credentials_yaml,
         profile_name=args.aws_profile,
+        assume_pod_identity=args.assume_pod_identity,
     )
     docker_image = get_docker_image(args, instance_config)
     if docker_image is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.14.3
+service-configuration-lib==2.15.0
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0


### PR DESCRIPTION
Add a new parameter that will get a session based off a web identity token, and uses that session in a spark job. This is entirely just a passthrough parameter to a new feature of service_configuration_lib, added here: https://github.com/Yelp/service_configuration_lib/pull/105/files

`aws_creds` already supports session based credentials, so no other changes are needed.
