### PR TITLE
Add iam_role and provider to adhoc schema

### DIFF
--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -61,6 +61,14 @@
                         "type": "string"
                     }
                 },
+                "iam_role": {
+                    "type": "string"
+                },
+                "iam_role_provider": {
+                    "enum": [
+                        "aws"
+                    ]
+                },
                 "crypto_keys": {
                     "type": "object",
                     "additionalProperties": false,


### PR DESCRIPTION
https://github.com/Yelp/paasta/pull/3532 added a feature that allows `local-run` to use the `iam_role` setting of a service to assume the role locally. This means that `iam_role` now has a use case for being configured in adhoc service instances, as that is where `local-run` will read from by default. This allows you to set those. 