### PR TITLE
Bump service-configuration-lib to v2.14.5

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -49,7 +49,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.14.4
+service-configuration-lib >= 2.14.5
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.14.4
+service-configuration-lib==2.14.5
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0


### PR DESCRIPTION
Bump service-configuration-lib to v2.14.5.

Tested via running `paasta spark-run` locally.
