### PR TITLE
Support shared secrets in secrets for owner team

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -3635,7 +3635,7 @@ def get_kubernetes_secret_env_variables(
             decrypted_secrets[k] = str(
                 get_kubernetes_secret(
                     kube_client,
-                    service_name,
+                    SHARED_SECRET_SERVICE if is_shared_secret(v) else service_name,
                     secret_name,
                     decode=True,
                     namespace=namespace,

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -4243,11 +4243,12 @@ def test_get_kubernetes_secret_env_variables():
             "MY": "aaa",
             "SECRET_NAME1": "SECRET(SECRET_NAME1)",
             "SECRET_NAME2": "SECRET(SECRET_NAME2)",
+            "SHARED_SECRET1": "SHARED_SECRET(SHARED_SECRET1)",
         }
 
         mock_is_secret_ref.side_effect = lambda val: "SECRET" in val
-        mock_get_ref.side_effect = ["SECRET_NAME1", "SECRET_NAME2"]
-        mock_get_kubernetes_secret.side_effect = ["123", "abc"]
+        mock_get_ref.side_effect = ["SECRET_NAME1", "SECRET_NAME2", "SHARED_SECRET1"]
+        mock_get_kubernetes_secret.side_effect = ["123", "abc", "shared"]
         mock_client = mock.Mock()
         mock_kube_client.return_value = mock_client
 
@@ -4256,7 +4257,11 @@ def test_get_kubernetes_secret_env_variables():
             environment=mock_environment,
             service_name="universe",
         )
-        assert ret == {"SECRET_NAME1": "123", "SECRET_NAME2": "abc"}
+        assert ret == {
+            "SECRET_NAME1": "123",
+            "SECRET_NAME2": "abc",
+            "SHARED_SECRET1": "shared",
+        }
 
         assert mock_get_kubernetes_secret.call_args_list == [
             mock.call(
@@ -4264,6 +4269,13 @@ def test_get_kubernetes_secret_env_variables():
             ),
             mock.call(
                 mock_client, "universe", "SECRET_NAME2", decode=True, namespace="paasta"
+            ),
+            mock.call(
+                mock_client,
+                SHARED_SECRET_SERVICE,
+                "SHARED_SECRET1",
+                decode=True,
+                namespace="paasta",
             ),
         ]
 


### PR DESCRIPTION
## Problem
The secrets for owner team implementation uses the wrong key for referencing shared secrets

## Solution
Copied [the same pattern used elsewhere](https://github.com/Yelp/paasta/blob/2e1cafdc687f231eca07388f468bf4b00ebb95cd/paasta_tools/kubernetes_tools.py#L2083) to reference the correct secret name when the secret is a shared one

## Testing
Confirmed this works with a service that uses shared secret and has `secrets_for_owner_team: true`
```
@@ -10,5 +10,6 @@ main:
+    PAASTA_SECRET_MY_SHARED_SECRET: SHARED_SECRET(test-shared)
```

```
$ paasta local-run --service the-service --cluster the-cluster -i main --interactive --pull
Re-executing paasta local-run --pull with sudo..
[...]
nobody@the-host:/code$ env | grep SHARED
PAASTA_SECRET_MY_SHARED_SECRET=SHARED_SECRET_TEST
nobody@the-host:/code$ exit
```


Without the fix in this PR:
```
$ paasta local-run --service the-service --cluster the-cluster -i main --interactive --pull
Re-executing paasta local-run --pull with sudo..
[...]
Failed to retrieve kubernetes secrets with ApiException: (404)
Reason: Not Found
HTTP response headers: HTTPHeaderDict({'Audit-Id': 'deadbeef-dead-beef-dead-beefdeadbeef', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Kubernetes-Pf-Flowschema-Uid': 'deadbeef-dead-beef-dead-beefdeadbeef', 'X-Kubernetes-Pf-Prioritylevel-Uid': 'deadbeef-dead-beef-dead-beefdeadbeef', 'Date': 'Fri, 17 Mar 2023 19:29:57 GMT', 'Content-Length': '264'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"secrets \"paasta-secret-the--service-test-shared\" not found","reason":"NotFound","details":{"name":"paasta-secret-the--service-test-shared","kind":"secrets"},"code":404}

If you don't need the secrets for local-run, you can add --skip-secrets
```