### PR TITLE
Add AWS_SECURITY_TOKEN to local-run assume-role env vars

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -76,6 +76,7 @@ class AWSSessionCreds(TypedDict):
     AWS_ACCESS_KEY_ID: str
     AWS_SECRET_ACCESS_KEY: str
     AWS_SESSION_TOKEN: str
+    AWS_SECURITY_TOKEN: str
 
 
 def parse_date(date_string):

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -778,6 +778,7 @@ def assume_aws_role(
         "AWS_ACCESS_KEY_ID": cmd_output["AccessKeyId"],
         "AWS_SECRET_ACCESS_KEY": cmd_output["SecretAccessKey"],
         "AWS_SESSION_TOKEN": cmd_output["SessionToken"],
+        "AWS_SECURITY_TOKEN": cmd_output["SessionToken"],
     }
     return creds_dict
 


### PR DESCRIPTION
This change supports older boto(2) clients that use AWS_SECURITY_TOKEN. While this has been deprecated for some time, I don't see any reason why we should support it. 