### PR TITLE
MLCOMPUTE-537 | remove DRA enable logic, bump up version

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -991,23 +991,6 @@ def _auto_add_timeout_for_job(cmd, timeout_job_runtime):
     return cmd
 
 
-def _enable_dra_default(args, user_spark_opts):
-    if (
-        args.cluster_manager == CLUSTER_MANAGER_K8S
-        and "spark.dynamicAllocation.enabled" not in user_spark_opts
-    ):
-        log.warning(
-            PaastaColors.yellow(
-                "Spark Dynamic Resource Allocation (DRA) enabled for this batch. "
-                "More info: y/spark-dra. If your job is performing worse because "
-                "of DRA, consider disabling DRA. To disable, please provide "
-                "spark.dynamicAllocation.enabled=false in --spark-args\n"
-            )
-        )
-        user_spark_opts["spark.dynamicAllocation.enabled"] = "true"
-    return user_spark_opts
-
-
 def _validate_pool(args, system_paasta_config):
     if args.pool:
         valid_pools = system_paasta_config.get_cluster_pools().get(args.cluster, [])
@@ -1141,9 +1124,6 @@ def paasta_spark_run(args):
             user_spark_opts[key] = value
 
     paasta_instance = get_smart_paasta_instance_name(args)
-
-    # Spark DRA is enabled by default for all batches unless disabled explicitly. More info: y/spark-dra
-    user_spark_opts = _enable_dra_default(args, user_spark_opts)
 
     spark_conf = get_spark_conf(
         cluster_manager=args.cluster_manager,

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -49,7 +49,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.14.5
+service-configuration-lib >= 2.15.1
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.14.5
+service-configuration-lib==2.15.1
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0


### PR DESCRIPTION
- Default DRA enable logic has been moved to service-configuration-lib
- Bump up service-configuration-lib version to 2.15.1