### PR TITLE
Set correct value of spark.kubernetes.decommission.script 

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1140,6 +1140,11 @@ def paasta_spark_run(args):
         aws_region=args.aws_region,
         force_spark_resource_configs=args.force_spark_resource_configs,
     )
+    # TODO: Remove this after MLCOMPUTE-699 is complete
+    if "spark.kubernetes.decommission.script" not in spark_conf:
+        spark_conf[
+            "spark.kubernetes.decommission.script"
+        ] = "/opt/spark/kubernetes/dockerfiles/spark/decom.sh"
 
     # Experimental: TODO: Move to service_configuration_lib once confirmed that there are no issues
     # Enable AQE: Adaptive Query Execution


### PR DESCRIPTION
MLCOMPUTE-700

Manual Test run: MLCOMPUTE-700
Expectation: Jobs on batch pool should run faster. There is no downside of this config as long the spark job is running. 
Context in the ticket.