### PR TITLE
Split NOT_RUNNING state into different states for different underlying conditions.

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1503,8 +1503,16 @@ def get_version_table_entry(
 class ReplicaState(Enum):
     # Order will be preserved in count summary
     RUNNING = "Healthy", PaastaColors.green
+
     UNREACHABLE = "Unreachable", PaastaColors.red
-    NOT_RUNNING = "Not Running", PaastaColors.red
+    EVICTED = "Evicted", PaastaColors.red
+    ALL_CONTAINERS_WAITING = "All Containers Waiting", PaastaColors.red
+    FAILED = "Failed", PaastaColors.red
+    MAIN_CONTAINER_NOT_RUNNING = "Main Container Not Running", PaastaColors.red
+    NO_CONTAINERS_YET = "No Containers Yet", PaastaColors.red
+    NOT_READY = "Not Ready", PaastaColors.red
+    SOME_CONTAINERS_WAITING = "Some Containers Waiting", PaastaColors.red
+
     WARNING = "Warning", PaastaColors.yellow
     UNSCHEDULED = "Unscheduled", PaastaColors.yellow
     STARTING = "Starting", PaastaColors.yellow
@@ -1513,7 +1521,7 @@ class ReplicaState(Enum):
     UNKNOWN = "Unknown", PaastaColors.yellow
 
     def is_unhealthy(self):
-        return self.name in ["UNREACHABLE", "NOT_RUNNING"]
+        return self.color == PaastaColors.red
 
     @property
     def color(self) -> Callable:
@@ -1564,17 +1572,21 @@ def get_replica_state(pod: KubernetesPodV2) -> ReplicaState:
     phase = pod.phase
     state = ReplicaState.UNKNOWN
     reason = pod.reason
-    if phase == "Failed" or reason == "Evicted":
-        state = ReplicaState.NOT_RUNNING
+    if reason == "Evicted":
+        state = ReplicaState.EVICTED
+    elif phase == "Failed":
+        state = ReplicaState.FAILED
     elif phase is None or not pod.scheduled:
         state = ReplicaState.UNSCHEDULED
     elif pod.delete_timestamp:
         state = ReplicaState.TERMINATING
     elif phase == "Pending":
-        if not pod.containers or all([c.state == "waiting" for c in pod.containers]):
-            state = ReplicaState.STARTING
+        if not pod.containers:
+            state = ReplicaState.NO_CONTAINERS_YET
+        elif all([c.state == "waiting" for c in pod.containers]):
+            state = ReplicaState.ALL_CONTAINERS_WAITING
         else:
-            state = ReplicaState.NOT_RUNNING
+            state = ReplicaState.SOME_CONTAINERS_WAITING
     elif phase == "Running":
         ####
         # TODO: Take sidecar containers into account
@@ -1588,11 +1600,11 @@ def get_replica_state(pod: KubernetesPodV2) -> ReplicaState:
             )
             if pod.mesh_ready is False:
                 if main_container.state != "running":
-                    state = ReplicaState.NOT_RUNNING
+                    state = ReplicaState.MAIN_CONTAINER_NOT_RUNNING
                 else:
                     state = ReplicaState.UNREACHABLE
             elif not pod.ready:
-                state = ReplicaState.NOT_RUNNING
+                state = ReplicaState.NOT_READY
             else:
                 if recent_liveness_failure(pod) or recent_container_restart(
                     main_container

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1583,7 +1583,7 @@ def get_replica_state(pod: KubernetesPodV2) -> ReplicaState:
     elif phase == "Pending":
         if not pod.containers:
             state = ReplicaState.NO_CONTAINERS_YET
-        elif all([c.state == "waiting" for c in pod.containers]):
+        elif all([c.state.lower() == "waiting" for c in pod.containers]):
             state = ReplicaState.ALL_CONTAINERS_WAITING
         else:
             state = ReplicaState.SOME_CONTAINERS_WAITING

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -2012,7 +2012,7 @@ class TestGetVersionsTable:
         assert "aabbccdd (new)" in versions_table[0]
         assert "2021-03-03" in versions_table[0]
         assert PaastaColors.green("1 Healthy") in versions_table[1]
-        assert PaastaColors.red("1 Not Running") in versions_table[1]
+        assert PaastaColors.red("1 Evicted") in versions_table[1]
 
         assert "ff112233 (old)" in versions_table[7]
         assert "2021-03-01" in versions_table[7]
@@ -2053,10 +2053,7 @@ class TestGetVersionsTable:
             ["curl http://1.2.3.5:8888/healthcheck" in row for row in versions_table]
         )
         assert any(
-            [
-                "1 Not Running" in remove_ansi_escape_sequences(row)
-                for row in versions_table
-            ]
+            ["1 Evicted" in remove_ansi_escape_sequences(row) for row in versions_table]
         )
 
     def test_restart_tip(self, mock_replicasets, mock_bad_container):
@@ -2190,7 +2187,7 @@ class TestGetVersionsTable:
         versions_table = get_versions_table(
             mock_replicasets, "service", "instance", "cluster", verbose=1
         )
-        assert any(["1 Not Running" in row for row in versions_table])
+        assert any(["1 Evicted" in row for row in versions_table])
 
 
 class TestPrintKubernetesStatus:


### PR DESCRIPTION
I don't find it particularly helpful to have 4 different conditions end up with the same `Not Running` message, so I've distinguished between them. This should help with after-the-fact debugging in situations like https://jira.yelpcorp.com/browse/COMPINFRA-2270 where we just have `paasta status` / `paasta mark-for-deployment --wait-for-deployment` output.