### PR TITLE
If existing_app has status.replicas=None, treat it as 0 replicas.

### DIFF
--- a/paasta_tools/cleanup_kubernetes_jobs.py
+++ b/paasta_tools/cleanup_kubernetes_jobs.py
@@ -119,7 +119,8 @@ def instance_is_not_bouncing(
         if isinstance(application, DeploymentWrapper):
             existing_app = application.item
             if existing_app.metadata.namespace == instance_config.get_namespace() and (
-                instance_config.get_instances() <= existing_app.status.ready_replicas
+                instance_config.get_instances()
+                <= (existing_app.status.ready_replicas or 0)
             ):
                 return True
 


### PR DESCRIPTION
this should help cleanup_kubernetes_job not crash when it finds services with `instances: 0`.