### PR TITLE
Make resource minimums in k8s schemas inclusive

### DIFF
--- a/paasta_tools/cli/schemas/autotuned_defaults/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/autotuned_defaults/kubernetes_schema.json
@@ -23,12 +23,12 @@
                 "disk": {
                     "type": "number",
                     "minimum": 128,
-                    "exclusiveMinimum": true
+                    "exclusiveMinimum": false
                 },
                 "mem": {
                     "type": "number",
                     "minimum": 32,
-                    "exclusiveMinimum": true
+                    "exclusiveMinimum": false
                 },
                 "min_instances": {
                     "type": "integer",

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -105,13 +105,13 @@
                 "mem": {
                     "type": "number",
                     "minimum": 32,
-                    "exclusiveMinimum": true,
+                    "exclusiveMinimum": false,
                     "default": 1024
                 },
                 "disk": {
                     "type": "number",
                     "minimum": 0,
-                    "exclusiveMinimum": true,
+                    "exclusiveMinimum": false,
                     "default": 1024
                 },
                 "gpus": {

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -111,7 +111,7 @@
                 "disk": {
                     "type": "number",
                     "minimum": 0,
-                    "exclusiveMinimum": false,
+                    "exclusiveMinimum": true,
                     "default": 1024
                 },
                 "gpus": {


### PR DESCRIPTION
We have a couple instances in our code where we assume that these limits are inclusive, but recent changes to metric collection have shown that this is not true :)

Rather than try to fix every location where we made this incorrect assumption - let's just make that assumption reality.