### PR TITLE
Add note when running paasta local-run for an undeployed tron action

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -728,6 +728,14 @@ class TronJobConfig:
                     f'Docker image unavailable for {action_service}.{self.get_name()}.{action_dict.get("name")}'
                     " is it deployed yet?"
                 )
+
+                if self.soa_dir != DEFAULT_SOA_DIR:
+                    log.warning(
+                        f"Error: No deployments.json found in {self.soa_dir}/{action_service}. "
+                        "You can generate this by running: "
+                        f"generate_deployments_for_service -d {self.soa_dir} -s {action_service}"
+                    )
+
                 branch_dict = None
         else:
             branch_dict = None


### PR DESCRIPTION
Ideally this would hit the existing code in local-run that prints out a similar message for other instance types, but refactoring to make that possible would take longer than we want to spend right now and this confuses developers (and anyone that's never run into this before) not too infrequently :)