### PR TITLE
Make paasta secrets for teams decrypt available for multiple instance types and namespaces

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -20,9 +20,9 @@ import sys
 from service_configuration_lib import DEFAULT_SOA_DIR
 
 from paasta_tools.cli.utils import get_instance_config
+from paasta_tools.cli.utils import get_namespace_for_secret
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
-from paasta_tools.cli.utils import get_namespace_for_secret
 from paasta_tools.kubernetes_tools import get_kubernetes_secret
 from paasta_tools.kubernetes_tools import KUBE_CONFIG_USER_PATH
 from paasta_tools.kubernetes_tools import KubeClient
@@ -403,11 +403,15 @@ def paasta_secret(args):
 
         kube_client = KubeClient(config_file=KUBE_CONFIG_USER_PATH, context=clusters[0])
 
-        secret_to_k8s_mapping = get_namespace_for_secret(service, clusters[0], args.secret_name, args.yelpsoa_config_root)
-        if (secret_to_k8s_mapping):
+        secret_to_k8s_mapping = get_namespace_for_secret(
+            service, clusters[0], args.secret_name, args.yelpsoa_config_root
+        )
+        if secret_to_k8s_mapping:
             # assuming that if multiple namespaces, they should be the same
             namespace = secret_to_k8s_mapping.pop()
-            print(get_kubernetes_secret(kube_client, service, args.secret_name, namespace))
+            print(
+                get_kubernetes_secret(kube_client, service, args.secret_name, namespace)
+            )
         # fallback to default in case mapping fails
         else:
             print(get_kubernetes_secret(kube_client, service, args.secret_name))

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -20,9 +20,10 @@ import sys
 from service_configuration_lib import DEFAULT_SOA_DIR
 
 from paasta_tools.cli.utils import get_instance_config
-from paasta_tools.cli.utils import get_namespace_for_secret
+from paasta_tools.cli.utils import get_namespaces_for_secret
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
+from paasta_tools.cli.utils import select_k8s_secret_namespace
 from paasta_tools.kubernetes_tools import get_kubernetes_secret
 from paasta_tools.kubernetes_tools import KUBE_CONFIG_USER_PATH
 from paasta_tools.kubernetes_tools import KubeClient
@@ -403,12 +404,13 @@ def paasta_secret(args):
 
         kube_client = KubeClient(config_file=KUBE_CONFIG_USER_PATH, context=clusters[0])
 
-        secret_to_k8s_mapping = get_namespace_for_secret(
+        secret_to_k8s_mapping = get_namespaces_for_secret(
             service, clusters[0], args.secret_name, args.yelpsoa_config_root
         )
-        if secret_to_k8s_mapping:
-            # assuming that if multiple namespaces, they should be the same
-            namespace = secret_to_k8s_mapping.pop()
+
+        namespace = select_k8s_secret_namespace(secret_to_k8s_mapping)
+
+        if namespace:
             print(
                 get_kubernetes_secret(kube_client, service, args.secret_name, namespace)
             )

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -22,6 +22,7 @@ from service_configuration_lib import DEFAULT_SOA_DIR
 from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
+from paasta_tools.cli.utils import get_namespace_for_secret
 from paasta_tools.kubernetes_tools import get_kubernetes_secret
 from paasta_tools.kubernetes_tools import KUBE_CONFIG_USER_PATH
 from paasta_tools.kubernetes_tools import KubeClient
@@ -401,7 +402,15 @@ def paasta_secret(args):
             sys.exit(1)
 
         kube_client = KubeClient(config_file=KUBE_CONFIG_USER_PATH, context=clusters[0])
-        print(get_kubernetes_secret(kube_client, service, args.secret_name))
+
+        secret_to_k8s_mapping = get_namespace_for_secret(service, clusters[0], args.secret_name, args.yelpsoa_config_root)
+        if (secret_to_k8s_mapping):
+            # assuming that if multiple namespaces, they should be the same
+            namespace = secret_to_k8s_mapping.pop()
+            print(get_kubernetes_secret(kube_client, service, args.secret_name, namespace))
+        # fallback to default in case mapping fails
+        else:
+            print(get_kubernetes_secret(kube_client, service, args.secret_name))
         return
 
     if args.action in ["add", "update"]:

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -849,7 +849,7 @@ def get_instance_config(
 
 def get_namespace_for_secret(
     service: str, cluster: str, secret_name: str, soa_dir: str = DEFAULT_SOA_DIR
-):
+) -> Set:
     secret_to_k8s_namespace = set()
 
     for instance_type in INSTANCE_TYPES:

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -849,7 +849,7 @@ def get_instance_config(
 
 def get_namespace_for_secret(
     service: str, cluster: str, secret_name: str, soa_dir: str = DEFAULT_SOA_DIR
-) -> Set:
+) -> Set[str]:
     secret_to_k8s_namespace = set()
 
     for instance_type in INSTANCE_TYPES:

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -869,7 +869,7 @@ def get_namespace_for_secret(
 
             for serv, instance in instances:
                 config = get_instance_config(serv, instance, cluster, soa_dir)
-                if secret_name in config.get_secret_env():
+                if secret_name in config.get_env():
                     secret_to_k8s_namespace.add(
                         INSTANCE_TYPE_TO_K8S_NAMESPACE[instance_type]
                     )

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -886,18 +886,12 @@ def select_k8s_secret_namespace(namespaces: Set[str]) -> Optional[str]:
     if namespaces_count == 1:
         return namespaces.pop()
 
-    prioritized_k8s_namespaces = [
-        "paasta",
-        "tron",
-        "paasta-flinks",
-        "paasta-cassandraclusters",
-        "paasta-kafkaclusters",
-        "paasta-nrtsearchservices",
-    ]
-
-    for k8s_namespace in prioritized_k8s_namespaces:
-        if k8s_namespace in namespaces:
-            return k8s_namespace
+    # prioritise paasta, tron namespaces when found
+    for namespace in namespaces:
+        if namespace.startswith("paasta"):
+            return namespace
+        if namespace == "tron":
+            return namespace
 
     # only experimental k8s namespaces
     return namespaces.pop()

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -847,7 +847,7 @@ def get_instance_config(
     )
 
 
-def get_namespace_for_secret(
+def get_namespaces_for_secret(
     service: str, cluster: str, secret_name: str, soa_dir: str = DEFAULT_SOA_DIR
 ) -> Set[str]:
     secret_to_k8s_namespace = set()
@@ -875,6 +875,32 @@ def get_namespace_for_secret(
                     )
 
     return secret_to_k8s_namespace
+
+
+def select_k8s_secret_namespace(namespaces: Set[str]) -> Optional[str]:
+    namespaces_count = len(namespaces)
+
+    if not namespaces_count:
+        return None
+
+    if namespaces_count == 1:
+        return namespaces.pop()
+
+    prioritized_k8s_namespaces = [
+        "paasta",
+        "tron",
+        "paasta-flinks",
+        "paasta-cassandraclusters",
+        "paasta-kafkaclusters",
+        "paasta-nrtsearchservices",
+    ]
+
+    for k8s_namespace in prioritized_k8s_namespaces:
+        if k8s_namespace in namespaces:
+            return k8s_namespace
+
+    # only experimental k8s namespaces
+    return namespaces.pop()
 
 
 def extract_tags(paasta_tag: str) -> Mapping[str, str]:

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -150,7 +150,9 @@ def test_paasta_secret():
         "paasta_tools.cli.cmds.secret.get_kubernetes_secret", autospec=True
     ) as mock_get_kubernetes_secret, mock.patch(
         "paasta_tools.cli.cmds.secret.KubeClient", autospec=True
-    ) as mock_kube_client:
+    ) as mock_kube_client, mock.patch(
+        "paasta_tools.cli.cmds.secret.get_namespace_for_secret", autospec=True
+    ) as mock_get_namespace_for_secret:
         mock_secret_provider = mock.Mock(secret_dir="/nail/blah")
         mock_get_secret_provider_for_service.return_value = mock_secret_provider
         mock_args = mock.Mock(
@@ -231,6 +233,7 @@ def test_paasta_secret():
         )
         kube_client = mock.Mock()
         mock_is_secrets_for_teams_enabled.return_value = True
+        mock_get_namespace_for_secret.return_value = {"paasta"}
         mock_kube_client.return_value = kube_client
 
         secret.paasta_secret(mock_args)
@@ -239,6 +242,13 @@ def test_paasta_secret():
         mock_kube_client.assert_called_with(
             config_file=KUBE_CONFIG_USER_PATH, context="mesosstage"
         )
+        mock_get_kubernetes_secret.assert_called_with(
+            kube_client, "middleearth", "theonering", "paasta"
+        )
+
+        # empty namespace list
+        mock_get_namespace_for_secret.return_value = set()
+        secret.paasta_secret(mock_args)
         mock_get_kubernetes_secret.assert_called_with(
             kube_client, "middleearth", "theonering"
         )

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -151,8 +151,10 @@ def test_paasta_secret():
     ) as mock_get_kubernetes_secret, mock.patch(
         "paasta_tools.cli.cmds.secret.KubeClient", autospec=True
     ) as mock_kube_client, mock.patch(
-        "paasta_tools.cli.cmds.secret.get_namespace_for_secret", autospec=True
-    ) as mock_get_namespace_for_secret:
+        "paasta_tools.cli.cmds.secret.get_namespaces_for_secret", autospec=True
+    ) as mock_get_namespaces_for_secret, mock.patch(
+        "paasta_tools.cli.cmds.secret.select_k8s_secret_namespace", autospec=True
+    ) as mock_select_k8s_secret_namespace:
         mock_secret_provider = mock.Mock(secret_dir="/nail/blah")
         mock_get_secret_provider_for_service.return_value = mock_secret_provider
         mock_args = mock.Mock(
@@ -233,7 +235,8 @@ def test_paasta_secret():
         )
         kube_client = mock.Mock()
         mock_is_secrets_for_teams_enabled.return_value = True
-        mock_get_namespace_for_secret.return_value = {"paasta"}
+        mock_get_namespaces_for_secret.return_value = {"paasta"}
+        mock_select_k8s_secret_namespace.return_value = "paasta"
         mock_kube_client.return_value = kube_client
 
         secret.paasta_secret(mock_args)
@@ -247,7 +250,8 @@ def test_paasta_secret():
         )
 
         # empty namespace list
-        mock_get_namespace_for_secret.return_value = set()
+        mock_get_namespaces_for_secret.return_value = set()
+        mock_select_k8s_secret_namespace.return_value = None
         secret.paasta_secret(mock_args)
         mock_get_kubernetes_secret.assert_called_with(
             kube_client, "middleearth", "theonering"

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -557,8 +557,12 @@ def test_select_k8s_secret_namespace():
     namespaces = {"random_experiment", "paasta"}
     assert select_k8s_secret_namespace(namespaces) == "paasta"
 
-    namespaces = {"tron", "paasta-flinks", "paasta-nrtsearchservices"}
-    assert select_k8s_secret_namespace(namespaces) == "tron"
+    namespaces = {"paasta-flinks", "paastasvc-something"}
+    assert select_k8s_secret_namespace(namespaces).startswith("paasta")
+
+    namespaces = {"paasta-flinks", "tron", "something"}
+    namespace = select_k8s_secret_namespace(namespaces)
+    assert namespace == "paasta-flinks" or namespace == "tron"
 
     namespaces = {"a", "b"}
     assert select_k8s_secret_namespace(namespaces) in {"a", "b"}

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -24,6 +24,7 @@ from pytest import raises
 
 from paasta_tools.cli import utils
 from paasta_tools.cli.utils import extract_tags
+from paasta_tools.cli.utils import select_k8s_secret_namespace
 from paasta_tools.cli.utils import verify_instances
 from paasta_tools.marathon_tools import MarathonServiceConfig
 from paasta_tools.utils import SystemPaastaConfig
@@ -544,3 +545,20 @@ def test_verify_instances_with_suffixes(mock_list_all_instances_for_service):
 )
 def test_extract_tags(tag, expected_result):
     assert extract_tags(tag) == expected_result
+
+
+def test_select_k8s_secret_namespace():
+    namespaces = {}
+    assert not select_k8s_secret_namespace(namespaces)
+
+    namespaces = {"random_experiment"}
+    assert select_k8s_secret_namespace(namespaces) == "random_experiment"
+
+    namespaces = {"random_experiment", "paasta"}
+    assert select_k8s_secret_namespace(namespaces) == "paasta"
+
+    namespaces = {"tron", "paasta-flinks", "paasta-nrtsearchservices"}
+    assert select_k8s_secret_namespace(namespaces) == "tron"
+
+    namespaces = {"a", "b"}
+    assert select_k8s_secret_namespace(namespaces) in {"a", "b"}


### PR DESCRIPTION
k8s secrets decryption used to rely on the default paasta namespace. Adding some functionality to trace back from a secret name to the instance types where it is used, followed by k8s namespaces that they are stored under.
Keeping a fallback to default, in case the mapping fails.