### PR TITLE
Show status of apps in other namespaces, in case migration to a new namespace gets stuck.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ else
 	export DOCKER_REGISTRY ?= ""
 endif
 
-.PHONY: all docs test itest k8s_itests
+.PHONY: all docs test itest k8s_itests quick-test
 
 dev: .paasta/bin/activate
 	.paasta/bin/tox -i $(PIP_INDEX_URL)
@@ -49,6 +49,9 @@ test-yelpy: .paasta/bin/activate
 
 test-not-yelpy: .paasta/bin/activate
 	.paasta/bin/tox -i $(PIP_INDEX_URL) -e tests
+
+quick-test: .tox/py37-linux
+	TZ=UTC .tox/py37-linux/bin/py.test --last-failed -x -- tests
 
 .tox/py37-linux: .paasta/bin/activate
 	.paasta/bin/tox -i $(PIP_INDEX_URL)

--- a/mypy.ini
+++ b/mypy.ini
@@ -99,3 +99,6 @@ disallow_untyped_defs = True
 
 [mypy-paasta_tools.dump_locally_running_services]
 disallow_untyped_defs = True
+
+[mypy-paasta_tools.instance.kubernetes]
+disallow_untyped_defs = True

--- a/paasta_tools/api/api_docs/oapi.yaml
+++ b/paasta_tools/api/api_docs/oapi.yaml
@@ -979,6 +979,9 @@ components:
           description: Number of replicas currently ready
           format: int32
           type: integer
+        namespace:
+          description: Kubernetes namespace this version is in
+          type: string
       type: object
     MarathonAppStatus:
       properties:

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -1846,6 +1846,10 @@
                     "type": "integer",
                     "format": "int32",
                     "description": "Number of replicas currently ready"
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Kubernetes namespace this version is in"
                 }
             }
         },

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1365,10 +1365,10 @@ def get_versions_table(
     else:
         versions = sorted(versions, key=lambda x: x.create_timestamp, reverse=True)
         config_shas = {v.config_sha for v in versions}
-        if len(config_shas) > 1:
-            show_config_sha = True
-        else:
-            show_config_sha = False
+        show_config_sha = len(config_shas) > 1
+
+        namespaces = {v.namespace for v in versions}
+        show_namespace = len(namespaces) > 1
 
         table: List[str] = []
         table.extend(
@@ -1379,6 +1379,7 @@ def get_versions_table(
                 cluster,
                 version_name_suffix="new",
                 show_config_sha=show_config_sha,
+                show_namespace=show_namespace,
                 verbose=verbose,
             )
         )
@@ -1391,6 +1392,7 @@ def get_versions_table(
                     cluster,
                     version_name_suffix="old",
                     show_config_sha=show_config_sha,
+                    show_namespace=show_namespace,
                     verbose=verbose,
                 )
             )
@@ -1404,6 +1406,7 @@ def get_version_table_entry(
     cluster: str,
     version_name_suffix: str = None,
     show_config_sha: bool = False,
+    show_namespace: bool = False,
     verbose: int = 0,
 ) -> List[str]:
     version_name = version.git_sha[:8]
@@ -1413,6 +1416,8 @@ def get_version_table_entry(
         version_name += f" (image_version: {version.image_version})"
     if version_name_suffix is not None:
         version_name += f" ({version_name_suffix})"
+    if version.namespace is not None and (show_namespace or verbose > 1):
+        version_name += f" (namespace: {version.namespace})"
     version_name = PaastaColors.blue(version_name)
 
     start_datetime = datetime.fromtimestamp(version.create_timestamp)

--- a/paasta_tools/delete_kubernetes_deployments.py
+++ b/paasta_tools/delete_kubernetes_deployments.py
@@ -34,7 +34,7 @@ from paasta_tools.utils import SPACER
 log = logging.getLogger(__name__)
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(args=None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Deletes list of deployments.")
     parser.add_argument(
         "service_instance_list",
@@ -42,7 +42,7 @@ def parse_args() -> argparse.Namespace:
         help="The list of service instances to delete",
         metavar=f"SERVICE{SPACER}INSTANCE",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(args=args)
     return args
 
 
@@ -61,8 +61,8 @@ def get_deployment_names_from_list(service_instance_list):
     return app_names
 
 
-def main() -> None:
-    args = parse_args()
+def main(args=None) -> None:
+    args = parse_args(args=args)
     service_instance_list = args.service_instance_list
     deployment_names = get_deployment_names_from_list(service_instance_list)
 

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -106,7 +106,7 @@ def set_cr_desired_state(
     instance: str,
     instance_type: str,
     desired_state: str,
-):
+) -> None:
     try:
         kubernetes_tools.set_cr_desired_state(
             kube_client=kube_client,
@@ -181,7 +181,7 @@ async def pod_info(
     pod: V1Pod,
     client: kubernetes_tools.KubeClient,
     num_tail_lines: int,
-):
+) -> Dict[str, Any]:
     container_statuses = pod.status.container_statuses or []
     try:
         pod_event_messages = await get_pod_event_messages(client, pod)
@@ -461,7 +461,7 @@ def bounce_status(
     service: str,
     instance: str,
     settings: Any,
-):
+) -> Dict[str, Any]:
     status: Dict[str, Any] = {}
     job_config = kubernetes_tools.load_kubernetes_service_config(
         service=service,
@@ -554,10 +554,10 @@ async def get_pods_for_service_instance_multiple_namespaces(
 
 
 def find_all_relevant_namespaces(
-    service,
-    instance,
-    kube_client,
-    job_config,
+    service: str,
+    instance: str,
+    kube_client: kubernetes_tools.KubeClient,
+    job_config: LongRunningServiceConfig,
 ) -> Set[str]:
     return {job_config.get_kubernetes_namespace()} | {
         deployment.namespace
@@ -577,7 +577,7 @@ async def kubernetes_status_v2(
     include_envoy: bool,
     instance_type: str,
     settings: Any,
-):
+) -> Dict[str, Any]:
     status: Dict[str, Any] = {}
     config_loader = LONG_RUNNING_INSTANCE_TYPE_HANDLERS[instance_type].loader
     job_config = config_loader(
@@ -938,7 +938,7 @@ async def get_pod_containers(
 
                     last_timestamp = this_state["started_at"].timestamp()
 
-        async def get_tail_lines():
+        async def get_tail_lines() -> MutableMapping[str, Any]:
             try:
                 return await get_tail_lines_for_kubernetes_container(
                     client,
@@ -951,8 +951,7 @@ async def get_pod_containers(
                 return {"error_message": f"Could not fetch logs for {cs.name}"}
 
         # get previous log lines as well if this container restarted recently
-        async def get_previous_tail_lines():
-            nonlocal previous_tail_lines
+        async def get_previous_tail_lines() -> MutableMapping[str, Any]:
             if state == "running" and kubernetes_tools.recent_container_restart(
                 cs.restart_count, last_state, last_timestamp
             ):

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -82,6 +82,7 @@ class KubernetesVersionDict(TypedDict, total=False):
     image_version: Optional[str]
     config_sha: str
     pods: Sequence[Mapping[str, Any]]
+    namespace: str
 
 
 def cr_id(service: str, instance: str, instance_type: str) -> Mapping[str, str]:
@@ -803,6 +804,7 @@ async def get_replicaset_status(
         ),
         "config_sha": replicaset.metadata.labels.get("paasta.yelp.com/config_sha"),
         "pods": await asyncio.gather(*pod_status_tasks) if pod_status_tasks else [],
+        "namespace": replicaset.metadata.namespace,
     }
 
 
@@ -1085,6 +1087,7 @@ async def get_version_for_controller_revision(
         "image_version": cr.metadata.labels.get("paasta.yelp.com/image_version", None),
         "config_sha": cr.metadata.labels.get("paasta.yelp.com/config_sha"),
         "pods": [task.result() for task in all_pod_status_tasks],
+        "namespace": cr.metadata.namespace,
     }
 
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2719,6 +2719,17 @@ def list_matching_deployments(
     )
 
 
+def list_matching_deployments_in_all_namespaces(
+    service: str,
+    instance: str,
+    kube_client: KubeClient,
+) -> Sequence[KubeDeployment]:
+    return list_deployments_in_all_namespaces(
+        kube_client,
+        f"paasta.yelp.com/service={service},paasta.yelp.com/instance={instance}",
+    )
+
+
 @async_timeout()
 async def replicasets_for_service_instance(
     service: str, instance: str, kube_client: KubeClient, namespace: str = "paasta"

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2302,7 +2302,7 @@ def ensure_paasta_api_rolebinding(kube_client: KubeClient, namespace: str) -> No
 
 def list_deployments_in_all_namespaces(
     kube_client: KubeClient, label_selector: str
-) -> Sequence[KubeDeployment]:
+) -> List[KubeDeployment]:
     deployments = kube_client.deployments.list_deployment_for_all_namespaces(
         label_selector=label_selector
     )
@@ -2723,7 +2723,7 @@ def list_matching_deployments_in_all_namespaces(
     service: str,
     instance: str,
     kube_client: KubeClient,
-) -> Sequence[KubeDeployment]:
+) -> List[KubeDeployment]:
     return list_deployments_in_all_namespaces(
         kube_client,
         f"paasta.yelp.com/service={service},paasta.yelp.com/instance={instance}",

--- a/paasta_tools/paastaapi/model/kubernetes_version.py
+++ b/paasta_tools/paastaapi/model/kubernetes_version.py
@@ -90,6 +90,7 @@ class KubernetesVersion(ModelNormal):
             'pods': ([KubernetesPodV2],),  # noqa: E501
             'replicas': (int,),  # noqa: E501
             'ready_replicas': (int,),  # noqa: E501
+            'namespace': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -107,6 +108,7 @@ class KubernetesVersion(ModelNormal):
         'pods': 'pods',  # noqa: E501
         'replicas': 'replicas',  # noqa: E501
         'ready_replicas': 'ready_replicas',  # noqa: E501
+        'namespace': 'namespace',  # noqa: E501
     }
 
     _composed_schemas = {}
@@ -164,6 +166,7 @@ class KubernetesVersion(ModelNormal):
             pods ([KubernetesPodV2]): Pods associated to this version. [optional]  # noqa: E501
             replicas (int): Desired number of replicas for this version. [optional]  # noqa: E501
             ready_replicas (int): Number of replicas currently ready. [optional]  # noqa: E501
+            namespace (str): Kubernetes namespace this version is in. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/tests/instance/test_kubernetes.py
+++ b/tests/instance/test_kubernetes.py
@@ -256,6 +256,14 @@ class TestKubernetesStatusV2:
         ) as mock_get_pod_event_messages:
             yield mock_get_pod_event_messages
 
+    @pytest.fixture
+    def mock_find_all_relevant_namespaces(self):
+        with asynctest.patch(
+            "paasta_tools.instance.kubernetes.find_all_relevant_namespaces",
+            autospec=True,
+        ) as mock_find_all_relevant_namespaces:
+            yield mock_find_all_relevant_namespaces
+
     def test_replicaset(
         self,
         mock_replicasets_for_service_instance,
@@ -265,7 +273,9 @@ class TestKubernetesStatusV2:
         mock_mesh_status,
         mock_get_pod_event_messages,
         mock_pod,
+        mock_find_all_relevant_namespaces,
     ):
+        mock_find_all_relevant_namespaces.return_value = ["paasta"]
         mock_job_config = mock.Mock(
             get_persistent_volumes=mock.Mock(return_value=[]),
         )
@@ -375,7 +385,9 @@ class TestKubernetesStatusV2:
         mock_pods_for_service_instance,
         mock_mesh_status,
         mock_pod,
+        mock_find_all_relevant_namespaces,
     ):
+        mock_find_all_relevant_namespaces.return_value = ["paasta"]
         mock_job_config = mock.Mock(
             get_persistent_volumes=mock.Mock(return_value=[mock.Mock]),
         )
@@ -433,7 +445,9 @@ class TestKubernetesStatusV2:
         mock_pods_for_service_instance,
         mock_mesh_status,
         mock_pod,
+        mock_find_all_relevant_namespaces,
     ):
+        mock_find_all_relevant_namespaces.return_value = ["paasta"]
         mock_job_config = mock.Mock(
             get_persistent_volumes=mock.Mock(return_value=[mock.Mock]),
         )
@@ -493,7 +507,9 @@ class TestKubernetesStatusV2:
         mock_mesh_status,
         mock_get_pod_event_messages,
         mock_pod,
+        mock_find_all_relevant_namespaces,
     ):
+        mock_find_all_relevant_namespaces.return_value = ["paasta"]
         mock_job_config = mock.Mock(
             get_persistent_volumes=mock.Mock(return_value=[]),
         )
@@ -545,7 +561,9 @@ class TestKubernetesStatusV2:
         mock_mesh_status,
         mock_get_pod_event_messages,
         mock_pod,
+        mock_find_all_relevant_namespaces,
     ):
+        mock_find_all_relevant_namespaces.return_value = ["paasta"]
         mock_job_config = mock.Mock(
             get_persistent_volumes=mock.Mock(return_value=[]),
         )

--- a/tests/instance/test_kubernetes.py
+++ b/tests/instance/test_kubernetes.py
@@ -287,6 +287,7 @@ class TestKubernetesStatusV2:
                 spec=Struct(replicas=1),
                 metadata=Struct(
                     name="replicaset_1",
+                    namespace="paasta",
                     creation_timestamp=datetime.datetime(2021, 3, 5),
                     deletion_timestamp=None,
                     labels={
@@ -326,6 +327,7 @@ class TestKubernetesStatusV2:
                     "git_sha": "aaa000",
                     "image_version": None,
                     "config_sha": "config000",
+                    "namespace": "paasta",
                     "pods": [
                         {
                             "name": "pod_1",
@@ -398,6 +400,7 @@ class TestKubernetesStatusV2:
             Struct(
                 metadata=Struct(
                     name="controller_revision_1",
+                    namespace="paasta",
                     creation_timestamp=datetime.datetime(2021, 4, 1),
                     labels={
                         "paasta.yelp.com/git_sha": "aaa000",
@@ -435,6 +438,7 @@ class TestKubernetesStatusV2:
             "image_version": None,
             "config_sha": "config000",
             "pods": [mock.ANY],
+            "namespace": "paasta",
         }
 
     def test_statefulset_with_image_version(
@@ -458,6 +462,7 @@ class TestKubernetesStatusV2:
             Struct(
                 metadata=Struct(
                     name="controller_revision_1",
+                    namespace="paasta",
                     creation_timestamp=datetime.datetime(2021, 4, 1),
                     labels={
                         "paasta.yelp.com/git_sha": "aaa000",
@@ -496,6 +501,7 @@ class TestKubernetesStatusV2:
             "image_version": "extrastuff",
             "config_sha": "config000",
             "pods": [mock.ANY],
+            "namespace": "paasta",
         }
 
     def test_event_timeout(
@@ -521,6 +527,7 @@ class TestKubernetesStatusV2:
                 spec=Struct(replicas=1),
                 metadata=Struct(
                     name="replicaset_1",
+                    namespace="paasta",
                     creation_timestamp=datetime.datetime(2021, 3, 5),
                     deletion_timestamp=None,
                     labels={

--- a/tests/test_delete_kubernetes_deployments.py
+++ b/tests/test_delete_kubernetes_deployments.py
@@ -22,7 +22,7 @@ def test_main():
         # Test main() success
         mock_get_deployment_names_from_list.return_value = ["fake_pcm_deployment"]
         with raises(SystemExit) as e:
-            main()
+            main(args=["fake_pcm_deployment"])
         assert e.value.code == 0
         assert mock_ensure_namespace.called
         mock_delete_deployment.assert_called_with(
@@ -33,7 +33,7 @@ def test_main():
         # Test main() failed
         mock_delete_deployment.side_effect = Exception("Delete Error")
         with raises(SystemExit) as e:
-            main()
+            main(args=["fake_pcm_deployment"])
         assert e.value.code == 1
 
 


### PR DESCRIPTION
example output with new API (which returns namespace for each version): https://fluffy.yelpcorp.com/i/JV5mGznpQ8kZZlSGr1J5r4VJq68gNc0K.html (see lines 31, 35, 39).

example output with old API (which doesn't include namespace, and doesn't include versions in the old namespace): https://fluffy.yelpcorp.com/i/r5zMQhHCfdssxNsgkFFJZFHbnsrwqq6R.html