### PR TITLE
When determining which namespaces to query in the status API endpoint…

### DIFF
--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -38,6 +38,7 @@ from paasta_tools.instance.hpa_metrics_parser import HPAMetricsParser
 from paasta_tools.kubernetes_tools import get_pod_event_messages
 from paasta_tools.kubernetes_tools import get_tail_lines_for_kubernetes_container
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
+from paasta_tools.kubernetes_tools import paasta_prefixed
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
 from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
 from paasta_tools.smartstack_tools import KubeSmartstackEnvoyReplicationChecker
@@ -563,7 +564,7 @@ def find_all_relevant_namespaces(
         deployment.namespace
         for deployment in kubernetes_tools.list_deployments_in_managed_namespaces(
             kube_client=kube_client,
-            label_selector=f"paasta.yelp.com/service={service},paasta.yelp.com/instance={instance}",
+            label_selector=f"{paasta_prefixed('service')}={service},{paasta_prefixed('instance')}={instance}",
         )
     }
 

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -561,7 +561,7 @@ def find_all_relevant_namespaces(
 ) -> Set[str]:
     return {job_config.get_kubernetes_namespace()} | {
         deployment.namespace
-        for deployment in kubernetes_tools.list_deployments_in_all_namespaces(
+        for deployment in kubernetes_tools.list_deployments_in_managed_namespaces(
             kube_client=kube_client,
             label_selector=f"paasta.yelp.com/service={service},paasta.yelp.com/instance={instance}",
         )

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2432,7 +2432,6 @@ def list_deployments_in_managed_namespaces(
                 f"Error fetching deployments from namespace {namespace}: "
                 f"status: {exc.status}, reason: {exc.reason}."
             )
-            pass
     return ret
 
 


### PR DESCRIPTION
…, only look at namespaces which have the paasta.yelp.com/managed=true label.

This avoids a permissions issue introduced in #3585, because we don't give paasta-api permissions to list deployments/statefulsets in all namespaces.

Any namespace with the label `paasta.yelp.com/managed=true` should have been created by `ensure_namespace`, which will [make sure we have the appropriate role binding](https://github.com/Yelp/paasta/blob/a53c8982bb874d309347174c5c4ef5e4a73c62ee/paasta_tools/kubernetes_tools.py#L2320)