### PR TITLE
Allow vault options override for paasta secret add and update

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -152,6 +152,7 @@ def add_run_subparser(subparsers):
 
 def _add_and_update_args(parser: argparse.ArgumentParser):
     """common args for `add` and `update`."""
+    _add_vault_auth_args(parser)
     parser.add_argument(
         "-p",
         "--plain-text",
@@ -423,9 +424,14 @@ def paasta_secret(args):
         plaintext = get_plaintext_input(args)
         if not plaintext:
             print("Warning: Given plaintext is an empty string.")
+        secret_provider_extra_kwargs = {
+            "vault_auth_method": args.vault_auth_method,
+            "vault_token_file": args.vault_token_file,
+        }
         secret_provider = _get_secret_provider_for_service(
             service,
             cluster_names=args.clusters,
+            secret_provider_extra_kwargs=secret_provider_extra_kwargs,
         )
         secret_provider.write_secret(
             action=args.action,

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -167,7 +167,9 @@ def test_paasta_secret():
         )
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(
-            "middleearth", cluster_names="mesosstage"
+            "middleearth",
+            cluster_names="mesosstage",
+            secret_provider_extra_kwargs=mock.ANY,
         )
         mock_secret_provider.write_secret.assert_called_with(
             action="add",
@@ -191,7 +193,9 @@ def test_paasta_secret():
         )
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(
-            "middleearth", cluster_names="mesosstage"
+            "middleearth",
+            cluster_names="mesosstage",
+            secret_provider_extra_kwargs=mock.ANY,
         )
         mock_secret_provider.write_secret.assert_called_with(
             action="update",
@@ -266,7 +270,9 @@ def test_paasta_secret():
         )
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(
-            secret.SHARED_SECRET_SERVICE, cluster_names="mesosstage"
+            secret.SHARED_SECRET_SERVICE,
+            cluster_names="mesosstage",
+            secret_provider_extra_kwargs=mock.ANY,
         )
         mock_decrypt_secret.assert_called_with(
             secret_provider=mock_secret_provider, secret_name="theonering"


### PR DESCRIPTION
## Problem or Feature

The add and update subcommands of `paasta secret` prompt for password each time. 

## Solution

Similar to the decrypt subcommand, allow overriding vault configs with the default values.

## Context

https://jira.yelpcorp.com/browse/DREIMP-9626