### PR TITLE
Temporarily upper-bound urllib3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -89,6 +89,7 @@ commands =
 basepython = python3.7
 whitelist_externals = bash
 deps =
+    urllib3<2.0
     docker-compose=={[tox]docker_compose_version}
 setenv =
 passenv =


### PR DESCRIPTION
Just like in Clusterman, looks like we're not pinning dependencies for a tox env and are finally getting bit by that

related clusterman pr: https://github.com/Yelp/clusterman/pull/318