### PR TITLE
Add support for vault token file for paasta {add,update} secret

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -56,6 +56,7 @@ def check_secret_name(secret_name_arg: str):
 def add_add_subparser(subparsers):
     secret_parser_add = subparsers.add_parser("add", help="adds a paasta secret")
     _add_common_args(secret_parser_add)
+    _add_vault_auth_args(secret_parser_add)
     _add_and_update_args(secret_parser_add)
 
 
@@ -420,12 +421,17 @@ def paasta_secret(args):
         return
 
     if args.action in ["add", "update"]:
+        secret_provider_extra_kwargs = {
+            "vault_auth_method": args.vault_auth_method,
+            "vault_token_file": args.vault_token_file,
+        }
         plaintext = get_plaintext_input(args)
         if not plaintext:
             print("Warning: Given plaintext is an empty string.")
         secret_provider = _get_secret_provider_for_service(
             service,
             cluster_names=args.clusters,
+            secret_provider_extra_kwargs=secret_provider_extra_kwargs,
         )
         secret_provider.write_secret(
             action=args.action,

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -167,7 +167,9 @@ def test_paasta_secret():
         )
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(
-            "middleearth", cluster_names="mesosstage"
+            "middleearth",
+            cluster_names="mesosstage",
+            secret_provider_extra_kwargs=mock.ANY,
         )
         mock_secret_provider.write_secret.assert_called_with(
             action="add",
@@ -191,7 +193,9 @@ def test_paasta_secret():
         )
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(
-            "middleearth", cluster_names="mesosstage"
+            "middleearth",
+            cluster_names="mesosstage",
+            secret_provider_extra_kwargs=mock.ANY,
         )
         mock_secret_provider.write_secret.assert_called_with(
             action="update",
@@ -266,7 +270,9 @@ def test_paasta_secret():
         )
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(
-            secret.SHARED_SECRET_SERVICE, cluster_names="mesosstage"
+            secret.SHARED_SECRET_SERVICE,
+            cluster_names="mesosstage",
+            secret_provider_extra_kwargs=mock.ANY,
         )
         mock_decrypt_secret.assert_called_with(
             secret_provider=mock_secret_provider, secret_name="theonering"


### PR DESCRIPTION
## Problem
I found this desirable when adding lots of secrets in an environment so that don't have to re-auth for every secret. I basically just copied the pattern used for other APIs. Not sure if this was purposely omitted for add/update, so let me know if I'm missing any context on why this isn't desirable.

## Testing done
Made the unit tests pass, albeit kinda lazily by using mock.ANY. Happy to improve the tests if there are strong opinions.