### PR TITLE
Add support for --use-eks in paasta spark-run

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1068,8 +1068,7 @@ def _validate_pool(args, system_paasta_config):
 
 
 def _get_k8s_url_for_cluster(cluster: str) -> Optional[str]:
-    system_paasta_config = load_system_paasta_config()
-    return system_paasta_config.get_kube_clusters().get(cluster, {}).get("server")
+    return load_system_paasta_config().system_paasta_config.get_kube_clusters().get(cluster, {}).get("server")
 
 
 def paasta_spark_run(args):

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -320,6 +320,13 @@ def add_subparser(subparsers):
         default=False,
     )
 
+    list_parser.add_argument(
+        "--use-eks",
+        help="Use the EKS version of the target cluster rather than the Yelp-managed target cluster",
+        action="store_true",
+        dest="use_eks",
+    )
+
     if clusterman_metrics:
         list_parser.add_argument(
             "--suppress-clusterman-metrics-errors",
@@ -567,6 +574,7 @@ def get_spark_env(
     spark_conf_str: str,
     aws_creds: Tuple[Optional[str], Optional[str], Optional[str]],
     ui_port: str,
+    system_paasta_config: SystemPaastaConfig,
 ) -> Dict[str, str]:
     """Create the env config dict to configure on the docker container"""
 
@@ -607,6 +615,9 @@ def get_spark_env(
         )
         spark_env["SPARK_DAEMON_CLASSPATH"] = "/opt/spark/extra_jars/*"
         spark_env["SPARK_NO_DAEMONIZE"] = "true"
+
+    if args.use_eks:
+        spark_env["KUBECONFIG"] = system_paasta_config.get_spark_kubeconfig()
 
     return spark_env
 
@@ -810,10 +821,21 @@ def configure_and_run_docker_container(
     if args.enable_compact_bin_packing:
         volumes.append(f"{pod_template_path}:{pod_template_path}:rw")
 
+    if args.use_eks:
+        volumes.append(
+            f"{system_paasta_config.get_spark_kubeconfig()}:{system_paasta_config.get_spark_kubeconfig()}:ro"
+        )
+
     environment = instance_config.get_env_dictionary()  # type: ignore
     spark_conf_str = create_spark_config_str(spark_conf, is_mrjob=args.mrjob)
     environment.update(
-        get_spark_env(args, spark_conf_str, aws_creds, spark_conf["spark.ui.port"])
+        get_spark_env(
+            args=args,
+            spark_conf_str=spark_conf_str,
+            aws_creds=aws_creds,
+            ui_port=spark_conf["spark.ui.port"],
+            system_paasta_config=system_paasta_config,
+        )
     )  # type:ignore
 
     webui_url = get_webui_url(spark_conf["spark.ui.port"])
@@ -1032,6 +1054,11 @@ def _validate_pool(args, system_paasta_config):
     return True
 
 
+def _get_k8s_url_for_cluster(cluster: str) -> Optional[str]:
+    system_paasta_config = load_system_paasta_config()
+    return system_paasta_config.get_kube_clusters().get(cluster, {}).get("server")
+
+
 def paasta_spark_run(args):
     # argparse does not work as expected with both default and
     # type=validate_work_dir.
@@ -1161,6 +1188,10 @@ def paasta_spark_run(args):
         needs_docker_cfg=needs_docker_cfg,
         aws_region=args.aws_region,
         force_spark_resource_configs=args.force_spark_resource_configs,
+        use_eks=args.use_eks,
+        k8s_server_address=_get_k8s_url_for_cluster(args.cluster)
+        if args.use_eks
+        else None,
     )
     # TODO: Remove this after MLCOMPUTE-699 is complete
     if "spark.kubernetes.decommission.script" not in spark_conf:

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1047,6 +1047,7 @@ def _auto_add_timeout_for_job(cmd, timeout_job_runtime):
 
 
 def _validate_pool(args, system_paasta_config):
+    return True
     if args.pool:
         valid_pools = system_paasta_config.get_cluster_pools().get(args.cluster, [])
         if not valid_pools:
@@ -1068,7 +1069,9 @@ def _validate_pool(args, system_paasta_config):
 
 
 def _get_k8s_url_for_cluster(cluster: str) -> Optional[str]:
-    return load_system_paasta_config().system_paasta_config.get_kube_clusters().get(cluster, {}).get("server")
+    return (
+        load_system_paasta_config().get_kube_clusters().get(cluster, {}).get("server")
+    )
 
 
 def paasta_spark_run(args):

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1047,7 +1047,6 @@ def _auto_add_timeout_for_job(cmd, timeout_job_runtime):
 
 
 def _validate_pool(args, system_paasta_config):
-    return True
     if args.pool:
         valid_pools = system_paasta_config.get_cluster_pools().get(args.cluster, [])
         if not valid_pools:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2001,6 +2001,8 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     skip_cpu_burst_validation: List[str]
     tron_default_pool_override: str
     uwsgi_offset_multiplier: float
+    spark_kubeconfig: str
+    kube_clusters: Dict
 
 
 def load_system_paasta_config(
@@ -2751,6 +2753,12 @@ class SystemPaastaConfig:
         To be removed once PAASTA-17840 is done.
         """
         return self.config_dict.get("uwsgi_offset_multiplier", 1.0)
+
+    def get_spark_kubeconfig(self) -> str:
+        return self.config_dict.get("spark_kubeconfig", "/etc/kubernetes/spark.conf")
+
+    def get_kube_clusters(self) -> Dict:
+        return self.config_dict.get("kube_clusters", {})
 
 
 def _run(

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -49,7 +49,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.16.4
+service-configuration-lib >= 2.17.0
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.16.4
+service-configuration-lib==2.17.0
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ docker_compose_version = 1.26.2
 # running outside of Yelp.
 indexserver = https://pypi.yelpcorp.com/simple
 basepython = python3.7
-usedevelop = true
 passenv = SSH_AUTH_SOCK
 setenv =
     TZ = UTC

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ docker_compose_version = 1.26.2
 # running outside of Yelp.
 indexserver = https://pypi.yelpcorp.com/simple
 basepython = python3.7
+usedevelop = true
 passenv = SSH_AUTH_SOCK
 setenv =
     TZ = UTC


### PR DESCRIPTION
`paasta spark-run` (when run with `--use-eks`) will require a different set of configuration: we'll be using a kubeconfig with the standard EKS setup rather than giving spark a URL to our masters + certs to auth with.

Technically can we do the env var shenanigans inside service-configuration-lib, but imo the added layer makes changing spark things more painful then necessary - and, most importantly, doesn't really use anything like PaastaSystemConfig or srv-configs in a standard way to support changing values without a PaaSTA or service-configuration-lib release.