### PR TITLE
Change default directory to `paasta secret {add,update}`

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -20,8 +20,6 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 
-from service_configuration_lib import DEFAULT_SOA_DIR
-
 from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.cli.utils import get_namespaces_for_secret
 from paasta_tools.cli.utils import lazy_choices_completer
@@ -211,7 +209,7 @@ def _add_vault_auth_args(parser: argparse.ArgumentParser):
         type=str,
         dest="vault_auth_method",
         required=False,
-        default="token",  # token falls back to ldap if token file is unreadable
+        default="ldap",  # must have LDAP to get 2FA push for prod
         choices=["token", "ldap"],
     )
     parser.add_argument(
@@ -231,7 +229,7 @@ def _add_common_args(parser: argparse.ArgumentParser, allow_shared: bool = True)
         "--yelpsoa-config-root",
         dest="yelpsoa_config_root",
         help="A directory from which yelpsoa-configs should be read from",
-        default=DEFAULT_SOA_DIR,
+        default=os.getcwd(),
     )
 
     _add_vault_auth_args(parser)
@@ -449,7 +447,7 @@ def paasta_secret(args):
             # want to use the working directory rather
             # than whatever the actual soa_dir path is
             # configured as
-            soa_dir=os.getcwd(),
+            soa_dir=args.yelpsoa_config_root,
             secret_provider_extra_kwargs={
                 "vault_token_file": args.vault_token_file,
                 "vault_auth_method": args.vault_auth_method,

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -229,6 +229,11 @@ def _add_common_args(parser: argparse.ArgumentParser, allow_shared: bool = True)
         "--yelpsoa-config-root",
         dest="yelpsoa_config_root",
         help="A directory from which yelpsoa-configs should be read from",
+        # this will only be invoked on a devbox
+        # and only in a context where we certainly
+        # want to use the working directory rather
+        # than whatever the actual soa_dir path is
+        # configured as
         default=os.getcwd(),
     )
 
@@ -442,11 +447,6 @@ def paasta_secret(args):
         secret_provider = _get_secret_provider_for_service(
             service,
             cluster_names=args.clusters,
-            # this will only be invoked on a devbox
-            # and only in a context where we certainly
-            # want to use the working directory rather
-            # than whatever the actual soa_dir path is
-            # configured as
             soa_dir=args.yelpsoa_config_root,
             secret_provider_extra_kwargs={
                 "vault_token_file": args.vault_token_file,

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -444,7 +444,7 @@ def paasta_secret(args):
         secret_provider = _get_secret_provider_for_service(
             service,
             cluster_names=args.clusters,
-            soa_dir=args.yelpsoa_config_root,
+            soa_dir="./",
             secret_provider_extra_kwargs={
                 "vault_token_file": args.vault_token_file,
                 "vault_auth_method": args.vault_auth_method,

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -444,7 +444,12 @@ def paasta_secret(args):
         secret_provider = _get_secret_provider_for_service(
             service,
             cluster_names=args.clusters,
-            soa_dir="./",
+            # this will only be invoked on a devbox
+            # and only in a context where we certainly
+            # want to use the working directory rather
+            # than whatever the actual soa_dir path is
+            # configured as
+            soa_dir=os.getcwd(),
             secret_provider_extra_kwargs={
                 "vault_token_file": args.vault_token_file,
                 "vault_auth_method": args.vault_auth_method,


### PR DESCRIPTION
There have been 3 PRs so far that wanted to add passing Vault token to the CLI `paasta secret`: https://github.com/Yelp/paasta/pull/3598 https://github.com/Yelp/paasta/pull/3588 but #3596  was merged

## Preserve existing behaviour
Since `vault_auth_method="token"` falls back to LDAP authentication, we don't have to change the default argument. However, because current directory is hard-coded the script must be run in the soa directory.

Was not sure if `DEFAULT_SOA_DIR` was safe to change
```diff
@@ -231,7 +231,7 @@ def _add_common_args(parser: argparse.ArgumentParser, allow_shared: bool = True)
         "--yelpsoa-config-root",
         dest="yelpsoa_config_root",
         help="A directory from which yelpsoa-configs should be read from",
-        default=DEFAULT_SOA_DIR,
+        default="./",
     )
```

The change should be safe because previously the argument was not passed at all. Previously, I passed the argument from argparse because it was more convenient to run from another directory.

**Update**: @nemacysts confirmed that the script is used only under dev environment and invoked by a user, so it's safe to change the defaults
