### PR TITLE
Hard-code current directory only for `paasta secret {add,update}`

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -20,6 +20,8 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 
+from service_configuration_lib import DEFAULT_SOA_DIR
+
 from paasta_tools.cli.utils import get_instance_config
 from paasta_tools.cli.utils import get_namespaces_for_secret
 from paasta_tools.cli.utils import lazy_choices_completer
@@ -229,12 +231,7 @@ def _add_common_args(parser: argparse.ArgumentParser, allow_shared: bool = True)
         "--yelpsoa-config-root",
         dest="yelpsoa_config_root",
         help="A directory from which yelpsoa-configs should be read from",
-        # this will only be invoked on a devbox
-        # and only in a context where we certainly
-        # want to use the working directory rather
-        # than whatever the actual soa_dir path is
-        # configured as
-        default=os.getcwd(),
+        default=DEFAULT_SOA_DIR,
     )
 
     _add_vault_auth_args(parser)
@@ -447,7 +444,12 @@ def paasta_secret(args):
         secret_provider = _get_secret_provider_for_service(
             service,
             cluster_names=args.clusters,
-            soa_dir=args.yelpsoa_config_root,
+            # this will only be invoked on a devbox
+            # and only in a context where we certainly
+            # want to use the working directory rather
+            # than whatever the actual soa_dir path is
+            # configured as
+            soa_dir=os.getcwd(),
             secret_provider_extra_kwargs={
                 "vault_token_file": args.vault_token_file,
                 "vault_auth_method": args.vault_auth_method,

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -441,7 +441,6 @@ def paasta_secret(args):
         plaintext = get_plaintext_input(args)
         if not plaintext:
             print("Warning: Given plaintext is an empty string.")
-        print(args)
         secret_provider = _get_secret_provider_for_service(
             service,
             cluster_names=args.clusters,

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -211,7 +211,7 @@ def _add_vault_auth_args(parser: argparse.ArgumentParser):
         type=str,
         dest="vault_auth_method",
         required=False,
-        default="ldap",  # must have LDAP to get 2FA push for prod
+        default="token",
         choices=["token", "ldap"],
     )
     parser.add_argument(
@@ -441,6 +441,7 @@ def paasta_secret(args):
         plaintext = get_plaintext_input(args)
         if not plaintext:
             print("Warning: Given plaintext is an empty string.")
+        print(args)
         secret_provider = _get_secret_provider_for_service(
             service,
             cluster_names=args.clusters,
@@ -452,7 +453,9 @@ def paasta_secret(args):
             soa_dir=os.getcwd(),
             secret_provider_extra_kwargs={
                 "vault_token_file": args.vault_token_file,
-                "vault_auth_method": args.vault_auth_method,
+                # best solution so far is to change the below string to "token",
+                # so that token file is picked up from argparse
+                "vault_auth_method": "ldap",  # must have LDAP to get 2FA push for prod
             },
         )
         secret_provider.write_secret(


### PR DESCRIPTION
Changing default directory in argparse resulted in YM playground failing, so hard-coding location only for `add` and `update` commands which retain original behaviour.

Introduced by https://github.com/Yelp/paasta/pull/3603