### PR TITLE
Separate arguments for `paasta secret` (decrypt, run) vs (add, update)

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -470,7 +470,7 @@ def paasta_secret(args):
         return
 
     if args.action in ["add", "update"]:
-        # this will only be invoked on a devbox only
+        # this should really only ever be invoked on a devbox
         plaintext = get_plaintext_input(args)
         if not plaintext:
             print("Warning: Given plaintext is an empty string.")

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -470,7 +470,6 @@ def paasta_secret(args):
         return
 
     if args.action in ["add", "update"]:
-        print(args)
         # this will only be invoked on a devbox only
         plaintext = get_plaintext_input(args)
         if not plaintext:


### PR DESCRIPTION
Based of how default arguments are assumed across different environment, we can separate the arguments so that all commands retain original behaviour while allowing to override with command flags because `paasta secret {decrypt,run}` are run on a service instance, while `paasta secret {add,update}` are ran on a devbox.

## Changes
- Separate args with different default arguments, but should still be noop

## Notes
- For passing token, initially I thought I could use `VAULT_TOKEN_OVERRIDE` in conjunction with `--vault-auth-method token`, but that's not possible if `vault_auth_method="ldap"` hard-coded

### Tests
Tested locally `add`, `update` and `run`,  https://fluffy.yelpcorp.com/i/Pv94gRPCbtCjHcx88Szfqsh9Qfp4Vkg5.html