### PR TITLE
Use sha256 digest for paasta spark-run

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -891,7 +891,7 @@ def _should_get_resource_requirements(docker_cmd: str, is_mrjob: bool) -> bool:
 def get_docker_cmd(
     args: argparse.Namespace, instance_config: InstanceConfig, spark_conf_str: str
 ) -> str:
-    original_docker_cmd = args.cmd or instance_config.get_cmd()
+    original_docker_cmd = str(args.cmd or instance_config.get_cmd())
 
     if args.mrjob:
         return original_docker_cmd + " " + spark_conf_str

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1101,10 +1101,7 @@ def paasta_spark_run(args):
     docker_client = get_docker_client()
     image_details = docker_client.inspect_image(docker_image)
     if len(image_details["RepoDigests"]) < 1:
-        print(
-            "Failed to get docker image digest",
-            file=sys.stderr,
-        )
+        print("Failed to get docker image digest", file=sys.stderr)
         return None
     docker_image_digest = image_details["RepoDigests"][0]
 

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -16,6 +16,7 @@ import argparse
 import mock
 import pytest
 from boto3.exceptions import Boto3Error
+from mock import Mock
 
 from paasta_tools.cli.cmds import spark_run
 from paasta_tools.cli.cmds.spark_run import _should_get_resource_requirements
@@ -31,6 +32,9 @@ from paasta_tools.cli.cmds.spark_run import sanitize_container_name
 from paasta_tools.cli.cmds.spark_run import should_enable_compact_bin_packing
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import SystemPaastaConfig
+
+
+DUMMY_DOCKER_IMAGE_DIGEST = "MOCK-docker-dev.yelpcorp.com/paasta-spark-run-user@sha256:103ce91c65d42498ca61cdfe8d799fab8ab1c37dac58b743b49ced227bc7bc06"
 
 
 @mock.patch("paasta_tools.cli.cmds.spark_run.os.geteuid", autospec=True)
@@ -128,6 +132,23 @@ def mock_instance_config():
 @pytest.fixture
 def mock_run():
     with mock.patch.object(spark_run, "_run") as m:
+        yield m
+
+
+@pytest.fixture
+def mock_get_docker_client():
+    fake_image_info = {
+        "RepoDigests": [
+            DUMMY_DOCKER_IMAGE_DIGEST,
+        ],
+    }
+    docker_client = Mock(inspect_image=Mock(return_value=fake_image_info))
+
+    with mock.patch(
+        "paasta_tools.cli.cmds.spark_run.get_docker_client",
+        return_value=docker_client,
+        autospec=True,
+    ) as m:
         yield m
 
 
@@ -1062,6 +1083,7 @@ def test_paasta_spark_run_bash(
     mock_load_system_paasta_config,
     mock_validate_work_dir,
     mock_generate_pod_template_path,
+    mock_get_docker_client,
 ):
     args = argparse.Namespace(
         work_dir="/tmp/local",
@@ -1115,7 +1137,7 @@ def test_paasta_spark_run_bash(
     mock_get_spark_conf.assert_called_once_with(
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
         spark_app_base_name=mock_get_spark_app_name.return_value,
-        docker_img=mock_get_docker_image.return_value,
+        docker_img=DUMMY_DOCKER_IMAGE_DIGEST,
         user_spark_opts=mock_parse_user_spark_args.return_value,
         paasta_cluster="test-cluster",
         paasta_pool="test-pool",
@@ -1131,7 +1153,7 @@ def test_paasta_spark_run_bash(
     mock_spark_conf["spark.sql.adaptive.enabled"] = "true"
     mock_configure_and_run_docker_container.assert_called_once_with(
         args,
-        docker_img=mock_get_docker_image.return_value,
+        docker_img=DUMMY_DOCKER_IMAGE_DIGEST,
         instance_config=mock_get_instance_config.return_value,
         system_paasta_config=mock_load_system_paasta_config.return_value,
         spark_conf=mock_spark_conf,
@@ -1164,6 +1186,7 @@ def test_paasta_spark_run(
     mock_load_system_paasta_config,
     mock_validate_work_dir,
     mock_generate_pod_template_path,
+    mock_get_docker_client,
 ):
     args = argparse.Namespace(
         work_dir="/tmp/local",
@@ -1217,7 +1240,7 @@ def test_paasta_spark_run(
     mock_get_spark_conf.assert_called_once_with(
         cluster_manager=spark_run.CLUSTER_MANAGER_MESOS,
         spark_app_base_name=mock_get_spark_app_name.return_value,
-        docker_img=mock_get_docker_image.return_value,
+        docker_img=DUMMY_DOCKER_IMAGE_DIGEST,
         user_spark_opts=mock_parse_user_spark_args.return_value,
         paasta_cluster="test-cluster",
         paasta_pool="test-pool",
@@ -1231,7 +1254,7 @@ def test_paasta_spark_run(
     )
     mock_configure_and_run_docker_container.assert_called_once_with(
         args,
-        docker_img=mock_get_docker_image.return_value,
+        docker_img=DUMMY_DOCKER_IMAGE_DIGEST,
         instance_config=mock_get_instance_config.return_value,
         system_paasta_config=mock_load_system_paasta_config.return_value,
         spark_conf=mock_get_spark_conf.return_value,
@@ -1266,6 +1289,7 @@ def test_paasta_spark_run_pyspark(
     mock_load_system_paasta_config,
     mock_validate_work_dir,
     mock_generate_pod_template_path,
+    mock_get_docker_client,
 ):
     args = argparse.Namespace(
         work_dir="/tmp/local",
@@ -1327,7 +1351,7 @@ def test_paasta_spark_run_pyspark(
     mock_get_spark_conf.assert_called_once_with(
         cluster_manager=spark_run.CLUSTER_MANAGER_K8S,
         spark_app_base_name=mock_get_spark_app_name.return_value,
-        docker_img=mock_get_docker_image.return_value,
+        docker_img=DUMMY_DOCKER_IMAGE_DIGEST,
         user_spark_opts=mock_parse_user_spark_args.return_value,
         paasta_cluster="test-cluster",
         paasta_pool="test-pool",
@@ -1341,7 +1365,7 @@ def test_paasta_spark_run_pyspark(
     )
     mock_configure_and_run_docker_container.assert_called_once_with(
         args,
-        docker_img=mock_get_docker_image.return_value,
+        docker_img=DUMMY_DOCKER_IMAGE_DIGEST,
         instance_config=mock_get_instance_config.return_value,
         system_paasta_config=mock_load_system_paasta_config.return_value,
         spark_conf=mock_get_spark_conf.return_value,


### PR DESCRIPTION
## Description
Explicitly specify docker image digest instead of using image tag when launching a spark cluster to avoid inconsistent docker image between the driver and executors.

## Test
run locally in a service repo which has a cook-image makefile target.

```bash
# Auth
aws-okta -r core-ml -a dev -k -p dev

# Test 1: `--build`
paasta/.tox/py37-linux/bin/paasta spark-run --build --aws-profile=dev --cmd "spark-submit /work/integration_tests/s3.py"

# Test 2: `--image`
paasta/.tox/py37-linux/bin/paasta spark-run --image docker-dev.yelpcorp.com/paasta-spark-run-chi --aws-profile=dev --cmd "spark-submit /work/integration_tests/s3.py"

# Test 3: `--service`
paasta/.tox/py37-linux/bin/paasta spark-run --service spark --aws-profile=dev --cmd "spark-submit /work/integration_tests/s3.py"
```

### Before

Log output:  
<img width="707" alt="image" src="https://github.com/Yelp/paasta/assets/8851038/780e3912-5b70-421b-8bb9-5d4adf33496d">


In SparkUI:  
![image](https://github.com/Yelp/paasta/assets/8851038/8d47755a-9200-4943-813a-2cda7e341a03)


### After

Log output:  
<img width="702" alt="image" src="https://github.com/Yelp/paasta/assets/8851038/ce0d8632-96d0-4167-b1f6-f7e39299b9a9">
<img width="1248" alt="image" src="https://github.com/Yelp/paasta/assets/8851038/a3f193a1-9d13-41a2-bf66-9214ed8a1d40">

In SparkUI:  
<img width="1500" alt="image" src="https://github.com/Yelp/paasta/assets/8851038/b40d5346-2de5-4b77-a25a-8e8946575a83">


