### PR TITLE
updated apiextensions.k8s.io CRD references to V1

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -46,7 +46,6 @@ from kubernetes import config as kube_config
 from kubernetes.client import models
 from kubernetes.client import V1Affinity
 from kubernetes.client import V1AWSElasticBlockStoreVolumeSource
-from kubernetes.client import V1beta1CustomResourceDefinition
 from kubernetes.client import V1beta1PodDisruptionBudget
 from kubernetes.client import V1beta1PodDisruptionBudgetSpec
 from kubernetes.client import V1Capabilities
@@ -55,6 +54,7 @@ from kubernetes.client import V1Container
 from kubernetes.client import V1ContainerPort
 from kubernetes.client import V1ContainerStatus
 from kubernetes.client import V1ControllerRevision
+from kubernetes.client import V1CustomResourceDefinition
 from kubernetes.client import V1CustomResourceDefinitionList
 from kubernetes.client import V1DeleteOptions
 from kubernetes.client import V1Deployment
@@ -522,7 +522,7 @@ class KubeClient:
         self.deployments = kube_client.AppsV1Api(self.api_client)
         self.core = kube_client.CoreV1Api(self.api_client)
         self.policy = kube_client.PolicyV1beta1Api(self.api_client)
-        self.apiextensions = kube_client.ApiextensionsV1beta1Api(self.api_client)
+        self.apiextensions = kube_client.ApiextensionsV1Api(self.api_client)
         self.custom = kube_client.CustomObjectsApi(self.api_client)
         self.autoscaling = kube_client.AutoscalingV2beta2Api(self.api_client)
         self.rbac = kube_client.RbacAuthorizationV1Api(self.api_client)
@@ -3723,7 +3723,7 @@ def mode_to_int(mode: Optional[Union[str, int]]) -> Optional[int]:
 
 def update_crds(
     kube_client: KubeClient,
-    desired_crds: Collection[V1beta1CustomResourceDefinition],
+    desired_crds: Collection[V1CustomResourceDefinition],
     existing_crds: V1CustomResourceDefinitionList,
 ) -> bool:
     success = True

--- a/paasta_tools/setup_kubernetes_crd.py
+++ b/paasta_tools/setup_kubernetes_crd.py
@@ -27,7 +27,7 @@ import sys
 from typing import Sequence
 
 import service_configuration_lib
-from kubernetes.client import V1beta1CustomResourceDefinition
+from kubernetes.client import V1CustomResourceDefinition
 
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import paasta_prefixed
@@ -118,7 +118,7 @@ def setup_kube_crd(
             metadata["labels"] = {}
         metadata["labels"]["yelp.com/paasta_service"] = service
         metadata["labels"][paasta_prefixed("service")] = service
-        desired_crd = V1beta1CustomResourceDefinition(
+        desired_crd = V1CustomResourceDefinition(
             api_version=crd_config.get("apiVersion"),
             kind=crd_config.get("kind"),
             metadata=metadata,

--- a/paasta_tools/setup_kubernetes_internal_crd.py
+++ b/paasta_tools/setup_kubernetes_internal_crd.py
@@ -23,7 +23,7 @@ import argparse
 import logging
 import sys
 
-from kubernetes.client import V1beta1CustomResourceDefinition
+from kubernetes.client import V1CustomResourceDefinition
 
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import paasta_prefixed
@@ -33,8 +33,8 @@ log = logging.getLogger(__name__)
 
 
 INTERNAL_CRDS = [
-    V1beta1CustomResourceDefinition(
-        api_version="apiextensions.k8s.io/v1beta1",
+    V1CustomResourceDefinition(
+        api_version="apiextensions.k8s.io/v1",
         kind="CustomResourceDefinition",
         metadata={
             "name": "deploygroups.paasta.yelp.com",
@@ -44,7 +44,24 @@ INTERNAL_CRDS = [
         },
         spec={
             "group": "paasta.yelp.com",
-            "versions": [{"name": "v1beta1", "served": True, "storage": True}],
+            "versions": [
+                {
+                    "name": "v1beta1",
+                    "served": True,
+                    "storage": True,
+                    "schema": {
+                        "openAPIV3Schema": {
+                            "type": "object",
+                            "properties": {
+                                "service": {"type": "string"},
+                                "deploy_group": {"type": "string"},
+                                "git_sha": {"type": "string"},
+                                "image_version": {"type": "string"},
+                            },
+                        }
+                    },
+                }
+            ],
             "scope": "Namespaced",
             "names": {
                 "plural": "deploygroups",
@@ -52,21 +69,10 @@ INTERNAL_CRDS = [
                 "kind": "DeployGroup",
                 "shortNames": ["dg"],
             },
-            "validation": {
-                "openAPIV3Schema": {
-                    "type": "object",
-                    "properties": {
-                        "service": {"type": "string"},
-                        "deploy_group": {"type": "string"},
-                        "git_sha": {"type": "string"},
-                        "image_version": {"type": "string"},
-                    },
-                }
-            },
         },
     ),
-    V1beta1CustomResourceDefinition(
-        api_version="apiextensions.k8s.io/v1beta1",
+    V1CustomResourceDefinition(
+        api_version="apiextensions.k8s.io/v1",
         kind="CustomResourceDefinition",
         metadata={
             "name": "startstopcontrols.paasta.yelp.com",
@@ -76,23 +82,29 @@ INTERNAL_CRDS = [
         },
         spec={
             "group": "paasta.yelp.com",
-            "versions": [{"name": "v1beta1", "served": True, "storage": True}],
+            "versions": [
+                {
+                    "name": "v1beta1",
+                    "served": True,
+                    "storage": True,
+                    "schema": {
+                        "openAPIV3Schema": {
+                            "type": "object",
+                            "properties": {
+                                "service": {"type": "string"},
+                                "instance": {"type": "string"},
+                                "desired_state": {"type": "string"},
+                                "force_bounce": {"type": "string"},
+                            },
+                        }
+                    },
+                }
+            ],
             "scope": "Namespaced",
             "names": {
                 "plural": "startstopcontrols",
                 "singular": "startstopcontrol",
                 "kind": "StartStopControl",
-            },
-            "validation": {
-                "openAPIV3Schema": {
-                    "type": "object",
-                    "properties": {
-                        "service": {"type": "string"},
-                        "instance": {"type": "string"},
-                        "desired_state": {"type": "string"},
-                        "force_bounce": {"type": "string"},
-                    },
-                }
             },
         },
     ),
@@ -131,7 +143,6 @@ def setup_kube_internal_crd(
     existing_crds = kube_client.apiextensions.list_custom_resource_definition(
         label_selector=paasta_prefixed("internal")
     )
-
     return update_crds(
         kube_client=kube_client, desired_crds=INTERNAL_CRDS, existing_crds=existing_crds
     )


### PR DESCRIPTION
##Problem
There are couple of places where we refer to `V1beta1CustomResourceDefinition` which has been removed in k8s v1.22

I have update its references to `V1CustomResourceDefinition`

ref: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122

Tests:
https://fluffy.yelpcorp.com/i/x26KCgz9pTtZVM7678wH1bwBmnncV4M1.html