### PR TITLE
TRON-1636: Setup tron secret_volumes in setup_tron_namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ example_cluster/paasta/docker_registry.json
 general_itests/fake_etc_paasta/clusters.json
 pip-wheel-metadata
 debian/debhelper-build-stamp
+unique-run
 
 # Coverage artifacts
 .coverage

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1203,7 +1203,7 @@ def paasta_spark_run(args):
         document = POD_TEMPLATE.format(
             spark_pod_label=limit_size_with_hash(f"exec-{app_base_name}"),
         )
-        parsed_pod_template = yaml.load(document)
+        parsed_pod_template = yaml.safe_load(document)
         with open(pod_template_path, "w") as f:
             yaml.dump(parsed_pod_template, f)
 

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -557,6 +557,7 @@
                             },
                             "items": {
                                 "type": "array",
+                                "maxItems": 1,
                                 "items": {
                                     "type": "object",
                                     "properties": {

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -236,6 +236,51 @@
                     },
                     "uniqueItems": true
                 },
+                "secret_volumes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "container_path": {
+                                "type": "string"
+                            },
+                            "secret_name": {
+                                "type": "string"
+                            },
+                            "default_mode": {
+                                "type": "string"
+                            },
+                            "items": {
+                                "type": "array",
+                                "maxItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "key": {
+                                            "type": "string"
+                                        },
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "mode": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "key",
+                                        "path"
+                                    ]
+                                },
+                                "uniqueItems": true
+                            }
+                        },
+                        "required": [
+                            "container_path",
+                            "secret_name"
+                        ]
+                    },
+                    "uniqueItems": true
+                },
                 "cluster": {
                     "type": "string"
                 },

--- a/paasta_tools/secret_tools.py
+++ b/paasta_tools/secret_tools.py
@@ -42,6 +42,14 @@ def is_shared_secret(env_var_val: str) -> bool:
     return env_var_val.startswith("SHARED_")
 
 
+def is_shared_secret_from_secret_name(soa_dir: str, secret_name: str) -> bool:
+    """Alternative way of figuring if a secret is shared, directly from the secret_name."""
+    secret_path = os.path.join(
+        soa_dir, SHARED_SECRET_SERVICE, "secrets", f"{secret_name}.json"
+    )
+    return os.path.isfile(secret_path)
+
+
 def get_hmac_for_secret(
     env_var_val: str, service: str, soa_dir: str, secret_environment: str
 ) -> Optional[str]:

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -52,6 +52,7 @@ from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDeploymentsAvailable
 from paasta_tools.utils import time_cache
 from paasta_tools.utils import filter_templates_from_config
+from paasta_tools.utils import TronSecretVolume
 from paasta_tools.kubernetes_tools import (
     allowlist_denylist_to_requirements,
     create_or_find_service_account_name,
@@ -68,6 +69,7 @@ from paasta_tools.spark_tools import (
 )
 from paasta_tools.secret_tools import is_secret_ref
 from paasta_tools.secret_tools import is_shared_secret
+from paasta_tools.secret_tools import is_shared_secret_from_secret_name
 from paasta_tools.secret_tools import get_secret_name_from_ref
 from paasta_tools.kubernetes_tools import get_paasta_secret_name
 from paasta_tools.secret_tools import SHARED_SECRET_SERVICE
@@ -413,9 +415,39 @@ class TronActionConfig(InstanceConfig):
     def get_action_name(self):
         return self.action
 
+    def get_secret_volumes(self) -> List[TronSecretVolume]:  # type: ignore
+        """Adds the secret_volume_name to the objet so tron/task_processing can load it downstream without replicating code."""
+        secret_volumes = super().get_secret_volumes()
+        return [
+            TronSecretVolume(
+                secret_volume_name=self.get_secret_volume_name(
+                    secret_volume["secret_name"]
+                ),
+                secret_name=secret_volume["secret_name"],
+                container_path=secret_volume["container_path"],
+                default_mode=secret_volume["default_mode"],
+                items=secret_volume["items"],
+            )
+            for secret_volume in secret_volumes
+        ]
+
     def get_namespace(self) -> str:
         """Get namespace from config, default to 'paasta'"""
         return self.config_dict.get("namespace", KUBERNETES_NAMESPACE)
+
+    def get_secret_volume_name(self, secret_name: str) -> str:
+        service = (
+            self.service
+            if not is_shared_secret_from_secret_name(
+                soa_dir=self.soa_dir, secret_name=secret_name
+            )
+            else SHARED_SECRET_SERVICE
+        )
+        return get_paasta_secret_name(
+            self.get_namespace(),
+            service,
+            secret_name,
+        )
 
     def get_deploy_group(self) -> Optional[str]:
         return self.config_dict.get("deploy_group", None)
@@ -869,6 +901,7 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
         "node": action_config.get_node(),
         "retries": action_config.get_retries(),
         "retries_delay": action_config.get_retries_delay(),
+        "secret_volumes": action_config.get_secret_volumes(),
         "expected_runtime": action_config.get_expected_runtime(),
         "trigger_downstreams": action_config.get_trigger_downstreams(),
         "triggered_by": action_config.get_triggered_by(),

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -273,6 +273,10 @@ class SecretVolume(TypedDict, total=False):
     items: List[SecretVolumeItem]
 
 
+class TronSecretVolume(SecretVolume, total=False):
+    secret_volume_name: str
+
+
 class MonitoringDict(TypedDict, total=False):
     alert_after: Union[str, float]
     check_every: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ python-iptables==1.0.1
 python-utils==2.0.1
 pytimeparse==1.1.5
 pytz==2016.10
-pyyaml==5.4.1
+pyyaml==6.0.1
 repoze.lru==0.6
 requests==2.25.0
 requests-cache==0.6.3


### PR DESCRIPTION
Ticket: [TRON-1636](https://jira.yelpcorp.com/browse/TRON-1636)

This  pipes secret_volumes in tron. It was already set up in kubernetes, so most of the work here was adjusting the tests.

- Had to use a file-based approach to figure out if the secret is shared or not, as it's not explicit for secret_volumes.
- Added a TronSecretVolume type to allow passing secret_volume_name to Tron/task_processing, so they don't have to figure that out themselves.
- Tested with patched wheel of https://github.com/Yelp/task_processing/pull/188. So once this task_proc PR is merged, we should update requirements.txt

This was tested with 2 real tron jobs and patched paasta and tron on our `tron-infrastage` box.
Success: https://fluffy.yelpcorp.com/i/bsJZQ3TlDR9N6fx3dNjT6WQfT0NVGh03.html
Jobs config: https://sourcegraph.yelpcorp.com/sysgit/yelpsoa-configs/-/blob/compute-infra-test-service/tron-infrastage.yaml?L94-119
