### PR TITLE
returns image url in case docker pull fails

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -530,7 +530,7 @@ def get_docker_image(
 
     docker_url = ""
     if args.image:
-        docker_url = args.image
+        return args.image
     else:
         try:
             docker_url = instance_config.get_docker_url()


### PR DESCRIPTION
This change avoids the error when `docker pull` fails before correct url can be passed.