### PR TITLE
Adding support for disabling ANSI colors

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1133,6 +1133,10 @@ class PaastaColors:
         :param color: ANSI color code
         :param text: a string
         :return: a string with ANSI color encoding"""
+
+        if os.getenv("NO_COLOR", "0") == "1":
+            return text
+
         # any time text returns to default, we want to insert our color.
         replaced = text.replace(PaastaColors.DEFAULT, PaastaColors.DEFAULT + color)
         # then wrap the beginning and end in our color/default.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1244,6 +1244,13 @@ def test_color_text_nested():
     assert actual == expected
 
 
+def test_color_text_with_no_color():
+    expected = "hi"
+    with mock.patch.dict(os.environ, {"NO_COLOR": "1"}):
+        actual = utils.PaastaColors.color_text(utils.PaastaColors.RED, "hi")
+    assert actual == expected
+
+
 def test_DeploymentsJson_read():
     file_mock = mock.mock_open()
     fake_dir = "/var/dir_of_fake"


### PR DESCRIPTION
Reading environment variable NO_COLOR to check if ANSI colors should be omitted, see https://no-color.org/