### PR TITLE
Have kubernetes_remove_evicted_pods iterate one namespace at a time i…

### DIFF
--- a/paasta_tools/kubernetes/bin/kubernetes_remove_evicted_pods.py
+++ b/paasta_tools/kubernetes/bin/kubernetes_remove_evicted_pods.py
@@ -135,8 +135,12 @@ def evicted_pods_per_service(
     evicted_pods_aggregated: Dict[str, List[EvictedPod]] = defaultdict(list)
 
     for namespace in get_all_namespaces(client):
-        all_pods = get_all_pods(kube_client=client, namespace=namespace)
-        evicted_pods = get_evicted_pods(all_pods)
+        failed_pods = get_all_pods(
+            kube_client=client,
+            namespace=namespace,
+            field_selector="status.phase=Failed",
+        )
+        evicted_pods = get_evicted_pods(failed_pods)
         log.info(
             f"Pods in evicted state in {namespace}: {[pod.metadata.name for pod in evicted_pods]}"
         )

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2971,8 +2971,14 @@ def get_pods_by_node(kube_client: KubeClient, node: V1Node) -> Sequence[V1Pod]:
     ).items
 
 
-def get_all_pods(kube_client: KubeClient, namespace: str = "paasta") -> List[V1Pod]:
-    return kube_client.core.list_namespaced_pod(namespace=namespace).items
+def get_all_pods(
+    kube_client: KubeClient,
+    namespace: str = "paasta",
+    field_selector: Optional[str] = None,
+) -> List[V1Pod]:
+    return kube_client.core.list_namespaced_pod(
+        namespace=namespace, field_selector=field_selector
+    ).items
 
 
 @time_cache(ttl=300)

--- a/tests/kubernetes/bin/test_kubernetes_remove_evicted_pods.py
+++ b/tests/kubernetes/bin/test_kubernetes_remove_evicted_pods.py
@@ -176,7 +176,11 @@ def test_evicted_pods_per_service():
     with mock.patch(
         "paasta_tools.kubernetes.bin.kubernetes_remove_evicted_pods.get_all_pods",
         autospec=True,
-    ) as mock_get_all_pods:
+    ) as mock_get_all_pods, mock.patch(
+        "paasta_tools.kubernetes.bin.kubernetes_remove_evicted_pods.get_all_namespaces",
+        autospec=True,
+        return_value=["namespace1"],
+    ):
         mock_get_all_pods.return_value = [pod1, pod2, pod3]
         evicted_pods = evicted_pods_per_service(mock_client)
         assert evicted_pods == {


### PR DESCRIPTION
…nstead of fetching all pods. This should decrease its peak memory usage.

I might try to make this use a field selector when listing pods, rather than doing the filtering in python.