### PR TITLE
Use a single KubeClient for all namespaces in get_running_task_alloca…

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -79,6 +79,9 @@ disallow_untyped_defs = True
 [mypy-paasta_tools.contrib.*]
 ignore_errors = True
 
+[mypy-paasta_tools.contrib.get_running_task_allocation]
+ignore_errors = False
+
 [mypy-paasta_tools.cli.cmds.cook_image]
 disallow_untyped_defs = True
 


### PR DESCRIPTION
…tion so that get_pod_node/get_all_nodes_cached doesn't cache all the nodes separately per namespace.

