### PR TITLE
Update uwsgi_exporter dockerfile + build

### DIFF
--- a/yelp_package/dockerfiles/uwsgi_exporter-sidecar/Dockerfile
+++ b/yelp_package/dockerfiles/uwsgi_exporter-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-dev.yelpcorp.com/xenial_yelp
+FROM docker-dev.yelpcorp.com/jammy_yelp
 
 COPY ./uwsgi_exporter/uwsgi_exporter /bin/uwsgi_exporter
 ENV STATS_PORT=8889

--- a/yelp_package/dockerfiles/uwsgi_exporter-sidecar/Makefile
+++ b/yelp_package/dockerfiles/uwsgi_exporter-sidecar/Makefile
@@ -1,6 +1,6 @@
 UWSGI_EXPORTER_REPO ?= https://github.com/timonwong/uwsgi_exporter
 UWSGI_EXPORTER_TAG ?= v1.3.0
-YELP_SUFFIX ?= luisp_testing
+YELP_SUFFIX ?= yelp0
 
 DOCKER_IMAGE ?= docker-paasta.yelpcorp.com:443/uwsgi_exporter-k8s-sidecar:$(UWSGI_EXPORTER_TAG)-$(YELP_SUFFIX)
 

--- a/yelp_package/dockerfiles/uwsgi_exporter-sidecar/Makefile
+++ b/yelp_package/dockerfiles/uwsgi_exporter-sidecar/Makefile
@@ -4,7 +4,7 @@ YELP_SUFFIX ?= yelp0
 
 DOCKER_IMAGE ?= docker-paasta.yelpcorp.com:443/uwsgi_exporter-k8s-sidecar:$(UWSGI_EXPORTER_TAG)-$(YELP_SUFFIX)
 
-all: docker_image push
+all: docker_image check_if_push_needed push
 
 uwsgi_exporter:
 	git clone --branch $(UWSGI_EXPORTER_TAG) $(UWSGI_EXPORTER_REPO)
@@ -21,3 +21,18 @@ docker_image: uwsgi_exporter/uwsgi_exporter
 
 push: docker_image
 	sudo -H docker push $(DOCKER_IMAGE)
+
+# NOTE: we can get rid of this target if we're ok with overwriting the currently
+# tagged image on every run of the CI pipeline that will use this Makefile
+.PHONY: check_if_push_needed
+check_if_push_needed:
+	# if run on a non-Jammy box, this requires `DOCKER_CLI_EXPERIMENTAL=enabled`
+	# to be set as an env var
+	# this will return 1 if the image does not exist, 0 otherwise - so we need to invert
+	# these
+	if sudo -H docker manifest inspect ${DOCKER_IMAGE} > /dev/null 2>&1; \
+	then \
+		echo 'Image already exists - cowardly refusing to continue' && false; \
+	else \
+		echo 'Image does not exist' && true; \
+	fi

--- a/yelp_package/dockerfiles/uwsgi_exporter-sidecar/Makefile
+++ b/yelp_package/dockerfiles/uwsgi_exporter-sidecar/Makefile
@@ -1,6 +1,6 @@
 UWSGI_EXPORTER_REPO ?= https://github.com/timonwong/uwsgi_exporter
 UWSGI_EXPORTER_TAG ?= v1.3.0
-YELP_SUFFIX ?= yelp0
+YELP_SUFFIX ?= luisp_testing
 
 DOCKER_IMAGE ?= docker-paasta.yelpcorp.com:443/uwsgi_exporter-k8s-sidecar:$(UWSGI_EXPORTER_TAG)-$(YELP_SUFFIX)
 

--- a/yelp_package/dockerfiles/uwsgi_exporter-sidecar/Makefile
+++ b/yelp_package/dockerfiles/uwsgi_exporter-sidecar/Makefile
@@ -1,6 +1,6 @@
 UWSGI_EXPORTER_REPO ?= https://github.com/timonwong/uwsgi_exporter
-UWSGI_EXPORTER_TAG ?= v1.0.0
-YELP_SUFFIX ?= yelp2
+UWSGI_EXPORTER_TAG ?= v1.3.0
+YELP_SUFFIX ?= yelp0
 
 DOCKER_IMAGE ?= docker-paasta.yelpcorp.com:443/uwsgi_exporter-k8s-sidecar:$(UWSGI_EXPORTER_TAG)-$(YELP_SUFFIX)
 
@@ -14,7 +14,7 @@ checkout: uwsgi_exporter
 	git -C uwsgi_exporter checkout --force $(UWSGI_EXPORTER_TAG)
 
 uwsgi_exporter/uwsgi_exporter: checkout
-	make -C uwsgi_exporter
+	make -C uwsgi_exporter test build
 
 docker_image: uwsgi_exporter/uwsgi_exporter
 	docker build -t $(DOCKER_IMAGE) .


### PR DESCRIPTION
This change updates us to the latest uwsgi_exporter binary + builds a sidecar using an Ubuntu Jammy base image rather than an ancient Xenial base image.

Additionally, we now explicitly call the Make targets we're interested in (test and build) rather than the default (which goes into a very full-featured common Makefile that does a whole lot of things we don't necerssarily want to run)