### PR TITLE
Introduce gunicorn_exporter-sidecar

### DIFF
--- a/yelp_package/dockerfiles/gunicorn_exporter-sidecar/.gitignore
+++ b/yelp_package/dockerfiles/gunicorn_exporter-sidecar/.gitignore
@@ -1,0 +1,1 @@
+statsd_exporter/

--- a/yelp_package/dockerfiles/gunicorn_exporter-sidecar/Dockerfile
+++ b/yelp_package/dockerfiles/gunicorn_exporter-sidecar/Dockerfile
@@ -1,0 +1,10 @@
+FROM docker-dev.yelpcorp.com/jammy_yelp
+
+COPY ./statsd_exporter/statsd_exporter /bin/statsd_exporter
+RUN mkdir /etc/statsd_exporter
+COPY gunicorn.mapping /etc/statsd_exporter/gunicorn.mapping
+
+ENV STATS_INGESTION_PORT=8889
+ENV HTTP_LISTEN_PORT=9117
+
+CMD /bin/statsd_exporter --statsd.listen-udp=":${STATS_INGESTION_PORT}" --web.listen-address=":${HTTP_LISTEN_PORT}" --statsd.listen-tcp="" --statsd.mapping-config=/etc/statsd_exporter/gunicorn.mapping --log.level=debug

--- a/yelp_package/dockerfiles/gunicorn_exporter-sidecar/Makefile
+++ b/yelp_package/dockerfiles/gunicorn_exporter-sidecar/Makefile
@@ -1,0 +1,42 @@
+EXPORTER_REPO ?= https://github.com/prometheus/statsd_exporter
+EXPORTER_TAG ?= v0.24.0
+YELP_SUFFIX ?= yelp0
+
+DOCKER_IMAGE ?= docker-paasta.yelpcorp.com:443/gunicorn_exporter-k8s-sidecar:$(EXPORTER_TAG)-$(YELP_SUFFIX)
+
+all: docker_image check_if_push_needed push
+
+statsd_exporter:
+	git clone --branch $(EXPORTER_TAG) $(EXPORTER_REPO)
+
+checkout: statsd_exporter
+	git -C statsd_exporter fetch --tags $(EXPORTER_REPO)
+	git -C statsd_exporter checkout --force $(EXPORTER_TAG)
+
+statsd_exporter/statsd_exporter: checkout
+	make -C statsd_exporter test build
+
+docker_image: statsd_exporter/statsd_exporter
+	docker build -t $(DOCKER_IMAGE) .
+
+push: docker_image
+ifeq ($(CI), true)
+	docker push $(DOCKER_IMAGE)
+else
+	sudo -H docker push $(DOCKER_IMAGE)
+endif
+
+# NOTE: we can get rid of this target if we're ok with overwriting the currently
+# tagged image on every run of the CI pipeline that will use this Makefile
+.PHONY: check_if_push_needed
+check_if_push_needed:
+	# if run on a non-Jammy box, this requires `DOCKER_CLI_EXPERIMENTAL=enabled`
+	# to be set as an env var
+	# this will return 1 if the image does not exist, 0 otherwise - so we need to invert
+	# these
+	if sudo -H docker manifest inspect ${DOCKER_IMAGE} > /dev/null 2>&1; \
+	then \
+		echo 'Image already exists - cowardly refusing to continue' && false; \
+	else \
+		echo 'Image does not exist' && true; \
+	fi

--- a/yelp_package/dockerfiles/gunicorn_exporter-sidecar/gunicorn.mapping
+++ b/yelp_package/dockerfiles/gunicorn_exporter-sidecar/gunicorn.mapping
@@ -1,0 +1,10 @@
+mappings:
+- match: "gunicorn.workers"
+  name: "gunicorn_workers"
+  labels:
+    stats_uri: "http://127.0.0.1:9117"
+- match: "gunicorn.workers.*.status"
+  name: "gunicorn_worker_busy"
+  labels:
+    stats_uri: "http://127.0.0.1:9117"
+    worker_id: "$1"


### PR DESCRIPTION
I am adding autoscaling support for gunicorn services to paasta - allowing for existing uwsgi paasta services to switch to gunicorn.

This is a multi-part process:

- [x] Add `metrics_provider: gunicorn` to config validation (#3630)
- [ ] Add new statsd-exporter sidecar (named gunicorn_exporter-sidecar) (this PR)
- [ ] Duplicate uwsgi logic for gunicorn 

## In this PR

Add new statsd-exporter sidecar (named gunicorn-exporter-sidecar)

* Replicate the `uwsgi_exporter-sidecar` setup
  * listens on 9117 for the prometheus scraper
* Provides total worker and worker busy stats for prometheus consumption

## Notes

The `statsd-exporter` comes from https://github.com/prometheus/statsd_exporter
A gunicorn paasta service sends metrics via statsd to the exporter sidecar. Prometheus scrapes metrics from the sidecar.