### PR TITLE
Add `metrics_provider: gunicorn' to schema

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -197,6 +197,7 @@
                                 "uwsgi",
                                 "cpu",
                                 "piscina",
+                                "gunicorn",
                                 "arbitrary_promql"
                             ]
                         },
@@ -285,6 +286,7 @@
                                                 "uwsgi",
                                                 "cpu",
                                                 "piscina",
+                                                "gunicorn",
                                                 "if metrics_provider is arbitrary_promql, the prometheus_adapter_config parameter is required"
                                             ]
                                         }


### PR DESCRIPTION
I am adding autoscaling support for gunicorn services to paasta - allowing for existing uwsgi paasta services to switch to gunicorn.

This is a multi-part process:

- [ ] Add `metrics_provider: gunicorn` to config validation (this PR)
- [ ] Add new statsd-exporter sidecar (named gunicorn_exporter-sidecar) (#3629)
- [ ] Duplicate uwsgi logic for gunicorn 

## In this PR

Add `metrics_provider: gunicorn' to schema