### PR TITLE
Update the default uwsgi_exporter image to the latest

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2656,7 +2656,7 @@ class SystemPaastaConfig:
         """Get the docker image URL for the uwsgi_exporter sidecar container"""
         return self.config_dict.get(
             "uwsgi_exporter_sidecar_image_url",
-            "docker-paasta.yelpcorp.com:443/uwsgi_exporter-k8s-sidecar:v1.0.0-yelp2",
+            "docker-paasta.yelpcorp.com:443/uwsgi_exporter-k8s-sidecar:v1.3.0-yelp0",
         )
 
     def default_should_run_uwsgi_exporter_sidecar(self) -> bool:


### PR DESCRIPTION
I've rolled this out through puppet overrides everywhere - this just changes the default here should we remove the puppet override