### PR TITLE
Gunicorn autoscaling

### DIFF
--- a/docs/source/autoscaling.rst
+++ b/docs/source/autoscaling.rst
@@ -80,6 +80,10 @@ The currently available metrics providers are:
     the port that your uWSGI master process will respond to with stats.
     Defaults to 8889.
 
+:gunicorn:
+  With the ``gunicorn`` metrics provider, Paasta will configure your pods to run an additional container with the `statsd_exporter <https://github.com/prometheus/statsd_exporter>`_ image.
+  This sidecar will listen on port 9117 and receive stats from the gunicorn service. The ``statsd_exporter`` will translate the stats into Prometheus format, which Prometheus will scrape.
+
 
 Decision policies
 ^^^^^^^^^^^^^^^^^

--- a/docs/source/installation/getting_started.rst
+++ b/docs/source/installation/getting_started.rst
@@ -95,7 +95,7 @@ Mesos
 -----
 
 PaaSTA uses Mesos to do the heavy lifting of running the actual services on
-pools of machines.  See the `official documentation <http://mesos.apache.org/gettingstarted/>`_
+pools of machines.  See the `official documentation <http://mesos.apache.org/getting-started/>`_
 on how to get started with Mesos.
 
 Marathon
@@ -163,11 +163,11 @@ Hacheck provides several behaviors that are useful for Paasta:
 Sensu
 -----
 
-`Sensu <https://sensuapp.org/>`_ is a flexible and scalable monitoring system
+`Sensu <https://sensu.io/>`_ is a flexible and scalable monitoring system
 that allows clients to send alerts for arbitrary events. PaaSTA uses Sensu to
 allow individual teams to get alerts for their services.
 
-The `official documentation <https://sensuapp.org/docs/latest/overview>`_ has
+The `official documentation <https://docs.sensu.io/sensu-go/latest/>`_ has
 instructions on how to set it up.
 
 Out of the box Sensu doesn't understand team-centric routing, and must be combined

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -387,7 +387,7 @@ instance MAY have:
   * ``autoscaling``: See the `autoscaling docs <autoscaling.html>`_ for details
 
     * ``metrics_provider``: Which method the autoscaler will use to determine a service's utilization.
-      Should be ``cpu`` or ``uwsgi``.
+      Should be ``cpu``, ``uwsgi``, or ``gunicorn``.
 
     * ``decision_policy``: Which method the autoscaler will use to determine when to autoscale a service.
       Should be ``proportional`` or ``bespoke``.

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -149,6 +149,24 @@ Kubernetes
 
 These options are only applicable to tasks scheduled on Kubernetes.
 
+  * ``topology_spread_constraints``: A set of rules to spread Pods across topologies, for example to try spreading Pods evenly across both nodes and availability zones::
+
+      topology_spread_constraints:
+        - max_skew: 1
+          topology_key: "topology.kubernetes.io/zone"
+          when_unsatisfiable: "ScheduleAnyway"
+        - max_skew: 1
+          topology_key: "kubernetes.io/hostname"
+          when_unsatisfiable: "ScheduleAnyway"
+
+    These can be configured per cluster (or globally) and will be added to every Pod Spec template, using `paasta.yelp.com/service` and `paasta.yelp.com/instance` as selectors.
+
+    To avoid conflicts with the `deploy_whitelist` and `deploy_blacklist`, please only use `when_unsatisfiable: "ScheduleAnyway"` (at least until PAASTA-17951 is resolved).
+
+    For more information, see the official Kubernetes
+    documentation on `topology spread constraints
+    <https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/>`_.
+
   * ``node_selectors``: A map of labels a node is required to have for a task
     to be launched on said node. There are several ways to define a selector.
     The simplest is a key-value pair. For example, this selector restricts a

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -334,6 +334,7 @@ KubePodLabels = TypedDict(
         "paasta.yelp.com/prometheus_shard": str,
         "paasta.yelp.com/scrape_uwsgi_prometheus": str,
         "paasta.yelp.com/scrape_piscina_prometheus": str,
+        "paasta.yelp.com/scrape_gunicorn_prometheus": str,
         "paasta.yelp.com/service": str,
         "paasta.yelp.com/autoscaled": str,
         "yelp.com/paasta_git_sha": str,
@@ -2127,6 +2128,10 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         elif self.should_setup_piscina_prometheus_scraping():
             labels["paasta.yelp.com/deploy_group"] = self.get_deploy_group()
             labels["paasta.yelp.com/scrape_piscina_prometheus"] = "true"
+
+        elif self.should_run_gunicorn_exporter_sidecar():
+            labels["paasta.yelp.com/deploy_group"] = self.get_deploy_group()
+            labels["paasta.yelp.com/scrape_gunicorn_prometheus"] = "true"
 
         return V1PodTemplateSpec(
             metadata=V1ObjectMeta(

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -198,7 +198,6 @@ DEFAULT_HADOWN_PRESTOP_SLEEP_SECONDS = DEFAULT_PRESTOP_SLEEP_SECONDS + 1
 
 DEFAULT_USE_PROMETHEUS_CPU = False
 DEFAULT_USE_PROMETHEUS_UWSGI = True
-DEFAULT_USE_PROMETHEUS_GUNICORN = True
 DEFAULT_USE_RESOURCE_METRICS_CPU = True
 
 
@@ -1109,7 +1108,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         system_paasta_config: SystemPaastaConfig,
     ) -> Optional[V1Container]:
 
-        if self.should_run_gunicorn_exporter_sidecar(system_paasta_config):
+        if self.should_run_gunicorn_exporter_sidecar():
             return V1Container(
                 image=system_paasta_config.get_gunicorn_exporter_sidecar_image_url(),
                 resources=self.get_sidecar_resource_requirements("gunicorn_exporter"),
@@ -1133,19 +1132,11 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
         return None
 
-    def should_run_gunicorn_exporter_sidecar(
-        self,
-        system_paasta_config: SystemPaastaConfig,
-    ) -> bool:
+    def should_run_gunicorn_exporter_sidecar(self) -> bool:
         if self.is_autoscaling_enabled():
             autoscaling_params = self.get_autoscaling_params()
             if autoscaling_params["metrics_provider"] == "gunicorn":
-                if autoscaling_params.get(
-                    "use_prometheus",
-                    DEFAULT_USE_PROMETHEUS_GUNICORN
-                    or system_paasta_config.default_should_run_gunicorn_exporter_sidecar(),
-                ):
-                    return True
+                return True
         return False
 
     def should_setup_piscina_prometheus_scraping(

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -965,12 +965,17 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         uwsgi_exporter_container = self.get_uwsgi_exporter_sidecar_container(
             system_paasta_config
         )
+        gunicorn_exporter_container = self.get_gunicorn_exporter_sidecar_container(
+            system_paasta_config
+        )
 
         sidecars = []
         if hacheck_container:
             sidecars.append(hacheck_container)
         if uwsgi_exporter_container:
             sidecars.append(uwsgi_exporter_container)
+        if gunicorn_exporter_container:
+            sidecars.append(gunicorn_exporter_container)
         return sidecars
 
     def get_readiness_check_prefix(

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -102,6 +102,7 @@ from kubernetes.client import V1StatefulSet
 from kubernetes.client import V1StatefulSetSpec
 from kubernetes.client import V1Subject
 from kubernetes.client import V1TCPSocketAction
+from kubernetes.client import V1TopologySpreadConstraint
 from kubernetes.client import V1Volume
 from kubernetes.client import V1VolumeMount
 from kubernetes.client import V1WeightedPodAffinityTerm
@@ -1970,6 +1971,17 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             affinity.pod_anti_affinity = pod_anti_affinity
             pod_spec_kwargs["affinity"] = affinity
 
+        # PAASTA-17941: Allow configuring topology spread constraints per cluster
+        pod_topology_spread_constraints = create_pod_topology_spread_constraints(
+            service=self.get_service(),
+            instance=self.get_instance(),
+            topology_spread_constraints=system_paasta_config.get_topology_spread_constraints(),
+        )
+        if pod_topology_spread_constraints:
+            constraints = pod_spec_kwargs.get("topologySpreadConstraints", [])
+            constraints += pod_topology_spread_constraints
+            pod_spec_kwargs["topologySpreadConstraints"] = constraints
+
         termination_grace_period = self.get_termination_grace_period()
         if termination_grace_period is not None:
             pod_spec_kwargs[
@@ -3558,6 +3570,43 @@ def load_custom_resource_definitions(
             )
         )
     return custom_resources
+
+
+def create_pod_topology_spread_constraints(
+    service: str,
+    instance: str,
+    topology_spread_constraints: List[Dict[str, Any]],
+) -> List[V1TopologySpreadConstraint]:
+    """
+    Applies cluster-level topology spread constraints to every Pod template.
+    This allows us to configure default topology spread constraints on EKS where we cannot configure the scheduler.
+    """
+    if not topology_spread_constraints:
+        return []
+
+    selector = V1LabelSelector(
+        match_labels={
+            "paasta.yelp.com/service": service,
+            "paasta.yelp.com/instance": instance,
+        }
+    )
+
+    pod_topology_spread_constraints = []
+    for constraint in topology_spread_constraints:
+        pod_topology_spread_constraints.append(
+            V1TopologySpreadConstraint(
+                label_selector=selector,
+                topology_key=constraint.get(
+                    "topology_key", None
+                ),  # ValueError will be raised if unset
+                max_skew=constraint.get("max_skew", 1),
+                when_unsatisfiable=constraint.get(
+                    "when_unsatisfiable", "ScheduleAnyway"
+                ),
+            )
+        )
+
+    return pod_topology_spread_constraints
 
 
 def sanitised_cr_name(service: str, instance: str) -> str:

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1122,7 +1122,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 env=self.get_kubernetes_environment(),
                 ports=[V1ContainerPort(container_port=9117)],
                 lifecycle=V1Lifecycle(
-                    pre_stop=V1Handler(
+                    pre_stop=V1LifecycleHandler(
                         _exec=V1ExecAction(
                             command=[
                                 "/bin/sh",

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -787,7 +787,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                         ),
                     )
                 )
-        elif metrics_provider in {"uwsgi", "piscina"}:
+        elif metrics_provider in {"uwsgi", "piscina", "gunicorn"}:
             metrics.append(
                 V2beta2MetricSpec(
                     type="Object",

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1947,7 +1947,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
     ) -> str:
         """Return whether the routable_ip label should be true or false.
 
-        Services with a `prometheus_port` defined or that use the uwsgi_exporter sidecar must have a routable IP
+        Services with a `prometheus_port` defined or that use certain sidecars must have a routable IP
         address to allow Prometheus shards to scrape metrics.
         """
         if (
@@ -1955,6 +1955,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             or service_namespace_config.is_in_smartstack()
             or self.get_prometheus_port() is not None
             or self.should_run_uwsgi_exporter_sidecar(system_paasta_config)
+            or self.should_run_gunicorn_exporter_sidecar()
         ):
             return "true"
         return "false"

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -31,6 +31,7 @@ DEFAULT_CONTAINER_PORT = 8888
 DEFAULT_AUTOSCALING_SETPOINT = 0.8
 DEFAULT_UWSGI_AUTOSCALING_MOVING_AVERAGE_WINDOW = 1800
 DEFAULT_PISCINA_AUTOSCALING_MOVING_AVERAGE_WINDOW = 1800
+DEFAULT_GUNICORN_AUTOSCALING_MOVING_AVERAGE_WINDOW = 1800
 # we set a different default moving average window so that we can reuse our existing PromQL
 # without having to write a different query for existing users that want to autoscale on
 # instantaneous CPU

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2672,7 +2672,7 @@ class SystemPaastaConfig:
         """Get the docker image URL for the gunicorn_exporter sidecar container"""
         return self.config_dict.get(
             "gunicorn_exporter_sidecar_image_url",
-            "docker-dev.yelpcorp.com/gunicorn_exporter-k8s-sidecar:v0.24.0-yelp0",
+            "docker-paasta.yelpcorp.com/gunicorn_exporter-k8s-sidecar:v0.24.0-yelp0",
         )
 
     def get_mark_for_deployment_max_polling_threads(self) -> int:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1913,7 +1913,6 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     dashboard_links: Dict[str, Dict[str, str]]
     default_push_groups: List
     default_should_run_uwsgi_exporter_sidecar: bool
-    default_should_run_gunicorn_exporter_sidecar: bool
     deploy_blacklist: UnsafeDeployBlacklist
     deployd_big_bounce_deadline: float
     deployd_log_level: str
@@ -2674,11 +2673,6 @@ class SystemPaastaConfig:
         return self.config_dict.get(
             "gunicorn_exporter_sidecar_image_url",
             "docker-dev.yelpcorp.com/gunicorn_exporter-k8s-sidecar:v0.24.0-yelp0",
-        )
-
-    def default_should_run_gunicorn_exporter_sidecar(self) -> bool:
-        return self.config_dict.get(
-            "default_should_run_gunicorn_exporter_sidecar", False
         )
 
     def get_mark_for_deployment_max_polling_threads(self) -> int:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1970,6 +1970,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     pdb_max_unavailable: Union[str, int]
     pki_backend: str
     pod_defaults: Dict[str, Any]
+    topology_spread_constraints: List[Dict[str, Any]]
     previous_marathon_servers: List[MarathonConfigDict]
     readiness_check_prefix_template: List[str]
     register_k8s_pods: bool
@@ -2555,6 +2556,10 @@ class SystemPaastaConfig:
 
     def get_disabled_watchers(self) -> List:
         return self.config_dict.get("disabled_watchers", [])
+
+    def get_topology_spread_constraints(self) -> List[Dict[str, Any]]:
+        """List of TopologySpreadConstraints that will be applied to all Pods in the cluster"""
+        return self.config_dict.get("topology_spread_constraints", [])
 
     def get_vault_environment(self) -> Optional[str]:
         """Get the environment name for the vault cluster

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1913,6 +1913,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     dashboard_links: Dict[str, Dict[str, str]]
     default_push_groups: List
     default_should_run_uwsgi_exporter_sidecar: bool
+    default_should_run_gunicorn_exporter_sidecar: bool
     deploy_blacklist: UnsafeDeployBlacklist
     deployd_big_bounce_deadline: float
     deployd_log_level: str
@@ -1992,6 +1993,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     taskproc: Dict
     tron: Dict
     uwsgi_exporter_sidecar_image_url: str
+    gunicorn_exporter_sidecar_image_url: str
     vault_cluster_map: Dict
     vault_environment: str
     volumes: List[DockerVolume]
@@ -2666,6 +2668,18 @@ class SystemPaastaConfig:
 
     def default_should_run_uwsgi_exporter_sidecar(self) -> bool:
         return self.config_dict.get("default_should_run_uwsgi_exporter_sidecar", False)
+
+    def get_gunicorn_exporter_sidecar_image_url(self) -> str:
+        """Get the docker image URL for the gunicorn_exporter sidecar container"""
+        return self.config_dict.get(
+            "gunicorn_exporter_sidecar_image_url",
+            "docker-dev.yelpcorp.com/gunicorn_exporter-k8s-sidecar:v0.24.0-yelp0",
+        )
+
+    def default_should_run_gunicorn_exporter_sidecar(self) -> bool:
+        return self.config_dict.get(
+            "default_should_run_gunicorn_exporter_sidecar", False
+        )
 
     def get_mark_for_deployment_max_polling_threads(self) -> int:
         return self.config_dict.get("mark_for_deployment_max_polling_threads", 4)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2656,7 +2656,7 @@ class SystemPaastaConfig:
         """Get the docker image URL for the uwsgi_exporter sidecar container"""
         return self.config_dict.get(
             "uwsgi_exporter_sidecar_image_url",
-            "docker-paasta.yelpcorp.com:443/uwsgi_exporter-k8s-sidecar:v1.0.0-yelp2",
+            "docker-paasta.yelpcorp.com:443/uwsgi_exporter-k8s-sidecar:v1.3.0-yelp0",
         )
 
     def default_should_run_uwsgi_exporter_sidecar(self) -> bool:

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -911,6 +911,7 @@ class TestKubernetesDeploymentConfig:
         ret = self.deployment.get_kubernetes_environment()
         assert "PAASTA_POD_IP" in [env.name for env in ret]
         assert "POD_NAME" in [env.name for env in ret]
+        assert "PAASTA_CLUSTER" in [env.name for env in ret]
 
     def test_get_resource_requirements(self):
         with mock.patch(
@@ -1710,6 +1711,7 @@ class TestKubernetesDeploymentConfig:
             "paasta.yelp.com/instance": mock_get_instance.return_value,
             "paasta.yelp.com/service": mock_get_service.return_value,
             "paasta.yelp.com/autoscaled": "false",
+            "paasta.yelp.com/cluster": "brentford",
             "registrations.paasta.yelp.com/kurupt.fm": "true",
             "yelp.com/owner": "compute_infra_platform_experience",
             "paasta.yelp.com/managed": "true",
@@ -1999,6 +2001,7 @@ class TestKubernetesDeploymentConfig:
                     "paasta.yelp.com/service": mock_get_service.return_value,
                     "paasta.yelp.com/autoscaled": autoscaled_label,
                     "paasta.yelp.com/pool": "default",
+                    "paasta.yelp.com/cluster": "brentford",
                     "yelp.com/owner": "compute_infra_platform_experience",
                     "paasta.yelp.com/managed": "true",
                 },
@@ -3905,7 +3908,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config9e0d925d"
+            == "configf6939dba"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 
@@ -3951,7 +3954,7 @@ def test_warning_big_bounce_routable_pod():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config295207ad"
+            == "config0107126a"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every smartstack-registered service to bounce!"
 
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1738,14 +1738,14 @@ class TestKubernetesDeploymentConfig:
                 autoscaling={"metrics_provider": autoscaling_metric_provider},
                 deploy_group="fake_group",
             )
-            deployment = KubernetesDeploymentConfig(
+            autoscaled_deployment = KubernetesDeploymentConfig(
                 service="kurupt",
                 instance="fm",
                 cluster="brentford",
                 config_dict=mock_config_dict,
                 branch_dict=None,
             )
-            ret = deployment.get_pod_template_spec(
+            ret = autoscaled_deployment.get_pod_template_spec(
                 git_sha="aaaa123", system_paasta_config=mock_system_paasta_config
             )
         else:

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1794,30 +1794,40 @@ class TestKubernetesDeploymentConfig:
         "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.should_run_uwsgi_exporter_sidecar",
         autospec=True,
     )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.should_run_gunicorn_exporter_sidecar",
+        autospec=True,
+    )
     @pytest.mark.parametrize(
-        "ip_configured,in_smtstk,prometheus_port,should_run_uwsgi_exporter_sidecar_retval,expected",
+        "ip_configured,in_smtstk,prometheus_port,should_run_uwsgi_exporter_sidecar_retval,should_run_gunicorn_exporter_sidecar_retval,expected",
         [
-            (False, True, 8888, False, "true"),
-            (False, False, 8888, False, "true"),
-            (False, True, None, False, "true"),
-            (True, False, None, False, "true"),
-            (False, False, None, True, "true"),
-            (False, False, None, False, "false"),
+            (False, True, 8888, False, False, "true"),
+            (False, False, 8888, False, False, "true"),
+            (False, True, None, False, False, "true"),
+            (True, False, None, False, False, "true"),
+            (False, False, None, True, False, "true"),
+            (False, False, None, False, False, "false"),
+            (False, False, None, False, True, "true"),
         ],
     )
     def test_routable_ip(
         self,
         mock_should_run_uwsgi_exporter_sidecar,
+        mock_should_run_gunicorn_exporter_sidecar,
         mock_get_prometheus_port,
         ip_configured,
         in_smtstk,
         prometheus_port,
         should_run_uwsgi_exporter_sidecar_retval,
+        should_run_gunicorn_exporter_sidecar_retval,
         expected,
     ):
         mock_get_prometheus_port.return_value = prometheus_port
         mock_should_run_uwsgi_exporter_sidecar.return_value = (
             should_run_uwsgi_exporter_sidecar_retval
+        )
+        mock_should_run_gunicorn_exporter_sidecar.return_value = (
+            should_run_gunicorn_exporter_sidecar_retval
         )
         mock_service_namespace_config = mock.Mock()
         mock_service_namespace_config.is_in_smartstack.return_value = in_smtstk

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -890,31 +890,7 @@ class TestKubernetesDeploymentConfig:
                 is None
             )
 
-    def test_should_run_gunicorn_exporter_sidecar_explicit(self):
-        self.deployment.config_dict.update(
-            {
-                "max_instances": 5,
-                "autoscaling": {
-                    "metrics_provider": "gunicorn",
-                    "use_prometheus": True,
-                },
-            }
-        )
-
-        system_paasta_config = mock.Mock()
-
-        assert (
-            self.deployment.should_run_gunicorn_exporter_sidecar(system_paasta_config)
-            is True
-        )
-
-        self.deployment.config_dict["autoscaling"]["use_prometheus"] = False
-        assert (
-            self.deployment.should_run_gunicorn_exporter_sidecar(system_paasta_config)
-            is False
-        )
-
-    def test_should_run_gunicorn_exporter_sidecar_defaults(self):
+    def test_should_run_gunicorn_exporter_sidecar(self):
         self.deployment.config_dict.update(
             {
                 "max_instances": 5,
@@ -924,50 +900,7 @@ class TestKubernetesDeploymentConfig:
             }
         )
 
-        system_paasta_config_enabled = mock.Mock(
-            default_should_run_gunicorn_exporter_sidecar=mock.Mock(return_value=True)
-        )
-        system_paasta_config_disabled = mock.Mock(
-            default_should_run_gunicorn_exporter_sidecar=mock.Mock(return_value=False)
-        )
-
-        with mock.patch(
-            "paasta_tools.kubernetes_tools.DEFAULT_USE_PROMETHEUS_GUNICORN",
-            autospec=False,
-            new=False,
-        ):
-            assert (
-                self.deployment.should_run_gunicorn_exporter_sidecar(
-                    system_paasta_config_enabled
-                )
-                is True
-            )
-            assert (
-                self.deployment.should_run_gunicorn_exporter_sidecar(
-                    system_paasta_config_disabled
-                )
-                is False
-            )
-
-        # If the default for use_prometheus is True and config_dict doesn't specify use_prometheus, we should run
-        # gunicorn_exporter regardless of default_should_run_gunicorn_exporter_sidecar.
-        with mock.patch(
-            "paasta_tools.kubernetes_tools.DEFAULT_USE_PROMETHEUS_GUNICORN",
-            autospec=False,
-            new=True,
-        ):
-            assert (
-                self.deployment.should_run_gunicorn_exporter_sidecar(
-                    system_paasta_config_enabled
-                )
-                is True
-            )
-            assert (
-                self.deployment.should_run_gunicorn_exporter_sidecar(
-                    system_paasta_config_disabled
-                )
-                is True
-            )
+        assert self.deployment.should_run_gunicorn_exporter_sidecar() is True
 
     def test_get_env(self):
         with mock.patch(


### PR DESCRIPTION
I am adding autoscaling support for gunicorn services to paasta - allowing for existing uwsgi paasta services to switch to gunicorn.

This is a multi-part process:

- [x] Add `metrics_provider: gunicorn` to config validation (#3630 )
- [x] Add new statsd-exporter sidecar (named gunicorn_exporter-sidecar) (#3629)
- [ ] Duplicate uwsgi logic for gunicorn (this PR)

## In this PR

Duplicate uwsgi logic for gunicorn

* Update utilities and tools
* Add scaling rule
* Add gunicorn sidecar when requested
* Label pod appropriately

### Notes

I've duplicated most of uwsgi logic for gunicorn.

Changes from uwsgi:
* Dropped support for `offset` since that option is deprecated
* Assume prometheus will always be used.

## Testing

I've validated this branch in our staging environment with a gunicorn service. I was able to see the service scale up and down in response to changes in worker utilization.