### PR TITLE
PAASTA-17941: add topology spread constraints option

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -149,6 +149,22 @@ Kubernetes
 
 These options are only applicable to tasks scheduled on Kubernetes.
 
+  * ``topology_spread_constraints``: A set of rules to spread Pods across topologies, for example to try spreading Pods evenly across both nodes and availability zones::
+
+      topology_spread_constraints:
+        - max_skew: 1
+          topology_key: "topology.kubernetes.io/zone"
+          when_unsatisfiable: "ScheduleAnyway"
+        - max_skew: 1
+          topology_key: "kubernetes.io/hostname"
+          when_unsatisfiable: "ScheduleAnyway"
+
+    These can be configured per cluster (or globally) and will be added to every Pod Spec template, using `paasta.yelp.com/service` and `paasta.yelp.com/instance` as selectors.
+
+    For more information, see the official Kubernetes
+    documentation on `topology spread constraints
+    <https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/>`_.
+
   * ``node_selectors``: A map of labels a node is required to have for a task
     to be launched on said node. There are several ways to define a selector.
     The simplest is a key-value pair. For example, this selector restricts a

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -161,6 +161,8 @@ These options are only applicable to tasks scheduled on Kubernetes.
 
     These can be configured per cluster (or globally) and will be added to every Pod Spec template, using `paasta.yelp.com/service` and `paasta.yelp.com/instance` as selectors.
 
+    To avoid conflicts with the `deploy_whitelist` and `deploy_blacklist`, please only use `when_unsatisfiable: "ScheduleAnyway"` (at least until PAASTA-17951 is resolved).
+
     For more information, see the official Kubernetes
     documentation on `topology spread constraints
     <https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/>`_.

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -155,7 +155,6 @@ from paasta_tools.utils import PersistentVolume
 from paasta_tools.utils import SecretVolume
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import time_cache
-from paasta_tools.utils import TopologySpreadConstraint
 from paasta_tools.utils import VolumeWithMode
 
 
@@ -3556,7 +3555,7 @@ def load_custom_resource_definitions(
 
 
 def create_pod_topology_spread_constraints(
-    service: str, instance: str, topology_spread_constraints: List[TopologySpreadConstraint]
+    service: str, instance: str, topology_spread_constraints: List[Dict[str, object]]
 ) -> List[V1TopologySpreadConstraint]:
     """
     Applies cluster-level topology spread constraints to every Pod template.

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -155,6 +155,7 @@ from paasta_tools.utils import PersistentVolume
 from paasta_tools.utils import SecretVolume
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import time_cache
+from paasta_tools.utils import TopologySpreadConstraint
 from paasta_tools.utils import VolumeWithMode
 
 
@@ -3555,7 +3556,7 @@ def load_custom_resource_definitions(
 
 
 def create_pod_topology_spread_constraints(
-    service: str, instance: str, topology_spread_constraints: List[TypedDict]
+    service: str, instance: str, topology_spread_constraints: List[TopologySpreadConstraint]
 ) -> List[V1TopologySpreadConstraint]:
     """
     Applies cluster-level topology spread constraints to every Pod template.

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -3557,7 +3557,7 @@ def load_custom_resource_definitions(
 def create_pod_topology_spread_constraints(
     service: str,
     instance: str,
-    topology_spread_constraints: List[Dict[Any, Any]],
+    topology_spread_constraints: List[Dict[str, Any]],
 ) -> List[V1TopologySpreadConstraint]:
     """
     Applies cluster-level topology spread constraints to every Pod template.
@@ -3578,10 +3578,10 @@ def create_pod_topology_spread_constraints(
         pod_topology_spread_constraints.append(
             V1TopologySpreadConstraint(
                 label_selector=selector,
-                max_skew=constraint.get("max_skew", 1),
                 topology_key=constraint.get(
                     "topology_key", None
                 ),  # ValueError will be raised if unset
+                max_skew=constraint.get("max_skew", 1),
                 when_unsatisfiable=constraint.get(
                     "when_unsatisfiable", "ScheduleAnyway"
                 ),

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -3557,7 +3557,7 @@ def load_custom_resource_definitions(
 def create_pod_topology_spread_constraints(
     service: str,
     instance: str,
-    topology_spread_constraints: List[dict],
+    topology_spread_constraints: List[Dict[Any, Any]],
 ) -> List[V1TopologySpreadConstraint]:
     """
     Applies cluster-level topology spread constraints to every Pod template.

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -155,7 +155,6 @@ from paasta_tools.utils import PersistentVolume
 from paasta_tools.utils import SecretVolume
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import time_cache
-from paasta_tools.utils import TopologySpreadConstraint
 from paasta_tools.utils import VolumeWithMode
 
 
@@ -3558,7 +3557,7 @@ def load_custom_resource_definitions(
 def create_pod_topology_spread_constraints(
     service: str,
     instance: str,
-    topology_spread_constraints: List[TopologySpreadConstraint],
+    topology_spread_constraints: List[dict],
 ) -> List[V1TopologySpreadConstraint]:
     """
     Applies cluster-level topology spread constraints to every Pod template.

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -154,6 +154,7 @@ from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import PersistentVolume
 from paasta_tools.utils import SecretVolume
 from paasta_tools.utils import SystemPaastaConfig
+from paasta_tools.utils import TopologySpreadConstraint
 from paasta_tools.utils import time_cache
 from paasta_tools.utils import VolumeWithMode
 
@@ -3555,7 +3556,7 @@ def load_custom_resource_definitions(
 
 
 def create_pod_topology_spread_constraints(
-    service: str, instance: str, topology_spread_constraints: List[Dict[str, object]]
+    service: str, instance: str, topology_spread_constraints: List[TopologySpreadConstraint]
 ) -> List[V1TopologySpreadConstraint]:
     """
     Applies cluster-level topology spread constraints to every Pod template.

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1961,9 +1961,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             topology_spread_constraints=system_paasta_config.get_topology_spread_constraints(),
         )
         if pod_topology_spread_constraints:
-            constraints = pod_spec_kwargs.get(
-                "topologySpreadConstraints", []
-            )
+            constraints = pod_spec_kwargs.get("topologySpreadConstraints", [])
             constraints += pod_topology_spread_constraints
             pod_spec_kwargs["topologySpreadConstraints"] = constraints
 
@@ -2087,10 +2085,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         return node_selectors
 
     def get_pod_topology_spread_constraints(
-            self,
-            service: str,
-            instance: str,
-            topology_spread_constraints: List[TypedDict]
+        self, service: str, instance: str, topology_spread_constraints: List[TypedDict]
     ) -> List[V1TopologySpreadConstraint]:
         """
         Applies cluster-level topology spread constraints to every Pod template.

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -102,6 +102,7 @@ from kubernetes.client import V1StatefulSet
 from kubernetes.client import V1StatefulSetSpec
 from kubernetes.client import V1Subject
 from kubernetes.client import V1TCPSocketAction
+from kubernetes.client import V1TopologySpreadConstraint
 from kubernetes.client import V1Volume
 from kubernetes.client import V1VolumeMount
 from kubernetes.client import V1WeightedPodAffinityTerm
@@ -1953,6 +1954,19 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             affinity.pod_anti_affinity = pod_anti_affinity
             pod_spec_kwargs["affinity"] = affinity
 
+        # PAASTA-17941: Allow configuring topology spread constraints per cluster
+        pod_topology_spread_constraints = self.get_pod_topology_spread_constraints(
+            service=self.get_service(),
+            instance=self.get_instance(),
+            topology_spread_constraints=system_paasta_config.get_topology_spread_constraints(),
+        )
+        if pod_topology_spread_constraints:
+            constraints = pod_spec_kwargs.get(
+                "topologySpreadConstraints", []
+            )
+            constraints += pod_topology_spread_constraints
+            pod_spec_kwargs["topologySpreadConstraints"] = constraints
+
         termination_grace_period = self.get_termination_grace_period()
         if termination_grace_period is not None:
             pod_spec_kwargs[
@@ -2071,6 +2085,43 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         }
         node_selectors["yelp.com/pool"] = self.get_pool()
         return node_selectors
+
+    def get_pod_topology_spread_constraints(
+            self,
+            service: str,
+            instance: str,
+            topology_spread_constraints: List[TypedDict]
+    ) -> List[V1TopologySpreadConstraint]:
+        """
+        Applies cluster-level topology spread constraints to every Pod template.
+        This allows us to configure default topology spread constraints on EKS where we cannot configure the scheduler.
+        """
+        if not topology_spread_constraints:
+            return []
+
+        selector = V1LabelSelector(
+            match_labels={
+                "paasta.yelp.com/service": service,
+                "paasta.yelp.com/instance": instance,
+            }
+        )
+
+        pod_topology_spread_constraints = []
+        for constraint in topology_spread_constraints:
+            pod_topology_spread_constraints.append(
+                V1TopologySpreadConstraint(
+                    label_selector=selector,
+                    max_skew=constraint.get("max_skew", 1),
+                    topology_key=constraint.get(
+                        "topology_key", None
+                    ),  # ValueError will be raised if unset
+                    when_unsatisfiable=constraint.get(
+                        "when_unsatisfiable", "ScheduleAnyway"
+                    ),
+                )
+            )
+
+        return pod_topology_spread_constraints
 
     def get_node_affinity(self) -> Optional[V1NodeAffinity]:
         """Converts deploy_whitelist and deploy_blacklist in node affinities.

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -154,8 +154,8 @@ from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import PersistentVolume
 from paasta_tools.utils import SecretVolume
 from paasta_tools.utils import SystemPaastaConfig
-from paasta_tools.utils import TopologySpreadConstraint
 from paasta_tools.utils import time_cache
+from paasta_tools.utils import TopologySpreadConstraint
 from paasta_tools.utils import VolumeWithMode
 
 
@@ -3556,7 +3556,9 @@ def load_custom_resource_definitions(
 
 
 def create_pod_topology_spread_constraints(
-    service: str, instance: str, topology_spread_constraints: List[TopologySpreadConstraint]
+    service: str,
+    instance: str,
+    topology_spread_constraints: List[TopologySpreadConstraint],
 ) -> List[V1TopologySpreadConstraint]:
     """
     Applies cluster-level topology spread constraints to every Pod template.

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1871,6 +1871,8 @@ class PaastaNativeConfig(TypedDict, total=False):
     secret: str
 
 
+# PAASTA-17941: Allow configuring TSC.
+# Please only do not use `when_unsatisfiable: DoNotSchedule` until PAASTA-17951 is resolved
 class TopologySpreadConstraint(TypedDict, total=False):
     topology_key: str  # Must not be empty
     max_skew: int  # Defaults to 1

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1871,6 +1871,12 @@ class PaastaNativeConfig(TypedDict, total=False):
     secret: str
 
 
+class TopologySpreadConstraint(TypedDict, total=False):
+    topology_key: str  # Must not be empty
+    max_skew: int  # Defaults to 1
+    when_unsatisfiable: str  # Defaults to ScheduleAnyway
+
+
 ExpectedSlaveAttributes = List[Dict[str, Any]]
 
 
@@ -1970,6 +1976,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     pdb_max_unavailable: Union[str, int]
     pki_backend: str
     pod_defaults: Dict[str, Any]
+    topology_spread_constraints: List[TopologySpreadConstraint]
     previous_marathon_servers: List[MarathonConfigDict]
     readiness_check_prefix_template: List[str]
     register_k8s_pods: bool
@@ -2555,6 +2562,10 @@ class SystemPaastaConfig:
 
     def get_disabled_watchers(self) -> List:
         return self.config_dict.get("disabled_watchers", [])
+
+    def get_topology_spread_constraints(self) -> List[TopologySpreadConstraint]:
+        """List of TopologySpreadConstraints that will be applied to all Pods in the cluster"""
+        return self.config_dict.get("topology_spread_constraints", [])
 
     def get_vault_environment(self) -> Optional[str]:
         """Get the environment name for the vault cluster

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1871,14 +1871,6 @@ class PaastaNativeConfig(TypedDict, total=False):
     secret: str
 
 
-# PAASTA-17941: Allow configuring TSC.
-# Please only do not use `when_unsatisfiable: DoNotSchedule` until PAASTA-17951 is resolved
-class TopologySpreadConstraint(TypedDict, total=False):
-    topology_key: str  # Must not be empty
-    max_skew: int  # Defaults to 1
-    when_unsatisfiable: str  # Defaults to ScheduleAnyway
-
-
 ExpectedSlaveAttributes = List[Dict[str, Any]]
 
 
@@ -1978,7 +1970,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     pdb_max_unavailable: Union[str, int]
     pki_backend: str
     pod_defaults: Dict[str, Any]
-    topology_spread_constraints: List[TopologySpreadConstraint]
+    topology_spread_constraints: List[Dict[str, Any]]
     previous_marathon_servers: List[MarathonConfigDict]
     readiness_check_prefix_template: List[str]
     register_k8s_pods: bool
@@ -2565,7 +2557,7 @@ class SystemPaastaConfig:
     def get_disabled_watchers(self) -> List:
         return self.config_dict.get("disabled_watchers", [])
 
-    def get_topology_spread_constraints(self) -> List[TopologySpreadConstraint]:
+    def get_topology_spread_constraints(self) -> List[Dict[str, Any]]:
         """List of TopologySpreadConstraints that will be applied to all Pods in the cluster"""
         return self.config_dict.get("topology_spread_constraints", [])
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1654,7 +1654,7 @@ class TestKubernetesDeploymentConfig:
                     )
                 },
                 None,
-                []
+                [],
             ),
         ],
     )

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1774,7 +1774,9 @@ class TestKubernetesDeploymentConfig:
 
         assert ret == expected
 
-    def test_get_pod_topology_spread_constraints(self, topology_spread_constraints, expected):
+    def test_get_pod_topology_spread_constraints(
+        self, topology_spread_constraints, expected
+    ):
         configured_constraints = [
             {
                 "topology_key": "kubernetes.io/hostname",
@@ -1813,9 +1815,12 @@ class TestKubernetesDeploymentConfig:
             ),
         ]
 
-        assert self.deployment.get_pod_topology_spread_constraints(
-            "schematizer", "main", configured_constraints
-        ) == expected_constraints
+        assert (
+            self.deployment.get_pod_topology_spread_constraints(
+                "schematizer", "main", configured_constraints
+            )
+            == expected_constraints
+        )
 
     @pytest.mark.parametrize(
         "raw_selectors,expected",

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1774,9 +1774,7 @@ class TestKubernetesDeploymentConfig:
 
         assert ret == expected
 
-    def test_get_pod_topology_spread_constraints(
-        self, topology_spread_constraints, expected
-    ):
+    def test_create_pod_topology_spread_constraints(self):
         configured_constraints = [
             {
                 "topology_key": "kubernetes.io/hostname",
@@ -1816,7 +1814,7 @@ class TestKubernetesDeploymentConfig:
         ]
 
         assert (
-            self.deployment.get_pod_topology_spread_constraints(
+            kubernetes_tools.create_pod_topology_spread_constraints(
                 "schematizer", "main", configured_constraints
             )
             == expected_constraints

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1622,6 +1622,10 @@ class TestKubernetesDeploymentConfig:
         "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_pod_anti_affinity",
         autospec=True,
     )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.create_pod_topology_spread_constraints",
+        autospec=True,
+    )
     @pytest.mark.parametrize(
         "in_smtstk,routable_ip,node_affinity,anti_affinity,spec_affinity,termination_grace_period",
         [
@@ -1654,6 +1658,7 @@ class TestKubernetesDeploymentConfig:
     )
     def test_get_pod_template_spec(
         self,
+        mock_create_pod_topology_spread_constraints,
         mock_get_pod_anti_affinity,
         mock_get_termination_grace_period,
         mock_load_service_namespace_config,
@@ -1665,6 +1670,7 @@ class TestKubernetesDeploymentConfig:
         mock_get_volumes,
         in_smtstk,
         routable_ip,
+        pod_topology,
         node_affinity,
         anti_affinity,
         spec_affinity,
@@ -1675,9 +1681,13 @@ class TestKubernetesDeploymentConfig:
         mock_service_namespace_config.is_in_smartstack.return_value = in_smtstk
         mock_get_node_affinity.return_value = node_affinity
         mock_get_pod_anti_affinity.return_value = anti_affinity
+        mock_create_pod_topology_spread_constraints.return_value = pod_topology
         mock_system_paasta_config = mock.Mock()
         mock_system_paasta_config.get_kubernetes_add_registration_labels.return_value = (
             True
+        )
+        mock_system_paasta_config.get_topology_spread_constraints.return_value = (
+            []
         )
         mock_system_paasta_config.get_pod_defaults.return_value = dict(dns_policy="foo")
         mock_get_termination_grace_period.return_value = termination_grace_period

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1627,10 +1627,10 @@ class TestKubernetesDeploymentConfig:
         autospec=True,
     )
     @pytest.mark.parametrize(
-        "in_smtstk,routable_ip,node_affinity,anti_affinity,spec_affinity,termination_grace_period",
+        "in_smtstk,routable_ip,node_affinity,anti_affinity,spec_affinity,termination_grace_period,pod_topology",
         [
-            (True, "true", None, None, {}, None),
-            (False, "false", None, None, {}, 10),
+            (True, "true", None, None, {}, None, []),
+            (False, "false", None, None, {}, 10, []),
             # an node affinity absent but pod anti affinity present
             (
                 False,
@@ -1639,6 +1639,7 @@ class TestKubernetesDeploymentConfig:
                 "pod_anti_affinity",
                 {"affinity": V1Affinity(pod_anti_affinity="pod_anti_affinity")},
                 None,
+                [],
             ),
             # an affinity obj is only added if there is a node affinity
             (
@@ -1653,6 +1654,7 @@ class TestKubernetesDeploymentConfig:
                     )
                 },
                 None,
+                []
             ),
         ],
     )
@@ -1686,9 +1688,7 @@ class TestKubernetesDeploymentConfig:
         mock_system_paasta_config.get_kubernetes_add_registration_labels.return_value = (
             True
         )
-        mock_system_paasta_config.get_topology_spread_constraints.return_value = (
-            []
-        )
+        mock_system_paasta_config.get_topology_spread_constraints.return_value = []
         mock_system_paasta_config.get_pod_defaults.return_value = dict(dns_policy="foo")
         mock_get_termination_grace_period.return_value = termination_grace_period
 

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -1,5 +1,5 @@
 --index-url=https://pypi.yelpcorp.com/simple
-atomicfile==1.0
+atomicfile==1.0.1
 cached-property==1.3.1
 cffi==1.15.0
 cffi==1.15.0

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -1,5 +1,5 @@
 --index-url=https://pypi.yelpcorp.com/simple
-atomicfile==1.0.1
+atomicfile==1.0
 cached-property==1.3.1
 cffi==1.15.0
 cffi==1.15.0


### PR DESCRIPTION
Ticket: PAASTA-17941

Problem
-----
On EKS, we cannot configure the default Kubernetes scheduler with pod topology constraints.
But to support the Karpenter migration and to be able to tune our spread of Pods across zones and nodes, we want to be able to configure cluster wide topology constraints via PaaSTA.

Solution
-----
Add a `topology_spread_constraints` option to the PaaSTA system config that allows defining rules to spread Pods across topologies per cluster.
For example to try spreading Pods evenly across both nodes and availability zones, we'd set:
```
topology_spread_constraints:
    - max_skew: 1
      topology_key: "topology.kubernetes.io/zone"
      when_unsatisfiable: "ScheduleAnyway"
    - max_skew: 1
      topology_key: "kubernetes.io/hostname"
      when_unsatisfiable: "ScheduleAnyway"
```
This can be configured once per cluster (or globally) and will be added to every Pod Spec template (i.e. both Deployments and StatefulSets), using `paasta.yelp.com/service` and `paasta.yelp.com/instance` as label selectors.

Future Work
------
There is a potentially conflicting interaction of this new configuration option with `deploy_whitelist` and `deploy_blacklist` because those use node affinities and could constrain a deployment to one specific habitat/AZ while the topology spread constraint might be configured to spread Pods across multiple AZs. If `when_unsatisfiable: "DoNotSchedule"` is set, this would lead to Pods being unable to get scheduled.

For now, this will be handled by not defining any default spread constraints and only using `ScheduleAnyway` but we'll probably pose a follow-up PR to change the implementation of the whitelist/blacklist options from node affinities (which are somewhat expensive anyway) to topology spread constraints and give priority to the whitelist/blacklist options, if defined.

Signed-off-by: Max Falk <gfalk@yelp.com>
