### PR TITLE
Revert "Upgrading kubernetes client library to v24.2.0"

### DIFF
--- a/paasta_tools/setup_kubernetes_crd.py
+++ b/paasta_tools/setup_kubernetes_crd.py
@@ -27,7 +27,7 @@ import sys
 from typing import Sequence
 
 import service_configuration_lib
-from kubernetes.client import V1CustomResourceDefinition
+from kubernetes.client import V1beta1CustomResourceDefinition
 
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import paasta_prefixed
@@ -118,7 +118,7 @@ def setup_kube_crd(
             metadata["labels"] = {}
         metadata["labels"]["yelp.com/paasta_service"] = service
         metadata["labels"][paasta_prefixed("service")] = service
-        desired_crd = V1CustomResourceDefinition(
+        desired_crd = V1beta1CustomResourceDefinition(
             api_version=crd_config.get("apiVersion"),
             kind=crd_config.get("kind"),
             metadata=metadata,

--- a/paasta_tools/setup_kubernetes_internal_crd.py
+++ b/paasta_tools/setup_kubernetes_internal_crd.py
@@ -23,7 +23,7 @@ import argparse
 import logging
 import sys
 
-from kubernetes.client import V1CustomResourceDefinition
+from kubernetes.client import V1beta1CustomResourceDefinition
 
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import paasta_prefixed
@@ -33,8 +33,8 @@ log = logging.getLogger(__name__)
 
 
 INTERNAL_CRDS = [
-    V1CustomResourceDefinition(
-        api_version="apiextensions.k8s.io/v1",
+    V1beta1CustomResourceDefinition(
+        api_version="apiextensions.k8s.io/v1beta1",
         kind="CustomResourceDefinition",
         metadata={
             "name": "deploygroups.paasta.yelp.com",
@@ -44,24 +44,7 @@ INTERNAL_CRDS = [
         },
         spec={
             "group": "paasta.yelp.com",
-            "versions": [
-                {
-                    "name": "v1beta1",
-                    "served": True,
-                    "storage": True,
-                    "schema": {
-                        "openAPIV3Schema": {
-                            "type": "object",
-                            "properties": {
-                                "service": {"type": "string"},
-                                "deploy_group": {"type": "string"},
-                                "git_sha": {"type": "string"},
-                                "image_version": {"type": "string"},
-                            },
-                        }
-                    },
-                }
-            ],
+            "versions": [{"name": "v1beta1", "served": True, "storage": True}],
             "scope": "Namespaced",
             "names": {
                 "plural": "deploygroups",
@@ -69,10 +52,21 @@ INTERNAL_CRDS = [
                 "kind": "DeployGroup",
                 "shortNames": ["dg"],
             },
+            "validation": {
+                "openAPIV3Schema": {
+                    "type": "object",
+                    "properties": {
+                        "service": {"type": "string"},
+                        "deploy_group": {"type": "string"},
+                        "git_sha": {"type": "string"},
+                        "image_version": {"type": "string"},
+                    },
+                }
+            },
         },
     ),
-    V1CustomResourceDefinition(
-        api_version="apiextensions.k8s.io/v1",
+    V1beta1CustomResourceDefinition(
+        api_version="apiextensions.k8s.io/v1beta1",
         kind="CustomResourceDefinition",
         metadata={
             "name": "startstopcontrols.paasta.yelp.com",
@@ -82,29 +76,23 @@ INTERNAL_CRDS = [
         },
         spec={
             "group": "paasta.yelp.com",
-            "versions": [
-                {
-                    "name": "v1beta1",
-                    "served": True,
-                    "storage": True,
-                    "schema": {
-                        "openAPIV3Schema": {
-                            "type": "object",
-                            "properties": {
-                                "service": {"type": "string"},
-                                "instance": {"type": "string"},
-                                "desired_state": {"type": "string"},
-                                "force_bounce": {"type": "string"},
-                            },
-                        }
-                    },
-                }
-            ],
+            "versions": [{"name": "v1beta1", "served": True, "storage": True}],
             "scope": "Namespaced",
             "names": {
                 "plural": "startstopcontrols",
                 "singular": "startstopcontrol",
                 "kind": "StartStopControl",
+            },
+            "validation": {
+                "openAPIV3Schema": {
+                    "type": "object",
+                    "properties": {
+                        "service": {"type": "string"},
+                        "instance": {"type": "string"},
+                        "desired_state": {"type": "string"},
+                        "force_bounce": {"type": "string"},
+                    },
+                }
             },
         },
     ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ jmespath==0.9.3
 jsonref==0.1
 jsonschema==2.5.1
 kazoo==2.8.0
-kubernetes==24.2.0
+kubernetes==18.20.0
 ldap3==2.6
 manhole==1.5.0
 marathon==0.12.0

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -24,12 +24,12 @@ from kubernetes.client import V1DeploymentStrategy
 from kubernetes.client import V1EnvVar
 from kubernetes.client import V1EnvVarSource
 from kubernetes.client import V1ExecAction
+from kubernetes.client import V1Handler
 from kubernetes.client import V1HostPathVolumeSource
 from kubernetes.client import V1HTTPGetAction
 from kubernetes.client import V1KeyToPath
 from kubernetes.client import V1LabelSelector
 from kubernetes.client import V1Lifecycle
-from kubernetes.client import V1LifecycleHandler
 from kubernetes.client import V1NodeAffinity
 from kubernetes.client import V1NodeSelector
 from kubernetes.client import V1NodeSelectorRequirement
@@ -559,7 +559,7 @@ class TestKubernetesDeploymentConfig:
                     ],
                     image="some-docker-image",
                     lifecycle=V1Lifecycle(
-                        pre_stop=V1LifecycleHandler(
+                        pre_stop=V1Handler(
                             _exec=V1ExecAction(
                                 command=[
                                     "/bin/sh",
@@ -605,7 +605,7 @@ class TestKubernetesDeploymentConfig:
                     ],
                     image="some-docker-image",
                     lifecycle=V1Lifecycle(
-                        pre_stop=V1LifecycleHandler(
+                        pre_stop=V1Handler(
                             _exec=V1ExecAction(
                                 command=[
                                     "/bin/sh",
@@ -1005,7 +1005,7 @@ class TestKubernetesDeploymentConfig:
                     resources=mock_get_resource_requirements.return_value,
                     image=mock_get_docker_url.return_value,
                     lifecycle=V1Lifecycle(
-                        pre_stop=V1LifecycleHandler(
+                        pre_stop=V1Handler(
                             _exec=V1ExecAction(command=["/bin/sh", "-c", "sleep 30"])
                         )
                     ),
@@ -1949,7 +1949,7 @@ class TestKubernetesDeploymentConfig:
             self.deployment.config_dict["lifecycle"] = {
                 "pre_stop_command": termination_action
             }
-        handler = V1LifecycleHandler(_exec=V1ExecAction(command=expected))
+        handler = V1Handler(_exec=V1ExecAction(command=expected))
         assert self.deployment.get_kubernetes_container_termination_action() == handler
 
     @pytest.mark.parametrize(
@@ -3965,7 +3965,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "configd6531f39"
+            == "configf6939dba"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 
@@ -4011,7 +4011,7 @@ def test_warning_big_bounce_routable_pod():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "configa5abd828"
+            == "config0107126a"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every smartstack-registered service to bounce!"
 
 


### PR DESCRIPTION
Need to do a clean release of PaaSTA v0.183.0 that we can release to production.

This PR is currently blocking that release because PaaSTA cannot apply CRDs with version `v1beta1`.

We'll re-apply this PR once 183 is released.

Reverts Yelp/paasta#3632