### PR TITLE
make sidecar resource limit configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ unique-run
 
 # Coverage artifacts
 .coverage
+
+unique-run

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -349,6 +349,17 @@ class DockerParameter(TypedDict):
     value: str
 
 
+KubeContainerResourceRequest = TypedDict(
+    "KubeContainerResourceRequest",
+    {
+        "cpu": float,
+        "memory": str,
+        "ephemeral-storage": str,
+    },
+    total=False,
+)
+
+
 def safe_deploy_blacklist(input: UnsafeDeployBlacklist) -> DeployBlacklist:
     return [(t, l) for t, l in input]
 
@@ -2017,6 +2028,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     spark_kubeconfig: str
     kube_clusters: Dict
     spark_use_eks_default: bool
+    sidecar_requirements_config: Dict[str, KubeContainerResourceRequest]
 
 
 def load_system_paasta_config(
@@ -2095,6 +2107,11 @@ class SystemPaastaConfig:
 
     def get_spark_use_eks_default(self) -> bool:
         return self.config_dict.get("spark_use_eks_default", False)
+
+    def get_sidecar_requirements_config(
+        self,
+    ) -> Dict[str, KubeContainerResourceRequest]:
+        return self.config_dict.get("sidecar_requirements_config", {})
 
     def get_tron_default_pool_override(self) -> str:
         """Get the default pool override variable defined in this host's cluster config file.


### PR DESCRIPTION
Currently the default limits/request of the hacheck, uwsgi containers is huge for a sidecar containers.
making these configuration configurable.
for now I have set the default limit as same as the current limit.