### PR TITLE
Adding support for extensions v1 v1beta1

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -533,6 +533,9 @@ class KubeClient:
         self.core = kube_client.CoreV1Api(self.api_client)
         self.policy = kube_client.PolicyV1beta1Api(self.api_client)
         self.apiextensions = kube_client.ApiextensionsV1Api(self.api_client)
+        self.apiextensions_v1_beta1 = kube_client.ApiextensionsV1beta1Api(
+            self.api_client
+        )
         self.custom = kube_client.CustomObjectsApi(self.api_client)
         self.autoscaling = kube_client.AutoscalingV2beta2Api(self.api_client)
         self.rbac = kube_client.RbacAuthorizationV1Api(self.api_client)
@@ -544,17 +547,6 @@ class KubeClient:
         # to monkey-patch the JSON data with configs the api supports, but the
         # Python client lib may not yet.
         self.jsonify = self.api_client.sanitize_for_serialization
-
-
-class KubeClientV1Beta1(KubeClient):
-    def __init__(
-        self,
-        component: Optional[str] = None,
-        config_file: Optional[str] = None,
-        context: Optional[str] = None,
-    ) -> None:
-        super().__init__(component, config_file, context)
-        self.apiextensions = kube_client.ApiextensionsV1beta1Api(self.api_client)
 
 
 def allowlist_denylist_to_requirements(

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -553,7 +553,7 @@ class KubeClientV1Beta1(KubeClient):
         config_file: Optional[str] = None,
         context: Optional[str] = None,
     ) -> None:
-        super().__init__(self, component, config_file, context)
+        super().__init__(component, config_file, context)
         self.apiextensions = kube_client.ApiextensionsV1Beta1Api(self.api_client)
 
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -554,7 +554,7 @@ class KubeClientV1Beta1(KubeClient):
         context: Optional[str] = None,
     ) -> None:
         super().__init__(component, config_file, context)
-        self.apiextensions = kube_client.ApiextensionsV1Beta1Api(self.api_client)
+        self.apiextensions = kube_client.ApiextensionsV1beta1Api(self.api_client)
 
 
 def allowlist_denylist_to_requirements(

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1134,7 +1134,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 env=self.get_kubernetes_environment(),
                 ports=[V1ContainerPort(container_port=9117)],
                 lifecycle=V1Lifecycle(
-                    pre_stop=V1LifecycleHandler(
+                    pre_stop=V1Handler(
                         _exec=V1ExecAction(
                             command=[
                                 "/bin/sh",

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -533,6 +533,10 @@ class KubeClient:
         self.core = kube_client.CoreV1Api(self.api_client)
         self.policy = kube_client.PolicyV1beta1Api(self.api_client)
         self.apiextensions = kube_client.ApiextensionsV1Api(self.api_client)
+
+        # We need to support apiextensions /v1 and /v1beta1 in order
+        # to make our upgrade to k8s 1.22 smooth, otherwise
+        # updating the CRDs make this script fail
         self.apiextensions_v1_beta1 = kube_client.ApiextensionsV1beta1Api(
             self.api_client
         )

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -47,6 +47,7 @@ from kubernetes.client import CoreV1Event
 from kubernetes.client import models
 from kubernetes.client import V1Affinity
 from kubernetes.client import V1AWSElasticBlockStoreVolumeSource
+from kubernetes.client import V1Beta1CustomResourceDefinition
 from kubernetes.client import V1beta1PodDisruptionBudget
 from kubernetes.client import V1beta1PodDisruptionBudgetSpec
 from kubernetes.client import V1Capabilities
@@ -543,6 +544,17 @@ class KubeClient:
         # to monkey-patch the JSON data with configs the api supports, but the
         # Python client lib may not yet.
         self.jsonify = self.api_client.sanitize_for_serialization
+
+
+class KubeClientV1Beta1(KubeClient):
+    def __init__(
+        self,
+        component: Optional[str] = None,
+        config_file: Optional[str] = None,
+        context: Optional[str] = None,
+    ) -> None:
+        super().__init__(self, component, config_file, context)
+        self.apiextensions = kube_client.ApiextensionsV1Beta1Api(self.api_client)
 
 
 def allowlist_denylist_to_requirements(
@@ -3852,7 +3864,9 @@ def mode_to_int(mode: Optional[Union[str, int]]) -> Optional[int]:
 
 def update_crds(
     kube_client: KubeClient,
-    desired_crds: Collection[V1CustomResourceDefinition],
+    desired_crds: Collection[
+        V1CustomResourceDefinition | V1Beta1CustomResourceDefinition
+    ],
     existing_crds: V1CustomResourceDefinitionList,
 ) -> bool:
     success = True

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -36,6 +36,7 @@ from paasta_tools.kubernetes_tools import create_custom_resource
 from paasta_tools.kubernetes_tools import CustomResourceDefinition
 from paasta_tools.kubernetes_tools import ensure_namespace
 from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.kubernetes_tools import KubeClientV1Beta1
 from paasta_tools.kubernetes_tools import KubeCustomResource
 from paasta_tools.kubernetes_tools import KubeKind
 from paasta_tools.kubernetes_tools import list_custom_resources
@@ -127,6 +128,7 @@ def main() -> None:
         logging.basicConfig(level=logging.INFO)
 
     kube_client: Any = KubeClient()
+    kube_client_v1_beta1: Any = KubeClientV1Beta1()
     if args.dry_run:
         kube_client = StdoutKubeClient(kube_client)
 
@@ -135,6 +137,13 @@ def main() -> None:
     custom_resource_definitions = load_custom_resource_definitions(system_paasta_config)
     setup_kube_succeeded = setup_all_custom_resources(
         kube_client=kube_client,
+        soa_dir=soa_dir,
+        cluster=cluster,
+        custom_resource_definitions=custom_resource_definitions,
+        service=args.service,
+        instance=args.instance,
+    ) or setup_all_custom_resources(
+        kube_client=kube_client_v1_beta1,
         soa_dir=soa_dir,
         cluster=cluster,
         custom_resource_definitions=custom_resource_definitions,

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -36,7 +36,6 @@ from paasta_tools.kubernetes_tools import create_custom_resource
 from paasta_tools.kubernetes_tools import CustomResourceDefinition
 from paasta_tools.kubernetes_tools import ensure_namespace
 from paasta_tools.kubernetes_tools import KubeClient
-from paasta_tools.kubernetes_tools import KubeClientV1Beta1
 from paasta_tools.kubernetes_tools import KubeCustomResource
 from paasta_tools.kubernetes_tools import KubeKind
 from paasta_tools.kubernetes_tools import list_custom_resources
@@ -128,7 +127,6 @@ def main() -> None:
         logging.basicConfig(level=logging.INFO)
 
     kube_client: Any = KubeClient()
-    kube_client_v1_beta1: Any = KubeClientV1Beta1()
     if args.dry_run:
         kube_client = StdoutKubeClient(kube_client)
 
@@ -137,13 +135,6 @@ def main() -> None:
     custom_resource_definitions = load_custom_resource_definitions(system_paasta_config)
     setup_kube_succeeded = setup_all_custom_resources(
         kube_client=kube_client,
-        soa_dir=soa_dir,
-        cluster=cluster,
-        custom_resource_definitions=custom_resource_definitions,
-        service=args.service,
-        instance=args.instance,
-    ) or setup_all_custom_resources(
-        kube_client=kube_client_v1_beta1,
         soa_dir=soa_dir,
         cluster=cluster,
         custom_resource_definitions=custom_resource_definitions,
@@ -161,44 +152,54 @@ def setup_all_custom_resources(
     service: str = None,
     instance: str = None,
 ) -> bool:
-    cluster_crds = {
-        crd.spec.names.kind
-        for crd in kube_client.apiextensions.list_custom_resource_definition(
-            label_selector=paasta_prefixed("service")
-        ).items
-    }
-    log.debug(f"CRDs found: {cluster_crds}")
-    results = []
-    for crd in custom_resource_definitions:
-        if crd.kube_kind.singular not in cluster_crds:
-            # TODO: kube_kind.singular seems to correspond to `crd.names.kind`
-            # and not `crd.names.singular`
-            log.warning(f"CRD {crd.kube_kind.singular} " f"not found in {cluster}")
-            continue
 
-        # by convention, entries where key begins with _ are used as templates
-        # and will be filter out here
-        config_dicts = load_all_configs(
-            cluster=cluster, file_prefix=crd.file_prefix, soa_dir=soa_dir
-        )
+    got_results = False
+    for apiextension in [
+        kube_client.apiextensions,
+        kube_client.apiextensions_v1_beta1,
+    ]:
+        cluster_crds = {
+            crd.spec.names.kind
+            for crd in apiextension.list_custom_resource_definition(
+                label_selector=paasta_prefixed("service")
+            ).items
+        }
+        log.debug(f"CRDs found: {cluster_crds}")
+        results = []
+        for crd in custom_resource_definitions:
+            if crd.kube_kind.singular not in cluster_crds:
+                # TODO: kube_kind.singular seems to correspond to `crd.names.kind`
+                # and not `crd.names.singular`
+                log.warning(f"CRD {crd.kube_kind.singular} " f"not found in {cluster}")
+                continue
 
-        ensure_namespace(
-            kube_client=kube_client, namespace=f"paasta-{crd.kube_kind.plural}"
-        )
-        results.append(
-            setup_custom_resources(
-                kube_client=kube_client,
-                kind=crd.kube_kind,
-                crd=crd,
-                config_dicts=config_dicts,
-                version=crd.version,
-                group=crd.group,
-                cluster=cluster,
-                service=service,
-                instance=instance,
+            # by convention, entries where key begins with _ are used as templates
+            # and will be filter out here
+            config_dicts = load_all_configs(
+                cluster=cluster, file_prefix=crd.file_prefix, soa_dir=soa_dir
             )
-        )
-    return any(results) if results else True
+
+            ensure_namespace(
+                kube_client=kube_client, namespace=f"paasta-{crd.kube_kind.plural}"
+            )
+            results.append(
+                setup_custom_resources(
+                    kube_client=kube_client,
+                    kind=crd.kube_kind,
+                    crd=crd,
+                    config_dicts=config_dicts,
+                    version=crd.version,
+                    group=crd.group,
+                    cluster=cluster,
+                    service=service,
+                    instance=instance,
+                )
+            )
+        if results:
+            got_results = True
+            if any(results):
+                return True
+    return not got_results
 
 
 def setup_custom_resources(

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -203,6 +203,9 @@ def setup_all_custom_resources(
             got_results = True
             if any(results):
                 return True
+    # we want to return True if we never called `setup_custom_resources` 
+    # (i.e., we noop'd) or if any call to `setup_custom_resources` 
+    # succeed (handled above) - otherwise, we want to return False 
     return not got_results
 
 

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -203,9 +203,9 @@ def setup_all_custom_resources(
             got_results = True
             if any(results):
                 return True
-    # we want to return True if we never called `setup_custom_resources` 
-    # (i.e., we noop'd) or if any call to `setup_custom_resources` 
-    # succeed (handled above) - otherwise, we want to return False 
+    # we want to return True if we never called `setup_custom_resources`
+    # (i.e., we noop'd) or if any call to `setup_custom_resources`
+    # succeed (handled above) - otherwise, we want to return False
     return not got_results
 
 

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -154,6 +154,10 @@ def setup_all_custom_resources(
 ) -> bool:
 
     got_results = False
+    # We support two versions due to our upgrade to 1.22
+    # this functions runs succefully when any of the two apiextensions
+    # succeed to update the CRDs as the cluster could be in any version
+    # we need to try both possibilities
     for apiextension in [
         kube_client.apiextensions,
         kube_client.apiextensions_v1_beta1,

--- a/paasta_tools/setup_kubernetes_crd.py
+++ b/paasta_tools/setup_kubernetes_crd.py
@@ -31,7 +31,6 @@ from kubernetes.client import V1beta1CustomResourceDefinition
 from kubernetes.client import V1CustomResourceDefinition
 
 from paasta_tools.kubernetes_tools import KubeClient
-from paasta_tools.kubernetes_tools import KubeClientV1Beta1
 from paasta_tools.kubernetes_tools import paasta_prefixed
 from paasta_tools.kubernetes_tools import update_crds
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -86,15 +85,9 @@ def main() -> None:
         cluster = system_paasta_config.get_cluster()
 
     kube_client = KubeClient()
-    kube_client_v1_beta1 = KubeClientV1Beta1()
 
     success = setup_kube_crd(
         kube_client=kube_client,
-        cluster=cluster,
-        services=args.service_list,
-        soa_dir=soa_dir,
-    ) or setup_kube_crd(
-        kube_client=kube_client_v1_beta1,
         cluster=cluster,
         services=args.service_list,
         soa_dir=soa_dir,
@@ -108,45 +101,43 @@ def setup_kube_crd(
     services: Sequence[str],
     soa_dir: str = DEFAULT_SOA_DIR,
 ) -> bool:
-    existing_crds = kube_client.apiextensions.list_custom_resource_definition(
-        label_selector=paasta_prefixed("service")
-    )
-
-    desired_crds = []
-    for service in services:
-        crd_config = service_configuration_lib.read_extra_service_information(
-            service, f"crd-{cluster}", soa_dir=soa_dir
+    for apiextension, crd_class in [
+        (kube_client.apiextensions, V1CustomResourceDefinition),
+        (kube_client.apiextensions_v1_beta1, V1beta1CustomResourceDefinition),
+    ]:
+        existing_crds = apiextension.list_custom_resource_definition(
+            label_selector=paasta_prefixed("service")
         )
-        if not crd_config:
-            log.info("nothing to deploy")
-            continue
 
-        metadata = crd_config.get("metadata", {})
-        if "labels" not in metadata:
-            metadata["labels"] = {}
-        metadata["labels"]["yelp.com/paasta_service"] = service
-        metadata["labels"][paasta_prefixed("service")] = service
-        if isinstance(kube_client, KubeClientV1Beta1):
-            desired_crd = V1beta1CustomResourceDefinition(
+        desired_crds = []
+        for service in services:
+            crd_config = service_configuration_lib.read_extra_service_information(
+                service, f"crd-{cluster}", soa_dir=soa_dir
+            )
+            if not crd_config:
+                log.info("nothing to deploy")
+                continue
+
+            metadata = crd_config.get("metadata", {})
+            if "labels" not in metadata:
+                metadata["labels"] = {}
+            metadata["labels"]["yelp.com/paasta_service"] = service
+            metadata["labels"][paasta_prefixed("service")] = service
+            desired_crd = crd_class(
                 api_version=crd_config.get("apiVersion"),
                 kind=crd_config.get("kind"),
                 metadata=metadata,
                 spec=crd_config.get("spec"),
             )
-        else:
-            desired_crd = V1CustomResourceDefinition(
-                api_version=crd_config.get("apiVersion"),
-                kind=crd_config.get("kind"),
-                metadata=metadata,
-                spec=crd_config.get("spec"),
-            )
-        desired_crds.append(desired_crd)
+            desired_crds.append(desired_crd)
 
-    return update_crds(
-        kube_client=kube_client,
-        desired_crds=desired_crds,
-        existing_crds=existing_crds,
-    )
+        if update_crds(
+            kube_client=kube_client,
+            desired_crds=desired_crds,
+            existing_crds=existing_crds,
+        ):
+            return True
+    return False
 
 
 if __name__ == "__main__":

--- a/paasta_tools/setup_kubernetes_crd.py
+++ b/paasta_tools/setup_kubernetes_crd.py
@@ -27,7 +27,7 @@ import sys
 from typing import Sequence
 
 import service_configuration_lib
-from kubernetes.client import V1Beta1CustomResourceDefinition
+from kubernetes.client import V1beta1CustomResourceDefinition
 from kubernetes.client import V1CustomResourceDefinition
 
 from paasta_tools.kubernetes_tools import KubeClient
@@ -127,7 +127,7 @@ def setup_kube_crd(
         metadata["labels"]["yelp.com/paasta_service"] = service
         metadata["labels"][paasta_prefixed("service")] = service
         if isinstance(kube_client, KubeClientV1Beta1):
-            desired_crd = V1Beta1CustomResourceDefinition(
+            desired_crd = V1beta1CustomResourceDefinition(
                 api_version=crd_config.get("apiVersion"),
                 kind=crd_config.get("kind"),
                 metadata=metadata,

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -24,7 +24,7 @@ ipaddress >= 1.0.22
 isodate >= 0.5.0
 jsonschema[format]
 kazoo >= 2.0.0
-kubernetes >= 21.7.0
+kubernetes >= 18.20.0
 ldap3
 manhole
 marathon >= 0.12.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -24,7 +24,7 @@ ipaddress >= 1.0.22
 isodate >= 0.5.0
 jsonschema[format]
 kazoo >= 2.0.0
-kubernetes >= 18.20.0
+kubernetes >= 21.7.0
 ldap3
 manhole
 marathon >= 0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ jmespath==0.9.3
 jsonref==0.1
 jsonschema==2.5.1
 kazoo==2.8.0
-kubernetes==24.2.0
+kubernetes==21.7.0
 ldap3==2.6
 manhole==1.5.0
 marathon==0.12.0

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -24,12 +24,12 @@ from kubernetes.client import V1DeploymentStrategy
 from kubernetes.client import V1EnvVar
 from kubernetes.client import V1EnvVarSource
 from kubernetes.client import V1ExecAction
+from kubernetes.client import V1Handler
 from kubernetes.client import V1HostPathVolumeSource
 from kubernetes.client import V1HTTPGetAction
 from kubernetes.client import V1KeyToPath
 from kubernetes.client import V1LabelSelector
 from kubernetes.client import V1Lifecycle
-from kubernetes.client import V1LifecycleHandler
 from kubernetes.client import V1NodeAffinity
 from kubernetes.client import V1NodeSelector
 from kubernetes.client import V1NodeSelectorRequirement
@@ -559,7 +559,7 @@ class TestKubernetesDeploymentConfig:
                     ],
                     image="some-docker-image",
                     lifecycle=V1Lifecycle(
-                        pre_stop=V1LifecycleHandler(
+                        pre_stop=V1Handler(
                             _exec=V1ExecAction(
                                 command=[
                                     "/bin/sh",
@@ -605,7 +605,7 @@ class TestKubernetesDeploymentConfig:
                     ],
                     image="some-docker-image",
                     lifecycle=V1Lifecycle(
-                        pre_stop=V1LifecycleHandler(
+                        pre_stop=V1Handler(
                             _exec=V1ExecAction(
                                 command=[
                                     "/bin/sh",
@@ -1049,7 +1049,7 @@ class TestKubernetesDeploymentConfig:
                     resources=mock_get_resource_requirements.return_value,
                     image=mock_get_docker_url.return_value,
                     lifecycle=V1Lifecycle(
-                        pre_stop=V1LifecycleHandler(
+                        pre_stop=V1Handler(
                             _exec=V1ExecAction(command=["/bin/sh", "-c", "sleep 30"])
                         )
                     ),
@@ -2031,7 +2031,7 @@ class TestKubernetesDeploymentConfig:
             self.deployment.config_dict["lifecycle"] = {
                 "pre_stop_command": termination_action
             }
-        handler = V1LifecycleHandler(_exec=V1ExecAction(command=expected))
+        handler = V1Handler(_exec=V1ExecAction(command=expected))
         assert self.deployment.get_kubernetes_container_termination_action() == handler
 
     @pytest.mark.parametrize(
@@ -4124,7 +4124,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "configd6531f39"
+            == "config5abf6b07"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 
@@ -4170,7 +4170,7 @@ def test_warning_big_bounce_routable_pod():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "configa5abd828"
+            == "config8ee1bd70"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every smartstack-registered service to bounce!"
 
 

--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -60,8 +60,12 @@ def test_setup_all_custom_resources():
         cassandra_crd.spec.names = mock.Mock(
             plural="cassandraclusters", kind="CassandraCluster"
         )
+        mock_client.apiextensions_v1_beta1.list_custom_resource_definition.return_value = mock.Mock(
+            items=[flink_crd, cassandra_crd]
+        )
+
         mock_client.apiextensions.list_custom_resource_definition.return_value = (
-            mock.Mock(items=[flink_crd, cassandra_crd])
+            mock.Mock(items=[])
         )
 
         custom_resource_definitions = [


### PR DESCRIPTION
As part of our upgrade to k8s 1.22 we need to support both api extensions for v1 and v1beta1 on our  `setup_kubernetes_crd` scripts in order to make a smooth transition to 1.22

[PAASTA-17925](https://jira.yelpcorp.com/browse/PAASTA-17925)