### PR TITLE
TRON-1968: Catch exceptions when updaitng MASTER config

### DIFF
--- a/paasta_tools/setup_tron_namespace.py
+++ b/paasta_tools/setup_tron_namespace.py
@@ -105,12 +105,16 @@ def main():
         log.info(f"{master_config}")
         updated.append(MASTER_NAMESPACE)
     else:
-        if client.update_namespace(MASTER_NAMESPACE, master_config):
-            updated.append(MASTER_NAMESPACE)
-            log.debug(f"Updated {MASTER_NAMESPACE}")
-        else:
-            skipped.append(MASTER_NAMESPACE)
-            log.debug(f"Skipped {MASTER_NAMESPACE}")
+        try:
+            if client.update_namespace(MASTER_NAMESPACE, master_config):
+                updated.append(MASTER_NAMESPACE)
+                log.debug(f"Updated {MASTER_NAMESPACE}")
+            else:
+                skipped.append(MASTER_NAMESPACE)
+                log.debug(f"Skipped {MASTER_NAMESPACE}")
+        except Exception:
+            failed.append(MASTER_NAMESPACE)
+            log.exception(f"Error while updating {MASTER_NAMESPACE}:")
 
     k8s_enabled_for_cluster = (
         yaml.safe_load(master_config).get("k8s_options", {}).get("enabled", False)


### PR DESCRIPTION
Currently `setup_tron_namespace` can fail prematurely if there is an error updating the `MASTER_NAMESPACE`.

One situation in which we can throw an error when updating this namespace is when a job namespace has a future-scheduled run using a node which we are trying to remove in the MASTER config -- we find no issues with the new MASTER config on its own, so we attempt to update the configuration. However, upon trying to apply the new configuration to the tron [MasterControlProgram](https://github.com/Yelp/Tron/blob/master/tron/mcp.py#L47-L54), we will throw the error since the job configuration (whose namespace has not been modified) is no longer valid. 

While we were properly tracking exceptions when updating service namespaces, we were not doing so for the MASTER namespace, which meant we never got around to updating any services in this state. 

With this change, if someone removed a node from MASTER config + a job that used the removed node, things should reconcile after 2 runs, rather than just breaking all deployments.

Because we're appending `MASTER_NAMESPACE` to the `failed` list, this will still throw an error & be tracked as a failure correctly as well. 

Confirmed w/ a manual reproduction of the error in infrastage, while 2 runs of the new setup_tron_namespace properly updated both service + master namespaces. 