### PR TITLE
COMPINFRA-2938: Support security-check in parallel steps

### DIFF
--- a/paasta_tools/cli/cmds/check.py
+++ b/paasta_tools/cli/cmds/check.py
@@ -77,7 +77,13 @@ def deploy_check(service_path):
 
 def deploy_has_security_check(service, soa_dir):
     pipeline = get_pipeline_config(service=service, soa_dir=soa_dir)
-    steps = [step["step"] for step in pipeline]
+    steps = [step["step"] for step in pipeline if not step.get("parallel")]
+    steps += [
+        substep["step"]
+        for step in pipeline
+        if step.get("parallel")
+        for substep in step.get("parallel")
+    ]
     if "security-check" in steps:
         print(PaastaCheckMessages.DEPLOY_SECURITY_FOUND)
         return True

--- a/tests/cli/test_cmds_check.py
+++ b/tests/cli/test_cmds_check.py
@@ -417,6 +417,24 @@ def test_deploy_has_security_check_true(mock_pipeline_config, capfd):
     assert actual is True
 
 
+@patch("paasta_tools.cli.cmds.check.get_pipeline_config", autospec=True)
+def test_deploy_has_parallel_security_check_true(mock_pipeline_config, capfd):
+    mock_pipeline_config.return_value = [
+        {
+            "step": "initial",
+            "parallel": [
+                {"step": "test"},
+                {"step": "security-check"},
+            ],
+        },
+        {"step": "push-to-registry"},
+        {"step": "hab.canary", "trigger_next_step_manually": True},
+        {"step": "hab.main"},
+    ]
+    actual = deploy_has_security_check(service="fake_service", soa_dir="/fake/path")
+    assert actual is True
+
+
 @patch("paasta_tools.cli.cmds.check.get_instance_config", autospec=True)
 @patch("paasta_tools.cli.cmds.check.list_clusters", autospec=True)
 @patch("paasta_tools.cli.cmds.check.get_service_instance_list", autospec=True)


### PR DESCRIPTION
Since we added `parallel` step support to `deploy.yaml`, `paasta check` has been complaining about pipelines that run the `security-check` in parallel with anything else (which is actually what we provide as a default nowadays!).

This updates `paasta check` to now also look at parallel steps to verify we have a security-check step, along with a test to verify. 