### PR TITLE
SEC-18177: Enable secret_volumes in adhoc jobs

### DIFF
--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -91,6 +91,51 @@
                         }
                     }
                 },
+                "secret_volumes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "container_path": {
+                                "type": "string"
+                            },
+                            "secret_name": {
+                                "type": "string"
+                            },
+                            "default_mode": {
+                                "type": "string"
+                            },
+                            "items": {
+                                "type": "array",
+                                "maxItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "key": {
+                                            "type": "string"
+                                        },
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "mode": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "key",
+                                        "path"
+                                    ]
+                                },
+                                "uniqueItems": true
+                            }
+                        },
+                        "required": [
+                            "container_path",
+                            "secret_name"
+                        ]
+                    },
+                    "uniqueItems": true
+                },
                 "extra_volumes": {
                     "type": "array",
                     "items": {

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -415,6 +415,7 @@ class TronActionConfig(InstanceConfig):
     def get_action_name(self):
         return self.action
 
+    # mypy does not like the SecretVolume -> TronSecretVolume conversion, because TypedDict inheritence is broken. Until this is fixed, let's ignore this issue.
     def get_secret_volumes(self) -> List[TronSecretVolume]:  # type: ignore
         """Adds the secret_volume_name to the objet so tron/task_processing can load it downstream without replicating code."""
         secret_volumes = super().get_secret_volumes()
@@ -425,7 +426,7 @@ class TronActionConfig(InstanceConfig):
                     secret_volume["secret_name"]
                 )
             )
-            tron_secret_volume.update(secret_volume)
+            tron_secret_volume.update(secret_volume)  # type: ignore
             tron_secret_volumes.append(tron_secret_volume)
         return tron_secret_volumes
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -424,9 +424,14 @@ class TronActionConfig(InstanceConfig):
             tron_secret_volume = TronSecretVolume(
                 secret_volume_name=self.get_secret_volume_name(
                     secret_volume["secret_name"]
-                )
+                ),
+                secret_name=secret_volume["secret_name"],
+                container_path=secret_volume["container_path"],
+                items=secret_volume.get("items", []),
             )
-            tron_secret_volume.update(secret_volume)  # type: ignore
+            if "default_mode" in secret_volume:
+                tron_secret_volume["default_mode"] = secret_volume["default_mode"]
+
             tron_secret_volumes.append(tron_secret_volume)
         return tron_secret_volumes
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -429,6 +429,7 @@ class TronActionConfig(InstanceConfig):
                 container_path=secret_volume["container_path"],
                 items=secret_volume.get("items", []),
             )
+            # we have a different place where the default can come from (tron) and we don't want to insert the wrong default here
             if "default_mode" in secret_volume:
                 tron_secret_volume["default_mode"] = secret_volume["default_mode"]
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -418,18 +418,16 @@ class TronActionConfig(InstanceConfig):
     def get_secret_volumes(self) -> List[TronSecretVolume]:  # type: ignore
         """Adds the secret_volume_name to the objet so tron/task_processing can load it downstream without replicating code."""
         secret_volumes = super().get_secret_volumes()
-        return [
-            TronSecretVolume(
+        tron_secret_volumes = []
+        for secret_volume in secret_volumes:
+            tron_secret_volume = TronSecretVolume(
                 secret_volume_name=self.get_secret_volume_name(
                     secret_volume["secret_name"]
-                ),
-                secret_name=secret_volume["secret_name"],
-                container_path=secret_volume["container_path"],
-                default_mode=secret_volume["default_mode"],
-                items=secret_volume["items"],
+                )
             )
-            for secret_volume in secret_volumes
-        ]
+            tron_secret_volume.update(secret_volume)
+            tron_secret_volumes.append(tron_secret_volume)
+        return tron_secret_volumes
 
     def get_namespace(self) -> str:
         """Get namespace from config, default to 'paasta'"""


### PR DESCRIPTION
All this is needed for this to work in paasta local-run is to add it to adhoc_schema.json, conveniant!
Tested locally here: https://yelp.slack.com/archives/C048HCBDD0U/p1690896906993479

I also included a patch about a KeyError because it was trying to grab a non-existent optional key.