### PR TITLE
Add kubernetes upper-bound for things using paasta as a library

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -24,7 +24,12 @@ ipaddress >= 1.0.22
 isodate >= 0.5.0
 jsonschema[format]
 kazoo >= 2.0.0
-kubernetes >= 18.20.0
+# the upper-bound here is mainly for things that use paasta-tools as a library and don't benefit
+# from our pinned-dependencies. The upper-bound should generally be the latest kubernetes version
+# that we can use across our different clusters (e.g, if X.0.0 removes an API version that we use
+# in any cluster, this upper-bound should be < X.0.0)
+# we should probably also be better at setting a correct lower-bound, but that's less likely to cause issues.
+kubernetes >= 18.20.0, < 22.0.0
 ldap3
 manhole
 marathon >= 0.12.0


### PR DESCRIPTION
This most often pops up as folks unable to use paasta validate when they have the soaconfigs venv activated as pip will grab the latest kubernetes version available - which is not guaranteed to work with our code in paasta.