### PR TITLE
Fix `gunicorn_exporter_sidecar_image_url`

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2696,7 +2696,7 @@ class SystemPaastaConfig:
         """Get the docker image URL for the gunicorn_exporter sidecar container"""
         return self.config_dict.get(
             "gunicorn_exporter_sidecar_image_url",
-            "docker-paasta.yelpcorp.com/gunicorn_exporter-k8s-sidecar:v0.24.0-yelp0",
+            "docker-paasta.yelpcorp.com:443/gunicorn_exporter-k8s-sidecar:v0.24.0-yelp0",
         )
 
     def get_mark_for_deployment_max_polling_threads(self) -> int:


### PR DESCRIPTION
Missing port number here. This needs to match the tag exactly: https://github.com/Yelp/paasta/blob/master/yelp_package/dockerfiles/gunicorn_exporter-sidecar/Makefile#L5