### PR TITLE
Added --docker-shm-size for spark-run

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -174,7 +174,7 @@ def add_subparser(subparsers):
         "--docker-memory-limit",
         help=(
             "Set docker memory limit. Should be greater than driver memory. Defaults to 2x spark.driver.memory. Example: 2g, 500m, Max: 64g"
-            "Note: If memory limit provided is greater than associated with the batch instance, it will default to max memory of the box."
+            " Note: If memory limit provided is greater than associated with the batch instance, it will default to max memory of the box."
         ),
         default=None,
     )
@@ -182,17 +182,27 @@ def add_subparser(subparsers):
         "--docker-cpu-limit",
         help=(
             "Set docker cpus limit. Should be greater than driver cores. Defaults to 1x spark.driver.cores."
-            "Note: The job will fail if the limit provided is greater than number of cores present on batch box (8 for production batch boxes)."
+            " Note: The job will fail if the limit provided is greater than number of cores present on batch box (8 for production batch boxes)."
         ),
         default=None,
     )
+
     list_parser.add_argument(
         "--docker-shm-size",
         help=(
-            "Set docker shared memory size limit. This is the same as setting docker run --shm-size and is mounted to /dev/shm in the container."
-            "Anything written to the shared memory mount point counts towards the docker memory limit. Therefore, this should be less than --docker-memory-limit"
-            f"Defaults to {DEFAULT_DOCKER_SHM_SIZE}. Example: 8g, 256m"
-            "Note: this option also adds the --ulimit memlock=-1 to the docker run command since this is recommended for Tensorflow applications that use NCCL."
+            "Set docker shared memory size limit for the driver's container. This is the same as setting docker run --shm-size and the shared"
+            " memory is mounted to /dev/shm in the container. Anything written to the shared memory mount point counts towards the docker memory"
+            " limit for the driver's container. Therefore, this should be less than --docker-memory-limit."
+            f" Defaults to {DEFAULT_DOCKER_SHM_SIZE}. Example: 8g, 256m"
+            " Note: this option is mainly useful when training TensorFlow models in the driver, with multiple GPUs using NCCL. The shared memory"
+            f" space is used to sync gradient updates between GPUs during training. The default value of {DEFAULT_DOCKER_SHM_SIZE} is typically not large enough for"
+            " this inter-gpu communication to run efficiently. We recommend a starting value of 8g to ensure that the entire set of model parameters"
+            " can fit in the shared memory. This can be less if you are training a smaller model (<1g parameters) or more if you are using a larger model (>2.5g parameters)"
+            " If you are observing low, average GPU utilization during epoch training (<65-70 percent) you can also try increasing this value; you may be"
+            " resource constrained when GPUs sync training weights between mini-batches (there are other potential bottlenecks that could cause this as well)."
+            " A tool such as nvidia-smi can be use to check GPU utilization."
+            " This option also adds the --ulimit memlock=-1 to the docker run command since this is recommended for TensorFlow applications that use NCCL."
+            " Please refer to docker run documentation for more details on --shm-size and --ulimit memlock=-1."
         ),
         default=None,
     )

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -189,8 +189,10 @@ def add_subparser(subparsers):
     list_parser.add_argument(
         "--docker-shm-size",
         help=(
-            f"Set docker shared memory size limit. Shared memory usage doesn't count towards the memory limit. Defaults to {DEFAULT_DOCKER_SHM_SIZE}. Example: 8g, 256m"
-            "Note: Shared memory and memory limit should not exceed the total memory in the pod."
+            "Set docker shared memory size limit. This is the same as setting docker run --shm-size and is mounted to /dev/shm in the container."
+            "Anything written to the shared memory mount point counts towards the docker memory limit. Therefore, this should be less than --docker-memory-limit"
+            f"Defaults to {DEFAULT_DOCKER_SHM_SIZE}. Example: 8g, 256m"
+            "Note: this option also adds the --ulimit memlock=-1 to the docker run command since this is recommended for Tensorflow applications that use NCCL."
         ),
         default=None,
     )
@@ -525,7 +527,7 @@ def get_docker_run_cmd(
     )
     cmd = ["paasta_docker_wrapper", "run"]
     cmd.append(f"--memory={docker_memory_limit}")
-    cmd.append(f"--shm-size={docker_shm_size}")
+    cmd.append(f"--shm-size={docker_shm_size} --ulimit memlock=-1")
     cmd.append(f"--cpus={docker_cpu_limit}")
     cmd.append("--rm")
     cmd.append("--net=host")

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -537,7 +537,10 @@ def get_docker_run_cmd(
     )
     cmd = ["paasta_docker_wrapper", "run"]
     cmd.append(f"--memory={docker_memory_limit}")
-    cmd.append(f"--shm-size={docker_shm_size} --ulimit memlock=-1")
+    if docker_shm_size is not None:
+        cmd.append(f"--shm-size={docker_shm_size}")
+        cmd.append("--ulimit")
+        cmd.append("memlock=-1")
     cmd.append(f"--cpus={docker_cpu_limit}")
     cmd.append("--rm")
     cmd.append("--net=host")

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -25,6 +25,7 @@ from paasta_tools.cli.cmds.spark_run import CLUSTER_MANAGER_K8S
 from paasta_tools.cli.cmds.spark_run import CLUSTER_MANAGER_MESOS
 from paasta_tools.cli.cmds.spark_run import configure_and_run_docker_container
 from paasta_tools.cli.cmds.spark_run import decide_final_eks_toggle_state
+from paasta_tools.cli.cmds.spark_run import DEFAULT_DOCKER_SHM_SIZE
 from paasta_tools.cli.cmds.spark_run import DEFAULT_DRIVER_CORES_BY_SPARK
 from paasta_tools.cli.cmds.spark_run import DEFAULT_DRIVER_MEMORY_BY_SPARK
 from paasta_tools.cli.cmds.spark_run import get_docker_run_cmd
@@ -52,6 +53,7 @@ def test_get_docker_run_cmd(mock_getegid, mock_geteuid):
     docker_cmd = "pyspark"
     nvidia = False
     docker_memory_limit = "2g"
+    docker_shm_size = "1g"
     docker_cpu_limit = "2"
 
     actual = get_docker_run_cmd(
@@ -62,10 +64,11 @@ def test_get_docker_run_cmd(mock_getegid, mock_geteuid):
         docker_cmd,
         nvidia,
         docker_memory_limit,
+        docker_shm_size,
         docker_cpu_limit,
     )
 
-    assert actual[7:] == [
+    assert actual[8:] == [
         "--user=1234:100",
         "--name=fake_name",
         "--env",
@@ -473,6 +476,7 @@ def test_run_docker_container(
             dry_run=dry_run,
             nvidia=nvidia,
             docker_memory_limit=DEFAULT_DRIVER_MEMORY_BY_SPARK,
+            docker_shm_size=DEFAULT_DOCKER_SHM_SIZE,
             docker_cpu_limit=DEFAULT_DRIVER_CORES_BY_SPARK,
         )
         mock_get_docker_run_cmd.assert_called_once_with(
@@ -483,6 +487,7 @@ def test_run_docker_container(
             docker_cmd=docker_cmd,
             nvidia=nvidia,
             docker_memory_limit=DEFAULT_DRIVER_MEMORY_BY_SPARK,
+            docker_shm_size=DEFAULT_DOCKER_SHM_SIZE,
             docker_cpu_limit=DEFAULT_DRIVER_CORES_BY_SPARK,
         )
         if dry_run:
@@ -605,6 +610,7 @@ class TestConfigureAndRunDockerContainer:
         args.cluster_manager = cluster_manager
         args.docker_cpu_limit = False
         args.docker_memory_limit = False
+        args.docker_shm_size = False
         args.use_eks_override = False
         with mock.patch.object(
             self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
@@ -642,6 +648,7 @@ class TestConfigureAndRunDockerContainer:
             dry_run=True,
             nvidia=False,
             docker_memory_limit="2g",
+            docker_shm_size=DEFAULT_DOCKER_SHM_SIZE,
             docker_cpu_limit="1",
         )
 
@@ -717,6 +724,7 @@ class TestConfigureAndRunDockerContainer:
         args.cluster_manager = cluster_manager
         args.docker_cpu_limit = 3
         args.docker_memory_limit = "4g"
+        args.docker_shm_size = "1g"
         args.use_eks_override = False
         with mock.patch.object(
             self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
@@ -754,6 +762,7 @@ class TestConfigureAndRunDockerContainer:
             dry_run=True,
             nvidia=False,
             docker_memory_limit="4g",
+            docker_shm_size="1g",
             docker_cpu_limit=3,
         )
 
@@ -829,6 +838,7 @@ class TestConfigureAndRunDockerContainer:
         args.cluster_manager = cluster_manager
         args.docker_cpu_limit = False
         args.docker_memory_limit = False
+        args.docker_shm_size = False
         args.use_eks_override = False
         with mock.patch.object(
             self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
@@ -866,6 +876,7 @@ class TestConfigureAndRunDockerContainer:
             dry_run=True,
             nvidia=False,
             docker_memory_limit="2g",
+            docker_shm_size=DEFAULT_DOCKER_SHM_SIZE,
             docker_cpu_limit="2",
         )
 

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -67,8 +67,7 @@ def test_get_docker_run_cmd(mock_getegid, mock_geteuid):
         docker_shm_size,
         docker_cpu_limit,
     )
-
-    assert actual[8:] == [
+    assert actual[-12:] == [
         "--user=1234:100",
         "--name=fake_name",
         "--env",


### PR DESCRIPTION
Added a pass through argument for docker run --shm-size to the spark-run command. Allows the user to set a value for `docker run --shm-size` via `paasta spark-run` using the `--docker-shm-size` option.