### PR TITLE
Creating an instance type class for EKS - PAASTA-17991

### DIFF
--- a/paasta_tools/eks_tools.py
+++ b/paasta_tools/eks_tools.py
@@ -1,0 +1,119 @@
+from typing import Optional
+
+import service_configuration_lib
+
+from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
+from paasta_tools.kubernetes_tools import KubernetesDeploymentConfigDict
+from paasta_tools.utils import BranchDictV2
+from paasta_tools.utils import deep_merge_dictionaries
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import load_service_instance_config
+from paasta_tools.utils import load_v2_deployments_json
+from paasta_tools.utils import time_cache
+
+
+class EksDeploymentConfig(KubernetesDeploymentConfig):
+    config_dict: KubernetesDeploymentConfigDict
+
+    config_filename_prefix = "eks"
+
+    def __init__(
+        self,
+        service: str,
+        cluster: str,
+        instance: str,
+        config_dict: KubernetesDeploymentConfigDict,
+        branch_dict: Optional[BranchDictV2],
+        soa_dir: str = DEFAULT_SOA_DIR,
+    ) -> None:
+        super().__init__(
+            cluster=cluster,
+            instance=instance,
+            service=service,
+            config_dict=config_dict,
+            branch_dict=branch_dict,
+            soa_dir=soa_dir,
+        )
+
+
+def load_eks_service_config_no_cache(
+    service: str,
+    instance: str,
+    cluster: str,
+    load_deployments: bool = True,
+    soa_dir: str = DEFAULT_SOA_DIR,
+) -> "EksDeploymentConfig":
+    """Read a service instance's configuration for EKS.
+
+    If a branch isn't specified for a config, the 'branch' key defaults to
+    paasta-${cluster}.${instance}.
+
+    :param name: The service name
+    :param instance: The instance of the service to retrieve
+    :param cluster: The cluster to read the configuration for
+    :param load_deployments: A boolean indicating if the corresponding deployments.json for this service
+                             should also be loaded
+    :param soa_dir: The SOA configuration directory to read from
+    :returns: A dictionary of whatever was in the config for the service instance"""
+    general_config = service_configuration_lib.read_service_configuration(
+        service, soa_dir=soa_dir
+    )
+    instance_config = load_service_instance_config(
+        service, instance, "eks", cluster, soa_dir=soa_dir
+    )
+    general_config = deep_merge_dictionaries(
+        overrides=instance_config, defaults=general_config
+    )
+
+    branch_dict: Optional[BranchDictV2] = None
+    if load_deployments:
+        deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
+        temp_instance_config = EksDeploymentConfig(
+            service=service,
+            cluster=cluster,
+            instance=instance,
+            config_dict=general_config,
+            branch_dict=None,
+            soa_dir=soa_dir,
+        )
+        branch = temp_instance_config.get_branch()
+        deploy_group = temp_instance_config.get_deploy_group()
+        branch_dict = deployments_json.get_branch_dict(service, branch, deploy_group)
+
+    return EksDeploymentConfig(
+        service=service,
+        cluster=cluster,
+        instance=instance,
+        config_dict=general_config,
+        branch_dict=branch_dict,
+        soa_dir=soa_dir,
+    )
+
+
+@time_cache(ttl=5)
+def load_eks_service_config(
+    service: str,
+    instance: str,
+    cluster: str,
+    load_deployments: bool = True,
+    soa_dir: str = DEFAULT_SOA_DIR,
+) -> "EksDeploymentConfig":
+    """Read a service instance's configuration for EKS.
+
+    If a branch isn't specified for a config, the 'branch' key defaults to
+    paasta-${cluster}.${instance}.
+
+    :param name: The service name
+    :param instance: The instance of the service to retrieve
+    :param cluster: The cluster to read the configuration for
+    :param load_deployments: A boolean indicating if the corresponding deployments.json for this service
+                             should also be loaded
+    :param soa_dir: The SOA configuration directory to read from
+    :returns: A dictionary of whatever was in the config for the service instance"""
+    return load_eks_service_config_no_cache(
+        service=service,
+        instance=instance,
+        cluster=cluster,
+        load_deployments=load_deployments,
+        soa_dir=soa_dir,
+    )

--- a/tests/test_eks_tools.py
+++ b/tests/test_eks_tools.py
@@ -1,0 +1,79 @@
+import mock
+
+from paasta_tools.eks_tools import load_eks_service_config
+from paasta_tools.eks_tools import load_eks_service_config_no_cache
+
+
+def test_load_eks_service_config_no_cache():
+    with mock.patch(
+        "service_configuration_lib.read_service_configuration", autospec=True
+    ) as mock_read_service_configuration, mock.patch(
+        "paasta_tools.eks_tools.load_service_instance_config", autospec=True
+    ) as mock_load_service_instance_config, mock.patch(
+        "paasta_tools.eks_tools.load_v2_deployments_json", autospec=True
+    ) as mock_load_v2_deployments_json, mock.patch(
+        "paasta_tools.eks_tools.EksDeploymentConfig", autospec=True
+    ) as mock_eks_deploy_config:
+        mock_config = {"freq": "108.9"}
+        mock_load_service_instance_config.return_value = mock_config
+        mock_read_service_configuration.return_value = {}
+        ret = load_eks_service_config_no_cache(
+            service="kurupt",
+            instance="fm",
+            cluster="brentford",
+            load_deployments=False,
+            soa_dir="/nail/blah",
+        )
+        mock_load_service_instance_config.assert_called_with(
+            service="kurupt",
+            instance="fm",
+            instance_type="eks",
+            cluster="brentford",
+            soa_dir="/nail/blah",
+        )
+        mock_eks_deploy_config.assert_called_with(
+            service="kurupt",
+            instance="fm",
+            cluster="brentford",
+            config_dict={"freq": "108.9"},
+            branch_dict=None,
+            soa_dir="/nail/blah",
+        )
+        assert not mock_load_v2_deployments_json.called
+        assert ret == mock_eks_deploy_config.return_value
+
+        mock_eks_deploy_config.reset_mock()
+        ret = load_eks_service_config_no_cache(
+            service="kurupt",
+            instance="fm",
+            cluster="brentford",
+            load_deployments=True,
+            soa_dir="/nail/blah",
+        )
+        mock_load_v2_deployments_json.assert_called_with(
+            service="kurupt", soa_dir="/nail/blah"
+        )
+        mock_eks_deploy_config.assert_called_with(
+            service="kurupt",
+            instance="fm",
+            cluster="brentford",
+            config_dict={"freq": "108.9"},
+            branch_dict=mock_load_v2_deployments_json.return_value.get_branch_dict(),
+            soa_dir="/nail/blah",
+        )
+        assert ret == mock_eks_deploy_config.return_value
+
+
+def test_load_eks_service_config():
+    with mock.patch(
+        "paasta_tools.eks_tools.load_eks_service_config_no_cache",
+        autospec=True,
+    ) as mock_load_kubernetes_service_config_no_cache:
+        ret = load_eks_service_config(
+            service="kurupt",
+            instance="fm",
+            cluster="brentford",
+            load_deployments=True,
+            soa_dir="/nail/blah",
+        )
+        assert ret == mock_load_kubernetes_service_config_no_cache.return_value


### PR DESCRIPTION
I'm reusing the same config Dict ``KubernetesDeploymentConfigDict`` for ``EksDeploymentConfig`` as we want this class to be similar to ``KubernetesDeploymentConfig``

### Testing
unit tests for eks_tools.py