### PR TITLE
Bump service-configuration-lib to v2.18.6

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -195,6 +195,11 @@ def add_subparser(subparsers):
         default=False,
     )
     list_parser.add_argument(
+        "--app-id",
+        help="Explicitly set spark app id. This is strongly not recommended.",
+        default="",
+    )
+    list_parser.add_argument(
         "--docker-registry",
         help="Docker registry to push the Spark image built.",
         default=DEFAULT_SPARK_DOCKER_REGISTRY,
@@ -1278,6 +1283,7 @@ def paasta_spark_run(args):
         force_spark_resource_configs=args.force_spark_resource_configs,
         use_eks=use_eks,
         k8s_server_address=k8s_server_address,
+        spark_app_id=args.app_id,
     )
     # TODO: Remove this after MLCOMPUTE-699 is complete
     if "spark.kubernetes.decommission.script" not in spark_conf:

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -54,7 +54,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.18.0
+service-configuration-lib >= 2.18.6
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.18.0
+service-configuration-lib==2.18.5
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.3.3
 sensu-plugin==0.3.1
-service-configuration-lib==2.18.5
+service-configuration-lib==2.18.6
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -1137,6 +1137,7 @@ def test_paasta_spark_run_bash(
         aws_role_duration=3600,
         use_eks_override=False,
         k8s_server_address=None,
+        app_id="",
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     mock_load_system_paasta_config.return_value.get_cluster_pools.return_value = {
@@ -1183,6 +1184,7 @@ def test_paasta_spark_run_bash(
         force_spark_resource_configs=False,
         use_eks=False,
         k8s_server_address=None,
+        spark_app_id="",
     )
     mock_spark_conf = mock_spark_conf_builder.return_value.get_spark_conf.return_value
     mock_configure_and_run_docker_container.assert_called_once_with(
@@ -1251,6 +1253,7 @@ def test_paasta_spark_run(
         aws_role_duration=3600,
         use_eks_override=False,
         k8s_server_address=None,
+        app_id="",
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     mock_load_system_paasta_config.return_value.get_cluster_pools.return_value = {
@@ -1297,6 +1300,7 @@ def test_paasta_spark_run(
         force_spark_resource_configs=False,
         use_eks=False,
         k8s_server_address=None,
+        spark_app_id="",
     )
     mock_configure_and_run_docker_container.assert_called_once_with(
         args,
@@ -1364,6 +1368,7 @@ def test_paasta_spark_run_pyspark(
         aws_role_duration=3600,
         use_eks_override=False,
         k8s_server_address=None,
+        app_id="",
     )
     mock_load_system_paasta_config.return_value.get_spark_use_eks_default.return_value = (
         False
@@ -1419,6 +1424,7 @@ def test_paasta_spark_run_pyspark(
         force_spark_resource_configs=False,
         use_eks=False,
         k8s_server_address=None,
+        spark_app_id="",
     )
     mock_configure_and_run_docker_container.assert_called_once_with(
         args,


### PR DESCRIPTION
## Description
To mainly include the following changes:
* Assign spark.app.id to a more intuitive name
* Pick spark ui port with preference
* Temporary adding `--add-id` argument for explicitly specifying spark.app.id when anything goes wrong

Full list: https://github.com/Yelp/service_configuration_lib/compare/v2.18.0...v2.18.6

## Test
```bash
. ./.tox/py38-linux/bin/activate
paasta spark-run --aws-credentials-yaml=/etc/boto_cfg/mrjob.yaml --cmd "spark-submit /work/integration_tests/s3.py"
```
Spark UI:  

<img width="1207" alt="image" src="https://github.com/Yelp/paasta/assets/8851038/bad6e8ca-09ea-4c5a-950d-7db9f993bea2">

With `--app-id` provided:  

<img width="1197" alt="image" src="https://github.com/Yelp/paasta/assets/8851038/186a73a7-eefa-447b-9e54-9da107e48287">


