### PR TITLE
Add API support for paasta <CMD>ing eks-* instances

### DIFF
--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -75,15 +75,11 @@ from paasta_tools.utils import get_git_sha_from_dockerurl
 from paasta_tools.utils import get_image_version_from_dockerurl
 from paasta_tools.utils import NoConfigurationForServiceError
 from paasta_tools.utils import NoDockerImageError
+from paasta_tools.utils import PAASTA_K8S_INSTANCE_TYPES
 from paasta_tools.utils import TimeoutError
 from paasta_tools.utils import validate_service_instance
 
 log = logging.getLogger(__name__)
-
-K8S_INSTANCE_TYPES = {
-    "eks",
-    "kubernetes",
-}
 
 
 def tron_instance_status(
@@ -869,7 +865,7 @@ def bounce_status(request):
         error_message = traceback.format_exc()
         raise ApiFailure(error_message, 500)
 
-    if instance_type not in K8S_INSTANCE_TYPES:
+    if instance_type not in PAASTA_K8S_INSTANCE_TYPES:
         # We are using HTTP 204 to indicate that the instance exists but has
         # no bounce status to be returned.  The client should just mark the
         # instance as bounced.

--- a/paasta_tools/cli/cmds/autoscale.py
+++ b/paasta_tools/cli/cmds/autoscale.py
@@ -88,7 +88,7 @@ def paasta_autoscale(args):
     api = client.get_paasta_oapi_client(
         cluster=get_paasta_oapi_api_clustername(
             cluster=args.cluster,
-            is_eks=instance_config.__class__ == EksDeploymentConfig,
+            is_eks=(instance_config.__class__ == EksDeploymentConfig),
         ),
         http_res=True,
     )

--- a/paasta_tools/cli/cmds/autoscale.py
+++ b/paasta_tools/cli/cmds/autoscale.py
@@ -17,9 +17,13 @@ import logging
 import paasta_tools.paastaapi.models as paastamodels
 from paasta_tools.api import client
 from paasta_tools.cli.utils import figure_out_service_name
+from paasta_tools.cli.utils import get_instance_configs_for_service
+from paasta_tools.cli.utils import get_paasta_oapi_api_clustername
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
+from paasta_tools.eks_tools import EksDeploymentConfig
 from paasta_tools.utils import _log_audit
+from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
 from paasta_tools.utils import PaastaColors
@@ -52,13 +56,42 @@ def add_subparser(subparsers):
     autoscale_parser.add_argument(
         "--set", help="Set the number to scale to. Must be an Int.", type=int
     )
+    autoscale_parser.add_argument(
+        "-d",
+        "--soa-dir",
+        dest="soa_dir",
+        metavar="SOA_DIR",
+        default=DEFAULT_SOA_DIR,
+        help="define a different soa config directory",
+    )
     autoscale_parser.set_defaults(command=paasta_autoscale)
 
 
 def paasta_autoscale(args):
     log.setLevel(logging.DEBUG)
     service = figure_out_service_name(args)
-    api = client.get_paasta_oapi_client(cluster=args.cluster, http_res=True)
+    instance_config = next(
+        get_instance_configs_for_service(
+            service=service,
+            soa_dir=args.soa_dir,
+            clusters=[args.cluster],
+            instances=[args.instance],
+        ),
+        None,
+    )
+    if not instance_config:
+        print(
+            "Could not find config files for this service instance in soaconfigs. Maybe you mispelled an argument?"
+        )
+        return 1
+
+    api = client.get_paasta_oapi_client(
+        cluster=get_paasta_oapi_api_clustername(
+            cluster=args.cluster,
+            is_eks=instance_config.__class__ == EksDeploymentConfig,
+        ),
+        http_res=True,
+    )
     if not api:
         print("Could not connect to paasta api. Maybe you misspelled the cluster?")
         return 1

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1501,7 +1501,7 @@ def diagnose_why_instance_is_stuck(
     api = client.get_paasta_oapi_client(
         cluster=get_paasta_oapi_api_clustername(
             cluster=cluster,
-            is_eks=instance_config.get_instance_type() == "eks",
+            is_eks=(instance_config.get_instance_type() == "eks"),
         ),
     )
     try:
@@ -1632,7 +1632,7 @@ def check_if_instance_is_done(
         api = client.get_paasta_oapi_client(
             cluster=get_paasta_oapi_api_clustername(
                 cluster=cluster,
-                is_eks=instance_config.get_instance_type() == "eks",
+                is_eks=(instance_config.get_instance_type() == "eks"),
             ),
         )
         if not api:

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -286,10 +286,7 @@ def paasta_status_on_api_endpoint(
 ) -> int:
     output = ["", f"\n{service}.{PaastaColors.cyan(instance)} in {cluster}"]
     client = get_paasta_oapi_client(
-        cluster=get_paasta_oapi_api_clustername(
-            cluster=cluster,
-            is_eks=is_eks
-        ),
+        cluster=get_paasta_oapi_api_clustername(cluster=cluster, is_eks=is_eks),
         system_paasta_config=system_paasta_config,
     )
     if not client:
@@ -2196,7 +2193,7 @@ def report_status_for_cluster(
                 lock=lock,
                 verbose=verbose,
                 new=new,
-                is_eks=(instance_config_class == EksDeploymentConfig,)
+                is_eks=(instance_config_class == EksDeploymentConfig),
             )
         )
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -285,7 +285,6 @@ def paasta_status_on_api_endpoint(
     is_eks: bool = False,
 ) -> int:
     output = ["", f"\n{service}.{PaastaColors.cyan(instance)} in {cluster}"]
-    api_cluster = 
     client = get_paasta_oapi_client(
         cluster=get_paasta_oapi_api_clustername(
             cluster=cluster,

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -285,8 +285,14 @@ def paasta_status_on_api_endpoint(
     is_eks: bool = False,
 ) -> int:
     output = ["", f"\n{service}.{PaastaColors.cyan(instance)} in {cluster}"]
-    api_cluster = get_paasta_oapi_api_clustername(cluster=cluster, is_eks=is_eks)
-    client = get_paasta_oapi_client(api_cluster, system_paasta_config)
+    api_cluster = 
+    client = get_paasta_oapi_client(
+        cluster=get_paasta_oapi_api_clustername(
+            cluster=cluster,
+            is_eks=is_eks
+        ),
+        system_paasta_config=system_paasta_config,
+    )
     if not client:
         print("Cannot get a paasta-api client")
         exit(1)
@@ -2191,7 +2197,7 @@ def report_status_for_cluster(
                 lock=lock,
                 verbose=verbose,
                 new=new,
-                is_eks=instance_config_class == EksDeploymentConfig,
+                is_eks=(instance_config_class == EksDeploymentConfig,)
             )
         )
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -52,6 +52,7 @@ from paasta_tools.api.client import PaastaOApiClient
 from paasta_tools.cassandracluster_tools import CassandraClusterDeploymentConfig
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_instance_configs_for_service
+from paasta_tools.cli.utils import get_paasta_oapi_api_clustername
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import NoSuchService
@@ -284,11 +285,7 @@ def paasta_status_on_api_endpoint(
     is_eks: bool = False,
 ) -> int:
     output = ["", f"\n{service}.{PaastaColors.cyan(instance)} in {cluster}"]
-    # this is a tiny bit of a lie so that we hit the correct paasta-api for
-    # eks instances since the "cluster" is otherwise the same
-    api_cluster = cluster
-    if is_eks:
-        api_cluster = f"eks-{cluster}"
+    api_cluster = get_paasta_oapi_api_clustername(cluster=cluster, is_eks=is_eks)
     client = get_paasta_oapi_client(api_cluster, system_paasta_config)
     if not client:
         print("Cannot get a paasta-api client")

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -68,6 +68,7 @@ from paasta_tools.utils import list_all_instances_for_service
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import PAASTA_K8S_INSTANCE_TYPES
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import validate_service_instance
@@ -864,7 +865,7 @@ def get_namespaces_for_secret(
         "eks": EksDeploymentConfig,
     }
     for instance_type in INSTANCE_TYPES:
-        if instance_type in {"kubernetes", "eks"}:
+        if instance_type in PAASTA_K8S_INSTANCE_TYPES:
             config_loader = PaastaServiceConfigLoader(service, soa_dir)
             for service_instance_config in config_loader.instance_configs(
                 cluster=cluster,

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -26,6 +26,7 @@ from collections import defaultdict
 from shlex import quote
 from typing import Callable
 from typing import Collection
+from typing import Generator
 from typing import Iterable
 from typing import List
 from typing import Mapping
@@ -1057,7 +1058,7 @@ def get_instance_configs_for_service(
     type_filter: Optional[Iterable[str]] = None,
     clusters: Optional[Sequence[str]] = None,
     instances: Optional[Sequence[str]] = None,
-) -> Iterable[InstanceConfig]:
+) -> Generator[InstanceConfig, None, None]:
     if not clusters:
         clusters = list_clusters(service=service, soa_dir=soa_dir)
 
@@ -1189,3 +1190,15 @@ def verify_instances(
                 print("  %s" % instance)
 
     return misspelled_instances
+
+
+def get_paasta_oapi_api_clustername(cluster: str, is_eks: bool) -> str:
+    """
+    We'll be doing a tiny bit of lying while we have both EKS and non-EKS
+    clusters: these will generally share the same PaaSTA name (i.e., the
+    soaconfigs suffix will stay the same) - but we'll need a way to route API
+    requests to the correct place. To do so, we'll add "fake" entries to our
+    api_endpoints SystemPaastaConfig that are the PaaSTA clustername with an
+    "eks-" prefix
+    """
+    return f"eks-{cluster}" if is_eks else cluster

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -129,6 +129,7 @@ INSTANCE_TYPES = (
     "paasta_native",
     "adhoc",
     "kubernetes",
+    "eks",
     "tron",
     "flink",
     "cassandracluster",

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -136,7 +136,6 @@ INSTANCE_TYPES = (
     "kafkacluster",
     "monkrelays",
     "nrtsearchservice",
-    "eks",
 )
 
 INSTANCE_TYPE_TO_K8S_NAMESPACE = {

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -138,6 +138,11 @@ INSTANCE_TYPES = (
     "nrtsearchservice",
 )
 
+PAASTA_K8S_INSTANCE_TYPES = {
+    "kubernetes",
+    "eks",
+}
+
 INSTANCE_TYPE_TO_K8S_NAMESPACE = {
     "marathon": "paasta",
     "adhoc": "paasta",

--- a/tests/cli/test_cmds_autoscale.py
+++ b/tests/cli/test_cmds_autoscale.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import mock
+import pytest
 
 from paasta_tools.cli.cmds.autoscale import paasta_autoscale
+from paasta_tools.eks_tools import EksDeploymentConfig
+from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 
 
 @mock.patch("paasta_tools.cli.cmds.autoscale.figure_out_service_name", autospec=True)
@@ -21,8 +24,18 @@ from paasta_tools.cli.cmds.autoscale import paasta_autoscale
     "paasta_tools.cli.cmds.autoscale.client.get_paasta_oapi_client", autospec=True
 )
 @mock.patch("paasta_tools.cli.cmds.autoscale._log_audit", autospec=True)
+@pytest.mark.parametrize(
+    "instance_type_class",
+    (
+        EksDeploymentConfig,
+        KubernetesDeploymentConfig,
+    ),
+)
 def test_paasta_autoscale(
-    mock__log_audit, mock_get_paasta_oapi_client, mock_figure_out_service_name
+    mock__log_audit,
+    mock_get_paasta_oapi_client,
+    mock_figure_out_service_name,
+    instance_type_class,
 ):
     service = "fake_service"
     instance = "fake_instance"
@@ -45,5 +58,42 @@ def test_paasta_autoscale(
     )
     mock__log_audit.return_value = None
 
-    paasta_autoscale(args)
+    with mock.patch(
+        "paasta_tools.cli.cmds.autoscale.get_instance_configs_for_service",
+        return_value=iter([mock.Mock(__class__=instance_type_class)]),
+        autospec=True,
+    ):
+        paasta_autoscale(args)
     assert mock_api.update_autoscaler_count.call_count == 1
+
+
+@mock.patch("paasta_tools.cli.cmds.autoscale.figure_out_service_name", autospec=True)
+@mock.patch(
+    "paasta_tools.cli.cmds.autoscale.client.get_paasta_oapi_client", autospec=True
+)
+@mock.patch("paasta_tools.cli.cmds.autoscale._log_audit", autospec=True)
+def test_paasta_autoscale_no_config(
+    mock__log_audit,
+    mock_get_paasta_oapi_client,
+    mock_figure_out_service_name,
+):
+    service = "fake_service"
+    instance = "fake_instance"
+    cluster = "fake_cluster"
+
+    mock_figure_out_service_name.return_value = service
+    mock_api = mock.Mock()
+    mock_get_paasta_oapi_client.return_value = mock.Mock(autoscaler=mock_api)
+
+    args = mock.MagicMock()
+    args.service = service
+    args.clusters = cluster
+    args.instances = instance
+    args.set = 14
+
+    with mock.patch(
+        "paasta_tools.cli.cmds.autoscale.get_instance_configs_for_service",
+        return_value=iter(()),
+        autospec=True,
+    ):
+        assert paasta_autoscale(args) == 1


### PR DESCRIPTION
We do a tiny bit of lying here in order to keep the same paasta cluster name in the soaconfigs filenames (and CLI), but introduce the concept of an api cluster so that we can direct queries for things running from eks-* files to the correct PaaSTA API

This has somewhat been tested on my local PaaSTA playground and I've added some unit tests :)