### PR TITLE
Update paasta_list_kubernetes_service_instances to show only eks instances when specified - PAASTA-17986

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -135,6 +135,7 @@ INSTANCE_TYPES = (
     "kafkacluster",
     "monkrelays",
     "nrtsearchservice",
+    "eks",
 )
 
 INSTANCE_TYPE_TO_K8S_NAMESPACE = {

--- a/tests/test_list_kubernetes_service_instances.py
+++ b/tests/test_list_kubernetes_service_instances.py
@@ -26,6 +26,8 @@ def test_parse_args():
         ("kubernetes", False, "service_1.instance1\nservice_2.instance1", False, None),
         ("kubernetes", True, "service--1-instance1\nservice--2-instance1", False, None),
         ("flink", True, "service--1-instance1\nservice--2-instance1", False, None),
+        ("eks", False, "service_1.instance1\nservice_2.instance1", False, None),
+        ("eks", True, "service--1-instance1\nservice--2-instance1", False, None),
     ],
 )
 def test_main(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2275,6 +2275,7 @@ def test_validate_service_instance_invalid():
     mock_paasta_native_instances = [("service1", "main2"), ("service1", "main3")]
     mock_adhoc_instances = [("service1", "interactive")]
     mock_k8s_instances = [("service1", "k8s")]
+    mock_eks_instances = [("service1", "eks")]
     mock_tron_instances = [("service1", "job.action")]
     mock_flink_instances = [("service1", "flink")]
     mock_cassandracluster_instances = [("service1", "cassandracluster")]
@@ -2293,6 +2294,7 @@ def test_validate_service_instance_invalid():
             mock_paasta_native_instances,
             mock_adhoc_instances,
             mock_k8s_instances,
+            mock_eks_instances,
             mock_tron_instances,
             mock_flink_instances,
             mock_cassandracluster_instances,


### PR DESCRIPTION
This PR adds "eks" to the list of instance_types which allows us when running paasta_list_kubernetes_service_instances to specify "-t eks". This only spit out eks instances "eks-clustername.yaml" in soaconfigs.


### Testing
Tested on paasta playground. I added an ``eks-kind-emanelsabban-k8s-test.yaml`` file with two instances in playground soa configs and ran ``paasta_list_kubernetes_service_instances -t eks -c kind-${env:USER}-k8s-test -d ./soa_config_playground`` I got back the two instances in this yaml file:
```
(py38-linux) emanelsabban@dev208-uswest1adevc:~/pg/paasta$  cd /nail/home/emanelsabban/pg/paasta ; /usr/bin/env /nail/home/emanelsabban/pg/paasta/.tox/py38-linux/bin/python /nail/home/emanelsabban/.vscode-server/extensions/ms-python.python-2023.14.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher 33127 -- -m paasta_tools.list_kubernetes_service_instances -c kind-emanelsabban-k8s-test -d ./soa_config_playground -t eks 
compute-infra-test-service.eks-autoscaling
compute-infra-test-service.eks-new_instance_test
```