### PR TITLE
Explictly set wget cipher suite

### DIFF
--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -52,10 +52,13 @@ else
 endif
 
 go_entrypoint:
+	# GH appears to require using TLS1.2+ in a way that breaks wget's automatic protocol selection
+	# we can somewhat future-proof ourselves for a while by forcing TLS1.3 - but we should go back
+	# to auto once (if?) GH fixes the way that they're blocking TLS1.1
 	rm -rf gopath && \
 	mkdir -p gopath && \
 	cd gopath && \
-	wget https://github.com/Yelp/paasta-tools-go/archive/v$(PTG_VERSION).zip && \
+	wget --secure-protocol=TLSv1_3 https://github.com/Yelp/paasta-tools-go/archive/v$(PTG_VERSION).zip && \
 	sha256sum v$(PTG_VERSION).zip | grep -q ^$(PTG_SUM) && \
 	unzip v$(PTG_VERSION).zip && \
 	cd paasta-tools-go-$(PTG_VERSION) && \


### PR DESCRIPTION
See https://github.com/orgs/community/discussions/65227 - it appears that GH is doing something that is breaking wget's automatic cipher selection.

From wget's docs:
> If ‘auto’ is used, the SSL library is given the liberty of choosing
> the appropriate protocol automatically, which is achieved by
> sending a TLSv1 greeting. This is the default

I assume that this means that GH is blocking the TLSv1 greeting in an unexpected way, thereby breaking wget.