### PR TITLE
MLCOMPUTE-1008 | update regex for Spark volume names to be alphanumeric

### DIFF
--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -176,12 +176,12 @@ def get_volumes_from_spark_k8s_configs(spark_conf: Mapping[str, str]) -> List[st
             "spark.kubernetes.executor.volumes.hostPath." in key
             and ".mount.path" in key
         ):
-            volume_name = re.match(
+            v_name = re.match(
                 r"spark.kubernetes.executor.volumes.hostPath.([a-z0-9]([-a-z0-9]*[a-z0-9])?).mount.path",
                 key,
             )
-            if volume_name:
-                volume_names.append(volume_name.group(1))
+            if v_name:
+                volume_names.append(v_name.group(1))
             else:
                 log.error(
                     f"Volume names must consist of lower case alphanumeric characters or '-', "

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -171,7 +171,6 @@ def get_volumes_from_spark_mesos_configs(spark_conf: Mapping[str, str]) -> List[
 
 def get_volumes_from_spark_k8s_configs(spark_conf: Mapping[str, str]) -> List[str]:
     volume_names = []
-    invalid_configs = []
     for key in list(spark_conf.keys()):
         if (
             "spark.kubernetes.executor.volumes.hostPath." in key
@@ -184,7 +183,6 @@ def get_volumes_from_spark_k8s_configs(spark_conf: Mapping[str, str]) -> List[st
             if volume_name:
                 volume_names.append(volume_name.group(1))
             else:
-                invalid_configs.append(key)
                 log.error(
                     f"Volume names must consist of lower case alphanumeric characters or '-', "
                     f"and must start and end with an alphanumeric character. Config -> '{key}' must be fixed."

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -171,7 +171,10 @@ def get_volumes_from_spark_mesos_configs(spark_conf: Mapping[str, str]) -> List[
 def get_volumes_from_spark_k8s_configs(spark_conf: Mapping[str, str]) -> List[str]:
     volume_names = []
     for key in spark_conf.keys():
-        if "spark.kubernetes.executor.volumes.hostPath." in key and ".mount.path" in key:
+        if (
+            "spark.kubernetes.executor.volumes.hostPath." in key
+            and ".mount.path" in key
+        ):
             volume_name = re.match(
                 r"spark.kubernetes.executor.volumes.hostPath.(\w+).mount.path", key
             )

--- a/tests/test_spark_tools.py
+++ b/tests/test_spark_tools.py
@@ -1,3 +1,4 @@
+import sys
 from unittest import mock
 
 import pytest
@@ -29,3 +30,39 @@ def test_inject_spark_conf_str(cmd, expected):
     assert (
         spark_tools.inject_spark_conf_str(cmd, "--conf spark.max.cores=100") == expected
     )
+
+
+@pytest.mark.parametrize(
+    "spark_conf,expected",
+    [
+        (
+            {
+                "spark.kubernetes.executor.volumes.hostPath.nailsrv-123.mount.path": "/nail/srv",
+                "spark.kubernetes.executor.volumes.hostPath.nailsrv-123.options.path": "/nail/srv",
+                "spark.kubernetes.executor.volumes.hostPath.nailsrv-123.mount.readOnly": "true",
+                "spark.kubernetes.executor.volumes.hostPath.123.mount.path": "/nail/123",
+                "spark.kubernetes.executor.volumes.hostPath.123.options.path": "/nail/123",
+                "spark.kubernetes.executor.volumes.hostPath.123.mount.readOnly": "false",
+            },
+            ["/nail/srv:/nail/srv:ro", "/nail/123:/nail/123:rw"],
+        ),
+        (
+            {
+                "spark.kubernetes.executor.volumes.hostPath.NAILsrv-123.mount.path": "/one/two",
+                "spark.kubernetes.executor.volumes.hostPath.NAILsrv-123.options.path": "/one/two",
+                "spark.kubernetes.executor.volumes.hostPath.NAILsrv-123.mount.readOnly": "true",
+            },
+            [""],
+        ),
+    ],
+)
+@mock.patch.object(sys, "exit")
+def test_get_volumes_from_spark_k8s_configs(mock_sys, spark_conf, expected):
+    result = spark_tools.get_volumes_from_spark_k8s_configs(spark_conf)
+    if (
+        "spark.kubernetes.executor.volumes.hostPath.NAILsrv-123.mount.path"
+        in spark_conf
+    ):
+        mock_sys.assert_called_with(1)
+    else:
+        assert result == expected


### PR DESCRIPTION
- Updated Spark volume names regex to match alphanumeric names. 
- Also failing with an error message if the name is incorrect.

According to K8s documentation:
```
Volume names must be - a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
```
So I am replacing the regex to be the same.
Testing with failed and successful runs:
https://fluffy.yelpcorp.com/i/KGd5qFPK9fW3SSHPQXpHZPBXf5b7Md52.html