### PR TITLE
[COREJAVA-869] Add active requests to kubernetes schema

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -291,6 +291,7 @@
                                                 "cpu",
                                                 "piscina",
                                                 "gunicorn",
+                                                "active-requests",
                                                 "if metrics_provider is arbitrary_promql, the prometheus_adapter_config parameter is required"
                                             ]
                                         }


### PR DESCRIPTION
## Details
Add active-requests to the kubernetes schema. The use of `active-requests` in example happyhour scaling config was failing. https://github.yelpcorp.com/sysgit/yelpsoa-configs/pull/34128

```
+ git checkout sclg/COREJAVA-869/enable_active_requests_autoscaling_ehh_stagef
Already on 'sclg/COREJAVA-869/enable_active_requests_autoscaling_ehh_stagef'
Your branch is ahead of 'origin/sclg/COREJAVA-869/enable_active_requests_autoscaling_ehh_stagef' by 17 commits.
  (use "git push" to publish your local commits)
+ /usr/bin/yelpsoa-configs-checker
example_happyhour_java
✓ Successfully validated schema: kubernetes-everywhere-testopia.yaml
✓ Successfully validated schema: kubernetes-norcal-devc.yaml
✓ Successfully validated schema: kubernetes-norcal-stageg.yaml
✓ Successfully validated schema: kubernetes-nova-prod.yaml
✓ Successfully validated schema: kubernetes-pnw-prod.yaml
✗ Failed to validate schema. More info: http://paasta.readthedocs.io/en/latest/yelpsoa_configs.html: /home/jenkins/agent/workspace/sysgit-yelpsoa-configs-integrate/example_happyhour_java/kubernetes-norcal-stagef.yaml
  Validation Message: 'active-requests' is not one of ['uwsgi', 'cpu', 'piscina', 'gunicorn', 'if metrics_provider is arbitrary_promql, the prometheus_adapter_config parameter is required']
✓ All PaaSTA Instances for are valid for all clusters
✓ All example_happyhour_java's instance names in cluster everywhere-testopia are unique
✓ All example_happyhour_java's instance names in cluster norcal-devc are unique
✓ All example_happyhour_java's instance names in cluster norcal-stagef are unique
✓ All example_happyhour_java's instance names in cluster norcal-stageg are unique
✓ All example_happyhour_java's instance names in cluster nova-prod are unique
✓ All example_happyhour_java's instance names in cluster pnw-prod are unique
✓ No orphan secrets found
 Traceback (most recent call last):
  File "/usr/bin/yelpsoa-configs-checker", line 11, in 
    load_entry_point('py-gitolite==6.0.1', 'console_scripts', 'yelpsoa-configs-checker')()
  File "/opt/venvs/py-gitolite/lib/python3.7/site-packages/gitolite/hooks/repo_specific/yelpsoa_configs.py", line 798, in yelpsoa_configs_checker
    validator.validate_changed_paasta_configs('HEAD')
  File "/opt/venvs/py-gitolite/lib/python3.7/site-packages/gitolite/hooks/repo_specific/yelpsoa_configs.py", line 316, in validate_changed_paasta_configs
    raise ValueError('PaaSTA failed to validate %s (see above output)' % service_dir)
ValueError: PaaSTA failed to validate example_happyhour_java (see above output)
```