### PR TITLE
Add support for autotuned type aliases

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1917,6 +1917,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     api_profiling_config: Dict
     auth_certificate_ttl: str
     auto_config_instance_types_enabled: Dict[str, bool]
+    auto_config_instance_type_aliases: Dict[str, str]
     auto_hostname_unique_size: int
     boost_regions: List[str]
     cluster_autoscaler_max_decrease: float

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2214,6 +2214,13 @@ class SystemPaastaConfig:
     def get_auto_config_instance_types_enabled(self) -> Dict[str, bool]:
         return self.config_dict.get("auto_config_instance_types_enabled", {})
 
+    def get_auto_config_instance_type_aliases(self) -> Dict[str, str]:
+        """
+        Allow re-using another instance type's autotuned data. This is useful when an instance can be trivially moved around
+        type-wise as it allows us to avoid data races/issues with the autotuned recommendations generator/updater.
+        """
+        return self.config_dict.get("auto_config_instance_type_aliases", {})
+
     def get_api_endpoints(self) -> Mapping[str, str]:
         return self.config_dict["api_endpoints"]
 
@@ -3406,8 +3413,18 @@ def load_service_instance_auto_configs(
     soa_dir: str = DEFAULT_SOA_DIR,
 ) -> Dict[str, Dict[str, Any]]:
     enabled_types = load_system_paasta_config().get_auto_config_instance_types_enabled()
-    conf_file = f"{instance_type}-{cluster}"
-    if enabled_types.get(instance_type):
+    # this looks a little funky: but what we're generally trying to do here is ensure that
+    # certain types of instances can be moved between instance types without having to worry
+    # about any sort of data races (or data weirdness) in autotune.
+    # instead, what we do is map certain instance types to whatever we've picked as the "canonical"
+    # instance type in autotune and always merge from there.
+    realized_type = (
+        load_system_paasta_config()
+        .get_auto_config_instance_type_aliases()
+        .get(instance_type, instance_type)
+    )
+    conf_file = f"{realized_type}-{cluster}"
+    if enabled_types.get(realized_type):
         return service_configuration_lib.read_extra_service_information(
             service,
             f"{AUTO_SOACONFIG_SUBDIR}/{conf_file}",


### PR DESCRIPTION
For some instance types that are autotuned (e.g., `kubernetes`), we may
have a largely-similar instance type (e.g., `eks`) and the ability to
trivially move instances back and forth between these.

For these, there's a couple different options for how to handle
autotune:
1) have tooling/documentation to migrate data between
   `autotuned_defaults/` files on instance moves + teach the autotune
   machinery what the correct cluster/filename to update should be (as
   well as teach autotune how to gather data correctly)
2) have tooling/documentation to temporarily pin the new instance type at
   the old autotuned request until autotune has updated with the new
   instance type data
3) add some form of aliasing and pretend (at the autotune level) that
   there's a single instance type for these largely-similar instance
   types

This PR goes for option 3 as it is the least complex and has the fewest
moving parts/places for things to horribly blow up.
