### PR TITLE
PAASTA-18017: Read secret where instance service is defined, rather than service defined in CLI args.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ paasta_itests/fake_etc_paasta/marathon.json
 yelp_package/gopath
 .mypy_cache/
 .pytest_cache/
+.hypothesis/
 debian/.debhelper
 example_cluster/paasta/docker_registry.json
 general_itests/fake_etc_paasta/clusters.json

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -857,7 +857,7 @@ def run_docker_container(
                     secret_provider_name=secret_provider_name,
                     environment=environment,
                     soa_dir=soa_dir,
-                    service_name=service,
+                    service_name=instance_config.get_service(),
                     cluster_name=instance_config.cluster,
                     secret_provider_kwargs=secret_provider_kwargs,
                 )
@@ -865,7 +865,7 @@ def run_docker_container(
                     secret_provider_name=secret_provider_name,
                     secret_volumes_config=instance_config.get_secret_volumes(),
                     soa_dir=soa_dir,
-                    service_name=service,
+                    service_name=instance_config.get_service(),
                     cluster_name=instance_config.cluster,
                     secret_provider_kwargs=secret_provider_kwargs,
                 )

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -2081,9 +2081,6 @@ def test_run_docker_container_assume_aws_role(
     assert 0 == return_code
 
 
-fake_service_names = ["fake_service", "override_service_name"]
-
-
 @mock.patch(
     "paasta_tools.cli.cmds.local_run.pick_random_port",
     autospec=True,
@@ -2116,7 +2113,13 @@ fake_service_names = ["fake_service", "override_service_name"]
     autospec=None,
 )
 @mock.patch("os.makedirs", autospec=True)
-@mark.parametrize("override_service_name", fake_service_names)
+@mark.parametrize(
+    "original_service_name, override_service_name",
+    (
+        ("fake_service", "fake_service"),  # no service override
+        ("fake_service", "super_fake_service"),  # service override
+    ),
+)
 def test_run_docker_container_secret_volumes(
     mock_os_makedirs,
     mock_open,
@@ -2127,6 +2130,7 @@ def test_run_docker_container_secret_volumes(
     mock_execlpe,
     mock_get_docker_run_cmd,
     mock_pick_random_port,
+    original_service_name,
     override_service_name,
 ):
     mock_docker_client = mock.MagicMock(spec_set=docker.Client)
@@ -2158,7 +2162,7 @@ def test_run_docker_container_secret_volumes(
     os.environ["TMPDIR"] = "/tmp/"
     return_code = run_docker_container(
         docker_client=mock_docker_client,
-        service=fake_service_names[0],
+        service=original_service_name,
         instance="fake_instance",
         docker_url="fake_hash",
         volumes=[],


### PR DESCRIPTION
Ticket: PAASTA-18017

This fixes the issue of secret usage when the "service: something" override is used.

Test simply confirms that service name while decrypting is based on the instance_config service name, not the service name given by the CLI args

tested on dev6:
test action (did not use private.py since there is no devc version): https://fluffy.yelpcorp.com/i/lK6F4r99Sm0sHmjWhHNS3BdC2tdBVdvv.html
result: https://fluffy.yelpcorp.com/i/XBRnjNSccFTMpr5kvrkr0g7zGmqgCLCw.html