### PR TITLE
MLCOMPUTE-746 | Remove the spark app-id option

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -195,11 +195,6 @@ def add_subparser(subparsers):
         default=False,
     )
     list_parser.add_argument(
-        "--app-id",
-        help="Explicitly set spark app id. This is strongly not recommended.",
-        default="",
-    )
-    list_parser.add_argument(
         "--docker-registry",
         help="Docker registry to push the Spark image built.",
         default=DEFAULT_SPARK_DOCKER_REGISTRY,
@@ -1283,7 +1278,6 @@ def paasta_spark_run(args):
         force_spark_resource_configs=args.force_spark_resource_configs,
         use_eks=use_eks,
         k8s_server_address=k8s_server_address,
-        spark_app_id=args.app_id,
     )
     # TODO: Remove this after MLCOMPUTE-699 is complete
     if "spark.kubernetes.decommission.script" not in spark_conf:

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -1137,7 +1137,6 @@ def test_paasta_spark_run_bash(
         aws_role_duration=3600,
         use_eks_override=False,
         k8s_server_address=None,
-        app_id="",
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     mock_load_system_paasta_config.return_value.get_cluster_pools.return_value = {
@@ -1184,7 +1183,6 @@ def test_paasta_spark_run_bash(
         force_spark_resource_configs=False,
         use_eks=False,
         k8s_server_address=None,
-        spark_app_id="",
     )
     mock_spark_conf = mock_spark_conf_builder.return_value.get_spark_conf.return_value
     mock_configure_and_run_docker_container.assert_called_once_with(
@@ -1253,7 +1251,6 @@ def test_paasta_spark_run(
         aws_role_duration=3600,
         use_eks_override=False,
         k8s_server_address=None,
-        app_id="",
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     mock_load_system_paasta_config.return_value.get_cluster_pools.return_value = {
@@ -1300,7 +1297,6 @@ def test_paasta_spark_run(
         force_spark_resource_configs=False,
         use_eks=False,
         k8s_server_address=None,
-        spark_app_id="",
     )
     mock_configure_and_run_docker_container.assert_called_once_with(
         args,
@@ -1368,7 +1364,6 @@ def test_paasta_spark_run_pyspark(
         aws_role_duration=3600,
         use_eks_override=False,
         k8s_server_address=None,
-        app_id="",
     )
     mock_load_system_paasta_config.return_value.get_spark_use_eks_default.return_value = (
         False
@@ -1424,7 +1419,6 @@ def test_paasta_spark_run_pyspark(
         force_spark_resource_configs=False,
         use_eks=False,
         k8s_server_address=None,
-        spark_app_id="",
     )
     mock_configure_and_run_docker_container.assert_called_once_with(
         args,


### PR DESCRIPTION
We added the option for explicitly specifying Spark app id in #3682 as a safety measure for rolling out the new app id naming convention.

Now the new naming convention has been fully rolled out without any problem and no one is currently using the option. So I'm going to remove the option to cleanup the logic and avoid problems caused by user explicitly set the id.