### PR TITLE
[COREJAVA-888] Add kube deployment label to envoy metrics aggregation

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -305,9 +305,12 @@ def create_instance_active_requests_scaling_rule(
         ) by (kube_deployment))
     """
     load_per_instance = f"""
-        avg(
-            paasta_instance:envoy_cluster__egress_cluster_upstream_rq_active{{{worker_filter_terms}}}
-        ) by (kube_pod, kube_deployment)
+        label_replace(
+            avg(
+                paasta_instance:envoy_cluster__egress_cluster_upstream_rq_active{{{worker_filter_terms}}}
+            ), 
+            "kube_deployment", {deployment_name}, "", "(.*)
+        )
     """
     missing_instances = f"""
         clamp_min(

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -309,7 +309,7 @@ def create_instance_active_requests_scaling_rule(
             avg(
                 paasta_instance:envoy_cluster__egress_cluster_upstream_rq_active{{{worker_filter_terms}}}
             ),
-            "kube_deployment", {deployment_name}, "", "(.*)
+            "kube_deployment", {deployment_name}, "", "(.*)"
         )
     """
     missing_instances = f"""

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -308,7 +308,7 @@ def create_instance_active_requests_scaling_rule(
         label_replace(
             avg(
                 paasta_instance:envoy_cluster__egress_cluster_upstream_rq_active{{{worker_filter_terms}}}
-            ), 
+            ),
             "kube_deployment", {deployment_name}, "", "(.*)
         )
     """


### PR DESCRIPTION
## Details
Add the kube_deployment label to envoy metrics aggregation

## JIRA
COREJAVA-888

## Testing
[Tested the query in grafana.](https://grafana.yelpcorp.com/explore?orgId=1&left=%7B%22datasource%22:%22P0A14DA14C82905AE%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22avg_over_time%28%5Cn%20%20%28%5Cn%20%20%20%20%28%5Cn%20%20%20%20%20%20sum%28%5Cn%20%20%20%20%20%20%20%20label_replace%28avg%28%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_instance:envoy_cluster__egress_cluster_upstream_rq_active%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_cluster%3D%27norcal-stagef%27,%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_service%3D%27example_happyhour_java%27,%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_instance%3D%27main%27%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%29,%20%5C%22kube_deployment%5C%22,%20%5C%22example--happyhour--java-main%5C%22,%20%5C%22%5C%22,%20%5C%22%28.%2A%29%5C%22%29%5Cn%20%20%20%20%20%20%29%20by%20%28kube_deployment%29%5Cn%20%20%20%20%20%20%2B%20%28%5Cn%20%20%20%20%20%20%20%20clamp_min%28%5Cn%20%20%20%20%20%20%20%20%20%20%28%5Cn%20%20%20%20%20%20%20%20%20%20%20%20sum%28%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20k8s:deployment:pods_status_ready%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_cluster%3D%27norcal-stagef%27,%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_service%3D%27example_happyhour_java%27,%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_instance%3D%27main%27%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%20%3E%3D%200%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20or%20max_over_time%28%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20k8s:deployment:pods_status_ready%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_cluster%3D%27norcal-stagef%27,%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_service%3D%27example_happyhour_java%27,%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_instance%3D%27main%27%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5B100s%5D%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%29%20by%20%28kube_deployment%29%5Cn%20%20%20%20%20%20%20%20%20%20%29%5Cn%20%20%20%20%20%20%20%20%20%20-%20count%28%5Cn%20%20%20%20%20%20%20%20%20%20%20%20label_replace%28avg%28%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_instance:envoy_cluster__egress_cluster_upstream_rq_active%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_cluster%3D%27norcal-stagef%27,%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_service%3D%27example_happyhour_java%27,%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_instance%3D%27main%27%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%29,%20%5C%22kube_deployment%5C%22,%20%5C%22example--happyhour--java-main%5C%22,%20%5C%22%5C%22,%20%5C%22%28.%2A%29%5C%22%29%5Cn%20%20%20%20%20%20%20%20%20%20%29%20by%20%28kube_deployment%29,%5Cn%20%20%20%20%20%20%20%20%20%200%5Cn%20%20%20%20%20%20%20%20%29%20%2A%202%5Cn%20%20%20%20%20%20%29%5Cn%20%20%20%20%29%20%2F%202%5Cn%20%20%29%5B1800s:%5D%5Cn%29%20%2F%20sum%28%5Cn%20%20label_join%28%5Cn%20%20%20%20%28%5Cn%20%20%20%20%20%20kube_deployment_spec_replicas%7B%5Cn%20%20%20%20%20%20%20%20paasta_cluster%3D%27norcal-stagef%27,%5Cn%20%20%20%20%20%20%20%20deployment%3D%27example--happyhour--java-main%27,%5Cn%20%20%20%20%20%20%20%20namespace%3D%27paastasvc-example--happyhour--java%27%5Cn%20%20%20%20%20%20%7D%20%3E%3D%200%5Cn%20%20%20%20%20%20or%20max_over_time%28%5Cn%20%20%20%20%20%20%20%20kube_deployment_spec_replicas%7B%5Cn%20%20%20%20%20%20%20%20%20%20paasta_cluster%3D%27norcal-stagef%27,%5Cn%20%20%20%20%20%20%20%20%20%20deployment%3D%27example--happyhour--java-main%27,%5Cn%20%20%20%20%20%20%20%20%20%20namespace%3D%27paastasvc-example--happyhour--java%27%5Cn%20%20%20%20%20%20%20%20%7D%5B100s%5D%5Cn%20%20%20%20%20%20%29%5Cn%20%20%20%20%29,%5Cn%20%20%20%20%5C%22kube_deployment%5C%22,%5Cn%20%20%20%20%5C%22%5C%22,%5Cn%20%20%20%20%5C%22deployment%5C%22%5Cn%20%20%29%5Cn%29%20by%20%28kube_deployment%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P0A14DA14C82905AE%22%7D,%22editorMode%22:%22code%22%7D%5D,%22range%22:%7B%22from%22:%22now-15m%22,%22to%22:%22now%22%7D%7D) Results are as expected.