### PR TITLE
Add eks support for cleanup kubernetes job - PAASTA-17988

### DIFF
--- a/paasta_tools/cleanup_kubernetes_jobs.py
+++ b/paasta_tools/cleanup_kubernetes_jobs.py
@@ -30,6 +30,8 @@ Command line options:
 - -t <KILL_THRESHOLD>, --kill-threshold: The decimal fraction of apps we think
     is sane to kill when this job runs
 - -f, --force: Force the killing of apps if we breach the threshold
+- -c, --cluster: Specifies the paasta cluster to check
+- --eks: This flag cleans up only k8 services that shouldn't be running on EKS leaving instances from eks-*.yaml files
 """
 import argparse
 import logging
@@ -41,11 +43,14 @@ from typing import Generator
 from typing import List
 from typing import Set
 from typing import Tuple
+from typing import Union
 
 from kubernetes.client import V1Deployment
 from kubernetes.client import V1StatefulSet
 from pysensu_yelp import Status
 
+from paasta_tools.eks_tools import EksDeploymentConfig
+from paasta_tools.eks_tools import load_eks_service_config
 from paasta_tools.kubernetes.application.controller_wrappers import DeploymentWrapper
 from paasta_tools.kubernetes.application.controller_wrappers import StatefulSetWrapper
 from paasta_tools.kubernetes.application.tools import Application
@@ -106,12 +111,12 @@ def alert_state_change(application: Application, cluster: str) -> Generator:
 
 
 def instance_is_not_bouncing(
-    instance_config: KubernetesDeploymentConfig,
+    instance_config: Union[KubernetesDeploymentConfig, EksDeploymentConfig],
     applications: List[Application],
 ) -> bool:
     """
 
-    :param instance_config: a KubernetesDeploymentConfig with the configuration of the instance
+    :param instance_config: a KubernetesDeploymentConfig or an EksDeploymentConfig with the configuration of the instance
     :param applications: a list of all deployments or stateful sets on the cluster that match the service
      and instance of provided instance_config
     """
@@ -144,6 +149,7 @@ def get_applications_to_kill(
     cluster: str,
     valid_services: Set[Tuple[str, str]],
     soa_dir: str,
+    eks: bool = False,
 ) -> List[Application]:
     """
 
@@ -161,9 +167,21 @@ def get_applications_to_kill(
             if (service, instance) not in valid_services:
                 applications_to_kill.extend(applications)
             else:
-                instance_config = load_kubernetes_service_config(
-                    cluster=cluster, service=service, instance=instance, soa_dir=soa_dir
-                )
+                instance_config: Union[KubernetesDeploymentConfig, EksDeploymentConfig]
+                if eks:
+                    instance_config = load_eks_service_config(
+                        cluster=cluster,
+                        service=service,
+                        instance=instance,
+                        soa_dir=soa_dir,
+                    )
+                else:
+                    instance_config = load_kubernetes_service_config(
+                        cluster=cluster,
+                        service=service,
+                        instance=instance,
+                        soa_dir=soa_dir,
+                    )
                 try:
                     not_bouncing = instance_is_not_bouncing(
                         instance_config, applications
@@ -200,6 +218,7 @@ def cleanup_unused_apps(
     cluster: str,
     kill_threshold: float = 0.5,
     force: bool = False,
+    eks: bool = False,
 ) -> None:
     """Clean up old or invalid jobs/apps from kubernetes. Retrieves
     both a list of apps currently in kubernetes and a list of valid
@@ -217,11 +236,13 @@ def cleanup_unused_apps(
     applications_dict = list_all_applications(kube_client, APPLICATION_TYPES)
     log.info("Retrieving valid apps from yelpsoa_configs")
     valid_services = set(
-        get_services_for_cluster(instance_type="kubernetes", soa_dir=soa_dir)
+        get_services_for_cluster(
+            instance_type="eks" if eks else "kubernetes", soa_dir=soa_dir
+        )
     )
 
     applications_to_kill: List[Application] = get_applications_to_kill(
-        applications_dict, cluster, valid_services, soa_dir
+        applications_dict, cluster, valid_services, soa_dir, eks
     )
 
     log.debug("Running apps: %s" % list(applications_dict))
@@ -280,6 +301,13 @@ def parse_args(argv):
         default=False,
         help="Force the cleanup if we are above the " "kill_threshold",
     )
+    parser.add_argument(
+        "--eks",
+        help="This flag cleans up only k8 services that shouldn't be running on EKS leaving instances from eks-*.yaml files",
+        dest="eks",
+        action="store_true",
+        default=False,
+    )
     return parser.parse_args(argv)
 
 
@@ -289,13 +317,18 @@ def main(argv=None) -> None:
     kill_threshold = args.kill_threshold
     force = args.force
     cluster = args.cluster
+    eks = args.eks
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
     else:
         logging.basicConfig(level=logging.WARNING)
     try:
         cleanup_unused_apps(
-            soa_dir, cluster=cluster, kill_threshold=kill_threshold, force=force
+            soa_dir,
+            cluster=cluster,
+            kill_threshold=kill_threshold,
+            force=force,
+            eks=eks,
         )
     except DontKillEverythingError:
         sys.exit(1)

--- a/tests/test_cleanup_kubernetes_jobs.py
+++ b/tests/test_cleanup_kubernetes_jobs.py
@@ -15,6 +15,7 @@
 from copy import deepcopy
 
 import mock
+import pytest
 from kubernetes.client import V1Deployment
 from kubernetes.client import V1StatefulSet
 from pytest import fixture
@@ -23,6 +24,7 @@ from pytest import raises
 from paasta_tools.cleanup_kubernetes_jobs import cleanup_unused_apps
 from paasta_tools.cleanup_kubernetes_jobs import DontKillEverythingError
 from paasta_tools.cleanup_kubernetes_jobs import main
+from paasta_tools.eks_tools import EksDeploymentConfig
 from paasta_tools.kubernetes.application.controller_wrappers import DeploymentWrapper
 from paasta_tools.kubernetes.application.controller_wrappers import StatefulSetWrapper
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
@@ -121,6 +123,39 @@ def fake_instance_config(
     return fake_instance_config
 
 
+def fake_eks_instance_config(
+    cluster, service, instance, soa_dir="soa_dir", load_deployments=False
+):
+    fake_eks_instance_config = EksDeploymentConfig(
+        service,
+        instance,
+        cluster,
+        {
+            "port": None,
+            "monitoring": {},
+            "deploy": {"pipeline": [{"step": "default"}]},
+            "data": {},
+            "smartstack": {},
+            "dependencies": {},
+            "cpus": 0.1,
+            "mem": 100,
+            "min_instances": 1,
+            "max_instances": 10,
+            "deploy_group": "prod.main",
+            "autoscaling": {"setpoint": 0.7},
+        },
+        {
+            "docker_image": "services-compute-infra-test-service:paasta-5b861b3bd42ef9674d3ca04a1259c79eddb71694",
+            "git_sha": "5b861b3bd42ef9674d3ca04a1259c79eddb71694",
+            "image_version": None,
+            "desired_state": "start",
+            "force_bounce": None,
+        },
+        soa_dir,
+    )
+    return fake_eks_instance_config
+
+
 def get_fake_instances(self, with_limit: bool = True) -> int:
     return self.config_dict.get("max_instances", None)
 
@@ -136,7 +171,7 @@ def test_main(fake_deployment, fake_stateful_set, invalid_app):
         load_config_patch.return_value.get_cluster.return_value = "fake_cluster"
         main(("--soa-dir", soa_dir, "--cluster", cluster))
         cleanup_patch.assert_called_once_with(
-            soa_dir, cluster, kill_threshold=0.5, force=False
+            soa_dir, cluster, kill_threshold=0.5, force=False, eks=False
         )
 
 
@@ -166,7 +201,14 @@ def test_list_apps(fake_deployment, fake_stateful_set, invalid_app):
         )
 
 
-def test_cleanup_unused_apps(fake_deployment, fake_stateful_set, invalid_app):
+@pytest.mark.parametrize(
+    "eks_flag",
+    [
+        (False),
+        (True),
+    ],
+)
+def test_cleanup_unused_apps(eks_flag, fake_deployment, fake_stateful_set, invalid_app):
     mock_kube_client = mock.MagicMock()
     with mock.patch(
         "paasta_tools.cleanup_kubernetes_jobs.KubeClient",
@@ -181,6 +223,10 @@ def test_cleanup_unused_apps(fake_deployment, fake_stateful_set, invalid_app):
         autospec=True,
         side_effect=fake_instance_config,
     ), mock.patch(
+        "paasta_tools.eks_tools.load_eks_service_config_no_cache",
+        autospec=True,
+        side_effect=fake_eks_instance_config,
+    ), mock.patch(
         "paasta_tools.cleanup_kubernetes_jobs.KubernetesDeploymentConfig.get_instances",
         side_effect=get_fake_instances,
         autospec=True,
@@ -193,12 +239,21 @@ def test_cleanup_unused_apps(fake_deployment, fake_stateful_set, invalid_app):
     ) as mock_alert_state_change:
         mock_alert_state_change.__enter__ = mock.Mock(return_value=(mock.Mock(), None))
         mock_alert_state_change.__exit__ = mock.Mock(return_value=None)
-        cleanup_unused_apps("soa_dir", "fake cluster", kill_threshold=1, force=False)
+        cleanup_unused_apps(
+            "soa_dir", "fake cluster", kill_threshold=1, force=False, eks=eks_flag
+        )
         assert mock_kube_client.deployments.delete_namespaced_deployment.call_count == 1
 
 
+@pytest.mark.parametrize(
+    "eks_flag",
+    [
+        (False),
+        (True),
+    ],
+)
 def test_cleanup_unused_apps_in_multiple_namespaces(
-    fake_deployment, fake_stateful_set, invalid_app
+    eks_flag, fake_deployment, fake_stateful_set, invalid_app
 ):
     mock_kube_client = mock.MagicMock()
     fake_deployment2 = deepcopy(fake_deployment)
@@ -223,6 +278,10 @@ def test_cleanup_unused_apps_in_multiple_namespaces(
         autospec=True,
         side_effect=fake_instance_config,
     ), mock.patch(
+        "paasta_tools.eks_tools.load_eks_service_config_no_cache",
+        autospec=True,
+        side_effect=fake_eks_instance_config,
+    ), mock.patch(
         "paasta_tools.cleanup_kubernetes_jobs.get_services_for_cluster",
         return_value={("service", "instance-1")},
         autospec=True,
@@ -235,12 +294,21 @@ def test_cleanup_unused_apps_in_multiple_namespaces(
     ) as mock_alert_state_change:
         mock_alert_state_change.__enter__ = mock.Mock(return_value=(mock.Mock(), None))
         mock_alert_state_change.__exit__ = mock.Mock(return_value=None)
-        cleanup_unused_apps("soa_dir", "fake cluster", kill_threshold=2, force=False)
+        cleanup_unused_apps(
+            "soa_dir", "fake cluster", kill_threshold=2, force=False, eks=eks_flag
+        )
         assert mock_kube_client.deployments.delete_namespaced_deployment.call_count == 1
 
 
+@pytest.mark.parametrize(
+    "eks_flag",
+    [
+        (False),
+        (True),
+    ],
+)
 def test_cleanup_unused_apps_does_not_delete(
-    fake_deployment, fake_stateful_set, invalid_app
+    eks_flag, fake_deployment, fake_stateful_set, invalid_app
 ):
     mock_kube_client = mock.MagicMock()
     with mock.patch(
@@ -251,6 +319,10 @@ def test_cleanup_unused_apps_does_not_delete(
         "paasta_tools.kubernetes_tools.load_kubernetes_service_config_no_cache",
         autospec=True,
         side_effect=fake_instance_config,
+    ), mock.patch(
+        "paasta_tools.eks_tools.load_eks_service_config_no_cache",
+        autospec=True,
+        side_effect=fake_eks_instance_config,
     ), mock.patch(
         "paasta_tools.cleanup_kubernetes_jobs.list_all_applications",
         return_value={("service", "instance-1"): [DeploymentWrapper(fake_deployment)]},
@@ -268,12 +340,21 @@ def test_cleanup_unused_apps_does_not_delete(
     ) as mock_alert_state_change:
         mock_alert_state_change.__enter__ = mock.Mock(return_value=(mock.Mock(), None))
         mock_alert_state_change.__exit__ = mock.Mock(return_value=None)
-        cleanup_unused_apps("soa_dir", "fake cluster", kill_threshold=1, force=False)
+        cleanup_unused_apps(
+            "soa_dir", "fake cluster", kill_threshold=1, force=False, eks=eks_flag
+        )
         assert mock_kube_client.deployments.delete_namespaced_deployment.call_count == 0
 
 
+@pytest.mark.parametrize(
+    "eks_flag",
+    [
+        (False),
+        (True),
+    ],
+)
 def test_cleanup_unused_apps_does_not_delete_bouncing_apps(
-    fake_deployment, fake_stateful_set, invalid_app
+    eks_flag, fake_deployment, fake_stateful_set, invalid_app
 ):
     mock_kube_client = mock.MagicMock()
     fake_deployment2 = deepcopy(fake_deployment)
@@ -298,6 +379,10 @@ def test_cleanup_unused_apps_does_not_delete_bouncing_apps(
         autospec=True,
         side_effect=fake_instance_config,
     ), mock.patch(
+        "paasta_tools.eks_tools.load_eks_service_config_no_cache",
+        autospec=True,
+        side_effect=fake_eks_instance_config,
+    ), mock.patch(
         "paasta_tools.cleanup_kubernetes_jobs.get_services_for_cluster",
         return_value={("service", "instance-1")},
         autospec=True,
@@ -310,12 +395,21 @@ def test_cleanup_unused_apps_does_not_delete_bouncing_apps(
     ) as mock_alert_state_change:
         mock_alert_state_change.__enter__ = mock.Mock(return_value=(mock.Mock(), None))
         mock_alert_state_change.__exit__ = mock.Mock(return_value=None)
-        cleanup_unused_apps("soa_dir", "fake cluster", kill_threshold=2, force=False)
+        cleanup_unused_apps(
+            "soa_dir", "fake cluster", kill_threshold=2, force=False, eks=eks_flag
+        )
         assert mock_kube_client.deployments.delete_namespaced_deployment.call_count == 0
 
 
+@pytest.mark.parametrize(
+    "eks_flag",
+    [
+        (False),
+        (True),
+    ],
+)
 def test_cleanup_unused_apps_does_not_delete_recently_created_apps(
-    fake_deployment, fake_stateful_set, invalid_app
+    eks_flag, fake_deployment, fake_stateful_set, invalid_app
 ):
     mock_kube_client = mock.MagicMock()
     fake_deployment.status.ready_replicas = 10
@@ -337,6 +431,10 @@ def test_cleanup_unused_apps_does_not_delete_recently_created_apps(
         autospec=True,
         side_effect=fake_instance_config,
     ), mock.patch(
+        "paasta_tools.eks_tools.load_eks_service_config_no_cache",
+        autospec=True,
+        side_effect=fake_eks_instance_config,
+    ), mock.patch(
         "paasta_tools.cleanup_kubernetes_jobs.get_services_for_cluster",
         return_value={("service", "instance-1")},
         autospec=True,
@@ -349,12 +447,21 @@ def test_cleanup_unused_apps_does_not_delete_recently_created_apps(
     ) as mock_alert_state_change:
         mock_alert_state_change.__enter__ = mock.Mock(return_value=(mock.Mock(), None))
         mock_alert_state_change.__exit__ = mock.Mock(return_value=None)
-        cleanup_unused_apps("soa_dir", "fake cluster", kill_threshold=2, force=False)
+        cleanup_unused_apps(
+            "soa_dir", "fake cluster", kill_threshold=2, force=False, eks=eks_flag
+        )
         assert mock_kube_client.deployments.delete_namespaced_deployment.call_count == 0
 
 
+@pytest.mark.parametrize(
+    "eks_flag",
+    [
+        (False),
+        (True),
+    ],
+)
 def test_cleanup_unused_apps_dont_kill_everything(
-    fake_deployment, fake_stateful_set, invalid_app
+    eks_flag, fake_deployment, fake_stateful_set, invalid_app
 ):
     mock_kube_client = mock.MagicMock()
     with mock.patch(
@@ -365,6 +472,10 @@ def test_cleanup_unused_apps_dont_kill_everything(
         "paasta_tools.kubernetes_tools.load_kubernetes_service_config_no_cache",
         autospec=True,
         side_effect=fake_instance_config,
+    ), mock.patch(
+        "paasta_tools.eks_tools.load_eks_service_config_no_cache",
+        autospec=True,
+        side_effect=fake_eks_instance_config,
     ), mock.patch(
         "paasta_tools.cleanup_kubernetes_jobs.list_all_applications",
         return_value={("service", "instance-1"): [DeploymentWrapper(fake_deployment)]},
@@ -384,13 +495,20 @@ def test_cleanup_unused_apps_dont_kill_everything(
         mock_alert_state_change.__exit__ = mock.Mock(return_value=None)
         with raises(DontKillEverythingError):
             cleanup_unused_apps(
-                "soa_dir", "fake_cluster", kill_threshold=0, force=False
+                "soa_dir", "fake_cluster", kill_threshold=0, force=False, eks=eks_flag
             )
         assert mock_kube_client.deployments.delete_namespaced_deployment.call_count == 0
 
 
+@pytest.mark.parametrize(
+    "eks_flag",
+    [
+        (False),
+        (True),
+    ],
+)
 def test_cleanup_unused_apps_dont_kill_statefulsets(
-    fake_deployment, fake_stateful_set, invalid_app
+    eks_flag, fake_deployment, fake_stateful_set, invalid_app
 ):
     mock_kube_client = mock.MagicMock()
     with mock.patch(
@@ -401,6 +519,10 @@ def test_cleanup_unused_apps_dont_kill_statefulsets(
         "paasta_tools.kubernetes_tools.load_kubernetes_service_config_no_cache",
         autospec=True,
         side_effect=fake_instance_config,
+    ), mock.patch(
+        "paasta_tools.eks_tools.load_eks_service_config_no_cache",
+        autospec=True,
+        side_effect=fake_eks_instance_config,
     ), mock.patch(
         "paasta_tools.cleanup_kubernetes_jobs.list_all_applications",
         return_value={
@@ -419,11 +541,22 @@ def test_cleanup_unused_apps_dont_kill_statefulsets(
     ) as mock_alert_state_change:
         mock_alert_state_change.__enter__ = mock.Mock(return_value=(mock.Mock(), None))
         mock_alert_state_change.__exit__ = mock.Mock(return_value=None)
-        cleanup_unused_apps("soa_dir", "fake_cluster", kill_threshold=0.5, force=False)
+        cleanup_unused_apps(
+            "soa_dir", "fake_cluster", kill_threshold=0.5, force=False, eks=eks_flag
+        )
         assert mock_kube_client.deployments.delete_namespaced_deployment.call_count == 0
 
 
-def test_cleanup_unused_apps_force(fake_deployment, fake_stateful_set, invalid_app):
+@pytest.mark.parametrize(
+    "eks_flag",
+    [
+        (False),
+        (True),
+    ],
+)
+def test_cleanup_unused_apps_force(
+    eks_flag, fake_deployment, fake_stateful_set, invalid_app
+):
     mock_kube_client = mock.MagicMock()
     with mock.patch(
         "paasta_tools.cleanup_kubernetes_jobs.KubeClient",
@@ -433,6 +566,10 @@ def test_cleanup_unused_apps_force(fake_deployment, fake_stateful_set, invalid_a
         "paasta_tools.kubernetes_tools.load_kubernetes_service_config_no_cache",
         autospec=True,
         side_effect=fake_instance_config,
+    ), mock.patch(
+        "paasta_tools.eks_tools.load_eks_service_config_no_cache",
+        autospec=True,
+        side_effect=fake_eks_instance_config,
     ), mock.patch(
         "paasta_tools.cleanup_kubernetes_jobs.list_all_applications",
         return_value={("service", "instance-1"): [DeploymentWrapper(fake_deployment)]},
@@ -450,12 +587,21 @@ def test_cleanup_unused_apps_force(fake_deployment, fake_stateful_set, invalid_a
     ) as mock_alert_state_change:
         mock_alert_state_change.__enter__ = mock.Mock(return_value=(mock.Mock(), None))
         mock_alert_state_change.__exit__ = mock.Mock(return_value=None)
-        cleanup_unused_apps("soa_dir", "fake_cluster", kill_threshold=0, force=True)
+        cleanup_unused_apps(
+            "soa_dir", "fake_cluster", kill_threshold=0, force=True, eks=eks_flag
+        )
         assert mock_kube_client.deployments.delete_namespaced_deployment.call_count == 1
 
 
+@pytest.mark.parametrize(
+    "eks_flag",
+    [
+        (False),
+        (True),
+    ],
+)
 def test_cleanup_unused_apps_ignore_invalid_apps(
-    fake_deployment, fake_stateful_set, invalid_app
+    eks_flag, fake_deployment, fake_stateful_set, invalid_app
 ):
     mock_kube_client = mock.MagicMock()
     with mock.patch(
@@ -474,5 +620,7 @@ def test_cleanup_unused_apps_ignore_invalid_apps(
         mock_kube_client.deployments.list_namespaced_deployment.return_value = (
             mock.MagicMock(items=[invalid_app])
         )
-        cleanup_unused_apps("soa_dir", "fake_cluster", kill_threshold=0, force=True)
+        cleanup_unused_apps(
+            "soa_dir", "fake_cluster", kill_threshold=0, force=True, eks=eks_flag
+        )
         assert mock_kube_client.deployments.delete_namespaced_deployment.call_count == 0


### PR DESCRIPTION
This PR adds the ``--eks`` flag which will allow us to load the eks instance type instead of the kubernetes instance type when used

### Testing

- Modified the unit tests to account for the flag
- Manually tested cleanup kubernetes job on paasta playground:

1. without the usage of the ``--eks`` flag and the usage of ``--force`` flag:
```
emanelsabban@dev208-uswest1adevc:~$ kubectl --context kind-emanelsabban-k8s-test --kubeconfig /nail/home/emanelsabban/pg/paasta/k8s_itests/kubeconfig get pods -A
NAMESPACE            NAME                                                              READY   STATUS        RESTARTS   AGE
eks-autoscaling      compute-infra-test-service-eks-autoscaling-6545db6bfb-4sk94       1/1     Terminating   0          4d4h
eks-autoscaling      compute-infra-test-service-eks-autoscaling-6545db6bfb-dltb5       1/1     Terminating   0          4d4h
eks-autoscaling      compute-infra-test-service-eks-autoscaling-6545db6bfb-l4x2l       1/1     Terminating   0          4d4h
eks-autoscaling      compute-infra-test-service-eks-autoscaling-6545db6bfb-sdhch       1/1     Terminating   0          4d4h
eks-autoscaling      compute-infra-test-service-eks-autoscaling-6545db6bfb-wqvmw       1/1     Terminating   0          4d4h
new-instance-test    compute-infra-test-service-eks-new--instance--test-596b4958qbmm   1/1     Terminating   0          4d4h
...
new-instance-test    compute-infra-test-service-eks-new--instance--test-596b495d2br9   1/1     Terminating   0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-6f5dg            1/1     Running       0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-7khbs            1/1     Running       0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-7ljgn            1/1     Running       0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-8xn7p            1/1     Running       0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-dkjhk            1/1     Running       0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-gxjst            1/1     Running       0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-j4prh            1/1     Running       0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-jdth7            1/1     Running       0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-qvhn6            1/1     Running       0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-tswt4            1/1     Running       0          4d4h
```
verbose of running cleanup kubernetes job : https://fluffy.yelpcorp.com/i/MHgrs4pjXl5P9j8hMCNwF7LjB1WPqLP0.html

2. with the usage of the ``--eks`` flag and ``--force`` flag:
```

emanelsabban@dev208-uswest1adevc:~$ kubectl --context kind-emanelsabban-k8s-test --kubeconfig /nail/home/emanelsabban/pg/paasta/k8s_itests/kubeconfig get pods -A
NAMESPACE            NAME                                                          READY   STATUS        RESTARTS   AGE
...
paasta               compute-infra-test-service-autoscaling-8bcbb8987-6f5dg        1/1     Terminating   0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-7khbs        1/1     Terminating   0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-7ljgn        1/1     Terminating   0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-8xn7p        1/1     Terminating   0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-dkjhk        1/1     Terminating   0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-gxjst        1/1     Terminating   0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-j4prh        1/1     Terminating   0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-jdth7        1/1     Terminating   0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-qvhn6        1/1     Terminating   0          4d4h
paasta               compute-infra-test-service-autoscaling-8bcbb8987-tswt4        1/1     Terminating   0          4d4h
emanelsabban@dev208-uswest1adevc:~$ 
```
verbose of running cleanup with the ``--eks`` flag: https://fluffy.yelpcorp.com/i/Zgl4zW7Mh38kxsrp3zlKkbBVpPLRfBHX.html