### PR TITLE
COMPINFRA-3079: Add cassandracluster to known autotuned config types

### DIFF
--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -17,7 +17,13 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 log = logging.getLogger(__name__)
 
 # Must have a schema defined
-KNOWN_CONFIG_TYPES = ("marathon", "kubernetes", "deploy", "smartstack")
+KNOWN_CONFIG_TYPES = (
+    "marathon",
+    "kubernetes",
+    "deploy",
+    "smartstack",
+    "cassandracluster",
+)
 
 
 def my_represent_none(self, data):

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -91,9 +91,15 @@ def test_write_auto_config_data_file_exists(tmpdir):
 
 @mock.patch("paasta_tools.config_utils.validate_schema", autospec=True)
 def test_validate_auto_config_file_config_types(mock_validate, tmpdir):
-    for config_type in config_utils.KNOWN_CONFIG_TYPES:
+    for config_type in (
+        "marathon",
+        "kubernetes",
+        "deploy",
+        "smartstack",
+        "cassandracluster",
+    ):
         filepath = f"service/{config_type}-cluster.yaml"
-        config_utils.validate_auto_config_file(filepath, AUTO_SOACONFIG_SUBDIR)
+        assert config_utils.validate_auto_config_file(filepath, AUTO_SOACONFIG_SUBDIR)
         mock_validate.assert_called_with(filepath, f"autotuned_defaults/{config_type}")
 
 


### PR DESCRIPTION
## Problem or Feature

We have started generating autotuned_defaults for the cassandra_k8s service. However, autotuned configs generation is failing (search for `cassandra-paasta-autotune` in y/jenkins) while validating the filenames.

```
[2023-09-13T10:55:24.220Z] ERROR:paasta_tools.config_utils:Files failed validation, not committing changes
[2023-09-13T10:55:24.521Z] Traceback (most recent call last):
[2023-09-13T10:55:24.521Z]   File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
[2023-09-13T10:55:24.521Z]     return _run_code(code, main_globals, None,
[2023-09-13T10:55:24.521Z]   File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
[2023-09-13T10:55:24.521Z]     exec(code, run_globals)
[2023-09-13T10:55:24.521Z]   File "/opt/venvs/paasta-tools/lib/python3.8/site-packages/paasta_tools/contrib/rightsizer_soaconfigs_update.py", line 254, in <module>
[2023-09-13T10:55:24.521Z]     main(args)
[2023-09-13T10:55:24.521Z]   File "/opt/venvs/paasta-tools/lib/python3.8/site-packages/paasta_tools/contrib/rightsizer_soaconfigs_update.py", line 245, in main
[2023-09-13T10:55:24.522Z]     updater.commit_to_remote(extra_message=extra_message)
[2023-09-13T10:55:24.522Z]   File "/opt/venvs/paasta-tools/lib/python3.8/site-packages/paasta_tools/config_utils.py", line 231, in commit_to_remote
[2023-09-13T10:55:24.522Z]     raise ValidationError
[2023-09-13T10:55:24.522Z] paasta_tools.config_utils.ValidationError
script returned exit code 1
```

## Solution

Cassandra configs start with `cassandracluster-{superregion}.yaml` as opposed to the usual `kubernetes-{superregion}.yaml`, because they are deployed as `cassandracluster` CRs. We would like to fix this by allowing configs that look like `{instancetype}-{superregion}.yaml`.

## Context

[COMPINFRA-3079](http://y/COMPINFRA-3079)