### PR TITLE
[COREJAVA-897] Avoid using label_replace in series query

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -357,13 +357,7 @@ def create_instance_active_requests_scaling_rule(
         )
     """
     series_query = f"""
-        label_replace(
-            label_replace(
-                paasta_instance:envoy_cluster__egress_cluster_upstream_rq_active{{{worker_filter_terms}}},
-                "kube_deployment", "{deployment_name}", "", ""
-            ),
-            "kube_namespace", "{namespace}", "", ""
-        )
+        k8s:deployment:pods_status_ready{{{worker_filter_terms}}}
     """
 
     metric_name = f"{deployment_name}-active-requests-prom"


### PR DESCRIPTION
## Details
Avoid using label_replace in series query. 

Using promql within the query would fail the metrics discovery.

```
curl 'http://thanoslocal-compute-infra-hpa-infrastage.discovery:9090/api/v1/series?match%5B%5D=label_replace%28label_replace%28paasta_instance%3Aenvoy_cluster__egress_cluster_upstream_rq_active%7Bpaasta_cluster%3D%27infrastage%27%2Cpaasta_service%3D%27example_happyhour_java%27%2Cpaasta_instance%3D%27main%27%7D%2C%27kube_deployment%27%2C+%27example--happyhour--java-main%27%2C+%27%27%2C+%27%27%29%2C%27kube_namespace%27%2C+%27paastasvc-example--happyhour--java%27%2C+%27%27%2C+%27%27%29&start=16946'
{"status":"error","errorType":"bad_data","error":"1:14: parse error: unexpected \"(\""}
```

## Validation
Tested manually by replacing the query in stagef and load testing on example_happhour_java. Scaling works as expected. 

## JIRA 
COREJAVA-897