### PR TITLE
[COREJAVA-901] Remove calculation of missing instances as it can't be calculated with data in HPA

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -292,18 +292,6 @@ def create_instance_active_requests_scaling_rule(
             )
         ) by (kube_deployment)
     """
-    # k8s:deployment:pods_status_ready is a metric created by summing kube_pod_status_ready
-    # over paasta service/instance/cluster. it counts the number of ready pods in a paasta
-    # deployment.
-    ready_pods = f"""
-        (sum(
-            k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
-            or
-            max_over_time(
-                k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
-            )
-        ) by (kube_deployment))
-    """
 
     # envoy-based metrics have no labels corresponding to the k8s resources that they
     # front, but we can trivially add one in since our deployment names are of the form


### PR DESCRIPTION
## Details
As the metric from envoy is already aggregated for us, there would only ever be a single data point for the metric. 
When we try to calculate the missing instances we do `{ready_pods} - count({load_per_instance}) by (kube_deployment),`

So, the missing instance count, will always be `{ready_pods} - 1` as there is only a single data point and the count would always be 1. This tells the HPA that there is data only from a single pod. 

When calculating the total load, we are almost doubling it as we think there is only data coming from 1 pod and we try to worst case estimate that every pod is at full capacity.

This change will remove any calculations around missing instances as we cannot figure that out with the data within the HPA as we record aggregated metrics already. so we only have a single datapoint per service, instance. 


This is they query we want to run - [link](https://grafana.yelpcorp.com/explore?orgId=1&left=%7B%22datasource%22:%22P0A14DA14C82905AE%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%20%20avg_over_time%28%5Cn%20%20%20%20%28%5Cn%20%20%20%20%20%20%20%20%28%5Cn%20%20%20%20%20%20%20%20%20%20sum%20by%20%28kube_deployment%29%20%28%5Cn%20%20%20%20%20%20%20%20%20%20%20%20label_replace%28%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20paasta_instance:envoy_cluster__egress_cluster_upstream_rq_active%7Bpaasta_cluster%3D%5C%22norcal-stagef%5C%22,paasta_instance%3D%5C%22main%5C%22,paasta_service%3D%5C%22example_happyhour_java%5C%22%7D,%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22kube_deployment%5C%22,%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22example--happyhour--java-main%5C%22,%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22%5C%22,%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22%5C%22%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%29%5Cn%20%20%20%20%20%20%20%20%20%20%29%5Cn%20%20%20%20%20%20%20%20%29%5Cn%20%20%20%20%20%20%2F%5Cn%20%20%20%20%20%20%20%202%5Cn%20%20%20%20%29%5B5m:%5D%5Cn%20%20%29%5Cn%2F%5Cn%20%20sum%20by%20%28kube_deployment%29%20%28%5Cn%20%20%20%20label_join%28%5Cn%20%20%20%20%20%20%28%5Cn%20%20%20%20%20%20%20%20%20%20%20%20kube_deployment_spec_replicas%7Bdeployment%3D%5C%22example--happyhour--java-main%5C%22,namespace%3D%5C%22paastasvc-example--happyhour--java%5C%22,paasta_cluster%3D%5C%22norcal-stagef%5C%22%7D%5Cn%20%20%20%20%20%20%20%20%20%20%3E%3D%5Cn%20%20%20%20%20%20%20%20%20%20%20%200%5Cn%20%20%20%20%20%20%20%20or%5Cn%20%20%20%20%20%20%20%20%20%20max_over_time%28%5Cn%20%20%20%20%20%20%20%20%20%20%20%20kube_deployment_spec_replicas%7Bdeployment%3D%5C%22example--happyhour--java-main%5C%22,namespace%3D%5C%22paastasvc-example--happyhour--java%5C%22,paasta_cluster%3D%5C%22norcal-stagef%5C%22%7D%5B1m40s%5D%5Cn%20%20%20%20%20%20%20%20%20%20%29%5Cn%20%20%20%20%20%20%29,%5Cn%20%20%20%20%20%20%5C%22kube_deployment%5C%22,%5Cn%20%20%20%20%20%20%5C%22%5C%22,%5Cn%20%20%20%20%20%20%5C%22deployment%5C%22%5Cn%20%20%20%20%29%5Cn%20%20%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P0A14DA14C82905AE%22%7D,%22editorMode%22:%22code%22%7D%5D,%22range%22:%7B%22from%22:%22now-3h%22,%22to%22:%22now%22%7D%7D).

## JIRA
COREJAVA-901