### PR TITLE
Ensure secret_volume volumes are not optional

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1535,6 +1535,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                         ),
                         default_mode=mode_to_int(secret_volume.get("default_mode")),
                         items=items,
+                        optional=False,
                     ),
                 )
             )

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1299,12 +1299,16 @@ class TestKubernetesDeploymentConfig:
             ),
             V1Volume(
                 name="secret--waldo",
-                secret=V1SecretVolumeSource(secret_name="paasta-secret-kurupt-waldo"),
+                secret=V1SecretVolumeSource(
+                    secret_name="paasta-secret-kurupt-waldo", optional=False
+                ),
             ),
             V1Volume(
                 name="secret--waldo",
                 secret=V1SecretVolumeSource(
-                    secret_name="paasta-secret-kurupt-waldo", default_mode=0o765
+                    secret_name="paasta-secret-kurupt-waldo",
+                    default_mode=0o765,
+                    optional=False,
                 ),
             ),
             V1Volume(
@@ -1315,6 +1319,7 @@ class TestKubernetesDeploymentConfig:
                         V1KeyToPath(key="aaa", mode=0o567, path="bbb"),
                         V1KeyToPath(key="ccc", path="ddd"),
                     ],
+                    optional=False,
                 ),
             ),
         ]


### PR DESCRIPTION
We noticed some logging from a newly added use of secret_volume that makes us think that the default for these is that V1SecretVolumeSources are optional - let's clear up any ambiguity and explicitly set a value for this

NOTE: I'm not quite sure if this will require a big bounce of anything using secret_volume - but I guess that's also less of a concern than a big bounce of *everything*