### PR TITLE
COMPINFRA-3079: Add cassandracluster crd autotune spec schema

### DIFF
--- a/paasta_tools/cli/schemas/autotuned_defaults/cassandracluster_schema.json
+++ b/paasta_tools/cli/schemas/autotuned_defaults/cassandracluster_schema.json
@@ -15,9 +15,9 @@
                     "minimum": 0,
                     "exclusiveMinimum": true
                 },
-                "cpu_burst_add": {
+                "cpu_burst_percent": {
                     "type": "number",
-                    "minimum": 0.0,
+                    "minimum": 0,
                     "exclusiveMinimum": false
                 },
                 "disk": {

--- a/paasta_tools/cli/schemas/autotuned_defaults/cassandracluster_schema.json
+++ b/paasta_tools/cli/schemas/autotuned_defaults/cassandracluster_schema.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Properties that can be set by automated processes for cassandracluster spec files",
+    "type": "object",
+    "additionalProperties": false,
+    "minProperties": 1,
+    "patternProperties": {
+        "^([a-z0-9]|[a-z0-9][a-z0-9_-]*[a-z0-9])*$": {
+            "type": "object",
+            "additionalProperties": false,
+            "minProperties": 1,
+            "properties": {
+                "cpus": {
+                    "type": "number",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                },
+                "cpu_burst_add": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "exclusiveMinimum": false
+                },
+                "disk": {
+                    "type": "string"
+                },
+                "mem": {
+                    "type": "string"
+                },
+                "replicas": {
+                    "type": "number",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to https://github.com/Yelp/paasta/pull/3703

`rightsizer_soaconfigs_update` is failing for Cassandra autotune recs because validation doesn't pass.

```
  File "/opt/venvs/paasta-tools/lib/python3.8/site-packages/paasta_tools/config_utils.py", line 244, in commit_to_remote
    raise ValidationError
paasta_tools.config_utils.ValidationError
```
followed by
```
Failed to find schema to validate against.
```

The JSON schema file is not available for Cassandra CRD spec in the autotune directory `paasta_tools/cli/schemas/autotuned_defaults/` https://github.com/Yelp/paasta/blob/32c4cb7d310a5e174c7b3f120505f04f89adb9aa/paasta_tools/cli/cmds/validate.py#L165-L175

I've added a spec similar to `kubernetes_schema.json`. The format for sidecar resource spec is slightly different, I'm omitting it as we don't need it now. I've also added `replicas` as it's a Cassandra specific config field.

See yelpsoa `msurnin-test` branch for the generated recs that the rightsizer committed.