### PR TITLE
Remove sfx autoscaling link

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1724,7 +1724,6 @@ def get_autoscaling_table(
             f"       Desired instances: {autoscaling_status['desired_replicas']}"
         )
         table.append(f"       Last scale time: {autoscaling_status['last_scale_time']}")
-        table.append(f"       Dashboard: y/sfx-autoscaling")
         NA = PaastaColors.red("N/A")
         if len(autoscaling_status["metrics"]) > 0:
             table.append(f"       Metrics:")


### PR DESCRIPTION
We haven't used SFX for autoscaling in quite some time and this confuses people that see it referenced in the output of `paasta status`

At some point we'll want to replace this with a dashboard that visualizes how the Prometheus-based autoscaling works - but that's for future-us to do :)