### PR TITLE
Run tox envs in parallel in GHA tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         toxenv:
-          - py38-linux,docs,mypy,tests
+          - py38-linux
+          - docs
+          - mypy
+          - tests
           - general_itests
     env:
       DOCKER_REGISTRY: ""


### PR DESCRIPTION
This will have two side effects:
1) it'll be easier to find what failed (rather than having to wade
   through an ocean of python setup logs)
2) hopefully make things faster since we'll do all these tests in
   parallel.