### PR TITLE
Create new function for getting cassandracluster result values

### DIFF
--- a/paasta_tools/contrib/rightsizer_soaconfigs_update.py
+++ b/paasta_tools/contrib/rightsizer_soaconfigs_update.py
@@ -178,7 +178,7 @@ def get_cassandra_recommendation_from_result(result, keys_to_apply):
         if key == "cpus":
             rec["cpus"] = float(val)
         elif key == "cpu_burst_percent":
-            rec["cpu_burst_percent"] = min(1, float(val))
+            rec["cpu_burst_percent"] = float(val)
         elif key == "mem":
             rec["mem"] = val
         elif key == "disk":

--- a/paasta_tools/contrib/rightsizer_soaconfigs_update.py
+++ b/paasta_tools/contrib/rightsizer_soaconfigs_update.py
@@ -13,6 +13,7 @@ from typing import Union
 
 from paasta_tools.config_utils import AutoConfigUpdater
 from paasta_tools.contrib.paasta_update_soa_memcpu import get_report_from_splunk
+from paasta_tools.kubernetes_tools import SidecarResourceRequirements
 from paasta_tools.utils import AUTO_SOACONFIG_SUBDIR
 from paasta_tools.utils import DEFAULT_SOA_CONFIGS_GIT_URL
 from paasta_tools.utils import format_git_url
@@ -188,19 +189,6 @@ class KubernetesRightsizerResult(TypedDict):
     suggested_max_instances: int
 
 
-class CPU(TypedDict):
-    cpu: float
-
-
-class Hacheck(TypedDict):
-    requests: CPU
-    limits: CPU
-
-
-class SidecarResourceRequirements(TypedDict):
-    hacheck: Hacheck
-
-
 class KubernetesRecommendation(TypedDict, total=False):
     disk: float
     mem: float
@@ -208,7 +196,7 @@ class KubernetesRecommendation(TypedDict, total=False):
     cpu_burst_add: float
     max_instances: int
     min_instances: int
-    sidecar_resource_requirements: SidecarResourceRequirements
+    sidecar_resource_requirements: Dict[str, SidecarResourceRequirements]
 
 
 def get_kubernetes_recommendation_from_result(

--- a/paasta_tools/contrib/rightsizer_soaconfigs_update.py
+++ b/paasta_tools/contrib/rightsizer_soaconfigs_update.py
@@ -192,7 +192,6 @@ def get_recommendation_from_result(instance_type, result, keys_to_apply):
     function_map = {
         "cassandracluster": get_cassandra_recommendation_from_result,
         "kubernetes": get_kubernetes_recommendation_from_result,
-        "marathon": get_kubernetes_recommendation_from_result,
     }
     return function_map[instance_type](result, keys_to_apply)
 


### PR DESCRIPTION
## Feature or Problem

At the moment, the script raises an exception when trying to extract `disk` values from cassandracluster recommendation values:

```
$ /opt/venvs/paasta-tools/bin/python ./paasta_tools/contrib/rightsizer_soaconfigs_update.py --csv-report cassandra_paasta_rightsizer_disk_recs.csv --csv-key disk --splunk-creds **** --source-id fake-source-id --app yelp_dre --local-dir=~/pg/sysgit/yelpsoa-configs

INFO:root:Found services to rightsize
Traceback (most recent call last):
  File "./paasta_tools/contrib/rightsizer_soaconfigs_update.py", line 254, in <module>
    main(args)
  File "./paasta_tools/contrib/rightsizer_soaconfigs_update.py", line 213, in main
    results = get_recommendations_by_service_file(
  File "./paasta_tools/contrib/rightsizer_soaconfigs_update.py", line 192, in get_recommendations_by_service_file
    rec = get_recommendation_from_result(result, keys_to_apply)
  File "./paasta_tools/contrib/rightsizer_soaconfigs_update.py", line 152, in get_recommendation_from_result
    rec["disk"] = max(128, round(float(val)))
ValueError: could not convert string to float: '5Gi'
```

This is because the `get_recommendation_from_result` function expects `disk` values to be numbers, while for `cassandracluster-*` they must be strings e.g. `"2Gi"`.

This issue causes the script to fail for both `disk` and `mem` values.

## Solution

Specs for the cassandracluster instance type differs from the kubernetes instance type and in this PR we are separating them.

This way we can also handle `mem` differently and handle spec fields that do not exist in kubernetes instance type specs such as `cpu_burst_percent`, and remove those that don't exist in cassandracluster specs such as `cpu_burst_add`

## Verification

```
$ /opt/venvs/paasta-tools/bin/python ./paasta_tools/contrib/rightsizer_soaconfigs_update.py --csv-report cassandra_paasta_rightsizer_disk_recs.csv --csv-key disk --splunk-creds **** --source-id fake-source-id --app yelp_dre --local-dir=~/pg/sysgit/yelpsoa-configs

INFO:root:Found services to rightsize
✓ Successfully validated schema: cassandracluster-norcal-stagef.yaml
✓ Successfully validated schema: cassandracluster-nova-prod.yaml
✓ Successfully validated schema: cassandracluster-pnw-prod.yaml
✓ Successfully validated schema: cassandracluster-norcal-devc.yaml
✓ Successfully validated schema: cassandracluster-pnw-devc.yaml
```

## Context

[DREIMP-10074](http://y/DREIMP-10074)