### PR TITLE
Set DNSPolicy for spark executors

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -82,6 +82,7 @@ metadata:
   labels:
     spark: {spark_pod_label}
 spec:
+  dnsPolicy: Default
   affinity:
     podAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This is required by the PaaSTA Workload contract and should lower the incidence of weird DNS-related issues.