### PR TITLE
Validate iam_role and stop supporting kiam

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -629,7 +629,8 @@
                 },
                 "iam_role": {
                     "type": "string",
-                    "pattern": "^arn:aws:iam::[0-9]+:role/[a-zA-Z0-9+=,.@_-]+$"
+                    "pattern": "^arn:aws:iam::[0-9]+:role/[a-zA-Z0-9+=,.@_-]+$",
+                    "$comment": "This should be a valid AWS IAM role ARN, see https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-names"
                 },
                 "iam_role_provider": {
                     "enum": [

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -628,11 +628,11 @@
                     "type": "array"
                 },
                 "iam_role": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^arn:aws:iam::[0-9]+:role/[a-zA-Z0-9+=,.@_-]+$"
                 },
                 "iam_role_provider": {
                     "enum": [
-                        "kiam",
                         "aws"
                     ]
                 },

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -101,7 +101,8 @@
                     "type": "string"
                 },
                 "iam_role": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^arn:aws:iam::[0-9]+:role/[a-zA-Z0-9+=,.@_-]+$"
                 },
                 "iam_role_provider": {
                     "enum": [

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -102,7 +102,8 @@
                 },
                 "iam_role": {
                     "type": "string",
-                    "pattern": "^arn:aws:iam::[0-9]+:role/[a-zA-Z0-9+=,.@_-]+$"
+                    "pattern": "^arn:aws:iam::[0-9]+:role/[a-zA-Z0-9+=,.@_-]+$",
+                    "$comment": "This should be a valid AWS IAM role ARN, see https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-names"
                 },
                 "iam_role_provider": {
                     "enum": [

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -945,7 +945,7 @@ class InstanceConfig:
         return self.config_dict.get("iam_role", "")
 
     def get_iam_role_provider(self) -> str:
-        return self.config_dict.get("iam_role_provider", "kiam")
+        return self.config_dict.get("iam_role_provider", "aws")
 
     def get_role(self) -> Optional[str]:
         """Which mesos role of nodes this job should run on."""


### PR DESCRIPTION
Since we removed kiam from our environments, we can stop supporting it and set the default of `iam_role_provider` to be `aws` now (similar to how this is already configured for tron)

In addition, that means iam_role must always be an AWS IAM role ARN, which has some very specific structure.

This applies the valid patterns per [aws's docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-names) and adds some minor tests to check a few different cases