### PR TITLE
[COREJAVA-995] Refactor to pass instance_config to all scaling rules

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -61,6 +61,7 @@ from paasta_tools.long_running_service_tools import (
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_services_for_cluster
+from paasta_tools.utils import InstanceConfig_T
 from paasta_tools.utils import load_system_paasta_config
 
 log = logging.getLogger(__name__)
@@ -248,14 +249,16 @@ def should_create_active_requests_scaling_rule(
 
 def create_instance_active_requests_scaling_rule(
     service: str,
-    instance: str,
-    autoscaling_config: AutoscalingParamsDict,
+    instance_config: InstanceConfig_T,
     paasta_cluster: str,
     namespace: str = "paasta",
 ) -> PrometheusAdapterRule:
     """
     Creates a Prometheus adapter rule config for a given service instance.
     """
+    autoscaling_config = instance_config.get_autoscaling_params()
+    instance = instance_config.instance
+    namespace = instance_config.get_namespace() or "paasta"
     desired_active_requests_per_replica = autoscaling_config.get(
         "desired_active_requests_per_replica",
         DEFAULT_DESIRED_ACTIVE_REQUESTS_PER_REPLICA,
@@ -347,14 +350,15 @@ def create_instance_active_requests_scaling_rule(
 
 def create_instance_uwsgi_scaling_rule(
     service: str,
-    instance: str,
-    autoscaling_config: AutoscalingParamsDict,
+    instance_config: InstanceConfig_T,
     paasta_cluster: str,
-    namespace: str = "paasta",
 ) -> PrometheusAdapterRule:
     """
     Creates a Prometheus adapter rule config for a given service instance.
     """
+    autoscaling_config = instance_config.get_autoscaling_params()
+    instance = instance_config.instance
+    namespace = instance_config.get_namespace() or "paasta"
     setpoint = autoscaling_config["setpoint"]
     moving_average_window = autoscaling_config.get(
         "moving_average_window_seconds", DEFAULT_UWSGI_AUTOSCALING_MOVING_AVERAGE_WINDOW
@@ -450,14 +454,15 @@ def create_instance_uwsgi_scaling_rule(
 
 def create_instance_piscina_scaling_rule(
     service: str,
-    instance: str,
-    autoscaling_config: AutoscalingParamsDict,
+    instance_config: InstanceConfig_T,
     paasta_cluster: str,
-    namespace: str = "paasta",
 ) -> PrometheusAdapterRule:
     """
     Creates a Prometheus adapter rule config for a given service instance.
     """
+    autoscaling_config = instance_config.get_autoscaling_params()
+    instance = instance_config.instance
+    namespace = instance_config.get_namespace() or "paasta"
     setpoint = autoscaling_config["setpoint"]
     moving_average_window = autoscaling_config.get(
         "moving_average_window_seconds",
@@ -561,14 +566,15 @@ def should_create_cpu_scaling_rule(
 
 def create_instance_cpu_scaling_rule(
     service: str,
-    instance: str,
-    autoscaling_config: AutoscalingParamsDict,
+    instance_config: InstanceConfig_T,
     paasta_cluster: str,
-    namespace: str = "paasta",
 ) -> PrometheusAdapterRule:
     """
     Creates a Prometheus adapter rule config for a given service instance.
     """
+    autoscaling_config = instance_config.get_autoscaling_params()
+    instance = instance_config.instance
+    namespace = instance_config.get_namespace() or "paasta"
     deployment_name = get_kubernetes_app_name(service=service, instance=instance)
     sanitized_instance_name = sanitise_kubernetes_name(instance)
     metric_name = f"{deployment_name}-cpu-prom"
@@ -709,14 +715,15 @@ def create_instance_cpu_scaling_rule(
 
 def create_instance_gunicorn_scaling_rule(
     service: str,
-    instance: str,
-    autoscaling_config: AutoscalingParamsDict,
+    instance_config: InstanceConfig_T,
     paasta_cluster: str,
-    namespace: str = "paasta",
 ) -> PrometheusAdapterRule:
     """
     Creates a Prometheus adapter rule config for a given service instance.
     """
+    autoscaling_config = instance_config.get_autoscaling_params()
+    instance = instance_config.instance
+    namespace = instance_config.get_namespace() or "paasta"
     setpoint = autoscaling_config["setpoint"]
     moving_average_window = autoscaling_config.get(
         "moving_average_window_seconds",
@@ -821,11 +828,12 @@ def should_create_arbitrary_promql_scaling_rule(
 
 def create_instance_arbitrary_promql_scaling_rule(
     service: str,
-    instance: str,
-    autoscaling_config: AutoscalingParamsDict,
+    instance_config: InstanceConfig_T,
     paasta_cluster: str,
-    namespace: str,
 ) -> PrometheusAdapterRule:
+    autoscaling_config = instance_config.get_autoscaling_params()
+    instance = instance_config.instance
+    namespace = instance_config.get_namespace()
     prometheus_adapter_config = autoscaling_config["prometheus_adapter_config"]
     deployment_name = get_kubernetes_app_name(service=service, instance=instance)
 
@@ -881,10 +889,8 @@ def create_instance_arbitrary_promql_scaling_rule(
 
 def get_rules_for_service_instance(
     service_name: str,
-    instance_name: str,
-    autoscaling_config: AutoscalingParamsDict,
+    instance_config: InstanceConfig_T,
     paasta_cluster: str,
-    namespace: str,
 ) -> List[PrometheusAdapterRule]:
     """
     Returns a list of Prometheus Adapter rules for a given service instance. For now, this
@@ -904,23 +910,21 @@ def get_rules_for_service_instance(
         (should_create_gunicorn_scaling_rule, create_instance_gunicorn_scaling_rule),
     ):
         should_create, skip_reason = should_create_scaling_rule(
-            autoscaling_config=autoscaling_config,
+            autoscaling_config=instance_config.get_autoscaling_params(),
         )
         if should_create:
             rules.append(
                 create_instance_scaling_rule(
                     service=service_name,
-                    instance=instance_name,
-                    autoscaling_config=autoscaling_config,
+                    instance_config=instance_config,
                     paasta_cluster=paasta_cluster,
-                    namespace=namespace,
                 )
             )
         else:
             log.debug(
                 "Skipping %s.%s - %s.",
                 service_name,
-                instance_name,
+                instance_config.instance,
                 skip_reason,
             )
 
@@ -959,10 +963,8 @@ def create_prometheus_adapter_config(
             rules.extend(
                 get_rules_for_service_instance(
                     service_name=service_name,
-                    instance_name=instance_config.instance,
-                    autoscaling_config=instance_config.get_autoscaling_params(),
+                    instance_config=instance_config,
                     paasta_cluster=paasta_cluster,
-                    namespace=instance_config.get_namespace(),
                 )
             )
 

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -250,7 +250,6 @@ def create_instance_active_requests_scaling_rule(
     service: str,
     instance_config: KubernetesDeploymentConfig,
     paasta_cluster: str,
-    namespace: str = "paasta",
 ) -> PrometheusAdapterRule:
     """
     Creates a Prometheus adapter rule config for a given service instance.

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -61,7 +61,6 @@ from paasta_tools.long_running_service_tools import (
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_services_for_cluster
-from paasta_tools.utils import InstanceConfig_T
 from paasta_tools.utils import load_system_paasta_config
 
 log = logging.getLogger(__name__)
@@ -249,7 +248,7 @@ def should_create_active_requests_scaling_rule(
 
 def create_instance_active_requests_scaling_rule(
     service: str,
-    instance_config: InstanceConfig_T,
+    instance_config: KubernetesDeploymentConfig,
     paasta_cluster: str,
     namespace: str = "paasta",
 ) -> PrometheusAdapterRule:
@@ -350,7 +349,7 @@ def create_instance_active_requests_scaling_rule(
 
 def create_instance_uwsgi_scaling_rule(
     service: str,
-    instance_config: InstanceConfig_T,
+    instance_config: KubernetesDeploymentConfig,
     paasta_cluster: str,
 ) -> PrometheusAdapterRule:
     """
@@ -454,7 +453,7 @@ def create_instance_uwsgi_scaling_rule(
 
 def create_instance_piscina_scaling_rule(
     service: str,
-    instance_config: InstanceConfig_T,
+    instance_config: KubernetesDeploymentConfig,
     paasta_cluster: str,
 ) -> PrometheusAdapterRule:
     """
@@ -566,7 +565,7 @@ def should_create_cpu_scaling_rule(
 
 def create_instance_cpu_scaling_rule(
     service: str,
-    instance_config: InstanceConfig_T,
+    instance_config: KubernetesDeploymentConfig,
     paasta_cluster: str,
 ) -> PrometheusAdapterRule:
     """
@@ -715,7 +714,7 @@ def create_instance_cpu_scaling_rule(
 
 def create_instance_gunicorn_scaling_rule(
     service: str,
-    instance_config: InstanceConfig_T,
+    instance_config: KubernetesDeploymentConfig,
     paasta_cluster: str,
 ) -> PrometheusAdapterRule:
     """
@@ -828,7 +827,7 @@ def should_create_arbitrary_promql_scaling_rule(
 
 def create_instance_arbitrary_promql_scaling_rule(
     service: str,
-    instance_config: InstanceConfig_T,
+    instance_config: KubernetesDeploymentConfig,
     paasta_cluster: str,
 ) -> PrometheusAdapterRule:
     autoscaling_config = instance_config.get_autoscaling_params()
@@ -889,7 +888,7 @@ def create_instance_arbitrary_promql_scaling_rule(
 
 def get_rules_for_service_instance(
     service_name: str,
-    instance_config: InstanceConfig_T,
+    instance_config: KubernetesDeploymentConfig,
     paasta_cluster: str,
 ) -> List[PrometheusAdapterRule]:
     """

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -256,7 +256,7 @@ def create_instance_active_requests_scaling_rule(
     """
     autoscaling_config = instance_config.get_autoscaling_params()
     instance = instance_config.instance
-    namespace = instance_config.get_namespace() or "paasta"
+    namespace = instance_config.get_namespace()
     desired_active_requests_per_replica = autoscaling_config.get(
         "desired_active_requests_per_replica",
         DEFAULT_DESIRED_ACTIVE_REQUESTS_PER_REPLICA,
@@ -356,7 +356,7 @@ def create_instance_uwsgi_scaling_rule(
     """
     autoscaling_config = instance_config.get_autoscaling_params()
     instance = instance_config.instance
-    namespace = instance_config.get_namespace() or "paasta"
+    namespace = instance_config.get_namespace()
     setpoint = autoscaling_config["setpoint"]
     moving_average_window = autoscaling_config.get(
         "moving_average_window_seconds", DEFAULT_UWSGI_AUTOSCALING_MOVING_AVERAGE_WINDOW
@@ -460,7 +460,7 @@ def create_instance_piscina_scaling_rule(
     """
     autoscaling_config = instance_config.get_autoscaling_params()
     instance = instance_config.instance
-    namespace = instance_config.get_namespace() or "paasta"
+    namespace = instance_config.get_namespace()
     setpoint = autoscaling_config["setpoint"]
     moving_average_window = autoscaling_config.get(
         "moving_average_window_seconds",
@@ -572,7 +572,7 @@ def create_instance_cpu_scaling_rule(
     """
     autoscaling_config = instance_config.get_autoscaling_params()
     instance = instance_config.instance
-    namespace = instance_config.get_namespace() or "paasta"
+    namespace = instance_config.get_namespace()
     deployment_name = get_kubernetes_app_name(service=service, instance=instance)
     sanitized_instance_name = sanitise_kubernetes_name(instance)
     metric_name = f"{deployment_name}-cpu-prom"
@@ -721,7 +721,7 @@ def create_instance_gunicorn_scaling_rule(
     """
     autoscaling_config = instance_config.get_autoscaling_params()
     instance = instance_config.instance
-    namespace = instance_config.get_namespace() or "paasta"
+    namespace = instance_config.get_namespace()
     setpoint = autoscaling_config["setpoint"]
     moving_average_window = autoscaling_config.get(
         "moving_average_window_seconds",

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -1,6 +1,7 @@
 import mock
 import pytest
 
+from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.long_running_service_tools import AutoscalingParamsDict
 from paasta_tools.setup_prometheus_adapter_config import _minify_promql
 from paasta_tools.setup_prometheus_adapter_config import (
@@ -29,7 +30,6 @@ from paasta_tools.setup_prometheus_adapter_config import (
 from paasta_tools.setup_prometheus_adapter_config import (
     should_create_uwsgi_scaling_rule,
 )
-from paasta_tools.utils import InstanceConfig_T
 from paasta_tools.utils import SystemPaastaConfig
 
 MOCK_SYSTEM_PAASTA_CONFIG = SystemPaastaConfig(
@@ -456,7 +456,7 @@ def test_create_instance_gunicorn_scaling_rule() -> None:
     ],
 )
 def test_get_rules_for_service_instance(
-    instance_config: InstanceConfig_T,
+    instance_config: KubernetesDeploymentConfig,
     expected_rules: int,
 ) -> None:
     with mock.patch(

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -29,6 +29,7 @@ from paasta_tools.setup_prometheus_adapter_config import (
 from paasta_tools.setup_prometheus_adapter_config import (
     should_create_uwsgi_scaling_rule,
 )
+from paasta_tools.utils import InstanceConfig_T
 from paasta_tools.utils import SystemPaastaConfig
 
 MOCK_SYSTEM_PAASTA_CONFIG = SystemPaastaConfig(
@@ -82,13 +83,17 @@ def test_should_create_active_requests_scaling_rule(
 
 def test_create_instance_active_requests_scaling_rule() -> None:
     service_name = "test_service"
-    instance_name = "test_instance"
+    instance_config = mock.Mock(
+        instance="test_instance",
+        get_autoscaling_params=mock.Mock(
+            return_value={
+                "metrics_provider": "active-requests",
+                "desired_active_requests_per_replica": 12,
+                "moving_average_window_seconds": 20120302,
+            }
+        ),
+    )
     paasta_cluster = "test_cluster"
-    autoscaling_config: AutoscalingParamsDict = {
-        "metrics_provider": "active-requests",
-        "desired_active_requests_per_replica": 12,
-        "moving_average_window_seconds": 20120302,
-    }
 
     with mock.patch(
         "paasta_tools.setup_prometheus_adapter_config.load_system_paasta_config",
@@ -97,9 +102,8 @@ def test_create_instance_active_requests_scaling_rule() -> None:
     ):
         rule = create_instance_active_requests_scaling_rule(
             service=service_name,
-            instance=instance_name,
+            instance_config=instance_config,
             paasta_cluster=paasta_cluster,
-            autoscaling_config=autoscaling_config,
         )
 
     # we test that the format of the dictionary is as expected with mypy
@@ -107,15 +111,20 @@ def test_create_instance_active_requests_scaling_rule() -> None:
     # we're basically just writting a change-detector test - instead, we test
     # that we're actually using our inputs
     assert service_name in rule["seriesQuery"]
-    assert instance_name in rule["seriesQuery"]
+    assert instance_config.instance in rule["seriesQuery"]
     assert paasta_cluster in rule["seriesQuery"]
     # these two numbers are distinctive and unlikely to be used as constants
     assert (
-        str(autoscaling_config["desired_active_requests_per_replica"])
+        str(
+            instance_config.get_autoscaling_params()[
+                "desired_active_requests_per_replica"
+            ]
+        )
         in rule["metricsQuery"]
     )
     assert (
-        str(autoscaling_config["moving_average_window_seconds"]) in rule["metricsQuery"]
+        str(instance_config.get_autoscaling_params()["moving_average_window_seconds"])
+        in rule["metricsQuery"]
     )
 
 
@@ -175,14 +184,18 @@ def test_should_create_uswgi_scaling_rule(
 
 def test_create_instance_uwsgi_scaling_rule() -> None:
     service_name = "test_service"
-    instance_name = "test_instance"
+    instance_config = mock.Mock(
+        instance="test_instance",
+        get_autoscaling_params=mock.Mock(
+            return_value={
+                "metrics_provider": "uwsgi",
+                "setpoint": 0.1234567890,
+                "moving_average_window_seconds": 20120302,
+                "use_prometheus": True,
+            }
+        ),
+    )
     paasta_cluster = "test_cluster"
-    autoscaling_config: AutoscalingParamsDict = {
-        "metrics_provider": "uwsgi",
-        "setpoint": 0.1234567890,
-        "moving_average_window_seconds": 20120302,
-        "use_prometheus": True,
-    }
 
     with mock.patch(
         "paasta_tools.setup_prometheus_adapter_config.load_system_paasta_config",
@@ -191,9 +204,8 @@ def test_create_instance_uwsgi_scaling_rule() -> None:
     ):
         rule = create_instance_uwsgi_scaling_rule(
             service=service_name,
-            instance=instance_name,
+            instance_config=instance_config,
             paasta_cluster=paasta_cluster,
-            autoscaling_config=autoscaling_config,
         )
 
     # we test that the format of the dictionary is as expected with mypy
@@ -201,12 +213,16 @@ def test_create_instance_uwsgi_scaling_rule() -> None:
     # we're basically just writting a change-detector test - instead, we test
     # that we're actually using our inputs
     assert service_name in rule["seriesQuery"]
-    assert instance_name in rule["seriesQuery"]
+    assert instance_config.instance in rule["seriesQuery"]
     assert paasta_cluster in rule["seriesQuery"]
     # these two numbers are distinctive and unlikely to be used as constants
-    assert str(autoscaling_config["setpoint"]) in rule["metricsQuery"]
     assert (
-        str(autoscaling_config["moving_average_window_seconds"]) in rule["metricsQuery"]
+        str(instance_config.get_autoscaling_params()["setpoint"])
+        in rule["metricsQuery"]
+    )
+    assert (
+        str(instance_config.get_autoscaling_params()["moving_average_window_seconds"])
+        in rule["metricsQuery"]
     )
 
 
@@ -265,29 +281,33 @@ def test_should_create_cpu_scaling_rule(
 
 def test_create_instance_cpu_scaling_rule() -> None:
     service_name = "test_service"
-    instance_name = "test_instance"
+    instance_config = mock.Mock(
+        instance="test_instance",
+        get_namespace=mock.Mock(return_value="test_namespace"),
+        get_autoscaling_params=mock.Mock(
+            return_value={
+                "metrics_provider": "cpu",
+                "setpoint": 0.1234567890,
+                "moving_average_window_seconds": 20120302,
+                "use_prometheus": True,
+            }
+        ),
+    )
     paasta_cluster = "test_cluster"
-    namespace = "test_namespace"
-    autoscaling_config: AutoscalingParamsDict = {
-        "metrics_provider": "cpu",
-        "setpoint": 0.1234567890,
-        "moving_average_window_seconds": 20120302,
-        "use_prometheus": True,
-    }
 
     rule = create_instance_cpu_scaling_rule(
         service=service_name,
-        instance=instance_name,
+        instance_config=instance_config,
         paasta_cluster=paasta_cluster,
-        autoscaling_config=autoscaling_config,
-        namespace=namespace,
     )
 
     # our query doesn't include the setpoint as we'll just give the HPA the current CPU usage and
     # let the HPA compare that to the setpoint directly
     assert (
-        str(autoscaling_config["moving_average_window_seconds"]) in rule["metricsQuery"]
+        str(instance_config.get_autoscaling_params()["moving_average_window_seconds"])
+        in rule["metricsQuery"]
     )
+    assert str(instance_config.get_namespace()) in rule["metricsQuery"]
 
 
 @pytest.mark.parametrize(
@@ -328,14 +348,18 @@ def test_should_create_gunicorn_scaling_rule(
 
 def test_create_instance_gunicorn_scaling_rule() -> None:
     service_name = "test_service"
-    instance_name = "test_instance"
+    instance_config = mock.Mock(
+        instance="test_instance",
+        get_autoscaling_params=mock.Mock(
+            return_value={
+                "metrics_provider": "gunicorn",
+                "setpoint": 0.1234567890,
+                "moving_average_window_seconds": 20120302,
+                "use_prometheus": True,
+            }
+        ),
+    )
     paasta_cluster = "test_cluster"
-    autoscaling_config: AutoscalingParamsDict = {
-        "metrics_provider": "gunicorn",
-        "setpoint": 0.1234567890,
-        "moving_average_window_seconds": 20120302,
-        "use_prometheus": True,
-    }
 
     with mock.patch(
         "paasta_tools.setup_prometheus_adapter_config.load_system_paasta_config",
@@ -344,9 +368,8 @@ def test_create_instance_gunicorn_scaling_rule() -> None:
     ):
         rule = create_instance_gunicorn_scaling_rule(
             service=service_name,
-            instance=instance_name,
+            instance_config=instance_config,
             paasta_cluster=paasta_cluster,
-            autoscaling_config=autoscaling_config,
         )
 
     # we test that the format of the dictionary is as expected with mypy
@@ -354,58 +377,86 @@ def test_create_instance_gunicorn_scaling_rule() -> None:
     # we're basically just writting a change-detector test - instead, we test
     # that we're actually using our inputs
     assert service_name in rule["seriesQuery"]
-    assert instance_name in rule["seriesQuery"]
+    assert instance_config.instance in rule["seriesQuery"]
     assert paasta_cluster in rule["seriesQuery"]
     # these two numbers are distinctive and unlikely to be used as constants
-    assert str(autoscaling_config["setpoint"]) in rule["metricsQuery"]
     assert (
-        str(autoscaling_config["moving_average_window_seconds"]) in rule["metricsQuery"]
+        str(instance_config.get_autoscaling_params()["setpoint"])
+        in rule["metricsQuery"]
+    )
+    assert (
+        str(instance_config.get_autoscaling_params()["moving_average_window_seconds"])
+        in rule["metricsQuery"]
     )
 
 
 @pytest.mark.parametrize(
-    "autoscaling_config,expected_rules",
+    "instance_config,expected_rules",
     [
         (
-            {
-                "metrics_provider": "uwsgi",
-                "setpoint": 0.1234567890,
-                "moving_average_window_seconds": 20120302,
-                "use_prometheus": True,
-            },
+            mock.Mock(
+                instance="instance",
+                get_namespace=mock.Mock(return_value="test_namespace"),
+                get_autoscaling_params=mock.Mock(
+                    return_value={
+                        "metrics_provider": "uwsgi",
+                        "setpoint": 0.1234567890,
+                        "moving_average_window_seconds": 20120302,
+                        "use_prometheus": True,
+                    }
+                ),
+            ),
             1,
         ),
         (
-            {
-                "metrics_provider": "uwsgi",
-                "setpoint": 0.1234567890,
-                "moving_average_window_seconds": 20120302,
-                "use_prometheus": False,
-            },
+            mock.Mock(
+                instance="instance",
+                get_namespace=mock.Mock(return_value="test_namespace"),
+                get_autoscaling_params=mock.Mock(
+                    return_value={
+                        "metrics_provider": "uwsgi",
+                        "setpoint": 0.1234567890,
+                        "moving_average_window_seconds": 20120302,
+                        "use_prometheus": False,
+                    }
+                ),
+            ),
             0,
         ),
         (
-            {
-                "metrics_provider": "cpu",
-                "setpoint": 0.1234567890,
-                "moving_average_window_seconds": 20120302,
-                "use_prometheus": False,
-            },
+            mock.Mock(
+                instance="instance",
+                get_namespace=mock.Mock(return_value="test_namespace"),
+                get_autoscaling_params=mock.Mock(
+                    return_value={
+                        "metrics_provider": "cpu",
+                        "setpoint": 0.1234567890,
+                        "moving_average_window_seconds": 20120302,
+                        "use_prometheus": False,
+                    }
+                ),
+            ),
             0,
         ),
         (
-            {
-                "metrics_provider": "cpu",
-                "setpoint": 0.1234567890,
-                "moving_average_window_seconds": 20120302,
-                "use_prometheus": True,
-            },
+            mock.Mock(
+                instance="instance",
+                get_namespace=mock.Mock(return_value="test_namespace"),
+                get_autoscaling_params=mock.Mock(
+                    return_value={
+                        "metrics_provider": "cpu",
+                        "setpoint": 0.1234567890,
+                        "moving_average_window_seconds": 20120302,
+                        "use_prometheus": True,
+                    }
+                ),
+            ),
             1,
         ),
     ],
 )
 def test_get_rules_for_service_instance(
-    autoscaling_config: AutoscalingParamsDict,
+    instance_config: InstanceConfig_T,
     expected_rules: int,
 ) -> None:
     with mock.patch(
@@ -417,10 +468,8 @@ def test_get_rules_for_service_instance(
             len(
                 get_rules_for_service_instance(
                     service_name="service",
-                    instance_name="instance",
-                    autoscaling_config=autoscaling_config,
+                    instance_config=instance_config,
                     paasta_cluster="cluster",
-                    namespace="test_namespace",
                 )
             )
             == expected_rules
@@ -447,10 +496,14 @@ def test__minify_promql(query: str, expected: str) -> None:
 def test_create_instance_arbitrary_promql_scaling_rule_no_seriesQuery():
     rule = create_instance_arbitrary_promql_scaling_rule(
         service="service",
-        instance="instance",
-        autoscaling_config={"prometheus_adapter_config": {"metricsQuery": "foo"}},
+        instance_config=mock.Mock(
+            instance="instance",
+            get_namespace=mock.Mock(return_value="paasta"),
+            get_autoscaling_params=mock.Mock(
+                return_value={"prometheus_adapter_config": {"metricsQuery": "foo"}}
+            ),
+        ),
         paasta_cluster="cluster",
-        namespace="paasta",
     )
 
     assert rule == {
@@ -469,12 +522,19 @@ def test_create_instance_arbitrary_promql_scaling_rule_no_seriesQuery():
 def test_create_instance_arbitrary_promql_scaling_rule_with_seriesQuery():
     rule = create_instance_arbitrary_promql_scaling_rule(
         service="service",
-        instance="instance",
-        autoscaling_config={
-            "prometheus_adapter_config": {"metricsQuery": "foo", "seriesQuery": "bar"}
-        },
+        instance_config=mock.Mock(
+            instance="instance",
+            get_namespace=mock.Mock(return_value="test_namespace"),
+            get_autoscaling_params=mock.Mock(
+                return_value={
+                    "prometheus_adapter_config": {
+                        "metricsQuery": "foo",
+                        "seriesQuery": "bar",
+                    }
+                }
+            ),
+        ),
         paasta_cluster="cluster",
-        namespace="test_namespace",
     )
 
     assert rule == {


### PR DESCRIPTION
## Details
This is purely refactor PR to setup passing of instance_config to all scaling rules methods. 

The instance_config will be used later in `create_instance_active_requests_scaling_rule` to read registrations configured in yelpsoa configs. 

## Testing
Updated the unit tests.

## JIRA
COREJAVA-995