### PR TITLE
[COREJAVA-998] Use registration name for paasta_instance name if a single custom registration is used

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -604,6 +604,14 @@ def validate_autoscaling_configs(service_path):
                                 link="",
                             )
                         )
+                    if len(instance_config.get_registrations()) > 1:
+                        returncode = False
+                        print(
+                            failure(
+                                msg="Autoscaling configuration is invalid: active-requests autoscaler doesn't support instances with multiple registrations.",
+                                link="",
+                            )
+                        )
                 if autoscaling_params["metrics_provider"] in {
                     "uwsgi",
                     "piscina",

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -294,6 +294,15 @@ def create_instance_active_requests_scaling_rule(
         ) by (kube_deployment)
     """
 
+    # TODO - add a note on whats happening here :)
+    registrations = instance_config.get_registrations()
+
+    envoy_filter_terms = (
+        f"paasta_cluster='{paasta_cluster}',paasta_service='{service}',paasta_instance='{registrations[0].split('.')[-1]}'"
+        if len(registrations) == 1
+        else worker_filter_terms
+    )
+
     # envoy-based metrics have no labels corresponding to the k8s resources that they
     # front, but we can trivially add one in since our deployment names are of the form
     # {service_name}-{instance_name} - which are both things in `worker_filter_terms` so
@@ -304,7 +313,7 @@ def create_instance_active_requests_scaling_rule(
     (
         sum(
             label_replace(
-                paasta_instance:envoy_cluster__egress_cluster_upstream_rq_active{{{worker_filter_terms}}},
+                paasta_instance:envoy_cluster__egress_cluster_upstream_rq_active{{{envoy_filter_terms}}},
                 "kube_deployment", "{deployment_name}", "", ""
             )
         ) by (kube_deployment)

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -302,10 +302,8 @@ def create_instance_active_requests_scaling_rule(
     # More than one custom registrations are not supported and config validation takes care of rejecting such configs.
     registrations = instance_config.get_registrations()
 
-    mesh_instance = registrations[0].split('.')[-1] if registrations else None
-    envoy_filter_terms = (
-        f"paasta_cluster='{paasta_cluster}',paasta_service='{service}',paasta_instance='{mesh_instance or instance}'"
-    )
+    mesh_instance = registrations[0].split(".")[-1] if len(registrations) == 1 else None
+    envoy_filter_terms = f"paasta_cluster='{paasta_cluster}',paasta_service='{service}',paasta_instance='{mesh_instance or instance}'"
 
     # envoy-based metrics have no labels corresponding to the k8s resources that they
     # front, but we can trivially add one in since our deployment names are of the form

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -302,10 +302,9 @@ def create_instance_active_requests_scaling_rule(
     # More than one custom registrations are not supported and config validation takes care of rejecting such configs.
     registrations = instance_config.get_registrations()
 
+    mesh_instance = registrations[0].split('.')[-1] if registrations else None
     envoy_filter_terms = (
-        f"paasta_cluster='{paasta_cluster}',paasta_service='{service}',paasta_instance='{registrations[0].split('.')[-1]}'"
-        if len(registrations) == 1
-        else worker_filter_terms
+        f"paasta_cluster='{paasta_cluster}',paasta_service='{service}',paasta_instance='{mesh_instance or instance}'"
     )
 
     # envoy-based metrics have no labels corresponding to the k8s resources that they

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -294,7 +294,12 @@ def create_instance_active_requests_scaling_rule(
         ) by (kube_deployment)
     """
 
-    # TODO - add a note on whats happening here :)
+    # Envoy tracks metrics at the smartstack namespace level. In most cases the paasta instance name matches the smartstack namespace.
+    # In rare cases, there are custom registration added to instance configs.
+    # If there is no custom registration the envoy and instance names match and no need to update the worker_filter_terms.
+    # If there is a single custom registration for an instance, we will process the registration value and extract the value to be used.
+    # The registrations usually follow the format of {service_name}.{smartstack_name}. Hence we split the string by dot and extract the last token.
+    # More than one custom registrations are not supported and config validation takes care of rejecting such configs.
     registrations = instance_config.get_registrations()
 
     envoy_filter_terms = (

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -1099,82 +1099,58 @@ def test_validate_autoscaling_configs_no_offset_specified(
 @patch("paasta_tools.cli.cmds.validate.list_all_instances_for_service", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
-def test_validate_autoscaling_configs_active_requests_no_default_threshold_config(
-    mock_path_to_soa_dir_service,
-    mock_list_clusters,
-    mock_list_all_instances_for_service,
-    mock_get_instance_config,
-):
-    mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
-    mock_list_clusters.return_value = ["fake_cluster"]
-    mock_list_all_instances_for_service.return_value = {"fake_instance1"}
-    mock_get_instance_config.return_value = mock.Mock(
-        get_instance=mock.Mock(return_value="fake_instance1"),
-        get_instance_type=mock.Mock(return_value="kubernetes"),
-        is_autoscaling_enabled=mock.Mock(return_value=True),
-        get_autoscaling_params=mock.Mock(
-            return_value={
+@pytest.mark.parametrize(
+    "autoscaling_config,registrations,expected",
+    [
+        (
+            {
                 "metrics_provider": "active-requests",
-            }
+            },
+            [],
+            True,
         ),
-    )
-
-    with mock.patch(
-        "paasta_tools.cli.cmds.validate.load_system_paasta_config",
-        autospec=True,
-        return_value=SystemPaastaConfig(
-            config={"skip_cpu_override_validation": ["not-a-real-service"]},
-            directory="/some/test/dir",
-        ),
-    ):
-        assert validate_autoscaling_configs("fake-service-path") is True
-
-
-@patch("paasta_tools.cli.cmds.validate.get_instance_config", autospec=True)
-@patch("paasta_tools.cli.cmds.validate.list_all_instances_for_service", autospec=True)
-@patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
-@patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
-def test_validate_autoscaling_configs_active_requests_invalid_threshold(
-    mock_path_to_soa_dir_service,
-    mock_list_clusters,
-    mock_list_all_instances_for_service,
-    mock_get_instance_config,
-):
-    mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
-    mock_list_clusters.return_value = ["fake_cluster"]
-    mock_list_all_instances_for_service.return_value = {"fake_instance1"}
-    mock_get_instance_config.return_value = mock.Mock(
-        get_instance=mock.Mock(return_value="fake_instance1"),
-        get_instance_type=mock.Mock(return_value="kubernetes"),
-        is_autoscaling_enabled=mock.Mock(return_value=True),
-        get_autoscaling_params=mock.Mock(
-            return_value={
+        (
+            {
                 "metrics_provider": "active-requests",
                 "desired_active_requests_per_replica": -5,
-            }
+            },
+            [],
+            False,
         ),
-    )
-
-    with mock.patch(
-        "paasta_tools.cli.cmds.validate.load_system_paasta_config",
-        autospec=True,
-        return_value=SystemPaastaConfig(
-            config={"skip_cpu_override_validation": ["not-a-real-service"]},
-            directory="/some/test/dir",
+        (
+            {
+                "metrics_provider": "active-requests",
+                "desired_active_requests_per_replica": 5,
+            },
+            [],
+            True,
         ),
-    ):
-        assert validate_autoscaling_configs("fake-service-path") is False
-
-
-@patch("paasta_tools.cli.cmds.validate.get_instance_config", autospec=True)
-@patch("paasta_tools.cli.cmds.validate.list_all_instances_for_service", autospec=True)
-@patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
-@patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
-def test_validate_autoscaling_configs_active_requests_valid(
+        (
+            {
+                "metrics_provider": "active-requests",
+                "desired_active_requests_per_replica": 5,
+            },
+            ["fake_service.abc"],
+            True,
+        ),
+        (
+            {
+                "metrics_provider": "active-requests",
+                "desired_active_requests_per_replica": 5,
+            },
+            ["fake_service.abc", "fake_service.def"],
+            False,
+        ),
+    ],
+)
+def test_validate_autoscaling_configs_active_requests(
     mock_path_to_soa_dir_service,
     mock_list_clusters,
     mock_list_all_instances_for_service,
     mock_get_instance_config,
+    autoscaling_config,
+    registrations,
+    expected,
 ):
     mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
     mock_list_clusters.return_value = ["fake_cluster"]
@@ -1183,12 +1159,8 @@ def test_validate_autoscaling_configs_active_requests_valid(
         get_instance=mock.Mock(return_value="fake_instance1"),
         get_instance_type=mock.Mock(return_value="kubernetes"),
         is_autoscaling_enabled=mock.Mock(return_value=True),
-        get_autoscaling_params=mock.Mock(
-            return_value={
-                "metrics_provider": "active-requests",
-                "desired_active_requests_per_replica": 5,
-            }
-        ),
+        get_autoscaling_params=mock.Mock(return_value=autoscaling_config),
+        get_registrations=mock.Mock(return_value=registrations),
     )
 
     with mock.patch(
@@ -1199,7 +1171,7 @@ def test_validate_autoscaling_configs_active_requests_valid(
             directory="/some/test/dir",
         ),
     ):
-        assert validate_autoscaling_configs("fake-service-path") is True
+        assert validate_autoscaling_configs("fake-service-path") is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -82,24 +82,20 @@ def test_should_create_active_requests_scaling_rule(
 
 
 @pytest.mark.parametrize(
-    "registrations,registration_expected_in_metrics_query",
+    "registrations,expected_instance",
     [
         (
-            [],
-            False,
-        ),
-        (
             ["test_service.abc", "test_service.xyz", "test_service.123"],
-            False,
+            "test_instance",
         ),
         (
             ["test_service.xyz"],
-            True,
+            "xyz",
         ),
     ],
 )
 def test_create_instance_active_requests_scaling_rule(
-    registrations: list, registration_expected_in_metrics_query: bool
+    registrations: list, expected_instance: str
 ) -> None:
     service_name = "test_service"
     instance_config = mock.Mock(
@@ -146,13 +142,8 @@ def test_create_instance_active_requests_scaling_rule(
         str(instance_config.get_autoscaling_params()["moving_average_window_seconds"])
         in rule["metricsQuery"]
     )
-    if registration_expected_in_metrics_query:
-        assert (
-            f"paasta_instance='{registrations[0].split('.')[-1]}'"
-            in rule["metricsQuery"]
-        )
-    else:
-        assert f"paasta_instance='{instance_config.instance}'" in rule["metricsQuery"]
+    print(rule["metricsQuery"])
+    assert f"paasta_instance='{expected_instance}'" in rule["metricsQuery"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -142,7 +142,6 @@ def test_create_instance_active_requests_scaling_rule(
         str(instance_config.get_autoscaling_params()["moving_average_window_seconds"])
         in rule["metricsQuery"]
     )
-    print(rule["metricsQuery"])
     assert f"paasta_instance='{expected_instance}'" in rule["metricsQuery"]
 
 


### PR DESCRIPTION
## Details
If any services uses registrations and there is exactly one registration, in the active-requests scaler, use the registration name instead of paasta instance name in the metrics query as envoy tracks metrics at smartstack level.


ex - For language models - they have a custom registration - https://github.yelpcorp.com/sysgit/yelpsoa-configs/blob/master/language_models/kubernetes-pnw-prod.yaml#L13 .. hence the envoy metrics are tracked with the registration name.  

```
paasta_instance:envoy_cluster__egress_cluster_upstream_rq_active{paasta_cluster='pnw-prod',paasta_service='language_models',paasta_instance='main'}
vs
paasta_instance:envoy_cluster__egress_cluster_upstream_rq_active{paasta_cluster='pnw-prod',paasta_service='language_models',paasta_instance='main_uswest2'} 
```

## Testing
Added unit tests.

## JIRA
[COREJAVA-998](https://jira.yelpcorp.com/browse/COREJAVA-998)