### PR TITLE
Sync paasta secrets for eks instances as well

### DIFF
--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -35,6 +35,7 @@ from typing import Tuple
 from kubernetes.client.rest import ApiException
 from typing_extensions import Literal
 
+from paasta_tools.eks_tools import EksDeploymentConfig
 from paasta_tools.kubernetes_tools import create_secret
 from paasta_tools.kubernetes_tools import create_secret_signature
 from paasta_tools.kubernetes_tools import get_paasta_secret_name
@@ -58,6 +59,12 @@ from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import SHARED_SECRETS_K8S_NAMESPACES
 
 log = logging.getLogger(__name__)
+
+
+K8S_INSTANCE_TYPE_CLASSES = (
+    KubernetesDeploymentConfig,
+    EksDeploymentConfig,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -212,28 +219,29 @@ def get_services_to_k8s_namespaces_to_allowlist(
             continue
 
         config_loader = PaastaServiceConfigLoader(service, soa_dir)
-        for service_instance_config in config_loader.instance_configs(
-            cluster=cluster, instance_type_class=KubernetesDeploymentConfig
-        ):
-            secrets_used, shared_secrets_used = get_secrets_used_by_instance(
-                service_instance_config
-            )
-            allowlist = services_to_k8s_namespaces_to_allowlist[service].setdefault(
-                service_instance_config.get_namespace(),
-                set(),
-            )
-            if allowlist is not None:
-                allowlist.update(secrets_used)
-
-            if "_shared" in service_list:
-                shared_allowlist = services_to_k8s_namespaces_to_allowlist[
-                    "_shared"
-                ].setdefault(
+        for instance_type_class in K8S_INSTANCE_TYPE_CLASSES:
+            for service_instance_config in config_loader.instance_configs(
+                cluster=cluster, instance_type_class=instance_type_class
+            ):
+                secrets_used, shared_secrets_used = get_secrets_used_by_instance(
+                    service_instance_config
+                )
+                allowlist = services_to_k8s_namespaces_to_allowlist[service].setdefault(
                     service_instance_config.get_namespace(),
                     set(),
                 )
-                if shared_allowlist is not None:
-                    shared_allowlist.update(shared_secrets_used)
+                if allowlist is not None:
+                    allowlist.update(secrets_used)
+
+                if "_shared" in service_list:
+                    shared_allowlist = services_to_k8s_namespaces_to_allowlist[
+                        "_shared"
+                    ].setdefault(
+                        service_instance_config.get_namespace(),
+                        set(),
+                    )
+                    if shared_allowlist is not None:
+                        shared_allowlist.update(shared_secrets_used)
 
         for instance_type in INSTANCE_TYPES:
             if instance_type == "kubernetes":
@@ -463,64 +471,67 @@ def sync_datastore_credentials(
         system_paasta_config.get_datastore_credentials_vault_overrides()
     )
 
-    for instance_config in config_loader.instance_configs(
-        cluster=cluster, instance_type_class=KubernetesDeploymentConfig
-    ):
-        namespace = (
-            overwrite_namespace
-            if overwrite_namespace is not None
-            else instance_config.get_namespace()
-        )
-        datastore_credentials = instance_config.get_datastore_credentials()
-        with set_temporary_environment_variables(datastore_credentials_vault_overrides):
-            # expects VAULT_ADDR_OVERRIDE, VAULT_CA_OVERRIDE, and VAULT_TOKEN_OVERRIDE to be set
-            # in order to use a custom vault shard. overriden temporarily in this context
-            provider = get_secret_provider(
-                secret_provider_name=secret_provider_name,
-                soa_dir=soa_dir,
-                service_name=service,
-                cluster_names=[cluster],
-                # overridden by env variables but still needed here for spec validation
-                secret_provider_kwargs={
-                    "vault_cluster_config": vault_cluster_config,
-                    "vault_auth_method": "token",
-                    "vault_token_file": vault_token_file,
-                },
+    for instance_type_class in K8S_INSTANCE_TYPE_CLASSES:
+        for instance_config in config_loader.instance_configs(
+            cluster=cluster, instance_type_class=instance_type_class
+        ):
+            namespace = (
+                overwrite_namespace
+                if overwrite_namespace is not None
+                else instance_config.get_namespace()
             )
+            datastore_credentials = instance_config.get_datastore_credentials()
+            with set_temporary_environment_variables(
+                datastore_credentials_vault_overrides
+            ):
+                # expects VAULT_ADDR_OVERRIDE, VAULT_CA_OVERRIDE, and VAULT_TOKEN_OVERRIDE to be set
+                # in order to use a custom vault shard. overriden temporarily in this context
+                provider = get_secret_provider(
+                    secret_provider_name=secret_provider_name,
+                    soa_dir=soa_dir,
+                    service_name=service,
+                    cluster_names=[cluster],
+                    # overridden by env variables but still needed here for spec validation
+                    secret_provider_kwargs={
+                        "vault_cluster_config": vault_cluster_config,
+                        "vault_auth_method": "token",
+                        "vault_token_file": vault_token_file,
+                    },
+                )
 
-            secret_data = {}
-            for datastore, credentials in datastore_credentials.items():
-                # mypy loses type hints on '.items' and throws false positives. unfortunately have to type: ignore
-                # https://github.com/python/mypy/issues/7178
-                for credential in credentials:  # type: ignore
-                    vault_path = f"secrets/datastore/{datastore}/{credential}"
-                    secrets = provider.get_data_from_vault_path(vault_path)
-                    if not secrets:
-                        # no secrets found at this path. skip syncing
-                        log.debug(
-                            f"Warning: no secrets found at requested path {vault_path}."
-                        )
-                        continue
+                secret_data = {}
+                for datastore, credentials in datastore_credentials.items():
+                    # mypy loses type hints on '.items' and throws false positives. unfortunately have to type: ignore
+                    # https://github.com/python/mypy/issues/7178
+                    for credential in credentials:  # type: ignore
+                        vault_path = f"secrets/datastore/{datastore}/{credential}"
+                        secrets = provider.get_data_from_vault_path(vault_path)
+                        if not secrets:
+                            # no secrets found at this path. skip syncing
+                            log.debug(
+                                f"Warning: no secrets found at requested path {vault_path}."
+                            )
+                            continue
 
-                    # decrypt and save in secret_data
-                    vault_key_path = get_vault_key_secret_name(vault_path)
+                        # decrypt and save in secret_data
+                        vault_key_path = get_vault_key_secret_name(vault_path)
 
-                    # kubernetes expects data to be base64 encoded binary in utf-8 when put into secret maps
-                    # may look like:
-                    # {'master': {'passwd': '****', 'user': 'v-approle-mysql-serv-nVcYexH95A2'}, 'reporting': {'passwd': '****', 'user': 'v-approle-mysql-serv-GgCpRIh9Ut7'}, 'slave': {'passwd': '****', 'user': 'v-approle-mysql-serv-PzjPwqNMbqu'}
-                    secret_data[vault_key_path] = base64.b64encode(
-                        json.dumps(secrets).encode("utf-8")
-                    ).decode("utf-8")
+                        # kubernetes expects data to be base64 encoded binary in utf-8 when put into secret maps
+                        # may look like:
+                        # {'master': {'passwd': '****', 'user': 'v-approle-mysql-serv-nVcYexH95A2'}, 'reporting': {'passwd': '****', 'user': 'v-approle-mysql-serv-GgCpRIh9Ut7'}, 'slave': {'passwd': '****', 'user': 'v-approle-mysql-serv-PzjPwqNMbqu'}
+                        secret_data[vault_key_path] = base64.b64encode(
+                            json.dumps(secrets).encode("utf-8")
+                        ).decode("utf-8")
 
-        create_or_update_k8s_secret(
-            service=service,
-            signature_name=instance_config.get_datastore_credentials_signature_name(),
-            secret_name=instance_config.get_datastore_credentials_secret_name(),
-            get_secret_data=(lambda: secret_data),
-            secret_signature=_get_dict_signature(secret_data),
-            kube_client=kube_client,
-            namespace=namespace,
-        )
+            create_or_update_k8s_secret(
+                service=service,
+                signature_name=instance_config.get_datastore_credentials_signature_name(),
+                secret_name=instance_config.get_datastore_credentials_secret_name(),
+                get_secret_data=(lambda: secret_data),
+                secret_signature=_get_dict_signature(secret_data),
+                kube_client=kube_client,
+                namespace=namespace,
+            )
 
     return True
 
@@ -543,50 +554,51 @@ def sync_crypto_secrets(
     So each replica of a service instance gets the same key, thereby reducing requests to Vault API as we only talk to vault during secret syncing
     """
     config_loader = PaastaServiceConfigLoader(service=service, soa_dir=soa_dir)
-    for instance_config in config_loader.instance_configs(
-        cluster=cluster, instance_type_class=KubernetesDeploymentConfig
-    ):
-        crypto_keys = instance_config.get_crypto_keys_from_config()
-        if not crypto_keys:
-            continue
-        secret_data = {}
-        provider = get_secret_provider(
-            secret_provider_name=secret_provider_name,
-            soa_dir=soa_dir,
-            service_name=service,
-            cluster_names=[cluster],
-            secret_provider_kwargs={
-                "vault_cluster_config": vault_cluster_config,
-                "vault_auth_method": "token",
-                "vault_token_file": vault_token_file,
-            },
-        )
-        for key in crypto_keys:
-            key_versions = provider.get_key_versions(key)
-            if not key_versions:
-                log.error(
-                    f"No key versions found for {key} on {instance_config.get_sanitised_deployment_name()}"
-                )
+    for instance_type_class in K8S_INSTANCE_TYPE_CLASSES:
+        for instance_config in config_loader.instance_configs(
+            cluster=cluster, instance_type_class=instance_type_class
+        ):
+            crypto_keys = instance_config.get_crypto_keys_from_config()
+            if not crypto_keys:
+                continue
+            secret_data = {}
+            provider = get_secret_provider(
+                secret_provider_name=secret_provider_name,
+                soa_dir=soa_dir,
+                service_name=service,
+                cluster_names=[cluster],
+                secret_provider_kwargs={
+                    "vault_cluster_config": vault_cluster_config,
+                    "vault_auth_method": "token",
+                    "vault_token_file": vault_token_file,
+                },
+            )
+            for key in crypto_keys:
+                key_versions = provider.get_key_versions(key)
+                if not key_versions:
+                    log.error(
+                        f"No key versions found for {key} on {instance_config.get_sanitised_deployment_name()}"
+                    )
+                    continue
+
+                secret_data[get_vault_key_secret_name(key)] = base64.b64encode(
+                    json.dumps(key_versions).encode("utf-8")
+                ).decode("utf-8")
+
+            if not secret_data:
                 continue
 
-            secret_data[get_vault_key_secret_name(key)] = base64.b64encode(
-                json.dumps(key_versions).encode("utf-8")
-            ).decode("utf-8")
-
-        if not secret_data:
-            continue
-
-        create_or_update_k8s_secret(
-            service=service,
-            signature_name=instance_config.get_crypto_secret_signature_name(),
-            # the secret name here must match the secret name given in the secret volume config,
-            # i.e. `kubernetes.client.V1SecretVolumeSource`'s `secret_name` must match below
-            secret_name=instance_config.get_crypto_secret_name(),
-            get_secret_data=(lambda: secret_data),
-            secret_signature=_get_dict_signature(secret_data),
-            kube_client=kube_client,
-            namespace=instance_config.get_namespace(),
-        )
+            create_or_update_k8s_secret(
+                service=service,
+                signature_name=instance_config.get_crypto_secret_signature_name(),
+                # the secret name here must match the secret name given in the secret volume config,
+                # i.e. `kubernetes.client.V1SecretVolumeSource`'s `secret_name` must match below
+                secret_name=instance_config.get_crypto_secret_name(),
+                get_secret_data=(lambda: secret_data),
+                secret_signature=_get_dict_signature(secret_data),
+                kube_client=kube_client,
+                namespace=instance_config.get_namespace(),
+            )
 
     return True
 
@@ -598,40 +610,41 @@ def sync_boto_secrets(
     soa_dir: str,
 ) -> bool:
     config_loader = PaastaServiceConfigLoader(service=service, soa_dir=soa_dir)
-    for instance_config in config_loader.instance_configs(
-        cluster=cluster, instance_type_class=KubernetesDeploymentConfig
-    ):
-        boto_keys = instance_config.config_dict.get("boto_keys", [])
-        if not boto_keys:
-            continue
-        boto_keys.sort()
-        secret_data = {}
-        for key in boto_keys:
-            for filetype in ["sh", "yaml", "json", "cfg"]:
-                this_key = key + "." + filetype
-                sanitised_key = this_key.replace(".", "-").replace("_", "--")
-                try:
-                    with open(f"/etc/boto_cfg_private/{this_key}") as f:
-                        secret_data[sanitised_key] = base64.b64encode(
-                            f.read().encode("utf-8")
-                        ).decode("utf-8")
-                except IOError:
-                    log.warning(
-                        f"Boto key {this_key} required for {service} could not be found."
-                    )
+    for instance_type_class in K8S_INSTANCE_TYPE_CLASSES:
+        for instance_config in config_loader.instance_configs(
+            cluster=cluster, instance_type_class=instance_type_class
+        ):
+            boto_keys = instance_config.config_dict.get("boto_keys", [])
+            if not boto_keys:
+                continue
+            boto_keys.sort()
+            secret_data = {}
+            for key in boto_keys:
+                for filetype in ["sh", "yaml", "json", "cfg"]:
+                    this_key = key + "." + filetype
+                    sanitised_key = this_key.replace(".", "-").replace("_", "--")
+                    try:
+                        with open(f"/etc/boto_cfg_private/{this_key}") as f:
+                            secret_data[sanitised_key] = base64.b64encode(
+                                f.read().encode("utf-8")
+                            ).decode("utf-8")
+                    except IOError:
+                        log.warning(
+                            f"Boto key {this_key} required for {service} could not be found."
+                        )
 
-        if not secret_data:
-            continue
+            if not secret_data:
+                continue
 
-        create_or_update_k8s_secret(
-            service=service,
-            signature_name=instance_config.get_boto_secret_signature_name(),
-            secret_name=instance_config.get_boto_secret_name(),
-            get_secret_data=(lambda: secret_data),
-            secret_signature=_get_dict_signature(secret_data),
-            kube_client=kube_client,
-            namespace=instance_config.get_namespace(),
-        )
+            create_or_update_k8s_secret(
+                service=service,
+                signature_name=instance_config.get_boto_secret_signature_name(),
+                secret_name=instance_config.get_boto_secret_name(),
+                get_secret_data=(lambda: secret_data),
+                secret_signature=_get_dict_signature(secret_data),
+                kube_client=kube_client,
+                namespace=instance_config.get_namespace(),
+            )
     return True
 
 

--- a/tests/kubernetes/bin/test_paasta_secrets_sync.py
+++ b/tests/kubernetes/bin/test_paasta_secrets_sync.py
@@ -665,7 +665,16 @@ def test_sync_boto_secrets_create(boto_keys_patches):
         "scribereader-cfg": "ZmlsZTQ=",
     }
 
-    mock_open_handle.read.side_effect = ["file1", "file2", "file3", "file4"]
+    mock_open_handle.read.side_effect = [
+        "file1",
+        "file2",
+        "file3",
+        "file4",
+        "eksfile1",
+        "eksfile2",
+        "eksfile3",
+        "eksfile4",
+    ]
     mock_get_kubernetes_secret_signature.return_value = None
     assert sync_boto_secrets(
         kube_client=mock.Mock(),
@@ -711,7 +720,16 @@ def test_sync_boto_secrets_update(boto_keys_patches):
     )
     mock_config_loader_instances.return_value = [deployment]
 
-    mock_open_handle.read.side_effect = ["file1", "file2", "file3", "file4"]
+    mock_open_handle.read.side_effect = [
+        "file1",
+        "file2",
+        "file3",
+        "file4",
+        "eksfile1",
+        "eksfile2",
+        "eksfile3",
+        "eksfile4",
+    ]
     mock_get_kubernetes_secret_signature.return_value = "1235abc"
     assert sync_boto_secrets(
         kube_client=mock.Mock(),
@@ -738,7 +756,16 @@ def test_sync_boto_secrets_noop(boto_keys_patches):
         mock_config_loader_instances,
     ) = boto_keys_patches
 
-    mock_open_handle.read.side_effect = ["file1", "file2", "file3", "file4"]
+    mock_open_handle.read.side_effect = [
+        "file1",
+        "file2",
+        "file3",
+        "file4",
+        "eksfile1",
+        "eksfile2",
+        "eksfile3",
+        "eksfile4",
+    ]
     mock_get_kubernetes_secret_signature.return_value = (
         "4c3da4da5d97294f69527dc92c2b930ce127522c"
     )
@@ -778,7 +805,16 @@ def test_sync_boto_secrets_exists_but_no_signature(boto_keys_patches):
     )
     mock_config_loader_instances.return_value = [deployment]
 
-    mock_open_handle.read.side_effect = ["file1", "file2", "file3", "file4"]
+    mock_open_handle.read.side_effect = [
+        "file1",
+        "file2",
+        "file3",
+        "file4",
+        "eksfile1",
+        "eksfile2",
+        "eksfile3",
+        "eksfile4",
+    ]
     mock_get_kubernetes_secret_signature.return_value = None
     mock_create_secret.side_effect = ApiException(409)
 


### PR DESCRIPTION
We could also teach this to only sync secrets for self-managed OR EKS clusters individually - but that seems like more effort (and there's no real harm to syncing these to both: in fact, it makes rolling back even easier since there's no need to wait for secrets to re-sync)