### PR TITLE
Change the default k8s namespace for kubernetes services.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test-not-yelpy: .paasta/bin/activate
 	.paasta/bin/tox -e tests
 
 quick-test: .tox/py38-linux
-	TZ=UTC .tox/py38-linux/bin/py.test --last-failed -x -- tests
+	TZ=UTC .tox/py38-linux/bin/py.test --failed-first -x --disable-warnings -- tests
 
 .tox/py38-linux: .paasta/bin/activate
 	.paasta/bin/tox

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -423,7 +423,8 @@ def paasta_secret(args):
                 get_secret(
                     kube_client,
                     get_paasta_secret_name(namespace, service, args.secret_name),
-                    namespace,
+                    key_name=args.secret_name,
+                    namespace=namespace,
                 )
             )
         # fallback to default in case mapping fails
@@ -432,7 +433,8 @@ def paasta_secret(args):
                 get_secret(
                     kube_client,
                     get_paasta_secret_name("paasta", service, args.secret_name),
-                    "paasta",
+                    key_name=args.secret_name,
+                    namespace="paasta",
                 )
             )
         return

--- a/paasta_tools/delete_kubernetes_deployments.py
+++ b/paasta_tools/delete_kubernetes_deployments.py
@@ -73,7 +73,11 @@ def main(args=None) -> None:
     for deployment_name in deployment_names:
         try:
             log.debug(f"Deleting {deployment_name}")
-            delete_deployment(kube_client=kube_client, deployment_name=deployment_name)
+            delete_deployment(
+                kube_client=kube_client,
+                deployment_name=deployment_name,
+                namespace="paasta",
+            )
         except Exception as err:
             log.error(f"Unable to delete {deployment_name}: {err}")
             sys.exit(1)

--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -150,7 +150,7 @@ class Application(ABC):
             )
 
     def ensure_pod_disruption_budget(
-        self, kube_client: KubeClient, namespace: str = "paasta"
+        self, kube_client: KubeClient, namespace: str
     ) -> V1beta1PodDisruptionBudget:
         max_unavailable: Union[str, int]
         if "bounce_margin_factor" in self.soa_config.config_dict:

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1985,7 +1985,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
     def get_namespace(self) -> str:
         """Get namespace from config, default to 'paasta'"""
-        return self.config_dict.get("namespace", "paasta")
+        return self.config_dict.get(
+            "namespace", f"paastasvc-{self.get_sanitised_service_name()}"
+        )
 
     def get_pod_management_policy(self) -> str:
         """Get sts pod_management_policy from config, default to 'OrderedReady'"""

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -723,7 +723,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         name: str,
         cluster: str,
         kube_client: KubeClient,
-        namespace: str = "paasta",
+        namespace: str,
     ) -> Optional[Union[V2beta2HorizontalPodAutoscaler, Dict]]:
         # Returns None if an HPA should not be attached based on the config,
         # or the config is invalid.
@@ -2463,7 +2463,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
 
 def get_kubernetes_secret_hashes(
-    environment_variables: Mapping[str, str], service: str, namespace: str = "paasta"
+    environment_variables: Mapping[str, str], service: str, namespace: str
 ) -> Mapping[str, str]:
     hashes = {}
     to_get_hash = []
@@ -2621,6 +2621,7 @@ def force_delete_pods(
         paasta_service,
         instance,
         kube_client,
+        namespace=namespace,
     )
     delete_options = V1DeleteOptions()
     for pod in pods_to_delete:
@@ -2734,8 +2735,9 @@ def list_deployments_in_all_namespaces(
 
 def list_deployments(
     kube_client: KubeClient,
+    *,
+    namespace: str,
     label_selector: str = "",
-    namespace: str = "paasta",
 ) -> Sequence[KubeDeployment]:
 
     deployments = kube_client.deployments.list_namespaced_deployment(
@@ -3030,7 +3032,7 @@ def pod_disruption_budget_for_service_instance(
     service: str,
     instance: str,
     max_unavailable: Union[str, int],
-    namespace: str = "paasta",
+    namespace: str,
 ) -> V1beta1PodDisruptionBudget:
     return V1beta1PodDisruptionBudget(
         metadata=V1ObjectMeta(
@@ -3052,7 +3054,7 @@ def pod_disruption_budget_for_service_instance(
 def create_pod_disruption_budget(
     kube_client: KubeClient,
     pod_disruption_budget: V1beta1PodDisruptionBudget,
-    namespace: str = "paasta",
+    namespace: str,
 ) -> None:
     return kube_client.policy.create_namespaced_pod_disruption_budget(
         namespace=namespace, body=pod_disruption_budget
@@ -3127,7 +3129,7 @@ def list_all_paasta_deployments(kube_client: KubeClient) -> Sequence[KubeDeploym
 
 
 def list_all_deployments(
-    kube_client: KubeClient, namespace: str = "paasta"
+    kube_client: KubeClient, namespace: str
 ) -> Sequence[KubeDeployment]:
     return list_deployments(kube_client=kube_client, namespace=namespace)
 
@@ -3135,12 +3137,13 @@ def list_all_deployments(
 def list_matching_deployments(
     service: str,
     instance: str,
+    *,
+    namespace: str,
     kube_client: KubeClient,
-    namespace: str = "paasta",
 ) -> Sequence[KubeDeployment]:
     return list_deployments(
         kube_client,
-        f"paasta.yelp.com/service={service},paasta.yelp.com/instance={instance}",
+        label_selector=f"paasta.yelp.com/service={service},paasta.yelp.com/instance={instance}",
         namespace=namespace,
     )
 
@@ -3158,7 +3161,7 @@ def list_matching_deployments_in_all_namespaces(
 
 @async_timeout()
 async def replicasets_for_service_instance(
-    service: str, instance: str, kube_client: KubeClient, namespace: str = "paasta"
+    service: str, instance: str, kube_client: KubeClient, namespace: str
 ) -> Sequence[V1ReplicaSet]:
     async_list_replica_set = a_sync.to_async(
         kube_client.deployments.list_namespaced_replica_set
@@ -3172,7 +3175,7 @@ async def replicasets_for_service_instance(
 
 @async_timeout()
 async def controller_revisions_for_service_instance(
-    service: str, instance: str, kube_client: KubeClient, namespace: str = "paasta"
+    service: str, instance: str, kube_client: KubeClient, namespace: str
 ) -> Sequence[V1ControllerRevision]:
     async_list_controller_revisions = a_sync.to_async(
         kube_client.deployments.list_namespaced_controller_revision
@@ -3186,7 +3189,7 @@ async def controller_revisions_for_service_instance(
 
 @async_timeout(15)
 async def pods_for_service_instance(
-    service: str, instance: str, kube_client: KubeClient, namespace: str = "paasta"
+    service: str, instance: str, kube_client: KubeClient, namespace: str
 ) -> Sequence[V1Pod]:
     async_list_pods = a_sync.to_async(kube_client.core.list_namespaced_pod)
     response = await async_list_pods(
@@ -3202,14 +3205,12 @@ def get_pods_by_node(kube_client: KubeClient, node: V1Node) -> Sequence[V1Pod]:
     ).items
 
 
-def get_all_pods(kube_client: KubeClient, namespace: str = "paasta") -> List[V1Pod]:
+def get_all_pods(kube_client: KubeClient, namespace: str) -> List[V1Pod]:
     return kube_client.core.list_namespaced_pod(namespace=namespace).items
 
 
 @time_cache(ttl=300)
-def get_all_pods_cached(
-    kube_client: KubeClient, namespace: str = "paasta"
-) -> Sequence[V1Pod]:
+def get_all_pods_cached(kube_client: KubeClient, namespace: str) -> Sequence[V1Pod]:
     pods: Sequence[V1Pod] = get_all_pods(kube_client, namespace)
     return pods
 
@@ -3401,7 +3402,7 @@ def get_kubernetes_app_name(service: str, instance: str) -> str:
 
 
 def get_kubernetes_app_by_name(
-    name: str, kube_client: KubeClient, namespace: str = "paasta"
+    name: str, kube_client: KubeClient, namespace: str
 ) -> Union[V1Deployment, V1StatefulSet]:
     try:
         app = kube_client.deployments.read_namespaced_deployment_status(
@@ -3421,7 +3422,7 @@ def get_kubernetes_app_by_name(
 def create_deployment(
     kube_client: KubeClient,
     formatted_deployment: V1Deployment,
-    namespace: str = "paasta",
+    namespace: str,
 ) -> None:
     return kube_client.deployments.create_namespaced_deployment(
         namespace=namespace, body=formatted_deployment
@@ -3431,7 +3432,7 @@ def create_deployment(
 def update_deployment(
     kube_client: KubeClient,
     formatted_deployment: V1Deployment,
-    namespace: str = "paasta",
+    namespace: str,
 ) -> None:
     return kube_client.deployments.replace_namespaced_deployment(
         name=formatted_deployment.metadata.name,
@@ -3443,7 +3444,7 @@ def update_deployment(
 def patch_deployment(
     kube_client: KubeClient,
     formatted_deployment: V1Deployment,
-    namespace: str = "paasta",
+    namespace: str,
 ) -> None:
     return kube_client.deployments.patch_namespaced_deployment(
         name=formatted_deployment.metadata.name,
@@ -3455,7 +3456,7 @@ def patch_deployment(
 def delete_deployment(
     kube_client: KubeClient,
     deployment_name: str,
-    namespace: str = "paasta",
+    namespace: str,
 ) -> None:
     return kube_client.deployments.delete_namespaced_deployment(
         name=deployment_name,
@@ -3466,7 +3467,7 @@ def delete_deployment(
 def create_stateful_set(
     kube_client: KubeClient,
     formatted_stateful_set: V1StatefulSet,
-    namespace: str = "paasta",
+    namespace: str,
 ) -> None:
     return kube_client.deployments.create_namespaced_stateful_set(
         namespace=namespace, body=formatted_stateful_set
@@ -3476,7 +3477,7 @@ def create_stateful_set(
 def update_stateful_set(
     kube_client: KubeClient,
     formatted_stateful_set: V1StatefulSet,
-    namespace: str = "paasta",
+    namespace: str,
 ) -> None:
     return kube_client.deployments.replace_namespaced_stateful_set(
         name=formatted_stateful_set.metadata.name,
@@ -3685,7 +3686,7 @@ def update_secret_signature(
     service_name: str,
     signature_name: str,
     secret_signature: str,
-    namespace: str = "paasta",
+    namespace: str,
 ) -> None:
     """
     :param service_name: Expect unsanitised service_name
@@ -3714,7 +3715,7 @@ def create_secret_signature(
     service_name: str,
     signature_name: str,
     secret_signature: str,
-    namespace: str = "paasta",
+    namespace: str,
 ) -> None:
     """
     :param service_name: Expect unsanitised service_name
@@ -3895,7 +3896,7 @@ _RE_NORMALIZE_IAM_ROLE = re.compile(r"[^0-9a-zA-Z]+")
 
 def create_or_find_service_account_name(
     iam_role: str,
-    namespace: str = "paasta",
+    namespace: str,
     k8s_role: Optional[str] = None,
     dry_run: bool = False,
 ) -> str:
@@ -4145,7 +4146,8 @@ def get_secret(
     kube_client: KubeClient,
     secret_name: str,
     key_name: str,
-    namespace: str = "paasta",
+    *,
+    namespace: str,
     decode: bool = True,
 ) -> Union[str, bytes]:
     """
@@ -4168,7 +4170,7 @@ def get_kubernetes_secret_env_variables(
     kube_client: KubeClient,
     environment: Dict[str, str],
     service_name: str,
-    namespace: str = "paasta",
+    namespace: str,
 ) -> Dict[str, str]:
     decrypted_secrets = {}
     for k, v in environment.items():
@@ -4196,7 +4198,7 @@ def get_kubernetes_secret_volumes(
     kube_client: KubeClient,
     secret_volumes_config: Sequence[SecretVolume],
     service_name: str,
-    namespace: str = "paasta",
+    namespace: str,
 ) -> Dict[str, Union[str, bytes]]:
     secret_volumes = {}
     # The config might look one of two ways:

--- a/paasta_tools/metrics/metastatus_lib.py
+++ b/paasta_tools/metrics/metastatus_lib.py
@@ -461,7 +461,7 @@ def assert_mesos_tasks_running(
 
 
 def assert_kube_pods_running(
-    kube_client: KubeClient, namespace: str = "paasta"
+    kube_client: KubeClient, namespace: str
 ) -> HealthCheckResult:
     statuses = [
         get_pod_status(pod) for pod in get_all_pods_cached(kube_client, namespace)
@@ -884,9 +884,10 @@ def get_resource_utilization_by_grouping(
 def get_resource_utilization_by_grouping_kube(
     grouping_func: _GenericNodeGroupingFunctionT,
     kube_client: KubeClient,
+    *,
+    namespace: str,
     filters: Sequence[_GenericNodeFilterFunctionT] = [],
     sort_func: _GenericNodeSortFunctionT = None,
-    namespace: str = "paasta",
 ) -> Mapping[_KeyFuncRetT, ResourceUtilizationDict]:
     """Given a function used to group nodes, calculate resource utilization
     for each value of a given attribute.
@@ -1045,7 +1046,7 @@ def assert_marathon_deployments(
 
 
 def assert_kube_deployments(
-    kube_client: KubeClient, namespace: str = "paasta"
+    kube_client: KubeClient, namespace: str
 ) -> HealthCheckResult:
     num_deployments = len(list_all_deployments(kube_client, namespace))
     return HealthCheckResult(
@@ -1065,7 +1066,7 @@ def get_marathon_status(
 
 
 def get_kube_status(
-    kube_client: KubeClient, namespace: str = "paasta"
+    kube_client: KubeClient, namespace: str
 ) -> Sequence[HealthCheckResult]:
     """Gather information about Kubernetes.
     :param kube_client: the KUbernetes client

--- a/paasta_tools/paasta_metastatus.py
+++ b/paasta_tools/paasta_metastatus.py
@@ -230,8 +230,9 @@ def utilization_table_by_grouping_from_kube(
     groupings: Sequence[str],
     threshold: float,
     kube_client: KubeClient,
+    *,
+    namespace: str,
     service_instance_stats: Optional[ServiceInstanceStats] = None,
-    namespace: str = "paasta",
 ) -> Tuple[Sequence[MutableSequence[str]], bool]:
     grouping_function = metastatus_lib.key_func_for_attribute_multi_kube(groupings)
 
@@ -317,7 +318,7 @@ def get_service_instance_stats(
 
 
 def _run_kube_checks(
-    kube_client: KubeClient, namespace: str = "paasta"
+    kube_client: KubeClient, namespace: str
 ) -> Sequence[HealthCheckResult]:
     kube_status = metastatus_lib.get_kube_status(kube_client, namespace)
     kube_metrics_status = metastatus_lib.get_kube_resource_utilization_health(

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -149,7 +149,7 @@ def test_paasta_secret():
         "paasta_tools.cli.cmds.secret.is_secrets_for_teams_enabled", autospec=True
     ) as mock_is_secrets_for_teams_enabled, mock.patch(
         "paasta_tools.cli.cmds.secret.get_secret", autospec=True
-    ) as mock_get_kubernetes_secret, mock.patch(
+    ) as mock_get_secret, mock.patch(
         "paasta_tools.cli.cmds.secret.KubeClient", autospec=True
     ) as mock_kube_client, mock.patch(
         "paasta_tools.cli.cmds.secret.get_namespaces_for_secret", autospec=True
@@ -242,8 +242,8 @@ def test_paasta_secret():
         )
         kube_client = mock.Mock()
         mock_is_secrets_for_teams_enabled.return_value = True
-        mock_get_namespaces_for_secret.return_value = {"paasta"}
-        mock_select_k8s_secret_namespace.return_value = "paasta"
+        mock_get_namespaces_for_secret.return_value = {"paastasvc-middleearth"}
+        mock_select_k8s_secret_namespace.return_value = "paastasvc-middleearth"
         mock_kube_client.return_value = kube_client
 
         secret.paasta_secret(mock_args)
@@ -252,20 +252,24 @@ def test_paasta_secret():
         mock_kube_client.assert_called_with(
             config_file=KUBE_CONFIG_USER_PATH, context="mesosstage"
         )
-        mock_get_kubernetes_secret.assert_called_with(
+        mock_get_secret.assert_called_with(
             kube_client,
-            get_paasta_secret_name("paasta", "middleearth", "theonering"),
-            "paasta",
+            get_paasta_secret_name(
+                "paastasvc-middleearth", "middleearth", "theonering"
+            ),
+            key_name="theonering",
+            namespace="paastasvc-middleearth",
         )
 
         # empty namespace list
         mock_get_namespaces_for_secret.return_value = set()
         mock_select_k8s_secret_namespace.return_value = None
         secret.paasta_secret(mock_args)
-        mock_get_kubernetes_secret.assert_called_with(
+        mock_get_secret.assert_called_with(
             kube_client,
             get_paasta_secret_name("paasta", "middleearth", "theonering"),
-            "paasta",
+            key_name="theonering",
+            namespace="paasta",
         )
 
         mock_args = mock.Mock(

--- a/tests/kubernetes/application/test_controller_wrapper.py
+++ b/tests/kubernetes/application/test_controller_wrapper.py
@@ -120,7 +120,9 @@ def test_ensure_pod_disruption_budget_create(
         app.soa_config.get_bounce_margin_factor.return_value = 0.1
     app.kube_deployment.service.return_value = "fake_service"
     app.kube_deployment.instance.return_value = "fake_instance"
-    Application.ensure_pod_disruption_budget(self=app, kube_client=mock_client)
+    Application.ensure_pod_disruption_budget(
+        self=app, kube_client=mock_client, namespace="paasta"
+    )
     mock_client.policy.create_namespaced_pod_disruption_budget.assert_called_once_with(
         body=mock_req_pdr, namespace=mock_req_pdr.metadata.namespace
     )
@@ -145,7 +147,9 @@ def test_ensure_pod_disruption_budget_replaces_outdated(
     app.soa_config.get_bounce_margin_factor.return_value = 0.1
     app.kube_deployment.service.return_value = "fake_service"
     app.kube_deployment.instance.return_value = "fake_instance"
-    Application.ensure_pod_disruption_budget(self=app, kube_client=mock_client)
+    Application.ensure_pod_disruption_budget(
+        self=app, kube_client=mock_client, namespace="paasta"
+    )
 
     mock_client.policy.patch_namespaced_pod_disruption_budget.assert_called_once_with(
         name=mock_req_pdr.metadata.name,
@@ -173,7 +177,9 @@ def test_ensure_pod_disruption_budget_noop_when_min_available_is_set(
     app.soa_config.get_bounce_margin_factor.return_value = 0.1
     app.kube_deployment.service.return_value = "fake_service"
     app.kube_deployment.instance.return_value = "fake_instance"
-    Application.ensure_pod_disruption_budget(self=app, kube_client=mock_client)
+    Application.ensure_pod_disruption_budget(
+        self=app, kube_client=mock_client, namespace="paasta"
+    )
 
     mock_client.policy.patch_namespaced_pod_disruption_budget.assert_not_called()
 

--- a/tests/metrics/test_metastatus_lib.py
+++ b/tests/metrics/test_metastatus_lib.py
@@ -265,7 +265,7 @@ def test_assert_kube_deployments():
     ) as mock_list_all_deployments:
         client = Mock()
         mock_list_all_deployments.return_value = ["KubeDeployment:1"]
-        output, ok = metastatus_lib.assert_kube_deployments(client)
+        output, ok = metastatus_lib.assert_kube_deployments(client, namespace="paasta")
         assert re.match("Kubernetes deployments:   1", output)
         assert ok
 
@@ -283,7 +283,7 @@ def test_assert_kube_pods_running():
             V1Pod(status=V1PodStatus(phase="Failed")),
             V1Pod(status=V1PodStatus(phase="Failed")),
         ]
-        output, ok = metastatus_lib.assert_kube_pods_running(client)
+        output, ok = metastatus_lib.assert_kube_pods_running(client, namespace="paasta")
         assert re.match("Pods: running: 1 pending: 2 failed: 3", output)
         assert ok
 

--- a/tests/test_cleanup_kubernetes_jobs.py
+++ b/tests/test_cleanup_kubernetes_jobs.py
@@ -34,7 +34,7 @@ from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 def fake_deployment():
     fake_deployment = V1Deployment(
         metadata=mock.Mock(
-            namespace="paasta",
+            namespace="paastasvc-service",
             labels={
                 "yelp.com/paasta_service": "service",
                 "yelp.com/paasta_instance": "instance-1",

--- a/tests/test_delete_kubernetes_deployments.py
+++ b/tests/test_delete_kubernetes_deployments.py
@@ -28,6 +28,7 @@ def test_main():
         mock_delete_deployment.assert_called_with(
             kube_client=mock_kube_client.return_value,
             deployment_name="fake_pcm_deployment",
+            namespace="paasta",
         )
 
         # Test main() failed

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2294,6 +2294,7 @@ class TestKubernetesDeploymentConfig:
             "fake_name",
             "cluster",
             KubeClient(),
+            "paasta",
         )
         annotations: Dict[Any, Any] = {}
         expected_res = V2beta2HorizontalPodAutoscaler(
@@ -2357,6 +2358,7 @@ class TestKubernetesDeploymentConfig:
             "fake_name",
             "cluster",
             KubeClient(),
+            "paasta",
         )
         annotations: Dict[Any, Any] = {}
         expected_res = V2beta2HorizontalPodAutoscaler(
@@ -2443,6 +2445,7 @@ class TestKubernetesDeploymentConfig:
             "fake_name",
             "cluster",
             KubeClient(),
+            "paasta",
         )
         expected_res = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
@@ -2520,6 +2523,7 @@ class TestKubernetesDeploymentConfig:
             "fake_name",
             "cluster",
             KubeClient(),
+            "paasta",
         )
         expected_res = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
@@ -2590,6 +2594,7 @@ class TestKubernetesDeploymentConfig:
             "fake_name",
             "cluster",
             KubeClient(),
+            "paasta",
         )
         assert hpa_dict["spec"]["behavior"]["scaleDown"] == {
             "stabilizationWindowSeconds": 123,
@@ -2617,6 +2622,7 @@ class TestKubernetesDeploymentConfig:
             "fake_name",
             "cluster",
             KubeClient(),
+            "paasta",
         )
         expected_res = None
         assert expected_res == return_value
@@ -3186,7 +3192,7 @@ def test_list_all_deployments(addl_labels, replicas):
             list_namespaced_stateful_set=mock.Mock(return_value=mock_stateful_sets),
         )
     )
-    assert list_all_deployments(kube_client=mock_client) == []
+    assert list_all_deployments(kube_client=mock_client, namespace="paasta") == []
 
     mock_items = [
         mock.Mock(
@@ -3235,7 +3241,7 @@ def test_list_all_deployments(addl_labels, replicas):
             list_namespaced_stateful_set=mock.Mock(return_value=mock_stateful_sets),
         )
     )
-    assert list_all_deployments(mock_client) == [
+    assert list_all_deployments(mock_client, namespace="paasta") == [
         KubeDeployment(
             service="kurupt",
             instance="fm",
@@ -3707,7 +3713,10 @@ def test_get_kubernetes_app_by_name():
     mock_client.deployments.read_namespaced_deployment_status.return_value = (
         mock_deployment
     )
-    assert get_kubernetes_app_by_name("someservice", mock_client) == mock_deployment
+    assert (
+        get_kubernetes_app_by_name("someservice", mock_client, namespace="paasta")
+        == mock_deployment
+    )
     assert mock_client.deployments.read_namespaced_deployment_status.called
     assert not mock_client.deployments.read_namespaced_stateful_set_status.called
 
@@ -3719,7 +3728,10 @@ def test_get_kubernetes_app_by_name():
     mock_client.deployments.read_namespaced_stateful_set_status.return_value = (
         mock_stateful_set
     )
-    assert get_kubernetes_app_by_name("someservice", mock_client) == mock_stateful_set
+    assert (
+        get_kubernetes_app_by_name("someservice", mock_client, namespace="paasta")
+        == mock_stateful_set
+    )
     assert mock_client.deployments.read_namespaced_deployment_status.called
     assert mock_client.deployments.read_namespaced_stateful_set_status.called
 
@@ -3728,7 +3740,7 @@ def test_get_kubernetes_app_by_name():
 async def test_pods_for_service_instance():
     mock_client = mock.Mock()
     assert (
-        await pods_for_service_instance("kurupt", "fm", mock_client)
+        await pods_for_service_instance("kurupt", "fm", mock_client, namespace="paasta")
         == mock_client.core.list_namespaced_pod.return_value.items
     )
 
@@ -3787,7 +3799,7 @@ def test_get_active_versions_for_service():
 def test_get_all_pods():
     mock_client = mock.Mock()
     assert (
-        get_all_pods(mock_client)
+        get_all_pods(mock_client, namespace="paasta")
         == mock_client.core.list_namespaced_pod.return_value.items
     )
 
@@ -4750,8 +4762,8 @@ def test_get_kubernetes_secret(decode):
             mock_client,
             get_paasta_secret_name(mock_namespace, service_name, secret_name),
             secret_name,
-            mock_namespace,
-            decode,
+            namespace=mock_namespace,
+            decode=decode,
         )
         mock_client.core.read_namespaced_secret.assert_called_with(
             name="paasta-secret-example--service-example--secret", namespace="paasta"
@@ -4788,6 +4800,7 @@ def test_get_kubernetes_secret_env_variables():
             kube_client=mock_client,
             environment=mock_environment,
             service_name="universe",
+            namespace="paasta",
         )
         assert ret == {
             "SECRET_NAME1": "123",
@@ -4854,6 +4867,7 @@ def test_get_kubernetes_secret_volumes_multiple_files():
             kube_client=mock_client,
             secret_volumes_config=mock_secret_volumes_config,
             service_name="universe",
+            namespace="paasta",
         )
         assert ret == {
             "/the/container/path/the_secret_filename1": "secret_contents1",
@@ -4883,6 +4897,7 @@ def test_get_kubernetes_secret_volumes_single_file():
             kube_client=mock_client,
             secret_volumes_config=mock_secret_volumes_config,
             service_name="universe",
+            namespace="paasta",
         )
         assert ret == {
             "/the/container/path/the_secret_name": "secret_contents",

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1300,13 +1300,13 @@ class TestKubernetesDeploymentConfig:
             V1Volume(
                 name="secret--waldo",
                 secret=V1SecretVolumeSource(
-                    secret_name="paasta-secret-kurupt-waldo", optional=False
+                    secret_name="paastasvc-kurupt-secret-kurupt-waldo", optional=False
                 ),
             ),
             V1Volume(
                 name="secret--waldo",
                 secret=V1SecretVolumeSource(
-                    secret_name="paasta-secret-kurupt-waldo",
+                    secret_name="paastasvc-kurupt-secret-kurupt-waldo",
                     default_mode=0o765,
                     optional=False,
                 ),
@@ -1314,7 +1314,7 @@ class TestKubernetesDeploymentConfig:
             V1Volume(
                 name="secret--waldo",
                 secret=V1SecretVolumeSource(
-                    secret_name="paasta-secret-kurupt-waldo",
+                    secret_name="paastasvc-kurupt-secret-kurupt-waldo",
                     items=[
                         V1KeyToPath(key="aaa", mode=0o567, path="bbb"),
                         V1KeyToPath(key="ccc", path="ddd"),
@@ -1394,14 +1394,14 @@ class TestKubernetesDeploymentConfig:
                 "zuora_integration",
                 "sync_ads_settings_post_budget_edit_batch_daemon",
                 "paasta-boto-key-zuora--integration-sync--ads--settings--po-4xbg",
-                "paasta-secret-zuora--integration-paasta-boto-key-zuora--integration-sync--ads--settings--po-4xbg-signature",
+                "paastasvc-zuora--integration-secret-zuora--integration-paasta-boto-key-zuora--integration-sync--ads--settings--po-4xbg-signature",
             ),
             (
                 {"boto_keys": ["few"]},
                 "zuora_integration",
                 "reprocess_zuora_amend_callouts_batch_daemon",
                 "paasta-boto-key-zuora--integration-reprocess--zuora--amend-jztw",
-                "paasta-secret-zuora--integration-paasta-boto-key-zuora--integration-reprocess--zuora--amend-jztw-signature",
+                "paastasvc-zuora--integration-secret-zuora--integration-paasta-boto-key-zuora--integration-reprocess--zuora--amend-jztw-signature",
             ),
             (
                 {
@@ -1410,14 +1410,14 @@ class TestKubernetesDeploymentConfig:
                 "kafka_discovery",
                 "main",
                 "paasta-boto-key-kafka--discovery-main",
-                "paasta-secret-kafka--discovery-paasta-boto-key-kafka--discovery-main-signature",
+                "paastasvc-kafka--discovery-secret-kafka--discovery-paasta-boto-key-kafka--discovery-main-signature",
             ),
             (
                 {"boto_keys": ["pew"]},
                 "yelp-main",
                 "lives_data_action_content_ingester_worker",
                 "paasta-boto-key-yelp-main-lives--data--action--content--in-4pxl",
-                "paasta-secret-yelp-main-paasta-boto-key-yelp-main-lives--data--action--content--in-4pxl-signature",
+                "paastasvc-yelp-main-secret-yelp-main-paasta-boto-key-yelp-main-lives--data--action--content--in-4pxl-signature",
             ),
             (
                 {
@@ -2266,7 +2266,7 @@ class TestKubernetesDeploymentConfig:
                     "paasta.yelp.com/managed": "true",
                 },
                 name="kurupt-fm",
-                namespace="paasta",
+                namespace="paastasvc-kurupt",
             )
 
     @pytest.mark.parametrize(
@@ -2695,7 +2695,9 @@ class TestKubernetesDeploymentConfig:
                 name="SOME",
                 value_from=V1EnvVarSource(
                     secret_key_ref=V1SecretKeySelector(
-                        name="paasta-secret-kurupt-a--ref", key="a_ref", optional=False
+                        name="paastasvc-kurupt-secret-kurupt-a--ref",
+                        key="a_ref",
+                        optional=False,
                     )
                 ),
             ),
@@ -2703,7 +2705,7 @@ class TestKubernetesDeploymentConfig:
                 name="A",
                 value_from=V1EnvVarSource(
                     secret_key_ref=V1SecretKeySelector(
-                        name="paasta-secret-underscore-shared-underscore-ref1",
+                        name="paastasvc-kurupt-secret-underscore-shared-underscore-ref1",
                         key="_ref1",
                         optional=False,
                     )


### PR DESCRIPTION
Incidentally, I spotted and fixed a bug in `paasta secret decrypt` where it wasn't passing the correct arguments to `get_secret` in certain situations.

Since `paasta` is no longer a reasonable default value for namespace, I deleted that default value for all the functions I could find that take namespace as an argument.