### PR TITLE
Use docker_client.logs instead of docker_client.attach during paasta local-run

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -1029,8 +1029,10 @@ def run_docker_container(
         running = docker_client.inspect_container(container_id)["State"]["Running"]
         if running:
             print("Your service is now running! Tailing stdout and stderr:")
-            for line in docker_client.attach(
-                container_id, stderr=True, stream=True, logs=True
+            for line in docker_client.logs(
+                container_id,
+                stderr=True,
+                stream=True,
             ):
                 # writing to sys.stdout.buffer lets us write the raw bytes we
                 # get from the docker client without having to convert them to


### PR DESCRIPTION
When running `paasta local-run` in unprivileged containers mode, `docker_client.attach` would cause paasta to crash with

```
Your service is now running! Tailing stdout and stderr:
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.8/http/client.py", line 556, in _get_chunk_left
    chunk_left = self._read_next_chunk_size()
  File "/usr/lib/python3.8/http/client.py", line 523, in _read_next_chunk_size
    return int(line, 16)
ValueError: invalid literal for int() with base 16: b''

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.8/http/client.py", line 588, in _readinto_chunked
    chunk_left = self._get_chunk_left()
  File "/usr/lib/python3.8/http/client.py", line 558, in _get_chunk_left
    raise IncompleteRead(b'')
http.client.IncompleteRead: IncompleteRead(0 bytes read)
```

This implies some kind of API incompatibility between the 2015 vintage of `docker-py`'s `docker_client.attach` with the set of parameters being passed to it and podman. By changing to `docker_client.logs` we maintain parity with the status quo log output and circumvent the crash.

FWIW, `docker_client.logs` is used elsewhere in `local-run` while doing healthchecks (added in https://github.com/Yelp/paasta/pull/2074 and there is some discussion about threads). TBH I'm not 100% clear why it was using `logs` there and `attach` here in the first place, or if we need to consider the same thread concerns addressed in the healthchecking code, since once we launch the paasta workload, we're just running indefinitely until the process finishes OR we terminate the process via ctrl+c, and both of those worked in my manual tests.

## Testing done
I'm going to assume that some unit tests will need updating, will circle back with those updates shortly. 

I manually tested the `paasta local-run` command in privileged docker mode without the patch and unprivileged docker mode with the patch and observed identical output. 