### PR TITLE
DREIMP-10150: Base new commits on remote branch, if it exists

### DIFF
--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -180,12 +180,11 @@ class AutoConfigUpdater:
         self.pwd = os.getcwd()
         os.chdir(self.working_dir)
         if self.branch != "master":
-            try:
-                # If there is a remote branch, checkout that branch
+            if self._remote_branch_exists():
                 subprocess.check_call(
                     ["git", "checkout", "-b", self.branch, f"origin/{self.branch}"]
                 )
-            except subprocess.CalledProcessError:
+            else:
                 subprocess.check_call(["git", "checkout", "-b", self.branch])
         return self
 
@@ -193,6 +192,14 @@ class AutoConfigUpdater:
         os.chdir(self.pwd)
         if self.tmp_dir:
             self.tmp_dir.cleanup()
+
+    def _remote_branch_exists(self) -> bool:
+        return (
+            subprocess.run(
+                ["git", "show-ref", "--quiet", f"refs/remotes/origin/{self.branch}"],
+            ).returncode
+            == 0
+        )
 
     def write_configs(
         self,

--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -180,7 +180,13 @@ class AutoConfigUpdater:
         self.pwd = os.getcwd()
         os.chdir(self.working_dir)
         if self.branch != "master":
-            subprocess.check_call(["git", "checkout", "-b", self.branch])
+            try:
+                # If there is a remote branch, checkout that branch
+                subprocess.check_call(
+                    ["git", "checkout", "-b", self.branch, f"origin/{self.branch}"]
+                )
+            except subprocess.CalledProcessError:
+                subprocess.check_call(["git", "checkout", "-b", self.branch])
         return self
 
     def __exit__(self, type, value, traceback):

--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -181,6 +181,7 @@ class AutoConfigUpdater:
         os.chdir(self.working_dir)
         if self.branch != "master":
             if self._remote_branch_exists():
+                subprocess.check_call(["git", "fetch", "origin", self.branch])
                 subprocess.check_call(
                     ["git", "checkout", "-b", self.branch, f"origin/{self.branch}"]
                 )
@@ -196,7 +197,7 @@ class AutoConfigUpdater:
     def _remote_branch_exists(self) -> bool:
         return (
             subprocess.run(
-                ["git", "show-ref", "--quiet", f"refs/remotes/origin/{self.branch}"],
+                ["git", "ls-remote", "--exit-code", "--heads", "origin", self.branch],
             ).returncode
             == 0
         )

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -155,7 +155,9 @@ def test_auto_config_updater_context(branch, tmpdir, mock_subprocess):
         expected_calls = [mock.call.check_call(["git", "clone", remote, clone_dir])]
         if branch != "master":
             expected_calls.append(
-                mock.call.check_call(["git", "checkout", "-b", branch])
+                mock.call.check_call(
+                    ["git", "checkout", "-b", branch, f"origin/{branch}"]
+                )
             )
         assert mock_subprocess.mock_calls == expected_calls
         assert os.getcwd() == clone_dir
@@ -182,7 +184,11 @@ def test_auto_config_updater_context_no_clone(branch, tmpdir, mock_subprocess):
         if branch == "master":
             expected_calls = []
         else:
-            expected_calls = [mock.call.check_call(["git", "checkout", "-b", branch])]
+            expected_calls = [
+                mock.call.check_call(
+                    ["git", "checkout", "-b", branch, f"origin/{branch}"]
+                ),
+            ]
         assert mock_subprocess.mock_calls == expected_calls
         assert os.getcwd() == working_dir
 

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -163,10 +163,13 @@ def test_auto_config_updater_context(
         expected_calls = [mock.call.check_call(["git", "clone", remote, clone_dir])]
         if branch != "master":
             if remote_branch_exists:
-                expected_calls.append(
-                    mock.call.check_call(
-                        ["git", "checkout", "-b", branch, f"origin/{branch}"]
-                    )
+                expected_calls.extend(
+                    [
+                        mock.call.check_call(["git", "fetch", "origin", branch]),
+                        mock.call.check_call(
+                            ["git", "checkout", "-b", branch, f"origin/{branch}"]
+                        ),
+                    ]
                 )
             else:
                 expected_calls.append(
@@ -207,9 +210,10 @@ def test_auto_config_updater_context_no_clone(
         else:
             if remote_branch_exists:
                 expected_calls = [
+                    mock.call.check_call(["git", "fetch", "origin", branch]),
                     mock.call.check_call(
                         ["git", "checkout", "-b", branch, f"origin/{branch}"]
-                    )
+                    ),
                 ]
             else:
                 expected_calls = [

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -141,11 +141,19 @@ def test_validate_auto_config_file_e2e(data, is_valid, tmpdir):
     )
 
 
-@pytest.mark.parametrize("branch", ["master", "other_test"])
-def test_auto_config_updater_context(branch, tmpdir, mock_subprocess):
+@pytest.mark.parametrize(
+    "branch, remote_branch_exists",
+    [("master", True), ("other_test", True), ("other_test", False)],
+)
+def test_auto_config_updater_context(
+    branch, remote_branch_exists, tmpdir, mock_subprocess
+):
     remote = "git_remote"
     updater = config_utils.AutoConfigUpdater(
         "test_source", remote, branch=branch, working_dir=tmpdir
+    )
+    updater._remote_branch_exists = mock.MagicMock(
+        autospec=True, return_value=remote_branch_exists
     )
     initial_wd = os.getcwd()
 
@@ -154,11 +162,16 @@ def test_auto_config_updater_context(branch, tmpdir, mock_subprocess):
         assert os.path.isdir(clone_dir)
         expected_calls = [mock.call.check_call(["git", "clone", remote, clone_dir])]
         if branch != "master":
-            expected_calls.append(
-                mock.call.check_call(
-                    ["git", "checkout", "-b", branch, f"origin/{branch}"]
+            if remote_branch_exists:
+                expected_calls.append(
+                    mock.call.check_call(
+                        ["git", "checkout", "-b", branch, f"origin/{branch}"]
+                    )
                 )
-            )
+            else:
+                expected_calls.append(
+                    mock.call.check_call(["git", "checkout", "-b", branch])
+                )
         assert mock_subprocess.mock_calls == expected_calls
         assert os.getcwd() == clone_dir
 
@@ -167,8 +180,13 @@ def test_auto_config_updater_context(branch, tmpdir, mock_subprocess):
     assert os.getcwd() == initial_wd
 
 
-@pytest.mark.parametrize("branch", ["master", "other_test"])
-def test_auto_config_updater_context_no_clone(branch, tmpdir, mock_subprocess):
+@pytest.mark.parametrize(
+    "branch, remote_branch_exists",
+    [("master", True), ("other_test", True), ("other_test", False)],
+)
+def test_auto_config_updater_context_no_clone(
+    branch, remote_branch_exists, tmpdir, mock_subprocess
+):
     remote = "git_remote"
     working_dir = tmpdir.mkdir("testing")
     updater = config_utils.AutoConfigUpdater(
@@ -178,17 +196,25 @@ def test_auto_config_updater_context_no_clone(branch, tmpdir, mock_subprocess):
         working_dir=working_dir,
         do_clone=False,
     )
+    updater._remote_branch_exists = mock.MagicMock(
+        autospec=True, return_value=remote_branch_exists
+    )
     initial_wd = os.getcwd()
 
     with updater:
         if branch == "master":
             expected_calls = []
         else:
-            expected_calls = [
-                mock.call.check_call(
-                    ["git", "checkout", "-b", branch, f"origin/{branch}"]
-                ),
-            ]
+            if remote_branch_exists:
+                expected_calls = [
+                    mock.call.check_call(
+                        ["git", "checkout", "-b", branch, f"origin/{branch}"]
+                    )
+                ]
+            else:
+                expected_calls = [
+                    mock.call.check_call(["git", "checkout", "-b", branch])
+                ]
         assert mock_subprocess.mock_calls == expected_calls
         assert os.getcwd() == working_dir
 


### PR DESCRIPTION
## Problem of Feature

When specifying branch name with `--branch`, first time we push succeeds, however, the second time it will fail, because the remote branch (from the first run) is based on a different commit than the new branch (from the second run):
```
+ ./.tox/py38-linux/bin/python ./paasta_tools/contrib/rightsizer_soaconfigs_update.py --csv-report sina_all.csv --splunk-creds xxxx --source-id fake-source-id --app yelp_dre --branch sina/test-cassandra-autotune -v --push-to-remote
INFO:root:Found 5 services to rightsize
Cloning into '/nail/tmp/tmp9lyrzip5'...
remote: Enumerating objects: 3861161, done.
remote: Counting objects: 100% (2129/2129), done.
remote: Compressing objects: 100% (359/359), done.
remote: Total 3861161 (delta 1828), reused 1992 (delta 1769), pack-reused 3859032
Receiving objects: 100% (3861161/3861161), 700.04 MiB | 45.78 MiB/s, done.
Resolving deltas: 100% (3524719/3524719), done.
Switched to a new branch 'sina/test-cassandra-autotune'
✓ Successfully validated schema: cassandracluster-nova-prod.yaml
✓ Successfully validated schema: cassandracluster-pnw-prod.yaml
[sina/test-cassandra-autotune 81ee3a4fe29] Update to configs from fake-source-id
 2 files changed, 5 insertions(+), 5 deletions(-)
Traceback (most recent call last):
  File "/nail/home/sina/pg/github.com/Yelp/paasta/paasta_tools/config_utils.py", line 106, in _push_to_remote
    subprocess.check_output(
  File "/usr/lib/python3.8/subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '('git', 'push', 'origin', 'sina/test-cassandra-autotune')' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./paasta_tools/contrib/rightsizer_soaconfigs_update.py", line 345, in <module>
    main(args)
  File "./paasta_tools/contrib/rightsizer_soaconfigs_update.py", line 336, in main
    updater.commit_to_remote(extra_message=extra_message)
  File "/nail/home/sina/pg/github.com/Yelp/paasta/paasta_tools/config_utils.py", line 252, in commit_to_remote
    _push_to_remote(self.branch)
  File "/nail/home/sina/pg/github.com/Yelp/paasta/paasta_tools/config_utils.py", line 111, in _push_to_remote
    raise PushNotFastForwardError()
paasta_tools.config_utils.PushNotFastForwardError
```

## Solution

If `--branch` is given, check if branch exists in the remote. If a remote branch exists fetch it and create a local branch based on it. Otherwise, create a new branch based on master.

## Verification

### First run

Remote branch does not exist:
```
+ ./.tox/py38-linux/bin/python ./paasta_tools/contrib/rightsizer_soaconfigs_update.py --csv-report sina_all.csv --splunk-creds xxxx --source-id fake-source-id --app yelp_dre --branch sina/test-cassandra-autotune-deleteme -v --push-to-remote
INFO:root:Found 5 services to rightsize
Cloning into '/nail/tmp/tmp7azdctfo'...
remote: Enumerating objects: 3861304, done.
remote: Counting objects: 100% (2270/2270), done.
remote: Compressing objects: 100% (450/450), done.
remote: Total 3861304 (delta 1905), reused 2105 (delta 1819), pack-reused 3859034
Receiving objects: 100% (3861304/3861304), 700.10 MiB | 48.99 MiB/s, done.
Resolving deltas: 100% (3524798/3524798), done.
Switched to a new branch 'sina/test-cassandra-autotune-deleteme'
✓ Successfully validated schema: cassandracluster-nova-prod.yaml
✓ Successfully validated schema: cassandracluster-pnw-prod.yaml
[sina/test-cassandra-autotune-deleteme 2a7e3c9216c] Update to configs from fake-source-id
 2 files changed, 8 insertions(+), 7 deletions(-)
```

### Second run
This time remote branch exists:
```
+ ./.tox/py38-linux/bin/python ./paasta_tools/contrib/rightsizer_soaconfigs_update.py --csv-report sina_all.csv --splunk-creds xxxx --source-id fake-source-id --app yelp_dre --branch sina/test-cassandra-autotune -v --push-to-remote
INFO:root:Found 5 services to rightsize
Cloning into '/nail/tmp/tmpffm6d468'...
remote: Enumerating objects: 3861292, done.
remote: Counting objects: 100% (2258/2258), done.
remote: Compressing objects: 100% (440/440), done.
remote: Total 3861292 (delta 1898), reused 2101 (delta 1817), pack-reused 3859034
Receiving objects: 100% (3861292/3861292), 700.09 MiB | 47.36 MiB/s, done.
Resolving deltas: 100% (3524791/3524791), done.
23f82d995eea3c52597174f820456c86905694c9        refs/heads/sina/test-cassandra-autotune
From github.yelpcorp.com:sysgit/yelpsoa-configs
 * branch                    sina/test-cassandra-autotune -> FETCH_HEAD
Branch 'sina/test-cassandra-autotune' set up to track remote branch 'sina/test-cassandra-autotune' from 'origin'.
Switched to a new branch 'sina/test-cassandra-autotune'
✓ Successfully validated schema: cassandracluster-nova-prod.yaml
✓ Successfully validated schema: cassandracluster-pnw-prod.yaml
[sina/test-cassandra-autotune 409fd81d38f] Update to configs from fake-source-id
 2 files changed, 5 insertions(+), 5 deletions(-)
```

## Context

[DREIMP-10150](http://y/DREIMP-10150)