### PR TITLE
making skj and ckj aware of downthenup bounces across namespaces

### DIFF
--- a/paasta_tools/cleanup_kubernetes_jobs.py
+++ b/paasta_tools/cleanup_kubernetes_jobs.py
@@ -124,7 +124,9 @@ def instance_is_not_bouncing(
         if isinstance(application, DeploymentWrapper):
             existing_app = application.item
             if (
-                existing_app.metadata.namespace == instance_config.get_namespace()
+                existing_app.metadata.namespace != instance_config.get_namespace()
+                and (instance_config.get_bounce_method() == "downthenup")
+                or existing_app.metadata.namespace == instance_config.get_namespace()
                 and (
                     instance_config.get_instances()
                     <= (existing_app.status.ready_replicas or 0)

--- a/paasta_tools/cleanup_kubernetes_jobs.py
+++ b/paasta_tools/cleanup_kubernetes_jobs.py
@@ -124,12 +124,16 @@ def instance_is_not_bouncing(
         if isinstance(application, DeploymentWrapper):
             existing_app = application.item
             if (
-                existing_app.metadata.namespace != instance_config.get_namespace()
-                and (instance_config.get_bounce_method() == "downthenup")
-                or existing_app.metadata.namespace == instance_config.get_namespace()
-                and (
-                    instance_config.get_instances()
-                    <= (existing_app.status.ready_replicas or 0)
+                (
+                    existing_app.metadata.namespace != instance_config.get_namespace()
+                    and (instance_config.get_bounce_method() == "downthenup")
+                )
+                or (
+                    existing_app.metadata.namespace == instance_config.get_namespace()
+                    and (
+                        instance_config.get_instances()
+                        <= (existing_app.status.ready_replicas or 0)
+                    )
                 )
             ) or instance_config.get_desired_state() == "stop":
                 return True

--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -271,13 +271,13 @@ def setup_kube_deployments(
                     if app.soa_config.get_bounce_method() == "downthenup":
                         if any(
                             (
-                                app[:2]
+                                existing_app[:2]
                                 == (
                                     app.kube_deployment.service,
                                     app.kube_deployment.instance,
                                 )
                             )
-                            for app in existing_apps
+                            for existing_app in existing_apps
                         ):
                             # For downthenup, we don't want to create until cleanup_kubernetes_job has cleaned up the instance in the other namespace.
                             continue

--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -233,14 +233,14 @@ def setup_kube_deployments(
     eks: bool = False,
 ) -> bool:
 
-    existing_apps = set()
-    existing_kube_deployments = set()
-    if service_instance_configs_list:
-        existing_kube_deployments = set(list_all_paasta_deployments(kube_client))
-        existing_apps = {
-            (deployment.service, deployment.instance, deployment.namespace)
-            for deployment in existing_kube_deployments
-        }
+    if not service_instance_configs_list:
+        return True
+
+    existing_kube_deployments = set(list_all_paasta_deployments(kube_client))
+    existing_apps = {
+        (deployment.service, deployment.instance, deployment.namespace)
+        for deployment in existing_kube_deployments
+    }
 
     applications = [
         create_application_object(
@@ -269,15 +269,17 @@ def setup_kube_deployments(
                     app.kube_deployment.namespace,
                 ) not in existing_apps:
                     if app.soa_config.get_bounce_method() == "downthenup":
-                        exist_on_other_namespace = False
-                        for existing_app in existing_apps:
-                            if existing_app[:2] == (
-                                app.kube_deployment.service,
-                                app.kube_deployment.instance,
-                            ):
-                                exist_on_other_namespace = True
-                                break
-                        if exist_on_other_namespace:
+                        if any(
+                            (
+                                app[:2]
+                                == (
+                                    app.kube_deployment.service,
+                                    app.kube_deployment.instance,
+                                )
+                            )
+                            for app in existing_apps
+                        ):
+                            # For downthenup, we don't want to create until cleanup_kubernetes_job has cleaned up the instance in the other namespace.
                             continue
                     log.info(f"Creating {app} because it does not exist yet.")
                     app.create(kube_client)

--- a/tests/test_setup_kubernetes_job.py
+++ b/tests/test_setup_kubernetes_job.py
@@ -476,7 +476,7 @@ def test_setup_kube_deployment_create_update(mock_kube_deploy_config, eks_flag):
     ) as mock_no_metrics, mock.patch(
         "paasta_tools.setup_kubernetes_job.get_kubernetes_deployment_config",
         autospec=True,
-    ) as mock_service_instance_configs_list:
+    ):
         mock_client = mock.Mock()
         # No instances created
         mock_service_instance_configs_list: List[

--- a/tests/test_setup_kubernetes_job.py
+++ b/tests/test_setup_kubernetes_job.py
@@ -1,4 +1,7 @@
-# from typing import Sequence
+from typing import List
+from typing import Tuple
+from typing import Union
+
 import mock
 import pytest
 from kubernetes.client import V1Deployment
@@ -10,6 +13,7 @@ from paasta_tools.kubernetes.application.controller_wrappers import Application
 from paasta_tools.kubernetes_tools import InvalidKubernetesConfig
 from paasta_tools.kubernetes_tools import KubeDeployment
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
+from paasta_tools.kubernetes_tools import KubernetesDeploymentConfigDict
 from paasta_tools.setup_kubernetes_job import create_application_object
 from paasta_tools.setup_kubernetes_job import get_kubernetes_deployment_config
 from paasta_tools.setup_kubernetes_job import get_service_instances_with_valid_names
@@ -51,7 +55,7 @@ def test_main_logging():
             service="my-service",
             instance="my-instance",
             cluster="cluster",
-            config_dict={},
+            config_dict=KubernetesDeploymentConfigDict(),
             branch_dict=None,
         )
         mock_service_instance_configs_list.return_value = [
@@ -80,7 +84,7 @@ def test_main_logging():
                 service="my-service",
                 instance="my-instance",
                 cluster="cluster",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
             False,
@@ -90,7 +94,7 @@ def test_main_logging():
                 service="my-service",
                 instance="my-instance",
                 cluster="cluster",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
             True,
@@ -213,7 +217,7 @@ def test_get_kubernetes_deployment_config():
             instance="instance",
             cluster="fake_cluster",
             soa_dir="nail/blah",
-            config_dict={},
+            config_dict=KubernetesDeploymentConfigDict(),
             branch_dict=None,
         )
         mock_load_kubernetes_service_config_no_cache.side_effect = None
@@ -232,7 +236,7 @@ def test_get_kubernetes_deployment_config():
                     instance="instance",
                     cluster="fake_cluster",
                     soa_dir="nail/blah",
-                    config_dict={},
+                    config_dict=KubernetesDeploymentConfigDict(),
                     branch_dict=None,
                 ),
             )
@@ -278,7 +282,7 @@ def test_get_eks_deployment_config():
             instance="instance",
             cluster="fake_cluster",
             soa_dir="nail/blah",
-            config_dict={},
+            config_dict=KubernetesDeploymentConfigDict(),
             branch_dict=None,
         )
         mock_load_eks_service_config_no_cache.side_effect = None
@@ -298,7 +302,7 @@ def test_get_eks_deployment_config():
                     instance="instance",
                     cluster="fake_cluster",
                     soa_dir="nail/blah",
-                    config_dict={},
+                    config_dict=KubernetesDeploymentConfigDict(),
                     branch_dict=None,
                 ),
             )
@@ -315,7 +319,7 @@ def test_get_eks_deployment_config():
                 instance="instance",
                 cluster="fake_cluster",
                 soa_dir="nail/blah",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
         ),
@@ -326,7 +330,7 @@ def test_get_eks_deployment_config():
                 instance="instance",
                 cluster="fake_cluster",
                 soa_dir="nail/blah",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
         ),
@@ -408,7 +412,7 @@ def test_create_application_object(eks_flag, mock_service_config):
                 instance="fm",
                 cluster="fake_cluster",
                 soa_dir="/nail/blah",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
             False,
@@ -419,7 +423,7 @@ def test_create_application_object(eks_flag, mock_service_config):
                 instance="fm",
                 cluster="fake_cluster",
                 soa_dir="/nail/blah",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
             True,
@@ -448,7 +452,14 @@ def test_setup_kube_deployment_create_update(mock_kube_deploy_config, eks_flag):
         fake_app.update = fake_update
         fake_app.update_related_api_objects = fake_update_related_api_objects
         fake_app.item = None
-        fake_app.soa_config = None
+        fake_app.soa_config = KubernetesDeploymentConfig(
+            service=service_instance_config.service,
+            cluster=cluster,
+            instance=service_instance_config.instance,
+            config_dict=KubernetesDeploymentConfigDict(),
+            branch_dict=None,
+            soa_dir=soa_dir,
+        )
         fake_app.__str__ = lambda app: "fake_app"
         return True, fake_app
 
@@ -468,7 +479,9 @@ def test_setup_kube_deployment_create_update(mock_kube_deploy_config, eks_flag):
     ) as mock_service_instance_configs_list:
         mock_client = mock.Mock()
         # No instances created
-        mock_service_instance_configs_list = []
+        mock_service_instance_configs_list: List[
+            Tuple[bool, Union[KubernetesDeploymentConfig, EksDeploymentConfig]]
+        ] = []
         setup_kube_deployments(
             kube_client=mock_client,
             service_instance_configs_list=mock_service_instance_configs_list,
@@ -629,7 +642,7 @@ def test_setup_kube_deployment_create_update(mock_kube_deploy_config, eks_flag):
             instance="garage",
             cluster="fake_cluster",
             soa_dir="/nail/blah",
-            config_dict={},
+            config_dict=KubernetesDeploymentConfigDict(),
             branch_dict=None,
         )
         mock_service_instance_configs_list = [
@@ -698,21 +711,21 @@ def test_setup_kube_deployment_create_update(mock_kube_deploy_config, eks_flag):
                 service="kurupt",
                 instance="fm",
                 cluster="fake_cluster",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
             KubernetesDeploymentConfig(
                 service="kurupt",
                 instance="garage",
                 cluster="fake_cluster",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
             KubernetesDeploymentConfig(
                 service="kurupt",
                 instance="radio",
                 cluster="fake_cluster",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
             False,
@@ -722,21 +735,21 @@ def test_setup_kube_deployment_create_update(mock_kube_deploy_config, eks_flag):
                 service="kurupt",
                 instance="fm",
                 cluster="fake_cluster",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
             EksDeploymentConfig(
                 service="kurupt",
                 instance="garage",
                 cluster="fake_cluster",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
             EksDeploymentConfig(
                 service="kurupt",
                 instance="radio",
                 cluster="fake_cluster",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
             True,
@@ -758,7 +771,9 @@ def test_setup_kube_deployments_rate_limit(
         "paasta_tools.setup_kubernetes_job.log", autospec=True
     ) as mock_log_obj:
         mock_client = mock.Mock()
-        mock_service_instance_configs_list = [
+        mock_service_instance_configs_list: List[
+            Tuple[bool, Union[KubernetesDeploymentConfig, EksDeploymentConfig]]
+        ] = [
             (True, mock_kube_deploy_config_fm),
             (True, mock_kube_deploy_config_garage),
             (True, mock_kube_deploy_config_radio),
@@ -801,14 +816,14 @@ def test_setup_kube_deployments_rate_limit(
                 service="fake",
                 instance="instance",
                 cluster="fake_cluster",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
             KubernetesDeploymentConfig(
                 service="mock",
                 instance="instance",
                 cluster="fake_cluster",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
             False,
@@ -818,14 +833,14 @@ def test_setup_kube_deployments_rate_limit(
                 service="fake",
                 instance="instance",
                 cluster="fake_cluster",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
             EksDeploymentConfig(
                 service="mock",
                 instance="instance",
                 cluster="fake_cluster",
-                config_dict={},
+                config_dict=KubernetesDeploymentConfigDict(),
                 branch_dict=None,
             ),
             True,
@@ -844,7 +859,9 @@ def test_setup_kube_deployments_skip_malformed_apps(
         "paasta_tools.setup_kubernetes_job.log", autospec=True
     ) as mock_log_obj:
         mock_client = mock.Mock()
-        mock_service_instance_configs_list = [
+        mock_service_instance_configs_list: List[
+            Tuple[bool, Union[KubernetesDeploymentConfig, EksDeploymentConfig]]
+        ] = [
             (True, mock_kube_deploy_config_fake),
             (True, mock_kube_deploy_config_mock),
         ]


### PR DESCRIPTION
making `setup_kubernetes_jobs.py` and `cleanup_kubernetes_jobs.py` aware of "_downthenup_" instance types bounces across namespaces