### PR TITLE
Use the correct registry_uri to check if we need to sudo

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1080,7 +1080,7 @@ def build_and_push_docker_image(args: argparse.Namespace) -> Optional[str]:
     if retcode != 0:
         return None
 
-    if args.docker_registry != DEFAULT_SPARK_DOCKER_REGISTRY:
+    if registry_uri != DEFAULT_SPARK_DOCKER_REGISTRY:
         command = "sudo -H docker push %s" % docker_url
     else:
         command = "docker push %s" % docker_url


### PR DESCRIPTION
In #3728 we changed the `--docker_registry`'s default value from our `DEFAULT_SPARK_DOCKER_REGISTRY` and instead leave it undefined by default.

However, we still used `args.docker_registry` in our check whehter we needed sudo to push ot this registry, rather than using the generated `registry_uri`, which caused all runs with `--build` to try to sudo to push the registry, which doesn't work w/ the default registry.

This fixes to use our new registry_uri which should be either the requested docker_registry or the service's default, to get back to the normal behavior. 