### PR TITLE
RFC: Add additional custom namespaces to k8s schema

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -864,7 +864,7 @@
                 },
                 "namespace": {
                     "type": "string",
-                    "pattern": "^(paasta|paastasvc-.*)$"
+                    "pattern": "^(paasta|jenkins|paastasvc-.*)$"
                 }
             }
         }


### PR DESCRIPTION
I see two potential solutions for allowing folks to use arbitrary namespaces:
* we gatekeep them by needing us to add their namespace to this allowlist (which lets us make sure that they've correctly labeled their namespace as well as done everything else that we expect) OR,
* we get rid of the allowlist and allow folks to put whatever namespace they'd like and expect that they know what they're doing :)