### PR TITLE
Allow non-paastasvc namespaces

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -483,8 +483,7 @@ instance MAY have:
   * ``namespace``:
     **Currently in development, do not use.**
     The Kubernetes namespace where Paasta will create objects related to this service.
-    Defaults to ``paasta``.
-    Currently, only ``paasta`` and namespaces starting with ``paastasvc-`` are permitted.
+    Defaults to ``paastasvc-service--name`` (that is, the service name will have underscores replaced with ``--``.)
 
 **Note**: Although many of these settings are inherited from ``smartstack.yaml``,
 their thresholds are not the same. The reason for this has to do with control

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -863,8 +863,7 @@
                     "minimum": 1
                 },
                 "namespace": {
-                    "type": "string",
-                    "pattern": "^(paasta|paastasvc-.*)$"
+                    "type": "string"
                 }
             }
         }


### PR DESCRIPTION
Remove the restriction that namespaces must start with paastasvc-, and remove the same assumption from check_services_replication_tools.py