### PR TITLE
Catch statefulset missing as 404 in API bounce_status

### DIFF
--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -881,8 +881,13 @@ def bounce_status(request):
         raise ApiFailure(
             "Temporary issue fetching bounce status. Please try again.", 599
         )
-    except Exception:
+    except Exception as e:
         error_message = traceback.format_exc()
+        if getattr(e, "status") == 404:
+            # some bounces delete the app & recreate
+            # in this case, we relay the 404 and cli handles gracefully
+            raise ApiFailure(error_message, 404)
+        # for all others, treat as a 500
         raise ApiFailure(error_message, 500)
 
 

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -221,6 +221,8 @@ async def pod_info(
     }
 
 
+# TODO: Cleanup
+# Only used in old kubernetes_status
 async def job_status(
     kstatus: MutableMapping[str, Any],
     client: kubernetes_tools.KubeClient,
@@ -1108,6 +1110,7 @@ async def get_version_for_controller_revision(
     }
 
 
+# TODO: Cleanup old kubernetes status
 @a_sync.to_blocking
 async def kubernetes_status(
     service: str,

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -18,6 +18,7 @@ import asynctest
 import mock
 import pytest
 from kubernetes.client import V1Pod
+from kubernetes.client.rest import ApiException
 from marathon.models.app import MarathonApp
 from marathon.models.app import MarathonTask
 from pyramid import testing
@@ -1317,6 +1318,18 @@ class TestBounceStatus:
         mock_request,
     ):
         mock_validate_service_instance.side_effect = NoConfigurationForServiceError
+        with pytest.raises(ApiFailure) as excinfo:
+            instance.bounce_status(mock_request)
+        assert excinfo.value.err == 404
+
+    def test_app_not_found(
+        self,
+        mock_pik_bounce_status,
+        mock_validate_service_instance,
+        mock_request,
+    ):
+        mock_validate_service_instance.return_value = "kubernetes"
+        mock_pik_bounce_status.side_effect = [ApiException(status=404)]
         with pytest.raises(ApiFailure) as excinfo:
             instance.bounce_status(mock_request)
         assert excinfo.value.err == 404


### PR DESCRIPTION
Currently, paasta_tools.instance.kubernetes.bounce_status  is the only thing we should be currently using that depends on [get_kubernetes_app_by_name](https://github.com/Yelp/paasta/blob/master/paasta_tools/kubernetes_tools.py#L3443-L3458) .  The other uses were in 'old' paasta status and no longer used.

This function attempted to fetch the k8s resource tied to a service+instance in a cluster, naively attempting to get a statefulset if the deployment wasn't found. This is left to raise the k8s ApiException giving us a 404 when it can't find the statefulset either.  In most situations, this should work fine, as the k8s resource is pretty much guaranteed by the time we hit this call, since the configs that would lead to that resource being created are also required to make it this far in bounce_status.  Unfortunately, for `brutal` bounces of statefulsets, we will have a short period of time where the k8s resource doesn't exist but the service+instance configs do. 
In this situation, we should tell the user we couldn't yet find the instance, and that it is a temporary issue.

To solve for this, I'm now ensuring we catch the 404 raised by instance.kubernetes.bounce_status in the API view and relay that to the client.

The cli only ever calls this endpoint during `mark-for-deployment` and is already configured to handle a 404 more gracefully than a 500 in this situation here: https://github.com/Yelp/paasta/blob/master/paasta_tools/cli/cmds/mark_for_deployment.py#L1652-L1661