### PR TITLE
Fix paasta secrets sync namespace checking for eks instances

### DIFF
--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -56,6 +56,7 @@ from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import INSTANCE_TYPE_TO_K8S_NAMESPACE
 from paasta_tools.utils import INSTANCE_TYPES
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.utils import PAASTA_K8S_INSTANCE_TYPES
 from paasta_tools.utils import SHARED_SECRETS_K8S_NAMESPACES
 
 log = logging.getLogger(__name__)
@@ -244,7 +245,7 @@ def get_services_to_k8s_namespaces_to_allowlist(
                         shared_allowlist.update(shared_secrets_used)
 
         for instance_type in INSTANCE_TYPES:
-            if instance_type == "kubernetes":
+            if instance_type in PAASTA_K8S_INSTANCE_TYPES:
                 continue  # handled above.
 
             instances = get_service_instance_list(


### PR DESCRIPTION
We're currently getting the error
```
Traceback (most recent call last):
  File "/usr/bin/paasta_secrets_sync", line 732, in <module>
    main()
  File "/usr/bin/paasta_secrets_sync", line 163, in main
    get_services_to_k8s_namespaces_to_allowlist(
  File "/usr/bin/paasta_secrets_sync", line 262, in get_services_to_k8s_namespaces_to_allowlist
    INSTANCE_TYPE_TO_K8S_NAMESPACE[instance_type]
KeyError: 'eks'
```

This is because we generally handle paasta k8s instance types in the block above, where we are able to infer the desired namespace from the instance config, and only intend to store non-paasta mappings from instance types to their single namespaces in `INSTANCE_TYPE_TO_K8S_NAMESPACE`. 

This updates this code to check all paasta k8s instance types (currently only `kubernetes`+`eks`)