### PR TITLE
Fix conditions for displaying disable auto rollbacks button

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -986,8 +986,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
                 "dest": None,  # Don't actually change state, just call the before function.
                 "trigger": "disable_auto_rollbacks_button_clicked",
                 "conditions": [
-                    self.any_slo_failing,
-                    self.any_metric_failing,
+                    self.any_rollback_condition_failing,
                     self.auto_rollbacks_enabled,
                 ],
                 "before": self.disable_auto_rollbacks,

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -878,11 +878,16 @@ def test_MarkForDeployProcess_happy_path_skips_complete_if_no_auto_rollback(
 
 
 @patch(
+    "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+    autospec=True,
+)
+@patch(
     "paasta_tools.cli.cmds.mark_for_deployment.MarkForDeploymentProcess.any_slo_failing",
     autospec=True,
 )
 def test_MarkForDeployProcess_get_available_buttons_failing_slos_show_disable_rollback(
     mock_any_slo_failing,
+    mock_get_instance_configs,
 ):
     mock_any_slo_failing.return_value = True
     mfdp = WrappedMarkForDeploymentProcess(

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -43,6 +43,10 @@ class FakeArgs:
     auto_abandon_delay = 1.0
     auto_rollback_delay = 1.0
     authors = None
+    warn = 17
+    polling_interval = None
+    diagnosis_interval = None
+    time_before_first_diagnosis = None
 
 
 @fixture
@@ -137,31 +141,44 @@ def test_paasta_mark_for_deployment_when_verify_image_fails(
     mock_is_docker_image_already_in_registry.return_value = False
     with raises(ValueError):
         mark_for_deployment.paasta_mark_for_deployment(FakeArgsRollback)
+    mock_is_docker_image_already_in_registry.assert_called_with(
+        "test_service",
+        "fake_soa_dir",
+        "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+        "extrastuff",
+    )
 
 
-@patch("paasta_tools.cli.cmds.mark_for_deployment.validate_service_name", autospec=True)
 @patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.is_docker_image_already_in_registry",
-    autospec=True,
+    "paasta_tools.cli.cmds.mark_for_deployment.can_user_deploy_service", autospec=True
 )
+@patch("paasta_tools.cli.cmds.mark_for_deployment.validate_service_name", autospec=True)
 @patch(
     "paasta_tools.cli.cmds.mark_for_deployment.get_currently_deployed_version",
     autospec=True,
 )
 @patch("paasta_tools.cli.cmds.mark_for_deployment.list_deploy_groups", autospec=True)
-def test_paasta_mark_for_deployment_when_verify_image_succeeds(
+@patch(
+    "paasta_tools.cli.cmds.mark_for_deployment.is_docker_image_already_in_registry",
+    autospec=True,
+)
+def test_paasta_mark_for_deployment_when_verify_image_succeeds_no_privs(
+    mock_is_docker_image_already_in_registry,
     mock_list_deploy_groups,
     mock_get_currently_deployed_version,
-    mock_is_docker_image_already_in_registry,
     mock_validate_service_name,
+    mock_can_user_deploy,
 ):
     class FakeArgsRollback(FakeArgs):
         verify_image = True
 
     mock_list_deploy_groups.return_value = ["test_deploy_groups"]
-    mock_is_docker_image_already_in_registry.return_value = False
-    with raises(ValueError):
+    mock_is_docker_image_already_in_registry.return_value = True
+    mock_can_user_deploy.return_value = False  # we just want to test verify_image logic
+
+    with raises(SystemExit) as sysexit:
         mark_for_deployment.paasta_mark_for_deployment(FakeArgsRollback)
+        assert sysexit.exception.code == 1
     mock_is_docker_image_already_in_registry.assert_called_with(
         "test_service",
         "fake_soa_dir",
@@ -858,3 +875,60 @@ def test_MarkForDeployProcess_happy_path_skips_complete_if_no_auto_rollback(
     assert mfdp.run() == 0
     assert mfdp.trigger_history == ["start_deploy", "mfd_succeeded", "deploy_finished"]
     assert mfdp.state_history == ["start_deploy", "deploying", "deployed"]
+
+
+@patch(
+    "paasta_tools.cli.cmds.mark_for_deployment.MarkForDeploymentProcess.any_slo_failing",
+    autospec=True,
+)
+def test_MarkForDeployProcess_get_available_buttons_failing_slos_show_disable_rollback(
+    mock_any_slo_failing,
+):
+    mock_any_slo_failing.return_value = True
+    mfdp = WrappedMarkForDeploymentProcess(
+        service="service",
+        deploy_info=MagicMock(),
+        deploy_group="deploy_group",
+        commit="commit",
+        old_git_sha="old_git_sha",
+        git_url="git_url",
+        auto_rollback=True,
+        block=True,
+        soa_dir="soa_dir",
+        timeout=3600,
+        warn_pct=50,
+        auto_certify_delay=None,
+        auto_abandon_delay=600,
+        auto_rollback_delay=30,
+        authors=None,
+    )
+
+    # Test only get_available_buttons
+    mfdp.run_timeout = 1
+    mfdp.state = "deploying"
+    assert "disable_auto_rollbacks" in mfdp.get_available_buttons()
+    assert "enable_auto_rollbacks" not in mfdp.get_available_buttons()
+
+    mock_any_slo_failing.return_value = True
+    mfdp = WrappedMarkForDeploymentProcess(
+        service="service",
+        deploy_info=MagicMock(),
+        deploy_group="deploy_group",
+        commit="commit",
+        old_git_sha="old_git_sha",
+        git_url="git_url",
+        auto_rollback=False,
+        block=True,
+        soa_dir="soa_dir",
+        timeout=3600,
+        warn_pct=50,
+        auto_certify_delay=None,
+        auto_abandon_delay=600,
+        auto_rollback_delay=30,
+        authors=None,
+    )
+
+    mfdp.run_timeout = 1
+    mfdp.state = "deploying"
+    assert "disable_auto_rollbacks" not in mfdp.get_available_buttons()
+    assert "enable_auto_rollbacks" in mfdp.get_available_buttons()

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -150,44 +150,6 @@ def test_paasta_mark_for_deployment_when_verify_image_fails(
 
 
 @patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.can_user_deploy_service", autospec=True
-)
-@patch("paasta_tools.cli.cmds.mark_for_deployment.validate_service_name", autospec=True)
-@patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.get_currently_deployed_version",
-    autospec=True,
-)
-@patch("paasta_tools.cli.cmds.mark_for_deployment.list_deploy_groups", autospec=True)
-@patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.is_docker_image_already_in_registry",
-    autospec=True,
-)
-def test_paasta_mark_for_deployment_when_verify_image_succeeds_no_privs(
-    mock_is_docker_image_already_in_registry,
-    mock_list_deploy_groups,
-    mock_get_currently_deployed_version,
-    mock_validate_service_name,
-    mock_can_user_deploy,
-):
-    class FakeArgsRollback(FakeArgs):
-        verify_image = True
-
-    mock_list_deploy_groups.return_value = ["test_deploy_groups"]
-    mock_is_docker_image_already_in_registry.return_value = True
-    mock_can_user_deploy.return_value = False  # we just want to test verify_image logic
-
-    with raises(SystemExit) as sysexit:
-        mark_for_deployment.paasta_mark_for_deployment(FakeArgsRollback)
-        assert sysexit.exception.code == 1
-    mock_is_docker_image_already_in_registry.assert_called_with(
-        "test_service",
-        "fake_soa_dir",
-        "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
-        "extrastuff",
-    )
-
-
-@patch(
     "paasta_tools.cli.cmds.mark_for_deployment.MarkForDeploymentProcess.run_timeout",
     new=1.0,
     autospec=False,


### PR DESCRIPTION
It looks like we added a new condition with the intent that we would start to rollback if any SLO or new generic 'rollback metric' started to fail.

However, a valid transition's `conditions` must *all* be true to enable the transition.  As we don't yet have any services using metric rollbacks, a service would likely only ever be failing SLOs (`any_slo_failing`) but not ever failing rollback metrics (`any_metric_failing`). 

This replaces the two separate any_*_failing conditions with the new `any_rollback_condition_failing` method which applies the intended logic already of returning true if either any_slo_failing or any_metric_failing: https://github.com/Yelp/sticht/blob/master/sticht/rollbacks/base.py#L245-L246 

This was preventing the "Disable auto-rollbacks" button to be displayed as well, as the trigger's conditions must also `all()` succeed for the button to be included in displayed buttons: https://github.com/Yelp/sticht/blob/master/sticht/slack.py#L296-L308

This also adds a simple test to verify `get_available_buttons` returns the right things for this scenario, plus ~fixes~ deletes a test that I think was not actually testing what it claimed to be (`test_paasta_mark_for_deployment_when_verify_image_succeeds` was testing the same thing as `test_paasta_mark_for_deployment_when_verify_image_fails`!)
