### PR TITLE
Add validation for namespaces in `paasta validate`

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -863,7 +863,9 @@
                     "minimum": 1
                 },
                 "namespace": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "maxLength": 63
                 }
             }
         }

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -246,6 +246,32 @@ def test_get_schema_missing():
 
 
 @patch("paasta_tools.cli.cmds.validate.get_file_contents", autospec=True)
+def test_k8s_namespace_schema_good(mock_get_file_contents, capsys):
+    mock_get_file_contents.return_value = """
+main:
+    namespace: this-is-good
+"""
+    for schema_type in ["kubernetes", "eks"]:
+        assert validate_schema("unused_service_path.yaml", schema_type)
+
+    output, _ = capsys.readouterr()
+    assert SCHEMA_VALID in output
+
+
+@patch("paasta_tools.cli.cmds.validate.get_file_contents", autospec=True)
+def test_k8s_namespace_schema_bad(mock_get_file_contents, capsys):
+    mock_get_file_contents.return_value = """
+main:
+    namspace: bad_namespace
+"""
+    for schema_type in ["kubernetes", "eks"]:
+        assert not validate_schema("unused_service_path.yaml", schema_type)
+
+        output, _ = capsys.readouterr()
+        assert SCHEMA_INVALID in output
+
+
+@patch("paasta_tools.cli.cmds.validate.get_file_contents", autospec=True)
 def test_marathon_validate_schema_list_hashes_good(mock_get_file_contents, capsys):
     marathon_content = """
 ---


### PR DESCRIPTION
We've had a couple of instances where folks have put in an invalid namespace in soaconfigs - this will block that from happening whenever folks run `paasta validate` locally or when the integration pipeline does so.