### PR TITLE
MLCOMPUTE-1035 Update dnsPolicy

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -83,6 +83,7 @@ metadata:
   labels:
     spark: {spark_pod_label}
 spec:
+  dnsPolicy: Default
   affinity:
     podAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Applied when arguments are provided [https://github.com/Yelp/paasta/blob/08c14d329080a0ef8ce29a7a26ac29b022446c06/paasta_tools/cli/cmds/spark_run.py#L702] requires a fix that can go into other prs and potentially not needed when driver is on k8s