### PR TITLE
Add readthedocs v2 config file, update to py38, and fix requirements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# RTD defaults as of 2023-11-08
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#   - pdf
+#   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: requirements-docs.txt

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -11,6 +11,7 @@ freezegun==0.3.7
 identify==1.0.6
 imagesize==0.7.1
 isort==4.2.5
+jinja2==3.0.3
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
 mock==2.0.0


### PR DESCRIPTION
RTD changed things a few months back and now require a new v2 config file: https://docs.readthedocs.io/en/stable/config-file/v2.html

This adds the new file and fixes a jinja dependency issue in requirements-docs.txt for py3.8; we need to stay <3.1 per https://github.com/readthedocs/readthedocs.org/issues/9038 

We should review the requirements, this may be instead improved by a bump to many of the other requirements-docs but this just gets builds passing again as a first step. 

verified in a personal rtd instance https://readthedocs.org/projects/test-jfong-project/builds/22496330/ 