### PR TITLE
PAASTA-18143: remove use_k8s deprecated flag

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -469,9 +469,6 @@
             ],
             "additionalProperties": false,
             "properties": {
-                "use_k8s": {
-                    "type": "boolean"
-                },
                 "name": {
                     "$ref": "#definitions/name"
                 },

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -210,10 +210,6 @@ def parse_time_variables(command: str, parse_time: datetime.datetime = None) -> 
     return StringFormatter(job_context).format(command)
 
 
-def _use_k8s_default() -> bool:
-    return load_system_paasta_config().get_tron_use_k8s_default()
-
-
 def _get_tron_k8s_cluster_override(cluster: str) -> Optional[str]:
     """
     Return the name of a compute cluster if there's a different compute cluster that should be used to run a Tronjob.
@@ -665,9 +661,6 @@ class TronJobConfig:
         # Indicate whether this config object is created for validation
         self.for_validation = for_validation
 
-    def get_use_k8s(self) -> bool:
-        return self.config_dict.get("use_k8s", _use_k8s_default())
-
     def get_name(self):
         return self.name
 
@@ -781,17 +774,10 @@ class TronJobConfig:
         action_dict["monitoring"] = self.get_monitoring()
 
         cluster_override = _get_tron_k8s_cluster_override(self.get_cluster())
-        # technically, we should also be checking if k8s is enabled, but at this stage
-        # of our migration we're not expecting any issues and when we clean up all the
-        # Mesos remnants on-completion we can also rip out all the code that fallsback
-        # to Mesos and just do this unconditionally.
-        use_k8s_cluster_override = cluster_override is not None and self.get_use_k8s()
         return TronActionConfig(
             service=action_service,
             instance=compose_instance(self.get_name(), action_name),
-            cluster=cluster_override
-            if use_k8s_cluster_override
-            else self.get_cluster(),
+            cluster=cluster_override or self.get_cluster(),
             config_dict=action_dict,
             branch_dict=branch_dict,
             soa_dir=self.soa_dir,
@@ -893,7 +879,7 @@ def format_master_config(master_config, default_volumes, dockercfg_location):
     return master_config
 
 
-def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = False):
+def format_tron_action_dict(action_config: TronActionConfig):
     """Generate a dict of tronfig for an action, from the TronActionConfig.
 
     :param job_config: TronActionConfig
@@ -921,12 +907,7 @@ def format_tron_action_dict(action_config: TronActionConfig, use_k8s: bool = Fal
         "service_account_name": action_config.get_service_account_name(),
     }
 
-    # while we're tranisitioning, we want to be able to cleanly fallback to Mesos
-    # so we'll default to Mesos unless k8s usage is enabled for both the cluster
-    # and job.
-    # there are slight differences between k8s and Mesos configs, so we'll translate
-    # whatever is in soaconfigs to the k8s equivalent here as well.
-    if executor in KUBERNETES_EXECUTOR_NAMES and use_k8s:
+    if executor in KUBERNETES_EXECUTOR_NAMES:
         # we'd like Tron to be able to distinguish between spark and normal actions
         # even though they both run on k8s
         result["executor"] = EXECUTOR_NAME_TO_TRON_EXECUTOR_TYPE.get(
@@ -1046,11 +1027,9 @@ def format_tron_job_dict(job_config: TronJobConfig, k8s_enabled: bool = False):
 
     :param job_config: TronJobConfig
     """
-    # TODO: this use_k8s flag should be removed once we've fully migrated off of mesos
-    use_k8s = job_config.get_use_k8s() and k8s_enabled
     action_dict = {
         action_config.get_action_name(): format_tron_action_dict(
-            action_config=action_config, use_k8s=use_k8s
+            action_config=action_config,
         )
         for action_config in job_config.get_actions()
     }
@@ -1069,16 +1048,11 @@ def format_tron_job_dict(job_config: TronJobConfig, k8s_enabled: bool = False):
         "time_zone": job_config.get_time_zone(),
         "expected_runtime": job_config.get_expected_runtime(),
     }
-    # TODO: this should be directly inlined, but we need to update tron everywhere first so it'll
-    # be slightly less tedious to just conditionally send this now until we clean things up on the
-    # removal of all the Mesos code
-    if job_config.get_use_k8s():
-        result["use_k8s"] = job_config.get_use_k8s()
 
     cleanup_config = job_config.get_cleanup_action()
     if cleanup_config:
         cleanup_action = format_tron_action_dict(
-            action_config=cleanup_config, use_k8s=use_k8s
+            action_config=cleanup_config,
         )
         result["cleanup_action"] = cleanup_action
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2035,7 +2035,6 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     vault_environment: str
     volumes: List[DockerVolume]
     zookeeper: str
-    tron_use_k8s: bool
     tron_k8s_cluster_overrides: Dict[str, str]
     skip_cpu_override_validation: List[str]
     spark_k8s_role: str
@@ -2754,9 +2753,6 @@ class SystemPaastaConfig:
         return self.config_dict.get(
             "mark_for_deployment_should_ping_for_unhealthy_pods", True
         )
-
-    def get_tron_use_k8s_default(self) -> bool:
-        return self.config_dict.get("tron_use_k8s", False)
 
     def get_spark_k8s_role(self) -> str:
         return self.config_dict.get("spark_k8s_role", "spark")

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -32,7 +32,6 @@ MOCK_SYSTEM_PAASTA_CONFIG_OVERRIDES = utils.SystemPaastaConfig(
         "volumes": [],
         "dockercfg_location": "/mock/dockercfg",
         "tron_default_pool_override": "big_pool",
-        "tron_use_k8s": True,
         "tron_k8s_cluster_overrides": {
             "paasta-dev-test": "paasta-dev",
         },
@@ -231,32 +230,20 @@ class TestTronJobConfig:
             yield f
 
     @pytest.mark.parametrize(
-        "action_service,action_deploy,cluster,expected_cluster,use_k8s",
+        "action_service,action_deploy,cluster,expected_cluster",
         [
             # normal case - no cluster override present and k8s enabled
-            (None, None, "paasta-dev", "paasta-dev", True),
-            (None, "special_deploy", "paasta-dev", "paasta-dev", True),
-            ("other_service", None, "paasta-dev", "paasta-dev", True),
-            (None, None, "paasta-dev", "paasta-dev", True),
-            (None, None, "paasta-dev", "paasta-dev", True),
+            (None, None, "paasta-dev", "paasta-dev"),
+            (None, "special_deploy", "paasta-dev", "paasta-dev"),
+            ("other_service", None, "paasta-dev", "paasta-dev"),
+            (None, None, "paasta-dev", "paasta-dev"),
+            (None, None, "paasta-dev", "paasta-dev"),
             # cluster override present and k8s enabled
-            (None, None, "paasta-dev-test", "paasta-dev", True),
-            (None, "special_deploy", "paasta-dev-test", "paasta-dev", True),
-            ("other_service", None, "paasta-dev-test", "paasta-dev", True),
-            (None, None, "paasta-dev-test", "paasta-dev", True),
-            (None, None, "paasta-dev-test", "paasta-dev", True),
-            # no cluster override present and k8s disabled
-            (None, None, "paasta-dev", "paasta-dev", False),
-            (None, "special_deploy", "paasta-dev", "paasta-dev", False),
-            ("other_service", None, "paasta-dev", "paasta-dev", False),
-            (None, None, "paasta-dev", "paasta-dev", False),
-            (None, None, "paasta-dev", "paasta-dev", False),
-            # cluster override present and k8s disabled
-            (None, None, "paasta-dev-test", "paasta-dev-test", False),
-            (None, "special_deploy", "paasta-dev-test", "paasta-dev-test", False),
-            ("other_service", None, "paasta-dev-test", "paasta-dev-test", False),
-            (None, None, "paasta-dev-test", "paasta-dev-test", False),
-            (None, None, "paasta-dev-test", "paasta-dev-test", False),
+            (None, None, "paasta-dev-test", "paasta-dev"),
+            (None, "special_deploy", "paasta-dev-test", "paasta-dev"),
+            ("other_service", None, "paasta-dev-test", "paasta-dev"),
+            (None, None, "paasta-dev-test", "paasta-dev"),
+            (None, None, "paasta-dev-test", "paasta-dev"),
         ],
     )
     @mock.patch("paasta_tools.tron_tools.load_v2_deployments_json", autospec=True)
@@ -267,7 +254,6 @@ class TestTronJobConfig:
         action_deploy,
         cluster,
         expected_cluster,
-        use_k8s,
     ):
         """Check resulting action config with various overrides from the action."""
         action_dict = {"command": "echo first"}
@@ -289,7 +275,6 @@ class TestTronJobConfig:
             "max_runtime": "2h",
             "actions": {"normal": action_dict},
             "monitoring": {"team": "noop"},
-            "use_k8s": use_k8s,
         }
 
         soa_dir = "/other_dir"
@@ -429,7 +414,6 @@ class TestTronJobConfig:
         )
         mock_format_action.assert_called_once_with(
             action_config=mock_get_action_config.return_value,
-            use_k8s=False,
         )
 
         assert result == {
@@ -455,7 +439,6 @@ class TestTronJobConfig:
         actions = {action_name: action_dict}
 
         job_dict = {
-            "use_k8s": True,
             "node": "batch_server",
             "schedule": "daily 12:10:00",
             "service": "my_service",
@@ -484,7 +467,6 @@ class TestTronJobConfig:
         )
         mock_format_action.assert_called_once_with(
             action_config=mock_get_action_config.return_value,
-            use_k8s=True,
         )
 
         assert result == {
@@ -496,7 +478,6 @@ class TestTronJobConfig:
             },
             "expected_runtime": "1h",
             "monitoring": {"team": "noop"},
-            "use_k8s": True,
         }
 
     @mock.patch(
@@ -831,7 +812,7 @@ class TestTronTools:
             autospec=True,
         ):
             result = tron_tools.format_tron_action_dict(action_config)
-        assert result["executor"] == "mesos"
+        assert result["executor"] == "kubernetes"
 
     def test_format_tron_action_dict_paasta(self):
         action_dict = {
@@ -898,7 +879,7 @@ class TestTronTools:
             "retries": 2,
             "retries_delay": "5m",
             "docker_image": mock.ANY,
-            "executor": "mesos",
+            "executor": "kubernetes",
             "cpus": 2,
             "mem": 1200,
             "disk": 42,
@@ -915,10 +896,19 @@ class TestTronTools:
             "extra_volumes": [
                 {"container_path": "/nail/tmp", "host_path": "/nail/tmp", "mode": "RW"}
             ],
-            "docker_parameters": mock.ANY,
-            "constraints": [
-                {"attribute": "pool", "operator": "LIKE", "value": "special_pool"}
-            ],
+            "field_selector_env": {"PAASTA_POD_IP": {"field_path": "status.podIP"}},
+            "node_selectors": {"yelp.com/pool": "special_pool"},
+            "labels": {
+                "paasta.yelp.com/cluster": "test-cluster",
+                "paasta.yelp.com/instance": "my_job.do_something",
+                "paasta.yelp.com/pool": "special_pool",
+                "paasta.yelp.com/service": "my_service",
+                "yelp.com/owner": "compute_infra_platform_experience",
+            },
+            "annotations": {"paasta.yelp.com/routable_ip": "false"},
+            "cap_drop": CAPS_DROP,
+            "cap_add": [],
+            "secret_env": {},
             "trigger_downstreams": True,
             "triggered_by": ["foo.bar.{shortdate}"],
             "trigger_timeout": "5m",
@@ -928,7 +918,6 @@ class TestTronTools:
         )
         assert result["docker_image"] == expected_docker
         assert result["env"]["SHELL"] == "/bin/bash"
-        assert isinstance(result["docker_parameters"], list)
 
     @mock.patch("paasta_tools.spark_tools.spark_config.SparkConfBuilder", autospec=True)
     def test_format_tron_action_dict_spark(self, mock_spark_conf_builder):
@@ -1031,7 +1020,7 @@ class TestTronTools:
                 "spark.sql.files.minPartitionNum": "12",
                 "spark.default.parallelism": "12",
             }
-            result = tron_tools.format_tron_action_dict(action_config, use_k8s=True)
+            result = tron_tools.format_tron_action_dict(action_config)
 
         assert result == {
             "command": "spark-submit "
@@ -1172,7 +1161,7 @@ class TestTronTools:
             "paasta_tools.tron_tools.load_system_paasta_config",
             autospec=True,
         ):
-            result = tron_tools.format_tron_action_dict(action_config, use_k8s=True)
+            result = tron_tools.format_tron_action_dict(action_config)
 
         assert result == {
             "command": "echo something",
@@ -1295,7 +1284,7 @@ class TestTronTools:
             autospec=True,
             return_value=False,
         ):
-            result = tron_tools.format_tron_action_dict(action_config, use_k8s=True)
+            result = tron_tools.format_tron_action_dict(action_config)
 
         assert result == {
             "command": "echo something",
@@ -1411,7 +1400,7 @@ class TestTronTools:
             "requires": ["required_action"],
             "retries": 2,
             "docker_image": "",
-            "executor": "mesos",
+            "executor": "kubernetes",
             "cpus": 2,
             "mem": 1200,
             "disk": 42,
@@ -1428,13 +1417,21 @@ class TestTronTools:
             "extra_volumes": [
                 {"container_path": "/nail/tmp", "host_path": "/nail/tmp", "mode": "RW"}
             ],
-            "docker_parameters": mock.ANY,
-            "constraints": [
-                {"attribute": "pool", "operator": "LIKE", "value": "special_pool"}
-            ],
+            "field_selector_env": {"PAASTA_POD_IP": {"field_path": "status.podIP"}},
+            "node_selectors": {"yelp.com/pool": "special_pool"},
+            "labels": {
+                "paasta.yelp.com/cluster": "paasta-dev",
+                "paasta.yelp.com/instance": "my_job.do_something",
+                "paasta.yelp.com/pool": "special_pool",
+                "paasta.yelp.com/service": "my_service",
+                "yelp.com/owner": "compute_infra_platform_experience",
+            },
+            "annotations": {"paasta.yelp.com/routable_ip": "false"},
+            "cap_drop": CAPS_DROP,
+            "cap_add": [],
+            "secret_env": {},
         }
         assert result["env"]["SHELL"] == "/bin/bash"
-        assert isinstance(result["docker_parameters"], list)
 
     @mock.patch("paasta_tools.tron_tools.read_extra_service_information", autospec=True)
     def test_load_tron_service_config(self, mock_read_extra_service_information):
@@ -1571,7 +1568,7 @@ fake_job:
         # that are not static, this will cause continuous reconfiguration, which
         # will add significant load to the Tron API, which happened in DAR-1461.
         # but if this is intended, just change the hash.
-        assert hasher.hexdigest() == "35972651618a848ac6bf7947245dbaea"
+        assert hasher.hexdigest() == "ba2ccfd2477b2ce2233de42619aa810a"
 
     def test_override_default_pool_override(self, tmpdir):
         soa_dir = tmpdir.mkdir("test_create_complete_config_soa")


### PR DESCRIPTION
This removes the deprecated use_k8s flag now that we are fully on Kubernetes.