### PR TITLE
Add missing symlink for check_autoscaler_max_instances

### DIFF
--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -8,6 +8,7 @@ opt/venvs/paasta-tools/bin/check_marathon_has_apps.py usr/bin/check_marathon_has
 opt/venvs/paasta-tools/bin/check_marathon_services_frontends.py usr/bin/check_marathon_services_frontends
 opt/venvs/paasta-tools/bin/check_kubernetes_api.py usr/bin/check_kubernetes_api
 opt/venvs/paasta-tools/bin/check_kubernetes_services_replication.py usr/bin/check_kubernetes_services_replication
+opt/venvs/paasta-tools/bin/check_autoscaler_max_instances.py usr/bin/check_autoscaler_max_instances
 opt/venvs/paasta-tools/bin/check_mesos_active_frameworks.py usr/bin/check_mesos_active_frameworks
 opt/venvs/paasta-tools/bin/check_mesos_duplicate_frameworks.py usr/bin/check_mesos_duplicate_frameworks
 opt/venvs/paasta-tools/bin/check_mesos_quorum.py usr/bin/check_mesos_quorum


### PR DESCRIPTION
This makes sure our new `check_autoscaler_max_instances` script  from #3747  is available in our standard PATHs like our other system scripts

Upon building the new deb & installing on a test box, I can see the symlink is created appropriately:
```
 $ sudo dpkg -i dist/paasta-tools_0.209.0-yelp1_amd64.deb
(Reading database ... 1664070 files and directories currently installed.)
Preparing to unpack .../paasta-tools_0.209.0-yelp1_amd64.deb ...
Unpacking paasta-tools (0.209.0-yelp1) over (0.209.0-yelp1) ...
ls -l /usr/bin/check_auto
Setting up paasta-tools (0.209.0-yelp1) ...
Successfully updated /opt/venvs/paasta-tools/bin/python3.8
$ ls -l /usr/bin/check_autoscaler_max_instances
lrwxrwxrwx 1 root root 61 Dec 14 15:55 /usr/bin/check_autoscaler_max_instances -> /opt/venvs/paasta-tools/bin/check_autoscaler_max_instances.py*
```