### PR TITLE
Set include_smartstack default to False since we no longer support it

### DIFF
--- a/paasta_tools/api/api_docs/oapi.yaml
+++ b/paasta_tools/api/api_docs/oapi.yaml
@@ -1831,7 +1831,7 @@ paths:
         required: false
         schema:
           type: boolean
-          default: true
+          default: false
       - description: Include Envoy information
         in: query
         name: include_envoy

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -643,7 +643,7 @@ def instance_status(request):
     use_new = request.swagger_data.get("new") or False
     include_smartstack = request.swagger_data.get("include_smartstack")
     if include_smartstack is None:
-        include_smartstack = True
+        include_smartstack = False
     include_envoy = request.swagger_data.get("include_envoy")
     if include_envoy is None:
         include_envoy = True

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -1305,7 +1305,7 @@ async def kubernetes_mesh_status(
     instance: str,
     instance_type: str,
     settings: Any,
-    include_smartstack: bool = True,
+    include_smartstack: bool = False,
     include_envoy: bool = True,
 ) -> Mapping[str, Any]:
 

--- a/paasta_tools/paastaapi/api/service_api.py
+++ b/paasta_tools/paastaapi/api/service_api.py
@@ -1186,7 +1186,7 @@ class ServiceApi(object):
                 instance (str): Instance name
 
             Keyword Args:
-                include_smartstack (bool): Include Smartstack information. [optional] if omitted the server will use the default value of True
+                include_smartstack (bool): Include Smartstack information. [optional] if omitted the server will use the default value of False
                 include_envoy (bool): Include Envoy information. [optional] if omitted the server will use the default value of True
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.


### PR DESCRIPTION
We have nothing actually running smartstack so attempting to get that information in a paasta API call will fail.

While I wasn't brave enough to outright delete this code yet (it _may_ be useful to have this prior art to show how to toggle one mesh provider in mesh_status vs another?), let's at least set the default to False to prevent accidental uses which can clog the API logs with errors. 