### PR TITLE
Always use docker registry server's digest information for pushed spark images

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1104,7 +1104,7 @@ def build_and_push_docker_image(args: argparse.Namespace) -> Optional[str]:
     digest_line = output.split("\n")[-1]
     digest_match = re.match(r"[^:]*: [^:]*: (?P<digest>[^\s]*)", digest_line)
     if not digest_match:
-        raise Exception(f"Could not determine digest from output: {output}")
+        raise ValueError(f"Could not determine digest from output: {output}")
     digest = digest_match.group("digest")
     return f"{docker_url}@{digest}"
 


### PR DESCRIPTION
## Problem
Because of https://github.com/containers/podman/issues/14779, `docker push` has different behavior w.r.t. the local vs remote image digest value when run in privileged vs unprivileged mode. This was causing `paasta spark run` commands using `--build` to fail to allocate an executor node in unprivileged container mode because it was referring to an image digest that paasta couldn't find because it only exists on the devbox where `paasta spark run` is called.

## Solution
Parse the message from the remote docker registry when running `docker push` during `paasta spark run --build` so that we always use the server version of the image digest as the source of truth.

## Testing Done
Ran `paasta spark run` manually for both `--pull` and `--build` with this patch and confirmed the executor can be allocated and the jobs can complete.