### PR TITLE
Add workaround script to fix habitat labels

### DIFF
--- a/debian/paasta-tools.links
+++ b/debian/paasta-tools.links
@@ -57,3 +57,4 @@ opt/venvs/paasta-tools/bin/setup_kubernetes_cr.py usr/bin/setup_kubernetes_cr
 opt/venvs/paasta-tools/bin/setup_prometheus_adapter_config.py usr/bin/setup_prometheus_adapter_config
 opt/venvs/paasta-tools/bin/synapse_srv_namespaces_fact.py usr/bin/synapse_srv_namespaces_fact
 opt/venvs/paasta-tools/bin/paasta_update_soa_memcpu.py usr/bin/paasta_update_soa_memcpu
+opt/venvs/paasta-tools/bin/paasta_habitat_fixer.py usr/bin/paasta_habitat_fixer

--- a/paasta_tools/contrib/habitat_fixer.py
+++ b/paasta_tools/contrib/habitat_fixer.py
@@ -38,7 +38,7 @@ def is_affected_node(node: V1Node) -> bool:
 
 def get_desired_habitat(node: V1Node) -> str:
     zone = node.metadata.labels["topology.kubernetes.io/zone"].replace("-", "")
-    _, ecosystem = node.metadata.labels["yelp.com/superregion"].rsplit("-")
+    ecosystem = node.metadata.labels["yelp.com/ecosystem"]
 
     return f"{zone}{ecosystem}"
 

--- a/paasta_tools/contrib/habitat_fixer.py
+++ b/paasta_tools/contrib/habitat_fixer.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+import argparse
+from pathlib import Path
+
+from kubernetes.client import V1Node
+
+from paasta_tools.kubernetes_tools import KUBE_CONFIG_PATH
+from paasta_tools.kubernetes_tools import KUBE_CONFIG_USER_PATH
+from paasta_tools.kubernetes_tools import KubeClient
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Karpenter Habitat Corruption Workaround"
+    )
+    parser.add_argument("-c", "--cluster", required=True)
+    parser.add_argument(
+        "-k",
+        "--kubeconfig",
+        default=KUBE_CONFIG_PATH
+        if Path(KUBE_CONFIG_PATH).exists()
+        else KUBE_CONFIG_USER_PATH,
+    )
+    parser.add_argument(
+        "--for-real",
+        action="store_true",
+    )
+    return parser.parse_args()
+
+
+def is_affected_node(node: V1Node) -> bool:
+    try:
+        int(node.metadata.labels["yelp.com/habitat"])
+        return True
+    except ValueError:
+        return False
+
+
+def get_desired_habitat(node: V1Node) -> str:
+    zone = node.metadata.labels["topology.kubernetes.io/zone"].replace("-", "")
+    _, ecosystem = node.metadata.labels["yelp.com/superregion"].rsplit("-")
+
+    return f"{zone}{ecosystem}"
+
+
+def main():
+    args = parse_args()
+    client = KubeClient(config_file=args.kubeconfig, context=args.cluster)
+    for node in client.core.list_node().items:
+        if not is_affected_node(node):
+            continue
+
+        if args.for_real:
+            client.core.patch_node(
+                name=node.metadata.name,
+                body={
+                    "metadata": {
+                        "labels": {
+                            "yelp.com/habitat": get_desired_habitat(node),
+                        },
+                    }
+                },
+            )
+        else:
+            print(
+                f"Would have edited {node.metadata.name} in pool={node.metadata.labels['yelp.com/pool']} to have habitat={get_desired_habitat(node)} (from {node.metadata.labels['yelp.com/habitat']})",
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setup(
             "paasta_oom_logger=paasta_tools.oom_logger:main",
             "paasta_broadcast_log=paasta_tools.broadcast_log_to_services:main",
             "paasta_dump_locally_running_services=paasta_tools.dump_locally_running_services:main",
+            "paasta_habitat_fixer=paasta_tools.contrib.habitat_fixer:main",
         ],
         "paste.app_factory": ["paasta-api-config=paasta_tools.api.api:make_app"],
     },


### PR DESCRIPTION
We're seeing some weirdness with Karpenter where one of our custom labels (yelp.com/habitat) is sometimes being set as a random integer.

While we debug this, we have enough information to write a script to fix these.