### PR TITLE
Remove include_smartstack

### DIFF
--- a/paasta_tools/api/api_docs/oapi.yaml
+++ b/paasta_tools/api/api_docs/oapi.yaml
@@ -1771,12 +1771,6 @@ paths:
         schema:
           format: int32
           type: integer
-      - description: Include Smartstack information
-        in: query
-        name: include_smartstack
-        required: false
-        schema:
-          type: boolean
       - description: Include Envoy information
         in: query
         name: include_envoy
@@ -1825,13 +1819,6 @@ paths:
         required: true
         schema:
           type: string
-      - description: Include Smartstack information
-        in: query
-        name: include_smartstack
-        required: false
-        schema:
-          type: boolean
-          default: false
       - description: Include Envoy information
         in: query
         name: include_envoy

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1507,7 +1507,6 @@ def diagnose_why_instance_is_stuck(
         status = api.service.status_instance(
             service=service,
             instance=instance,
-            include_smartstack=False,
             include_envoy=False,
             include_mesos=False,
             new=True,

--- a/paasta_tools/cli/cmds/mesh_status.py
+++ b/paasta_tools/cli/cmds/mesh_status.py
@@ -110,7 +110,6 @@ def paasta_mesh_status_on_api_endpoint(
         mesh_status = client.service.mesh_instance(
             service=service,
             instance=instance,
-            include_smartstack=False,
         )
     except client.api_error as exc:
         # 405 (method not allowed) is returned for instances that are not configured

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -298,7 +298,6 @@ def paasta_status_on_api_endpoint(
             instance=instance,
             verbose=verbose,
             new=new,
-            include_smartstack=False,
         )
     except client.api_error as exc:
         output.append(PaastaColors.red(exc.reason))

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -593,7 +593,6 @@ async def kubernetes_status_v2(
     service: str,
     instance: str,
     verbose: int,
-    include_smartstack: bool,
     include_envoy: bool,
     instance_type: str,
     settings: Any,
@@ -1116,7 +1115,6 @@ async def kubernetes_status(
     service: str,
     instance: str,
     verbose: int,
-    include_smartstack: bool,
     include_envoy: bool,
     instance_type: str,
     settings: Any,
@@ -1204,35 +1202,23 @@ async def kubernetes_status(
             evicted_count += 1
     kstatus["evicted_count"] = evicted_count
 
-    if include_smartstack or include_envoy:
+    if include_envoy:
         service_namespace_config = kubernetes_tools.load_service_namespace_config(
             service=service,
             namespace=job_config.get_nerve_namespace(),
             soa_dir=settings.soa_dir,
         )
         if "proxy_port" in service_namespace_config:
-            if include_smartstack:
-                kstatus["smartstack"] = await mesh_status(
-                    service=service,
-                    service_mesh=ServiceMesh.SMARTSTACK,
-                    instance=job_config.get_nerve_namespace(),
-                    job_config=job_config,
-                    service_namespace_config=service_namespace_config,
-                    pods_task=pods_task,
-                    should_return_individual_backends=verbose > 0,
-                    settings=settings,
-                )
-            if include_envoy:
-                kstatus["envoy"] = await mesh_status(
-                    service=service,
-                    service_mesh=ServiceMesh.ENVOY,
-                    instance=job_config.get_nerve_namespace(),
-                    job_config=job_config,
-                    service_namespace_config=service_namespace_config,
-                    pods_task=pods_task,
-                    should_return_individual_backends=verbose > 0,
-                    settings=settings,
-                )
+            kstatus["envoy"] = await mesh_status(
+                service=service,
+                service_mesh=ServiceMesh.ENVOY,
+                instance=job_config.get_nerve_namespace(),
+                job_config=job_config,
+                service_namespace_config=service_namespace_config,
+                pods_task=pods_task,
+                should_return_individual_backends=verbose > 0,
+                settings=settings,
+            )
     return kstatus
 
 
@@ -1240,7 +1226,6 @@ def instance_status(
     service: str,
     instance: str,
     verbose: int,
-    include_smartstack: bool,
     include_envoy: bool,
     use_new: bool,
     instance_type: str,
@@ -1270,7 +1255,6 @@ def instance_status(
                 instance=instance,
                 instance_type=instance_type,
                 verbose=verbose,
-                include_smartstack=include_smartstack,
                 include_envoy=include_envoy,
                 settings=settings,
             )
@@ -1280,7 +1264,6 @@ def instance_status(
                 instance=instance,
                 instance_type=instance_type,
                 verbose=verbose,
-                include_smartstack=include_smartstack,
                 include_envoy=include_envoy,
                 settings=settings,
             )
@@ -1305,11 +1288,10 @@ async def kubernetes_mesh_status(
     instance: str,
     instance_type: str,
     settings: Any,
-    include_smartstack: bool = False,
     include_envoy: bool = True,
 ) -> Mapping[str, Any]:
 
-    if not include_smartstack and not include_envoy:
+    if not include_envoy:
         raise RuntimeError("No mesh types specified when requesting mesh status")
     if instance_type not in LONG_RUNNING_INSTANCE_TYPE_HANDLERS:
         raise RuntimeError(
@@ -1354,11 +1336,6 @@ async def kubernetes_mesh_status(
         should_return_individual_backends=True,
         settings=settings,
     )
-    if include_smartstack:
-        kmesh["smartstack"] = await mesh_status(
-            service_mesh=ServiceMesh.SMARTSTACK,
-            **mesh_status_kwargs,
-        )
     if include_envoy:
         kmesh["envoy"] = await mesh_status(
             service_mesh=ServiceMesh.ENVOY,

--- a/paasta_tools/paastaapi/api/service_api.py
+++ b/paasta_tools/paastaapi/api/service_api.py
@@ -1186,7 +1186,6 @@ class ServiceApi(object):
                 instance (str): Instance name
 
             Keyword Args:
-                include_smartstack (bool): Include Smartstack information. [optional] if omitted the server will use the default value of False
                 include_envoy (bool): Include Envoy information. [optional] if omitted the server will use the default value of True
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
@@ -1251,7 +1250,6 @@ class ServiceApi(object):
                 'all': [
                     'service',
                     'instance',
-                    'include_smartstack',
                     'include_envoy',
                 ],
                 'required': [
@@ -1275,21 +1273,17 @@ class ServiceApi(object):
                         (str,),
                     'instance':
                         (str,),
-                    'include_smartstack':
-                        (bool,),
                     'include_envoy':
                         (bool,),
                 },
                 'attribute_map': {
                     'service': 'service',
                     'instance': 'instance',
-                    'include_smartstack': 'include_smartstack',
                     'include_envoy': 'include_envoy',
                 },
                 'location_map': {
                     'service': 'path',
                     'instance': 'path',
-                    'include_smartstack': 'query',
                     'include_envoy': 'query',
                 },
                 'collection_format_map': {
@@ -1325,7 +1319,6 @@ class ServiceApi(object):
 
             Keyword Args:
                 verbose (int): Include verbose status information. [optional]
-                include_smartstack (bool): Include Smartstack information. [optional]
                 include_envoy (bool): Include Envoy information. [optional]
                 include_mesos (bool): Include Mesos information. [optional]
                 new (bool): Use new version of paasta status for services. [optional]
@@ -1393,7 +1386,6 @@ class ServiceApi(object):
                     'service',
                     'instance',
                     'verbose',
-                    'include_smartstack',
                     'include_envoy',
                     'include_mesos',
                     'new',
@@ -1421,8 +1413,6 @@ class ServiceApi(object):
                         (str,),
                     'verbose':
                         (int,),
-                    'include_smartstack':
-                        (bool,),
                     'include_envoy':
                         (bool,),
                     'include_mesos':
@@ -1434,7 +1424,6 @@ class ServiceApi(object):
                     'service': 'service',
                     'instance': 'instance',
                     'verbose': 'verbose',
-                    'include_smartstack': 'include_smartstack',
                     'include_envoy': 'include_envoy',
                     'include_mesos': 'include_mesos',
                     'new': 'new',
@@ -1443,7 +1432,6 @@ class ServiceApi(object):
                     'service': 'path',
                     'instance': 'path',
                     'verbose': 'query',
-                    'include_smartstack': 'query',
                     'include_envoy': 'query',
                     'include_mesos': 'query',
                     'new': 'query',

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -50,7 +50,6 @@ from tests.conftest import wrap_value_in_task
 
 @pytest.mark.parametrize("include_mesos", [False, True])
 @pytest.mark.parametrize("include_envoy", [False, True])
-@pytest.mark.parametrize("include_smartstack", [False, True])
 @mock.patch("paasta_tools.api.views.instance.marathon_mesos_status", autospec=True)
 @mock.patch(
     "paasta_tools.api.views.instance.marathon_service_mesh_status", autospec=True
@@ -84,7 +83,6 @@ def test_instance_status_marathon(
     mock_load_service_namespace_config,
     mock_marathon_service_mesh_status,
     mock_marathon_mesos_status,
-    include_smartstack,
     include_envoy,
     include_mesos,
 ):
@@ -123,7 +121,6 @@ def test_instance_status_marathon(
         "service": "fake_service",
         "instance": "fake_instance",
         "verbose": 2,
-        "include_smartstack": include_smartstack,
         "include_envoy": include_envoy,
         "include_mesos": include_mesos,
     }
@@ -133,8 +130,6 @@ def test_instance_status_marathon(
         "marathon_job_status_field1": "field1_value",
         "marathon_job_status_field2": "field2_value",
     }
-    if include_smartstack:
-        expected_response["smartstack"] = mock_marathon_service_mesh_status.return_value
     if include_envoy:
         expected_response["envoy"] = mock_marathon_service_mesh_status.return_value
     if include_mesos:
@@ -153,18 +148,6 @@ def test_instance_status_marathon(
             "fake_service", "fake_instance", 2
         )
     expected_marathon_service_mesh_status_calls = []
-    if include_smartstack:
-        expected_marathon_service_mesh_status_calls.append(
-            mock.call(
-                "fake_service",
-                ServiceMesh.SMARTSTACK,
-                "fake_instance",
-                mock_service_config,
-                mock_load_service_namespace_config.return_value,
-                mock_app.tasks,
-                should_return_individual_backends=True,
-            ),
-        )
     if include_envoy:
         expected_marathon_service_mesh_status_calls.append(
             mock.call(
@@ -1114,7 +1097,6 @@ def test_kubernetes_instance_status_bounce_method():
             instance=inst,
             instance_type="kubernetes",
             verbose=0,
-            include_smartstack=False,
             include_envoy=False,
             settings=settings,
         )
@@ -1149,7 +1131,6 @@ def test_kubernetes_instance_status_evicted_nodes():
             instance="fake-inst",
             instance_type="kubernetes",
             verbose=0,
-            include_smartstack=False,
             include_envoy=False,
             settings=mock_settings,
         )
@@ -1210,7 +1191,6 @@ def test_instance_mesh_status(
     request.swagger_data = {
         "service": "fake_service",
         "instance": "fake_inst",
-        "include_smartstack": False,
     }
     instance_mesh = instance.instance_mesh_status(request)
 
@@ -1226,7 +1206,6 @@ def test_instance_mesh_status(
             instance="fake_inst",
             instance_type="flink",
             settings=settings,
-            include_smartstack=False,
             include_envoy=None,  # default of true in api specs
         ),
     ]
@@ -1263,7 +1242,6 @@ def test_instance_mesh_status_error(
     request.swagger_data = {
         "service": "fake_service",
         "instance": "fake_inst",
-        "include_smartstack": False,
     }
 
     with pytest.raises(ApiFailure) as excinfo:

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -920,7 +920,7 @@ def test_status_with_registration(
 
 
 @pytest.fixture
-def mock_marathon_status(include_envoy=True, include_smartstack=True):
+def mock_marathon_status(include_envoy=True):
     kwargs = dict(
         desired_state="start",
         desired_app_id="abc.def",
@@ -937,12 +937,6 @@ def mock_marathon_status(include_envoy=True, include_smartstack=True):
             non_running_tasks=[],
         ),
     )
-    if include_smartstack:
-        kwargs["smartstack"] = paastamodels.SmartstackStatus(
-            registration="fake_service.fake_instance",
-            expected_backends_per_location=1,
-            locations=[],
-        )
     if include_envoy:
         kwargs["envoy"] = paastamodels.EnvoyStatus(
             registration="fake_service.fake_instance",


### PR DESCRIPTION
This removes the include_smartstack parameter everywhere and associated references in our code, since we no longer support it anywhere in our environment.

Since we deployed https://github.com/Yelp/paasta/pull/3752 , shipping this should now be safe as any clients that remove include_smartstack in their requests with this PR will still get `include_smartstack=false` on the server side (rather than attempt to collect smartstack information and throw an error).

