### PR TITLE
Fix get_instance_configs_for_service to use cluster arg

### DIFF
--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -1066,7 +1066,7 @@ def get_instance_configs_for_service(
     if type_filter is None:
         type_filter = INSTANCE_TYPE_HANDLERS.keys()
 
-    for cluster in list_clusters(service=service, soa_dir=soa_dir):
+    for cluster in clusters:
         for instance_type, instance_handlers in INSTANCE_TYPE_HANDLERS.items():
             if instance_type not in type_filter:
                 continue


### PR DESCRIPTION
While running `paasta mesh-status`, I was getting an odd error indicating that we were trying to get information for an EksInstance for an instance and cluster that should not have been running on EKS.

Turns out that this is due to us naively getting the first instance_config from the results of get_instance_configs_for_service, which was not honoring the `clusters` argument.

This change now starts to honor said clusters argument.

All uses of this function either did not pass the `clusters` arg (and therefore used the full list of supported clusters from system configs), or expected only a single instance and was impacted by this same bug.

No clusters arg:
* generate_deployments_for_service: https://github.com/Yelp/paasta/blob/master/paasta_tools/generate_deployments_for_service.py#L139

Unaffected by bug:
* paasta status: https://github.com/Yelp/paasta/blob/master/paasta_tools/cli/cmds/status.py#L2367-L2370
  * Additional filtering done on results to apply cluster filter

Probably buggy:
* paasta autoscale (does this still work?): https://github.com/Yelp/paasta/blob/master/paasta_tools/cli/cmds/autoscale.py#L73-L81
* paasta mesh-status: https://github.com/Yelp/paasta/blob/master/paasta_tools/cli/cmds/mesh_status.py#L83C1-L91