### PR TITLE
Load eks- and kubernetes- files in autotune merging

### DIFF
--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -337,8 +337,8 @@ class AutoConfigUpdater:
             # and eks- files for the existing configs, as there are services that at any given time will
             # only exist on one of these or may have a mix (and the csv file that we get fakes the current
             # cluster type)
-            # NOTE: if an instance appears in both files, the counterpart will always "win" - this 
-            # should only be possible while an instance is being migrated from one instance type to 
+            # NOTE: if an instance appears in both files, the counterpart will always "win" - this
+            # should only be possible while an instance is being migrated from one instance type to
             # another
             instance_type, _ = instance_type_cluster.split("-", maxsplit=1)
             existing_configs = {

--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -337,6 +337,9 @@ class AutoConfigUpdater:
             # and eks- files for the existing configs, as there are services that at any given time will
             # only exist on one of these or may have a mix (and the csv file that we get fakes the current
             # cluster type)
+            # NOTE: if an instance appears in both files, the counterpart will always "win" - this 
+            # should only be possible while an instance is being migrated from one instance type to 
+            # another
             instance_type, _ = instance_type_cluster.split("-", maxsplit=1)
             existing_configs = {
                 # if we upgrate to py3.9 before getting rid of this code, this should use PEP-584-style dict merging

--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -28,6 +28,11 @@ KNOWN_CONFIG_TYPES = (
     "cassandracluster",
 )
 
+# this could use a better name - but basically, this is for pairs of instance types
+# where you generally want to check both types (i.e.,g a status-quo and migration
+# instance type)
+INSTANCE_TYPE_COUNTERPARTS = {"eks": "kubernetes", "kubernetes": "eks"}
+
 
 def my_represent_none(self, data):
     return self.represent_scalar("tag:yaml.org,2002:null", "null")
@@ -327,10 +332,25 @@ class AutoConfigUpdater:
             log.debug(
                 f"Getting current configs for {service}/{instance_type_cluster}.yaml..."
             )
-            existing_configs = self.get_existing_configs(
-                service=service,
-                file_name=instance_type_cluster,
-            )
+            # i'm so sorry.
+            # basically, we need to make sure that for every autotuned service, we load both kubernetes-
+            # and eks- files for the existing configs, as there are services that at any given time will
+            # only exist on one of these or may have a mix (and the csv file that we get fakes the current
+            # cluster type)
+            instance_type, _ = instance_type_cluster.split("-", maxsplit=1)
+            existing_configs = {
+                # if we upgrate to py3.9 before getting rid of this code, this should use PEP-584-style dict merging
+                **self.get_existing_configs(
+                    service=service,
+                    file_name=instance_type_cluster,
+                ),
+                **self.get_existing_configs(
+                    service=service,
+                    file_name=instance_type_cluster.replace(
+                        instance_type, INSTANCE_TYPE_COUNTERPARTS.get(instance_type, "")
+                    ),
+                ),
+            }
 
             for instance_name, recommendation in recommendations_by_instance.items():
                 log.debug(

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -356,7 +356,16 @@ def test_auto_config_updater_merge_recommendations_limits(updater):
         updater,
         "get_existing_configs",
         autospec=True,
-        side_effect=[autotune_data, user_data],
+        side_effect=[
+            # first get the autotune data
+            autotune_data,
+            # then we get both the eks- and kuberentes- data
+            user_data,
+            # there could be data in both of these, but for a
+            # simpler test, we just assume that we're looking
+            # at something that's 100% on Yelp-managed k8s
+            {},
+        ],
     ):
         assert updater.merge_recommendations(recs) == {
             (service, conf_file): {


### PR DESCRIPTION
It's possible for a service to be in one of several states:
* 100% on Yelp-managed k8s
* 100% on AWS-managed k8s
* X% on Yelp-managed k8s and 100-X% on AWS-managed k8s

Everything is fine in the first case, but for the other two we need to make sure that we load the eks- files as we cannot actually rely on the instance_type_cluster from the autotune CSV as we "fake" the instance type there to always be kubernetes

For now, we'll basically try to load both types and merge the resulting configuration to get the current configs (which we need in order to clamp autotune values if there are user-configured limits)