### PR TITLE
Change the default branch name to push to

### DIFF
--- a/paasta_tools/contrib/rightsizer_soaconfigs_update.py
+++ b/paasta_tools/contrib/rightsizer_soaconfigs_update.py
@@ -96,8 +96,8 @@ def parse_args():
     )
     parser.add_argument(
         "--branch",
-        help="Branch name to push to. Defaults to master",
-        default="master",
+        help="Branch name to push to. Defaults to main",
+        default="main",
         required=False,
         dest="branch",
     )


### PR DESCRIPTION
This PR proposes the change of the default value of the `--branch` argument to make it more inclusive.