### PR TITLE
Allow using preferred node affinity on its own

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2409,15 +2409,19 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         if len(requirements) == 0 and len(preferred_terms) == 0:
             return None
 
-        required_term = V1NodeSelectorTerm(
-            match_expressions=[
-                V1NodeSelectorRequirement(
-                    key=key,
-                    operator=op,
-                    values=vs,
-                )
-                for key, op, vs in requirements
-            ]
+        required_term = (
+            V1NodeSelectorTerm(
+                match_expressions=[
+                    V1NodeSelectorRequirement(
+                        key=key,
+                        operator=op,
+                        values=vs,
+                    )
+                    for key, op, vs in requirements
+                ]
+            )
+            if requirements
+            else None
         )
 
         if not preferred_terms:
@@ -2426,7 +2430,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         return V1NodeAffinity(
             required_during_scheduling_ignored_during_execution=V1NodeSelector(
                 node_selector_terms=[required_term]
-            ),
+            )
+            if required_term
+            else None,
             preferred_during_scheduling_ignored_during_execution=preferred_terms,
         )
 


### PR DESCRIPTION
There was a subtle bug in the original implementation where setting only a preferred node affinity would result in a required node affinity being created with an empty match_expressions - which in our infra does not match any nodes.

This patch ensures that we only created a required node affinity if there is actually one configured.