### PR TITLE
Minor improvements to check_autoscaler_max_instances

### DIFF
--- a/docs/source/autoscaling.rst
+++ b/docs/source/autoscaling.rst
@@ -149,7 +149,7 @@ attempt to autoscale your service with the default autoscaling method.
 ``max_instances`` alerting
 --------------------------
 
-In order to make you aware of when your ``max_instances`` may be too low, causing issues with your service, paasta will send you alerts if all of the following conditions are true:
+In order to make you aware of when your ``max_instances`` may be too low, causing issues with your service, Paasta will send you ``check_autoscaler_max_instances`` alerts if all of the following conditions are true:
 
   * The autoscaler has scaled your service to ``max_instances``.
 

--- a/paasta_tools/check_autoscaler_max_instances.py
+++ b/paasta_tools/check_autoscaler_max_instances.py
@@ -136,6 +136,7 @@ async def check_max_instances(
                 {
                     "page": False,  # TODO: remove this line once this alert has been deployed for a little while.
                     "runbook": "y/check-autoscaler-max-instances",
+                    "realert_every": 60,  # The check runs once a minute, so this would realert every hour.
                     "tip": (
                         "The autoscaler wants to scale up to handle additional load"
                         " because your service is overloaded, but cannot scale any"


### PR DESCRIPTION
Before we make this paging, I'd like to reduce the frequency of realerting, and make sure this shows up in docsearch if you search for `check_autoscaler_max_instances`.