### PR TITLE
Add placeholder value for non-existent boto_keys

### DIFF
--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -633,6 +633,9 @@ def sync_boto_secrets(
                         log.warning(
                             f"Boto key {this_key} required for {service} could not be found."
                         )
+                        secret_data[
+                            sanitised_key
+                        ] = "This user no longer exists. Remove it from boto_keys."
 
             if not secret_data:
                 continue


### PR DESCRIPTION
Previously, using an invalid value here would cause the service to fail to launch. Now that we're migrating away from using AWS users, people mess this up more often, and it may be desirable to let the pod launch with placeholder values.

Placeholder values instead just ignoring them and not placing keys was much simpler to implement, and only very marginally less desirable IMO. 

We still get a log line that we can alert on when this happens.