### PR TITLE
Stop using uwsgi sidecars and supporting custom stats port (Again)

### DIFF
--- a/docs/source/autoscaling.rst
+++ b/docs/source/autoscaling.rst
@@ -65,20 +65,13 @@ The currently available metrics providers are:
   Measures the CPU usage of your service's container.
 
 :uwsgi:
-  With the ``uwsgi`` metrics provider, Paasta will configure your pods to run an additional container with the `uwsgi_exporter <https://github.com/timonwong/uwsgi_exporter>`_ image.
-  This sidecar will listen on port 9117, and will request metrics from your uWSGI master via its `stats server <http://uwsgi-docs.readthedocs.io/en/latest/StatsServer.html>`_.
-  The uwsgi_exporter container needs to know what port your uWSGI master's stats server is on - you can configure this with the ``uwsgi_stats_port`` key in the ``autoscaling`` dictionary.
-  ``uwsgi_exporter`` will translate the uWSGI stats into Prometheus format, which Prometheus will scrape.
+  With the ``uwsgi`` metrics provider, Paasta will configure your pods to be scraped from your uWSGI master via its `stats server <http://uwsgi-docs.readthedocs.io/en/latest/StatsServer.html>`_.
+  We currently only support uwsgi stats on port 8889, and Prometheus will attempt to scrape that port.
 
   .. note::
 
-    If you have configured your service to use a non-default stats port (8889), you need to explicity set ``uwsgi_stats_port`` in your autoscaling config with the same value to ensure that metrics are being exported.
+    If you have configured your service to use a non-default stats port (8889), PaaSTA will not scale your service correctly!
 
-  Extra parameters:
-
-  :uwsgi_stats_port:
-    the port that your uWSGI master process will respond to with stats.
-    Defaults to 8889.
 
 :gunicorn:
   With the ``gunicorn`` metrics provider, Paasta will configure your pods to run an additional container with the `statsd_exporter <https://github.com/prometheus/statsd_exporter>`_ image.

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -229,9 +229,6 @@
                         "use_resource_metrics": {
                             "type": "boolean"
                         },
-                        "uwsgi_stats_port": {
-                            "type": "integer"
-                        },
                         "scaledown_policies": {
                             "type": "object"
                         },

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1136,16 +1136,10 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         self,
         system_paasta_config: SystemPaastaConfig,
     ) -> bool:
-        if self.is_autoscaling_enabled():
-            autoscaling_params = self.get_autoscaling_params()
-            if autoscaling_params["metrics_provider"] == "uwsgi":
-                if autoscaling_params.get(
-                    "use_prometheus",
-                    DEFAULT_USE_PROMETHEUS_UWSGI
-                    or system_paasta_config.default_should_use_uwsgi_exporter(),
-                ):
-                    return True
-        return False
+        return (
+            self.is_autoscaling_enabled()
+            and self.get_autoscaling_params()["metrics_provider"] == "uwsgi"
+        )
 
     def get_gunicorn_exporter_sidecar_container(
         self,
@@ -2288,7 +2282,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             # character limit for k8s labels (63 chars)
             labels["paasta.yelp.com/deploy_group"] = self.get_deploy_group()
 
-        if self.should_setup_piscina_prometheus_scraping():
+        elif self.should_setup_piscina_prometheus_scraping():
             labels["paasta.yelp.com/deploy_group"] = self.get_deploy_group()
             labels["paasta.yelp.com/scrape_piscina_prometheus"] = "true"
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -181,11 +181,9 @@ KUBE_DEPLOY_STATEGY_MAP = {
     "brutal": "RollingUpdate",
 }
 HACHECK_POD_NAME = "hacheck"
-UWSGI_EXPORTER_POD_NAME = "uwsgi--exporter"
 GUNICORN_EXPORTER_POD_NAME = "gunicorn--exporter"
 SIDECAR_CONTAINER_NAMES = [
     HACHECK_POD_NAME,
-    UWSGI_EXPORTER_POD_NAME,
     GUNICORN_EXPORTER_POD_NAME,
 ]
 KUBERNETES_NAMESPACE = "paasta"
@@ -341,7 +339,6 @@ KubePodLabels = TypedDict(
         "paasta.yelp.com/image_version": str,
         "paasta.yelp.com/instance": str,
         "paasta.yelp.com/prometheus_shard": str,
-        "paasta.yelp.com/scrape_uwsgi_prometheus": str,
         "paasta.yelp.com/scrape_piscina_prometheus": str,
         "paasta.yelp.com/scrape_gunicorn_prometheus": str,
         "paasta.yelp.com/service": str,
@@ -1040,9 +1037,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             service_namespace_config,
             hacheck_sidecar_volumes,
         )
-        uwsgi_exporter_container = self.get_uwsgi_exporter_sidecar_container(
-            system_paasta_config
-        )
         gunicorn_exporter_container = self.get_gunicorn_exporter_sidecar_container(
             system_paasta_config
         )
@@ -1050,8 +1044,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         sidecars = []
         if hacheck_container:
             sidecars.append(hacheck_container)
-        if uwsgi_exporter_container:
-            sidecars.append(uwsgi_exporter_container)
         if gunicorn_exporter_container:
             sidecars.append(gunicorn_exporter_container)
         return sidecars
@@ -1140,44 +1132,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             )
         return None
 
-    def get_uwsgi_exporter_sidecar_container(
-        self,
-        system_paasta_config: SystemPaastaConfig,
-    ) -> Optional[V1Container]:
-
-        if self.should_run_uwsgi_exporter_sidecar(system_paasta_config):
-            stats_port_env = V1EnvVar(
-                name="STATS_PORT",
-                value=str(self.get_autoscaling_params().get("uwsgi_stats_port", 8889)),
-            )
-
-            return V1Container(
-                image=system_paasta_config.get_uwsgi_exporter_sidecar_image_url(),
-                resources=self.get_sidecar_resource_requirements(
-                    "uwsgi_exporter",
-                    system_paasta_config,
-                ),
-                name=UWSGI_EXPORTER_POD_NAME,
-                env=self.get_kubernetes_environment() + [stats_port_env],
-                ports=[V1ContainerPort(container_port=9117)],
-                lifecycle=V1Lifecycle(
-                    pre_stop=V1Handler(
-                        _exec=V1ExecAction(
-                            command=[
-                                "/bin/sh",
-                                "-c",
-                                # we sleep for the same amount of time as we do after an hadown to ensure that we have accurate
-                                # metrics up until our Pod dies
-                                f"sleep {DEFAULT_HADOWN_PRESTOP_SLEEP_SECONDS}",
-                            ]
-                        )
-                    )
-                ),
-            )
-
-        return None
-
-    def should_run_uwsgi_exporter_sidecar(
+    def should_use_uwsgi_exporter(
         self,
         system_paasta_config: SystemPaastaConfig,
     ) -> bool:
@@ -1187,7 +1142,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 if autoscaling_params.get(
                     "use_prometheus",
                     DEFAULT_USE_PROMETHEUS_UWSGI
-                    or system_paasta_config.default_should_run_uwsgi_exporter_sidecar(),
+                    or system_paasta_config.default_should_use_uwsgi_exporter(),
                 ):
                     return True
         return False
@@ -2164,7 +2119,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             self.config_dict.get("routable_ip", False)
             or service_namespace_config.is_in_smartstack()
             or self.get_prometheus_port() is not None
-            or self.should_run_uwsgi_exporter_sidecar(system_paasta_config)
+            or self.should_use_uwsgi_exporter(system_paasta_config)
             or self.should_run_gunicorn_exporter_sidecar()
         ):
             return "true"
@@ -2321,22 +2276,19 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         if self.is_istio_sidecar_injection_enabled():
             labels["sidecar.istio.io/inject"] = "true"
 
-        # not all services use uwsgi autoscaling, so we label those that do in order to have
+        # not all services use autoscaling, so we label those that do in order to have
         # prometheus selectively discover/scrape them
-        if self.should_run_uwsgi_exporter_sidecar(
-            system_paasta_config=system_paasta_config
-        ):
-            # this is kinda silly, but k8s labels must be strings
-            labels["paasta.yelp.com/scrape_uwsgi_prometheus"] = "true"
-
+        if self.should_use_uwsgi_exporter(system_paasta_config=system_paasta_config):
+            # UWSGI no longer needs a label to indicate it needs to be scraped as all pods are checked for the uwsgi stats port by our centralized uwsgi-exporter
+            # But we do still need deploy_group for relabeling properly
             # this should probably eventually be made into a default label,
-            # but for now we're fine with it being behind this feature toggle.
+            # but for now we're fine with it being behind these feature toggles.
             # ideally, we'd also have the docker image here for ease-of-use
             # in Prometheus relabeling, but that information is over the
             # character limit for k8s labels (63 chars)
             labels["paasta.yelp.com/deploy_group"] = self.get_deploy_group()
 
-        elif self.should_setup_piscina_prometheus_scraping():
+        if self.should_setup_piscina_prometheus_scraping():
             labels["paasta.yelp.com/deploy_group"] = self.get_deploy_group()
             labels["paasta.yelp.com/scrape_piscina_prometheus"] = "true"
 

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -50,7 +50,6 @@ class AutoscalingParamsDict(TypedDict, total=False):
     moving_average_window_seconds: Optional[int]
     use_prometheus: bool
     use_resource_metrics: bool
-    uwsgi_stats_port: int
     scaledown_policies: Optional[dict]
     good_enough_window: List[float]
     prometheus_adapter_config: Optional[dict]

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1956,7 +1956,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     dashboard_links: Dict[str, Dict[str, str]]
     datastore_credentials_vault_env_overrides: Dict[str, str]
     default_push_groups: List
-    default_should_run_uwsgi_exporter_sidecar: bool
+    default_should_use_uwsgi_exporter: bool
     deploy_blacklist: UnsafeDeployBlacklist
     deployd_big_bounce_deadline: float
     deployd_log_level: str
@@ -2035,7 +2035,6 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     synapse_port: int
     taskproc: Dict
     tron: Dict
-    uwsgi_exporter_sidecar_image_url: str
     gunicorn_exporter_sidecar_image_url: str
     vault_cluster_map: Dict
     vault_environment: str
@@ -2722,15 +2721,8 @@ class SystemPaastaConfig:
         """
         return self.get_git_config().get("repos", {}).get(repo_name, {})
 
-    def get_uwsgi_exporter_sidecar_image_url(self) -> str:
-        """Get the docker image URL for the uwsgi_exporter sidecar container"""
-        return self.config_dict.get(
-            "uwsgi_exporter_sidecar_image_url",
-            "docker-paasta.yelpcorp.com:443/uwsgi_exporter-k8s-sidecar:v1.3.0-yelp0",
-        )
-
-    def default_should_run_uwsgi_exporter_sidecar(self) -> bool:
-        return self.config_dict.get("default_should_run_uwsgi_exporter_sidecar", False)
+    def default_should_use_uwsgi_exporter(self) -> bool:
+        return self.config_dict.get("default_should_use_uwsgi_exporter", False)
 
     def get_gunicorn_exporter_sidecar_image_url(self) -> str:
         """Get the docker image URL for the gunicorn_exporter sidecar container"""

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -783,7 +783,7 @@ class TestKubernetesDeploymentConfig:
             requests={"cpu": 0.1, "memory": "1024Mi", "ephemeral-storage": "256Mi"},
         )
 
-    def test_should_run_uwsgi_exporter_sidecar_explicit(self):
+    def test_should_use_uwsgi_exporter_explicit(self):
         self.deployment.config_dict.update(
             {
                 "max_instances": 5,
@@ -798,7 +798,7 @@ class TestKubernetesDeploymentConfig:
 
         assert self.deployment.should_use_uwsgi_exporter(system_paasta_config) is True
 
-        self.deployment.config_dict["autoscaling"]["use_prometheus"] = False
+        self.deployment.config_dict["autoscaling"]["metrics_provider"] = "cpu"
         assert self.deployment.should_use_uwsgi_exporter(system_paasta_config) is False
 
     def test_get_gunicorn_exporter_sidecar_container_should_run(self):

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -746,11 +746,6 @@ class TestKubernetesDeploymentConfig:
                         "memory": "512Mi",
                         "ephemeral-storage": "256Mi",
                     },
-                    "uwsgi_exporter": {
-                        "cpu": 0.1,
-                        "memory": "512Mi",
-                        "ephemeral-storage": "256Mi",
-                    },
                 }
             )
         )
@@ -778,11 +773,6 @@ class TestKubernetesDeploymentConfig:
                         "memory": "1024Mi",
                         "ephemeral-storage": "256Mi",
                     },
-                    "uwsgi_exporter": {
-                        "cpu": 0.1,
-                        "memory": "1024Mi",
-                        "ephemeral-storage": "256Mi",
-                    },
                 }
             )
         )
@@ -792,71 +782,6 @@ class TestKubernetesDeploymentConfig:
             limits={"cpu": 1.0, "memory": "1024Mi", "ephemeral-storage": "256Mi"},
             requests={"cpu": 0.1, "memory": "1024Mi", "ephemeral-storage": "256Mi"},
         )
-
-    def test_get_uwsgi_exporter_sidecar_container_should_run(self):
-        system_paasta_config = mock.Mock(
-            get_uwsgi_exporter_sidecar_image_url=mock.Mock(
-                return_value="uwsgi_exporter_image"
-            )
-        )
-        with mock.patch.object(
-            self.deployment, "should_run_uwsgi_exporter_sidecar", return_value=True
-        ):
-            ret = self.deployment.get_uwsgi_exporter_sidecar_container(
-                system_paasta_config
-            )
-            assert ret is not None
-            assert ret.image == "uwsgi_exporter_image"
-            assert ret.ports[0].container_port == 9117
-
-    @pytest.mark.parametrize(
-        "uwsgi_stats_port,expected_port",
-        [
-            (None, "8889"),
-            (31337, "31337"),
-        ],
-    )
-    def test_get_uwsgi_exporter_sidecar_container_stats_port(
-        self, uwsgi_stats_port, expected_port
-    ):
-        system_paasta_config = mock.Mock(
-            get_uwsgi_exporter_sidecar_image_url=mock.Mock(
-                return_value="uwsgi_exporter_image"
-            )
-        )
-        self.deployment.config_dict.update(
-            {
-                "max_instances": 5,
-                "autoscaling": {
-                    "metrics_provider": "uwsgi",
-                    "use_prometheus": True,
-                },
-            }
-        )
-        if uwsgi_stats_port is not None:
-            self.deployment.config_dict["autoscaling"][
-                "uwsgi_stats_port"
-            ] = uwsgi_stats_port
-
-        ret = self.deployment.get_uwsgi_exporter_sidecar_container(system_paasta_config)
-        expected_env_var = V1EnvVar(name="STATS_PORT", value=expected_port)
-        assert expected_env_var in ret.env
-
-    def test_get_uwsgi_exporter_sidecar_container_shouldnt_run(self):
-        system_paasta_config = mock.Mock(
-            get_uwsgi_exporter_sidecar_image_url=mock.Mock(
-                return_value="uwsgi_exporter_image"
-            )
-        )
-        with mock.patch.object(
-            self.deployment, "should_run_uwsgi_exporter_sidecar", return_value=False
-        ):
-            assert (
-                self.deployment.get_uwsgi_exporter_sidecar_container(
-                    system_paasta_config
-                )
-                is None
-            )
 
     def test_should_run_uwsgi_exporter_sidecar_explicit(self):
         self.deployment.config_dict.update(
@@ -871,71 +796,10 @@ class TestKubernetesDeploymentConfig:
 
         system_paasta_config = mock.Mock()
 
-        assert (
-            self.deployment.should_run_uwsgi_exporter_sidecar(system_paasta_config)
-            is True
-        )
+        assert self.deployment.should_use_uwsgi_exporter(system_paasta_config) is True
 
         self.deployment.config_dict["autoscaling"]["use_prometheus"] = False
-        assert (
-            self.deployment.should_run_uwsgi_exporter_sidecar(system_paasta_config)
-            is False
-        )
-
-    def test_should_run_uwsgi_exporter_sidecar_defaults(self):
-        self.deployment.config_dict.update(
-            {
-                "max_instances": 5,
-                "autoscaling": {
-                    "metrics_provider": "uwsgi",
-                },
-            }
-        )
-
-        system_paasta_config_enabled = mock.Mock(
-            default_should_run_uwsgi_exporter_sidecar=mock.Mock(return_value=True)
-        )
-        system_paasta_config_disabled = mock.Mock(
-            default_should_run_uwsgi_exporter_sidecar=mock.Mock(return_value=False)
-        )
-
-        with mock.patch(
-            "paasta_tools.kubernetes_tools.DEFAULT_USE_PROMETHEUS_UWSGI",
-            autospec=False,
-            new=False,
-        ):
-            assert (
-                self.deployment.should_run_uwsgi_exporter_sidecar(
-                    system_paasta_config_enabled
-                )
-                is True
-            )
-            assert (
-                self.deployment.should_run_uwsgi_exporter_sidecar(
-                    system_paasta_config_disabled
-                )
-                is False
-            )
-
-        # If the default for use_prometheus is True and config_dict doesn't specify use_prometheus, we should run
-        # uwsgi_exporter regardless of default_should_run_uwsgi_exporter_sidecar.
-        with mock.patch(
-            "paasta_tools.kubernetes_tools.DEFAULT_USE_PROMETHEUS_UWSGI",
-            autospec=False,
-            new=True,
-        ):
-            assert (
-                self.deployment.should_run_uwsgi_exporter_sidecar(
-                    system_paasta_config_enabled
-                )
-                is True
-            )
-            assert (
-                self.deployment.should_run_uwsgi_exporter_sidecar(
-                    system_paasta_config_disabled
-                )
-                is True
-            )
+        assert self.deployment.should_use_uwsgi_exporter(system_paasta_config) is False
 
     def test_get_gunicorn_exporter_sidecar_container_should_run(self):
         system_paasta_config = mock.Mock(
@@ -1943,9 +1807,10 @@ class TestKubernetesDeploymentConfig:
 
         if autoscaling_metric_provider:
             expected_labels["paasta.yelp.com/deploy_group"] = "fake_group"
-            expected_labels[
-                f"paasta.yelp.com/scrape_{autoscaling_metric_provider}_prometheus"
-            ] = "true"
+            if autoscaling_metric_provider != "uwsgi":
+                expected_labels[
+                    f"paasta.yelp.com/scrape_{autoscaling_metric_provider}_prometheus"
+                ] = "true"
         if autoscaling_metric_provider in ("uwsgi", "gunicorn"):
             routable_ip = "true"
 
@@ -1972,7 +1837,7 @@ class TestKubernetesDeploymentConfig:
         autospec=True,
     )
     @mock.patch(
-        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.should_run_uwsgi_exporter_sidecar",
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.should_use_uwsgi_exporter",
         autospec=True,
     )
     @mock.patch(
@@ -1980,7 +1845,7 @@ class TestKubernetesDeploymentConfig:
         autospec=True,
     )
     @pytest.mark.parametrize(
-        "ip_configured,in_smtstk,prometheus_port,should_run_uwsgi_exporter_sidecar_retval,should_run_gunicorn_exporter_sidecar_retval,expected",
+        "ip_configured,in_smtstk,prometheus_port,should_use_uwsgi_exporter_retval,should_run_gunicorn_exporter_sidecar_retval,expected",
         [
             (False, True, 8888, False, False, "true"),
             (False, False, 8888, False, False, "true"),
@@ -1993,20 +1858,18 @@ class TestKubernetesDeploymentConfig:
     )
     def test_routable_ip(
         self,
-        mock_should_run_uwsgi_exporter_sidecar,
+        mock_should_use_uwsgi_exporter,
         mock_should_run_gunicorn_exporter_sidecar,
         mock_get_prometheus_port,
         ip_configured,
         in_smtstk,
         prometheus_port,
-        should_run_uwsgi_exporter_sidecar_retval,
+        should_use_uwsgi_exporter_retval,
         should_run_gunicorn_exporter_sidecar_retval,
         expected,
     ):
         mock_get_prometheus_port.return_value = prometheus_port
-        mock_should_run_uwsgi_exporter_sidecar.return_value = (
-            should_run_uwsgi_exporter_sidecar_retval
-        )
+        mock_should_use_uwsgi_exporter.return_value = should_use_uwsgi_exporter_retval
         mock_should_run_gunicorn_exporter_sidecar.return_value = (
             should_run_gunicorn_exporter_sidecar_retval
         )


### PR DESCRIPTION
https://github.com/Yelp/paasta/pull/3775 take 2, this time I won't accidentally merge to master before I'm ready. 🤦 

We now have a centralized uwsgi-exporter set up which is responsible for scraping all uwsgi-stats-enabled services. This unfortunately means we need to standardize on stats port 8889 and stop supporting custom ports, but more importantly means we no longer need to run the uwsgi sidecar for these services.

This PR:

- stops deploying the uwsgi sidecar at all
- removes uwsgi_stats_port from the schema and stops using it entirely
- updates uwsgi autoscaling docs to remove wording about the sidecar + highlight we don't support custom stats port

This _will_ cause a bounce for all uwsgi-autoscaled instances due to the `scrape_uwsgi_prometheus` label removal, and will stop deploying the uwsgi sidecar in all environments. However this should be safe as we no longer configure any prometheus to scrape the sidecar's port.

Note that I've kept the labelling for adding a routable_ip as well as deploy_group, as we still need prometheus to be able to scrape the metrics from the pod + apparently currently still use the deploy_group label in our relabeling configs for the metrics pulled via the centralized uwsgi-exporter.

I tested the deb in infrastage against the example_happyhour test service using uwsgi autoscaling, and it was deployed without uwsgi sidecars but was still able to autoscale based on load.