### PR TITLE
Base64 encode the boto_key missing error placeholder text

### DIFF
--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -633,9 +633,11 @@ def sync_boto_secrets(
                         log.warning(
                             f"Boto key {this_key} required for {service} could not be found."
                         )
-                        secret_data[
-                            sanitised_key
-                        ] = "This user no longer exists. Remove it from boto_keys."
+                        secret_data[sanitised_key] = base64.b64encode(
+                            "This user no longer exists. Remove it from boto_keys.".encode(
+                                "utf-8"
+                            )
+                        ).decode("utf-8")
 
             if not secret_data:
                 continue


### PR DESCRIPTION
This placeholder text was not previously base64 encoded, which resulted in a 400 error from the Kube api when trying to add it as a secret. This should resolve that issue by doing the encoding first.