### PR TITLE
Allow skipping cleanup of tagged CRDs

### DIFF
--- a/paasta_tools/cleanup_kubernetes_crd.py
+++ b/paasta_tools/cleanup_kubernetes_crd.py
@@ -106,6 +106,13 @@ def cleanup_kube_crd(
             log.error(f"CRD {crd.metadata.name} has empty {service_attr} label")
             continue
 
+        protected_attr = paasta_prefixed("protected")
+        if crd.metadata.labels.get(protected_attr) is not None:
+            log.info(
+                f"CRD {crd.metadata.name} has {protected_attr} label set - skipping."
+            )
+            continue
+
         crd_config = service_configuration_lib.read_extra_service_information(
             service, f"crd-{cluster}", soa_dir=soa_dir
         )


### PR DESCRIPTION
Open-source operators may need to have N CRDs created, which is not currently suppored by PaaSTA due to our current 1 CRD per file approach.

For teach cases, we tend to manage CRDs with Flux - but PaaSTA will clean these CRDs up since they're in a PaaSTA-managed namespace, but there's no record of them in soaconfigs.