### PR TITLE
Fix for secret_volumes differences in tron vs k8s

### DIFF
--- a/paasta_tools/secret_tools.py
+++ b/paasta_tools/secret_tools.py
@@ -219,7 +219,7 @@ def decrypt_secret_volumes(
     # This ^ should result in 2 files (/nail/foo/bar.yaml, /nail/foo/baz.yaml)
     # We need to support both cases
     for secret_volume in secret_volumes_config:
-        if "items" not in secret_volume:
+        if not secret_volume.get("items"):
             secret_contents = decrypt_secret(
                 secret_provider_name=secret_provider_name,
                 soa_dir=soa_dir,


### PR DESCRIPTION
## Problem or feature
Tron and Kubernetes yelpsoa-configs parsing return different representations for secret volumes that don't have `items` explicitly defined:

kubernetes:
```
(Pdb) secret_volume
{'container_path': '/nail/tls/keystore', 'secret_name': 'cassandra_apis-ubis-tls-keystore'}
```

tron:
```
(Pdb) secret_volume
{'secret_volume_name': 'tron-secret-conversion--feed-google--conversion--api--refresh--token', 'secret_name': 'google_conversion_api_refresh_token', 'container_path': '/conversion_feed/secret.txt', 'items': []}
```

Because of this, `paasta local-run` was not working correctly with the status quo code for tron jobs that didn't have items explicitly configured

## Solution
Instead of checking for the presence of the property, just use `.get` to check for truthyness

## Testing Done
Verified via a local-run with the patch that both formats now work for kubernetes and tron workloads
No new tests added.