### PR TITLE
SEC-18515: Bump boto3 to enable IMDSv2 usage

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ cfgv==2.0.1
 coverage==6.5.0
 debugpy==1.8.0
 distlib==0.3.4
+docutils==0.12
 exceptiongroup==1.1.2
 filelock==3.0.12
 flake8==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ async-timeout==3.0.0
 attrs==19.2.0
 binaryornot==0.4.4
 boto==2.48.0
-boto3==1.11.11
+boto3==1.34.22
 boto3-type-annotations==0.3.1
-botocore==1.14.11
+botocore==1.34.22
 bravado==10.4.1
 bravado-core==5.12.1
 cachetools==2.0.1
@@ -22,7 +22,6 @@ cookiecutter==1.4.0
 croniter==1.3.4
 decorator==4.1.2
 docker-py==1.2.3
-docutils==0.12
 dulwich==0.17.3
 ephemeral-port-reserve==1.1.0
 future==0.16.0
@@ -89,7 +88,7 @@ retry==0.9.2
 rfc3987==1.3.7
 rsa==4.7.2
 ruamel.yaml==0.15.96
-s3transfer==0.3.3
+s3transfer==0.10.0
 sensu-plugin==0.3.1
 service-configuration-lib==2.18.11
 setuptools==39.0.1
@@ -111,7 +110,7 @@ translationstring==1.3
 typing-extensions==4.3.0
 tzlocal==1.2
 url-normalize==1.4.2
-urllib3==1.24.3
+urllib3==1.26.18
 utaw==0.2.0
 venusian==1.1.0
 webcolors==1.7


### PR DESCRIPTION
Ticket: [SEC-18515](https://jira.yelpcorp.com/browse/SEC-18515)
Current boto3 version cannot use IMDSv2, let's fix that to be closer to IMDSv2 adoption.

Bumped using `pip install boto3 -U` and copying changes in requirements.txt