### PR TITLE
Include both kubernetes and eks instances in prometheus adapter config

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -967,6 +967,14 @@ def create_prometheus_adapter_config(
             cluster=paasta_cluster, instance_type="kubernetes", soa_dir=str(soa_dir)
         )
     }
+    services.update(
+        {
+            service_name
+            for service_name, _ in get_services_for_cluster(
+                cluster=paasta_cluster, instance_type="eks", soa_dir=str(soa_dir)
+            )
+        }
+    )
     for service_name in services:
         config_loader = PaastaServiceConfigLoader(
             service=service_name, soa_dir=str(soa_dir)


### PR DESCRIPTION
Currently, this script iterates over all `kubernetes` instance types only and adds them to the paasta cluster's `adapter-config`. 

This means it is skipping any rules needed for `eks` instance types.

This change also adds rules for `eks` types for a cluster.  This does mean the adapter configs in both non-EKS and EKS clusters will include rules for instances that may not be running in the local cluster, but this should not cause any issues. 

Validated in eks-infrastage and infrastage to generate the correct rules; infrastage is running example_happyhour_java.main (odd it is using uwsgi autoscaling!), while eks-infrastage is running example_happyhour.testing, and running the new version in both clusters generated the adapter-config listing both rules. 