### PR TITLE
allow local-run to use currently set pod identity

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -734,13 +734,13 @@ def assume_aws_role(
         )
         boto_session = boto3.Session()
         credentials = boto_session.get_credentials()
-        creds_dict: AWSSessionCreds = {
+        assumed_creds_dict: AWSSessionCreds = {
             "AWS_ACCESS_KEY_ID": credentials.access_key,
             "AWS_SECRET_ACCESS_KEY": credentials.secret_key,
             "AWS_SESSION_TOKEN": credentials.token,
             "AWS_SECURITY_TOKEN": credentials.token,
         }
-        return creds_dict
+        return assumed_creds_dict
     else:
         # use_okta_role, assume_pod_identity, and assume_role are all empty, and there's no
         # pod identity (web identity token) in the env. This shouldn't happen

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -2542,3 +2542,33 @@ def test_assume_aws_role(
         assert env["AWS_ACCESS_KEY_ID"] == "AKIAFOOBAR"
     else:
         assert env["AWS_ACCESS_KEY_ID"] == "AKIAFOOBAR2"
+
+
+@mock.patch("paasta_tools.cli.cmds.local_run.subprocess.run", autospec=True)
+@mock.patch("paasta_tools.cli.cmds.local_run.boto3.Session", autospec=True)
+def test_assume_aws_role_with_web_identity(
+    mock_boto,
+    mock_subprocess_run,
+):
+    mock_config = mock.MagicMock()
+    mock_config.get_iam_role.return_value = None
+    mock_service = "mockservice"
+
+    mock_credentials = mock.MagicMock()
+    mock_credentials.access_key = "AKIAFOOBAR"
+    mock_credentials.secret_key = "SECRETKEY"
+    mock_credentials.token = "SESSION_TOKEN"
+    mock_boto.return_value.get_credentials.return_value = mock_credentials
+
+    os.environ["AWS_ROLE_ARN"] = "arn:aws:iam::123456789:role/mock_role"
+    os.environ["AWS_WEB_IDENTITY_TOKEN_FILE"] = "/tokenfile"
+
+    env = assume_aws_role(mock_config, mock_service, False, False, False)
+
+    os.environ.pop("AWS_ROLE_ARN")
+    os.environ.pop("AWS_WEB_IDENTITY_TOKEN_FILE")
+
+    assert "AWS_ACCESS_KEY_ID" in env
+    assert "AWS_SECRET_ACCESS_KEY" in env
+    assert "AWS_SESSION_TOKEN" in env
+    assert env["AWS_ACCESS_KEY_ID"] == "AKIAFOOBAR"


### PR DESCRIPTION
We've encountered a couple of requests to allow the use of local-run within a kubernetes pod, and to have the pod identity be passed through from parent to child container. This change causes paasta local-run to detect a web identity token, assume into the relevant role, and launch the container with that session.

Manual test here: https://fluffy.yelpcorp.com/i/fR178F7KH9Sf7Cs1FT7s2vF6507RX6SG.html

The existing behavior will remain when using any of the aws related command line options, but this will be used by default if the env variables are present. You could override this behavior by running something like `env -u AWS_WEB_IDENTITY_TOKEN_FILE paasta local-run ...`, so I didn't see the need to add another argument to do that.

This resolves the internal jira ticket SEC-18598