### PR TITLE
PAASTA-18171: Displays EKS in PaaSTA Status output

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -284,7 +284,10 @@ def paasta_status_on_api_endpoint(
     new: bool = False,
     is_eks: bool = False,
 ) -> int:
-    output = ["", f"\n{service}.{PaastaColors.cyan(instance)} in {cluster}"]
+    output = [
+        "",
+        f"\n{service}.{PaastaColors.cyan(instance)} in {cluster}{' (EKS)' if is_eks else ''}",
+    ]
     client = get_paasta_oapi_client(
         cluster=get_paasta_oapi_api_clustername(cluster=cluster, is_eks=is_eks),
         system_paasta_config=system_paasta_config,


### PR DESCRIPTION
This change will print out whether or not the cluster is running on EKS when invoking PaaSTA status.
Tested locally with a service already migrated onto EKS.

```
sessions.main in norcal-stageg (EKS)
    Version:    7e8b2bd3 (desired)
    State: Running
    Running versions:
      Rerun with -v to see all replicas
      7e8b2bd3 - Started 2024-01-29 13:26:10 (18 hours ago)
        Replica States: 3 Healthy
```