### PR TITLE
Expose AWS account for role assumption

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -712,8 +712,7 @@ def resolve_aws_account_from_runtimeenv(aws_account: str = None) -> str:
         "stage": "dev",
         "corp": "corpprod",
     }
-    aws_account = runtimeenv_to_account_overrides.get(runtimeenv, runtimeenv)
-    return aws_account
+    return runtimeenv_to_account_overrides.get(runtimeenv, runtimeenv)
 
 
 def assume_aws_role(

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -965,8 +965,8 @@ def run_docker_container(
         except TypeError:
             # If that fails, try to write it as bytes
             # This is for binary files like TLS keys
-            with open(temp_secret_filename, "wb") as f:
-                f.write(secret_content)
+            with open(temp_secret_filename, "wb") as fb:
+                fb.write(secret_content)
 
         # Append this to the list of volumes passed to docker run
         volumes.append(f"{temp_secret_filename}:{container_mount_path}:ro")

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -856,7 +856,7 @@ def run_docker_container(
     else:
         chosen_port = pick_random_port(service)
     environment = instance_config.get_env_dictionary()
-    secret_volumes = {}
+    secret_volumes = {}  # type: ignore
     if not skip_secrets:
         # if secrets_for_owner_team enabled in yelpsoa for service
         if is_secrets_for_teams_enabled(service, soa_dir):

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -407,6 +407,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
         cluster="fake_cluster",
         system_paasta_config=system_paasta_config,
         args=args,
+        assume_role_aws_account=None,
     )
     assert return_code == 0
     mock_run_docker_container.assert_called_once_with(
@@ -430,6 +431,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
         skip_secrets=False,
         assume_role_arn="",
         assume_pod_identity=False,
+        assume_role_aws_account=None,
         use_okta_role=False,
     )
 
@@ -475,6 +477,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
         cluster="fake_cluster",
         system_paasta_config=system_paasta_config,
         args=args,
+        assume_role_aws_account="dev",
     )
     assert return_code == 0
     mock_secret_provider_kwargs = {
@@ -502,6 +505,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
         secret_provider_kwargs=mock_secret_provider_kwargs,
         skip_secrets=False,
         assume_role_arn="",
+        assume_role_aws_account="dev",
         assume_pod_identity=False,
         use_okta_role=False,
     )
@@ -555,6 +559,7 @@ def test_configure_and_run_pulls_image_when_asked(
         args=args,
         system_paasta_config=system_paasta_config,
         pull_image=True,
+        assume_role_aws_account="dev",
     )
     assert return_code == 0
     mock_docker_pull_image.assert_called_once_with("fake_registry/fake_image")
@@ -584,6 +589,7 @@ def test_configure_and_run_pulls_image_when_asked(
         skip_secrets=False,
         assume_role_arn="",
         assume_pod_identity=False,
+        assume_role_aws_account="dev",
         use_okta_role=False,
     )
 
@@ -633,6 +639,7 @@ def test_configure_and_run_docker_container_defaults_to_interactive_instance(
             cluster="fake_cluster",
             args=args,
             system_paasta_config=system_paasta_config,
+            assume_role_aws_account="dev",
         )
         assert return_code == 0
         mock_secret_provider_kwargs = {
@@ -661,6 +668,7 @@ def test_configure_and_run_docker_container_defaults_to_interactive_instance(
             skip_secrets=False,
             assume_role_arn="",
             assume_pod_identity=False,
+            assume_role_aws_account="dev",
             use_okta_role=False,
         )
 
@@ -718,6 +726,7 @@ def test_configure_and_run_docker_container_respects_docker_sha(
             cluster="fake_cluster",
             args=args,
             system_paasta_config=system_paasta_config,
+            assume_role_aws_account="dev",
         )
         expected = "fake_registry/services-fake_service:paasta-abcdefg"
         assert mock_run_docker_container.call_args[1]["docker_url"] == expected
@@ -1925,6 +1934,7 @@ def test_volumes_are_deduped(mock_exists):
                 "/etc/paasta",
             ),
             args=mock.Mock(yelpsoa_config_root="/blurp/durp", volumes=[]),
+            assume_role_aws_account="dev",
         )
         args, kwargs = mock_run_docker_container.call_args
         assert kwargs["volumes"] == ["/hostPath:/containerPath:ro"]
@@ -1980,6 +1990,7 @@ def test_missing_volumes_skipped(mock_exists):
                 "/etc/paasta",
             ),
             args=mock.Mock(yelpsoa_config_root="/blurp/durp", volumes=[]),
+            assume_role_aws_account="dev",
         )
         args, kwargs = mock_run_docker_container.call_args
         assert kwargs["volumes"] == []
@@ -2519,12 +2530,18 @@ def test_assume_aws_role(
                 assume_role,
                 assume_pod_identity,
                 use_okta_role,
+                "dev",
             )
         assert sys_exit.value.code == 1
         return
     else:
         env = assume_aws_role(
-            mock_config, mock_service, assume_role, assume_pod_identity, use_okta_role
+            mock_config,
+            mock_service,
+            assume_role,
+            assume_pod_identity,
+            use_okta_role,
+            "dev",
         )
 
     if as_root:
@@ -2563,7 +2580,7 @@ def test_assume_aws_role_with_web_identity(
     os.environ["AWS_ROLE_ARN"] = "arn:aws:iam::123456789:role/mock_role"
     os.environ["AWS_WEB_IDENTITY_TOKEN_FILE"] = "/tokenfile"
 
-    env = assume_aws_role(mock_config, mock_service, False, False, False)
+    env = assume_aws_role(mock_config, mock_service, False, False, False, "dev")
 
     os.environ.pop("AWS_ROLE_ARN")
     os.environ.pop("AWS_WEB_IDENTITY_TOKEN_FILE")

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -781,6 +781,7 @@ def test_run_success(
         ("pnw-prod", "dev", "dev"),
     ],
 )
+@mock.patch("paasta_tools.cli.cmds.local_run.load_system_paasta_config", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.local_run.figure_out_service_name", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.cook_image.validate_service_name", autospec=True)
 @mock.patch(
@@ -790,10 +791,14 @@ def test_assume_role_aws_account(
     mock_run_docker_container,
     mock_validate_service_name,
     mock_figure_out_service_name,
+    mock_system_paasta_config,
     cluster,
     aws_account,
     expected_aws_account,
+    system_paasta_config,
 ):
+    mock_system_paasta_config.return_value = system_paasta_config
+
     args = mock.MagicMock()
     args.cluster = cluster
     args.assume_role_aws_account = aws_account

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,10 @@ def system_paasta_config():
                 }
             ],
             "service_discovery_providers": {"smartstack": {}, "envoy": {}},
+            "kube_clusters": {
+                "pnw-prod": {"aws_account": "prod"},
+                "pnw-devc": {"aws_account": "dev"},
+            },
         },
         "/fake_dir/",
     )


### PR DESCRIPTION
## Problem

* There are use cases when a `paasta local-run` runs with a prod role in dev environment [[thread](https://yelp.slack.com/archives/CA4N6NW93/p1706909725006629?thread_ts=1696617970.548759&cid=CA4N6NW93)]
* @danielpops suggested something simlilar https://github.com/Yelp/paasta/pull/3532#discussion_r1081774925 . That is mapping cluster (`-c`) to the account.

## Solution

Expose the source AWS account as CLI-flag that is used for role assumption.

## Verification 

- Worked with `--assume-pod-identity` [[fluffy](https://fluffy.yelpcorp.com/i/mBMC27Lcm9tZpD54Lwg46Xdqz1hShR5t.html)]
- Worked with `--assume-role-arn` [[fluffy](https://fluffy.yelpcorp.com/i/XDxmSWVqmT6PKZ5fPscWVsRG3TQCfFGR.html)]
- Without `-a prod` running on dev you get AccessDenied as expected [[fluffy](https://fluffy.yelpcorp.com/i/sMVMlM6cNSfpzlC7JbG0SqCK87L7MNvv.html)]
- Using `-a prod` but omitting cluster (i.e. using current) will result in error as well as expected [[fluffy](https://fluffy.yelpcorp.com/i/BgMkFspnFRHMD7tDLLsJwCWXqCz8zqcM.html)]