### PR TITLE
Call ensure_namespace() in paasta_secrets_sync

### DIFF
--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -38,6 +38,7 @@ from typing_extensions import Literal
 from paasta_tools.eks_tools import EksDeploymentConfig
 from paasta_tools.kubernetes_tools import create_secret
 from paasta_tools.kubernetes_tools import create_secret_signature
+from paasta_tools.kubernetes_tools import ensure_namespace
 from paasta_tools.kubernetes_tools import get_paasta_secret_name
 from paasta_tools.kubernetes_tools import get_paasta_secret_signature_name
 from paasta_tools.kubernetes_tools import get_secret_signature
@@ -318,6 +319,7 @@ def sync_all_secrets(
                 else namespaces_to_allowlist.get(overwrite_namespace, set()),
             }
         for namespace, secret_allowlist in namespaces_to_allowlist.items():
+            ensure_namespace(kube_client, namespace)
             sync_service_secrets["paasta-secret"].append(
                 partial(
                     sync_secrets,

--- a/tests/kubernetes/bin/test_paasta_secrets_sync.py
+++ b/tests/kubernetes/bin/test_paasta_secrets_sync.py
@@ -64,6 +64,9 @@ def test_sync_all_secrets():
     ) as mock_sync_secrets, mock.patch(
         "paasta_tools.kubernetes.bin.paasta_secrets_sync.PaastaServiceConfigLoader",
         autospec=True,
+    ), mock.patch(
+        "paasta_tools.kubernetes.bin.paasta_secrets_sync.ensure_namespace",
+        autospec=True,
     ):
         services_to_k8s_namespaces_to_allowlist = {
             "foo": {"paastasvc-foo": None},


### PR DESCRIPTION
At the moment, you cannot pre-create secrets on a new dual-name cluster since the namespaces for services will not yet have been created by setup_kubernetes_job (and they may not have been created by Flux yet either).

We can fix this by calling ensure_namespace() in the secret sync code - the caching we have on ensure_namespace()/get_all_namespaces() means that this *should* be pretty fast as it should be grabbing cached data most of the time.