### PR TITLE
Downpin cryptography in k8s_itests to fix GHA build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -83,8 +83,10 @@ commands =
 [testenv:k8s_itests]
 basepython = python3.8
 whitelist_externals = bash
+# one day we'll use a fully pinned venv here...
 deps =
     urllib3<2.0
+    cryptography<42
     docker-compose=={[tox]docker_compose_version}
 setenv =
 passenv =


### PR DESCRIPTION
Unfortunately, not every package on public PyPI has wheels like we generally enforce internally.

Rather than figure out what we need available to be able to install cryptography in GHA, I figured we could pin for now since this only affects k8s_itests and I presume that in the near-ish future we'll probably figure out a way to migrate our open-source stuff to Poetry/de-tox things and we can forget I ever wrote this screed.