### PR TITLE
MLCOMPUTE-872 | Support driver on k8s config format for paasta spark-run

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1199,7 +1199,7 @@ def _get_k8s_url_for_cluster(cluster: str) -> Optional[str]:
     )
 
 
-def parse_tronfig(tronfig_path: str, tronfig_target: str) -> Optional[Dict[str, str]]:
+def parse_tronfig(tronfig_path: str, tronfig_target: str) -> Optional[Dict[str, Any]]:
     splitted = tronfig_target.split(".")
     if len(splitted) != 2:
         return None
@@ -1289,7 +1289,7 @@ def update_args_from_tronfig(args: argparse.Namespace) -> Optional[Dict[str, str
 
 
 def paasta_spark_run(args: argparse.Namespace) -> int:
-    driver_envs_from_tronfig = dict()
+    driver_envs_from_tronfig: Dict[str, str] = dict()
     if args.tronfig is not None:
         if args.tronfig_target is None:
             print(
@@ -1297,9 +1297,10 @@ def paasta_spark_run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return False
-        driver_envs_from_tronfig = update_args_from_tronfig(args)
-        if driver_envs_from_tronfig is None:
+        result = update_args_from_tronfig(args)
+        if result is None:
             return False
+        driver_envs_from_tronfig = result
 
     # argparse does not work as expected with both default and
     # type=validate_work_dir.

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -885,7 +885,7 @@ def configure_and_run_docker_container(
     aws_creds: Tuple[Optional[str], Optional[str], Optional[str]],
     cluster_manager: str,
     pod_template_path: str,
-    extra_driver_envs: Dict[str, str],
+    extra_driver_envs: Dict[str, str] = dict(),
 ) -> int:
     docker_memory_limit = _calculate_docker_memory_limit(
         spark_conf, args.docker_memory_limit

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -340,14 +340,14 @@ def add_subparser(subparsers):
 
     list_parser.add_argument(
         "--tronfig",
-        help="Load the Tron config yaml. Use with --tronfig-target.",
+        help="Load the Tron config yaml. Use with --job-id.",
         type=str,
         default=None,
     )
 
     list_parser.add_argument(
-        "--tronfig-target",
-        help="Target <job_name>.<action_name> in the Tronfig to run. Use wuth --tronfig.",
+        "--job-id",
+        help="Tron job id <job_name>.<action_name> in the Tronfig to run. Use wuth --tronfig.",
         type=str,
         default=None,
     )
@@ -1199,8 +1199,8 @@ def _get_k8s_url_for_cluster(cluster: str) -> Optional[str]:
     )
 
 
-def parse_tronfig(tronfig_path: str, tronfig_target: str) -> Optional[Dict[str, Any]]:
-    splitted = tronfig_target.split(".")
+def parse_tronfig(tronfig_path: str, job_id: str) -> Optional[Dict[str, Any]]:
+    splitted = job_id.split(".")
     if len(splitted) != 2:
         return None
     job_name, action_name = splitted
@@ -1225,12 +1225,10 @@ def update_args_from_tronfig(args: argparse.Namespace) -> Optional[Dict[str, str
 
     Returns: environment variables dictionary or None if failed.
     """
-    action_dict = parse_tronfig(args.tronfig, args.tronfig_target)
+    action_dict = parse_tronfig(args.tronfig, args.job_id)
     if action_dict is None:
         print(
-            PaastaColors.red(
-                f"Unable to get configs from tronfig-target: {args.tronfig_target}"
-            ),
+            PaastaColors.red(f"Unable to get configs from job-id: {args.job_id}"),
             file=sys.stderr,
         )
         return None
@@ -1291,9 +1289,9 @@ def update_args_from_tronfig(args: argparse.Namespace) -> Optional[Dict[str, str
 def paasta_spark_run(args: argparse.Namespace) -> int:
     driver_envs_from_tronfig: Dict[str, str] = dict()
     if args.tronfig is not None:
-        if args.tronfig_target is None:
+        if args.job_id is None:
             print(
-                PaastaColors.red("Missing --tronfig-target when --tronfig is provided"),
+                PaastaColors.red("Missing --job-id when --tronfig is provided"),
                 file=sys.stderr,
             )
             return False

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -17,6 +17,7 @@ from typing import Union
 
 import yaml
 from service_configuration_lib import read_service_configuration
+from service_configuration_lib import read_yaml_file
 from service_configuration_lib import spark_config
 from service_configuration_lib.spark_config import get_aws_credentials
 from service_configuration_lib.spark_config import get_grafana_url
@@ -38,6 +39,7 @@ from paasta_tools.spark_tools import get_webui_url
 from paasta_tools.spark_tools import inject_spark_conf_str
 from paasta_tools.utils import _run
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import filter_templates_from_config
 from paasta_tools.utils import get_possible_launched_by_user_variable_from_env
 from paasta_tools.utils import get_username
 from paasta_tools.utils import InstanceConfig
@@ -334,6 +336,20 @@ def add_subparser(subparsers):
         ),
         action="store_true",
         default=False,
+    )
+
+    list_parser.add_argument(
+        "--tronfig",
+        help="Load the Tron config yaml. Use with --tronfig-target.",
+        type=str,
+        default=None,
+    )
+
+    list_parser.add_argument(
+        "--tronfig-target",
+        help="Target <job_name>.<action_name> in the Tronfig to run. Use wuth --tronfig.",
+        type=str,
+        default=None,
     )
 
     k8s_target_cluster_type_group = list_parser.add_mutually_exclusive_group()
@@ -869,6 +885,7 @@ def configure_and_run_docker_container(
     aws_creds: Tuple[Optional[str], Optional[str], Optional[str]],
     cluster_manager: str,
     pod_template_path: str,
+    extra_driver_envs: Dict[str, str],
 ) -> int:
     docker_memory_limit = _calculate_docker_memory_limit(
         spark_conf, args.docker_memory_limit
@@ -908,6 +925,7 @@ def configure_and_run_docker_container(
             system_paasta_config=system_paasta_config,
         )
     )  # type:ignore
+    environment.update(extra_driver_envs)
 
     webui_url = get_webui_url(spark_conf["spark.ui.port"])
     webui_url_msg = PaastaColors.green(f"\nSpark monitoring URL: ") + f"{webui_url}\n"
@@ -1181,7 +1199,108 @@ def _get_k8s_url_for_cluster(cluster: str) -> Optional[str]:
     )
 
 
-def paasta_spark_run(args):
+def parse_tronfig(tronfig_path: str, tronfig_target: str) -> Optional[Dict[str, str]]:
+    splitted = tronfig_target.split(".")
+    if len(splitted) != 2:
+        return None
+    job_name, action_name = splitted
+
+    file_content = read_yaml_file(tronfig_path)
+    jobs = filter_templates_from_config(file_content)
+    if job_name not in jobs or action_name not in jobs[job_name].get("actions", {}):
+        return None
+    return jobs[job_name]["actions"][action_name]
+
+
+def update_args_from_tronfig(args: argparse.Namespace) -> Optional[Dict[str, str]]:
+    """
+    Load and check the following config fields from the provided Tronfig.
+      - executor
+      - pool
+      - iam_role
+      - iam_role_provider
+      - command
+      - env
+      - spark_args
+
+    Returns: environment variables dictionary or None if failed.
+    """
+    action_dict = parse_tronfig(args.tronfig, args.tronfig_target)
+    if action_dict is None:
+        print(
+            PaastaColors.red(
+                f"Unable to get configs from tronfig-target: {args.tronfig_target}"
+            ),
+            file=sys.stderr,
+        )
+        return None
+
+    # executor === spark
+    if action_dict.get("executor", "") != "spark":
+        print(
+            PaastaColors.red("Invalid Tronfig: executor should be 'spark'"),
+            file=sys.stderr,
+        )
+        return None
+
+    # iam_role / aws_profile
+    if "iam_role" in action_dict and action_dict.get("iam_role_provider", "") != "aws":
+        print(
+            PaastaColors.red("Invalid Tronfig: iam_role_provider should be 'aws'"),
+            file=sys.stderr,
+        )
+        return None
+
+    # Other args
+    fields_to_args = {
+        "pool": "pool",
+        "iam_role": "assume_aws_role",
+        "command": "cmd",
+        "spark_args": "spark_args",
+    }
+    for field_name, arg_name in fields_to_args.items():
+        if field_name in action_dict:
+            value = action_dict[field_name]
+            if field_name == "spark_args":
+                value = " ".join([f"{k}={v}" for k, v in dict(value).items()])
+
+            arg_name_str = (f"--{arg_name.replace('_', '-')}").ljust(20, " ")
+            field_name_str = field_name.ljust(12)
+
+            if field_name == "iam_role" and args.aws_profile != "default":
+                print(
+                    PaastaColors.yellow(
+                        f"Overwriting args with Tronfig: {arg_name_str} => {field_name_str} : IGNORE, "
+                        "since --aws-profile is provided"
+                    ),
+                )
+                continue
+
+            if hasattr(args, arg_name):
+                print(
+                    PaastaColors.yellow(
+                        f"Overwriting args with Tronfig: {arg_name_str} => {field_name_str} : {value}"
+                    ),
+                )
+            setattr(args, arg_name, value)
+
+    # env (currently paasta spark-run does not support Spark driver secrets environment variables)
+    return action_dict.get("env", dict())
+
+
+def paasta_spark_run(args: argparse.Namespace) -> int:
+    driver_envs_from_tronfig = dict()
+    if args.tronfig is not None:
+        if args.tronfig_target is None:
+            print(
+                PaastaColors.red("Missing --tronfig-target when --tronfig is provided"),
+                file=sys.stderr,
+            )
+            return False
+        driver_envs_from_tronfig = update_args_from_tronfig(args)
+        if driver_envs_from_tronfig is None:
+            return False
+
     # argparse does not work as expected with both default and
     # type=validate_work_dir.
     validate_work_dir(args.work_dir)
@@ -1338,4 +1457,5 @@ def paasta_spark_run(args):
         aws_creds=aws_creds,
         cluster_manager=args.cluster_manager,
         pod_template_path=pod_template_path,
+        extra_driver_envs=driver_envs_from_tronfig,
     )

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -579,7 +579,7 @@ class TestConfigureAndRunDockerContainer:
         args.docker_shm_size = False
         args.use_eks_override = False
         args.tronfig = None
-        args.tronfig_target = None
+        args.job_id = None
         with mock.patch.object(
             self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
         ):
@@ -1050,7 +1050,7 @@ def test_paasta_spark_run_bash(
         use_eks_override=False,
         k8s_server_address=None,
         tronfig=None,
-        tronfig_target=None,
+        job_id=None,
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     mock_load_system_paasta_config.return_value.get_cluster_pools.return_value = {
@@ -1167,7 +1167,7 @@ def test_paasta_spark_run(
         use_eks_override=False,
         k8s_server_address=None,
         tronfig=None,
-        tronfig_target=None,
+        job_id=None,
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     mock_load_system_paasta_config.return_value.get_cluster_pools.return_value = {
@@ -1283,7 +1283,7 @@ def test_paasta_spark_run_pyspark(
         use_eks_override=False,
         k8s_server_address=None,
         tronfig=None,
-        tronfig_target=None,
+        job_id=None,
     )
     mock_load_system_paasta_config.return_value.get_spark_use_eks_default.return_value = (
         False

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -578,6 +578,8 @@ class TestConfigureAndRunDockerContainer:
         args.docker_memory_limit = False
         args.docker_shm_size = False
         args.use_eks_override = False
+        args.tronfig = None
+        args.tronfig_target = None
         with mock.patch.object(
             self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
         ):
@@ -1047,6 +1049,8 @@ def test_paasta_spark_run_bash(
         aws_role_duration=3600,
         use_eks_override=False,
         k8s_server_address=None,
+        tronfig=None,
+        tronfig_target=None,
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     mock_load_system_paasta_config.return_value.get_cluster_pools.return_value = {
@@ -1105,6 +1109,7 @@ def test_paasta_spark_run_bash(
         aws_creds=mock_get_aws_credentials.return_value,
         cluster_manager=spark_run.CLUSTER_MANAGER_K8S,
         pod_template_path="unique-run",
+        extra_driver_envs=dict(),
     )
     mock_generate_pod_template_path.assert_called_once()
 
@@ -1161,6 +1166,8 @@ def test_paasta_spark_run(
         aws_role_duration=3600,
         use_eks_override=False,
         k8s_server_address=None,
+        tronfig=None,
+        tronfig_target=None,
     )
     mock_load_system_paasta_config.return_value.get_cluster_aliases.return_value = {}
     mock_load_system_paasta_config.return_value.get_cluster_pools.return_value = {
@@ -1218,6 +1225,7 @@ def test_paasta_spark_run(
         aws_creds=mock_get_aws_credentials.return_value,
         cluster_manager=spark_run.CLUSTER_MANAGER_K8S,
         pod_template_path="unique-run",
+        extra_driver_envs=dict(),
     )
     mock_generate_pod_template_path.assert_called_once()
 
@@ -1274,6 +1282,8 @@ def test_paasta_spark_run_pyspark(
         aws_role_duration=3600,
         use_eks_override=False,
         k8s_server_address=None,
+        tronfig=None,
+        tronfig_target=None,
     )
     mock_load_system_paasta_config.return_value.get_spark_use_eks_default.return_value = (
         False
@@ -1340,6 +1350,7 @@ def test_paasta_spark_run_pyspark(
         aws_creds=mock_get_aws_credentials.return_value,
         cluster_manager=spark_run.CLUSTER_MANAGER_K8S,
         pod_template_path="unique-run",
+        extra_driver_envs=dict(),
     )
     mock_generate_pod_template_path.assert_called_once()
 


### PR DESCRIPTION
## Description
To provide a way for users to test their Spark tronfig (driver on k8s) with the ad-hoc `paasta spark-run`.

This implementation just simply loads the yaml file and parse selected fields instead to using `tron_tools` to avoid tron-specific logic being included to the existing `paasta spark-run` and let user able to test simplified configs.

## Test

With tronfig`~/tmp/tron-spark-pnw-devc.yaml`
```
_role_template: &role_template
  iam_role: arn:aws:iam::<account_id>:role/spark_test_role
  iam_role_provider: aws

spark_driver_test_paasta_secrets:
  # every 30 mins for testing
  schedule: "cron */30 * * * *"
  deploy_group: dev.pnw
  enabled: false
  actions:
    bash:
      <<: *role_template
      executor: spark
      env:
        ENV1: env1_value
        SAMPLE_ENV: SECRET(classified_sample)
      pool: batch
      spark_args:
        spark.kubernetes.executor.secretKeyRef.SAMPLE_ENV: paasta-spark-secret-spark-classified--sample:classified_sample
      command: "
        /bin/bash
        "
```

In devbox:  
```
./.tox/py38-linux/bin/paasta spark-run --aws-profile=dev --tronfig ~/tmp/tron-spark-pnw-devc.yaml --job-id spark_driver_test_paasta_secrets.bash
```
<img width="1679" alt="image" src="https://github.com/Yelp/paasta/assets/8851038/83760af6-8699-42bf-8cca-fe0ca65ce62c">


In batch server:  
```
sudo ./.tox/py38-linux/bin/paasta spark-run --aws-role-duration=900 --tronfig ~/tmp/tron-spark-pnw-devc.yaml --job-id spark_driver_test_paasta_secrets.bash
```
![image](https://github.com/Yelp/paasta/assets/8851038/1ad52240-f9d1-4ac2-a563-f6da2d54e5c3)



