### PR TITLE
PAASTA-18005: Add default timeout to paasta-api

### DIFF
--- a/paasta_tools/api/client.py
+++ b/paasta_tools/api/client.py
@@ -60,6 +60,10 @@ def get_paasta_oapi_client_by_url(
     config.ssl_ca_cert = ssl_ca_cert
 
     client = paastaapi.ApiClient(configuration=config)
+    # PAASTA-18005: Adds default timeout to paastaapi client
+    client.rest_client.pool_manager.connection_pool_kw[
+        "timeout"
+    ] = load_system_paasta_config().get_api_client_timeout()
     return PaastaOApiClient(
         autoscaler=paastaapis.AutoscalerApi(client),
         default=paastaapis.DefaultApi(client),

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1939,6 +1939,7 @@ class TopologySpreadConstraintDict(TypedDict, total=False):
 
 class SystemPaastaConfigDict(TypedDict, total=False):
     allowed_pools: Dict[str, List[str]]
+    api_client_timeout: int
     api_endpoints: Dict[str, str]
     api_profiling_config: Dict
     auth_certificate_ttl: str
@@ -2245,6 +2246,13 @@ class SystemPaastaConfig:
         type-wise as it allows us to avoid data races/issues with the autotuned recommendations generator/updater.
         """
         return self.config_dict.get("auto_config_instance_type_aliases", {})
+
+    def get_api_client_timeout(self) -> int:
+        """
+        We've seen the Paasta API get hung up sometimes and the client not realizing this will sit idle forever.
+        This will be used to specify the default timeout
+        """
+        return self.config_dict.get("api_client_timeout", 120)
 
     def get_api_endpoints(self) -> Mapping[str, str]:
         return self.config_dict["api_endpoints"]

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -2485,12 +2485,15 @@ class TestPrintKafkaStatus:
 
 class TestPrintFlinkStatus:
     @patch("paasta_tools.cli.cmds.status.load_system_paasta_config", autospec=True)
+    @patch("paasta_tools.api.client.load_system_paasta_config", autospec=True)
     def test_error_no_flink(
         self,
+        mock_load_system_paasta_config_api,
         mock_load_system_paasta_config,
         mock_flink_status,
         system_paasta_config,
     ):
+        mock_load_system_paasta_config_api.return_value = system_paasta_config
         mock_load_system_paasta_config.return_value = system_paasta_config
         mock_flink_status["status"] = None
         output = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ def system_paasta_config():
         {
             "cluster": "fake_cluster",
             "api_endpoints": {"fake_cluster": "http://fake_cluster:5054"},
+            "api_client_timeout": 120,
             "docker_registry": "fake_registry",
             "volumes": [
                 {


### PR DESCRIPTION
We've noticed that sometimes the paasta API can hang/get stuck and clients end up hanging indefinitely, this fix adds a default timeout to avoid this.