### PR TITLE
Fixes local tests and openapi-codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ k8s_clean: .paasta/bin/activate
 #   in paasta repo: java -jar ~/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar
 openapi-codegen:
 	rm -rf paasta_tools/paastaapi
-	docker run --rm -i --user `id -u`:`id -g` -v `pwd`:/src -w /src \
-		yelp/openapi-generator-cli:20201026 \
+	docker run --rm -i -v `pwd`:/src -w /src \
+		registry.hub.docker.com/yelp/openapi-generator-cli:20201026 \
 		generate \
 		-i paasta_tools/api/api_docs/oapi.yaml \
 		-g python-experimental \
@@ -127,8 +127,8 @@ openapi-codegen:
 	rm -rf temp-openapi-client
 
 swagger-validate:
-	docker run --rm -i --user `id -u`:`id -g` -v `pwd`:/src -w /src \
-		yelp/openapi-generator-cli:20201026 \
+	docker run --rm -i -v `pwd`:/src -w /src \
+		registry.hub.docker.com/yelp/openapi-generator-cli:20201026 \
 		validate \
 		-i paasta_tools/api/api_docs/swagger.json
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ else
 	export INDEX_URL_BUILD_ARG ?= PIP_INDEX_URL
 endif
 
+# Use this variable for the docker run command
+DOCKER_REGISTRY_ARG=$(if [ "$(DOCKER_REGISTRY)" != "" ]; then echo "$(DOCKER_REGISTRY)"; fi)
+
 .PHONY: all docs test itest k8s_itests quick-test
 
 dev: .paasta/bin/activate
@@ -116,7 +119,7 @@ k8s_clean: .paasta/bin/activate
 openapi-codegen:
 	rm -rf paasta_tools/paastaapi
 	docker run --rm -i -v `pwd`:/src -w /src \
-		registry.hub.docker.com/yelp/openapi-generator-cli:20201026 \
+		${DOCKER_REGISTRY_ARG}yelp/openapi-generator-cli:20201026 \
 		generate \
 		-i paasta_tools/api/api_docs/oapi.yaml \
 		-g python-experimental \
@@ -128,7 +131,7 @@ openapi-codegen:
 
 swagger-validate:
 	docker run --rm -i -v `pwd`:/src -w /src \
-		registry.hub.docker.com/yelp/openapi-generator-cli:20201026 \
+		${DOCKER_REGISTRY_ARG}yelp/openapi-generator-cli:20201026 \
 		validate \
 		-i paasta_tools/api/api_docs/swagger.json
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ifeq ($(PAASTA_ENV),YELP)
 	export DOCKER_REGISTRY ?= docker-dev.yelpcorp.com/
 	export DOCKER_OPT_ARGS ?=
 else
-	export DOCKER_REGISTRY ?= ""
+	export DOCKER_REGISTRY ?= docker.io/
 	export DOCKER_OPT_ARGS ?= --user `id -u`:`id -g`
 	export INDEX_URL_BUILD_ARG ?= PIP_INDEX_URL
 endif

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,10 @@ endif
 
 ifeq ($(PAASTA_ENV),YELP)
 	export DOCKER_REGISTRY ?= docker-dev.yelpcorp.com/
+	export DOCKER_OPT_ARGS ?=
 else
-	export DOCKER_REGISTRY ?= docker.io/
+	export DOCKER_REGISTRY ?= ""
+	export DOCKER_OPT_ARGS ?= --user `id -u`:`id -g`
 	export INDEX_URL_BUILD_ARG ?= PIP_INDEX_URL
 endif
 
@@ -115,7 +117,7 @@ k8s_clean: .paasta/bin/activate
 #   in paasta repo: java -jar ~/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar
 openapi-codegen:
 	rm -rf paasta_tools/paastaapi
-	docker run --rm -i -v `pwd`:/src -w /src \
+	docker run --rm -i ${DOCKER_OPT_ARGS} -v `pwd`:/src -w /src \
 		${DOCKER_REGISTRY}yelp/openapi-generator-cli:20201026 \
 		generate \
 		-i paasta_tools/api/api_docs/oapi.yaml \
@@ -127,7 +129,7 @@ openapi-codegen:
 	rm -rf temp-openapi-client
 
 swagger-validate:
-	docker run --rm -i -v `pwd`:/src -w /src \
+	docker run --rm -i ${DOCKER_OPT_ARGS} -v `pwd`:/src -w /src \
 		${DOCKER_REGISTRY}yelp/openapi-generator-cli:20201026 \
 		validate \
 		-i paasta_tools/api/api_docs/swagger.json

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 ifeq ($(PAASTA_ENV),YELP)
 	export DOCKER_REGISTRY ?= docker-dev.yelpcorp.com/
 else
-	export DOCKER_REGISTRY ?= ""
+	export DOCKER_REGISTRY ?= docker.io/
 	export INDEX_URL_BUILD_ARG ?= PIP_INDEX_URL
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,6 @@ else
 	export INDEX_URL_BUILD_ARG ?= PIP_INDEX_URL
 endif
 
-# Use this variable for the docker run command
-DOCKER_REGISTRY_ARG=$(if [ "$(DOCKER_REGISTRY)" != "" ]; then echo "$(DOCKER_REGISTRY)"; fi)
-
 .PHONY: all docs test itest k8s_itests quick-test
 
 dev: .paasta/bin/activate
@@ -119,7 +116,7 @@ k8s_clean: .paasta/bin/activate
 openapi-codegen:
 	rm -rf paasta_tools/paastaapi
 	docker run --rm -i -v `pwd`:/src -w /src \
-		${DOCKER_REGISTRY_ARG}yelp/openapi-generator-cli:20201026 \
+		${DOCKER_REGISTRY}yelp/openapi-generator-cli:20201026 \
 		generate \
 		-i paasta_tools/api/api_docs/oapi.yaml \
 		-g python-experimental \
@@ -131,7 +128,7 @@ openapi-codegen:
 
 swagger-validate:
 	docker run --rm -i -v `pwd`:/src -w /src \
-		${DOCKER_REGISTRY_ARG}yelp/openapi-generator-cli:20201026 \
+		${DOCKER_REGISTRY}yelp/openapi-generator-cli:20201026 \
 		validate \
 		-i paasta_tools/api/api_docs/swagger.json
 

--- a/paasta_tools/contrib/check_manual_oapi_changes.sh
+++ b/paasta_tools/contrib/check_manual_oapi_changes.sh
@@ -15,7 +15,7 @@ if [ ! -z "$api_touched" -a -z "$schema_touched" ]; then
     exit 1
 fi
 
-make openapi-codegen &>/dev/null
+make openapi-codegen
 diff=$(git diff --name-only | grep paasta_tools/paastaapi)
 if [ ! -z "$diff" ]; then
     echo "paasta_tools/paastaapi codegen has a diff, either commit the changes or fix oapi.yaml:" >&2

--- a/paasta_tools/contrib/check_manual_oapi_changes.sh
+++ b/paasta_tools/contrib/check_manual_oapi_changes.sh
@@ -15,7 +15,7 @@ if [ ! -z "$api_touched" -a -z "$schema_touched" ]; then
     exit 1
 fi
 
-make openapi-codegen
+make openapi-codegen &>/dev/null
 diff=$(git diff --name-only | grep paasta_tools/paastaapi)
 if [ ! -z "$diff" ]; then
     echo "paasta_tools/paastaapi codegen has a diff, either commit the changes or fix oapi.yaml:" >&2


### PR DESCRIPTION
This fixes a change made with the unprivileged containers switch which causes openapi-codegen to fail. The full url is needed now to pull the image from the docker registry.