### PR TITLE
Scale with ready pods count rather current replicas for uwsgi

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -395,7 +395,7 @@ def create_instance_uwsgi_scaling_rule(
     # This makes sure that desired_instances includes load from all namespaces, but that the scaling ratio calculated
     # by (desired_instances / current_replicas) is meaningful for each namespace.
     worker_filter_terms = f"paasta_cluster='{paasta_cluster}',paasta_service='{service}',paasta_instance='{instance}'"
-    replica_filter_terms = f"paasta_cluster='{paasta_cluster}',deployment='{deployment_name}',namespace='{namespace}'"
+    replica_filter_terms = f"paasta_cluster='{paasta_cluster}',kube_deployment='{deployment_name}',namespace='{namespace}'"
 
     # k8s:deployment:pods_status_ready is a metric created by summing kube_pod_status_ready
     # over paasta service/instance/cluster. it counts the number of ready pods in a paasta

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -456,6 +456,7 @@ def create_instance_uwsgi_scaling_rule(
     # number of replicas.
     # k8s happens to multiply by the # of ready pods - so we divide by that rather than by the amount of current replicas (which may
     # include non-ready pods)
+    # ref: https://github.com/kubernetes/kubernetes/blob/7ec1a89a509906dad9fd6a4635d7bfc157b47790/pkg/controller/podautoscaler/replica_calculator.go#L278
     metrics_query = f"""
         {desired_instances} / {ready_pods_namespaced}
     """


### PR DESCRIPTION
We had some surprising behavior recently where an autoscaled app was crashlooping and the HPA did not keep the desired scale as-is - we believe that this is due to a mismatch in how we calculate the value we send to k8s:

The existing PromQL divides by current replica to turn things into a utilization percentage such that when the HPA multiplies later on by the number of current replicas, we reach our target replicas.

However, the HPA will actually multiply by the number of ready replicas, leading to a mismatch.