### PR TITLE
Speed up secret syncing

### DIFF
--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -696,7 +696,7 @@ def create_or_update_k8s_secret(
     :param get_secret_data: is a function to postpone fetching data in order to reduce service load, e.g. Vault API
     """
     # In order to prevent slamming the k8s API, add some artificial delay here
-    time.sleep(0.3)
+    time.sleep(load_system_paasta_config().get_secret_sync_delay_seconds())
 
     kubernetes_signature = get_secret_signature(
         kube_client=kube_client,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2060,6 +2060,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     spark_use_eks_default: bool
     sidecar_requirements_config: Dict[str, KubeContainerResourceRequest]
     eks_cluster_aliases: Dict[str, str]
+    secret_sync_delay_seconds: float
 
 
 def load_system_paasta_config(
@@ -2135,6 +2136,9 @@ class SystemPaastaConfig:
 
     def __repr__(self) -> str:
         return f"SystemPaastaConfig({self.config_dict!r}, {self.directory!r})"
+
+    def get_secret_sync_delay_seconds(self) -> float:
+        return self.config_dict.get("secret_sync_delay_seconds", 0.0)
 
     def get_spark_use_eks_default(self) -> bool:
         return self.config_dict.get("spark_use_eks_default", False)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2138,7 +2138,7 @@ class SystemPaastaConfig:
         return f"SystemPaastaConfig({self.config_dict!r}, {self.directory!r})"
 
     def get_secret_sync_delay_seconds(self) -> float:
-        return self.config_dict.get("secret_sync_delay_seconds", 0.0)
+        return self.config_dict.get("secret_sync_delay_seconds", 0)
 
     def get_spark_use_eks_default(self) -> bool:
         return self.config_dict.get("spark_use_eks_default", False)

--- a/tests/kubernetes/bin/test_paasta_secrets_sync.py
+++ b/tests/kubernetes/bin/test_paasta_secrets_sync.py
@@ -264,7 +264,11 @@ def paasta_secrets_patches():
         "paasta_tools.kubernetes.bin.paasta_secrets_sync.json.load", autospec=True
     ), mock.patch(
         "os.path.isdir", autospec=True, return_value=True
+    ), mock.patch(
+        "paasta_tools.kubernetes.bin.paasta_secrets_sync.load_system_paasta_config",
+        autospec=True,
     ):
+
         yield (
             mock_get_secret_provider,
             mock_scandir,
@@ -623,7 +627,10 @@ def boto_keys_patches():
     ) as mock_update_kubernetes_secret_signature, mock.patch(
         "paasta_tools.kubernetes.bin.paasta_secrets_sync.PaastaServiceConfigLoader",
         autospec=True,
-    ) as mock_config_loader:
+    ) as mock_config_loader, mock.patch(
+        "paasta_tools.kubernetes.bin.paasta_secrets_sync.load_system_paasta_config",
+        autospec=True,
+    ):
         yield (
             mock_open,
             mock_open.return_value.__enter__.return_value,
@@ -857,7 +864,10 @@ def crypto_keys_patches():
     ) as mock_update_kubernetes_secret_signature, mock.patch(
         "paasta_tools.kubernetes.bin.paasta_secrets_sync.PaastaServiceConfigLoader",
         autospec=True,
-    ) as mock_config_loader:
+    ) as mock_config_loader, mock.patch(
+        "paasta_tools.kubernetes.bin.paasta_secrets_sync.load_system_paasta_config",
+        autospec=True,
+    ):
         yield (
             provider,
             mock_get_kubernetes_secret_signature,


### PR DESCRIPTION
It turns out that the slowness here was due to our hardcoded .3s sleep - we're
now syncing a lot more secrets (and generally doing more work) because of our
namespace sharding, so this sleep ends up taking quite a bit of time.

We generally haven't had to throttle much (outside of Pod creation, but that's
generally due to other constraints: e.g., cluster autoscaling and whatnot), so
it's probably fine to remove this sleep entirely for the time being.

That said, in the interest of safety, I've made this delay configurable - so if
this ends up causing issues after release (or in the far future), we can easily
tweak the delay.