### PR TITLE
spark-run: set home directory when using unpriv containers

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -571,6 +571,9 @@ def get_docker_run_cmd(
             cmd.append(k)
         else:
             cmd.append(f"{k}={v}")
+    if is_using_unprivileged_containers():
+        cmd.append("--env")
+        cmd.append(f"HOME=/nail/home/{get_username()}")
     if nvidia:
         cmd.append("--env")
         cmd.append("NVIDIA_VISIBLE_DEVICES=all")


### PR DESCRIPTION
Since when running in an unprivileged container the user is set to root, its home directory would be `/root` by default.
To fix that, we for the HOME environment variable to the right location.

Testing:
```
$ python -m paasta_tools.cli.cli spark-run --image whatever:latest --cmd 'bash' --aws-profile=dev

....

root@dev5-uswest2adevc:/work# echo $HOME
/nail/home/mpiano
root@dev5-uswest2adevc:/work# cd
root@dev5-uswest2adevc:~# pwd
/nail/home/mpiano
root@dev5-uswest2adevc:~# ls -al | head
total 552
drwxr-xr-x   41 root   root     4096 Feb 22 13:50 .
drwxr-xr-x 1445 nobody nogroup 36864 Feb 21 10:14 ..
drwxr-xr-x    3 root   root     4096 Jan 18  2023 .ansible
drwx------    2 root   root     4096 Jan  5  2023 .aptitude
drwxr-xr-x    3 root   root     4096 Feb 14 13:07 .aws
-rw-------    1 root   root    49419 Feb 22 13:50 .bash_history
-rw-r--r--    1 root   root      220 Jan  6  2022 .bash_logout
-rw-r--r--    1 root   root     3771 Jan  6  2022 .bashrc
drwxr-xr-x    3 root   root     4096 Jan  5  2023 .bundle
```