### PR TITLE
Fix PAASTA_PORT in local-run containers

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -661,8 +661,11 @@ def get_local_run_environment_vars(instance_config, port0, framework):
         "PAASTA_DOCKER_IMAGE": docker_image,
         "PAASTA_LAUNCHED_BY": get_possible_launched_by_user_variable_from_env(),
         "PAASTA_HOST": hostname,
-        "PAASTA_PORT": str(instance_config.get_container_port()),
     }
+
+    if hasattr(instance_config, "get_container_port"):
+        env["PAASTA_PORT"] = str(instance_config.get_container_port())
+
     if framework == "marathon":
         fake_taskid = uuid.uuid4()
         env["MESOS_SANDBOX"] = "/mnt/mesos/sandbox"

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -661,10 +661,9 @@ def get_local_run_environment_vars(instance_config, port0, framework):
         "PAASTA_DOCKER_IMAGE": docker_image,
         "PAASTA_LAUNCHED_BY": get_possible_launched_by_user_variable_from_env(),
         "PAASTA_HOST": hostname,
+        # Kubernetes instances remove PAASTA_CLUSTER, so we need to re-add it ourselves
+        "PAASTA_CLUSTER": instance_config.get_cluster(),
     }
-
-    if hasattr(instance_config, "get_container_port"):
-        env["PAASTA_PORT"] = str(instance_config.get_container_port())
 
     if framework == "marathon":
         fake_taskid = uuid.uuid4()
@@ -858,7 +857,7 @@ def run_docker_container(
             sys.exit(1)
     else:
         chosen_port = pick_random_port(service)
-    environment = instance_config.get_env_dictionary()
+    environment = instance_config.get_env()
     secret_volumes = {}  # type: ignore
     if not skip_secrets:
         # if secrets_for_owner_team enabled in yelpsoa for service

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -661,7 +661,7 @@ def get_local_run_environment_vars(instance_config, port0, framework):
         "PAASTA_DOCKER_IMAGE": docker_image,
         "PAASTA_LAUNCHED_BY": get_possible_launched_by_user_variable_from_env(),
         "PAASTA_HOST": hostname,
-        "PAASTA_PORT": str(port0),
+        "PAASTA_PORT": str(instance_config.get_container_port()),
     }
     if framework == "marathon":
         fake_taskid = uuid.uuid4()

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -1914,12 +1914,14 @@ def test_get_local_run_environment_vars_other(
     mock_instance_config.get_mem.return_value = 123
     mock_instance_config.get_disk.return_value = 123
     mock_instance_config.get_cpus.return_value = 123
+    mock_instance_config.get_container_port.return_value = 8888
     mock_instance_config.get_docker_image.return_value = "fake_docker_image"
 
     actual = get_local_run_environment_vars(
         instance_config=mock_instance_config, port0=1234, framework="adhoc"
     )
     assert actual["PAASTA_DOCKER_IMAGE"] == "fake_docker_image"
+    assert actual["PAASTA_PORT"] == "8888"
     assert "MARATHON_PORT" not in actual
 
 


### PR DESCRIPTION
Looks like we've been setting `PAASTA_PORT` to the port used to bind docker to the container port.  This conflicts with what we specify in the [paasta contract](https://paasta.readthedocs.io/en/latest/about/contract.html#http-tcp-services) which says service owners should listen on `PAASTA_PORT` inside the container.

This switches to let the instance config's `get_env` set `PAASTA_PORT` which should match our expectations, especially as we are using container port in the docker `--publish` flag: https://github.com/Yelp/paasta/blob/master/paasta_tools/cli/cmds/local_run.py#L560-L561 +
https://github.com/Yelp/paasta/blob/master/paasta_tools/cli/cmds/local_run.py#L944

The switch to defer this work to the instance config's `get_env` also meant that for Kubernetes instances, we lose the `PAASTA_CLUSTER` envvar, so this also updates `get_local_run_environment_vars` to include it. 