### PR TITLE
Support building Debian package with unprivileged docker

### DIFF
--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -73,6 +73,11 @@ package_%: build_$$*_docker go_entrypoint
 
 	# noddebs to work around https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=897569
 	$(DOCKER_RUN) /bin/bash -c "DEB_BUILD_OPTIONS=noddebs dpkg-buildpackage -d && mv ../*.deb dist/"
+	# The in-house Podman deployment (unprivileged Docker) maps a virtual UID in the OS to root in the container,
+	# so we skip this chown statement to avoid broken permissions.
+ifeq ($(findstring podman,$(DOCKER_HOST)),)
+	$(DOCKER_RUN) chown -R $(UID):$(GID) /work
+endif
 	# then move them back
 	mv ../requirements.txt.old ../requirements.txt
 	mv ../debian/changelog.old ../debian/changelog

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -19,7 +19,7 @@ SHELL=/bin/bash
 
 UID:=`id -u`
 GID:=`id -g`
-DOCKER_RUN=docker run -t -v $(CURDIR)/../:/work:rw yelp/paastatools_$*_container
+DOCKER_RUN=docker run -t -v $(CURDIR)/../:/work:rw docker.io/yelp/paastatools_$*_container
 
 NOOP = true
 ifeq ($(PAASTA_ENV),YELP)
@@ -34,10 +34,10 @@ endif
 
 build_%_docker:
 	[ -d ../dist ] || mkdir ../dist
-	docker pull "yelp/paastatools_$*_container" || true
+	docker pull "docker.io/yelp/paastatools_$*_container" || true
 	cd dockerfiles/$*/ && docker build --build-arg DOCKER_REGISTRY=$(DOCKER_REGISTRY) \
 	$(if $(filter-out $(PAASTA_ENV),YELP), --build-arg PIP_INDEX_URL=https://pypi.org/simple,) \
-		-t "yelp/paastatools_$*_container" .
+		-t "docker.io/yelp/paastatools_$*_container" .
 
 .SECONDEXPANSION:
 itest_%: package_$$*
@@ -73,7 +73,6 @@ package_%: build_$$*_docker go_entrypoint
 
 	# noddebs to work around https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=897569
 	$(DOCKER_RUN) /bin/bash -c "DEB_BUILD_OPTIONS=noddebs dpkg-buildpackage -d && mv ../*.deb dist/"
-	$(DOCKER_RUN) chown -R $(UID):$(GID) /work
 	# then move them back
 	mv ../requirements.txt.old ../requirements.txt
 	mv ../debian/changelog.old ../debian/changelog


### PR DESCRIPTION
## Description

We have rolled out unprivileged docker to dev boxes, which causes the following problems when building Debian packages:
1. Does not support resolving short image names
  => Error when running `docker pull "docker.io/yelp/paastatools_bionic_container"`.
2. Has a virtual in-container uid to system uid mapping.
  => The whole repository directory will be changed to a incorrect UID/GID, causing the build abort.

This PR fixes both issues during the build process.

## Test
`make -C yelp_package PAASTA_ENV=YELP package_bionic` in devbox.