### PR TITLE
Remove spark SignalFx dashboard URLs

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -22,7 +22,6 @@ from service_configuration_lib import spark_config
 from service_configuration_lib.spark_config import get_aws_credentials
 from service_configuration_lib.spark_config import get_grafana_url
 from service_configuration_lib.spark_config import get_resources_requested
-from service_configuration_lib.spark_config import get_signalfx_url
 from service_configuration_lib.spark_config import get_spark_hourly_cost
 from service_configuration_lib.spark_config import UnsupportedClusterManagerException
 
@@ -946,12 +945,8 @@ def configure_and_run_docker_container(
         print(PaastaColors.green(f"\nSpark history server URL: ") + f"{webui_url}\n")
     elif any(c in docker_cmd for c in ["pyspark", "spark-shell", "spark-submit"]):
         grafana_url = get_grafana_url(spark_conf)
-        signalfx_url = get_signalfx_url(spark_conf)
         dashboard_url_msg = (
-            PaastaColors.green(f"\nGrafana dashboard: ")
-            + f"{grafana_url}\n"
-            + PaastaColors.green(f"\nSignalfx dashboard: ")
-            + f"{signalfx_url}\n"
+            PaastaColors.green(f"\nGrafana dashboard: ") + f"{grafana_url}\n"
         )
         print(webui_url_msg)
         print(dashboard_url_msg)

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -493,7 +493,6 @@ def test_run_docker_container(
 @mock.patch("paasta_tools.cli.cmds.spark_run.get_webui_url", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.spark_run.create_spark_config_str", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.spark_run.get_docker_cmd", autospec=True)
-@mock.patch("paasta_tools.cli.cmds.spark_run.get_signalfx_url", autospec=True)
 @mock.patch.object(spark_config.SparkConfBuilder(), "get_history_url", autospec=True)
 class TestConfigureAndRunDockerContainer:
 
@@ -551,7 +550,6 @@ class TestConfigureAndRunDockerContainer:
     def test_configure_and_run_docker_container(
         self,
         mock_get_history_url,
-        mock_et_signalfx_url,
         mock_get_docker_cmd,
         mock_create_spark_config_str,
         mock_get_webui_url,
@@ -657,7 +655,6 @@ class TestConfigureAndRunDockerContainer:
     def test_configure_and_run_docker_driver_resource_limits_config(
         self,
         mock_get_history_url,
-        mock_et_signalfx_url,
         mock_get_docker_cmd,
         mock_create_spark_config_str,
         mock_get_webui_url,
@@ -763,7 +760,6 @@ class TestConfigureAndRunDockerContainer:
     def test_configure_and_run_docker_driver_resource_limits(
         self,
         mock_get_history_url,
-        mock_et_signalfx_url,
         mock_get_docker_cmd,
         mock_create_spark_config_str,
         mock_get_webui_url,
@@ -840,7 +836,6 @@ class TestConfigureAndRunDockerContainer:
     def test_configure_and_run_docker_container_nvidia(
         self,
         mock_get_history_url,
-        mock_et_signalfx_url,
         mock_get_docker_cmd,
         mock_create_spark_config_str,
         mock_get_webui_url,
@@ -878,7 +873,6 @@ class TestConfigureAndRunDockerContainer:
     def test_configure_and_run_docker_container_mrjob(
         self,
         mock_get_history_url,
-        mock_et_signalfx_url,
         mock_get_docker_cmd,
         mock_create_spark_config_str,
         mock_get_webui_url,
@@ -916,7 +910,6 @@ class TestConfigureAndRunDockerContainer:
     def test_dont_emit_metrics_for_inappropriate_commands(
         self,
         mock_get_history_url,
-        mock_et_signalfx_url,
         mock_get_docker_cmd,
         mock_create_spark_config_str,
         mock_get_webui_url,


### PR DESCRIPTION
As we are deprecating Spark SignalFx dashboards.

Tested by running the following cmd:
```
./.tox/py38-linux/bin/paasta spark-run --aws-profile=dev --cmd "spark-submit /work/integration_tests/s3.py"
```