### PR TITLE
stop monkey-patching the HPA object

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -789,7 +789,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         cluster: str,
         kube_client: KubeClient,
         namespace: str,
-    ) -> Optional[Union[V2beta2HorizontalPodAutoscaler, Dict]]:
+    ) -> Optional[V2beta2HorizontalPodAutoscaler]:
         # Returns None if an HPA should not be attached based on the config,
         # or the config is invalid.
 
@@ -906,12 +906,17 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             )
             return None
 
+        scaling_policy = self.get_autoscaling_scaling_policy(
+            max_replicas,
+            autoscaling_params,
+        )
         hpa = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
                 name=name, namespace=namespace, annotations=annotations
             ),
             spec=V2beta2HorizontalPodAutoscalerSpec(
+                behavior=scaling_policy,
                 max_replicas=max_replicas,
                 min_replicas=min_replicas,
                 metrics=metrics,
@@ -921,18 +926,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             ),
         )
 
-        # In k8s v1.18, HPA scaling policies can be set:
-        #   https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
-        # However, the python client library currently only supports v1.17, so
-        # we need to monkey-patch scaling policies until the library is updated
-        # v1.18.
-        scaling_policy = self.get_autoscaling_scaling_policy(
-            max_replicas,
-            autoscaling_params,
-        )
-        if scaling_policy:
-            hpa = kube_client.jsonify(hpa)  # this is a hack, see KubeClient class
-            hpa["spec"]["behavior"] = scaling_policy
         return hpa
 
     def get_deployment_strategy_config(self) -> V1DeploymentStrategy:


### PR DESCRIPTION
PaaSTA is on a modern-enough version of the Python kubernetes client that we don't need to monkey-patch the HPA dict anymore.

# Testing done
- make test

cc @jfongatyelp 