### PR TITLE
Rootless podman support for PaaSTA playground

### DIFF
--- a/k8s_itests/Makefile
+++ b/k8s_itests/Makefile
@@ -32,7 +32,7 @@ ifeq (,$(wildcard ./kind))
 	./scripts/install-kind.sh
 
 .create_cluster: kind
-	./kind create cluster --name=$(CLUSTER) --config=$(KIND_CONFIG) --kubeconfig $(KUBECONFIG)
+	KIND_EXPERIMENTAL_PROVIDER=podman ./kind create cluster --name=$(CLUSTER) --config=$(KIND_CONFIG) --kubeconfig $(KUBECONFIG)
 	touch .create_cluster
 endif
 

--- a/k8s_itests/Makefile
+++ b/k8s_itests/Makefile
@@ -9,6 +9,10 @@ export PAASTA_SYSTEM_CONFIG_DIR=$(PAASTA_CONFIG_DIR)/fake_etc_paasta
 export PAASTA_API_PORT=$(shell ephemeral-port-reserve)
 export KUBECONFIG=$(CWD)/kubeconfig
 
+ifeq ($(findstring podman,${DOCKER_HOST}), podman)
+	export CREATE_CLUSTER_ENVS=KIND_EXPERIMENTAL_PROVIDER=podman
+endif
+
 ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
 	export KIND_CONFIG=deployments/kind/cluster-devbox.yaml
 	PAASTA_K8S_ENV ?= YELP
@@ -32,7 +36,7 @@ ifeq (,$(wildcard ./kind))
 	./scripts/install-kind.sh
 
 .create_cluster: kind
-	KIND_EXPERIMENTAL_PROVIDER=podman ./kind create cluster --name=$(CLUSTER) --config=$(KIND_CONFIG) --kubeconfig $(KUBECONFIG)
+	$(CREATE_CLUSTER_ENVS) ./kind create cluster --name=$(CLUSTER) --config=$(KIND_CONFIG) --kubeconfig $(KUBECONFIG)
 	touch .create_cluster
 endif
 

--- a/k8s_itests/deployments/kind/resources/metrics-server/1.8+/metrics-apiservice.yaml
+++ b/k8s_itests/deployments/kind/resources/metrics-server/1.8+/metrics-apiservice.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:

--- a/k8s_itests/deployments/kind/resources/metrics-server/1.8+/metrics-apiservice.yaml
+++ b/k8s_itests/deployments/kind/resources/metrics-server/1.8+/metrics-apiservice.yaml
@@ -1,5 +1,4 @@
----
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io

--- a/k8s_itests/scripts/containerd_registry_setup.py
+++ b/k8s_itests/scripts/containerd_registry_setup.py
@@ -8,13 +8,10 @@ containerdcfg = toml.load(containerdcfg_file_path)
 dockercfg = json.load(open("/nail/etc/docker-registry-ro"))
 registry = list(dockercfg.keys())[0]
 
-containerdcfg["plugins"]["io.containerd.grpc.v1.cri"]["registry"]["configs"] = {
-    registry: {"auth": {"auth": dockercfg[registry]["auth"]}}
+containerdcfg["plugins"]["io.containerd.grpc.v1.cri"]["registry"] = {
+    "configs": {registry: {"auth": {"auth": dockercfg[registry]["auth"]}}},
+    "mirrors": {registry: {"endpoint": [f"https://{registry}"]}},
 }
-
-containerdcfg["plugins"]["io.containerd.grpc.v1.cri"]["registry"]["mirrors"][
-    registry
-] = {"endpoint": [f"https://{registry}"]}
 
 with open(containerdcfg_file_path, "w") as containerdcfg_file:
     containerdcfg_file.write(toml.dumps(containerdcfg))

--- a/paasta_tools/contrib/render_template.py
+++ b/paasta_tools/contrib/render_template.py
@@ -23,25 +23,28 @@ def replace(s, values):
     )
 
 
-def render_file(src, dst, values):
+def render_file(src, dst, values, overwrite=True):
     basename = os.path.basename(src)
     new_name = replace(basename, values)
-    with open(f"{dst}/{new_name}", "w") as new:
+    if not os.path.exists(new_name) or overwrite:
+        write_file(dst, new_name, src, values)
+
+
+def write_file(dst, name, src, values):
+    with open(f"{dst}/{name}", "w") as new:
         with open(f"{src}", "r") as old:
             new.write(replace(old.read(), values))
 
 
 def render(src, dst, values={}, exclude={}, overwrite=True):
     if os.path.isfile(src):
-        if overwrite:
-            render_file(src, dst, values)
+        render_file(src, dst, values, overwrite)
         return
     for f in os.scandir(src):
         if f.name.startswith(".") or f.path in exclude:
             continue
         if os.path.isfile(f.path):
-            if overwrite:
-                render_file(f.path, dst, values)
+            render_file(f.path, dst, values, overwrite)
         else:
             new_dst = replace(f"{dst}/{f.name}", values)
             try:


### PR DESCRIPTION
Rootless podman support for PaaSTA playground. This will need a [somewhat modern version of kind](https://github.com/Yelp/kind/pull/7) and k8s nodes >=1.22 