### PR TITLE
Updated flink ingress for eks clusters

### DIFF
--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -218,8 +218,8 @@ def _filter_for_endpoint(json_response: Any, endpoint: str) -> Mapping[str, Any]
 def _get_jm_rest_api_base_url(cr: Mapping[str, Any]) -> str:
     metadata = cr["metadata"]
     cluster = metadata["labels"][paasta_prefixed("cluster")]
-    is_eks = bool(metadata["labels"].get("is_eks", "false"))
-    base_url = get_flink_ingress_url_root(cluster, bool(is_eks))
+    is_eks = metadata["labels"].get("paasta.yelp.com/eks", "False")
+    base_url = get_flink_ingress_url_root(cluster, is_eks == "True")
 
     # this will look something like http://flink-jobmanager-host:port/paasta-service-cr-name
     _, _, service_cr_name, *_ = urlparse(

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -184,8 +184,8 @@ def get_flink_ingress_url_root(cluster: str, is_eks: bool) -> str:
         return f"http://flink.k8s.{cluster}.paasta:{FLINK_INGRESS_PORT}/"
 
 
-def _dashboard_get(cr_name: str, cluster: str, path: str) -> str:
-    root = get_flink_ingress_url_root(cluster)
+def _dashboard_get(cr_name: str, cluster: str, path: str, is_eks: bool) -> str:
+    root = get_flink_ingress_url_root(cluster, is_eks)
     url = f"{root}{cr_name}/{path}"
     response = requests.get(url, timeout=FLINK_DASHBOARD_TIMEOUT_SECONDS)
     response.raise_for_status()
@@ -259,9 +259,11 @@ def curl_flink_endpoint(cr_id: Mapping[str, str], endpoint: str) -> Mapping[str,
         raise ValueError(f"failed HTTP request to flink API: {e}")
 
 
-def get_flink_jobmanager_overview(cr_name: str, cluster: str) -> Mapping[str, Any]:
+def get_flink_jobmanager_overview(
+    cr_name: str, cluster: str, is_eks: bool
+) -> Mapping[str, Any]:
     try:
-        response = _dashboard_get(cr_name, cluster, "overview")
+        response = _dashboard_get(cr_name, cluster, "overview", is_eks)
         return json.loads(response)
     except requests.RequestException as e:
         url = e.request.url

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -177,8 +177,11 @@ def cr_id(service: str, instance: str) -> Mapping[str, str]:
     )
 
 
-def get_flink_ingress_url_root(cluster: str) -> str:
-    return f"http://flink.k8s.{cluster}.paasta:{FLINK_INGRESS_PORT}/"
+def get_flink_ingress_url_root(cluster: str, is_eks: bool) -> str:
+    if is_eks:
+        return f"http://flink.eks.{cluster}.paasta:{FLINK_INGRESS_PORT}/"
+    else:
+        return f"http://flink.k8s.{cluster}.paasta:{FLINK_INGRESS_PORT}/"
 
 
 def _dashboard_get(cr_name: str, cluster: str, path: str) -> str:
@@ -215,7 +218,8 @@ def _filter_for_endpoint(json_response: Any, endpoint: str) -> Mapping[str, Any]
 def _get_jm_rest_api_base_url(cr: Mapping[str, Any]) -> str:
     metadata = cr["metadata"]
     cluster = metadata["labels"][paasta_prefixed("cluster")]
-    base_url = get_flink_ingress_url_root(cluster)
+    is_eks = bool(metadata["labels"].get("is_eks", "false"))
+    base_url = get_flink_ingress_url_root(cluster, bool(is_eks))
 
     # this will look something like http://flink-jobmanager-host:port/paasta-service-cr-name
     _, _, service_cr_name, *_ = urlparse(

--- a/tests/test_check_flink_services_health.py
+++ b/tests/test_check_flink_services_health.py
@@ -49,7 +49,10 @@ def instance_config():
 )
 def test_check_under_registered_taskmanagers_ok(mock_overview, instance_config):
     under, output, description = check_under_registered_taskmanagers(
-        instance_config, expected_count=3, cr_name="fake--service-575c857546"
+        instance_config,
+        expected_count=3,
+        cr_name="fake--service-575c857546",
+        is_eks=False,
     )
     assert not under
     assert (
@@ -66,7 +69,10 @@ def test_check_under_registered_taskmanagers_ok(mock_overview, instance_config):
 )
 def test_check_under_registered_taskmanagers_under(mock_overview, instance_config):
     under, output, description = check_under_registered_taskmanagers(
-        instance_config, expected_count=3, cr_name="fake--service-575c857546"
+        instance_config,
+        expected_count=3,
+        cr_name="fake--service-575c857546",
+        is_eks=False,
     )
     assert under
     assert (
@@ -86,7 +92,10 @@ def test_check_under_registered_taskmanagers_under(mock_overview, instance_confi
 )
 def test_check_under_registered_taskmanagers_error(mock_overview, instance_config):
     under, output, description = check_under_registered_taskmanagers(
-        instance_config, expected_count=3, cr_name="fake--service-575c857546"
+        instance_config,
+        expected_count=3,
+        cr_name="fake--service-575c857546",
+        is_eks=False,
     )
     assert under
     assert (
@@ -145,7 +154,7 @@ def test_check_flink_service_health_healthy(instance_config):
         ]
         mock_check_under_replication.assert_has_calls(expected)
         mock_check_under_registered_taskmanagers.assert_called_once_with(
-            instance_config=instance_config, expected_count=3, cr_name=""
+            instance_config=instance_config, expected_count=3, cr_name="", is_eks=False
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
@@ -210,7 +219,7 @@ def test_check_flink_service_health_too_few_taskmanagers(instance_config):
         ]
         mock_check_under_replication.assert_has_calls(expected)
         mock_check_under_registered_taskmanagers.assert_called_once_with(
-            instance_config=instance_config, expected_count=3, cr_name=""
+            instance_config=instance_config, expected_count=3, cr_name="", is_eks=False
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
@@ -267,7 +276,10 @@ def test_check_flink_service_health_under_registered_taskamanagers(instance_conf
         ]
         mock_check_under_replication.assert_has_calls(expected)
         mock_check_under_registered_taskmanagers.assert_called_once_with(
-            instance_config=instance_config, expected_count=3, cr_name=""
+            instance_config=instance_config,
+            expected_count=3,
+            cr_name="",
+            is_eks=False,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -234,9 +234,9 @@ def test_get_flink_jobmanager_overview():
     ) as mock_dashboard_get:
         cluster = "mycluster"
         cr_name = "kurupt--fm-7c7b459d59"
-        overview = flink_tools.get_flink_jobmanager_overview(cr_name, cluster)
+        overview = flink_tools.get_flink_jobmanager_overview(cr_name, cluster, False)
         mock_dashboard_get.assert_called_once_with(
-            cr_name=cr_name, cluster=cluster, path="overview"
+            cr_name=cr_name, cluster=cluster, path="overview", is_eks=False
         )
         assert overview == {
             "taskmanagers": 10,

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -18,7 +18,7 @@ import paasta_tools.flink_tools as flink_tools
 
 def test_get_flink_ingress_url_root():
     assert (
-        flink_tools.get_flink_ingress_url_root("mycluster")
+        flink_tools.get_flink_ingress_url_root("mycluster", False)
         == "http://flink.k8s.mycluster.paasta:31080/"
     )
 

--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -317,7 +317,7 @@ def test_format_custom_resource():
                     "paasta.yelp.com/cluster": "mycluster",
                     "paasta.yelp.com/config_sha": mock_get_config_hash.return_value,
                     "paasta.yelp.com/git_sha": "gitsha",
-                    "paasta.yelp.com/eks": "True",
+                    "paasta.yelp.com/eks": "False",
                 },
                 "annotations": {
                     "yelp.com/desired_state": "running",

--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -317,6 +317,7 @@ def test_format_custom_resource():
                     "paasta.yelp.com/cluster": "mycluster",
                     "paasta.yelp.com/config_sha": mock_get_config_hash.return_value,
                     "paasta.yelp.com/git_sha": "gitsha",
+                    "paasta.yelp.com/eks": "True",
                 },
                 "annotations": {
                     "yelp.com/desired_state": "running",
@@ -337,6 +338,7 @@ def test_format_custom_resource():
                 group="yelp.com",
                 namespace="paasta-flinks",
                 git_sha="gitsha",
+                is_eks=False,
             )
             == expected
         )
@@ -357,8 +359,7 @@ def test_paasta_config_flink_dashboard_base_url():
         expected = "http://flink.mycluster.paasta/"
         assert (
             setup_kubernetes_cr.get_dashboard_base_url(
-                kind="flink",
-                cluster="mycluster",
+                kind="flink", cluster="mycluster", is_eks=False
             )
             == expected
         )


### PR DESCRIPTION
in EKS clusters flink dashboard has a different URL. overiding this in EKS cluster.
added a new label 'paasta.yelp.com/eks' for CR objects to identify the eks clusters, which can be used 

also updated the check_flink_services_health check: it will use --eks flag to determine the eks environment