### PR TITLE
removed default eks var in kubernetes_cr.py

### DIFF
--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -298,12 +298,13 @@ def format_custom_resource(
                 paasta_prefixed("service"): service,
                 paasta_prefixed("instance"): instance,
                 paasta_prefixed("cluster"): cluster,
-                "paasta.yelp.com/eks": str(is_eks),
             },
             "annotations": {},
         },
         "spec": instance_config,
     }
+    if is_eks:
+        resource["metadata"]["labels"][paasta_prefixed("eks")] = str(is_eks)
 
     url = get_dashboard_base_url(kind, cluster, is_eks)
     if url:

--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -317,7 +317,6 @@ def test_format_custom_resource():
                     "paasta.yelp.com/cluster": "mycluster",
                     "paasta.yelp.com/config_sha": mock_get_config_hash.return_value,
                     "paasta.yelp.com/git_sha": "gitsha",
-                    "paasta.yelp.com/eks": "False",
                 },
                 "annotations": {
                     "yelp.com/desired_state": "running",


### PR DESCRIPTION
This will only add "paasta.yelp.com/eks" label when true, otherwise operators fails to reconcile existing stateful sets and other immutable k8s objects 