### PR TITLE
Add service/instance/managed labels to HPAs. PAASTA-18226

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -910,10 +910,18 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             max_replicas,
             autoscaling_params,
         )
+
+        labels = {
+            paasta_prefixed("service"): self.service,
+            paasta_prefixed("instance"): self.instance,
+            paasta_prefixed("pool"): self.get_pool(),
+            paasta_prefixed("managed"): "true",
+        }
+
         hpa = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
-                name=name, namespace=namespace, annotations=annotations
+                name=name, namespace=namespace, annotations=annotations, labels=labels
             ),
             spec=V2beta2HorizontalPodAutoscalerSpec(
                 behavior=scaling_policy,

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2233,7 +2233,10 @@ class TestKubernetesDeploymentConfig:
         expected_res = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
-                name="fake_name", namespace="paasta", annotations=annotations
+                name="fake_name",
+                namespace="paasta",
+                annotations=annotations,
+                labels=mock.ANY,
             ),
             spec=V2beta2HorizontalPodAutoscalerSpec(
                 behavior=mock_config.get_autoscaling_scaling_policy(
@@ -2298,7 +2301,10 @@ class TestKubernetesDeploymentConfig:
         expected_res = V2beta2HorizontalPodAutoscaler(
             kind="HorizontalPodAutoscaler",
             metadata=V1ObjectMeta(
-                name="fake_name", namespace="paasta", annotations=annotations
+                name="fake_name",
+                namespace="paasta",
+                annotations=annotations,
+                labels=mock.ANY,
             ),
             spec=V2beta2HorizontalPodAutoscalerSpec(
                 behavior=mock_config.get_autoscaling_scaling_policy(
@@ -2388,6 +2394,7 @@ class TestKubernetesDeploymentConfig:
                 name="fake_name",
                 namespace="paasta",
                 annotations={},
+                labels=mock.ANY,
             ),
             spec=V2beta2HorizontalPodAutoscalerSpec(
                 behavior=mock_config.get_autoscaling_scaling_policy(
@@ -2467,6 +2474,7 @@ class TestKubernetesDeploymentConfig:
                 name="fake_name",
                 namespace="paasta",
                 annotations={},
+                labels=mock.ANY,
             ),
             spec=V2beta2HorizontalPodAutoscalerSpec(
                 behavior=mock_config.get_autoscaling_scaling_policy(


### PR DESCRIPTION
This should make the kube_horizontalpodautoscaler_labels metric from kube-state-metrics more useful.