### PR TITLE
remove good_enough_window

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -232,14 +232,6 @@
                         "scaledown_policies": {
                             "type": "object"
                         },
-                        "good_enough_window": {
-                            "type": "array",
-                            "items": {
-                                "type": "number"
-                            },
-                            "minItems": 2,
-                            "maxItems": 2
-                        },
                         "prometheus_adapter_config": {
                             "type": "object",
                             "additionalProperties": false,

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -51,7 +51,6 @@ class AutoscalingParamsDict(TypedDict, total=False):
     use_prometheus: bool
     use_resource_metrics: bool
     scaledown_policies: Optional[dict]
-    good_enough_window: List[float]
     prometheus_adapter_config: Optional[dict]
     max_instances_alert_threshold: float
 

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -1641,41 +1641,6 @@ def test_proportional_decision_policy_nonzero_offset(mock_fetch_historical_load)
 
 
 @mock.patch(
-    "paasta_tools.autoscaling.autoscaling_service_lib.fetch_historical_load",
-    autospec=True,
-    return_value=[],
-)
-def test_proportional_decision_policy_good_enough(mock_fetch_historical_load):
-    assert 0 == autoscaling_service_lib.proportional_decision_policy(
-        zookeeper_path="/test",
-        current_instances=100,
-        num_healthy_instances=100,
-        min_instances=50,
-        max_instances=150,
-        forecast_policy="current",
-        offset=0.0,
-        setpoint=0.50,
-        utilization=0.54,
-        good_enough_window=(0.45, 0.55),
-        persist_data=False,
-    )
-
-    assert 0 == autoscaling_service_lib.proportional_decision_policy(
-        zookeeper_path="/test",
-        current_instances=100,
-        num_healthy_instances=100,
-        min_instances=50,
-        max_instances=150,
-        forecast_policy="current",
-        offset=0.0,
-        setpoint=0.50,
-        utilization=0.46,
-        good_enough_window=(0.45, 0.55),
-        persist_data=False,
-    )
-
-
-@mock.patch(
     "paasta_tools.autoscaling.autoscaling_service_lib.save_historical_load",
     autospec=True,
 )


### PR DESCRIPTION
Following up on https://github.yelpcorp.com/sysgit/yelpsoa-configs/pull/42719, this removes good_enough_window from paasta completely.

## Testing done
`make test` still passes