### PR TITLE
Allow to use default value of iam_role_provider

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1019,7 +1019,10 @@ def update_args_from_tronfig(args: argparse.Namespace) -> Optional[Dict[str, str
         return None
 
     # iam_role / aws_profile
-    if "iam_role" in action_dict and action_dict.get("iam_role_provider", "") != "aws":
+    if (
+        "iam_role" in action_dict
+        and action_dict.get("iam_role_provider", "aws") != "aws"
+    ):
         print(
             PaastaColors.red("Invalid Tronfig: iam_role_provider should be 'aws'"),
             file=sys.stderr,


### PR DESCRIPTION
Default value is set here:
https://sourcegraph.com/github.com/Yelp/paasta@15799523e976a7e611342e9b9b8cadfffdd3406c/-/blob/paasta_tools/utils.py?L965

## Test
Same as #3798, but remove `iam_role_provider` in the provided Tronfig.
