### PR TITLE
Fix volume mount of spark-run on local cluster

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -763,7 +763,8 @@ def configure_and_run_docker_container(
     volumes.append("%s:rw" % args.work_dir)
     volumes.append("/nail/home:/nail/home:rw")
 
-    volumes.append(f"{pod_template_path}:{pod_template_path}:rw")
+    if pod_template_path:
+        volumes.append(f"{pod_template_path}:{pod_template_path}:rw")
 
     volumes.append(
         f"{system_paasta_config.get_spark_kubeconfig()}:{system_paasta_config.get_spark_kubeconfig()}:ro"


### PR DESCRIPTION
## Description

Error when running `paasta spark-run --cluster-manager local ...`
```
$ paasta spark-run --aws-profile dev --cluster-manager local --cmd 'echo done'
...
docker: Error response from daemon: fill out specgen: host directory cannot be empty. 
```

This happens after a [recent refactor](https://github.com/Yelp/paasta/pull/3679/files#diff-30f8e9c33224158fab1e77efc4004f7d2344230ea7b4ffbf64b3fca21513cc00L1467-R1228) which makes `pod_template_path` be empty when `cluster-manager` is `local`.

## Test
```
./.tox/py38-linux/bin/paasta spark-run --aws-profile=dev --cluster-manager local --cmd 'echo done'
```
