### PR TITLE
Support pod identity in `spark-run`

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1284,7 +1284,6 @@ def paasta_spark_run(args):
 
     aws_creds = get_aws_credentials(
         service=args.service,
-        no_aws_credentials=args.no_aws_credentials,
         aws_credentials_yaml=args.aws_credentials_yaml,
         profile_name=args.aws_profile,
         assume_aws_role_arn=args.assume_aws_role,

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -22,7 +22,6 @@ from service_configuration_lib import spark_config
 from service_configuration_lib.spark_config import get_aws_credentials
 from service_configuration_lib.spark_config import get_grafana_url
 from service_configuration_lib.spark_config import get_resources_requested
-from service_configuration_lib.spark_config import get_signalfx_url
 from service_configuration_lib.spark_config import get_spark_hourly_cost
 from service_configuration_lib.spark_config import send_and_calculate_resources_cost
 from service_configuration_lib.spark_config import UnsupportedClusterManagerException
@@ -947,12 +946,8 @@ def configure_and_run_docker_container(
         print(PaastaColors.green(f"\nSpark history server URL: ") + f"{webui_url}\n")
     elif any(c in docker_cmd for c in ["pyspark", "spark-shell", "spark-submit"]):
         grafana_url = get_grafana_url(spark_conf)
-        signalfx_url = get_signalfx_url(spark_conf)
         dashboard_url_msg = (
-            PaastaColors.green(f"\nGrafana dashboard: ")
-            + f"{grafana_url}\n"
-            + PaastaColors.green(f"\nSignalfx dashboard: ")
-            + f"{signalfx_url}\n"
+            PaastaColors.green(f"\nGrafana dashboard: ") + f"{grafana_url}\n"
         )
         print(webui_url_msg)
         print(dashboard_url_msg)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -439,7 +439,10 @@ def add_subparser(subparsers):
 
     aws_group.add_argument(
         "--assume-aws-role",
-        help="Takes an AWS IAM role ARN and attempts to create a session",
+        help=(
+            "Takes an AWS IAM role ARN and attempts to create a session using "
+            "spark_role_assumer"
+        ),
     )
 
     aws_group.add_argument(
@@ -450,6 +453,18 @@ def add_subparser(subparsers):
         ),
         type=int,
         default=43200,
+    )
+
+    aws_group.add_argument(
+        "--use-web-identity",
+        help=(
+            "If the current environment contains AWS_ROLE_ARN and "
+            "AWS_WEB_IDENTITY_TOKEN_FILE, creates a session to use. These "
+            "ENV vars must be present, and will be in the context of a pod-"
+            "identity enabled pod."
+        ),
+        action="store_true",
+        default=False,
     )
 
     jupyter_group = list_parser.add_argument_group(
@@ -1274,6 +1289,7 @@ def paasta_spark_run(args):
         profile_name=args.aws_profile,
         assume_aws_role_arn=args.assume_aws_role,
         session_duration=args.aws_role_duration,
+        use_web_identity=args.use_web_identity,
     )
     docker_image_digest = get_docker_image(args, instance_config)
     if docker_image_digest is None:

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -54,7 +54,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.18.11
+service-configuration-lib >= 2.18.17
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -90,7 +90,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.10.0
 sensu-plugin==0.3.1
-service-configuration-lib==2.18.11
+service-configuration-lib==2.18.17
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -1434,10 +1434,10 @@ def test_get_aws_credentials():
     ), mock.patch(
         "service_configuration_lib.spark_config.open",
         mock.mock_open(read_data="token-content"),
-        autospec=True,
+        autospec=False,
     ), mock.patch(
         "service_configuration_lib.spark_config.boto3.client",
-        autospec=True,
+        autospec=False,
     ) as boto3_client:
         get_aws_credentials(
             service="some-service",

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -1117,7 +1117,6 @@ def test_paasta_spark_run_bash(
         cluster="test-cluster",
         pool="test-pool",
         yelpsoa_config_root="/path/to/soa",
-        no_aws_credentials=False,
         aws_credentials_yaml="/path/to/creds",
         aws_profile=None,
         spark_args="spark.cores.max=100 spark.executor.cores=10",
@@ -1149,7 +1148,6 @@ def test_paasta_spark_run_bash(
     )
     mock_get_aws_credentials.assert_called_once_with(
         service="test-service",
-        no_aws_credentials=False,
         aws_credentials_yaml="/path/to/creds",
         profile_name=None,
         assume_aws_role_arn=None,
@@ -1231,7 +1229,6 @@ def test_paasta_spark_run(
         cluster="test-cluster",
         pool="test-pool",
         yelpsoa_config_root="/path/to/soa",
-        no_aws_credentials=False,
         aws_credentials_yaml="/path/to/creds",
         aws_profile=None,
         spark_args="spark.cores.max=100 spark.executor.cores=10",
@@ -1263,7 +1260,6 @@ def test_paasta_spark_run(
     )
     mock_get_aws_credentials.assert_called_once_with(
         service="test-service",
-        no_aws_credentials=False,
         aws_credentials_yaml="/path/to/creds",
         profile_name=None,
         assume_aws_role_arn=None,
@@ -1344,7 +1340,6 @@ def test_paasta_spark_run_pyspark(
         cluster="test-cluster",
         pool="test-pool",
         yelpsoa_config_root="/path/to/soa",
-        no_aws_credentials=False,
         aws_credentials_yaml="/path/to/creds",
         aws_profile=None,
         spark_args="spark.cores.max=70 spark.executor.cores=10",
@@ -1379,7 +1374,6 @@ def test_paasta_spark_run_pyspark(
     )
     mock_get_aws_credentials.assert_called_once_with(
         service="test-service",
-        no_aws_credentials=False,
         aws_credentials_yaml="/path/to/creds",
         profile_name=None,
         assume_aws_role_arn=None,

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -979,6 +979,7 @@ def test_paasta_spark_run_bash(
         k8s_server_address=None,
         tronfig=None,
         job_id=None,
+        use_web_identity=False,
     )
     mock_load_system_paasta_config_utils.return_value.get_kube_clusters.return_value = (
         {}
@@ -1012,6 +1013,7 @@ def test_paasta_spark_run_bash(
         profile_name=None,
         assume_aws_role_arn=None,
         session_duration=3600,
+        use_web_identity=False,
     )
     mock_get_docker_image.assert_called_once_with(
         args, mock_get_instance_config.return_value
@@ -1103,6 +1105,7 @@ def test_paasta_spark_run(
         k8s_server_address=None,
         tronfig=None,
         job_id=None,
+        use_web_identity=False,
     )
     mock_load_system_paasta_config_utils.return_value.get_kube_clusters.return_value = (
         {}
@@ -1139,6 +1142,7 @@ def test_paasta_spark_run(
         profile_name=None,
         assume_aws_role_arn=None,
         session_duration=3600,
+        use_web_identity=False,
     )
     mock_get_docker_image.assert_called_once_with(
         args, mock_get_instance_config.return_value
@@ -1227,6 +1231,7 @@ def test_paasta_spark_run_pyspark(
         k8s_server_address=None,
         tronfig=None,
         job_id=None,
+        use_web_identity=False,
     )
     mock_load_system_paasta_config_utils.return_value.get_kube_clusters.return_value = (
         {}
@@ -1265,6 +1270,7 @@ def test_paasta_spark_run_pyspark(
         profile_name=None,
         assume_aws_role_arn=None,
         session_duration=3600,
+        use_web_identity=False,
     )
     mock_get_docker_image.assert_called_once_with(
         args, mock_get_instance_config.return_value


### PR DESCRIPTION
## Changes
- Picking up from https://github.com/Yelp/paasta/pull/3787
- `args.no_aws_credentials` was removed in https://github.com/Yelp/paasta/pull/3679 [[error](https://fluffy.yelpcorp.com/i/VHnLpxxbNCxSN5QmdVnt0BMtj1R81C2Q.html)]
- [x] Waiting on being merged https://github.com/Yelp/service_configuration_lib/pull/137
- `get_signalfx_url()` was deleted in https://github.com/Yelp/service_configuration_lib/pull/143
   - Should be safe because the dashboard says that the license has expired