### PR TITLE
optional min/max instance values instead of defaults

### DIFF
--- a/paasta_tools/contrib/service_shard_update.py
+++ b/paasta_tools/contrib/service_shard_update.py
@@ -56,14 +56,12 @@ def parse_args():
         "--min-instance-count",
         help="If a deploy group is added, the min_instance count to create it with",
         required=False,
-        default=1,
         dest="min_instance_count",
     )
     parser.add_argument(
         "--prod-max-instance-count",
         help="If a deploy group is added, the prod max_instance count to create it with",
         required=False,
-        default=100,
         type=int,
         dest="prod_max_instance_count",
     )
@@ -71,7 +69,6 @@ def parse_args():
         "--non-prod-max-instance-count",
         help="If a deploy group is added, the non-prod max_instance count to create it with",
         required=False,
-        default=5,
         type=int,
         dest="non_prod_max_instance_count",
     )
@@ -194,14 +191,28 @@ def main(args):
 
                     instance_config = {
                         "deploy_group": f"{deploy_prefix}.{args.shard_name}",
-                        "min_instances": args.min_instance_count,
-                        "max_instances": args.prod_max_instance_count
-                        if deploy_prefix == "prod"
-                        else args.non_prod_max_instance_count,
                         "env": {
                             "PAASTA_SECRET_BUGSNAG_API_KEY": "SECRET(bugsnag_api_key)",
                         },
                     }
+
+                    if args.min_instance_count is not None:
+                        instance_config["min_instances"] = args.min_instance_count
+
+                    if (
+                        args.prod_max_instance_count is not None
+                        and deploy_prefix == "prod"
+                    ):
+                        instance_config["max_instances"] = args.prod_max_instance_count
+
+                    if (
+                        args.non_prod_max_instance_count is not None
+                        and deploy_prefix != "prod"
+                    ):
+                        instance_config[
+                            "max_instances"
+                        ] = args.non_prod_max_instance_count
+
                     if args.metrics_provider is not None or args.setpoint is not None:
                         instance_config["autoscaling"] = {}
                         if args.metrics_provider is not None:


### PR DESCRIPTION
Our auto created shards are being instantiated with a minimum/maximum of the defaults described in the diff. Eventually we’d like to only define autotune cpu configs, so this PR allows us to not define any min/max if desired