### PR TITLE
remove offset from paasta

### DIFF
--- a/docs/source/autoscaling.rst
+++ b/docs/source/autoscaling.rst
@@ -90,28 +90,6 @@ The currently available decicion policies are:
 
   Extra parameters:
 
-  :offset:
-    Float between 0.0 and 1.0, representing expected baseline load for each container.
-    Defaults to 0.0.
-
-    **DEPRECATED** - while it was previously more complicated, offset is now simply subtracted from your setpoint.
-    For example, ``setpoint: 0.6`` with ``offset: 0.25`` is equivalent to ``setpoint: 0.35`` with no ``offset``.
-    We recommend you just lower your setpoint by the same amount and remove the ``offset``.
-
-    Previously, offset was used to counteract the fake utilization that would be seen by our old uWSGI metrics provider.
-    Under the old system, the uWSGI metrics provider would always see 1 extra worker busy, because the metrics query was proxied through the actual uWSGI workers.
-    Having the autoscaler understand how much load was fake and how much was real helped it converge faster to your target load.
-    Nowadays, we measure uWSGI utilization in a different way that does not use a uWSGI worker, so this is no longer necessary.
-    Support for ``offset`` was only retained to provide a smooth transition from the old system to the new system.
-
-  :good_enough_window:
-    **Not currently supported**
-    An array of two utilization values [low, high].
-    If utilization per container at the forecasted total load is within the window, instances will not scale.
-    Optional parameter (defaults to None).
-
-    This is not currently supported under Kubernetes (see PAASTA-17262), but Kubernetes has a `global 10% tolerance by default. <https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details>`_
-    This is equivalent to a good_enough_window of ``[0.9*setpoint, 1.1*setpoint]``
   :moving_average_window_seconds:
     The number of seconds to load data points over in order to calculate the average.
     Defaults to 1800s (30m).

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -632,13 +632,11 @@ def validate_autoscaling_configs(service_path):
                     # default setpoint for all metrics providers so we are safe to
                     # unconditionally read it
                     setpoint = autoscaling_params["setpoint"]
-                    offset = autoscaling_params.get("offset", 0)
-                    if setpoint - offset <= 0:
+                    if setpoint <= 0:
                         returncode = False
                         print(
                             failure(
-                                msg="Autoscaling configuration is invalid: offset must be "
-                                f"smaller than setpoint\n\t(setpoint: {setpoint} | offset: {offset})",
+                                msg="Autoscaling configuration is invalid: setpoint must be greater than zero",
                                 link="",
                             )
                         )

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -217,9 +217,6 @@
                                 "current"
                             ]
                         },
-                        "offset": {
-                            "type": "number"
-                        },
                         "moving_average_window_seconds": {
                             "type": "integer"
                         },

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -46,7 +46,6 @@ class AutoscalingParamsDict(TypedDict, total=False):
     setpoint: float
     desired_active_requests_per_replica: int
     forecast_policy: Optional[str]
-    offset: Optional[float]
     moving_average_window_seconds: Optional[int]
     use_prometheus: bool
     use_resource_metrics: bool

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -62,7 +62,6 @@ from paasta_tools.long_running_service_tools import (
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_services_for_cluster
-from paasta_tools.utils import load_system_paasta_config
 
 log = logging.getLogger(__name__)
 
@@ -378,11 +377,6 @@ def create_instance_uwsgi_scaling_rule(
     moving_average_window = autoscaling_config.get(
         "moving_average_window_seconds", DEFAULT_UWSGI_AUTOSCALING_MOVING_AVERAGE_WINDOW
     )
-    # this should always be set, but we default to 0 for safety as the worst thing that would happen
-    # is that we take a couple more iterations than required to hit the desired setpoint
-    offset = autoscaling_config.get("offset", 0)
-    offset_multiplier = load_system_paasta_config().get_uwsgi_offset_multiplier()
-
     deployment_name = get_kubernetes_app_name(service=service, instance=instance)
 
     # In order for autoscaling to work safely while a service migrates from one namespace to another, the HPA needs to
@@ -441,7 +435,7 @@ def create_instance_uwsgi_scaling_rule(
     )
     """
     desired_instances_at_each_point_in_time = f"""
-        {total_load} / {setpoint - (offset * offset_multiplier)}
+        {total_load} / {setpoint}
     """
     desired_instances = f"""
         avg_over_time(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2056,7 +2056,6 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     spark_blockmanager_port: int
     skip_cpu_burst_validation: List[str]
     tron_default_pool_override: str
-    uwsgi_offset_multiplier: float
     spark_kubeconfig: str
     kube_clusters: Dict
     spark_use_eks_default: bool
@@ -2858,15 +2857,6 @@ class SystemPaastaConfig:
         tron master -> compute cluster override which this function will read.
         """
         return self.config_dict.get("tron_k8s_cluster_overrides", {})
-
-    def get_uwsgi_offset_multiplier(self) -> float:
-        """
-        Temporary configuration to allow us to slowly deprecate the usage of `offset` in uwsgi-based autoscaling
-        configurations without making a single massive change to how usage is calculated.
-
-        To be removed once PAASTA-17840 is done.
-        """
-        return self.config_dict.get("uwsgi_offset_multiplier", 1.0)
 
     def get_spark_kubeconfig(self) -> str:
         return self.config_dict.get("spark_kubeconfig", "/etc/kubernetes/spark.conf")

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -1584,63 +1584,6 @@ def test_proportional_decision_policy(mock_fetch_historical_load):
 
 
 @mock.patch(
-    "paasta_tools.autoscaling.autoscaling_service_lib.fetch_historical_load",
-    autospec=True,
-    return_value=[],
-)
-def test_proportional_decision_policy_nonzero_offset(mock_fetch_historical_load):
-    common_kwargs = {
-        "zookeeper_path": "/test",
-        "current_instances": 10,
-        "num_healthy_instances": 10,
-        "min_instances": 5,
-        "max_instances": 15,
-        "forecast_policy": "current",
-        "offset": 0.2,
-        "persist_data": False,
-    }
-
-    # if utilization == setpoint, delta should be 0.
-    assert 0 == autoscaling_service_lib.proportional_decision_policy(
-        setpoint=0.5, utilization=0.5, **common_kwargs
-    )
-
-    # if utilization is fairly close to setpoint, delta should be 0.
-    assert 0 == autoscaling_service_lib.proportional_decision_policy(
-        setpoint=0.5,
-        utilization=0.514,  # Just under 0.515 = (0.5 - 0.2) * 1.05 + 0.2
-        **common_kwargs,
-    )
-    assert 0 == autoscaling_service_lib.proportional_decision_policy(
-        setpoint=0.5,
-        utilization=0.486,  # Just over 0.485 = (0.5 - 0.2) * 0.95 + 0.2
-        **common_kwargs,
-    )
-
-    assert 1 == autoscaling_service_lib.proportional_decision_policy(
-        setpoint=0.5,
-        utilization=0.516,  # Just over 0.515 = (0.5 - 0.2) * 1.05 + 0.2
-        **common_kwargs,
-    )
-
-    assert -1 == autoscaling_service_lib.proportional_decision_policy(
-        setpoint=0.5,
-        utilization=0.484,  # Just under 0.485 = (0.5 - 0.2) * 0.95 + 0.2
-        **common_kwargs,
-    )
-
-    # If we're 50% overutilized, scale up by 50%
-    assert 5 == autoscaling_service_lib.proportional_decision_policy(
-        setpoint=0.5, utilization=0.65, **common_kwargs
-    )
-
-    # If we're 50% underutilized, scale down by 50%
-    assert -5 == autoscaling_service_lib.proportional_decision_policy(
-        setpoint=0.5, utilization=0.35, **common_kwargs
-    )
-
-
-@mock.patch(
     "paasta_tools.autoscaling.autoscaling_service_lib.save_historical_load",
     autospec=True,
 )

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2367,8 +2367,7 @@ class TestKubernetesDeploymentConfig:
                 "max_instances": 3,
                 "autoscaling": {
                     "metrics_provider": "uwsgi",
-                    "setpoint": 0.5,
-                    "offset": 0.1,
+                    "setpoint": 0.4,
                     "forecast_policy": "moving_average",
                     "moving_average_window_seconds": 300,
                 },

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -110,17 +110,11 @@ def test_create_instance_active_requests_scaling_rule(
         get_registrations=mock.Mock(return_value=registrations),
     )
     paasta_cluster = "test_cluster"
-
-    with mock.patch(
-        "paasta_tools.setup_prometheus_adapter_config.load_system_paasta_config",
-        autospec=True,
-        return_value=MOCK_SYSTEM_PAASTA_CONFIG,
-    ):
-        rule = create_instance_active_requests_scaling_rule(
-            service=service_name,
-            instance_config=instance_config,
-            paasta_cluster=paasta_cluster,
-        )
+    rule = create_instance_active_requests_scaling_rule(
+        service=service_name,
+        instance_config=instance_config,
+        paasta_cluster=paasta_cluster,
+    )
 
     # we test that the format of the dictionary is as expected with mypy
     # and we don't want to test the full contents of the retval since then
@@ -213,17 +207,11 @@ def test_create_instance_uwsgi_scaling_rule() -> None:
         ),
     )
     paasta_cluster = "test_cluster"
-
-    with mock.patch(
-        "paasta_tools.setup_prometheus_adapter_config.load_system_paasta_config",
-        autospec=True,
-        return_value=MOCK_SYSTEM_PAASTA_CONFIG,
-    ):
-        rule = create_instance_uwsgi_scaling_rule(
-            service=service_name,
-            instance_config=instance_config,
-            paasta_cluster=paasta_cluster,
-        )
+    rule = create_instance_uwsgi_scaling_rule(
+        service=service_name,
+        instance_config=instance_config,
+        paasta_cluster=paasta_cluster,
+    )
 
     # we test that the format of the dictionary is as expected with mypy
     # and we don't want to test the full contents of the retval since then
@@ -377,17 +365,11 @@ def test_create_instance_gunicorn_scaling_rule() -> None:
         ),
     )
     paasta_cluster = "test_cluster"
-
-    with mock.patch(
-        "paasta_tools.setup_prometheus_adapter_config.load_system_paasta_config",
-        autospec=True,
-        return_value=MOCK_SYSTEM_PAASTA_CONFIG,
-    ):
-        rule = create_instance_gunicorn_scaling_rule(
-            service=service_name,
-            instance_config=instance_config,
-            paasta_cluster=paasta_cluster,
-        )
+    rule = create_instance_gunicorn_scaling_rule(
+        service=service_name,
+        instance_config=instance_config,
+        paasta_cluster=paasta_cluster,
+    )
 
     # we test that the format of the dictionary is as expected with mypy
     # and we don't want to test the full contents of the retval since then
@@ -476,21 +458,16 @@ def test_get_rules_for_service_instance(
     instance_config: KubernetesDeploymentConfig,
     expected_rules: int,
 ) -> None:
-    with mock.patch(
-        "paasta_tools.setup_prometheus_adapter_config.load_system_paasta_config",
-        autospec=True,
-        return_value=MOCK_SYSTEM_PAASTA_CONFIG,
-    ):
-        assert (
-            len(
-                get_rules_for_service_instance(
-                    service_name="service",
-                    instance_config=instance_config,
-                    paasta_cluster="cluster",
-                )
+    assert (
+        len(
+            get_rules_for_service_instance(
+                service_name="service",
+                instance_config=instance_config,
+                paasta_cluster="cluster",
             )
-            == expected_rules
         )
+        == expected_rules
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
To ship once https://github.yelpcorp.com/sysgit/yelpsoa-configs/pull/43202 lands.

We remove offset from PaaSTA since we won't be using it anymore.

# Testing Done
- Diff between Prometheus adapter config before and after is empty
- `make test` passes