### PR TITLE
multiple metrics support for paasta

### DIFF
--- a/paasta_tools/autoscaling/autoscaling_service_lib.py
+++ b/paasta_tools/autoscaling/autoscaling_service_lib.py
@@ -91,7 +91,7 @@ ServiceAutoscalingInfo = namedtuple(
 )
 
 
-SERVICE_METRICS_PROVIDER_KEY = "metrics_provider"
+SERVICE_METRICS_PROVIDER_KEY = "metrics_providers"
 DECISION_POLICY_KEY = "decision_policy"
 
 AUTOSCALING_DELAY = 300
@@ -566,7 +566,7 @@ def get_new_instance_count(
     persist_data: bool,
 ):
     autoscaling_decision_policy = get_decision_policy(
-        autoscaling_params[DECISION_POLICY_KEY]
+        autoscaling_params[SERVICE_METRICS_PROVIDER_KEY][0][DECISION_POLICY_KEY]
     )
 
     zookeeper_path = compose_autoscaling_zookeeper_root(
@@ -605,7 +605,7 @@ def get_utilization(
     mesos_tasks,
 ):
     autoscaling_metrics_provider = get_service_metrics_provider(
-        autoscaling_params[SERVICE_METRICS_PROVIDER_KEY]
+        autoscaling_params[SERVICE_METRICS_PROVIDER_KEY][0]
     )
 
     return autoscaling_metrics_provider(
@@ -652,7 +652,7 @@ def autoscale_marathon_instance(
             )
             error = get_error_from_utilization(
                 utilization=utilization,
-                setpoint=autoscaling_params["setpoint"],
+                setpoint=autoscaling_params["metrics_providers"][0]["setpoint"],
                 current_instances=current_instances,
             )
             num_healthy_instances = len(marathon_tasks)
@@ -762,7 +762,7 @@ def _record_autoscaling_decision(
         "paasta_cluster": marathon_service_config.cluster,
         "paasta_instance": marathon_service_config.instance,
         "paasta_pool": marathon_service_config.get_pool(),
-        "decision_policy": autoscaling_params[DECISION_POLICY_KEY],  # type: ignore
+        "decision_policy": autoscaling_params[SERVICE_METRICS_PROVIDER_KEY][0][DECISION_POLICY_KEY],  # type: ignore
     }
     if yelp_meteorite:
         gauge = yelp_meteorite.create_gauge("paasta.service.instances", meteorite_dims)
@@ -802,7 +802,9 @@ def get_configs_of_services_to_scale(
             if (
                 instance_config.get_max_instances()
                 and instance_config.get_desired_state() == "start"
-                and instance_config.get_autoscaling_params()["decision_policy"]
+                and instance_config.get_autoscaling_params()["metrics_providers"][0][
+                    "decision_policy"
+                ]
                 != "bespoke"
             ):
                 configs.append(instance_config)

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -28,6 +28,7 @@ from typing import cast
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Set
 from typing import Tuple
 from typing import Union
 
@@ -680,6 +681,7 @@ def validate_autoscaling_configs(service_path: str) -> bool:
     """
     soa_dir, service = path_to_soa_dir_service(service_path)
     returncode = True
+    link = ""
     skip_cpu_override_validation_list = (
         load_system_paasta_config().get_skip_cpu_override_validation_services()
     )
@@ -711,10 +713,31 @@ def validate_autoscaling_configs(service_path: str) -> bool:
                 should_skip_cpu_override_validation = (
                     service in skip_cpu_override_validation_list
                 )
+                seen_provider_types: Set[str] = set()
+                configured_provider_count = len(autoscaling_params["metrics_providers"])
 
                 for metrics_provider in autoscaling_params["metrics_providers"]:
                     try:
+                        # Generic validation of the config
                         _validate_autoscaling_config(metrics_provider)
+
+                        # Multi-metrics specific validation:
+                        # 1. Bespoke policies cannot use multi-metrics scaling
+                        # 2. Can't set the same metrics provider multiple times
+                        if (
+                            metrics_provider.get("decision_policy") == "bespoke"
+                            and configured_provider_count > 1
+                        ):
+                            raise AutoscalingValidationError(
+                                f"cannot use bespoke autoscaling with HPA autoscaling"
+                            )
+                        if metrics_provider["type"] in seen_provider_types:
+                            raise AutoscalingValidationError(
+                                f"cannot set the same metrics provider multiple times: {metrics_provider['type']}"
+                            )
+                        seen_provider_types.add(metrics_provider["type"])
+
+                        # Metrics-provider specific validations
                         if metrics_provider["type"] == METRICS_PROVIDER_ACTIVE_REQUESTS:
                             _validate_active_requests_autoscaling_configs(
                                 instance_config, metrics_provider
@@ -746,6 +769,14 @@ def validate_autoscaling_configs(service_path: str) -> bool:
                                 use_ruamel=True,
                             )
                             if config[instance].get("cpus") is None:
+                                # If we're using multiple scaling metrics and one of them is CPU, we must
+                                # opt out of CPU autotuning
+                                if configured_provider_count > 1:
+                                    link = "y/override-cpu-autotune"
+                                    raise AutoscalingValidationError(
+                                        "using CPU-based scaling with multiple scaling metrics requires explicit "
+                                        "'cpus' setting; see the following link for more info:"
+                                    )
                                 # cpu autoscaled, but using autotuned values - can skip
                                 continue
 
@@ -763,20 +794,17 @@ def validate_autoscaling_configs(service_path: str) -> bool:
                                 )
                                 is None
                             ):
-                                returncode = False
-                                print(
-                                    failure(
-                                        msg=f"CPU override detected for a CPU-autoscaled instance in {cluster}: {service}.{instance}. Please read "
-                                        "the following link for next steps:",
-                                        link="y/override-cpu-autotune",
-                                    )
+                                link = "y/override-cpu-autotune"
+                                raise AutoscalingValidationError(
+                                    f"CPU override detected for a CPU-autoscaled instance; "
+                                    "see the following link for next steps:"
                                 )
                     except AutoscalingValidationError as e:
                         returncode = False
                         print(
                             failure(
                                 msg=f"Autoscaling validation failed for {service}.{instance} in {cluster}: {str(e)}",
-                                link="",
+                                link=link,
                             )
                         )
 

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -53,9 +53,15 @@ from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import PaastaColors
 from paasta_tools.cli.utils import success
 from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
-from paasta_tools.long_running_service_tools import AutoscalingParamsDict
 from paasta_tools.long_running_service_tools import DEFAULT_AUTOSCALING_SETPOINT
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_ACTIVE_REQUESTS
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_CPU
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_GUNICORN
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_PISCINA
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_PROMQL
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI
+from paasta_tools.long_running_service_tools import MetricsProviderDict
 from paasta_tools.secret_tools import get_secret_name_from_ref
 from paasta_tools.secret_tools import is_secret_ref
 from paasta_tools.secret_tools import is_shared_secret
@@ -134,12 +140,24 @@ K8S_TYPES = {"eks", "kubernetes"}
 INVALID_AUTOSCALING_FIELDS = {
     # setpoint isn't included here because we need to confirm that setpoint = 0.8
     # (since it's auto-added at parse-time)
-    "active-requests": {"prometheus-adapter-config"},
-    "cpu": {"desired_active_requests_per_replica", "prometheus-adapter-config"},
-    "gunicorn": {"desired_active_requests_per_replica", "prometheus-adapter-config"},
-    "piscina": {"desired_active_requests_per_replica", "prometheus-adapter-config"},
-    "uwsgi": {"desired_active_requests_per_replica", "prometheus-adapter-config"},
-    "arbitrary_promql": {"desired_active_requests_per_replica"},
+    METRICS_PROVIDER_ACTIVE_REQUESTS: {"prometheus-adapter-config"},
+    METRICS_PROVIDER_CPU: {
+        "desired_active_requests_per_replica",
+        "prometheus-adapter-config",
+    },
+    METRICS_PROVIDER_GUNICORN: {
+        "desired_active_requests_per_replica",
+        "prometheus-adapter-config",
+    },
+    METRICS_PROVIDER_PISCINA: {
+        "desired_active_requests_per_replica",
+        "prometheus-adapter-config",
+    },
+    METRICS_PROVIDER_UWSGI: {
+        "desired_active_requests_per_replica",
+        "prometheus-adapter-config",
+    },
+    METRICS_PROVIDER_PROMQL: {"desired_active_requests_per_replica"},
 }
 
 
@@ -609,7 +627,7 @@ def __is_templated(service: str, soa_dir: str, cluster: str, workload: str) -> b
 
 def _validate_active_requests_autoscaling_configs(
     instance_config: LongRunningServiceConfig,
-    autoscaling_params: AutoscalingParamsDict,
+    metrics_provider_config: MetricsProviderDict,
 ) -> None:
     if len(instance_config.get_registrations()) > 1:
         raise AutoscalingValidationError(
@@ -619,7 +637,7 @@ def _validate_active_requests_autoscaling_configs(
     # someone could theoretically bypass this by setting setpoint: 0.8 in their
     # soaconfigs; but I think it's approximately fine for now
     if (
-        autoscaling_params.get("setpoint", DEFAULT_AUTOSCALING_SETPOINT)
+        metrics_provider_config.get("setpoint", DEFAULT_AUTOSCALING_SETPOINT)
         != DEFAULT_AUTOSCALING_SETPOINT
     ):
         raise AutoscalingValidationError(
@@ -628,30 +646,30 @@ def _validate_active_requests_autoscaling_configs(
 
 
 def _validate_arbitrary_promql_autoscaling_configs(
-    autoscaling_params: AutoscalingParamsDict,
-):
+    metrics_provider_config: MetricsProviderDict,
+) -> None:
     # This is a bit incorrect, since the default autoscaling setpoint is 0.8,
     # someone could theoretically bypass this by setting setpoint: 0.8 in their
     # soaconfigs; but I think it's approximately fine for now
     if (
-        autoscaling_params.get("setpoint", DEFAULT_AUTOSCALING_SETPOINT)
+        metrics_provider_config.get("setpoint", DEFAULT_AUTOSCALING_SETPOINT)
         != DEFAULT_AUTOSCALING_SETPOINT
     ):
         raise AutoscalingValidationError(
             "setpoint is not supported for arbitrary PromQL"
         )
-    if not autoscaling_params.get("prometheus_adapter_config"):
+    if not metrics_provider_config.get("prometheus_adapter_config"):
         raise AutoscalingValidationError(
             "arbitrary promql metrics provider requires prometheus_adapter_config to be set"
         )
 
 
-def _validate_autoscaling_config(autoscaling_params: AutoscalingParamsDict):
-    metrics_provider = autoscaling_params["metrics_provider"]
-    for field in INVALID_AUTOSCALING_FIELDS[metrics_provider]:
-        if field in autoscaling_params:
+def _validate_autoscaling_config(metrics_provider_config: MetricsProviderDict) -> None:
+    metrics_provider_type = metrics_provider_config["type"]
+    for field in INVALID_AUTOSCALING_FIELDS[metrics_provider_type]:
+        if field in metrics_provider_config:
             raise AutoscalingValidationError(
-                f"metric provider {metrics_provider} does not support {field}"
+                f"metric provider {metrics_provider_type} does not support {field}"
             )
 
 
@@ -694,69 +712,73 @@ def validate_autoscaling_configs(service_path: str) -> bool:
                     service in skip_cpu_override_validation_list
                 )
 
-                try:
-                    _validate_autoscaling_config(autoscaling_params)
-                    if autoscaling_params["metrics_provider"] == "active-requests":
-                        _validate_active_requests_autoscaling_configs(
-                            instance_config, autoscaling_params
-                        )
-
-                    elif autoscaling_params["metrics_provider"] == "arbitrary_promql":
-                        _validate_arbitrary_promql_autoscaling_configs(
-                            autoscaling_params
-                        )
-
-                    elif (
-                        autoscaling_params["metrics_provider"] == "cpu"
-                        # to enable kew autoscaling we just set a decision policy of "bespoke", but
-                        # the metrics_provider is (confusingly) left as "cpu"
-                        and autoscaling_params.get("decision_policy") != "bespoke"
-                        and not should_skip_cpu_override_validation
-                    ):
-                        # we need access to the comments, so we need to read the config with ruamel to be able
-                        # to actually get them in a "nice" automated fashion
-                        config = get_config_file_dict(
-                            os.path.join(
-                                soa_dir,
-                                service,
-                                f"{instance_config.get_instance_type()}-{cluster}.yaml",
-                            ),
-                            use_ruamel=True,
-                        )
-                        if config[instance].get("cpus") is None:
-                            # cpu autoscaled, but using autotuned values - can skip
-                            continue
-
-                        cpu_comment = _get_comments_for_key(
-                            data=config[instance], key="cpus"
-                        )
-                        # we could probably have a separate error message if there's a comment that doesn't match
-                        # the ack pattern, but that seems like overkill - especially for something that could cause
-                        # a DAR if people aren't being careful.
-                        if (
-                            cpu_comment is None
-                            or re.search(
-                                pattern=OVERRIDE_CPU_AUTOTUNE_ACK_PATTERN,
-                                string=cpu_comment,
+                for metrics_provider in autoscaling_params["metrics_providers"]:
+                    try:
+                        _validate_autoscaling_config(metrics_provider)
+                        if metrics_provider["type"] == METRICS_PROVIDER_ACTIVE_REQUESTS:
+                            _validate_active_requests_autoscaling_configs(
+                                instance_config, metrics_provider
                             )
-                            is None
+
+                        elif metrics_provider["type"] == METRICS_PROVIDER_PROMQL:
+                            _validate_arbitrary_promql_autoscaling_configs(
+                                metrics_provider
+                            )
+
+                        elif (
+                            metrics_provider["type"] == METRICS_PROVIDER_CPU
+                            # to enable kew autoscaling we just set a decision policy of "bespoke", but
+                            # the metrics_provider is (confusingly) left as "cpu"
+                            and metrics_provider.get("decision_policy") != "bespoke"
+                            and not should_skip_cpu_override_validation
                         ):
-                            returncode = False
-                            print(
-                                failure(
-                                    msg=f"CPU override detected for a CPU-autoscaled instance in {cluster}: {service}.{instance}. Please read "
-                                    "the following link for next steps:",
-                                    link="y/override-cpu-autotune",
-                                )
+                            # Do some extra validation below: we don't abstract that into the above function
+                            # call because it needs a lot of extra information
+
+                            # we need access to the comments, so we need to read the config with ruamel to be able
+                            # to actually get them in a "nice" automated fashion
+                            config = get_config_file_dict(
+                                os.path.join(
+                                    soa_dir,
+                                    service,
+                                    f"{instance_config.get_instance_type()}-{cluster}.yaml",
+                                ),
+                                use_ruamel=True,
                             )
-                except AutoscalingValidationError as e:
-                    returncode = False
-                    print(
-                        failure(
-                            msg=f"Autoscaling validation failed for {service}.{instance} in {cluster}: {str(e)}",
-                            link="",
+                            if config[instance].get("cpus") is None:
+                                # cpu autoscaled, but using autotuned values - can skip
+                                continue
+
+                            cpu_comment = _get_comments_for_key(
+                                data=config[instance], key="cpus"
+                            )
+                            # we could probably have a separate error message if there's a comment that doesn't match
+                            # the ack pattern, but that seems like overkill - especially for something that could cause
+                            # a DAR if people aren't being careful.
+                            if (
+                                cpu_comment is None
+                                or re.search(
+                                    pattern=OVERRIDE_CPU_AUTOTUNE_ACK_PATTERN,
+                                    string=cpu_comment,
+                                )
+                                is None
+                            ):
+                                returncode = False
+                                print(
+                                    failure(
+                                        msg=f"CPU override detected for a CPU-autoscaled instance in {cluster}: {service}.{instance}. Please read "
+                                        "the following link for next steps:",
+                                        link="y/override-cpu-autotune",
+                                    )
+                                )
+                    except AutoscalingValidationError as e:
+                        returncode = False
+                        print(
+                            failure(
+                                msg=f"Autoscaling validation failed for {service}.{instance} in {cluster}: {str(e)}",
+                                link="",
+                            )
                         )
-                    )
 
     return returncode
 

--- a/paasta_tools/cli/schemas/autoscaling_schema.json
+++ b/paasta_tools/cli/schemas/autoscaling_schema.json
@@ -84,5 +84,92 @@
             }
         },
         "additionalProperties": false
+    },
+    "metrics_provider_config": {
+        "type": "object",
+        "properties": {
+            "type": {
+                "enum": [
+                    "uwsgi",
+                    "cpu",
+                    "piscina",
+                    "gunicorn",
+                    "arbitrary_promql",
+                    "active-requests"
+                ]
+            },
+            "decision_policy": {
+                "type": "string"
+            },
+            "desired_active_requests_per_replica": {
+                "type": "number"
+            },
+            "setpoint": {
+                "type": "number"
+            },
+            "forecast_policy": {
+                "enum": [
+                    "moving_average",
+                    "current"
+                ]
+            },
+            "moving_average_window_seconds": {
+                "type": "integer"
+            },
+            "prometheus_adapter_config": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "seriesQuery": {
+                        "type": "string"
+                    },
+                    "metricsQuery": {
+                        "type": "string"
+                    },
+                    "resources": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "overrides": {
+                                "type": "object",
+                                "properties": {
+                                    "group": {
+                                        "type": "string"
+                                    },
+                                    "resource": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "template": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "metricsQuery"
+                ]
+            }
+        },
+        "additionalProperties": false
+    },
+    "autoscaling_params_v2": {
+        "type": "object",
+        "properties": {
+            "metrics_providers": {
+                "type": "array",
+                "items": {
+                    "$ref": "#metrics_provider_config"
+                }
+            },
+            "scaledown_policies": {
+                "type": "object"
+            },
+            "max_instances_alert_threshold": {
+                "type": "number"
+            }
+        },
+        "additionalProperties": false
     }
 }

--- a/paasta_tools/cli/schemas/autoscaling_schema.json
+++ b/paasta_tools/cli/schemas/autoscaling_schema.json
@@ -107,6 +107,9 @@
             "setpoint": {
                 "type": "number"
             },
+            "max_instances_alert_threshold": {
+                "type": "number"
+            },
             "forecast_policy": {
                 "enum": [
                     "moving_average",
@@ -165,9 +168,6 @@
             },
             "scaledown_policies": {
                 "type": "object"
-            },
-            "max_instances_alert_threshold": {
-                "type": "number"
             }
         },
         "additionalProperties": false

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -190,7 +190,14 @@
                     "type": "string"
                 },
                 "autoscaling": {
-                    "$ref": "autoscaling_schema.json#autoscaling_params_v1"
+                    "anyOf": [
+                        {
+                            "$ref": "autoscaling_schema.json#autoscaling_params_v1"
+                        },
+                        {
+                            "$ref": "autoscaling_schema.json#autoscaling_params_v2"
+                        }
+                    ]
                 },
                 "sfn_autoscaling": {
                     "type": "object"

--- a/paasta_tools/eks_tools.py
+++ b/paasta_tools/eks_tools.py
@@ -1,9 +1,11 @@
+import copy
 from typing import Optional
 
 import service_configuration_lib
 
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfigDict
+from paasta_tools.paasta_service_config_loader import transform_autoscaling_params_dict
 from paasta_tools.utils import BranchDictV2
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -64,6 +66,15 @@ def load_eks_service_config_no_cache(
     general_config = deep_merge_dictionaries(
         overrides=instance_config, defaults=general_config
     )
+
+    # TODO: remove when yelpsoa-configs is on the new schema (COREJAVA-1339)
+    if (
+        "autoscaling" in general_config
+        and "metrics_providers" not in general_config["autoscaling"]  # type: ignore
+    ):
+        general_config["autoscaling"] = transform_autoscaling_params_dict(  # type: ignore
+            copy.deepcopy(general_config["autoscaling"])  # type: ignore
+        )
 
     branch_dict: Optional[BranchDictV2] = None
     if load_deployments:

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import socket
 from typing import Dict
@@ -39,17 +40,37 @@ DEFAULT_GUNICORN_AUTOSCALING_MOVING_AVERAGE_WINDOW = 1800
 # instantaneous CPU
 DEFAULT_CPU_AUTOSCALING_MOVING_AVERAGE_WINDOW = 60
 
+METRICS_PROVIDER_CPU = "cpu"
+METRICS_PROVIDER_UWSGI = "uwsgi"
+METRICS_PROVIDER_GUNICORN = "gunicorn"
+METRICS_PROVIDER_PISCINA = "piscina"
+METRICS_PROVIDER_ACTIVE_REQUESTS = "active-requests"
+METRICS_PROVIDER_PROMQL = "arbitrary_promql"
 
-class AutoscalingParamsDict(TypedDict, total=False):
-    metrics_provider: str
+ALL_METRICS_PROVIDERS = [
+    METRICS_PROVIDER_CPU,
+    METRICS_PROVIDER_UWSGI,
+    METRICS_PROVIDER_GUNICORN,
+    METRICS_PROVIDER_PISCINA,
+    METRICS_PROVIDER_ACTIVE_REQUESTS,
+    METRICS_PROVIDER_PROMQL,
+]
+
+
+class MetricsProviderDict(TypedDict, total=False):
+    type: str
     decision_policy: str
     setpoint: float
     desired_active_requests_per_replica: int
     forecast_policy: Optional[str]
     moving_average_window_seconds: Optional[int]
     use_resource_metrics: bool
-    scaledown_policies: Optional[dict]
     prometheus_adapter_config: Optional[dict]
+
+
+class AutoscalingParamsDict(TypedDict, total=False):
+    metrics_providers: List[MetricsProviderDict]
+    scaledown_policies: Optional[dict]
     max_instances_alert_threshold: float
 
 
@@ -344,20 +365,49 @@ class LongRunningServiceConfig(InstanceConfig):
         return max(self.get_min_instances(), min(self.get_max_instances(), instances))
 
     def get_autoscaling_params(self) -> AutoscalingParamsDict:
-        default_params: AutoscalingParamsDict = {
-            "metrics_provider": "cpu",
+        default_provider_params: MetricsProviderDict = {
+            "type": METRICS_PROVIDER_CPU,
             "decision_policy": "proportional",
             "setpoint": DEFAULT_AUTOSCALING_SETPOINT,
         }
-        return deep_merge_dictionaries(
-            overrides=self.config_dict.get("autoscaling", AutoscalingParamsDict({})),
-            defaults=default_params,
+
+        params = copy.deepcopy(
+            self.config_dict.get("autoscaling", AutoscalingParamsDict({}))
         )
+        if "metrics_providers" not in params or len(params["metrics_providers"]) == 0:
+            params["metrics_providers"] = [default_provider_params]
+        else:
+            params["metrics_providers"] = [
+                deep_merge_dictionaries(
+                    overrides=provider,
+                    defaults=default_provider_params,
+                )
+                for provider in params["metrics_providers"]
+            ]
+        return params
 
     def get_autoscaling_max_instances_alert_threshold(self) -> float:
         autoscaling_params = self.get_autoscaling_params()
         return autoscaling_params.get(
-            "max_instances_alert_threshold", autoscaling_params["setpoint"]
+            # TODO this default doesn't make sense for metrics providers that don't use setpoint
+            "max_instances_alert_threshold",
+            DEFAULT_AUTOSCALING_SETPOINT,
+        )
+
+    def get_autoscaling_metrics_provider(
+        self, provider_type: str
+    ) -> Optional[MetricsProviderDict]:
+        autoscaling_params = self.get_autoscaling_params()
+        # We only allow one metric provider of each type, so we can bail early if we find a match
+        for provider in autoscaling_params["metrics_providers"]:
+            if provider["type"] == provider_type:
+                return provider
+        return None
+
+    def should_use_metrics_provider(self, provider_type: str) -> bool:
+        return (
+            self.is_autoscaling_enabled()
+            and self.get_autoscaling_metrics_provider(provider_type) is not None
         )
 
     def validate(

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -66,12 +66,12 @@ class MetricsProviderDict(TypedDict, total=False):
     moving_average_window_seconds: Optional[int]
     use_resource_metrics: bool
     prometheus_adapter_config: Optional[dict]
+    max_instances_alert_threshold: float
 
 
 class AutoscalingParamsDict(TypedDict, total=False):
     metrics_providers: List[MetricsProviderDict]
     scaledown_policies: Optional[dict]
-    max_instances_alert_threshold: float
 
 
 class LongRunningServiceConfigDict(InstanceConfigDict, total=False):
@@ -385,14 +385,6 @@ class LongRunningServiceConfig(InstanceConfig):
                 for provider in params["metrics_providers"]
             ]
         return params
-
-    def get_autoscaling_max_instances_alert_threshold(self) -> float:
-        autoscaling_params = self.get_autoscaling_params()
-        return autoscaling_params.get(
-            # TODO this default doesn't make sense for metrics providers that don't use setpoint
-            "max_instances_alert_threshold",
-            DEFAULT_AUTOSCALING_SETPOINT,
-        )
 
     def get_autoscaling_metrics_provider(
         self, provider_type: str

--- a/paasta_tools/paasta_service_config_loader.py
+++ b/paasta_tools/paasta_service_config_loader.py
@@ -220,16 +220,9 @@ def transform_autoscaling_params_dict(
     metrics_provider_type = old_autoscaling_params.pop("metrics_provider", "cpu")
     old_autoscaling_params["type"] = metrics_provider_type
     scaledown_policies = old_autoscaling_params.pop("scaledown_policies", None)
-    max_instances_alert_threshold = old_autoscaling_params.pop(
-        "max_instances_alert_threshold", None
-    )
 
     new_autoscaling_params = {"metrics_providers": [old_autoscaling_params]}
     if scaledown_policies is not None:
         new_autoscaling_params["scaledown_policies"] = scaledown_policies
-    if max_instances_alert_threshold is not None:
-        new_autoscaling_params[
-            "max_instances_alert_threshold"
-        ] = max_instances_alert_threshold
 
     return new_autoscaling_params  # type: ignore

--- a/paasta_tools/paasta_service_config_loader.py
+++ b/paasta_tools/paasta_service_config_loader.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import logging
+from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List
@@ -21,6 +23,7 @@ from typing import Type
 from service_configuration_lib import read_service_configuration
 
 from paasta_tools import utils
+from paasta_tools.long_running_service_tools import AutoscalingParamsDict
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import InstanceConfig_T
@@ -180,6 +183,15 @@ class PaastaServiceConfigLoader:
 
         merged_config = self._get_merged_config(config)
 
+        # These type: ignore annotations will go away once yelpsoa-configs is migrated (COREJAVA-1339)
+        if (
+            "autoscaling" in merged_config
+            and "metrics_providers" not in merged_config["autoscaling"]  # type: ignore
+        ):
+            merged_config["autoscaling"] = transform_autoscaling_params_dict(  # type: ignore
+                copy.deepcopy(merged_config["autoscaling"])  # type: ignore
+            )
+
         temp_instance_config = config_class(
             service=self._service,
             cluster=cluster,
@@ -199,3 +211,25 @@ class PaastaServiceConfigLoader:
             branch_dict=branch_dict,
             soa_dir=self._soa_dir,
         )
+
+
+# Remove this once yelpsoa-configs is using the new format (COREJAVA-1339)
+def transform_autoscaling_params_dict(
+    old_autoscaling_params: Dict[str, Any]
+) -> AutoscalingParamsDict:
+    metrics_provider_type = old_autoscaling_params.pop("metrics_provider", "cpu")
+    old_autoscaling_params["type"] = metrics_provider_type
+    scaledown_policies = old_autoscaling_params.pop("scaledown_policies", None)
+    max_instances_alert_threshold = old_autoscaling_params.pop(
+        "max_instances_alert_threshold", None
+    )
+
+    new_autoscaling_params = {"metrics_providers": [old_autoscaling_params]}
+    if scaledown_policies is not None:
+        new_autoscaling_params["scaledown_policies"] = scaledown_policies
+    if max_instances_alert_threshold is not None:
+        new_autoscaling_params[
+            "max_instances_alert_threshold"
+        ] = max_instances_alert_threshold
+
+    return new_autoscaling_params  # type: ignore

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -22,7 +22,6 @@ from typing import cast
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Tuple
 
 import ruamel.yaml as yaml
 from kubernetes.client import V1ConfigMap
@@ -37,7 +36,7 @@ from paasta_tools.kubernetes_tools import get_kubernetes_app_name
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.kubernetes_tools import V1Pod
-from paasta_tools.long_running_service_tools import AutoscalingParamsDict
+from paasta_tools.long_running_service_tools import ALL_METRICS_PROVIDERS
 from paasta_tools.long_running_service_tools import (
     DEFAULT_ACTIVE_REQUESTS_AUTOSCALING_MOVING_AVERAGE_WINDOW,
 )
@@ -53,6 +52,13 @@ from paasta_tools.long_running_service_tools import (
 from paasta_tools.long_running_service_tools import (
     DEFAULT_UWSGI_AUTOSCALING_MOVING_AVERAGE_WINDOW,
 )
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_ACTIVE_REQUESTS
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_CPU
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_GUNICORN
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_PISCINA
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_PROMQL
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI
+from paasta_tools.long_running_service_tools import MetricsProviderDict
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_services_for_cluster
@@ -72,8 +78,6 @@ PROMETHEUS_ADAPTER_POD_PHASES_TO_REMOVE = (
 DEFAULT_SCRAPE_PERIOD_S = 10
 DEFAULT_EXTRAPOLATION_PERIODS = 10
 DEFAULT_EXTRAPOLATION_TIME = DEFAULT_SCRAPE_PERIOD_S * DEFAULT_EXTRAPOLATION_PERIODS
-
-CPU_METRICS_PROVIDER = "cpu"
 
 K8S_INSTANCE_TYPE_CLASSES = (
     KubernetesDeploymentConfig,
@@ -192,72 +196,57 @@ def _minify_promql(query: str) -> str:
     return (" ".join(trimmed_query)).strip()
 
 
-def should_create_uwsgi_scaling_rule(
-    autoscaling_config: AutoscalingParamsDict,
-) -> Tuple[bool, Optional[str]]:
-    """
-    Determines whether we should configure the prometheus adapter for a given service.
-    Returns a 2-tuple of (should_create, reason_to_skip)
-    """
-    if autoscaling_config["metrics_provider"] == "uwsgi":
-        return True, None
+def create_instance_scaling_rule(
+    service: str,
+    instance_config: KubernetesDeploymentConfig,
+    metrics_provider_config: MetricsProviderDict,
+    paasta_cluster: str,
+) -> Optional[PrometheusAdapterRule]:
+    if metrics_provider_config["type"] == METRICS_PROVIDER_CPU:
+        log.debug("[{service}] prometheus-based CPU scaling is not supported")
+        return None
+    if metrics_provider_config["type"] == METRICS_PROVIDER_UWSGI:
+        return create_instance_uwsgi_scaling_rule(
+            service, instance_config, metrics_provider_config, paasta_cluster
+        )
+    if metrics_provider_config["type"] == METRICS_PROVIDER_PISCINA:
+        return create_instance_piscina_scaling_rule(
+            service, instance_config, metrics_provider_config, paasta_cluster
+        )
+    if metrics_provider_config["type"] == METRICS_PROVIDER_GUNICORN:
+        return create_instance_gunicorn_scaling_rule(
+            service, instance_config, metrics_provider_config, paasta_cluster
+        )
+    if metrics_provider_config["type"] == METRICS_PROVIDER_ACTIVE_REQUESTS:
+        return create_instance_active_requests_scaling_rule(
+            service, instance_config, metrics_provider_config, paasta_cluster
+        )
+    if metrics_provider_config["type"] == METRICS_PROVIDER_PROMQL:
+        return create_instance_arbitrary_promql_scaling_rule(
+            service, instance_config, metrics_provider_config, paasta_cluster
+        )
 
-    return False, "did not request uwsgi autoscaling"
-
-
-def should_create_gunicorn_scaling_rule(
-    autoscaling_config: AutoscalingParamsDict,
-) -> Tuple[bool, Optional[str]]:
-    """
-    Determines whether we should configure the prometheus adapter for a given service.
-    Returns a 2-tuple of (should_create, reason_to_skip)
-    """
-    if autoscaling_config["metrics_provider"] == "gunicorn":
-        return True, None
-
-    return False, "did not request gunicorn autoscaling"
-
-
-def should_create_piscina_scaling_rule(
-    autoscaling_config: AutoscalingParamsDict,
-) -> Tuple[bool, Optional[str]]:
-    """
-    Determines whether we should configure the prometheus adapter for a given service.
-    Returns a 2-tuple of (should_create, reason_to_skip)
-    """
-    if autoscaling_config["metrics_provider"] == "piscina":
-        return True, None
-    return False, "did not request piscina autoscaling"
-
-
-def should_create_active_requests_scaling_rule(
-    autoscaling_config: AutoscalingParamsDict,
-) -> Tuple[bool, Optional[str]]:
-    """
-    Determines whether we should configure the prometheus adapter for a given service.
-    Returns a 2-tuple of (should_create, reason_to_skip)
-    """
-    if autoscaling_config["metrics_provider"] == "active-requests":
-        return True, None
-    return False, "did not request active-requests autoscaling"
+    raise ValueError(
+        f"unknown metrics provider type: {metrics_provider_config['type']}"
+    )
 
 
 def create_instance_active_requests_scaling_rule(
     service: str,
     instance_config: KubernetesDeploymentConfig,
+    metrics_provider_config: MetricsProviderDict,
     paasta_cluster: str,
 ) -> PrometheusAdapterRule:
     """
     Creates a Prometheus adapter rule config for a given service instance.
     """
-    autoscaling_config = instance_config.get_autoscaling_params()
     instance = instance_config.instance
     namespace = instance_config.get_namespace()
-    desired_active_requests_per_replica = autoscaling_config.get(
+    desired_active_requests_per_replica = metrics_provider_config.get(
         "desired_active_requests_per_replica",
         DEFAULT_DESIRED_ACTIVE_REQUESTS_PER_REPLICA,
     )
-    moving_average_window = autoscaling_config.get(
+    moving_average_window = metrics_provider_config.get(
         "moving_average_window_seconds",
         DEFAULT_ACTIVE_REQUESTS_AUTOSCALING_MOVING_AVERAGE_WINDOW,
     )
@@ -356,16 +345,16 @@ def create_instance_active_requests_scaling_rule(
 def create_instance_uwsgi_scaling_rule(
     service: str,
     instance_config: KubernetesDeploymentConfig,
+    metrics_provider_config: MetricsProviderDict,
     paasta_cluster: str,
 ) -> PrometheusAdapterRule:
     """
     Creates a Prometheus adapter rule config for a given service instance.
     """
-    autoscaling_config = instance_config.get_autoscaling_params()
     instance = instance_config.instance
     namespace = instance_config.get_namespace()
-    setpoint = autoscaling_config["setpoint"]
-    moving_average_window = autoscaling_config.get(
+    setpoint = metrics_provider_config["setpoint"]
+    moving_average_window = metrics_provider_config.get(
         "moving_average_window_seconds", DEFAULT_UWSGI_AUTOSCALING_MOVING_AVERAGE_WINDOW
     )
     deployment_name = get_kubernetes_app_name(service=service, instance=instance)
@@ -459,16 +448,16 @@ def create_instance_uwsgi_scaling_rule(
 def create_instance_piscina_scaling_rule(
     service: str,
     instance_config: KubernetesDeploymentConfig,
+    metrics_provider_config: MetricsProviderDict,
     paasta_cluster: str,
 ) -> PrometheusAdapterRule:
     """
     Creates a Prometheus adapter rule config for a given service instance.
     """
-    autoscaling_config = instance_config.get_autoscaling_params()
     instance = instance_config.instance
     namespace = instance_config.get_namespace()
-    setpoint = autoscaling_config["setpoint"]
-    moving_average_window = autoscaling_config.get(
+    setpoint = metrics_provider_config["setpoint"]
+    moving_average_window = metrics_provider_config.get(
         "moving_average_window_seconds",
         DEFAULT_PISCINA_AUTOSCALING_MOVING_AVERAGE_WINDOW,
     )
@@ -555,16 +544,16 @@ def create_instance_piscina_scaling_rule(
 def create_instance_gunicorn_scaling_rule(
     service: str,
     instance_config: KubernetesDeploymentConfig,
+    metrics_provider_config: MetricsProviderDict,
     paasta_cluster: str,
 ) -> PrometheusAdapterRule:
     """
     Creates a Prometheus adapter rule config for a given service instance.
     """
-    autoscaling_config = instance_config.get_autoscaling_params()
     instance = instance_config.instance
     namespace = instance_config.get_namespace()
-    setpoint = autoscaling_config["setpoint"]
-    moving_average_window = autoscaling_config.get(
+    setpoint = metrics_provider_config["setpoint"]
+    moving_average_window = metrics_provider_config.get(
         "moving_average_window_seconds",
         DEFAULT_GUNICORN_AUTOSCALING_MOVING_AVERAGE_WINDOW,
     )
@@ -653,27 +642,15 @@ def create_instance_gunicorn_scaling_rule(
     }
 
 
-def should_create_arbitrary_promql_scaling_rule(
-    autoscaling_config: AutoscalingParamsDict,
-) -> Tuple[bool, Optional[str]]:
-    """
-    Determines whether we should configure the prometheus adapter for a given service.
-    Returns a 2-tuple of (should_create, reason_to_skip)
-    """
-    if autoscaling_config["metrics_provider"] == "arbitrary_promql":
-        return True, None
-    return False, "did not request arbitrary_promql autoscaling"
-
-
 def create_instance_arbitrary_promql_scaling_rule(
     service: str,
     instance_config: KubernetesDeploymentConfig,
+    metrics_provider_config: MetricsProviderDict,
     paasta_cluster: str,
 ) -> PrometheusAdapterRule:
-    autoscaling_config = instance_config.get_autoscaling_params()
     instance = instance_config.instance
     namespace = instance_config.get_namespace()
-    prometheus_adapter_config = autoscaling_config["prometheus_adapter_config"]
+    prometheus_adapter_config = metrics_provider_config["prometheus_adapter_config"]
     deployment_name = get_kubernetes_app_name(service=service, instance=instance)
 
     if "seriesQuery" in prometheus_adapter_config:
@@ -738,33 +715,24 @@ def get_rules_for_service_instance(
     """
     rules: List[PrometheusAdapterRule] = []
 
-    for should_create_scaling_rule, create_instance_scaling_rule in (
-        (
-            should_create_active_requests_scaling_rule,
-            create_instance_active_requests_scaling_rule,
-        ),
-        (should_create_uwsgi_scaling_rule, create_instance_uwsgi_scaling_rule),
-        (should_create_piscina_scaling_rule, create_instance_piscina_scaling_rule),
-        (should_create_gunicorn_scaling_rule, create_instance_gunicorn_scaling_rule),
-    ):
-        should_create, skip_reason = should_create_scaling_rule(
-            autoscaling_config=instance_config.get_autoscaling_params(),
+    for metrics_provider_type in ALL_METRICS_PROVIDERS:
+        metrics_provider_config = instance_config.get_autoscaling_metrics_provider(
+            metrics_provider_type
         )
-        if should_create:
-            rules.append(
-                create_instance_scaling_rule(
-                    service=service_name,
-                    instance_config=instance_config,
-                    paasta_cluster=paasta_cluster,
-                )
-            )
-        else:
+        if metrics_provider_config is None:
             log.debug(
-                "Skipping %s.%s - %s.",
-                service_name,
-                instance_config.instance,
-                skip_reason,
+                f"Skipping {service_name}.{instance_config.instance} - no Prometheus-based autoscaling configured for {metrics_provider_type}"
             )
+            continue
+
+        rule = create_instance_scaling_rule(
+            service=service_name,
+            instance_config=instance_config,
+            metrics_provider_config=metrics_provider_config,
+            paasta_cluster=paasta_cluster,
+        )
+        if rule is not None:
+            rules.append(rule)
 
     return rules
 

--- a/tests/autoscaling/test_autoscaling_service_lib.py
+++ b/tests/autoscaling/test_autoscaling_service_lib.py
@@ -23,9 +23,13 @@ from kazoo.exceptions import NoNodeError
 from paasta_tools import marathon_tools
 from paasta_tools.autoscaling import autoscaling_service_lib
 from paasta_tools.autoscaling.autoscaling_service_lib import autoscaling_is_paused
+from paasta_tools.autoscaling.autoscaling_service_lib import DECISION_POLICY_KEY
 from paasta_tools.autoscaling.autoscaling_service_lib import filter_autoscaling_tasks
 from paasta_tools.autoscaling.autoscaling_service_lib import MAX_TASK_DELTA
 from paasta_tools.autoscaling.autoscaling_service_lib import MetricsProviderNoDataError
+from paasta_tools.autoscaling.autoscaling_service_lib import (
+    SERVICE_METRICS_PROVIDER_KEY,
+)
 from paasta_tools.utils import NoDeploymentsAvailable
 
 
@@ -1083,7 +1087,7 @@ def test_autoscale_services_bespoke_doesnt_autoscale():
             "min_instances": 1,
             "max_instances": 10,
             "desired_state": "start",
-            "autoscaling": {"decision_policy": "bespoke"},
+            "autoscaling": {"metrics_providers": [{"decision_policy": "bespoke"}]},
         },
         branch_dict=None,
     )
@@ -1310,8 +1314,7 @@ def test_get_utilization():
         mock_system_paasta_config = mock.Mock()
         mock_log_utilization_data = mock.Mock()
         mock_autoscaling_params = {
-            autoscaling_service_lib.SERVICE_METRICS_PROVIDER_KEY: "mock_provider",
-            "mock_param": 2,
+            SERVICE_METRICS_PROVIDER_KEY: [{"type": "mock_provider", "mock_param": 2}],
         }
         ret = autoscaling_service_lib.get_utilization(
             marathon_service_config=mock_marathon_service_config,
@@ -1327,8 +1330,7 @@ def test_get_utilization():
             marathon_tasks=mock_marathon_tasks,
             mesos_tasks=mock_mesos_tasks,
             log_utilization_data=mock_log_utilization_data,
-            mock_param=2,
-            metrics_provider="mock_provider",
+            metrics_providers=[{"type": "mock_provider", "mock_param": 2}],
         )
         assert ret == mock_metrics_provider.return_value
 
@@ -1345,8 +1347,12 @@ def test_get_new_instance_count():
         mock_get_decision_policy.return_value = mock_decision_policy
         mock_marathon_service_config = mock.Mock()
         mock_autoscaling_params = {
-            autoscaling_service_lib.DECISION_POLICY_KEY: "mock_dp",
-            "mock_param": 2,
+            SERVICE_METRICS_PROVIDER_KEY: [
+                {
+                    DECISION_POLICY_KEY: "mock_dp",
+                    "mock_param": 2,
+                }
+            ]
         }
         ret = autoscaling_service_lib.get_new_instance_count(
             utilization=0.7,
@@ -1361,9 +1367,8 @@ def test_get_new_instance_count():
             error=0.1,
             current_instances=4,
             zookeeper_path=mock_compose_autoscaling_zookeeper_root.return_value,
-            decision_policy="mock_dp",
+            metrics_providers=[{"decision_policy": "mock_dp", "mock_param": 2}],
             utilization=0.7,
-            mock_param=2,
             num_healthy_instances=4,
             persist_data=False,
         )
@@ -1374,8 +1379,12 @@ def test_get_new_instance_count():
         mock_decision_policy = mock.Mock(return_value=-4)
         mock_get_decision_policy.return_value = mock_decision_policy
         mock_autoscaling_params = {
-            autoscaling_service_lib.DECISION_POLICY_KEY: "mock_dp",
-            "mock_param": 2,
+            SERVICE_METRICS_PROVIDER_KEY: [
+                {
+                    DECISION_POLICY_KEY: "mock_dp",
+                    "mock_param": 2,
+                }
+            ]
         }
         ret = autoscaling_service_lib.get_new_instance_count(
             utilization=0.7,

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -39,6 +39,9 @@ from paasta_tools.cli.cmds.validate import validate_schema
 from paasta_tools.cli.cmds.validate import validate_secrets
 from paasta_tools.cli.cmds.validate import validate_tron
 from paasta_tools.cli.cmds.validate import validate_unique_instance_names
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_ACTIVE_REQUESTS
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_CPU
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI
 from paasta_tools.utils import SystemPaastaConfig
 
 
@@ -1066,8 +1069,9 @@ def test_validate_autoscaling_configs(
                 is_autoscaling_enabled=mock.Mock(return_value=True),
                 get_autoscaling_params=mock.Mock(
                     return_value={
-                        "metrics_provider": "uwsgi",
-                        "setpoint": setpoint,
+                        "metrics_providers": [
+                            {"type": METRICS_PROVIDER_UWSGI, "setpoint": setpoint}
+                        ],
                     }
                 ),
             ),
@@ -1095,32 +1099,42 @@ def test_validate_autoscaling_configs(
     "autoscaling_config,registrations,expected",
     [
         (
+            {"metrics_providers": [{"type": METRICS_PROVIDER_ACTIVE_REQUESTS}]},
+            [],
+            True,
+        ),
+        (
             {
-                "metrics_provider": "active-requests",
+                "metrics_providers": [
+                    {
+                        "type": METRICS_PROVIDER_ACTIVE_REQUESTS,
+                        "desired_active_requests_per_replica": 5,
+                    }
+                ]
             },
             [],
             True,
         ),
         (
             {
-                "metrics_provider": "active-requests",
-                "desired_active_requests_per_replica": 5,
-            },
-            [],
-            True,
-        ),
-        (
-            {
-                "metrics_provider": "active-requests",
-                "desired_active_requests_per_replica": 5,
+                "metrics_providers": [
+                    {
+                        "type": METRICS_PROVIDER_ACTIVE_REQUESTS,
+                        "desired_active_requests_per_replica": 5,
+                    }
+                ]
             },
             ["fake_service.abc"],
             True,
         ),
         (
             {
-                "metrics_provider": "active-requests",
-                "desired_active_requests_per_replica": 5,
+                "metrics_providers": [
+                    {
+                        "type": METRICS_PROVIDER_ACTIVE_REQUESTS,
+                        "desired_active_requests_per_replica": 5,
+                    }
+                ]
             },
             ["fake_service.abc", "fake_service.def"],
             False,
@@ -1201,8 +1215,9 @@ def test_validate_cpu_autotune_override(
                 is_autoscaling_enabled=mock.Mock(return_value=True),
                 get_autoscaling_params=mock.Mock(
                     return_value={
-                        "metrics_provider": "cpu",
-                        "setpoint": 0.8,
+                        "metrics_providers": [
+                            {"type": METRICS_PROVIDER_CPU, "setpoint": 0.8}
+                        ],
                     }
                 ),
             ),

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -1037,70 +1037,53 @@ def test_check_secrets_for_instance_missing_secret(
     )
 
 
-@pytest.mark.parametrize(
-    "setpoint,expected,instance_type",
-    [
-        (0.55, True, "kubernetes"),
-        (0.55, True, "eks"),
-    ],
-)
 @patch(
     "paasta_tools.cli.cmds.validate.load_all_instance_configs_for_service",
     autospec=True,
 )
 @patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
-def test_validate_autoscaling_configs(
-    mock_path_to_soa_dir_service,
-    mock_list_clusters,
-    mock_load_all_instance_configs_for_service,
-    setpoint,
-    expected,
-    instance_type,
-):
-    mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
-    mock_list_clusters.return_value = ["fake_cluster"]
-    mock_load_all_instance_configs_for_service.return_value = [
+@pytest.mark.parametrize(
+    "autoscaling_config,registrations,instance_type,expected",
+    [
         (
-            "fake_instance1",
-            mock.Mock(
-                get_instance=mock.Mock(return_value="fake_instance1"),
-                get_instance_type=mock.Mock(return_value=instance_type),
-                is_autoscaling_enabled=mock.Mock(return_value=True),
-                get_autoscaling_params=mock.Mock(
-                    return_value={
-                        "metrics_providers": [
-                            {"type": METRICS_PROVIDER_UWSGI, "setpoint": setpoint}
-                        ],
-                    }
-                ),
-            ),
-        )
-    ]
-
-    with mock.patch(
-        "paasta_tools.cli.cmds.validate.load_system_paasta_config",
-        autospec=True,
-        return_value=SystemPaastaConfig(
-            config={"skip_cpu_override_validation": ["not-a-real-service"]},
-            directory="/some/test/dir",
+            {"metrics_providers": [{"type": METRICS_PROVIDER_UWSGI, "setpoint": 0.55}]},
+            [],
+            "eks",
+            True,
         ),
-    ):
-        assert validate_autoscaling_configs("fake-service-path") is expected
-
-
-@patch(
-    "paasta_tools.cli.cmds.validate.load_all_instance_configs_for_service",
-    autospec=True,
-)
-@patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
-@patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
-@pytest.mark.parametrize(
-    "autoscaling_config,registrations,expected",
-    [
+        (
+            {"metrics_providers": [{"type": METRICS_PROVIDER_UWSGI, "setpoint": 0.55}]},
+            [],
+            "kubernetes",
+            True,
+        ),
+        (
+            {
+                "metrics_providers": [
+                    {"type": METRICS_PROVIDER_UWSGI, "setpoint": 0.55},
+                    {"type": METRICS_PROVIDER_CPU, "decision_policy": "bespoke"},
+                ]
+            },
+            [],
+            "kubernetes",
+            False,
+        ),
+        (
+            {
+                "metrics_providers": [
+                    {"type": METRICS_PROVIDER_UWSGI, "setpoint": 0.55},
+                    {"type": METRICS_PROVIDER_UWSGI, "setpoint": 0.35},
+                ]
+            },
+            [],
+            "kubernetes",
+            False,
+        ),
         (
             {"metrics_providers": [{"type": METRICS_PROVIDER_ACTIVE_REQUESTS}]},
             [],
+            "kubernetes",
             True,
         ),
         (
@@ -1113,6 +1096,7 @@ def test_validate_autoscaling_configs(
                 ]
             },
             [],
+            "kubernetes",
             True,
         ),
         (
@@ -1125,6 +1109,7 @@ def test_validate_autoscaling_configs(
                 ]
             },
             ["fake_service.abc"],
+            "kubernetes",
             True,
         ),
         (
@@ -1137,16 +1122,18 @@ def test_validate_autoscaling_configs(
                 ]
             },
             ["fake_service.abc", "fake_service.def"],
+            "kubernetes",
             False,
         ),
     ],
 )
-def test_validate_autoscaling_configs_active_requests(
+def test_validate_autoscaling_configs(
     mock_path_to_soa_dir_service,
     mock_list_clusters,
     mock_load_all_instance_configs_for_service,
     autoscaling_config,
     registrations,
+    instance_type,
     expected,
 ):
     mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
@@ -1176,16 +1163,17 @@ def test_validate_autoscaling_configs_active_requests(
 
 
 @pytest.mark.parametrize(
-    "filecontents,expected, instance_type",
+    "has_cpu_override,annotation,expected,instance_type",
     [
-        ("# overridexxx-cpu-setting", False, "kubernetes"),
-        ("# override-cpu-setting", False, "kubernetes"),
-        ("", False, "kubernetes"),
-        ("# override-cpu-setting (PAASTA-17522)", True, "kubernetes"),
-        ("# overridexxx-cpu-setting", False, "eks"),
-        ("# override-cpu-setting", False, "eks"),
-        ("", False, "eks"),
-        ("# override-cpu-setting (PAASTA-17522)", True, "eks"),
+        (True, "# overridexxx-cpu-setting", False, "kubernetes"),
+        (True, "# override-cpu-setting", False, "kubernetes"),
+        (True, "", False, "kubernetes"),
+        (False, "", False, "kubernetes"),
+        (True, "# override-cpu-setting (PAASTA-17522)", True, "kubernetes"),
+        (True, "# overridexxx-cpu-setting", False, "eks"),
+        (True, "# override-cpu-setting", False, "eks"),
+        (True, "", False, "eks"),
+        (True, "# override-cpu-setting (PAASTA-17522)", True, "eks"),
     ],
 )
 @patch("paasta_tools.cli.cmds.validate.get_file_contents", autospec=True)
@@ -1200,10 +1188,16 @@ def test_validate_cpu_autotune_override(
     mock_list_clusters,
     mock_load_all_instance_configs_for_service,
     mock_get_file_contents,
-    filecontents,
+    has_cpu_override,
+    annotation,
     expected,
     instance_type,
 ):
+    metrics_providers = [
+        {"type": METRICS_PROVIDER_CPU, "setpoint": 0.8},
+        {"type": METRICS_PROVIDER_UWSGI, "setpoint": 0.4},
+    ]
+
     mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
     mock_list_clusters.return_value = ["fake_cluster"]
     mock_load_all_instance_configs_for_service.return_value = [
@@ -1215,9 +1209,7 @@ def test_validate_cpu_autotune_override(
                 is_autoscaling_enabled=mock.Mock(return_value=True),
                 get_autoscaling_params=mock.Mock(
                     return_value={
-                        "metrics_providers": [
-                            {"type": METRICS_PROVIDER_CPU, "setpoint": 0.8}
-                        ],
+                        "metrics_providers": metrics_providers,
                     }
                 ),
             ),
@@ -1226,7 +1218,11 @@ def test_validate_cpu_autotune_override(
     mock_get_file_contents.return_value = f"""
 ---
 fake_instance1:
-  cpus: 1 {filecontents}
+  mem: 2
+"""
+    if has_cpu_override:
+        mock_get_file_contents.return_value += f"""
+  cpus: 1 {annotation}
 """
 
     with mock.patch(

--- a/tests/kubernetes/application/test_controller_wrapper.py
+++ b/tests/kubernetes/application/test_controller_wrapper.py
@@ -267,7 +267,10 @@ def test_sync_horizontal_pod_autoscaler_do_not_create_hpa_bespoke(
 ):
     mock_client = mock.MagicMock()
     # Create
-    config_dict = {"max_instances": 3, "autoscaling": {"decision_policy": "bespoke"}}
+    config_dict = {
+        "max_instances": 3,
+        "autoscaling": {"metrics_providers": [{"decision_policy": "bespoke"}]},
+    }
     app = setup_app(config_dict, False)
 
     app.sync_horizontal_pod_autoscaler(kube_client=mock_client)

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -2,7 +2,10 @@ import mock
 import pytest
 
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
-from paasta_tools.long_running_service_tools import AutoscalingParamsDict
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_ACTIVE_REQUESTS
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_GUNICORN
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI
+from paasta_tools.long_running_service_tools import MetricsProviderDict
 from paasta_tools.setup_prometheus_adapter_config import _minify_promql
 from paasta_tools.setup_prometheus_adapter_config import (
     create_instance_active_requests_scaling_rule,
@@ -17,64 +20,12 @@ from paasta_tools.setup_prometheus_adapter_config import (
     create_instance_uwsgi_scaling_rule,
 )
 from paasta_tools.setup_prometheus_adapter_config import get_rules_for_service_instance
-from paasta_tools.setup_prometheus_adapter_config import (
-    should_create_active_requests_scaling_rule,
-)
-from paasta_tools.setup_prometheus_adapter_config import (
-    should_create_gunicorn_scaling_rule,
-)
-from paasta_tools.setup_prometheus_adapter_config import (
-    should_create_uwsgi_scaling_rule,
-)
 from paasta_tools.utils import SystemPaastaConfig
 
 MOCK_SYSTEM_PAASTA_CONFIG = SystemPaastaConfig(
     {},
     "/mock/system/configs",
 )
-
-
-@pytest.mark.parametrize(
-    "autoscaling_config,expected",
-    [
-        (
-            {
-                "metrics_provider": "cpu",
-                "decision_policy": "bespoke",
-                "moving_average_window_seconds": 123,
-                "setpoint": 0.653,
-            },
-            False,
-        ),
-        (
-            {
-                "metrics_provider": "active-requests",
-                "moving_average_window_seconds": 124,
-                "desired_active_requests_per_replica": 0.425,
-            },
-            True,
-        ),
-        (
-            {
-                "metrics_provider": "active-requests",
-                "desired_active_requests_per_replica": 0.764,
-            },
-            True,
-        ),
-    ],
-)
-def test_should_create_active_requests_scaling_rule(
-    autoscaling_config: AutoscalingParamsDict, expected: bool
-) -> None:
-    should_create, reason = should_create_active_requests_scaling_rule(
-        autoscaling_config=autoscaling_config
-    )
-
-    assert should_create == expected
-    if expected:
-        assert reason is None
-    else:
-        assert reason is not None
 
 
 @pytest.mark.parametrize(
@@ -96,19 +47,20 @@ def test_create_instance_active_requests_scaling_rule(
     service_name = "test_service"
     instance_config = mock.Mock(
         instance="test_instance",
-        get_autoscaling_params=mock.Mock(
-            return_value={
-                "metrics_provider": "active-requests",
-                "desired_active_requests_per_replica": 12,
-                "moving_average_window_seconds": 20120302,
-            }
-        ),
         get_registrations=mock.Mock(return_value=registrations),
+    )
+    metrics_provider_config = MetricsProviderDict(
+        {
+            "type": METRICS_PROVIDER_ACTIVE_REQUESTS,
+            "desired_active_requests_per_replica": 12,
+            "moving_average_window_seconds": 20120302,
+        }
     )
     paasta_cluster = "test_cluster"
     rule = create_instance_active_requests_scaling_rule(
         service=service_name,
         instance_config=instance_config,
+        metrics_provider_config=metrics_provider_config,
         paasta_cluster=paasta_cluster,
     )
 
@@ -121,80 +73,31 @@ def test_create_instance_active_requests_scaling_rule(
     assert paasta_cluster in rule["seriesQuery"]
     # these two numbers are distinctive and unlikely to be used as constants
     assert (
-        str(
-            instance_config.get_autoscaling_params()[
-                "desired_active_requests_per_replica"
-            ]
-        )
+        str(metrics_provider_config["desired_active_requests_per_replica"])
         in rule["metricsQuery"]
     )
     assert (
-        str(instance_config.get_autoscaling_params()["moving_average_window_seconds"])
+        str(metrics_provider_config["moving_average_window_seconds"])
         in rule["metricsQuery"]
     )
     assert f"paasta_instance='{expected_instance}'" in rule["metricsQuery"]
 
 
-@pytest.mark.parametrize(
-    "autoscaling_config,expected",
-    [
-        (
-            {
-                "metrics_provider": "cpu",
-                "decision_policy": "bespoke",
-                "moving_average_window_seconds": 123,
-                "setpoint": 0.653,
-            },
-            False,
-        ),
-        (
-            {
-                "metrics_provider": "uwsgi",
-                "moving_average_window_seconds": 124,
-                "setpoint": 0.425,
-            },
-            True,
-        ),
-        (
-            {
-                "metrics_provider": "uwsgi",
-                "moving_average_window_seconds": 544,
-                "setpoint": 0.764,
-            },
-            True,
-        ),
-    ],
-)
-def test_should_create_uswgi_scaling_rule(
-    autoscaling_config: AutoscalingParamsDict, expected: bool
-) -> None:
-    should_create, reason = should_create_uwsgi_scaling_rule(
-        autoscaling_config=autoscaling_config
-    )
-
-    assert should_create == expected
-    if expected:
-        assert reason is None
-    else:
-        assert reason is not None
-
-
 def test_create_instance_uwsgi_scaling_rule() -> None:
     service_name = "test_service"
-    instance_config = mock.Mock(
-        instance="test_instance",
-        get_autoscaling_params=mock.Mock(
-            return_value={
-                "metrics_provider": "uwsgi",
-                "setpoint": 0.1234567890,
-                "moving_average_window_seconds": 20120302,
-            }
-        ),
+    instance_config = mock.Mock(instance="test_instance")
+    metrics_provider_config = MetricsProviderDict(
+        {
+            "type": METRICS_PROVIDER_UWSGI,
+            "setpoint": 0.1234567890,
+            "moving_average_window_seconds": 20120302,
+        }
     )
     paasta_cluster = "test_cluster"
     rule = create_instance_uwsgi_scaling_rule(
         service=service_name,
         instance_config=instance_config,
+        metrics_provider_config=metrics_provider_config,
         paasta_cluster=paasta_cluster,
     )
 
@@ -206,68 +109,28 @@ def test_create_instance_uwsgi_scaling_rule() -> None:
     assert instance_config.instance in rule["seriesQuery"]
     assert paasta_cluster in rule["seriesQuery"]
     # these two numbers are distinctive and unlikely to be used as constants
+    assert str(metrics_provider_config["setpoint"]) in rule["metricsQuery"]
     assert (
-        str(instance_config.get_autoscaling_params()["setpoint"])
+        str(metrics_provider_config["moving_average_window_seconds"])
         in rule["metricsQuery"]
     )
-    assert (
-        str(instance_config.get_autoscaling_params()["moving_average_window_seconds"])
-        in rule["metricsQuery"]
-    )
-
-
-@pytest.mark.parametrize(
-    "autoscaling_config,expected",
-    [
-        (
-            {
-                "metrics_provider": "cpu",
-                "decision_policy": "bespoke",
-                "moving_average_window_seconds": 123,
-                "setpoint": 0.653,
-            },
-            False,
-        ),
-        (
-            {
-                "metrics_provider": "gunicorn",
-                "moving_average_window_seconds": 124,
-                "setpoint": 0.425,
-            },
-            True,
-        ),
-    ],
-)
-def test_should_create_gunicorn_scaling_rule(
-    autoscaling_config: AutoscalingParamsDict, expected: bool
-) -> None:
-    should_create, reason = should_create_gunicorn_scaling_rule(
-        autoscaling_config=autoscaling_config
-    )
-
-    assert should_create == expected
-    if expected:
-        assert reason is None
-    else:
-        assert reason is not None
 
 
 def test_create_instance_gunicorn_scaling_rule() -> None:
     service_name = "test_service"
-    instance_config = mock.Mock(
-        instance="test_instance",
-        get_autoscaling_params=mock.Mock(
-            return_value={
-                "metrics_provider": "gunicorn",
-                "setpoint": 0.1234567890,
-                "moving_average_window_seconds": 20120302,
-            }
-        ),
+    instance_config = mock.Mock(instance="test_instance")
+    metrics_provider_config = MetricsProviderDict(
+        {
+            "type": METRICS_PROVIDER_GUNICORN,
+            "setpoint": 0.1234567890,
+            "moving_average_window_seconds": 20120302,
+        }
     )
     paasta_cluster = "test_cluster"
     rule = create_instance_gunicorn_scaling_rule(
         service=service_name,
         instance_config=instance_config,
+        metrics_provider_config=metrics_provider_config,
         paasta_cluster=paasta_cluster,
     )
 
@@ -279,12 +142,9 @@ def test_create_instance_gunicorn_scaling_rule() -> None:
     assert instance_config.instance in rule["seriesQuery"]
     assert paasta_cluster in rule["seriesQuery"]
     # these two numbers are distinctive and unlikely to be used as constants
+    assert str(metrics_provider_config["setpoint"]) in rule["metricsQuery"]
     assert (
-        str(instance_config.get_autoscaling_params()["setpoint"])
-        in rule["metricsQuery"]
-    )
-    assert (
-        str(instance_config.get_autoscaling_params()["moving_average_window_seconds"])
+        str(metrics_provider_config["moving_average_window_seconds"])
         in rule["metricsQuery"]
     )
 
@@ -296,12 +156,14 @@ def test_create_instance_gunicorn_scaling_rule() -> None:
             mock.Mock(
                 instance="instance",
                 get_namespace=mock.Mock(return_value="test_namespace"),
-                get_autoscaling_params=mock.Mock(
-                    return_value={
-                        "metrics_provider": "uwsgi",
+                get_autoscaling_metrics_provider=mock.Mock(
+                    side_effect=lambda x: {
+                        "type": METRICS_PROVIDER_UWSGI,
                         "setpoint": 0.1234567890,
                         "moving_average_window_seconds": 20120302,
                     }
+                    if x == METRICS_PROVIDER_UWSGI
+                    else None
                 ),
             ),
             1,
@@ -347,10 +209,8 @@ def test_create_instance_arbitrary_promql_scaling_rule_no_seriesQuery():
         instance_config=mock.Mock(
             instance="instance",
             get_namespace=mock.Mock(return_value="paasta"),
-            get_autoscaling_params=mock.Mock(
-                return_value={"prometheus_adapter_config": {"metricsQuery": "foo"}}
-            ),
         ),
+        metrics_provider_config={"prometheus_adapter_config": {"metricsQuery": "foo"}},
         paasta_cluster="cluster",
     )
 
@@ -373,15 +233,13 @@ def test_create_instance_arbitrary_promql_scaling_rule_with_seriesQuery():
         instance_config=mock.Mock(
             instance="instance",
             get_namespace=mock.Mock(return_value="test_namespace"),
-            get_autoscaling_params=mock.Mock(
-                return_value={
-                    "prometheus_adapter_config": {
-                        "metricsQuery": "foo",
-                        "seriesQuery": "bar",
-                    }
-                }
-            ),
         ),
+        metrics_provider_config={
+            "prometheus_adapter_config": {
+                "metricsQuery": "foo",
+                "seriesQuery": "bar",
+            }
+        },
         paasta_cluster="cluster",
     )
 

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -3,6 +3,7 @@ import pytest
 
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_ACTIVE_REQUESTS
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_CPU
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_GUNICORN
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI
 from paasta_tools.long_running_service_tools import MetricsProviderDict
@@ -157,16 +158,88 @@ def test_create_instance_gunicorn_scaling_rule() -> None:
                 instance="instance",
                 get_namespace=mock.Mock(return_value="test_namespace"),
                 get_autoscaling_metrics_provider=mock.Mock(
-                    side_effect=lambda x: {
-                        "type": METRICS_PROVIDER_UWSGI,
-                        "setpoint": 0.1234567890,
-                        "moving_average_window_seconds": 20120302,
-                    }
-                    if x == METRICS_PROVIDER_UWSGI
-                    else None
+                    side_effect=lambda x: (
+                        {
+                            "type": METRICS_PROVIDER_CPU,
+                            "setpoint": 0.1234567890,
+                            "moving_average_window_seconds": 20120302,
+                        }
+                        if x == METRICS_PROVIDER_CPU
+                        else None
+                    )
+                ),
+            ),
+            0,
+        ),
+        (
+            mock.Mock(
+                instance="instance",
+                get_namespace=mock.Mock(return_value="test_namespace"),
+                get_autoscaling_metrics_provider=mock.Mock(
+                    side_effect=lambda x: (
+                        {
+                            "type": METRICS_PROVIDER_UWSGI,
+                            "setpoint": 0.1234567890,
+                            "moving_average_window_seconds": 20120302,
+                        }
+                        if x == METRICS_PROVIDER_UWSGI
+                        else None
+                    )
                 ),
             ),
             1,
+        ),
+        (
+            mock.Mock(
+                instance="instance",
+                get_namespace=mock.Mock(return_value="test_namespace"),
+                get_autoscaling_metrics_provider=mock.Mock(
+                    side_effect=lambda x: (
+                        {
+                            "type": METRICS_PROVIDER_UWSGI,
+                            "setpoint": 0.1234567890,
+                            "moving_average_window_seconds": 20120302,
+                        }
+                        if x == METRICS_PROVIDER_UWSGI
+                        else (
+                            {
+                                "type": METRICS_PROVIDER_CPU,
+                                "setpoint": 0.1234567890,
+                                "moving_average_window_seconds": 20120302,
+                            }
+                            if x == METRICS_PROVIDER_CPU
+                            else None
+                        )
+                    )
+                ),
+            ),
+            1,
+        ),
+        (
+            mock.Mock(
+                instance="instance",
+                get_namespace=mock.Mock(return_value="test_namespace"),
+                get_autoscaling_metrics_provider=mock.Mock(
+                    side_effect=lambda x: (
+                        {
+                            "type": METRICS_PROVIDER_UWSGI,
+                            "setpoint": 0.1234567890,
+                            "moving_average_window_seconds": 20120302,
+                        }
+                        if x == METRICS_PROVIDER_UWSGI
+                        else (
+                            {
+                                "type": METRICS_PROVIDER_GUNICORN,
+                                "setpoint": 0.1234567890,
+                                "moving_average_window_seconds": 20120302,
+                            }
+                            if x == METRICS_PROVIDER_GUNICORN
+                            else None
+                        )
+                    )
+                ),
+            ),
+            2,
         ),
     ],
 )


### PR DESCRIPTION
This change introduces the ability to add multiple metrics configs to an HPA via paasta.  We transform the existing AutoscalingParamsDict into a new version that looks like this:

```yaml
metrics_providers:
  - type: cpu
    setpoint: 0.8
  - type: active-requests
    desired_requests_per_replica: 10
scaledown_policies: ...
max_instances_alert_threshold: ...
```

In this PR, we support both the old and the new ways of doing things, and we transform the old autoscaling params dict into the new version when we read the YAML files.  After this PR is shipped, we will do a mass-refactor of yelpsoa into the new format and remove the "transformation" code so that only the new format is supported.  

The first commit shows the bulk of the changes, and the second commit shows additional validation code and tests that are performed.

## Testing done
- make test/tox -e mypy passes (with new tests added)
- paasta validate passes on all existing yelpsoa instances
- paasta validate passes on yelpsoa instances using the new format (just tested locally, there's none of these in production yet)
- setup_prometheus_adapter_config diffs in pnw-prod and nova-prod are empty
- confirmed that the before/after instance configs and the prometheus adapter configs for all of yelpsoa are identical (part of the testing in https://github.yelpcorp.com/sysgit/yelpsoa-configs/pull/43847)

## Open questions
- What to do if someone's using `active-requests` in check_autoscaler_max_instances?  ([link1](https://github.com/Yelp/paasta/pull/3837/files#diff-329d31e4ca35b5deeb89fe08cff4f72d9fc55c9b79ae786e415886f433e2830fR107), [link2](https://github.com/Yelp/paasta/pull/3837/files?diff=split&w=1#diff-719160feb410077ed31b8c62c719bf6d2495cbd251119458fb74ad4aea59942fR394))

cc @sclg-yelp 