### PR TITLE
remove use_prometheus for cpu and uwsgi

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -220,12 +220,6 @@
                         "moving_average_window_seconds": {
                             "type": "integer"
                         },
-                        "use_prometheus": {
-                            "type": "boolean"
-                        },
-                        "use_resource_metrics": {
-                            "type": "boolean"
-                        },
                         "scaledown_policies": {
                             "type": "object"
                         },

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -47,7 +47,6 @@ class AutoscalingParamsDict(TypedDict, total=False):
     desired_active_requests_per_replica: int
     forecast_policy: Optional[str]
     moving_average_window_seconds: Optional[int]
-    use_prometheus: bool
     use_resource_metrics: bool
     scaledown_policies: Optional[dict]
     prometheus_adapter_config: Optional[dict]

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -32,20 +32,14 @@ from kubernetes.client.rest import ApiException
 from mypy_extensions import TypedDict
 
 from paasta_tools.eks_tools import EksDeploymentConfig
-from paasta_tools.kubernetes_tools import DEFAULT_USE_PROMETHEUS_CPU
-from paasta_tools.kubernetes_tools import DEFAULT_USE_PROMETHEUS_UWSGI
 from paasta_tools.kubernetes_tools import ensure_namespace
 from paasta_tools.kubernetes_tools import get_kubernetes_app_name
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
-from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
 from paasta_tools.kubernetes_tools import V1Pod
 from paasta_tools.long_running_service_tools import AutoscalingParamsDict
 from paasta_tools.long_running_service_tools import (
     DEFAULT_ACTIVE_REQUESTS_AUTOSCALING_MOVING_AVERAGE_WINDOW,
-)
-from paasta_tools.long_running_service_tools import (
-    DEFAULT_CPU_AUTOSCALING_MOVING_AVERAGE_WINDOW,
 )
 from paasta_tools.long_running_service_tools import (
     DEFAULT_DESIRED_ACTIVE_REQUESTS_PER_REPLICA,
@@ -206,9 +200,6 @@ def should_create_uwsgi_scaling_rule(
     Returns a 2-tuple of (should_create, reason_to_skip)
     """
     if autoscaling_config["metrics_provider"] == "uwsgi":
-        if not autoscaling_config.get("use_prometheus", DEFAULT_USE_PROMETHEUS_UWSGI):
-            return False, "requested uwsgi autoscaling, but not using Prometheus"
-
         return True, None
 
     return False, "did not request uwsgi autoscaling"
@@ -561,171 +552,6 @@ def create_instance_piscina_scaling_rule(
     }
 
 
-def should_create_cpu_scaling_rule(
-    autoscaling_config: AutoscalingParamsDict,
-) -> Tuple[bool, Optional[str]]:
-    """
-    Determines whether we should configure the prometheus adapter for a given service.
-    Returns a 2-tuple of (should_create, reason_to_skip)
-    """
-    if autoscaling_config["metrics_provider"] == CPU_METRICS_PROVIDER:
-        if not autoscaling_config.get("use_prometheus", DEFAULT_USE_PROMETHEUS_CPU):
-            return False, "requested cpu autoscaling, but not using Prometheus"
-
-        return True, None
-
-    return False, "did not request cpu autoscaling"
-
-
-def create_instance_cpu_scaling_rule(
-    service: str,
-    instance_config: KubernetesDeploymentConfig,
-    paasta_cluster: str,
-) -> PrometheusAdapterRule:
-    """
-    Creates a Prometheus adapter rule config for a given service instance.
-    """
-    autoscaling_config = instance_config.get_autoscaling_params()
-    instance = instance_config.instance
-    namespace = instance_config.get_namespace()
-    deployment_name = get_kubernetes_app_name(service=service, instance=instance)
-    sanitized_instance_name = sanitise_kubernetes_name(instance)
-    metric_name = f"{deployment_name}-cpu-prom"
-    moving_average_window = autoscaling_config.get(
-        "moving_average_window_seconds", DEFAULT_CPU_AUTOSCALING_MOVING_AVERAGE_WINDOW
-    )
-
-    # this series query is a bit of a hack: we don't use the Prometheus adapter as expected (i.e., very generic rules)
-    # but we still need to give it a query that returns something even though we're not going to use the series/label
-    # templates that are auto-extracted for us. That said: we still need this query to return labels that can be tied
-    # back to k8s objects WITHOUT using label_replace
-    series_query = f"""
-        kube_deployment_labels{{
-            deployment='{deployment_name}',
-            paasta_cluster='{paasta_cluster}',
-            namespace='{namespace}'
-        }}
-    """
-
-    cpu_usage = f"""
-        avg(
-            irate(
-                container_cpu_usage_seconds_total{{
-                    namespace='{namespace}',
-                    container='{sanitized_instance_name}',
-                    paasta_cluster='{paasta_cluster}'
-                }}[1m]
-            )
-        ) by (pod, container)
-    """
-
-    cpus_available = f"""
-        sum(
-            container_spec_cpu_quota{{
-                namespace='{namespace}',
-                container='{sanitized_instance_name}',
-                paasta_cluster='{paasta_cluster}'
-            }}
-            / container_spec_cpu_period{{
-                namespace='{namespace}',
-                paasta_cluster='{paasta_cluster}'
-            }}
-        ) by (pod, container)
-    """
-
-    # NOTE: we only have Pod names in our container_cpu* metrics, but we can't get a
-    # Deployment from those consistenly due to k8s limitations on certain field lengths
-    # - thus we need to extract this information from the ReplicaSet name (which is made
-    # possible by the fact that our ReplicaSets are named
-    # {{deployment}}-{{10 character hex string}}) so that our query only considers the
-    # service that we want to autoscale - without this we're only filtering by instance
-    # name and these are very much not unique
-    # k8s:pod:info is an internal recording rule that joins kube_pod_info with
-    # kube_pod_status_phase
-    pod_info_join = f"""
-        on (pod) group_left(kube_deployment) label_replace(
-            k8s:pod:info{{
-                created_by_name=~'{deployment_name}.*',
-                created_by_kind='ReplicaSet',
-                namespace='{namespace}',
-                paasta_cluster='{paasta_cluster}',
-                phase='Running'
-            }},
-            'kube_deployment',
-            '$1',
-            'created_by_name',
-            '(.+)-[a-f0-9]{{10}}'
-        )
-    """
-
-    # get the total usage of all of our Pods divided by the number of CPUs available to
-    # those Pods (i.e., the k8s CPU limit) in order to get the % of CPU used and then add
-    # some labels to this vector
-    load = f"""
-        sum(
-            (({cpu_usage}) / ({cpus_available})) * {pod_info_join}
-        ) by (kube_deployment)
-    """
-
-    current_replicas = f"""
-        (
-            scalar(
-                kube_deployment_spec_replicas{{paasta_cluster='{paasta_cluster}',deployment='{deployment_name}'}} >= 0
-                or
-                max_over_time(
-                    kube_deployment_spec_replicas{{paasta_cluster='{paasta_cluster}',deployment='{deployment_name}'}}[{DEFAULT_EXTRAPOLATION_TIME}s]
-                )
-            )
-        )
-    """
-
-    # we want to calculate:
-    # * the desired replicas based on instantaneous load,
-    # * smooth that over time,
-    # * and then divide by the non-smoothed current number of replicas.
-    # otherwise, if we do the naive thing and take the average of the load inside avg_over_time,
-    # then we'll see the oscillations that we fixed in PR #2862
-    moving_average_load = f"""
-        avg_over_time(({load})[{moving_average_window}s:]) / {current_replicas}
-    """
-
-    # for some reason, during bounces we lose the labels from the previous timeseries (and thus end up with two
-    # timeseries), so we avg these to merge them together
-    # NOTE: we multiply by 100 to return a number between [0, 100] to the HPA
-    moving_average_load_percent = f"avg({moving_average_load}) * 100"
-
-    # we need to do some somwhat hacky label_replaces to inject labels that will then be used for association
-    # without these, the adapter doesn't know what deployment to associate the query result with
-    # NOTE: these labels MUST match the equivalent ones in the seriesQuery
-    metrics_query = f"""
-        label_replace(
-            label_replace(
-                {moving_average_load_percent},
-                'deployment',
-                '{deployment_name}',
-                '',
-                ''
-            ),
-            'namespace',
-            '{namespace}',
-            '',
-            ''
-        )
-    """
-
-    return {
-        "name": {"as": metric_name},
-        "seriesQuery": _minify_promql(series_query),
-        "metricsQuery": _minify_promql(metrics_query),
-        "resources": {
-            "overrides": {
-                "namespace": {"resource": "namespace"},
-                "deployment": {"group": "apps", "resource": "deployments"},
-            },
-        },
-    }
-
-
 def create_instance_gunicorn_scaling_rule(
     service: str,
     instance_config: KubernetesDeploymentConfig,
@@ -919,7 +745,6 @@ def get_rules_for_service_instance(
         ),
         (should_create_uwsgi_scaling_rule, create_instance_uwsgi_scaling_rule),
         (should_create_piscina_scaling_rule, create_instance_piscina_scaling_rule),
-        (should_create_cpu_scaling_rule, create_instance_cpu_scaling_rule),
         (should_create_gunicorn_scaling_rule, create_instance_gunicorn_scaling_rule),
     ):
         should_create, skip_reason = should_create_scaling_rule(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -775,7 +775,6 @@ class TestKubernetesDeploymentConfig:
                 "max_instances": 5,
                 "autoscaling": {
                     "metrics_provider": "uwsgi",
-                    "use_prometheus": True,
                 },
             }
         )
@@ -2256,91 +2255,6 @@ class TestKubernetesDeploymentConfig:
                             ),
                         ),
                     )
-                ],
-                scale_target_ref=V2beta2CrossVersionObjectReference(
-                    api_version="apps/v1",
-                    kind="Deployment",
-                    name="fake_name",
-                ),
-            ),
-        )
-        assert expected_res == return_value
-
-    @pytest.mark.parametrize(
-        "metrics_provider",
-        ("cpu",),
-    )
-    def test_get_autoscaling_metric_spec_cpu_prometheus(self, metrics_provider):
-        # with cpu
-        config_dict = KubernetesDeploymentConfigDict(
-            {
-                "min_instances": 1,
-                "max_instances": 3,
-                "autoscaling": {
-                    "metrics_provider": metrics_provider,
-                    "setpoint": 0.5,
-                    "use_prometheus": True,
-                },
-            }
-        )
-        mock_config = KubernetesDeploymentConfig(  # type: ignore
-            service="service",
-            cluster="cluster",
-            instance="instance",
-            config_dict=config_dict,
-            branch_dict=None,
-        )
-        return_value = KubernetesDeploymentConfig.get_autoscaling_metric_spec(
-            mock_config,
-            "fake_name",
-            "cluster",
-            KubeClient(),
-            "paasta",
-        )
-        annotations: Dict[Any, Any] = {}
-        expected_res = V2beta2HorizontalPodAutoscaler(
-            kind="HorizontalPodAutoscaler",
-            metadata=V1ObjectMeta(
-                name="fake_name",
-                namespace="paasta",
-                annotations=annotations,
-                labels=mock.ANY,
-            ),
-            spec=V2beta2HorizontalPodAutoscalerSpec(
-                behavior=mock_config.get_autoscaling_scaling_policy(
-                    autoscaling_params={},
-                    max_replicas=3,
-                ),
-                max_replicas=3,
-                min_replicas=1,
-                metrics=[
-                    V2beta2MetricSpec(
-                        type="Object",
-                        object=V2beta2ObjectMetricSource(
-                            metric=V2beta2MetricIdentifier(
-                                name=f"service-instance-{metrics_provider}-prom"
-                            ),
-                            described_object=V2beta2CrossVersionObjectReference(
-                                api_version="apps/v1",
-                                kind="Deployment",
-                                name="fake_name",
-                            ),
-                            target=V2beta2MetricTarget(
-                                type="Value",
-                                value=50,
-                            ),
-                        ),
-                    ),
-                    V2beta2MetricSpec(
-                        type="Resource",
-                        resource=V2beta2ResourceMetricSource(
-                            name="cpu",
-                            target=V2beta2MetricTarget(
-                                type="Utilization",
-                                average_utilization=50.0,
-                            ),
-                        ),
-                    ),
                 ],
                 scale_target_ref=V2beta2CrossVersionObjectReference(
                     api_version="apps/v1",


### PR DESCRIPTION
The use_prometheus flag for uwsgi is out of date because all the uwsgi stuff should be using prometheus, and the use_prometheus flag for cpu was an experiment that never went anywhere (or so sayeth @nemacysts).  So let's just delete them both.

## Testing done
- make tests/tox -e mypy
- setup_prometheus_adapter_config diff for nova-prod and pnw-prod is empty
- paasta validate (even using the stricter validation in https://github.com/Yelp/paasta/pull/3835) passes for all yelpsoa services

(following up after https://github.yelpcorp.com/sysgit/yelpsoa-configs/pull/43786)

COREJAVA-1250

cc @sclg-yelp 