### PR TITLE
Add schema validation for service.yaml

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -101,6 +101,7 @@ UNKNOWN_SERVICE = (
 )
 
 SCHEMA_TYPES = {
+    "service",  # service metadata
     "adhoc",
     "kubernetes",  # long-running services
     "rollback",  # automatic rollbacks during deployments

--- a/paasta_tools/cli/schemas/service_schema.json
+++ b/paasta_tools/cli/schemas/service_schema.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "https://docs.google.com/a/yelp.com/document/d/1ZBg5ykniRU30UXj4YcsKfmmnuegQbtR2VuqCAIGi-50/edit",
+    "type": "object",
+    "properties": {
+        "needs_puppet_help": {
+            "type": "boolean"
+        },
+        "description": {
+            "type": "string"
+        },
+        "git_url": {
+            "type": "string",
+            "pattern": "^git@github.yelpcorp.com:[-a-z]+/[-_a-z0-9]+(\\.git)?$",
+            "$comment": "this is obviously very tied to how we name repos at Yelp"
+        },
+        "external_link": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "description",
+        "external_link"
+    ]
+}


### PR DESCRIPTION
This is a tad silly: we have a pre-existing schema in py-gitolite (which we're trying to get rid of), but none in here - which means that folks can attempt to integrate PRs that pass `paasta validate` but that will fail in py-gitolite.

More silliness: the py-gitolite code does not do any validation on `git_url` which means that folks can pass in URLs that dulwich will not be happy with (see COMPINFRA-3914 internally) - so let's add a regex to validate these :)

NOTE: I tested this locally with:
`paasta list | xargs -P10 -n1 --no-run-if-empty paasta validate -y $LOCALSOA -s 2>&1 | rg ✗` and saw that there were no failures (apart from the case from COMPINFRA-3914)