### PR TITLE
Fix make test on Yelpy boxes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ docker_compose_version = 1.26.2
 
 [testenv]
 basepython = python3.8
-passenv = SSH_AUTH_SOCK
+passenv = SSH_AUTH_SOCK PAASTA_ENV DOCKER_HOST
 setenv =
     TZ = UTC
 deps =


### PR DESCRIPTION
Without this change, `make openapi-codegen` will fail on Yelpy boxes using unprivileged containers as moving the generated code from a temp directory to the final location will encounter permissions issues due to falling back to Docker instead of Podman and not passing user/group flags to Docker