### PR TITLE
Pass docker args in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,12 @@ else
 	export INDEX_URL_BUILD_ARG ?= PIP_INDEX_URL
 endif
 
+# If running in CI, pass UID and GID to avoid permission issues
+# since Jenkins does not use Podman
+ifdef CI
+	export DOCKER_OPT_ARGS := --user `id -u`:`id -g`
+endif
+
 .PHONY: all docs test itest k8s_itests quick-test
 
 dev: .paasta/bin/activate

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ docker_compose_version = 1.26.2
 
 [testenv]
 basepython = python3.8
-passenv = SSH_AUTH_SOCK PAASTA_ENV DOCKER_HOST
+passenv = SSH_AUTH_SOCK PAASTA_ENV DOCKER_HOST CI
 setenv =
     TZ = UTC
 deps =


### PR DESCRIPTION
I forgot that Jenkins does not use Podman and needs the uid/gid set for things to work