### PR TITLE
PAASTA-18198: add pool_node_affinities to improve Karpenter AZ balance

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -689,10 +689,7 @@ def registration_label(namespace: str) -> str:
 
 
 def contains_zone_label(node_selectors: Dict[str, NodeSelectorConfig]) -> bool:
-    return any(
-        k in node_selectors
-        for k in ZONE_LABELS
-    )
+    return any(k in node_selectors for k in ZONE_LABELS)
 
 
 class KubernetesDeploymentConfig(LongRunningServiceConfig):

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -681,6 +681,12 @@ def registration_label(namespace: str) -> str:
     return f"registrations.{PAASTA_ATTRIBUTE_PREFIX}{limited_namespace}"
 
 
+def contains_zone_label(node_selectors):
+    return any(k in node_selectors for k in (
+    "topology.kubernetes.io/zone", paasta_prefixed("habitat"), paasta_prefixed("eni_config"), "karpenter.sh/nodepool",
+    "topology.ebs.csi.aws.com/zone"))
+
+
 class KubernetesDeploymentConfig(LongRunningServiceConfig):
     config_dict: KubernetesDeploymentConfigDict
 
@@ -2310,7 +2316,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             # If the service already has a node selector for a zone, we don't want to override it
             if (
                 current_pool_node_affinities
-                and "topology.kubernetes.io/zone" not in node_selectors
+                and not contains_zone_label(node_selectors)
             ):
                 requirements.extend(
                     raw_selectors_to_requirements(

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2139,7 +2139,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         )
         # need to check if there are node selectors/affinities. if there are none
         # and we create an empty affinity object, k8s will deselect all nodes.
-        node_affinity = self.get_node_affinity(system_paasta_config.get_pool_node_selectors())
+        node_affinity = self.get_node_affinity(
+            system_paasta_config.get_pool_node_selectors()
+        )
         if node_affinity is not None:
             pod_spec_kwargs["affinity"] = V1Affinity(node_affinity=node_affinity)
 
@@ -2283,7 +2285,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         node_selectors["yelp.com/pool"] = self.get_pool()
         return node_selectors
 
-    def get_node_affinity(self, pool_node_selectors: Dict[str, Dict[str, Any]] = None) -> Optional[V1NodeAffinity]:
+    def get_node_affinity(
+        self, pool_node_selectors: Dict[str, Dict[str, Any]] = None
+    ) -> Optional[V1NodeAffinity]:
         """Converts deploy_whitelist and deploy_blacklist in node affinities.
 
         note: At the time of writing, `kubectl describe` does not show affinities,
@@ -2302,7 +2306,10 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         if pool_node_selectors:
             current_pool_node_selectors = pool_node_selectors[self.get_pool()]
             # If the service already has a node selector for a zone, we don't want to override it
-            if current_pool_node_selectors and "topology.kubernetes.io/zone" not in node_selectors:
+            if (
+                current_pool_node_selectors
+                and "topology.kubernetes.io/zone" not in node_selectors
+            ):
                 requirements.extend(
                     raw_selectors_to_requirements(
                         raw_selectors=current_pool_node_selectors,

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -682,9 +682,16 @@ def registration_label(namespace: str) -> str:
 
 
 def contains_zone_label(node_selectors):
-    return any(k in node_selectors for k in (
-    "topology.kubernetes.io/zone", paasta_prefixed("habitat"), paasta_prefixed("eni_config"), "karpenter.sh/nodepool",
-    "topology.ebs.csi.aws.com/zone"))
+    return any(
+        k in node_selectors
+        for k in (
+            "topology.kubernetes.io/zone",
+            paasta_prefixed("habitat"),
+            paasta_prefixed("eni_config"),
+            "karpenter.sh/nodepool",
+            "topology.ebs.csi.aws.com/zone",
+        )
+    )
 
 
 class KubernetesDeploymentConfig(LongRunningServiceConfig):
@@ -2314,10 +2321,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         if pool_node_affinities:
             current_pool_node_affinities = pool_node_affinities[self.get_pool()]
             # If the service already has a node selector for a zone, we don't want to override it
-            if (
-                current_pool_node_affinities
-                and not contains_zone_label(node_selectors)
-            ):
+            if current_pool_node_affinities and not contains_zone_label(node_selectors):
                 requirements.extend(
                     raw_selectors_to_requirements(
                         raw_selectors=current_pool_node_affinities,

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2139,7 +2139,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         )
         # need to check if there are node selectors/affinities. if there are none
         # and we create an empty affinity object, k8s will deselect all nodes.
-        node_affinity = self.get_node_affinity(system_paasta_config)
+        node_affinity = self.get_node_affinity(system_paasta_config.get_pool_node_selectors())
         if node_affinity is not None:
             pod_spec_kwargs["affinity"] = V1Affinity(node_affinity=node_affinity)
 
@@ -2283,9 +2283,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         node_selectors["yelp.com/pool"] = self.get_pool()
         return node_selectors
 
-    def get_node_affinity(
-        self, system_paasta_config: SystemPaastaConfig
-    ) -> Optional[V1NodeAffinity]:
+    def get_node_affinity(self, pool_node_selectors: Dict[str, Dict[str, Any]] = None) -> Optional[V1NodeAffinity]:
         """Converts deploy_whitelist and deploy_blacklist in node affinities.
 
         note: At the time of writing, `kubectl describe` does not show affinities,
@@ -2301,16 +2299,15 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 raw_selectors=node_selectors,
             )
         )
-        pool_node_selectors = system_paasta_config.get_pool_node_selectors()[
-            self.get_pool()
-        ]
-        # If the service already has a node selector for a zone, we don't want to override it
-        if pool_node_selectors and "topology.kubernetes.io/zone" not in node_selectors:
-            requirements.extend(
-                raw_selectors_to_requirements(
-                    raw_selectors=pool_node_selectors,
+        if pool_node_selectors:
+            current_pool_node_selectors = pool_node_selectors[self.get_pool()]
+            # If the service already has a node selector for a zone, we don't want to override it
+            if current_pool_node_selectors and "topology.kubernetes.io/zone" not in node_selectors:
+                requirements.extend(
+                    raw_selectors_to_requirements(
+                        raw_selectors=current_pool_node_selectors,
+                    )
                 )
-            )
 
         preferred_terms = []
         for node_selectors_prefered_config_dict in self.config_dict.get(

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -681,7 +681,7 @@ def registration_label(namespace: str) -> str:
     return f"registrations.{PAASTA_ATTRIBUTE_PREFIX}{limited_namespace}"
 
 
-def contains_zone_label(node_selectors):
+def contains_zone_label(node_selectors: Dict[str, NodeSelectorConfig]):
     return any(
         k in node_selectors
         for k in (

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2283,7 +2283,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         node_selectors["yelp.com/pool"] = self.get_pool()
         return node_selectors
 
-    def get_node_affinity(self, system_paasta_config: SystemPaastaConfig) -> Optional[V1NodeAffinity]:
+    def get_node_affinity(
+        self, system_paasta_config: SystemPaastaConfig
+    ) -> Optional[V1NodeAffinity]:
         """Converts deploy_whitelist and deploy_blacklist in node affinities.
 
         note: At the time of writing, `kubectl describe` does not show affinities,
@@ -2299,7 +2301,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 raw_selectors=node_selectors,
             )
         )
-        pool_node_selectors = system_paasta_config.get_pool_node_selectors()[self.get_pool()]
+        pool_node_selectors = system_paasta_config.get_pool_node_selectors()[
+            self.get_pool()
+        ]
         # If the service already has a node selector for a zone, we don't want to override it
         if pool_node_selectors and "topology.kubernetes.io/zone" not in node_selectors:
             requirements.extend(

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2303,6 +2303,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 raw_selectors=node_selectors,
             )
         )
+
         if pool_node_selectors:
             current_pool_node_selectors = pool_node_selectors[self.get_pool()]
             # If the service already has a node selector for a zone, we don't want to override it

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2020,7 +2020,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     pdb_max_unavailable: Union[str, int]
     pki_backend: str
     pod_defaults: Dict[str, Any]
-    pool_node_selectors: Dict[str, Dict[str, any]]
+    pool_node_affinities: Dict[str, Dict[str, List[str]]]
     topology_spread_constraints: List[TopologySpreadConstraintDict]
     previous_marathon_servers: List[MarathonConfigDict]
     readiness_check_prefix_template: List[str]
@@ -2646,9 +2646,9 @@ class SystemPaastaConfig:
     def get_disabled_watchers(self) -> List:
         return self.config_dict.get("disabled_watchers", [])
 
-    def get_pool_node_selectors(self) -> Dict[str, Dict[str, Any]]:
+    def get_pool_node_affinities(self) -> Dict[str, Dict[str, List[str]]]:
         """Node selectors that will be applied to all Pods in a pool"""
-        return self.config_dict.get("pool_node_selectors", {})
+        return self.config_dict.get("pool_node_affinities", {})
 
     def get_topology_spread_constraints(self) -> List[TopologySpreadConstraintDict]:
         """List of TopologySpreadConstraints that will be applied to all Pods in the cluster"""

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2020,6 +2020,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     pdb_max_unavailable: Union[str, int]
     pki_backend: str
     pod_defaults: Dict[str, Any]
+    pool_node_selectors: Dict[str, Dict[str, any]]
     topology_spread_constraints: List[TopologySpreadConstraintDict]
     previous_marathon_servers: List[MarathonConfigDict]
     readiness_check_prefix_template: List[str]
@@ -2644,6 +2645,10 @@ class SystemPaastaConfig:
 
     def get_disabled_watchers(self) -> List:
         return self.config_dict.get("disabled_watchers", [])
+
+    def get_pool_node_selectors(self) -> Dict[str, Dict[str, Any]]:
+        """Node selectors that will be applied to all Pods in a pool"""
+        return self.config_dict.get("pool_node_selectors", {})
 
     def get_topology_spread_constraints(self) -> List[TopologySpreadConstraintDict]:
         """List of TopologySpreadConstraints that will be applied to all Pods in the cluster"""

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1946,9 +1946,7 @@ class TestKubernetesDeploymentConfig:
             soa_dir="/nail/blah",
         )
 
-        assert deployment.get_node_affinity(
-            SystemPaastaConfig({}, "")
-        ) == V1NodeAffinity(
+        assert deployment.get_node_affinity() == V1NodeAffinity(
             required_during_scheduling_ignored_during_execution=V1NodeSelector(
                 node_selector_terms=[
                     V1NodeSelectorTerm(
@@ -1979,7 +1977,7 @@ class TestKubernetesDeploymentConfig:
             soa_dir="/nail/blah",
         )
 
-        assert deployment.get_node_affinity(SystemPaastaConfig({}, "")) is None
+        assert deployment.get_node_affinity() is None
 
     def test_get_node_affinity_with_preferences(self):
         deployment = KubernetesDeploymentConfig(
@@ -2001,9 +1999,7 @@ class TestKubernetesDeploymentConfig:
             soa_dir="/nail/blah",
         )
 
-        assert deployment.get_node_affinity(
-            SystemPaastaConfig({}, "")
-        ) == V1NodeAffinity(
+        assert deployment.get_node_affinity() == V1NodeAffinity(
             required_during_scheduling_ignored_during_execution=V1NodeSelector(
                 node_selector_terms=[
                     V1NodeSelectorTerm(
@@ -2038,16 +2034,7 @@ class TestKubernetesDeploymentConfig:
         Given global node affinity overrides and no deployment specific requirements, the globals should be used
         """
         assert self.deployment.get_node_affinity(
-            SystemPaastaConfig(
-                {
-                    "pool_node_selectors": {
-                        "default": {
-                            "topology.kubernetes.io/zone": ["us-west-1a", "us-west-1b"]
-                        }
-                    }
-                },
-                "",
-            )
+                {"default": {"topology.kubernetes.io/zone": ["us-west-1a", "us-west-1b"]}},
         ) == V1NodeAffinity(
             required_during_scheduling_ignored_during_execution=V1NodeSelector(
                 node_selector_terms=[
@@ -2087,16 +2074,7 @@ class TestKubernetesDeploymentConfig:
             soa_dir="/nail/blah",
         )
         assert deployment.get_node_affinity(
-            SystemPaastaConfig(
-                {
-                    "pool_node_selectors": {
-                        "default": {
-                            "topology.kubernetes.io/zone": ["us-west-1a", "us-west-1b"]
-                        }
-                    }
-                },
-                "",
-            )
+                {"default": {"topology.kubernetes.io/zone": ["us-west-1a", "us-west-1b"]}},
         ) == V1NodeAffinity(
             required_during_scheduling_ignored_during_execution=V1NodeSelector(
                 node_selector_terms=[

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2060,7 +2060,9 @@ class TestKubernetesDeploymentConfig:
             instance="fm",
             cluster="brentford",
             config_dict={
-                "deploy_whitelist": ["habitat", ["us-west-1a"]],
+                "node_selectors": {
+                    "topology.kubernetes.io/zone": "us-west-1a"
+                },
                 "node_selectors_preferred": [
                     {
                         "weight": 1,
@@ -2081,7 +2083,7 @@ class TestKubernetesDeploymentConfig:
                     V1NodeSelectorTerm(
                         match_expressions=[
                             V1NodeSelectorRequirement(
-                                key="yelp.com/habitat",
+                                key="topology.kubernetes.io/zone",
                                 operator="In",
                                 values=["us-west-1a"],
                             ),

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2034,7 +2034,7 @@ class TestKubernetesDeploymentConfig:
         Given global node affinity overrides and no deployment specific requirements, the globals should be used
         """
         assert self.deployment.get_node_affinity(
-                {"default": {"topology.kubernetes.io/zone": ["us-west-1a", "us-west-1b"]}},
+            {"default": {"topology.kubernetes.io/zone": ["us-west-1a", "us-west-1b"]}},
         ) == V1NodeAffinity(
             required_during_scheduling_ignored_during_execution=V1NodeSelector(
                 node_selector_terms=[
@@ -2074,7 +2074,7 @@ class TestKubernetesDeploymentConfig:
             soa_dir="/nail/blah",
         )
         assert deployment.get_node_affinity(
-                {"default": {"topology.kubernetes.io/zone": ["us-west-1a", "us-west-1b"]}},
+            {"default": {"topology.kubernetes.io/zone": ["us-west-1a", "us-west-1b"]}},
         ) == V1NodeAffinity(
             required_during_scheduling_ignored_during_execution=V1NodeSelector(
                 node_selector_terms=[

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2107,6 +2107,40 @@ class TestKubernetesDeploymentConfig:
         )
         assert actual == expected
 
+    def test_get_node_affinity_no_reqs_with_global_override_and_deployment_config(self):
+        """
+        Given global node affinity overrides and deployment specific zone selector, globals should be ignored
+        """
+        deployment = KubernetesDeploymentConfig(
+            service="kurupt",
+            instance="fm",
+            cluster="brentford",
+            config_dict={
+                "node_selectors": {"yelp.com/habitat": ["uswest1astagef"]}
+            },
+            branch_dict=None,
+            soa_dir="/nail/blah",
+        )
+        actual = deployment.get_node_affinity(
+            {"default": {"topology.kubernetes.io/zone": ["us-west-1a", "us-west-1b"]}},
+        )
+        expected = V1NodeAffinity(
+            required_during_scheduling_ignored_during_execution=V1NodeSelector(
+                node_selector_terms=[
+                    V1NodeSelectorTerm(
+                        match_expressions=[
+                            V1NodeSelectorRequirement(
+                                key="yelp.com/habitat",
+                                operator="In",
+                                values=["uswest1astagef"],
+                            ),
+                        ]
+                    )
+                ],
+            )
+        )
+        assert actual == expected
+
     @pytest.mark.parametrize(
         "anti_affinity,expected",
         [

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1946,7 +1946,9 @@ class TestKubernetesDeploymentConfig:
             soa_dir="/nail/blah",
         )
 
-        assert deployment.get_node_affinity(SystemPaastaConfig({}, "")) == V1NodeAffinity(
+        assert deployment.get_node_affinity(
+            SystemPaastaConfig({}, "")
+        ) == V1NodeAffinity(
             required_during_scheduling_ignored_during_execution=V1NodeSelector(
                 node_selector_terms=[
                     V1NodeSelectorTerm(
@@ -1999,7 +2001,9 @@ class TestKubernetesDeploymentConfig:
             soa_dir="/nail/blah",
         )
 
-        assert deployment.get_node_affinity(SystemPaastaConfig({}, "")) == V1NodeAffinity(
+        assert deployment.get_node_affinity(
+            SystemPaastaConfig({}, "")
+        ) == V1NodeAffinity(
             required_during_scheduling_ignored_during_execution=V1NodeSelector(
                 node_selector_terms=[
                     V1NodeSelectorTerm(
@@ -2035,8 +2039,14 @@ class TestKubernetesDeploymentConfig:
         """
         assert self.deployment.get_node_affinity(
             SystemPaastaConfig(
-                {"pool_node_selectors": {"default": {"topology.kubernetes.io/zone": ["us-west-1a", "us-west-1b"]}}},
-                ""
+                {
+                    "pool_node_selectors": {
+                        "default": {
+                            "topology.kubernetes.io/zone": ["us-west-1a", "us-west-1b"]
+                        }
+                    }
+                },
+                "",
             )
         ) == V1NodeAffinity(
             required_during_scheduling_ignored_during_execution=V1NodeSelector(
@@ -2078,8 +2088,14 @@ class TestKubernetesDeploymentConfig:
         )
         assert deployment.get_node_affinity(
             SystemPaastaConfig(
-                {"pool_node_selectors": {"default": {"topology.kubernetes.io/zone": ["us-west-1a", "us-west-1b"]}}},
-                ""
+                {
+                    "pool_node_selectors": {
+                        "default": {
+                            "topology.kubernetes.io/zone": ["us-west-1a", "us-west-1b"]
+                        }
+                    }
+                },
+                "",
             )
         ) == V1NodeAffinity(
             required_during_scheduling_ignored_during_execution=V1NodeSelector(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2107,7 +2107,9 @@ class TestKubernetesDeploymentConfig:
         )
         assert actual == expected
 
-    def test_get_node_affinity_no_reqs_with_global_override_and_deployment_config(self):
+    def test_get_node_affinity_no_reqs_with_global_override_and_deployment_config_habitat(
+        self,
+    ):
         """
         Given global node affinity overrides and deployment specific zone selector, globals should be ignored
         """
@@ -2115,9 +2117,7 @@ class TestKubernetesDeploymentConfig:
             service="kurupt",
             instance="fm",
             cluster="brentford",
-            config_dict={
-                "node_selectors": {"yelp.com/habitat": ["uswest1astagef"]}
-            },
+            config_dict={"node_selectors": {"yelp.com/habitat": ["uswest1astagef"]}},
             branch_dict=None,
             soa_dir="/nail/blah",
         )

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2060,9 +2060,7 @@ class TestKubernetesDeploymentConfig:
             instance="fm",
             cluster="brentford",
             config_dict={
-                "node_selectors": {
-                    "topology.kubernetes.io/zone": "us-west-1a"
-                },
+                "node_selectors": {"topology.kubernetes.io/zone": "us-west-1a"},
                 "node_selectors_preferred": [
                     {
                         "weight": 1,

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2060,7 +2060,7 @@ class TestKubernetesDeploymentConfig:
             instance="fm",
             cluster="brentford",
             config_dict={
-                "node_selectors": {"topology.kubernetes.io/zone": "us-west-1a"},
+                "node_selectors": {"topology.kubernetes.io/zone": ["us-west-1a"]},
                 "node_selectors_preferred": [
                     {
                         "weight": 1,
@@ -2073,9 +2073,10 @@ class TestKubernetesDeploymentConfig:
             branch_dict=None,
             soa_dir="/nail/blah",
         )
-        assert deployment.get_node_affinity(
+        actual = deployment.get_node_affinity(
             {"default": {"topology.kubernetes.io/zone": ["us-west-1a", "us-west-1b"]}},
-        ) == V1NodeAffinity(
+        )
+        expected = V1NodeAffinity(
             required_during_scheduling_ignored_during_execution=V1NodeSelector(
                 node_selector_terms=[
                     V1NodeSelectorTerm(
@@ -2104,6 +2105,7 @@ class TestKubernetesDeploymentConfig:
                 )
             ],
         )
+        assert actual == expected
 
     @pytest.mark.parametrize(
         "anti_affinity,expected",


### PR DESCRIPTION
This adds a new system config option, `pool_node_affinities`.
It's necessary to configure pods with a preselection of preferred 2-3 AZs per pool so that Karpenter does not try to consider all 6+ AZs in a region for scheduling decisions.

This option is a temporary solution and the proper fix will likely be to adopt something like the descheduler to achieve a better AZ balance (along with other benefits).
 
Signed-off-by: Max Falk <gfalk@yelp.com>
