### PR TITLE
Add a timer to some of our slowest cronjobs

### DIFF
--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -48,6 +48,7 @@ from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
 from paasta_tools.kubernetes_tools import update_secret
 from paasta_tools.kubernetes_tools import update_secret_signature
+from paasta_tools.metrics import metrics_lib
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.secret_tools import get_secret_name_from_ref
 from paasta_tools.secret_tools import get_secret_provider
@@ -158,6 +159,14 @@ def main() -> None:
         cluster = args.cluster
     else:
         cluster = system_paasta_config.get_cluster()
+
+    timer = metrics_lib.system_timer(
+        dimensions=dict(
+            cluster=cluster,
+        )
+    )
+
+    timer.start()
     secret_provider_name = system_paasta_config.get_secret_provider_name()
     vault_cluster_config = system_paasta_config.get_vault_cluster_config()
     kube_client = KubeClient()
@@ -170,7 +179,7 @@ def main() -> None:
         )
     )
 
-    sys.exit(0) if sync_all_secrets(
+    result = sync_all_secrets(
         kube_client=kube_client,
         cluster=cluster,
         services_to_k8s_namespaces_to_allowlist=services_to_k8s_namespaces_to_allowlist,
@@ -180,7 +189,12 @@ def main() -> None:
         vault_token_file=args.vault_token_file,
         overwrite_namespace=args.namespace,
         secret_type=args.secret_type,
-    ) else sys.exit(1)
+    )
+    timer.stop(tmp_dimensions={"result": result})
+    logging.info(
+        f"Stopping timer for {cluster} with result {result}: {timer()}ms elapsed"
+    )
+    sys.exit(0) if result else sys.exit(1)
 
 
 def get_services_to_k8s_namespaces_to_allowlist(

--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -190,11 +190,13 @@ def main() -> None:
         overwrite_namespace=args.namespace,
         secret_type=args.secret_type,
     )
-    timer.stop(tmp_dimensions={"result": result})
+    exit_code = 0 if result else 1
+
+    timer.stop(tmp_dimensions={"result": exit_code})
     logging.info(
-        f"Stopping timer for {cluster} with result {result}: {timer()}ms elapsed"
+        f"Stopping timer for {cluster} with result {exit_code}: {timer()}ms elapsed"
     )
-    sys.exit(0) if result else sys.exit(1)
+    sys.exit(exit_code)
 
 
 def get_services_to_k8s_namespaces_to_allowlist(

--- a/paasta_tools/metrics/metrics_lib.py
+++ b/paasta_tools/metrics/metrics_lib.py
@@ -39,6 +39,11 @@ class TimerProtocol(Protocol):
     ) -> None:
         raise NotImplementedError()
 
+    def __call__(
+        self,
+    ) -> Optional[float]:
+        raise NotImplementedError()
+
     def start(self) -> None:
         raise NotImplementedError()
 
@@ -120,6 +125,7 @@ class MeteoriteMetrics(BaseMetrics):
 class Timer(TimerProtocol):
     def __init__(self, name: str) -> None:
         self.name = name
+        self.elapsed_ms: Optional[float] = None
 
     def __enter__(self) -> TimerProtocol:
         self.start()
@@ -133,6 +139,11 @@ class Timer(TimerProtocol):
     ) -> None:
         if not err_type:
             self.stop()
+
+    def __call__(self) -> Optional[float]:
+        if self.elapsed_ms is None:
+            self.stop()
+        return self.elapsed_ms
 
     def start(self) -> None:
         log.debug("timer {} start at {}".format(self.name, time.time()))

--- a/paasta_tools/metrics/metrics_lib.py
+++ b/paasta_tools/metrics/metrics_lib.py
@@ -207,6 +207,7 @@ def system_timer(
     default_dimensions = {
         "path": path,
         "host": hostname,
+        # ppid is included given some system processes are called multiple times in parallel for a single 'run'
         "parent_pid": parent_pid,
         "pid": pid,
     }

--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -113,7 +113,18 @@ def main() -> None:
         logging.getLogger("kazoo").setLevel(logging.WARN)
         logging.basicConfig(level=logging.INFO)
 
+    # emit deploy events for updated jobs
     deploy_metrics = metrics_lib.get_metrics_interface("paasta")
+
+    # emit timing metrics for s_k_j
+    cluster = args.cluster or load_system_paasta_config().get_cluster()
+    timer = metrics_lib.system_timer(
+        dimensions=dict(
+            cluster=cluster,
+            eks=args.eks,
+        ),
+    )
+    timer.start()
 
     kube_client = KubeClient()
     service_instances_valid = True
@@ -126,7 +137,7 @@ def main() -> None:
     # returns a list of pairs of (No error?, KubernetesDeploymentConfig | EksDeploymentConfig) for every service_instance
     service_instance_configs_list = get_kubernetes_deployment_config(
         service_instances_with_valid_names=service_instances_with_valid_names,
-        cluster=args.cluster or load_system_paasta_config().get_cluster(),
+        cluster=cluster,
         soa_dir=soa_dir,
         eks=args.eks,
     )
@@ -154,6 +165,10 @@ def main() -> None:
         )
     else:
         setup_kube_succeeded = False
+    timer.stop(tmp_dimensions={"result": setup_kube_succeeded})
+    logging.info(
+        f"Stopping timer for {cluster} (eks={args.eks}) with result {setup_kube_succeeded}: {timer()}ms elapsed"
+    )
     sys.exit(0 if setup_kube_succeeded and service_instances_valid else 1)
 
 

--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -165,11 +165,13 @@ def main() -> None:
         )
     else:
         setup_kube_succeeded = False
-    timer.stop(tmp_dimensions={"result": setup_kube_succeeded})
+    exit_code = 0 if setup_kube_succeeded and service_instances_valid else 1
+
+    timer.stop(tmp_dimensions={"result": exit_code})
     logging.info(
-        f"Stopping timer for {cluster} (eks={args.eks}) with result {setup_kube_succeeded}: {timer()}ms elapsed"
+        f"Stopping timer for {cluster} (eks={args.eks}) with result {exit_code}: {timer()}ms elapsed"
     )
-    sys.exit(0 if setup_kube_succeeded and service_instances_valid else 1)
+    sys.exit(exit_code)
 
 
 def get_service_instances_with_valid_names(

--- a/tests/kubernetes/bin/test_paasta_secrets_sync.py
+++ b/tests/kubernetes/bin/test_paasta_secrets_sync.py
@@ -43,6 +43,9 @@ def test_main():
         "paasta_tools.kubernetes.bin.paasta_secrets_sync.load_system_paasta_config",
         autospec=True,
     ), mock.patch(
+        "paasta_tools.kubernetes.bin.paasta_secrets_sync.metrics_lib.system_timer",
+        autospec=True,
+    ), mock.patch(
         "paasta_tools.kubernetes.bin.paasta_secrets_sync.KubeClient", autospec=True
     ), mock.patch(
         "paasta_tools.kubernetes.bin.paasta_secrets_sync.sync_all_secrets",

--- a/tests/test_check_service_replication_tools.py
+++ b/tests/test_check_service_replication_tools.py
@@ -20,12 +20,16 @@ def test_main_kubernetes():
         "paasta_tools.check_services_replication_tools.yelp_meteorite",
         autospec=True,
     ) as mock_yelp_meteorite, mock.patch(
+        "paasta_tools.check_services_replication_tools.metrics_lib.system_timer",
+        autospec=True,
+    ) as mock_system_timer, mock.patch(
         "paasta_tools.check_services_replication_tools.sys.exit",
         autospec=True,
     ) as mock_sys_exit:
         mock_parse_args.return_value.under_replicated_crit_pct = 5
         mock_parse_args.return_value.min_count_critical = 1
         mock_parse_args.return_value.dry_run = False
+
         mock_check_services_replication.return_value = (6, 100)
 
         check_services_replication_tools.main(
@@ -43,6 +47,9 @@ def test_main_kubernetes():
         mock_gauge = mock_yelp_meteorite.create_gauge.return_value
         mock_gauge.set.assert_called_once_with(6)
 
+        mock_timer = mock_system_timer.return_value
+        assert mock_timer.start.called
+        mock_timer.stop.assert_called_once_with(tmp_dimensions={"result": 2})
         mock_sys_exit.assert_called_once_with(2)
 
 


### PR DESCRIPTION
We currently have no way of knowing conclusively whether some of our cronjobs that don't emit start/stop lines are getting slower and approximations based on existing log lines seem to have always fallen flat in previous attempts, and relies on 100% success of our syslog-based pipeline. 

Instead, let's time this from a few of our slowest cronjobs itself and emit timings with some relevant info that I think will allow us to group by the things we need.  We can always adjust dimensions/names of metrics later if they don't end up being quite right, but I'd like to see if this is a worthwhile exercise at all first.

This adds a new helper `system_timer` in metrics_lib that gives us a timer to use in various system components of paasta that have to run periodically.
It uses a few base dimensions:
- `path`: the caller of system_timer, which will generally tell us which cronjob this is
- `host`: the hostname running this cronjob; probably not terribly useful but perhaps one host is slower than the other
- `parent_pid`: really only useful where we 'shard' our cronjobs by running multiple processes at once, spreading them across the full list of targets (e.g. service instances for s_k_j); had we just done 'pid' we might not be able to aggregate timings across a 'single' s_k_j 'run'/cron invocation, and instead only the individual calls for the subset of service instances passed to this particular run
- `pid`: not sure we'll need this but this would be the only distinguishing factor between each individual s_k_j call for a single cron run, for example

By collecting `parent_pid` (which seems to correctly get the bash pid started from the cronjob which then spawns parallel runs of setup_kubernetes_job), we can just grab relevant maximum/aggregate runtimes for each cron invocation, but by keeping individual s_k_j `pid` we could also see if there were outliers. 

When we stop timers, we also generally include the result, typically indicative of the exit code of the script. 

I've also added a few log lines that include info about the timers, _if_ we needed to with a log-based solution instead. 

I installed this version of paasta onto eksstage and so we can start graphing timings such as: https://grafana.yelpcorp.com/explore?schemaVersion=1&panes=%7B%2295q%22:%7B%22datasource%22:%22P627274A7C77417EA%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22avg(paasta_system_process_duration%7B%7D)%20by%20(path)%5Cn%5Cn%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P627274A7C77417EA%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%221715041055454%22,%22to%22:%221715042491591%22%7D%7D%7D&orgId=1

