### PR TITLE
PAASTA-18203: Catch missing metrics in check_autoscaler_max_instances

### DIFF
--- a/docs/source/autoscaling.rst
+++ b/docs/source/autoscaling.rst
@@ -182,3 +182,5 @@ The default value for ``max_instances_alert_threshold`` is whatever your ``setpo
 This means by default the alert will trigger when the autoscaler wants to scale up but is prevented from doing so by your ``max_instances`` setting.
 If this alert is noisy, you can try setting ``max_instances_alert_threshold`` to something a little higher than your ``setpoint``.
 Setting a very high value (a utilization value your metrics_provider would never measure) will effectively disable this alert.
+
+If this alert reports an UNKNOWN status, this indicates an error with your metrics provided by the ``metrics_provider`` you've specified.  Please review the metric_provider and service configuration to ensure metrics can be collected as expected.

--- a/paasta_tools/check_autoscaler_max_instances.py
+++ b/paasta_tools/check_autoscaler_max_instances.py
@@ -150,7 +150,7 @@ async def check_max_instances(
                         # we likely couldn't find values for the current metric from autoscaling status
                         # if this is the only metric, we will return UNKNOWN+this error
                         # suggest fixing their autoscaling config
-                        output = f'{service}.{instance}: Service is at max_instances, and there is an error fetching your {metrics_provider_config["type"]} metric.  Check your autoscaling configs or reach out to #paasta.'
+                        output = f'{service}.{instance}: Service is at max_instances, and there is an error fetching your {metrics_provider_config["type"]} metric. Check your autoscaling configs or reach out to #paasta.'
             else:
                 status = pysensu_yelp.Status.OK
                 output = f"{service}.{instance} is below max_instances."


### PR DESCRIPTION
We found that a service where the HPA is unable fetch its metrics would cause this script to error out with:
```
Would've sent an OK event for check 'check_autoscaler_max_instances.cassandra_apis.dev-v1-40'
Traceback (most recent call last):
  File "/opt/venvs/paasta-tools/bin/check_autoscaler_max_instances.py", line 199, in <module>
    main()
  File "/opt/venvs/paasta-tools/bin/check_autoscaler_max_instances.py", line 187, in main
    asyncio.run(
  File "/usr/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/opt/venvs/paasta-tools/bin/check_autoscaler_max_instances.py", line 128, in check_max_instances
    current_value = suffixed_number_value(metric["current_value"])
KeyError: 'current_value'
```

This PR simply catches this KeyError and will send an alert with status `UNKNOWN` (the current default) and a new error message in the check output indicating there's an error w/ the metric, and adds a small note to the documentation about this alert what an UNKNOWN status means.  We may need to provide more concrete information about why different metric providers may be broken, let me know if you think that's worth while. 

## Testing
On a dry-run with an HPA that exhibits this behavior, this script would have sent the expected error:
```
$ sudo ./check_autoscaler_max_instances.py --dry-run
Would've sent an OK event for check 'check_autoscaler_max_instances.cassandra_apis.dev-v1-40'
Would've sent the following alert for check 'check_autoscaler_max_instances.example_happyhour_java.main':
{'alert_after': '5m',
 'check_every': '1m',
 'component': None,
 'description': 'An example service written in Java',
 'irc_channels': None,
 'name': 'check_autoscaler_max_instances.example_happyhour_java.main',
 'notification_email': None,
 'output': 'example_happyhour_java.main: Service is at max_instances, and '
           'there is an error fetching your active-requests metric.  Check '
           'your autoscaling configs or reach out to #paasta.',
 'page': False,
 'priority': None,
 'project': None,
 'realert_every': 60,
 'runbook': 'y/check-autoscaler-max-instances',
 'sensu_host': 'localhost',
 'sensu_port': 3030,
 'slack_channels': None,
 'source': 'paasta-infrastage',
 'status': 3,
 'tags': [],
 'team': 'core-java',
 'ticket': False,
 'tip': 'The autoscaler wants to scale up to handle additional load because '
        'your service is overloaded, but cannot scale any higher because of '
        'max_instances. You may want to bump max_instances. To make this alert '
        'quieter, adjust '
        'autoscaling.metrics_providers[n].max_instances_alert_threshold in '
        'yelpsoa-configs.',
 'ttl': None}
HPA example--happyhour-testing not found.
```

