### PR TITLE
support SA projected volumes

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -700,6 +700,43 @@
                     },
                     "uniqueItems": true
                 },
+                "projected_volumes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "container_path": {
+                                "type": "string"
+                            },
+                            "sources": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "audience": {
+                                            "type": "string"
+                                        },
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "expiration_seconds": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "required": [
+                                        "audience"
+                                    ]
+                                },
+                                "uniqueItems": true
+                            }
+                        },
+                        "required": [
+                            "container_path",
+                            "sources"
+                        ]
+                    },
+                    "uniqueItems": true
+                },
                 "replication_threshold": {
                     "type": "integer",
                     "minimum": 0

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -700,7 +700,7 @@
                     },
                     "uniqueItems": true
                 },
-                "projected_volumes": {
+                "projected_sa_volumes": {
                     "type": "array",
                     "items": {
                         "type": "object",
@@ -708,31 +708,16 @@
                             "container_path": {
                                 "type": "string"
                             },
-                            "sources": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "audience": {
-                                            "type": "string"
-                                        },
-                                        "path": {
-                                            "type": "string"
-                                        },
-                                        "expiration_seconds": {
-                                            "type": "integer"
-                                        }
-                                    },
-                                    "required": [
-                                        "audience"
-                                    ]
-                                },
-                                "uniqueItems": true
+                            "audience": {
+                                "type": "string"
+                            },
+                            "expiration_seconds": {
+                                "type": "integer"
                             }
                         },
                         "required": [
                             "container_path",
-                            "sources"
+                            "audience"
                         ]
                     },
                     "uniqueItems": true

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -283,6 +283,43 @@
                     },
                     "uniqueItems": true
                 },
+                "projected_volumes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "container_path": {
+                                "type": "string"
+                            },
+                            "sources": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "audience": {
+                                            "type": "string"
+                                        },
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "expiration_seconds": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "required": [
+                                        "audience"
+                                    ]
+                                },
+                                "uniqueItems": true
+                            }
+                        },
+                        "required": [
+                            "container_path",
+                            "sources"
+                        ]
+                    },
+                    "uniqueItems": true
+                },
                 "cluster": {
                     "type": "string"
                 },

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -283,7 +283,7 @@
                     },
                     "uniqueItems": true
                 },
-                "projected_volumes": {
+                "projected_sa_volumes": {
                     "type": "array",
                     "items": {
                         "type": "object",
@@ -291,31 +291,16 @@
                             "container_path": {
                                 "type": "string"
                             },
-                            "sources": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "audience": {
-                                            "type": "string"
-                                        },
-                                        "path": {
-                                            "type": "string"
-                                        },
-                                        "expiration_seconds": {
-                                            "type": "integer"
-                                        }
-                                    },
-                                    "required": [
-                                        "audience"
-                                    ]
-                                },
-                                "uniqueItems": true
+                            "audience": {
+                                "type": "string"
+                            },
+                            "expiration_seconds": {
+                                "type": "integer"
                             }
                         },
                         "required": [
                             "container_path",
-                            "sources"
+                            "audience"
                         ]
                     },
                     "uniqueItems": true

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -165,7 +165,7 @@ from paasta_tools.utils import load_v2_deployments_json
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import PersistentVolume
-from paasta_tools.utils import ProjectedVolume
+from paasta_tools.utils import ProjectedSAVolume
 from paasta_tools.utils import SecretVolume
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import time_cache
@@ -217,6 +217,9 @@ DEFAULT_SIDECAR_REQUEST: KubeContainerResourceRequest = {
     "memory": "1024Mi",
     "ephemeral-storage": "256Mi",
 }
+
+DEFAULT_PROJECTED_SA_EXPIRATION_SECONDS = 3600
+PROJECTED_SA_TOKEN_PATH = "token"
 
 
 # conditions is None when creating a new HPA, but the client raises an error in that case.
@@ -1004,13 +1007,11 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "secret--{name}".format(name=secret_volume["secret_name"]), length_limit=63
         )
 
-    def get_projected_volume_name(self, projected_volume: ProjectedVolume) -> str:
+    def get_projected_sa_volume_name(
+        self, projected_sa_volume: ProjectedSAVolume
+    ) -> str:
         return self.get_sanitised_volume_name(
-            "projected-sa--{audiences}".format(
-                audiences="-".join(
-                    src["audience"] for src in projected_volume["sources"]
-                ),
-            ),
+            "projected-sa--{audience}".format(audience=projected_sa_volume["audience"]),
             length_limit=63,
         )
 
@@ -1142,7 +1143,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     aws_ebs_volumes=[],
                     persistent_volumes=[],
                     secret_volumes=[],
-                    projected_volumes=[],
+                    projected_sa_volumes=[],
                 ),
             )
         return None
@@ -1477,7 +1478,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 aws_ebs_volumes=aws_ebs_volumes,
                 persistent_volumes=self.get_persistent_volumes(),
                 secret_volumes=secret_volumes,
-                projected_volumes=self.get_projected_volumes(),
+                projected_sa_volumes=self.get_projected_sa_volumes(),
             ),
         )
         containers = [service_container] + self.get_sidecar_containers(  # type: ignore
@@ -1515,7 +1516,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         docker_volumes: Sequence[DockerVolume],
         aws_ebs_volumes: Sequence[AwsEbsVolume],
         secret_volumes: Sequence[SecretVolume],
-        projected_volumes: Sequence[ProjectedVolume],
+        projected_sa_volumes: Sequence[ProjectedSAVolume],
     ) -> Sequence[V1Volume]:
         pod_volumes = []
         unique_docker_volumes = {
@@ -1573,22 +1574,22 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     ),
                 )
             )
-        for projected_volume in projected_volumes:
+        for projected_volume in projected_sa_volumes:
             pod_volumes.append(
                 V1Volume(
-                    name=self.get_projected_volume_name(projected_volume),
+                    name=self.get_projected_sa_volume_name(projected_volume),
                     projected=V1ProjectedVolumeSource(
                         sources=[
                             V1VolumeProjection(
                                 service_account_token=V1ServiceAccountTokenProjection(
-                                    audience=src["audience"],
-                                    expiration_seconds=src.get(
-                                        "expiration_seconds", 3600
+                                    audience=projected_volume["audience"],
+                                    expiration_seconds=projected_volume.get(
+                                        "expiration_seconds",
+                                        DEFAULT_PROJECTED_SA_EXPIRATION_SECONDS,
                                     ),
-                                    path=src.get("path", "token"),
+                                    path=PROJECTED_SA_TOKEN_PATH,
                                 )
                             )
-                            for src in projected_volume["sources"]
                         ],
                     ),
                 ),
@@ -1754,7 +1755,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         aws_ebs_volumes: Sequence[AwsEbsVolume],
         persistent_volumes: Sequence[PersistentVolume],
         secret_volumes: Sequence[SecretVolume],
-        projected_volumes: Sequence[ProjectedVolume],
+        projected_sa_volumes: Sequence[ProjectedSAVolume],
     ) -> Sequence[V1VolumeMount]:
         volume_mounts = (
             [
@@ -1792,10 +1793,10 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             + [
                 V1VolumeMount(
                     mount_path=volume["container_path"],
-                    name=self.get_projected_volume_name(volume),
+                    name=self.get_projected_sa_volume_name(volume),
                     read_only=True,
                 )
-                for volume in projected_volumes
+                for volume in projected_sa_volumes
             ]
         )
         if self.config_dict.get("boto_keys", []):
@@ -2210,7 +2211,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 docker_volumes=docker_volumes + hacheck_sidecar_volumes,
                 aws_ebs_volumes=self.get_aws_ebs_volumes(),
                 secret_volumes=self.get_secret_volumes(),
-                projected_volumes=self.get_projected_volumes(),
+                projected_sa_volumes=self.get_projected_sa_volumes(),
             ),
         )
         # need to check if there are node selectors/affinities. if there are none

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -283,15 +283,10 @@ class SecretVolume(TypedDict, total=False):
     items: List[SecretVolumeItem]
 
 
-class ProjectedVolumeSASource(TypedDict):
+class ProjectedSAVolume(TypedDict, total=False):
+    container_path: str
     audience: str
     expiration_seconds: int
-    path: str
-
-
-class ProjectedVolume(TypedDict):
-    container_path: str
-    sources: List[ProjectedVolumeSASource]
 
 
 class TronSecretVolume(SecretVolume, total=False):
@@ -338,7 +333,7 @@ class InstanceConfigDict(TypedDict, total=False):
     extra_volumes: List[DockerVolume]
     aws_ebs_volumes: List[AwsEbsVolume]
     secret_volumes: List[SecretVolume]
-    projected_volumes: List[ProjectedVolume]
+    projected_sa_volumes: List[ProjectedSAVolume]
     security: SecurityConfigDict
     dependencies_reference: str
     dependencies: Dict[str, Dict]
@@ -968,8 +963,8 @@ class InstanceConfig:
     def get_secret_volumes(self) -> List[SecretVolume]:
         return self.config_dict.get("secret_volumes", [])
 
-    def get_projected_volumes(self) -> List[ProjectedVolume]:
-        return self.config_dict.get("projected_volumes", [])
+    def get_projected_sa_volumes(self) -> List[ProjectedSAVolume]:
+        return self.config_dict.get("projected_sa_volumes", [])
 
     def get_iam_role(self) -> str:
         return self.config_dict.get("iam_role", "")

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -283,6 +283,17 @@ class SecretVolume(TypedDict, total=False):
     items: List[SecretVolumeItem]
 
 
+class ProjectedVolumeSASource(TypedDict):
+    audience: str
+    expiration_seconds: int
+    path: str
+
+
+class ProjectedVolume(TypedDict):
+    container_path: str
+    sources: List[ProjectedVolumeSASource]
+
+
 class TronSecretVolume(SecretVolume, total=False):
     secret_volume_name: str
 
@@ -327,6 +338,7 @@ class InstanceConfigDict(TypedDict, total=False):
     extra_volumes: List[DockerVolume]
     aws_ebs_volumes: List[AwsEbsVolume]
     secret_volumes: List[SecretVolume]
+    projected_volumes: List[ProjectedVolume]
     security: SecurityConfigDict
     dependencies_reference: str
     dependencies: Dict[str, Dict]
@@ -955,6 +967,9 @@ class InstanceConfig:
 
     def get_secret_volumes(self) -> List[SecretVolume]:
         return self.config_dict.get("secret_volumes", [])
+
+    def get_projected_volumes(self) -> List[ProjectedVolume]:
+        return self.config_dict.get("projected_volumes", [])
 
     def get_iam_role(self) -> str:
         return self.config_dict.get("iam_role", "")

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -152,8 +152,7 @@ from paasta_tools.utils import CAPS_DROP
 from paasta_tools.utils import DeploymentVersion
 from paasta_tools.utils import DockerVolume
 from paasta_tools.utils import PersistentVolume
-from paasta_tools.utils import ProjectedVolume
-from paasta_tools.utils import ProjectedVolumeSASource
+from paasta_tools.utils import ProjectedSAVolume
 from paasta_tools.utils import SecretVolume
 from paasta_tools.utils import SecretVolumeItem
 from paasta_tools.utils import SystemPaastaConfig
@@ -1176,19 +1175,11 @@ class TestKubernetesDeploymentConfig:
                 ],
             ),
         ]
-        mock_projected_volumes = [
-            ProjectedVolume(
+        mock_projected_sa_volumes = [
+            ProjectedSAVolume(
                 container_path="/var/secret/something",
-                sources=[
-                    ProjectedVolumeSASource(
-                        audience="a.b.c",
-                    ),
-                    ProjectedVolumeSASource(
-                        audience="d.e.f",
-                        expiration_seconds=1234,
-                        path="nottoken",
-                    ),
-                ],
+                audience="a.b.c",
+                expiration_seconds=1234,
             )
         ]
         expected_volumes = [
@@ -1239,21 +1230,14 @@ class TestKubernetesDeploymentConfig:
                 ),
             ),
             V1Volume(
-                name="projected-sa--adot-bdot-c-ddot-edot-f",
+                name="projected-sa--adot-bdot-c",
                 projected=V1ProjectedVolumeSource(
                     sources=[
                         V1VolumeProjection(
                             service_account_token=V1ServiceAccountTokenProjection(
                                 audience="a.b.c",
-                                expiration_seconds=3600,
-                                path="token",
-                            )
-                        ),
-                        V1VolumeProjection(
-                            service_account_token=V1ServiceAccountTokenProjection(
-                                audience="d.e.f",
                                 expiration_seconds=1234,
-                                path="nottoken",
+                                path="token",
                             )
                         ),
                     ],
@@ -1265,7 +1249,7 @@ class TestKubernetesDeploymentConfig:
                 docker_volumes=mock_docker_volumes + mock_hacheck_volumes,
                 aws_ebs_volumes=mock_aws_ebs_volumes,
                 secret_volumes=mock_secret_volumes,
-                projected_volumes=mock_projected_volumes,
+                projected_sa_volumes=mock_projected_sa_volumes,
             )
             == expected_volumes
         )
@@ -1301,14 +1285,10 @@ class TestKubernetesDeploymentConfig:
             mock_secret_volumes = [
                 SecretVolume(container_path="/garply", secret_name="waldo")
             ]
-            mock_projected_volumes = [
-                ProjectedVolume(
+            mock_projected_sa_volumes = [
+                ProjectedSAVolume(
                     container_path="/var/secret/something",
-                    sources=[
-                        ProjectedVolumeSASource(
-                            audience="a.b.c",
-                        ),
-                    ],
+                    audience="a.b.c",
                 )
             ]
             expected_volumes = [
@@ -1335,7 +1315,7 @@ class TestKubernetesDeploymentConfig:
                     aws_ebs_volumes=mock_aws_ebs_volumes,
                     persistent_volumes=mock_persistent_volumes,
                     secret_volumes=mock_secret_volumes,
-                    projected_volumes=mock_projected_volumes,
+                    projected_sa_volumes=mock_projected_sa_volumes,
                 )
                 == expected_volumes
             )


### PR DESCRIPTION
This is a very partial support of [projected volumes](https://kubernetes.io/docs/concepts/storage/projected-volumes/), but I didn't want to introduce too many new options (that we don't need) in one go.
Ideally these setting will then be automatically generated by parsing the authorization configs and setting up the volumes for the services that need them, but for a first testing phase it'd be handy to be able to just control them manually (we may end up mounting them for all services if catching changes to those configs is a pain, but it'd be nice to be selective).

PS: Tron will be fun, cause those pod definitions are handled in a completely different manner.