### PR TITLE
Add cluster to check_services_replication timer

### DIFF
--- a/paasta_tools/check_services_replication_tools.py
+++ b/paasta_tools/check_services_replication_tools.py
@@ -208,7 +208,7 @@ def main(
     cluster = system_paasta_config.get_cluster()
     replication_checker: ReplicationChecker
 
-    timer = metrics_lib.system_timer(dimensions=dict(eks=args.eks))
+    timer = metrics_lib.system_timer(dimensions=dict(eks=args.eks, cluster=cluster))
 
     timer.start()
 


### PR DESCRIPTION
In #3852 I'd missed adding the `cluster` dimension to the check_services_replication timer (which is proving to be the slowest of the bunch and would most benefit from this timer!)

This brings this script in line w/ what I added for both s_k_j and paasta_sync_secrets as well. 