### PR TITLE
Improve paasta rollback messaging

### DIFF
--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -52,11 +52,11 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
             "'paasta rollback' is a human-friendly tool for marking a particular "
             "docker image for deployment, which invokes a bounce. While the command "
             "is called 'rollback', it can be used to roll forward or back, as long "
-            "as there is a docker image available for the input git SHA."
+            "as there is a docker image available for the input Git SHA."
         ),
         epilog=(
             "This rollback command uses the Git control plane, which requires network "
-            "connectivity as well as authorization to the git repo.\n\n"
+            "connectivity as well as authorization to the Git repo.\n\n"
             + PaastaColors.red(
                 "WARNING: You MUST manually revert changes in Git and go through the normal push process after using this command.\n"
             )

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -56,8 +56,17 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
         ),
         epilog=(
             "This rollback command uses the Git control plane, which requires network "
-            "connectivity as well as authorization to the git repo."
+            "connectivity as well as authorization to the git repo.\n\n"
+            + PaastaColors.red(
+                "WARNING: You MUST manually revert changes in Git and go through the normal push process after using this command.\n"
+            )
+            + PaastaColors.red(
+                "WARNING: Failing to do so means that Jenkins will redeploy the latest code on the next scheduled build!"
+            )
         ),
+        # we manually format the epilog to add newlines + give it an attention-grabbing color
+        # re: reverting changes in Git post-rollback
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     arg_commit = list_parser.add_argument(
         "-k",
@@ -66,7 +75,6 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
         "A commit to rollback to is required for paasta rollback to run. However if one is not provided, "
         "paasta rollback will instead output a list of valid git shas to rollback to.",
         required=False,
-        type=validate_full_git_sha,
     )
     arg_commit.completer = lazy_choices_completer(list_previously_deployed_shas)  # type: ignore
     arg_version = list_parser.add_argument(
@@ -228,6 +236,13 @@ def paasta_rollback(args: argparse.Namespace) -> int:
     deploy groups and sha. These arguments will be verified and passed onto
     mark_for_deployment.
     """
+
+    try:
+        validate_full_git_sha(args.commit)
+    except argparse.ArgumentTypeError as e:
+        print(PaastaColors.red(f"Error: {e}"))
+        return 1
+
     soa_dir = args.soa_dir
     service = figure_out_service_name(args, soa_dir)
 
@@ -319,8 +334,13 @@ def paasta_rollback(args: argparse.Namespace) -> int:
 
     if returncode == 0:
         print(
-            PaastaColors.cyan(
-                f"Warning: Don't forget to revert in git as well. Use 'git revert {rolled_back_from.sha}', and go through the normal push process. "
+            PaastaColors.red(
+                f"WARNING: You MUST manually revert changes in Git! Use 'git revert {rolled_back_from.sha}', and go through the normal push process. "
+            )
+        )
+        print(
+            PaastaColors.red(
+                f"WARNING: Failing to do so means that Jenkins will redeploy the latest code on the next scheduled build!"
             )
         )
 

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -968,11 +968,11 @@ def validate_given_deploy_groups(
 
 
 def short_to_full_git_sha(short, refs):
-    """Converts a short git sha to a full sha
+    """Converts a short git sha to a full SHA
 
-    :param short: A short git sha represented as a string
-    :param refs: A list of refs in the git repository
-    :return: The full git sha or None if one can't be found
+    :param short: A short Git SHA represented as a string
+    :param refs: A list of refs in the Git repository
+    :return: The full Git SHA or None if one can't be found
     """
     return [sha for sha in set(refs.values()) if sha.startswith(short)]
 
@@ -980,15 +980,15 @@ def short_to_full_git_sha(short, refs):
 def validate_short_git_sha(value):
     pattern = re.compile("[a-f0-9]{4,40}")
     if not pattern.match(value):
-        raise argparse.ArgumentTypeError("%s is not a valid git sha" % value)
+        raise argparse.ArgumentTypeError("%s is not a valid Git SHA" % value)
     return value
 
 
-def validate_full_git_sha(value):
+def validate_full_git_sha(value: str) -> str:
     pattern = re.compile("[a-f0-9]{40}")
     if not pattern.match(value):
         raise argparse.ArgumentTypeError(
-            "%s is not a full git sha, and PaaSTA needs the full sha" % value
+            "%s is not a full Git SHA, and PaaSTA needs the full SHA" % value
         )
     return value
 
@@ -1002,7 +1002,7 @@ def validate_git_sha(sha, git_url):
         commits = short_to_full_git_sha(short=sha, refs=refs)
         if len(commits) != 1:
             raise ValueError(
-                "%s matched %d git shas (with refs pointing at them). Must match exactly 1."
+                "%s matched %d Git SHAs (with refs pointing at them). Must match exactly 1."
                 % (sha, len(commits))
             )
         return commits[0]


### PR DESCRIPTION
Printing out the --help output when passing a short SHA is not helpful - and neither is not very loudly mentioning that changes *need* to be reverted in Git for a rollback to become permanent