### PR TITLE
Use vanilla pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,8 @@ dev-api: .tox/py38-linux
 
 .paasta/bin/activate: requirements.txt requirements-dev.txt
 	test -d .paasta/bin/activate || virtualenv -p python3.8 .paasta
-	.paasta/bin/pip install -U \
-		pip==18.1 \
-		virtualenv==16.2.0 \
-		tox==3.7.0 \
-		tox-pip-extensions==1.4.2
+	.paasta/bin/pip install -r requirements-bootstrap.txt
+	.paasta/bin/pip install -U tox==3.28.0
 	touch .paasta/bin/activate
 
 itest: test .paasta/bin/activate

--- a/requirements-bootstrap.txt
+++ b/requirements-bootstrap.txt
@@ -1,4 +1,3 @@
-pip==18.1
-setuptools==39.0.1
-venv-update==3.2.4
-wheel==0.32.3
+pip==24.0
+setuptools==68.0.0
+wheel==0.42.0

--- a/requirements-gha.txt
+++ b/requirements-gha.txt
@@ -1,3 +1,3 @@
 coveralls
 ephemeral-port-reserve
-tox==3.2
+tox==3.28.0

--- a/requirements-gha.txt
+++ b/requirements-gha.txt
@@ -1,4 +1,3 @@
 coveralls
 ephemeral-port-reserve
 tox==3.2
-tox-pip-extensions==1.3.0

--- a/requirements-gha.txt
+++ b/requirements-gha.txt
@@ -1,3 +1,4 @@
+-r requirements-bootstrap.txt
 coveralls
 ephemeral-port-reserve
 tox==3.28.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ hupper==1.0
 idna==2.6
 inotify==0.2.8
 ipaddress==1.0.22
-isodate==0.5.1
+isodate==0.6.0
 itsdangerous==2.0.1
 Jinja2==2.11.3
 jinja2-time==0.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -144,7 +144,7 @@ deps =
 commands =
     # TODO: upgrade behave if they ever take this reasonable PR
     pip install git+https://github.com/Yelp/behave@1.2.5-issue_533-fork
-    pylint -E paasta_tools/mesos/ --ignore master.py,task.py
+    pylint -E {toxinidir}/paasta_tools/mesos/ --ignore master.py,task.py
     behave {posargs}
 
 [testenv:mypy]

--- a/tox.ini
+++ b/tox.ini
@@ -186,6 +186,3 @@ extend-ignore = E501,E203,W503
 
 [pep8]
 ignore = E265,E501
-
-[testenv:.tox]
-envdir = {toxworkdir}/{envname}

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 skipsdist=True
 envlist=py38-linux
 docker_compose_version = 1.26.2
+requires =
+    tox==3.28.0
+
 
 [testenv]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -186,3 +186,6 @@ extend-ignore = E501,E203,W503
 
 [pep8]
 ignore = E265,E501
+
+[testenv:.tox]
+envdir = {toxworkdir}/{envname}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 skipsdist=True
 envlist=py38-linux
-tox_pip_extensions_ext_venv_update = true
 docker_compose_version = 1.26.2
 
 [testenv]
@@ -17,7 +16,7 @@ commands =
     # these are only available at yelp so we optionally install them so that internal devs don't need to
     # manually do so (through pip or make)
     # that said, most of the time people will run make test which will use tox to install these in a
-    # faster way (using venv-update) - so this is really just here for anyone that like to just invoke
+    # faster way - so this is really just here for anyone that like to just invoke
     # `tox` directly and with no explicit env
     -pip install -r yelp_package/extra_requirements_yelp.txt
 


### PR DESCRIPTION
## Problem

`venv-update` is limited to `pip<=18.1` which does not support manylinux wheels. In order to continue supporting this repo, we need to update pip.

## Solution

* Drop `venv-update`
* Update bootstrap dependencies in Makefile and GHA
* Minor fixes for newer tox and venv behaviour