### PR TITLE
Allow python deps in GHA to be specified in branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: 3.7
       - run: python -m pip install --upgrade pip
-      - run: pip install coveralls tox==3.2 tox-pip-extensions==1.3.0 ephemeral-port-reserve
+      - run: pip install -r requirements-gha.txt
       - run: tox -e ${{ matrix.toxenv }}
   k8s_itests:
     runs-on: ubuntu-20.04

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: 3.7
       - run: python -m pip install --upgrade pip
-      - run: pip install coveralls tox==3.2 tox-pip-extensions==1.3.0 ephemeral-port-reserve
+      - run: pip install -r requirements-gha.txt
       - run: tox -e ${{ matrix.toxenv }}
   pypi:
     # lets run tests before we push anything to pypi, much like we do internally

--- a/requirements-gha.txt
+++ b/requirements-gha.txt
@@ -1,0 +1,4 @@
+coveralls
+ephemeral-port-reserve
+tox==3.2
+tox-pip-extensions==1.3.0


### PR DESCRIPTION
## Problem

I need to update boostrap dependencies, but the deps in GHA are co-located in the github workflow files which are sourced from the main branch.

## Solution

Move dependencies into a requirements file which can be updated with the branch.

## Validation

Requires a PR merge to validate the change.