### PR TITLE
Bump yelp-clog and scribereader

### DIFF
--- a/paasta_tools/check_oom_events.py
+++ b/paasta_tools/check_oom_events.py
@@ -28,7 +28,7 @@ from paasta_tools.utils import load_system_paasta_config
 
 try:
     from scribereader import scribereader
-    from clog.readers import StreamTailerSetupError
+    from scribereader.clog.readers import StreamTailerSetupError
 except ImportError:
     scribereader = None
 

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -1,40 +1,39 @@
-atomicfile==1.0
-cached-property==1.3.1
-cffi==1.15.0
-cffi==1.15.0
+atomicfile==1.0                     # vault-tools dependency
+cached-property==1.3.1              # slo-transcoder dependency
+cffi==1.15.0                        # vault-tools dependency
 clusterman_metrics==2.2.0
-crypto-lib==4.0.0
-cryptography==3.0
-dateglob==0.3
-geogrid==1.3.5
-gitdb2==2.0.3
-gitpython==2.1.9
-hvac==0.11.0
-inflection==0.3.1
-iso8601==0.1.14
-markdown==2.4
-monk==1.3.0
-mrjob==0.7.4
-named-decorator==0.1.4
-ndg-httpsclient==0.4.3
-pycparser==2.20
-pygpgme==0.3
-pyopenssl==19.0.0
-PySubnetTree==0.34
-python-jsonschema-objects==0.3.1
-retrying==1.3.3
+crypto-lib==4.0.0                   # vault-tools dependency
+cryptography==3.0                   # vault-tools dependency
+dateglob==0.3                       # scribereader dependency
+geogrid==1.3.5                      # scribereader dependency
+gitdb2==2.0.3                       # slo-transcoder dependency
+gitpython==2.1.9                    # slo-transcoder, vault-tools dependency
+hvac==0.11.0                        # vault-tools dependency
+inflection==0.3.1                   # slo-transcoder dependency
+iso8601==2.1.0                      # yelp-ips dependency
+markdown==2.4                       # slo-transcoder dependency
+monk==1.3.0                         # yelp-clog dependency
+mrjob==0.7.4                        # scribereader dependency
+named-decorator==0.1.4              # yelp-profiling dependency
+ndg-httpsclient==0.4.3              # vault-tools dependency
+pycparser==2.20                     # vault-tools dependency
+pygpgme==0.3                        # vault-tools dependency
+pyopenssl==19.0.0                   # vault-tools dependency
+PySubnetTree==0.34                  # yelp-lib dependency
+python-jsonschema-objects==0.3.1    # slo-transcoder dependency
 scribereader==1.1.1
-signalform-tools==0.0.16
+signalform-tools==0.0.16            # slo-transcoder dependency
 slo-transcoder==3.3.0
-smmap2==2.0.3
-splunk-sdk==1.7.0
-srv-configs==1.1.0
+smmap2==2.0.3                       # slo-transcoder, vault-tools dependency
+splunk-sdk==1.7.0                   # sticht dependency
+srv-configs==1.1.0                  # yelp-profiling dependency
 sticht[yelp_internal]==1.1.18
+tenacity==8.3.0                     # yelp-clog dependency
 vault-tools==0.9.2
-yelp-cgeom==1.3.1
+yelp-cgeom==1.3.1                   # scribereader dependency
 yelp-clog==7.1.1
-yelp-ips==1.0.5
-yelp-lib==17.1.0
-yelp-logging==1.0.37
+yelp-ips==1.1.1                     # yelp-profiling dependency
+yelp-lib==17.1.2                    # yelp-ips dependency
+yelp-logging==1.0.37                # scribereader dependency
 yelp_meteorite==2.1.3
 yelp_profiling==9.1.1

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -23,7 +23,7 @@ pyopenssl==19.0.0
 PySubnetTree==0.34
 python-jsonschema-objects==0.3.1
 retrying==1.3.3
-scribereader==0.15.0
+scribereader==1.1.1
 signalform-tools==0.0.16
 slo-transcoder==3.3.0
 smmap2==2.0.3
@@ -32,7 +32,7 @@ srv-configs==1.1.0
 sticht[yelp_internal]==1.1.18
 vault-tools==0.9.2
 yelp-cgeom==1.3.1
-yelp-clog==5.2.3
+yelp-clog==7.1.1
 yelp-ips==1.0.5
 yelp-lib==17.1.0
 yelp-logging==1.0.37


### PR DESCRIPTION
Based on the 7+ version changelog:
> Deprecated support for logging bytes lines, emitting a [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning) if bytes lines are logged.
A future version of yelp-clog will only support str lines. 
Removed support for the scribe protocol
Removed ScribeLogger, ScribeHandler, and ScribeMonkLogger classes.
Only Monk is supported as a backend for clog.
Removed the scribe readers
Removed NetCLogStreamReader and all other classes under the clog.readers module.
These classes are now available in the scribereader package.

none of the above seems to be used. 

Removing the only reference I could find to deprecated `clog.readers`. Everything else should be already using Monk backend and should work without changes.

Smoke test:
```python
➜  paasta git:(u/yaro/OBSPLAT-1830_clog_upgrade) ✗
 -> python
Python 3.8.13 (default, Apr 19 2022, 02:32:06)
[GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from paasta_tools.utils import _log
>>> _log(service='statsite', line='test log 123', component='monitoring', level='debug', cluster='pnw-devc', instance='main')
[service statsite] test log 123
```