### PR TITLE
Add noble package build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dist: [bionic, jammy]
+        dist: [bionic, jammy, noble]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/debian/rules
+++ b/debian/rules
@@ -26,3 +26,8 @@ override_dh_virtualenv:
 	cp yelp_package/gopath/paasta_go $(DH_VENV_DIR)/bin/paasta_go
 	@echo patching k8s client lib
 	patch $(DH_VENV_DIR)/lib/python3.8/site-packages/kubernetes/client/api_client.py contrib/python-k8s-client.diff
+
+override_dh_shlibdeps:
+	# pylibmc manylinux bundle libraries fail unless this is passed.
+	# See https://dh-virtualenv.readthedocs.io/en/latest/howtos.html#handling-binary-wheels for more details
+	dh_shlibdeps --exclude=/pygpgme.libs/ --exclude=/cryptography.libs/ --exclude=/dulwich/

--- a/yelp_package/dockerfiles/noble/Dockerfile
+++ b/yelp_package/dockerfiles/noble/Dockerfile
@@ -1,0 +1,50 @@
+# Copyright 2015-2022 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
+FROM ${DOCKER_REGISTRY}ubuntu:noble
+
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
+RUN rm /etc/dpkg/dpkg.cfg.d/excludes
+RUN apt-get update && apt-get install -yq gnupg2
+
+RUN apt-get update > /dev/null && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa
+
+RUN apt-get update > /dev/null && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        debhelper \
+        dh-virtualenv \
+        gdebi-core \
+        git \
+        libffi-dev \
+        libgpgme11 \
+        libgpgme-dev \
+        libssl-dev \
+        libyaml-dev \
+        python3.8-dev \
+        python3-pip \
+        python3.8-distutils \
+        tox \
+        wget \
+        sphinx-rtd-theme-common \
+        zsh > /dev/null \
+    && rm -rf /var/lib/apt/lists/*
+
+ADD mesos-slave-secret /etc/mesos-slave-secret
+
+WORKDIR /work

--- a/yelp_package/dockerfiles/noble/mesos-slave-secret
+++ b/yelp_package/dockerfiles/noble/mesos-slave-secret
@@ -1,0 +1,4 @@
+{
+  "principal": "slave",
+  "secret": "secret1"
+}


### PR DESCRIPTION
## Feature

Let's build for noble!

## Notes

Noble doesn't ship with python3.8 and we need to grab it from deadsnakes ppa. We'll want to update paasta to python3.10 soon...