### PR TITLE
Pin request in k8s_itests

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -48,7 +48,9 @@ python-dateutil >= 2.4.0
 python-iptables
 pytimeparse >= 1.1.0
 pytz >= 2014.10
-requests >= 2.18.4
+# the upper-bound is required for older docker-py (<=7.0.0)
+# to function: https://github.com/psf/requests/issues/6707
+requests >= 2.18.4, <2.32.0
 requests-cache >= 0.4.10
 retry
 ruamel.yaml

--- a/tox.ini
+++ b/tox.ini
@@ -88,6 +88,7 @@ whitelist_externals = bash
 # one day we'll use a fully pinned venv here...
 deps =
     urllib3<2.0
+    requests<2.32.0	# tmp fix for broken python docker: https://github.com/psf/requests/issues/6707
     cryptography<42
     docker-compose=={[tox]docker_compose_version}
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ whitelist_externals = bash
 # one day we'll use a fully pinned venv here...
 deps =
     urllib3<2.0
-    requests<2.32.0	# tmp fix for broken python docker: https://github.com/psf/requests/issues/6707
+    requests<2.32.0	# required for older docker-py (<=7.0.0) to function: https://github.com/psf/requests/issues/6707
     cryptography<42
     docker-compose=={[tox]docker_compose_version}
 setenv =


### PR DESCRIPTION
Current `master` pipeline is broken due to a recent release of `requests`, which seems to be incompatible with python lib for `docker`