### PR TITLE
clean up code from old autoscaling config

### DIFF
--- a/paasta_tools/cli/schemas/autoscaling_schema.json
+++ b/paasta_tools/cli/schemas/autoscaling_schema.json
@@ -1,90 +1,5 @@
 {
     "$id": "autoscaling_schema.json",
-    "autoscaling_params_v1": {
-        "type": "object",
-        "properties": {
-            "metrics_provider": {
-                "enum": [
-                    "uwsgi",
-                    "cpu",
-                    "piscina",
-                    "gunicorn",
-                    "arbitrary_promql",
-                    "active-requests"
-                ]
-            },
-            "decision_policy": {
-                "type": "string"
-            },
-            "desired_active_requests_per_replica": {
-                "type": "integer",
-                "minimum": 0,
-                "exclusiveMinimum": true
-            },
-            "setpoint": {
-                "type": "number",
-                "minimum": 0,
-                "maximum": 1.0,
-                "exclusiveMinimum": true,
-                "exclusiveMaximum": false
-            },
-            "forecast_policy": {
-                "enum": [
-                    "moving_average",
-                    "current"
-                ]
-            },
-            "moving_average_window_seconds": {
-                "type": "integer",
-                "minimum": 0,
-                "exclusiveMinimum": true
-            },
-            "scaledown_policies": {
-                "type": "object"
-            },
-            "prometheus_adapter_config": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "seriesQuery": {
-                        "type": "string"
-                    },
-                    "metricsQuery": {
-                        "type": "string"
-                    },
-                    "resources": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                            "overrides": {
-                                "type": "object",
-                                "properties": {
-                                    "group": {
-                                        "type": "string"
-                                    },
-                                    "resource": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "template": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "required": [
-                    "metricsQuery"
-                ]
-            },
-            "max_instances_alert_threshold": {
-                "type": "number",
-                "minimum": 0,
-                "exclusiveMinimum": true
-            }
-        },
-        "additionalProperties": false
-    },
     "metrics_provider_config": {
         "type": "object",
         "properties": {
@@ -157,7 +72,7 @@
         },
         "additionalProperties": false
     },
-    "autoscaling_params_v2": {
+    "autoscaling_params": {
         "type": "object",
         "properties": {
             "metrics_providers": {

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -190,14 +190,7 @@
                     "type": "string"
                 },
                 "autoscaling": {
-                    "anyOf": [
-                        {
-                            "$ref": "autoscaling_schema.json#autoscaling_params_v1"
-                        },
-                        {
-                            "$ref": "autoscaling_schema.json#autoscaling_params_v2"
-                        }
-                    ]
+                    "$ref": "autoscaling_schema.json#autoscaling_params"
                 },
                 "sfn_autoscaling": {
                     "type": "object"

--- a/paasta_tools/eks_tools.py
+++ b/paasta_tools/eks_tools.py
@@ -1,11 +1,9 @@
-import copy
 from typing import Optional
 
 import service_configuration_lib
 
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfigDict
-from paasta_tools.paasta_service_config_loader import transform_autoscaling_params_dict
 from paasta_tools.utils import BranchDictV2
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -66,15 +64,6 @@ def load_eks_service_config_no_cache(
     general_config = deep_merge_dictionaries(
         overrides=instance_config, defaults=general_config
     )
-
-    # TODO: remove when yelpsoa-configs is on the new schema (COREJAVA-1339)
-    if (
-        "autoscaling" in general_config
-        and "metrics_providers" not in general_config["autoscaling"]  # type: ignore
-    ):
-        general_config["autoscaling"] = transform_autoscaling_params_dict(  # type: ignore
-            copy.deepcopy(general_config["autoscaling"])  # type: ignore
-        )
 
     branch_dict: Optional[BranchDictV2] = None
     if load_deployments:

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import base64
-import copy
 import functools
 import hashlib
 import itertools
@@ -150,7 +149,6 @@ from paasta_tools.long_running_service_tools import METRICS_PROVIDER_PISCINA
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_PROMQL
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI
 from paasta_tools.long_running_service_tools import ServiceNamespaceConfig
-from paasta_tools.paasta_service_config_loader import transform_autoscaling_params_dict
 from paasta_tools.secret_tools import get_secret_name_from_ref
 from paasta_tools.secret_tools import is_secret_ref
 from paasta_tools.secret_tools import is_shared_secret
@@ -467,15 +465,6 @@ def load_kubernetes_service_config_no_cache(
     general_config = deep_merge_dictionaries(
         overrides=instance_config, defaults=general_config
     )
-
-    # TODO: Remove once yelpsoa-configs is on the new schema (COREJAVA-1339)
-    if (
-        "autoscaling" in general_config
-        and "metrics_providers" not in general_config["autoscaling"]  # type: ignore
-    ):
-        general_config["autoscaling"] = transform_autoscaling_params_dict(  # type: ignore
-            copy.deepcopy(general_config["autoscaling"])  # type: ignore
-        )
 
     branch_dict: Optional[BranchDictV2] = None
     if load_deployments:

--- a/paasta_tools/paasta_service_config_loader.py
+++ b/paasta_tools/paasta_service_config_loader.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import copy
 import logging
-from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List
@@ -23,7 +21,6 @@ from typing import Type
 from service_configuration_lib import read_service_configuration
 
 from paasta_tools import utils
-from paasta_tools.autoscaling.utils import AutoscalingParamsDict
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import InstanceConfig_T
@@ -183,15 +180,6 @@ class PaastaServiceConfigLoader:
 
         merged_config = self._get_merged_config(config)
 
-        # These type: ignore annotations will go away once yelpsoa-configs is migrated (COREJAVA-1339)
-        if (
-            "autoscaling" in merged_config
-            and "metrics_providers" not in merged_config["autoscaling"]  # type: ignore
-        ):
-            merged_config["autoscaling"] = transform_autoscaling_params_dict(  # type: ignore
-                copy.deepcopy(merged_config["autoscaling"])  # type: ignore
-            )
-
         temp_instance_config = config_class(
             service=self._service,
             cluster=cluster,
@@ -211,18 +199,3 @@ class PaastaServiceConfigLoader:
             branch_dict=branch_dict,
             soa_dir=self._soa_dir,
         )
-
-
-# Remove this once yelpsoa-configs is using the new format (COREJAVA-1339)
-def transform_autoscaling_params_dict(
-    old_autoscaling_params: Dict[str, Any]
-) -> AutoscalingParamsDict:
-    metrics_provider_type = old_autoscaling_params.pop("metrics_provider", "cpu")
-    old_autoscaling_params["type"] = metrics_provider_type
-    scaledown_policies = old_autoscaling_params.pop("scaledown_policies", None)
-
-    new_autoscaling_params = {"metrics_providers": [old_autoscaling_params]}
-    if scaledown_policies is not None:
-        new_autoscaling_params["scaledown_policies"] = scaledown_policies
-
-    return new_autoscaling_params  # type: ignore


### PR DESCRIPTION
Now that everything is on the "new" autoscaling schema, we can clean up all the transform code.

## Testing done
- make test passes
- `paasta validate` passes on all of yelpsoa:
```
> paasta list | xargs -P10 -n1 --no-run-if-empty python -m paasta_tools.cli.cli validate -y ~/src/yelpsoa-configs -s 2>&1 &> output
> grep ✗ output -A 1
> # no errors reported
```
- no changes detected between prometheus_adapter configs before and after:
```
> paasta list-clusters | xargs -I{} bash -c "python -m paasta_tools.setup_prometheus_adapter_config -d ~/src/yelpsoa-configs -c {} --dry-run &> ~/tmp/{}-prom-conf-inst-conf.new"
> git co master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
> paasta list-clusters | xargs -I{} bash -c "python -m paasta_tools.setup_prometheus_adapter_config -d ~/src/yelpsoa-configs -c {} --dry-run &> ~/tmp/{}-prom-conf-inst-conf.mast
er"
> paasta list-clusters | xargs -I{} diff {}-prom-conf-inst-conf.master {}-prom-conf-inst-conf.new
> # no changes detected
```

cc @sclg-yelp 