### PR TITLE
Add support for VitessCluster CRs on EKS

### DIFF
--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -75,6 +75,7 @@ from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import validate_service_instance
 from paasta_tools.vitesscluster_tools import load_vitess_instance_config
+from paasta_tools.vitessclustereks_tools import load_vitesseks_instance_config
 
 log = logging.getLogger(__name__)
 
@@ -664,6 +665,9 @@ INSTANCE_TYPE_HANDLERS: Mapping[str, InstanceTypeHandler] = defaultdict(
     vitesscluster=InstanceTypeHandler(
         get_service_instance_list, load_vitess_instance_config
     ),
+    vitessclustereks=InstanceTypeHandler(
+        get_service_instance_list, load_vitesseks_instance_config
+    ),
     nrtsearchservice=InstanceTypeHandler(
         get_service_instance_list, load_nrtsearchservice_instance_config
     ),
@@ -696,6 +700,9 @@ LONG_RUNNING_INSTANCE_TYPE_HANDLERS: Mapping[
     ),
     vitesscluster=LongRunningInstanceTypeHandler(
         get_service_instance_list, load_vitess_instance_config
+    ),
+    vitessclustereks=LongRunningInstanceTypeHandler(
+        get_service_instance_list, load_vitesseks_instance_config
     ),
     nrtsearchservice=LongRunningInstanceTypeHandler(
         get_service_instance_list, load_nrtsearchservice_instance_config

--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -72,6 +72,7 @@ INSTANCE_TYPE_CR_ID = dict(
     cassandracluster=cassandracluster_tools.cr_id,
     kafkacluster=kafkacluster_tools.cr_id,
     vitesscluster=vitesscluster_tools.cr_id,
+    vitessclustereks=vitesscluster_tools.cr_id,
     nrtsearchservice=nrtsearchservice_tools.cr_id,
     nrtsearchserviceeks=nrtsearchservice_tools.cr_id,
     monkrelaycluster=monkrelaycluster_tools.cr_id,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -135,6 +135,7 @@ INSTANCE_TYPES = (
     "cassandracluster",
     "kafkacluster",
     "vitesscluster",
+    "vitessclustereks",
     "monkrelays",
     "nrtsearchservice",
     "nrtsearchserviceeks",
@@ -154,6 +155,7 @@ INSTANCE_TYPE_TO_K8S_NAMESPACE = {
     "cassandracluster": "paasta-cassandraclusters",
     "kafkacluster": "paasta-kafkaclusters",
     "vitesscluster": "paasta-vitessclusters",
+    "vitessclustereks": "paasta-vitessclusters",
     "nrtsearchservice": "paasta-nrtsearchservices",
     "nrtsearchserviceeks": "paasta-nrtsearchservices",
 }

--- a/paasta_tools/vitessclustereks_tools.py
+++ b/paasta_tools/vitessclustereks_tools.py
@@ -1,0 +1,60 @@
+import logging
+from typing import Optional
+
+import service_configuration_lib
+
+from paasta_tools.utils import BranchDictV2
+from paasta_tools.utils import deep_merge_dictionaries
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import load_service_instance_config
+from paasta_tools.utils import load_v2_deployments_json
+from paasta_tools.vitesscluster_tools import VitessDeploymentConfig
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class VitessEKSDeploymentConfig(VitessDeploymentConfig):
+    config_filename_prefix = "vitessclustereks"
+
+
+def load_vitesseks_instance_config(
+    service: str,
+    instance: str,
+    cluster: str,
+    load_deployments: bool = True,
+    soa_dir: str = DEFAULT_SOA_DIR,
+) -> VitessEKSDeploymentConfig:
+    general_config = service_configuration_lib.read_service_configuration(
+        service, soa_dir=soa_dir
+    )
+    instance_config = load_service_instance_config(
+        service, instance, "vitessclustereks", cluster, soa_dir=soa_dir
+    )
+    general_config = deep_merge_dictionaries(
+        overrides=instance_config, defaults=general_config
+    )
+
+    branch_dict: Optional[BranchDictV2] = None
+    if load_deployments:
+        deployments_json = load_v2_deployments_json(service, soa_dir=soa_dir)
+        temp_instance_config = VitessEKSDeploymentConfig(
+            service=service,
+            cluster=cluster,
+            instance=instance,
+            config_dict=general_config,
+            branch_dict=None,
+            soa_dir=soa_dir,
+        )
+        branch = temp_instance_config.get_branch()
+        deploy_group = temp_instance_config.get_deploy_group()
+        branch_dict = deployments_json.get_branch_dict(service, branch, deploy_group)
+
+    return VitessEKSDeploymentConfig(
+        service=service,
+        cluster=cluster,
+        instance=instance,
+        config_dict=general_config,
+        branch_dict=branch_dict,
+        soa_dir=soa_dir,
+    )

--- a/tests/test_vitessclustereks_tools.py
+++ b/tests/test_vitessclustereks_tools.py
@@ -1,0 +1,48 @@
+import mock
+
+from paasta_tools.vitessclustereks_tools import (
+    load_vitesseks_instance_config,
+)
+
+
+def test_load_vitessclustereks_instance_config():
+    with mock.patch(
+        "paasta_tools.vitessclustereks_tools.load_v2_deployments_json", autospec=True
+    ) as mock_load_v2_deployments_json, mock.patch(
+        "paasta_tools.vitessclustereks_tools.load_service_instance_config",
+        autospec=True,
+    ), mock.patch(
+        "paasta_tools.vitessclustereks_tools.VitessEKSDeploymentConfig",
+        autospec=True,
+    ) as mock_vitessclustereks_deployment_config:
+        mock_config = {
+            "port": None,
+            "monitoring": {},
+            "deploy": {},
+            "data": {},
+            "smartstack": {},
+            "dependencies": {},
+        }
+        vitessclustereks_deployment_config = load_vitesseks_instance_config(
+            service="fake_vitesscluster_service",
+            instance="fake_instance",
+            cluster="fake_cluster",
+            load_deployments=True,
+            soa_dir="/foo/bar",
+        )
+        mock_load_v2_deployments_json.assert_called_with(
+            service="fake_vitesscluster_service", soa_dir="/foo/bar"
+        )
+        mock_vitessclustereks_deployment_config.assert_called_with(
+            service="fake_vitesscluster_service",
+            instance="fake_instance",
+            cluster="fake_cluster",
+            config_dict=mock_config,
+            branch_dict=mock_load_v2_deployments_json.return_value.get_branch_dict(),
+            soa_dir="/foo/bar",
+        )
+
+        assert (
+            vitessclustereks_deployment_config
+            == mock_vitessclustereks_deployment_config.return_value
+        )


### PR DESCRIPTION
vitess-operator is migrated already, this is to prepare for the move of vitess-k8s service
https://jira.yelpcorp.com/browse/DREIMP-10779 