### PR TITLE
Move git sha validation in paasta rollback

### DIFF
--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -237,12 +237,6 @@ def paasta_rollback(args: argparse.Namespace) -> int:
     mark_for_deployment.
     """
 
-    try:
-        validate_full_git_sha(args.commit)
-    except argparse.ArgumentTypeError as e:
-        print(PaastaColors.red(f"Error: {e}"))
-        return 1
-
     soa_dir = args.soa_dir
     service = figure_out_service_name(args, soa_dir)
 
@@ -303,6 +297,12 @@ def paasta_rollback(args: argparse.Namespace) -> int:
         list_previous_versions(
             service, deploy_groups, bool(given_deploy_groups), versions
         )
+        return 1
+
+    try:
+        validate_full_git_sha(args.commit)
+    except argparse.ArgumentTypeError as e:
+        print(PaastaColors.red(f"Error: {e}"))
         return 1
 
     # TODO: Add similar check for when image_version is empty and no-commit redeploys is enforced for requested deploy_group


### PR DESCRIPTION
After we moved 'long' commit validation to `paasta rollback` in #3862 , this inadvertently broke the feature of `paasta rollback` where it listed recent deployed versions when no commit was specified.

Before this change, `paasta rollback -s paasta-contract-monitor -a` simply threw an error:
```
$ /usr/bin/paasta rollback -s paasta-contract-monitor -a
Traceback (most recent call last):
  File "/opt/venvs/paasta-tools/bin/paasta", line 8, in <module>
    sys.exit(main())
  File "/opt/venvs/paasta-tools/lib/python3.8/site-packages/paasta_tools/cli/cli.py", line 252, in main
    return_code = args.command(args)
  File "/opt/venvs/paasta-tools/lib/python3.8/site-packages/paasta_tools/cli/cmds/rollback.py", line 241, in paasta_rollback
    validate_full_git_sha(args.commit)
  File "/opt/venvs/paasta-tools/lib/python3.8/site-packages/paasta_tools/cli/utils.py", line 863, in validate_full_git_sha
    if not pattern.match(value):
TypeError: expected string or bytes-like object
```

Whereas now it goes back to listing recent deploys & example command to roll back: 
```
 $ paasta rollback -s paasta-contract-monitor -a
Please specify a commit to mark for rollback (-k, --commit).
Below is a list of recent commits:
Timestamp -- UTC  Human time     deploy_group  Version
20240215T193955   3 months ago   everything    323d1bd0db8e30831f3b12360bc4cd856be65748
20231116T232021   6 months ago   everything    87057aa1662cd44fabb4881edf448763f0db53ca
20231010T142509   7 months ago   everything    a0c12fd6fbce6707947ce1fafcfdf7a7c6aaff9d
20231010T121244   7 months ago   everything    74feec3308847749fbd405a4494b3253a3b4ae01
20231005T120615   7 months ago   everything    60e9eae69670906b324cbed1ee6bcbf2bcb4412f
20230918T231252   8 months ago   everything    2db115f5812207cef7481b00beb3ac3e26f8a89c
20230616T191810   11 months ago  everything    d7baff2328d51f97adfbf3a076753f9998da6e31
20230613T162709   11 months ago  everything    59923d9dc97a5a15dbcdc39793a70d4d583a5e04
20230612T211009   11 months ago  everything    6b05caf0281034ab4ba4f57a3117d2911f4b28ab
20230608T162845   11 months ago  everything    fb9e09bc9da85b96ebbf3df22090a3daff47c965

For example, to use the second to last version from 6 months ago used on everything, run:
    paasta rollback -s paasta-contract-monitor -l everything -k 87057aa1662cd44fabb4881edf448763f0db53ca
 ```
 
 Since this moves the validation to after just arg parsing (figuring out deploy groups, git url, and this piece of printing help if no commit was provided) but still before any attempt to use args.commit for actual rollbacks, this should still achieve what we wanted in #3862 