### PR TITLE
automatically mount service account tokens when needed

### DIFF
--- a/paasta_tools/generate_authenticating_services.py
+++ b/paasta_tools/generate_authenticating_services.py
@@ -27,6 +27,7 @@ from typing import Set
 import yaml
 
 from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import write_json_configuration_file
 from paasta_tools.utils import write_yaml_configuration_file
 
@@ -53,6 +54,7 @@ def enumerate_authenticating_services() -> Dict[str, List[str]]:
     config_path_pattern = os.path.join(DEFAULT_SOA_DIR, "*", AUTHORIZATION_CONFIG_FILE)
     for authz_config in glob.glob(config_path_pattern):
         result.update(list_services_in_authz_config(authz_config))
+    result.update(load_system_paasta_config().get_always_authenticating_services())
     return {"services": sorted(result)}
 
 

--- a/paasta_tools/generate_authenticating_services.py
+++ b/paasta_tools/generate_authenticating_services.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-A simple script to enumerate all services partecipating in authenticated
+A simple script to enumerate all services participating in authenticated
 communications, and list them in a YAML/JSON file.
 """
 import argparse

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -4424,7 +4424,7 @@ def get_kubernetes_secret_volumes(
 
 @lru_cache()
 def get_authenticating_services(soa_dir: str = DEFAULT_SOA_DIR) -> Set[str]:
-    """Load list of services partecipating in authenticated traffic"""
+    """Load list of services participating in authenticated traffic"""
     authenticating_services_conf_path = os.path.join(soa_dir, "authenticating.yaml")
     config = service_configuration_lib.read_yaml_file(authenticating_services_conf_path)
     return set(config.get("services", []))

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2017,6 +2017,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     sidecar_requirements_config: Dict[str, KubeContainerResourceRequest]
     eks_cluster_aliases: Dict[str, str]
     secret_sync_delay_seconds: float
+    service_auth_token_settings: ProjectedSAVolume
 
 
 def load_system_paasta_config(
@@ -2702,6 +2703,9 @@ class SystemPaastaConfig:
 
     def get_kube_clusters(self) -> Dict:
         return self.config_dict.get("kube_clusters", {})
+
+    def get_service_auth_token_volume_config(self) -> ProjectedSAVolume:
+        return self.config_dict.get("service_auth_token_settings", {})
 
 
 def _run(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2018,6 +2018,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     eks_cluster_aliases: Dict[str, str]
     secret_sync_delay_seconds: float
     service_auth_token_settings: ProjectedSAVolume
+    always_authenticating_services: List[str]
 
 
 def load_system_paasta_config(
@@ -2706,6 +2707,9 @@ class SystemPaastaConfig:
 
     def get_service_auth_token_volume_config(self) -> ProjectedSAVolume:
         return self.config_dict.get("service_auth_token_settings", {})
+
+    def get_always_authenticating_services(self) -> List[str]:
+        return self.config_dict.get("always_authenticating_services", [])
 
 
 def _run(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2790,11 +2790,15 @@ class TestKubernetesDeploymentConfig:
     def test_get_projected_sa_volumes_token_automount(
         self, mock_get_auth_services, mock_system_config
     ):
+        # pretending that a couple random services, plus the one referenced by the mock
+        # deployment config need to perform authentication
         mock_get_auth_services.return_value = {"service_a", "service_b", "kurupt"}
+        # setting up mock system config for service auth token mounts
         mock_system_config.return_value.get_service_auth_token_volume_config.return_value = {
             "audience": "foo.bar",
             "container_path": "/var/secret/something",
         }
+        # test that the extra project volume mount was added to the deployment
         assert self.deployment.get_projected_sa_volumes() == [
             {"audience": "foo.bar", "container_path": "/var/secret/something"},
         ]

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -817,6 +817,10 @@ class TestTronTools:
         ), mock.patch(
             "paasta_tools.tron_tools.load_system_paasta_config",
             autospec=True,
+        ), mock.patch(
+            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
+            autospec=True,
+            return_value=[],
         ):
             result = tron_tools.format_tron_action_dict(action_config)
         assert result["executor"] == "kubernetes"
@@ -873,6 +877,12 @@ class TestTronTools:
         ), mock.patch(
             "paasta_tools.tron_tools.load_system_paasta_config",
             autospec=True,
+        ), mock.patch(
+            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
+            autospec=True,
+            return_value=[
+                {"audience": "foo.bar.com", "container_path": "/var/foo/bar"}
+            ],
         ):
             result = tron_tools.format_tron_action_dict(action_config)
 
@@ -898,6 +908,9 @@ class TestTronTools:
             ],
             "extra_volumes": [
                 {"container_path": "/nail/tmp", "host_path": "/nail/tmp", "mode": "RW"}
+            ],
+            "projected_sa_volumes": [
+                {"audience": "foo.bar.com", "container_path": "/var/foo/bar"},
             ],
             "field_selector_env": {"PAASTA_POD_IP": {"field_path": "status.podIP"}},
             "node_selectors": {"yelp.com/pool": "special_pool"},
@@ -993,6 +1006,10 @@ class TestTronTools:
             "paasta_tools.tron_tools.load_system_paasta_config",
             autospec=True,
             return_value=MOCK_SYSTEM_PAASTA_CONFIG,
+        ), mock.patch(
+            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
+            autospec=True,
+            return_value=[],
         ), mock.patch(
             "paasta_tools.tron_tools.get_k8s_url_for_cluster",
             autospec=True,
@@ -1295,6 +1312,10 @@ class TestTronTools:
         ), mock.patch(
             "paasta_tools.tron_tools.load_system_paasta_config",
             autospec=True,
+        ), mock.patch(
+            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
+            autospec=True,
+            return_value=[],
         ):
             result = tron_tools.format_tron_action_dict(action_config)
 
@@ -1415,6 +1436,10 @@ class TestTronTools:
             "paasta_tools.secret_tools.is_shared_secret_from_secret_name",
             autospec=True,
             return_value=False,
+        ), mock.patch(
+            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
+            autospec=True,
+            return_value=[],
         ):
             result = tron_tools.format_tron_action_dict(action_config)
 
@@ -1522,6 +1547,10 @@ class TestTronTools:
         ), mock.patch(
             "paasta_tools.tron_tools.load_system_paasta_config",
             autospec=True,
+        ), mock.patch(
+            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
+            autospec=True,
+            return_value=[],
         ):
             result = tron_tools.format_tron_action_dict(action_config)
         assert result == {
@@ -1682,6 +1711,10 @@ fake_job:
             "paasta_tools.utils.load_system_paasta_config",
             autospec=True,
             return_value=MOCK_SYSTEM_PAASTA_CONFIG,
+        ), mock.patch(
+            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
+            autospec=True,
+            return_value=[],
         ):
             tronfig = tron_tools.create_complete_config(
                 service="fake_service",
@@ -1732,6 +1765,10 @@ fake_job:
             "paasta_tools.utils.load_system_paasta_config",
             autospec=True,
             return_value=MOCK_SYSTEM_PAASTA_CONFIG_OVERRIDES,
+        ), mock.patch(
+            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
+            autospec=True,
+            return_value=[],
         ):
             tronfig = tron_tools.create_complete_config(
                 service="fake_service",


### PR DESCRIPTION
I thought I would need to jump through many hoops, but this simple of a change should work.

* For new service instances, the list of volume gets updated dynamically on top of what is loaded from the config, so everything easy peasy there.
* For existing instances, I saw that the configuration hash is calculated on the whole pod spec, minus a couple of fields, but definitely including volumes, so if a service which was not required to do auth, and some point becomes required, the hash should mismatch and a new pod get deployed.

The only thing I'm not crazy about is hardcoding that "authenticating.yaml". Maybe I could place that in a field of the system config? Although that may be a way to add a step without much of a benefit. Very open to suggestions here.