### PR TITLE
Add support for generating vitess config from minimal yelpsoa configs

### DIFF
--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -360,7 +360,6 @@ def reconcile_kubernetes_resource(
                 config = INSTANCE_TYPE_TO_CONFIG_LOADER[crd.file_prefix](
                     service=service,
                     instance=inst,
-                    instance_type=crd.file_prefix,
                     cluster=cluster,
                     soa_dir=DEFAULT_SOA_DIR,
                 )

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -49,9 +49,13 @@ from paasta_tools.utils import get_config_hash
 from paasta_tools.utils import get_git_sha_from_dockerurl
 from paasta_tools.utils import load_all_configs
 from paasta_tools.utils import load_system_paasta_config
+from paasta_tools.vitesscluster_tools import load_vitess_service_instance_configs
 
 
 log = logging.getLogger(__name__)
+
+
+INSTANCE_TYPE_TO_CONFIG_LOADER = {"vitesscluster": load_vitess_service_instance_configs}
 
 
 class StdoutKubeClient:
@@ -352,6 +356,14 @@ def reconcile_kubernetes_resource(
                 load_deployments=True,
                 soa_dir=DEFAULT_SOA_DIR,
             )
+            if crd.file_prefix in INSTANCE_TYPE_TO_CONFIG_LOADER:
+                config = INSTANCE_TYPE_TO_CONFIG_LOADER[crd.file_prefix](
+                    service=service,
+                    instance=inst,
+                    instance_type=crd.file_prefix,
+                    cluster=cluster,
+                    soa_dir=DEFAULT_SOA_DIR,
+                )
             git_sha = get_git_sha_from_dockerurl(soa_config.get_docker_url(), long=True)
             formatted_resource = format_custom_resource(
                 instance_config=config,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2735,23 +2735,9 @@ class SystemPaastaConfig:
 
     def get_always_authenticating_services(self) -> List[str]:
         return self.config_dict.get("always_authenticating_services", [])
-    
+
     def get_mysql_port_mappings(self) -> Dict:
         return self.config_dict.get("mysql_port_mappings", {})
-    
-    def get_vitess_images(self) -> Dict:
-        return self.config_dict.get(
-            "vitess_images",
-            {
-                "vtctld_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
-                "vtgate_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
-                "vttablet_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
-                "vtadmin_image": "docker-paasta.yelpcorp.com:443/vtadmin:v16.0.3",
-            },
-        )
-
-    def get_superregion_to_region_mapping(self) -> Dict:
-        return self.config_dict.get("superregion_to_region_mapping", {})
 
     def get_vitess_images(self) -> Dict:
         return self.config_dict.get(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2764,6 +2764,9 @@ class SystemPaastaConfig:
             },
         )
 
+    def get_superregion_to_region_mapping(self) -> Dict:
+        return self.config_dict.get("superregion_to_region_mapping", {})
+
 
 def _run(
     command: Union[str, List[str]],

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2025,6 +2025,9 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     mysql_port_mappings: Dict
     vitess_images: Dict
     superregion_to_region_mapping: Dict
+    vitess_tablet_types: List[str]
+    vitess_tablet_pool_type_mapping: Dict
+    vitess_throttling_config: Dict
 
 
 def load_system_paasta_config(
@@ -2752,6 +2755,35 @@ class SystemPaastaConfig:
 
     def get_superregion_to_region_mapping(self) -> Dict:
         return self.config_dict.get("superregion_to_region_mapping", {})
+
+    def get_vitess_tablet_types(self) -> List:
+        return self.config_dict.get("vitess_tablet_types", ["primary", "migration"])
+
+    def get_vitess_tablet_pool_type_mapping(self) -> Dict:
+        return self.config_dict.get("vitess_tablet_pool_type_mapping", {})
+
+    def get_vitess_throttling_config(self) -> Dict:
+        return self.config_dict.get(
+            "vitess_throttling_config",
+            {
+                "migration": {
+                    "throttle_query_table": "migration_replication_delay",
+                    "throttle_metrics_threshold": "7200",
+                },
+                "read": {
+                    "throttle_query_table": "read_replication_delay",
+                    "throttle_metrics_threshold": "3",
+                },
+                "reporting": {
+                    "throttle_query_table": "reporting_replication_delay",
+                    "throttle_metrics_threshold": "7200",
+                },
+                "primary": {
+                    "throttle_query_table": "read_replication_delay",
+                    "throttle_metrics_threshold": "3",
+                },
+            },
+        )
 
 
 def _run(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2753,6 +2753,17 @@ class SystemPaastaConfig:
     def get_superregion_to_region_mapping(self) -> Dict:
         return self.config_dict.get("superregion_to_region_mapping", {})
 
+    def get_vitess_images(self) -> Dict:
+        return self.config_dict.get(
+            "vitess_images",
+            {
+                "vtctld_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
+                "vtgate_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
+                "vttablet_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
+                "vtadmin_image": "docker-dev.yelpcorp.com/vtadmin:v16.0.3",
+            },
+        )
+
 
 def _run(
     command: Union[str, List[str]],

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2760,7 +2760,7 @@ class SystemPaastaConfig:
                 "vtctld_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
                 "vtgate_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
                 "vttablet_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
-                "vtadmin_image": "docker-dev.yelpcorp.com/vtadmin:v16.0.3",
+                "vtadmin_image": "docker-paasta.yelpcorp.com:443/vtadmin:v16.0.3",
             },
         )
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2022,6 +2022,9 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     use_multiple_log_readers: Optional[List[str]]
     service_auth_token_settings: ProjectedSAVolume
     always_authenticating_services: List[str]
+    mysql_port_mappings: Dict
+    vitess_images: Dict
+    superregion_to_region_mapping: Dict
 
 
 def load_system_paasta_config(
@@ -2732,6 +2735,23 @@ class SystemPaastaConfig:
 
     def get_always_authenticating_services(self) -> List[str]:
         return self.config_dict.get("always_authenticating_services", [])
+    
+    def get_mysql_port_mappings(self) -> Dict:
+        return self.config_dict.get("mysql_port_mappings", {})
+    
+    def get_vitess_images(self) -> Dict:
+        return self.config_dict.get(
+            "vitess_images",
+            {
+                "vtctld_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
+                "vtgate_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
+                "vttablet_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
+                "vtadmin_image": "docker-paasta.yelpcorp.com:443/vtadmin:v16.0.3",
+            },
+        )
+
+    def get_superregion_to_region_mapping(self) -> Dict:
+        return self.config_dict.get("superregion_to_region_mapping", {})
 
 
 def _run(

--- a/paasta_tools/vitesscluster_tools.py
+++ b/paasta_tools/vitesscluster_tools.py
@@ -33,7 +33,6 @@ KUBERNETES_NAMESPACE = "paasta-vitessclusters"
 TOPO_IMPLEMENTATION = "zk2"
 TOPO_GLOBAL_ROOT = "/vitess-paasta/global"
 SOURCE_DB_HOST = "169.254.255.254"
-TABLET_TYPES = load_system_paasta_config().get_vitess_tablet_types()
 WEB_PORT = "15000"
 GRPC_PORT = "15999"
 
@@ -380,10 +379,6 @@ def get_tablet_pool_config(
         log.error(
             f"Tablet type {tablet_type} not found in system paasta config vitess_tablet_pool_type_mapping"
         )
-    if tablet_type == "primary":
-        type = "externalmaster"
-    else:
-        type = "externalreplica"
 
     try:
         replicas = int(vttablet_resources.get("replicas"))
@@ -482,7 +477,8 @@ def get_keyspaces_config(
         mysql_port_mappings = load_system_paasta_config().get_mysql_port_mappings()
 
         # get vttablets
-        for tablet_type in TABLET_TYPES:
+        tablet_types = load_system_paasta_config().get_vitess_tablet_types()
+        for tablet_type in tablet_types:
             # We don't have migration or reporting tablets in all clusters
             if cluster not in mysql_port_mappings:
                 log.error(

--- a/paasta_tools/vitesscluster_tools.py
+++ b/paasta_tools/vitesscluster_tools.py
@@ -1,4 +1,6 @@
+import copy
 import logging
+from typing import Dict
 from typing import List
 from typing import Mapping
 from typing import Optional
@@ -15,6 +17,594 @@ from paasta_tools.utils import load_service_instance_config
 from paasta_tools.utils import load_v2_deployments_json
 
 KUBERNETES_NAMESPACE = "paasta-vitessclusters"
+# Image variables
+IMAGE_TAG = "v16.0.3"
+VTCTLD_IMAGE = f"docker-paasta.yelpcorp.com:443/vitess_base:{IMAGE_TAG}"
+VT_GATE_IMAGE = f"docker-paasta.yelpcorp.com:443/vitess_base:{IMAGE_TAG}"
+VT_TABLET_IMAGE = f"docker-paasta.yelpcorp.com:443/vitess_base:{IMAGE_TAG}"
+VT_ADMIN_IMAGE = f"docker-dev.yelpcorp.com/vtadmin:{IMAGE_TAG}"
+
+
+# Global variables
+TOPO_IMPLEMENTATION = "zk2"
+TOPO_GLOBAL_ROOT = "/vitess-paasta/global"
+SOURCE_DB_HOST = "169.254.255.254"
+TABLET_TYPES = ["primary", "migration"]
+WEB_PORT = "15000"
+GRPC_PORT = "15999"
+
+# Mapping of mysql cluster to target role envoy port
+MYSQL_CLUSTER_PORT_MAP = {
+    "main": {
+        "primary": 23129,
+        "migration": 22212,
+        "read": 23133,
+        "reporting": 23137,
+    },
+    "aux": {
+        "primary": 23126,
+        "migration": 22085,
+        "read": 23131,
+        "reporting": 23135,
+    },
+    "service": {
+        "primary": 23130,
+        "migration": 22388,
+        "read": 23134,
+        "reporting": 23138,
+    },
+    "nowaithost": {
+        "primary": 23184,
+        "migration": 22220,
+        "read": 23186,
+    },
+    "nowaitcad": {
+        "primary": 23183,
+        "migration": 22756,
+        "read": 23185,
+    },
+    "schematizer": {
+        "primary": 23213,
+        "migration": 22679,
+        "read": 23214,
+        "reporting": 23062,
+    },
+    "mlflow": {
+        "primary": 23955,
+        "migration": 22209,
+        "read": 23571,
+        "reporting": 23095,
+    },
+    "vitess-testing-environment": {
+        "primary": 22281,
+        "read": 22545,
+        "reporting": 22541,
+    },
+    "refresh-main": {
+        "primary": 22747,
+        "read": 22879,
+    },
+    "refresh-aux": {
+        "primary": 22505,
+        "read": 22291,
+    },
+    "refresh-service": {
+        "primary": 22790,
+        "read": 22687,
+    },
+    "refresh-nowaithost": {
+        "primary": 22351,
+        "read": 22160,
+    },
+    "refresh-nowaitcad": {
+        "primary": 22419,
+        "read": 22468,
+    },
+    "refresh-schematizer": {
+        "primary": 22840,
+        "read": 22827,
+    },
+    "sanitized-vitess": {
+        "primary": 23824,
+        "read": 23454,
+        "reporting": 23161,
+    },
+}
+
+# Environment variables
+VTCTLD_EXTRA_ENV = [
+    {
+        "name": "WEB_PORT",
+        "value": WEB_PORT,
+    },
+    {
+        "name": "GRPC_PORT",
+        "value": GRPC_PORT,
+    },
+    {
+        "name": "TOPOLOGY_FLAGS",
+        "value": "",
+    },
+]
+
+VTTABLET_EXTRA_ENV = [
+    {
+        "name": "CELL_TOPOLOGY_SERVERS",
+        "value": "",
+    },
+    {
+        "name": "SHARD",
+        "value": "0",
+    },
+    {
+        "name": "DB",
+        "value": "",
+    },
+    {
+        "name": "EXTERNAL_DB",
+        "value": "1",
+    },
+    {
+        "name": "KEYSPACE",
+        "value": "",
+    },
+    {
+        "name": "ROLE",
+        "value": "rdonly",
+    },
+    {
+        "name": "WEB_PORT",
+        "value": WEB_PORT,
+    },
+    {
+        "name": "GRPC_PORT",
+        "value": GRPC_PORT,
+    },
+    {
+        "name": "TOPOLOGY_FLAGS",
+        "value": "",
+    },
+    {
+        "name": "VAULT_ADDR",
+        "value": "https://vault-dre.uswest1-devc.yelpcorp.com:8200",
+    },
+    {
+        "name": "VAULT_ROLEID",
+        "valueFrom": {
+            "secretKeyRef": {
+                "name": "paasta-vitessclusters-secret-vitess-k8s-vault-vttablet-approle-roleid",
+                "key": "vault-vttablet-approle-roleid",
+            }
+        },
+    },
+    {
+        "name": "VAULT_SECRETID",
+        "valueFrom": {
+            "secretKeyRef": {
+                "name": "paasta-vitessclusters-secret-vitess-k8s-vault-vttablet-approle-secretid",
+                "key": "vault-vttablet-approle-secretid",
+            }
+        },
+    },
+    {
+        "name": "VAULT_CACERT",
+        "value": "/etc/vault/all_cas/acm-privateca-uswest1-devc.crt",
+    },
+]
+
+# Vault auth related variables
+VTGATE_EXTRA_ENV = [
+    {
+        "name": "VAULT_ADDR",
+        "value": "https://vault-dre.uswest1-devc.yelpcorp.com:8200",
+    },
+    {
+        "name": "VAULT_ROLEID",
+        "valueFrom": {
+            "secretKeyRef": {
+                "name": "paasta-vitessclusters-secret-vitess-k8s-vault-vtgate-approle-roleid",
+                "key": "vault-vtgate-approle-roleid",
+            }
+        },
+    },
+    {
+        "name": "VAULT_SECRETID",
+        "valueFrom": {
+            "secretKeyRef": {
+                "name": "paasta-vitessclusters-secret-vitess-k8s-vault-vtgate-approle-secretid",
+                "key": "vault-vtgate-approle-secretid",
+            }
+        },
+    },
+    {
+        "name": "VAULT_CACERT",
+        "value": "/etc/vault/all_cas/acm-privateca-uswest1-devc.crt",
+    },
+]
+
+
+# Extra Flags
+VTADMIN_EXTRA_FLAGS = {"grpc-allow-reflection": "true"}
+
+VTCTLD_EXTRA_FLAGS = {
+    "disable_active_reparents": "true",
+    "security_policy": "read-only",
+}
+
+VTTABLET_EXTRA_FLAGS = {
+    "log_err_stacks": "true",
+    "grpc_max_message_size": "134217728",
+    "init_tablet_type": "replica",
+    "queryserver-config-schema-reload-time": "1800",
+    "dba_pool_size": "4",
+    "vreplication_heartbeat_update_interval": "60",
+    "vreplication_tablet_type": "REPLICA",
+    "keep_logs": "72h",
+    "enable-lag-throttler": "true",
+    "throttle_check_as_check_self": "true",
+    "throttle_metrics_query": "",
+    "throttle_metrics_threshold": "",
+    "db_charset": "utf8mb4",
+    "disable_active_reparents": "true",
+}
+
+
+def build_affinity_spec(paasta_pool):
+    spec = {
+        "nodeAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                    {
+                        "matchExpressions": [
+                            {
+                                "key": "yelp.com/pool",
+                                "operator": "In",
+                                "values": [paasta_pool],
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+    return spec
+
+
+def build_extra_labels(paasta_pool, paasta_cluster):
+    """
+    Build extra labels to adhere to paasta contract
+    """
+    extra_labels = {
+        "yelp.com/owner": "dre_mysql_working_hours",
+        "paasta.yelp.com/cluster": paasta_cluster,
+        "paasta.yelp.com/pool": paasta_pool,
+    }
+    return extra_labels
+
+
+def build_extra_env(paasta_cluster):
+    """
+    Build extra env to adhere to paasta contract
+    """
+    extra_env = [
+        {
+            "name": "PAASTA_POD_IP",
+            "valueFrom": {"fieldRef": {"fieldPath": "status.podIP"}},
+        },
+        {"name": "PAASTA_CLUSTER", "value": paasta_cluster},
+    ]
+    return extra_env
+
+
+def build_cell_config(cell, paasta_pool, paasta_cluster, region):
+    """
+    Build vtgate config
+    """
+    config = {
+        "name": cell,
+        "gateway": {
+            "extraFlags": {
+                "mysql_auth_server_impl": "vault",
+                "mysql_auth_vault_addr": f"https://vault-dre.{region}.yelpcorp.com:8200",
+                "mysql_auth_vault_path": "secrets/vitess/vt-gate/vttablet_credentials.json",
+                "mysql_auth_vault_tls_ca": f"/etc/vault/all_cas/acm-privateca-{region}.crt",
+                "mysql_auth_vault_ttl": "60s",
+            },
+            "affinity": build_affinity_spec(paasta_pool),
+            "extraLabels": build_extra_labels(paasta_pool, paasta_cluster),
+            "extraEnv": build_extra_env(paasta_cluster),
+            "replicas": 1,
+            "resources": {
+                "requests": {
+                    "cpu": "100m",
+                    "memory": "256Mi",
+                },
+                "limits": {"memory": "256Mi"},
+            },
+        },
+    }
+    vtgate_extra_env = copy.deepcopy(VTGATE_EXTRA_ENV)
+    for env in vtgate_extra_env:
+        if env["name"] == "VAULT_ADDR":
+            env["value"] = f"https://vault-dre.{region}.yelpcorp.com:8200"
+        if env["name"] == "VAULT_CACERT":
+            env["value"] = f"/etc/vault/all_cas/acm-privateca-{region}.crt"
+        config["gateway"]["extraEnv"].append(env)
+    return config
+
+
+def build_vitess_dashboard_config(cells, paasta_pool, paasta_cluster, zk_address):
+    """
+    Build vtctld config
+    """
+    config = {
+        "cells": cells,
+        "affinity": build_affinity_spec(paasta_pool),
+        "extraLabels": build_extra_labels(paasta_pool, paasta_cluster),
+        "extraEnv": build_extra_env(paasta_cluster),
+        "extraFlags": VTCTLD_EXTRA_FLAGS,
+        "replicas": 1,
+        "resources": {
+            "requests": {
+                "cpu": "100m",
+                "memory": "128Mi",
+            },
+            "limits": {"memory": "128Mi"},
+        },
+    }
+    vtctld_extra_env = copy.deepcopy(VTCTLD_EXTRA_ENV)
+    for env in vtctld_extra_env:
+        if env["name"] == "TOPOLOGY_FLAGS":
+            env[
+                "value"
+            ] = f"--topo_implementation {TOPO_IMPLEMENTATION} --topo_global_server_address ${zk_address} --topo_global_root {TOPO_GLOBAL_ROOT}"
+        config["extraEnv"].append(env)
+
+    return config
+
+
+def build_vt_admin_config(cells, paasta_pool, paasta_cluster):
+    """
+    Build vtadmin config
+    """
+    config = {
+        "cells": cells,
+        "apiAddresses": ["http://localhost:15000"],
+        "affinity": build_affinity_spec(paasta_pool),
+        "extraLabels": build_extra_labels(paasta_pool, paasta_cluster),
+        "extraFlags": VTADMIN_EXTRA_FLAGS,
+        "extraEnv": build_extra_env(paasta_cluster),
+        "replicas": 1,
+        "readOnly": False,
+        "apiResources": {
+            "requests": {
+                "cpu": "100m",
+                "memory": "128Mi",
+            },
+            "limits": {"memory": "128Mi"},
+        },
+        "webResources": {
+            "requests": {
+                "cpu": "100m",
+                "memory": "128Mi",
+            },
+            "limits": {"memory": "128Mi"},
+        },
+    }
+    return config
+
+
+def build_tablet_pool_config(
+    cell,
+    db_name,
+    keyspace,
+    port,
+    paasta_pool,
+    paasta_cluster,
+    zk_address,
+    throttle_query_table,
+    throttle_metrics_threshold,
+    tablet_type,
+    region,
+):
+    """
+    Build vttablet config
+    """
+    vttablet_extra_flags = VTTABLET_EXTRA_FLAGS.copy()
+    vttablet_extra_flags[
+        "throttle_metrics_query"
+    ] = f"select max_replication_delay from max_mysql_replication_delay.{throttle_query_table};"
+    vttablet_extra_flags["throttle_metrics_threshold"] = throttle_metrics_threshold
+    vttablet_extra_flags["enforce-tableacl-config"] = "true"
+    vttablet_extra_flags[
+        "table-acl-config"
+    ] = f"/etc/vitess_keyspace_acls/acls_for_{db_name}.json"
+    vttablet_extra_flags["table-acl-config-reload-interval"] = "60s"
+    vttablet_extra_flags["queryserver-config-strict-table-acl"] = "true"
+    vttablet_extra_flags["db-credentials-server"] = "vault"
+    vttablet_extra_flags[
+        "db-credentials-vault-addr"
+    ] = f"https://vault-dre.{region}.yelpcorp.com:8200"
+    vttablet_extra_flags[
+        "db-credentials-vault-path"
+    ] = "secrets/vitess/vt-tablet/vttablet_credentials.json"
+    vttablet_extra_flags[
+        "db-credentials-vault-tls-ca"
+    ] = f"/etc/vault/all_cas/acm-privateca-{region}.crt"
+    vttablet_extra_flags["db-credentials-vault-ttl"] = "60s"
+
+    if tablet_type == "primary":
+        type = "externalmaster"
+    else:
+        type = "externalreplica"
+
+    config = {
+        "cell": cell,
+        "name": f"{db_name}_{tablet_type}",
+        "type": type,
+        "affinity": build_affinity_spec(paasta_pool),
+        "extraLabels": build_extra_labels(paasta_pool, paasta_cluster),
+        "extraEnv": build_extra_env(paasta_cluster),
+        "extraVolumeMounts": [
+            {
+                "mountPath": "/etc/vault/all_cas",
+                "name": "vault-secrets",
+                "readOnly": True,
+            },
+            {
+                "mountPath": "/etc/vitess_keyspace_acls",
+                "name": "acls",
+                "readOnly": True,
+            },
+            {
+                "mountPath": "etc/credentials.yaml",
+                "name": "vttablet-fake-credentials",
+                "readOnly": True,
+            },
+            {
+                "mountPath": "/etc/init_db.sql",
+                "name": "keyspace-fake-init-script",
+                "readOnly": True,
+            },
+        ],
+        "extraVolumes": [
+            {"name": "vault-secrets", "hostPath": {"path": "/nail/etc/vault/all_cas"}},
+            {
+                "name": "acls",
+                "hostPath": {"path": "/nail/srv/configs/vitess_keyspace_acls"},
+            },
+            {"name": "vttablet-fake-credentials", "hostPath": {"path": "/dev/null"}},
+            {"name": "keyspace-fake-init-script", "hostPath": {"path": "/dev/null"}},
+        ],
+        "replicas": 1,
+        "vttablet": {
+            "extraFlags": vttablet_extra_flags,
+            "resources": {
+                "requests": {
+                    "cpu": "100m",
+                    "memory": "256Mi",
+                },
+                "limits": {"memory": "256Mi"},
+            },
+        },
+        "externalDatastore": {
+            "database": db_name,
+            "host": SOURCE_DB_HOST,
+            "port": port,
+            "user": "vt_app",
+            "credentialsSecret": {
+                "key": "/etc/credentials.yaml",
+                "volumeName": "vttablet-fake-credentials",
+            },
+        },
+        "dataVolumeClaimTemplate": {
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": "10Gi"}},
+            "storageClassName": "ebs-csi-gp3",
+        },
+    }
+
+    vttablet_extra_env = copy.deepcopy(VTTABLET_EXTRA_ENV)
+    for env in vttablet_extra_env:
+        if env["name"] == "TOPOLOGY_FLAGS":
+            env[
+                "value"
+            ] = f"--topo_implementation {TOPO_IMPLEMENTATION} --topo_global_server_address ${zk_address} --topo_global_root {TOPO_GLOBAL_ROOT}"
+        if env["name"] == "CELL_TOPOLOGY_SERVERS":
+            env["value"] = zk_address
+        if env["name"] == "DB":
+            env["value"] = db_name
+        if env["name"] == "KEYSPACE":
+            env["value"] = keyspace
+        if env["name"] == "VAULT_ADDR":
+            env["value"] = f"https://vault-dre.{region}.yelpcorp.com:8200"
+        if env["name"] == "VAULT_CACERT":
+            env["value"] = f"/etc/vault/all_cas/acm-privateca-{region}.crt"
+        config["extraEnv"].append(env)
+
+    # Add extra pod label to filter
+    config["extraLabels"]["tablet_type"] = f"{db_name}_{tablet_type}"
+
+    return config
+
+
+def build_keyspaces_config(
+    cells, keyspaces, paasta_pool, paasta_cluster, zk_address, region
+):
+    """
+    Build vitess keyspace config
+    """
+    config = []
+
+    for keyspace_config in keyspaces:
+        keyspace = keyspace_config["keyspace"]
+        db_name = keyspace_config["keyspace"]
+        cluster = keyspace_config["cluster"]
+
+        tablet_pools = []
+
+        # Build vttablets
+        for tablet_type in TABLET_TYPES:
+            # We don't have migration or reporting tablets in all clusters
+            if tablet_type not in MYSQL_CLUSTER_PORT_MAP[cluster]:
+                continue
+            port = MYSQL_CLUSTER_PORT_MAP[cluster][tablet_type]
+
+            # We use migration_replication delay for migration tablets and read_replication_delay for everything else
+            # Also throttling threshold for migration tablets is 2 hours, refresh and sanitized primaries at 30 seconds and everything else at 3 seconds
+            if tablet_type == "migration":
+                throttle_query_table = "migration_replication_delay"
+                throttle_metrics_threshold = "7200"
+            else:
+                throttle_query_table = "read_replication_delay"
+                if cluster.startswith("refresh") or cluster.startswith("sanitized"):
+                    throttle_metrics_threshold = "30"
+                else:
+                    throttle_metrics_threshold = "3"
+
+            tablet_pools.extend(
+                [
+                    build_tablet_pool_config(
+                        cell,
+                        db_name,
+                        keyspace,
+                        port,
+                        paasta_pool,
+                        paasta_cluster,
+                        zk_address,
+                        throttle_query_table,
+                        throttle_metrics_threshold,
+                        tablet_type,
+                        region,
+                    )
+                    for cell in cells
+                ]
+            )
+
+        config.append(
+            {
+                "name": keyspace,
+                "durabilityPolicy": "none",
+                "turndownPolicy": "Immediate",
+                "partitionings": [
+                    {
+                        "equal": {
+                            "parts": 1,
+                            "shardTemplate": {
+                                "databaseInitScriptSecret": {
+                                    "volumeName": "keyspace-fake-init-script",
+                                    "key": "/etc/init_db.sql",
+                                },
+                                "tabletPools": tablet_pools,
+                            },
+                        }
+                    }
+                ],
+            }
+        )
+
+    return config
+
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -72,6 +662,89 @@ class VitessDeploymentConfig(LongRunningServiceConfig):
             return []
 
 
+def generate_vitess_instance_config(
+    instance_config: Dict,
+) -> Dict:
+    # Generate the vitess instance config from the yelpsoa config
+
+    cpus = instance_config.get("cpus")
+    mem = instance_config.get("mem")
+    deploy_group = instance_config.get("deploy_group")
+    zk_address = instance_config.get("zk_address")
+    paasta_pool = instance_config.get("paasta_pool")
+    paasta_cluster = instance_config.get("paasta_cluster")
+    cells = instance_config.get("cells")
+    keyspaces = instance_config.get("keyspaces")
+    region = instance_config.get("region")
+
+    vitess_instance_config = {
+        "namespace": "paasta-vitessclusters",
+        "cpus": cpus,
+        "mem": mem,
+        "min_instances": 1,
+        "max_instances": 1,
+        "deploy_group": deploy_group,
+        "autoscaling": {"setpoint": 0.7},
+        "env": {
+            "OPERATOR_NAME": "vitess-operator",
+            "POD_NAME": "vitess-k8s",
+            "PS_OPERATOR_POD_NAME": "vitess-k8s",
+            "PS_OPERATOR_POD_NAMESPACE": "paasta-vitessclusters",
+            "WATCH_NAMESPACE": "paasta-vitessclusters",
+        },
+        "healthcheck_grace_period_seconds": 60,
+        "healthcheck_mode": "cmd",
+        "healthcheck_cmd": "true",
+        "images": {
+            "vtctld": VTCTLD_IMAGE,
+            "vtadmin": VT_ADMIN_IMAGE,
+            "vtgate": VT_GATE_IMAGE,
+            "vttablet": VT_TABLET_IMAGE,
+        },
+        "globalLockserver": {
+            "external": {
+                "implementation": TOPO_IMPLEMENTATION,
+                "address": zk_address,
+                "rootPath": TOPO_GLOBAL_ROOT,
+            }
+        },
+        "cells": [
+            build_cell_config(cell, paasta_pool, paasta_cluster, region)
+            for cell in cells
+        ],
+        "vitessDashboard": build_vitess_dashboard_config(
+            cells, paasta_pool, paasta_cluster, zk_address
+        ),
+        "vtadmin": build_vt_admin_config(cells, paasta_pool, paasta_cluster),
+        "keyspaces": build_keyspaces_config(
+            cells, keyspaces, paasta_pool, paasta_cluster, zk_address, region
+        ),
+        "updateStrategy": {"type": "Immediate"},
+    }
+    return vitess_instance_config
+
+
+def load_vitess_service_instance_configs(
+    service: str,
+    instance: str,
+    instance_type: str,
+    cluster: str,
+    soa_dir: str = DEFAULT_SOA_DIR,
+) -> VitessDeploymentConfigDict:
+    general_config = service_configuration_lib.read_service_configuration(
+        service, soa_dir=soa_dir
+    )
+    instance_config = load_service_instance_config(
+        service, instance, instance_type, cluster, soa_dir=soa_dir
+    )
+    vitess_instance_config = generate_vitess_instance_config(Dict(instance_config))
+
+    general_config = deep_merge_dictionaries(
+        overrides=vitess_instance_config, defaults=general_config
+    )
+    return general_config
+
+
 def load_vitess_instance_config(
     service: str,
     instance: str,
@@ -79,14 +752,8 @@ def load_vitess_instance_config(
     load_deployments: bool = True,
     soa_dir: str = DEFAULT_SOA_DIR,
 ) -> VitessDeploymentConfig:
-    general_config = service_configuration_lib.read_service_configuration(
-        service, soa_dir=soa_dir
-    )
-    instance_config = load_service_instance_config(
+    general_config = load_vitess_service_instance_configs(
         service, instance, "vitesscluster", cluster, soa_dir=soa_dir
-    )
-    general_config = deep_merge_dictionaries(
-        overrides=instance_config, defaults=general_config
     )
 
     branch_dict: Optional[BranchDictV2] = None

--- a/paasta_tools/vitesscluster_tools.py
+++ b/paasta_tools/vitesscluster_tools.py
@@ -632,7 +632,10 @@ class VitessDeploymentConfig(KubernetesDeploymentConfig):
             system_paasta_config=load_system_paasta_config()
         )
         git_sha = get_git_sha_from_dockerurl(docker_url)
-        return self.get_kubernetes_metadata(git_sha=git_sha).labels
+        labels = self.get_kubernetes_metadata(git_sha=git_sha).labels
+        if "yelp.com/owner" in labels.keys():
+            labels["yelp.com/owner"] = "dre_mysql"
+        return labels
 
     def get_vitess_node_affinity(self) -> dict:
         paasta_pool = self.get_pool()

--- a/paasta_tools/vitesscluster_tools.py
+++ b/paasta_tools/vitesscluster_tools.py
@@ -749,6 +749,7 @@ class VitessDeploymentConfig(KubernetesDeploymentConfig):
 
     def get_vitess_config(self) -> VitessDeploymentConfigDict:
         vitess_config = VitessDeploymentConfigDict(
+            namespace=self.get_namespace(),
             images=self.get_images(),
             globalLockserver=self.get_global_lock_server(),
             cells=self.get_cells(),

--- a/tests/test_vitesscluster_tools.py
+++ b/tests/test_vitesscluster_tools.py
@@ -1,0 +1,718 @@
+import mock
+import pytest
+from kubernetes.client import V1ObjectMeta
+
+from paasta_tools.utils import SystemPaastaConfig
+from paasta_tools.vitesscluster_tools import load_vitess_instance_config
+from paasta_tools.vitesscluster_tools import load_vitess_service_instance_configs
+from paasta_tools.vitesscluster_tools import VitessDeploymentConfig
+
+
+CONFIG_DICT = {
+    "cells": ["fake_cell"],
+    "data": {},
+    "dependencies": {},
+    "deploy": {"pipeline": [{"step": "fake_deploy_group"}]},
+    "deploy_group": "fake_deploy_group",
+    "description": "Test Description",
+    "external_link": "fake_link",
+    "git_url": "git@github.yelpcorp.com:services/vitess-k8s",
+    "healthcheck_cmd": "fake_cmd",
+    "healthcheck_grace_period_seconds": 60,
+    "healthcheck_mode": "cmd",
+    "keyspaces": [
+        {
+            "cluster": "fake_cluster",
+            "keyspace": "fake_keyspaces",
+            "vttablet_resources": {
+                "replicas": 1,
+                "requests": {"cpu": "100m", "memory": "256Mi"},
+            },
+        }
+    ],
+    "monitoring": {},
+    "node_selectors": {"fake_pool": ["fake_pool_value"]},
+    "paasta_pool": "fake_pool_value",
+    "port": None,
+    "smartstack": {},
+    "vtadmin_resources": {
+        "replicas": 1,
+        "requests": {"cpu": "100m", "memory": "256Mi"},
+    },
+    "vtctld_resources": {"replicas": 1, "requests": {"cpu": "100m", "memory": "256Mi"}},
+    "vtgate_resources": {"replicas": 1, "requests": {"cpu": "100m", "memory": "256Mi"}},
+    "zk_address": "fake_zk_address",
+}
+
+MOCK_SYSTEM_PAASTA_CONFIG = SystemPaastaConfig(
+    config={
+        "superregion_to_region_mapping": {"fake_superregion": "fake_region"},
+        "mysql_port_mappings": {
+            "fake_cluster": {
+                "primary": 1234,
+                "migration": 1234,
+                "read": 1234,
+                "reporting": 1234,
+            },
+        },
+        "vitess_tablet_pool_type_mapping": {
+            "primary": "externalmaster",
+            "migration": "externalreplica",
+        },
+    },
+    directory="/fake/config/directory",
+)
+
+VITESS_CONFIG = {
+    "namespace": "paasta-vitessclusters",
+    "cells": [
+        {
+            "gateway": {
+                "affinity": {
+                    "nodeAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "nodeSelectorTerms": [
+                                {
+                                    "matchExpressions": [
+                                        {
+                                            "key": "fake_pool",
+                                            "operator": "In",
+                                            "values": ["fake_pool_value"],
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                "extraEnv": [
+                    {
+                        "name": "VAULT_ADDR",
+                        "value": "https://vault-dre.mock_region.yelpcorp.com:8200",
+                    },
+                    {
+                        "name": "VAULT_CACERT",
+                        "value": "/etc/vault/all_cas/acm-privateca-mock_region.crt",
+                    },
+                    {
+                        "name": "VAULT_ROLEID",
+                        "valueFrom": {
+                            "secretKeyRef": {
+                                "key": "vault-vtgate-approle-roleid",
+                                "name": "paasta-vitessclusters-secret-vitess-k8s-vault-vtgate-approle-roleid",
+                            }
+                        },
+                    },
+                    {
+                        "name": "VAULT_SECRETID",
+                        "valueFrom": {
+                            "secretKeyRef": {
+                                "key": "vault-vtgate-approle-secretid",
+                                "name": "paasta-vitessclusters-secret-vitess-k8s-vault-vtgate-approle-secretid",
+                            }
+                        },
+                    },
+                ],
+                "extraFlags": {
+                    "mysql_auth_server_impl": "vault",
+                    "mysql_auth_vault_addr": "https://vault-dre.mock_region.yelpcorp.com:8200",
+                    "mysql_auth_vault_path": "secrets/vitess/vt-gate/vttablet_credentials.json",
+                    "mysql_auth_vault_tls_ca": "/etc/vault/all_cas/acm-privateca-mock_region.crt",
+                    "mysql_auth_vault_ttl": "60s",
+                },
+                "extraLabels": {"tablet_type": "fake_keyspaces_migration"},
+                "replicas": 1,
+                "resources": {
+                    "limits": {"cpu": "100m", "memory": "256Mi"},
+                    "requests": {"cpu": "100m", "memory": "256Mi"},
+                },
+            },
+            "name": "fake_cell",
+        }
+    ],
+    "globalLockserver": {
+        "external": {
+            "address": "fake_zk_address",
+            "implementation": "zk2",
+            "rootPath": "/vitess-paasta/global",
+        }
+    },
+    "images": {
+        "vtadmin": "docker-paasta.yelpcorp.com:443/vtadmin:v16.0.3",
+        "vtctld": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
+        "vtgate": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
+        "vttablet": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
+    },
+    "keyspaces": [
+        {
+            "durabilityPolicy": "none",
+            "name": "fake_keyspaces",
+            "partitionings": [
+                {
+                    "equal": {
+                        "parts": 1,
+                        "shardTemplate": {
+                            "databaseInitScriptSecret": {
+                                "key": "/etc/init_db.sql",
+                                "volumeName": "keyspace-fake-init-script",
+                            },
+                            "tabletPools": [
+                                {
+                                    "affinity": {
+                                        "nodeAffinity": {
+                                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                "nodeSelectorTerms": [
+                                                    {
+                                                        "matchExpressions": [
+                                                            {
+                                                                "key": "fake_pool",
+                                                                "operator": "In",
+                                                                "values": [
+                                                                    "fake_pool_value"
+                                                                ],
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "cell": "fake_cell",
+                                    "dataVolumeClaimTemplate": {
+                                        "accessModes": ["ReadWriteOnce"],
+                                        "resources": {"requests": {"storage": "10Gi"}},
+                                        "storageClassName": "ebs-csi-gp3",
+                                    },
+                                    "externalDatastore": {
+                                        "credentialsSecret": {
+                                            "key": "/etc/credentials.yaml",
+                                            "volumeName": "vttablet-fake-credentials",
+                                        },
+                                        "database": "fake_keyspaces",
+                                        "host": "169.254.255.254",
+                                        "port": 1234,
+                                        "user": "vt_app",
+                                    },
+                                    "extraEnv": [
+                                        {
+                                            "name": "VAULT_ADDR",
+                                            "value": "https://vault-dre.mock_region.yelpcorp.com:8200",
+                                        },
+                                        {
+                                            "name": "VAULT_CACERT",
+                                            "value": "/etc/vault/all_cas/acm-privateca-mock_region.crt",
+                                        },
+                                        {
+                                            "name": "TOPOLOGY_FLAGS",
+                                            "value": "--topo_implementation "
+                                            "zk2 "
+                                            "--topo_global_server_address "
+                                            "$fake_zk_address "
+                                            "--topo_global_root "
+                                            "/vitess-paasta/global",
+                                        },
+                                        {
+                                            "name": "CELL_TOPOLOGY_SERVERS",
+                                            "value": "fake_zk_address",
+                                        },
+                                        {"name": "DB", "value": "fake_keyspaces"},
+                                        {"name": "KEYSPACE", "value": "fake_keyspaces"},
+                                        {"name": "WEB_PORT", "value": "15000"},
+                                        {"name": "GRPC_PORT", "value": "15999"},
+                                        {"name": "SHARD", "value": "0"},
+                                        {"name": "EXTERNAL_DB", "value": "1"},
+                                        {"name": "ROLE", "value": "replica"},
+                                        {
+                                            "name": "VAULT_ROLEID",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "key": "vault-vttablet-approle-roleid",
+                                                    "name": "paasta-vitessclusters-secret-vitess-k8s-vault-vttablet-approle-roleid",
+                                                }
+                                            },
+                                        },
+                                        {
+                                            "name": "VAULT_SECRETID",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "key": "vault-vttablet-approle-secretid",
+                                                    "name": "paasta-vitessclusters-secret-vitess-k8s-vault-vttablet-approle-secretid",
+                                                }
+                                            },
+                                        },
+                                    ],
+                                    "extraLabels": {
+                                        "tablet_type": "fake_keyspaces_migration"
+                                    },
+                                    "extraVolumeMounts": [
+                                        {
+                                            "mountPath": "/etc/vault/all_cas",
+                                            "name": "vault-secrets",
+                                            "readOnly": True,
+                                        },
+                                        {
+                                            "mountPath": "/etc/srv",
+                                            "name": "srv-configs",
+                                            "readOnly": True,
+                                        },
+                                        {
+                                            "mountPath": "etc/credentials.yaml",
+                                            "name": "vttablet-fake-credentials",
+                                            "readOnly": True,
+                                        },
+                                        {
+                                            "mountPath": "/etc/init_db.sql",
+                                            "name": "keyspace-fake-init-script",
+                                            "readOnly": True,
+                                        },
+                                    ],
+                                    "extraVolumes": [
+                                        {
+                                            "hostPath": {
+                                                "path": "/nail/etc/vault/all_cas"
+                                            },
+                                            "name": "vault-secrets",
+                                        },
+                                        {
+                                            "hostPath": {"path": "/nail/srv"},
+                                            "name": "srv-configs",
+                                        },
+                                        {
+                                            "hostPath": {"path": "/dev/null"},
+                                            "name": "vttablet-fake-credentials",
+                                        },
+                                        {
+                                            "hostPath": {"path": "/dev/null"},
+                                            "name": "keyspace-fake-init-script",
+                                        },
+                                    ],
+                                    "name": "fake_keyspaces_primary",
+                                    "replicas": 1,
+                                    "type": "externalmaster",
+                                    "vttablet": {
+                                        "extraFlags": {
+                                            "db-credentials-server": "vault",
+                                            "db-credentials-vault-addr": "https://vault-dre.mock_region.yelpcorp.com:8200",
+                                            "db-credentials-vault-path": "secrets/vitess/vt-tablet/vttablet_credentials.json",
+                                            "db-credentials-vault-tls-ca": "/etc/vault/all_cas/acm-privateca-mock_region.crt",
+                                            "db-credentials-vault-ttl": "60s",
+                                            "db_charset": "utf8mb4",
+                                            "dba_pool_size": "4",
+                                            "disable_active_reparents": "true",
+                                            "enable-lag-throttler": "true",
+                                            "enforce-tableacl-config": "true",
+                                            "grpc_max_message_size": "134217728",
+                                            "init_tablet_type": "replica",
+                                            "keep_logs": "72h",
+                                            "log_err_stacks": "true",
+                                            "queryserver-config-schema-reload-time": "1800",
+                                            "queryserver-config-strict-table-acl": "true",
+                                            "table-acl-config": "/etc/srv/configs/vitess_keyspace_acls/acls_for_fake_keyspaces.json",
+                                            "table-acl-config-reload-interval": "60s",
+                                            "throttle_check_as_check_self": "true",
+                                            "throttle_metrics_query": "select "
+                                            "max_replication_delay "
+                                            "from "
+                                            "max_mysql_replication_delay.read_replication_delay;",
+                                            "throttle_metrics_threshold": "3",
+                                            "vreplication_heartbeat_update_interval": "60",
+                                            "vreplication_tablet_type": "REPLICA",
+                                        },
+                                        "resources": {
+                                            "limits": {
+                                                "cpu": "100m",
+                                                "memory": "256Mi",
+                                            },
+                                            "requests": {
+                                                "cpu": "100m",
+                                                "memory": "256Mi",
+                                            },
+                                        },
+                                    },
+                                },
+                                {
+                                    "affinity": {
+                                        "nodeAffinity": {
+                                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                "nodeSelectorTerms": [
+                                                    {
+                                                        "matchExpressions": [
+                                                            {
+                                                                "key": "fake_pool",
+                                                                "operator": "In",
+                                                                "values": [
+                                                                    "fake_pool_value"
+                                                                ],
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "cell": "fake_cell",
+                                    "dataVolumeClaimTemplate": {
+                                        "accessModes": ["ReadWriteOnce"],
+                                        "resources": {"requests": {"storage": "10Gi"}},
+                                        "storageClassName": "ebs-csi-gp3",
+                                    },
+                                    "externalDatastore": {
+                                        "credentialsSecret": {
+                                            "key": "/etc/credentials.yaml",
+                                            "volumeName": "vttablet-fake-credentials",
+                                        },
+                                        "database": "fake_keyspaces",
+                                        "host": "169.254.255.254",
+                                        "port": 1234,
+                                        "user": "vt_app",
+                                    },
+                                    "extraEnv": [
+                                        {
+                                            "name": "VAULT_ADDR",
+                                            "value": "https://vault-dre.mock_region.yelpcorp.com:8200",
+                                        },
+                                        {
+                                            "name": "VAULT_CACERT",
+                                            "value": "/etc/vault/all_cas/acm-privateca-mock_region.crt",
+                                        },
+                                        {
+                                            "name": "TOPOLOGY_FLAGS",
+                                            "value": "--topo_implementation "
+                                            "zk2 "
+                                            "--topo_global_server_address "
+                                            "$fake_zk_address "
+                                            "--topo_global_root "
+                                            "/vitess-paasta/global",
+                                        },
+                                        {
+                                            "name": "CELL_TOPOLOGY_SERVERS",
+                                            "value": "fake_zk_address",
+                                        },
+                                        {"name": "DB", "value": "fake_keyspaces"},
+                                        {"name": "KEYSPACE", "value": "fake_keyspaces"},
+                                        {"name": "WEB_PORT", "value": "15000"},
+                                        {"name": "GRPC_PORT", "value": "15999"},
+                                        {"name": "SHARD", "value": "0"},
+                                        {"name": "EXTERNAL_DB", "value": "1"},
+                                        {"name": "ROLE", "value": "replica"},
+                                        {
+                                            "name": "VAULT_ROLEID",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "key": "vault-vttablet-approle-roleid",
+                                                    "name": "paasta-vitessclusters-secret-vitess-k8s-vault-vttablet-approle-roleid",
+                                                }
+                                            },
+                                        },
+                                        {
+                                            "name": "VAULT_SECRETID",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "key": "vault-vttablet-approle-secretid",
+                                                    "name": "paasta-vitessclusters-secret-vitess-k8s-vault-vttablet-approle-secretid",
+                                                }
+                                            },
+                                        },
+                                    ],
+                                    "extraLabels": {
+                                        "tablet_type": "fake_keyspaces_migration"
+                                    },
+                                    "extraVolumeMounts": [
+                                        {
+                                            "mountPath": "/etc/vault/all_cas",
+                                            "name": "vault-secrets",
+                                            "readOnly": True,
+                                        },
+                                        {
+                                            "mountPath": "/etc/srv",
+                                            "name": "srv-configs",
+                                            "readOnly": True,
+                                        },
+                                        {
+                                            "mountPath": "etc/credentials.yaml",
+                                            "name": "vttablet-fake-credentials",
+                                            "readOnly": True,
+                                        },
+                                        {
+                                            "mountPath": "/etc/init_db.sql",
+                                            "name": "keyspace-fake-init-script",
+                                            "readOnly": True,
+                                        },
+                                    ],
+                                    "extraVolumes": [
+                                        {
+                                            "hostPath": {
+                                                "path": "/nail/etc/vault/all_cas"
+                                            },
+                                            "name": "vault-secrets",
+                                        },
+                                        {
+                                            "hostPath": {"path": "/nail/srv"},
+                                            "name": "srv-configs",
+                                        },
+                                        {
+                                            "hostPath": {"path": "/dev/null"},
+                                            "name": "vttablet-fake-credentials",
+                                        },
+                                        {
+                                            "hostPath": {"path": "/dev/null"},
+                                            "name": "keyspace-fake-init-script",
+                                        },
+                                    ],
+                                    "name": "fake_keyspaces_migration",
+                                    "replicas": 1,
+                                    "type": "externalreplica",
+                                    "vttablet": {
+                                        "extraFlags": {
+                                            "db-credentials-server": "vault",
+                                            "db-credentials-vault-addr": "https://vault-dre.mock_region.yelpcorp.com:8200",
+                                            "db-credentials-vault-path": "secrets/vitess/vt-tablet/vttablet_credentials.json",
+                                            "db-credentials-vault-tls-ca": "/etc/vault/all_cas/acm-privateca-mock_region.crt",
+                                            "db-credentials-vault-ttl": "60s",
+                                            "db_charset": "utf8mb4",
+                                            "dba_pool_size": "4",
+                                            "disable_active_reparents": "true",
+                                            "enable-lag-throttler": "true",
+                                            "enforce-tableacl-config": "true",
+                                            "grpc_max_message_size": "134217728",
+                                            "init_tablet_type": "replica",
+                                            "keep_logs": "72h",
+                                            "log_err_stacks": "true",
+                                            "queryserver-config-schema-reload-time": "1800",
+                                            "queryserver-config-strict-table-acl": "true",
+                                            "table-acl-config": "/etc/srv/configs/vitess_keyspace_acls/acls_for_fake_keyspaces.json",
+                                            "table-acl-config-reload-interval": "60s",
+                                            "throttle_check_as_check_self": "true",
+                                            "throttle_metrics_query": "select "
+                                            "max_replication_delay "
+                                            "from "
+                                            "max_mysql_replication_delay.migration_replication_delay;",
+                                            "throttle_metrics_threshold": "3",
+                                            "vreplication_heartbeat_update_interval": "60",
+                                            "vreplication_tablet_type": "REPLICA",
+                                        },
+                                        "resources": {
+                                            "limits": {
+                                                "cpu": "100m",
+                                                "memory": "256Mi",
+                                            },
+                                            "requests": {
+                                                "cpu": "100m",
+                                                "memory": "256Mi",
+                                            },
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    }
+                }
+            ],
+            "turndownPolicy": "Immediate",
+        }
+    ],
+    "updateStrategy": {"type": "Immediate"},
+    "vitessDashboard": {
+        "affinity": {
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "fake_pool",
+                                    "operator": "In",
+                                    "values": ["fake_pool_value"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "cells": ["fake_cell"],
+        "extraEnv": [
+            {
+                "name": "TOPOLOGY_FLAGS",
+                "value": "--topo_implementation zk2 "
+                "--topo_global_server_address "
+                "fake_zk_address "
+                "--topo_global_root "
+                "/vitess-paasta/global",
+            },
+            {"name": "WEB_PORT", "value": "15000"},
+            {"name": "GRPC_PORT", "value": "15999"},
+        ],
+        "extraFlags": {
+            "disable_active_reparents": "true",
+            "security_policy": "read-only",
+        },
+        "extraLabels": {"tablet_type": "fake_keyspaces_migration"},
+        "replicas": 1,
+        "resources": {
+            "limits": {"cpu": "100m", "memory": "256Mi"},
+            "requests": {"cpu": "100m", "memory": "256Mi"},
+        },
+    },
+    "vtadmin": {
+        "affinity": {
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "fake_pool",
+                                    "operator": "In",
+                                    "values": ["fake_pool_value"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "apiAddresses": ["http://localhost:15000"],
+        "apiResources": {
+            "limits": {"cpu": "100m", "memory": "256Mi"},
+            "requests": {"cpu": "100m", "memory": "256Mi"},
+        },
+        "cells": ["fake_cell"],
+        "extraEnv": [],
+        "extraFlags": {"grpc-allow-reflection": "true"},
+        "extraLabels": {"tablet_type": "fake_keyspaces_migration"},
+        "readOnly": False,
+        "replicas": 1,
+        "webResources": {
+            "limits": {"cpu": "100m", "memory": "256Mi"},
+            "requests": {"cpu": "100m", "memory": "256Mi"},
+        },
+    },
+}
+
+
+@pytest.fixture
+def mock_vitess_deployment_config():
+    with mock.patch.object(
+        VitessDeploymentConfig, "get_region", return_value="mock_region"
+    ), mock.patch.object(
+        VitessDeploymentConfig, "get_container_env", return_value=[]
+    ), mock.patch.object(
+        VitessDeploymentConfig, "get_docker_url", return_value="fake_docker_url"
+    ), mock.patch.object(
+        VitessDeploymentConfig, "get_cluster", return_value="fake_superregion"
+    ), mock.patch.object(
+        VitessDeploymentConfig,
+        "get_kubernetes_metadata",
+        return_value=V1ObjectMeta(labels={}),
+    ):
+        yield
+
+
+@mock.patch(
+    "paasta_tools.vitesscluster_tools.load_vitess_instance_config",
+    autospec=True,
+)
+@mock.patch(
+    "paasta_tools.vitesscluster_tools.load_system_paasta_config",
+    autospec=True,
+)
+def test_load_vitess_service_instance_configs(
+    mock_load_system_paasta_config,
+    mock_load_vitess_instance_config,
+    mock_vitess_deployment_config,
+):
+    mock_load_vitess_instance_config.return_value = VitessDeploymentConfig(
+        service="fake_service",
+        instance="fake_instance",
+        cluster="fake_cluster",
+        config_dict=CONFIG_DICT,
+        branch_dict={},
+        soa_dir="fake_soa_dir",
+    )
+    mock_load_system_paasta_config.return_value = MOCK_SYSTEM_PAASTA_CONFIG
+    vitess_service_instance_configs = load_vitess_service_instance_configs(
+        service="fake_service",
+        soa_dir="fake_soa_dir",
+        cluster="fake_cluster",
+        instance="fake_instance",
+    )
+    assert vitess_service_instance_configs == VITESS_CONFIG
+
+
+@mock.patch(
+    "paasta_tools.vitesscluster_tools.load_vitess_instance_config",
+    autospec=True,
+)
+@mock.patch(
+    "paasta_tools.vitesscluster_tools.load_system_paasta_config",
+    autospec=True,
+)
+def test_load_vitess_service_instance_configs_missing_mysql_cluster_mapping_entry(
+    mock_load_system_paasta_config,
+    mock_load_vitess_instance_config,
+    mock_vitess_deployment_config,
+):
+    mock_load_vitess_instance_config.return_value = VitessDeploymentConfig(
+        service="fake_service",
+        instance="fake_instance",
+        cluster="fake_cluster",
+        config_dict=CONFIG_DICT,
+        branch_dict={},
+        soa_dir="fake_soa_dir",
+    )
+    mock_load_system_paasta_config.return_value = SystemPaastaConfig(
+        config={},
+        directory="/fake/config/directory",
+    )
+    with pytest.raises(KeyError):
+        load_vitess_service_instance_configs(
+            service="fake_service",
+            soa_dir="fake_soa_dir",
+            cluster="fake_cluster",
+            instance="fake_instance",
+        )
+
+
+@mock.patch("paasta_tools.vitesscluster_tools.load_v2_deployments_json", autospec=True)
+@mock.patch(
+    "paasta_tools.vitesscluster_tools.load_service_instance_config",
+    autospec=True,
+)
+@mock.patch(
+    "paasta_tools.vitesscluster_tools.VitessDeploymentConfig",
+    autospec=True,
+)
+def test_load_vitess_instance_config(
+    mock_vitess_deployment_config,
+    mock_load_service_instance_config,
+    mock_load_v2_deployments_json,
+):
+    mock_config = {
+        "port": None,
+        "monitoring": {},
+        "deploy": {},
+        "data": {},
+        "smartstack": {},
+        "dependencies": {},
+    }
+    vitess_deployment_config = load_vitess_instance_config(
+        service="fake_vitesscluster_service",
+        instance="fake_instance",
+        cluster="fake_cluster",
+        load_deployments=True,
+        soa_dir="/foo/bar",
+    )
+    mock_load_v2_deployments_json.assert_called_with(
+        service="fake_vitesscluster_service", soa_dir="/foo/bar"
+    )
+    mock_vitess_deployment_config.assert_called_with(
+        service="fake_vitesscluster_service",
+        instance="fake_instance",
+        cluster="fake_cluster",
+        config_dict=mock_config,
+        branch_dict=mock_load_v2_deployments_json.return_value.get_branch_dict(),
+        soa_dir="/foo/bar",
+    )
+
+    assert vitess_deployment_config == mock_vitess_deployment_config.return_value


### PR DESCRIPTION
*Using multiple commits to iterate on comments and making incremental changes, will squash into a single commit at the end*

Local testing:
Added a make target
```
+.PHONY: setup-kubernetes-cr
+setup-kubernetes-cr:  setup-kubernetes-job
+       export KUBECONFIG=./k8s_itests/kubeconfig;\
+       export PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/;\
+       export PAASTA_TEST_CLUSTER=kind-${USER}-k8s-test;\
+       .tox/py38-linux/bin/python -m paasta_tools.setup_kubernetes_cr -d ./soa_config_playground -c kind-${USER}-k8s-test -s vitess-k8s
```
*Need to use kubeconfig context to apply CRD's in the expected namespace before vitess-k8s deployment can happen*
Test run output: https://fluffy.yelpcorp.com/i/zMjmrhtFwdqh1rz5mcvwPdRHb1XMNl13.html

Sample yelpsoa specification used for local testing:
```
_low_priority_resource_requirements: &low_priority_resource_requirements
  replicas: 1
  requests:
    cpu: 100m
    memory: 256Mi

main:
  deploy_group: "infrastage"
  cells:
  - "uswest1devc"
  zk_address: "10.40.10.198:2181,10.40.23.30:2181,10.40.11.46:2181"
  paasta_pool: "default"
  node_selectors:
    yelp.com/pool: ["default"]
  healthcheck_grace_period_seconds: 60
  healthcheck_mode: cmd
  healthcheck_cmd: 'true'
  vtgate_resources:
    <<: *low_priority_resource_requirements
  vtadmin_resources:
    <<: *low_priority_resource_requirements
  vtctld_resources:
    replicas: 1
    <<: *low_priority_resource_requirements
  keyspaces:
  - keyspace: "yelp_vitess_testing_environment"
    cluster: "vitess-testing-environment"
    vttablet_resources:
      <<: *low_priority_resource_requirements
  - keyspace: "yelp_aux"
    cluster: "aux"
    vttablet_resources:
      <<: *low_priority_resource_requirements
  - keyspace: "yelp"
    cluster: "main"
    vttablet_resources:
      <<: *low_priority_resource_requirements
```

Sample system paasta config added locally in paasta playground:
```
{
    "mysql_port_mappings": {
        "main": {
            "primary": 23129,
            "migration": 22212,
            "read": 23133,
            "reporting": 23137
        },
        "aux": {
            "primary": 23126,
            "migration": 22085,
            "read": 23131,
            "reporting": 23135
        },
        "service": {
            "primary": 23130,
            "migration": 22388,
            "read": 23134,
            "reporting": 23138
        },
        "nowaithost": {
            "primary": 23184,
            "migration": 22220,
            "read": 23186
        },
        "nowaitcad": {
            "primary": 23183,
            "migration": 22756,
            "read": 23185
        },
        "schematizer": {
            "primary": 23213,
            "migration": 22679,
            "read": 23214,
            "reporting": 23062
        },
        "mlflow": {
            "primary": 23955,
            "migration": 22209,
            "read": 23571,
            "reporting": 23095
        },
        "vitess-testing-environment": {
            "primary": 22281,
            "read": 22545,
            "reporting": 22541
        },
        "refresh-main": {
            "primary": 22747,
            "read": 22879
        },
        "refresh-aux": {
            "primary": 22505,
            "read": 22291
        },
        "refresh-service": {
            "primary": 22790,
            "read": 22687
        },
        "refresh-nowaithost": {
            "primary": 22351,
            "read": 22160
        },
        "refresh-nowaitcad": {
            "primary": 22419,
            "read": 22468
        },
        "refresh-schematizer": {
            "primary": 22840,
            "read": 22827
        },
        "sanitized-vitess": {
            "primary": 23824,
            "read": 23454,
            "reporting": 23161
        }
    },
    "vitess_images": {
        "vtctld_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
        "vtgate_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
        "vttablet_image": "docker-paasta.yelpcorp.com:443/vitess_base:v16.0.3",
        "vtadmin_image": "docker-paasta.yelpcorp.com:443/vtadmin:v16.0.3"
    },
    "superregion_to_region_mapping": {
        "norcal": "uswest1",
        "pnw": "uswest2",
        "nova": "useast1",
        "kind-gonabavi-k8s-test": "uswest1-devc"
    },
    "vitess_tablet_types": [
        "primary",
        "migration"
    ],
    "vitess_tablet_pool_type_mapping": {
        "primary": "externalmaster",
        "migration": "externalreplica",
        "read": "externalreplica",
        "reporting": "externalreplica"
    },
    "vitess_throttling_config": {
        "migration": {
            "throttle_query_table": "migration_replication_delay",
            "throttle_metrics_threshold": "7200"
        },
        "read": {
            "throttle_query_table": "read_replication_delay",
            "throttle_metrics_threshold": "3"
        },
        "reporting": {
            "throttle_query_table": "reporting_replication_delay",
            "throttle_metrics_threshold": "7200"
        },
        "primary": {
            "throttle_query_table": "read_replication_delay",
            "throttle_metrics_threshold": "3"
        }
    }
}
```

Test coverage
```
paasta_tools/vitesscluster_tools.py                                               300     25    92%   221, 400-404, 509, 524-525, 530, 654, 664-680, 775-781, 842
```