### PR TITLE
Bump sticht to fix slack buttons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -97,7 +97,7 @@ slackclient==1.2.1
 splunk-sdk==1.7.0
 sseclient-py==1.7
 # make sure you bump sticht in extra_requirements_yelp.txt as well
-sticht==1.1.18
+sticht==1.2.0
 strict-rfc3339==0.7
 swagger-spec-validator==2.1.0
 syslogmp==0.2.2

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -27,7 +27,7 @@ slo-transcoder==3.3.0
 smmap2==2.0.3                       # slo-transcoder, vault-tools dependency
 splunk-sdk==1.7.0                   # sticht dependency
 srv-configs==1.1.0                  # yelp-profiling dependency
-sticht[yelp_internal]==1.1.18
+sticht[yelp_internal]==1.2.0
 tenacity==8.3.0                     # yelp-clog dependency
 vault-tools==0.9.2
 yelp-cgeom==1.3.1                   # scribereader dependency


### PR DESCRIPTION
We released https://github.com/Yelp/sticht/pull/58 in sticht 1.2.0 , so this bumps in paasta accordingly to fix the issue of slack buttons no longer working. 

