### PR TITLE
Add a bulkdata flag

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -105,6 +105,8 @@ specify the following options:
     volume on a sensitive part of the filesystem, as root. PaaSTA does not
     validate that the bind mounts are "safe".
 
+  * ``uses_bulkdata```: A boolean indicating whether the service should mount the directory /nail/bulkdata on the host into the container. Defaults to true.
+
 
 Placement Options
 -----------------

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -928,6 +928,10 @@
                         "required": []
                     },
                     "uniqueItems": true
+                },
+                "uses_bulkdata": {
+                    "type": "boolean",
+                    "default": true
                 }
             }
         }

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -736,9 +736,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             instance=self.instance,
             cluster=self.cluster,
             config_dict=self.config_dict.copy(),
-            branch_dict=self.branch_dict.copy()
-            if self.branch_dict is not None
-            else None,
+            branch_dict=(
+                self.branch_dict.copy() if self.branch_dict is not None else None
+            ),
             soa_dir=self.soa_dir,
         )
 
@@ -1960,7 +1960,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             supported_storage_classes = (
                 system_paasta_config.get_supported_storage_classes()
             )
-        except (PaastaNotConfiguredError):
+        except PaastaNotConfiguredError:
             log.warning("No PaaSTA configuration was found, returning default value")
             supported_storage_classes = []
         storage_class_name = volume.get("storage_class_name", "ebs")
@@ -2144,6 +2144,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         docker_volumes = self.get_volumes(
             system_volumes=system_paasta_config.get_volumes()
         )
+
         hacheck_sidecar_volumes = system_paasta_config.get_hacheck_sidecar_volumes()
         has_routable_ip = self.has_routable_ip(
             service_namespace_config, system_paasta_config
@@ -2406,11 +2407,11 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             preferred_terms = None
 
         return V1NodeAffinity(
-            required_during_scheduling_ignored_during_execution=V1NodeSelector(
-                node_selector_terms=[required_term]
-            )
-            if required_term
-            else None,
+            required_during_scheduling_ignored_during_execution=(
+                V1NodeSelector(node_selector_terms=[required_term])
+                if required_term
+                else None
+            ),
             preferred_during_scheduling_ignored_during_execution=preferred_terms,
         )
 
@@ -2701,7 +2702,7 @@ def get_kubernetes_services_running_here_for_nerve(
                     }
                 nerve_dict["weight"] = kubernetes_service.weight
                 nerve_list.append((registration, nerve_dict))
-        except (KeyError):
+        except KeyError:
             continue  # SOA configs got deleted for this app, it'll get cleaned up
 
     return nerve_list
@@ -2872,10 +2873,12 @@ def list_deployments_in_all_namespaces(
             ),
             namespace=item.metadata.namespace,
             config_sha=item.metadata.labels.get("paasta.yelp.com/config_sha", ""),
-            replicas=item.spec.replicas
-            if item.metadata.labels.get(paasta_prefixed("autoscaled"), "false")
-            == "false"
-            else None,
+            replicas=(
+                item.spec.replicas
+                if item.metadata.labels.get(paasta_prefixed("autoscaled"), "false")
+                == "false"
+                else None
+            ),
         )
         for item in deployments.items + stateful_sets.items
     ]
@@ -2904,10 +2907,12 @@ def list_deployments(
             ),
             namespace=item.metadata.namespace,
             config_sha=item.metadata.labels["paasta.yelp.com/config_sha"],
-            replicas=item.spec.replicas
-            if item.metadata.labels.get(paasta_prefixed("autoscaled"), "false")
-            == "false"
-            else None,
+            replicas=(
+                item.spec.replicas
+                if item.metadata.labels.get(paasta_prefixed("autoscaled"), "false")
+                == "false"
+                else None
+            ),
         )
         for item in deployments.items + stateful_sets.items
     ]

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -1948,7 +1948,8 @@ def test_volumes_are_deduped(mock_exists):
                         "containerPath": "/containerPath",
                         "mode": "RO",
                     }
-                ]
+                ],
+                "uses_bulkdata": False,
             },
             branch_dict=None,
         )

--- a/tests/frameworks/test_native_scheduler.py
+++ b/tests/frameworks/test_native_scheduler.py
@@ -305,6 +305,7 @@ class TestNativeServiceConfig:
                 "extra_volumes": [
                     {"containerPath": "/foo", "hostPath": "/bar", "mode": "RW"}
                 ],
+                "uses_bulkdata": False,
             },
             branch_dict={
                 "docker_image": "busybox",

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -4273,7 +4273,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config5abf6b07"
+            == "config39f2013b"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 
@@ -4319,7 +4319,7 @@ def test_warning_big_bounce_routable_pod():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config8ee1bd70"
+            == "configc59c068d"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every smartstack-registered service to bounce!"
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,10 +36,8 @@ from paasta_tools.utils import SystemPaastaConfigDict
 def test_get_git_url_provided_by_serviceyaml():
     service = "giiiiiiiiiiit"
     expected = "git@some_random_host:foobar"
-    with (
-        mock.patch(
-            "service_configuration_lib.read_service_configuration", autospec=True
-        )
+    with mock.patch(
+        "service_configuration_lib.read_service_configuration", autospec=True
     ) as mock_read_service_configuration:
         mock_read_service_configuration.return_value = {"git_url": expected}
         assert utils.get_git_url(service) == expected
@@ -51,10 +49,8 @@ def test_get_git_url_provided_by_serviceyaml():
 def test_get_git_url_default():
     service = "giiiiiiiiiiit"
     expected = "git@github.yelpcorp.com:services/%s" % service
-    with (
-        mock.patch(
-            "service_configuration_lib.read_service_configuration", autospec=True
-        )
+    with mock.patch(
+        "service_configuration_lib.read_service_configuration", autospec=True
     ) as mock_read_service_configuration:
         mock_read_service_configuration.return_value = {}
         assert utils.get_git_url(service) == expected
@@ -2031,7 +2027,8 @@ class TestInstanceConfig:
                 "extra_volumes": [
                     {"containerPath": "/a", "hostPath": "/a", "mode": "RW"},
                     {"containerPath": "/a", "hostPath": "/a", "mode": "RO"},
-                ]
+                ],
+                "uses_bulkdata": False,
             },
             branch_dict=None,
         )
@@ -2049,7 +2046,8 @@ class TestInstanceConfig:
                 "extra_volumes": [
                     {"containerPath": "/a", "hostPath": "/a", "mode": "RO"},
                     {"containerPath": "/a", "hostPath": "/other_a", "mode": "RO"},
-                ]
+                ],
+                "uses_bulkdata": False,
             },
             branch_dict=None,
         )
@@ -2071,7 +2069,8 @@ class TestInstanceConfig:
                     {"containerPath": "/a", "hostPath": "/a", "mode": "RO"},
                     {"containerPath": "/b", "hostPath": "/b", "mode": "RO"},
                     {"containerPath": "/c", "hostPath": "/c", "mode": "RO"},
-                ]
+                ],
+                "uses_bulkdata": False,
             },
             branch_dict=None,
         )
@@ -2095,7 +2094,8 @@ class TestInstanceConfig:
             config_dict={
                 "extra_volumes": [
                     {"containerPath": "/a", "hostPath": "/a", "mode": "RW"}
-                ]
+                ],
+                "uses_bulkdata": False,
             },
             branch_dict=None,
         )
@@ -2115,7 +2115,8 @@ class TestInstanceConfig:
                 "extra_volumes": [
                     {"containerPath": "/a", "hostPath": "/a", "mode": "RO"},
                     {"containerPath": "/b", "hostPath": "/b", "mode": "RO"},
-                ]
+                ],
+                "uses_bulkdata": False,
             },
             branch_dict=None,
         )
@@ -2137,7 +2138,8 @@ class TestInstanceConfig:
             config_dict={
                 "extra_volumes": [
                     {"containerPath": "/a/", "hostPath": "/a/", "mode": "RW"}
-                ]
+                ],
+                "uses_bulkdata": False,
             },
             branch_dict=None,
         )
@@ -2147,6 +2149,23 @@ class TestInstanceConfig:
         assert fake_conf.get_volumes(system_volumes) == [
             {"containerPath": "/a/", "hostPath": "/a/", "mode": "RW"},
             {"containerPath": "/b/", "hostPath": "/b/", "mode": "RW"},
+        ]
+
+    def test_get_volumes_with_bulkdata(self):
+        fake_conf = utils.InstanceConfig(
+            service="",
+            cluster="",
+            instance="",
+            config_dict={"uses_bulkdata": True},
+            branch_dict=None,
+        )
+        system_volumes: List[utils.DockerVolume] = []
+        assert fake_conf.get_volumes(system_volumes) == [
+            {
+                "hostPath": "/nail/bulkdata",
+                "containerPath": "/nail/bulkdata",
+                "mode": "RO",
+            },
         ]
 
     def test_get_docker_url_no_error(self):


### PR DESCRIPTION
If this is set to false, do not mount the /nail/bulkdata volume

Tested by
* following instructions on [this page](https://yelpwiki.yelpcorp.com/pages/viewpage.action?pageId=234312044)
* editing `etc_paasta_playground/volumes.json` and adding the bulkdata volume
* running `docker ps | grep kind` to find the worker node container ids
* using these ids, running `docker exec -t -i <id> bash` and creating the /nail/bulkdata directory on the worker nodes
* editing `config_playground/compute-infra-test-service/kubernetes-kind-tmower-k8s-test.yaml` and setting bulkdata: false

* verifying with `KUBECONFIG=./.paasta-kube-config kubectl get deployment -n paastasvc-compute-infra-test-service -oyaml` the /nail/bulkdata volume was not added

I'm not entirely sure why `black` has reformatted the `kubernetes_tools.py` file