### PR TITLE
Fix incorrect help text for --cluster in paasta logs

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -97,7 +97,7 @@ def add_subparser(subparsers) -> None:
     status_parser.add_argument(
         "-c",
         "--cluster",
-        help="The cluster to see relevant logs for. Defaults to all clusters to which this service is deployed.",
+        help="The cluster to see relevant logs for.",
         nargs=1,
     ).completer = completer_clusters
     status_parser.add_argument(


### PR DESCRIPTION
`paasta logs` only supports grabbing logs from a single cluster at a time.