### PR TITLE
Update autoscaling config to use metrics_providers

### DIFF
--- a/paasta_tools/contrib/service_shard_update.py
+++ b/paasta_tools/contrib/service_shard_update.py
@@ -203,13 +203,14 @@ def main(args):
                         },
                     }
                     if args.metrics_provider is not None or args.setpoint is not None:
-                        instance_config["autoscaling"] = {}
+                        instance_config["autoscaling"] = {"metrics_providers": []}
+                        metrics_provider_config = {}
                         if args.metrics_provider is not None:
-                            instance_config["autoscaling"][
-                                "metrics_provider"
-                            ] = args.metrics_provider
+                            metrics_provider_config["type"] = args.metrics_provider
                         if args.setpoint is not None:
-                            instance_config["autoscaling"]["setpoint"] = args.setpoint
+                            metrics_provider_config["setpoint"] = args.setpoint
+                        instance_config["autoscaling"]["metrics_providers"].append(metrics_provider_config)
+
                     if args.cpus is not None:
                         instance_config["cpus"] = args.cpus
                     if args.mem is not None:

--- a/paasta_tools/contrib/service_shard_update.py
+++ b/paasta_tools/contrib/service_shard_update.py
@@ -209,7 +209,9 @@ def main(args):
                             metrics_provider_config["type"] = args.metrics_provider
                         if args.setpoint is not None:
                             metrics_provider_config["setpoint"] = args.setpoint
-                        instance_config["autoscaling"]["metrics_providers"].append(metrics_provider_config)
+                        instance_config["autoscaling"]["metrics_providers"].append(
+                            metrics_provider_config
+                        )
 
                     if args.cpus is not None:
                         instance_config["cpus"] = args.cpus


### PR DESCRIPTION
This PR updates the script to handle the new autoscaling configuration format, which now uses a list of `metrics_providers` instead of a single `metrics_provider`. The following changes were made:

- Modified the script to construct the `instance_config` with a `metrics_providers` list.
- Ensured that the `metrics_provider` and `setpoint` are added as dictionaries within the `metrics_providers` list.
- Updated the handling of the `autoscaling` configuration to match the new format specified in the provided config file.

These changes address the recent update in the autoscaling configuration format, ensuring that the script correctly handles the new structure.

