### PR TITLE
Add NATS tailing for vector-logs reader

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -40,7 +40,9 @@ from typing import Tuple
 from typing import Type
 from typing import Union
 
+import a_sync
 import isodate
+import nats
 import pytz
 from dateutil import tz
 
@@ -1166,8 +1168,10 @@ class ScribeLogReader(LogReader):
 
 @register_log_reader("vector-logs")
 class VectorLogsReader(LogReader):
+    SUPPORTS_TAILING = True
     SUPPORTS_TIME = True
 
+    # def __init__(self, cluster_map: Mapping[str, Any], nats_endpoint_map: Mapping[str, Any]) -> None:
     def __init__(self, cluster_map: Mapping[str, Any]) -> None:
         super().__init__()
 
@@ -1175,9 +1179,14 @@ class VectorLogsReader(LogReader):
             raise Exception("yelp_clog package must be available to use S3LogsReader")
 
         self.cluster_map = cluster_map
+        # self.nats_endpoint_map = nats_endpoint_map
+        self.nats_endpoint_map = {"pnw-devc": "nats-logs.infra.uswest2-devc.eks:4222"}
 
     def get_superregion_for_cluster(self, cluster: str) -> Optional[str]:
         return self.cluster_map.get(cluster, None)
+
+    def get_nats_endpoint_for_cluster(self, cluster: str) -> Optional[str]:
+        return self.nats_endpoint_map.get(cluster, None)
 
     def print_logs_by_time(
         self,
@@ -1229,6 +1238,59 @@ class VectorLogsReader(LogReader):
 
         for line in aggregated_logs:
             print_log(line["raw_line"], levels, raw_mode, strip_headers)
+
+    def tail_logs(
+        self,
+        service: str,
+        levels: Sequence[str],
+        components: Iterable[str],
+        clusters: Sequence[str],
+        instances: List[str],
+        pods: Iterable[str] = None,
+        raw_mode: bool = False,
+        strip_headers: bool = False,
+    ) -> None:
+        stream_name = get_log_name_for_service(service, prefix="app_output")
+        endpoint = self.get_nats_endpoint_for_cluster(clusters[0])
+        if not endpoint:
+            raise NotImplementedError(
+                "Tailing logs is not supported in this cluster yet, sorry"
+            )
+
+        async def tail_logs_from_nats() -> None:
+            nc = await nats.connect(f"nats://{endpoint}")
+            sub = await nc.subscribe(stream_name)
+
+            while True:
+                # Wait indefinitely for a new message (no timeout)
+                msg = await sub.next_msg(timeout=None)
+                decoded_data = msg.data.decode("utf-8")
+
+                # TODO: Make NATS send this data in the correct format in the
+                # first place by adding transforms and filters into Vector to
+                # only send the necessary data. Then none of this should be
+                # needed and the raw JSON could be passed along without
+                # JSON-loading and then JSON dumping it again
+                message_data = json.loads(decoded_data)["message"]
+                message_data[
+                    "message"
+                ] = f"{message_data['hostname']} ({message_data['pod_name']}) {message_data['message']}"
+                json_message_data = json.dumps(message_data)
+
+                if paasta_log_line_passes_filter(
+                    json_message_data,
+                    levels,
+                    service,
+                    components,
+                    clusters,
+                    instances,
+                    pods,
+                ):
+                    await a_sync.run(
+                        print_log, json_message_data, levels, raw_mode, strip_headers
+                    )
+
+        a_sync.block(tail_logs_from_nats)
 
 
 def scribe_env_to_locations(scribe_env) -> Mapping[str, Any]:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2349,7 +2349,8 @@ class SystemPaastaConfig:
         """
         Get the list of clusters that are using multiple log readers
         """
-        return self.config_dict.get("use_multiple_log_readers")
+        # return self.config_dict.get("use_multiple_log_readers")
+        return ["kubestage", "pnw-devc"]
 
     def get_metrics_provider(self) -> Optional[str]:
         """Get the metrics_provider configuration out of global paasta config

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2349,8 +2349,7 @@ class SystemPaastaConfig:
         """
         Get the list of clusters that are using multiple log readers
         """
-        # return self.config_dict.get("use_multiple_log_readers")
-        return ["kubestage", "pnw-devc"]
+        return self.config_dict.get("use_multiple_log_readers")
 
     def get_metrics_provider(self) -> Optional[str]:
         """Get the metrics_provider configuration out of global paasta config

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -31,6 +31,7 @@ kubernetes >= 18.20.0, < 22.0.0
 ldap3
 manhole
 mypy-extensions >= 0.3.0
+nats-py
 nulltype
 objgraph
 ply

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,6 +51,7 @@ monotonic==1.4
 msgpack-python==0.5.6
 multidict==4.7.6
 mypy-extensions==0.4.1
+nats-py==2.8.0
 nulltype==2.3.1
 oauthlib==3.1.0
 objgraph==3.4.0

--- a/tests/cli/test_cmds_logs.py
+++ b/tests/cli/test_cmds_logs.py
@@ -897,7 +897,7 @@ def test_vector_logs_read_logs_empty_clusters():
     with mock.patch("paasta_tools.cli.cmds.logs.log", autospec=True), mock.patch(
         "paasta_tools.cli.cmds.logs.S3LogsReader", autospec=None
     ), pytest.raises(IndexError) as e:
-        logs.VectorLogsReader(cluster_map={}).print_logs_by_time(
+        logs.VectorLogsReader(cluster_map={}, nats_endpoint_map={}).print_logs_by_time(
             service,
             start_time,
             end_time,
@@ -942,7 +942,7 @@ def test_vector_logs_print_logs_by_time():
         start_time = pytz.utc.localize(isodate.parse_datetime("2016-06-08T06:00"))
         end_time = pytz.utc.localize(isodate.parse_datetime("2016-06-08T07:00"))
 
-        logs.VectorLogsReader(cluster_map={}).print_logs_by_time(
+        logs.VectorLogsReader(cluster_map={}, nats_endpoint_map={}).print_logs_by_time(
             service,
             start_time,
             end_time,
@@ -1045,7 +1045,7 @@ def test_get_log_reader():
         },
         {
             "driver": "vector-logs",
-            "options": {"cluster_map": {}},
+            "options": {"cluster_map": {}, "nats_endpoint_map": {}},
             "components": ["stdout", "stderr"],
         },
     ]


### PR DESCRIPTION
I think this is fully ready to go! I've tested this locally with commands like `python paasta_tools/cli/cli.py logs -s example_happyhour -c pnw-devc -i main -f` or `python paasta_tools/cli/cli.py logs -s marley -c pnw-devc -i marley2 -f`

This does depend on some changes on the vector side of things (in `splunk/vector-logs`) in order to transform logs there so that the correct fields are present so that the JSON that NATS returns doesn't need to be parsed, changed a bit, and then re-encoded again. I won't merge this until that work is done and some more testing can be performed.

In order to test I've also been modifying https://github.com/Yelp/paasta/blob/4b465c299882784f01faf4f57ccb116ca7fa7fe6/paasta_tools/utils.py#L2348-L2352 to return `pnw-devc` and not just `kubestage` so that I can test locally without enabling this tailing for everyone actually using pnw-devc. Merging this should essentially be a noop for that reason, since this isn't enabled anywhere besides kubestage, and tailing will also only have infra set up in pnw-devc for the time being until it is rolled out to more locations.