### PR TITLE
Speed up the default preStop hook to allow for graceful shutdown

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1472,7 +1472,10 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         if not command:
             return V1Handler(
                 _exec=V1ExecAction(
-                    command=["/bin/sh", "-c", f"sleep {DEFAULT_PRESTOP_SLEEP_SECONDS}"]
+                    # NOTE: we could also probably look into seeing what happens if we return None
+                    # instead of a V1Handler, but in the meantime, having a funny message as the pre-stop
+                    # hook doesn't seem particularly harmful
+                    command=["/bin/sh", "-c", f"echo Goodbye, cruel world."]
                 )
             )
         if isinstance(command, str):


### PR DESCRIPTION
The default PaaSTA preStop hook sleeps for 30s - which is exactly the same as the default termination grace period, therefore preventing anything that gets this default hook from being able to gracefully shutdown.

We could (should?) look into simply not adding a hook for things that don't need one (i.e., not mesh-registed and no custom hooks), but in the meantime adding a silly message doesn't seem particularly harmful.