### PR TITLE
Fix ensure_service_account breakages from the get_or_create_service_account refactor

### DIFF
--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -134,11 +134,12 @@ class Application(ABC):
         Ensure that the service account for this application exists
         :param kube_client:
         """
-        ensure_service_account(
-            iam_role=self.soa_config.get_iam_role(),
-            namespace=self.soa_config.get_namespace(),
-            kube_client=kube_client,
-        )
+        if self.soa_config.get_iam_role():
+            ensure_service_account(
+                iam_role=self.soa_config.get_iam_role(),
+                namespace=self.soa_config.get_namespace(),
+                kube_client=kube_client,
+            )
 
     def delete_pod_disruption_budget(self, kube_client: KubeClient) -> None:
         try:

--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -15,6 +15,7 @@ from paasta_tools.eks_tools import load_eks_service_config_no_cache
 from paasta_tools.kubernetes_tools import create_deployment
 from paasta_tools.kubernetes_tools import create_pod_disruption_budget
 from paasta_tools.kubernetes_tools import create_stateful_set
+from paasta_tools.kubernetes_tools import ensure_service_account
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import KubeDeployment
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfig
@@ -119,6 +120,25 @@ class Application(ABC):
         :param kube_client:
         """
         self.ensure_pod_disruption_budget(kube_client, self.soa_config.get_namespace())
+
+    def update_dependency_api_objects(self, kube_client: KubeClient) -> None:
+        """
+        Update related Kubernetes API objects that should be updated before the main object,
+        such as service accounts.
+        :param kube_client:
+        """
+        self.ensure_service_account(kube_client)
+
+    def ensure_service_account(self, kube_client: KubeClient) -> None:
+        """
+        Ensure that the service account for this application exists
+        :param kube_client:
+        """
+        ensure_service_account(
+            iam_role=self.soa_config.get_iam_role(),
+            namespace=self.soa_config.get_namespace(),
+            kube_client=kube_client,
+        )
 
     def delete_pod_disruption_budget(self, kube_client: KubeClient) -> None:
         try:

--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -281,6 +281,7 @@ def setup_kube_deployments(
                 "paasta_namespace": app.kube_deployment.namespace,
             }
             try:
+                app.update_dependency_api_objects(kube_client)
                 if (
                     app.kube_deployment.service,
                     app.kube_deployment.instance,

--- a/paasta_tools/setup_tron_namespace.py
+++ b/paasta_tools/setup_tron_namespace.py
@@ -26,8 +26,13 @@ import sys
 
 import ruamel.yaml as yaml
 
+from paasta_tools import spark_tools
 from paasta_tools import tron_tools
+from paasta_tools.kubernetes_tools import ensure_service_account
+from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.tron_tools import KUBERNETES_NAMESPACE
 from paasta_tools.tron_tools import MASTER_NAMESPACE
+from paasta_tools.utils import load_system_paasta_config
 
 log = logging.getLogger(__name__)
 
@@ -61,6 +66,32 @@ def parse_args():
     )
     args = parser.parse_args()
     return args
+
+
+def ensure_service_accounts(
+    raw_config: str, kube_client: KubeClient, spark_kube_client: KubeClient
+) -> None:
+    # this is kinda silly, but the tron create_config functions return strings
+    # we should refactor to pass the dicts around until the we're going to send the config to tron
+    # (where we can finally convert it to a string)
+    config = yaml.safe_load(raw_config)
+    for _, job in config.get("jobs", {}).items():
+        for _, action in job.get("actions", {}).items():
+            if action.get("service_account_name") is not None:
+                ensure_service_account(
+                    action["service_account_name"],
+                    namespace=KUBERNETES_NAMESPACE,
+                    kube_client=kube_client,
+                )
+                # spark executors are special in that we want the SA to exist in two namespaces:
+                # the tron namespace - for the spark driver
+                # and the spark namespace - for the spark executor
+                if action.get("executor") == "spark":
+                    ensure_service_account(
+                        action["service_account_name"],
+                        namespace=spark_tools.SPARK_EXECUTOR_NAMESPACE,
+                        kube_client=spark_kube_client,
+                    )
 
 
 def main():
@@ -133,6 +164,16 @@ def main():
                 log.info(f"{new_config}")
                 updated.append(service)
             else:
+                # NOTE: these are all lru_cache'd so it should be fine to call these for every service
+                system_paasta_config = load_system_paasta_config()
+                kube_client = KubeClient()
+                spark_kube_client = KubeClient(
+                    config_file=system_paasta_config.get_spark_kubeconfig()
+                )
+                # PaaSTA will not necessarily have created the SAs we want to use
+                # ...so let's go ahead and create them!
+                ensure_service_accounts(new_config, kube_client, spark_kube_client)
+
                 if client.update_namespace(service, new_config):
                     updated.append(service)
                     log.debug(f"Updated {service}")

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -62,7 +62,7 @@ from paasta_tools import spark_tools
 
 from paasta_tools.kubernetes_tools import (
     allowlist_denylist_to_requirements,
-    create_or_find_service_account_name,
+    get_service_account_name,
     limit_size_with_hash,
     raw_selectors_to_requirements,
     to_node_label,
@@ -354,15 +354,11 @@ class TronActionConfig(InstanceConfig):
             "spark.kubernetes.executor.label.yelp.com/owner", self.get_team()
         )
 
-        # We need to make sure the Service Account used by the executors has been created.
         # We are using the Service Account created using the provided or default IAM role.
         spark_conf[
             "spark.kubernetes.authenticate.executor.serviceAccountName"
-        ] = create_or_find_service_account_name(
+        ] = get_service_account_name(
             iam_role=self.get_spark_executor_iam_role(),
-            namespace=spark_tools.SPARK_EXECUTOR_NAMESPACE,
-            kubeconfig_file=system_paasta_config.get_spark_kubeconfig(),
-            dry_run=self.for_validation,
         )
 
         return spark_conf
@@ -952,20 +948,14 @@ def format_tron_action_dict(action_config: TronActionConfig):
 
         result["labels"]["yelp.com/owner"] = "compute_infra_platform_experience"
 
-        # create_or_find_service_account_name requires k8s credentials, and we don't
-        # have those available for CI to use (nor do we check these for normal PaaSTA
-        # services, so we're not doing anything "new" by skipping this)
         if (
             action_config.get_iam_role_provider() == "aws"
             and action_config.get_iam_role()
-            and not action_config.for_validation
         ):
             # this service account will be used for normal Tron batches as well as for Spark drivers
-            result["service_account_name"] = create_or_find_service_account_name(
+            result["service_account_name"] = get_service_account_name(
                 iam_role=action_config.get_iam_role(),
-                namespace=EXECUTOR_TYPE_TO_NAMESPACE[executor],
                 k8s_role=None,
-                dry_run=action_config.for_validation,
             )
 
         # service account token volumes for service authentication

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -280,8 +280,39 @@ class TronActionConfig(InstanceConfig):
             soa_dir=soa_dir,
         )
         self.job, self.action = decompose_instance(instance)
+
         # Indicate whether this config object is created for validation
         self.for_validation = for_validation
+
+        self.action_spark_config = None
+        if self.get_executor() == "spark":
+            # build the complete Spark configuration
+            # TODO: add conditional check for Spark specific commands spark-submit, pyspark etc ?
+            self.action_spark_config = self.build_spark_config()
+
+    def get_cpus(self) -> float:
+        # set Spark driver pod CPU if it is specified by Spark arguments
+        if (
+            self.action_spark_config
+            and "spark.driver.cores" in self.action_spark_config
+        ):
+            return float(self.action_spark_config["spark.driver.cores"])
+        # we fall back to this default if there's no spark.driver.cores config
+        return super().get_cpus()
+
+    def get_mem(self) -> float:
+        # set Spark driver pod memory if it is specified by Spark arguments
+        if (
+            self.action_spark_config
+            and "spark.driver.memory" in self.action_spark_config
+        ):
+            return int(
+                spark_tools.get_spark_memory_in_unit(
+                    self.action_spark_config["spark.driver.memory"], "m"
+                )
+            )
+        # we fall back to this default if there's no spark.driver.memory config
+        return super().get_mem()
 
     def build_spark_config(self) -> Dict[str, str]:
         system_paasta_config = load_system_paasta_config()
@@ -436,7 +467,6 @@ class TronActionConfig(InstanceConfig):
         system_paasta_config: Optional["SystemPaastaConfig"] = None,
     ) -> Dict[str, str]:
         env = super().get_env(system_paasta_config=system_paasta_config)
-
         if self.get_executor() == "spark":
             # Required by some sdks like boto3 client. Throws NoRegionError otherwise.
             # AWS_REGION takes precedence if set.
@@ -601,6 +631,20 @@ class TronActionConfig(InstanceConfig):
             error_msgs.append(
                 f"{self.get_job_name()}.{self.get_action_name()} must have a deploy_group set"
             )
+        # We are not allowing users to specify `cpus` and `mem` configuration if the action is a Spark job
+        # with driver running on k8s (executor: spark), because we derive these values from `spark.driver.cores`
+        # and `spark.driver.memory` in order to avoid confusion.
+        if self.get_executor() == "spark":
+            if "cpus" in self.config_dict:
+                error_msgs.append(
+                    f"{self.get_job_name()}.{self.get_action_name()} is a Spark job. `cpus` config is not allowed. "
+                    f"Please specify the driver cores using `spark.driver.cores`."
+                )
+            if "mem" in self.config_dict:
+                error_msgs.append(
+                    f"{self.get_job_name()}.{self.get_action_name()} is a Spark job. `mem` config is not allowed. "
+                    f"Please specify the driver memory using `spark.driver.memory`."
+                )
         return error_msgs
 
     def get_pool(self) -> str:
@@ -965,21 +1009,26 @@ def format_tron_action_dict(action_config: TronActionConfig):
         if executor == "spark":
             is_mrjob = action_config.config_dict.get("mrjob", False)
             system_paasta_config = load_system_paasta_config()
-            # inject spark configs to the original spark-submit command
-            spark_config = action_config.build_spark_config()
+            # inject additional Spark configs in case of Spark commands
             result["command"] = spark_tools.build_spark_command(
                 result["command"],
-                spark_config,
+                action_config.action_spark_config,
                 is_mrjob,
                 action_config.config_dict.get(
                     "max_runtime", spark_tools.DEFAULT_SPARK_RUNTIME_TIMEOUT
                 ),
             )
+            # point to the KUBECONFIG needed by Spark driver
             result["env"]["KUBECONFIG"] = system_paasta_config.get_spark_kubeconfig()
+
             # spark, unlike normal batches, needs to expose several ports for things like the spark
             # ui and for executor->driver communication
             result["ports"] = list(
-                set(spark_tools.get_spark_ports_from_config(spark_config))
+                set(
+                    spark_tools.get_spark_ports_from_config(
+                        action_config.action_spark_config
+                    )
+                )
             )
             # mount KUBECONFIG file for Spark drivers to communicate with EKS cluster
             extra_volumes.append(
@@ -993,10 +1042,12 @@ def format_tron_action_dict(action_config: TronActionConfig):
             )
             # Add pod annotations and labels for Spark monitoring metrics
             monitoring_annotations = (
-                spark_tools.get_spark_driver_monitoring_annotations(spark_config)
+                spark_tools.get_spark_driver_monitoring_annotations(
+                    action_config.action_spark_config
+                )
             )
             monitoring_labels = spark_tools.get_spark_driver_monitoring_labels(
-                spark_config
+                action_config.action_spark_config
             )
             result["annotations"].update(monitoring_annotations)
             result["labels"].update(monitoring_labels)

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -89,7 +89,6 @@ from paasta_tools.kubernetes_tools import add_volumes_for_authenticating_service
 from paasta_tools.kubernetes_tools import allowlist_denylist_to_requirements
 from paasta_tools.kubernetes_tools import create_custom_resource
 from paasta_tools.kubernetes_tools import create_deployment
-from paasta_tools.kubernetes_tools import create_or_find_service_account_name
 from paasta_tools.kubernetes_tools import create_pod_disruption_budget
 from paasta_tools.kubernetes_tools import create_secret
 from paasta_tools.kubernetes_tools import create_secret_signature
@@ -97,6 +96,7 @@ from paasta_tools.kubernetes_tools import create_stateful_set
 from paasta_tools.kubernetes_tools import ensure_namespace
 from paasta_tools.kubernetes_tools import ensure_paasta_api_rolebinding
 from paasta_tools.kubernetes_tools import ensure_paasta_namespace_limits
+from paasta_tools.kubernetes_tools import ensure_service_account
 from paasta_tools.kubernetes_tools import filter_nodes_by_blacklist
 from paasta_tools.kubernetes_tools import filter_pods_by_service_instance
 from paasta_tools.kubernetes_tools import force_delete_pods
@@ -117,6 +117,7 @@ from paasta_tools.kubernetes_tools import get_paasta_secret_signature_name
 from paasta_tools.kubernetes_tools import get_secret
 from paasta_tools.kubernetes_tools import get_secret_name_from_ref
 from paasta_tools.kubernetes_tools import get_secret_signature
+from paasta_tools.kubernetes_tools import get_service_account_name
 from paasta_tools.kubernetes_tools import InvalidKubernetesConfig
 from paasta_tools.kubernetes_tools import is_node_ready
 from paasta_tools.kubernetes_tools import is_pod_ready
@@ -4457,7 +4458,7 @@ def test_get_pod_management_policy(config_dict, expected_management_policy):
     assert deployment.get_pod_management_policy() == expected_management_policy
 
 
-def test_create_or_find_service_account_name_new():
+def test_ensure_service_account_new():
     iam_role = "arn:aws:iam::000000000000:role/some_role"
     namespace = "test_namespace"
     k8s_role = None
@@ -4477,8 +4478,8 @@ def test_create_or_find_service_account_name_new():
         mock_client.core.list_namespaced_service_account.return_value.items = []
         mock_kube_client.return_value = mock_client
 
-        assert expected_sa_name == create_or_find_service_account_name(
-            iam_role, namespace=namespace, k8s_role=k8s_role
+        ensure_service_account(
+            iam_role, namespace=namespace, kube_client=mock_client, k8s_role=k8s_role
         )
         mock_client.core.create_namespaced_service_account.assert_called_once_with(
             namespace=namespace,
@@ -4494,7 +4495,7 @@ def test_create_or_find_service_account_name_new():
         mock_client.rbac.create_namespaced_role_binding.assert_not_called()
 
 
-def test_create_or_find_service_account_name_with_k8s_role_new():
+def test_ensure_service_account_with_k8s_role_new():
     iam_role = "arn:aws:iam::000000000000:role/some_role"
     namespace = "test_namespace"
     k8s_role = "mega-admin"
@@ -4518,8 +4519,8 @@ def test_create_or_find_service_account_name_with_k8s_role_new():
         mock_client.rbac.list_namespaced_role_binding.return_value.items = []
         mock_kube_client.return_value = mock_client
 
-        assert expected_sa_name == create_or_find_service_account_name(
-            iam_role, namespace=namespace, k8s_role=k8s_role
+        ensure_service_account(
+            iam_role, namespace=namespace, kube_client=mock_client, k8s_role=k8s_role
         )
         mock_client.core.create_namespaced_service_account.assert_called_once_with(
             namespace=namespace,
@@ -4555,7 +4556,7 @@ def test_create_or_find_service_account_name_with_k8s_role_new():
         )
 
 
-def test_create_or_find_service_account_name_existing():
+def test_ensure_service_account_existing():
     iam_role = "arn:aws:iam::000000000000:role/some_role"
     namespace = "test_namespace"
     k8s_role = "mega-admin"
@@ -4608,14 +4609,14 @@ def test_create_or_find_service_account_name_existing():
         ]
         mock_kube_client.return_value = mock_client
 
-        assert expected_sa_name == create_or_find_service_account_name(
-            iam_role, namespace=namespace, k8s_role=k8s_role
+        ensure_service_account(
+            iam_role, namespace=namespace, kube_client=mock_client, k8s_role=k8s_role
         )
         mock_client.core.create_namespaced_service_account.assert_not_called()
         mock_client.rbac.create_namespaced_role_binding.assert_not_called()
 
 
-def test_create_or_find_service_account_name_existing_create_rb_only():
+def test_ensure_service_account_existing_create_rb_only():
     iam_role = "arn:aws:iam::000000000000:role/some_role"
     namespace = "test_namespace"
     k8s_role = "mega-admin"
@@ -4648,48 +4649,25 @@ def test_create_or_find_service_account_name_existing_create_rb_only():
         mock_client.rbac.list_namespaced_role_binding.return_value.items = []
         mock_kube_client.return_value = mock_client
 
-        assert expected_sa_name == create_or_find_service_account_name(
-            iam_role, namespace=namespace, k8s_role=k8s_role
+        ensure_service_account(
+            iam_role, namespace=namespace, kube_client=mock_client, k8s_role=k8s_role
         )
         mock_client.core.create_namespaced_service_account.assert_not_called()
         assert mock_client.rbac.create_namespaced_role_binding.called is True
 
 
-def test_create_or_find_service_account_name_caps():
+def test_ensure_service_account_caps():
     iam_role = "arn:aws:iam::000000000000:role/Some_Role"
-    namespace = "test_namespace"
     expected_sa_name = "paasta--arn-aws-iam-000000000000-role-some-role"
     with mock.patch(
         "paasta_tools.kubernetes_tools.kube_config.load_kube_config", autospec=True
-    ), mock.patch(
-        "paasta_tools.kubernetes_tools.KubeClient",
-        autospec=False,
-    ) as mock_kube_client:
-        mock_client = mock.Mock()
-        mock_client.core = mock.Mock(spec=kube_client.CoreV1Api)
-        mock_client.core.list_namespaced_service_account.return_value = mock.Mock(
-            spec=V1ServiceAccountList
-        )
-        mock_client.core.list_namespaced_service_account.return_value.items = [
-            V1ServiceAccount(
-                kind="ServiceAccount",
-                metadata=V1ObjectMeta(
-                    name=expected_sa_name,
-                    namespace=namespace,
-                    annotations={"eks.amazonaws.com/role-arn": iam_role},
-                ),
-            )
-        ]
-        mock_kube_client.return_value = mock_client
-
-        assert expected_sa_name == create_or_find_service_account_name(
+    ):
+        assert expected_sa_name == get_service_account_name(
             iam_role,
-            namespace=namespace,
         )
-        mock_client.core.create_namespaced_service_account.assert_not_called()
 
 
-def test_create_or_find_service_account_name_caps_with_k8s():
+def test_ensure_service_account_caps_with_k8s():
     iam_role = "arn:aws:iam::000000000000:role/Some_Role"
     namespace = "test_namespace"
     k8s_role = "mega-admin"
@@ -4742,8 +4720,8 @@ def test_create_or_find_service_account_name_caps_with_k8s():
         ]
         mock_kube_client.return_value = mock_client
 
-        assert expected_sa_name == create_or_find_service_account_name(
-            iam_role, namespace=namespace, k8s_role=k8s_role
+        ensure_service_account(
+            iam_role, namespace=namespace, kube_client=mock_client, k8s_role=k8s_role
         )
         mock_client.core.create_namespaced_service_account.assert_not_called()
         mock_client.rbac.create_namespaced_role_binding.assert_not_called()

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1426,7 +1426,7 @@ class TestTronTools:
             autospec=True,
             return_value=False,
         ), mock.patch(
-            "paasta_tools.tron_tools.create_or_find_service_account_name",
+            "paasta_tools.tron_tools.get_service_account_name",
             autospec=True,
             return_value="some--service--account",
         ), mock.patch(

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -637,6 +637,101 @@ class TestTronJobConfig:
         errors = job_config.validate()
         assert len(errors) == 0
 
+    @mock.patch(
+        "paasta_tools.tron_tools.TronActionConfig.build_spark_config", autospec=True
+    )
+    @mock.patch("paasta_tools.utils.get_pipeline_deploy_groups", autospec=True)
+    @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)
+    def test_validate_invalid_cpus_in_executor_spark_action(
+        self,
+        mock_load_system_paasta_config,
+        mock_get_pipeline_deploy_groups,
+        mock_build_spark_config,
+    ):
+        job_dict = {
+            "node": "batch_server",
+            "schedule": "daily 12:10:00",
+            "monitoring": {"team": "noop", "page": True},
+            "actions": {
+                "first": {
+                    "executor": "spark",
+                    "cpus": 1,
+                    "command": "echo first",
+                    "deploy_group": "deploy_group_2",
+                }
+            },
+        }
+        mock_get_pipeline_deploy_groups.return_value = [
+            "deploy_group_1",
+            "deploy_group_2",
+        ]
+        job_config = tron_tools.TronJobConfig("my_job", job_dict, "fake-cluster")
+        errors = job_config.validate()
+        assert len(errors) == 1
+
+    @mock.patch(
+        "paasta_tools.tron_tools.TronActionConfig.build_spark_config", autospec=True
+    )
+    @mock.patch("paasta_tools.utils.get_pipeline_deploy_groups", autospec=True)
+    @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)
+    def test_validate_invalid_mem_in_executor_spark_action(
+        self,
+        mock_load_system_paasta_config,
+        mock_get_pipeline_deploy_groups,
+        mock_build_spark_config,
+    ):
+        job_dict = {
+            "node": "batch_server",
+            "schedule": "daily 12:10:00",
+            "monitoring": {"team": "noop", "page": True},
+            "actions": {
+                "first": {
+                    "executor": "spark",
+                    "mem": 4096,
+                    "command": "echo first",
+                    "deploy_group": "deploy_group_2",
+                }
+            },
+        }
+        mock_get_pipeline_deploy_groups.return_value = [
+            "deploy_group_1",
+            "deploy_group_2",
+        ]
+        job_config = tron_tools.TronJobConfig("my_job", job_dict, "fake-cluster")
+        errors = job_config.validate()
+        assert len(errors) == 1
+
+    @mock.patch(
+        "paasta_tools.tron_tools.TronActionConfig.build_spark_config", autospec=True
+    )
+    @mock.patch("paasta_tools.utils.get_pipeline_deploy_groups", autospec=True)
+    @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)
+    def test_validate_valid_executor_spark_action(
+        self,
+        mock_load_system_paasta_config,
+        mock_get_pipeline_deploy_groups,
+        mock_build_spark_config,
+    ):
+        job_dict = {
+            "node": "batch_server",
+            "schedule": "daily 12:10:00",
+            "monitoring": {"team": "noop", "page": True},
+            "actions": {
+                "first": {
+                    "executor": "spark",
+                    "command": "echo first",
+                    "deploy_group": "deploy_group_2",
+                }
+            },
+        }
+        mock_get_pipeline_deploy_groups.return_value = [
+            "deploy_group_1",
+            "deploy_group_2",
+        ]
+        job_config = tron_tools.TronJobConfig("my_job", job_dict, "fake-cluster")
+        errors = job_config.validate()
+        assert len(errors) == 0
+
     @mock.patch("paasta_tools.utils.get_pipeline_deploy_groups", autospec=True)
     @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)
     def test_validate_monitoring(
@@ -936,7 +1031,33 @@ class TestTronTools:
         assert result["docker_image"] == expected_docker
         assert result["env"]["SHELL"] == "/bin/bash"
 
-    def test_format_tron_action_dict_spark(self):
+    @mock.patch(
+        "paasta_tools.tron_tools.TronActionConfig.get_docker_registry", autospec=True
+    )
+    @mock.patch("paasta_tools.kubernetes_tools.kube_client", autospec=True)
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.kube_config.load_kube_config", autospec=True
+    )
+    @mock.patch("paasta_tools.tron_tools.load_system_paasta_config", autospec=True)
+    @mock.patch("paasta_tools.tron_tools.get_k8s_url_for_cluster", autospec=True)
+    @mock.patch(
+        "service_configuration_lib.spark_config._get_k8s_docker_volumes_conf",
+        autospec=True,
+    )
+    @mock.patch(
+        "service_configuration_lib.spark_config.utils.load_spark_srv_conf",
+        autospec=True,
+    )
+    def test_format_tron_action_dict_spark(
+        self,
+        mock_load_spark_srv_conf,
+        mock_get_k8s_docker_volumes_conf,
+        mock_get_k8s_url_for_cluster,
+        mock_load_system_paasta_config,
+        mock_load_kube_config,
+        mock_kube_client,
+        mock_get_docker_registry,
+    ):
         action_dict = {
             "iam_role_provider": "aws",
             "iam_role": "arn:aws:iam::000000000000:role/some_role",
@@ -953,8 +1074,6 @@ class TestTronTools:
             "service": "my_service",
             "deploy_group": "prod",
             "executor": "spark",
-            "cpus": 2,
-            "mem": 1200,
             "disk": 42,
             "pool": "special_pool",
             "env": {"SHELL": "/bin/bash"},
@@ -979,111 +1098,54 @@ class TestTronTools:
             "desired_state": "start",
             "force_bounce": None,
         }
-        action_config = tron_tools.TronActionConfig(
-            service="my_service",
-            instance=tron_tools.compose_instance("my_job", "do_something"),
-            config_dict=TronActionConfigDict(action_dict),
-            branch_dict=utils.BranchDictV2(branch_dict),
-            cluster="test-cluster",
-        )
-
-        with mock.patch.object(
-            action_config, "get_docker_registry", return_value="docker-registry.com:400"
-        ), mock.patch(
-            "paasta_tools.utils.InstanceConfig.use_docker_disk_quota",
-            autospec=True,
-            return_value=False,
-        ), mock.patch(
-            "paasta_tools.kubernetes_tools.kube_config.load_kube_config", autospec=True
-        ), mock.patch(
-            "paasta_tools.kubernetes_tools.kube_client",
-            autospec=True,
-        ), mock.patch(
-            "paasta_tools.tron_tools._spark_k8s_role",
-            autospec=True,
-            return_value="spark",
-        ), mock.patch(
-            "paasta_tools.tron_tools.load_system_paasta_config",
-            autospec=True,
-            return_value=MOCK_SYSTEM_PAASTA_CONFIG,
-        ), mock.patch(
-            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
-            autospec=True,
-            return_value=[],
-        ), mock.patch(
-            "paasta_tools.tron_tools.get_k8s_url_for_cluster",
-            autospec=True,
-            return_value="https://k8s.test-cluster.paasta:6443",
-        ), mock.patch(
-            "service_configuration_lib.spark_config._get_k8s_docker_volumes_conf",
-            autospec=True,
-            return_value={
-                "spark.kubernetes.executor.volumes.hostPath.0.mount.path": "/nail/tmp",
-                "spark.kubernetes.executor.volumes.hostPath.0.options.path": "/nail/tmp",
-                "spark.kubernetes.executor.volumes.hostPath.0.mount.readOnly": "false",
-                "spark.kubernetes.executor.volumes.hostPath.1.mount.path": "/etc/pki/spark",
-                "spark.kubernetes.executor.volumes.hostPath.1.options.path": "/etc/pki/spark",
-                "spark.kubernetes.executor.volumes.hostPath.1.mount.readOnly": "true",
-                "spark.kubernetes.executor.volumes.hostPath.2.mount.path": "/etc/passwd",
-                "spark.kubernetes.executor.volumes.hostPath.2.options.path": "/etc/passwd",
-                "spark.kubernetes.executor.volumes.hostPath.2.mount.readOnly": "true",
-                "spark.kubernetes.executor.volumes.hostPath.3.mount.path": "/etc/group",
-                "spark.kubernetes.executor.volumes.hostPath.3.options.path": "/etc/group",
-                "spark.kubernetes.executor.volumes.hostPath.3.mount.readOnly": "true",
-            },
-        ), mock.patch(
-            "service_configuration_lib.spark_config.utils.load_spark_srv_conf",
-            autospec=True,
-            return_value=(
-                {},
-                {
-                    "target_mem_cpu_ratio": 7,
-                    "resource_configs": {
-                        "recommended": {
-                            "cpu": 4,
-                            "mem": 28,
-                        },
-                        "medium": {
-                            "cpu": 8,
-                            "mem": 56,
-                        },
-                        "max": {
-                            "cpu": 12,
-                            "mem": 110,
-                        },
+        mock_get_k8s_docker_volumes_conf.return_value = {
+            "spark.kubernetes.executor.volumes.hostPath.0.mount.path": "/nail/tmp",
+            "spark.kubernetes.executor.volumes.hostPath.0.options.path": "/nail/tmp",
+            "spark.kubernetes.executor.volumes.hostPath.0.mount.readOnly": "false",
+            "spark.kubernetes.executor.volumes.hostPath.1.mount.path": "/etc/pki/spark",
+            "spark.kubernetes.executor.volumes.hostPath.1.options.path": "/etc/pki/spark",
+            "spark.kubernetes.executor.volumes.hostPath.1.mount.readOnly": "true",
+            "spark.kubernetes.executor.volumes.hostPath.2.mount.path": "/etc/passwd",
+            "spark.kubernetes.executor.volumes.hostPath.2.options.path": "/etc/passwd",
+            "spark.kubernetes.executor.volumes.hostPath.2.mount.readOnly": "true",
+            "spark.kubernetes.executor.volumes.hostPath.3.mount.path": "/etc/group",
+            "spark.kubernetes.executor.volumes.hostPath.3.options.path": "/etc/group",
+            "spark.kubernetes.executor.volumes.hostPath.3.mount.readOnly": "true",
+        }
+        mock_load_spark_srv_conf.return_value = (
+            {},
+            {
+                "target_mem_cpu_ratio": 7,
+                "resource_configs": {
+                    "recommended": {
+                        "cpu": 4,
+                        "mem": 28,
                     },
-                    "cost_factor": {
-                        "test-cluster": {
-                            "test-pool": 100,
-                        },
-                        "spark-pnw-prod": {
-                            "batch": 0.041,
-                            "stable_batch": 0.142,
-                        },
+                    "medium": {
+                        "cpu": 8,
+                        "mem": 56,
                     },
-                    "adjust_executor_res_ratio_thresh": 99999,
-                    "default_resources_waiting_time_per_executor": 2,
-                    "default_clusterman_observed_scaling_time": 15,
-                    "high_cost_threshold_daily": 500,
-                    "preferred_spark_ui_port_start": 39091,
-                    "preferred_spark_ui_port_end": 39100,
-                    "defaults": {
-                        "spark.executor.cores": 4,
-                        "spark.executor.instances": 2,
-                        "spark.executor.memory": 28,
-                        "spark.task.cpus": 1,
-                        "spark.sql.shuffle.partitions": 128,
-                        "spark.dynamicAllocation.executorAllocationRatio": 0.8,
-                        "spark.dynamicAllocation.cachedExecutorIdleTimeout": "1500s",
-                        "spark.yelp.dra.minExecutorRatio": 0.25,
-                    },
-                    "mandatory_defaults": {
-                        "spark.kubernetes.allocation.batch.size": 512,
-                        "spark.kubernetes.decommission.script": "/opt/spark/kubernetes/dockerfiles/spark/decom.sh",
-                        "spark.logConf": "true",
+                    "max": {
+                        "cpu": 12,
+                        "mem": 110,
                     },
                 },
-                {
+                "cost_factor": {
+                    "test-cluster": {
+                        "test-pool": 100,
+                    },
+                    "spark-pnw-prod": {
+                        "batch": 0.041,
+                        "stable_batch": 0.142,
+                    },
+                },
+                "adjust_executor_res_ratio_thresh": 99999,
+                "default_resources_waiting_time_per_executor": 2,
+                "default_clusterman_observed_scaling_time": 15,
+                "high_cost_threshold_daily": 500,
+                "preferred_spark_ui_port_start": 39091,
+                "preferred_spark_ui_port_end": 39100,
+                "defaults": {
                     "spark.executor.cores": 4,
                     "spark.executor.instances": 2,
                     "spark.executor.memory": 28,
@@ -1093,21 +1155,62 @@ class TestTronTools:
                     "spark.dynamicAllocation.cachedExecutorIdleTimeout": "1500s",
                     "spark.yelp.dra.minExecutorRatio": 0.25,
                 },
-                {
+                "mandatory_defaults": {
                     "spark.kubernetes.allocation.batch.size": 512,
                     "spark.kubernetes.decommission.script": "/opt/spark/kubernetes/dockerfiles/spark/decom.sh",
                     "spark.logConf": "true",
                 },
-                {
-                    "test-cluster": {
-                        "test-pool": 100,
-                    },
-                    "spark-pnw-prod": {
-                        "batch": 0.041,
-                        "stable_batch": 0.142,
-                    },
+            },
+            {
+                "spark.executor.cores": 4,
+                "spark.executor.instances": 2,
+                "spark.executor.memory": 28,
+                "spark.task.cpus": 1,
+                "spark.sql.shuffle.partitions": 128,
+                "spark.dynamicAllocation.executorAllocationRatio": 0.8,
+                "spark.dynamicAllocation.cachedExecutorIdleTimeout": "1500s",
+                "spark.yelp.dra.minExecutorRatio": 0.25,
+            },
+            {
+                "spark.kubernetes.allocation.batch.size": 512,
+                "spark.kubernetes.decommission.script": "/opt/spark/kubernetes/dockerfiles/spark/decom.sh",
+                "spark.logConf": "true",
+            },
+            {
+                "test-cluster": {
+                    "test-pool": 100,
                 },
-            ),
+                "spark-pnw-prod": {
+                    "batch": 0.041,
+                    "stable_batch": 0.142,
+                },
+            },
+        )
+        mock_get_k8s_url_for_cluster.return_value = (
+            "https://k8s.test-cluster.paasta:6443"
+        )
+        mock_load_system_paasta_config.return_value = MOCK_SYSTEM_PAASTA_CONFIG
+        mock_get_docker_registry.return_value = "docker-registry.com:400"
+        action_config = tron_tools.TronActionConfig(
+            service="my_service",
+            instance=tron_tools.compose_instance("my_job", "do_something"),
+            config_dict=TronActionConfigDict(action_dict),
+            branch_dict=utils.BranchDictV2(branch_dict),
+            cluster="test-cluster",
+        )
+
+        with mock.patch(
+            "paasta_tools.utils.InstanceConfig.use_docker_disk_quota",
+            autospec=True,
+            return_value=False,
+        ), mock.patch(
+            "paasta_tools.tron_tools._spark_k8s_role",
+            autospec=True,
+            return_value="spark",
+        ), mock.patch(
+            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
+            autospec=True,
+            return_value=[],
         ):
             result = tron_tools.format_tron_action_dict(action_config)
 
@@ -1212,8 +1315,8 @@ class TestTronTools:
                 "PAASTA_CLUSTER": "test-cluster",
                 "PAASTA_DEPLOY_GROUP": "prod",
                 "PAASTA_DOCKER_IMAGE": "my_service:paasta-123abcde",
-                "PAASTA_RESOURCE_CPUS": "2",
-                "PAASTA_RESOURCE_MEM": "1200",
+                "PAASTA_RESOURCE_CPUS": "1",
+                "PAASTA_RESOURCE_MEM": "1024",
                 "PAASTA_RESOURCE_DISK": "42",
                 "PAASTA_GIT_SHA": "123abcde",
                 "PAASTA_INSTANCE_TYPE": "spark",
@@ -1266,8 +1369,8 @@ class TestTronTools:
                 },
             ],
             "ports": [39091],
-            "cpus": 2,
-            "mem": 1200,
+            "cpus": 1,
+            "mem": 1024,
             "disk": 42,
             "docker_image": "docker-registry.com:400/my_service:paasta-123abcde",
         }


### PR DESCRIPTION
#3906 and #3903 were reverted due to issues with missing kubeconfigs on tron and ValueErrors on system nodes - these have both been fixed with 40ad655fb9c4f98887c4070446300f6a529f7ef9 (tron) and 30d5de84da9ad65caefa45168e96f8c7da6a2519 (system nodes)