### PR TITLE
Skip autotune merging for deleted instances

### DIFF
--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -355,6 +355,12 @@ class AutoConfigUpdater:
             }
 
             for instance_name, recommendation in recommendations_by_instance.items():
+                if instance_name not in existing_configs:
+                    log.debug(
+                        f"Skipping config merge for {instance_name} as it no longer exists in {instance_type_cluster}.yaml."
+                    )
+                    continue
+
                 log.debug(
                     f"Merging recommendations for {instance_name} in {service}/{AUTO_SOACONFIG_SUBDIR}/{instance_type_cluster}.yaml..."
                 )


### PR DESCRIPTION
It's possible for autotune results to include instances that no longer exist in a given file: either because the instance has been completely deleted or moved to another cluster.

In these cases, it should be safe to simply skip the config merge since there's nothing to merge with.

We could technically still do the config update/merge here and simply skip the resource clamping - but imo, we should simply bail out early.