### PR TITLE
Adjust the output of check_autoscaler_max_instances to be more readable…

### DIFF
--- a/paasta_tools/check_autoscaler_max_instances.py
+++ b/paasta_tools/check_autoscaler_max_instances.py
@@ -123,34 +123,42 @@ async def check_max_instances(
                         setpoint,
                     )
 
-                    metric_threshold_target_ratio = threshold / setpoint
                     try:
                         current_value = suffixed_number_value(metric["current_value"])
                         target_value = suffixed_number_value(metric["target_value"])
-
-                        if current_value / target_value > metric_threshold_target_ratio:
-                            status = pysensu_yelp.Status.CRITICAL
-                            output = (
-                                f"{service}.{instance}: Service is at max_instances, and"
-                                " ratio of current value to target value"
-                                f" ({current_value} / {target_value}) is greater than the"
-                                " ratio of max_instances_alert_threshold to setpoint"
-                                f" ({threshold} / {setpoint})"
-                            )
-                        else:
-                            status = pysensu_yelp.Status.OK
-                            output = (
-                                f"{service}.{instance}: Service is at max_instances, but"
-                                " ratio of current value to target value"
-                                f" ({current_value} / {target_value}) is below the ratio of"
-                                f" max_instances_alert_threshold to setpoint ({threshold} /"
-                                f" {setpoint})"
-                            )
                     except KeyError:
                         # we likely couldn't find values for the current metric from autoscaling status
                         # if this is the only metric, we will return UNKNOWN+this error
                         # suggest fixing their autoscaling config
                         output = f'{service}.{instance}: Service is at max_instances, and there is an error fetching your {metrics_provider_config["type"]} metric. Check your autoscaling configs or reach out to #paasta.'
+                    else:
+                        # target_value can be 100*setpoint (for cpu), 1 (for uwsgi, piscina, gunicorn,
+                        # active_requests), or setpoint (for promql).
+                        # Here we divide current_value by target_value to find the ratio of utilization to setpoint,
+                        # and then multiply by setpoint to find the actual utilization in the same units as setpoint.
+                        utilization = setpoint * current_value / target_value
+
+                        if threshold == setpoint:
+                            threshold_description = f"setpoint ({threshold})"
+                        else:
+                            threshold_description = (
+                                f"max_instances_alert_threshold ({threshold})"
+                            )
+
+                        if utilization > threshold:
+                            status = pysensu_yelp.Status.CRITICAL
+                            output = (
+                                f"{service}.{instance}: Service is at max_instances, and"
+                                f" utilization ({utilization}) is greater than"
+                                f" {threshold_description}."
+                            )
+                        else:
+                            status = pysensu_yelp.Status.OK
+                            output = (
+                                f"{service}.{instance}: Service is at max_instances, but"
+                                f" utilization ({utilization}) is less than"
+                                f" {threshold_description}."
+                            )
             else:
                 status = pysensu_yelp.Status.OK
                 output = f"{service}.{instance} is below max_instances."


### PR DESCRIPTION
… (less mathy)

Now that `offset` is gone, we can make this message a lot clearer -- no reason to use a ratio.