### PR TITLE
adding sidecars for prometheus pushgateway and metric scrapper

### DIFF
--- a/tests/test_vitesscluster_tools.py
+++ b/tests/test_vitesscluster_tools.py
@@ -610,6 +610,21 @@ VITESS_CONFIG = {
             "requests": {"cpu": "100m", "memory": "256Mi"},
         },
     },
+    "prometheusPushGateway": {
+        "name": "prometheusPushGateway",
+        "image": "prometheus/pushgateway",
+        "restartPolicy": "OnFailure",
+        "command": ['--web.listen-address=":8000"'],
+    },
+    "vitessMetricScrapper": {
+        "name": "vitessMetricScrapper",
+        "restartPolicy": "OnFailure",
+        "command": [
+            "sh",
+            "-c",
+            "puppet:///modules/profile_vitess/scrape-vitess-containers.sh",
+        ],
+    },
 }
 
 


### PR DESCRIPTION
Adding k8s sidecars for Vitess paasta deployement Prometheus pushgateway and Vitess metric scrapper to run bash script. Additional information can be found in JIRA ticket below:
https://jira.yelpcorp.com/browse/DREIMP-10714