### PR TITLE
local-run: add option to set service auth token in container environment

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -38,6 +38,7 @@ from paasta_tools.cli.cmds.check import makefile_responds_to
 from paasta_tools.cli.cmds.cook_image import paasta_cook_image
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_instance_config
+from paasta_tools.cli.utils import get_service_auth_token
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import pick_random_port
@@ -507,6 +508,17 @@ def add_subparser(subparsers):
         default=False,
     )
     list_parser.add_argument(
+        "--use-service-auth-token",
+        help=(
+            "Acquire service authentication token for the underlying instance,"
+            " and set it in the container environment"
+        ),
+        action="store_true",
+        dest="use_service_auth_token",
+        required=False,
+        default=False,
+    )
+    list_parser.add_argument(
         "--sha",
         help=(
             "SHA to run instead of the currently marked-for-deployment SHA. Ignored when used with --build."
@@ -817,6 +829,7 @@ def run_docker_container(
     assume_role_arn="",
     use_okta_role=False,
     assume_role_aws_account: Optional[str] = None,
+    use_service_auth_token: bool = False,
 ):
     """docker-py has issues running a container with a TTY attached, so for
     consistency we execute 'docker run' directly in both interactive and
@@ -905,6 +918,9 @@ def run_docker_container(
             assume_role_aws_account,
         )
         environment.update(aws_creds)
+
+    if use_service_auth_token:
+        environment["YELP_SVC_AUTHZ_TOKEN"] = get_service_auth_token()
 
     local_run_environment = get_local_run_environment_vars(
         instance_config=instance_config, port0=chosen_port, framework=framework
@@ -1251,6 +1267,7 @@ def configure_and_run_docker_container(
         assume_role_arn=args.assume_role_arn,
         assume_role_aws_account=assume_role_aws_account,
         use_okta_role=args.use_okta_role,
+        use_service_auth_token=args.use_service_auth_token,
     )
 
 

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -1104,10 +1104,13 @@ def get_paasta_oapi_api_clustername(cluster: str, is_eks: bool) -> str:
 
 
 def get_current_ecosystem() -> str:
-    """Infer ecosystem from local-run configuration"""
-    local_run_config = load_system_paasta_config().get_local_run_config()
-    ecosystem = local_run_config["default_cluster"].split("-", 1)[-1]
-    return f"{ecosystem}prod" if ecosystem == "corp" else ecosystem
+    """Get current ecosystem from host configs, defaults to dev if no config is found"""
+    try:
+        with open("/nail/etc/ecosystem") as f:
+            return f.read().strip()
+    except IOError:
+        pass
+    return "devc"
 
 
 def get_service_auth_token() -> str:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2041,6 +2041,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     secret_sync_delay_seconds: float
     use_multiple_log_readers: Optional[List[str]]
     service_auth_token_settings: ProjectedSAVolume
+    service_auth_vault_role: str
     always_authenticating_services: List[str]
     mysql_port_mappings: Dict
     vitess_images: Dict
@@ -2755,6 +2756,9 @@ class SystemPaastaConfig:
 
     def get_service_auth_token_volume_config(self) -> ProjectedSAVolume:
         return self.config_dict.get("service_auth_token_settings", {})
+
+    def get_service_auth_vault_role(self) -> str:
+        return self.config_dict.get("service_auth_vault_role", "service_authz")
 
     def get_always_authenticating_services(self) -> List[str]:
         return self.config_dict.get("always_authenticating_services", [])

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -394,6 +394,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
     args.assume_role_arn = ""
     args.assume_pod_identity = False
     args.use_okta_role = False
+    args.use_service_auth_token = False
 
     mock_secret_provider_kwargs = {
         "vault_cluster_config": {},
@@ -436,6 +437,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
         assume_pod_identity=False,
         assume_role_aws_account=None,
         use_okta_role=False,
+        use_service_auth_token=False,
     )
 
 
@@ -470,6 +472,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
     args.assume_role_arn = ""
     args.assume_pod_identity = False
     args.use_okta_role = False
+    args.use_service_auth_token = False
 
     return_code = configure_and_run_docker_container(
         docker_client=mock_docker_client,
@@ -511,6 +514,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
         assume_role_aws_account="dev",
         assume_pod_identity=False,
         use_okta_role=False,
+        use_service_auth_token=False,
     )
 
 
@@ -551,6 +555,7 @@ def test_configure_and_run_pulls_image_when_asked(
     args.assume_role_arn = ""
     args.assume_pod_identity = False
     args.use_okta_role = False
+    args.use_service_auth_token = False
 
     return_code = configure_and_run_docker_container(
         docker_client=mock_docker_client,
@@ -594,6 +599,7 @@ def test_configure_and_run_pulls_image_when_asked(
         assume_pod_identity=False,
         assume_role_aws_account="dev",
         use_okta_role=False,
+        use_service_auth_token=False,
     )
 
 
@@ -630,6 +636,7 @@ def test_configure_and_run_docker_container_defaults_to_interactive_instance(
         args.assume_role_arn = ""
         args.assume_pod_identity = False
         args.use_okta_role = False
+        args.use_service_auth_token = False
 
         mock_config = mock.create_autospec(AdhocJobConfig)
         mock_get_default_interactive_config.return_value = mock_config
@@ -673,6 +680,7 @@ def test_configure_and_run_docker_container_defaults_to_interactive_instance(
             assume_pod_identity=False,
             assume_role_aws_account="dev",
             use_okta_role=False,
+            use_service_auth_token=False,
         )
 
 

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -17,7 +17,6 @@ from socket import gaierror
 
 import ephemeral_port_reserve
 import mock
-import pytest
 from mock import call
 from mock import patch
 from pytest import mark
@@ -25,7 +24,6 @@ from pytest import raises
 
 from paasta_tools.cli import utils
 from paasta_tools.cli.utils import extract_tags
-from paasta_tools.cli.utils import get_current_ecosystem
 from paasta_tools.cli.utils import get_service_auth_token
 from paasta_tools.cli.utils import select_k8s_secret_namespace
 from paasta_tools.cli.utils import verify_instances
@@ -479,18 +477,6 @@ def test_select_k8s_secret_namespace():
 
     namespaces = {"a", "b"}
     assert select_k8s_secret_namespace(namespaces) in {"a", "b"}
-
-
-@pytest.mark.parametrize(
-    "default_cluster,expected",
-    (("whatever-dev", "dev"), ("something-corp", "corpprod")),
-)
-@patch("paasta_tools.cli.utils.load_system_paasta_config", autospec=True)
-def test_get_current_ecosystem(mock_config, default_cluster, expected):
-    mock_config.return_value.get_local_run_config.return_value = {
-        "default_cluster": default_cluster
-    }
-    assert get_current_ecosystem() == expected
 
 
 @patch("paasta_tools.cli.utils.load_system_paasta_config", autospec=True)


### PR DESCRIPTION
Unit tests are a bit pointless since it's just a waterfall of mocks, but the implementation works:
```
$ paasta local-run ... --use-service-auth-token --dry-run --json-dict | jq .env.YELP_SVC_AUTHZ_TOKEN | wc -c
839
```

