### PR TITLE
MLCOMPUTE-1389 | remove spark.app.id and generate static spark.app.name

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -531,8 +531,8 @@ def limit_size_with_hash(name: str, limit: int = 63, suffix: int = 4) -> str:
     """
     if len(name) > limit:
         digest = hashlib.md5(name.encode()).digest()
-        hash = base64.b32encode(digest).decode().replace("=", "").lower()
-        return f"{name[:(limit-suffix-1)]}-{hash[:suffix]}"
+        hashed = base64.b32encode(digest).decode().replace("=", "").lower()
+        return f"{name[:(limit-suffix-1)]}-{hashed[:suffix]}"
     else:
         return name
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -373,8 +373,8 @@ class TronActionConfig(InstanceConfig):
         if "spark.app.name" in spark_conf:
             spark_conf["spark.app.name"] = limit_size_with_hash(
                 f"tron_spark_{self.get_service()}_{self.get_instance()}_{self.get_action_name()}"
-                if "spark.app.name" not in stringified_spark_args else
-                stringified_spark_args["spark.app.name"]
+                if "spark.app.name" not in stringified_spark_args
+                else stringified_spark_args["spark.app.name"]
             )
         # TODO: Remove this once dynamic pod template is generated inside the driver using spark-submit wrapper
         if "spark.kubernetes.executor.podTemplateFile" in spark_conf:

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -373,6 +373,8 @@ class TronActionConfig(InstanceConfig):
         if "spark.app.name" in spark_conf:
             spark_conf["spark.app.name"] = limit_size_with_hash(
                 f"tron_spark_{self.get_service()}_{self.get_instance()}_{self.get_action_name()}"
+                if "spark.app.name" not in stringified_spark_args else
+                stringified_spark_args["spark.app.name"]
             )
         # TODO: Remove this once dynamic pod template is generated inside the driver using spark-submit wrapper
         if "spark.kubernetes.executor.podTemplateFile" in spark_conf:

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1216,12 +1216,9 @@ class TestTronTools:
 
         confs = result["command"].split(" ")
         spark_app_name = ""
-        spark_app_id = ""
         for s in confs:
             if s.startswith("spark.app.name"):
                 spark_app_name = s.split("=")[1]
-            if s.startswith("spark.app.id"):
-                spark_app_id = s.split("=")[1]
 
         expected = {
             "command": "timeout 12h spark-submit "
@@ -1230,7 +1227,6 @@ class TestTronTools:
             "--conf spark.executor.memory=1g "
             "--conf spark.executor.cores=2 "
             f"--conf spark.app.name={spark_app_name} "
-            f"--conf spark.app.id={spark_app_id} "
             "--conf spark.ui.port=39091 "
             "--conf spark.executor.instances=0 "
             "--conf spark.kubernetes.executor.limit.cores=2 "


### PR DESCRIPTION
- `spark.app.id` is generated fresh and added by service_configuration_lib with a random postfix because of which Tron keeps running update config flow every few minutes. This config should be removed and generated by yelp spark-submit wrapper or by Spark itself.
- `spark.app.name` is also generated fresh with a random timestamp and postfix which leads to the same problem. This config should be made static and potentially replaced by yelp spark-submit wrapper later