### PR TITLE
MLCOMPUTE-1497 | include spark driver memory overhead in driver pod memory

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -445,7 +445,7 @@
                             "type": "boolean"
                         },
                         "spark.app.name": {
-                            "type": "boolean"
+                            "type": "string"
                         },
                         "spark.task.maxFailures": {
                             "type": "integer",

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -6,7 +6,6 @@ from typing import Any
 from typing import cast
 from typing import Dict
 from typing import List
-from typing import Literal
 from typing import Mapping
 from typing import Set
 

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -264,7 +264,21 @@ def get_spark_memory_in_unit(mem: str, unit: Literal["k", "m", "g", "t"]) -> flo
         try:
             memory_bytes = float(mem[:-1]) * MEM_MULTIPLIER[mem[-1]]
         except (ValueError, IndexError):
-            print(f"Unable to parse memory value {mem}. Defaulting to 2 GB.")
-            memory_bytes = 2147483648  # default to 2 GB
+            print(f"Unable to parse memory value {mem}. Defaulting to 0.")
+            memory_bytes = 0  # default to 0
     memory_unit = memory_bytes / MEM_MULTIPLIER[unit]
     return memory_unit
+
+
+def get_spark_driver_memory_overhead_in_mb(spark_config: Dict[str, str]) -> float:
+    """
+    Returns the Spark driver memory overhead in bytes.
+    """
+    driver_mem_overhead = "0"
+    if "spark.driver.memoryOverhead" in spark_config:
+        driver_mem_overhead = spark_config["spark.driver.memoryOverhead"]
+    try:
+        memory_mb = float(driver_mem_overhead)
+    except ValueError:
+        memory_mb = get_spark_memory_in_unit(driver_mem_overhead, "m")
+    return memory_mb

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -249,36 +249,3 @@ def get_spark_driver_monitoring_labels(
         "spark.yelp.com/driver_ui_port": ui_port_str,
     }
     return labels
-
-
-def get_spark_memory_in_unit(mem: str, unit: Literal["k", "m", "g", "t"]) -> float:
-    """
-    Converts Spark memory to the desired unit.
-    mem is the same format as JVM memory strings: just number or number followed by 'k', 'm', 'g' or 't'.
-    unit can be 'k', 'm', 'g' or 't'.
-    Returns memory as a float converted to the desired unit.
-    """
-    try:
-        memory_bytes = float(mem)
-    except ValueError:
-        try:
-            memory_bytes = float(mem[:-1]) * MEM_MULTIPLIER[mem[-1]]
-        except (ValueError, IndexError):
-            print(f"Unable to parse memory value {mem}. Defaulting to 0.")
-            memory_bytes = 0  # default to 0
-    memory_unit = memory_bytes / MEM_MULTIPLIER[unit]
-    return memory_unit
-
-
-def get_spark_driver_memory_overhead_in_mb(spark_config: Dict[str, str]) -> float:
-    """
-    Returns the Spark driver memory overhead in bytes.
-    """
-    driver_mem_overhead = "0"
-    if "spark.driver.memoryOverhead" in spark_config:
-        driver_mem_overhead = spark_config["spark.driver.memoryOverhead"]
-    try:
-        memory_mb = float(driver_mem_overhead)
-    except ValueError:
-        memory_mb = get_spark_memory_in_unit(driver_mem_overhead, "m")
-    return memory_mb

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -24,6 +24,7 @@ SPARK_JOB_USER = "TRON"
 SPARK_PROMETHEUS_SHARD = "ml-compute"
 SPARK_DNS_POD_TEMPLATE = "/nail/srv/configs/spark_dns_pod_template.yaml"
 MEM_MULTIPLIER = {"k": 1024, "m": 1024**2, "g": 1024**3, "t": 1024**4}
+SPARK_DRIVER_DEFAULT_DISK_MB = 5120  # 5GB
 
 log = logging.getLogger(__name__)
 

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -308,6 +308,13 @@ class TronActionConfig(InstanceConfig):
         # we fall back to this default if there's no Spark config
         return super().get_mem()
 
+    def get_disk(self, default: float = 1024) -> float:
+        # increase default threshold for Spark driver pod memory because 1G is too low
+        if self.action_spark_config:
+            return spark_tools.SPARK_DRIVER_DEFAULT_DISK_MB
+        # we fall back to this default if there's no Spark config
+        return super().get_disk()
+
     def build_spark_config(self) -> Dict[str, str]:
         system_paasta_config = load_system_paasta_config()
         resolved_cluster = system_paasta_config.get_eks_cluster_aliases().get(

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -310,7 +310,7 @@ class TronActionConfig(InstanceConfig):
 
     def get_disk(self, default: float = 1024) -> float:
         # increase default threshold for Spark driver pod memory because 1G is too low
-        if self.action_spark_config:
+        if self.action_spark_config and "disk" not in self.config_dict:
             return spark_tools.SPARK_DRIVER_DEFAULT_DISK_MB
         # we fall back to this default if there's no Spark config
         return super().get_disk()

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -54,7 +54,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.18.19
+service-configuration-lib >= 2.18.20
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,7 +89,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.10.0
 sensu-plugin==0.3.1
-service-configuration-lib==2.18.19
+service-configuration-lib==2.18.20
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1312,7 +1312,7 @@ class TestTronTools:
                 "PAASTA_DEPLOY_GROUP": "prod",
                 "PAASTA_DOCKER_IMAGE": "my_service:paasta-123abcde",
                 "PAASTA_RESOURCE_CPUS": "1",
-                "PAASTA_RESOURCE_MEM": "1024",
+                "PAASTA_RESOURCE_MEM": "1126",
                 "PAASTA_RESOURCE_DISK": "42",
                 "PAASTA_GIT_SHA": "123abcde",
                 "PAASTA_INSTANCE_TYPE": "spark",
@@ -1366,7 +1366,7 @@ class TestTronTools:
             ],
             "ports": [39091],
             "cpus": 1,
-            "mem": 1024,
+            "mem": 1126,
             "disk": 42,
             "docker_image": "docker-registry.com:400/my_service:paasta-123abcde",
         }


### PR DESCRIPTION
- Spark driver pod memory needs to allocate memory for driver memory overhead config along with the driver memory config