### PR TITLE
Allow setting a uses_bulkdata default

### DIFF
--- a/paasta_tools/frameworks/native_service_config.py
+++ b/paasta_tools/frameworks/native_service_config.py
@@ -171,7 +171,8 @@ class NativeServiceConfig(LongRunningServiceConfig):
         computed separately.
         """
         docker_volumes = self.get_volumes(
-            system_volumes=system_paasta_config.get_volumes()
+            system_volumes=system_paasta_config.get_volumes(),
+            uses_bulkdata_default=system_paasta_config.get_uses_bulkdata_default(),
         )
         task: TaskInfo = {
             "name": "",

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2142,7 +2142,8 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             service=self.service, namespace=self.get_nerve_namespace()
         )
         docker_volumes = self.get_volumes(
-            system_volumes=system_paasta_config.get_volumes()
+            system_volumes=system_paasta_config.get_volumes(),
+            uses_bulkdata_default=system_paasta_config.get_uses_bulkdata_default(),
         )
 
         hacheck_sidecar_volumes = system_paasta_config.get_hacheck_sidecar_volumes()

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -357,7 +357,10 @@ class TronActionConfig(InstanceConfig):
             paasta_service=self.get_service(),
             paasta_instance=self.get_instance(),
             docker_img=docker_img_url,
-            extra_volumes=self.get_volumes(system_paasta_config.get_volumes()),
+            extra_volumes=self.get_volumes(
+                system_paasta_config.get_volumes(),
+                uses_bulkdata_default=system_paasta_config.get_uses_bulkdata_default(),
+            ),
             use_eks=True,
             k8s_server_address=get_k8s_url_for_cluster(self.get_cluster()),
             force_spark_resource_configs=self.config_dict.get(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -624,7 +624,8 @@ class InstanceConfig:
 
         Defaults to 1024 (1GiB) if no value is specified in the config.
 
-        :returns: The amount of disk space specified by the config, 1024 MiB if not specified"""
+        :returns: The amount of disk space specified by the config, 1024 MiB if not specified
+        """
         disk = self.config_dict.get("disk", default)
         return disk
 
@@ -979,7 +980,8 @@ class InstanceConfig:
 
         Eventually this may be implemented with Mesos roles, once a framework can register under multiple roles.
 
-        :returns: the "pool" attribute in your config dict, or the string "default" if not specified."""
+        :returns: the "pool" attribute in your config dict, or the string "default" if not specified.
+        """
         return self.config_dict.get("pool", "default")
 
     def get_pool_constraints(self) -> List[Constraint]:
@@ -998,17 +1000,17 @@ class InstanceConfig:
         """
         return self.config_dict.get("net", "bridge")
 
-    def has_bulkdata(
-        self,
-    ) -> bool:
-        return self.config_dict.get("uses_bulkdata", True)
-
-    def get_volumes(self, system_volumes: Sequence[DockerVolume]) -> List[DockerVolume]:
+    def get_volumes(
+        self, system_volumes: Sequence[DockerVolume], uses_bulkdata_default: bool = True
+    ) -> List[DockerVolume]:
         volumes = list(system_volumes) + list(self.get_extra_volumes())
         # we used to add bulkdata as a default mount - but as part of the
         # effort to deprecate the entire system, we're swapping to an opt-in
         # model so that we can shrink the blast radius of any changes
-        if self.has_bulkdata():
+        if self.config_dict.get(
+            "uses_bulkdata",
+            uses_bulkdata_default,
+        ):
             # bulkdata is mounted RO as the data is produced by another
             # system and we want to ensure that there are no inadvertent
             # changes by misbehaved code
@@ -1038,7 +1040,8 @@ class InstanceConfig:
 
         Defaults to None if not specified in the config.
 
-        :returns: A list of dictionaries specified in the dependencies_dict, None if not specified"""
+        :returns: A list of dictionaries specified in the dependencies_dict, None if not specified
+        """
         dependencies = self.config_dict.get("dependencies")
         if not dependencies:
             return None
@@ -1119,7 +1122,6 @@ def compose(
 
 
 class PaastaColors:
-
     """Collection of static variables and methods to assist in coloring text."""
 
     # ANSI color codes
@@ -2048,6 +2050,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     vitess_tablet_types: List[str]
     vitess_tablet_pool_type_mapping: Dict
     vitess_throttling_config: Dict
+    uses_bulkdata_default: bool
 
 
 def load_system_paasta_config(
@@ -2418,7 +2421,8 @@ class SystemPaastaConfig:
         """Get a format string for the URL to query for haproxy-synapse state. This format string gets two keyword
         arguments, host and port. Defaults to "http://{host:s}:{port:d}/;csv;norefresh".
 
-        :returns: A format string for constructing the URL of haproxy-synapse's status page."""
+        :returns: A format string for constructing the URL of haproxy-synapse's status page.
+        """
         return self.config_dict.get(
             "synapse_haproxy_url_format", DEFAULT_SYNAPSE_HAPROXY_URL_FORMAT
         )
@@ -2433,7 +2437,8 @@ class SystemPaastaConfig:
         """Get a format string that constructs a DNS name pointing at the paasta masters in a cluster. This format
         string gets one parameter: cluster. Defaults to 'paasta-{cluster:s}.yelp'.
 
-        :returns: A format string for constructing the FQDN of the masters in a given cluster."""
+        :returns: A format string for constructing the FQDN of the masters in a given cluster.
+        """
         return self.config_dict.get("cluster_fqdn_format", "paasta-{cluster:s}.yelp")
 
     def get_paasta_status_version(self) -> str:
@@ -2804,6 +2809,9 @@ class SystemPaastaConfig:
                 },
             },
         )
+
+    def get_uses_bulkdata_default(self) -> bool:
+        return self.config_dict.get("uses_bulkdata_default", True)
 
 
 def _run(


### PR DESCRIPTION
In global paasta config, so we can set it on a per ecosystem/region level in puppet to enable us to roll this out without having to modify every instance in yelpsoa_configs to set uses_bulkdata: true

This is part of the [new proposed rollout
plan](https://docs.google.com/document/d/1RwcJ5JVi2G0Sc2IAXA6tze2CNj2NR8WHN3-rFLjxuOU/edit#bookmark=id.edii46zhxpmu)

Tested by creating a test cluster (from [these instructions](https://yelpwiki.yelpcorp.com/pages/viewpage.action?pageId=234312044)

```
make k8s_fake_cluster
make generate_deployments_for_service
```

saving kubeconfig to a file

```
kind get kubeconfig --name tmower-k8s-test > .paasta-kube-config 
```

Editing `k8s_itests/deployments/paasta/fake_etc_paasta/clusters.json` and setting `uses_bulkdata_default` to `false`

Then running `Run setup k8s job in playground` from the vscode run / debug menu

Then running

```
KUBECONFIG=./.paasta-kube-config kubectl get deployment -n paastasvc-compute-infra-test-service -oyaml | grep volume -i -C5
```

no /nail/bulkdata volume was added

Setting the uses_bulkdata_default value back to true, and rerunning setup k8s job in playground, the above command showed a bulkdata volume

I'm not sure if its sustainable to run `load_system_paasta_config()` every time `has_bulkdata` is called, or even if we move this call to when `InstanceConfig` is instantiated, but i'm not familiar enough with the code to know if theres a better way of calling `load_system_paasta_config()` once and passing it into `InstanceConfig`, or if we could add a `lru_cache` to `load_system_paasta_config` - so would appreciate help here