### PR TITLE
Add uses_bulkdata to tron schema

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -650,6 +650,9 @@
                 },
                 "deploy_group": {
                     "type": "string"
+                },
+                "uses_bulkdata": {
+                    "type": "boolean"
                 }
             }
         }


### PR DESCRIPTION
Following comments from @nemacysts
[here](https://yelp.slack.com/archives/CA53J9UJ0/p1721332229482589?thread_ts=1721143523.159819&cid=CA53J9UJ0)
- all we should need to do is add a boolean field to the tron schema to indicate
whether or not a job uses bulk data.