### PR TITLE
Add lifecycle hooks for cloudmap (de)registration operations on vtgate pods

### DIFF
--- a/paasta_tools/vitesscluster_tools.py
+++ b/paasta_tools/vitesscluster_tools.py
@@ -545,7 +545,10 @@ def get_keyspaces_config(
         tablet_types = load_system_paasta_config().get_vitess_tablet_types()
         for tablet_type in tablet_types:
             ecosystem = region.split("-")[-1]
-            host = f"mysql-{cluster}-{tablet_type}.dre-{ecosystem}"
+            if tablet_type == "primary":
+                host = f"mysql-{cluster}.dre-{ecosystem}"
+            else:
+                host = f"mysql-{cluster}-{tablet_type}.dre-{ecosystem}"
 
             # We use migration_replication delay for migration tablets and read_replication_delay for everything else
             # Also throttling threshold for refresh and sanitized primaries is set at 30 seconds and everything else at 3 seconds

--- a/tests/test_vitesscluster_tools.py
+++ b/tests/test_vitesscluster_tools.py
@@ -209,7 +209,7 @@ VITESS_CONFIG = {
                                             "volumeName": "vttablet-fake-credentials",
                                         },
                                         "database": "fake_keyspaces",
-                                        "host": "mysql-fake_cluster-primary.dre-devc",
+                                        "host": "mysql-fake_cluster.dre-devc",
                                         "port": 3306,
                                         "user": "vt_app",
                                     },

--- a/tests/test_vitesscluster_tools.py
+++ b/tests/test_vitesscluster_tools.py
@@ -117,6 +117,26 @@ VITESS_CONFIG = {
                     "mysql_auth_vault_ttl": "60s",
                 },
                 "extraLabels": {"tablet_type": "fake_keyspaces_migration"},
+                "lifecycle": {
+                    "postStart": {
+                        "exec": {
+                            "command": [
+                                "/bin/sh",
+                                "-c",
+                                "/cloudmap/scripts/register_to_cloudmap.sh vtgate-fake_cell mo-ck_r-e",
+                            ]
+                        }
+                    },
+                    "preStop": {
+                        "exec": {
+                            "command": [
+                                "/bin/sh",
+                                "-c",
+                                "/cloudmap/scripts/deregister_from_cloudmap.sh vtgate-fake_cell mo-ck_r-e",
+                            ]
+                        }
+                    },
+                },
                 "replicas": 1,
                 "resources": {
                     "limits": {"cpu": "100m", "memory": "256Mi"},


### PR DESCRIPTION
Added the scripts to the docker image in https://github.yelpcorp.com/docker-images/vitess_base/pull/21
AWS role and policy added for namespace pods in https://github.yelpcorp.com/misc/terraform-code/pull/24481