### PR TITLE
Allow to modify namespace when creating/updating/listing custom resources

### DIFF
--- a/paasta_tools/cleanup_kubernetes_cr.py
+++ b/paasta_tools/cleanup_kubernetes_cr.py
@@ -31,6 +31,7 @@ from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import list_custom_resources
 from paasta_tools.kubernetes_tools import load_custom_resource_definitions
 from paasta_tools.kubernetes_tools import paasta_prefixed
+from paasta_tools.setup_kubernetes_cr import INSTANCE_TYPE_TO_NAMESPACE_LOADER
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import load_all_configs
 from paasta_tools.utils import load_system_paasta_config
@@ -105,11 +106,16 @@ def cleanup_all_custom_resources(
         )
         if not config_dicts:
             continue
+        if crd.file_prefix in INSTANCE_TYPE_TO_NAMESPACE_LOADER:
+            namespace = INSTANCE_TYPE_TO_NAMESPACE_LOADER[crd.file_prefix]
+        else:
+            namespace = ""
         crs = list_custom_resources(
             kube_client=kube_client,
             kind=crd.kube_kind,
             version=crd.version,
             group=crd.group,
+            namespace=namespace,
         )
         for cr in crs:
             service = config_dicts.get(cr.service)

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -3081,11 +3081,14 @@ def create_custom_resource(
     version: str,
     kind: KubeKind,
     group: str,
+    namespace: str = "",
 ) -> None:
+    if not namespace:
+        namespace = f"paasta-{kind.plural}"
     return kube_client.custom.create_namespaced_custom_object(
         group=group,
         version=version,
-        namespace=f"paasta-{kind.plural}",
+        namespace=namespace,
         plural=kind.plural,
         body=formatted_resource,
     )
@@ -3098,12 +3101,15 @@ def update_custom_resource(
     name: str,
     kind: KubeKind,
     group: str,
+    namespace: str = "",
 ) -> None:
+    if not namespace:
+        namespace = f"paasta-{kind.plural}"
     co = kube_client.custom.get_namespaced_custom_object(
         name=name,
         group=group,
         version=version,
-        namespace=f"paasta-{kind.plural}",
+        namespace=namespace,
         plural=kind.plural,
     )
     formatted_resource["metadata"]["resourceVersion"] = co["metadata"][
@@ -3113,7 +3119,7 @@ def update_custom_resource(
         name=name,
         group=group,
         version=version,
-        namespace=f"paasta-{kind.plural}",
+        namespace=namespace,
         plural=kind.plural,
         body=formatted_resource,
     )
@@ -3125,13 +3131,16 @@ def list_custom_resources(
     kube_client: KubeClient,
     group: str,
     label_selector: str = "",
+    namespace: str = "",
 ) -> Sequence[KubeCustomResource]:
+    if not namespace:
+        namespace = f"paasta-{kind.plural}"
     crs = kube_client.custom.list_namespaced_custom_object(
         group=group,
         version=version,
         label_selector=label_selector,
         plural=kind.plural,
-        namespace=f"paasta-{kind.plural}",
+        namespace=namespace,
     )
     kube_custom_resources = []
     for cr in crs["items"]:

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -50,8 +50,11 @@ from paasta_tools.utils import get_git_sha_from_dockerurl
 from paasta_tools.utils import load_all_configs
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.vitesscell_tools import load_vitess_cell_instance_configs
+from paasta_tools.vitesscell_tools import VITESSCELL_KUBERNETES_NAMESPACE
 from paasta_tools.vitesscluster_tools import load_vitess_cluster_instance_configs
+from paasta_tools.vitesscluster_tools import VITESSCLUSTER_KUBERNETES_NAMESPACE
 from paasta_tools.vitesskeyspace_tools import load_vitess_keyspace_instance_configs
+from paasta_tools.vitesskeyspace_tools import VITESSKEYSPACE_KUBERNETES_NAMESPACE
 
 
 log = logging.getLogger(__name__)
@@ -61,6 +64,13 @@ INSTANCE_TYPE_TO_CONFIG_LOADER = {
     "vitesscluster": load_vitess_cluster_instance_configs,
     "vitesscell": load_vitess_cell_instance_configs,
     "vitesskeyspace": load_vitess_keyspace_instance_configs,
+}
+
+
+INSTANCE_TYPE_TO_NAMESPACE_LOADER = {
+    "vitesscluster": VITESSCLUSTER_KUBERNETES_NAMESPACE,
+    "vitesscell": VITESSCELL_KUBERNETES_NAMESPACE,
+    "vitesskeyspace": VITESSKEYSPACE_KUBERNETES_NAMESPACE,
 }
 
 
@@ -240,8 +250,16 @@ def setup_custom_resources(
 ) -> bool:
     succeded = True
     if config_dicts:
+        if crd.file_prefix in INSTANCE_TYPE_TO_NAMESPACE_LOADER:
+            namespace = INSTANCE_TYPE_TO_NAMESPACE_LOADER[crd.file_prefix]
+        else:
+            namespace = f"paasta-{kind.plural}"
         crs = list_custom_resources(
-            kube_client=kube_client, kind=kind, version=version, group=group
+            kube_client=kube_client,
+            kind=kind,
+            version=version,
+            group=group,
+            namespace=namespace,
         )
     for svc, config in config_dicts.items():
         if service is not None and service != svc:
@@ -369,6 +387,10 @@ def reconcile_kubernetes_resource(
                     cluster=cluster,
                     soa_dir=DEFAULT_SOA_DIR,
                 )
+            if crd.file_prefix in INSTANCE_TYPE_TO_NAMESPACE_LOADER:
+                namespace = INSTANCE_TYPE_TO_NAMESPACE_LOADER[crd.file_prefix]
+            else:
+                namespace = f"paasta-{kind.plural}"
             git_sha = get_git_sha_from_dockerurl(soa_config.get_docker_url(), long=True)
             formatted_resource = format_custom_resource(
                 instance_config=config,
@@ -378,7 +400,7 @@ def reconcile_kubernetes_resource(
                 kind=kind.singular,
                 version=version,
                 group=group,
-                namespace=f"paasta-{kind.plural}",
+                namespace=namespace,
                 git_sha=git_sha,
                 is_eks=is_eks,
             )
@@ -393,7 +415,7 @@ def reconcile_kubernetes_resource(
                 ),
                 kind=kind.singular,
                 name=formatted_resource["metadata"]["name"],
-                namespace=f"paasta-{kind.plural}",
+                namespace=namespace,
             )
             if not (service, inst, kind.singular) in [
                 (c.service, c.instance, c.kind) for c in custom_resources
@@ -405,6 +427,7 @@ def reconcile_kubernetes_resource(
                     kind=kind,
                     formatted_resource=formatted_resource,
                     group=group,
+                    namespace=namespace,
                 )
             elif desired_resource not in custom_resources:
                 sanitised_service = sanitise_kubernetes_name(service)
@@ -417,6 +440,7 @@ def reconcile_kubernetes_resource(
                     kind=kind,
                     formatted_resource=formatted_resource,
                     group=group,
+                    namespace=namespace,
                 )
             else:
                 log.info(f"{desired_resource} is up to date, no action taken")

--- a/paasta_tools/vitesscell_tools.py
+++ b/paasta_tools/vitesscell_tools.py
@@ -30,7 +30,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-KUBERNETES_NAMESPACE = "paasta-vitessclusters"
+VITESSCELL_KUBERNETES_NAMESPACE = "paasta-vitessclusters"
 
 
 # Global variables
@@ -283,7 +283,7 @@ def cr_id(service: str, instance: str) -> Mapping[str, str]:
     return dict(
         group="planetscale.com",
         version="v2",
-        namespace=KUBERNETES_NAMESPACE,
+        namespace=VITESSCELL_KUBERNETES_NAMESPACE,
         plural="vitesscells",
         name=sanitised_cr_name(service, instance),
     )

--- a/paasta_tools/vitesscluster_tools.py
+++ b/paasta_tools/vitesscluster_tools.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-KUBERNETES_NAMESPACE = "paasta-vitessclusters"
+VITESSCLUSTER_KUBERNETES_NAMESPACE = "paasta-vitessclusters"
 
 
 # Global variables
@@ -249,7 +249,7 @@ class VitessClusterInstanceConfigDict(KubernetesDeploymentConfigDict, total=Fals
 
 class VitessDeploymentConfig(KubernetesDeploymentConfig):
     def get_namespace(self) -> str:
-        return KUBERNETES_NAMESPACE
+        return VITESSCLUSTER_KUBERNETES_NAMESPACE
 
     def get_env_variables(self) -> List[Union[KVEnvVar, KVEnvVarValueFrom]]:
         # get all K8s container env vars and format their keys to camel case
@@ -493,7 +493,7 @@ def cr_id(service: str, instance: str) -> Mapping[str, str]:
     return dict(
         group="planetscale.com",
         version="v2",
-        namespace=KUBERNETES_NAMESPACE,
+        namespace=VITESSCLUSTER_KUBERNETES_NAMESPACE,
         plural="vitessclusters",
         name=sanitised_cr_name(service, instance),
     )

--- a/paasta_tools/vitesskeyspace_tools.py
+++ b/paasta_tools/vitesskeyspace_tools.py
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-KUBERNETES_NAMESPACE = "paasta-vitessclusters"
+VITESSKEYSPACE_KUBERNETES_NAMESPACE = "paasta-vitessclusters"
 
 
 # Global variables
@@ -533,7 +533,7 @@ def cr_id(service: str, instance: str) -> Mapping[str, str]:
     return dict(
         group="planetscale.com",
         version="v2",
-        namespace=KUBERNETES_NAMESPACE,
+        namespace=VITESSKEYSPACE_KUBERNETES_NAMESPACE,
         plural="vitesskeyspaces",
         name=sanitised_cr_name(service, instance),
     )

--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -457,6 +457,7 @@ def test_reconcile_kubernetes_resource(mock_LONG_RUNNING_INSTANCE_TYPE_HANDLERS)
             kind=mock_kind,
             formatted_resource=mock_format_custom_resource.return_value,
             group="yelp.com",
+            namespace="paasta-flinks",
         )
 
         # instance not exist, create
@@ -477,6 +478,7 @@ def test_reconcile_kubernetes_resource(mock_LONG_RUNNING_INSTANCE_TYPE_HANDLERS)
             kind=mock_kind,
             formatted_resource=mock_format_custom_resource.return_value,
             group="yelp.com",
+            namespace="paasta-flinks",
         )
 
         # instance not exist, create but error with k8s
@@ -498,4 +500,5 @@ def test_reconcile_kubernetes_resource(mock_LONG_RUNNING_INSTANCE_TYPE_HANDLERS)
             kind=mock_kind,
             formatted_resource=mock_format_custom_resource.return_value,
             group="yelp.com",
+            namespace="paasta-flinks",
         )


### PR DESCRIPTION
Context: Vitess custom resources are created in each environment in the same kubernetes namespace. This is to not limit one namespace per custom resource created/updated/listed/deleted