### PR TITLE
MLCOMPUTE-1209 | allow 0 in spark.driver.maxResultSize

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -424,9 +424,10 @@
                                     "pattern": "^[1-9]+[0-9]*[kmgt]$"
                                 },
                                 {
+                                    "$comment": "The value 0 can be used to specify unlimited max result size.",
                                     "type": "number",
                                     "minimum": 0,
-                                    "exclusiveMinimum": true
+                                    "exclusiveMinimum": false
                                 }
                             ]
                         },


### PR DESCRIPTION
- spark.driver.maxResultSize = 0 is used to specify unlimited max result size, so this value should be allowed