### PR TITLE
Fix the timestamps errors in the failed tests

### DIFF
--- a/tests/api/tweens/test_request_logger.py
+++ b/tests/api/tweens/test_request_logger.py
@@ -86,7 +86,7 @@ def test_request_logger_tween_factory_log(mock_clog, mock_factory):
                 '{"additional_key": "additional_value", '
                 '"cluster": "a_cluster", '
                 '"hostname": "a_hostname", '
-                '"human_timestamp": "2020-05-18T11:54:09", '
+                '"human_timestamp": "2020-05-18T18:54:09", '
                 '"level": "ERROR", '
                 '"unix_timestamp": 1589828049.0}'
             ),

--- a/tests/api/tweens/test_request_logger.py
+++ b/tests/api/tweens/test_request_logger.py
@@ -86,7 +86,7 @@ def test_request_logger_tween_factory_log(mock_clog, mock_factory):
                 '{"additional_key": "additional_value", '
                 '"cluster": "a_cluster", '
                 '"hostname": "a_hostname", '
-                '"human_timestamp": "2020-05-18T18:54:09", '
+                '"human_timestamp": "2020-05-18T11:54:09", '
                 '"level": "ERROR", '
                 '"unix_timestamp": 1589828049.0}'
             ),

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -2162,8 +2162,10 @@ class TestPrintKubernetesStatus:
     )
     @patch("paasta_tools.cli.cmds.status.desired_state_human", autospec=True)
     @patch("paasta_tools.cli.cmds.status.bouncing_status_human", autospec=True)
+    @patch("paasta_tools.cli.cmds.status.datetime", autospec=True)
     def test_output(
         self,
+        mock_datetime,
         mock_bouncing_status,
         mock_desired_state,
         mock_kubernetes_app_deploy_status_human,
@@ -2173,6 +2175,8 @@ class TestPrintKubernetesStatus:
         mock_kubernetes_status,
     ):
         mock_bouncing_status.return_value = "Bouncing (crossover)"
+        specific_datetime = datetime.datetime(2019, 7, 12, 13, 31)
+        mock_datetime.fromtimestamp.return_value = specific_datetime
         mock_desired_state.return_value = "Started"
         mock_kubernetes_app_deploy_status_human.return_value = "Running"
         mock_naturaltime.return_value = "a month ago"
@@ -2869,11 +2873,16 @@ class TestFormatKubernetesPodTable:
             config_sha=None,
         )
 
+    @patch("paasta_tools.cli.cmds.status.datetime", autospec=True)
     def test_format_kubernetes_pod_table(
         self,
+        mock_datetime,
         mock_naturaltime,
         mock_kubernetes_pod,
     ):
+        mock_date = MagicMock()
+        mock_date.strftime.return_value = "2019-08-12T15:23"
+        mock_datetime.fromtimestamp.return_value = mock_date
         output = format_kubernetes_pod_table([mock_kubernetes_pod], verbose=0)
         pod_table_dict = _formatted_table_to_dict(output)
         assert pod_table_dict == {
@@ -2883,11 +2892,16 @@ class TestFormatKubernetesPodTable:
             "Health": PaastaColors.green("Healthy"),
         }
 
+    @patch("paasta_tools.cli.cmds.status.datetime", autospec=True)
     def test_format_kubernetes_replicaset_table(
         self,
+        mock_datetime,
         mock_naturaltime,
         mock_kubernetes_replicaset,
     ):
+        mock_date = MagicMock()
+        mock_date.strftime.return_value = "2019-08-12T15:23"
+        mock_datetime.fromtimestamp.return_value = mock_date
         output = format_kubernetes_replicaset_table([mock_kubernetes_replicaset])
         replicaset_table_dict = _formatted_table_to_dict(output)
         assert replicaset_table_dict == {

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -2233,13 +2233,13 @@ class TestPrintKubernetesStatus:
         expected_output += [
             f"      Pods:",
             f"        Pod ID  Host deployed to  Deployed at what localtime      Health",
-            f"        app_1   fake_host1        2019-07-12T20:31 ({mock_naturaltime.return_value})  {PaastaColors.green('Healthy')}",
-            f"        app_2   fake_host2        2019-07-12T20:31 ({mock_naturaltime.return_value})  {PaastaColors.green('Healthy')}",
-            f"        app_3   fake_host3        2019-07-12T20:31 ({mock_naturaltime.return_value})  {PaastaColors.red('Evicted')}",
+            f"        app_1   fake_host1        2019-07-12T13:31 ({mock_naturaltime.return_value})  {PaastaColors.green('Healthy')}",
+            f"        app_2   fake_host2        2019-07-12T13:31 ({mock_naturaltime.return_value})  {PaastaColors.green('Healthy')}",
+            f"        app_3   fake_host3        2019-07-12T13:31 ({mock_naturaltime.return_value})  {PaastaColors.red('Evicted')}",
             f"        {PaastaColors.grey('  Disk quota exceeded')}",
             f"      ReplicaSets:",
             f"        ReplicaSet Name  Ready / Desired  Created at what localtime       Service git SHA  Config hash",
-            f"        replicaset_1     {PaastaColors.red('2/3')}              2019-07-12T20:31 ({mock_naturaltime.return_value})  Unknown          Unknown",
+            f"        replicaset_1     {PaastaColors.red('2/3')}              2019-07-12T13:31 ({mock_naturaltime.return_value})  Unknown          Unknown",
         ]
 
         assert expected_output == output
@@ -2879,7 +2879,7 @@ class TestFormatKubernetesPodTable:
         assert pod_table_dict == {
             "Pod ID": "abc123",
             "Host deployed to": "paasta.cloud",
-            "Deployed at what localtime": f"2019-08-12T22:23 ({mock_naturaltime.return_value})",
+            "Deployed at what localtime": f"2019-08-12T15:23 ({mock_naturaltime.return_value})",
             "Health": PaastaColors.green("Healthy"),
         }
 
@@ -2893,7 +2893,7 @@ class TestFormatKubernetesPodTable:
         assert replicaset_table_dict == {
             "ReplicaSet Name": "abc123",
             "Ready / Desired": PaastaColors.green("3/3"),
-            "Created at what localtime": f"2019-08-12T22:23 ({mock_naturaltime.return_value})",
+            "Created at what localtime": f"2019-08-12T15:23 ({mock_naturaltime.return_value})",
             "Service git SHA": "def456",
             "Config hash": "Unknown",
         }

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,6 @@ requires =
 [testenv]
 basepython = python3.8
 passenv = SSH_AUTH_SOCK PAASTA_ENV DOCKER_HOST CI
-setenv =
-    TZ = UTC
 deps =
     --only-binary=grpcio
     --requirement={toxinidir}/requirements.txt


### PR DESCRIPTION
These tests were failing due to difference in timestamps. This PR fixes the timestamps to match the expected ones