### PR TITLE
Autoscale vtgate replicas using HPA

### DIFF
--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -362,6 +362,7 @@ def reconcile_kubernetes_resource(
                     instance=inst,
                     cluster=cluster,
                     soa_dir=DEFAULT_SOA_DIR,
+                    kube_client=kube_client,
                 )
             git_sha = get_git_sha_from_dockerurl(soa_config.get_docker_url(), long=True)
             formatted_resource = format_custom_resource(
@@ -414,6 +415,9 @@ def reconcile_kubernetes_resource(
                 )
             else:
                 log.info(f"{desired_resource} is up to date, no action taken")
+            log.info(f"Ensuring related API objects for {desired_resource} are in sync")
+            if hasattr(soa_config, "update_related_api_objects"):
+                soa_config.update_related_api_objects(kube_client)
         except Exception as e:
             log.error(str(e))
             succeeded = False

--- a/paasta_tools/vitesscluster_tools.py
+++ b/paasta_tools/vitesscluster_tools.py
@@ -1216,6 +1216,18 @@ def load_vitess_service_instance_configs(
     return vitess_service_instance_configs
 
 
+def update_related_api_objects(
+    service: str,
+    instance: str,
+    cluster: str,
+    kube_client: KubeClient,
+    soa_dir: str = DEFAULT_SOA_DIR,
+) -> None:
+    load_vitess_instance_config(
+        service, instance, cluster, soa_dir=soa_dir
+    ).update_related_api_objects(kube_client)
+
+
 # TODO: read this from CRD in service configs
 def cr_id(service: str, instance: str) -> Mapping[str, str]:
     return dict(

--- a/paasta_tools/vitesscluster_tools.py
+++ b/paasta_tools/vitesscluster_tools.py
@@ -1152,9 +1152,7 @@ class VitessDeploymentConfig(KubernetesDeploymentConfig):
                 if e.status != 404:
                     raise e
                 else:
-                    log.error(
-                        f"{SCALABLEVTGATE_CRD['kind']} {name} has been created yet found"
-                    )
+                    log.error(f"{SCALABLEVTGATE_CRD['kind']} {name} not found")
 
             if not scalablevtgate_cr:
                 log.error(f"{SCALABLEVTGATE_CRD['kind']} {name} not found")

--- a/paasta_tools/vitesscluster_tools.py
+++ b/paasta_tools/vitesscluster_tools.py
@@ -993,7 +993,7 @@ class VitessDeploymentConfig(KubernetesDeploymentConfig):
 
         if should_exist:
             hpa = self.get_autoscaling_metric_spec(
-                name=sanitised_cr_name(self.service, self.instance),
+                name=name,
                 cluster=self.get_cluster(),
                 kube_client=kube_client,
                 namespace=self.get_namespace(),

--- a/paasta_tools/vitesscluster_tools.py
+++ b/paasta_tools/vitesscluster_tools.py
@@ -114,6 +114,14 @@ VTTABLET_EXTRA_FLAGS = {
     "disable_active_reparents": "true",
 }
 
+SCALABLEVTGATE_CRD = {
+    "group": "yelp.com",
+    "version": "v1alpha1",
+    "api_version": "yelp.com/v1alpha1",
+    "plural": "scalablevtgates",
+    "kind": "ScalableVtgate",
+}
+
 
 class KVEnvVar(TypedDict, total=False):
     name: str
@@ -861,8 +869,8 @@ class VitessDeploymentConfig(KubernetesDeploymentConfig):
         pod_selector: Dict[str, str],
     ) -> Optional[Dict[str, Any]]:
         return {
-            "apiVersion": "yelp.com/v1alpha1",
-            "kind": "ScalableVtgate",
+            "apiVersion": SCALABLEVTGATE_CRD["api_version"],
+            "kind": SCALABLEVTGATE_CRD["kind"],
             "metadata": {
                 "name": name,
                 "namespace": self.get_namespace(),
@@ -890,7 +898,9 @@ class VitessDeploymentConfig(KubernetesDeploymentConfig):
 
     def get_autoscaling_target(self, name: str) -> V2beta2CrossVersionObjectReference:
         return V2beta2CrossVersionObjectReference(
-            api_version="yelp.com/v1alpha1", kind="ScalableVtgate", name=name
+            api_version=SCALABLEVTGATE_CRD["api_version"],
+            kind=SCALABLEVTGATE_CRD["kind"],
+            name=name,
         )
 
     def get_autoscaling_metric_spec(
@@ -1036,10 +1046,10 @@ class VitessDeploymentConfig(KubernetesDeploymentConfig):
         cr = None
         try:
             cr = kube_client.custom.get_namespaced_custom_object(
-                group="yelp.com",
-                version="v1alpha1",
+                group=SCALABLEVTGATE_CRD["group"],
+                version=SCALABLEVTGATE_CRD["version"],
                 namespace=self.get_namespace(),
-                plural="scalablevtgates",
+                plural=SCALABLEVTGATE_CRD["plural"],
                 name=name,
             )
         except ApiException as e:
@@ -1054,27 +1064,27 @@ class VitessDeploymentConfig(KubernetesDeploymentConfig):
                 ]
                 kube_client.custom.replace_namespaced_custom_object(
                     name=name,
-                    group="yelp.com",
-                    version="v1alpha1",
+                    group=SCALABLEVTGATE_CRD["group"],
+                    version=SCALABLEVTGATE_CRD["version"],
                     namespace=self.get_namespace(),
-                    plural="scalablevtgates",
+                    plural=SCALABLEVTGATE_CRD["plural"],
                     body=scalablevtgate_cr,
                 )
             else:
                 kube_client.custom.create_namespaced_custom_object(
-                    group="yelp.com",
-                    version="v1alpha1",
+                    group=SCALABLEVTGATE_CRD["group"],
+                    version=SCALABLEVTGATE_CRD["version"],
                     namespace=self.get_namespace(),
-                    plural="scalablevtgates",
+                    plural=SCALABLEVTGATE_CRD["plural"],
                     body=scalablevtgate_cr,
                 )
         elif exists:
             kube_client.custom.delete_namespaced_custom_object(
                 name=name,
-                group="yelp.com",
-                version="v1alpha1",
+                group=SCALABLEVTGATE_CRD["group"],
+                version=SCALABLEVTGATE_CRD["version"],
                 namespace=self.get_namespace(),
-                plural="scalablevtgates",
+                plural=SCALABLEVTGATE_CRD["plural"],
             )
 
     def update_related_api_objects(self, kube_client: KubeClient):
@@ -1116,20 +1126,22 @@ class VitessDeploymentConfig(KubernetesDeploymentConfig):
             scalablevtgate_cr = None
             try:
                 scalablevtgate_cr = kube_client.custom.get_namespaced_custom_object(
-                    group="yelp.com",
-                    version="v1alpha1",
+                    group=SCALABLEVTGATE_CRD["group"],
+                    version=SCALABLEVTGATE_CRD["version"],
                     namespace=self.get_namespace(),
-                    plural="scalablevtgates",
+                    plural=SCALABLEVTGATE_CRD["plural"],
                     name=name,
                 )
             except ApiException as e:
                 if e.status != 404:
                     raise e
                 else:
-                    log.error(f"ScalableVtgate {name} has been created yet found")
+                    log.error(
+                        f"{SCALABLEVTGATE_CRD['kind']} {name} has been created yet found"
+                    )
 
             if not scalablevtgate_cr:
-                log.error(f"ScalableVtgate {name} not found")
+                log.error(f"{SCALABLEVTGATE_CRD['kind']} {name} not found")
                 continue
 
             autoscaled_replicas = scalablevtgate_cr["spec"].get("replicas")

--- a/paasta_tools/vitesscluster_tools.py
+++ b/paasta_tools/vitesscluster_tools.py
@@ -512,8 +512,8 @@ def get_tablet_pool_config(
                 "name": "etc-srv-configs",
                 "hostPath": {"path": "/nail/etc/srv-configs"},
             },
-            {"name": "vttablet-fake-credentials", "emptyDir": {}},
-            {"name": "keyspace-fake-init-script", "emptyDir": {}},
+            {"name": "vttablet-fake-credentials", "hostPath": {"path": "/dev/null"}},
+            {"name": "keyspace-fake-init-script", "hostPath": {"path": "/dev/null"}},
         ],
         replicas=replicas,
         vttablet={

--- a/tests/test_vitesscluster_tools.py
+++ b/tests/test_vitesscluster_tools.py
@@ -138,6 +138,8 @@ VITESS_CONFIG = {
                     },
                 },
                 "replicas": 1,
+                "min_instances": None,
+                "max_instances": None,
                 "resources": {
                     "limits": {"cpu": "100m", "memory": "256Mi"},
                     "requests": {"cpu": "100m", "memory": "256Mi"},
@@ -690,6 +692,7 @@ def test_load_vitess_service_instance_configs(
         soa_dir="fake_soa_dir",
         cluster="fake_cluster",
         instance="fake_instance",
+        kube_client="fake_kube_client",
     )
     assert vitess_service_instance_configs == VITESS_CONFIG
 


### PR DESCRIPTION
## Problem or Feature

Note: This PR will be unnecessary if the following one is merged: https://github.com/planetscale/vitess-operator/pull/598

We want to auto-scale vtgate using HPA. However, there are 2 problems:

1. VitessCells are created and reconciled by the vitess-operator. So, if we autoscale number of replicas in a cell, the value will be overwritten by the operator and copied from VitessCluster. Therefore, we need to do one of these things:
    - a. either create cells that are unmanaged by clusters (ie we create VitessCells, instead of having vitess-operator create them from VitessClusters),
    - b. or autoscale replicas in a VitessCluster in some other way
2. VitessCell (where vtgate is specified) is not scalable with HPA, because it does not define the /scale subresource.

## Solution

Therefore, this PR is doing the following:

1. Create a CR whose only purpose is to autoscale vtgate, call it ScalableVtgate
2. Create an HPA to auto-scale that ^
3. When reconciling the VitessCluster, read the number of replicas from ScalableVtgate

## Context

- This PR depends on https://github.yelpcorp.com/misc/compute-infra-k8s/pull/1973
- http://y/DREIMP-10951