### PR TITLE
Remove unnecessary uses_bulkdata entry from tron schema

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -663,10 +663,6 @@
                 },
                 "deploy_group": {
                     "type": "string"
-                },
-                "uses_bulkdata": {
-                    "type": "boolean",
-                    "$comment": "XXX: this entry should be deleted once we've refactored existing configs to use the correct toggle location"
                 }
             }
         }


### PR DESCRIPTION
We've now moved this to the correct place in soaconfigs and can get rid of this entry from the schema (in favor of the action-level one)