### PR TITLE
Bump service-configuration-lib to 2.18.22 to reduce logspam + IO

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -56,7 +56,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.18.21
+service-configuration-lib >= 2.18.22
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.10.0
 sensu-plugin==0.3.1
-service-configuration-lib==2.18.21
+service-configuration-lib==2.18.22
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0


### PR DESCRIPTION
The previous version printed out a log line for every volume that did not exist on the host running a spark config getter - but that's not necessarily an error as the set of files on a kube node do not always match those on boxes where s-c-l is being invoked from