### PR TITLE
PAASTA-18194: Stop querying all managed namespaces by default for paasta status

### DIFF
--- a/paasta_tools/api/api_docs/oapi.yaml
+++ b/paasta_tools/api/api_docs/oapi.yaml
@@ -1480,6 +1480,12 @@ paths:
         required: false
         schema:
           type: boolean
+      - description: Search all namespaces for running copies
+        in: query
+        name: all_namespaces
+        required: false
+        schema:
+          type: boolean
       responses:
         "200":
           content:

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -540,6 +540,13 @@
                         "name": "new",
                         "required": false,
                         "type": "boolean"
+                    },
+                    {
+                        "in": "query",
+                        "description": "Search all namespaces for running copies",
+                        "name": "all_namespaces",
+                        "required": false,
+                        "type": "boolean"
                     }
                 ]
             }

--- a/paasta_tools/api/views/instance.py
+++ b/paasta_tools/api/views/instance.py
@@ -136,6 +136,7 @@ def instance_status(request):
     instance = request.swagger_data.get("instance")
     verbose = request.swagger_data.get("verbose") or 0
     use_new = request.swagger_data.get("new") or False
+    all_namespaces = request.swagger_data.get("all_namespaces") or False
     include_envoy = request.swagger_data.get("include_envoy")
     if include_envoy is None:
         include_envoy = True
@@ -199,6 +200,7 @@ def instance_status(request):
                     use_new=use_new,
                     instance_type=instance_type,
                     settings=settings,
+                    all_namespaces=all_namespaces,
                 )
             )
         elif instance_type == "tron":

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -170,6 +170,14 @@ def add_subparser(
         default=DEFAULT_SOA_DIR,
         help="define a different soa config directory",
     )
+    status_parser.add_argument(
+        "-A",
+        "--all-namespaces",
+        dest="all_namespaces",
+        action="store_true",
+        default=False,
+        help="Search all PaaSTA-managed namespaces for possible running versions (Will search only your currently-configured namespace by default). Useful if you are moving your instance(s) to a new namespace",
+    )
 
     version = status_parser.add_mutually_exclusive_group()
 
@@ -292,6 +300,7 @@ def paasta_status_on_api_endpoint(
     verbose: int,
     new: bool = False,
     is_eks: bool = False,
+    all_namespaces: bool = False,
 ) -> int:
     output = [
         "",
@@ -310,6 +319,7 @@ def paasta_status_on_api_endpoint(
             instance=instance,
             verbose=verbose,
             new=new,
+            all_namespaces=all_namespaces,
         )
     except client.api_error as exc:
         output.append(PaastaColors.red(exc.reason))
@@ -2140,6 +2150,7 @@ def report_status_for_cluster(
     lock: Lock,
     verbose: int = 0,
     new: bool = False,
+    all_namespaces: bool = False,
 ) -> Tuple[int, Sequence[str]]:
     """With a given service and cluster, prints the status of the instances
     in that cluster"""
@@ -2193,6 +2204,7 @@ def report_status_for_cluster(
                 lock=lock,
                 verbose=verbose,
                 new=new,
+                all_namespaces=all_namespaces,
                 is_eks=(instance_config_class in EKS_DEPLOYMENT_CONFIGS),
             )
         )
@@ -2416,6 +2428,7 @@ def paasta_status(args) -> int:
                             lock=lock,
                             verbose=args.verbose,
                             new=new,
+                            all_namespaces=args.all_namespaces,
                         ),
                     )
                 )

--- a/paasta_tools/paastaapi/api/service_api.py
+++ b/paasta_tools/paastaapi/api/service_api.py
@@ -1322,6 +1322,7 @@ class ServiceApi(object):
                 include_envoy (bool): Include Envoy information. [optional]
                 include_mesos (bool): Include Mesos information. [optional]
                 new (bool): Use new version of paasta status for services. [optional]
+                all_namespaces (bool): Search all namespaces for running copies. [optional]
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -1389,6 +1390,7 @@ class ServiceApi(object):
                     'include_envoy',
                     'include_mesos',
                     'new',
+                    'all_namespaces',
                 ],
                 'required': [
                     'service',
@@ -1419,6 +1421,8 @@ class ServiceApi(object):
                         (bool,),
                     'new':
                         (bool,),
+                    'all_namespaces':
+                        (bool,),
                 },
                 'attribute_map': {
                     'service': 'service',
@@ -1427,6 +1431,7 @@ class ServiceApi(object):
                     'include_envoy': 'include_envoy',
                     'include_mesos': 'include_mesos',
                     'new': 'new',
+                    'all_namespaces': 'all_namespaces',
                 },
                 'location_map': {
                     'service': 'path',
@@ -1435,6 +1440,7 @@ class ServiceApi(object):
                     'include_envoy': 'query',
                     'include_mesos': 'query',
                     'new': 'query',
+                    'all_namespaces': 'query',
                 },
                 'collection_format_map': {
                 }

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -340,6 +340,7 @@ def test_status_calls_sergeants(
     args.registration = None
     args.service_instance = None
     args.new = False
+    args.all_namespaces = False
     return_value = paasta_status(args)
 
     assert return_value == 1776
@@ -355,6 +356,7 @@ def test_status_calls_sergeants(
         lock=mock.ANY,
         verbose=False,
         new=False,
+        all_namespaces=False,
     )
 
 
@@ -390,6 +392,7 @@ class StatusArgs:
         service_instance=None,
         new=False,
         old=False,
+        all_namespaces=False,
     ):
         self.service = service
         self.soa_dir = soa_dir
@@ -402,6 +405,7 @@ class StatusArgs:
         self.service_instance = service_instance
         self.new = new
         self.old = old
+        self.all_namespaces = all_namespaces
 
 
 @patch("paasta_tools.cli.cmds.status.get_instance_configs_for_service", autospec=True)
@@ -890,6 +894,7 @@ def test_status_with_registration(
         verbose=False,
         service_instance=None,
         new=False,
+        all_namespaces=True,  # Bonus all_namespaces test
     )
     return_value = paasta_status(args)
 
@@ -908,6 +913,7 @@ def test_status_with_registration(
         lock=mock.ANY,
         verbose=args.verbose,
         new=False,
+        all_namespaces=True,
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 
 [testenv:dev-api]
 envdir = .tox/py38-linux/
-passenv = PAASTA_TEST_CLUSTER KUBECONFIG PAASTA_SYSTEM_CONFIG_DIR
+passenv = PAASTA_TEST_CLUSTER KUBECONFIG PAASTA_SYSTEM_CONFIG_DIR KUBECONTEXT AWS_PROFILE
 deps =
     --only-binary=grpcio
     --requirement={toxinidir}/requirements.txt


### PR DESCRIPTION
Right now, for `paasta status` on any instance, we call `find_all_relevant_namespaces` to get the namespaces that have a deployment/sts for it, which in turn tries to `list_deployments` in _every_ managed namespace.

Since we should rarely need to look through _all_ managed namespaces for any running deployments (usually only when someone is moving their service), this PR just adds a new flag to go back to this behavior, but changes the default to search only the single configured namespace. 

Verified that calls to the API still work and `paasta status` honors the flag appropriately. 

The reduction is time is sorta shocking on norcal-devc:
Without all_namespaces param:
```
$ time curl "http://localhost:41893/v1/services/paasta-contract-monitor/main_eks/status?new=1 | jq '.'
...
real    0m0.355s
user    0m0.026s
sys     0m0.000s
```

With all_namespaces param (our current status quo):
```
$ time curl "http://localhost:41893/v1/services/paasta-contract-monitor/main_eks/status?new=1&all_namespaces=1" | jq '.'
...
real    0m5.254s
user    0m0.020s
sys     0m0.007s
```

And with cli:
```
$ time PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_for_development/ .tox/py38-linux/bin/python paasta_tools/cli/cli.py status -c norcal-devc -s paasta-contract-monitor -i main_eks


paasta-contract-monitor.main_eks in norcal-devc (EKS)
    Version:    5f01b83e (desired)
    State: Launching replicas
    Running versions:
      Rerun with -v to see all replicas
      5f01b83e - Started 2024-09-02 03:16:04 (9 days ago)
        Replica States: 7 Healthy / 3 All Containers Waiting
          Unhealthy Replicas:
      ...

real    0m1.182s
user    0m0.698s
sys     0m0.180s

$ time PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_for_development/ .tox/py38-linux/bin/python paasta_tools/cli/cli.py status -c norcal-devc -s paasta-contract-monitor -i main_eks -A


paasta-contract-monitor.main_eks in norcal-devc (EKS)
    Version:    5f01b83e (desired)
    State: Launching replicas
    Running versions:
      Rerun with -v to see all replicas
      5f01b83e - Started 2024-09-02 03:16:04 (9 days ago)
        Replica States: 7 Healthy / 3 All Containers Waiting
          Unhealthy Replicas:
         ...
         
real    0m7.130s
user    0m0.681s
sys     0m0.196s
```

Since the status endpoint accepts unknown parameters but just ignores them, the api+cli changes should be safe to deploy together. 

I have not added a systempaastaconfig to control the default for this, as I think it's pretty sure that we want to make the deafult search only the configured namespace for the requested instance.   Open to discussion if you think otherwise. 

There is also a minor fix to tox.ini to support some additional envvars that may be needed to set up your dev paasta api instances if you are testing w/ an EKS cluster.