### PR TITLE
Update vector-logs filter fn usage

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -1209,7 +1209,7 @@ class VectorLogsReader(LogReader):
         for line in reader.get_log_reader(
             log_name=stream_name, start_datetime=start_time, end_datetime=end_time
         ):
-            if paasta_log_line_passes_filter(
+            if paasta_app_output_passes_filter(
                 line,
                 levels,
                 service,
@@ -1266,7 +1266,7 @@ class VectorLogsReader(LogReader):
                 msg = await sub.next_msg(timeout=None)
                 decoded_data = msg.data.decode("utf-8")
 
-                if paasta_log_line_passes_filter(
+                if paasta_app_output_passes_filter(
                     decoded_data,
                     levels,
                     service,


### PR DESCRIPTION
similar to scribereader https://github.com/Yelp/paasta/blob/546734de23307a263bd6fca5e2fb48f50263b6eb/paasta_tools/cli/cmds/logs.py#L611
we should be actually using `paasta_app_output_passes_filter` function to filter `stdout` and `stderr` stream log messages, as the current one doesn't respect pod filter (`-p` flag).


