### PR TITLE
Update regular filename reference in autotune files

### DIFF
--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -70,7 +70,14 @@ def write_auto_config_data(
         if comment:
             content = (
                 yaml.round_trip_load(
-                    comment.format(regular_filename=f"{service}/{extra_info}.yaml")
+                    comment.format(
+                        # this is a bit of a hack, but we've decided to not rename files back to kubernetes-*
+                        # files. while we still need to update things to reference the eks files directly, there's
+                        # still a couple of places where we still need kubernetes-* files (e.g., unmigrated operators)
+                        # so for now let's just assume that autotuned things will always actually have their human-managed
+                        # config in eks-* files
+                        regular_filename=f"{service}/{extra_info.replace('kubernetes-', 'eks-')}.yaml",
+                    )
                 )
                 if comment
                 else {}


### PR DESCRIPTION
We've generally decided that we'll be leaving files as eks-*.yaml - and while there's some additional steps that need to be taken, those will need to happen once we've gotten rid of all of the kubernetes-*.yaml files.

As we still have some unmigrated operators, that means we still need to wait. However, we can go ahead and update the comment in the autotune files since those have recently caused some confusion (and assume that anyone looking at autotune files is looking at them for non-operator services)

example diff:
```diff
--- a/yelp_eng_people/autotuned_defaults/kubernetes-pnw-corpdev.yaml
+++ b/yelp_eng_people/autotuned_defaults/kubernetes-pnw-corpdev.yaml
@@ -2,10 +2,10 @@
 # automated processes.
 #
 # Your service will use these values if they are not defined in
-# yelp_eng_people/kubernetes-pnw-corpdev.yaml.
+# yelp_eng_people/eks-pnw-corpdev.yaml.
 #
 # If you would like to override a config value defined here, add the config
-# value to yelp_eng_people/kubernetes-pnw-corpdev.yaml instead of editing this file.
+# value to yelp_eng_people/eks-pnw-corpdev.yaml instead of editing this file.
```