### PR TITLE
local-run: add option to authenticate as the calling user

### DIFF
--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -82,6 +82,7 @@ try:
     from vault_tools.paasta_secret import get_client as get_vault_client
     from vault_tools.paasta_secret import get_vault_url
     from vault_tools.paasta_secret import get_vault_ca
+    from okta_auth import get_and_cache_jwt_default
 except ImportError:
 
     def get_vault_client(url: str, capath: str) -> None:
@@ -91,6 +92,9 @@ except ImportError:
         return ""
 
     def get_vault_ca(ecosystem: str) -> str:
+        return ""
+
+    def get_and_cache_jwt_default(client_id: str) -> str:
         return ""
 
 
@@ -1132,3 +1136,9 @@ def get_service_auth_token() -> str:
     )
     response = vault_client.secrets.identity.generate_signed_id_token(name=vault_role)
     return response["data"]["token"]
+
+
+def get_sso_service_auth_token() -> str:
+    """Generate an authentication token for the calling user from the Single Sign On provider"""
+    client_id = load_system_paasta_config().get_service_auth_sso_oidc_client_id()
+    return get_and_cache_jwt_default(client_id)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2044,6 +2044,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     use_multiple_log_readers: Optional[List[str]]
     service_auth_token_settings: ProjectedSAVolume
     service_auth_vault_role: str
+    service_auth_sso_oidc_client_id: str
     always_authenticating_services: List[str]
     vitess_images: Dict
     superregion_to_region_mapping: Dict
@@ -2763,6 +2764,9 @@ class SystemPaastaConfig:
 
     def get_service_auth_vault_role(self) -> str:
         return self.config_dict.get("service_auth_vault_role", "service_authz")
+
+    def get_service_auth_sso_oidc_client_id(self) -> str:
+        return self.config_dict.get("service_auth_sso_oidc_client_id", "")
 
     def get_always_authenticating_services(self) -> List[str]:
         return self.config_dict.get("always_authenticating_services", [])

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -395,6 +395,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
     args.assume_pod_identity = False
     args.use_okta_role = False
     args.use_service_auth_token = False
+    args.use_sso_service_auth_token = False
 
     mock_secret_provider_kwargs = {
         "vault_cluster_config": {},
@@ -438,6 +439,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
         assume_role_aws_account=None,
         use_okta_role=False,
         use_service_auth_token=False,
+        use_sso_service_auth_token=False,
     )
 
 
@@ -473,6 +475,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
     args.assume_pod_identity = False
     args.use_okta_role = False
     args.use_service_auth_token = False
+    args.use_sso_service_auth_token = False
 
     return_code = configure_and_run_docker_container(
         docker_client=mock_docker_client,
@@ -515,6 +518,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
         assume_pod_identity=False,
         use_okta_role=False,
         use_service_auth_token=False,
+        use_sso_service_auth_token=False,
     )
 
 
@@ -556,6 +560,7 @@ def test_configure_and_run_pulls_image_when_asked(
     args.assume_pod_identity = False
     args.use_okta_role = False
     args.use_service_auth_token = False
+    args.use_sso_service_auth_token = False
 
     return_code = configure_and_run_docker_container(
         docker_client=mock_docker_client,
@@ -600,6 +605,7 @@ def test_configure_and_run_pulls_image_when_asked(
         assume_role_aws_account="dev",
         use_okta_role=False,
         use_service_auth_token=False,
+        use_sso_service_auth_token=False,
     )
 
 
@@ -637,6 +643,7 @@ def test_configure_and_run_docker_container_defaults_to_interactive_instance(
         args.assume_pod_identity = False
         args.use_okta_role = False
         args.use_service_auth_token = False
+        args.use_sso_service_auth_token = False
 
         mock_config = mock.create_autospec(AdhocJobConfig)
         mock_get_default_interactive_config.return_value = mock_config
@@ -681,6 +688,7 @@ def test_configure_and_run_docker_container_defaults_to_interactive_instance(
             assume_role_aws_account="dev",
             use_okta_role=False,
             use_service_auth_token=False,
+            use_sso_service_auth_token=False,
         )
 
 

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -16,11 +16,14 @@ monk==1.3.0                         # yelp-clog dependency
 mrjob==0.7.4                        # scribereader dependency
 named-decorator==0.1.4              # yelp-profiling dependency
 ndg-httpsclient==0.4.3              # vault-tools dependency
+okta-auth==1.0.1
 pycparser==2.20                     # vault-tools dependency
 pygpgme==0.3                        # vault-tools dependency
+pyjwt==2.9.0                        # okta-auth dependency
 pyopenssl==19.0.0                   # vault-tools dependency
 PySubnetTree==0.34                  # yelp-lib dependency
 python-jsonschema-objects==0.3.1    # slo-transcoder dependency
+saml-helper==2.3.3                  # okta-auth dependency
 scribereader==1.1.1
 signalform-tools==0.0.16            # slo-transcoder dependency
 slo-transcoder==3.3.0


### PR DESCRIPTION
It can be useful to provide users the option to authenticate to services with their own identity rather than using the role associated to the instance they are running on.
Authentication with our SSO provider is all handled by an internal library, and the rest of the logic is specular to https://github.com/Yelp/paasta/pull/3922.