### PR TITLE
Fixing paasta clean up stale nodes

### DIFF
--- a/paasta_tools/kubernetes/bin/paasta_cleanup_stale_nodes.py
+++ b/paasta_tools/kubernetes/bin/paasta_cleanup_stale_nodes.py
@@ -59,7 +59,7 @@ def nodes_for_cleanup(ec2_client: Client, nodes: Sequence[V1Node]) -> List[V1Nod
         node
         for node in nodes
         if not is_node_ready(node)
-        and "node-role.kubernetes.io/master" not in node.metadata.labels
+        and "node-role.kubernetes.io/control-plane" not in node.metadata.labels
     ]
     terminated = terminated_nodes(ec2_client, not_ready)
     return terminated


### PR DESCRIPTION
As of k8s 1.24, master label is not used anymore for the control plane nodes.

The `control-plane` label was already included in k8s 1.20 so it's safe to roll out this.