### PR TITLE
Only drop capabilities that are not added

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1403,7 +1403,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     # NOTE: this is necessary as containerd differs in behavior from dockershim: in dockershim
                     # dropped capabilities were overriden if the same capability was added - but in containerd
                     # the dropped capabilities appear to have higher priority.
-                    # (or maybe this is a k8s behavior change?)
                     drop=list(set(CAPS_DROP) - set(cap_add)),
                 )
             )

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1067,8 +1067,9 @@ class TestKubernetesDeploymentConfig:
 
     def test_get_security_context_with_cap_add(self):
         self.deployment.config_dict["cap_add"] = ["SETGID"]
+        expected_dropped_caps = list(set(CAPS_DROP) - {"SETGID"})
         expected_security_context = V1SecurityContext(
-            capabilities=V1Capabilities(add=["SETGID"], drop=CAPS_DROP)
+            capabilities=V1Capabilities(add=["SETGID"], drop=expected_dropped_caps)
         )
         assert self.deployment.get_security_context() == expected_security_context
 


### PR DESCRIPTION
It appears that containerd (or k8s 1.24?) have  changed the behavior around adding/dropping linux capabilities and added caps no longer take precedence over dropped ones