### PR TITLE
let enable_automated_redeploys default value be configurable

### DIFF
--- a/paasta_tools/cli/cmds/get_image_version.py
+++ b/paasta_tools/cli/cmds/get_image_version.py
@@ -27,6 +27,7 @@ from paasta_tools.utils import format_timestamp
 from paasta_tools.utils import get_pipeline_deploy_group_configs
 from paasta_tools.utils import list_services
 from paasta_tools.utils import load_v2_deployments_json
+from paasta_tools.utils import optionally_load_system_paasta_config
 from paasta_tools.utils import parse_timestamp
 
 
@@ -71,9 +72,16 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
 
 
 def check_enable_automated_redeploys(service: str, soa_dir: str) -> bool:
-    # TODO: Handle global flag
     deploy_steps = get_pipeline_deploy_group_configs(service, soa_dir)
-    return any([step.get("enable_automated_redeploys", False) for step in deploy_steps])
+    enabled_by_default = (
+        optionally_load_system_paasta_config().get_enable_automated_redeploys_default()
+    )
+    return any(
+        [
+            step.get("enable_automated_redeploys", enabled_by_default)
+            for step in deploy_steps
+        ]
+    )
 
 
 def extract_timestamp(image_version: str) -> Optional[datetime.datetime]:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2052,6 +2052,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     vitess_tablet_pool_type_mapping: Dict
     vitess_throttling_config: Dict
     uses_bulkdata_default: bool
+    enable_automated_redeploys_default: bool
 
 
 def load_system_paasta_config(
@@ -2816,6 +2817,9 @@ class SystemPaastaConfig:
 
     def get_uses_bulkdata_default(self) -> bool:
         return self.config_dict.get("uses_bulkdata_default", True)
+
+    def get_enable_automated_redeploys_default(self) -> bool:
+        return self.config_dict.get("enable_automated_redeploys_default", False)
 
 
 def _run(


### PR DESCRIPTION
`paasta get-image-version` will output an empty string if the service has no deploy steps with `enable_automated_redeploys` enabled (for compatibility with pre-automated-redeploys behavior).

This introduces a new system config `enable_automated_redeploys_default`, itself defaulted to False, that controls whether `paasta get-image-version` treats a deploy step with no explicit `enable_automated_redeploys` as enabled or disabled.

(If set to True this doesn't actually cause automated redeploys to happen, that requires separate additional Jenkins changes.)


### Testing

I ran a random `paasta get-image-version -s <service> -c <commit>` for a service with no `enable_automated_redeploys` specified and confirmed that existing behavior continues (empty string with a stderr warning), and that you do get an image version if `enable_automated_redeploys_default` is set to True.