### PR TITLE
Update smartstack schema for min error rps to be numbers instead of ints

### DIFF
--- a/paasta_tools/cli/schemas/smartstack_schema.json
+++ b/paasta_tools/cli/schemas/smartstack_schema.json
@@ -255,7 +255,7 @@
                         "maximum": 1
                     },
                     "minimum_error_rps": {
-                        "type": "integer",
+                        "type": "number",
                         "minimum": 0
                     },
                     "default_endpoint_alerting": {
@@ -267,7 +267,7 @@
                         "maximum": 1
                     },
                     "endpoint_minimum_error_rps": {
-                        "type": "integer",
+                        "type": "number",
                         "minimum": 0
                     },
                     "endpoints": {
@@ -284,7 +284,7 @@
                                     "maximum": 1
                                 },
                                 "minimum_error_rps": {
-                                    "type": "integer",
+                                    "type": "number",
                                     "minimum": 0
                                 },
                                 "team": {


### PR DESCRIPTION
... since RPS can reaaaaally vary, depending on your service, and floats would be useful.