### PR TITLE
Handle AttributeError exceptions in logs CLI

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -330,7 +330,10 @@ def paasta_app_output_passes_filter(
     except ValueError:
         return True
     except AttributeError:
-        # timestamp might be missing at all
+        # Timestamp might be missing. We had an issue where OTel was splitting overly long log lines
+        # and not including timestamps in the resulting log records (OBSPLAT-2216).
+        # Although this was then fixed in OTel, we should not rely on timestamps being present,
+        # as the format cannot be guaranteed.
         return False
     if not check_timestamp_in_range(timestamp, start_time, end_time):
         return False

--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -329,6 +329,9 @@ def paasta_app_output_passes_filter(
     # https://github.com/gweis/isodate/issues/53
     except ValueError:
         return True
+    except AttributeError:
+        # timestamp might be missing at all
+        return False
     if not check_timestamp_in_range(timestamp, start_time, end_time):
         return False
     return (


### PR DESCRIPTION
Prevent `paasta logs` from crashing when timestamp field is missing in the original log  from S3. 
```
Traceback (most recent call last):
  File "/opt/venvs/paasta-tools/bin/paasta", line 8, in <module>
    sys.exit(main())
  File "/opt/venvs/paasta-tools/lib/python3.8/site-packages/paasta_tools/cli/cli.py", line 252, in main
    return_code = args.command(args)
  File "/opt/venvs/paasta-tools/lib/python3.8/site-packages/paasta_tools/cli/cmds/logs.py", line 1538, in paasta_logs
    return pick_default_log_mode(
  File "/opt/venvs/paasta-tools/lib/python3.8/site-packages/paasta_tools/cli/cmds/logs.py", line 1449, in pick_default_log_mode
    log_reader.print_logs_by_time(
  File "/opt/venvs/paasta-tools/lib/python3.8/site-packages/paasta_tools/cli/cmds/logs.py", line 1212, in print_logs_by_time
    if paasta_app_output_passes_filter(
  File "/opt/venvs/paasta-tools/lib/python3.8/site-packages/paasta_tools/cli/cmds/logs.py", line 328, in paasta_app_output_passes_filter
    timestamp = isodate.parse_datetime(parsed_line.get("timestamp"))
  File "/opt/venvs/paasta-tools/lib/python3.8/site-packages/isodate/isodatetime.py", line 51, in parse_datetime
    datestring, timestring = datetimestring.split('T')
AttributeError: 'NoneType' object has no attribute 'split'
```