### PR TITLE
Bump service-configuration-lib to v3 to stop mounting /etc/pki/spark

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -56,7 +56,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 2.18.21
+service-configuration-lib >= 3.0.0
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.10.0
 sensu-plugin==0.3.1
-service-configuration-lib==2.18.24
+service-configuration-lib==3.0.0
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0


### PR DESCRIPTION
This is no longer needed since we've been running Spark on just EKS for a while.