### PR TITLE
validate eks files

### DIFF
--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -25,6 +25,7 @@ KNOWN_CONFIG_TYPES = (
     "deploy",
     "smartstack",
     "cassandracluster",
+    "eks",
 )
 
 # this could use a better name - but basically, this is for pairs of instance types

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -232,7 +232,7 @@ def test_auto_config_updater_validate(mock_validate_file, all_valid, updater):
     mock_validate_file.side_effect = [True, all_valid, True]
 
     updater.write_configs("foo", "kubernetes-norcal-devc", {"a": 2})
-    updater.write_configs("foo", "kubernetes-pnw-devc", {"a": 2})
+    updater.write_configs("foo", "eks-pnw-devc", {"a": 2})
     assert updater.validate() == all_valid
     assert mock_validate_file.call_count == 2
 


### PR DESCRIPTION
We have automated tooling that modifies eks files, but the validator workflow is setup will cause those automated changes to error if there are modified files that are not able to be validated at all (https://github.com/Yelp/paasta/blob/kedar-validate-eks/paasta_tools/config_utils.py#L253-L266)

I think this should just work given the eks schema exists here: https://github.com/Yelp/paasta/blob/334e743605aeb0d7fac01c34dd38d74013bb156d/paasta_tools/cli/schemas/eks_schema.json