### PR TITLE
auth support for paasta APIs

### DIFF
--- a/paasta_tools/api/api.py
+++ b/paasta_tools/api/api.py
@@ -31,6 +31,7 @@ from wsgicors import CORS
 import paasta_tools.api
 from paasta_tools import kubernetes_tools
 from paasta_tools.api import settings
+from paasta_tools.api.tweens import auth
 from paasta_tools.api.tweens import profiling
 from paasta_tools.api.tweens import request_logger
 from paasta_tools.utils import load_system_paasta_config
@@ -79,6 +80,18 @@ def parse_paasta_api_args():
         default=4,
         help="Number of gunicorn workers to run",
     )
+    parser.add_argument(
+        "--auth-endpoint",
+        type=str,
+        default="",
+        help="External API authorization endpoint",
+    )
+    parser.add_argument(
+        "--auth-enforce",
+        action="store_true",
+        default=False,
+        help="Enforce API authorization",
+    )
     args = parser.parse_args()
     return args
 
@@ -105,6 +118,7 @@ def make_app(global_config=None):
 
     config.include("pyramid_swagger")
     config.include(request_logger)
+    config.include(auth)
 
     config.add_route(
         "flink.service.instance.jobs", "/v1/flink/{service}/{instance}/jobs"
@@ -256,6 +270,11 @@ def main(argv=None):
 
     if args.cluster:
         os.environ["PAASTA_API_CLUSTER"] = args.cluster
+
+    if args.auth_endpoint:
+        os.environ["PAASTA_API_AUTH_ENDPOINT"] = args.auth_endpoint
+        if args.auth_enforce:
+            os.environ["PAASTA_API_AUTH_ENFORCE"] = "1"
 
     gunicorn_args = [
         "gunicorn",

--- a/paasta_tools/api/client.py
+++ b/paasta_tools/api/client.py
@@ -48,6 +48,7 @@ def get_paasta_oapi_client_by_url(
     cert_file: Optional[str] = None,
     key_file: Optional[str] = None,
     ssl_ca_cert: Optional[str] = None,
+    auth_token: str = "",
 ) -> PaastaOApiClient:
     server_variables = dict(scheme=parsed_url.scheme, host=parsed_url.netloc)
     config = paastaapi.Configuration(
@@ -63,6 +64,9 @@ def get_paasta_oapi_client_by_url(
     client.rest_client.pool_manager.connection_pool_kw[
         "timeout"
     ] = load_system_paasta_config().get_api_client_timeout()
+    # SEC-19555: support auth in PaaSTA APIs
+    if auth_token:
+        client.set_default_header("Authorization", f"Bearer {auth_token}")
     return PaastaOApiClient(
         autoscaler=paastaapis.AutoscalerApi(client),
         default=paastaapis.DefaultApi(client),
@@ -79,6 +83,7 @@ def get_paasta_oapi_client(
     cluster: str = None,
     system_paasta_config: SystemPaastaConfig = None,
     http_res: bool = False,
+    auth_token: str = "",
 ) -> Optional[PaastaOApiClient]:
     if not system_paasta_config:
         system_paasta_config = load_system_paasta_config()
@@ -94,4 +99,6 @@ def get_paasta_oapi_client(
     parsed = urlparse(api_endpoints[cluster])
     cert_file = key_file = ssl_ca_cert = None
 
-    return get_paasta_oapi_client_by_url(parsed, cert_file, key_file, ssl_ca_cert)
+    return get_paasta_oapi_client_by_url(
+        parsed, cert_file, key_file, ssl_ca_cert, auth_token
+    )

--- a/paasta_tools/api/tweens/__init__.py
+++ b/paasta_tools/api/tweens/__init__.py
@@ -1,0 +1,6 @@
+from typing import Callable
+
+from pyramid.request import Request
+from pyramid.response import Response
+
+Handler = Callable[[Request], Response]

--- a/paasta_tools/api/tweens/auth.py
+++ b/paasta_tools/api/tweens/auth.py
@@ -102,10 +102,11 @@ class AuthTweenFactory:
             logger.exception(f"Issue communicating with auth endpoint: {e}")
             return AuthorizationOutcome(False, "Auth backend error")
 
-        if "result" not in response or "allowed" not in response["result"]:
+        auth_result_allowed = response.get("result", {}).get("allowed")
+        if auth_result_allowed is None:
             return AuthorizationOutcome(False, "Malformed auth response")
 
-        if not response["result"]["allowed"]:
+        if not auth_result_allowed:
             reason = response["result"].get("reason", "Denied")
             return AuthorizationOutcome(False, reason)
 

--- a/paasta_tools/api/tweens/auth.py
+++ b/paasta_tools/api/tweens/auth.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import logging
+import os
+from typing import NamedTuple
+
+import cachetools.func
+import pyramid
+import requests
+from pyramid.config import Configurator
+from pyramid.httpexceptions import HTTPForbidden
+from pyramid.registry import Registry
+from pyramid.request import Request
+from pyramid.response import Response
+
+from paasta_tools.api.tweens import Handler
+
+
+logger = logging.getLogger(__name__)
+AUTH_CACHE_SIZE = 50000
+AUTH_CACHE_TTL = 30 * 60
+
+
+class AuthorizationOutcome(NamedTuple):
+    authorized: bool
+    reason: str
+
+
+class AuthTweenFactory:
+    def __init__(self, handler: Handler, registry: Registry) -> None:
+        self.handler = handler
+        self.registry = registry
+        self.enforce = bool(os.getenv("PAASTA_API_AUTH_ENFORCE", ""))
+        self.endpoint = os.getenv("PAASTA_API_AUTH_ENDPOINT")
+        self.session = requests.Session()
+
+    def __call__(self, request: Request) -> Response:
+        """
+        Extracts relevant metadata from request, and checks if it is authorized
+        """
+        token = request.headers.get("Authorization", "").strip()
+        token = token.split()[-1] if token else ""  # removes "Bearer" prefix
+        auth_outcome = self.is_request_authorized(request.path, token, request.method)
+        if self.enforce and not auth_outcome.authorized:
+            return HTTPForbidden(
+                body=json.dumps({"reason": auth_outcome.reason}),
+                headers={"X-Auth-Failure-Reason": auth_outcome.reason},
+                content_type="application/json",
+                charset="utf-8",
+            )
+        return self.handler(request)
+
+    @cachetools.func.ttl_cache(maxsize=AUTH_CACHE_SIZE, ttl=AUTH_CACHE_TTL)
+    def is_request_authorized(
+        self, path: str, token: str, method: str
+    ) -> AuthorizationOutcome:
+        """Check if API request is authorized
+
+        :param str path: API path
+        :param str token: authentication token
+        :param str method: http method
+        :return: auth outcome
+        """
+        try:
+            response = self.session.post(
+                url=self.endpoint,
+                json={
+                    "input": {
+                        "path": path,
+                        "backend": "paasta",
+                        "token": token,
+                        "method": method,
+                    },
+                },
+                timeout=2,
+            ).json()
+        except Exception as e:
+            logger.exception(f"Issue communicating with auth endpoint: {e}")
+            return AuthorizationOutcome(False, "Auth backend error")
+
+        if "result" not in response or "allowed" not in response["result"]:
+            return AuthorizationOutcome(False, "Malformed auth response")
+
+        if not response["result"]["allowed"]:
+            reason = response["result"].get("reason", "Denied")
+            return AuthorizationOutcome(False, reason)
+
+        reason = response["result"].get("reason", "Ok")
+        return AuthorizationOutcome(True, reason)
+
+
+def includeme(config: Configurator):
+    if os.getenv("PAASTA_API_AUTH_ENDPOINT"):
+        config.add_tween(
+            "paasta_tools.api.tweens.auth.AuthTweenFactory",
+            under=(
+                pyramid.tweens.INGRESS,
+                "paasta_tools.api.tweens.request_logger.request_logger_tween_factory",
+            ),
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ boto3-type-annotations==0.3.1
 botocore==1.34.22
 bravado==10.4.1
 bravado-core==5.12.1
-cachetools==2.0.1
+cachetools==5.5.0
 certifi==2017.11.5
 chardet==3.0.4
 choice==0.1

--- a/tests/api/tweens/test_auth.py
+++ b/tests/api/tweens/test_auth.py
@@ -17,8 +17,10 @@ from unittest.mock import patch
 
 import pytest
 from pyramid.httpexceptions import HTTPForbidden
+from pyramid.registry import Registry
 
 from paasta_tools.api.tweens import auth
+from paasta_tools.api.tweens import Handler
 
 
 @pytest.fixture
@@ -31,7 +33,10 @@ def mock_auth_tween():
         },
     ):
         with patch("paasta_tools.api.tweens.auth.requests"):
-            yield auth.AuthTweenFactory(MagicMock(), MagicMock())
+            yield auth.AuthTweenFactory(
+                MagicMock(spec=Handler),
+                MagicMock(spec=Registry),
+            )
 
 
 def test_call(mock_auth_tween):

--- a/tests/api/tweens/test_auth.py
+++ b/tests/api/tweens/test_auth.py
@@ -1,0 +1,95 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from pyramid.httpexceptions import HTTPForbidden
+
+from paasta_tools.api.tweens import auth
+
+
+@pytest.fixture
+def mock_auth_tween():
+    with patch.dict(
+        os.environ,
+        {
+            "PAASTA_API_AUTH_ENFORCE": "1",
+            "PAASTA_API_AUTH_ENDPOINT": "http://localhost:31337",
+        },
+    ):
+        with patch("paasta_tools.api.tweens.auth.requests"):
+            yield auth.AuthTweenFactory(MagicMock(), MagicMock())
+
+
+def test_call(mock_auth_tween):
+    mock_request = MagicMock(
+        path="/something",
+        method="post",
+        headers={"Authorization": "Bearer aaa.bbb.ccc"},
+    )
+    with patch.object(mock_auth_tween, "is_request_authorized") as mock_is_authorized:
+        mock_is_authorized.return_value = auth.AuthorizationOutcome(True, "Ok")
+        mock_auth_tween(mock_request)
+        mock_is_authorized.assert_called_once_with("/something", "aaa.bbb.ccc", "post")
+        mock_auth_tween.handler.assert_called_once_with(mock_request)
+
+
+def test_call_deny(mock_auth_tween):
+    mock_request = MagicMock(
+        path="/something",
+        method="post",
+        headers={"Authorization": "Bearer aaa.bbb.ccc"},
+    )
+    with patch.object(mock_auth_tween, "is_request_authorized") as mock_is_authorized:
+        mock_is_authorized.return_value = auth.AuthorizationOutcome(False, "Denied")
+        response = mock_auth_tween(mock_request)
+        assert isinstance(response, HTTPForbidden)
+        assert response.headers.get("X-Auth-Failure-Reason") == "Denied"
+
+
+def test_is_request_authorized(mock_auth_tween):
+    mock_auth_tween.session.post.return_value.json.return_value = {
+        "result": {"allowed": True, "reason": "User allowed"}
+    }
+    assert mock_auth_tween.is_request_authorized(
+        "/allowed", "aaa.bbb.ccc", "get"
+    ) == auth.AuthorizationOutcome(True, "User allowed")
+    mock_auth_tween.session.post.assert_called_once_with(
+        url="http://localhost:31337",
+        json={
+            "input": {
+                "path": "/allowed",
+                "backend": "paasta",
+                "token": "aaa.bbb.ccc",
+                "method": "get",
+            }
+        },
+        timeout=2,
+    )
+
+
+def test_is_request_authorized_fail(mock_auth_tween):
+    mock_auth_tween.session.post.side_effect = Exception
+    assert mock_auth_tween.is_request_authorized(
+        "/allowed", "eee.ddd.fff", "get"
+    ) == auth.AuthorizationOutcome(False, "Auth backend error")
+
+
+def test_is_request_authorized_malformed(mock_auth_tween):
+    mock_auth_tween.session.post.return_value.json.return_value = {"foo": "bar"}
+    assert mock_auth_tween.is_request_authorized(
+        "/allowed", "eee.ddd.fff", "post"
+    ) == auth.AuthorizationOutcome(False, "Malformed auth response")


### PR DESCRIPTION
Support for an authn/z tween in the PaaSTA API (mostly inspired by previous work).

There's nothing too surprising here. Maybe the only unusual aspect is that I picked to make "dry-run" the default rather than the other way around. It makes things easier to roll out.

For how the codebase is structured loading the token transparently could be a bit of a pain, especially if we want to maintain a bunch of un-auth endpoints, so I just added the option to set the token header in the API client. From there in the CLI implementations that need auth we can do

```python
from paasta_tools.cli.utils import get_sso_service_auth_token
...
get_paasta_oapi_client(..., get_sso_service_auth_token())
```