### PR TITLE
Enable topology spread constraints by default for tron

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2823,7 +2823,7 @@ class SystemPaastaConfig:
         return self.config_dict.get("enable_automated_redeploys_default", False)
 
     def get_enable_tron_tsc(self) -> bool:
-        return self.config_dict.get("enable_tron_tsc", False)
+        return self.config_dict.get("enable_tron_tsc", True)
 
 
 def _run(


### PR DESCRIPTION
I debated getting rid of this toggle entirely, but I guess it's nice to keep around just in case?

I'll also follow this up with a Puppet PR to clean things up there