### PR TITLE
Fix backwards "Bouncing to" status

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1100,7 +1100,9 @@ def get_instance_state(status: InstanceStatusKubernetesV2) -> str:
             else:
                 return PaastaColors.green("Running")
         else:
-            versions = sorted(status.versions, key=lambda x: x.create_timestamp)
+            versions = sorted(
+                status.versions, key=lambda x: x.create_timestamp, reverse=True
+            )
             git_shas = {r.git_sha for r in versions}
             config_shas = {r.config_sha for r in versions}
             bouncing_to = []


### PR DESCRIPTION
We've been reporting which version we are "Bouncing to" incorrectly for quite some time. 

Old status:
```
paasta-contract-monitor.main in eksstage (EKS)
    Version:    5f01b83e (desired)
    State: Bouncing to configd345863a <--- reports the config version from "(old)" version
    Running versions:
      Rerun with -v to see all replicas
      5f01b83e, config6df36c8b (new) - Started 2024-11-26 12:29:06 (21 seconds ago) <--- most recent version, the one we are actually bouncing to
        Replica States: 10 Warming Up
      5f01b83e, configd345863a (old) - Started 2024-11-06 09:09:05 (20 days ago)
```

With my change: 
```
paasta-contract-monitor.main in eksstage (EKS)
    Version:    5f01b83e (desired)
    State: Bouncing to config6df36c8b
    Running versions:
      Rerun with -v to see all replicas
      5f01b83e, config6df36c8b (new) - Started 2024-11-26 12:29:06 (now)
        0 pods found
      5f01b83e, configd345863a (old) - Started 2024-11-06 09:09:05 (20 days ago)
        Replica States: 3 Healthy / 7 Warning
```

This also fixes the tests to actually catch this behavior, and verify earlier/later timestamps get sorted the way we want. 