### PR TITLE
s/V1beta1PodDisruptionBudget/V1PodDisruptionBudget/ for COMPINFRA-4409

### DIFF
--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -4,9 +4,9 @@ from abc import abstractmethod
 from typing import Optional
 from typing import Union
 
-from kubernetes.client import V1beta1PodDisruptionBudget
 from kubernetes.client import V1DeleteOptions
 from kubernetes.client import V1Deployment
+from kubernetes.client import V1PodDisruptionBudget
 from kubernetes.client import V1StatefulSet
 from kubernetes.client.rest import ApiException
 
@@ -168,7 +168,7 @@ class Application(ABC):
 
     def ensure_pod_disruption_budget(
         self, kube_client: KubeClient, namespace: str
-    ) -> V1beta1PodDisruptionBudget:
+    ) -> V1PodDisruptionBudget:
         max_unavailable: Union[str, int]
         if "bounce_margin_factor" in self.soa_config.config_dict:
             max_unavailable = (

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -52,8 +52,6 @@ from kubernetes.client import CoreV1Event
 from kubernetes.client import models
 from kubernetes.client import V1Affinity
 from kubernetes.client import V1AWSElasticBlockStoreVolumeSource
-from kubernetes.client import V1beta1PodDisruptionBudget
-from kubernetes.client import V1beta1PodDisruptionBudgetSpec
 from kubernetes.client import V1Capabilities
 from kubernetes.client import V1ConfigMap
 from kubernetes.client import V1Container
@@ -92,6 +90,8 @@ from kubernetes.client import V1Pod
 from kubernetes.client import V1PodAffinityTerm
 from kubernetes.client import V1PodAntiAffinity
 from kubernetes.client import V1PodCondition
+from kubernetes.client import V1PodDisruptionBudget
+from kubernetes.client import V1PodDisruptionBudgetSpec
 from kubernetes.client import V1PodSecurityContext
 from kubernetes.client import V1PodSpec
 from kubernetes.client import V1PodTemplateSpec
@@ -318,7 +318,7 @@ class DatastoreCredentialsConfig(TypedDict, total=False):
 
 
 def _set_disrupted_pods(self: Any, disrupted_pods: Mapping[str, datetime]) -> None:
-    """Private function used to patch the setter for V1beta1PodDisruptionBudgetStatus.
+    """Private function used to patch the setter for V1PodDisruptionBudgetStatus.
     Can be removed once https://github.com/kubernetes-client/python/issues/466 is resolved
     """
     self._disrupted_pods = disrupted_pods
@@ -582,8 +582,8 @@ class KubeClient:
             context=context,
         )
 
-        models.V1beta1PodDisruptionBudgetStatus.disrupted_pods = property(
-            fget=lambda *args, **kwargs: models.V1beta1PodDisruptionBudgetStatus.disrupted_pods(
+        models.V1PodDisruptionBudgetStatus.disrupted_pods = property(
+            fget=lambda *args, **kwargs: models.V1PodDisruptionBudgetStatus.disrupted_pods(
                 *args, **kwargs
             ),
             fset=_set_disrupted_pods,
@@ -603,7 +603,7 @@ class KubeClient:
 
         self.deployments = kube_client.AppsV1Api(self.api_client)
         self.core = kube_client.CoreV1Api(self.api_client)
-        self.policy = kube_client.PolicyV1beta1Api(self.api_client)
+        self.policy = kube_client.PolicyV1Api(self.api_client)
         self.apiextensions = kube_client.ApiextensionsV1Api(self.api_client)
 
         self.custom = kube_client.CustomObjectsApi(self.api_client)
@@ -3190,13 +3190,13 @@ def pod_disruption_budget_for_service_instance(
     instance: str,
     max_unavailable: Union[str, int],
     namespace: str,
-) -> V1beta1PodDisruptionBudget:
-    return V1beta1PodDisruptionBudget(
+) -> V1PodDisruptionBudget:
+    return V1PodDisruptionBudget(
         metadata=V1ObjectMeta(
             name=get_kubernetes_app_name(service, instance),
             namespace=namespace,
         ),
-        spec=V1beta1PodDisruptionBudgetSpec(
+        spec=V1PodDisruptionBudgetSpec(
             max_unavailable=max_unavailable,
             selector=V1LabelSelector(
                 match_labels={
@@ -3210,7 +3210,7 @@ def pod_disruption_budget_for_service_instance(
 
 def create_pod_disruption_budget(
     kube_client: KubeClient,
-    pod_disruption_budget: V1beta1PodDisruptionBudget,
+    pod_disruption_budget: V1PodDisruptionBudget,
     namespace: str,
 ) -> None:
     return kube_client.policy.create_namespaced_pod_disruption_budget(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -15,7 +15,6 @@ from hypothesis.strategies import integers
 from kubernetes import client as kube_client
 from kubernetes.client import V1Affinity
 from kubernetes.client import V1AWSElasticBlockStoreVolumeSource
-from kubernetes.client import V1beta1PodDisruptionBudget
 from kubernetes.client import V1Capabilities
 from kubernetes.client import V1Container
 from kubernetes.client import V1ContainerPort
@@ -41,6 +40,7 @@ from kubernetes.client import V1PersistentVolumeClaim
 from kubernetes.client import V1PersistentVolumeClaimSpec
 from kubernetes.client import V1PodAffinityTerm
 from kubernetes.client import V1PodAntiAffinity
+from kubernetes.client import V1PodDisruptionBudget
 from kubernetes.client import V1PodSpec
 from kubernetes.client import V1PodTemplateSpec
 from kubernetes.client import V1PreferredSchedulingTerm
@@ -3440,7 +3440,7 @@ def test_pod_disruption_budget_for_service_instance():
 
 def test_create_pod_disruption_budget():
     mock_client = mock.Mock()
-    mock_pdr = V1beta1PodDisruptionBudget()
+    mock_pdr = V1PodDisruptionBudget()
     mock_namespace = "paasta"
     create_pod_disruption_budget(mock_client, mock_pdr, mock_namespace)
     mock_client.policy.create_namespaced_pod_disruption_budget.assert_called_with(


### PR DESCRIPTION
This seems to work fine -- I've confirmed via the paasta playground that it's going through the V1PodDisruptionBudget code paths at least, and seems to function in the 1.24-based playground.

I tried upgrading the playground to 1.25 but then my pods are Pending forever -- I suspect it's just something with the playground. Without the changes in this PR, testing setup_kubernetes_job against the 1.25 playground results in 
```
ERROR:__main__:Error while processing: compute-infra-test-service-autoscaling-cb9e0385bfc73cb2288a5b12894720ab3d2a744f-config2468529d
Traceback (most recent call last):
  File "/nail/home/krall/pg/paasta/paasta_tools/setup_kubernetes_job.py", line 324, in setup_kube_deployments
    app.update_related_api_objects(kube_client)
  File "/nail/home/krall/pg/paasta/paasta_tools/kubernetes/application/controller_wrappers.py", line 278, in update_related_api_objects
    super().update_related_api_objects(kube_client)
  File "/nail/home/krall/pg/paasta/paasta_tools/kubernetes/application/controller_wrappers.py", line 122, in update_related_api_objects
    self.ensure_pod_disruption_budget(kube_client, self.soa_config.get_namespace())
  File "/nail/home/krall/pg/paasta/paasta_tools/kubernetes/application/controller_wrappers.py", line 212, in ensure_pod_disruption_budget
    return create_pod_disruption_budget(
  File "/nail/home/krall/pg/paasta/paasta_tools/kubernetes_tools.py", line 3216, in create_pod_disruption_budget
    return kube_client.policy.create_namespaced_pod_disruption_budget(
  File "/nail/home/krall/pg/paasta/.tox/py38-linux/lib/python3.8/site-packages/kubernetes/client/api/policy_v1beta1_api.py", line 67, in create_namespaced_pod_disruption_budget
    return self.create_namespaced_pod_disruption_budget_with_http_info(namespace, body, **kwargs)  # noqa: E501
  File "/nail/home/krall/pg/paasta/.tox/py38-linux/lib/python3.8/site-packages/kubernetes/client/api/policy_v1beta1_api.py", line 166, in create_namespaced_pod_disruption_budget_with_http_info
    return self.api_client.call_api(
  File "/nail/home/krall/pg/paasta/.tox/py38-linux/lib/python3.8/site-packages/kubernetes/client/api_client.py", line 348, in call_api
    return self.__call_api(resource_path, method,
  File "/nail/home/krall/pg/paasta/.tox/py38-linux/lib/python3.8/site-packages/kubernetes/client/api_client.py", line 180, in __call_api
    response_data = self.request(
  File "/nail/home/krall/pg/paasta/.tox/py38-linux/lib/python3.8/site-packages/kubernetes/client/api_client.py", line 391, in request
    return self.rest_client.POST(url,
  File "/nail/home/krall/pg/paasta/.tox/py38-linux/lib/python3.8/site-packages/kubernetes/client/rest.py", line 275, in POST
    return self.request("POST", url,
  File "/nail/home/krall/pg/paasta/.tox/py38-linux/lib/python3.8/site-packages/kubernetes/client/rest.py", line 234, in request
    raise ApiException(http_resp=r)
kubernetes.client.exceptions.ApiException: (404)
```
so this at least makes progress.