### PR TITLE
Disallow having service account + iam_role

### DIFF
--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -93,6 +93,14 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "not": {
+                        "required": [
+                            "service_account_name",
+                            "iam_role"
+                        ]
+                    }
                 }
             ],
             "properties": {

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -17,6 +17,16 @@
             "required": [
                 "command"
             ],
+            "allOf": [
+                {
+                    "not": {
+                        "required": [
+                            "service_account_name",
+                            "iam_role"
+                        ]
+                    }
+                }
+            ],
             "properties": {
                 "name": {
                     "$ref": "#definitions/name"

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -745,6 +745,40 @@ test_job:
 
 
 @pytest.mark.parametrize(
+    "iam_role, service_account_name, expected",
+    [
+        ("arn:aws:iam::12345678:role/some_role", None, True),
+        ("arn:aws:iam::12345678:role/some_role", "some_svc_account", False),
+        (None, "some_svc_account", True),
+    ],
+)
+def test_tron_validate_schema_sa_and_iam_role(
+    iam_role,
+    service_account_name,
+    expected,
+    capsys,
+):
+    tron_content = f"""
+test_job:
+  node: paasta
+  schedule: "daily 04:00:00"
+  actions:
+    first:
+      {"iam_role: "+iam_role if iam_role else ""}
+      {"service_account_name: "+service_account_name if service_account_name else ""}
+      command: echo hello world
+"""
+    with patch(
+        "paasta_tools.cli.cmds.validate.get_file_contents", autospec=True
+    ) as mock_get_file_contents:
+        mock_get_file_contents.return_value = tron_content
+        assert validate_schema("unused_service_path.yaml", "tron") == expected
+        output, _ = capsys.readouterr()
+        expected_output = SCHEMA_VALID if expected else SCHEMA_INVALID
+        assert expected_output in output
+
+
+@pytest.mark.parametrize(
     "mock_content",
     (
         """\


### PR DESCRIPTION
Since we have to manage the service account (and its pod identity annotation) if someone specifies an `iam_role` for their instance, this is probably incompatible with specifying a service_account.

Technically nothing would break with both, we just wouldn't do anything with the iam_role they'd provided and it would be more difficult for them to troubleshoot iam issues. 

This will give a validation error like the following:
![Screenshot 2024-12-04 at 11 27 25 AM](https://github.com/user-attachments/assets/649548cb-10ba-44a7-943e-a4c4dbfd6ecd)

And for tron: 
![Screenshot 2024-12-04 at 1 10 31 PM](https://github.com/user-attachments/assets/d326d73d-5a23-49e2-aff9-c28c9f0b0084)
