### PR TITLE
Fix inconsistent spark driver and executor image

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -357,7 +357,7 @@ class TronActionConfig(InstanceConfig):
             paasta_pool=self.get_spark_executor_pool(),
             paasta_service=self.get_service(),
             paasta_instance=self.get_instance(),
-            docker_img="$PAASTA_DOCKER_IMAGE",
+            docker_img=f"{self.get_docker_registry()}/$PAASTA_DOCKER_IMAGE",
             extra_volumes=self.get_volumes(
                 system_paasta_config.get_volumes(),
                 uses_bulkdata_default=system_paasta_config.get_uses_bulkdata_default(),

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -348,8 +348,6 @@ class TronActionConfig(InstanceConfig):
             f"tron_spark_{self.get_service()}_{self.get_instance()}",
         )
 
-        docker_img_url = self.get_docker_url(system_paasta_config)
-
         spark_conf_builder = SparkConfBuilder(is_driver_on_k8s_tron=True)
         spark_conf = spark_conf_builder.get_spark_conf(
             cluster_manager="kubernetes",
@@ -359,7 +357,7 @@ class TronActionConfig(InstanceConfig):
             paasta_pool=self.get_spark_executor_pool(),
             paasta_service=self.get_service(),
             paasta_instance=self.get_instance(),
-            docker_img=docker_img_url,
+            docker_img="$PAASTA_DOCKER_IMAGE",
             extra_volumes=self.get_volumes(
                 system_paasta_config.get_volumes(),
                 uses_bulkdata_default=system_paasta_config.get_uses_bulkdata_default(),

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1322,7 +1322,7 @@ class TestTronTools:
             "--conf spark.executorEnv.PAASTA_INSTANCE_TYPE=spark "
             "--conf spark.executorEnv.SPARK_EXECUTOR_DIRS=/tmp "
             "--conf spark.kubernetes.pyspark.pythonVersion=3 "
-            "--conf spark.kubernetes.container.image=docker-registry.com:400/my_service:paasta-123abcde "
+            "--conf spark.kubernetes.container.image=$PAASTA_DOCKER_IMAGE "
             "--conf spark.kubernetes.namespace=paasta-spark "
             "--conf spark.kubernetes.executor.label.yelp.com/paasta_service=my_service "
             "--conf spark.kubernetes.executor.label.yelp.com/paasta_instance=my_job.do_something "

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1322,7 +1322,7 @@ class TestTronTools:
             "--conf spark.executorEnv.PAASTA_INSTANCE_TYPE=spark "
             "--conf spark.executorEnv.SPARK_EXECUTOR_DIRS=/tmp "
             "--conf spark.kubernetes.pyspark.pythonVersion=3 "
-            "--conf spark.kubernetes.container.image=$PAASTA_DOCKER_IMAGE "
+            "--conf spark.kubernetes.container.image=docker-registry.com:400/$PAASTA_DOCKER_IMAGE "
             "--conf spark.kubernetes.namespace=paasta-spark "
             "--conf spark.kubernetes.executor.label.yelp.com/paasta_service=my_service "
             "--conf spark.kubernetes.executor.label.yelp.com/paasta_instance=my_job.do_something "


### PR DESCRIPTION
## Description

The Spark driver and executor image version can be inconsistent in a Tron action run when a job is already scheduled before the image is updated, which causes an InvalidClassException if the image's Spark version was changed.

Behavior:
- The action was run with old spark.kubernetes.container.image
- The image is different with the version in the latest Config command
- In the Tron web's `META` section, the `PAASTA_DOCKER_IMAGE` used is the latest version in the `Config command`

## Solution
Set `spark.kubernetes.container.image` to `$PAASTA_DOCKER_IMAGE` when generating the spark-submit command, to read the environment variable set by Tron, which is the image that Spark driver uses.

## Test
Checking the environment variable we are referencing for Tron in this PR
```bash
$ paasta spark-run --aws-profile=dev --cmd '/bin/env | grep PAASTA_DOCKER_IMAGE'
...
PAASTA_DOCKER_IMAGE=services-spark:paasta-<iamge_tag>
```
and `spark.kubernetes.container.image` should be something like: `docker-paasta.yelpcorp.com:443/services-spark:<iamge_tag>`

## Release Plan
Pin the paasta version everywhere except pnw-devc, to test in devc first.