### PR TITLE
PAASTA-18479: Add list-namespaces tool

### DIFF
--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -110,6 +110,7 @@ PAASTA_SUBCOMMANDS = {
     "itest": "itest",
     "list-clusters": "list_clusters",
     "list-deploy-queue": "list_deploy_queue",
+    "list-namespaces": "list_namespaces",
     "list": "list",
     "local-run": "local_run",
     "logs": "logs",

--- a/paasta_tools/cli/cmds/autoscale.py
+++ b/paasta_tools/cli/cmds/autoscale.py
@@ -39,18 +39,20 @@ def add_subparser(subparsers):
     )
 
     autoscale_parser.add_argument(
-        "-s", "--service", help="Service that you want to stop. Like 'example_service'."
+        "-s",
+        "--service",
+        help="Service that you want to autoscale. Like 'example_service'.",
     ).completer = lazy_choices_completer(list_services)
     autoscale_parser.add_argument(
         "-i",
         "--instance",
-        help="Instance of the service that you want to stop. Like 'main' or 'canary'.",
+        help="Instance of the service that you want to autoscale. Like 'main' or 'canary'.",
         required=True,
     ).completer = lazy_choices_completer(list_instances)
     autoscale_parser.add_argument(
         "-c",
         "--cluster",
-        help="The PaaSTA cluster that has the service instance you want to stop. Like 'pnw-prod'.",
+        help="The PaaSTA cluster that has the service instance you want to autoscale. Like 'pnw-prod'.",
         required=True,
     ).completer = lazy_choices_completer(list_clusters)
     autoscale_parser.add_argument(

--- a/paasta_tools/cli/cmds/list_namespaces.py
+++ b/paasta_tools/cli/cmds/list_namespaces.py
@@ -15,6 +15,7 @@
 from paasta_tools.cli.utils import get_instance_configs_for_service
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import validate_service_name
+from paasta_tools.spark_tools import SPARK_EXECUTOR_NAMESPACE
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
@@ -69,8 +70,14 @@ def paasta_list_namespaces(args):
         # We skip non-k8s instance types
         if instance.get_instance_type() in ("paasta-native", "adhoc"):
             continue
-        else:
-            namespaces.add(instance.get_namespace())
+        namespaces.add(instance.get_namespace())
+        # Tron instances are TronActionConfigs
+        if (
+            instance.get_instance_type() == "tron"
+            and instance.get_executor() == "spark"
+        ):
+            # We also need paasta-spark for spark executors
+            namespaces.add(SPARK_EXECUTOR_NAMESPACE)
 
     # Print in list format to be used in iam_roles
     print(list(namespaces))

--- a/paasta_tools/cli/cmds/list_namespaces.py
+++ b/paasta_tools/cli/cmds/list_namespaces.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from paasta_tools.cli.utils import get_instance_configs_for_service
+from paasta_tools.cli.utils import lazy_choices_completer
+from paasta_tools.cli.utils import validate_service_name
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import list_clusters
+from paasta_tools.utils import list_services
+
+
+def add_subparser(subparsers) -> None:
+    list_parser = subparsers.add_parser(
+        "list-namespaces",
+        help="Lists all k8s namespaces used by instances of a service",
+    )
+    list_parser.add_argument(
+        "-s",
+        "--service",
+        help="Name of the service which you want to list the namespaces for.",
+        required=True,
+    ).completer = lazy_choices_completer(list_services)
+    # Most services likely don't need to filter by cluster/instance, and can add namespaces from all instances
+    list_parser.add_argument(
+        "-i",
+        "--instance",
+        help="Instance of the service that you want to list namespaces for. Like 'main' or 'canary'.",
+        required=False,
+    )
+    list_parser.add_argument(
+        "-c",
+        "--cluster",
+        help="Clusters that you want to list namespaces for. Like 'pnw-prod' or 'norcal-stagef'.",
+        required=False,
+    ).completer = lazy_choices_completer(list_clusters)
+    list_parser.add_argument(
+        "-y",
+        "-d",
+        "--soa-dir",
+        dest="soa_dir",
+        default=DEFAULT_SOA_DIR,
+        required=False,
+        help="define a different soa config directory",
+    )
+    list_parser.set_defaults(command=paasta_list_namespaces)
+
+
+def paasta_list_namespaces(args):
+    service = args.service
+    soa_dir = args.soa_dir
+    validate_service_name(service, soa_dir)
+
+    namespaces = set()
+    instance_configs = get_instance_configs_for_service(
+        service=service, soa_dir=soa_dir, instances=args.instance, clusters=args.cluster
+    )
+    for instance in instance_configs:
+        # We skip non-k8s instance types
+        if instance.get_instance_type() in ("paasta-native", "adhoc"):
+            continue
+        else:
+            namespaces.add(instance.get_namespace())
+
+    # Print in list format to be used in iam_roles
+    print(list(namespaces))
+    return 0

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -149,10 +149,6 @@ class LongRunningServiceConfig(InstanceConfig):
     def get_bounce_method(self) -> str:
         raise NotImplementedError
 
-    def get_namespace(self) -> str:
-        """Get namespace from config"""
-        raise NotImplementedError
-
     def get_kubernetes_namespace(self) -> str:
         """
         Only needed on kubernetes LongRunningServiceConfig

--- a/tests/cli/test_cmds_list_namespaces.py
+++ b/tests/cli/test_cmds_list_namespaces.py
@@ -1,0 +1,88 @@
+# tests/cli/cmds/test_list_namespaces.py
+from mock import MagicMock
+from mock import patch
+
+from paasta_tools.cli.cmds.list_namespaces import paasta_list_namespaces
+
+
+def test_list_namespaces_no_instances(capfd):
+    mock_args = MagicMock(
+        service="fake_service",
+        instance=None,
+        cluster=None,
+        soa_dir="/fake/soa/dir",
+    )
+    with patch(
+        "paasta_tools.cli.cmds.list_namespaces.get_instance_configs_for_service",
+        return_value=[],
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.list_namespaces.validate_service_name",
+        autospec=True,
+    ):
+        assert paasta_list_namespaces(mock_args) == 0
+        stdout, _ = capfd.readouterr()
+        assert stdout.strip() == "[]"
+
+
+def create_mock_instance_config(instance_type, namespace):
+    """
+    Creates a mock InstanceConfig with specified instance_type and namespace.
+
+    :param instance_type: The type of the instance (e.g., "kubernetes", "paasta-native").
+    :param namespace: The namespace associated with the instance.
+    :return: A mock InstanceConfig object.
+    """
+    mock_instance_config = MagicMock()
+    mock_instance_config.get_instance_type.return_value = instance_type
+    mock_instance_config.get_namespace.return_value = namespace
+    return mock_instance_config
+
+
+def test_list_namespaces_with_instances(capfd):
+    mock_args = MagicMock(
+        service="fake_service",
+        instance=None,
+        cluster=None,
+        soa_dir="/fake/soa/dir",
+    )
+    mock_instance_configs = [
+        create_mock_instance_config("kubernetes", "k8s_namespace"),
+        create_mock_instance_config("kubernetes", "k8s_namespace"),
+    ]
+
+    with patch(
+        "paasta_tools.cli.cmds.list_namespaces.get_instance_configs_for_service",
+        return_value=mock_instance_configs,
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.list_namespaces.validate_service_name",
+        autospec=True,
+    ):
+        assert paasta_list_namespaces(mock_args) == 0
+        stdout, _ = capfd.readouterr()
+        assert stdout.strip() == "['k8s_namespace']"
+
+
+def test_list_namespaces_skips_non_k8s_instances(capfd):
+    mock_args = MagicMock(
+        service="fake_service",
+        instance=None,
+        cluster=None,
+        soa_dir="/fake/soa/dir",
+    )
+
+    mock_k8s_instance_config = create_mock_instance_config("eks", "k8s_namespace")
+    mock_adhoc_instance_config = create_mock_instance_config("adhoc", None)
+
+    with patch(
+        "paasta_tools.cli.cmds.list_namespaces.get_instance_configs_for_service",
+        return_value=[mock_k8s_instance_config, mock_adhoc_instance_config],
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.list_namespaces.validate_service_name",
+        autospec=True,
+    ):
+        assert paasta_list_namespaces(mock_args) == 0
+        stdout, _ = capfd.readouterr()
+        assert stdout.strip() == "['k8s_namespace']"


### PR DESCRIPTION
Our iam_role configs depend on role owners being able to fill out which k8s namespaces their role is going to be used in in `pod_identity_namespaces`, but paasta normally is figuring out that translation, and users don't usually need to care about this info.

This `list-namespaces` tool should just spit out the namespaces their service will be using, in list format to match what our iam_roles module needs.

I don't expect people will need to specify the instance/cluster filters at all since roles can be used across those lines, but this command leaves the hard work of filtering on those values to the already-existing `get_instance_configs_for_service` util. 

The tests already capture most of the list-namespaces specific logic we want, but testing this against some example services seems to also work as expected:
```
$ paasta list-namespaces -s ad_event
['paasta-spark', 'tron']

$ paasta list-namespaces -s ad_event -i ad_event.wait_for_ad_opportunity # not a spark action
['tron']

$ paasta list-namespaces -s ad_event -i ad_event.wait_for_ad_opportunity -c pnw-devc # Currently no errors thrown if filters do not match a real instance
[]
```

There are also 2 non-list-namespaces changes in here:
1. LongRunningServiceConfig used to throw a `NotImplementedError` for `get_namespace()`, but by me deleting that override, LongRunningServiceConfig.get_namespace() will use [InstanceConfig.get_namespace()](https://github.com/Yelp/paasta/blob/master/paasta_tools/utils.py#L452-L457) which uses [INSTANCE_TYPE_TO_K8S_NAMESPACE](https://github.com/Yelp/paasta/blob/master/paasta_tools/utils.py#L149-L159) to return the correct value.  I think the exception may not be necessary, as from a search of cases of us catching the `NotImplementedError`, we never expect to do $something if it was due to `get_namespaces()` throwing this error.
  * This _will_ actually stop throwing exceptions for anything trying to run `get_namespace` on a LongRunningServiceConfig subclass that does not define this method, such as Flink or NRTSearch.  However, I didn't find any code that expected to hit an exception when using get_namespace, as they mostly related to secret syncing, which special-case operator namespaces already. In fact, by allowing flink instances to actually `get_namespace`, we may be able to remove the special-case sync jobs later!
  * From original discussion when we started supporting arbitrary namespaces ([PR](https://github.com/Yelp/paasta/pull/3548#discussion_r1103221893)) on the `get_namespace` method, it seems like we generally want this to come from InstanceConfig anyhow, using default values if no override is specified, so this seems fine. 
  * PaaSTA services will still default to the correct default of paastasvc-* since we override get_namespace [here](https://github.com/Yelp/paasta/blob/master/paasta_tools/kubernetes_tools.py#L2022-L2026)
2. I noticed some copypaasta in the `autoscale` cli cmd's help text, so I s/stop/autoscale/ where I found this issue. 