### PR TITLE
Minor fixes for `paasta info`

### DIFF
--- a/paasta_tools/cli/cmds/info.py
+++ b/paasta_tools/cli/cmds/info.py
@@ -94,14 +94,9 @@ def get_deployments_strings(service: str, soa_dir: str) -> List[str]:
         )
         service_mode = service_config.get_mode()
         for cluster in deployments_to_clusters(deployments):
-            if service_mode == "tcp":
-                service_port = service_config.get("proxy_port")
+            if service_mode == "http" or service_mode == "https":
                 link = PaastaColors.cyan(
-                    "%s://paasta-%s.yelp:%d/" % (service_mode, cluster, service_port)
-                )
-            elif service_mode == "http" or service_mode == "https":
-                link = PaastaColors.cyan(
-                    f"{service_mode}://{service}.paasta-{cluster}.yelp/"
+                    f"{service_mode}://{service}.proxy.{cluster}.paasta/"
                 )
             else:
                 link = "N/A"
@@ -111,8 +106,7 @@ def get_deployments_strings(service: str, soa_dir: str) -> List[str]:
 
 def get_dashboard_urls(service):
     output = [
-        " - %s (Sensu Alerts)"
-        % (PaastaColors.cyan("https://uchiwa.yelpcorp.com/#/events?q=%s" % service))
+        " - %s (service load y/sl2)" % (PaastaColors.cyan(f"http://y/{service}_load"))
     ]
     return output
 
@@ -137,7 +131,9 @@ def get_service_info(service, soa_dir):
         % PaastaColors.cyan(get_runbook(service=service, overrides={}, soa_dir=soa_dir))
     )
     output.append("Git Repo: %s" % git_url)
-    output.append("Deployed to the following clusters:")
+    output.append(
+        "Deployed to the following clusters (with test URLs, where available):"
+    )
     output.extend(get_deployments_strings(service, soa_dir))
     if smartstack_endpoints:
         output.append("Smartstack endpoint(s):")

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2431,11 +2431,11 @@ class SystemPaastaConfig:
 
     def get_cluster_fqdn_format(self) -> str:
         """Get a format string that constructs a DNS name pointing at the paasta masters in a cluster. This format
-        string gets one parameter: cluster. Defaults to 'paasta-{cluster:s}.yelp'.
+        string gets one parameter: cluster. Defaults to '{cluster:s}.paasta'.
 
         :returns: A format string for constructing the FQDN of the masters in a given cluster.
         """
-        return self.config_dict.get("cluster_fqdn_format", "paasta-{cluster:s}.yelp")
+        return self.config_dict.get("cluster_fqdn_format", "{cluster:s}.paasta")
 
     def get_paasta_status_version(self) -> str:
         """Get paasta status version string (new | old). Defaults to 'old'.

--- a/tests/cli/test_cmds_info.py
+++ b/tests/cli/test_cmds_info.py
@@ -65,12 +65,12 @@ def test_get_service_info():
         assert "Deployed to the following" in actual
         assert (
             "clusterA (%s)"
-            % PaastaColors.cyan("http://fake_service.paasta-clusterA.yelp/")
+            % PaastaColors.cyan("http://fake_service.proxy.clusterA.paasta/")
             in actual
         )
         assert (
             "clusterB (%s)"
-            % PaastaColors.cyan("http://fake_service.paasta-clusterB.yelp/")
+            % PaastaColors.cyan("http://fake_service.proxy.clusterB.paasta/")
             in actual
         )
         assert "Smartstack endpoint" in actual
@@ -78,8 +78,7 @@ def test_get_service_info():
         assert "tcp://bar:1234" in actual
         assert "Dashboard" in actual
         assert (
-            "%s (Sensu Alerts)"
-            % PaastaColors.cyan("https://uchiwa.yelpcorp.com/#/events?q=fake_service")
+            "%s (service load y/sl2)" % PaastaColors.cyan("http://y/fake_service_load")
             in actual
         )
         mock_get_team.assert_called_with(
@@ -135,12 +134,12 @@ def test_get_deployments_strings_default_case_with_smartstack():
         actual = info.get_deployments_strings("fake_service", "/fake/soa/dir")
         assert (
             " - clusterA (%s)"
-            % PaastaColors.cyan("http://fake_service.paasta-clusterA.yelp/")
+            % PaastaColors.cyan("http://fake_service.proxy.clusterA.paasta/")
             in actual
         )
         assert (
             " - clusterB (%s)"
-            % PaastaColors.cyan("http://fake_service.paasta-clusterB.yelp/")
+            % PaastaColors.cyan("http://fake_service.proxy.clusterB.paasta/")
             in actual
         )
 
@@ -156,14 +155,8 @@ def test_get_deployments_strings_protocol_tcp_case():
             {"mode": "tcp", "proxy_port": 8080}
         )
         actual = info.get_deployments_strings("unused", "/fake/soa/dir")
-        assert (
-            " - clusterA (%s)" % PaastaColors.cyan("tcp://paasta-clusterA.yelp:8080/")
-            in actual
-        )
-        assert (
-            " - clusterB (%s)" % PaastaColors.cyan("tcp://paasta-clusterB.yelp:8080/")
-            in actual
-        )
+        assert " - clusterA (N/A)" in actual
+        assert " - clusterB (N/A)" in actual
 
 
 def test_get_deployments_strings_non_listening_service():

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -36,7 +36,7 @@ def test_bad_calculate_remote_master(mock_get_by_hostname, system_paasta_config)
     mock_get_by_hostname.side_effect = gaierror(42, "bar")
     ips, output = utils.calculate_remote_masters("myhost", system_paasta_config)
     assert ips == []
-    assert "ERROR while doing DNS lookup of paasta-myhost.yelp:\nbar\n" in output
+    assert "ERROR while doing DNS lookup of myhost.paasta:\nbar\n" in output
 
 
 @patch("socket.gethostbyname_ex", autospec=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -553,7 +553,7 @@ def test_SystemPaastaConfig_get_metrics_provider():
 def test_SystemPaastaConfig_get_cluster_fqdn_format_default():
     fake_config = utils.SystemPaastaConfig({}, "/some/fake/dir")
     actual = fake_config.get_cluster_fqdn_format()
-    expected = "paasta-{cluster:s}.yelp"
+    expected = "{cluster:s}.paasta"
     assert actual == expected
 
 


### PR DESCRIPTION
1. stop displaying `tcp://` urls for tcp services under `deployments` list; access via smartstack port is no longer supported thru paasta proxies
2. replace `paasta-$cluster.yelp` domains with the appropriate `proxy.$cluster.paasta` domains instead
3. make it clearer the urls provided for the 'deployments' are for testing purposes only, not for production/client access
4. Replace long-dead uchiwa dashboard link w/ y/sl2 dashboard instead
5. fix tests