### PR TITLE
Use S3LogsReader from logreader package

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -53,7 +53,7 @@ except ImportError:
     scribereader = None
 
 try:
-    from clog.readers import S3LogsReader
+    from logreader.readers import S3LogsReader
 except ImportError:
     S3LogsReader = None
 

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -11,6 +11,7 @@ gitpython==2.1.9                    # slo-transcoder, vault-tools dependency
 hvac==0.11.0                        # vault-tools dependency
 inflection==0.3.1                   # slo-transcoder dependency
 iso8601==2.1.0                      # yelp-ips dependency
+logreader==1.2.0
 markdown==2.4                       # slo-transcoder dependency
 monk==1.3.0                         # yelp-clog dependency
 mrjob==0.7.4                        # scribereader dependency


### PR DESCRIPTION
S3LogsReader has been moved to `logreader` package. Using it instead 