### PR TITLE
Set value for uses_bulkdata_default to False

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -999,7 +999,9 @@ class InstanceConfig:
         return self.config_dict.get("net", "bridge")
 
     def get_volumes(
-        self, system_volumes: Sequence[DockerVolume], uses_bulkdata_default: bool = True
+        self,
+        system_volumes: Sequence[DockerVolume],
+        uses_bulkdata_default: bool = False,
     ) -> List[DockerVolume]:
         volumes = list(system_volumes) + list(self.get_extra_volumes())
         # we used to add bulkdata as a default mount - but as part of the
@@ -2760,7 +2762,7 @@ class SystemPaastaConfig:
         return self.config_dict.get("always_authenticating_services", [])
 
     def get_uses_bulkdata_default(self) -> bool:
-        return self.config_dict.get("uses_bulkdata_default", True)
+        return self.config_dict.get("uses_bulkdata_default", False)
 
     def get_enable_automated_redeploys_default(self) -> bool:
         return self.config_dict.get("enable_automated_redeploys_default", False)

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -4282,7 +4282,7 @@ def test_warning_big_bounce_default_config():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config3bd814d2"
+            == "config1c7deb78"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 
@@ -4328,7 +4328,7 @@ def test_warning_big_bounce_routable_pod():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "configf23a3edb"
+            == "config45672f04"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every smartstack-registered service to bounce!"
 
 
@@ -4375,7 +4375,7 @@ def test_warning_big_bounce_common_config():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "configb24f9dd2"
+            == "configa4afe5c4"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1561,13 +1561,7 @@ class TestTronTools:
             "secret_env": {},
             "field_selector_env": {"PAASTA_POD_IP": {"field_path": "status.podIP"}},
             "secret_volumes": [],
-            "extra_volumes": [
-                {
-                    "container_path": "/nail/bulkdata",
-                    "host_path": "/nail/bulkdata",
-                    "mode": "RO",
-                }
-            ],
+            "extra_volumes": [],
             "service_account_name": "a-magic-sa",
         }
         expected_docker = "{}/{}".format(

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -2002,7 +2002,7 @@ fake_job:
         # that are not static, this will cause continuous reconfiguration, which
         # will add significant load to the Tron API, which happened in DAR-1461.
         # but if this is intended, just change the hash.
-        assert hasher.hexdigest() == "31634ab048abe9b40b71851797d48e4d"
+        assert hasher.hexdigest() == "7ba92b71a5cdf536665260ac3fca76b3"
 
     def test_override_default_pool_override(self, tmpdir):
         soa_dir = tmpdir.mkdir("test_create_complete_config_soa")


### PR DESCRIPTION
This changes the default value of uses_bulkdata to false, meaning that we can then remove the puppet hiera value which makes the default false that way. Everywhere that puppet is installed has a default value of False, so this shouldn't require a big bounce.