### PR TITLE
MLCOMPUTE-2733 | Add paasta names to spark driver pod annotations

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -7,6 +7,7 @@ import shlex
 import socket
 import sys
 from typing import Any
+from typing import cast
 from typing import Dict
 from typing import List
 from typing import Mapping
@@ -34,7 +35,6 @@ from paasta_tools.spark_tools import auto_add_timeout_for_spark_job
 from paasta_tools.spark_tools import create_spark_config_str
 from paasta_tools.spark_tools import DEFAULT_SPARK_RUNTIME_TIMEOUT
 from paasta_tools.spark_tools import DEFAULT_SPARK_SERVICE
-from paasta_tools.spark_tools import docker_volumes_to_mappings
 from paasta_tools.spark_tools import get_volumes_from_spark_k8s_configs
 from paasta_tools.spark_tools import get_webui_url
 from paasta_tools.spark_tools import inject_spark_conf_str
@@ -1254,7 +1254,7 @@ def paasta_spark_run(args: argparse.Namespace) -> int:
         paasta_pool=args.pool,
         paasta_service=args.service,
         paasta_instance=paasta_instance,
-        extra_volumes=docker_volumes_to_mappings(volumes),
+        extra_volumes=cast(List[Mapping[str, str]], volumes),
         aws_creds=aws_creds,
         aws_region=args.aws_region,
         force_spark_resource_configs=args.force_spark_resource_configs,

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -34,6 +34,7 @@ from paasta_tools.spark_tools import auto_add_timeout_for_spark_job
 from paasta_tools.spark_tools import create_spark_config_str
 from paasta_tools.spark_tools import DEFAULT_SPARK_RUNTIME_TIMEOUT
 from paasta_tools.spark_tools import DEFAULT_SPARK_SERVICE
+from paasta_tools.spark_tools import docker_volumes_to_mappings
 from paasta_tools.spark_tools import get_volumes_from_spark_k8s_configs
 from paasta_tools.spark_tools import get_webui_url
 from paasta_tools.spark_tools import inject_spark_conf_str
@@ -1253,7 +1254,7 @@ def paasta_spark_run(args: argparse.Namespace) -> int:
         paasta_pool=args.pool,
         paasta_service=args.service,
         paasta_instance=paasta_instance,
-        extra_volumes=volumes,
+        extra_volumes=docker_volumes_to_mappings(volumes),
         aws_creds=aws_creds,
         aws_region=args.aws_region,
         force_spark_resource_configs=args.force_spark_resource_configs,

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -235,9 +235,18 @@ def get_spark_driver_monitoring_annotations(
     Returns Spark driver pod annotations - currently used for Prometheus metadata.
     """
     ui_port_str = str(spark_config.get("spark.ui.port", ""))
+    paasta_service_non_truncated = spark_config.get(
+        "spark.kubernetes.executor.annotation.paasta.yelp.com/service", ""
+    )
+    paasta_instance_non_truncated = spark_config.get(
+        "spark.kubernetes.executor.annotation.paasta.yelp.com/instance", ""
+    )
+
     annotations = {
         "prometheus.io/port": ui_port_str,
         "prometheus.io/path": "/metrics/prometheus",
+        "paasta.yelp.com/service": paasta_service_non_truncated,
+        "paasta.yelp.com/instance": paasta_instance_non_truncated,
     }
     return annotations
 

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -265,3 +265,9 @@ def get_spark_driver_monitoring_labels(
         "spark.yelp.com/driver_ui_port": ui_port_str,
     }
     return labels
+
+
+def docker_volumes_to_mappings(
+    docker_volumes: List[DockerVolume],
+) -> List[Mapping[str, str]]:
+    return [{k: str(v) for k, v in volume.items()} for volume in docker_volumes]

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -234,20 +234,23 @@ def get_spark_driver_monitoring_annotations(
     """
     Returns Spark driver pod annotations - currently used for Prometheus metadata.
     """
-    ui_port_str = str(spark_config.get("spark.ui.port", ""))
+    annotations: Dict[str, str] = dict()
+
+    ui_port_str = spark_config.get("spark.ui.port", "")
+    if ui_port_str != "":
+        annotations["prometheus.io/port"] = ui_port_str
+        annotations["prometheus.io/path"] = "/metrics/prometheus"
+
     paasta_service_non_truncated = spark_config.get(
         "spark.kubernetes.executor.annotation.paasta.yelp.com/service", ""
     )
     paasta_instance_non_truncated = spark_config.get(
         "spark.kubernetes.executor.annotation.paasta.yelp.com/instance", ""
     )
+    if paasta_service_non_truncated != "" and paasta_instance_non_truncated != "":
+        annotations["paasta.yelp.com/service"] = paasta_service_non_truncated
+        annotations["paasta.yelp.com/instance"] = paasta_instance_non_truncated
 
-    annotations = {
-        "prometheus.io/port": ui_port_str,
-        "prometheus.io/path": "/metrics/prometheus",
-        "paasta.yelp.com/service": paasta_service_non_truncated,
-        "paasta.yelp.com/instance": paasta_instance_non_truncated,
-    }
     return annotations
 
 

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -234,22 +234,30 @@ def get_spark_driver_monitoring_annotations(
     """
     Returns Spark driver pod annotations - currently used for Prometheus metadata.
     """
-    annotations: Dict[str, str] = dict()
+    annotations: Dict[str, str] = {}
 
-    ui_port_str = spark_config.get("spark.ui.port", "")
-    if ui_port_str != "":
-        annotations["prometheus.io/port"] = ui_port_str
-        annotations["prometheus.io/path"] = "/metrics/prometheus"
+    ui_port_str = spark_config.get("spark.ui.port")
+    if ui_port_str:
+        annotations.update(
+            {
+                "prometheus.io/port": ui_port_str,
+                "prometheus.io/path": "/metrics/prometheus",
+            }
+        )
 
     paasta_service_non_truncated = spark_config.get(
-        "spark.kubernetes.executor.annotation.paasta.yelp.com/service", ""
+        "spark.kubernetes.executor.annotation.paasta.yelp.com/service"
     )
     paasta_instance_non_truncated = spark_config.get(
-        "spark.kubernetes.executor.annotation.paasta.yelp.com/instance", ""
+        "spark.kubernetes.executor.annotation.paasta.yelp.com/instance"
     )
-    if paasta_service_non_truncated != "" and paasta_instance_non_truncated != "":
-        annotations["paasta.yelp.com/service"] = paasta_service_non_truncated
-        annotations["paasta.yelp.com/instance"] = paasta_instance_non_truncated
+    if paasta_service_non_truncated and paasta_instance_non_truncated:
+        annotations.update(
+            {
+                "paasta.yelp.com/service": paasta_service_non_truncated,
+                "paasta.yelp.com/instance": paasta_instance_non_truncated,
+            }
+        )
 
     return annotations
 

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -276,9 +276,3 @@ def get_spark_driver_monitoring_labels(
         "spark.yelp.com/driver_ui_port": ui_port_str,
     }
     return labels
-
-
-def docker_volumes_to_mappings(
-    docker_volumes: List[DockerVolume],
-) -> List[Mapping[str, str]]:
-    return [{k: str(v) for k, v in volume.items()} for volume in docker_volumes]

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -358,9 +358,11 @@ class TronActionConfig(InstanceConfig):
             paasta_service=self.get_service(),
             paasta_instance=self.get_instance(),
             docker_img=f"{self.get_docker_registry()}/$PAASTA_DOCKER_IMAGE",
-            extra_volumes=self.get_volumes(
-                system_paasta_config.get_volumes(),
-                uses_bulkdata_default=system_paasta_config.get_uses_bulkdata_default(),
+            extra_volumes=spark_tools.docker_volumes_to_mappings(
+                self.get_volumes(
+                    system_paasta_config.get_volumes(),
+                    uses_bulkdata_default=system_paasta_config.get_uses_bulkdata_default(),
+                ),
             ),
             use_eks=True,
             k8s_server_address=get_k8s_url_for_cluster(self.get_cluster()),

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -20,6 +20,7 @@ import pkgutil
 import re
 import subprocess
 from string import Formatter
+from typing import cast
 from typing import List
 from typing import Mapping
 from typing import Tuple
@@ -358,7 +359,8 @@ class TronActionConfig(InstanceConfig):
             paasta_service=self.get_service(),
             paasta_instance=self.get_instance(),
             docker_img=f"{self.get_docker_registry()}/$PAASTA_DOCKER_IMAGE",
-            extra_volumes=spark_tools.docker_volumes_to_mappings(
+            extra_volumes=cast(
+                List[Mapping[str, str]],
                 self.get_volumes(
                     system_paasta_config.get_volumes(),
                     uses_bulkdata_default=system_paasta_config.get_uses_bulkdata_default(),

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -56,7 +56,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 3.0.0
+service-configuration-lib >= 3.1.1
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ rsa==4.7.2
 ruamel.yaml==0.15.96
 s3transfer==0.10.0
 sensu-plugin==0.3.1
-service-configuration-lib==3.0.0
+service-configuration-lib==3.1.1
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -981,7 +981,6 @@ def test_get_docker_cmd(args, instance_config, spark_conf_str, expected):
 @mock.patch.object(spark_run, "validate_work_dir", autospec=True)
 @mock.patch.object(utils, "load_system_paasta_config", autospec=True)
 @mock.patch.object(spark_run, "load_system_paasta_config", autospec=True)
-@mock.patch.object(spark_run, "docker_volumes_to_mappings", autospec=True)
 @mock.patch.object(spark_run, "get_instance_config", autospec=True)
 @mock.patch.object(spark_run, "get_aws_credentials", autospec=True)
 @mock.patch.object(spark_run, "get_docker_image", autospec=True)
@@ -1001,7 +1000,6 @@ def test_paasta_spark_run_bash(
     mock_get_docker_image,
     mock_get_aws_credentials,
     mock_get_instance_config,
-    mock_docker_volumes_to_mappings,
     mock_load_system_paasta_config_spark_run,
     mock_load_system_paasta_config_utils,
     mock_validate_work_dir,
@@ -1060,9 +1058,6 @@ def test_paasta_spark_run_bash(
         load_deployments=False,
         soa_dir="/path/to/soa",
     )
-    mock_docker_volumes_to_mappings.assert_called_once_with(
-        mock_get_instance_config.return_value.get_volumes.return_value
-    )
     mock_get_aws_credentials.assert_called_once_with(
         service="test-service",
         aws_credentials_yaml="/path/to/creds",
@@ -1087,7 +1082,7 @@ def test_paasta_spark_run_bash(
         paasta_pool="test-pool",
         paasta_service="test-service",
         paasta_instance=mock_get_smart_paasta_instance_name.return_value,
-        extra_volumes=mock_docker_volumes_to_mappings.return_value,
+        extra_volumes=mock_get_instance_config.return_value.get_volumes.return_value,
         aws_creds=mock_get_aws_credentials.return_value,
         aws_region="test-region",
         force_spark_resource_configs=False,
@@ -1111,7 +1106,6 @@ def test_paasta_spark_run_bash(
 @mock.patch.object(spark_run, "validate_work_dir", autospec=True)
 @mock.patch.object(utils, "load_system_paasta_config", autospec=True)
 @mock.patch.object(spark_run, "load_system_paasta_config", autospec=True)
-@mock.patch.object(spark_run, "docker_volumes_to_mappings", autospec=True)
 @mock.patch.object(spark_run, "get_instance_config", autospec=True)
 @mock.patch.object(spark_run, "get_aws_credentials", autospec=True)
 @mock.patch.object(spark_run, "get_docker_image", autospec=True)
@@ -1133,7 +1127,6 @@ def test_paasta_spark_run(
     mock_get_docker_image,
     mock_get_aws_credentials,
     mock_get_instance_config,
-    mock_docker_volumes_to_mappings,
     mock_load_system_paasta_config_spark_run,
     mock_load_system_paasta_config_utils,
     mock_validate_work_dir,
@@ -1195,9 +1188,6 @@ def test_paasta_spark_run(
         load_deployments=False,
         soa_dir="/path/to/soa",
     )
-    mock_docker_volumes_to_mappings.assert_called_once_with(
-        mock_get_instance_config.return_value.get_volumes.return_value
-    )
     mock_get_aws_credentials.assert_called_once_with(
         service="test-service",
         aws_credentials_yaml="/path/to/creds",
@@ -1222,7 +1212,7 @@ def test_paasta_spark_run(
         paasta_pool="test-pool",
         paasta_service="test-service",
         paasta_instance=mock_get_smart_paasta_instance_name.return_value,
-        extra_volumes=mock_docker_volumes_to_mappings.return_value,
+        extra_volumes=mock_get_instance_config.return_value.get_volumes.return_value,
         aws_creds=mock_get_aws_credentials.return_value,
         aws_region="test-region",
         force_spark_resource_configs=False,
@@ -1245,7 +1235,6 @@ def test_paasta_spark_run(
 @mock.patch.object(spark_run, "validate_work_dir", autospec=True)
 @mock.patch.object(utils, "load_system_paasta_config", autospec=True)
 @mock.patch.object(spark_run, "load_system_paasta_config", autospec=True)
-@mock.patch.object(spark_run, "docker_volumes_to_mappings", autospec=True)
 @mock.patch.object(spark_run, "get_instance_config", autospec=True)
 @mock.patch.object(spark_run, "get_aws_credentials", autospec=True)
 @mock.patch.object(spark_run, "get_docker_image", autospec=True)
@@ -1265,7 +1254,6 @@ def test_paasta_spark_run_pyspark(
     mock_get_docker_image,
     mock_get_aws_credentials,
     mock_get_instance_config,
-    mock_docker_volumes_to_mappings,
     mock_load_system_paasta_config_spark_run,
     mock_load_system_paasta_config_utils,
     mock_validate_work_dir,
@@ -1329,9 +1317,6 @@ def test_paasta_spark_run_pyspark(
         load_deployments=False,
         soa_dir="/path/to/soa",
     )
-    mock_docker_volumes_to_mappings.assert_called_once_with(
-        mock_get_instance_config.return_value.get_volumes.return_value
-    )
     mock_get_aws_credentials.assert_called_once_with(
         service="test-service",
         aws_credentials_yaml="/path/to/creds",
@@ -1356,7 +1341,7 @@ def test_paasta_spark_run_pyspark(
         paasta_pool="test-pool",
         paasta_service="test-service",
         paasta_instance=mock_get_smart_paasta_instance_name.return_value,
-        extra_volumes=mock_docker_volumes_to_mappings.return_value,
+        extra_volumes=mock_get_instance_config.return_value.get_volumes.return_value,
         aws_creds=mock_get_aws_credentials.return_value,
         aws_region="test-region",
         force_spark_resource_configs=False,
@@ -1379,7 +1364,6 @@ def test_paasta_spark_run_pyspark(
 @mock.patch.object(spark_run, "validate_work_dir", autospec=True)
 @mock.patch.object(utils, "load_system_paasta_config", autospec=True)
 @mock.patch.object(spark_run, "load_system_paasta_config", autospec=True)
-@mock.patch.object(spark_run, "docker_volumes_to_mappings", autospec=True)
 @mock.patch.object(spark_run, "get_instance_config", autospec=True)
 @mock.patch.object(spark_run, "get_aws_credentials", autospec=True)
 @mock.patch.object(spark_run, "get_docker_image", autospec=True)
@@ -1410,7 +1394,6 @@ def test_paasta_spark_run_uses_bulkdata(
     mock_get_docker_image,
     mock_get_aws_credentials,
     mock_get_instance_config,
-    mock_docker_volumes_to_mappings,
     mock_load_system_paasta_config_spark_run,
     mock_load_system_paasta_config_utils,
     mock_validate_work_dir,

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -981,6 +981,7 @@ def test_get_docker_cmd(args, instance_config, spark_conf_str, expected):
 @mock.patch.object(spark_run, "validate_work_dir", autospec=True)
 @mock.patch.object(utils, "load_system_paasta_config", autospec=True)
 @mock.patch.object(spark_run, "load_system_paasta_config", autospec=True)
+@mock.patch.object(spark_run, "docker_volumes_to_mappings", autospec=True)
 @mock.patch.object(spark_run, "get_instance_config", autospec=True)
 @mock.patch.object(spark_run, "get_aws_credentials", autospec=True)
 @mock.patch.object(spark_run, "get_docker_image", autospec=True)
@@ -1000,6 +1001,7 @@ def test_paasta_spark_run_bash(
     mock_get_docker_image,
     mock_get_aws_credentials,
     mock_get_instance_config,
+    mock_docker_volumes_to_mappings,
     mock_load_system_paasta_config_spark_run,
     mock_load_system_paasta_config_utils,
     mock_validate_work_dir,
@@ -1058,6 +1060,9 @@ def test_paasta_spark_run_bash(
         load_deployments=False,
         soa_dir="/path/to/soa",
     )
+    mock_docker_volumes_to_mappings.assert_called_once_with(
+        mock_get_instance_config.return_value.get_volumes.return_value
+    )
     mock_get_aws_credentials.assert_called_once_with(
         service="test-service",
         aws_credentials_yaml="/path/to/creds",
@@ -1082,7 +1087,7 @@ def test_paasta_spark_run_bash(
         paasta_pool="test-pool",
         paasta_service="test-service",
         paasta_instance=mock_get_smart_paasta_instance_name.return_value,
-        extra_volumes=mock_get_instance_config.return_value.get_volumes.return_value,
+        extra_volumes=mock_docker_volumes_to_mappings.return_value,
         aws_creds=mock_get_aws_credentials.return_value,
         aws_region="test-region",
         force_spark_resource_configs=False,
@@ -1106,6 +1111,7 @@ def test_paasta_spark_run_bash(
 @mock.patch.object(spark_run, "validate_work_dir", autospec=True)
 @mock.patch.object(utils, "load_system_paasta_config", autospec=True)
 @mock.patch.object(spark_run, "load_system_paasta_config", autospec=True)
+@mock.patch.object(spark_run, "docker_volumes_to_mappings", autospec=True)
 @mock.patch.object(spark_run, "get_instance_config", autospec=True)
 @mock.patch.object(spark_run, "get_aws_credentials", autospec=True)
 @mock.patch.object(spark_run, "get_docker_image", autospec=True)
@@ -1127,6 +1133,7 @@ def test_paasta_spark_run(
     mock_get_docker_image,
     mock_get_aws_credentials,
     mock_get_instance_config,
+    mock_docker_volumes_to_mappings,
     mock_load_system_paasta_config_spark_run,
     mock_load_system_paasta_config_utils,
     mock_validate_work_dir,
@@ -1188,6 +1195,9 @@ def test_paasta_spark_run(
         load_deployments=False,
         soa_dir="/path/to/soa",
     )
+    mock_docker_volumes_to_mappings.assert_called_once_with(
+        mock_get_instance_config.return_value.get_volumes.return_value
+    )
     mock_get_aws_credentials.assert_called_once_with(
         service="test-service",
         aws_credentials_yaml="/path/to/creds",
@@ -1212,7 +1222,7 @@ def test_paasta_spark_run(
         paasta_pool="test-pool",
         paasta_service="test-service",
         paasta_instance=mock_get_smart_paasta_instance_name.return_value,
-        extra_volumes=mock_get_instance_config.return_value.get_volumes.return_value,
+        extra_volumes=mock_docker_volumes_to_mappings.return_value,
         aws_creds=mock_get_aws_credentials.return_value,
         aws_region="test-region",
         force_spark_resource_configs=False,
@@ -1235,6 +1245,7 @@ def test_paasta_spark_run(
 @mock.patch.object(spark_run, "validate_work_dir", autospec=True)
 @mock.patch.object(utils, "load_system_paasta_config", autospec=True)
 @mock.patch.object(spark_run, "load_system_paasta_config", autospec=True)
+@mock.patch.object(spark_run, "docker_volumes_to_mappings", autospec=True)
 @mock.patch.object(spark_run, "get_instance_config", autospec=True)
 @mock.patch.object(spark_run, "get_aws_credentials", autospec=True)
 @mock.patch.object(spark_run, "get_docker_image", autospec=True)
@@ -1254,6 +1265,7 @@ def test_paasta_spark_run_pyspark(
     mock_get_docker_image,
     mock_get_aws_credentials,
     mock_get_instance_config,
+    mock_docker_volumes_to_mappings,
     mock_load_system_paasta_config_spark_run,
     mock_load_system_paasta_config_utils,
     mock_validate_work_dir,
@@ -1317,6 +1329,9 @@ def test_paasta_spark_run_pyspark(
         load_deployments=False,
         soa_dir="/path/to/soa",
     )
+    mock_docker_volumes_to_mappings.assert_called_once_with(
+        mock_get_instance_config.return_value.get_volumes.return_value
+    )
     mock_get_aws_credentials.assert_called_once_with(
         service="test-service",
         aws_credentials_yaml="/path/to/creds",
@@ -1341,7 +1356,7 @@ def test_paasta_spark_run_pyspark(
         paasta_pool="test-pool",
         paasta_service="test-service",
         paasta_instance=mock_get_smart_paasta_instance_name.return_value,
-        extra_volumes=mock_get_instance_config.return_value.get_volumes.return_value,
+        extra_volumes=mock_docker_volumes_to_mappings.return_value,
         aws_creds=mock_get_aws_credentials.return_value,
         aws_region="test-region",
         force_spark_resource_configs=False,
@@ -1364,6 +1379,7 @@ def test_paasta_spark_run_pyspark(
 @mock.patch.object(spark_run, "validate_work_dir", autospec=True)
 @mock.patch.object(utils, "load_system_paasta_config", autospec=True)
 @mock.patch.object(spark_run, "load_system_paasta_config", autospec=True)
+@mock.patch.object(spark_run, "docker_volumes_to_mappings", autospec=True)
 @mock.patch.object(spark_run, "get_instance_config", autospec=True)
 @mock.patch.object(spark_run, "get_aws_credentials", autospec=True)
 @mock.patch.object(spark_run, "get_docker_image", autospec=True)
@@ -1394,6 +1410,7 @@ def test_paasta_spark_run_uses_bulkdata(
     mock_get_docker_image,
     mock_get_aws_credentials,
     mock_get_instance_config,
+    mock_docker_volumes_to_mappings,
     mock_load_system_paasta_config_spark_run,
     mock_load_system_paasta_config_utils,
     mock_validate_work_dir,

--- a/tests/test_spark_tools.py
+++ b/tests/test_spark_tools.py
@@ -70,6 +70,73 @@ def test_get_volumes_from_spark_k8s_configs(mock_sys, spark_conf, expected):
 
 
 @pytest.mark.parametrize(
+    "spark_config,expected",
+    [
+        # Empty config
+        ({}, {}),
+        # Only UI port specified
+        (
+            {"spark.ui.port": "4040"},
+            {
+                "prometheus.io/port": "4040",
+                "prometheus.io/path": "/metrics/prometheus",
+            },
+        ),
+        # Only service and instance specified
+        (
+            {
+                "spark.kubernetes.executor.annotation.paasta.yelp.com/service": "my-service",
+                "spark.kubernetes.executor.annotation.paasta.yelp.com/instance": "my-instance",
+            },
+            {
+                "paasta.yelp.com/service": "my-service",
+                "paasta.yelp.com/instance": "my-instance",
+            },
+        ),
+        # All annotations specified
+        (
+            {
+                "spark.ui.port": "4040",
+                "spark.kubernetes.executor.annotation.paasta.yelp.com/service": "my-service",
+                "spark.kubernetes.executor.annotation.paasta.yelp.com/instance": "my-instance",
+            },
+            {
+                "prometheus.io/port": "4040",
+                "prometheus.io/path": "/metrics/prometheus",
+                "paasta.yelp.com/service": "my-service",
+                "paasta.yelp.com/instance": "my-instance",
+            },
+        ),
+        # Missing service
+        (
+            {
+                "spark.ui.port": "4040",
+                "spark.kubernetes.executor.annotation.paasta.yelp.com/instance": "my-instance",
+            },
+            {
+                "prometheus.io/port": "4040",
+                "prometheus.io/path": "/metrics/prometheus",
+            },
+        ),
+        # Missing instance
+        (
+            {
+                "spark.ui.port": "4040",
+                "spark.kubernetes.executor.annotation.paasta.yelp.com/service": "my-service",
+            },
+            {
+                "prometheus.io/port": "4040",
+                "prometheus.io/path": "/metrics/prometheus",
+            },
+        ),
+    ],
+)
+def test_get_spark_driver_monitoring_annotations(spark_config, expected):
+    result = spark_tools.get_spark_driver_monitoring_annotations(spark_config)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
     "docker_volumes,expected",
     [
         # Empty list

--- a/tests/test_spark_tools.py
+++ b/tests/test_spark_tools.py
@@ -4,7 +4,6 @@ from unittest import mock
 import pytest
 
 from paasta_tools import spark_tools
-from paasta_tools.utils import DockerVolume
 
 
 def test_get_webui_url():
@@ -133,70 +132,4 @@ def test_get_volumes_from_spark_k8s_configs(mock_sys, spark_conf, expected):
 )
 def test_get_spark_driver_monitoring_annotations(spark_config, expected):
     result = spark_tools.get_spark_driver_monitoring_annotations(spark_config)
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    "docker_volumes,expected",
-    [
-        # Empty list
-        ([], []),
-        # Single volume
-        (
-            [
-                DockerVolume(
-                    hostPath="/host/path",
-                    containerPath="/container/path",
-                    mode="RW",
-                )
-            ],
-            [
-                {
-                    "hostPath": "/host/path",
-                    "containerPath": "/container/path",
-                    "mode": "RW",
-                },
-            ],
-        ),
-        # Multiple volumes with different modes
-        (
-            [
-                DockerVolume(
-                    hostPath="/etc/passwd",
-                    containerPath="/etc/passwd",
-                    mode="RO",
-                ),
-                DockerVolume(
-                    hostPath="/etc/group",
-                    containerPath="/etc/group",
-                    mode="RO",
-                ),
-                DockerVolume(
-                    hostPath="/etc/hello",
-                    containerPath="/etc/hello2",
-                    mode="RW",
-                ),
-            ],
-            [
-                {
-                    "hostPath": "/etc/passwd",
-                    "containerPath": "/etc/passwd",
-                    "mode": "RO",
-                },
-                {
-                    "hostPath": "/etc/group",
-                    "containerPath": "/etc/group",
-                    "mode": "RO",
-                },
-                {
-                    "hostPath": "/etc/hello",
-                    "containerPath": "/etc/hello2",
-                    "mode": "RW",
-                },
-            ],
-        ),
-    ],
-)
-def test_docker_volumes_to_mappings(docker_volumes, expected):
-    result = spark_tools.docker_volumes_to_mappings(docker_volumes)
     assert result == expected

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1330,6 +1330,8 @@ class TestTronTools:
             "--conf spark.kubernetes.executor.label.paasta.yelp.com/service=my_service "
             "--conf spark.kubernetes.executor.label.paasta.yelp.com/instance=my_job.do_something "
             "--conf spark.kubernetes.executor.label.paasta.yelp.com/cluster=test-cluster "
+            "--conf spark.kubernetes.executor.annotation.paasta.yelp.com/service=my_service "
+            "--conf spark.kubernetes.executor.annotation.paasta.yelp.com/instance=my_job.do_something "
             "--conf spark.kubernetes.executor.label.spark.yelp.com/user=TRON "
             "--conf spark.kubernetes.executor.label.spark.yelp.com/driver_ui_port=39091 "
             "--conf spark.kubernetes.node.selector.yelp.com/pool=special_pool "


### PR DESCRIPTION
Add paasta names to spark driver pod annotations.
Follow up by: https://github.com/Yelp/service_configuration_lib/pull/153 which is for executor pod annotations.