### PR TITLE
move auth tween below pyramid_swagger

### DIFF
--- a/paasta_tools/api/tweens/auth.py
+++ b/paasta_tools/api/tweens/auth.py
@@ -120,6 +120,6 @@ def includeme(config: Configurator):
             "paasta_tools.api.tweens.auth.AuthTweenFactory",
             under=(
                 pyramid.tweens.INGRESS,
-                "paasta_tools.api.tweens.request_logger.request_logger_tween_factory",
+                "pyramid_swagger.tween.validation_tween_factory",
             ),
         )


### PR DESCRIPTION
The tween tries to access `swagger_data`, which won't be available before the swagger tween validated and loaded the request body, so it's currently failing.

I was undecided on whether to go this route, or trying to extract the "service" field from get/post data manually, but at the end I settled on moving the tween down the stack. This implementation does not include that many tweens, so I don't think not having auth right on top is going to be that impactful / dangerous.
