### PR TITLE
Fix timeout regex for spark submit command

### DIFF
--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -184,6 +184,9 @@ def auto_add_timeout_for_spark_job(
     if "spark-submit" not in cmd:
         return cmd
     try:
+        # Not supporting `=` for now, to support `=` we need to do lot of error checking,
+        # regex becomes a bit complex, use cases are very less, same command can be
+        # achieved without `=` also
         options_regex = "((-[a-zA-Z]+|\\-\\-[a-zA-Z\\-]+)(\\s+[a-zA-Z0-9\\-]+)?\\s*)*"
         duration_regex = r"[\d]+[\.]?[\d]*[m|h]"
         timeout_present = re.match(

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -184,8 +184,10 @@ def auto_add_timeout_for_spark_job(
     if "spark-submit" not in cmd:
         return cmd
     try:
+        options_regex = "((-[a-zA-Z]+|\\-\\-[a-zA-Z\\-]+)(\\s+[a-zA-Z0-9\\-]+)?\\s*)*"
+        duration_regex = r"[\d]+[\.]?[\d]*[m|h]"
         timeout_present = re.match(
-            r"^.*timeout[\s]+[\d]+[\.]?[\d]*[m|h][\s]+spark-submit .*$", cmd
+            rf"^.*timeout[\s]+{options_regex}{duration_regex}[\s]+spark-submit .*$", cmd
         )
         if not timeout_present:
             split_cmd = cmd.split("spark-submit")

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -184,13 +184,13 @@ def auto_add_timeout_for_spark_job(
     if "spark-submit" not in cmd:
         return cmd
     try:
-        # Not supporting `=` for now, to support `=` we need to do lot of error checking,
-        # regex becomes a bit complex, use cases are very less, same command can be
-        # achieved without `=` also
-        options_regex = "((-[a-zA-Z]+|\\-\\-[a-zA-Z\\-]+)(\\s+[a-zA-Z0-9\\-]+)?\\s*)*"
-        duration_regex = r"[\d]+[\.]?[\d]*[m|h]"
+        # This is not an exhaustive regex, matches the invalid ones also, where as the invalid
+        # timeout command will fail during execution
+        options_regex = r"(--?[a-z][a-z-]*((\s+|=)[\w\d-]+)?\s+)*"
+        duration_regex = r"\d+\.?\d*[smhd]?"
+
         timeout_present = re.match(
-            rf"^.*timeout[\s]+{options_regex}{duration_regex}[\s]+spark-submit .*$", cmd
+            rf"^.*timeout\s+{options_regex}{duration_regex}\s+spark-submit .*$", cmd
         )
         if not timeout_present:
             split_cmd = cmd.split("spark-submit")

--- a/tests/test_spark_tools.py
+++ b/tests/test_spark_tools.py
@@ -167,6 +167,12 @@ def test_get_spark_driver_monitoring_annotations(spark_config, expected):
             "timeout -v -s 1 2h spark-submit abc.py",
             id="Timeout with multiple options",
         ),
+        pytest.param(
+            "timeout --signal SIGKILL 2h spark-submit abc.py",
+            "12h",
+            "timeout --signal SIGKILL 2h spark-submit abc.py",
+            id="Timeout with double dash option",
+        ),
     ],
 )
 def test_auto_add_timeout_for_spark_job(cmd, timeout_duration, expected):

--- a/tests/test_spark_tools.py
+++ b/tests/test_spark_tools.py
@@ -168,9 +168,9 @@ def test_get_spark_driver_monitoring_annotations(spark_config, expected):
             id="Timeout with multiple options",
         ),
         pytest.param(
-            "timeout --signal SIGKILL 2h spark-submit abc.py",
+            "timeout -k 10m --signal=SIGKILL 2h spark-submit abc.py",
             "12h",
-            "timeout --signal SIGKILL 2h spark-submit abc.py",
+            "timeout -k 10m --signal=SIGKILL 2h spark-submit abc.py",
             id="Timeout with double dash option",
         ),
     ],

--- a/tests/test_spark_tools.py
+++ b/tests/test_spark_tools.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 
 from paasta_tools import spark_tools
+from paasta_tools.spark_tools import auto_add_timeout_for_spark_job
 
 
 def test_get_webui_url():
@@ -132,4 +133,43 @@ def test_get_volumes_from_spark_k8s_configs(mock_sys, spark_conf, expected):
 )
 def test_get_spark_driver_monitoring_annotations(spark_config, expected):
     result = spark_tools.get_spark_driver_monitoring_annotations(spark_config)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    argnames=[
+        "cmd",
+        "timeout_duration",
+        "expected",
+    ],
+    argvalues=[
+        pytest.param(
+            "spark-submit abc.py",
+            "4h",
+            "timeout 4h spark-submit abc.py",
+            id="No timeout",
+        ),
+        pytest.param(
+            "timeout 2h spark-submit abc.py",
+            "12h",
+            "timeout 2h spark-submit abc.py",
+            id="Timeout without options",
+        ),
+        pytest.param(
+            "timeout -v 2h spark-submit abc.py",
+            "12h",
+            "timeout -v 2h spark-submit abc.py",
+            id="Timeout with options",
+        ),
+        pytest.param(
+            "timeout -v -s 1 2h spark-submit abc.py",
+            "12h",
+            "timeout -v -s 1 2h spark-submit abc.py",
+            id="Timeout with multiple options",
+        ),
+    ],
+)
+def test_auto_add_timeout_for_spark_job(cmd, timeout_duration, expected):
+    result = auto_add_timeout_for_spark_job(cmd, timeout_duration)
+
     assert result == expected


### PR DESCRIPTION
### Problem
We check if there is already a timeout command in the user's spark command before auto adding it, but the check doesn't work with the case that an CLI argument is used, e.g. `timeout -v spark-submit`

### Solution
Fix the regex which checks if timeout is already present

### Testing
I test ran the `spark-submit` locally on dev-box with `timeout -v 1m`, as expected it timed out at `1m` 
command and output logs can be found [here](https://fluffy.yelpcorp.com/i/wbjZ7FrpPNGVCrg9TgXGnJcd2Hc48rVX.html)
