### PR TITLE
Remove references to get_uses_bulkdata_default

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -1227,7 +1227,6 @@ def configure_and_run_docker_container(
 
     for volume in instance_config.get_volumes(
         system_paasta_config.get_volumes(),
-        system_paasta_config.get_uses_bulkdata_default(),
     ):
         if os.path.exists(volume["hostPath"]):
             volumes.append(

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1219,7 +1219,6 @@ def paasta_spark_run(args: argparse.Namespace) -> int:
 
     volumes = instance_config.get_volumes(
         system_paasta_config.get_volumes(),
-        system_paasta_config.get_uses_bulkdata_default(),
     )
     app_base_name = get_spark_app_name(args.cmd or instance_config.get_cmd())
 

--- a/paasta_tools/frameworks/native_service_config.py
+++ b/paasta_tools/frameworks/native_service_config.py
@@ -172,7 +172,6 @@ class NativeServiceConfig(LongRunningServiceConfig):
         """
         docker_volumes = self.get_volumes(
             system_volumes=system_paasta_config.get_volumes(),
-            uses_bulkdata_default=system_paasta_config.get_uses_bulkdata_default(),
         )
         task: TaskInfo = {
             "name": "",

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2208,7 +2208,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         )
         docker_volumes = self.get_volumes(
             system_volumes=system_paasta_config.get_volumes(),
-            uses_bulkdata_default=system_paasta_config.get_uses_bulkdata_default(),
         )
 
         hacheck_sidecar_volumes = system_paasta_config.get_hacheck_sidecar_volumes()

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -363,7 +363,6 @@ class TronActionConfig(InstanceConfig):
                 List[Mapping[str, str]],
                 self.get_volumes(
                     system_paasta_config.get_volumes(),
-                    uses_bulkdata_default=system_paasta_config.get_uses_bulkdata_default(),
                 ),
             ),
             use_eks=True,
@@ -1080,7 +1079,6 @@ def format_tron_action_dict(action_config: TronActionConfig):
         # we can get rid of the default_volumes from the Tron master config
         extra_volumes = action_config.get_volumes(
             system_paasta_config.get_volumes(),
-            uses_bulkdata_default=system_paasta_config.get_uses_bulkdata_default(),
         )
         if executor == "spark":
             is_mrjob = action_config.config_dict.get("mrjob", False)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2750,9 +2750,6 @@ class SystemPaastaConfig:
     def get_always_authenticating_services(self) -> List[str]:
         return self.config_dict.get("always_authenticating_services", [])
 
-    def get_uses_bulkdata_default(self) -> bool:
-        return self.config_dict.get("uses_bulkdata_default", False)
-
     def get_enable_automated_redeploys_default(self) -> bool:
         return self.config_dict.get("enable_automated_redeploys_default", False)
 


### PR DESCRIPTION
This PR removes references to get_uses_bulkdata_default in the code because there is now no such default on disk in puppet.