### PR TITLE
update service_shard_update to deploy on environment

### DIFF
--- a/paasta_tools/contrib/service_shard_update.py
+++ b/paasta_tools/contrib/service_shard_update.py
@@ -210,7 +210,9 @@ def main(args):
     )
     deploy_environments = DEPLOY_MAPPINGS
     if args.environment is not None:
-        deploy_environments = {k: v for k, v in DEPLOY_MAPPINGS.items() if k == args.environment}
+        deploy_environments = {
+            k: v for k, v in DEPLOY_MAPPINGS.items() if k == args.environment
+        }
 
     with updater:
         deploy_file = updater.get_existing_configs(args.service, "deploy")

--- a/paasta_tools/contrib/service_shard_update.py
+++ b/paasta_tools/contrib/service_shard_update.py
@@ -208,11 +208,7 @@ def main(args):
         working_dir=args.local_dir or "/nail/tmp",
         do_clone=args.local_dir is None,
     )
-    deploy_environments = DEPLOY_MAPPINGS
-    if args.environment is not None:
-        deploy_environments = {
-            k: v for k, v in DEPLOY_MAPPINGS.items() if k == args.environment
-        }
+    deploy_environments = {args.environment: DEPLOY_MAPPINGS[args.environment]} if args.environment else DEPLOY_MAPPINGS
 
     with updater:
         deploy_file = updater.get_existing_configs(args.service, "deploy")

--- a/paasta_tools/contrib/service_shard_update.py
+++ b/paasta_tools/contrib/service_shard_update.py
@@ -208,7 +208,11 @@ def main(args):
         working_dir=args.local_dir or "/nail/tmp",
         do_clone=args.local_dir is None,
     )
-    deploy_environments = {args.environment: DEPLOY_MAPPINGS[args.environment]} if args.environment else DEPLOY_MAPPINGS
+    deploy_environments = (
+        {args.environment: DEPLOY_MAPPINGS[args.environment]}
+        if args.environment
+        else DEPLOY_MAPPINGS
+    )
 
     with updater:
         deploy_file = updater.get_existing_configs(args.service, "deploy")


### PR DESCRIPTION
follow up for https://github.com/Yelp/paasta/pull/3994

we should allow for deploys for certain environments, especially when using `--iam-role` because roles are often environment specific.
for backwards compatibility, this deploys to all environments when `--environment` is not passed in as an option.