### PR TITLE
fix job pod labelling

### DIFF
--- a/paasta_tools/kubernetes/remote_run.py
+++ b/paasta_tools/kubernetes/remote_run.py
@@ -259,7 +259,7 @@ def find_job_pod(
     """
     selectors = (
         f"{paasta_prefixed(JOB_TYPE_LABEL_NAME)}={job_label}",
-        f"batch.kubernetes.io/job-name={job_name}",
+        f"job-name={job_name}",
     )
     for _ in range(retries):
         pod_list = kube_client.core.list_namespaced_pod(

--- a/tests/kubernetes/test_remote_run.py
+++ b/tests/kubernetes/test_remote_run.py
@@ -229,7 +229,7 @@ def test_find_job_pod(mock_sleep):
         [
             call(
                 "namespace",
-                label_selector="paasta.yelp.com/job_type=remote-run,batch.kubernetes.io/job-name=somejob",
+                label_selector="paasta.yelp.com/job_type=remote-run,job-name=somejob",
             )
         ]
         * 2

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1500,6 +1500,7 @@ class TestKubernetesDeploymentConfig:
             mock_get_kubernetes_metadata.return_value.labels = {
                 "paasta.yelp.com/owner": "whatever"
             }
+            mock_get_pod_template_spec.return_value.metadata.labels = {}
             job = self.deployment.format_kubernetes_job("foobar", 100)
             assert job == V1Job(
                 api_version="batch/v1",
@@ -1528,6 +1529,10 @@ class TestKubernetesDeploymentConfig:
             )
             assert job.metadata.labels == {
                 "paasta.yelp.com/owner": "whatever",
+                "paasta.yelp.com/image_version": mock_get_image_version.return_value,
+                "paasta.yelp.com/job_type": "foobar",
+            }
+            assert mock_get_pod_template_spec.return_value.metadata.labels == {
                 "paasta.yelp.com/image_version": mock_get_image_version.return_value,
                 "paasta.yelp.com/job_type": "foobar",
             }


### PR DESCRIPTION
* The documentation lied to me, pods only have `job-name` rather than `batch.kubernetes.io/job-name` (maybe it's a difference across versions, I have not checked).
* I wrongly assumed that job labels would propagate to be pod labels. I'm too naive.