### PR TITLE
Load credentials from file

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -640,9 +640,8 @@ def get_spark_env(
         spark_env["GET_EKS_TOKEN_AWS_SECRET_ACCESS_KEY"] = config["default"][
             "aws_secret_access_key"
         ]
-        spark_env["KUBECONFIG"] = "/etc/kubernetes/spark2.conf"
-    else:
-        spark_env["KUBECONFIG"] = system_paasta_config.get_spark_kubeconfig()
+
+    spark_env["KUBECONFIG"] = system_paasta_config.get_spark_kubeconfig()
 
     return spark_env
 
@@ -819,9 +818,8 @@ def configure_and_run_docker_container(
     if pod_template_path:
         volumes.append(f"{pod_template_path}:{pod_template_path}:rw")
 
-    volumes.append(
-        f"{system_paasta_config.get_spark_kubeconfig()}:{system_paasta_config.get_spark_kubeconfig()}:ro"
-    )
+    kubeconfig_dir = os.path.dirname(system_paasta_config.get_spark_kubeconfig())
+    volumes.append(f"{kubeconfig_dir}:{kubeconfig_dir}:ro")
 
     environment = instance_config.get_env_dictionary()  # type: ignore
     spark_conf_str = create_spark_config_str(spark_conf, is_mrjob=args.mrjob)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -655,6 +655,10 @@ def get_spark_env(
         spark_env["SPARK_NO_DAEMONIZE"] = "true"
 
     if args.get_eks_token_via_iam_user:
+        # config looks as follows:
+        # [default]
+        # aws_access_key_id = ...
+        # aws_secret_access_key = ...
         with open(
             "/nail/etc/spark_driver_k8s_role_assumer/spark_driver_k8s_role_assumer.ini"
         ) as f:

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -85,6 +85,14 @@ DEPRECATED_OPTS = {
 
 SPARK_COMMANDS = {"pyspark", "spark-submit"}
 
+# config looks as follows:
+# [default]
+# aws_access_key_id = ...
+# aws_secret_access_key = ...
+SPARK_DRIVER_IAM_USER = (
+    "/nail/etc/spark_driver_k8s_role_assumer/spark_driver_k8s_role_assumer.ini"
+)
+
 log = logging.getLogger(__name__)
 
 
@@ -655,13 +663,6 @@ def get_spark_env(
         spark_env["SPARK_NO_DAEMONIZE"] = "true"
 
     if args.get_eks_token_via_iam_user:
-        # config looks as follows:
-        # [default]
-        # aws_access_key_id = ...
-        # aws_secret_access_key = ...
-        SPARK_DRIVER_IAM_USER = (
-            "/nail/etc/spark_driver_k8s_role_assumer/spark_driver_k8s_role_assumer.ini"
-        )
         with open(SPARK_DRIVER_IAM_USER) as f:
             config = ConfigParser()
             config.read_file(f)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -664,6 +664,8 @@ def get_spark_env(
         ) as f:
             config = ConfigParser()
             config.read_file(f)
+
+        # these ENV variables are consumed by spark's KUBECONFIG command
         spark_env["GET_EKS_TOKEN_AWS_ACCESS_KEY_ID"] = config["default"][
             "aws_access_key_id"
         ]

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -659,9 +659,10 @@ def get_spark_env(
         # [default]
         # aws_access_key_id = ...
         # aws_secret_access_key = ...
-        with open(
+        SPARK_DRIVER_IAM_USER = (
             "/nail/etc/spark_driver_k8s_role_assumer/spark_driver_k8s_role_assumer.ini"
-        ) as f:
+        )
+        with open(SPARK_DRIVER_IAM_USER) as f:
             config = ConfigParser()
             config.read_file(f)
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -819,7 +819,9 @@ def configure_and_run_docker_container(
     if pod_template_path:
         volumes.append(f"{pod_template_path}:{pod_template_path}:rw")
 
-    volumes.append("/etc/kubernetes:/etc/kubernetes:ro")
+    volumes.append(
+        f"{system_paasta_config.get_spark_kubeconfig()}:{system_paasta_config.get_spark_kubeconfig()}:ro"
+    )
 
     environment = instance_config.get_env_dictionary()  # type: ignore
     spark_conf_str = create_spark_config_str(spark_conf, is_mrjob=args.mrjob)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1167,7 +1167,7 @@ def update_args_from_tronfig(args: argparse.Namespace) -> Optional[Dict[str, str
 
 def paasta_spark_run(args: argparse.Namespace) -> int:
     if args.get_eks_token_via_iam_user and os.getuid() != 0:
-        print("Re-run proccess as root", file=sys.stderr)
+        print("Re-executing paasta spark-run with sudo..", file=sys.stderr)
         # argv[0] is treated as command name, so prepending "sudo"
         os.execvp("sudo", ["sudo"] + sys.argv)
         return  # will not reach unless above function is mocked

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -640,9 +640,8 @@ def get_spark_env(
         spark_env["GET_EKS_TOKEN_AWS_SECRET_ACCESS_KEY"] = config["default"][
             "aws_secret_access_key"
         ]
-        spark_env["KUBECONFIG"] = "/etc/kubernetes/spark2.conf"
-    else:
-        spark_env["KUBECONFIG"] = system_paasta_config.get_spark_kubeconfig()
+
+    spark_env["KUBECONFIG"] = system_paasta_config.get_spark_kubeconfig()
 
     return spark_env
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -865,6 +865,7 @@ def configure_and_run_docker_container(
     if pod_template_path:
         volumes.append(f"{pod_template_path}:{pod_template_path}:rw")
 
+    # Mounting directory because there are multiple KUBECONFIGs due to migration
     kubeconfig_dir = os.path.dirname(system_paasta_config.get_spark_kubeconfig())
     volumes.append(f"{kubeconfig_dir}:{kubeconfig_dir}:ro")
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -640,8 +640,9 @@ def get_spark_env(
         spark_env["GET_EKS_TOKEN_AWS_SECRET_ACCESS_KEY"] = config["default"][
             "aws_secret_access_key"
         ]
-
-    spark_env["KUBECONFIG"] = system_paasta_config.get_spark_kubeconfig()
+        spark_env["KUBECONFIG"] = "/etc/kubernetes/spark2.conf"
+    else:
+        spark_env["KUBECONFIG"] = system_paasta_config.get_spark_kubeconfig()
 
     return spark_env
 
@@ -818,8 +819,7 @@ def configure_and_run_docker_container(
     if pod_template_path:
         volumes.append(f"{pod_template_path}:{pod_template_path}:rw")
 
-    kubeconfig_dir = os.path.dirname(system_paasta_config.get_spark_kubeconfig())
-    volumes.append(f"{kubeconfig_dir}:{kubeconfig_dir}:ro")
+    volumes.append("/etc/kubernetes:/etc/kubernetes:ro")
 
     environment = instance_config.get_env_dictionary()  # type: ignore
     spark_conf_str = create_spark_config_str(spark_conf, is_mrjob=args.mrjob)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -819,7 +819,8 @@ def configure_and_run_docker_container(
     if pod_template_path:
         volumes.append(f"{pod_template_path}:{pod_template_path}:rw")
 
-    volumes.append("/etc/kubernetes:/etc/kubernetes:ro")
+    kubeconfig_dir = os.path.dirname(system_paasta_config.get_spark_kubeconfig())
+    volumes.append(f"{kubeconfig_dir}:{kubeconfig_dir}:ro")
 
     environment = instance_config.get_env_dictionary()  # type: ignore
     spark_conf_str = create_spark_config_str(spark_conf, is_mrjob=args.mrjob)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -5,6 +5,7 @@ import os
 import re
 import shlex
 import socket
+import subprocess
 import sys
 from configparser import ConfigParser
 from typing import Any
@@ -786,6 +787,31 @@ def _calculate_docker_cpu_limit(
     )
 
 
+def create_volume_and_create_spark_conf(
+    spark_conf_volume,
+    spark_conf_name,
+):
+    subprocess.run(
+        ["docker", "volume", "create", spark_conf_volume],
+        check=True,  # raises error if non-0 return code
+        capture_output=True,  # no command output is shown without error
+    )
+    output = subprocess.check_output(
+        ["docker", "volume", "inspect", spark_conf_volume],
+    )
+
+    # write to volume without a container
+    volume_mountpoint = json.loads(output)[0]["Mountpoint"]
+    with open(os.path.join(volume_mountpoint, spark_conf_name), "w") as f:
+        f.write(get_spark_kubeconfig_template())
+
+
+def get_spark_kubeconfig_template():
+    return """
+<placeholder>
+    """
+
+
 def configure_and_run_docker_container(
     args: argparse.Namespace,
     docker_img: str,
@@ -819,9 +845,20 @@ def configure_and_run_docker_container(
     if pod_template_path:
         volumes.append(f"{pod_template_path}:{pod_template_path}:rw")
 
-    volumes.append(
-        f"{system_paasta_config.get_spark_kubeconfig()}:{system_paasta_config.get_spark_kubeconfig()}:ro"
-    )
+    if args.get_eks_token_via_iam_user:
+        spark_kubeconfig = system_paasta_config.get_spark_kubeconfig()
+        # can re-use volume because KUBECONFIG does not change across users
+        # or this could be UUID but will result in many volumes - should probably be fine since it'll have a small file
+        spark_conf_volume = "nalma-vol"
+        create_volume_and_create_spark_conf(
+            spark_conf_volume=spark_conf_volume,
+            spark_conf_name=os.path.basename(spark_kubeconfig),
+        )
+        volumes.append(f"{spark_conf_volume}:{os.path.dirname(spark_kubeconfig)}:ro")
+    else:
+        volumes.append(
+            f"{system_paasta_config.get_spark_kubeconfig()}:{system_paasta_config.get_spark_kubeconfig()}:ro"
+        )
 
     environment = instance_config.get_env_dictionary()  # type: ignore
     spark_conf_str = create_spark_config_str(spark_conf, is_mrjob=args.mrjob)

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1127,6 +1127,11 @@ def update_args_from_tronfig(args: argparse.Namespace) -> Optional[Dict[str, str
 
 
 def paasta_spark_run(args: argparse.Namespace) -> int:
+    if args.get_eks_token_via_iam_user and os.getuid() != 0:
+        print("Re-run proccess as root")
+        # argv[0] is treated as command name, so prepending "sudo"
+        os.execvp("sudo", ["sudo"] + sys.argv)
+
     driver_envs_from_tronfig: Dict[str, str] = dict()
     if args.tronfig is not None:
         if args.job_id is None:

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -866,7 +866,7 @@ def configure_and_run_docker_container(
     if pod_template_path:
         volumes.append(f"{pod_template_path}:{pod_template_path}:rw")
 
-    # Mounting directory because there are multiple KUBECONFIGs due to migration
+    # NOTE: we mount a directory here since the kubeconfig we're transitioning to requires a helper script that will co-exist in the same directory
     kubeconfig_dir = os.path.dirname(system_paasta_config.get_spark_kubeconfig())
     volumes.append(f"{kubeconfig_dir}:{kubeconfig_dir}:ro")
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -666,7 +666,7 @@ def get_spark_env(
             config = ConfigParser()
             config.read_file(f)
 
-        # these ENV variables are consumed by spark's KUBECONFIG command
+        # these env variables are consumed by a script specified in the spark kubeconfig - and which will result in a tightly-scoped IAM identity being used for EKS cluster access
         spark_env["GET_EKS_TOKEN_AWS_ACCESS_KEY_ID"] = config["default"][
             "aws_access_key_id"
         ]

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -675,7 +675,7 @@ def get_spark_env(
             "aws_secret_access_key"
         ]
 
-        spark_env["KUBECONFIG"] = system_paasta_config.get_spark2_kubeconfig()
+        spark_env["KUBECONFIG"] = system_paasta_config.get_spark_iam_user_kubeconfig()
     else:
         spark_env["KUBECONFIG"] = system_paasta_config.get_spark_kubeconfig()
 

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -1128,9 +1128,10 @@ def update_args_from_tronfig(args: argparse.Namespace) -> Optional[Dict[str, str
 
 def paasta_spark_run(args: argparse.Namespace) -> int:
     if args.get_eks_token_via_iam_user and os.getuid() != 0:
-        print("Re-run proccess as root")
+        print("Re-run proccess as root", file=sys.stderr)
         # argv[0] is treated as command name, so prepending "sudo"
         os.execvp("sudo", ["sudo"] + sys.argv)
+        return  # will not reach unless above function is mocked
 
     driver_envs_from_tronfig: Dict[str, str] = dict()
     if args.tronfig is not None:

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -667,7 +667,9 @@ def get_spark_env(
             "aws_secret_access_key"
         ]
 
-    spark_env["KUBECONFIG"] = system_paasta_config.get_spark_kubeconfig()
+        spark_env["KUBECONFIG"] = system_paasta_config.get_spark2_kubeconfig()
+    else:
+        spark_env["KUBECONFIG"] = system_paasta_config.get_spark_kubeconfig()
 
     return spark_env
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2032,7 +2032,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     skip_cpu_burst_validation: List[str]
     tron_default_pool_override: str
     spark_kubeconfig: str
-    spark2_kubeconfig: str
+    spark_iam_user_kubeconfig: str
     kube_clusters: Dict
     spark_use_eks_default: bool
     sidecar_requirements_config: Dict[str, KubeContainerResourceRequest]
@@ -2743,8 +2743,10 @@ class SystemPaastaConfig:
     def get_spark_kubeconfig(self) -> str:
         return self.config_dict.get("spark_kubeconfig", "/etc/kubernetes/spark.conf")
 
-    def get_spark2_kubeconfig(self) -> str:
-        return self.config_dict.get("spark2_kubeconfig", "/etc/kubernetes/spark2.conf")
+    def get_spark_iam_user_kubeconfig(self) -> str:
+        return self.config_dict.get(
+            "spark_iam_user_kubeconfig", "/etc/kubernetes/spark2.conf"
+        )
 
     def get_kube_clusters(self) -> Dict:
         return self.config_dict.get("kube_clusters", {})

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2032,6 +2032,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     skip_cpu_burst_validation: List[str]
     tron_default_pool_override: str
     spark_kubeconfig: str
+    spark2_kubeconfig: str
     kube_clusters: Dict
     spark_use_eks_default: bool
     sidecar_requirements_config: Dict[str, KubeContainerResourceRequest]

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2742,6 +2742,9 @@ class SystemPaastaConfig:
     def get_spark_kubeconfig(self) -> str:
         return self.config_dict.get("spark_kubeconfig", "/etc/kubernetes/spark.conf")
 
+    def get_spark2_kubeconfig(self) -> str:
+        return self.config_dict.get("spark2_kubeconfig", "/etc/kubernetes/spark2.conf")
+
     def get_kube_clusters(self) -> Dict:
         return self.config_dict.get("kube_clusters", {})
 

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -42,6 +42,10 @@ from paasta_tools.utils import SystemPaastaConfigDict
 
 DUMMY_DOCKER_IMAGE_DIGEST = "MOCK-docker-dev.yelpcorp.com/paasta-spark-run-user@sha256:103ce91c65d42498ca61cdfe8d799fab8ab1c37dac58b743b49ced227bc7bc06"
 
+SPARK_DRIVER_K8S_FILE = (
+    "/nail/etc/spark_driver_k8s_role_assumer/spark_driver_k8s_role_assumer.ini"
+)
+
 
 @mock.patch(
     "paasta_tools.cli.cmds.spark_run.is_using_unprivileged_containers",
@@ -313,9 +317,7 @@ aws_secret_access_key = <foo-secret>
                 "fake_dir",
             ),
         )
-        iam_creds_file.assert_called_once_with(
-            "/nail/etc/spark_driver_k8s_role_assumer/spark_driver_k8s_role_assumer.ini"
-        )
+        iam_creds_file.assert_called_once_with(SPARK_DRIVER_K8S_FILE)
 
         assert spark_env["GET_EKS_TOKEN_AWS_ACCESS_KEY_ID"] == "<foo-id>"
         assert spark_env["GET_EKS_TOKEN_AWS_SECRET_ACCESS_KEY"] == "<foo-secret>"

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -319,6 +319,7 @@ aws_secret_access_key = <foo-secret>
 
         assert spark_env["GET_EKS_TOKEN_AWS_ACCESS_KEY_ID"] == "<foo-id>"
         assert spark_env["GET_EKS_TOKEN_AWS_SECRET_ACCESS_KEY"] == "<foo-secret>"
+        assert spark_env["KUBECONFIG"] == "/etc/kubernetes/spark2.conf"
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -1083,6 +1083,7 @@ def test_paasta_spark_run_bash(
         job_id=None,
         use_web_identity=False,
         uses_bulkdata=True,
+        get_eks_token_via_iam_user=False,
     )
     mock_load_system_paasta_config_utils.return_value.get_kube_clusters.return_value = (
         {}
@@ -1210,6 +1211,7 @@ def test_paasta_spark_run(
         job_id=None,
         use_web_identity=False,
         uses_bulkdata=True,
+        get_eks_token_via_iam_user=False,
     )
     mock_load_system_paasta_config_utils.return_value.get_kube_clusters.return_value = (
         {}
@@ -1337,6 +1339,7 @@ def test_paasta_spark_run_pyspark(
         job_id=None,
         use_web_identity=False,
         uses_bulkdata=True,
+        get_eks_token_via_iam_user=False,
     )
     mock_load_system_paasta_config_utils.return_value.get_kube_clusters.return_value = (
         {}
@@ -1480,6 +1483,7 @@ def test_paasta_spark_run_uses_bulkdata(
         job_id=None,
         use_web_identity=False,
         uses_bulkdata=spark_run_arg_uses_bulkdata,
+        get_eks_token_via_iam_user=False,
     )
     mock_load_system_paasta_config_spark_run.return_value.get_pools_for_cluster.return_value = [
         "test-pool"

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -729,6 +729,7 @@ class TestConfigureAndRunDockerContainer:
         args.docker_memory_limit = False
         args.docker_shm_size = False
         args.use_service_auth_token = False
+        args.get_eks_token_via_iam_user = None
         with mock.patch.object(
             self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
         ):
@@ -756,7 +757,7 @@ class TestConfigureAndRunDockerContainer:
                     "/fake_dir:/spark_driver:rw",
                     "/nail/home:/nail/home:rw",
                     "unique-run:unique-run:rw",
-                    "/etc/kubernetes/spark.conf:/etc/kubernetes/spark.conf:ro",
+                    "/etc/kubernetes:/etc/kubernetes:ro",
                 ]
             ),
             environment={
@@ -801,7 +802,10 @@ class TestConfigureAndRunDockerContainer:
                 "spark.executorEnv.PAASTA_CLUSTER": "test-cluster",
             }
             args = mock.MagicMock(
-                cmd="pyspark", nvidia=True, use_service_auth_token=False
+                cmd="pyspark",
+                nvidia=True,
+                use_service_auth_token=False,
+                get_eks_token_via_iam_user=None,
             )
 
             configure_and_run_docker_container(
@@ -839,7 +843,10 @@ class TestConfigureAndRunDockerContainer:
                 "spark.executorEnv.PAASTA_CLUSTER": "test-cluster",
             }
             args = mock.MagicMock(
-                cmd="python mrjob_wrapper.py", mrjob=True, use_service_auth_token=False
+                cmd="python mrjob_wrapper.py",
+                mrjob=True,
+                use_service_auth_token=False,
+                get_eks_token_via_iam_user=None,
             )
 
             configure_and_run_docker_container(
@@ -868,7 +875,12 @@ class TestConfigureAndRunDockerContainer:
             "paasta_tools.cli.cmds.spark_run.clusterman_metrics", autospec=True
         ):
             mock_create_spark_config_str.return_value = "--conf spark.cores.max=5"
-            args = mock.MagicMock(cmd="bash", mrjob=False, use_service_auth_token=False)
+            args = mock.MagicMock(
+                cmd="bash",
+                mrjob=False,
+                use_service_auth_token=False,
+                get_eks_token_via_iam_user=None,
+            )
 
             configure_and_run_docker_container(
                 args=args,

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -1913,6 +1913,7 @@ def test_paasta_spark_run_with_pod_identity(
         uses_bulkdata=True,
         force_pod_identity=force_pod_identity,
         executor_pod_identity=True,
+        get_eks_token_via_iam_user=False,
     )
     # Use the expected return code to set the allowed iam roles
     if force_pod_identity and not should_exit_early:

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -613,6 +613,7 @@ class TestConfigureAndRunDockerContainer:
         args.docker_memory_limit = "4g"
         args.docker_shm_size = "1g"
         args.use_service_auth_token = False
+        args.get_eks_token_via_iam_user = None
         with mock.patch.object(
             self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
         ):
@@ -639,7 +640,7 @@ class TestConfigureAndRunDockerContainer:
                     "/fake_dir:/spark_driver:rw",
                     "/nail/home:/nail/home:rw",
                     "unique-run:unique-run:rw",
-                    "/etc/kubernetes/spark.conf:/etc/kubernetes/spark.conf:ro",
+                    "/etc/kubernetes:/etc/kubernetes:ro",
                 ]
             ),
             environment={

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -302,7 +302,7 @@ aws_secret_access_key = <foo-secret>
         "paasta_tools.cli.cmds.spark_run.open",
         return_value=io.StringIO(data),
         autospec=None,
-    ) as iam_creds_file:
+    ) as mock_open_iam_creds_file:
         spark_env = spark_run.get_spark_env(
             argparse.Namespace(
                 get_eks_token_via_iam_user=True, aws_region="us-west-2", cmd="sparkling"
@@ -317,7 +317,7 @@ aws_secret_access_key = <foo-secret>
                 "fake_dir",
             ),
         )
-        iam_creds_file.assert_called_once_with(SPARK_DRIVER_K8S_FILE)
+        mock_open_iam_creds_file.assert_called_once_with(SPARK_DRIVER_K8S_FILE)
 
         assert spark_env["GET_EKS_TOKEN_AWS_ACCESS_KEY_ID"] == "<foo-id>"
         assert spark_env["GET_EKS_TOKEN_AWS_SECRET_ACCESS_KEY"] == "<foo-secret>"
@@ -1554,10 +1554,10 @@ def test_paasta_spark_run_re_run_sudo():
         autospec=True,
     ), mock.patch(
         "paasta_tools.cli.cmds.spark_run.os.execvp", autospec=True
-    ) as exec_fn:
+    ) as mock_exec:
         spark_run.paasta_spark_run(args)
-        assert exec_fn.called
-        args, _ = exec_fn.call_args
+        assert mock_exec.called
+        args, _ = mock_exec.call_args
         assert args[0] == "sudo"
 
 
@@ -1622,9 +1622,9 @@ def test_paasta_spark_run_re_run_sudo_as_root(
         autospec=True,
     ), mock.patch(
         "paasta_tools.cli.cmds.spark_run.os.execvp", autospec=True
-    ) as exec_fn:
+    ) as mock_exec:
         spark_run.paasta_spark_run(args)
-        assert not exec_fn.called
+        assert not mock_exec.called
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -33,6 +33,7 @@ from paasta_tools.cli.cmds.spark_run import get_docker_run_cmd
 from paasta_tools.cli.cmds.spark_run import get_smart_paasta_instance_name
 from paasta_tools.cli.cmds.spark_run import get_spark_app_name
 from paasta_tools.cli.cmds.spark_run import sanitize_container_name
+from paasta_tools.cli.cmds.spark_run import SPARK_DRIVER_IAM_USER
 from paasta_tools.utils import BranchDictV2
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import InstanceConfigDict
@@ -41,10 +42,6 @@ from paasta_tools.utils import SystemPaastaConfigDict
 
 
 DUMMY_DOCKER_IMAGE_DIGEST = "MOCK-docker-dev.yelpcorp.com/paasta-spark-run-user@sha256:103ce91c65d42498ca61cdfe8d799fab8ab1c37dac58b743b49ced227bc7bc06"
-
-SPARK_DRIVER_K8S_FILE = (
-    "/nail/etc/spark_driver_k8s_role_assumer/spark_driver_k8s_role_assumer.ini"
-)
 
 
 @mock.patch(
@@ -317,7 +314,7 @@ aws_secret_access_key = <foo-secret>
                 "fake_dir",
             ),
         )
-        mock_open_iam_creds_file.assert_called_once_with(SPARK_DRIVER_K8S_FILE)
+        mock_open_iam_creds_file.assert_called_once_with(SPARK_DRIVER_IAM_USER)
 
         assert spark_env["GET_EKS_TOKEN_AWS_ACCESS_KEY_ID"] == "<foo-id>"
         assert spark_env["GET_EKS_TOKEN_AWS_SECRET_ACCESS_KEY"] == "<foo-secret>"

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import io
 import os
 
 import mock
@@ -202,6 +203,7 @@ def mock_get_possible_launced_by_user_variable_from_env():
                 cmd="jupyter-lab",
                 aws_region="test-region",
                 mrjob=False,
+                get_eks_token_via_iam_user=None,
             ),
             {
                 "JUPYTER_RUNTIME_DIR": "/source/.jupyter",
@@ -216,6 +218,7 @@ def mock_get_possible_launced_by_user_variable_from_env():
                 mrjob=False,
                 spark_args="spark.history.fs.logDirectory=s3a://bucket",
                 work_dir="/first:/second",
+                get_eks_token_via_iam_user=None,
             ),
             {
                 "SPARK_LOG_DIR": "/second",
@@ -229,6 +232,7 @@ def mock_get_possible_launced_by_user_variable_from_env():
                 cmd="spark-submit job.py",
                 aws_region="test-region",
                 mrjob=True,
+                get_eks_token_via_iam_user=None,
             ),
             {},
         ),
@@ -282,6 +286,39 @@ def test_get_spark_env(
         )
         == expected_output
     )
+
+
+def test_get_spark_env_load_iam_creds():
+    data = """
+[default]
+aws_access_key_id = <foo-id>
+aws_secret_access_key = <foo-secret>
+    """
+    with mock.patch(
+        "paasta_tools.cli.cmds.spark_run.open",
+        return_value=io.StringIO(data),
+        autospec=None,
+    ) as iam_creds_file:
+        spark_env = spark_run.get_spark_env(
+            argparse.Namespace(
+                get_eks_token_via_iam_user=True, aws_region="us-west-2", cmd="sparkling"
+            ),
+            "spark-conf-string",
+            (None, None, None),
+            "http://myrandomport",
+            SystemPaastaConfig(
+                SystemPaastaConfigDict(
+                    {"allowed_pools": {"test-cluster": ["test-pool", "fake-pool"]}}
+                ),
+                "fake_dir",
+            ),
+        )
+        iam_creds_file.assert_called_once_with(
+            "/nail/etc/spark_driver_k8s_role_assumer/spark_driver_k8s_role_assumer.ini"
+        )
+
+        assert spark_env["GET_EKS_TOKEN_AWS_ACCESS_KEY_ID"] == "<foo-id>"
+        assert spark_env["GET_EKS_TOKEN_AWS_SECRET_ACCESS_KEY"] == "<foo-secret>"
 
 
 @pytest.mark.parametrize(
@@ -494,6 +531,7 @@ class TestConfigureAndRunDockerContainer:
         args.tronfig = None
         args.job_id = None
         args.use_service_auth_token = False
+        args.get_eks_token_via_iam_user = None
         with mock.patch.object(
             self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
         ):
@@ -520,7 +558,7 @@ class TestConfigureAndRunDockerContainer:
                     "/fake_dir:/spark_driver:rw",
                     "/nail/home:/nail/home:rw",
                     "unique-run:unique-run:rw",
-                    "/etc/kubernetes/spark.conf:/etc/kubernetes/spark.conf:ro",
+                    "/etc/kubernetes:/etc/kubernetes:ro",
                 ]
             ),
             environment={
@@ -609,6 +647,7 @@ class TestConfigureAndRunDockerContainer:
         args.docker_memory_limit = "4g"
         args.docker_shm_size = "1g"
         args.use_service_auth_token = False
+        args.get_eks_token_via_iam_user = None
         with mock.patch.object(
             self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
         ):
@@ -635,7 +674,7 @@ class TestConfigureAndRunDockerContainer:
                     "/fake_dir:/spark_driver:rw",
                     "/nail/home:/nail/home:rw",
                     "unique-run:unique-run:rw",
-                    "/etc/kubernetes/spark.conf:/etc/kubernetes/spark.conf:ro",
+                    "/etc/kubernetes:/etc/kubernetes:ro",
                 ]
             ),
             environment={
@@ -724,6 +763,7 @@ class TestConfigureAndRunDockerContainer:
         args.docker_memory_limit = False
         args.docker_shm_size = False
         args.use_service_auth_token = False
+        args.get_eks_token_via_iam_user = None
         with mock.patch.object(
             self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
         ):
@@ -751,7 +791,7 @@ class TestConfigureAndRunDockerContainer:
                     "/fake_dir:/spark_driver:rw",
                     "/nail/home:/nail/home:rw",
                     "unique-run:unique-run:rw",
-                    "/etc/kubernetes/spark.conf:/etc/kubernetes/spark.conf:ro",
+                    "/etc/kubernetes:/etc/kubernetes:ro",
                 ]
             ),
             environment={
@@ -796,7 +836,10 @@ class TestConfigureAndRunDockerContainer:
                 "spark.executorEnv.PAASTA_CLUSTER": "test-cluster",
             }
             args = mock.MagicMock(
-                cmd="pyspark", nvidia=True, use_service_auth_token=False
+                cmd="pyspark",
+                nvidia=True,
+                use_service_auth_token=False,
+                get_eks_token_via_iam_user=None,
             )
 
             configure_and_run_docker_container(
@@ -834,7 +877,10 @@ class TestConfigureAndRunDockerContainer:
                 "spark.executorEnv.PAASTA_CLUSTER": "test-cluster",
             }
             args = mock.MagicMock(
-                cmd="python mrjob_wrapper.py", mrjob=True, use_service_auth_token=False
+                cmd="python mrjob_wrapper.py",
+                mrjob=True,
+                use_service_auth_token=False,
+                get_eks_token_via_iam_user=None,
             )
 
             configure_and_run_docker_container(
@@ -863,7 +909,12 @@ class TestConfigureAndRunDockerContainer:
             "paasta_tools.cli.cmds.spark_run.clusterman_metrics", autospec=True
         ):
             mock_create_spark_config_str.return_value = "--conf spark.cores.max=5"
-            args = mock.MagicMock(cmd="bash", mrjob=False, use_service_auth_token=False)
+            args = mock.MagicMock(
+                cmd="bash",
+                mrjob=False,
+                use_service_auth_token=False,
+                get_eks_token_via_iam_user=None,
+            )
 
             configure_and_run_docker_container(
                 args=args,
@@ -902,6 +953,7 @@ class TestConfigureAndRunDockerContainer:
             args = mock.MagicMock(
                 cmd="pyspark",
                 use_service_auth_token=True,
+                get_eks_token_via_iam_user=None,
             )
             configure_and_run_docker_container(
                 args=args,

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -497,6 +497,7 @@ class TestConfigureAndRunDockerContainer:
         args.tronfig = None
         args.job_id = None
         args.use_service_auth_token = False
+        args.get_eks_token_via_iam_user = None
         with mock.patch.object(
             self.instance_config, "get_env_dictionary", return_value={"env1": "val1"}
         ):
@@ -523,7 +524,7 @@ class TestConfigureAndRunDockerContainer:
                     "/fake_dir:/spark_driver:rw",
                     "/nail/home:/nail/home:rw",
                     "unique-run:unique-run:rw",
-                    "/etc/kubernetes/spark.conf:/etc/kubernetes/spark.conf:ro",
+                    "/etc/kubernetes:/etc/kubernetes:ro",
                 ]
             ),
             environment={

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -907,6 +907,7 @@ class TestConfigureAndRunDockerContainer:
             args = mock.MagicMock(
                 cmd="pyspark",
                 use_service_auth_token=True,
+                get_eks_token_via_iam_user=None,
             )
             configure_and_run_docker_container(
                 args=args,

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -202,6 +202,7 @@ def mock_get_possible_launced_by_user_variable_from_env():
                 cmd="jupyter-lab",
                 aws_region="test-region",
                 mrjob=False,
+                get_eks_token_via_iam_user=None,
             ),
             {
                 "JUPYTER_RUNTIME_DIR": "/source/.jupyter",
@@ -216,6 +217,7 @@ def mock_get_possible_launced_by_user_variable_from_env():
                 mrjob=False,
                 spark_args="spark.history.fs.logDirectory=s3a://bucket",
                 work_dir="/first:/second",
+                get_eks_token_via_iam_user=None,
             ),
             {
                 "SPARK_LOG_DIR": "/second",
@@ -229,6 +231,7 @@ def mock_get_possible_launced_by_user_variable_from_env():
                 cmd="spark-submit job.py",
                 aws_region="test-region",
                 mrjob=True,
+                get_eks_token_via_iam_user=None,
             ),
             {},
         ),


### PR DESCRIPTION
## Problem
We want to allow reading IAM credentials from a root protected file. So that there's a single point of entry otherwise many other roles can fetch EKS token.

## Changes
- [x] Read root protected file
- [x] Re-run `spark-run` as sudo when given `--get-eks-token-via-iam-user`
- [x] Mount `/etc/kubernetes` directory - will make switching between configs easier
- [x] New paasta config key

### Mounting `/etc/kubernetes`
Currently, only a single file is mounted https://github.com/Yelp/paasta/blob/2e706a1879cbd012ad18f8e3e9324ffa62633cc8/paasta_tools/utils.py#L2736-L2737

Changing that requires changes to `/etc/paasta/spark-run.json` loaded from https://github.com/Yelp/paasta/blob/2e706a1879cbd012ad18f8e3e9324ffa62633cc8/paasta_tools/utils.py#L93-L94

populated via Puppet https://sourcegraph.yelpcorp.com/sysgit/puppet@4c6d259bc8e5cf7c48e75358a010741933591191/-/blob/modules/paasta_tools/manifests/public_config.pp?L501-508

## Verification (Updated Apr 10)
- [x] can `spark-submit` using `/etc/kubernetes/spark.conf` - got expected PATH_NOT_FOUND since S3 object doesn't exist [[cmd](https://fluffy.yelpcorp.com/i/8lKS163j1QVWV5gn95JXrLp658RkdSkZ.html)]
- [x] `spark-submit` with `/etc/kubernetes/spark.conf` fails to fetch credentials if EC2 metadata service is disabled as expected [[cmd](https://fluffy.yelpcorp.com/i/NgwPz6fXlcN3LnkHc4PQsTqHbVrH7SLj.html)]
- [x] can fetch EKS token via loaded ENV vars - got PATH_NOT_FOUND as well [[cmd](https://fluffy.yelpcorp.com/i/mpW1z1g6kgP0bTRxTz8CdtPNjgMPvQTt.html)]
    Config changes to come from https://github.yelpcorp.com/sysgit/puppet/pull/14234
