### PR TITLE
improve cleanup of remote-run job resources

### DIFF
--- a/paasta_tools/api/views/remote_run.py
+++ b/paasta_tools/api/views/remote_run.py
@@ -17,20 +17,18 @@ from pyramid.view import view_config
 
 from paasta_tools.api import settings
 from paasta_tools.api.views.exception import ApiFailure
+from paasta_tools.kubernetes.remote_run import get_max_job_duration_limit
 from paasta_tools.kubernetes.remote_run import remote_run_ready
 from paasta_tools.kubernetes.remote_run import remote_run_start
 from paasta_tools.kubernetes.remote_run import remote_run_stop
 from paasta_tools.kubernetes.remote_run import remote_run_token
-from paasta_tools.utils import load_system_paasta_config
 
 
 DEFAULT_MAX_DURATION = 60 * 60  # 1 hour
-DEFAULT_MAX_DURATION_LIMIT = 8 * 60 * 60  # 8 hours
 
 
 @view_config(route_name="remote_run.start", request_method="POST", renderer="json")
 def view_remote_run_start(request):
-    system_config = load_system_paasta_config()
     service = request.swagger_data["service"]
     instance = request.swagger_data["instance"]
     user = request.swagger_data["json_body"]["user"]
@@ -38,7 +36,7 @@ def view_remote_run_start(request):
     recreate = request.swagger_data["json_body"].get("recreate", False)
     max_duration = min(
         request.swagger_data["json_body"].get("max_duration", DEFAULT_MAX_DURATION),
-        system_config.get_remote_run_duration_limit(DEFAULT_MAX_DURATION_LIMIT),
+        get_max_job_duration_limit(),
     )
     try:
         return remote_run_start(

--- a/paasta_tools/kubernetes/bin/paasta_cleanup_remote_run_resources.py
+++ b/paasta_tools/kubernetes/bin/paasta_cleanup_remote_run_resources.py
@@ -47,7 +47,7 @@ def clean_namespace(
 
     :param KubeClient kube_client: kubernetes client
     :param str namepsace: kubernetes namespace
-    :param datetime creds_age_limit: expiration time for authentication resources
+    :param datetime auth_age_limit: expiration time for authentication resources
     :param datetime job_age_limit: expiration time for job resources
     :param bool dry_run: delete resources for real or not
     """
@@ -122,7 +122,13 @@ def main():
     age_limit = now - timedelta(seconds=args.max_age)
     job_age_limit = now - timedelta(seconds=get_max_job_duration_limit())
     for namespace in get_all_managed_namespaces(kube_client):
-        clean_namespace(kube_client, namespace, age_limit, job_age_limit, args.dry_run)
+        clean_namespace(
+            kube_client,
+            namespace,
+            auth_age_limit=age_limit,
+            job_age_limit=job_age_limit,
+            dry_run=args.dry_run,
+        )
 
 
 if __name__ == "__main__":

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2088,6 +2088,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 metadata=self.get_kubernetes_metadata(git_sha),
                 spec=V1JobSpec(
                     active_deadline_seconds=deadline_seconds,
+                    ttl_seconds_after_finished=0,  # remove job resource after completion
                     template=pod_template,
                 ),
             )

--- a/tests/kubernetes/bin/test_paasta_cleanup_remote_run_resources.py
+++ b/tests/kubernetes/bin/test_paasta_cleanup_remote_run_resources.py
@@ -121,23 +121,23 @@ def test_main(
             call(
                 mock_kube.return_value,
                 "a",
-                datetime(2025, 1, 1, 0, 0, 0),
-                datetime(2024, 12, 31, 23, 1),
-                False,
+                auth_age_limit=datetime(2025, 1, 1, 0, 0, 0),
+                job_age_limit=datetime(2024, 12, 31, 23, 1),
+                dry_run=False,
             ),
             call(
                 mock_kube.return_value,
                 "b",
-                datetime(2025, 1, 1, 0, 0, 0),
-                datetime(2024, 12, 31, 23, 1),
-                False,
+                auth_age_limit=datetime(2025, 1, 1, 0, 0, 0),
+                job_age_limit=datetime(2024, 12, 31, 23, 1),
+                dry_run=False,
             ),
             call(
                 mock_kube.return_value,
                 "c",
-                datetime(2025, 1, 1, 0, 0, 0),
-                datetime(2024, 12, 31, 23, 1),
-                False,
+                auth_age_limit=datetime(2025, 1, 1, 0, 0, 0),
+                job_age_limit=datetime(2024, 12, 31, 23, 1),
+                dry_run=False,
             ),
         ]
     )

--- a/tests/kubernetes/test_remote_run.py
+++ b/tests/kubernetes/test_remote_run.py
@@ -32,6 +32,7 @@ from paasta_tools.kubernetes.remote_run import create_pod_scoped_role
 from paasta_tools.kubernetes.remote_run import create_remote_run_service_account
 from paasta_tools.kubernetes.remote_run import create_temp_exec_token
 from paasta_tools.kubernetes.remote_run import find_job_pod
+from paasta_tools.kubernetes.remote_run import get_remote_run_jobs
 from paasta_tools.kubernetes.remote_run import get_remote_run_role_bindings
 from paasta_tools.kubernetes.remote_run import get_remote_run_roles
 from paasta_tools.kubernetes.remote_run import remote_run_ready
@@ -365,4 +366,13 @@ def test_get_remote_run_role_bindings():
     get_remote_run_role_bindings(mock_client, "namespace")
     mock_client.rbac.list_namespaced_role_binding.assert_called_once_with(
         "namespace", label_selector="paasta.yelp.com/pod_owner"
+    )
+
+
+def test_get_remote_run_jobs():
+    mock_client = MagicMock()
+    get_remote_run_jobs(mock_client, "namespace")
+    mock_client.batches.list_namespaced_job.assert_called_once_with(
+        "namespace",
+        label_selector=f"paasta.yelp.com/job_type=remote-run",
     )

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1510,6 +1510,7 @@ class TestKubernetesDeploymentConfig:
                 metadata=mock_get_kubernetes_metadata.return_value,
                 spec=V1JobSpec(
                     active_deadline_seconds=100,
+                    ttl_seconds_after_finished=0,
                     template=mock_get_pod_template_spec.return_value,
                 ),
             )


### PR DESCRIPTION
`paasta remote-run` works fine now, but I noticed that unless people call `paasta remote-run stop` explicitly, the `job` resource would remain defined forever, even if the pod is terminated by the deadline being reached.

Tackling that on two different angles:
* Setting `ttl_seconds_after_finished` in the job spec should ensure that when the pod completes, the job gets cleaned up too by k8s itself.
* Adding jobs to the resources cleaned up by the cleanup script, but using the max duration as the age limit for that. Just in case k8s does not to the above correctly.