### PR TITLE
remote-run: use k8s conf from environment

### DIFF
--- a/paasta_tools/kubernetes/remote_run.py
+++ b/paasta_tools/kubernetes/remote_run.py
@@ -93,7 +93,7 @@ def remote_run_start(
     :param int max_duration: maximum allowed duration for the remote-ruh job
     :return: outcome of the operation, and resulting Kubernetes pod information
     """
-    kube_client = KubeClient(config_file="/etc/kubernetes/admin.conf")
+    kube_client = KubeClient()
 
     # Load the service deployment settings
     deployment_config = load_eks_service_config(service, instance, cluster)
@@ -149,7 +149,7 @@ def remote_run_ready(
     :param str job_name: name of the remote-run job to check
     :return: job status, with pod info
     """
-    kube_client = KubeClient(config_file="/etc/kubernetes/admin.conf")
+    kube_client = KubeClient()
 
     # Load the service deployment settings
     deployment_config = load_eks_service_config(service, instance, cluster)
@@ -182,7 +182,7 @@ def remote_run_stop(
     :param str user: the user requesting the remote-run sandbox
     :return: outcome of the operation
     """
-    kube_client = KubeClient(config_file="/etc/kubernetes/admin.conf")
+    kube_client = KubeClient()
 
     # Load the service deployment settings
     deployment_config = load_eks_service_config(service, instance, cluster)
@@ -216,7 +216,7 @@ def remote_run_token(
     :param str cluster: paasta cluster
     :param str user: the user requesting the remote-run sandbox
     """
-    kube_client = KubeClient(config_file="/etc/kubernetes/admin.conf")
+    kube_client = KubeClient()
 
     # Load the service deployment settings
     deployment_config = load_eks_service_config(service, instance, cluster)


### PR DESCRIPTION
As promised in https://github.com/Yelp/paasta/pull/4022#discussion_r2000670059.

This can only be shipped once the paasta-api permissions have been updated.