### PR TITLE
Added code to take spark driver pool from config

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -698,7 +698,7 @@ class TronActionConfig(InstanceConfig):
         which this function will read.
         """
         if self.get_executor() == "spark":
-            pool = load_system_paasta_config().get_spark_driver_default_pool_override()
+            pool = load_system_paasta_config().get_default_spark_driver_pool_override()
         else:
             pool = self.config_dict.get(
                 "pool", load_system_paasta_config().get_tron_default_pool_override()

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -697,13 +697,14 @@ class TronActionConfig(InstanceConfig):
         override this value. To control this, we have an optional config item that we'll puppet onto Tron masters
         which this function will read.
         """
-        return (
-            self.config_dict.get(
+        if self.get_executor() == "spark":
+            pool = load_system_paasta_config().get_spark_driver_default_pool_override()
+        else:
+            pool = self.config_dict.get(
                 "pool", load_system_paasta_config().get_tron_default_pool_override()
             )
-            if not self.get_executor() == "spark"
-            else spark_tools.SPARK_DRIVER_POOL
-        )
+
+        return pool
 
     def get_spark_executor_pool(self) -> str:
         return self.config_dict.get("pool", DEFAULT_SPARK_EXECUTOR_POOL)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -123,6 +123,10 @@ DEFAULT_CPU_BURST_ADD = 1
 
 DEFAULT_SOA_CONFIGS_GIT_URL = "sysgit.yelpcorp.com"
 
+# To ensure the Spark driver not being interrupted due to spot instances,
+# we use stable pool for drivers
+DEFAULT_SPARK_DRIVER_POOL = "stable"
+
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
@@ -2045,6 +2049,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     enable_automated_redeploys_default: bool
     enable_tron_tsc: bool
     default_spark_iam_user: str
+    spark_driver_default_pool_override: str
 
 
 def load_system_paasta_config(
@@ -2146,6 +2151,15 @@ class SystemPaastaConfig:
     def get_default_spark_iam_user(self) -> str:
         return self.config_dict.get(
             "default_spark_iam_user", "/etc/boto_cfg/mrjob.yaml"
+        )
+
+    def get_spark_driver_default_pool_override(self) -> str:
+        """Get the spark driver's default pool override variable defined in this host's cluster config file.
+
+        :returns: The spark_driver_default_pool_override specified in the paasta configuration
+        """
+        return self.config_dict.get(
+            "spark_driver_default_pool_override", DEFAULT_SPARK_DRIVER_POOL
         )
 
     def get_sidecar_requirements_config(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2153,15 +2153,15 @@ class SystemPaastaConfig:
             "default_spark_iam_user", "/etc/boto_cfg/mrjob.yaml"
         )
 
-    def get_spark_driver_default_pool_override(self) -> str:
+    def get_default_spark_driver_pool_override(self) -> str:
         """
         If defined, fetches the override for what pool to run a Spark driver in.
         Otherwise, returns the default Spark driver pool.
 
-        :returns: The spark_driver_default_pool_override specified in the paasta configuration
+        :returns: The default_spark_driver_pool_override specified in the paasta configuration
         """
         return self.config_dict.get(
-            "spark_driver_default_pool_override", DEFAULT_SPARK_DRIVER_POOL
+            "default_spark_driver_pool_override", DEFAULT_SPARK_DRIVER_POOL
         )
 
     def get_sidecar_requirements_config(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2049,7 +2049,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     enable_automated_redeploys_default: bool
     enable_tron_tsc: bool
     default_spark_iam_user: str
-    spark_driver_default_pool_override: str
+    default_spark_driver_pool_override: str
 
 
 def load_system_paasta_config(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2154,7 +2154,9 @@ class SystemPaastaConfig:
         )
 
     def get_spark_driver_default_pool_override(self) -> str:
-        """Get the spark driver's default pool override variable defined in this host's cluster config file.
+        """
+        If defined, fetches the override for what pool to run a Spark driver in.
+        Otherwise, returns the default Spark driver pool.
 
         :returns: The spark_driver_default_pool_override specified in the paasta configuration
         """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -433,13 +433,13 @@ def test_SystemPaastaConfig_get_tron_default_pool_override():
     argvalues=[
         pytest.param({}, DEFAULT_SPARK_DRIVER_POOL, id="default"),
         pytest.param(
-            {"spark_driver_default_pool_override": "spam-stable"},
+            {"default_spark_driver_pool_override": "spam-stable"},
             "spam-stable",
             id="spam",
         ),
     ],
 )
-def test_SystemPaastaConfig_get_spark_driver_default_pool_override(
+def test_SystemPaastaConfig_get_default_spark_driver_pool_override(
     paasta_config, expected_pool
 ):
     fake_config = utils.SystemPaastaConfig(
@@ -447,7 +447,7 @@ def test_SystemPaastaConfig_get_spark_driver_default_pool_override(
         "/some/fake/dir",
     )
 
-    actual_pool = fake_config.get_spark_driver_default_pool_override()
+    actual_pool = fake_config.get_default_spark_driver_pool_override()
 
     assert actual_pool == expected_pool
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,7 @@ from freezegun import freeze_time
 from pytest import raises
 
 from paasta_tools import utils
+from paasta_tools.utils import DEFAULT_SPARK_DRIVER_POOL
 from paasta_tools.utils import PoolsNotConfiguredError
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import SystemPaastaConfigDict
@@ -425,6 +426,30 @@ def test_SystemPaastaConfig_get_tron_default_pool_override():
     actual = fake_config.get_tron_default_pool_override()
     expected = "spam"
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    argnames=["paasta_config", "expected_pool"],
+    argvalues=[
+        pytest.param({}, DEFAULT_SPARK_DRIVER_POOL, id="default"),
+        pytest.param(
+            {"spark_driver_default_pool_override": "spam-stable"},
+            "spam-stable",
+            id="spam",
+        ),
+    ],
+)
+def test_SystemPaastaConfig_get_spark_driver_default_pool_override(
+    paasta_config, expected_pool
+):
+    fake_config = utils.SystemPaastaConfig(
+        paasta_config,
+        "/some/fake/dir",
+    )
+
+    actual_pool = fake_config.get_spark_driver_default_pool_override()
+
+    assert actual_pool == expected_pool
 
 
 def test_SystemPaastaConfig_get_hacheck_sidecar_volumes():


### PR DESCRIPTION
### Problem
Currently, the pool that the Spark driver of _driver on k8s tron jobs_ runs on is hardcoded to **_stable_** pool, to ensure the Spark driver not being interrupted due to spot interruptions.
 
However, in some cases, jobs need to pull images from the other docker registry which does not work in the stable pool. We need to make the driver pool configurable.

### Solution
Add the code to consider spark driver pool from config (if available) otherwise default to stable

### Testing
Unit tests