### PR TITLE
COMPINFRA-4866: restrict alert_after values for tron/k8s

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -1012,7 +1012,7 @@ Here is a list of options that PaaSTA will pass through:
 
  * ``alert_after``: Time string that represents how long a a check should be
    failing before an actual alert should be fired. Currently defaults to ``10m``
-   for the replication alert.
+   for the replication alert. See `pysensu-yelp documentation<https://pysensu-yelp.readthedocs.io/en/latest/#pysensu_yelp.human_to_seconds>` for accepted formats.
 
  * ``realert_every``: An integer (not a time unit) representing how many checks
    to execute between sending alerts. The default settings is ``-1``, which is

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -504,9 +504,17 @@
                             "type": "boolean"
                         },
                         "alert_after": {
-                            "type": "string",
-                            "pattern": "^[1-9]+[0-9]*[YMWDhms]$",
-                            "$comment": "See https://pysensu-yelp.readthedocs.io/en/latest/#pysensu_yelp.human_to_seconds"
+                            "oneOf": [
+                                {
+                                    "type": "string",
+                                    "pattern": "^[1-9]+[0-9]*[YMWDhms]$",
+                                    "$comment": "See https://pysensu-yelp.readthedocs.io/en/latest/#pysensu_yelp.human_to_seconds"
+                                },
+                                {
+                                    "type": "integer",
+                                    "minimum": 0
+                                }
+                            ]
                         }
                     },
                     "additionalProperties": true

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -502,6 +502,11 @@
                         },
                         "page": {
                             "type": "boolean"
+                        },
+                        "alert_after": {
+                            "type": "string",
+                            "pattern": "^[1-9]+[0-9]*[YMWDhms]$",
+                            "$comment": "See https://pysensu-yelp.readthedocs.io/en/latest/#pysensu_yelp.human_to_seconds"
                         }
                     },
                     "additionalProperties": true

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -622,9 +622,17 @@
                             "type": "string"
                         },
                         "alert_after": {
-                            "type": "string",
-                            "pattern": "^[1-9]+[0-9]*[YMWDhms]$",
-                            "$comment": "See https://pysensu-yelp.readthedocs.io/en/latest/#pysensu_yelp.human_to_seconds"
+                            "oneOf": [
+                                {
+                                    "type": "string",
+                                    "pattern": "^[1-9]+[0-9]*[YMWDhms]$",
+                                    "$comment": "See https://pysensu-yelp.readthedocs.io/en/latest/#pysensu_yelp.human_to_seconds"
+                                },
+                                {
+                                    "type": "integer",
+                                    "minimum": 0
+                                }
+                            ]
                         },
                         "check_that_every_day_has_a_successful_run": {
                             "type": "boolean"

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -622,7 +622,9 @@
                             "type": "string"
                         },
                         "alert_after": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^[1-9]+[0-9]*[YMWDhms]$",
+                            "$comment": "See https://pysensu-yelp.readthedocs.io/en/latest/#pysensu_yelp.human_to_seconds"
                         },
                         "check_that_every_day_has_a_successful_run": {
                             "type": "boolean"


### PR DESCRIPTION
This adds some extra validation for `alert_after` in tron and kubernetes/eks monitoring configs. 

Originally had hoped to create a monitoring.yaml schema + reuse definitions from within in each of these but we have some tooling that assumes each jsonschema here is self-contained so i'll need to detangle that before going that route.

For now, to prevent recurrences of these `1d` issues, this just adds individually to the separate schemas. 

new paasta validate would have caught this issue in both a tron-* and eks-* file: https://fluffy.yelpcorp.com/i/lXHsCt04BRWq9kBNjhKmq7QfBLcrfjZW.html

and am currently running validate against all services to ensure this doesn't catch anything else surprising that already exists. 
^ whoops, this caught that some folks are using a bare num of seconds for their alert_after, which both paasta + pysensu accept right now, so I've also adjusted the schema to accept either of these