### PR TITLE
Use 22.04 GHA runners (+ always use py3.8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   tox:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -33,7 +33,7 @@ jobs:
       - run: pip install -r requirements-gha.txt
       - run: tox -e ${{ matrix.toxenv }}
   k8s_itests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       DOCKER_REGISTRY: ""
     steps:
@@ -47,7 +47,7 @@ jobs:
       - run: pip install coveralls tox==3.2 tox-pip-extensions==1.3.0 ephemeral-port-reserve
       - run: make k8s_itests
   build_debs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-gha.txt
       - run: tox -e ${{ matrix.toxenv }}
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - run: python -m pip install --upgrade pip virtualenv
       - run: curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
       - run: python -m pip install --upgrade pip
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - run: sudo apt-get update
       - run: sudo apt-get install -yq devscripts
       - run: make itest_${{ matrix.dist }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tox:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -28,7 +28,7 @@ jobs:
   pypi:
     # lets run tests before we push anything to pypi, much like we do internally
     needs: tox
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       DOCKER_REGISTRY: ""
     steps:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-gha.txt
       - run: tox -e ${{ matrix.toxenv }}
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       # this will create a .tar.gz with all the code (i.e., an sdist)
       - run: python setup.py sdist
       # and finally, upload the above sdist to public PyPI

--- a/debian/rules
+++ b/debian/rules
@@ -22,7 +22,8 @@ override_dh_virtualenv:
 	dh_virtualenv \
         --python=/usr/bin/python3.8 \
 		--preinstall no-manylinux1 \
-		--preinstall=-rrequirements-bootstrap.txt
+		--preinstall=-rrequirements-bootstrap.txt \
+		--extra-pip-arg --only-binary=grpcio
 	cp yelp_package/gopath/paasta_go $(DH_VENV_DIR)/bin/paasta_go
 	@echo patching k8s client lib
 	patch $(DH_VENV_DIR)/lib/python3.8/site-packages/kubernetes/client/api_client.py contrib/python-k8s-client.diff

--- a/debian/rules
+++ b/debian/rules
@@ -22,8 +22,7 @@ override_dh_virtualenv:
 	dh_virtualenv \
         --python=/usr/bin/python3.8 \
 		--preinstall no-manylinux1 \
-		--preinstall=-rrequirements-bootstrap.txt \
-		--extra-pip-arg --only-binary=grpcio
+		--preinstall=-rrequirements-bootstrap.txt
 	cp yelp_package/gopath/paasta_go $(DH_VENV_DIR)/bin/paasta_go
 	@echo patching k8s client lib
 	patch $(DH_VENV_DIR)/lib/python3.8/site-packages/kubernetes/client/api_client.py contrib/python-k8s-client.diff

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,6 +89,7 @@ retry==0.9.2
 rfc3987==1.3.7
 rsa==4.7.2
 ruamel.yaml==0.17.35
+ruamel.yaml.clib==0.2.8
 s3transfer==0.10.0
 sensu-plugin==0.3.1
 service-configuration-lib==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ requests-oauthlib==1.2.0
 retry==0.9.2
 rfc3987==1.3.7
 rsa==4.7.2
-ruamel.yaml==0.15.96
+ruamel.yaml==0.17.35
 s3transfer==0.10.0
 sensu-plugin==0.3.1
 service-configuration-lib==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ requests-oauthlib==1.2.0
 retry==0.9.2
 rfc3987==1.3.7
 rsa==4.7.2
-ruamel.yaml==0.17.35
+ruamel.yaml==0.16.12
 ruamel.yaml.clib==0.2.8
 s3transfer==0.10.0
 sensu-plugin==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -122,4 +122,4 @@ ws4py==0.5.1
 wsgicors==0.7.0
 yarl==1.1.1
 zope.deprecation==4.2.0
-zope.interface==4.1.2
+zope.interface==4.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ python-utils==2.0.1
 pytimeparse==1.1.5
 pytz==2016.10
 pyyaml==6.0.1
-repoze.lru==0.6
+repoze.lru==0.7
 requests==2.25.0
 requests-cache==0.6.3
 requests-oauthlib==1.2.0


### PR DESCRIPTION
GitHub is deprecating the 20.04 runners, and for some reason we're setting up py3.7 even though we're expecting 3.8.

Note: this required some packages bump: for some reason, `check-requirements` was reporting
that not all packages were installed -- even though the preceding tox loglines reported that
the "missing" packages were installed.

I tried to be pretty conservative with the bumps since we need to do a mass-upgrade at some
point in the future and it wasn't worth dealing with breaking changes and whatnot at the 
moment