### PR TITLE
fix terminal size in remote-run interactive sessions

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
-import pty
-import shlex
 import time
 
 from paasta_tools.cli.utils import get_paasta_oapi_api_clustername
 from paasta_tools.cli.utils import get_paasta_oapi_client_with_auth
 from paasta_tools.cli.utils import lazy_choices_completer
+from paasta_tools.cli.utils import run_interactive_cli
 from paasta_tools.paastaapi.model.remote_run_start import RemoteRunStart
 from paasta_tools.paastaapi.model.remote_run_stop import RemoteRunStop
 from paasta_tools.utils import get_username
@@ -96,7 +95,7 @@ def paasta_remote_run_start(
         pod=poll_response.pod_name,
         token=token_response.token,
     )
-    pty.spawn(shlex.split(exec_command))
+    run_interactive_cli(exec_command)
     return 0
 
 

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -18,8 +18,10 @@ import getpass
 import hashlib
 import logging
 import os
+import pty
 import random
 import re
+import shutil
 import socket
 import subprocess
 from collections import defaultdict
@@ -1150,3 +1152,20 @@ def get_paasta_oapi_client_with_auth(
         http_res=http_res,
         auth_token=get_sso_service_auth_token(),
     )
+
+
+def run_interactive_cli(cmd: str, shell: str = "bash", term: str = "xterm-256color"):
+    """Runs interactive command in a pseudo terminal, handling terminal size management
+
+    :param str cmd: shell command
+    :param str shell: shell utility to use as wrapper
+    :param str term: terminal type
+    """
+    cols, rows = shutil.get_terminal_size()
+    wrapped_cmd = (
+        f"export SHELL={shell};"
+        f"export TERM={term};"
+        f"stty columns {cols} rows {rows};"
+        f"exec {cmd}"
+    )
+    pty.spawn([shell, "-c", wrapped_cmd])

--- a/tests/cli/test_cmds_remote_run.py
+++ b/tests/cli/test_cmds_remote_run.py
@@ -27,12 +27,12 @@ from paasta_tools.paastaapi.model.remote_run_stop import RemoteRunStop
     autospec=True,
 )
 @patch("paasta_tools.cli.cmds.remote_run.time", autospec=True)
-@patch("paasta_tools.cli.cmds.remote_run.pty", autospec=True)
+@patch("paasta_tools.cli.cmds.remote_run.run_interactive_cli", autospec=True)
 @patch(
     "paasta_tools.cli.cmds.remote_run.get_paasta_oapi_client_with_auth",
     autospec=True,
 )
-def test_paasta_remote_run_start(mock_get_client, mock_pty, mock_time, _):
+def test_paasta_remote_run_start(mock_get_client, mock_run_cli, mock_time, _):
     mock_config = MagicMock()
     mock_args = MagicMock(
         service="foo",
@@ -70,19 +70,8 @@ def test_paasta_remote_run_start(mock_get_client, mock_pty, mock_time, _):
     mock_client.remote_run.remote_run_token.assert_called_once_with(
         "foo", "bar", "pippo"
     )
-    mock_pty.spawn.assert_called_once_with(
-        [
-            "kubectl-eks-dev",
-            "--token",
-            "aaabbbccc",
-            "exec",
-            "-it",
-            "-n",
-            "svcfoo",
-            "foobar-123",
-            "--",
-            "/bin/bash",
-        ]
+    mock_run_cli.assert_called_once_with(
+        "kubectl-eks-dev --token aaabbbccc exec -it -n svcfoo foobar-123 -- /bin/bash",
     )
 
 


### PR DESCRIPTION
Because I'm not a huge fan of being stuck into an 80x24 size by default.

This is not dynamic, so if people resize their terminal window it'll break, but being able to react to that would be a huge pain, so going for a minimum viable product as a starting point.