### PR TITLE
PAASTA-18666: Include backends from all locations in backeds from mesh status

### DIFF
--- a/paasta_tools/instance/kubernetes.py
+++ b/paasta_tools/instance/kubernetes.py
@@ -294,7 +294,11 @@ async def get_backends_from_mesh_status(
 ) -> Set[str]:
     status = await mesh_status_task
     if status.get("locations"):
-        backends = {be["address"] for be in status["locations"][0].get("backends", [])}
+        backends = {
+            be["address"]
+            for location in status["locations"]
+            for be in location.get("backends", [])
+        }
     else:
         backends = set()
 

--- a/tests/instance/test_kubernetes.py
+++ b/tests/instance/test_kubernetes.py
@@ -914,6 +914,21 @@ def test_kubernetes_mesh_status_error(
     assert mock_mesh_status.call_args_list == []
 
 
+@pytest.mark.asyncio
+async def test_backends_from_mesh_status():
+    mock_mesh_status = {
+        "locations": [
+            {"backends": [{"address": "1.1.1.1"}, {"address": "1.2.2.2"}]},
+            {"backends": [{"address": "1.1.1.1"}, {"address": "2.2.2.2"}]},
+        ]
+    }
+
+    mesh_status_task = wrap_value_in_task(mock_mesh_status)
+
+    backends = await pik.get_backends_from_mesh_status(mesh_status_task)
+    assert backends == {"1.1.1.1", "1.2.2.2", "2.2.2.2"}
+
+
 def test_bounce_status():
     with asynctest.patch(
         "paasta_tools.instance.kubernetes.kubernetes_tools", autospec=True


### PR DESCRIPTION
## Problem
We allow people to control the advertisement of replicas in smartstack namespaces, and we allow people to have multiple paasta instances registering to the same namespace, and we allow people to control what locations their paasta instances run in.

To gather mesh status, we collect the backends registered and group them by 'location'.  However, we then assumed all backends would appear in each 'location', which is not the case when advertising is restricted to 'habitat', for example -- mesh status would report each habitat separately, and backends from each habitat would be the only ones included. 

Normally, when advertised at the region level (our default) or above, all backends do appear in each habitat 'location' key, but advertising at the habitat level is still a valid configuration.

Because of this assumption, only backends in the first 'location' would ever be counted, and any paasta instances with backends in other locations would report as 'UNREACHABLE' and pods marked with `mesh_ready = False` ([code](https://github.com/Yelp/paasta/blob/master/paasta_tools/instance/kubernetes.py#L882) ) , regardless of actual status in the mesh. 

## Solution
This now makes sure the full set of reported 'backends' includes those from _all_ locations found, not just the first one. 

## Testing

Added a small unit test to verify this behavior, but also running this version now reports the correct status for a paasta instance which matches this scenario.

```
## Old behavior - shows all pods as mesh_reaady = false
$ curl "http://api.norcal-devc.paasta:5054/v1/services/clb/main_uswest1c/status?new=1" | jq '.kubernetes_v2.versions[].pods[].mesh_ready'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5138  100  5138    0     0  11427      0 --:--:-- --:--:-- --:--:-- 11417
false
false
false

## New behavior -- correctly shows pods as mesh_ready = true
$ curl "http://0.0.0.0:41893/v1/services/clb/main_uswest1c/status?new=1" | jq '.kubernetes_v2.versions[].pods[].mesh_ready'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5135  100  5135    0     0   2905      0  0:00:01  0:00:01 --:--:--  2904
true
true
true
```