### PR TITLE
Catch 409 errors and support non-eks-prefixed clusters

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -15,6 +15,7 @@
 import argparse
 import pty
 import shlex
+import shutil
 import time
 
 from paasta_tools.cli.utils import get_paasta_oapi_api_clustername
@@ -30,7 +31,7 @@ from paasta_tools.utils import SystemPaastaConfig
 
 
 KUBECTL_CMD_TEMPLATE = (
-    "kubectl-eks-{cluster} --token {token} exec -it -n {namespace} {pod} -- /bin/bash"
+    "{kubectl_wrapper} --token {token} exec -it -n {namespace} {pod} -- /bin/bash"
 )
 
 
@@ -90,8 +91,11 @@ def paasta_remote_run_start(
         args.service, args.instance, user
     )
 
+    kubectl_wrapper = f"kubectl-eks-{args.cluster}"
+    if not shutil.which(kubectl_wrapper):
+        kubectl_wrapper = f"kubectl-{args.cluster}"
     exec_command = KUBECTL_CMD_TEMPLATE.format(
-        cluster=args.cluster,
+        kubectl_wrapper=kubectl_wrapper,
         namespace=poll_response.namespace,
         pod=poll_response.pod_name,
         token=token_response.token,

--- a/paasta_tools/kubernetes/remote_run.py
+++ b/paasta_tools/kubernetes/remote_run.py
@@ -374,7 +374,11 @@ def create_pod_scoped_role(
             labels={POD_OWNER_LABEL: user},
         ),
     )
-    kube_client.rbac.create_namespaced_role(namespace=namespace, body=role)
+    try:
+        kube_client.rbac.create_namespaced_role(namespace=namespace, body=role)
+    except ApiException as e:
+        if e.status != 409:
+            raise
     return role_name
 
 
@@ -411,10 +415,14 @@ def bind_role_to_service_account(
             ),
         ],
     )
-    kube_client.rbac.create_namespaced_role_binding(
-        namespace=namespace,
-        body=role_binding,
-    )
+    try:
+        kube_client.rbac.create_namespaced_role_binding(
+            namespace=namespace,
+            body=role_binding,
+        )
+    except ApiException as e:
+        if e.status != 409:
+            raise
 
 
 def get_remote_run_roles(kube_client: KubeClient, namespace: str) -> List[V1Role]:


### PR DESCRIPTION
1. Handle 409 errors, which you'd otherwise get for both of these commands when trying to start on an existing job
2. Support clusters that don't have an extra "eks-" in the wrapper 