### PR TITLE
[rfc] add AWS app id to services env variables

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1198,6 +1198,13 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "git_sha", ""
         )
 
+        # Our workloads interact with AWS quite a lot, so it comes handy to
+        # propagate an "application ID" in the user-agent of API requests
+        # for debugging purposes (max length is 50 chars from AWS docs).
+        # TODO: temporarily setting this here rather than in `InstanceConfig`
+        # to only affect long running services.
+        env["AWS_SDK_UA_APP_ID"] = f"{self.service}.{self.instance}"[:50]
+
         # We drop PAASTA_CLUSTER here because it will be added via `get_kubernetes_environment()`
         env.pop("PAASTA_CLUSTER", None)
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -794,6 +794,7 @@ class TestKubernetesDeploymentConfig:
             assert self.deployment.get_env() == {
                 "hello": "world",
                 "PAASTA_SOA_CONFIGS_SHA": "fake_soa_git_sha",
+                "AWS_SDK_UA_APP_ID": "kurupt.fm",
             }
 
     def test_get_container_env(self):
@@ -4440,7 +4441,7 @@ def test_warning_big_bounce_default_config():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config1c7deb78"
+            == "config8031ca07"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 
@@ -4486,7 +4487,7 @@ def test_warning_big_bounce_routable_pod():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config45672f04"
+            == "configae0706b5"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every smartstack-registered service to bounce!"
 
 
@@ -4533,7 +4534,7 @@ def test_warning_big_bounce_common_config():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "configa4afe5c4"
+            == "config17be5e89"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 


### PR DESCRIPTION
This is something that popped into Infrasec's conversations lately, as sometimes it's a bit hard to attribute specific AWS log events to service instances, [and since it's possible to inject identifiers into the User-Agent set by various AWS SDKs](https://docs.aws.amazon.com/sdkref/latest/guide/feature-appid.html), it'd be nice to get that by default from PaaSTA.

~I wouldn't want this to bump all services at the same time, nor to have to roll it out manually service-by-service with a feature flag, so I'd propose to temporarily exclude the env var form the config hash calculations, let some time pass so that services are redeployed naturally, and then clean up the exclusion. I care less about Tron deployments, since that'd be a single large update to job configs, but no disruption for stuff currently running.~

**RELEASING THIS WILL CAUSE ALL SERVICES TO BOUNCE** ([see conversation below](https://github.com/Yelp/paasta/pull/4052#discussion_r2060466965))