### PR TITLE
add auth support for Tron client

### DIFF
--- a/paasta_tools/cli/authentication.py
+++ b/paasta_tools/cli/authentication.py
@@ -1,0 +1,77 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from functools import lru_cache
+
+from botocore.credentials import InstanceMetadataFetcher
+from botocore.credentials import InstanceMetadataProvider
+
+from paasta_tools.utils import load_system_paasta_config
+
+
+try:
+    from vault_tools.paasta_secret import get_client as get_vault_client
+    from vault_tools.paasta_secret import get_vault_url
+    from vault_tools.paasta_secret import get_vault_ca
+    from okta_auth import get_and_cache_jwt_default
+except ImportError:
+
+    def get_vault_client(url: str, capath: str) -> None:
+        pass
+
+    def get_vault_url(ecosystem: str) -> str:
+        return ""
+
+    def get_vault_ca(ecosystem: str) -> str:
+        return ""
+
+    def get_and_cache_jwt_default(client_id: str) -> str:
+        return ""
+
+
+def get_current_ecosystem() -> str:
+    """Get current ecosystem from host configs, defaults to dev if no config is found"""
+    try:
+        with open("/nail/etc/ecosystem") as f:
+            return f.read().strip()
+    except IOError:
+        pass
+    return "devc"
+
+
+@lru_cache(maxsize=1)
+def get_service_auth_token() -> str:
+    """Uses instance profile to authenticate with Vault and generate token for service authentication"""
+    ecosystem = get_current_ecosystem()
+    vault_client = get_vault_client(get_vault_url(ecosystem), get_vault_ca(ecosystem))
+    vault_role = load_system_paasta_config().get_service_auth_vault_role()
+    metadata_provider = InstanceMetadataProvider(
+        iam_role_fetcher=InstanceMetadataFetcher(),
+    )
+    instance_credentials = metadata_provider.load().get_frozen_credentials()
+    vault_client.auth.aws.iam_login(
+        instance_credentials.access_key,
+        instance_credentials.secret_key,
+        instance_credentials.token,
+        mount_point="aws-iam",
+        role=vault_role,
+        use_token=True,
+    )
+    response = vault_client.secrets.identity.generate_signed_id_token(name=vault_role)
+    return response["data"]["token"]
+
+
+def get_sso_service_auth_token() -> str:
+    """Generate an authentication token for the calling user from the Single Sign On provider"""
+    client_id = load_system_paasta_config().get_service_auth_sso_oidc_client_id()
+    return get_and_cache_jwt_default(client_id)

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -34,12 +34,12 @@ from docker import errors
 from mypy_extensions import TypedDict
 
 from paasta_tools.adhoc_tools import get_default_interactive_config
+from paasta_tools.cli.authentication import get_service_auth_token
+from paasta_tools.cli.authentication import get_sso_service_auth_token
 from paasta_tools.cli.cmds.check import makefile_responds_to
 from paasta_tools.cli.cmds.cook_image import paasta_cook_image
 from paasta_tools.cli.utils import figure_out_service_name
 from paasta_tools.cli.utils import get_instance_config
-from paasta_tools.cli.utils import get_service_auth_token
-from paasta_tools.cli.utils import get_sso_service_auth_token
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import pick_random_port

--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -26,10 +26,10 @@ from service_configuration_lib.spark_config import get_resources_requested
 from service_configuration_lib.spark_config import get_spark_hourly_cost
 from service_configuration_lib.spark_config import UnsupportedClusterManagerException
 
+from paasta_tools.cli.authentication import get_service_auth_token
 from paasta_tools.cli.cmds.check import makefile_responds_to
 from paasta_tools.cli.cmds.cook_image import paasta_cook_image
 from paasta_tools.cli.utils import get_instance_config
-from paasta_tools.cli.utils import get_service_auth_token
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import list_instances
 from paasta_tools.clusterman import get_clusterman_metrics

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -39,8 +39,6 @@ from typing import Set
 from typing import Tuple
 
 import ephemeral_port_reserve
-from botocore.credentials import InstanceMetadataFetcher
-from botocore.credentials import InstanceMetadataProvider
 from mypy_extensions import NamedArg
 
 from paasta_tools import remote_git
@@ -48,6 +46,7 @@ from paasta_tools.adhoc_tools import load_adhoc_job_config
 from paasta_tools.api.client import get_paasta_oapi_client
 from paasta_tools.api.client import PaastaOApiClient
 from paasta_tools.cassandracluster_tools import load_cassandracluster_instance_config
+from paasta_tools.cli.authentication import get_sso_service_auth_token
 from paasta_tools.eks_tools import EksDeploymentConfig
 from paasta_tools.eks_tools import load_eks_service_config
 from paasta_tools.flink_tools import load_flink_instance_config
@@ -80,25 +79,6 @@ from paasta_tools.utils import PAASTA_K8S_INSTANCE_TYPES
 from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import validate_service_instance
-
-try:
-    from vault_tools.paasta_secret import get_client as get_vault_client
-    from vault_tools.paasta_secret import get_vault_url
-    from vault_tools.paasta_secret import get_vault_ca
-    from okta_auth import get_and_cache_jwt_default
-except ImportError:
-
-    def get_vault_client(url: str, capath: str) -> None:
-        pass
-
-    def get_vault_url(ecosystem: str) -> str:
-        return ""
-
-    def get_vault_ca(ecosystem: str) -> str:
-        return ""
-
-    def get_and_cache_jwt_default(client_id: str) -> str:
-        return ""
 
 
 log = logging.getLogger(__name__)
@@ -1102,43 +1082,6 @@ def get_paasta_oapi_api_clustername(cluster: str, is_eks: bool) -> str:
     "eks-" prefix
     """
     return f"eks-{cluster}" if is_eks else cluster
-
-
-def get_current_ecosystem() -> str:
-    """Get current ecosystem from host configs, defaults to dev if no config is found"""
-    try:
-        with open("/nail/etc/ecosystem") as f:
-            return f.read().strip()
-    except IOError:
-        pass
-    return "devc"
-
-
-def get_service_auth_token() -> str:
-    """Uses instance profile to authenticate with Vault and generate token for service authentication"""
-    ecosystem = get_current_ecosystem()
-    vault_client = get_vault_client(get_vault_url(ecosystem), get_vault_ca(ecosystem))
-    vault_role = load_system_paasta_config().get_service_auth_vault_role()
-    metadata_provider = InstanceMetadataProvider(
-        iam_role_fetcher=InstanceMetadataFetcher(),
-    )
-    instance_credentials = metadata_provider.load().get_frozen_credentials()
-    vault_client.auth.aws.iam_login(
-        instance_credentials.access_key,
-        instance_credentials.secret_key,
-        instance_credentials.token,
-        mount_point="aws-iam",
-        role=vault_role,
-        use_token=True,
-    )
-    response = vault_client.secrets.identity.generate_signed_id_token(name=vault_role)
-    return response["data"]["token"]
-
-
-def get_sso_service_auth_token() -> str:
-    """Generate an authentication token for the calling user from the Single Sign On provider"""
-    client_id = load_system_paasta_config().get_service_auth_sso_oidc_client_id()
-    return get_and_cache_jwt_default(client_id)
 
 
 def get_paasta_oapi_client_with_auth(

--- a/paasta_tools/tron/client.py
+++ b/paasta_tools/tron/client.py
@@ -11,12 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import os
 from typing import Dict
 from urllib.parse import urljoin
 
 import requests
 
 from paasta_tools import yaml_tools as yaml
+from paasta_tools.cli.authentication import get_service_auth_token
 from paasta_tools.utils import get_user_agent
 
 
@@ -43,6 +45,9 @@ class TronClient:
             response = requests.get(**kwargs)
         elif method == "POST":
             kwargs["data"] = data
+            if os.getenv("TRONCTL_API_AUTH"):
+                token = get_service_auth_token()
+                kwargs["headers"]["Authorization"] = f"Bearer {token}"
             response = requests.post(**kwargs)
         else:
             raise ValueError(f"Unrecognized method: {method}")

--- a/tests/cli/test_authentication.py
+++ b/tests/cli/test_authentication.py
@@ -1,0 +1,63 @@
+# Copyright 2015-2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import patch
+
+from paasta_tools.cli.authentication import get_service_auth_token
+
+
+@patch("paasta_tools.cli.authentication.load_system_paasta_config", autospec=True)
+@patch("paasta_tools.cli.authentication.get_current_ecosystem", autospec=True)
+@patch("paasta_tools.cli.authentication.InstanceMetadataProvider", autospec=True)
+@patch("paasta_tools.cli.authentication.InstanceMetadataFetcher", autospec=True)
+@patch("paasta_tools.cli.authentication.get_vault_client", autospec=True)
+@patch("paasta_tools.cli.authentication.get_vault_url", autospec=True)
+@patch("paasta_tools.cli.authentication.get_vault_ca", autospec=True)
+def test_get_service_auth_token(
+    mock_vault_ca,
+    mock_vault_url,
+    mock_get_vault_client,
+    mock_metadata_fetcher,
+    mock_metadata_provider,
+    mock_ecosystem,
+    mock_config,
+):
+    mock_ecosystem.return_value = "dev"
+    mock_config.return_value.get_service_auth_vault_role.return_value = "foobar"
+    mock_vault_client = mock_get_vault_client.return_value
+    mock_vault_client.secrets.identity.generate_signed_id_token.return_value = {
+        "data": {"token": "sometoken"},
+    }
+    assert get_service_auth_token() == "sometoken"
+    mock_instance_creds = (
+        mock_metadata_provider.return_value.load.return_value.get_frozen_credentials.return_value
+    )
+    mock_metadata_provider.assert_called_once_with(
+        iam_role_fetcher=mock_metadata_fetcher.return_value
+    )
+    mock_vault_url.assert_called_once_with("dev")
+    mock_vault_ca.assert_called_once_with("dev")
+    mock_get_vault_client.assert_called_once_with(
+        mock_vault_url.return_value, mock_vault_ca.return_value
+    )
+    mock_vault_client.auth.aws.iam_login.assert_called_once_with(
+        mock_instance_creds.access_key,
+        mock_instance_creds.secret_key,
+        mock_instance_creds.token,
+        mount_point="aws-iam",
+        role="foobar",
+        use_token=True,
+    )
+    mock_vault_client.secrets.identity.generate_signed_id_token.assert_called_once_with(
+        name="foobar"
+    )

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -24,7 +24,6 @@ from pytest import raises
 
 from paasta_tools.cli import utils
 from paasta_tools.cli.utils import extract_tags
-from paasta_tools.cli.utils import get_service_auth_token
 from paasta_tools.cli.utils import run_interactive_cli
 from paasta_tools.cli.utils import select_k8s_secret_namespace
 from paasta_tools.cli.utils import verify_instances
@@ -478,53 +477,6 @@ def test_select_k8s_secret_namespace():
 
     namespaces = {"a", "b"}
     assert select_k8s_secret_namespace(namespaces) in {"a", "b"}
-
-
-@patch("paasta_tools.cli.utils.load_system_paasta_config", autospec=True)
-@patch("paasta_tools.cli.utils.get_current_ecosystem", autospec=True)
-@patch("paasta_tools.cli.utils.InstanceMetadataProvider", autospec=True)
-@patch("paasta_tools.cli.utils.InstanceMetadataFetcher", autospec=True)
-@patch("paasta_tools.cli.utils.get_vault_client", autospec=True)
-@patch("paasta_tools.cli.utils.get_vault_url", autospec=True)
-@patch("paasta_tools.cli.utils.get_vault_ca", autospec=True)
-def test_get_service_auth_token(
-    mock_vault_ca,
-    mock_vault_url,
-    mock_get_vault_client,
-    mock_metadata_fetcher,
-    mock_metadata_provider,
-    mock_ecosystem,
-    mock_config,
-):
-    mock_ecosystem.return_value = "dev"
-    mock_config.return_value.get_service_auth_vault_role.return_value = "foobar"
-    mock_vault_client = mock_get_vault_client.return_value
-    mock_vault_client.secrets.identity.generate_signed_id_token.return_value = {
-        "data": {"token": "sometoken"},
-    }
-    assert get_service_auth_token() == "sometoken"
-    mock_instance_creds = (
-        mock_metadata_provider.return_value.load.return_value.get_frozen_credentials.return_value
-    )
-    mock_metadata_provider.assert_called_once_with(
-        iam_role_fetcher=mock_metadata_fetcher.return_value
-    )
-    mock_vault_url.assert_called_once_with("dev")
-    mock_vault_ca.assert_called_once_with("dev")
-    mock_get_vault_client.assert_called_once_with(
-        mock_vault_url.return_value, mock_vault_ca.return_value
-    )
-    mock_vault_client.auth.aws.iam_login.assert_called_once_with(
-        mock_instance_creds.access_key,
-        mock_instance_creds.secret_key,
-        mock_instance_creds.token,
-        mount_point="aws-iam",
-        role="foobar",
-        use_token=True,
-    )
-    mock_vault_client.secrets.identity.generate_signed_id_token.assert_called_once_with(
-        name="foobar"
-    )
 
 
 @patch("paasta_tools.cli.utils.shutil", autospec=True)


### PR DESCRIPTION
I recently discovered that there is a duplicate implementation of a Tron API client in here, so I'm giving it [the same treatment of the main implementation](https://github.com/Yelp/Tron/blob/e4310a1cd81ae18de7008b44ca8480a40b75b071/tron/commands/client.py#L57-L60).

In this case, this client is not meant to be used by human, so we are going to use Vault identities for authentication.

PS: I had to refactor the auth methods to avoid a circular import.