### PR TITLE
Enable labeling pods with AWS LB Controller readiness toggle

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -510,6 +510,9 @@ instance MAY have:
 
     NOTE: it's possible to set only one of the bounds, if you only want to set a lower or upper bound (i.e., setting both min/max is not required).
 
+  * ``enable_aws_lb_readiness_gate``: A boolean indicating whether to enable injecting AWS Load Balancer readiness gates for this instance. Defaults to ``false``.
+    This is only applicable to a very small subset of services at Yelp - please chat with #paasta before enabling this.
+
 **Note**: Although many of these settings are inherited from ``smartstack.yaml``,
 their thresholds are not the same. The reason for this has to do with control
 loops and infrastructure stability. The load balancer tier can be pickier

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -837,6 +837,9 @@
                 "routable_ip": {
                     "type": "boolean"
                 },
+                "enable_aws_lb_readiness_gate": {
+                    "type": "boolean"
+                },
                 "lifecycle": {
                     "type": "object",
                     "properties": {

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -374,6 +374,7 @@ KubePodLabels = TypedDict(
         "paasta.yelp.com/weight": str,
         "yelp.com/owner": str,
         "paasta.yelp.com/managed": str,
+        "elbv2.k8s.aws/pod-readiness-gate-inject": str,
     },
     total=False,
 )


### PR DESCRIPTION
As mentioned in the code comment below, the default way to enable this is per-namespace - that's somewhat annoying since we generally don't really edit namespace labels in PaaSTA post-creation (unless we're doing a one-time bulk edit): so let's instead see if we can configure the AWS LB Controller to only match on pods with this label (and remove the namespace selector)

NOTE: this pairs with https://github.yelpcorp.com/misc/compute-infra-k8s/pull/2505