### PR TITLE
Migrate Pytest fixture annotation

### DIFF
--- a/tests/frameworks/test_task_store.py
+++ b/tests/frameworks/test_task_store.py
@@ -52,7 +52,7 @@ class TestMesosTaskParameters:
 
 
 class TestZKTaskStore:
-    @pytest.yield_fixture
+    @pytest.fixture
     def mock_zk_client(self):
         spec_zk_client = KazooClient()
         mock_zk_client = mock.Mock(spec=spec_zk_client)

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -277,7 +277,7 @@ def test_add_argument(input_args, expected_args):
 
 
 class TestMain:
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def mock_execlp(self):
         # always patch execlp so we don't actually exec
         with mock.patch.object(
@@ -344,7 +344,7 @@ class TestMain:
             mock.call("docker", "docker", "ps", "--env=MESOS_TASK_ID=my-mesos-task-id")
         ]
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def mock_mac_address(self):
         with mock.patch.object(
             docker_wrapper_imports,

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -22,7 +22,7 @@ def service_group():
     return firewall.ServiceGroup(service="my_cool_service", instance="web")
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_get_running_mesos_docker_containers():
     with mock.patch.object(
         firewall,
@@ -79,7 +79,7 @@ def test_services_running_here():
     )
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_services_running_here():
     with mock.patch.object(
         firewall,
@@ -104,7 +104,7 @@ def test_service_group_chain_name(service_group):
     assert len(service_group.chain_name) <= 28
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_service_config():
     with mock.patch.object(
         firewall, "get_instance_config", autospec=True

--- a/tests/test_firewall_logging.py
+++ b/tests/test_firewall_logging.py
@@ -143,7 +143,7 @@ def fake_syslog_data(hostname, **kwargs):
     return (prefix + fields_str + " \n").encode()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_log():
     with mock.patch.object(firewall_logging, "_log", autospec=True) as mock_log:
         yield mock_log

--- a/tests/test_generate_services_file.py
+++ b/tests/test_generate_services_file.py
@@ -26,7 +26,7 @@ MOCK_NAMESPACES = [
 ]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_namespaces():
     with mock.patch(
         "paasta_tools.generate_services_file.get_all_namespaces",

--- a/tests/test_generate_services_yaml.py
+++ b/tests/test_generate_services_yaml.py
@@ -26,7 +26,7 @@ MOCK_NAMESPACES = [
 ]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_namespaces():
     with mock.patch(
         "paasta_tools.generate_services_file.get_all_namespaces",

--- a/tests/test_iptables.py
+++ b/tests/test_iptables.py
@@ -17,14 +17,14 @@ EMPTY_RULE = iptables.Rule(
 )
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_Table():
     with mock.patch.object(iptc, "Table", autospec=True) as m:
         m.return_value.autocommit = True
         yield m
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_Chain():
     with mock.patch.object(iptc, "Chain", autospec=True) as m:
         yield m
@@ -262,7 +262,7 @@ class TestReorderChain:
         def to_iptc(self):
             return self
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def chain_mock(self):
         with mock.patch.object(
             iptables, "iptables_txn", autospec=True

--- a/tests/test_mac_address.py
+++ b/tests/test_mac_address.py
@@ -71,7 +71,7 @@ def test_file_exists_flock(tmpdir):
         os.kill(flock_process, signal.SIGKILL)
 
 
-@pytest.yield_fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def mock_randbits():
     # make getrandbits() reliably return an incrementing counter starting at 0
     class counter(itertools.count):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -623,7 +623,7 @@ def test_SystemPaastaConfig_get_git_config(config, expected_git, expected_primar
     assert actual_repo["deploy_server"] == expected_primary
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def umask_022():
     old_umask = os.umask(0o022)
     yield
@@ -1365,7 +1365,7 @@ def test_run_returns_when_popen_fails():
     with mock.patch(
         "paasta_tools.utils.Popen", autospec=True, side_effect=fake_exception
     ):
-        return_code, output = utils._run("nonexistant command", timeout=10)
+        return_code, output = utils._run("nonexistent command", timeout=10)
     assert return_code == 1234
     assert "fake error" in output
 


### PR DESCRIPTION
# PR Summary
This PR resolves the Pytest deprecation warnings by migrating the fixture annotation from `pytest.yield_fixture` to `pytest.fixture`. It solves the following warnings in the [CI logs](https://github.com/Yelp/paasta/actions/runs/14738754656/job/41371316034#step:6:283):
```python
 /home/runner/work/paasta/paasta/tests/test_firewall.py:83: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.  Use @pytest.fixture instead; they are the same.
```