### PR TITLE
differentiate auth for services and paasta apis

### DIFF
--- a/paasta_tools/cli/authentication.py
+++ b/paasta_tools/cli/authentication.py
@@ -71,7 +71,15 @@ def get_service_auth_token() -> str:
     return response["data"]["token"]
 
 
-def get_sso_service_auth_token() -> str:
-    """Generate an authentication token for the calling user from the Single Sign On provider"""
-    client_id = load_system_paasta_config().get_service_auth_sso_oidc_client_id()
+def get_sso_auth_token(paasta_apis: bool = False) -> str:
+    """Generate an authentication token for the calling user from the Single Sign On provider
+
+    :param bool paasta_apis: authenticate for PaaSTA APIs
+    """
+    system_config = load_system_paasta_config()
+    client_id = (
+        system_config.get_api_auth_sso_oidc_client_id()
+        if paasta_apis
+        else system_config.get_service_auth_sso_oidc_client_id()
+    )
     return get_and_cache_jwt_default(client_id)

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -35,7 +35,7 @@ from mypy_extensions import TypedDict
 
 from paasta_tools.adhoc_tools import get_default_interactive_config
 from paasta_tools.cli.authentication import get_service_auth_token
-from paasta_tools.cli.authentication import get_sso_service_auth_token
+from paasta_tools.cli.authentication import get_sso_auth_token
 from paasta_tools.cli.cmds.check import makefile_responds_to
 from paasta_tools.cli.cmds.cook_image import paasta_cook_image
 from paasta_tools.cli.utils import figure_out_service_name
@@ -936,7 +936,7 @@ def run_docker_container(
     if use_service_auth_token:
         environment["YELP_SVC_AUTHZ_TOKEN"] = get_service_auth_token()
     elif use_sso_service_auth_token:
-        environment["YELP_SVC_AUTHZ_TOKEN"] = get_sso_service_auth_token()
+        environment["YELP_SVC_AUTHZ_TOKEN"] = get_sso_auth_token()
 
     local_run_environment = get_local_run_environment_vars(
         instance_config=instance_config, port0=chosen_port, framework=framework

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -46,7 +46,7 @@ from paasta_tools.adhoc_tools import load_adhoc_job_config
 from paasta_tools.api.client import get_paasta_oapi_client
 from paasta_tools.api.client import PaastaOApiClient
 from paasta_tools.cassandracluster_tools import load_cassandracluster_instance_config
-from paasta_tools.cli.authentication import get_sso_service_auth_token
+from paasta_tools.cli.authentication import get_sso_auth_token
 from paasta_tools.eks_tools import EksDeploymentConfig
 from paasta_tools.eks_tools import load_eks_service_config
 from paasta_tools.flink_tools import load_flink_instance_config
@@ -1093,7 +1093,7 @@ def get_paasta_oapi_client_with_auth(
         cluster=cluster,
         system_paasta_config=system_paasta_config,
         http_res=http_res,
-        auth_token=get_sso_service_auth_token(),
+        auth_token=get_sso_auth_token(paasta_apis=True),
     )
 
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1947,6 +1947,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     api_client_timeout: int
     api_endpoints: Dict[str, str]
     api_profiling_config: Dict
+    api_auth_sso_oidc_client_id: str
     auth_certificate_ttl: str
     auto_config_instance_types_enabled: Dict[str, bool]
     auto_config_instance_type_aliases: Dict[str, str]
@@ -2781,6 +2782,9 @@ class SystemPaastaConfig:
 
     def get_service_auth_sso_oidc_client_id(self) -> str:
         return self.config_dict.get("service_auth_sso_oidc_client_id", "")
+
+    def get_api_auth_sso_oidc_client_id(self) -> str:
+        return self.config_dict.get("api_auth_sso_oidc_client_id", "")
 
     def get_always_authenticating_services(self) -> List[str]:
         return self.config_dict.get("always_authenticating_services", [])


### PR DESCRIPTION
We want to be able to set different client IDs for the different use cases.
I also renamed the authentication method to be a bit more generic (which I should have done sooner).