### PR TITLE
fix get_git_sha_from_dockerurl when dealing with non-paasta image URLs

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -3760,6 +3760,8 @@ def get_git_sha_from_dockerurl(docker_url: str, long: bool = False) -> str:
         parts = docker_url.split("/")
         parts = parts[-1].split("-")
         git_sha = parts[-1]
+        # Further ensure to only grab the image label in case not using paasta images
+        git_sha = git_sha.split(":")[-1]
 
     return git_sha if long else git_sha[:8]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2936,3 +2936,34 @@ def test_validate_pool_error(cluster, pool, system_paasta_config):
         pool,
         system_paasta_config,
     )
+
+
+@pytest.mark.parametrize(
+    "docker_url,long,expected",
+    (
+        (
+            "registry.localhost:443/services-whatever:paasta-aaaabbbbccccdddd",
+            False,
+            "aaaabbbb",
+        ),
+        (
+            "registry.localhost:443/services-whatever:paasta-aaaabbbbccccdddd",
+            True,
+            "aaaabbbbccccdddd",
+        ),
+        (
+            "registry.localhost:443/services-whatever:foobar-aaaabbbbccccdddd",
+            False,
+            "aaaabbbb",
+        ),
+        (
+            "registry.localhost:443/services-whatever:foobar-aaaabbbbccccdddd",
+            True,
+            "aaaabbbbccccdddd",
+        ),
+        ("registry.localhost:443/toolbox-something-something:1.2.3", False, "1.2.3"),
+        ("registry.localhost:443/toolbox-something-something:1.2.3", True, "1.2.3"),
+    ),
+)
+def test_get_git_sha_from_dockerurl(docker_url, long, expected):
+    assert utils.get_git_sha_from_dockerurl(docker_url, long) == expected


### PR DESCRIPTION
With the images used for remote-run toolboxes not following the paasta labelling convention, this method ended up causing the `git_sha` label for the k8s pod to contain a semicolon, and k8s got really angry about that.

Things are looking more fine after this adjustment:
```
              'labels': {'paasta.yelp.com/autoscaled': 'false',
                         'paasta.yelp.com/cluster': 'pnw-prod',
                         'paasta.yelp.com/git_sha': '0.2.1',
                         'paasta.yelp.com/instance': 'main',
                         'paasta.yelp.com/job_type': 'remote-run',
                         'paasta.yelp.com/managed': 'true',
                         'paasta.yelp.com/pool': 'default',
                         'paasta.yelp.com/service': 'prod-toolbox-kafka',
                         'yelp.com/owner': 'compute_infra_platform_experience',
                         'yelp.com/paasta_git_sha': '0.2.1',
                         'yelp.com/paasta_instance': 'main',
                         'yelp.com/paasta_service': 'prod-toolbox-kafka'},
```