### PR TITLE
ensure run_interactive_cli uses abs path for shell

### DIFF
--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -1097,7 +1097,9 @@ def get_paasta_oapi_client_with_auth(
     )
 
 
-def run_interactive_cli(cmd: str, shell: str = "bash", term: str = "xterm-256color"):
+def run_interactive_cli(
+    cmd: str, shell: str = "/bin/bash", term: str = "xterm-256color"
+):
     """Runs interactive command in a pseudo terminal, handling terminal size management
 
     :param str cmd: shell command
@@ -1105,6 +1107,8 @@ def run_interactive_cli(cmd: str, shell: str = "bash", term: str = "xterm-256col
     :param str term: terminal type
     """
     cols, rows = shutil.get_terminal_size()
+    if not os.path.isabs(shell):
+        shell = shutil.which(shell)
     wrapped_cmd = (
         f"export SHELL={shell};"
         f"export TERM={term};"

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -486,8 +486,8 @@ def test_run_interactive_cli(mock_pty, mock_shutil):
     run_interactive_cli("kubectl exec foobar")
     mock_pty.spawn.assert_called_once_with(
         [
-            "bash",
+            "/bin/bash",
             "-c",
-            "export SHELL=bash;export TERM=xterm-256color;stty columns 120 rows 50;exec kubectl exec foobar",
+            "export SHELL=/bin/bash;export TERM=xterm-256color;stty columns 120 rows 50;exec kubectl exec foobar",
         ]
     )


### PR DESCRIPTION
`kubectl` and other small utils I tested were perfectly happy to work with just the executable name (it makes sense since it only serves the purpose of making them believe to be in a real interactive shell), but `ssh` not so much. I suppose because it tries to call it to establish the connection, but does a direct execve without path lookup, so wants an actual path.