### PR TITLE
Check iam_role for existing ServiceAccounts

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -4325,21 +4325,42 @@ def ensure_service_account(
     kube_client: KubeClient,
     k8s_role: Optional[str] = None,
 ) -> None:
+    role_annotation = "eks.amazonaws.com/role-arn"
     sa_name = get_service_account_name(iam_role, k8s_role)
 
-    if not any(
-        sa.metadata and sa.metadata.name == sa_name
-        for sa in get_all_service_accounts(kube_client, namespace)
-    ):
+    existing_sa = None
+    for sa in get_all_service_accounts(kube_client, namespace):
+        if sa.metadata and sa.metadata.name == sa_name:
+            existing_sa = sa
+            break
+    else:
         sa = V1ServiceAccount(
             kind="ServiceAccount",
             metadata=V1ObjectMeta(
                 name=sa_name,
                 namespace=namespace,
-                annotations={"eks.amazonaws.com/role-arn": iam_role},
+                annotations={role_annotation: iam_role},
             ),
         )
         kube_client.core.create_namespaced_service_account(namespace=namespace, body=sa)
+    if existing_sa:
+        requires_patch = False
+        if (
+            sa.metadata.annotations
+            and sa.metadata.annotations.get(role_annotation, None) != iam_role
+        ):
+            sa.metadata.annotations[role_annotation] = iam_role
+            requires_patch = True
+        elif sa.metadata.annotations is None:
+            sa.metadata.annotations = {role_annotation: iam_role}
+            requires_patch = True
+        if requires_patch:
+            kube_client.core.patch_namespaced_service_account(
+                namespace=namespace, body=sa, name=sa.metadata.name
+            )
+            log.info(
+                f"Updated ServiceAccount {sa.metadata.name} iam_role to {iam_role}"
+            )
 
     # we're expecting that any Role dynamically associated with a Service Account already exists.
     # at Yelp, this means that we have a version-controlled resource for the Role in Puppet.

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -4344,7 +4344,6 @@ def ensure_service_account(
         )
         kube_client.core.create_namespaced_service_account(namespace=namespace, body=sa)
     if existing_sa:
-        requires_patch = False
         if (
             not sa.metadata.annotations
             or sa.metadata.annotations.get(role_annotation, None) != iam_role
@@ -4353,8 +4352,6 @@ def ensure_service_account(
             # than the pod identity role ARN, so this will remove
             # any annotations that folks may have manually added
             sa.metadata.annotations = {role_annotation: iam_role}
-            requires_patch = True
-        if requires_patch:
             kube_client.core.patch_namespaced_service_account(
                 namespace=namespace, body=sa, name=sa.metadata.name
             )

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -4346,12 +4346,12 @@ def ensure_service_account(
     if existing_sa:
         requires_patch = False
         if (
-            sa.metadata.annotations
-            and sa.metadata.annotations.get(role_annotation, None) != iam_role
+            not sa.metadata.annotations
+            or sa.metadata.annotations.get(role_annotation, None) != iam_role
         ):
-            sa.metadata.annotations[role_annotation] = iam_role
-            requires_patch = True
-        elif sa.metadata.annotations is None:
+            # NOTE: we don't annotate SAs apart with anything other
+            # than the pod identity role ARN, so this will remove
+            # any annotations that folks may have manually added
             sa.metadata.annotations = {role_annotation: iam_role}
             requires_patch = True
         if requires_patch:

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -4844,6 +4844,80 @@ def test_ensure_service_account_existing():
         mock_client.rbac.create_namespaced_role_binding.assert_not_called()
 
 
+def test_ensure_service_account_existing_different_role():
+    old_iam_role = "arn:aws:iam::000000000000:role/some_role"
+    new_iam_role = "arn:aws:iam::000000000000:role/some-role"
+    namespace = "test_namespace"
+    k8s_role = "mega-admin"
+    expected_sa_name = "paasta--arn-aws-iam-000000000000-role-some-role--mega-admin"
+    with mock.patch(
+        "paasta_tools.kubernetes_tools.kube_config.load_kube_config", autospec=True
+    ), mock.patch(
+        "paasta_tools.kubernetes_tools.KubeClient",
+        autospec=False,
+    ) as mock_kube_client:
+        mock_client = mock.Mock()
+        mock_client.core = mock.Mock(spec=kube_client.CoreV1Api)
+        mock_client.rbac = mock.Mock(spec=kube_client.RbacAuthorizationV1Api)
+        mock_client.core.list_namespaced_service_account.return_value = mock.Mock(
+            spec=V1ServiceAccountList
+        )
+        mock_client.core.list_namespaced_service_account.return_value.items = [
+            V1ServiceAccount(
+                kind="ServiceAccount",
+                metadata=V1ObjectMeta(
+                    name=expected_sa_name,
+                    namespace=namespace,
+                    annotations={"eks.amazonaws.com/role-arn": old_iam_role},
+                ),
+            )
+        ]
+        mock_client.rbac.list_namespaced_role_binding.return_value = mock.Mock(
+            spec=V1RoleBinding,
+        )
+        mock_client.rbac.list_namespaced_role_binding.return_value.items = [
+            V1RoleBinding(
+                kind="ServiceAccount",
+                metadata=V1ObjectMeta(
+                    name=expected_sa_name,
+                    namespace=namespace,
+                ),
+                role_ref=V1RoleRef(
+                    api_group="rbac.authorization.k8s.io",
+                    kind="Role",
+                    name=k8s_role,
+                ),
+                subjects=[
+                    V1Subject(
+                        kind="ServiceAccount",
+                        namespace=namespace,
+                        name=expected_sa_name,
+                    )
+                ],
+            )
+        ]
+        mock_kube_client.return_value = mock_client
+        ensure_service_account(
+            new_iam_role,
+            namespace=namespace,
+            kube_client=mock_client,
+            k8s_role=k8s_role,
+        )
+        mock_client.core.create_namespaced_service_account.assert_not_called()
+        mock_client.core.patch_namespaced_service_account.assert_called_once_with(
+            namespace=namespace,
+            body=V1ServiceAccount(
+                kind="ServiceAccount",
+                metadata=V1ObjectMeta(
+                    name=expected_sa_name,
+                    namespace=namespace,
+                    annotations={"eks.amazonaws.com/role-arn": new_iam_role},
+                ),
+            ),
+            name=expected_sa_name,
+        )
+
+
 def test_ensure_service_account_existing_create_rb_only():
     iam_role = "arn:aws:iam::000000000000:role/some_role"
     namespace = "test_namespace"


### PR DESCRIPTION
## Problem
When an `iam_role` changes underscores to dashes or vice versa, the normalization function will treat it as identical, and the ServiceAccount won't be updated.

## Solution
Actually verify the `iam_role` value matches when an existing ServiceAccount is found, and if it differs, patch it. 

## Verification
Unit tests only right now. Will update here if I perform additional testing.