### PR TITLE
Migrate to correct logger interface

### DIFF
--- a/paasta_tools/cli/cmds/logs.py
+++ b/paasta_tools/cli/cmds/logs.py
@@ -178,7 +178,7 @@ def add_subparser(subparsers) -> None:
         help=(
             "The time to get logs up to. "
             'This can be an ISO-8601 timestamp or a human readable duration parsable by pytimeparse such as "5m", "1d3h" etc. '
-            "Incompatiable with --line-offset and --lines. "
+            "Incompatible with --line-offset and --lines. "
             "Defaults to now."
         ),
     )
@@ -190,7 +190,7 @@ def add_subparser(subparsers) -> None:
         help=(
             "The number of lines to retrieve from the specified offset. "
             'May optionally be prefixed with a "+" or "-" to specify which direction from the offset. '
-            "Incompatiable with --from and --to. "
+            "Incompatible with --from and --to. "
             'Defaults to "-100".'
         ),
         type=int,
@@ -204,7 +204,7 @@ def add_subparser(subparsers) -> None:
             "For example, --line-offset 1 would be the first line. "
             "Paired with --lines, --line-offset +100 would give you the first 100 lines of logs. "
             "Some logging backends may not support line offsetting by time or lines. "
-            "Incompatiable with --from and --to. "
+            "Incompatible with --from and --to. "
             "Defaults to the latest line's offset."
         ),
         type=int,
@@ -804,7 +804,7 @@ class ScribeLogReader(LogReader):
                     # sure all the tailers are still running.
                     running_processes = [tt.is_alive() for tt in spawned_processes]
                     if not running_processes or not all(running_processes):
-                        log.warn(
+                        log.warning(
                             "Quitting because I expected %d log tailers to be alive but only %d are alive."
                             % (len(spawned_processes), running_processes.count(True))
                         )
@@ -819,12 +819,12 @@ class ScribeLogReader(LogReader):
                     # This extra nested catch is because it's pretty easy to be in
                     # the above try block when the user hits Ctrl-C which otherwise
                     # dumps a stack trace.
-                    log.warn("Terminating.")
+                    log.warning("Terminating.")
                     break
             except KeyboardInterrupt:
                 # Die peacefully rather than printing N threads worth of stack
                 # traces.
-                log.warn("Terminating.")
+                log.warning("Terminating.")
                 break
 
     def print_logs_by_time(
@@ -1019,7 +1019,7 @@ class ScribeLogReader(LogReader):
             tzinfo=pytz.utc
         ) - datetime.timedelta(hours=4)
         if end_time > warning_end_time:
-            log.warn("Recent logs might be incomplete. Consider tailing instead.")
+            log.warning("Recent logs might be incomplete. Consider tailing instead.")
 
         # scribereader, sadly, is not based on UTC timestamps. It uses YST
         # dates instead.

--- a/paasta_tools/setup_istio_mesh.py
+++ b/paasta_tools/setup_istio_mesh.py
@@ -103,7 +103,7 @@ def load_smartstack_namespaces(soa_dir: str = DEFAULT_SOA_DIR) -> Mapping:
                 for (ns, details) in svc_namespaces.items():
                     namespaces[f"{dir}.{ns}"] = details
         except Exception as err:
-            log.warn(f"Failed to load namespaces for {dir}: {err}")
+            log.warning(f"Failed to load namespaces for {dir}: {err}")
 
     return namespaces
 

--- a/paasta_tools/smartstack_tools.py
+++ b/paasta_tools/smartstack_tools.py
@@ -473,7 +473,7 @@ def get_service_discovery_providers(
         elif name == "envoy":
             providers.append(EnvoyServiceDiscovery(system_paasta_config))
         else:
-            log.warn("unknown provider")
+            log.warning("unknown provider")
     return providers
 
 
@@ -530,7 +530,7 @@ class BaseReplicationChecker(ReplicationChecker):
                         )
                         break
                     except Exception as e:
-                        log.warn(
+                        log.warning(
                             f"Error while getting replication info for {location} from {hostname}: {e}"
                         )
                         if hostname == hostnames[-1]:

--- a/paasta_tools/spark_tools.py
+++ b/paasta_tools/spark_tools.py
@@ -133,7 +133,7 @@ def setup_volume_mounts(volumes: List[DockerVolume]) -> Dict[str, str]:
         )
 
         if host_path in seen_paths:
-            log.warn(f"Skipping {host_path} - already added a binding for it.")
+            log.warning(f"Skipping {host_path} - already added a binding for it.")
             continue
         seen_paths.add(host_path)
 
@@ -209,7 +209,7 @@ def auto_add_timeout_for_spark_job(
             f"'timeout' could not be added to spark command: '{cmd}' due to error '{e}'. "
             "Please report to #spark."
         )
-        log.warn(err_msg)
+        log.warning(err_msg)
         print(PaastaColors.red(err_msg))
     return cmd
 


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
It also fixes a few typos along the way.