### PR TITLE
Support None in `git_url` for toolboxes or other future pseudo-sevices

### DIFF
--- a/paasta_tools/cli/schemas/service_schema.json
+++ b/paasta_tools/cli/schemas/service_schema.json
@@ -10,7 +10,10 @@
             "type": "string"
         },
         "git_url": {
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "pattern": "^git@github.yelpcorp.com:[-a-z]+/[-_a-z0-9]+(\\.git)?$",
             "$comment": "this is obviously very tied to how we name repos at Yelp"
         },

--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -130,6 +130,10 @@ def get_deploy_group_mappings(
     v2_mappings: V2_Mappings = {"deployments": {}, "controls": {}}
     git_url = get_git_url(service=service, soa_dir=soa_dir)
 
+    # Some pseudo-services like toolboxes explicitly have no git_url, and therefore no deployments
+    if git_url is None:
+        return mappings, v2_mappings
+
     # Most of the time of this function is in two parts:
     # 1. getting remote refs from git. (Mostly IO, just waiting for git to get back to us.)
     # 2. loading instance configs. (Mostly CPU, copy.deepcopying yaml over and over again)


### PR DESCRIPTION
Allow setting the `git_url` of a service to `None` in order to have the generate deployment step skip it. Currently, if it tries to access a repo that doesn't exist, it will crash and the generate deployment script will stop completely. Returning these empty mapping objects is the same behavior as when a service "has no valid deploy groups" so it should be handled fine.

It will only be a `None` when it's explicitly set, as it will otherwise generate a default git url.


```
~/paasta (toolbox_generate_deployment) $ paasta validate -y /nail/home/qlo/yelpsoa-configs -s prod-toolbox
✓ Successfully validated schema: adhoc-pnw-prod.yaml
✓ Successfully validated schema: service.yaml
✓ All PaaSTA Instances for are valid for all clusters
✓ All prod-toolbox's instance names in cluster norcal-devc are unique
✓ All prod-toolbox's instance names in cluster norcal-stagef are unique
✓ All prod-toolbox's instance names in cluster norcal-stageg are unique
✓ All prod-toolbox's instance names in cluster nova-prod are unique
✓ All prod-toolbox's instance names in cluster pnw-corp are unique
✓ All prod-toolbox's instance names in cluster pnw-corpdev are unique
✓ All prod-toolbox's instance names in cluster pnw-devc are unique
✓ All prod-toolbox's instance names in cluster pnw-prod are unique
✓ No orphan secrets found

~/paasta (toolbox_generate_deployment) $ cat /nail/home/qlo/yelpsoa-configs/prod-toolbox/service.yaml
...
git_url: null
```