### PR TITLE
MLCOMPUTE-4648 | Bump service-configuration-lib to v3.3.2

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -56,7 +56,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 3.2.0
+service-configuration-lib >= 3.3.1
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -56,7 +56,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 3.3.1
+service-configuration-lib >= 3.3.2
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ ruamel.yaml==0.16.12
 ruamel.yaml.clib==0.2.8
 s3transfer==0.10.0
 sensu-plugin==0.3.1
-service-configuration-lib==3.2.0
+service-configuration-lib==3.3.1
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ ruamel.yaml==0.16.12
 ruamel.yaml.clib==0.2.8
 s3transfer==0.10.0
 sensu-plugin==0.3.1
-service-configuration-lib==3.3.1
+service-configuration-lib==3.3.2
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1357,7 +1357,6 @@ class TestTronTools:
             "--conf spark.dynamicAllocation.shuffleTracking.enabled=true "
             "--conf spark.dynamicAllocation.executorAllocationRatio=0.8 "
             "--conf spark.dynamicAllocation.cachedExecutorIdleTimeout=1500s "
-            "--conf spark.dynamicAllocation.minExecutors=0 "
             "--conf spark.dynamicAllocation.maxExecutors=2 "
             "--conf spark.ui.prometheus.enabled=true "
             "--conf spark.metrics.conf.*.sink.prometheusServlet.class=org.apache.spark.metrics.sink.PrometheusServlet "


### PR DESCRIPTION
Bump service-configuration-lib to v3.3.2 to include the followings:
- https://github.com/Yelp/service_configuration_lib/pull/157
- https://github.com/Yelp/service_configuration_lib/pull/162