### PR TITLE
Add --copy-file for remote-run

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 import argparse
 import shutil
+import subprocess
+import sys
 import time
 from typing import List
 
@@ -138,8 +140,12 @@ def paasta_remote_run_start(
                 pod=poll_response.pod_name,
                 filename=filename,
                 token=token_response.token,
-            )
-            run_interactive_cli(cp_command)
+            ).split(" ")
+            call = subprocess.run(cp_command, capture_output=True)
+            if call.returncode != 0:
+                print("Error copying file to remote-run pod: ", file=sys.stderr)
+                print(call.stderr.decode("utf-8"), file=sys.stderr)
+                return 1
 
     run_interactive_cli(exec_command)
     return 0


### PR DESCRIPTION
Add the ability to copy individual files into remote-run pods into /tmp. This covers a lot of use cases while still making it hard to modify code or copy whole directories.

```
$ paasta remote-run start -c norcal-devc -s redshift_credentials -i main --interactive --copy-file ~/test1 --copy-file ~/test2
Triggered remote-run job for redshift_credentials. Waiting for pod to come online...
Status: Pod not ready
Pod ready, establishing interactive session...
INFO: You are using an Okta authenticated kubectl wrapper
nobody@remote-run-qlo-redshift--credentials-main-d67jb:/code$ cat /tmp/test1
test
nobody@remote-run-qlo-redshift--credentials-main-d67jb:/code$ cat /tmp/test2
foo

$ paasta remote-run start -c norcal-devc -s redshift_credentials -i main --interactive --copy-file ~/test27657
Triggered remote-run job for redshift_credentials. Waiting for pod to come online...

Pod ready, establishing interactive session...
Error copying file to remote-run pod:
INFO: You are using an Okta authenticated kubectl wrapper
error: /nail/home/qlo/test27657 doesn't exist in local filesystem
```

