### PR TITLE
Remote run - handle terminating pods better

### DIFF
--- a/paasta_tools/api/api_docs/oapi.yaml
+++ b/paasta_tools/api/api_docs/oapi.yaml
@@ -1327,6 +1327,8 @@ paths:
           description: Unauthorized to remote-run this service
         "404":
           description: Service instance not found
+        "409":
+          description: A pod was found but is currently being terminated
         "500":
           description: Failure
   /remote_run/{service}/{instance}/token:

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -1037,6 +1037,9 @@
                     "404": {
                         "description": "Service instance not found"
                     },
+                    "409": {
+                        "description": "A pod was found but is currently being terminated"
+                    },
                     "500": {
                         "description": "Failure"
                     }

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -34,7 +34,9 @@ from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import SystemPaastaConfig
 
 
-KUBECTL_EXEC_CMD_TEMPLATE = "{kubectl_wrapper} --token {token} exec -it --pod-running-timeout=10s -n {namespace} {pod} -- /bin/bash"
+KUBECTL_EXEC_CMD_TEMPLATE = (
+    "{kubectl_wrapper} --token {token} exec -it -n {namespace} {pod} -- /bin/bash"
+)
 KUBECTL_CP_CMD_TEMPLATE = (
     "{kubectl_wrapper} --token {token} -n {namespace} cp {filename} {pod}:/tmp/"
 )

--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -62,7 +62,7 @@ def paasta_remote_run_start(
     system_paasta_config: SystemPaastaConfig,
     recursed: bool = False,
 ) -> int:
-    status_prefix = "\x1b[2K\r"  # Clear line, carridge return
+    status_prefix = "\x1b[2K\r"  # Clear line, carriage return
     client = get_paasta_oapi_client_with_auth(
         cluster=get_paasta_oapi_api_clustername(cluster=args.cluster, is_eks=True),
         system_paasta_config=system_paasta_config,

--- a/paasta_tools/kubernetes/remote_run.py
+++ b/paasta_tools/kubernetes/remote_run.py
@@ -189,6 +189,8 @@ def remote_run_ready(
     if not pod:
         return {"status": 404, "message": "No pod found"}
     if pod.status.phase == "Running":
+        if pod.metadata.deletion_timestamp:
+            return {"status": 409, "message": "Pod is terminating"}
         result: RemoteRunOutcome = {
             "status": 200,
             "message": "Pod ready",

--- a/tests/kubernetes/test_remote_run.py
+++ b/tests/kubernetes/test_remote_run.py
@@ -160,6 +160,7 @@ def test_remote_run_ready(
     mock_load_config.return_value.get_namespace.return_value = "namespace"
     mock_gen_config.return_value.get_namespace.return_value = "remote-run-toolbox"
     mock_find_job_pod.return_value.metadata.name = "somepod"
+    mock_find_job_pod.return_value.metadata.deletion_timestamp = None
     mock_find_job_pod.return_value.status.pod_ip = "127.1.33.7"
     # job found and ready
     mock_find_job_pod.return_value.status.phase = "Running"


### PR DESCRIPTION
## Problem
pod.status.phase will still be "Running" even when the pod is terminating. "Terminating" as a status is actually determined from the deletion_timestamp and is not a _real_ status. If a user enters a container like this, they will get booted out after a few seconds.

## Solution
Return a 409 (is there a better HTTP code?) status for terminating pods and keep polling. Terminating pods turn into non-existent pods, so the most likely reason for a 404 is this case. When that happens, call remote-run start again. If we still get a 404, bail out. 

## Other notes
- I experienced kubectl exec hanging one time, I think that was a race condition where the pod was terminating (running) but actually gone by the time kubectl exec ran. I wasn't able to reproduce that, but I think it should be solved by this. Maybe it could still be triggered by a pod being force deleted at a very inopportune time. 
- Added a line-clear to the poll message to prevent overlapping messages

## Testing
```
paasta remote-run start -c cluster -s test-service -i main --interactive
Triggered remote-run job for test-service. Waiting for pod to come online...
Status: No pod found
Pod finished terminating. Rerunning
Triggered remote-run job for test-service. Waiting for pod to come online...
Status: Pod not ready
Pod ready, establishing interactive session...
INFO: You are using an Okta authenticated kubectl wrapper
www-data@remote-run-qlo-test-service-main-82ccf:/$
```