### PR TITLE
Adding idempotent label to Tron pods - TRON-2154

### DIFF
--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -91,6 +91,11 @@
                     },
                     "uniqueItems": true
                 },
+                "idempotent": {
+                    "type": "boolean",
+                    "default": false,
+                    "$comment": "This will be used to determine whether the action can be retried without side effects."
+                },
                 "extra_constraints": {
                     "type": "array",
                     "items": {

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -422,6 +422,9 @@ class TronActionConfig(InstanceConfig):
     def get_job_name(self):
         return self.job
 
+    def get_idempotent(self) -> bool:
+        return self.config_dict.get("idempotent", False)
+
     def get_action_name(self):
         return self.action
 
@@ -1046,6 +1049,7 @@ def format_tron_action_dict(action_config: TronActionConfig):
                 limit=63,
                 suffix=4,
             ),
+            "tron.yelp.com/idempotent-action": action_config.get_idempotent(),
             # XXX: should this be different for Spark drivers launched by Tron?
             "app.kubernetes.io/managed-by": "tron",
         }

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -1083,6 +1083,7 @@ class TestTronTools:
                 "paasta.yelp.com/service": "my_service",
                 "yelp.com/owner": "compute_infra_platform_experience",
                 "app.kubernetes.io/managed-by": "tron",
+                "paasta.yelp.com/idempotent-action": False,
             },
             "annotations": {
                 "paasta.yelp.com/routable_ip": "false",
@@ -1150,6 +1151,7 @@ class TestTronTools:
             "deploy_group": "prod",
             "executor": "spark",
             "disk": 42,
+            "idempotent": True,
             "pool": "special_pool",
             "env": {"SHELL": "/bin/bash"},
             "secret_volumes": [
@@ -1449,6 +1451,7 @@ class TestTronTools:
                 "paasta.yelp.com/prometheus_shard": "ml-compute",
                 "spark.yelp.com/user": "TRON",
                 "spark.yelp.com/driver_ui_port": "39091",
+                "paasta.yelp.com/idempotent-action": True,
             },
             "annotations": {
                 "paasta.yelp.com/routable_ip": "true",
@@ -1493,6 +1496,7 @@ class TestTronTools:
             "deploy_group": "prod",
             "pool": "default",
             "executor": "paasta",
+            "idempotent": True,
         }
         branch_dict = {
             "docker_image": "my_service:paasta-123abcde",
@@ -1541,6 +1545,7 @@ class TestTronTools:
                 "paasta.yelp.com/service": "my_service",
                 "yelp.com/owner": "compute_infra_platform_experience",
                 "app.kubernetes.io/managed-by": "tron",
+                "paasta.yelp.com/idempotent-action": True,
             },
             "annotations": {
                 "paasta.yelp.com/routable_ip": "false",
@@ -1687,6 +1692,7 @@ class TestTronTools:
                 "paasta.yelp.com/service": "my_service",
                 "yelp.com/owner": "compute_infra_platform_experience",
                 "app.kubernetes.io/managed-by": "tron",
+                "paasta.yelp.com/idempotent-action": False,
             },
             "annotations": {
                 "paasta.yelp.com/routable_ip": "false",
@@ -1849,6 +1855,7 @@ class TestTronTools:
                 "paasta.yelp.com/service": "my_service",
                 "yelp.com/owner": "compute_infra_platform_experience",
                 "app.kubernetes.io/managed-by": "tron",
+                "paasta.yelp.com/idempotent-action": False,
             },
             "annotations": {
                 "paasta.yelp.com/routable_ip": "false",
@@ -2004,7 +2011,7 @@ fake_job:
         # that are not static, this will cause continuous reconfiguration, which
         # will add significant load to the Tron API, which happened in DAR-1461.
         # but if this is intended, just change the hash.
-        assert hasher.hexdigest() == "b4c7ee4d47787f081b58b44df10a07f1"
+        assert hasher.hexdigest() == "b0359064555555dec6cfb5476de143c7"
 
     def test_override_default_pool_override(self, tmpdir):
         soa_dir = tmpdir.mkdir("test_create_complete_config_soa")


### PR DESCRIPTION
This PR adds a new field in soaconfigs for "idempotent", which will help us identify which Tron actions are idempotent vs which ones are not. It also creates a pod label with its value