### PR TITLE
Allow setting temporary max_instances overrides

### DIFF
--- a/paasta_tools/api/api_docs/oapi.yaml
+++ b/paasta_tools/api/api_docs/oapi.yaml
@@ -269,12 +269,17 @@ components:
           type: integer
           description: Minimum number of instances to run
           minimum: 1
+        max_instances:
+          type: integer
+          description: Maximum number of instances to run
+          minimum: 1
         expire_after:
           format: float
           type: number
           description: Unix timestamp when this override is no longer valid
       required:
         - min_instances
+        - max_instances
         - expire_after
     InstanceBounceStatus:
       properties:
@@ -1494,7 +1499,12 @@ paths:
                     description: Instance name
                   min_instances:
                     type: integer
+                    nullable: true
                     description: Minimum number of instances to run
+                  max_instances:
+                    type: integer
+                    nullable: true
+                    description: Maximum number of instances to run
                   expire_after:
                     format: float
                     type: number

--- a/paasta_tools/api/api_docs/swagger.json
+++ b/paasta_tools/api/api_docs/swagger.json
@@ -322,7 +322,13 @@
                                 },
                                 "min_instances": {
                                     "type": "integer",
+                                    "x-nullable": true,
                                     "description": "Minimum number of instances to run"
+                                },
+                                "max_instances": {
+                                    "type": "integer",
+                                    "x-nullable": true,
+                                    "description": "Maximum number of instances to run"
                                 },
                                 "expire_after": {
                                     "type": "number",
@@ -1724,7 +1730,14 @@
             "properties": {
                 "min_instances": {
                     "type": "integer",
+                    "x-nullable": true,
                     "description": "Minimum number of instances to run",
+                    "minimum": 1
+                },
+                "max_instances": {
+                    "type": "integer",
+                    "x-nullable": true,
+                    "description": "Maximum number of instances to run",
                     "minimum": 1
                 },
                 "expire_after": {
@@ -1735,6 +1748,7 @@
             },
             "required": [
                 "min_instances",
+                "max_instances",
                 "expire_after"
             ]
         },

--- a/paasta_tools/cli/cmds/autoscale.py
+++ b/paasta_tools/cli/cmds/autoscale.py
@@ -76,6 +76,14 @@ def add_subparser(subparsers):
         default=None,
     )
     override_group.add_argument(
+        "--set-max",
+        help="Set the maximum number of replicas (must be >= 1). Requires --for parameter.",
+        type=lambda x: int(x)
+        if int(x) >= 1
+        else autoscale_parser.error("Maximum instances must be >= 1"),
+        default=None,
+    )
+    override_group.add_argument(
         "--for",
         dest="duration",
         help="Duration for the temporary override (e.g. '3h', '30m'). Required when using --set-min.",
@@ -113,7 +121,7 @@ def paasta_autoscale(args):
     log.setLevel(logging.DEBUG)
     service = figure_out_service_name(args)
 
-    if args.set_min is not None and not args.duration:
+    if (args.set_min is not None or args.set_max is not None) and not args.duration:
         print(
             PaastaColors.yellow(
                 "WARNING: --set-min requires --for parameter to specify duration - defaulting to 30m"
@@ -121,14 +129,16 @@ def paasta_autoscale(args):
         )
         args.duration = "30m"
 
-    if args.duration is not None and args.set_min is None:
-        print(PaastaColors.red("Error: --for requires --set-min parameter"))
+    if args.duration is not None and args.set_min is None and args.set_max is None:
+        print(
+            PaastaColors.red("Error: --for requires --set-min or --set-max parameter")
+        )
         return 1
 
-    if args.set is not None and args.set_min is not None:
+    if args.set is not None and args.set_min is not None and args.set_max is not None:
         print(
             PaastaColors.red(
-                "Error: Cannot use both --set and --set-min at the same time"
+                "Error: Cannot use both --set and --set-min or --set-max at the same time"
             )
         )
         return 1
@@ -161,7 +171,7 @@ def paasta_autoscale(args):
 
     try:
         # get current autoscaler count
-        if args.set is None and args.set_min is None:
+        if args.set is None and args.set_min is None and args.set_max is None:
             log.debug("Getting the current autoscaler count...")
             res, status, _ = api.autoscaler.get_autoscaler_count(
                 service=service, instance=args.instance, _return_http_data_only=False
@@ -187,7 +197,7 @@ def paasta_autoscale(args):
             )
 
         # set lower bound
-        elif args.set_min is not None:
+        elif args.set_min is not None or args.set_max is not None:
             duration_seconds = parse_duration_to_seconds(args.duration)
             if not duration_seconds:
                 print(
@@ -206,6 +216,7 @@ def paasta_autoscale(args):
             )
             msg = paastamodels.AutoscalingOverride(
                 min_instances=args.set_min,
+                max_instances=args.set_max,
                 expire_after=expiration_time,
             )
 
@@ -228,7 +239,7 @@ def paasta_autoscale(args):
     if not 200 <= status <= 299:
         print(
             PaastaColors.red(
-                f"ERROR: '{args.instance}' is not configured to autoscale OR you set min_instances above the current max_instances, "
+                f"ERROR: '{args.instance}' is not configured to autoscale OR you set impossible {{min, max}}_instances, "
                 f"and `paasta autoscale` could not update it. "
                 f"If you want to be able to boost this service, please configure autoscaling for the service "
                 f"in its config file by setting min and max instances appropriately. Example: \n"
@@ -242,10 +253,15 @@ def paasta_autoscale(args):
     log.debug(f"Res: {res} Http: {status}")
     if not args.set_min:
         print(f"Desired instances: {res.desired_instances}")
-    elif args.set_min:
-        print(
-            f"Temporary override set for {args.service}.{args.instance} with minimum instances: {args.set_min}"
-        )
+    elif args.set_min or args.set_max:
+        if args.set_min:
+            print(
+                f"Temporary override set for {args.service}.{args.instance} with minimum instances: {args.set_min}"
+            )
+        if args.set_max:
+            print(
+                f"Temporary override set for {args.service}.{args.instance} with maximum instances: {args.set_max}"
+            )
         # folks using this might be in different timezones, so let's convert the expiration time to a few common ones
         # to make it extra clear when the override will expire
         epoch_time = datetime.fromtimestamp(res.expire_after)

--- a/paasta_tools/kubernetes/application/controller_wrappers.py
+++ b/paasta_tools/kubernetes/application/controller_wrappers.py
@@ -301,7 +301,10 @@ class DeploymentWrapper(Application):
             kube_client=kube_client,
             namespace=self.item.metadata.namespace,
             min_instances_override=(
-                self.hpa_override["min_instances"] if self.hpa_override else None
+                self.hpa_override.get("min_instances") if self.hpa_override else None
+            ),
+            max_instances_override=(
+                self.hpa_override.get("max_instances") if self.hpa_override else None
             ),
         )
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -325,6 +325,7 @@ class DatastoreCredentialsConfig(TypedDict, total=False):
 
 class HpaOverride(TypedDict):
     min_instances: int
+    max_instances: int
     expire_after: str
 
 
@@ -899,6 +900,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         kube_client: KubeClient,
         namespace: str,
         min_instances_override: Optional[int] = None,
+        max_instances_override: Optional[int] = None,
     ) -> Optional[V2HorizontalPodAutoscaler]:
         # Returns None if an HPA should not be attached based on the config,
         # or the config is invalid.
@@ -914,7 +916,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             return None
 
         min_replicas = min_instances_override or self.get_min_instances()
-        max_replicas = self.get_max_instances()
+        max_replicas = max_instances_override or self.get_max_instances()
         if min_replicas == 0 or max_replicas == 0:
             log.error(
                 f"Invalid value for min or max_instances on {name}: {min_replicas}, {max_replicas}"

--- a/paasta_tools/paastaapi/model/autoscaling_override.py
+++ b/paasta_tools/paastaapi/model/autoscaling_override.py
@@ -62,6 +62,9 @@ class AutoscalingOverride(ModelNormal):
         ('min_instances',): {
             'inclusive_minimum': 1,
         },
+        ('max_instances',): {
+            'inclusive_minimum': 1,
+        },
     }
 
     additional_properties_type = None
@@ -80,6 +83,7 @@ class AutoscalingOverride(ModelNormal):
         """
         return {
             'min_instances': (int,),  # noqa: E501
+            'max_instances': (int,),  # noqa: E501
             'expire_after': (float,),  # noqa: E501
         }
 
@@ -90,6 +94,7 @@ class AutoscalingOverride(ModelNormal):
 
     attribute_map = {
         'min_instances': 'min_instances',  # noqa: E501
+        'max_instances': 'max_instances',  # noqa: E501
         'expire_after': 'expire_after',  # noqa: E501
     }
 
@@ -105,11 +110,12 @@ class AutoscalingOverride(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, min_instances, expire_after, *args, **kwargs):  # noqa: E501
+    def __init__(self, min_instances, max_instances, expire_after, *args, **kwargs):  # noqa: E501
         """AutoscalingOverride - a model defined in OpenAPI
 
         Args:
             min_instances (int): Minimum number of instances to run
+            max_instances (int): Maximum number of instances to run
             expire_after (float): Unix timestamp when this override is no longer valid
 
         Keyword Args:
@@ -169,6 +175,7 @@ class AutoscalingOverride(ModelNormal):
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
         self.min_instances = min_instances
+        self.max_instances = max_instances
         self.expire_after = expire_after
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \

--- a/paasta_tools/paastaapi/model/inline_response202.py
+++ b/paasta_tools/paastaapi/model/inline_response202.py
@@ -78,7 +78,8 @@ class InlineResponse202(ModelNormal):
         return {
             'service': (str,),  # noqa: E501
             'instance': (str,),  # noqa: E501
-            'min_instances': (int,),  # noqa: E501
+            'min_instances': (int, none_type,),  # noqa: E501
+            'max_instances': (int, none_type,),  # noqa: E501
             'expire_after': (float,),  # noqa: E501
             'status': (str,),  # noqa: E501
         }
@@ -92,6 +93,7 @@ class InlineResponse202(ModelNormal):
         'service': 'service',  # noqa: E501
         'instance': 'instance',  # noqa: E501
         'min_instances': 'min_instances',  # noqa: E501
+        'max_instances': 'max_instances',  # noqa: E501
         'expire_after': 'expire_after',  # noqa: E501
         'status': 'status',  # noqa: E501
     }
@@ -144,7 +146,8 @@ class InlineResponse202(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             service (str): Service name. [optional]  # noqa: E501
             instance (str): Instance name. [optional]  # noqa: E501
-            min_instances (int): Minimum number of instances to run. [optional]  # noqa: E501
+            min_instances (int, none_type): Minimum number of instances to run. [optional]  # noqa: E501
+            max_instances (int, none_type): Maximum number of instances to run. [optional]  # noqa: E501
             expire_after (float): Unix timestamp after which the override is no longer valid. [optional]  # noqa: E501
             status (str): Status of the operation. [optional]  # noqa: E501
         """


### PR DESCRIPTION
Just as setting temporary `min_instances` overrides is useful, so would being able to do the same for `max_instances`.