### PR TITLE
Handle non-existent configmaps for autoscaling overrides

### DIFF
--- a/paasta_tools/setup_kubernetes_job.py
+++ b/paasta_tools/setup_kubernetes_job.py
@@ -289,7 +289,7 @@ def get_hpa_overrides(kube_client: KubeClient) -> Dict[str, Dict[str, HpaOverrid
             kube_client=kube_client,
         )
 
-        if configmap.data:
+        if configmap and configmap.data:
             current_time = time.time()
 
             for service_instance, override_json in configmap.data.items():


### PR DESCRIPTION
I'm not quite sure why `mypy`/`pyright` didn't yell at me for this, but this should silence some noise in our logs in clusters where we haven't used the override functionality