### PR TITLE
Upgraded service_configuration_lib to v3.3.4

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -57,7 +57,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 3.3.3
+service-configuration-lib >= 3.3.4
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,7 +95,7 @@ ruamel.yaml==0.16.12
 ruamel.yaml.clib==0.2.8
 s3transfer==0.10.0
 sensu-plugin==0.3.1
-service-configuration-lib==3.3.3
+service-configuration-lib==3.3.4
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0


### PR DESCRIPTION
Upgraded **_service_configuration_lib_** to **_v3.3.4_** which includes the functionality of manually overriding the default spark run config file

https://github.com/Yelp/service_configuration_lib/releases/tag/v3.3.4