### PR TITLE
bump service-configuration-lib to 3.3.5

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -57,7 +57,7 @@ requests-cache >= 0.4.10
 retry
 ruamel.yaml
 sensu-plugin
-service-configuration-lib >= 3.3.4
+service-configuration-lib >= 3.3.5
 signalfx
 slackclient >= 1.2.1
 sticht >= 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,7 +95,7 @@ ruamel.yaml==0.16.12
 ruamel.yaml.clib==0.2.8
 s3transfer==0.10.0
 sensu-plugin==0.3.1
-service-configuration-lib==3.3.4
+service-configuration-lib==3.3.5
 setuptools==39.0.1
 signalfx==1.0.17
 simplejson==3.10.0


### PR DESCRIPTION
Incorporate the changes from [this PR](https://github.com/Yelp/service_configuration_lib/pull/164) in service-configuration-lib where we ensure that logs are written to scribe when `paasta spark-run` commands don't pass the `--jira-ticket` parameter.