### PR TITLE
Bump logreader to 1.3.0

### DIFF
--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -11,7 +11,7 @@ gitpython==2.1.9                    # slo-transcoder, vault-tools dependency
 hvac==1.2.1                         # vault-tools dependency
 inflection==0.3.1                   # slo-transcoder dependency
 iso8601==2.1.0                      # yelp-ips dependency
-logreader==1.2.0
+logreader==1.3.0
 markdown==2.4                       # slo-transcoder dependency
 monk==1.3.0                         # yelp-clog dependency
 mrjob==0.7.4                        # scribereader dependency


### PR DESCRIPTION
This primarily includes the ability to use an environment variable to use default AWS credentials instead of an instance profile.