### PR TITLE
Switch default spark user from mrjob to spark_driver

### DIFF
--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2166,7 +2166,7 @@ class SystemPaastaConfig:
 
     def get_default_spark_iam_user(self) -> str:
         return self.config_dict.get(
-            "default_spark_iam_user", "/etc/boto_cfg/mrjob.yaml"
+            "default_spark_iam_user", "/etc/boto_cfg/spark_driver.yaml"
         )
 
     def get_default_spark_driver_pool_override(self) -> str:

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -1974,7 +1974,7 @@ def test_paasta_spark_run_with_pod_identity(
         service="test-service",
         aws_credentials_yaml="/path/to/creds"
         if aws_creds_provided
-        else "/etc/boto_cfg/mrjob.yaml",
+        else "/etc/boto_cfg/spark_driver.yaml",
         profile_name=None,
         assume_aws_role_arn=None,
         session_duration=3600,

--- a/tests/cli/test_cmds_spark_run.py
+++ b/tests/cli/test_cmds_spark_run.py
@@ -1936,7 +1936,7 @@ def test_paasta_spark_run_with_pod_identity(
         {}
     )
     mock_load_system_paasta_config_spark_run.return_value.get_default_spark_iam_user.return_value = (
-        "/etc/boto_cfg/mrjob.yaml"
+        "/etc/boto_cfg/spark_driver.yaml"
     )
     mock_load_system_paasta_config_spark_run.return_value.get_cluster_aliases.return_value = (
         {}


### PR DESCRIPTION
I've recently created this new IAM user to replace `mrjob`. It has the necessary permissions for most Spark jobs. I'm doing this so we can eventually delete the mrjob user.

Note that this is only used if a user does *not* specify aws profile or another credentials file, so this isn't likely to break anything, as few if any spark jobs are using this yet. 