### PR TITLE
Support adhoc instances in remote-run

### DIFF
--- a/paasta_tools/kubernetes/remote_run.py
+++ b/paasta_tools/kubernetes/remote_run.py
@@ -80,8 +80,13 @@ def _format_remote_run_job_name(
 
 
 def load_eks_or_adhoc_deployment_config(
-    service: str, instance: str, cluster: str, is_toolbox: bool = False, user: str = ""
+    service: str,
+    instance: str,
+    cluster: str,
+    is_toolbox: bool = False,
+    user: Optional[str] = None,
 ) -> EksDeploymentConfig:
+    assert user or not is_toolbox, "User required for toolbox deployment"
     try:
         deployment_config = (
             generate_toolbox_deployment(service, cluster, user)


### PR DESCRIPTION
People may want to run adhoc configured instances with remote-run as they often do with local-run. To do this, we can load the adhoc deployment configuration and put the config dict into a new EKS deployment object, similar to how toolbox containers function.

I tested this with a very basic adhoc config file that only specified memory and cpu. https://fluffy.yelpcorp.com/i/QcpxxNgXnTv4WXSfgDzr2qfSDNhHn5pK.html