### PR TITLE
add fs_group to adhoc schema

### DIFF
--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -69,6 +69,9 @@
                         "aws"
                     ]
                 },
+                "fs_group": {
+                    "type": "string"
+                },
                 "crypto_keys": {
                     "type": "object",
                     "additionalProperties": false,


### PR DESCRIPTION
We need it to override [this behaviour](https://github.com/Yelp/paasta/blob/685e73f6ccdc3a30dc7482955c679de5f7733045/paasta_tools/kubernetes_tools.py#L2411-L2423) in remote-run toolbox instances.