### PR TITLE
remote-run: fix --copy-file for abs paths

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -256,7 +256,7 @@ def paasta_remote_run_start(
                 namespace=poll_response.namespace,
                 pod=poll_response.pod_name,
                 source=filename,
-                dest=os.path.join("/tmp", filename),
+                dest=os.path.join("/tmp", os.path.basename(filename)),
                 token=token_response.token,
             ).split(" ")
             call = subprocess.run(cp_command, capture_output=True)


### PR DESCRIPTION
We definitely just need to grab the filename here.

Not that it would have worked anyways, because I doubt kubectl would create directories, but implementation details are fun:
```
>>> import os
>>> os.path.join("/tmp", "/foo/bar/whatever")
'/foo/bar/whatever'
```