### PR TITLE
TRON-2481: Attempt to generate next run dates as part of validation

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -529,7 +529,7 @@ def validate_tron(service_path: str, verbose: bool = False) -> bool:
     return returncode
 
 
-def get_upcoming_runs(config: TronJobConfig, cron_expression: str) -> None:
+def get_upcoming_runs(config: TronJobConfig, cron_expression: str) -> List[str]:
 
     config_tz = config.get_time_zone() or DEFAULT_TZ
 

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -529,7 +529,7 @@ def validate_tron(service_path: str, verbose: bool = False) -> bool:
     return returncode
 
 
-def get_upcoming_runs(config: TronJobConfig, cron_expression: str) -> List[str]:
+def get_upcoming_runs(config: TronJobConfig, cron_expression: str) -> List[datetime]:
 
     config_tz = config.get_time_zone() or DEFAULT_TZ
 
@@ -881,7 +881,7 @@ def check_secrets_for_instance(
 
 def list_upcoming_runs(
     cron_schedule: str, starting_from: datetime, num_runs: int = 5
-) -> List[str]:
+) -> List[datetime]:
     iter = croniter(cron_schedule, starting_from)
     return [iter.get_next(datetime) for _ in range(num_runs)]
 

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -522,7 +522,7 @@ def validate_tron(service_path: str, verbose: bool = False) -> bool:
                     print(
                         failure(
                             f"Invalid schedule ({cron_expression}) for {config.get_name()}: {e}",
-                            "http://tron.readthedocs.io/en/latest/jobs.html#job-scheduling",
+                            "http://crontab.guru",
                         )
                     )
                     returncode = False


### PR DESCRIPTION
Entertainingly, our recent Tron issue caused by a cronjob with an 'impossible' date would've actually been caught in some way by a *verbose* `paasta validate`: 
```
✓ tron-infrastage.yaml is valid.
ℹ Upcoming runs for test_load_foo1:
Traceback (most recent call last):
  File "/nail/home/jfong/work/yelpsoa-configs/virtualenv_run/bin/paasta", line 8, in <module>
    sys.exit(main())
  File "/nail/home/jfong/work/yelpsoa-configs/virtualenv_run/lib/python3.8/site-packages/paasta_tools/cli/cli.py", line 253, in main
    return_code = args.command(args)
  File "/nail/home/jfong/work/yelpsoa-configs/virtualenv_run/lib/python3.8/site-packages/paasta_tools/cli/cmds/validate.py", line 1011, in paasta_validate
    if not paasta_validate_soa_configs(service, service_path, args.verbose):
  File "/nail/home/jfong/work/yelpsoa-configs/virtualenv_run/lib/python3.8/site-packages/paasta_tools/cli/cmds/validate.py", line 1001, in paasta_validate_soa_configs
    return all([check(service_path) for check in checks])
  File "/nail/home/jfong/work/yelpsoa-configs/virtualenv_run/lib/python3.8/site-packages/paasta_tools/cli/cmds/validate.py", line 1001, in <listcomp>
    return all([check(service_path) for check in checks])
  File "/nail/home/jfong/work/yelpsoa-configs/virtualenv_run/lib/python3.8/site-packages/paasta_tools/cli/cmds/validate.py", line 517, in validate_tron
    print_upcoming_runs(config, cron_expression)
  File "/nail/home/jfong/work/yelpsoa-configs/virtualenv_run/lib/python3.8/site-packages/paasta_tools/cli/cmds/validate.py", line 527, in print_upcoming_runs
    next_cron_runs = list_upcoming_runs(
  File "/nail/home/jfong/work/yelpsoa-configs/virtualenv_run/lib/python3.8/site-packages/paasta_tools/cli/cmds/validate.py", line 879, in list_upcoming_runs
    return [iter.get_next(datetime) for _ in range(num_runs)]
  File "/nail/home/jfong/work/yelpsoa-configs/virtualenv_run/lib/python3.8/site-packages/paasta_tools/cli/cmds/validate.py", line 879, in <listcomp>
    return [iter.get_next(datetime) for _ in range(num_runs)]
  File "/nail/home/jfong/work/yelpsoa-configs/virtualenv_run/lib/python3.8/site-packages/croniter/croniter.py", line 288, in get_next
    return self._get_next(
  File "/nail/home/jfong/work/yelpsoa-configs/virtualenv_run/lib/python3.8/site-packages/croniter/croniter.py", line 415, in _get_next
    result = self._calc(self.cur, expanded, nth_weekday_of_month, is_prev)
  File "/nail/home/jfong/work/yelpsoa-configs/virtualenv_run/lib/python3.8/site-packages/croniter/croniter.py", line 717, in _calc
    raise CroniterBadDateError("failed to find next date")
croniter.croniter.CroniterBadDateError: failed to find next date
```

So as a quick fix, this just runs the croniter code even when not in verbose mode to ensure we have _some_ cron validation as part of `paasta validate`.

A failure now looks like:
```
✗ Invalid schedule ( */5 * 30 2 *) for test_load_foo1: failed to find next date http://crontab.guru
```
or 
```
✗ Invalid schedule ( */5+5 * * * *) for test_load_foo1: [*/5+5 * * * *] is not acceptable http://crontab.guru
```

I also took the liberty of adding a final "Invalid configs found" warning at the bottom, because the final message being the last individual check's results that could still be successful, but the overall validation being a failure often confused people. 

I recognize that this is going to be distinct from some schedules that tron "supports" (or at least, allows through with surprises), but since we want to eventually get more consistent, we might as well enforce _some_ standard at precommit time. If we decide to consolidate on a different parser we can always change this at that time.   If we do switch to a better way of validating from paasta, it would also probably be worth supporting _all_ schedule types -- this check currently will only apply to `cron` types. 

I've run this across all service configs and only a handful didn't pass croniter's validation; those are being corrected in https://github.yelpcorp.com/sysgit/yelpsoa-configs/pull/59307

