### PR TITLE
Increase default duration for remote-run to 2 hours

### DIFF
--- a/paasta_tools/cli/cmds/remote_run.py
+++ b/paasta_tools/cli/cmds/remote_run.py
@@ -369,7 +369,7 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
             "automatically stopped (capped by the API backend)"
         ),
         type=int,
-        default=1800,
+        default=7200,
     )
     start_parser.add_argument(
         "-f",


### PR DESCRIPTION
30 minutes as a default was too aggressive and it has negatively impacted some people. I think 2 hours is probably a better default.