### PR TITLE
Add pod labels for all configured metrics providers

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2489,11 +2489,11 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             # character limit for k8s labels (63 chars)
             labels["paasta.yelp.com/deploy_group"] = self.get_deploy_group()
 
-        elif self.should_use_metrics_provider(METRICS_PROVIDER_PISCINA):
+        if self.should_use_metrics_provider(METRICS_PROVIDER_PISCINA):
             labels["paasta.yelp.com/deploy_group"] = self.get_deploy_group()
             labels["paasta.yelp.com/scrape_piscina_prometheus"] = "true"
 
-        elif self.should_use_metrics_provider(METRICS_PROVIDER_GUNICORN):
+        if self.should_use_metrics_provider(METRICS_PROVIDER_GUNICORN):
             labels["paasta.yelp.com/deploy_group"] = self.get_deploy_group()
             labels["paasta.yelp.com/scrape_gunicorn_prometheus"] = "true"
 


### PR DESCRIPTION
## Problem

Each autoscaling metric may have some specific pod labels to identify the pod for the scraper. In the case of multiple metrics, we'll need to add all the pod labels. Currently, we only provide the labels from one metric.

## Solution

Change if/else logic to if/if.

## Validation

Add tests.