### PR TITLE
Update gunicorn autoscaling metric

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -838,7 +838,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         elif provider["type"] in {
             METRICS_PROVIDER_UWSGI,
             METRICS_PROVIDER_PISCINA,
-            METRICS_PROVIDER_GUNICORN,
             METRICS_PROVIDER_ACTIVE_REQUESTS,
         }:
             return V2MetricSpec(
@@ -874,7 +873,10 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                     ),
                 ),
             )
-        elif provider["type"] == METRICS_PROVIDER_UWSGI_V2:
+        elif provider["type"] in {
+            METRICS_PROVIDER_UWSGI_V2,
+            METRICS_PROVIDER_GUNICORN,
+        }:
             return V2MetricSpec(
                 type="Object",
                 object=V2ObjectMetricSource(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -2704,8 +2704,8 @@ class TestKubernetesDeploymentConfig:
                                 name="service-instance-gunicorn-prom",
                             ),
                             target=V2MetricTarget(
-                                type="Value",
-                                value=1,
+                                type="AverageValue",
+                                average_value=0.5,
                             ),
                             described_object=V2CrossVersionObjectReference(
                                 api_version="apps/v1",

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -180,8 +180,9 @@ def test_create_instance_gunicorn_scaling_rule() -> None:
     assert service_name in rule["seriesQuery"]
     assert instance_config.instance in rule["seriesQuery"]
     assert paasta_cluster in rule["seriesQuery"]
-    # these two numbers are distinctive and unlikely to be used as constants
-    assert str(metrics_provider_config["setpoint"]) in rule["metricsQuery"]
+
+    # Like uwsgi_v2, we don't use the setpoint in this query -- the HPA will have the setpoint as its target.
+    assert str(metrics_provider_config["setpoint"]) not in rule["metricsQuery"]
     assert (
         str(metrics_provider_config["moving_average_window_seconds"])
         in rule["metricsQuery"]


### PR DESCRIPTION
## Feature

The gunicorn autoscaler functions the same way as the uwsgi autoscaler. The uwsgi_v2 (#4012) improves upon the calculations and we want to update the gunicorn autoscaler to follow.

## Solution

Update the gunicorn autoscaler policy and metric to follow that of the uwsgi_v2 autoscaler policy.

## Validation

Updated tests