### PR TITLE
[worker-load autoscaler] Add missing validation config

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -64,6 +64,7 @@ from paasta_tools.long_running_service_tools import METRICS_PROVIDER_PISCINA
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_PROMQL
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI_V2
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_WORKER_LOAD
 from paasta_tools.secret_tools import get_secret_name_from_ref
 from paasta_tools.secret_tools import is_secret_ref
 from paasta_tools.secret_tools import is_shared_secret
@@ -160,6 +161,10 @@ INVALID_AUTOSCALING_FIELDS = {
         "prometheus-adapter-config",
     },
     METRICS_PROVIDER_UWSGI_V2: {
+        "desired_active_requests_per_replica",
+        "prometheus-adapter-config",
+    },
+    METRICS_PROVIDER_WORKER_LOAD: {
         "desired_active_requests_per_replica",
         "prometheus-adapter-config",
     },

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -43,6 +43,7 @@ from paasta_tools.long_running_service_tools import METRICS_PROVIDER_ACTIVE_REQU
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_CPU
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI_V2
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_WORKER_LOAD
 from paasta_tools.utils import SystemPaastaConfig
 
 
@@ -1200,6 +1201,16 @@ def test_check_secrets_for_instance_missing_secret(
             ["fake_service.abc", "fake_service.def"],
             "kubernetes",
             False,
+        ),
+        (
+            {
+                "metrics_providers": [
+                    {"type": METRICS_PROVIDER_WORKER_LOAD, "setpoint": 0.55}
+                ]
+            },
+            [],
+            "eks",
+            True,
         ),
     ],
 )


### PR DESCRIPTION
## Problem

`paasta validate` is failing with the `worker-load` autoscaler because of a missing key

```
  File "/opt/venvs/paasta-tools/lib/python3.10/site-packages/paasta_tools/cli/cmds/validate.py", line 682, in _validate_autoscaling_config
    for field in INVALID_AUTOSCALING_FIELDS[metrics_provider_type]:
KeyError: 'worker-load'
```

## Solution

Duplicate the `uwsgi-v2` configs for invalid autoscaling fields