### PR TITLE
FLINK-5911: Extract pod/job state display to flink_tools (PR 2/4)

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -839,8 +839,10 @@ def _print_flink_status_from_job_manager(
         output.append(PaastaColors.red("    Flink cluster metadata is not available"))
         return 1
 
-    # Fetch flink config (version/revision) only when cluster is running
-    flink_config = None
+    labels = metadata.get("labels", {})
+    config_sha = labels.get(paasta_prefixed("config_sha"), "").removeprefix("config")
+    output.append(f"    Config SHA: {config_sha}")
+
     if status["state"] == "running":
         try:
             flink_config = get_flink_config_from_paasta_api_client(
@@ -851,76 +853,43 @@ def _print_flink_status_from_job_manager(
             output.append(str(e))
             return 1
 
-    try:
-        instance_details = flink_tools.get_flink_instance_details(
-            metadata, flink_config, flink_instance_config, service
-        )
-    except ValueError as e:
-        output.append(PaastaColors.red(str(e)))
-        return 1
-
-    dashboard_url = instance_details.get("dashboard_url")
-    output.extend(
-        flink_tools.format_flink_instance_header(instance_details, verbose > 0)
-    )
-
-    if verbose:
-        output.extend(
-            flink_tools.format_flink_instance_metadata(instance_details, service)
-        )
-        ecosystem = system_paasta_config.get_ecosystem_for_cluster(cluster)
-        output.extend(flink_tools.format_flink_config_links(service, ecosystem))
-        output.append(OUTPUT_HORIZONTAL_RULE)
-        output.extend(flink_tools.format_flink_log_commands(service, instance, cluster))
-        output.append(OUTPUT_HORIZONTAL_RULE)
-        output.extend(
-            flink_tools.format_flink_monitoring_links(
-                service, instance, ecosystem, cluster
+        try:
+            instance_details = flink_tools.get_flink_instance_details(
+                metadata, flink_config, flink_instance_config, service
             )
-        )
-        output.append(OUTPUT_HORIZONTAL_RULE)
+        except ValueError as e:
+            output.append(PaastaColors.red(str(e)))
+            return 1
 
-    # Print Flink Cluster State
-    color = PaastaColors.green if status["state"] == "running" else PaastaColors.yellow
-    output.append(f"    State: {color(status['state'].title())}")
-
-    # Print Flink Cluster Pod Info
-    pod_running_count = pod_evicted_count = pod_other_count = 0
-    # default for evicted in case where pod status is not available
-    evicted = f"{pod_evicted_count}"
-    for pod in status["pod_status"]:
-        if pod["phase"] == "Running":
-            pod_running_count += 1
-        elif pod["phase"] == "Failed" and pod["reason"] == "Evicted":
-            pod_evicted_count += 1
-        else:
-            pod_other_count += 1
-        evicted = (
-            PaastaColors.red(f"{pod_evicted_count}")
-            if pod_evicted_count > 0
-            else f"{pod_evicted_count}"
+        dashboard_url = instance_details.get("dashboard_url")
+        output.extend(
+            flink_tools.format_flink_instance_header(instance_details, verbose > 0)
         )
 
-    pods_total_count = pod_running_count + pod_evicted_count + pod_other_count
-    output.append(
-        "    Pods:"
-        f" {pod_running_count} running,"
-        f" {evicted} evicted,"
-        f" {pod_other_count} other,"
-        f" {pods_total_count} total"
-    )
+        if verbose:
+            output.extend(
+                flink_tools.format_flink_instance_metadata(instance_details, service)
+            )
+            ecosystem = system_paasta_config.get_ecosystem_for_cluster(cluster)
+            output.extend(flink_tools.format_flink_config_links(service, ecosystem))
+            output.append(OUTPUT_HORIZONTAL_RULE)
+            output.extend(
+                flink_tools.format_flink_log_commands(service, instance, cluster)
+            )
+            output.append(OUTPUT_HORIZONTAL_RULE)
+            output.extend(
+                flink_tools.format_flink_monitoring_links(
+                    service, instance, ecosystem, cluster
+                )
+            )
+            output.append(OUTPUT_HORIZONTAL_RULE)
+    else:
+        dashboard_url = None
 
-    if not should_job_info_be_shown(status["state"]):
-        # In case where the jobmanager of cluster is in crashloopbackoff
-        # The pods for the cluster will be available and we need to show the pods.
-        # So that paasta status -v and kubectl get pods show the same consistent result.
-        if verbose and len(status["pod_status"]) > 0:
-            append_pod_status(status["pod_status"], output)
-        output.append("    No other information available in non-running state")
-        return 0
-
+    # Fetch overview only when running; pass None otherwise so collect_flink_job_details
+    # can distinguish "not running" from "running but jobmanager not responding"
+    overview = None
     if status["state"] == "running":
-        # Flink cluster overview from paasta api client
         try:
             overview = get_flink_overview_from_paasta_api_client(
                 service=service, instance=instance, client=client
@@ -930,32 +899,17 @@ def _print_flink_status_from_job_manager(
             output.append(str(e))
             return 1
 
-        # Flink /overview returns all fields or none, so jobs_running
-        # is sufficient as a canary for the entire response.
-        if getattr(overview, "jobs_running", None) is None:
-            output.append(
-                PaastaColors.yellow("    Jobs: unknown (jobmanager is not responding)")
-            )
-        else:
-            jobs_total_count = (
-                overview.jobs_running
-                + overview.jobs_finished
-                + overview.jobs_failed
-                + overview.jobs_cancelled
-            )
-            output.append(
-                "    Jobs:"
-                f" {overview.jobs_running} running,"
-                f" {overview.jobs_finished} finished,"
-                f" {overview.jobs_failed} failed,"
-                f" {overview.jobs_cancelled} cancelled,"
-                f" {jobs_total_count} total"
-            )
-            output.append(
-                "   "
-                f" {overview.taskmanagers} taskmanagers,"
-                f" {overview.slots_available}/{overview.slots_total} slots available"
-            )
+    job_details = flink_tools.collect_flink_job_details(status, overview, [])
+    output.extend(flink_tools.format_flink_state_and_pods(job_details))
+
+    if not should_job_info_be_shown(status["state"]):
+        # In case where the jobmanager of cluster is in crashloopbackoff
+        # The pods for the cluster will be available and we need to show the pods.
+        # So that paasta status -v and kubectl get pods show the same consistent result.
+        if verbose and len(status.get("pod_status", [])) > 0:
+            append_pod_status(status["pod_status"], output)
+        output.append("    No other information available in non-running state")
+        return 0
 
     flink_jobs = FlinkJobs()
     flink_jobs.jobs = []

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -40,6 +40,7 @@ from paasta_tools.paastaapi.model.flink_job_details import FlinkJobDetails
 from paasta_tools.paastaapi.model.flink_jobs import FlinkJobs
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import BranchDictV2
+from paasta_tools.utils import PaastaColors
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import load_service_instance_config
 from paasta_tools.utils import load_v2_deployments_json
@@ -63,10 +64,36 @@ class TaskManagerConfig(TypedDict, total=False):
     instances: int
 
 
+class PodCounts(TypedDict):
+    running: int
+    evicted: int
+    other: int
+    total: int
+
+
+class JobCounts(TypedDict):
+    running: int
+    finished: int
+    failed: int
+    cancelled: int
+    total: int
+
+
+class FlinkJobDetailsDict(TypedDict):
+    state: str
+    pod_counts: PodCounts
+    job_counts: Optional[JobCounts]
+    taskmanagers: Optional[int]
+    slots_available: Optional[int]
+    slots_total: Optional[int]
+    jobs: List[FlinkJobDetails]
+    overview_available: bool
+
+
 class FlinkInstanceDetails(TypedDict):
     config_sha: str
-    version: Optional[str]
-    version_revision: Optional[str]
+    version: str
+    version_revision: str
     dashboard_url: Optional[str]
     pool: Optional[str]
     team: str
@@ -397,7 +424,7 @@ def get_flink_overview_from_paasta_api_client(
 
 def get_flink_instance_details(
     metadata: Mapping[str, Any],
-    flink_config: Optional[FlinkConfig],
+    flink_config: FlinkConfig,
     flink_instance_config: "FlinkDeploymentConfig",
     service: str,
     soa_dir: str = DEFAULT_SOA_DIR,
@@ -409,11 +436,10 @@ def get_flink_instance_details(
     config_sha = labels.get(paasta_prefixed("config_sha"))
     if config_sha is None:
         raise ValueError(f"expected config sha on Flink, but received {metadata}")
-    if config_sha.startswith("config"):
-        config_sha = config_sha[6:]  # strip "config" prefix (len("config") == 6)
+    config_sha = config_sha.removeprefix("config")
 
-    version = flink_config.flink_version if flink_config else None
-    version_revision = flink_config.flink_revision if flink_config else None
+    version = flink_config.flink_version
+    version_revision = flink_config.flink_revision
     dashboard_url = annotations.get("flink.yelp.com/dashboard_url")
 
     pool = flink_instance_config.get_pool()
@@ -438,22 +464,17 @@ def get_flink_instance_details(
 def format_flink_instance_header(
     details: FlinkInstanceDetails, verbose: bool
 ) -> List[str]:
-    """Format basic instance information (config SHA, version, dashboard URL)."""
+    """Format running cluster info (version, dashboard URL). Config SHA is shown separately."""
     output: List[str] = []
 
-    if details.get("config_sha"):
-        output.append(f"    Config SHA: {details['config_sha']}")
+    if verbose:
+        output.append(
+            f"    Flink version: {details['version']} {details['version_revision']}"
+        )
+    else:
+        output.append(f"    Flink version: {details['version']}")
 
-    if details.get("version"):
-        if verbose and details.get("version_revision"):
-            output.append(
-                f"    Flink version: {details['version']} {details['version_revision']}"
-            )
-        else:
-            output.append(f"    Flink version: {details['version']}")
-
-    # Dashboard URL is only useful when the cluster is running (version is set)
-    if details.get("dashboard_url") and details.get("version"):
+    if details.get("dashboard_url"):
         output.append(f"    URL: {details['dashboard_url']}/")
 
     return output
@@ -507,3 +528,118 @@ def format_flink_monitoring_links(
         f"      JVM Metrics: https://grafana.yelpcorp.com/d/flink-jvm-metrics/flink-jvm-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}&from=now-24h&to=now",
         f"      Flink Cost: https://app.cloudzero.com/explorer?activeCostType=invoiced_amortized_cost&partitions=costcontext%3AResource%20Summary&dateRange=Last%2030%20Days&costcontext%3AKube%20Paasta%20Cluster={cluster}&costcontext%3APaasta%20Instance={instance}&costcontext%3APaasta%20Service={service}&showRightFlyout=filters",
     ]
+
+
+def collect_flink_job_details(
+    status: Mapping[str, Any],
+    overview: Optional[FlinkClusterOverview],
+    jobs: List[FlinkJobDetails],
+) -> FlinkJobDetailsDict:
+    """Collect job, pod, and resource information from status and overview."""
+    pod_running_count = 0
+    pod_evicted_count = 0
+    pod_other_count = 0
+
+    for pod in status.get("pod_status", []):
+        phase = pod.get("phase")
+        if phase == "Running":
+            pod_running_count += 1
+        elif phase == "Failed" and pod.get("reason") == "Evicted":
+            pod_evicted_count += 1
+        else:
+            pod_other_count += 1
+
+    pod_counts: PodCounts = {
+        "running": pod_running_count,
+        "evicted": pod_evicted_count,
+        "other": pod_other_count,
+        "total": pod_running_count + pod_evicted_count + pod_other_count,
+    }
+
+    job_counts: Optional[JobCounts] = None
+    taskmanagers = None
+    slots_available = None
+    slots_total = None
+
+    if overview and getattr(overview, "jobs_running", None) is not None:
+        jobs_total_count = (
+            overview.jobs_running
+            + overview.jobs_finished
+            + overview.jobs_failed
+            + overview.jobs_cancelled
+        )
+        job_counts = {
+            "running": overview.jobs_running,
+            "finished": overview.jobs_finished,
+            "failed": overview.jobs_failed,
+            "cancelled": overview.jobs_cancelled,
+            "total": jobs_total_count,
+        }
+        taskmanagers = overview.taskmanagers
+        slots_available = overview.slots_available
+        slots_total = overview.slots_total
+
+    return {
+        "state": status["state"],
+        "pod_counts": pod_counts,
+        "job_counts": job_counts,
+        "taskmanagers": taskmanagers,
+        "slots_available": slots_available,
+        "slots_total": slots_total,
+        "jobs": jobs,
+        "overview_available": overview is not None,
+    }
+
+
+def format_flink_state_and_pods(job_details: FlinkJobDetailsDict) -> List[str]:
+    """Format state, pods, jobs summary, taskmanagers, and slots."""
+    output: List[str] = []
+
+    state = job_details["state"]
+    pod_counts = job_details["pod_counts"]
+    job_counts = job_details.get("job_counts")
+    taskmanagers = job_details.get("taskmanagers")
+    slots_available = job_details.get("slots_available")
+    slots_total = job_details.get("slots_total")
+
+    color = PaastaColors.green if state == "running" else PaastaColors.yellow
+    output.append(f"    State: {color(state.title())}")
+
+    formatted_evictions = (
+        PaastaColors.red(f"{pod_counts['evicted']}")
+        if pod_counts["evicted"] > 0
+        else f"{pod_counts['evicted']}"
+    )
+    output.append(
+        "    Pods:"
+        f" {pod_counts['running']} running,"
+        f" {formatted_evictions} evicted,"
+        f" {pod_counts['other']} other,"
+        f" {pod_counts['total']} total"
+    )
+
+    if job_counts is not None:
+        output.append(
+            "    Jobs:"
+            f" {job_counts['running']} running,"
+            f" {job_counts['finished']} finished,"
+            f" {job_counts['failed']} failed,"
+            f" {job_counts['cancelled']} cancelled,"
+            f" {job_counts['total']} total"
+        )
+    elif job_details.get("overview_available"):
+        output.append(
+            PaastaColors.yellow("    Jobs: unknown (jobmanager is not responding)")
+        )
+
+    if (
+        taskmanagers is not None
+        and slots_available is not None
+        and slots_total is not None
+    ):
+        output.append(
+            f"    {taskmanagers} taskmanagers,"
+            f" {slots_available}/{slots_total} slots available"
+        )
+
+    return output

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -2873,28 +2873,9 @@ class TestPrintFlinkStatus:
         )
 
         status = mock_flink_status["status"]
+        # Version/URL/metadata/links are only shown when running
         expected_output = [
             "    Config SHA: 00000",
-            "    Repo(git): https://github.yelpcorp.com/services/fake_service",
-            "    Repo(sourcegraph): https://sourcegraph.yelpcorp.com/services/fake_service",
-            "    Flink Pool: flink",
-            "    Owner: fake_owner",
-            "    Flink Runbook: fake_runbook_url",
-            "    Yelpsoa configs: https://github.yelpcorp.com/sysgit/yelpsoa-configs/tree/master/fake_service",
-            "    Srv configs: https://github.yelpcorp.com/sysgit/srv-configs/tree/master/ecosystem/devc/fake_service",
-            f"{OUTPUT_HORIZONTAL_RULE}",
-            "    Flink Log Commands:",
-            "      Service:     paasta logs -a 1h -c fake_cluster -s fake_service -i fake_instance",
-            "      Taskmanager: paasta logs -a 1h -c fake_cluster -s fake_service -i fake_instance.TASKMANAGER",
-            "      Jobmanager:  paasta logs -a 1h -c fake_cluster -s fake_service -i fake_instance.JOBMANAGER",
-            "      Supervisor:  paasta logs -a 1h -c fake_cluster -s fake_service -i fake_instance.SUPERVISOR",
-            f"{OUTPUT_HORIZONTAL_RULE}",
-            "    Flink Monitoring:",
-            "      Job Metrics: https://grafana.yelpcorp.com/d/flink-metrics/flink-job-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=fake_service&var-instance=fake_instance&var-job=All&from=now-24h&to=now",
-            "      Container Metrics: https://grafana.yelpcorp.com/d/flink-container-metrics/flink-container-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=fake_service&var-instance=fake_instance&from=now-24h&to=now",
-            "      JVM Metrics: https://grafana.yelpcorp.com/d/flink-jvm-metrics/flink-jvm-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=fake_service&var-instance=fake_instance&from=now-24h&to=now",
-            "      Flink Cost: https://app.cloudzero.com/explorer?activeCostType=invoiced_amortized_cost&partitions=costcontext%3AResource%20Summary&dateRange=Last%2030%20Days&costcontext%3AKube%20Paasta%20Cluster=fake_cluster&costcontext%3APaasta%20Instance=fake_instance&costcontext%3APaasta%20Service=fake_service&showRightFlyout=filters",
-            f"{OUTPUT_HORIZONTAL_RULE}",
             f"    State: {PaastaColors.yellow(status['state'].title())}",
             "    Pods: 3 running, 0 evicted, 0 other, 3 total",
         ]
@@ -2945,28 +2926,9 @@ class TestPrintFlinkStatus:
         )
 
         status = mock_flink_status["status"]
+        # Version/URL/metadata/links are only shown when running
         expected_output = [
             "    Config SHA: 00000",
-            "    Repo(git): https://github.yelpcorp.com/services/fake_service",
-            "    Repo(sourcegraph): https://sourcegraph.yelpcorp.com/services/fake_service",
-            "    Flink Pool: flink-spot",
-            "    Owner: fake_owner",
-            "    Flink Runbook: fake_runbook_url",
-            "    Yelpsoa configs: https://github.yelpcorp.com/sysgit/yelpsoa-configs/tree/master/fake_service",
-            "    Srv configs: https://github.yelpcorp.com/sysgit/srv-configs/tree/master/ecosystem/devc/fake_service",
-            f"{OUTPUT_HORIZONTAL_RULE}",
-            "    Flink Log Commands:",
-            "      Service:     paasta logs -a 1h -c fake_cluster -s fake_service -i fake_instance",
-            "      Taskmanager: paasta logs -a 1h -c fake_cluster -s fake_service -i fake_instance.TASKMANAGER",
-            "      Jobmanager:  paasta logs -a 1h -c fake_cluster -s fake_service -i fake_instance.JOBMANAGER",
-            "      Supervisor:  paasta logs -a 1h -c fake_cluster -s fake_service -i fake_instance.SUPERVISOR",
-            f"{OUTPUT_HORIZONTAL_RULE}",
-            "    Flink Monitoring:",
-            "      Job Metrics: https://grafana.yelpcorp.com/d/flink-metrics/flink-job-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=fake_service&var-instance=fake_instance&var-job=All&from=now-24h&to=now",
-            "      Container Metrics: https://grafana.yelpcorp.com/d/flink-container-metrics/flink-container-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=fake_service&var-instance=fake_instance&from=now-24h&to=now",
-            "      JVM Metrics: https://grafana.yelpcorp.com/d/flink-jvm-metrics/flink-jvm-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=fake_service&var-instance=fake_instance&from=now-24h&to=now",
-            "      Flink Cost: https://app.cloudzero.com/explorer?activeCostType=invoiced_amortized_cost&partitions=costcontext%3AResource%20Summary&dateRange=Last%2030%20Days&costcontext%3AKube%20Paasta%20Cluster=fake_cluster&costcontext%3APaasta%20Instance=fake_instance&costcontext%3APaasta%20Service=fake_service&showRightFlyout=filters",
-            f"{OUTPUT_HORIZONTAL_RULE}",
             f"    State: {PaastaColors.yellow(status['state'].title())}",
             "    Pods: 1 running, 0 evicted, 0 other, 1 total",
         ]

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -415,33 +415,23 @@ class TestGetFlinkInstanceDetails:
         assert result["team"] == "fake_owner"
         assert result["runbook"] == "fake_runbook_url"
 
-    def test_stopped_cluster(self, flink_instance_config):
-        metadata = {
-            "labels": {"paasta.yelp.com/config_sha": "config00000"},
-            "annotations": {},
-        }
-        result = flink_tools.get_flink_instance_details(
-            metadata, None, flink_instance_config, "test_service"
-        )
-        assert result["version"] is None
-        assert result["version_revision"] is None
-        assert result["dashboard_url"] is None
-
     def test_missing_config_sha(self, flink_instance_config):
+        flink_config = mock.Mock(flink_version="1.13.5", flink_revision="0ff28a7")
         metadata = {"labels": {}, "annotations": {}}
         with pytest.raises(ValueError, match="expected config sha"):
             flink_tools.get_flink_instance_details(
-                metadata, None, flink_instance_config, "test_service"
+                metadata, flink_config, flink_instance_config, "test_service"
             )
 
     def test_config_sha_without_prefix(self, flink_instance_config):
         # Labels without the "config" prefix should be used as-is
+        flink_config = mock.Mock(flink_version="1.13.5", flink_revision="0ff28a7")
         metadata = {
             "labels": {"paasta.yelp.com/config_sha": "abcdef12"},
             "annotations": {},
         }
         result = flink_tools.get_flink_instance_details(
-            metadata, None, flink_instance_config, "test_service"
+            metadata, flink_config, flink_instance_config, "test_service"
         )
         assert result["config_sha"] == "abcdef12"
 
@@ -458,9 +448,9 @@ class TestFormatFlinkInstanceHeader:
             "runbook": "test_runbook",
         }
         result = flink_tools.format_flink_instance_header(details, verbose=False)
-        assert "    Config SHA: 00000" in result
         assert "    Flink version: 1.13.5" in result
         assert "0ff28a7" not in "\n".join(result)
+        assert "Config SHA" not in "\n".join(result)
 
     def test_verbose(self):
         details = {
@@ -476,20 +466,18 @@ class TestFormatFlinkInstanceHeader:
         assert "    Flink version: 1.13.5 0ff28a7" in result
         assert "    URL: http://flink.k8s.test.paasta:31080/app/" in result
 
-    def test_no_version_hides_url(self):
-        # Dashboard URL should not be shown when cluster is not running (no version)
+    def test_no_dashboard_url(self):
+        # Dashboard URL line is omitted when annotation is absent
         details = {
             "config_sha": "00000",
-            "version": None,
-            "version_revision": None,
-            "dashboard_url": "http://flink.k8s.test.paasta:31080/app",
+            "version": "1.13.5",
+            "version_revision": "0ff28a7",
+            "dashboard_url": None,
             "pool": "flink",
             "team": "test_team",
             "runbook": "test_runbook",
         }
         result = flink_tools.format_flink_instance_header(details, verbose=True)
-        assert len(result) == 1
-        assert "Config SHA" in result[0]
         assert "URL" not in "\n".join(result)
 
 
@@ -550,3 +538,149 @@ class TestFormatFlinkMonitoringLinks:
         assert "var-instance=main" in result[1]
         assert "uswest2-devc" in result[1]
         assert "pnw-devc" in result[4]  # Flink Cost link uses cluster name
+
+
+class TestCollectFlinkJobDetails:
+    def test_running_with_overview(self):
+        status = {
+            "state": "running",
+            "pod_status": [
+                {"phase": "Running"},
+                {"phase": "Running"},
+                {"phase": "Failed", "reason": "Evicted"},
+            ],
+        }
+        overview = mock.Mock()
+        overview.jobs_running = 1
+        overview.jobs_finished = 0
+        overview.jobs_failed = 0
+        overview.jobs_cancelled = 0
+        overview.taskmanagers = 2
+        overview.slots_available = 3
+        overview.slots_total = 8
+
+        result = flink_tools.collect_flink_job_details(status, overview, [])
+
+        assert result["state"] == "running"
+        assert result["pod_counts"]["running"] == 2
+        assert result["pod_counts"]["evicted"] == 1
+        assert result["pod_counts"]["other"] == 0
+        assert result["pod_counts"]["total"] == 3
+        assert result["job_counts"] is not None
+        assert result["job_counts"]["running"] == 1
+        assert result["job_counts"]["total"] == 1
+        assert result["taskmanagers"] == 2
+        assert result["slots_available"] == 3
+        assert result["slots_total"] == 8
+        assert result["overview_available"] is True
+
+    def test_running_crashlooping_jobmanager(self):
+        # overview object returned but jobs_running is None (jobmanager not responding)
+        status = {"state": "running", "pod_status": [{"phase": "Running"}]}
+        overview = mock.Mock()
+        overview.jobs_running = None
+
+        result = flink_tools.collect_flink_job_details(status, overview, [])
+
+        assert result["job_counts"] is None
+        assert result["overview_available"] is True
+
+    def test_not_running_no_overview(self):
+        status = {"state": "stopped", "pod_status": [{"phase": "Running"}]}
+
+        result = flink_tools.collect_flink_job_details(status, None, [])
+
+        assert result["job_counts"] is None
+        assert result["overview_available"] is False
+
+    def test_defensive_pod_access(self):
+        # Pods without phase/reason should not crash
+        status = {
+            "state": "running",
+            "pod_status": [
+                {},  # no phase
+                {"phase": "Failed"},  # no reason
+                {"phase": "Failed", "reason": "OOMKilled"},
+            ],
+        }
+        result = flink_tools.collect_flink_job_details(status, None, [])
+
+        assert result["pod_counts"]["other"] == 3
+        assert result["pod_counts"]["evicted"] == 0
+
+
+class TestFormatFlinkStateAndPods:
+    def _make_details(self, **kwargs):
+        defaults = {
+            "state": "running",
+            "pod_counts": {"running": 2, "evicted": 0, "other": 0, "total": 2},
+            "job_counts": {
+                "running": 1,
+                "finished": 0,
+                "failed": 0,
+                "cancelled": 0,
+                "total": 1,
+            },
+            "taskmanagers": 1,
+            "slots_available": 2,
+            "slots_total": 8,
+            "jobs": [],
+            "overview_available": True,
+        }
+        defaults.update(kwargs)
+        return defaults
+
+    def test_running_state(self):
+        from paasta_tools.utils import PaastaColors
+
+        result = flink_tools.format_flink_state_and_pods(self._make_details())
+        assert f"    State: {PaastaColors.green('Running')}" in result
+
+    def test_stopped_state_is_yellow(self):
+        from paasta_tools.utils import PaastaColors
+
+        result = flink_tools.format_flink_state_and_pods(
+            self._make_details(state="stopped")
+        )
+        assert f"    State: {PaastaColors.yellow('Stopped')}" in result
+
+    def test_pods_line(self):
+        result = flink_tools.format_flink_state_and_pods(self._make_details())
+        pods_line = next(line for line in result if "Pods:" in line)
+        assert "2 running" in pods_line
+        assert "0 evicted" in pods_line
+        assert "2 total" in pods_line
+
+    def test_evicted_pods_red(self):
+        from paasta_tools.utils import PaastaColors
+
+        details = self._make_details(
+            pod_counts={"running": 1, "evicted": 2, "other": 0, "total": 3}
+        )
+        result = flink_tools.format_flink_state_and_pods(details)
+        pods_line = next(line for line in result if "Pods:" in line)
+        assert PaastaColors.red("2") in pods_line
+
+    def test_jobs_summary_line(self):
+        result = flink_tools.format_flink_state_and_pods(self._make_details())
+        jobs_line = next(line for line in result if "Jobs:" in line)
+        assert "1 running" in jobs_line
+        assert "1 total" in jobs_line
+
+    def test_jobmanager_not_responding(self):
+        details = self._make_details(job_counts=None, overview_available=True)
+        result = flink_tools.format_flink_state_and_pods(details)
+        assert any("jobmanager is not responding" in line for line in result)
+
+    def test_no_jobs_line_when_not_running(self):
+        details = self._make_details(
+            state="stopped", job_counts=None, overview_available=False
+        )
+        result = flink_tools.format_flink_state_and_pods(details)
+        assert not any("Jobs:" in line for line in result)
+
+    def test_taskmanagers_slots_line(self):
+        result = flink_tools.format_flink_state_and_pods(self._make_details())
+        slots_line = next(line for line in result if "taskmanagers" in line)
+        assert "1 taskmanagers" in slots_line
+        assert "2/8 slots available" in slots_line


### PR DESCRIPTION
Ticket: https://jira.yelpcorp.com/browse/FLINK-5911

Part 2 of 4 in the _print_flink_status_from_job_manager() refactor.

**Extracts pod counting and state/overview display into testable functions in flink_tools.py.**

Also folds in feedback from PR 1 (#4282):
- Use str.removeprefix("config") instead of startswith + slice for config SHA label stripping
- get_flink_instance_details now takes FlinkConfig (not Optional[FlinkConfig]) — removed None sentinel and ternary guards
- get_flink_instance_details, format_flink_instance_header, format_flink_instance_metadata, and config links/log/monitoring formatters are now only called when state == "running" — non-running instances only show Config SHA + State + Pods

**Changes**

paasta_tools/flink_tools.py
- PodCounts TypedDict — running, evicted, other, total counts
- JobCounts TypedDict — running, finished, failed, cancelled, total counts
- FlinkJobDetailsDict TypedDict — state, pod_counts, job_counts, taskmanagers, slots, jobs, overview_available flag
- collect_flink_job_details(status, overview, jobs) — defensive .get() for phase/reason on pod dicts (prevents KeyError on malformed pod status); tracks overview_available to distinguish "not running" vs "running but jobmanager crashlooping"
- format_flink_state_and_pods(job_details) — State (green/yellow), Pods line (red on evictions), Jobs summary, taskmanager/slot counts

paasta_tools/cli/cmds/status.py
- Config SHA extracted before running guard (shown for all states)
- All version/URL/metadata/links moved inside if state == "running": block
- State/pod block replaced with collect_flink_job_details + format_flink_state_and_pods calls

tests/test_flink_tools.py / tests/cli/test_cmds_status.py
- Tests for collect_flink_job_details: defensive pod access, evicted pods, overview null guard
- Tests for format_flink_state_and_pods: running/stopped state colors, eviction highlight, crashlooping jobmanager, slots line
- Stopping tests updated to only assert Config SHA + State + Pods (no verbose metadata for non-running)

## Paasta status test
```
(py310-linux) nathanleigh@dev55-uswest1adevc:~/source/paasta$ .tox/py310-linux/bin/paasta status -s beam_happyhour -c pnw-devc -i main -vvv


beam_happyhour.main in pnw-devc (EKS)
    Version:    DeploymentVersion(sha=f66b1c1d, image_version=20260327T041614) (desired)
    Config SHA: d3574868
    Flink version: 1.13.5 0ff28a7 @ 2021-12-14T23:26:04+01:00
    URL: http://flink.eks.pnw-devc.paasta:31080/beam--happyhour-7f797b79f6/
    Repo(git): https://github.yelpcorp.com/services/beam_happyhour
    Repo(sourcegraph): https://sourcegraph.yelpcorp.com/services/beam_happyhour
    Flink Pool: flink-spot
    Owner: core-streaming
    Flink Runbook: y/todo
    Yelpsoa configs: https://github.yelpcorp.com/sysgit/yelpsoa-configs/tree/master/beam_happyhour
    Srv configs: https://github.yelpcorp.com/sysgit/srv-configs/tree/master/ecosystem/devc/beam_happyhour
==================================================================
    Flink Log Commands:
      Service:     paasta logs -a 1h -c pnw-devc -s beam_happyhour -i main
      Taskmanager: paasta logs -a 1h -c pnw-devc -s beam_happyhour -i main.TASKMANAGER
      Jobmanager:  paasta logs -a 1h -c pnw-devc -s beam_happyhour -i main.JOBMANAGER
      Supervisor:  paasta logs -a 1h -c pnw-devc -s beam_happyhour -i main.SUPERVISOR
==================================================================
    Flink Monitoring:
      Job Metrics: https://grafana.yelpcorp.com/d/flink-metrics/flink-job-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=beam_happyhour&var-instance=main&var-job=All&from=now-24h&to=now
      Container Metrics: https://grafana.yelpcorp.com/d/flink-container-metrics/flink-container-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=beam_happyhour&var-instance=main&from=now-24h&to=now
      JVM Metrics: https://grafana.yelpcorp.com/d/flink-jvm-metrics/flink-jvm-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=beam_happyhour&var-instance=main&from=now-24h&to=now
      Flink Cost: https://app.cloudzero.com/explorer?activeCostType=invoiced_amortized_cost&partitions=costcontext%3AResource%20Summary&dateRange=Last%2030%20Days&costcontext%3AKube%20Paasta%20Cluster=pnw-devc&costcontext%3APaasta%20Instance=main&costcontext%3APaasta%20Service=beam_happyhour&showRightFlyout=filters
==================================================================
    State: Running
    Pods: 3 running, 0 evicted, 0 other, 3 total
    Jobs: 1 running, 0 finished, 0 failed, 0 cancelled, 1 total
    1 taskmanagers, 2/24 slots available
    Jobs:
      Job Name State       Job ID                           Started
      test_job Running 8c27c6dc08522e85d3aa8a528f77e7ce 2026-04-01 18:13:38 (9 hours ago)
        http://flink.eks.pnw-devc.paasta:31080/beam--happyhour-7f797b79f6/#/jobs/8c27c6dc08522e85d3aa8a528f77e7ce
        Checkpoints: 562 completed, 1 failed, 0 in progress, 10 restored
        Last restart: 2026-04-01 23:53:03 (4 hours ago)
    Pods:
      Pod Name                                                 Host                                        Phase    Uptime
      beam--happyhour-7f797b79f6-jobmanager-d588f887b-dwwgh    ip-10-81-20-225.us-west-2.compute.internal  Running  0d9h52m54s
      beam--happyhour-7f797b79f6-supervisor-8nzr6              ip-10-81-18-229.us-west-2.compute.internal  Running  0d1h7m13s
      beam--happyhour-7f797b79f6-taskmanager-5986cb449c-d927r  ip-10-81-16-25.us-west-2.compute.internal   Running  0d4h14m12s
```